### PR TITLE
feat(miner): export buildIssueQualityReport for self-review (#6057)

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -416,6 +416,10 @@ export {
 // live gate does), not this file's full internal surface.
 export { buildCollisionReport, type CollisionCluster, type CollisionReport } from "./signals/predicted-gate-engine.js";
 export type { CollisionItem } from "./types/predicted-gate-types.js";
+// Package-local twin of the host engine's buildIssueQualityReport (#6057). Do NOT re-export from
+// `./signals/engine.js` — that file is excluded from this package's tsc emit (host-bound imports) and
+// pulling it into the public barrel breaks `npm run build` (closed #6139).
+export { buildIssueQualityReport } from "./signals/issue-quality-report.js";
 // Unlinked-issue candidate pre-filter (#4883), extracted out of src/signals/unlinked-issue-candidates.ts so the
 // miner's self-review can run the SAME deterministic recall pass the maintainer gate uses to flag a PR's
 // likely-but-unlinked issue, instead of a driftable copy. PURE — no IO, no AI call.

--- a/packages/loopover-engine/src/signals/issue-quality-report.ts
+++ b/packages/loopover-engine/src/signals/issue-quality-report.ts
@@ -1,0 +1,302 @@
+/**
+ * Package-local `buildIssueQualityReport` (#6057).
+ *
+ * Canonical scoring lives in the host signals engine (`signals/engine.ts`), which is intentionally
+ * excluded from this package's `tsc` emit (host-bound imports). Re-exporting that file from the public
+ * barrel breaks `npm run build` inside `@loopover/engine` — see closed #6139.
+ *
+ * This module is the portable twin of that function, matching the same call signature and status rules,
+ * built only on package-local types/helpers the way `buildCollisionReport` already is.
+ */
+
+import type {
+  BountyLifecycle,
+  BountyRecord,
+  CollisionCluster,
+  CollisionReport,
+  IssueQualityReport,
+  IssueRecord,
+  LaneAdvice,
+  PullRequestRecord,
+  RecentMergedPullRequestRecord,
+  RepositoryRecord,
+} from "../types/predicted-gate-types.js";
+import { nowIso } from "../utils/json.js";
+import {
+  bountyIssueKey,
+  buildCollisionReport,
+  buildLaneAdvice,
+  classifyBountyLifecycle,
+  indexBountiesByIssue,
+} from "./predicted-gate-engine.js";
+
+const ISSUE_QUALITY_REPORT_CAP = 100;
+const ISSUE_DISCOVERY_LIFECYCLE_REPORT_CAP = 300;
+
+const MAINTAINER_WIP_LABELS = new Set([
+  "wip",
+  "work in progress",
+  "work-in-progress",
+  "in progress",
+  "in-progress",
+  "blocked",
+  "on hold",
+  "on-hold",
+  "draft",
+  "do not work",
+  "do-not-work",
+  "internal",
+]);
+
+type IssueDiscoveryLifecycleState =
+  | "open"
+  | "closed_not_solved"
+  | "solved"
+  | "valid_solved"
+  | "stale"
+  | "duplicate"
+  | "invalid";
+
+type LifecycleEntry = {
+  number: number;
+  title: string;
+  state: IssueDiscoveryLifecycleState;
+  solvedByPullRequests: number[];
+  reasons: string[];
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function daysSince(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  /* v8 ignore next -- Invalid timestamps normalize to fresh. */
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.floor((Date.now() - parsed) / 86_400_000);
+}
+
+function isMaintainerAssociation(value: string | null | undefined): boolean {
+  return value === "OWNER" || value === "MEMBER" || value === "COLLABORATOR";
+}
+
+function sameLogin(value: string | null | undefined, login: string): boolean {
+  return value?.toLowerCase() === login.toLowerCase();
+}
+
+function isMaintainerWipIssue(issue: IssueRecord): boolean {
+  return isMaintainerAssociation(issue.authorAssociation) && issue.labels.some((label) => MAINTAINER_WIP_LABELS.has(label.toLowerCase().trim()));
+}
+
+function indexPullRequestsByLinkedIssue<T extends { number: number; linkedIssues: number[] }>(pullRequests: T[]): Map<number, T[]> {
+  const byIssue = new Map<number, T[]>();
+  for (const pr of pullRequests) {
+    for (const issueNumber of new Set(pr.linkedIssues)) {
+      const bucket = byIssue.get(issueNumber);
+      if (bucket) bucket.push(pr);
+      else byIssue.set(issueNumber, [pr]);
+    }
+  }
+  return byIssue;
+}
+
+function indexCollisionClustersByIssue(clusters: CollisionCluster[]): Map<number, CollisionCluster[]> {
+  const byIssue = new Map<number, CollisionCluster[]>();
+  for (const cluster of clusters) {
+    const issueNumbers = new Set<number>();
+    for (const item of cluster.items) if (item.type === "issue") issueNumbers.add(item.number);
+    for (const issueNumber of issueNumbers) {
+      const bucket = byIssue.get(issueNumber);
+      if (bucket) bucket.push(cluster);
+      else byIssue.set(issueNumber, [cluster]);
+    }
+  }
+  return byIssue;
+}
+
+function resolveLinkedPullRequests<T extends { number: number }>(
+  issue: IssueRecord,
+  pullRequests: T[],
+  byLinkedIssue: Map<number, T[]>,
+  byNumber: Map<number, T>,
+): T[] {
+  const linkingPrs = byLinkedIssue.get(issue.number) ?? [];
+  let addedBackReference = false;
+  const matchedNumbers = new Set(linkingPrs.map((pr) => pr.number));
+  for (const prNumber of issue.linkedPrs) {
+    if (byNumber.has(prNumber) && !matchedNumbers.has(prNumber)) {
+      matchedNumbers.add(prNumber);
+      addedBackReference = true;
+    }
+  }
+  if (!addedBackReference) return [...linkingPrs];
+  return pullRequests.filter((pr) => matchedNumbers.has(pr.number));
+}
+
+function classifyIssueDiscoveryLifecycle(
+  issue: IssueRecord,
+  pullRequests: PullRequestRecord[],
+  recentMergedPullRequests: RecentMergedPullRequestRecord[],
+  lane: LaneAdvice,
+  linkedIndex?: { open: Map<number, PullRequestRecord[]>; merged: Map<number, RecentMergedPullRequestRecord[]> },
+): LifecycleEntry {
+  const linkedOpenPrs = linkedIndex ? (linkedIndex.open.get(issue.number) ?? []) : pullRequests.filter((pr) => pr.linkedIssues.includes(issue.number));
+  const linkedMergedPrs = linkedIndex
+    ? (linkedIndex.merged.get(issue.number) ?? [])
+    : recentMergedPullRequests.filter((pr) => pr.linkedIssues.includes(issue.number));
+  const mergedSolverPrs = [...linkedOpenPrs.filter((pr) => pr.mergedAt || pr.state === "merged"), ...linkedMergedPrs];
+  const solvedByPullRequests = [...new Set(mergedSolverPrs.map((pr) => pr.number))].sort((left, right) => left - right);
+  const issueAuthorLogin = issue.authorLogin;
+  const selfSolvedLoop = Boolean(
+    issueAuthorLogin && mergedSolverPrs.length > 0 && mergedSolverPrs.every((pr) => sameLogin(pr.authorLogin, issueAuthorLogin)),
+  );
+  const labels = issue.labels.map((label) => label.toLowerCase());
+  const stale = daysSince(issue.updatedAt ?? issue.createdAt) > 90;
+  const duplicate = labels.some((label) => /duplicate/.test(label));
+  const invalid = labels.some((label) => /invalid|wontfix|not planned|won't fix/.test(label));
+  const state: IssueDiscoveryLifecycleState = duplicate
+    ? "duplicate"
+    : invalid
+      ? "invalid"
+      : solvedByPullRequests.length > 0
+        ? (lane.lane === "issue_discovery" || lane.lane === "split") && !selfSolvedLoop
+          ? "valid_solved"
+          : "solved"
+        : issue.state !== "open"
+          ? "closed_not_solved"
+          : stale
+            ? "stale"
+            : "open";
+  const reasons = [
+    ...(duplicate ? ["Issue carries duplicate labeling."] : []),
+    ...(invalid ? ["Issue carries invalid or not-planned labeling."] : []),
+    ...(solvedByPullRequests.length > 0 ? [`Linked solver PR(s): ${solvedByPullRequests.map((number) => `#${number}`).join(", ")}.`] : []),
+    ...(selfSolvedLoop ? ["Linked solver PR author matches the issue reporter; cache treats this as solved but not valid issue-discovery evidence."] : []),
+    ...(issue.state !== "open" && solvedByPullRequests.length === 0 ? ["Issue is closed without cached solver PR evidence."] : []),
+    ...(stale && issue.state === "open" ? ["Issue is stale in cached metadata."] : []),
+    ...(lane.lane === "direct_pr" ? ["Repo is direct-PR first; lifecycle should not encourage issue filing."] : []),
+  ];
+  return {
+    number: issue.number,
+    title: issue.title,
+    state,
+    solvedByPullRequests,
+    reasons: reasons.length > 0 ? reasons : ["Issue is open with no solver or duplicate signal."],
+  };
+}
+
+function buildLifecycleByIssue(
+  repo: RepositoryRecord | null,
+  issues: IssueRecord[],
+  pullRequests: PullRequestRecord[],
+  fullName: string,
+  recentMergedPullRequests: RecentMergedPullRequestRecord[],
+): Map<number, LifecycleEntry> {
+  const lane = buildLaneAdvice(repo, fullName);
+  const linkedIndex = {
+    open: indexPullRequestsByLinkedIssue(pullRequests),
+    merged: indexPullRequestsByLinkedIssue(recentMergedPullRequests),
+  };
+  const cappedIssues = issues.slice(0, ISSUE_DISCOVERY_LIFECYCLE_REPORT_CAP);
+  return new Map(
+    cappedIssues.map((issue) => [issue.number, classifyIssueDiscoveryLifecycle(issue, pullRequests, recentMergedPullRequests, lane, linkedIndex)]),
+  );
+}
+
+/**
+ * Evaluate open issues for contribution readiness.
+ *
+ * Call signature matches the host engine:
+ * `(repo, issues, pullRequests, fullName, bounties?, prebuiltCollisions?, recentMergedPullRequests?)`.
+ */
+export function buildIssueQualityReport(
+  repo: RepositoryRecord | null,
+  issues: IssueRecord[],
+  pullRequests: PullRequestRecord[],
+  fullName: string,
+  bounties: BountyRecord[] = [],
+  prebuiltCollisions?: CollisionReport,
+  recentMergedPullRequests: RecentMergedPullRequestRecord[] = [],
+): IssueQualityReport {
+  const lane = buildLaneAdvice(repo, fullName);
+  const collisions = prebuiltCollisions ?? buildCollisionReport(fullName, issues, pullRequests, recentMergedPullRequests);
+  const bountyByIssue = indexBountiesByIssue(bounties);
+  const prsByLinkedIssue = indexPullRequestsByLinkedIssue(pullRequests);
+  const prByNumber = new Map(pullRequests.map((pr) => [pr.number, pr] as const));
+  const mergedPrsByLinkedIssue = indexPullRequestsByLinkedIssue(recentMergedPullRequests);
+  const mergedPrByNumber = new Map(recentMergedPullRequests.map((pr) => [pr.number, pr] as const));
+  const clustersByIssue = indexCollisionClustersByIssue(collisions.clusters);
+  const lifecycleByIssue = buildLifecycleByIssue(repo, issues, pullRequests, fullName, recentMergedPullRequests);
+  const reports = issues
+    .filter((issue) => issue.state === "open")
+    .map((issue) => {
+      const linkedPrs = resolveLinkedPullRequests(issue, pullRequests, prsByLinkedIssue, prByNumber);
+      const linkedMergedPrs = resolveLinkedPullRequests(issue, recentMergedPullRequests, mergedPrsByLinkedIssue, mergedPrByNumber);
+      const issueCollisions = clustersByIssue.get(issue.number) ?? [];
+      /* v8 ignore next -- Missing dates normalize to zero age. */
+      const age = daysSince(issue.updatedAt ?? issue.createdAt);
+      /* v8 ignore next -- Lifecycle map is built from the same issue set. */
+      const lifecycleEntry = lifecycleByIssue.get(issue.number);
+      const lifecycle = lifecycleEntry?.state ?? "open";
+      const bodyLength = issue.body?.trim().length ?? 0;
+      const bounty = bountyByIssue.get(bountyIssueKey(fullName, issue.number)) ?? null;
+      const bountyLifecycle: BountyLifecycle | null = bounty ? classifyBountyLifecycle(bounty, issue) : null;
+      const linkedWorkCount = linkedPrs.length + linkedMergedPrs.length + issue.linkedPrs.length;
+      const maintainerAuthored = isMaintainerAssociation(issue.authorAssociation);
+      const maintainerWip = isMaintainerWipIssue(issue);
+      const reasons = [
+        ...(bodyLength >= 200 ? ["Issue has enough body detail to evaluate."] : []),
+        ...(issue.labels.length > 0 ? [`Labels: ${issue.labels.join(", ")}.`] : []),
+        ...(linkedWorkCount === 0 ? ["No active PR is linked in cached metadata."] : []),
+        ...(bountyLifecycle === "active" ? ["Active bounty context is attached (contribution context, not guaranteed payout)."] : []),
+      ];
+      const warnings = [
+        ...(bodyLength < 80 ? ["Issue body is thin; contributor may need more proof before acting."] : []),
+        ...(linkedPrs.length > 0 ? [`${linkedPrs.length} active PR(s) already reference this issue.`] : []),
+        ...(linkedMergedPrs.length > 0 ? [`${linkedMergedPrs.length} merged PR(s) already reference this issue.`] : []),
+        ...(issue.linkedPrs.length > 0 && linkedPrs.length === 0 && linkedMergedPrs.length === 0
+          ? [`Cached issue metadata already references PR(s): ${issue.linkedPrs.map((number) => `#${number}`).join(", ")}.`]
+          : []),
+        ...(issueCollisions.length > 0 ? ["Potential duplicate or overlapping issue/PR context exists."] : []),
+        ...(age > 90 ? ["Issue is stale in cached metadata."] : []),
+        ...(lifecycle !== "open" ? [`Issue lifecycle is ${lifecycle.replace(/_/g, " ")}.`] : []),
+        ...(lane.lane === "direct_pr" ? ["Repo is direct-PR first; issue filing is not the primary Gittensor lane."] : []),
+        ...(bountyLifecycle === "completed" ? ["A completed bounty is attached; the work is likely already solved, not an open opportunity."] : []),
+        ...(bountyLifecycle === "cancelled" ? ["A cancelled bounty is attached; this is not an active opportunity."] : []),
+        ...(bountyLifecycle === "historical"
+          ? ["Historical bounty context is attached; this is not an active opportunity without upstream confirmation."]
+          : []),
+        ...(bountyLifecycle === "stale" ? ["Bounty context for this issue looks stale; confirm it is still active before acting."] : []),
+        ...(bountyLifecycle === "ambiguous" ? ["Bounty state for this issue is ambiguous; verify it before acting."] : []),
+        ...(maintainerAuthored && !maintainerWip ? ["Maintainer-authored; confirm it is open for outside contribution before starting."] : []),
+        ...(maintainerWip
+          ? ["Maintainer-authored and labelled in-progress/internal; not a recommended outside-contributor target without confirmation."]
+          : []),
+      ];
+      const score = clamp(100 - warnings.length * 18 + reasons.length * 5 - (age > 180 ? 15 : 0), 0, 100);
+      const bountyBlocks = bountyLifecycle === "completed" || bountyLifecycle === "cancelled" || bountyLifecycle === "historical";
+      const bountyCaution = bountyLifecycle === "stale" || bountyLifecycle === "ambiguous";
+      const status: IssueQualityReport["issues"][number]["status"] =
+        linkedWorkCount > 0 ||
+        issueCollisions.some((cluster) => cluster.risk === "high") ||
+        bountyBlocks ||
+        ["duplicate", "invalid", "solved", "valid_solved"].includes(lifecycle)
+          ? "do_not_use"
+          : maintainerWip || warnings.some((warning) => /thin|stale|direct-PR/i.test(warning)) || bountyCaution || lifecycle === "stale"
+            ? "needs_proof"
+            : score < 45
+              ? "hold"
+              : "ready";
+      return { number: issue.number, title: issue.title, status, score, reasons, warnings };
+    })
+    .sort((left, right) => right.score - left.score || left.number - right.number)
+    .slice(0, ISSUE_QUALITY_REPORT_CAP);
+  return {
+    repoFullName: fullName,
+    generatedAt: nowIso(),
+    lane,
+    issues: reports,
+    summary: `${reports.length} open issue(s) evaluated; ${reports.filter((report) => report.status === "ready").length} look ready from cached metadata.`,
+  };
+}

--- a/packages/loopover-engine/src/signals/issue-quality-report.ts
+++ b/packages/loopover-engine/src/signals/issue-quality-report.ts
@@ -141,7 +141,12 @@ function classifyIssueDiscoveryLifecycle(
   lane: LaneAdvice,
   linkedIndex?: { open: Map<number, PullRequestRecord[]>; merged: Map<number, RecentMergedPullRequestRecord[]> },
 ): LifecycleEntry {
+  // With a prebuilt index (the per-repo lifecycle report) look up this issue's linked PRs in O(1); ad-hoc
+  // single-issue callers pass no index and fall back to the original filter. buildIssueQualityReport always
+  // supplies an index, so the filter fallbacks are defensive mirrors of the host engine.
+  /* v8 ignore next 3 -- Ad-hoc no-index path is unused by this module's only caller. */
   const linkedOpenPrs = linkedIndex ? (linkedIndex.open.get(issue.number) ?? []) : pullRequests.filter((pr) => pr.linkedIssues.includes(issue.number));
+  /* v8 ignore next 3 -- Ad-hoc no-index path is unused by this module's only caller. */
   const linkedMergedPrs = linkedIndex
     ? (linkedIndex.merged.get(issue.number) ?? [])
     : recentMergedPullRequests.filter((pr) => pr.linkedIssues.includes(issue.number));
@@ -234,11 +239,10 @@ export function buildIssueQualityReport(
       const linkedPrs = resolveLinkedPullRequests(issue, pullRequests, prsByLinkedIssue, prByNumber);
       const linkedMergedPrs = resolveLinkedPullRequests(issue, recentMergedPullRequests, mergedPrsByLinkedIssue, mergedPrByNumber);
       const issueCollisions = clustersByIssue.get(issue.number) ?? [];
-      /* v8 ignore next -- Missing dates normalize to zero age. */
       const age = daysSince(issue.updatedAt ?? issue.createdAt);
-      /* v8 ignore next -- Lifecycle map is built from the same issue set. */
-      const lifecycleEntry = lifecycleByIssue.get(issue.number);
-      const lifecycle = lifecycleEntry?.state ?? "open";
+      // Every open issue was indexed into lifecycleByIssue above; non-null assertion keeps the
+      // package export free of an unreachable `?? "open"` arm that the host keeps for malformed payloads.
+      const lifecycle = lifecycleByIssue.get(issue.number)!.state;
       const bodyLength = issue.body?.trim().length ?? 0;
       const bounty = bountyByIssue.get(bountyIssueKey(fullName, issue.number)) ?? null;
       const bountyLifecycle: BountyLifecycle | null = bounty ? classifyBountyLifecycle(bounty, issue) : null;
@@ -277,6 +281,9 @@ export function buildIssueQualityReport(
       const score = clamp(100 - warnings.length * 18 + reasons.length * 5 - (age > 180 ? 15 : 0), 0, 100);
       const bountyBlocks = bountyLifecycle === "completed" || bountyLifecycle === "cancelled" || bountyLifecycle === "historical";
       const bountyCaution = bountyLifecycle === "stale" || bountyLifecycle === "ambiguous";
+      // Note: the host engine also has a `score < 45 → hold` arm, but with the current warning vocabulary
+      // that arm is unreachable without first matching needs_proof/do_not_use (only two warnings can fire
+      // without flipping those statuses). Ready is therefore observationally identical for reachable inputs.
       const status: IssueQualityReport["issues"][number]["status"] =
         linkedWorkCount > 0 ||
         issueCollisions.some((cluster) => cluster.risk === "high") ||
@@ -285,9 +292,7 @@ export function buildIssueQualityReport(
           ? "do_not_use"
           : maintainerWip || warnings.some((warning) => /thin|stale|direct-PR/i.test(warning)) || bountyCaution || lifecycle === "stale"
             ? "needs_proof"
-            : score < 45
-              ? "hold"
-              : "ready";
+            : "ready";
       return { number: issue.number, title: issue.title, status, score, reasons, warnings };
     })
     .sort((left, right) => right.score - left.score || left.number - right.number)

--- a/packages/loopover-miner/lib/self-review-context.d.ts
+++ b/packages/loopover-miner/lib/self-review-context.d.ts
@@ -1,8 +1,8 @@
 import type { SelfReviewContext } from "@loopover/engine";
 
-// bounties/issueQuality are always omitted (see this file's own header comment for why), so the result is
-// SelfReviewContext minus those two optional fields rather than the full type.
-export type SelfReviewContextResult = Omit<SelfReviewContext, "bounties" | "issueQuality">;
+// `bounties` is always omitted (see this file's own header comment for why), so the result is
+// SelfReviewContext minus that optional field rather than the full type. `issueQuality` is populated (#6057).
+export type SelfReviewContextResult = Omit<SelfReviewContext, "bounties">;
 
 // A narrower shape than `typeof fetch` on purpose: this module only ever calls it with a string URL and a
 // plain GET init, and the ambient `fetch` type in this repo's TS program is Cloudflare-Workers-flavored

--- a/packages/loopover-miner/lib/self-review-context.js
+++ b/packages/loopover-miner/lib/self-review-context.js
@@ -1,21 +1,23 @@
-import { buildCollisionReport, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "@loopover/engine";
+import {
+  buildCollisionReport,
+  buildIssueQualityReport,
+  MAX_FOCUS_MANIFEST_BYTES,
+  parseFocusManifestContent,
+} from "@loopover/engine";
 
 // Real SelfReviewContext fetcher (#5145, Wave 3.5). Builds the context object the miner's self-review pass
 // (packages/loopover-engine/src/miner/self-review-adapter.ts) needs, at the SAME fidelity the live gate's
 // own DB-backed construction produces (src/db/repositories.ts's toRepositoryRecord/toIssueRecord/
 // toPullRequestRecord) -- just built fresh from live GitHub data instead of a DB round-trip, since the miner
-// has no database. Two of SelfReviewContext's eight fields are DELIBERATELY left undefined, not stubbed:
+// has no database. One of SelfReviewContext's eight fields is DELIBERATELY left undefined, not stubbed:
 //
 //   - `bounties`: bounty data is not GitHub-native in this codebase -- it comes from an external "Gitt"
 //     system that PUSHES data into the live gate's own internal ingest route (src/api/routes.ts). There is
 //     no public endpoint the miner could legitimately pull from instead.
-//   - `issueQuality`: built by buildIssueQualityReport, which lives only in root src/signals/engine.ts and
-//     has never been extracted into @loopover/engine (the same "not yet extracted" situation
-//     src/signals/slop.ts documented before #5133 extracted slop scoring specifically).
 //
-// Both are already optional on SelfReviewContext, and buildPredictedGateVerdict already degrades gracefully
-// without them -- omitting them here is the same tradeoff the live gate itself makes for a repo it hasn't
-// computed bounty/quality data for yet, not a corner cut specific to the miner.
+// `issueQuality` is populated via buildIssueQualityReport (exported from @loopover/engine as a package-local
+// twin of the host engine helper — see #6057). Bounty rows and recent-merged PR history are passed as empty
+// arrays because this fetcher does not yet pull either source. `bounties` remains omitted for the reason above.
 
 const GITHUB_API_VERSION = "2022-11-28";
 const DEFAULT_API_BASE_URL = "https://api.github.com";
@@ -297,10 +299,10 @@ async function fetchConfirmedContributor(login, resolved) {
 // >= 2 threshold, inDuplicateCluster would fire on the completely normal case of "one PR already closes
 // this issue," not genuine overlapping/duplicate work. Checks the target ISSUE's presence instead of a
 // not-yet-existing PR number, since the miner's own submission doesn't exist as a real PullRequestRecord yet.
-function computeInDuplicateCluster(repoFullName, issues, pullRequests, targetIssueNumbers) {
+// Takes a prebuilt CollisionReport so issueQuality and inDuplicateCluster share one collision pass.
+function computeInDuplicateCluster(collisionReport, targetIssueNumbers) {
   if (targetIssueNumbers.length === 0) return false;
-  const report = buildCollisionReport(repoFullName, issues, pullRequests);
-  return report.clusters.some(
+  return collisionReport.clusters.some(
     (cluster) =>
       cluster.risk === "high" &&
       cluster.items.filter((item) => item.type === "pull_request").length >= 2 &&
@@ -310,8 +312,8 @@ function computeInDuplicateCluster(repoFullName, issues, pullRequests, targetIss
 
 /**
  * Build a real SelfReviewContext from live GitHub data, at the same fidelity the live gate's own DB-backed
- * construction produces. See this file's header for the two fields (bounties, issueQuality) deliberately
- * left undefined and why.
+ * construction produces. See this file's header for the one field (bounties) deliberately left undefined
+ * and why; issueQuality is populated from the live GitHub snapshot.
  *
  * @param {string} repoFullName
  * @param {{
@@ -335,7 +337,13 @@ export async function fetchSelfReviewContext(repoFullName, options = {}) {
   ]);
 
   const manifest = parseFocusManifestContent(manifestContent, "repo_file");
-  const inDuplicateCluster = computeInDuplicateCluster(`${target.owner}/${target.repo}`, issues, pullRequests, resolved.linkedIssues);
+  // Positional args match buildIssueQualityReport(repo, issues, pullRequests, fullName, bounties, collisions, recentMerged):
+  // repo is the full RepositoryRecord from fetchRepositoryRecord (not a string); empty bounties/recentMerged
+  // because this fetcher has no external bounty source and does not yet pull merge history.
+  const fullName = `${target.owner}/${target.repo}`;
+  const collisions = buildCollisionReport(fullName, issues, pullRequests);
+  const inDuplicateCluster = computeInDuplicateCluster(collisions, resolved.linkedIssues);
+  const issueQuality = buildIssueQualityReport(repo, issues, pullRequests, fullName, [], collisions, []);
 
   return {
     manifest,
@@ -344,5 +352,6 @@ export async function fetchSelfReviewContext(repoFullName, options = {}) {
     pullRequests,
     confirmedContributor,
     inDuplicateCluster,
+    issueQuality,
   };
 }

--- a/test/unit/issue-quality-report-package.test.ts
+++ b/test/unit/issue-quality-report-package.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { buildIssueQualityReport } from "../../packages/loopover-engine/src/signals/issue-quality-report";
+import type {
+  IssueRecord,
+  PullRequestRecord,
+  RegistryRepoConfig,
+  RepositoryRecord,
+} from "../../packages/loopover-engine/src/types/predicted-gate-types";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function registryConfig(overrides: Partial<RegistryRepoConfig> = {}): RegistryRepoConfig {
+  return {
+    repo: "acme/widgets",
+    emissionShare: 1,
+    issueDiscoveryShare: 0.5,
+    labelMultipliers: {},
+    maintainerCut: 0,
+    raw: {},
+    ...overrides,
+  };
+}
+
+function repo(fullName: string, overrides: Partial<RepositoryRecord> = {}): RepositoryRecord {
+  const [owner, name] = fullName.split("/");
+  return {
+    fullName,
+    owner: owner!,
+    name: name!,
+    installationId: undefined,
+    isInstalled: true,
+    isRegistered: true,
+    isPrivate: false,
+    htmlUrl: `https://github.com/${fullName}`,
+    defaultBranch: "main",
+    registryConfig: registryConfig(),
+    ...overrides,
+  };
+}
+
+function issueDiscoveryRepo(fullName: string): RepositoryRecord {
+  return repo(fullName, { registryConfig: registryConfig({ issueDiscoveryShare: 1 }) });
+}
+
+function directPrRepo(fullName: string): RepositoryRecord {
+  return repo(fullName, { registryConfig: registryConfig({ issueDiscoveryShare: 0 }) });
+}
+
+function issue(repoFullName: string, number: number, title: string, overrides: Partial<IssueRecord> = {}): IssueRecord {
+  return {
+    repoFullName,
+    number,
+    title,
+    state: "open",
+    authorLogin: "reporter",
+    authorAssociation: "NONE",
+    htmlUrl: `https://github.com/${repoFullName}/issues/${number}`,
+    body: "x".repeat(220),
+    createdAt: now(),
+    updatedAt: now(),
+    closedAt: null,
+    labels: [],
+    linkedPrs: [],
+    ...overrides,
+  };
+}
+
+function pr(repoFullName: string, number: number, overrides: Partial<PullRequestRecord> = {}): PullRequestRecord {
+  return {
+    repoFullName,
+    number,
+    title: `PR ${number}`,
+    state: "open",
+    authorLogin: "contributor",
+    authorAssociation: "NONE",
+    headSha: "abc",
+    headRef: "branch",
+    baseRef: "main",
+    htmlUrl: `https://github.com/${repoFullName}/pull/${number}`,
+    mergedAt: null,
+    isDraft: false,
+    mergeableState: "clean",
+    reviewDecision: null,
+    body: "",
+    createdAt: now(),
+    updatedAt: now(),
+    closedAt: null,
+    labels: [],
+    linkedIssues: [],
+    ...overrides,
+  };
+}
+
+describe("buildIssueQualityReport (#6057 package-local export)", () => {
+  it("keeps every fixed call-signature slot and returns ready for a detailed open issue with no linked work", () => {
+    const r = issueDiscoveryRepo("acme/ready");
+    const report = buildIssueQualityReport(r, [issue(r.fullName, 1, "Actionable")], [], r.fullName);
+    expect(report.issues).toHaveLength(1);
+    expect(report.issues[0]).toMatchObject({
+      number: 1,
+      status: "ready",
+      reasons: expect.arrayContaining(["Issue has enough body detail to evaluate.", "No active PR is linked in cached metadata."]),
+    });
+    expect(report.repoFullName).toBe("acme/ready");
+  });
+
+  it("marks linked open-PR issues do_not_use and downgrades thin bodies to needs_proof", () => {
+    const r = issueDiscoveryRepo("acme/linked");
+    const withPr = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 2, "Already claimed")],
+      [pr(r.fullName, 9, { linkedIssues: [2], body: "Fixes #2" })],
+      r.fullName,
+    );
+    expect(withPr.issues[0]?.status).toBe("do_not_use");
+
+    const thin = buildIssueQualityReport(r, [issue(r.fullName, 3, "Thin", { body: "Short." })], [], r.fullName);
+    expect(thin.issues[0]?.status).toBe("needs_proof");
+  });
+
+  it("accepts a prebuilt CollisionReport in the 6th positional slot and empty bounty/recent-merged arrays", () => {
+    const r = directPrRepo("acme/direct");
+    const issues = [issue(r.fullName, 4, "Direct lane", { body: "x".repeat(220), labels: ["bug"] })];
+    const collisions = {
+      repoFullName: r.fullName,
+      generatedAt: now(),
+      clusters: [],
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 },
+    };
+    const report = buildIssueQualityReport(r, issues, [], r.fullName, [], collisions, []);
+    expect(report.lane.lane).toBe("direct_pr");
+    expect(report.issues[0]?.status).toBe("needs_proof");
+    expect(report.issues[0]?.warnings.some((w) => /direct-PR first/i.test(w))).toBe(true);
+  });
+
+  it("defaults unknown absent bounty list and honors active/completed bounty lifecycle branches", () => {
+    const r = issueDiscoveryRepo("acme/bounty");
+    const openIssue = issue(r.fullName, 5, "Bountied");
+    const active = buildIssueQualityReport(r, [openIssue], [], r.fullName, [
+      {
+        id: "b1",
+        repoFullName: r.fullName,
+        issueNumber: 5,
+        status: "active",
+        discoveredAt: now(),
+        updatedAt: now(),
+        payload: {},
+      },
+    ]);
+    expect(active.issues[0]?.reasons.some((reason) => /Active bounty/i.test(reason))).toBe(true);
+
+    const completed = buildIssueQualityReport(r, [openIssue], [], r.fullName, [
+      {
+        id: "b2",
+        repoFullName: r.fullName,
+        issueNumber: 5,
+        status: "completed",
+        discoveredAt: now(),
+        updatedAt: now(),
+        payload: {},
+      },
+    ]);
+    expect(completed.issues[0]?.status).toBe("do_not_use");
+  });
+});

--- a/test/unit/issue-quality-report-package.test.ts
+++ b/test/unit/issue-quality-report-package.test.ts
@@ -1,14 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { buildIssueQualityReport } from "../../packages/loopover-engine/src/signals/issue-quality-report";
 import type {
+  BountyRecord,
+  CollisionReport,
   IssueRecord,
   PullRequestRecord,
+  RecentMergedPullRequestRecord,
   RegistryRepoConfig,
   RepositoryRecord,
 } from "../../packages/loopover-engine/src/types/predicted-gate-types";
 
 function now(): string {
   return new Date().toISOString();
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
 }
 
 function registryConfig(overrides: Partial<RegistryRepoConfig> = {}): RegistryRepoConfig {
@@ -35,17 +42,17 @@ function repo(fullName: string, overrides: Partial<RepositoryRecord> = {}): Repo
     isPrivate: false,
     htmlUrl: `https://github.com/${fullName}`,
     defaultBranch: "main",
-    registryConfig: registryConfig(),
+    registryConfig: registryConfig({ repo: fullName }),
     ...overrides,
   };
 }
 
 function issueDiscoveryRepo(fullName: string): RepositoryRecord {
-  return repo(fullName, { registryConfig: registryConfig({ issueDiscoveryShare: 1 }) });
+  return repo(fullName, { registryConfig: registryConfig({ repo: fullName, issueDiscoveryShare: 1 }) });
 }
 
 function directPrRepo(fullName: string): RepositoryRecord {
-  return repo(fullName, { registryConfig: registryConfig({ issueDiscoveryShare: 0 }) });
+  return repo(fullName, { registryConfig: registryConfig({ repo: fullName, issueDiscoveryShare: 0 }) });
 }
 
 function issue(repoFullName: string, number: number, title: string, overrides: Partial<IssueRecord> = {}): IssueRecord {
@@ -93,6 +100,41 @@ function pr(repoFullName: string, number: number, overrides: Partial<PullRequest
   };
 }
 
+function merged(repoFullName: string, number: number, overrides: Partial<RecentMergedPullRequestRecord> = {}): RecentMergedPullRequestRecord {
+  return {
+    repoFullName,
+    number,
+    title: `Merged ${number}`,
+    authorLogin: "contributor",
+    htmlUrl: `https://github.com/${repoFullName}/pull/${number}`,
+    labels: [],
+    linkedIssues: [],
+    ...overrides,
+  };
+}
+
+function bounty(repoFullName: string, issueNumber: number, status: string, overrides: Partial<BountyRecord> = {}): BountyRecord {
+  return {
+    id: `b-${issueNumber}-${status}`,
+    repoFullName,
+    issueNumber,
+    status,
+    discoveredAt: now(),
+    updatedAt: now(),
+    payload: {},
+    ...overrides,
+  };
+}
+
+function emptyCollisions(fullName: string): CollisionReport {
+  return {
+    repoFullName: fullName,
+    generatedAt: now(),
+    clusters: [],
+    summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 },
+  };
+}
+
 describe("buildIssueQualityReport (#6057 package-local export)", () => {
   it("keeps every fixed call-signature slot and returns ready for a detailed open issue with no linked work", () => {
     const r = issueDiscoveryRepo("acme/ready");
@@ -115,6 +157,7 @@ describe("buildIssueQualityReport (#6057 package-local export)", () => {
       r.fullName,
     );
     expect(withPr.issues[0]?.status).toBe("do_not_use");
+    expect(withPr.issues[0]?.warnings.some((w) => /active PR/i.test(w))).toBe(true);
 
     const thin = buildIssueQualityReport(r, [issue(r.fullName, 3, "Thin", { body: "Short." })], [], r.fullName);
     expect(thin.issues[0]?.status).toBe("needs_proof");
@@ -123,45 +166,244 @@ describe("buildIssueQualityReport (#6057 package-local export)", () => {
   it("accepts a prebuilt CollisionReport in the 6th positional slot and empty bounty/recent-merged arrays", () => {
     const r = directPrRepo("acme/direct");
     const issues = [issue(r.fullName, 4, "Direct lane", { body: "x".repeat(220), labels: ["bug"] })];
-    const collisions = {
-      repoFullName: r.fullName,
-      generatedAt: now(),
-      clusters: [],
-      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 },
-    };
-    const report = buildIssueQualityReport(r, issues, [], r.fullName, [], collisions, []);
+    const report = buildIssueQualityReport(r, issues, [], r.fullName, [], emptyCollisions(r.fullName), []);
     expect(report.lane.lane).toBe("direct_pr");
     expect(report.issues[0]?.status).toBe("needs_proof");
     expect(report.issues[0]?.warnings.some((w) => /direct-PR first/i.test(w))).toBe(true);
   });
 
-  it("defaults unknown absent bounty list and honors active/completed bounty lifecycle branches", () => {
+  it("honors bounty lifecycle branches: active/completed/cancelled/historical/stale/ambiguous", () => {
     const r = issueDiscoveryRepo("acme/bounty");
     const openIssue = issue(r.fullName, 5, "Bountied");
-    const active = buildIssueQualityReport(r, [openIssue], [], r.fullName, [
-      {
-        id: "b1",
-        repoFullName: r.fullName,
-        issueNumber: 5,
-        status: "active",
-        discoveredAt: now(),
-        updatedAt: now(),
-        payload: {},
-      },
-    ]);
+
+    const active = buildIssueQualityReport(r, [openIssue], [], r.fullName, [bounty(r.fullName, 5, "active")]);
     expect(active.issues[0]?.reasons.some((reason) => /Active bounty/i.test(reason))).toBe(true);
 
-    const completed = buildIssueQualityReport(r, [openIssue], [], r.fullName, [
-      {
-        id: "b2",
-        repoFullName: r.fullName,
-        issueNumber: 5,
-        status: "completed",
-        discoveredAt: now(),
-        updatedAt: now(),
-        payload: {},
-      },
+    expect(buildIssueQualityReport(r, [openIssue], [], r.fullName, [bounty(r.fullName, 5, "completed")]).issues[0]?.status).toBe("do_not_use");
+    expect(buildIssueQualityReport(r, [openIssue], [], r.fullName, [bounty(r.fullName, 5, "cancelled")]).issues[0]?.status).toBe("do_not_use");
+    expect(buildIssueQualityReport(r, [openIssue], [], r.fullName, [bounty(r.fullName, 5, "historical")]).issues[0]?.status).toBe("do_not_use");
+
+    const staleBounty = buildIssueQualityReport(r, [openIssue], [], r.fullName, [
+      bounty(r.fullName, 5, "active", { updatedAt: daysAgoIso(60), discoveredAt: daysAgoIso(60) }),
     ]);
-    expect(completed.issues[0]?.status).toBe("do_not_use");
+    expect(staleBounty.issues[0]?.status).toBe("needs_proof");
+    expect(staleBounty.issues[0]?.warnings.some((w) => /stale/i.test(w))).toBe(true);
+
+    const ambiguous = buildIssueQualityReport(r, [openIssue], [], r.fullName, [bounty(r.fullName, 5, "weird-unknown-status")]);
+    expect(ambiguous.issues[0]?.status).toBe("needs_proof");
+    expect(ambiguous.issues[0]?.warnings.some((w) => /ambiguous/i.test(w))).toBe(true);
+  });
+
+  it("classifies duplicate/invalid labels and closed issues as lifecycle do_not_use / closed_not_solved", () => {
+    const r = issueDiscoveryRepo("acme/labels");
+    const dup = buildIssueQualityReport(r, [issue(r.fullName, 10, "Dup", { labels: ["duplicate"] })], [], r.fullName);
+    expect(dup.issues[0]?.status).toBe("do_not_use");
+    expect(dup.issues[0]?.warnings.some((w) => /duplicate/i.test(w))).toBe(true);
+
+    const invalid = buildIssueQualityReport(r, [issue(r.fullName, 11, "Bad", { labels: ["wontfix"] })], [], r.fullName);
+    expect(invalid.issues[0]?.status).toBe("do_not_use");
+
+    // Closed issues are filtered from the quality report (open-only), but still exercise lifecycle helpers
+    // when co-present: an open sibling plus a closed one only emits open.
+    const mixed = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 12, "Closed", { state: "closed" }), issue(r.fullName, 13, "Still open")],
+      [],
+      r.fullName,
+    );
+    expect(mixed.issues.map((i) => i.number)).toEqual([13]);
+  });
+
+  it("treats merged solvers as solved/valid_solved and flags self-solved reporter loops", () => {
+    const r = issueDiscoveryRepo("acme/solved");
+    const solved = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 20, "Solved open still listed")],
+      [],
+      r.fullName,
+      [],
+      undefined,
+      [merged(r.fullName, 100, { linkedIssues: [20], authorLogin: "other" })],
+    );
+    expect(solved.issues[0]?.status).toBe("do_not_use");
+    expect(solved.issues[0]?.warnings.some((w) => /merged PR/i.test(w) || /valid solved|lifecycle is/i.test(w))).toBe(true);
+
+    const selfSolved = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 21, "Self", { authorLogin: "reporter" })],
+      [pr(r.fullName, 101, { linkedIssues: [21], authorLogin: "reporter", mergedAt: now(), state: "merged" })],
+      r.fullName,
+    );
+    expect(selfSolved.issues[0]?.status).toBe("do_not_use");
+  });
+
+  it("marks stale open issues needs_proof and applies age>180 score penalty", () => {
+    const r = issueDiscoveryRepo("acme/stale");
+    const stale = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 30, "Old", { updatedAt: daysAgoIso(100), createdAt: daysAgoIso(100) })],
+      [],
+      r.fullName,
+    );
+    expect(stale.issues[0]?.status).toBe("needs_proof");
+    expect(stale.issues[0]?.warnings.some((w) => /stale/i.test(w))).toBe(true);
+
+    const ancient = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 31, "Ancient", { updatedAt: daysAgoIso(200), createdAt: daysAgoIso(200), body: "x".repeat(220) })],
+      [],
+      r.fullName,
+    );
+    expect(ancient.issues[0]?.score).toBeLessThan(
+      buildIssueQualityReport(r, [issue(r.fullName, 32, "Fresh")], [], r.fullName).issues[0]!.score,
+    );
+  });
+
+  it("warns on maintainer-authored and maintainer-WIP issues", () => {
+    const r = issueDiscoveryRepo("acme/maint");
+    const authored = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 40, "From owner", { authorAssociation: "OWNER" })],
+      [],
+      r.fullName,
+    );
+    expect(authored.issues[0]?.warnings.some((w) => /Maintainer-authored; confirm/i.test(w))).toBe(true);
+
+    const wip = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 41, "WIP", { authorAssociation: "MEMBER", labels: ["wip"] })],
+      [],
+      r.fullName,
+    );
+    expect(wip.issues[0]?.status).toBe("needs_proof");
+    expect(wip.issues[0]?.warnings.some((w) => /in-progress\/internal/i.test(w))).toBe(true);
+  });
+
+  it("resolves issue.linkedPrs back-references and cached-only linkedPr metadata warnings", () => {
+    const r = issueDiscoveryRepo("acme/backref");
+    // PR does not list the issue, but the issue lists the PR — resolveLinkedPullRequests must add it.
+    const backref = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 50, "Backref", { linkedPrs: [77] })],
+      [pr(r.fullName, 77, { linkedIssues: [] })],
+      r.fullName,
+    );
+    expect(backref.issues[0]?.status).toBe("do_not_use");
+    expect(backref.issues[0]?.warnings.some((w) => /active PR/i.test(w))).toBe(true);
+
+    // linkedPrs point at a PR not present in the fetched list → cached-metadata warning.
+    const cachedOnly = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 51, "Cached", { linkedPrs: [999] })],
+      [],
+      r.fullName,
+    );
+    expect(cachedOnly.issues[0]?.warnings.some((w) => /Cached issue metadata already references PR\(s\): #999/i.test(w))).toBe(true);
+  });
+
+  it("treats high-risk collision clusters as do_not_use and medium/low as warning-only", () => {
+    const r = issueDiscoveryRepo("acme/collisions");
+    const high: CollisionReport = {
+      repoFullName: r.fullName,
+      generatedAt: now(),
+      summary: { clusterCount: 1, highRiskCount: 1, itemsReviewed: 2 },
+      clusters: [
+        {
+          id: "c1",
+          risk: "high",
+          reason: "overlap",
+          items: [
+            { type: "issue", number: 60, title: "A" },
+            { type: "pull_request", number: 1, title: "B" },
+          ],
+        },
+      ],
+    };
+    expect(buildIssueQualityReport(r, [issue(r.fullName, 60, "A")], [], r.fullName, [], high).issues[0]?.status).toBe("do_not_use");
+
+    const medium: CollisionReport = {
+      ...high,
+      summary: { clusterCount: 1, highRiskCount: 0, itemsReviewed: 2 },
+      clusters: [{ ...high.clusters[0]!, risk: "medium" }],
+    };
+    const medReport = buildIssueQualityReport(r, [issue(r.fullName, 60, "A")], [], r.fullName, [], medium);
+    expect(medReport.issues[0]?.warnings.some((w) => /duplicate or overlapping/i.test(w))).toBe(true);
+    expect(medReport.issues[0]?.status).not.toBe("do_not_use");
+  });
+
+  it("sorts by score desc then number asc, and skips building collisions when prebuilt is provided", () => {
+    const r = issueDiscoveryRepo("acme/sort");
+    const report = buildIssueQualityReport(
+      r,
+      [
+        issue(r.fullName, 2, "Thin second", { body: "Short." }),
+        issue(r.fullName, 1, "Ready first"),
+        issue(r.fullName, 3, "Ready third"),
+      ],
+      [],
+      r.fullName,
+      [],
+      emptyCollisions(r.fullName),
+    );
+    expect(report.issues.map((i) => i.number)).toEqual([1, 3, 2]);
+  });
+
+  it("handles null repo, missing dates, and blank bounty status without throwing", () => {
+    const report = buildIssueQualityReport(
+      null,
+      [issue("acme/null", 70, "No dates", { updatedAt: null, createdAt: null, body: null })],
+      [],
+      "acme/null",
+      [bounty("acme/null", 70, "   ")],
+    );
+    expect(report.lane.lane).toBe("unknown");
+    expect(report.issues[0]?.status).toBe("needs_proof");
+  });
+
+  it("covers multi-PR index buckets, split-lane valid_solved, and invalid timestamps", () => {
+    const split = repo("acme/split", {
+      registryConfig: registryConfig({ repo: "acme/split", emissionShare: 1, issueDiscoveryShare: 0.4 }),
+    });
+    // issueDiscoveryShare 0.4 with emission > 0 → split lane in buildLaneAdvice
+    expect(
+      buildIssueQualityReport(
+        split,
+        [issue(split.fullName, 90, "Split solved")],
+        [],
+        split.fullName,
+        [],
+        undefined,
+        [merged(split.fullName, 900, { linkedIssues: [90], authorLogin: "other" })],
+      ).issues[0]?.status,
+    ).toBe("do_not_use");
+
+    // Two open PRs link the same issue → indexPullRequestsByLinkedIssue bucket.push path
+    const r = issueDiscoveryRepo("acme/multi");
+    const multi = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 91, "Crowded")],
+      [pr(r.fullName, 1, { linkedIssues: [91] }), pr(r.fullName, 2, { linkedIssues: [91, 91] })],
+      r.fullName,
+    );
+    expect(multi.issues[0]?.status).toBe("do_not_use");
+    expect(multi.issues[0]?.warnings.some((w) => /2 active PR/i.test(w))).toBe(true);
+
+    // Invalid timestamps normalize to age 0 via daysSince
+    const badDate = buildIssueQualityReport(
+      r,
+      [issue(r.fullName, 92, "Bad date", { updatedAt: "not-a-date", createdAt: "also-bad" })],
+      [],
+      r.fullName,
+    );
+    expect(badDate.issues[0]?.status).toBe("ready");
+  });
+
+  it("returns the default open-lifecycle reason when no other signal applies", () => {
+    const r = issueDiscoveryRepo("acme/plain");
+    // No labels, no linked work, body detailed — reasons include detail + no-linked; lifecycle reasons default
+    // is only for the internal classify helper when reasons.length===0. Hit that by classifying a bare open
+    // issue through lifecycle (already exercised); assert ready stays stable.
+    const report = buildIssueQualityReport(r, [issue(r.fullName, 93, "Plain", { labels: [] })], [], r.fullName);
+    expect(report.issues[0]?.status).toBe("ready");
   });
 });

--- a/test/unit/miner-self-review-context.test.ts
+++ b/test/unit/miner-self-review-context.test.ts
@@ -199,7 +199,16 @@ describe("fetchSelfReviewContext (#5145)", () => {
     // high-risk cluster, not any overlap at all.
     expect(result.inDuplicateCluster).toBe(false);
     expect("bounties" in result).toBe(false);
-    expect("issueQuality" in result).toBe(false);
+    expect(result.issueQuality?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          number: 7,
+          title: "Uploads should retry on 5xx",
+          status: expect.any(String),
+          score: expect.any(Number),
+        }),
+      ]),
+    );
   });
 
   it("flags inDuplicateCluster true when the target issue already has 2+ open PRs referencing it (a real high-risk cluster)", async () => {
@@ -216,6 +225,23 @@ describe("fetchSelfReviewContext (#5145)", () => {
     expect(result.inDuplicateCluster).toBe(true);
   });
 
+  it("populates issueQuality from the live GitHub snapshot without bounty or recent-merged inputs (#6057)", async () => {
+    const fetchImpl = routedFetch({
+      "/repos/acme/widgets/issues": () => jsonResponse([issuePayload({ body: "x".repeat(220) })]),
+      "/repos/acme/widgets/pulls": () => jsonResponse([]),
+      "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
+      "raw.githubusercontent.com": () => jsonResponse(null, 404),
+      "api.gittensor.io/miners": () => jsonResponse([]),
+    });
+
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    expect(result.issueQuality?.issues).toHaveLength(1);
+    expect(result.issueQuality?.issues[0]).toMatchObject({ number: 7, status: expect.any(String) });
+    expect(result.issueQuality?.repoFullName).toBe("acme/widgets");
+    // Empty bounty/recent-merged inputs must not invent derived bounty warnings.
+    expect(result.issueQuality?.issues[0]?.warnings.join(" ")).not.toMatch(/bounty/i);
+    expect("bounties" in result).toBe(false);
+  });
   it("returns false for inDuplicateCluster when no linkedIssues are supplied", async () => {
     const fetchImpl = routedFetch({
       "/repos/acme/widgets/issues": () => jsonResponse([issuePayload()]),


### PR DESCRIPTION
## Summary

- Add a package-local `buildIssueQualityReport` in `packages/loopover-engine/src/signals/issue-quality-report.ts` (same call signature as the host engine: `repo, issues, pullRequests, fullName, bounties?, collisions?, recentMerged?`) so `@loopover/engine` can export it without importing excluded host-bound `signals/engine.ts` — that re-export path is what broke package `tsc` and closed #6139
- Re-export it from `packages/loopover-engine/src/index.ts` next to `buildCollisionReport`
- Wire `fetchSelfReviewContext` to populate `issueQuality` from the live GitHub snapshot (empty bounties + recent-merged arrays; `bounties` field still omitted); share one `buildCollisionReport` pass with `inDuplicateCluster`
- Correct the stale header/`SelfReviewContextResult` docs that claimed `issueQuality` was unexported

Closes #6057

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`
- [x] I linked a currently open issue this PR resolves (`Closes #6057`)

## Validation

- [x] `npx vitest run test/unit/issue-quality-report-package.test.ts test/unit/miner-self-review-context.test.ts` (26/26 pass)
- [ ] CI green including codecov/patch ≥99%

If any required check was skipped, explain why:

- Full `npm run test:ci` not run locally (sandbox Node/rolldown mismatch); relying on GitHub Actions. Engine package build was verified not to pull excluded `engine.ts` (the #6139 failure mode).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed
- [x] API/OpenAPI/MCP behavior is updated and tested where needed

## UI Evidence

Not applicable — no UI/frontend change.

## Notes

- Argument order is documented at the call site and matches the host signature `(repo, issues, pullRequests, fullName, bounties, collisions, recentMerged)`.
- This does **not** change the host `signals/engine.ts` implementation; the package export is the portable twin pattern already used for `buildCollisionReport`.

Made with [Cursor](https://cursor.com)