### PR TITLE
fix(review): gate the auto-tune tightening recommendation on a sufficient would-merge sample

### DIFF
--- a/src/review/auto-tune.ts
+++ b/src/review/auto-tune.ts
@@ -300,8 +300,13 @@ export function computeTuningRecommendations(report: GateEvalReport): TuningRec[
       continue;
     }
     let flagged = false;
-    // The dangerous error: would auto-merge something the human closed.
-    if (r.mergePrecision != null && r.mergePrecision < RISK_MERGE_PRECISION) {
+    // The dangerous error: would auto-merge something the human closed. Gate on wouldMerge, not just the
+    // top-of-loop `decided` check: mergePrecision is non-null over as few as ONE would-merge, and this warning
+    // carries an auto-applicable TIGHTENING overridePayload -- so without this guard a lone fluke would-merge
+    // (e.g. 9 holds + 1 wrong would-merge) autonomously raises the live floor off a statistically meaningless
+    // sample, exactly the case the sibling breakers planAutoTune / applyAutoTune / planCloseAutoTune all refuse
+    // via `wouldMerge >= AUTOTUNE_MIN_DECIDED` (== MIN_DECIDED).
+    if (r.mergePrecision != null && r.wouldMerge >= MIN_DECIDED && r.mergePrecision < RISK_MERGE_PRECISION) {
       recs.push({
         project: r.project,
         severity: "warn",

--- a/test/unit/auto-tune.test.ts
+++ b/test/unit/auto-tune.test.ts
@@ -397,6 +397,15 @@ describe("computeTuningRecommendations (#self-improve)", () => {
     expect(warn?.overridePayload).toEqual({ confidenceFloor: 0.95 });
   });
 
+  it("does NOT warn or attach a tightening payload on a thin WOULD-MERGE sample even when total decided is high (mirrors planAutoTune)", () => {
+    // 9 holds + 1 fluke would-merge the human closed: mergePrecision is 0% over a single would-merge. The
+    // breaker (planAutoTune) refuses to act on so meaningless a sample, so this advisor must not autonomously
+    // raise the live floor (overridePayload) off it either.
+    const recs = computeTuningRecommendations(report([row({ project: "p", decided: 20, wouldMerge: 1, mergeConfirmed: 0, mergeFalse: 1, mergePrecision: 0 })]));
+    expect(recs.find((r) => r.severity === "warn" && /do NOT flip live/i.test(r.message))).toBeUndefined();
+    expect(recs.every((r) => r.overridePayload === undefined)).toBe(true);
+  });
+
   it("WARNs to loosen when it would auto-close PRs the human merged — and attaches NO payload (loosening is never auto-applied)", () => {
     const recs = computeTuningRecommendations(report([row({ project: "p", decided: 15, wouldMerge: 10, mergeConfirmed: 10, mergePrecision: 1.0, wouldClose: 5, closeConfirmed: 3, closeFalse: 2, closePrecision: 0.6 })]));
     const loosen = recs.find((r) => r.severity === "warn" && /loosen/i.test(r.message));


### PR DESCRIPTION
## Problem

`computeTuningRecommendations` (`src/review/auto-tune.ts`) emits the merge-precision **warning** — which carries an auto-applicable **tightening** `overridePayload: { confidenceFloor: 0.95 }` — gated only by the top-of-loop `decided < MIN_DECIDED` check and `mergePrecision < RISK_MERGE_PRECISION`:

```ts
if (r.mergePrecision != null && r.mergePrecision < RISK_MERGE_PRECISION) { … overridePayload … }
```

But `mergePrecision` is non-null **iff `wouldMerge > 0`** (`mergePrecision = wouldMerge > 0 ? mergeConfirmed / wouldMerge : null`), so this fires on as few as **one** would-merge. A project with `decided: 20` that is `19 holds + 1` fluke would-merge the human closed (`mergePrecision: 0%` over a single sample) produces a `warn` **plus the autonomous tightening payload**, which `runAutoApplyRecommendations` → `evaluateShadowPromotion` can promote to the **live** confidence floor.

Every sibling action in this same file deliberately refuses that: `planAutoTune` (line 110), `applyAutoTune` (156), and `planCloseAutoTune`/close-breaker (199/242) all gate on `wouldMerge >= AUTOTUNE_MIN_DECIDED`, with `planAutoTune`'s comment naming this exact case — *"a project with many holds/closes but few would-merges (e.g. 9 holds + 1 wrong would-merge) must not trip the breaker on a statistically meaningless sample."* `computeTuningRecommendations` is the one path that autonomously acts without it.

## Fix

Add the same `wouldMerge >= MIN_DECIDED` guard to the merge-precision warning (`MIN_DECIDED === AUTOTUNE_MIN_DECIDED === 10`), so the autonomous tightening only fires once there is a meaningful would-merge sample — matching the breakers exactly. One-line condition change.

## Tests

`test/unit/auto-tune.test.ts` adds a case (mirroring `planAutoTune`'s existing thin-sample test) asserting that a `decided: 20`, `wouldMerge: 1`, `mergePrecision: 0` row produces **no** tightening warning and **no** `overridePayload` (fails before the fix). All existing `computeTuningRecommendations` cases (which use `wouldMerge >= 10`) still pass.

`npm run typecheck` clean; `test/unit/auto-tune.test.ts` green (56 tests).
