### PR TITLE
fix(miner): honor --json on manage status and queue dashboard runtime failures

### DIFF
--- a/packages/loopover-miner/lib/manage-status.js
+++ b/packages/loopover-miner/lib/manage-status.js
@@ -1,7 +1,7 @@
 import { initEventLedger } from "./event-ledger.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initRunStateStore } from "./run-state.js";
-import { argsWantJson, reportCliFailure } from "./cli-error.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 /** Event vocabulary for manage-phase PR snapshots written by manage poll. (#2325) */
 export const MANAGE_PR_UPDATE_EVENT = "manage_pr_update";
@@ -219,10 +219,13 @@ export function runManageStatus(args = [], options = {}) {
   const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
   const ownsEventLedger = options.initEventLedger === undefined;
   const ownsRunStateStore = options.initRunStateStore === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  const runStateStore = (options.initRunStateStore ?? initRunStateStore)();
+  let portfolioQueue;
+  let eventLedger;
+  let runStateStore;
   try {
+    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    eventLedger = (options.initEventLedger ?? initEventLedger)();
+    runStateStore = (options.initRunStateStore ?? initRunStateStore)();
     const rows = collectManageStatus({ portfolioQueue, eventLedger });
     const runPortfolio = collectRunPortfolio({ portfolioQueue, eventLedger, runStateStore });
     if (parsed.json) {
@@ -233,9 +236,11 @@ export function runManageStatus(args = [], options = {}) {
       console.log(`${renderManageStatusTable(rows)}\n\n${renderRunPortfolioTable(runPortfolio)}`);
     }
     return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
-    if (ownsPortfolioQueue) portfolioQueue.close();
-    if (ownsEventLedger) eventLedger.close();
-    if (ownsRunStateStore) runStateStore.close();
+    if (ownsPortfolioQueue) portfolioQueue?.close();
+    if (ownsEventLedger) eventLedger?.close();
+    if (ownsRunStateStore) runStateStore?.close();
   }
 }

--- a/packages/loopover-miner/lib/portfolio-dashboard.js
+++ b/packages/loopover-miner/lib/portfolio-dashboard.js
@@ -9,7 +9,7 @@
 // collector below is factored so it is directly reusable once such a channel exists.
 
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
-import { argsWantJson, reportCliFailure } from "./cli-error.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const QUEUE_STATUS_KEYS = ["queued", "in_progress", "done"];
 
@@ -94,12 +94,15 @@ export function runPortfolioDashboard(args = [], options = {}) {
     return reportCliFailure(argsWantJson(args), parsed.error);
   }
   const ownsQueue = options.initPortfolioQueue === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  let portfolioQueue;
   try {
+    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
     const summary = collectPortfolioDashboard({ portfolioQueue }, { nowMs: Number.isFinite(options.nowMs) ? options.nowMs : Date.now() });
     console.log(parsed.json ? JSON.stringify(summary, null, 2) : renderPortfolioDashboardTable(summary));
     return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
-    if (ownsQueue) portfolioQueue.close();
+    if (ownsQueue) portfolioQueue?.close();
   }
 }

--- a/test/unit/miner-manage-status.test.ts
+++ b/test/unit/miner-manage-status.test.ts
@@ -286,4 +286,22 @@ describe("loopover-miner manage status (#2325)", () => {
     expect(runManageStatus(["acme/widgets"])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Usage: loopover-miner manage status [--json]");
   });
+
+  it("reports store/runtime failures as parseable JSON on stdout when --json is set", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const brokenStore = () => {
+      throw new Error("queue_db");
+    };
+
+    expect(runManageStatus(["--json"], { initPortfolioQueue: brokenStore })).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ ok: false, error: "queue_db" });
+    expect(error).not.toHaveBeenCalled();
+
+    log.mockClear();
+    error.mockClear();
+    expect(runManageStatus([], { initPortfolioQueue: brokenStore })).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toBe("queue_db");
+    expect(log).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/miner-portfolio-dashboard.test.ts
+++ b/test/unit/miner-portfolio-dashboard.test.ts
@@ -95,4 +95,22 @@ describe("runPortfolioDashboard (#4287)", () => {
     });
     expect(err).not.toHaveBeenCalled();
   });
+
+  it("reports store/runtime failures as parseable JSON on stdout when --json is set", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const brokenStore = () => {
+      throw new Error("queue_db");
+    };
+
+    expect(runPortfolioDashboard(["--json"], { initPortfolioQueue: brokenStore })).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ ok: false, error: "queue_db" });
+    expect(error).not.toHaveBeenCalled();
+
+    log.mockClear();
+    error.mockClear();
+    expect(runPortfolioDashboard([], { initPortfolioQueue: brokenStore })).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toBe("queue_db");
+    expect(log).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- `runManageStatus` and `runPortfolioDashboard` wrap store init + collection in `try/catch` and route failures through `reportCliFailure`, matching the #4836 CLI contract used by sibling commands (`calibration`, `plan list`, `queue list`).
- Store opens moved inside `try`; `finally` uses optional chaining so partial init still closes opened stores.
- Tests cover both `--json` and plain-text store/runtime failure paths for both commands.

## Linked issue
No linked issue because: fork contributors cannot open issues on JSONbored/loopover (CreateIssue denied), and the existing help-wanted pool for this bug class is empty. This is a small, self-contained chore/cleanup of the established CLI JSON error contract — same gap class already fixed for discover/manage-poll (#6051/#6072) and loopover-mcp (#6113), applied to the remaining `manage status` / `queue dashboard` paths that still escape as uncaught stack traces.

Supersedes #6140 (auto-closed solely for missing upstream issue link; CI was green).

## Test plan
- [x] `npx vitest run test/unit/miner-manage-status.test.ts test/unit/miner-portfolio-dashboard.test.ts` (23/23 pass)
- [ ] CI validate-tests + codecov patch