### PR TITLE
chore(miner): remove dead parseJsonFlag from portfolio-queue-cli

### DIFF
--- a/packages/loopover-miner/lib/portfolio-queue-cli.js
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.js
@@ -25,29 +25,6 @@ function parseRepoArg(value, usage) {
   return { repoFullName: `${owner}/${repo}` };
 }
 
-function parseJsonFlag(args) {
-  const options = { json: false, dryRun: false };
-  const positional = [];
-
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
-    }
-    // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  return { positional, ...options };
-}
-
 export function parseQueueListArgs(args) {
   const options = { json: false, repoFullName: null };
   const positional = [];


### PR DESCRIPTION
## Summary

Closes #6164

- Removes `parseJsonFlag` from `packages/loopover-miner/lib/portfolio-queue-cli.js` (was lines 28-49). It was never called and never exported — every subcommand uses the real parsers instead (`parseQueueListArgs` / `parseQueueNextArgs` / `parseRepoIdentifierArgs` / `parseQueueClaimBatchArgs`).
- As the issue notes, it duplicated the `--dry-run`/`--json` parsing loop and carried the same `#4847` comment verbatim as `parseRepoIdentifierArgs`, which is what marks it as a superseded early draft that was never deleted.
- Deletion-only: **1 file, -23 lines, no behavior change.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the directly affected suites with vitest, all unmodified and green: `miner-portfolio-queue-cli` + `miner-plan-store-cli` (44 tests), plus `miner-portfolio-queue`, `miner-portfolio-queue-manager`, `miner-portfolio-queue-expiry`, `miner-portfolio-queue-crash-recovery`, `portfolio-queue` (83 tests) — **127 total**.
- Verified repo-wide (`grep -rn parseJsonFlag`) that the removed function had zero callers. `plan-store-cli.js` defines its **own separate module-scoped** `parseJsonFlag` that is still used at its line 55; that one is deliberately left untouched.
- This is a deletion-only diff that adds no lines, so there is no new code for `codecov/patch` to measure. The UI/MCP/workers suites are untouched by this change; leaving them to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No auth/API/UI/docs surface is touched — this only deletes unreachable code.

## Notes

Closes #6164
