### PR TITLE
docs(miner): fix stale header comment in submission-freshness-check

### DIFF
--- a/packages/loopover-miner/lib/submission-freshness-check.js
+++ b/packages/loopover-miner/lib/submission-freshness-check.js
@@ -5,7 +5,7 @@
 // replacing, the claim-time check (src/miner/soft-claim.ts) -- so a stale submission never reaches the Governor
 // chokepoint (governor-chokepoint.js) as a live write attempt: check freshness first, THEN prepareOpenPrSubmission
 // (harness-submission-trigger.js), THEN the Governor. These are separate, sequentially-composed units, not nested
-// calls -- a future real call site wires them together in that order.
+// calls -- attempt-runner.js (#2337) is the real call site that wires them together in that order.
 //
 // READ-ONLY BY CONTRACT: never writes anything except its own abort-reason audit event (on staleness only, not
 // on every check -- mirrors this issue's own "log the abort reason" wording, not a per-decision audit trail).


### PR DESCRIPTION
## Summary

Closes #6163

- `submission-freshness-check.js`'s header said the freshness → `prepareOpenPrSubmission` → Governor composition was something "a future real call site wires them together in that order". That call site already exists, so the comment was misleading a reader into thinking the module isn't wired in yet.
- `attempt-runner.js` is that call site: its own module comment (lines 8-13) documents composing `runIterateLoop → checkSubmissionFreshness → prepareOpenPrSubmission → the Governor chokepoint`, and it calls `checkSubmissionFreshness` directly before `prepareOpenPrSubmission` (lines 148-156).
- Comment-only: **1 file, 1 line, no behavior change.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Verified the issue's premise directly against `main` before changing anything, rather than trusting the description: `attempt-runner.js:8-13` documents the exact ordering and `:148-156` performs it.
- Ran the directly affected suites with vitest, unmodified and green: `miner-submission-freshness-check` + `miner-attempt-runner` (**44 tests**).
- This diff changes one comment line and no executable code, so there is nothing for `codecov/patch` to measure and no behavior to test. UI/MCP/workers surfaces are untouched; leaving them to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No code, auth, API, or UI surface is touched — this corrects a single stale comment.

## Notes

Closes #6163
