### PR TITLE
feat(miner-ui): add a pause-reason input to the governor control (#6186)

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -156,6 +156,58 @@ describe("LedgersPage (#4855)", () => {
       await waitFor(() => expect(screen.getByRole("button", { name: "Resume governor" })).toBeTruthy());
     });
 
+    it("passes the typed pause reason through to the pause action (#6186)", async () => {
+      const pausedResult: GovernorPauseStateResult = {
+        ok: true,
+        pauseState: { paused: true, reason: "deploying a hotfix", pausedAt: "2026-07-13T12:30:00.000Z" },
+      };
+      const pauseGovernorAction = vi.fn(async (): Promise<GovernorPauseStateResult> => pausedResult);
+      render(
+        <LedgersPage
+          loadLedgers={loadLedgersEmpty}
+          loadGovernorPauseState={loadGovernorPauseStateDefault}
+          pauseGovernorAction={pauseGovernorAction}
+        />,
+      );
+      await waitFor(() => expect(screen.getByText("Not paused")).toBeTruthy());
+      fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "deploying a hotfix" } });
+      fireEvent.click(screen.getByRole("button", { name: "Pause governor" }));
+      expect(pauseGovernorAction).toHaveBeenCalledWith("deploying a hotfix");
+      await waitFor(() => expect(screen.getByRole("button", { name: "Resume governor" })).toBeTruthy());
+    });
+
+    it("passes undefined to the pause action when the reason field is left empty (#6186)", async () => {
+      const pauseGovernorAction = vi.fn(async (): Promise<GovernorPauseStateResult> => ({
+        ok: true,
+        pauseState: { paused: true, reason: null, pausedAt: "2026-07-13T12:30:00.000Z" },
+      }));
+      render(
+        <LedgersPage
+          loadLedgers={loadLedgersEmpty}
+          loadGovernorPauseState={loadGovernorPauseStateDefault}
+          pauseGovernorAction={pauseGovernorAction}
+        />,
+      );
+      await waitFor(() => expect(screen.getByText("Not paused")).toBeTruthy());
+      expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("");
+      fireEvent.click(screen.getByRole("button", { name: "Pause governor" }));
+      expect(pauseGovernorAction).toHaveBeenCalledWith(undefined);
+    });
+
+    it("shows the reason input only while unpaused, not once the governor is paused (#6186)", async () => {
+      render(
+        <LedgersPage
+          loadLedgers={loadLedgersEmpty}
+          loadGovernorPauseState={async () => ({
+            ok: true,
+            pauseState: { paused: true, reason: "bad PR", pausedAt: "2026-07-13T12:00:00.000Z" },
+          })}
+        />,
+      );
+      await waitFor(() => expect(screen.getByRole("button", { name: "Resume governor" })).toBeTruthy());
+      expect(screen.queryByLabelText("Pause reason")).toBeNull();
+    });
+
     it("clicking Resume governor calls the injected resume action and updates the displayed state from its result", async () => {
       const initiallyPaused: GovernorPauseState = { paused: true, reason: null, pausedAt: "2026-07-13T12:00:00.000Z" };
       const resumeGovernorAction = vi.fn(async (): Promise<GovernorPauseStateResult> => ({

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@loopover/ui-kit/components/button";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
+import { Input } from "@loopover/ui-kit/components/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
 
 import { CLAIM_STATUSES, fetchLedgers, type ClaimStatus, type LedgersResult } from "../lib/ledgers";
@@ -64,9 +65,12 @@ export function GovernorControlSection({
 }: {
   result: GovernorPauseStateResult | null;
   pending: boolean;
-  onPause: () => void;
+  onPause: (reason?: string) => void;
   onResume: () => void;
 }) {
+  // Optional pause reason, mirroring the CLI's `governor pause [--reason <text>]`; an empty field
+  // is passed through as `undefined` so it matches the CLI's own optional-flag behavior.
+  const [reason, setReason] = useState("");
   return (
     <section className="grid gap-3">
       <h3 className="font-display text-token-base font-semibold">Governor control</h3>
@@ -88,9 +92,20 @@ export function GovernorControlSection({
               Resume governor
             </Button>
           ) : (
-            <Button size="sm" variant="destructive" disabled={pending} onClick={onPause}>
-              Pause governor
-            </Button>
+            <>
+              <Input
+                type="text"
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                disabled={pending}
+                placeholder="Reason (optional)"
+                aria-label="Pause reason"
+                className="w-auto flex-1 min-w-[12rem]"
+              />
+              <Button size="sm" variant="destructive" disabled={pending} onClick={() => onPause(reason || undefined)}>
+                Pause governor
+              </Button>
+            </>
           )}
         </div>
       )}
@@ -183,7 +198,7 @@ export function LedgersPage({
 }: {
   loadLedgers?: () => Promise<LedgersResult>;
   loadGovernorPauseState?: () => Promise<GovernorPauseStateResult>;
-  pauseGovernorAction?: () => Promise<GovernorPauseStateResult>;
+  pauseGovernorAction?: (reason?: string) => Promise<GovernorPauseStateResult>;
   resumeGovernorAction?: () => Promise<GovernorPauseStateResult>;
 }) {
   const [result, setResult] = useState<LedgersResult | null>(null);
@@ -231,7 +246,7 @@ export function LedgersPage({
           <GovernorControlSection
             result={pauseState}
             pending={actionPending}
-            onPause={() => runGovernorAction(pauseGovernorAction)}
+            onPause={(reason) => runGovernorAction(() => pauseGovernorAction(reason))}
             onResume={() => runGovernorAction(resumeGovernorAction)}
           />
           <LedgersView result={result} />


### PR DESCRIPTION
## Summary

`pauseGovernor` (`apps/loopover-miner-ui/src/lib/governor.ts:73`) has always accepted an optional
`reason`, mirroring `gittensory-miner governor pause [--reason <text>]`, and `GovernorControlSection`
already renders a captured reason when one exists. But the dashboard's Pause button called the action
with zero arguments (`routes/ledgers.tsx:234`), so a reason set from the dashboard was always
`undefined` — the one place in the system that could never record a reason, despite explicitly
mirroring the CLI that can.

This adds the missing text input:

- `GovernorControlSection` renders an optional `Reason (optional)` input (the shared `@loopover/ui-kit`
  `Input`) alongside the Pause button while the governor is unpaused, and passes its value through to
  the pause action on click.
- An empty field is passed as `undefined` (`reason || undefined`), matching the CLI's own optional
  `--reason` behavior; the input is only shown in the unpaused state (you resume, not re-pause, when
  already paused).
- `pauseGovernor`'s signature and the CLI's behavior are unchanged — this only wires an already-supported
  parameter to the UI. `onPause`/`pauseGovernorAction` are widened from `() => …` to `(reason?: string) => …`.

Closes #6186.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — no `.github/workflows/**` changes.
- [x] `npm run ui:typecheck` (this is a `apps/loopover-miner-ui` change; backend `npm run typecheck` is unaffected)
- [x] `npm run ui:test` — 420 UI tests pass, incl. the 133 `loopover-miner-ui` tests with the new cases. `codecov/patch` does not apply: `apps/**` is Codecov-ignored (`codecov.yml`).
- [ ] `npm run test:workers` — backend-only; untouched here.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — no MCP changes.
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:build` (and `npm --prefix apps/loopover-miner-ui run build`)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit tests: reason passed through, empty field → `undefined`, and the input hidden once paused.

If any required check was skipped, explain why:

- Skipped checks are backend/MCP/actionlint scopes with no changes in this UI-only diff (see notes above).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — none of those changed here.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed — no API/OpenAPI/MCP change; `ui:openapi:check` confirms no drift.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — the input feeds the existing `pauseGovernor` action; no mock/demo data added.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs — no doc/changelog change needed.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Unpaused — new reason input, with a reason typed, next to Pause governor | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/pr6186-desktop.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/pr6186-desktop.png" alt="Reason input with a reason typed, plus the paused state showing the recorded reason" width="240"></a> |
| Unpaused — empty reason input (optional, passes `undefined`) | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/pr6186-desktop-empty.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/pr6186-desktop-empty.png" alt="Empty optional reason input in the unpaused state" width="240"></a> |
| Mobile layout (390px) — input wraps above Pause; paused state records the reason | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/pr6186-mobile.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/pr6186-mobile.png" alt="Mobile layout of the reason input and paused state" width="180"></a> |

## Notes

- The paused-state panel in the screenshots shows the reason (`deploying a hotfix`) rendered back via the existing `Paused since … (reason)` line, confirming a dashboard-set reason now round-trips the same way a CLI-set one already did.
