### PR TITLE
fix(queue): honor autoCloseExemptLogins in the repeated-draft-cycling review-evasion guard

### DIFF
--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -966,6 +966,9 @@ async function closeRepeatedDraftCyclingIfDetected(
   /* v8 ignore next -- unreachable given the call site's own author-only increment guarantee; see comment above. */
   if (!converter || !authorLogin || converter !== authorLogin) return;
   if (isProtectedAutomationAuthor(pr.authorLogin)) return;
+  // Honor the maintainer's trusted-contributor allowlist, same as the two sibling review-evasion guards
+  // (closeReviewEvasionSelfCloseIfReviewed / closeReviewEvasionDraftConversionIfReviewed) already do (#6165).
+  if (isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) return;
   if (!pr.headSha) return;
   const headSha = pr.headSha;
   if (await hasMaintainerOrOwnerPermission(env, installationId, repoFullName, authorLogin)) return;

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -2952,6 +2952,22 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       expect(strike?.outcome).toBe("completed");
     });
 
+    it("REGRESSION (#6165): honors settings.autoCloseExemptLogins -- the shared allowlist the two sibling review-evasion guards already use, even after a repeated cycle", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env, { autoCloseExemptLogins: ["contributor"] });
+      await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
+
+      await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-exempt-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
+      await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-exempt-2", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
+
+      // Exempt author: the repeated-draft-cycling guard must skip enforcement just like its two siblings do.
+      expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+      const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("github_app.review_evasion_closed").first<{ n: number }>();
+      expect(audit?.n).toBe(0);
+    });
+
     it("does nothing when reviewEvasionProtection is off, even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);


### PR DESCRIPTION
## Summary

`src/queue/review-evasion.ts` has three sibling auto-close guards for review-evasion tactics. Two of them -- `closeReviewEvasionSelfCloseIfReviewed` and `closeReviewEvasionDraftConversionIfReviewed` -- call `if (isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) return;` before acting, honoring the maintainer's trusted-contributor allowlist (the same shared allowlist the contributor-cap/review-nag guards use). The third, `closeRepeatedDraftCyclingIfDetected` (added later, per its `#gaming-tactic-draft-cycle` comment), checks `isProtectedAutomationAuthor` but never calls `isAutoCloseExempt` -- so a maintainer-configured trusted-contributor exemption was silently bypassed by this one enforcement path, inconsistent with its two siblings.

## Changes

- Added the same `isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)` early-return to `closeRepeatedDraftCyclingIfDetected`, in the same position the two sibling guards use (immediately after the `isProtectedAutomationAuthor` check). Both checks coexist, matching the siblings.
- `isProtectedAutomationAuthor` and the two correct sibling guards are unchanged; `isAutoCloseExempt` was already imported.

## Scope

- [x] Single-purpose consistency fix in `src/queue/review-evasion.ts`.
- [x] No behavior change for non-exempt authors (the existing enforcement path is untouched).

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/queue-lifecycle-guards.test.ts` -- 193 passed, incl. the new exemption regression test and all existing draft-cycling/self-close/draft-conversion tests.
- [x] Coverage: the new `isAutoCloseExempt` branch is exercised both ways -- exempt author (new #6165 test, no close) and non-exempt author (existing enforce test, close).
- [x] Rebased onto latest `main`; mergeable-clean.

## Safety

- [x] No secrets or private terms. Tightens (never loosens) who gets auto-closed: an exempt trusted contributor is now correctly skipped, matching the two siblings.

Closes #6165