### PR TITLE
fix(engine): detect activity changes once the progress tail is full

### DIFF
--- a/packages/loopover-engine/src/loop-progress.ts
+++ b/packages/loopover-engine/src/loop-progress.ts
@@ -53,15 +53,34 @@ export function buildProgressSnapshot(state: LoopProgressState): ProgressSnapsho
   };
 }
 
+/**
+ * True when the activity tail differs — by length, or by CONTENT at the same length.
+ *
+ * Length alone is not enough (#6171): the tail is capped at {@link MAX_PROGRESS_ACTIVITY}, so once a loop has
+ * accumulated that many entries every further event evicts the oldest and appends the newest, holding the
+ * length at the cap forever. A length-only check therefore goes permanently blind to activity exactly on the
+ * long runs that stream the most. Comparing the entries themselves is O(cap) — bounded by that same constant,
+ * so a fixed handful of field reads, not a cost that grows with the run.
+ */
+function activityChanged(prev: readonly LoopProgressActivity[], next: readonly LoopProgressActivity[]): boolean {
+  if (prev.length !== next.length) return true;
+  for (let index = 0; index < next.length; index += 1) {
+    const before = prev[index]!;
+    const after = next[index]!;
+    if (before.step !== after.step || before.detail !== after.detail || before.at !== after.at) return true;
+  }
+  return false;
+}
+
 /** True when `next` differs from `prev` in a way worth pushing to the customer — so the surface streams
  *  ON CHANGE instead of polling on a fixed interval (#4800's acceptance). A null `prev` (the first snapshot)
- *  always pushes. Compares the displayed axes: phase, status, iteration, and the activity tail's length. */
+ *  always pushes. Compares the displayed axes: phase, status, iteration, and the activity tail's contents. */
 export function progressChanged(prev: ProgressSnapshot | null, next: ProgressSnapshot): boolean {
   if (prev === null) return true;
   return (
     prev.phase !== next.phase ||
     prev.status !== next.status ||
     prev.iteration !== next.iteration ||
-    prev.recentActivity.length !== next.recentActivity.length
+    activityChanged(prev.recentActivity, next.recentActivity)
   );
 }

--- a/test/unit/loop-progress.test.ts
+++ b/test/unit/loop-progress.test.ts
@@ -3,6 +3,7 @@ import {
   buildProgressSnapshot,
   progressChanged,
   MAX_PROGRESS_ACTIVITY,
+  type LoopProgressActivity,
   type LoopProgressState,
 } from "../../packages/loopover-engine/src/loop-progress";
 
@@ -57,5 +58,51 @@ describe("progressChanged — push on change, not on a fixed interval (#4800)", 
 
   it("does not push when nothing displayed has changed", () => {
     expect(progressChanged(base, buildProgressSnapshot(running({ recentActivity: [{ step: "a" }] })))).toBe(false);
+  });
+
+  // #6171: the tail is capped, so past the cap every new event evicts the oldest and the LENGTH stops moving.
+  // A length-only check went permanently blind here — exactly on the long runs that stream the most.
+  describe("activity tail at its cap (#6171)", () => {
+    const activity = (count: number): LoopProgressActivity[] =>
+      Array.from({ length: count }, (_, i) => ({ step: `step-${i}`, at: `2026-07-16T00:${String(i).padStart(2, "0")}:00Z` }));
+
+    it("REGRESSION: still pushes for a new activity once the tail is full", () => {
+      const full = buildProgressSnapshot(running({ recentActivity: activity(MAX_PROGRESS_ACTIVITY) }));
+      const oneMore = buildProgressSnapshot(running({ recentActivity: activity(MAX_PROGRESS_ACTIVITY + 1) }));
+
+      // The blind spot the length check could never see: both tails are pinned at the cap.
+      expect(full.recentActivity).toHaveLength(MAX_PROGRESS_ACTIVITY);
+      expect(oneMore.recentActivity).toHaveLength(MAX_PROGRESS_ACTIVITY);
+      expect(progressChanged(full, oneMore)).toBe(true);
+    });
+
+    it("keeps pushing for every subsequent event, not just the first past the cap", () => {
+      let prev = buildProgressSnapshot(running({ recentActivity: activity(MAX_PROGRESS_ACTIVITY) }));
+      for (let n = MAX_PROGRESS_ACTIVITY + 1; n <= MAX_PROGRESS_ACTIVITY + 5; n += 1) {
+        const next = buildProgressSnapshot(running({ recentActivity: activity(n) }));
+        expect(progressChanged(prev, next)).toBe(true);
+        prev = next;
+      }
+    });
+
+    it("still does not push when a full tail is genuinely unchanged", () => {
+      const a = buildProgressSnapshot(running({ recentActivity: activity(MAX_PROGRESS_ACTIVITY) }));
+      const b = buildProgressSnapshot(running({ recentActivity: activity(MAX_PROGRESS_ACTIVITY) }));
+      expect(progressChanged(a, b)).toBe(false);
+    });
+
+    it("detects a same-length change in any displayed activity field", () => {
+      const base10 = buildProgressSnapshot(running({ recentActivity: activity(MAX_PROGRESS_ACTIVITY) }));
+      const changedStep = activity(MAX_PROGRESS_ACTIVITY);
+      changedStep[MAX_PROGRESS_ACTIVITY - 1] = { ...changedStep[MAX_PROGRESS_ACTIVITY - 1]!, step: "different" };
+      const changedDetail = activity(MAX_PROGRESS_ACTIVITY);
+      changedDetail[0] = { ...changedDetail[0]!, detail: "now has a detail" };
+      const changedAt = activity(MAX_PROGRESS_ACTIVITY);
+      changedAt[0] = { ...changedAt[0]!, at: "2026-07-16T09:99:00Z" };
+
+      expect(progressChanged(base10, buildProgressSnapshot(running({ recentActivity: changedStep })))).toBe(true);
+      expect(progressChanged(base10, buildProgressSnapshot(running({ recentActivity: changedDetail })))).toBe(true);
+      expect(progressChanged(base10, buildProgressSnapshot(running({ recentActivity: changedAt })))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #6171

`progressChanged` decided the activity axis with a length comparison alone:

```ts
prev.recentActivity.length !== next.recentActivity.length
```

The tail is capped at `MAX_PROGRESS_ACTIVITY` (10). Once a loop has accumulated that many entries, every further event **evicts the oldest and appends the newest** — so the length stays pinned at the cap and the comparison is `false` forever. From that point the *"push ON CHANGE"* contract silently stopped firing for activity-only updates: **permanently blind exactly on the long runs that stream the most**, which is the opposite of what #4800 promises the customer.

**Fix:** compare the tail's contents, keeping the length check as the fast path. The scan is `O(MAX_PROGRESS_ACTIVITY)` — bounded by that same constant, so a fixed handful of field reads per snapshot, not a cost that grows with the run.

Scoped strictly to that blind spot, per the issue: the cap itself and the other change axes (`phase`/`status`/`iteration`) are untouched.

## Scope

- [x] Conventional Commit title (`fix(engine): …`).
- [x] Focused: one predicate + its regression tests. No other behavior changed.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable`; no changelog edit.
- [x] Linked open issue (Closes #6171, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run build:miner` — exit 0.
- [x] `npm run typecheck` — exit 0.
- [x] `npx vitest run test/unit/loop-progress.test.ts test/unit/customer-loop-view.test.ts` — **25 tests passed** (the customer-facing consumer of these snapshots is included, since it is the surface this contract serves).
- [x] Coverage on `packages/loopover-engine/src/loop-progress.ts` (in Codecov's `coverage.include`): **100% statements (16/16), 100% branch (21/21), 100% functions (3/3), 100% lines (12/12)**.
- [x] **Proved the tests catch the bug**: reverted only the source fix and confirmed the three new tests fail (`REGRESSION: still pushes for a new activity once the tail is full`, the sustained-push case, and the per-field case), then pass again with the fix restored. Not tautological.
- [x] Rebased onto current `main`.

The regression tests pin the exact scenario the old check could not see — **both tails at 10 entries, yet genuinely different**:

| Test | What it locks |
|---|---|
| `REGRESSION: still pushes … once the tail is full` | The blind spot itself: both snapshots at the cap, asserted, and still detected as changed |
| `keeps pushing for every subsequent event` | It stays fixed past the cap (10 → 15), not just for the first event after it |
| `still does not push when a full tail is genuinely unchanged` | The fix does not turn this into "always push" — the ON CHANGE contract is preserved |
| `detects a same-length change in any displayed activity field` | `step`, `detail`, and `at` each independently trigger a push |

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] No auth/cookie/CORS/GitHub App/session change.
- [x] Pure and side-effect-free: no IO, no storage, no clock read — same in/out transform as before.
- [x] **Strictly more correct, never less**: the change can only turn a missed push into a push. Every case the old code detected, the new code still detects (the length check runs first, unchanged), and an unchanged tail still does not push — covered by a test.
- [x] Bounded cost: the added scan is capped by `MAX_PROGRESS_ACTIVITY`, so it cannot grow with run length or become a hot loop.
- [x] No API/OpenAPI/MCP change; no schema change; no generated artifact affected.
- [x] No UI changes; no changelog edit.
