### PR TITLE
fix(engine): detect activity-tail change once recentActivity is at its cap (#6171)

### DIFF
--- a/packages/loopover-engine/src/loop-progress.ts
+++ b/packages/loopover-engine/src/loop-progress.ts
@@ -53,15 +53,27 @@ export function buildProgressSnapshot(state: LoopProgressState): ProgressSnapsho
   };
 }
 
+/** Same activity entry by every displayed field. New activity always appends to the tail, so comparing the
+ *  newest entry catches a tail that stayed the same length but shifted content — the case a length-only
+ *  check misses once the tail is capped at {@link MAX_PROGRESS_ACTIVITY} (#6171). */
+function sameActivity(a: LoopProgressActivity | undefined, b: LoopProgressActivity | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b;
+  return a.step === b.step && a.detail === b.detail && a.at === b.at;
+}
+
 /** True when `next` differs from `prev` in a way worth pushing to the customer — so the surface streams
  *  ON CHANGE instead of polling on a fixed interval (#4800's acceptance). A null `prev` (the first snapshot)
- *  always pushes. Compares the displayed axes: phase, status, iteration, and the activity tail's length. */
+ *  always pushes. Compares the displayed axes: phase, status, iteration, and the activity tail. The tail is
+ *  checked by both length AND newest entry: once it fills to MAX_PROGRESS_ACTIVITY a new event evicts the
+ *  oldest and appends the newest, so length stays constant — a length-only check would stop firing for
+ *  activity-only updates from that point on (#6171). */
 export function progressChanged(prev: ProgressSnapshot | null, next: ProgressSnapshot): boolean {
   if (prev === null) return true;
   return (
     prev.phase !== next.phase ||
     prev.status !== next.status ||
     prev.iteration !== next.iteration ||
-    prev.recentActivity.length !== next.recentActivity.length
+    prev.recentActivity.length !== next.recentActivity.length ||
+    !sameActivity(prev.recentActivity.at(-1), next.recentActivity.at(-1))
   );
 }

--- a/test/unit/loop-progress.test.ts
+++ b/test/unit/loop-progress.test.ts
@@ -58,4 +58,40 @@ describe("progressChanged — push on change, not on a fixed interval (#4800)", 
   it("does not push when nothing displayed has changed", () => {
     expect(progressChanged(base, buildProgressSnapshot(running({ recentActivity: [{ step: "a" }] })))).toBe(false);
   });
+
+  it("pushes on a new activity event once the tail is full at the cap (#6171)", () => {
+    // Once recentActivity fills to MAX_PROGRESS_ACTIVITY a new event evicts the oldest and appends the newest,
+    // so the tail length stays constant — the length-only check missed this and stopped firing (#6171).
+    const full = Array.from({ length: MAX_PROGRESS_ACTIVITY }, (_, i) => ({ step: `s${i}` }));
+    const prev = buildProgressSnapshot(running({ recentActivity: full }));
+    const nextState = running({ recentActivity: [...full.slice(1), { step: "s-new" }] });
+    const next = buildProgressSnapshot(nextState);
+    expect(prev.recentActivity).toHaveLength(MAX_PROGRESS_ACTIVITY);
+    expect(next.recentActivity).toHaveLength(MAX_PROGRESS_ACTIVITY);
+    expect(prev.recentActivity.length === next.recentActivity.length).toBe(true); // length alone can't tell them apart
+    expect(progressChanged(prev, next)).toBe(true);
+  });
+
+  it("pushes when the newest activity entry differs in step, detail, or at (same tail length)", () => {
+    const p = buildProgressSnapshot(running({ recentActivity: [{ step: "a", detail: "d", at: "t1" }] }));
+    expect(progressChanged(p, buildProgressSnapshot(running({ recentActivity: [{ step: "b", detail: "d", at: "t1" }] })))).toBe(true);
+    expect(progressChanged(p, buildProgressSnapshot(running({ recentActivity: [{ step: "a", detail: "e", at: "t1" }] })))).toBe(true);
+    expect(progressChanged(p, buildProgressSnapshot(running({ recentActivity: [{ step: "a", detail: "d", at: "t2" }] })))).toBe(true);
+  });
+
+  it("does not push when the newest activity entry matches on every field", () => {
+    const p = buildProgressSnapshot(running({ recentActivity: [{ step: "a", detail: "d", at: "t1" }] }));
+    expect(progressChanged(p, buildProgressSnapshot(running({ recentActivity: [{ step: "a", detail: "d", at: "t1" }] })))).toBe(false);
+  });
+
+  it("does not push when both activity tails are empty (newest entry undefined on both sides)", () => {
+    const empty = buildProgressSnapshot(running({ recentActivity: [] }));
+    expect(progressChanged(empty, buildProgressSnapshot(running({ recentActivity: [] })))).toBe(false);
+  });
+
+  it("pushes when one tail is empty and the other has activity (newest entry undefined on one side)", () => {
+    const empty = buildProgressSnapshot(running({ recentActivity: [] }));
+    const oneItem = buildProgressSnapshot(running({ recentActivity: [{ step: "a" }] }));
+    expect(progressChanged(empty, oneItem)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- `progressChanged` (`packages/loopover-engine/src/loop-progress.ts`) detected an activity-tail change by comparing `prev.recentActivity.length !== next.recentActivity.length` only. `recentActivity` is capped at `MAX_PROGRESS_ACTIVITY = 10`, so once a loop accumulates 10+ activity entries a new event evicts the oldest and appends the newest — the length stays 10, the comparison is always `false`, and the "push ON CHANGE" contract silently stopped firing for activity-only updates from that point on.
- Fix: also compare the newest activity entry (new activity always appends to the tail) via a small `sameActivity` helper, so a same-length-but-different-content tail is still detected. The legitimate no-change case (identical newest entry) still returns `false`, so the surface is not spammed.
- Scoped exactly to the activity-tail-full blind spot: `MAX_PROGRESS_ACTIVITY` and the phase/status/iteration change-detection are untouched.

Closes #6171

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6171`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the changed diff (`loop-progress.ts`) reports **100% statements / 100% branch / 100% lines** (22/22 branches); `codecov/patch` ≥99% satisfied on every changed line and branch.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has unit tests for the new branches: tail-full regression (11+/at-cap items), same-length newest-entry diff on `step`/`detail`/`at`, identical-entry no-push, and both-empty / one-empty tail cases.

If any required check was skipped, explain why:

- No OpenAPI/`cf-typegen`/migration regeneration needed — this is a pure in-package logic change with no API surface, Cloudflare binding, or DB schema change. `ui:openapi:check` was still run and is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP surface touched (`ui:openapi:check` clean).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section. — N/A: no visible UI/frontend/docs/extension change (pure `@loopover/engine` logic).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A: no docs/changelog change.

## Notes

- The bug was undetected because no existing test in `test/unit/loop-progress.test.ts` exercised more than 10 activity items; the regression test now pushes the tail to its cap and asserts a genuinely new activity item still returns `true`.
