### PR TITLE
chore(review): remove dead isIgnoredReviewAuthor wrapper (zero callers, thinly wraps decideReviewEligibility)

### DIFF
--- a/src/review/review-eligibility.ts
+++ b/src/review/review-eligibility.ts
@@ -51,7 +51,3 @@ export function decideReviewEligibility(input: ReviewEligibilityInput): ReviewEl
 
   return REVIEW_ELIGIBLE;
 }
-
-export function isIgnoredReviewAuthor(input: ReviewEligibilityInput): boolean {
-  return !decideReviewEligibility(input).eligible;
-}

--- a/test/unit/review-eligibility.test.ts
+++ b/test/unit/review-eligibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decideReviewEligibility, isIgnoredReviewAuthor } from "../../src/review/review-eligibility";
+import { decideReviewEligibility } from "../../src/review/review-eligibility";
 
 describe("decideReviewEligibility", () => {
   it("keeps authors eligible when no ignore list is configured", () => {
@@ -85,11 +85,6 @@ describe("decideReviewEligibility", () => {
       skipReason: "ignored_author",
       matchedPattern: "*[bot]",
     });
-  });
-
-  it("exposes a boolean helper for compact call sites", () => {
-    expect(isIgnoredReviewAuthor({ authorLogin: "renovate[bot]", ignoreAuthors: ["renovate*"] })).toBe(true);
-    expect(isIgnoredReviewAuthor({ authorLogin: "alice", ignoreAuthors: ["renovate*"] })).toBe(false);
   });
 
   it("treats a nullish ignore list as the default empty list", () => {


### PR DESCRIPTION
## Summary

`src/review/review-eligibility.ts`'s `isIgnoredReviewAuthor` is a thin boolean wrapper (`return !decideReviewEligibility(input).eligible;`) around the actively-used `decideReviewEligibility` (called from `src/signals/settings-preview.ts` and `src/queue/processors.ts`). A repo-wide search finds `isIgnoredReviewAuthor` has **zero callers outside its own test** -- every real caller uses the richer `decideReviewEligibility` directly.

## Changes

- Removed `isIgnoredReviewAuthor` from `review-eligibility.ts` and its dedicated test case + import. Pure deletion; `decideReviewEligibility` and its tests are untouched.

## Confirmation (per the issue)

- Repo-wide search: `isIgnoredReviewAuthor` had zero real callers (def + one test only).
- No engine twin -- `review-eligibility.ts` is backend-only, so no parity pair to keep in sync.

## Validation

- [x] `npm run typecheck` -- clean.
- [x] `npx vitest run test/unit/review-eligibility.test.ts` -- 39 passed (the remaining `decideReviewEligibility` tests).
- [x] `git diff --check` clean; rebased onto latest `main`, mergeable-clean.

## Safety

- [x] No secrets/private terms; removing an uncalled convenience wrapper changes no live behavior.

Closes #6169