### PR TITLE
docs(review): stop claiming the self-improve D1 tables don't exist

### DIFF
--- a/src/review/ops-wire.ts
+++ b/src/review/ops-wire.ts
@@ -25,10 +25,12 @@
 // ci_stuck_review_repeat_suppressed).
 //
 // DEFERRED (NOT implemented here): the auto-tune / auto-apply config-mutation self-improve loop. The ported
-// pure logic + D1 store already exist in src/review/auto-apply.ts, but actually CLOSING the loop (mutating a
-// live gate's tunables from the cron) is sensitive — it needs the `tunables_overrides` / `_shadow` /
-// `override_audit` D1 tables (none of which exist in loopover's migrations yet) plus a careful soak/promote
-// design. This module is READ-ONLY observability: it reports drift; it never changes what blocks a live PR.
+// pure logic + D1 store already exist in src/review/auto-apply.ts, and so do the `tunables_overrides` /
+// `_shadow` / `override_audit` tables it reads and writes (#4879's migration 0047_self_improve_tunables.sql).
+// The schema is NOT the remaining blocker: actually CLOSING the loop (mutating a live gate's tunables from the
+// cron) is sensitive and still needs the careful soak/promote design — the shadow-soak-then-promote lifecycle
+// auto-apply.ts's own isStrictlyTightening / evaluateShadowPromotion anticipate. This module is READ-ONLY
+// observability: it reports drift; it never changes what blocks a live PR.
 
 import { findHottestInconclusiveReviewTargetForRepo, findHottestReviewTargetForRepo, listRepositories, sumByokAiUsageForRepoSince } from "../db/repositories";
 import { incr } from "../selfhost/metrics";


### PR DESCRIPTION
## Summary

Closes #6195

`src/review/ops-wire.ts`'s header explained why the auto-tune/auto-apply loop stays deferred:

> it needs the `tunables_overrides` / `_shadow` / `override_audit` D1 tables **(none of which exist in loopover's migrations yet)** plus a careful soak/promote design

Verified against the repo — that premise is stale, and the comment contradicted **itself**:

- **#4879's `migrations/0047_self_improve_tunables.sql` creates all three**: `tunables_overrides` (line 22), `tunables_overrides_shadow` (line 33), `override_audit` (line 44).
- **`src/review/auto-apply.ts` already implements the store against them** — `loadOverride`/`writeLiveOverride`/`deleteLiveOverride`, `loadShadowOverride`/`writeShadowOverride`/`deleteShadowOverride`, `recordOverrideAudit`/`listOverrideAudit` — which the migration's own header documents table-by-table.
- The same sentence **already acknowledged** that store exists ("The ported pure logic + D1 store already exist in `src/review/auto-apply.ts`") while claiming its tables did not.

**Fix:** remove only the false premise. The deferred conclusion is still correct, so it stays — and the comment now names what the real remaining blocker actually is: the careful soak/promote design, i.e. the shadow-soak-then-promote lifecycle `auto-apply.ts`'s own `isStrictlyTightening` / `evaluateShadowPromotion` already anticipate (both verified to exist, at `auto-apply.ts:123` and `:145`). A reader is no longer misled into thinking the D1 schema is what's missing.

## Scope

- [x] Conventional Commit title (`docs(review): …`).
- [x] **Comment-only**, exactly as the issue requires ("No code behavior change"). Mechanically verified: every added/removed line in the diff is a comment line.
- [x] Keeps the comment's still-true point that the module remains deliberately read-only — only the stale premise is corrected, not the conclusion.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable`; no changelog edit.
- [x] Linked open issue (Closes #6195, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run typecheck` — exit 0.
- [x] **No coverage surface**: the diff changes zero executable lines, so no line/branch coverage can move. Verified mechanically over the whole diff, not by inspection.
- [x] Every claim in the replacement text was verified against the repo before writing it — the migration line numbers, the store functions, and the two symbols now cited (`isStrictlyTightening`, `evaluateShadowPromotion`) all exist.
- [x] Rebased onto current `main`.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows). Nothing executable changed, so no suite's behavior is affected.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] No auth/cookie/CORS/GitHub App/session change.
- [x] **No behavior change of any kind** — comment text only. No API/OpenAPI/MCP change, no schema change, no generated artifact affected.
- [x] Does not weaken a safety note: the module stays documented as READ-ONLY observability, and the deferral of the config-mutation loop stays in place — the correction only re-points the reason at the real blocker.
- [x] No UI changes; no changelog edit.
