### PR TITLE
docs(miner-ui): README no longer claims the data views are unshipped

### DIFF
--- a/apps/loopover-miner-ui/README.md
+++ b/apps/loopover-miner-ui/README.md
@@ -1,6 +1,6 @@
 # LoopOver Miner UI
 
-Local, read-only dashboard shell for a laptop or fleet miner instance. It mirrors the main
+Local, read-only dashboard for a laptop or fleet miner instance. It mirrors the main
 `apps/loopover-ui/` tooling versions (React 19, TanStack Router, Vite, Tailwind v4) but intentionally
 does **not** adopt that app's Cloudflare Worker deploy model or `@lovable.dev/*` scaffold dependency.
 
@@ -8,7 +8,8 @@ The miner package invariant is client-side only with no required phone-home to b
 (`packages/loopover-miner/DEPLOYMENT.md`). This app is a plain Vite dev server / static build that a
 local miner CLI can serve later — not a Wrangler deploy target.
 
-Phase 6 data views (run history, portfolio cards) land in follow-up issues after this empty shell.
+The Phase 6 data views have shipped: an overview summary (`routes/index.tsx`, #4853) alongside dedicated
+run-history, portfolio, and ledgers views, each fed by the local read-only `/api/*` endpoints below.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Closes #6188

- `apps/loopover-miner-ui/README.md` claimed the Phase 6 data views "land in follow-up issues after this empty shell". They already shipped, so a new contributor reading it would think the dashboard is still a placeholder.
- Verified against `main` before editing: `src/routes/run-history.tsx`, `portfolio.tsx` and `ledgers.tsx` all exist and are implemented, and `src/routes/index.tsx:12-17` documents that `#4853` "replaces the Phase-6 placeholder with a live, at-a-glance summary".
- Also drops "shell" from the opening line, which carried the same stale "empty placeholder" implication — the issue asks for the similarly-stale language nearby in the same file, not just line 11.
- Doc-only: **1 file, +3/-2, no code changes.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Confirmed the README's claim is actually stale by checking the referenced files on `main` rather than trusting the issue text: the three view routes exist and `index.tsx` documents the placeholder's replacement.
- `npx prettier --check apps/loopover-miner-ui/README.md` passes after the edit.
- This is a Markdown-only diff with no executable code, so there is nothing for `codecov/patch` to measure and no behavior to test. No source, API, or UI-component surface is touched; leaving the remaining suites to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No rendered UI changes — this only corrects prose in a README. `CHANGELOG.md` is untouched.

## Notes

Closes #6188
