### PR TITLE
feat(mcp): expose the maintain CLI controls as local stdio tools (#6152)

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -173,6 +173,32 @@ const skippedPrAuditShape = {
   limit: z.number().int().positive().optional(),
 };
 
+// #6152 — stdio counterparts of the `maintain` CLI subcommands (queue/approve/reject/pause/resume/
+// set-level/precision), so an agent on the local MCP server can drive the same maintainer controls
+// without shelling out. Each is backed by the exact REST endpoint its CLI subcommand already calls.
+const decidePendingActionShape = {
+  ...ownerRepoShape,
+  id: z.string().min(1),
+  // The approval-queue route's decision verb is accept|reject (the CLI's approve|reject alias maps onto it).
+  decision: z.enum(["accept", "reject"]),
+};
+
+const setAgentPausedShape = {
+  ...ownerRepoShape,
+  paused: z.boolean(),
+};
+
+const setActionAutonomyShape = {
+  ...ownerRepoShape,
+  action: z.enum(MAINTAIN_ACTION_CLASSES),
+  level: z.enum(MAINTAIN_AUTONOMY_LEVELS),
+};
+
+const gatePrecisionShape = {
+  ...ownerRepoShape,
+  windowDays: z.number().int().positive().optional(),
+};
+
 const loginShape = {
   login: z.string().min(1),
 };
@@ -601,6 +627,26 @@ const STDIO_TOOL_DESCRIPTORS = [
   {
     name: "loopover_get_skipped_pr_audit",
     description: "Return the skipped-PR audit trail: pull requests LoopOver's automated reviewer intentionally stayed quiet on, each with a reason code and a remediation hint. Optionally filter by repoFullName, reason, or since. Maintainer-authenticated; read-only measurement, not a moderation or override action.",
+  },
+  {
+    name: "loopover_list_pending_actions",
+    description: "List the agent actions staged in a repo's approval queue awaiting a maintainer decision (id, action class, target, reason) — the stdio counterpart of `loopover-mcp maintain queue`. Maintainer-authenticated.",
+  },
+  {
+    name: "loopover_decide_pending_action",
+    description: "Accept (execute) or reject a staged approval-queue action by id — the stdio counterpart of `loopover-mcp maintain approve|reject <id>`. Accept runs it through the live executor; reject cancels it. Repo-scoped; a guessed id from another repo's queue cannot be decided. Maintainer access required.",
+  },
+  {
+    name: "loopover_set_agent_paused",
+    description: "Pause or resume ALL agent actions on a repo (the kill-switch toggle) — the stdio counterpart of `loopover-mcp maintain pause|resume`. Maintainer access required.",
+  },
+  {
+    name: "loopover_set_action_autonomy",
+    description: "Set the autonomy level for one action class via a read-merge-write so the other classes are left untouched — the stdio counterpart of `loopover-mcp maintain set-level <action> <level>`. Maintainer access required.",
+  },
+  {
+    name: "loopover_get_gate_precision",
+    description: "Return per-gate-type false-positive telemetry for a repo's recorded gate blocks (blocked / blocked-then-merged counts and false-positive rates, with low-sample guards) — the stdio counterpart of `loopover-mcp maintain precision`. Optionally bound the ledger with windowDays. Maintainer-authenticated; read-only measurement.",
   },
 ];
 
@@ -1342,6 +1388,75 @@ registerStdioTool(
       "LoopOver feasibility gate.",
       buildFeasibilityVerdict({ claimStatus: ledgerClaimStatus ?? claimStatus, duplicateClusterRisk, issueStatus, found }),
     );
+  },
+);
+
+// #6152 maintainer controls, stdio side — thin proxies over the SAME REST endpoints the `maintain` CLI
+// subcommands already call (maintainCli, below), so an agent on the local server can run the queue /
+// kill-switch / autonomy / precision maintainer actions without shelling out. The API enforces maintainer
+// authorization; these never decide locally. The remote server mirrors the same five as MCP tools.
+registerStdioTool(
+  "loopover_list_pending_actions",
+  {
+    description: stdioToolDescription("loopover_list_pending_actions"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }) => {
+    const queueBase = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/agent/pending-actions`;
+    return toolResult(`LoopOver agent approval queue for ${owner}/${repo}.`, await apiGet(queueBase));
+  },
+);
+
+registerStdioTool(
+  "loopover_decide_pending_action",
+  {
+    description: stdioToolDescription("loopover_decide_pending_action"),
+    inputSchema: decidePendingActionShape,
+  },
+  async ({ owner, repo, id, decision }) => {
+    const queueBase = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/agent/pending-actions`;
+    return toolResult(`LoopOver approval-queue decision for ${owner}/${repo}.`, await apiPost(`${queueBase}/${encodeURIComponent(id)}/${decision}`, {}));
+  },
+);
+
+registerStdioTool(
+  "loopover_set_agent_paused",
+  {
+    description: stdioToolDescription("loopover_set_agent_paused"),
+    inputSchema: setAgentPausedShape,
+  },
+  async ({ owner, repo, paused }) => {
+    const repoBase = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    return toolResult(`LoopOver agent actions ${paused ? "paused" : "resumed"} for ${owner}/${repo}.`, await apiFetch(`${repoBase}/settings`, { method: "PUT", body: JSON.stringify({ agentPaused: paused }) }));
+  },
+);
+
+registerStdioTool(
+  "loopover_set_action_autonomy",
+  {
+    description: stdioToolDescription("loopover_set_action_autonomy"),
+    inputSchema: setActionAutonomyShape,
+  },
+  async ({ owner, repo, action, level }) => {
+    const repoBase = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    // Read-merge-write so setting one action class never clears the others (mirrors maintainCli's set-level).
+    const current = await apiGet(`${repoBase}/settings`);
+    const autonomy = { ...(current.autonomy ?? {}), [action]: level };
+    return toolResult(`LoopOver set ${action} autonomy to ${level} for ${owner}/${repo}.`, await apiFetch(`${repoBase}/settings`, { method: "PUT", body: JSON.stringify({ autonomy }) }));
+  },
+);
+
+registerStdioTool(
+  "loopover_get_gate_precision",
+  {
+    description: stdioToolDescription("loopover_get_gate_precision"),
+    inputSchema: gatePrecisionShape,
+  },
+  async ({ owner, repo, windowDays }) => {
+    const repoBase = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    // A non-positive/absent window falls through to full history server-side, same as the CLI's ?windowDays.
+    const query = windowDays ? `?windowDays=${encodeURIComponent(windowDays)}` : "";
+    return toolResult(`LoopOver gate precision for ${owner}/${repo}.`, await apiGet(`${repoBase}/gate-precision${query}`));
   },
 );
 

--- a/test/unit/mcp-cli-maintain-tools.test.ts
+++ b/test/unit/mcp-cli-maintain-tools.test.ts
@@ -1,0 +1,197 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import type { IncomingMessage } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #6152 — the five `maintain` CLI subcommands (queue/approve/reject/pause/resume/set-level/precision)
+// exposed as stdio MCP tools. Each tool is a thin proxy over the exact REST endpoint its CLI counterpart
+// already calls, so these tests assert the proxied URL/method/body as well as the returned payload.
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+const FORBIDDEN_PUBLIC_TERMS = /wallet\s*[:=]\s*\S+|hotkey\s*[:=]\s*\S+|coldkey\s*[:=]\s*\S+|raw trust score is|your trust score|reward estimate is|estimated reward/i;
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+let apiUrl: string;
+let capturedRequests: Array<{ url: string; method: string; body: string }>;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-maintain-tools-"));
+  capturedRequests = [];
+  apiUrl = await startFixtureServer({
+    onApiRequest: (request: IncomingMessage) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        capturedRequests.push({
+          url: request.url ?? "",
+          method: request.method ?? "GET",
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+      });
+    },
+  });
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...process.env,
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_API_TIMEOUT_MS: "5000",
+    },
+  });
+  client = new Client({ name: "maintain-tools-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+async function disconnect() {
+  await client.close().catch(() => undefined);
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+}
+
+function maintainRequests() {
+  return capturedRequests.filter((request) => request.url.startsWith("/v1/repos/"));
+}
+
+describe("loopover-mcp maintain stdio tools (#6152)", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("registers all five maintainer tools in the stdio tool list", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((tool) => tool.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "loopover_list_pending_actions",
+        "loopover_decide_pending_action",
+        "loopover_set_agent_paused",
+        "loopover_set_action_autonomy",
+        "loopover_get_gate_precision",
+      ]),
+    );
+  });
+
+  describe("loopover_list_pending_actions", () => {
+    it("lists the approval queue via GET /agent/pending-actions", async () => {
+      const result = await client.callTool({ name: "loopover_list_pending_actions", arguments: { owner: "owner", repo: "repo" } });
+      expect(result.isError).toBeFalsy();
+      const data = result.structuredContent as { repoFullName: string; pendingActions: Array<{ id: string; actionClass: string; pullNumber: number }> };
+      expect(data.pendingActions).toEqual([expect.objectContaining({ id: "pa-1", actionClass: "merge", pullNumber: 7 })]);
+      expect(JSON.stringify(result)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+      const [captured] = maintainRequests();
+      expect(captured).toMatchObject({ url: "/v1/repos/owner/repo/agent/pending-actions", method: "GET" });
+    });
+
+    it("surfaces a REST error as a tool error (unknown repo → 404)", async () => {
+      const result = await client.callTool({ name: "loopover_list_pending_actions", arguments: { owner: "ghost", repo: "missing" } });
+      expect(result.isError).toBeTruthy();
+      expect(JSON.stringify(result.content)).toMatch(/404/);
+    });
+  });
+
+  describe("loopover_decide_pending_action", () => {
+    it("accepts a staged action via POST /agent/pending-actions/:id/accept", async () => {
+      const result = await client.callTool({ name: "loopover_decide_pending_action", arguments: { owner: "owner", repo: "repo", id: "pa-1", decision: "accept" } });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({ status: "accepted", executionOutcome: "completed" });
+      const [captured] = maintainRequests();
+      expect(captured).toMatchObject({ url: "/v1/repos/owner/repo/agent/pending-actions/pa-1/accept", method: "POST" });
+    });
+
+    it("rejects a staged action via POST /agent/pending-actions/:id/reject", async () => {
+      const result = await client.callTool({ name: "loopover_decide_pending_action", arguments: { owner: "owner", repo: "repo", id: "pa-1", decision: "reject" } });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({ status: "rejected" });
+      expect(maintainRequests()[0]!.url).toBe("/v1/repos/owner/repo/agent/pending-actions/pa-1/reject");
+    });
+
+    it("rejects an out-of-enum decision before any request is made", async () => {
+      const result = await client.callTool({ name: "loopover_decide_pending_action", arguments: { owner: "owner", repo: "repo", id: "pa-1", decision: "maybe" } });
+      expect(result.isError).toBeTruthy();
+      expect(maintainRequests()).toHaveLength(0);
+    });
+  });
+
+  describe("loopover_set_agent_paused", () => {
+    it("pauses the repo via PUT /settings with agentPaused:true", async () => {
+      const result = await client.callTool({ name: "loopover_set_agent_paused", arguments: { owner: "owner", repo: "repo", paused: true } });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({ repoFullName: "owner/repo", agentPaused: true });
+      const captured = maintainRequests()[0]!;
+      expect(captured).toMatchObject({ url: "/v1/repos/owner/repo/settings", method: "PUT" });
+      expect(JSON.parse(captured.body)).toEqual({ agentPaused: true });
+    });
+
+    it("resumes the repo via PUT /settings with agentPaused:false", async () => {
+      const result = await client.callTool({ name: "loopover_set_agent_paused", arguments: { owner: "owner", repo: "repo", paused: false } });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({ agentPaused: false });
+      expect(JSON.parse(maintainRequests()[0]!.body)).toEqual({ agentPaused: false });
+    });
+
+    it("surfaces a REST error as a tool error (unknown repo → 404)", async () => {
+      const result = await client.callTool({ name: "loopover_set_agent_paused", arguments: { owner: "ghost", repo: "missing", paused: true } });
+      expect(result.isError).toBeTruthy();
+      expect(JSON.stringify(result.content)).toMatch(/404/);
+    });
+  });
+
+  describe("loopover_set_action_autonomy", () => {
+    it("read-merge-writes one action class, preserving the others", async () => {
+      const result = await client.callTool({ name: "loopover_set_action_autonomy", arguments: { owner: "owner", repo: "repo", action: "merge", level: "auto_with_approval" } });
+      expect(result.isError).toBeFalsy();
+      // The fixture echoes the PUT body's autonomy map back, so the merged shape is observable.
+      expect(result.structuredContent).toMatchObject({ autonomy: { label: "auto", merge: "auto_with_approval" } });
+      const requests = maintainRequests();
+      // Read (GET) then write (PUT) against the same settings endpoint.
+      expect(requests[0]).toMatchObject({ url: "/v1/repos/owner/repo/settings", method: "GET" });
+      expect(requests[1]).toMatchObject({ url: "/v1/repos/owner/repo/settings", method: "PUT" });
+      expect(JSON.parse(requests[1]!.body)).toEqual({ autonomy: { label: "auto", merge: "auto_with_approval" } });
+    });
+
+    it("rejects an out-of-enum action/level before writing anything", async () => {
+      const result = await client.callTool({ name: "loopover_set_action_autonomy", arguments: { owner: "owner", repo: "repo", action: "bogus", level: "auto" } });
+      expect(result.isError).toBeTruthy();
+      expect(maintainRequests()).toHaveLength(0);
+    });
+
+    it("surfaces a REST error as a tool error (unknown repo → 404 on the read)", async () => {
+      const result = await client.callTool({ name: "loopover_set_action_autonomy", arguments: { owner: "ghost", repo: "missing", action: "merge", level: "auto" } });
+      expect(result.isError).toBeTruthy();
+      // Fails on the read, so the write never happens.
+      expect(maintainRequests().every((request) => request.method === "GET")).toBe(true);
+    });
+  });
+
+  describe("loopover_get_gate_precision", () => {
+    it("reads gate precision via GET /gate-precision (full history by default)", async () => {
+      const result = await client.callTool({ name: "loopover_get_gate_precision", arguments: { owner: "owner", repo: "repo" } });
+      expect(result.isError).toBeFalsy();
+      const data = result.structuredContent as { overall: { blocked: number; falsePositiveRate: number }; windowDays: number | null };
+      expect(data.overall).toMatchObject({ blocked: 11, falsePositiveRate: 0.182 });
+      expect(data.windowDays).toBeNull();
+      const [captured] = maintainRequests();
+      expect(captured).toMatchObject({ url: "/v1/repos/owner/repo/gate-precision", method: "GET" });
+    });
+
+    it("passes windowDays through as the ?windowDays query", async () => {
+      const result = await client.callTool({ name: "loopover_get_gate_precision", arguments: { owner: "owner", repo: "repo", windowDays: 30 } });
+      expect(result.isError).toBeFalsy();
+      expect((result.structuredContent as { windowDays: number | null }).windowDays).toBe(30);
+      expect(maintainRequests()[0]!.url).toBe("/v1/repos/owner/repo/gate-precision?windowDays=30");
+    });
+
+    it("surfaces a REST error as a tool error (unknown repo → 404)", async () => {
+      const result = await client.callTool({ name: "loopover_get_gate_precision", arguments: { owner: "ghost", repo: "missing" } });
+      expect(result.isError).toBeTruthy();
+      expect(JSON.stringify(result.content)).toMatch(/404/);
+    });
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -1,5 +1,5 @@
 // #4777: retire every gittensory_-prefixed deprecated alias that #4775 left in place for one
-// minor-version deprecation cycle. This suite pins the post-retirement shape: exactly the 41
+// minor-version deprecation cycle. This suite pins the post-retirement shape: exactly the 46
 // canonical loopover_-prefixed stdio tools are registered, none of their old gittensory_-prefixed
 // alias names resolve anymore, no description carries a stale deprecation notice, and the CLI's
 // `tools --json` listing stays in lockstep with what the live server actually registers.
@@ -46,14 +46,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 41 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 46 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(41);
+    expect(primary.length).toBe(46);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(41);
+    expect(names.length).toBe(46);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -63,11 +63,11 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 41-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 46-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(41);
+    expect(payload.count).toBe(46);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual([...tools.map((t) => t.name)].sort());
   });
 });


### PR DESCRIPTION
## Summary

- The `maintain` CLI subcommands in `packages/loopover-mcp/bin/loopover-mcp.js` (`queue`/`approve`/`reject`/`pause`/`resume`/`set-level`/`precision`) hit real REST endpoints but had no counterpart on the **local stdio** MCP server — only the remote server (`src/mcp/server.ts`) mirrored them. An agent on the local server had to shell out to the CLI to run any maintainer control.
- Registers the five missing local stdio tools, each a thin proxy over the exact REST endpoint its CLI subcommand already calls (reusing the shared `apiGet`/`apiPost`/`apiFetch` client, no duplicated HTTP logic):
  - `loopover_list_pending_actions` → `GET /v1/repos/:owner/:repo/agent/pending-actions` (same as `maintain queue`).
  - `loopover_decide_pending_action` → `POST /v1/repos/:owner/:repo/agent/pending-actions/:id/:decision` (same as `maintain approve|reject`).
  - `loopover_set_agent_paused` → `PUT /v1/repos/:owner/:repo/settings` with `agentPaused` (same as `maintain pause|resume`).
  - `loopover_set_action_autonomy` → read-merge-write over `/settings` (same as `maintain set-level`).
  - `loopover_get_gate_precision` → `GET /v1/repos/:owner/:repo/gate-precision` (same as `maintain precision`).
- The remote server and the existing CLI subcommands are unchanged.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — see `Closes #6152`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run command-reference:check` / `npm run docs:drift-check` / `npm run manifest:drift-check`
- [x] `npx vitest run test/unit/mcp-cli-maintain-tools.test.ts` (15 tests) + the full `test/unit/mcp*` suite (477 tests) green
- [x] New behavior has unit tests: each new tool has success and failure-path coverage, plus an out-of-enum-rejects-before-any-request case for the two enum-validated tools

Not applicable: `ui:*` checks (no UI change); Codecov `patch` does not measure `packages/loopover-mcp/**` (coverage is collected over `src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**` per `codecov.yml`/`vitest.config.ts`).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, or private rankings are exposed. The tools proxy the same maintainer-authorized endpoints the CLI uses; the API enforces authorization and the tools never decide locally.
- [x] Public text stays sanitized and low-noise; a test asserts the queue payload carries none of the forbidden public terms.
- [x] MCP behavior is updated and tested (the tool-count discovery invariant in `mcp-tool-rename-aliases.test.ts` is updated from 41 to 46).

## Notes

- `loopover_set_action_autonomy` validates `action`/`level` against the CLI's own `MAINTAIN_ACTION_CLASSES`/`MAINTAIN_AUTONOMY_LEVELS` constants, keeping the tool in lockstep with the `maintain set-level` subcommand it exposes.
