### PR TITLE
fix(miner): exit 2, not 1, on a secret-mount failure

### DIFF
--- a/packages/loopover-miner/bin/loopover-miner.js
+++ b/packages/loopover-miner/bin/loopover-miner.js
@@ -38,11 +38,13 @@ import { resolveMinerVersion } from "../lib/version.js";
 // deeper in the call graph) reads plain env vars, so this single early pass is all that's needed for the whole
 // CLI (#5178). A broken secret mount fails the process fast and loud with a clear message, instead of an
 // uncaught-exception stack trace or a silent empty credential surfacing as a confusing GitHub 401 later.
+// Exits 2, not 1: docs/unattended-scheduling.md's contract only defines 0 (success) and 2 (failure -- "Alert
+// on this"), so an operator alerting strictly on 2 would otherwise miss a broken secret mount entirely.
 try {
   loadMinerFileSecrets();
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exit(2);
 }
 
 // Opt-in Sentry (#6011): a complete no-op unless the operator sets LOOPOVER_MINER_SENTRY_DSN themselves. Must

--- a/test/unit/miner-env-file-indirection.test.ts
+++ b/test/unit/miner-env-file-indirection.test.ts
@@ -149,7 +149,10 @@ describe("loadMinerFileSecrets (#5178)", () => {
       expect(result.stderr).not.toContain("ghp_end_to_end_value");
     });
 
-    it("fails the process fast with a clear error when GITHUB_TOKEN_FILE points at a missing file", () => {
+    // #6162: exit code 2, not 1 -- docs/unattended-scheduling.md's contract only defines 0 (success) and 2
+    // (failure -- "Alert on this"), so an operator wiring alerting strictly to 2 must catch a broken secret
+    // mount like this one.
+    it("fails the process fast with a clear error and the documented failure exit code when GITHUB_TOKEN_FILE points at a missing file", () => {
       const result = spawnSync("node", [bin, "status"], {
         encoding: "utf8",
         env: {
@@ -159,7 +162,8 @@ describe("loadMinerFileSecrets (#5178)", () => {
         },
       });
 
-      expect(result.status).toBe(1);
+      expect(result.status).toBe(2);
+      expect(result.status).not.toBe(1);
       expect(result.stderr).toContain("GITHUB_TOKEN_FILE");
       expect(result.stderr).toContain("/definitely/does/not/exist/github_token");
     });


### PR DESCRIPTION
## Summary

Closes #6162

- `bin/loopover-miner.js`'s `loadMinerFileSecrets()` catch called `process.exit(1)`, but `packages/loopover-miner/docs/unattended-scheduling.md:15-18`'s exit-code contract only defines `0` (success) and `2` (failure — "**Alert on this**"). An operator who wires alerting strictly to exit code `2`, exactly as that doc instructs, silently missed a real, reachable failure: a broken `GITHUB_TOKEN_FILE` secret mount.
- Now exits `2`, so the documented alerting catches it.
- **Checked every other exit in the same file** as the issue asks: this catch was the only hardcoded `exit(1)`. Every other `process.exit` passes a subcommand's own resolved code (or `0`), so there is no second miscoded startup path to fix.
- `lib/env-file-indirection.js` is deliberately **untouched** — its throw is correct; only the CLI-boundary translation was wrong.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The changed line is covered by an existing end-to-end test that **spawns the real bin** against a missing `GITHUB_TOKEN_FILE`. That test pinned the old `status === 1`, so it is updated to assert the documented `2` (plus an explicit `not.toBe(1)` regression guard). This is the test the issue's deliverable asks for; a second one asserting the same spawn would be redundant.
- Ran the affected suites with vitest, all green: `miner-env-file-indirection` (**13 tests**, includes the real-bin spawn), plus `miner-package-skeleton` and `check-miner-package` (**18 tests**) as the other bin/package consumers.
- No UI/MCP/worker surface is touched; leaving those suites to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The failure path is a credential-mount error: the test asserts the error names the offending var and its path, and no secret value is ever printed. This only changes the process exit code, not what is emitted.

## Notes

Closes #6162
