### PR TITLE
fix(miner): exit 2 (not 1) on a secret-mount failure to match the documented 0/2 exit-code contract

### DIFF
--- a/packages/loopover-miner/bin/loopover-miner.js
+++ b/packages/loopover-miner/bin/loopover-miner.js
@@ -42,7 +42,10 @@ try {
   loadMinerFileSecrets();
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  // Exit 2, not 1: a broken secret mount is a real startup failure, and docs/unattended-scheduling.md's
+  // exit-code contract is 0 (success) / 2 (failure — "Alert on this"). Exiting 1 here would slip past an
+  // operator whose alerting keys strictly on exit code 2 (#6162).
+  process.exit(2);
 }
 
 // Opt-in Sentry (#6011): a complete no-op unless the operator sets LOOPOVER_MINER_SENTRY_DSN themselves. Must

--- a/test/unit/miner-env-file-indirection.test.ts
+++ b/test/unit/miner-env-file-indirection.test.ts
@@ -149,7 +149,7 @@ describe("loadMinerFileSecrets (#5178)", () => {
       expect(result.stderr).not.toContain("ghp_end_to_end_value");
     });
 
-    it("fails the process fast with a clear error when GITHUB_TOKEN_FILE points at a missing file", () => {
+    it("fails the process fast with the documented failure exit code (2) when GITHUB_TOKEN_FILE points at a missing file (#6162)", () => {
       const result = spawnSync("node", [bin, "status"], {
         encoding: "utf8",
         env: {
@@ -159,7 +159,8 @@ describe("loadMinerFileSecrets (#5178)", () => {
         },
       });
 
-      expect(result.status).toBe(1);
+      // Exit 2 (not 1) so it matches docs/unattended-scheduling.md's 0/2 contract and an operator's exit-code-2 alerting.
+      expect(result.status).toBe(2);
       expect(result.stderr).toContain("GITHUB_TOKEN_FILE");
       expect(result.stderr).toContain("/definitely/does/not/exist/github_token");
     });


### PR DESCRIPTION
## Summary

`bin/loopover-miner.js`'s `loadMinerFileSecrets()` catch block exited with code `1` on failure, but `docs/unattended-scheduling.md`'s documented exit-code contract is `0` (success) / `2` (failure -- "Alert on this"). An operator wiring alerting strictly to exit code `2` would miss a real, reachable startup failure -- a broken `GITHUB_TOKEN_FILE` (or any secret-mount) misconfiguration.

## Changes

- `bin/loopover-miner.js`: the secret-mount-failure catch now `process.exit(2)` (was `1`), matching the documented contract.
- This is the only literal `exit(1)` startup path in the file (all other exits are `0`, a command's own return code, or `exitCode`), so no other path needed the same fix.
- `lib/env-file-indirection.js`'s `loadMinerFileSecrets` throw behavior is unchanged -- only the exit-code translation at the CLI boundary.

## Validation

- [x] `node --check bin/loopover-miner.js`; `npm run typecheck`.
- [x] Updated the existing CLI regression test (`test/unit/miner-env-file-indirection.test.ts`) that spawns the real bin with a missing `GITHUB_TOKEN_FILE` to assert exit code `2` (was `1`) -- 13 passed.
- [x] `git diff --check` clean; rebased onto latest `main`, mergeable-clean.

## Safety

- [x] No secrets/private terms. The failing path already redacts the secret value; only the exit code changed.

Closes #6162