### PR TITLE
fix(miner): wrap pr-disposition-poller GitHub calls in fetchWithRetry (#4829)

### DIFF
--- a/packages/loopover-miner/lib/pr-disposition-poller.js
+++ b/packages/loopover-miner/lib/pr-disposition-poller.js
@@ -11,6 +11,8 @@
 // "open" means "wait for a human to actually merge or close the PR", a potentially much longer, unbounded
 // wait) -- composing them into one poller would conflate two different backoff/timeout policies.
 
+import { fetchWithRetry } from "./http-retry.js";
+
 const defaultApiBaseUrl = "https://api.github.com";
 const defaultMinIntervalMs = 60_000;
 const defaultMaxIntervalMs = 5 * 60_000;
@@ -97,13 +99,16 @@ function githubError(response, payload) {
 }
 
 async function fetchPullRequest(target, prNumber, options) {
-  // Bounded so a stalled connection can't hang a poll cycle forever (#miner-github-read-timeouts) -- a fresh
-  // AbortSignal.timeout() per call, matching ci-poller.js's sibling fetchWithRetry treatment.
-  const response = await options.fetchFn(apiUrl(options.apiBaseUrl, repoPath(target, `/pulls/${prNumber}`)), {
-    method: "GET",
-    headers: githubHeaders(options.githubToken),
-    signal: AbortSignal.timeout(options.requestTimeoutMs),
-  });
+  // Retry transient network errors / 5xx around this single call (#4829), matching ci-poller.js's
+  // githubGetJsonResponse -- distinct from this poller's OWN outer pending-retry loop. requestTimeoutMs bounds
+  // each individual attempt with a fresh AbortSignal.timeout() (a stalled connection can't hang a poll cycle
+  // forever -- #miner-github-read-timeouts); the injected sleepFn keeps the retry backoff instant in tests.
+  const response = await fetchWithRetry(
+    options.fetchFn,
+    apiUrl(options.apiBaseUrl, repoPath(target, `/pulls/${prNumber}`)),
+    { method: "GET", headers: githubHeaders(options.githubToken) },
+    { sleepFn: options.sleepFn, timeoutMs: options.requestTimeoutMs },
+  );
   const payload = await response.json().catch(() => null);
   if (!response.ok) throw githubError(response, payload);
   return payload;

--- a/test/unit/miner-pr-disposition-poller.test.ts
+++ b/test/unit/miner-pr-disposition-poller.test.ts
@@ -29,6 +29,24 @@ describe("PR disposition poller (#5135)", () => {
     expect((init?.headers as Record<string, string>).authorization).toBe("Bearer github-token");
   });
 
+  it("retries a transient 5xx from the GitHub API during a poll and completes (#4829)", async () => {
+    let attempts = 0;
+    const fetchFn = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) return jsonResponse({}, { status: 503 }); // a brief transient server error
+      return prResponse({ state: "closed", merged: true, closed_at: "2026-07-12T00:00:00Z" });
+    });
+
+    const result = await pollPrDisposition("acme/widgets", 42, {
+      apiBaseUrl: API,
+      fetchFn,
+      sleepFn: async () => {}, // keep the per-call retry backoff instant
+    });
+
+    expect(attempts).toBe(2); // the 503 was retried, then succeeded — not surfaced as an immediate failure
+    expect(result).toMatchObject({ state: "closed", merged: true });
+  });
+
   it("returns terminal merged disposition immediately, without further polling", async () => {
     const fetchFn = vi.fn(async () =>
       prResponse({ state: "closed", merged: true, closed_at: "2026-07-12T00:00:00Z" }),


### PR DESCRIPTION
## Summary

`packages/loopover-miner/lib/pr-disposition-poller.js`'s `fetchPullRequest` comment claimed its GitHub API calls used the `#4829` `fetchWithRetry` treatment "matching ci-poller.js", but it called `options.fetchFn` directly — `fetchWithRetry` was never imported or used in the file. A transient 5xx during PR-disposition polling was surfaced as an **immediate failure** instead of being retried the way CI-status polling (`ci-poller.js`'s `githubGetJsonResponse`) already is.

## Change

Wrap the call in `fetchWithRetry` with the same `{ sleepFn, timeoutMs }` wiring `ci-poller.js` uses. Its per-call retry is deliberately distinct from this poller's own outer backoff loop; `requestTimeoutMs` still bounds each attempt (via `fetchWithRetry`'s fresh `AbortSignal.timeout()` per attempt), and the injected `sleepFn` keeps the retry backoff instant in tests. `ci-poller.js` is unchanged — it's the reference.

## Tests

New regression test proves a transient `503` is retried (`fetchFn` called twice) and the poll completes with the terminal disposition instead of throwing, mirroring `ci-poller.js`'s own `#4829` retry test. Full `miner-pr-disposition-poller` (16) + `miner-ci-poller` (17) suites + `tsc` green.

Closes #6161