### PR TITLE
docs(mcp): clarify ambiguous loopover-mcp stdio tool descriptions for LLM selection

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -444,7 +444,7 @@ const agentRunIdShape = {
 const STDIO_TOOL_DESCRIPTORS = [
   {
     name: "loopover_get_repo_context",
-    description: "Return the canonical repo intelligence bundle from the private LoopOver API.",
+    description: "Return the LoopOver repo-context bundle for a repo — registration state, recommended contribution lane, queue health, duplicate-PR collisions, and config quality — from the private LoopOver API. Takes owner and repo.",
   },
   {
     name: "loopover_get_pr_reviewability",
@@ -496,7 +496,7 @@ const STDIO_TOOL_DESCRIPTORS = [
   },
   {
     name: "loopover_get_registry_changes",
-    description: "Return latest cached Gittensor registry change report.",
+    description: "Return the latest cached report of changes to the Gittensor repo registry — repositories added, removed, or re-registered upstream. Read-only; takes no parameters.",
   },
   {
     name: "loopover_get_upstream_drift",
@@ -522,11 +522,11 @@ const STDIO_TOOL_DESCRIPTORS = [
   },
   {
     name: "loopover_get_decision_pack",
-    description: "Return the canonical private contributor decision pack for a GitHub login.",
+    description: "Return the private decision pack for a contributor: the ranked repos and issues to work on next, with per-repo go/raise/avoid guidance. Takes login (the contributor's GitHub username).",
   },
   {
     name: "loopover_explain_repo_decision",
-    description: "Return the contributor/repo decision from the canonical decision pack.",
+    description: "Return the go/raise/avoid decision for one specific contributor-and-repo pair, drawn from that contributor's decision pack — narrower than loopover_get_decision_pack, which returns the whole pack. Takes login (GitHub username), owner, and repo.",
   },
   {
     name: "loopover_compare_pr_variants",
@@ -570,15 +570,15 @@ const STDIO_TOOL_DESCRIPTORS = [
   },
   {
     name: "loopover_agent_plan_next_work",
-    description: "Run the deterministic LoopOver base-agent planner for a GitHub login.",
+    description: "Run the deterministic LoopOver planner for a contributor and return the single recommended next unit of work (repo, issue, and action). Planning only — does not queue or start a run. Takes login (GitHub username); optional objective and repoFullName narrow the result.",
   },
   {
     name: "loopover_agent_start_run",
-    description: "Create a queued copilot-only LoopOver base-agent run.",
+    description: "Queue a new LoopOver automated-agent run for a contributor. Copilot mode only: it proposes and records work but takes no GitHub actions on its own. Takes objective (what to accomplish) and actorLogin (the contributor's GitHub username); returns the new run's id and status.",
   },
   {
     name: "loopover_agent_get_run",
-    description: "Fetch a persisted LoopOver base-agent run.",
+    description: "Fetch a previously queued LoopOver agent run by its id, including current status and planned actions. Takes runId (the id returned by loopover_agent_start_run).",
   },
   {
     name: "loopover_agent_explain_next_action",

--- a/test/unit/mcp-discovery.test.ts
+++ b/test/unit/mcp-discovery.test.ts
@@ -78,6 +78,34 @@ describe("MCP workspace root boundaries", () => {
   });
 });
 
+describe("MCP tool discovery", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("every tool exposes a non-empty description unique enough to disambiguate from its siblings", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+    // An LLM client picks a tool from its description text, so two tools sharing identical
+    // wording are indistinguishable and get mis-selected (#6245).
+    const owners = new Map<string, string>();
+    for (const tool of tools) {
+      const description = (tool.description ?? "").trim();
+      expect(description.length, `empty description for ${tool.name}`).toBeGreaterThan(0);
+      const clash = owners.get(description);
+      expect(clash, `${tool.name} duplicates the description of ${clash}`).toBeUndefined();
+      owners.set(description, tool.name);
+    }
+  });
+
+  it("tool descriptions do not expose forbidden public terms", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      const text = [tool.name, tool.description ?? ""].join(" ");
+      expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+    }
+  });
+});
+
 describe("MCP resource discovery", () => {
   beforeEach(connect);
   afterEach(disconnect);


### PR DESCRIPTION
## What

Audit of the `loopover-mcp` stdio tool descriptions (`packages/loopover-mcp/bin/loopover-mcp.js`,
`STDIO_TOOL_DESCRIPTORS`) for LLM tool-selectability, per #6245. An MCP/agent client picks a tool
almost entirely from its registered description, so a vague, jargon-heavy, or parameter-silent
description leads to the wrong tool being called — or a fitting tool never being discovered.

I reviewed all 42 stdio tool descriptions against the issue's three flags and rewrote the 7 that
failed one of them. The rest were already clear enough to disambiguate and left untouched.

## Flagged and rewritten

| Tool | Problem | Fix |
| --- | --- | --- |
| `loopover_get_repo_context` | "canonical repo intelligence bundle" is opaque — doesn't say what's in it or which repo | Spells out the contents (registration, lane, queue health, collisions, config quality) and names the `owner`/`repo` inputs |
| `loopover_get_registry_changes` | "registry change report" undefined; no hint what a change is | Explains it reports repos added/removed/re-registered upstream; notes it takes no parameters |
| `loopover_get_decision_pack` | "decision pack" is internal jargon; no contents; "GitHub login" unexplained | Describes the ranked repos/issues + go/raise/avoid guidance and clarifies `login` is the contributor's username |
| `loopover_explain_repo_decision` | circular ("decision pack" again); not disambiguated from `get_decision_pack`; missing `owner`/`repo` | States it's the per-repo slice, cross-references the broader tool, names all three inputs |
| `loopover_agent_plan_next_work` | "base-agent planner" jargon; output unspecified | Says it returns the single recommended next unit of work; planning-only; names `login` + optional inputs |
| `loopover_agent_start_run` | "copilot-only base-agent run" jargon; required inputs unstated | Explains copilot mode (no GitHub writes) and names `objective`/`actorLogin` + return value |
| `loopover_agent_get_run` | required `runId` not mentioned — an agent can't construct a valid call | Names `runId` and points to `loopover_agent_start_run` as its source |

Every new description names its real input parameters (verified against each tool's `inputSchema`)
and stays inside the existing public-safe boundary — no scores, rewards, or wallet/key terms.

## Scope

This covers the `loopover-mcp` stdio package. The hosted `src/mcp/server.ts` surface is the sibling
tool set and is a natural separate PR, per the issue's "split into a few PRs by tool category"
guidance.

## Tests

No behavior change (descriptions are metadata). Existing tool-registration tests don't hardcode the
old text, so none break. Added two invariant checks to `test/unit/mcp-discovery.test.ts` that list
the live tools over the MCP protocol and assert every description is non-empty and unique enough to
disambiguate (no two tools share identical wording) and that no tool description leaks a forbidden
public term — the same safety property already enforced for resources and prompts, now extended to
tools.

Verified locally: `typecheck`, targeted `vitest` (`mcp-discovery`, `mcp-cli-tools`, `mcp-cli-basics`,
`mcp-tool-rename-aliases`, `mcp-cli-packets`), `build:mcp`, `test:mcp-pack`, and the
command-reference/docs/manifest drift checks all pass.

Closes #6245
