### PR TITLE
feat(review): expose a repo's effective self-tuned gate thresholds via a read-only endpoint

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -264,7 +264,7 @@ import { buildMaintainerActivationPreview, recommendedAdvisoryActivationSettings
 import { buildRepoOutcomeCalibration } from "../services/outcome-calibration";
 import { loadGatePrecisionReport } from "../services/gate-precision";
 import { computeOpsStats, isOpsEnabled } from "../review/ops-wire";
-import { deleteLiveOverride, listOverrideAudit, sanitizeOverridePayload, type StorageEnv } from "../review/auto-apply";
+import { deleteLiveOverride, listOverrideAudit, loadOverride, loadShadowOverride, sanitizeOverridePayload, type StorageEnv } from "../review/auto-apply";
 import { handleInternalCalibration, handleInternalDecision, type OpsAgentConfig } from "../review/ops";
 import { computeParityReadiness, isParityAuditEnabled } from "../review/parity-wire";
 import { computePredictedGateAgreement } from "../review/predicted-gate-agreement";
@@ -2967,6 +2967,31 @@ export function createApp() {
     });
     await persistSignal(c.env, "pr-reviewability", `${fullName}#${number}`, fullName, reviewability as unknown as Record<string, JsonValue>, reviewability.generatedAt);
     return c.json(reviewability);
+  });
+
+  // Read-only view of a repo's CURRENT effective self-tuned gate thresholds (#6247, groundwork for #6209).
+  // Returns only the resolved effective values from auto-apply.ts's live override — never the raw
+  // override_audit history or the shadow's queued recommendation, just a flag that a shadow is soaking.
+  // Gated behind the same most-conservative repo-scoped read precedent the reviewability route (#6154) uses.
+  app.get("/v1/repos/:owner/:repo/gate-config/effective", async (c) => {
+    const unauthorized = await requireStaticProtectedApiToken(c);
+    if (unauthorized) return unauthorized;
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const identity = await authenticateRequestIdentity(c);
+    if (identity?.kind === "static" && identity.actor === "mcp" && !(await import("../auth/security")).isMcpReadRepoAllowed(c.env.MCP_READ_REPO_ALLOWLIST, fullName)) return c.json({ error: "forbidden_repo" }, 403);
+    const storageEnv = c.env as unknown as StorageEnv;
+    const [override, shadow] = await Promise.all([loadOverride(storageEnv, fullName), loadShadowOverride(storageEnv, fullName)]);
+    return c.json({
+      repoFullName: fullName,
+      effective: {
+        confidenceFloor: override?.confidenceFloor ?? null,
+        scopeCap: {
+          files: override?.scopeCap?.files ?? null,
+          lines: override?.scopeCap?.lines ?? null,
+        },
+      },
+      shadowPending: shadow !== null,
+    });
   });
 
   app.get("/v1/repos/:owner/:repo/outcome-patterns", async (c) => {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -43,6 +43,7 @@ import { BURDEN_FORECAST_MAX_AGE_MS } from "../../src/services/burden-forecast";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
+import { recordOverrideAudit, writeLiveOverride, writeShadowOverride, type StorageEnv } from "../../src/review/auto-apply";
 import { createTestEnv } from "../helpers/d1";
 import type { JsonValue } from "../../src/types";
 
@@ -6708,6 +6709,46 @@ describe("api routes", () => {
       ]),
     );
     expect(JSON.stringify(malformedPayload.policy.publicSafe)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
+  });
+
+  it("exposes only a repo's effective self-tuned gate thresholds, never the raw override audit trail (#6247)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    // No override yet → effective values are all null and no shadow is soaking.
+    const empty = await app.request("/v1/repos/entrius/allways-ui/gate-config/effective", { headers: apiHeaders(env) }, env);
+    expect(empty.status).toBe(200);
+    await expect(empty.json()).resolves.toEqual({
+      repoFullName: "entrius/allways-ui",
+      effective: { confidenceFloor: null, scopeCap: { files: null, lines: null } },
+      shadowPending: false,
+    });
+
+    // A live override surfaces as the resolved effective values; a soaking shadow shows only as a boolean
+    // flag (never its queued recommendation); and audit rows exist but must never surface in this read.
+    const storageEnv = env as unknown as StorageEnv;
+    await writeLiveOverride(storageEnv, "entrius/allways-ui", { confidenceFloor: 0.9, scopeCap: { files: 12, lines: 400 } });
+    await writeShadowOverride(storageEnv, "entrius/allways-ui", { confidenceFloor: 0.8 }, "2099-01-01T00:00:00.000Z");
+    await recordOverrideAudit(storageEnv, "entrius/allways-ui", "apply", { note: "audit-detail-must-never-surface" });
+    const populated = await app.request("/v1/repos/entrius/allways-ui/gate-config/effective", { headers: apiHeaders(env) }, env);
+    expect(populated.status).toBe(200);
+    const body = (await populated.json()) as unknown;
+    expect(body).toEqual({
+      repoFullName: "entrius/allways-ui",
+      effective: { confidenceFloor: 0.9, scopeCap: { files: 12, lines: 400 } },
+      shadowPending: true,
+    });
+    // Hard guarantee (the whole point of #6247): no audit-history / event / detail fields ever leak.
+    expect(JSON.stringify(body)).not.toMatch(/override_audit|event_type|audit-detail-must-never-surface|"detail"/i);
+
+    // The shared static mcp credential is scoped to MCP_READ_REPO_ALLOWLIST, same precedent as reviewability (#6154).
+    const forbiddenEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    const forbidden = await app.request("/v1/repos/entrius/allways-ui/gate-config/effective", { headers: mcpHeaders(forbiddenEnv) }, forbiddenEnv);
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    // Unauthenticated calls are rejected before any repo lookup.
+    const unauth = await app.request("/v1/repos/entrius/allways-ui/gate-config/effective", {}, env);
+    expect(unauth.status).toBe(401);
   });
 });
 


### PR DESCRIPTION
## Summary

Groundwork for #6209 (part of the #6206 AMS+ORB synergy epic): a read-only endpoint that returns a repo's CURRENT effective, self-tuned gate thresholds — the output of `src/review/auto-apply.ts`'s self-tune loop — with none of the raw override-audit history.

- **`GET /v1/repos/:owner/:repo/gate-config/effective`** returns only the resolved effective values from `loadOverride` (`confidenceFloor`, `scopeCap.files`, `scopeCap.lines`), plus a `shadowPending` boolean derived from `loadShadowOverride`. It never exposes the `override_audit` rows or the shadow's queued recommendation values.
- Gated behind this repo's most-conservative existing repo-scoped read precedent — the same `isMcpReadRepoAllowed` check the reviewability route (#6154) uses for the shared static `mcp` credential. Per the issue, #6209 may revisit the access model once its own design lands.
- Read-only; no writes.

## Tests

`test/integration/api.test.ts` covers: empty repo (all-null effective, `shadowPending: false`), a live override + soaking shadow + a planted `override_audit` row (asserts the exact effective shape AND that no audit/event/detail field ever leaks), `forbidden_repo` for a static mcp credential outside `MCP_READ_REPO_ALLOWLIST`, and an unauthenticated 401.

Closes #6247.