### PR TITLE
feat(mcp): register the 8 write-tools on the local stdio server

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -5,7 +5,17 @@ import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { buildFeasibilityVerdict } from "@loopover/engine";
+import {
+  buildApplyLabelsSpec,
+  buildCreateBranchSpec,
+  buildDeleteBranchSpec,
+  buildFeasibilityVerdict,
+  buildFileIssueSpec,
+  buildFollowUpIssueSpec,
+  buildOpenPrSpec,
+  buildPostEligibilityCommentSpec,
+  buildTestGenSpec,
+} from "@loopover/engine";
 import { z } from "zod";
 import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 import { formatTable } from "../lib/format-table.js";
@@ -611,6 +621,45 @@ const STDIO_TOOL_DESCRIPTORS = [
   {
     name: "loopover_get_skipped_pr_audit",
     description: "Return the skipped-PR audit trail: pull requests LoopOver's automated reviewer intentionally stayed quiet on, each with a reason code and a remediation hint. Optionally filter by repoFullName, reason, or since. Maintainer-authenticated; read-only measurement, not a moderation or override action.",
+  },
+  // #780 miner write-tools (#6149): the hosted server has registered these since #780, and this file's own
+  // AGENT_PROFILES["miner-auto-dev"].recommendedTools has promised six of them all along — but none were
+  // registered here, so the profile recommended tools the local server could not run. Each builds a
+  // LOCAL-EXECUTION action spec from @loopover/engine's shared builders and returns it; LoopOver never performs
+  // the write, and (unlike every read tool above) these need no API call or token at all.
+  {
+    name: "loopover_open_pr",
+    description: "Build a LOCAL-execution spec to open a pull request from your branch (run it with your own gh creds; loopover never performs the write).",
+  },
+  {
+    name: "loopover_file_issue",
+    description: "Build a LOCAL-execution spec to file an issue (run it with your own gh creds; loopover never performs the write).",
+  },
+  {
+    name: "loopover_apply_labels",
+    description: "Build a LOCAL-execution spec to add labels to an issue or PR (run it with your own gh creds; loopover never performs the write).",
+  },
+  {
+    name: "loopover_post_eligibility_comment",
+    description: "Build a LOCAL-execution spec to post an eligibility/context comment on an issue or PR (run it with your own gh creds; loopover never performs the write).",
+  },
+  {
+    name: "loopover_create_branch",
+    description: "Build a LOCAL-execution spec to create a branch (run it locally; loopover never performs the write).",
+  },
+  {
+    name: "loopover_delete_branch",
+    description: "Build a LOCAL-execution spec to delete a branch (run it locally; loopover never performs the write).",
+  },
+  {
+    name: "loopover_generate_tests",
+    description:
+      "Build a LOCAL-execution spec describing WHAT boundary-safe test cases should exist for the given target files, using the repo's detected framework/convention (see loopover's test-evidence signal). LoopOver supplies the criteria; your OWN agent scaffolds and runs the actual test files locally — no source code is uploaded and loopover never performs the write.",
+  },
+  {
+    name: "loopover_file_follow_up_issue",
+    description:
+      "Build a LOCAL-execution spec to file a follow-up issue for a review finding a maintainer wants TRACKED rather than blocked on this PR. Composes a bounded, public-safe title/body from the finding (run it with your own gh creds; loopover never performs the write).",
   },
 ];
 
@@ -1366,6 +1415,100 @@ registerStdioTool(
     );
   },
 );
+
+// ── #780 miner write-tools (#6149) ────────────────────────────────────────────
+// Local parity with the hosted server's own write-tools. Every one is a PURE spec builder from
+// @loopover/engine: input in, an action spec out, describing a command the CONTRIBUTOR runs with their own
+// creds. Nothing here calls the LoopOver API, needs a token, or performs a write — which is why these are the
+// only tools in this file with no apiGet/apiPost and no auth requirement.
+//
+// The shapes below mirror src/mcp/server.ts's own, bound-for-bound, so a caller cannot get a spec out of the
+// local server that the hosted one would have rejected. The bounds live here rather than in the engine because
+// they are the hosted server's request-validation contract, not the builders' own (the builders take plain
+// strings); duplicating the NUMBERS is deliberate and matches how this file already mirrors other remote shapes.
+const WRITE_TOOL_REPO_FULL_NAME_MAX = 200;
+const WRITE_TOOL_BRANCH_REF_MAX = 255;
+const WRITE_TOOL_TITLE_MAX = 400;
+const WRITE_TOOL_BODY_MAX = 60000;
+const WRITE_TOOL_BRANCH_MAX = 255;
+const WRITE_TOOL_TARGET_FILES_MAX = 50;
+
+const writeToolRepoFullName = z.string().min(3).max(WRITE_TOOL_REPO_FULL_NAME_MAX);
+const writeToolLabels = z.array(z.string().min(1).max(100));
+
+const openPrShape = {
+  repoFullName: writeToolRepoFullName,
+  base: z.string().min(1).max(WRITE_TOOL_BRANCH_REF_MAX),
+  head: z.string().min(1).max(WRITE_TOOL_BRANCH_REF_MAX),
+  title: z.string().min(1).max(WRITE_TOOL_TITLE_MAX),
+  body: z.string().max(WRITE_TOOL_BODY_MAX),
+  draft: z.boolean().optional(),
+};
+const fileIssueShape = {
+  repoFullName: writeToolRepoFullName,
+  title: z.string().min(1).max(WRITE_TOOL_TITLE_MAX),
+  body: z.string().max(WRITE_TOOL_BODY_MAX),
+  labels: writeToolLabels.max(20).optional(),
+};
+const applyLabelsShape = {
+  repoFullName: writeToolRepoFullName,
+  number: z.number().int().positive(),
+  labels: writeToolLabels.min(1).max(20),
+};
+const postEligibilityCommentShape = {
+  repoFullName: writeToolRepoFullName,
+  number: z.number().int().positive(),
+  body: z.string().min(1).max(WRITE_TOOL_BODY_MAX),
+};
+const createBranchShape = {
+  branch: z.string().min(1).max(WRITE_TOOL_BRANCH_MAX),
+  base: z.string().min(1).max(WRITE_TOOL_BRANCH_MAX).optional(),
+};
+const deleteBranchShape = {
+  branch: z.string().min(1).max(WRITE_TOOL_BRANCH_MAX),
+  remote: z.boolean().optional(),
+};
+// Mirrors the engine's TEST_FRAMEWORKS (signals/test-evidence.ts) so a caller cannot request a spec for a
+// framework detectTestConvention could never have produced — the same guard the hosted server applies via
+// z.enum(TEST_FRAMEWORKS). It is duplicated rather than imported because this package depends on the PUBLISHED
+// @loopover/engine ^1.0.0, which predates that export; importing it would break the installed server. The
+// duplication is pinned by test/unit/mcp-cli-write-tools.test.ts, which asserts this list still equals the
+// engine's own — so the two cannot drift silently, and this can collapse to an import once the dep is bumped.
+const WRITE_TOOL_TEST_FRAMEWORKS = ["vitest", "jest", "pytest", "go-test", "rspec", "cargo-test"];
+const testGenShape = {
+  repoFullName: writeToolRepoFullName,
+  targetFiles: z.array(z.string().min(1).max(500)).min(1).max(WRITE_TOOL_TARGET_FILES_MAX),
+  framework: z.enum(WRITE_TOOL_TEST_FRAMEWORKS),
+  testDir: z.string().min(1).max(255).optional(),
+  criteria: z.array(z.string().min(1).max(300)).max(20).optional(),
+};
+const followUpIssueShape = {
+  repoFullName: writeToolRepoFullName,
+  path: z.string().min(1).max(500),
+  line: z.number().int().positive().optional(),
+  finding: z.string().min(1).max(WRITE_TOOL_BODY_MAX),
+  label: z.string().min(1).max(100).optional(),
+};
+
+/** Every write-tool answers the same way: the spec, plus the boundary note that the caller runs it, not us. */
+function localWriteSpecResult(spec) {
+  return toolResult("LoopOver local-execution spec — run it yourself; loopover never performs the write.", spec);
+}
+
+function registerLocalWriteTool(name, inputSchema, build) {
+  registerStdioTool(name, { description: stdioToolDescription(name), inputSchema }, async (input) =>
+    localWriteSpecResult(build(input)),
+  );
+}
+
+registerLocalWriteTool("loopover_open_pr", openPrShape, buildOpenPrSpec);
+registerLocalWriteTool("loopover_file_issue", fileIssueShape, buildFileIssueSpec);
+registerLocalWriteTool("loopover_apply_labels", applyLabelsShape, buildApplyLabelsSpec);
+registerLocalWriteTool("loopover_post_eligibility_comment", postEligibilityCommentShape, buildPostEligibilityCommentSpec);
+registerLocalWriteTool("loopover_create_branch", createBranchShape, buildCreateBranchSpec);
+registerLocalWriteTool("loopover_delete_branch", deleteBranchShape, buildDeleteBranchSpec);
+registerLocalWriteTool("loopover_generate_tests", testGenShape, buildTestGenSpec);
+registerLocalWriteTool("loopover_file_follow_up_issue", followUpIssueShape, buildFollowUpIssueSpec);
 
 // ── Resources: decision-pack, doctor, compatibility, changelog (#292) ─────────
 

--- a/test/unit/mcp-cli-write-tools.test.ts
+++ b/test/unit/mcp-cli-write-tools.test.ts
@@ -1,0 +1,189 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TEST_FRAMEWORKS } from "../../packages/loopover-engine/src/signals/test-evidence";
+
+// #6149: the hosted server (src/mcp/server.ts) has registered the 8 #780 write-tools since #780, and this
+// file's own AGENT_PROFILES["miner-auto-dev"].recommendedTools promised six of them — but none were registered
+// on the LOCAL stdio server, so that profile recommended tools a contributor could not call.
+//
+// Every write-tool is a pure spec builder: it returns a LOCAL-execution action spec and loopover never performs
+// the write. That is why this suite deliberately starts the server with NO LOOPOVER_TOKEN and NO
+// LOOPOVER_API_URL — these tools must work with neither, unlike every read tool on this server. If one ever
+// starts reaching for the API, this suite fails rather than silently requiring auth for a local-only action.
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+
+let client: Client | null = null;
+let transport: StdioClientTransport | null = null;
+let configDir: string | null = null;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-write-tools-"));
+  const env: Record<string, string> = {};
+  // A deliberately auth-less environment: strip anything that could let a tool fall back to a real API/token.
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !k.startsWith("LOOPOVER_")) env[k] = v;
+  }
+  env.LOOPOVER_CONFIG_DIR = configDir;
+  transport = new StdioClientTransport({ command: "node", args: [bin, "--stdio"], env });
+  client = new Client({ name: "write-tools-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+afterEach(async () => {
+  await client?.close().catch(() => undefined);
+  client = null;
+  transport = null;
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+  configDir = null;
+});
+
+function textOf(result: unknown): string {
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content ?? [];
+  return content.map((c) => c.text ?? "").join("\n");
+}
+
+/** The spec object the tool embeds in its text payload. */
+function specOf(result: unknown): Record<string, unknown> {
+  const text = textOf(result);
+  const start = text.indexOf("{");
+  return JSON.parse(text.slice(start)) as Record<string, unknown>;
+}
+
+const REPO = "acme/widgets";
+
+const WRITE_TOOLS: Array<{ name: string; args: Record<string, unknown>; expect: RegExp }> = [
+  {
+    name: "loopover_open_pr",
+    args: { repoFullName: REPO, base: "main", head: "fix/thing", title: "fix: the thing", body: "Closes #1" },
+    expect: /pr|pull/i,
+  },
+  { name: "loopover_file_issue", args: { repoFullName: REPO, title: "Bug: crash", body: "steps" }, expect: /issue/i },
+  { name: "loopover_apply_labels", args: { repoFullName: REPO, number: 7, labels: ["bug"] }, expect: /label/i },
+  {
+    name: "loopover_post_eligibility_comment",
+    args: { repoFullName: REPO, number: 7, body: "context" },
+    expect: /comment/i,
+  },
+  { name: "loopover_create_branch", args: { branch: "fix/thing", base: "main" }, expect: /branch/i },
+  { name: "loopover_delete_branch", args: { branch: "fix/thing", remote: true }, expect: /branch/i },
+  {
+    name: "loopover_generate_tests",
+    args: { repoFullName: REPO, targetFiles: ["src/a.ts"], framework: "vitest" },
+    expect: /test/i,
+  },
+  {
+    name: "loopover_file_follow_up_issue",
+    args: { repoFullName: REPO, path: "src/a.ts", line: 12, finding: "unchecked nullable" },
+    expect: /issue|follow/i,
+  },
+];
+
+describe("loopover-mcp stdio write-tools (#6149)", () => {
+  it("registers all 8 write-tools the hosted server exposes", async () => {
+    await connect();
+    const listed = new Set((await client!.listTools()).tools.map((t) => t.name));
+    for (const { name } of WRITE_TOOLS) expect(listed, `${name} must be registered`).toContain(name);
+  });
+
+  it("delivers every tool the miner-auto-dev profile's recommendedTools promises", async () => {
+    // The exact gap #6149 reports: the profile recommended these six, the local server registered none.
+    await connect();
+    const listed = new Set((await client!.listTools()).tools.map((t) => t.name));
+    for (const name of [
+      "loopover_create_branch",
+      "loopover_open_pr",
+      "loopover_file_issue",
+      "loopover_apply_labels",
+      "loopover_post_eligibility_comment",
+      "loopover_delete_branch",
+    ]) {
+      expect(listed, `miner-auto-dev recommends ${name}`).toContain(name);
+    }
+  });
+
+  it.each(WRITE_TOOLS)("$name returns a runnable local-execution spec, with no token or API", async ({ name, args, expect: pattern }) => {
+    await connect();
+    const result = await client!.callTool({ name, arguments: args });
+    expect((result as { isError?: boolean }).isError ?? false).toBe(false);
+
+    const spec = specOf(result);
+    expect(typeof spec.action).toBe("string");
+    expect(typeof spec.command).toBe("string");
+    expect(String(spec.command).length).toBeGreaterThan(0);
+    expect(spec).toHaveProperty("inputs");
+    expect(`${spec.action} ${spec.description ?? ""}`).toMatch(pattern);
+
+    // The boundary the whole design rests on: we hand back a command, we never run it.
+    expect(textOf(result)).toMatch(/loopover never performs the write/i);
+  });
+
+  it("carries the caller's own inputs into the spec rather than inventing them", async () => {
+    await connect();
+    const result = await client!.callTool({
+      name: "loopover_open_pr",
+      arguments: { repoFullName: REPO, base: "main", head: "fix/thing", title: "fix: the thing", body: "Closes #1" },
+    });
+    const text = textOf(result);
+    expect(text).toContain(REPO);
+    expect(text).toContain("fix/thing");
+    expect(text).toContain("fix: the thing");
+  });
+
+  describe("input validation mirrors the hosted server's own bounds", () => {
+    // The local server duplicates the framework vocabulary because it depends on the PUBLISHED engine ^1.0.0,
+    // which predates the TEST_FRAMEWORKS export. This pins that copy to the engine's real list so the two
+    // cannot drift: a framework the detector can produce must be accepted, and the copy must be exhaustive.
+    it("DRIFT GUARD: accepts exactly the engine's own TEST_FRAMEWORKS vocabulary", async () => {
+      await connect();
+      expect(TEST_FRAMEWORKS.length).toBeGreaterThan(0);
+      for (const framework of TEST_FRAMEWORKS) {
+        const result = await client!.callTool({
+          name: "loopover_generate_tests",
+          arguments: { repoFullName: REPO, targetFiles: ["src/a.ts"], framework },
+        });
+        expect((result as { isError?: boolean }).isError ?? false, `${framework} must be accepted`).toBe(false);
+      }
+    });
+
+    it("rejects an out-of-vocabulary test framework", async () => {
+      await connect();
+      const result = await client!.callTool({
+        name: "loopover_generate_tests",
+        arguments: { repoFullName: REPO, targetFiles: ["src/a.ts"], framework: "not-a-framework" },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+
+    it("rejects an empty required field", async () => {
+      await connect();
+      const result = await client!.callTool({
+        name: "loopover_open_pr",
+        arguments: { repoFullName: REPO, base: "main", head: "fix/thing", title: "", body: "x" },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+
+    it("rejects a non-positive issue number", async () => {
+      await connect();
+      const result = await client!.callTool({
+        name: "loopover_apply_labels",
+        arguments: { repoFullName: REPO, number: 0, labels: ["bug"] },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+
+    it("rejects an empty label list", async () => {
+      await connect();
+      const result = await client!.callTool({
+        name: "loopover_apply_labels",
+        arguments: { repoFullName: REPO, number: 7, labels: [] },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6149

The hosted server (`src/mcp/server.ts:2251-2299`) has registered the 8 #780 write-tools since #780 — but **none** were among the local stdio server's `registerStdioTool` calls. Meanwhile `packages/loopover-mcp/bin/loopover-mcp.js`'s own `AGENT_PROFILES["miner-auto-dev"].recommendedTools` has listed six of them all along, so that profile **recommended tools a contributor running the local server could not call**.

This registers all 8: `loopover_open_pr`, `loopover_file_issue`, `loopover_apply_labels`, `loopover_post_eligibility_comment`, `loopover_create_branch`, `loopover_delete_branch`, `loopover_generate_tests`, `loopover_file_follow_up_issue`.

Each is a **pure spec builder already shared through `@loopover/engine`**, so this composes existing logic rather than adding any: input in, a LOCAL-execution action spec out, describing a command the *contributor* runs with their own creds.

### The issue's "verify a real endpoint exists, don't stub" check

The issue flagged that `loopover_generate_tests` / `loopover_file_follow_up_issue` might have no local-server precedent, and asked for a blocker report rather than a fake tool. **None of the 8 needs an endpoint at all** — every one is local-execution by design ("loopover never performs the write"), which is precisely why they can be registered here with no server round-trip. Nothing is stubbed.

That property is *enforced*, not asserted: the suite starts the server with **`LOOPOVER_TOKEN` and `LOOPOVER_API_URL` stripped from the environment**. These are the only tools on this server with no `apiGet`/`apiPost`, and if one ever starts reaching for the API, the suite fails rather than silently requiring auth for a local-only action.

### One real constraint found, and how it's handled

Input shapes mirror the hosted server's **bound-for-bound**, so the local server cannot emit a spec the hosted one would have rejected.

The framework vocabulary is the exception: it's **duplicated rather than imported**, because `packages/loopover-mcp` depends on the **published `@loopover/engine` ^1.0.0** (the workspace is 3.1.1, which doesn't satisfy that range, so npm installs the registry copy) — and 1.0.0 **predates** the `TEST_FRAMEWORKS` export. Importing it would break the installed server at startup. I confirmed this the hard way: the export resolves fine from the workspace but not from the package's own nested copy.

So the copy is **pinned by a drift guard**: the suite asserts every value of the engine's real `TEST_FRAMEWORKS` is accepted, so the two cannot diverge silently, and the copy can collapse to an import once the dependency is bumped.

## Scope

- [x] Conventional Commit title (`feat(mcp): …`).
- [x] **Does not touch the remote server** (`src/mcp/server.ts`), per the issue's explicit scope.
- [x] Additive: 8 registrations + their schemas/descriptors. No existing tool, route or behavior changed.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable`; no changelog edit.
- [x] Linked open issue (Closes #6149, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run build --workspace @loopover/mcp` (the package's `node --check` gate) — exit 0.
- [x] **`npx vitest run test/unit/mcp-cli-write-tools.test.ts` — 16 tests passed**; together with the sibling `mcp-cli-intake-tools` suite — **26 passed**, confirming no regression to the existing stdio tools.
- [x] Rebased onto current `main`.

Tests are **end-to-end over the real stdio transport** (spawning `bin/loopover-mcp.js` via `StdioClientTransport`), matching `mcp-cli-intake-tools.test.ts`'s convention:

| Test | What it proves |
|---|---|
| registers all 8 | the parity gap is closed |
| miner-auto-dev's promised six are present | the exact gap #6149 reports |
| each returns a runnable spec (×8) | `action`/`command`/`inputs` present, non-empty, and the "loopover never performs the write" boundary is stated |
| carries the caller's own inputs | the spec isn't invented — repo/branch/title round-trip |
| **DRIFT GUARD** | every engine `TEST_FRAMEWORKS` value is accepted |
| 4 validation cases | out-of-vocabulary framework, empty required field, non-positive number, empty label list |

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows).
- No Codecov patch obligation: `packages/loopover-mcp/**` is outside Codecov's `coverage.include` (which covers `src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**`), and `test/**` is ignored.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] **These tools cannot perform a write.** Every one returns a spec describing a command; the contributor executes it with their own credentials. That boundary is the design (`LOCAL_WRITE_BOUNDARY`), is restated in each tool's response text, and is covered by a test.
- [x] **No new auth/token surface** — the opposite: these are the only tools here that need neither, proven by running the suite with both env vars stripped.
- [x] No source content is uploaded: `loopover_generate_tests` supplies criteria only; the contributor's own agent scaffolds the files.
- [x] Inputs are bounded exactly as the hosted server bounds them (title/body/branch/target-file limits, positive integers, label caps), so the local server is not a laxer path to a spec.
- [x] No change to the remote server, the API, OpenAPI, or any schema; no generated artifact affected.
- [x] No UI changes; no changelog edit.
