### PR TITLE
fix(github): retry label/assignee writes on a stale installation token (#6191)

### DIFF
--- a/src/github/assignees.ts
+++ b/src/github/assignees.ts
@@ -1,4 +1,4 @@
-import { createInstallationToken } from "./app";
+import { withInstallationTokenRetry } from "./app";
 import { githubRateLimitAdmissionKeyForInstallation, makeInstallationOctokit } from "./client";
 import type { AgentActionMode } from "../settings/agent-execution";
 
@@ -35,44 +35,47 @@ export async function ensurePullRequestAssignee(
 ): Promise<{ applied: boolean }> {
   const { owner, repo } = parseRepoFullName(repoFullName);
 
-  const token = await createInstallationToken(env, installationId);
-  // Non-live mode suppresses the assign write; the GET dedup probe below still runs.
-  const octokit = makeInstallationOctokit(env, token, options.mode ?? "live", githubRateLimitAdmissionKeyForInstallation(installationId));
-  const existing = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}", {
-    owner,
-    repo,
-    issue_number: pullNumber,
-  });
-  const existingAssignees = (existing.data.assignees ?? []) as GitHubUser[];
-  if (existingAssignees.some((assignee) => assignee.login?.toLowerCase() === login.toLowerCase())) {
-    return { applied: true };
-  }
-
-  let result;
-  try {
-    result = await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/assignees", {
+  // #6191: retry once with a freshly-minted token on a stale-cached-token (bad_credentials/permission-scope)
+  // rejection, self-healing like every other GitHub write path (comments.ts/pr-actions.ts).
+  return await withInstallationTokenRetry(env, installationId, async (token) => {
+    // Non-live mode suppresses the assign write; the GET dedup probe below still runs.
+    const octokit = makeInstallationOctokit(env, token, options.mode ?? "live", githubRateLimitAdmissionKeyForInstallation(installationId));
+    const existing = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}", {
       owner,
       repo,
       issue_number: pullNumber,
-      assignees: [login],
     });
-  } catch (error: unknown) {
-    // GitHub blocks assigning bot/agent logins via App installation tokens (HTTP 403). This is a GitHub
-    // platform restriction with no workaround using installation-token auth. Return applied:false so the
-    // caller can fall back to a by:{login} label instead of propagating an unactionable error.
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "status" in error &&
-      (error as { status: number }).status === 403 &&
-      "message" in error &&
-      typeof (error as { message: unknown }).message === "string" &&
-      (error as { message: string }).message.includes("Assigning agents is not supported")
-    ) {
-      return { applied: false };
+    const existingAssignees = (existing.data.assignees ?? []) as GitHubUser[];
+    if (existingAssignees.some((assignee) => assignee.login?.toLowerCase() === login.toLowerCase())) {
+      return { applied: true };
     }
-    throw error;
-  }
-  const resultAssignees = (result.data.assignees ?? []) as GitHubUser[];
-  return { applied: resultAssignees.some((assignee) => assignee.login?.toLowerCase() === login.toLowerCase()) };
+
+    let result;
+    try {
+      result = await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/assignees", {
+        owner,
+        repo,
+        issue_number: pullNumber,
+        assignees: [login],
+      });
+    } catch (error: unknown) {
+      // GitHub blocks assigning bot/agent logins via App installation tokens (HTTP 403). This is a GitHub
+      // platform restriction with no workaround using installation-token auth. Return applied:false so the
+      // caller can fall back to a by:{login} label instead of propagating an unactionable error.
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "status" in error &&
+        (error as { status: number }).status === 403 &&
+        "message" in error &&
+        typeof (error as { message: unknown }).message === "string" &&
+        (error as { message: string }).message.includes("Assigning agents is not supported")
+      ) {
+        return { applied: false };
+      }
+      throw error;
+    }
+    const resultAssignees = (result.data.assignees ?? []) as GitHubUser[];
+    return { applied: resultAssignees.some((assignee) => assignee.login?.toLowerCase() === login.toLowerCase()) };
+  });
 }

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -1,4 +1,4 @@
-import { createInstallationToken } from "./app";
+import { withInstallationTokenRetry } from "./app";
 import { githubRateLimitAdmissionKeyForInstallation, makeInstallationOctokit } from "./client";
 import type { AgentActionMode } from "../settings/agent-execution";
 
@@ -28,45 +28,48 @@ export async function ensurePullRequestLabel(
 ): Promise<{ applied: boolean; created: boolean }> {
   const { owner, repo } = parseRepoFullName(repoFullName);
 
-  const token = await createInstallationToken(env, installationId);
-  // Non-live mode suppresses the label create + apply writes; the GET dedup probe below still runs.
-  const octokit = makeInstallationOctokit(env, token, options.mode ?? "live", githubRateLimitAdmissionKeyForInstallation(installationId));
-  const existing = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/labels", {
-    owner,
-    repo,
-    issue_number: pullNumber,
-    per_page: 100,
-  });
-  const labels = existing.data as GitHubLabel[];
-  if (labels.some((label) => label.name?.toLowerCase() === labelName.toLowerCase())) {
-    return { applied: false, created: false };
-  }
-
-  let created = false;
-  if (options.createMissingLabel) {
-    try {
-      await octokit.request("POST /repos/{owner}/{repo}/labels", {
-        owner,
-        repo,
-        name: labelName,
-        color: "7ee787",
-        description: "Gittensor contributor context",
-      });
-      created = true;
-    } catch (error) {
-      const e = error as { status?: number; message?: string };
-      // Only swallow the specific "already_exists" duplicate; other 422s (e.g. invalid name) must propagate.
-      if (e.status !== 422 || !e.message?.includes("already_exists")) throw error;
+  // #6191: retry once with a freshly-minted token on a stale-cached-token (bad_credentials/permission-scope)
+  // rejection, self-healing like every other GitHub write path (comments.ts/pr-actions.ts).
+  return await withInstallationTokenRetry(env, installationId, async (token) => {
+    // Non-live mode suppresses the label create + apply writes; the GET dedup probe below still runs.
+    const octokit = makeInstallationOctokit(env, token, options.mode ?? "live", githubRateLimitAdmissionKeyForInstallation(installationId));
+    const existing = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/labels", {
+      owner,
+      repo,
+      issue_number: pullNumber,
+      per_page: 100,
+    });
+    const labels = existing.data as GitHubLabel[];
+    if (labels.some((label) => label.name?.toLowerCase() === labelName.toLowerCase())) {
+      return { applied: false, created: false };
     }
-  }
 
-  await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/labels", {
-    owner,
-    repo,
-    issue_number: pullNumber,
-    labels: [labelName],
+    let created = false;
+    if (options.createMissingLabel) {
+      try {
+        await octokit.request("POST /repos/{owner}/{repo}/labels", {
+          owner,
+          repo,
+          name: labelName,
+          color: "7ee787",
+          description: "Gittensor contributor context",
+        });
+        created = true;
+      } catch (error) {
+        const e = error as { status?: number; message?: string };
+        // Only swallow the specific "already_exists" duplicate; other 422s (e.g. invalid name) must propagate.
+        if (e.status !== 422 || !e.message?.includes("already_exists")) throw error;
+      }
+    }
+
+    await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/labels", {
+      owner,
+      repo,
+      issue_number: pullNumber,
+      labels: [labelName],
+    });
+    return { applied: true, created };
   });
-  return { applied: true, created };
 }
 
 /** Remove a single label from a PR if present. Best-effort — a 404 (label not on the PR) is ignored; any other
@@ -81,18 +84,21 @@ export async function removePullRequestLabel(env: Env, installationId: number, r
   } catch {
     return;
   }
-  const token = await createInstallationToken(env, installationId);
-  const octokit = makeInstallationOctokit(env, token, mode, githubRateLimitAdmissionKeyForInstallation(installationId));
-  try {
-    await octokit.request("DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}", {
-      owner,
-      repo,
-      issue_number: pullNumber,
-      name: labelName,
-    });
-  } catch (error) {
-    const e = error as { status?: number };
-    // Only swallow the documented "label not on the PR" 404; other failures must propagate (#6192).
-    if (e.status !== 404) throw error;
-  }
+  // #6191: retry once with a freshly-minted token on a stale-cached-token (bad_credentials/permission-scope)
+  // rejection, self-healing like every other GitHub write path (comments.ts/pr-actions.ts).
+  await withInstallationTokenRetry(env, installationId, async (token) => {
+    const octokit = makeInstallationOctokit(env, token, mode, githubRateLimitAdmissionKeyForInstallation(installationId));
+    try {
+      await octokit.request("DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}", {
+        owner,
+        repo,
+        issue_number: pullNumber,
+        name: labelName,
+      });
+    } catch (error) {
+      const e = error as { status?: number };
+      // Only swallow the documented "label not on the PR" 404; other failures must propagate (#6192).
+      if (e.status !== 404) throw error;
+    }
+  });
 }

--- a/test/unit/github-labels.test.ts
+++ b/test/unit/github-labels.test.ts
@@ -155,6 +155,41 @@ describe("GitHub PR labels", () => {
     expect(result).toEqual({ applied: true, created: false });
   });
 
+  it("expires a rejected cached installation token and retries the label write once (#6191)", async () => {
+    let mints = 0;
+    let rejectedReads = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) {
+        mints += 1;
+        return Response.json({ token: mints === 1 ? "stale-token" : "fresh-token", expires_at: new Date(Date.now() + 60 * 60_000).toISOString() });
+      }
+      const auth = new Headers(init?.headers).get("authorization") ?? "";
+      if (url.includes("/issues/4/labels") && auth.includes("stale-token")) {
+        rejectedReads += 1;
+        return Response.json({ message: "Bad credentials" }, { status: 401 });
+      }
+      if (url.includes("/issues/4/labels") && method === "GET") {
+        expect(auth).toContain("fresh-token");
+        return Response.json([]);
+      }
+      if (url.includes("/issues/4/labels") && method === "POST") {
+        expect(auth).toContain("fresh-token");
+        return Response.json([{ name: "gittensor" }]);
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const result = await ensurePullRequestLabel(createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }), 9988, "JSONbored/gittensory", 4, "gittensor", {
+      createMissingLabel: false,
+    });
+
+    expect(result).toEqual({ applied: true, created: false });
+    expect(mints).toBe(2); // stale token rejected, fresh token minted + retried
+    expect(rejectedReads).toBe(1);
+  });
+
   it("propagates a 422 that is not an already_exists duplicate (e.g. invalid label name)", async () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();


### PR DESCRIPTION
## Summary

`assignees.ts`'s `ensurePullRequestAssignee` and `labels.ts`'s `ensurePullRequestLabel`/`removePullRequestLabel` called `createInstallationToken` **directly**, unlike every other GitHub-write helper in `src/github/**` (`comments.ts`, `pr-actions.ts`'s 8 mutators, `repo-doc-pr.ts`, `e2e-test-commit.ts`), which wrap the call in `withInstallationTokenRetry` (`app.ts:174`) — a one-shot retry with a freshly-minted token on a `bad_credentials`/permission-scope rejection. Label/assignee writes would simply **fail on a stale cached token** instead of self-healing like the rest of the codebase.

## Change

Wrap all three writes in `withInstallationTokenRetry`, matching `comments.ts`/`pr-actions.ts`'s exact usage (owner/repo parsing stays outside the wrapper; the token-using body moves inside). `withInstallationTokenRetry` itself and the already-correct helpers are unchanged. The callers' existing `.catch(() => undefined)` fallbacks are unaffected — they now only trigger after a genuine retry failure.

## Tests

New regression test proves a stale-token `401` on a label write re-mints a fresh token and retries to success (`mints === 2`), mirroring `comments.ts`'s own `withInstallationTokenRetry` test. `github-labels` + `github-assignees` + `github-comments` suites (31 tests) + `tsc` green.

Closes #6191