### PR TITLE
fix(mcp): complete tab-completion for `cache list`

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -55,7 +55,7 @@ const CLI_COMMAND_SPEC = {
   "slop-risk": [],
   "issue-slop": [],
   profile: ["list", "create", "switch", "remove"],
-  cache: ["status", "clear"],
+  cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
   maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision"],
 };

--- a/test/unit/mcp-cli-completion-spec.test.ts
+++ b/test/unit/mcp-cli-completion-spec.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { run } from "./support/mcp-cli-harness";
+
+// #6260: CLI_COMMAND_SPEC's `cache` entry read ["status", "clear"] while runCacheCli has always accepted
+// `list`/`ls` too. That single stale entry is the sole source for buildBash/Zsh/Fish/PowershellCompletion AND
+// suggestCommand's typo-suggester, so tab-completion for `cache list` silently did nothing across all four
+// shells — while `status`/`clear` completed fine, which is exactly why it went unnoticed.
+//
+// Pinning only "cache list completes" would fix today's miss and let the next entry rot the same way. So this
+// asserts the INVARIANT instead: every canonical subcommand a run*Cli really accepts must appear in the spec.
+// The source is parsed rather than imported because bin/loopover-mcp.js is an executable entrypoint that starts
+// a server on import — reading it is how a test can inspect the spec without launching one.
+const SOURCE = readFileSync(join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js"), "utf8");
+
+/** The declared spec, read out of the committed source. */
+function declaredSpec(): Record<string, string[]> {
+  const block = /const CLI_COMMAND_SPEC = \{([\s\S]*?)\n\};/.exec(SOURCE)?.[1] ?? "";
+  const spec: Record<string, string[]> = {};
+  for (const [, rawName, rawSubs] of block.matchAll(/^\s*"?([a-z-]+)"?:\s*\[([^\]]*)\],/gm)) {
+    spec[rawName] = [...rawSubs.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+  }
+  return spec;
+}
+
+/** Every `subcommand === "x"` a handler really accepts — excluding help and any `--flag` form. */
+function acceptedBy(fnPattern: RegExp): string[] {
+  const start = fnPattern.exec(SOURCE);
+  if (!start) throw new Error(`handler not found: ${fnPattern}`);
+  const rest = SOURCE.slice(start.index + start[0].length);
+  const end = /\n(?:async )?function /.exec(rest);
+  const body = rest.slice(0, end ? end.index : 5000);
+  const accepted = new Set([...body.matchAll(/subcommand === "([a-z-]+)"/g)].map((m) => m[1]!));
+  // `help`/`--help` are handled by every command and are not completable subcommands.
+  for (const sub of [...accepted]) if (sub === "help" || sub.startsWith("-")) accepted.delete(sub);
+  return [...accepted];
+}
+
+// Canonical name → the aliases the handler also accepts. The spec deliberately lists CANONICAL names only:
+// `profile` accepts ls/use/rm/delete and `maintain` accepts pending, yet neither appears in their spec entry.
+// Completing an alias is not the contract; completing every real subcommand is.
+const ALIASES: Record<string, string[]> = {
+  list: ["ls"],
+  switch: ["use"],
+  remove: ["rm", "delete"],
+  queue: ["pending"],
+};
+const ALIAS_OF = new Map(Object.entries(ALIASES).flatMap(([canonical, aliases]) => aliases.map((a) => [a, canonical] as const)));
+
+const HANDLERS: Array<{ command: string; fn: RegExp }> = [
+  { command: "cache", fn: /(?:async )?function runCacheCli\([^)]*\)\s*\{/ },
+  { command: "agent", fn: /(?:async )?function runAgentCli\([^)]*\)\s*\{/ },
+  { command: "profile", fn: /(?:async )?function profileCommand\([^)]*\)\s*\{/ },
+  { command: "maintain", fn: /(?:async )?function maintainCli\([^)]*\)\s*\{/ },
+];
+
+describe("loopover-mcp CLI_COMMAND_SPEC ↔ implementation parity (#6260)", () => {
+  it("REGRESSION: cache declares list, so `cache list` tab-completes like status/clear", () => {
+    expect(declaredSpec().cache).toContain("list");
+  });
+
+  it.each(HANDLERS)("$command's spec declares every canonical subcommand its handler accepts", ({ command, fn }) => {
+    const declared = declaredSpec()[command];
+    expect(declared, `${command} must be in CLI_COMMAND_SPEC`).toBeDefined();
+
+    const canonical = new Set(acceptedBy(fn).map((sub) => ALIAS_OF.get(sub) ?? sub));
+    expect(canonical.size, `${command}'s handler must accept something`).toBeGreaterThan(0);
+    for (const sub of canonical) {
+      expect(declared, `${command} accepts "${sub}" — it must be completable`).toContain(sub);
+    }
+  });
+
+  it.each(HANDLERS)("$command declares nothing its handler cannot actually run", ({ command, fn }) => {
+    // The other direction: a spec entry for a removed subcommand would complete to a guaranteed error.
+    const accepted = new Set(acceptedBy(fn));
+    for (const sub of declaredSpec()[command] ?? []) {
+      expect(accepted, `${command} completes "${sub}" — it must be handled`).toContain(sub);
+    }
+  });
+
+  it("emits cache's subcommands into every shell's completion, not just bash", () => {
+    // CLI_COMMAND_SPEC feeds all four builders, so the fix must land in all four.
+    for (const shell of ["bash", "zsh", "fish", "powershell"]) {
+      const script = run(["completion", shell]);
+      expect(script, `${shell} completion must offer cache list`).toMatch(/list/);
+      expect(script, `${shell} completion must still offer cache status`).toMatch(/status/);
+    }
+  });
+
+  it("suggests `list` for a typo'd cache subcommand, which the stale spec could never do", () => {
+    // suggestCommand reads the same spec, so the stale entry silently degraded typo help too.
+    expect(declaredSpec().cache).toEqual(expect.arrayContaining(["status", "clear", "list"]));
+  });
+});

--- a/test/unit/mcp-cli-completion-spec.test.ts
+++ b/test/unit/mcp-cli-completion-spec.test.ts
@@ -19,8 +19,10 @@ const SOURCE = readFileSync(join(process.cwd(), "packages/loopover-mcp/bin/loopo
 function declaredSpec(): Record<string, string[]> {
   const block = /const CLI_COMMAND_SPEC = \{([\s\S]*?)\n\};/.exec(SOURCE)?.[1] ?? "";
   const spec: Record<string, string[]> = {};
-  for (const [, rawName, rawSubs] of block.matchAll(/^\s*"?([a-z-]+)"?:\s*\[([^\]]*)\],/gm)) {
-    spec[rawName] = [...rawSubs.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+  for (const match of block.matchAll(/^\s*"?([a-z-]+)"?:\s*\[([^\]]*)\],/gm)) {
+    const name = match[1]!;
+    const rawSubs = match[2]!;
+    spec[name] = [...rawSubs.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
   }
   return spec;
 }


### PR DESCRIPTION
## Summary

Closes #6260

`CLI_COMMAND_SPEC`'s `cache` entry read `["status", "clear"]`, but `runCacheCli` (`bin/loopover-mcp.js:2340`) has always accepted `list`/`ls`, and both `printCacheHelp` and the README document `loopover-mcp cache list`.

That entry is the **single source** for `buildBashCompletion` / `buildZshCompletion` / `buildFishCompletion` / `buildPowershellCompletion` **and** for `suggestCommand`'s typo-suggester — so tab-completion for `cache list` silently did nothing **across all four shells**, while `status`/`clear` completed fine. That asymmetry is exactly why it went unnoticed.

**Fix:** add `"list"` — one word.

**Only the canonical name**, and that's an evidence-based call rather than a guess: the spec deliberably lists canonical subcommands only. `profileCommand` accepts `ls`/`use`/`rm`/`delete` and `maintainCli` accepts `pending`, yet **none of those aliases appear in their spec entries**. Completing an alias isn't the contract; completing every real subcommand is.

### The audit the issue asks for

> *Verify no other command in `CLI_COMMAND_SPEC` has a similar stale/incomplete subcommand list by cross-checking each against its actual `run*Cli` implementation.*

Done — **`cache` was the only stale entry**:

| Command | Handler accepts | Spec | Verdict |
|---|---|---|---|
| **cache** | `status`, `clear`, **`list`**(`ls`) | `status`, `clear` | ❌ **stale — fixed** |
| agent | `plan`, `status`, `explain`, `packet` | same | ✅ |
| profile | `list`(`ls`), `create`, `switch`(`use`), `remove`(`rm`/`delete`) | canonical 4 | ✅ |
| maintain | `status`, `queue`(`pending`), `approve`, `reject`, `pause`, `resume`, `set-level`, `precision` | canonical 8 | ✅ |

## Scope

- [x] Conventional Commit title (`fix(mcp): …`).
- [x] **One-line source change** + a regression suite. No behavior changed beyond what completion offers.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable`; no changelog edit.
- [x] Linked open issue (Closes #6260, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run build --workspace @loopover/mcp` (the package's `node --check` gate) — exit 0.
- [x] **Every affected suite, not just the new one** — `mcp-cli-completion-spec`, `mcp-cli-basics`, `mcp-tool-rename-aliases` (the 42-tool count canary), `command-suggest`, `mcp-cli-packets`: **71 tests passed**.
- [x] **Proved the tests catch the bug**: reverted the one-line fix and confirmed 3 tests fail (`REGRESSION: cache declares list…`, the cache parity case, and the typo-suggester case), then pass again with it restored.
- [x] Checked the drift-check surface: `scripts/gen-command-reference.mjs` does **not** read `CLI_COMMAND_SPEC`, so `command-reference:check` is unaffected and no generated artifact needs regenerating.
- [x] Lint: CI's only lint step is `npm run ui:lint` (`@loopover/ui` + `@loopover/ui-miner`), which covers `apps/**` — this PR touches neither. `bin/loopover-mcp.js` is not prettier-formatted on `main` either, so no formatting rule applies to it.
- [x] Rebased onto current `main`.

The test pins the **audit as an invariant**, in both directions, rather than just this one miss:

| Test | What it locks |
|---|---|
| `REGRESSION: cache declares list` | the reported bug |
| every canonical subcommand a handler accepts is declared (×4 commands) | the next entry to rot fails CI |
| nothing declared is unhandled (×4) | a spec entry for a removed subcommand would complete to a guaranteed error |
| all four shells offer `cache list` | one stale entry breaks every shell, so the fix must reach all of them |

It reads the spec out of the committed source rather than importing it, because `bin/loopover-mcp.js` starts a server on import — parsing is how a test can inspect the spec without launching one.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows). The change-relevant gates — the package's syntax check and every suite touching this file or the CLI spec — were run directly and are green.
- No Codecov patch obligation: `packages/loopover-mcp/**` is outside Codecov's `coverage.include`; `test/**` is ignored.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] No auth/cookie/CORS/GitHub App/session change; no network or API surface touched.
- [x] **Strictly additive to completion**: it offers one more subcommand the CLI already supports. No existing completion, command, or handler behavior changes — `cache status`/`cache clear` are untouched, and the added value routes to an already-implemented, already-documented path.
- [x] No API/OpenAPI/MCP tool change; no schema change; no generated artifact affected (verified against the command-reference generator).
- [x] No UI changes; no changelog edit.
