### PR TITLE
feat(mcp): extract buildFocusManifestValidation into @loopover/engine for offline loopover_validate_config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20714,27 +20714,12 @@
       "version": "3.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@loopover/engine": "^1.0.0",
+        "@loopover/engine": "^3.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "^4.4.3"
       },
       "bin": {
         "loopover-mcp": "bin/loopover-mcp.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "packages/loopover-mcp/node_modules/@loopover/engine": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@loopover/engine/-/engine-1.0.0.tgz",
-      "integrity": "sha512-5OULTIoyl3ttEVZ0Sa9D8y89CbyM7n1CZFqhhx3EHP9YpYC+65xJz4u892d6a3U1f7lra9Bf2DrWwJr/GFHOIA==",
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.205",
-        "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.20.8",
-        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/packages/loopover-engine/package.json
+++ b/packages/loopover-engine/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/scoring/pending-pr-scenarios.d.ts",
       "default": "./dist/scoring/pending-pr-scenarios.js"
     },
+    "./focus-manifest-validation": {
+      "types": "./dist/focus-manifest-validation.d.ts",
+      "default": "./dist/focus-manifest-validation.js"
+    },
     "./signals/test-evidence": {
       "types": "./dist/signals/test-evidence.d.ts",
       "default": "./dist/signals/test-evidence.js"

--- a/packages/loopover-engine/src/focus-manifest-validation.ts
+++ b/packages/loopover-engine/src/focus-manifest-validation.ts
@@ -1,0 +1,165 @@
+import { parse as parseYaml } from "yaml";
+import {
+  MAX_FOCUS_MANIFEST_BYTES,
+  contentLaneConfigToJson,
+  featuresConfigToJson,
+  gateConfigToJson,
+  parseFocusManifestContent,
+  repoDocGenerationConfigToJson,
+  reviewConfigToJson,
+  reviewRecapConfigToJson,
+  maintainerRecapConfigToJson,
+  settingsOverrideToJson,
+  type FocusManifest,
+  type FocusManifestSource,
+} from "./focus-manifest.js";
+
+// The recognized top-level `.loopover.yml` fields. The single source of truth for both the unknown-field
+// warning below and the self-host config linter's recognized-field report (src/selfhost/config-lint.ts) —
+// keeping one list stops the two surfaces drifting when a new field lands (the class of miss #3002/#5281 fixed).
+export const TOP_LEVEL_FIELDS = [
+  "source",
+  "wantedPaths",
+  "preferredLabels",
+  "linkedIssuePolicy",
+  "testExpectations",
+  "issueDiscoveryPolicy",
+  "maintainerNotes",
+  "publicNotes",
+  "gate",
+  "settings",
+  "review",
+  "features",
+  "experimental",
+  "contentLane",
+  "repoDocGeneration",
+  "reviewRecap",
+  "maintainerRecap",
+] as const;
+
+const TOP_LEVEL_FIELD_SET = new Set<string>(TOP_LEVEL_FIELDS);
+
+// Fields retired from TOP_LEVEL_FIELDS that still warrant a migration-specific warning (rather than the
+// generic "unknown field" message) pointing operators at their replacement mechanism.
+const RETIRED_FIELD_MIGRATION_WARNINGS: Record<string, string> = {
+  blockedPaths: "blockedPaths is retired; use settings.hardGuardrailGlobs for path holds.",
+};
+
+export function unknownTopLevelWarnings(text: string | null | undefined): string[] {
+  const raw = text ?? "";
+  const trimmed = raw.trim();
+  if (!trimmed || isOversize(raw)) return [];
+  const parsed = parseTopLevelObject(trimmed);
+  if (parsed === null) return [];
+  const keys = Object.keys(parsed).filter((key) => !TOP_LEVEL_FIELD_SET.has(key));
+  // `hasOwnProperty.call`, NOT `key in`: a manifest field named like an Object.prototype member
+  // (`constructor`, `toString`, `hasOwnProperty`, ...) would otherwise test true for the inherited
+  // property and resolve to the prototype's function instead of a real retired-field warning string,
+  // corrupting the string[] result and suppressing the genuine unknown-field warning.
+  const isRetired = (key: string): boolean => Object.prototype.hasOwnProperty.call(RETIRED_FIELD_MIGRATION_WARNINGS, key);
+  const retiredWarnings = keys.filter(isRetired).map((key) => RETIRED_FIELD_MIGRATION_WARNINGS[key]!);
+  const unknown = keys.filter((key) => !isRetired(key)).map(formatFieldName);
+  return [
+    ...retiredWarnings,
+    ...(unknown.length > 0 ? [`Manifest contains unknown top-level field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}.`] : []),
+  ];
+}
+
+function parseTopLevelObject(text: string): Record<string, unknown> | null {
+  const looksLikeJson = text.startsWith("{") || text.startsWith("[");
+  if (looksLikeJson) {
+    try {
+      const parsed = JSON.parse(text);
+      return topLevelObjectOrNull(parsed);
+    } catch {
+      // YAML flow mappings can start with "{" or "[" while still being valid manifest syntax.
+    }
+  }
+  try {
+    return topLevelObjectOrNull(parseYaml(text));
+  } catch {
+    return null;
+  }
+}
+
+export function topLevelObjectOrNull(parsed: unknown): Record<string, unknown> | null {
+  return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+export function isOversize(text: string): boolean {
+  return text.length > MAX_FOCUS_MANIFEST_BYTES || new TextEncoder().encode(text).byteLength > MAX_FOCUS_MANIFEST_BYTES;
+}
+
+function formatFieldName(name: string): string {
+  const trimmed = name.replace(/[^\w.-]/g, "_").slice(0, 80);
+  return trimmed || "<blank>";
+}
+
+export type FocusManifestValidationStatus = "ok" | "warn" | "error";
+
+export type FocusManifestValidationResult = {
+  present: boolean;
+  warnings: string[];
+  normalized: Record<string, unknown>;
+  status: FocusManifestValidationStatus;
+};
+
+const PARSE_FAILURE_PATTERN = /not valid (JSON|YAML)|must be a mapping|exceeded \d+ bytes/i;
+
+export function buildFocusManifestValidation(input: {
+  content: string;
+  source?: FocusManifestSource | undefined;
+}): FocusManifestValidationResult {
+  const manifest = parseFocusManifestContent(input.content, input.source ?? "repo_file");
+  // Warn on unrecognized top-level fields (e.g. a typo'd `gates:` instead of `gate:`), matching the
+  // selfhost config-lint validator — parseFocusManifestContent reads only known fields, so a mistyped
+  // block is otherwise silently dropped with no warning (#5929).
+  const warnings = [...manifest.warnings, ...unknownTopLevelWarnings(input.content)];
+  const normalized = focusManifestToNormalizedJson(manifest);
+  return {
+    present: manifest.present,
+    warnings,
+    normalized,
+    status: resolveValidationStatus(manifest, warnings),
+  };
+}
+
+function resolveValidationStatus(manifest: FocusManifest, warnings: string[]): FocusManifestValidationStatus {
+  if (warnings.some((warning) => PARSE_FAILURE_PATTERN.test(warning))) return "error";
+  if (!manifest.present || warnings.length > 0) return "warn";
+  return "ok";
+}
+
+function focusManifestToNormalizedJson(manifest: FocusManifest): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {
+    present: manifest.present,
+    source: manifest.source,
+  };
+  if (manifest.wantedPaths.length > 0) normalized.wantedPaths = manifest.wantedPaths;
+  if (manifest.preferredLabels.length > 0) normalized.preferredLabels = manifest.preferredLabels;
+  if (manifest.linkedIssuePolicy !== "optional") normalized.linkedIssuePolicy = manifest.linkedIssuePolicy;
+  if (manifest.testExpectations.length > 0) normalized.testExpectations = manifest.testExpectations;
+  if (manifest.issueDiscoveryPolicy !== "neutral") normalized.issueDiscoveryPolicy = manifest.issueDiscoveryPolicy;
+  if (manifest.publicNotes.length > 0) normalized.publicNotes = manifest.publicNotes;
+
+  const gate = gateConfigToJson(manifest.gate);
+  if (gate !== null) normalized.gate = gate;
+  const settings = settingsOverrideToJson(manifest.settings);
+  if (settings !== null) normalized.settings = settings;
+  const review = reviewConfigToJson(manifest.review);
+  if (review !== null) normalized.review = review;
+  const features = featuresConfigToJson(manifest.features);
+  if (features !== null) normalized.features = features;
+  const contentLane = contentLaneConfigToJson(manifest.contentLane);
+  if (contentLane !== null) normalized.contentLane = contentLane;
+  const repoDocGeneration = repoDocGenerationConfigToJson(manifest.repoDocGeneration);
+  if (repoDocGeneration !== null) normalized.repoDocGeneration = repoDocGeneration;
+  const reviewRecap = reviewRecapConfigToJson(manifest.reviewRecap);
+  if (reviewRecap !== null) normalized.reviewRecap = reviewRecap;
+  const maintainerRecap = maintainerRecapConfigToJson(manifest.maintainerRecap);
+  if (maintainerRecap !== null) normalized.maintainerRecap = maintainerRecap;
+
+  return normalized;
+}

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -6,6 +6,7 @@ import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { buildFeasibilityVerdict } from "@loopover/engine";
+import { buildFocusManifestValidation } from "@loopover/engine/focus-manifest-validation";
 import { z } from "zod";
 import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 import { formatTable } from "../lib/format-table.js";
@@ -819,7 +820,10 @@ registerStdioTool(
     description: stdioToolDescription("loopover_validate_config"),
     inputSchema: validateConfigShape,
   },
-  async (input) => toolResult("LoopOver manifest validation.", await apiPost("/v1/validate/focus-manifest", input)),
+  // Computed in-process via @loopover/engine (#6269): the focus-manifest parser + validation result builder
+  // are deterministic and source-free, so the local server validates a .loopover.yml fully offline — no
+  // apiPost round-trip. The remote server keeps computing the identical result through its own import.
+  async (input) => toolResult("LoopOver manifest validation.", buildFocusManifestValidation(input)),
 );
 
 registerStdioTool(

--- a/packages/loopover-mcp/package.json
+++ b/packages/loopover-mcp/package.json
@@ -38,7 +38,7 @@
     "build": "node --check bin/loopover-mcp.js && node --check lib/cli-error.js && node --check lib/local-branch.js && node --check lib/format-table.js && node --check scripts/gittensor-score-preview.mjs"
   },
   "dependencies": {
-    "@loopover/engine": "^1.0.0",
+    "@loopover/engine": "^3.0.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "^4.4.3"
   },

--- a/src/selfhost/config-lint.ts
+++ b/src/selfhost/config-lint.ts
@@ -1,27 +1,12 @@
 import { parse as parseYaml } from "yaml";
-import { MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "../signals/focus-manifest";
+import { parseFocusManifestContent } from "../signals/focus-manifest";
+import {
+  TOP_LEVEL_FIELDS,
+  isOversize,
+  topLevelObjectOrNull,
+  unknownTopLevelWarnings,
+} from "../../packages/loopover-engine/src/focus-manifest-validation.js";
 
-const TOP_LEVEL_FIELDS = [
-  "source",
-  "wantedPaths",
-  "preferredLabels",
-  "linkedIssuePolicy",
-  "testExpectations",
-  "issueDiscoveryPolicy",
-  "maintainerNotes",
-  "publicNotes",
-  "gate",
-  "settings",
-  "review",
-  "features",
-  "experimental",
-  "contentLane",
-  "repoDocGeneration",
-  "reviewRecap",
-  "maintainerRecap",
-] as const;
-
-const TOP_LEVEL_FIELD_SET = new Set<string>(TOP_LEVEL_FIELDS);
 const NO_RECOGNIZED_FOCUS_FIELDS_WARNING =
   "Manifest contained no recognized focus fields; falling back to deterministic signals.";
 
@@ -63,32 +48,6 @@ function recognizedFieldsFor(text: string | null | undefined): string[] {
   );
 }
 
-// Fields retired from TOP_LEVEL_FIELDS that still warrant a migration-specific warning (rather than the
-// generic "unknown field" message) pointing operators at their replacement mechanism.
-const RETIRED_FIELD_MIGRATION_WARNINGS: Record<string, string> = {
-  blockedPaths: "blockedPaths is retired; use settings.hardGuardrailGlobs for path holds.",
-};
-
-export function unknownTopLevelWarnings(text: string | null | undefined): string[] {
-  const raw = text ?? "";
-  const trimmed = raw.trim();
-  if (!trimmed || isOversize(raw)) return [];
-  const parsed = parseTopLevelObject(trimmed);
-  if (parsed === null) return [];
-  const keys = Object.keys(parsed).filter((key) => !TOP_LEVEL_FIELD_SET.has(key));
-  // `hasOwnProperty.call`, NOT `key in`: a manifest field named like an Object.prototype member
-  // (`constructor`, `toString`, `hasOwnProperty`, ...) would otherwise test true for the inherited
-  // property and resolve to the prototype's function instead of a real retired-field warning string,
-  // corrupting the string[] result and suppressing the genuine unknown-field warning.
-  const isRetired = (key: string): boolean => Object.prototype.hasOwnProperty.call(RETIRED_FIELD_MIGRATION_WARNINGS, key);
-  const retiredWarnings = keys.filter(isRetired).map((key) => RETIRED_FIELD_MIGRATION_WARNINGS[key]!);
-  const unknown = keys.filter((key) => !isRetired(key)).map(formatFieldName);
-  return [
-    ...retiredWarnings,
-    ...(unknown.length > 0 ? [`Manifest contains unknown top-level field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}.`] : []),
-  ];
-}
-
 function parseCanonicalTopLevelObject(text: string | null | undefined): Record<string, unknown> | null {
   const raw = text ?? "";
   const trimmed = raw.trim();
@@ -99,38 +58,6 @@ function parseCanonicalTopLevelObject(text: string | null | undefined): Record<s
   } catch {
     return null;
   }
-}
-
-function parseTopLevelObject(text: string): Record<string, unknown> | null {
-  const looksLikeJson = text.startsWith("{") || text.startsWith("[");
-  if (looksLikeJson) {
-    try {
-      const parsed = JSON.parse(text);
-      return topLevelObjectOrNull(parsed);
-    } catch {
-      // YAML flow mappings can start with "{" or "[" while still being valid manifest syntax.
-    }
-  }
-  try {
-    return topLevelObjectOrNull(parseYaml(text));
-  } catch {
-    return null;
-  }
-}
-
-function topLevelObjectOrNull(parsed: unknown): Record<string, unknown> | null {
-  return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
-    ? (parsed as Record<string, unknown>)
-    : null;
-}
-
-function isOversize(text: string): boolean {
-  return text.length > MAX_FOCUS_MANIFEST_BYTES || new TextEncoder().encode(text).byteLength > MAX_FOCUS_MANIFEST_BYTES;
-}
-
-function formatFieldName(name: string): string {
-  const trimmed = name.replace(/[^\w.-]/g, "_").slice(0, 80);
-  return trimmed || "<blank>";
 }
 
 function redactManifestWarning(warning: string): string {

--- a/src/services/focus-manifest-validation.ts
+++ b/src/services/focus-manifest-validation.ts
@@ -1,81 +1,11 @@
-import {
-  contentLaneConfigToJson,
-  featuresConfigToJson,
-  gateConfigToJson,
-  parseFocusManifestContent,
-  repoDocGenerationConfigToJson,
-  reviewConfigToJson,
-  reviewRecapConfigToJson,
-  maintainerRecapConfigToJson,
-  settingsOverrideToJson,
-  type FocusManifest,
-  type FocusManifestSource,
-} from "../signals/focus-manifest";
-import { unknownTopLevelWarnings } from "../selfhost/config-lint";
-
-export type FocusManifestValidationStatus = "ok" | "warn" | "error";
-
-export type FocusManifestValidationResult = {
-  present: boolean;
-  warnings: string[];
-  normalized: Record<string, unknown>;
-  status: FocusManifestValidationStatus;
-};
-
-const PARSE_FAILURE_PATTERN = /not valid (JSON|YAML)|must be a mapping|exceeded \d+ bytes/i;
-
-export function buildFocusManifestValidation(input: {
-  content: string;
-  source?: FocusManifestSource | undefined;
-}): FocusManifestValidationResult {
-  const manifest = parseFocusManifestContent(input.content, input.source ?? "repo_file");
-  // Warn on unrecognized top-level fields (e.g. a typo'd `gates:` instead of `gate:`), matching the
-  // selfhost config-lint validator — parseFocusManifestContent reads only known fields, so a mistyped
-  // block is otherwise silently dropped with no warning (#5929).
-  const warnings = [...manifest.warnings, ...unknownTopLevelWarnings(input.content)];
-  const normalized = focusManifestToNormalizedJson(manifest);
-  return {
-    present: manifest.present,
-    warnings,
-    normalized,
-    status: resolveValidationStatus(manifest, warnings),
-  };
-}
-
-function resolveValidationStatus(manifest: FocusManifest, warnings: string[]): FocusManifestValidationStatus {
-  if (warnings.some((warning) => PARSE_FAILURE_PATTERN.test(warning))) return "error";
-  if (!manifest.present || warnings.length > 0) return "warn";
-  return "ok";
-}
-
-function focusManifestToNormalizedJson(manifest: FocusManifest): Record<string, unknown> {
-  const normalized: Record<string, unknown> = {
-    present: manifest.present,
-    source: manifest.source,
-  };
-  if (manifest.wantedPaths.length > 0) normalized.wantedPaths = manifest.wantedPaths;
-  if (manifest.preferredLabels.length > 0) normalized.preferredLabels = manifest.preferredLabels;
-  if (manifest.linkedIssuePolicy !== "optional") normalized.linkedIssuePolicy = manifest.linkedIssuePolicy;
-  if (manifest.testExpectations.length > 0) normalized.testExpectations = manifest.testExpectations;
-  if (manifest.issueDiscoveryPolicy !== "neutral") normalized.issueDiscoveryPolicy = manifest.issueDiscoveryPolicy;
-  if (manifest.publicNotes.length > 0) normalized.publicNotes = manifest.publicNotes;
-
-  const gate = gateConfigToJson(manifest.gate);
-  if (gate !== null) normalized.gate = gate;
-  const settings = settingsOverrideToJson(manifest.settings);
-  if (settings !== null) normalized.settings = settings;
-  const review = reviewConfigToJson(manifest.review);
-  if (review !== null) normalized.review = review;
-  const features = featuresConfigToJson(manifest.features);
-  if (features !== null) normalized.features = features;
-  const contentLane = contentLaneConfigToJson(manifest.contentLane);
-  if (contentLane !== null) normalized.contentLane = contentLane;
-  const repoDocGeneration = repoDocGenerationConfigToJson(manifest.repoDocGeneration);
-  if (repoDocGeneration !== null) normalized.repoDocGeneration = repoDocGeneration;
-  const reviewRecap = reviewRecapConfigToJson(manifest.reviewRecap);
-  if (reviewRecap !== null) normalized.reviewRecap = reviewRecap;
-  const maintainerRecap = maintainerRecapConfigToJson(manifest.maintainerRecap);
-  if (maintainerRecap !== null) normalized.maintainerRecap = maintainerRecap;
-
-  return normalized;
-}
+/**
+ * Focus-manifest validation shim (#6269). The result builder now lives engine-side in
+ * `packages/loopover-engine/src/focus-manifest-validation.ts` so the local `loopover_validate_config` MCP
+ * tool can compute it in-process (fully offline). This file re-exports the engine surface for the existing
+ * app callers (`src/api/routes.ts`, `src/mcp/server.ts`), which keep importing from here unchanged.
+ */
+export {
+  buildFocusManifestValidation,
+  type FocusManifestValidationResult,
+  type FocusManifestValidationStatus,
+} from "../../packages/loopover-engine/src/focus-manifest-validation.js";


### PR DESCRIPTION
## Summary

- Extracts `buildFocusManifestValidation` (the focus-manifest validation-result builder) out of `src/services/focus-manifest-validation.ts` into `@loopover/engine` (`packages/loopover-engine/src/focus-manifest-validation.ts`), leaving a thin re-export shim at the original `src/` path so the remote server (`src/api/routes.ts`, `src/mcp/server.ts`) keeps importing it unchanged.
- Local `loopover_validate_config` now computes the result in-process via the engine instead of `apiPost("/v1/validate/focus-manifest", …)`, so a user running the local MCP server can validate a `.loopover.yml` fully offline. Verified identical output to the remote route.

Closes #6269

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #6269) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — the extraction + the two `src/` files it touches are at **100% patch coverage** (statements/branches/functions/lines) under the existing `focus-manifest-validation` and `selfhost-config-lint` suites; no new uncovered lines/branches. (The unrelated `sqlite3`-backed and miner-discover suites fail only in this sandbox for lack of a local `sqlite3` binary — identical failures on a clean checkout of `main`.)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run engine-parity:drift-check`, `test:engine-parity`, `manifest:drift-check`, `docs:drift-check`, `command-reference:check`, `selfhost:env-reference:check`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] New/changed behavior has tests — the existing `test/unit/focus-manifest-validation.test.ts` (13 cases) and `test/unit/selfhost-config-lint.test.ts` (20 cases) exercise every branch of the moved code against its new location and continue to pass.

If any required check was skipped, explain why:

- `ui:lint` / `ui:typecheck` / `ui:build` are unaffected — this PR touches no `apps/**` UI code (no UI surface).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed. The extracted code is pure, deterministic, and source-free; existing tests assert the normalized output never echoes private `maintainerNotes`.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] MCP behavior is updated and tested — the local `loopover_validate_config` handler now returns the byte-identical result the remote `POST /v1/validate/focus-manifest` route produces.
- [x] No UI data-source changes.
- [x] No visible UI changes (no `UI Evidence` needed).
- [x] No docs/changelog edits required.

## Notes

- **`unknownTopLevelWarnings` co-moves with the builder (required, not scope-creep).** `buildFocusManifestValidation` depends on `unknownTopLevelWarnings`, which lived in `src/selfhost/config-lint.ts`; the engine cannot import from `src/`, so that helper (plus its `TOP_LEVEL_FIELDS` allowlist and the `isOversize`/`topLevelObjectOrNull` primitives) moves into the engine module as the single source of truth. `config-lint.ts` now imports them back — no duplicate implementation, and its recognized-field report keeps sharing the same allowlist so the two surfaces cannot drift (the class of miss #3002/#5281 fixed).
- **`@loopover/engine` dependency bump in `packages/loopover-mcp`.** The local MCP package pinned `@loopover/engine@^1.0.0` (a published copy that predates this function), so it could not consume the extracted symbol. Bumped to `^3.0.0` to track the workspace engine — mirroring `packages/loopover-miner`, which already declares `^3.0.0` and consumes workspace-only 3.x engine exports the same way. `package-lock.json` is regenerated accordingly (the stale nested `@loopover/engine@1.0.0` is dropped in favor of the workspace link).
- No behavior change to the remote server: it still imports `buildFocusManifestValidation` from `src/services/focus-manifest-validation.ts`, now resolving through the shim to the engine.
