### PR TITLE
fix(ui): generate fumadocs-mdx collections/* via postinstall

### DIFF
--- a/apps/loopover-ui/package.json
+++ b/apps/loopover-ui/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
+    "postinstall": "fumadocs-mdx",
     "dev": "vite dev",
     "build": "vite build",
     "build:cloudflare": "npm --prefix ../.. run ui:build",

--- a/package-lock.json
+++ b/package-lock.json
@@ -487,6 +487,7 @@
     "apps/loopover-ui": {
       "name": "@loopover/ui",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@loopover/ui-kit": ">=0.1.0 <2.0.0",
         "@radix-ui/react-accordion": "^1.2.15",


### PR DESCRIPTION
## Summary

- `apps/loopover-ui/tsconfig.json` maps `collections/*` to `./.source/*`, a directory fumadocs-mdx's Vite plugin generates from `source.config.ts`. `.source/` is gitignored and nothing generated it outside of an actual `vite dev`/`vite build` run.
- `npm run ui:typecheck` (and therefore CI's `validate-code`/`validate` jobs) runs bare `tsc --noEmit` with no prior Vite invocation, so on a genuinely fresh checkout `collections/browser`/`collections/server` fail to resolve (`TS2307: Cannot find module`).
- This has been broken since the fumadocs-mdx docs migration landed in [PR #6271](https://github.com/JSONbored/loopover/pull/6271) — that PR's own CI failed for this exact reason. Every PR touching `apps/loopover-ui` since inherits the same failure on a fresh CI runner, even when `npm run test:ci` passes locally on a working tree that has ever run `vite dev`/`build` before (which leaves `.source/` on disk).
- Fix: wire fumadocs-mdx's own generator (`node_modules/.bin/fumadocs-mdx`, its documented postinstall entry point) as `apps/loopover-ui/package.json`'s `postinstall` script, so `npm ci` always regenerates `.source/` before any other script runs.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: a 2-line fix (one `package.json` script, the corresponding `package-lock.json` metadata bit) isolated from any content/feature work.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Closes #6304

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `apps/loopover-ui/**` only, outside `coverage.include`; `codecov/patch` does not apply
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] Reproduced the exact CI failure locally and confirmed the fix: `rm -rf apps/loopover-ui/.source && npm ci --prefer-offline --no-audit --no-fund` (the literal command CI runs) regenerates `.source/` via the new `postinstall` hook, and `npm --workspace apps/loopover-ui run typecheck` then passes — it failed with the identical `TS2307` errors before this fix.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, build-tooling fix only, no UI behavior changes
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI Evidence table — this is a build-tooling fix with zero rendered-output changes.
- Unblocks every pending/future PR touching `apps/loopover-ui`, including the AMS docs-porting sub-issue PRs currently being worked (#6022, #6023, ...).