### PR TITLE
feat(engine): add shared TrustSignal type for ORB/AMS reputation bridging

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -143,6 +143,7 @@ export {
   type TrackRecordSummaryOutcomeCounts,
   type TrackRecordTenure,
 } from "./track-record-summary.js";
+export type { TrustLevel, TrustSignal, TrustSignalSource } from "./trust-signal.js";
 export * from "./governor/rate-limit.js";
 export * from "./governor/budget-cap.js";
 export * from "./governor/self-plagiarism.js";

--- a/packages/loopover-engine/src/trust-signal.ts
+++ b/packages/loopover-engine/src/trust-signal.ts
@@ -1,0 +1,32 @@
+// Shared cross-system trust-signal vocabulary (#6302). A minimal, additive type that ORB's review-history
+// reputation (src/review/submitter-reputation.ts) and AMS's track-record summary (track-record-summary.ts) can
+// both converge toward once #6208's reputation-bridge design resolves identity-linkage / data-path / weighting.
+//
+// SCOPE: this is a TYPE-ONLY definition — no runtime helper, no validation, no populate/consume logic, and it is
+// deliberately NOT wired into any real call site. #6208 owns how the signal is produced and read; #6246 (the
+// track-record read-API groundwork) is a natural consumer. Every field here is one BOTH existing systems can
+// already populate from public outcomes, so neither side has to invent a shape mid-implementation. It carries no
+// score / ranking / reward fields — only a coarse bucket plus provenance.
+
+/** How trustworthy a contributor's public history looks, as a coarse three-way bucket. Mirrors ORB's
+ *  `ReputationSignal` ("low" | "neutral" | "trusted") so that side maps 1:1; AMS can bucket its merge-rate /
+ *  incident summary onto the same three values. `"neutral"` is the safe default when the sample is thin. */
+export type TrustLevel = "low" | "neutral" | "trusted";
+
+/** Which system produced the signal, so a consumer can weigh provenance without assuming identity-linkage. */
+export type TrustSignalSource = "orb-review-history" | "ams-track-record";
+
+/** A minimal, shared trust signal both ORB and AMS can populate. Additive shared vocabulary only — this type is
+ *  not read or written by any current call site (see the file header); it exists so #6208's eventual reputation
+ *  bridge has a ready shape to converge both systems' internal representations toward. */
+export interface TrustSignal {
+  /** Coarse trust bucket. */
+  level: TrustLevel;
+  /** How many public outcomes backed the level — ORB's recent-window sample, or AMS's merge-rate denominator.
+   *  A larger sample means the level is better supported; `0` means "no evidence, treat as neutral". */
+  sampleSize: number;
+  /** Which system computed the signal. */
+  source: TrustSignalSource;
+  /** ISO-8601 timestamp of the data the signal was computed from, so a consumer can reason about staleness. */
+  asOf: string;
+}


### PR DESCRIPTION
## What

Adds a minimal, additive `TrustSignal` type to `@loopover/engine` so #6208's eventual
reputation-bridge implementation (and #6246's track-record read-API groundwork) have a
shared vocabulary to converge both systems' internal representations toward, instead of
inventing one mid-implementation.

New module `packages/loopover-engine/src/trust-signal.ts`, re-exported from the package
barrel:

```ts
export type TrustLevel = "low" | "neutral" | "trusted";
export type TrustSignalSource = "orb-review-history" | "ams-track-record";

export interface TrustSignal {
  level: TrustLevel;
  sampleSize: number;
  source: TrustSignalSource;
  asOf: string;
}
```

## Why these fields

Every field is one BOTH existing systems can already populate from public outcomes — no
invented fields neither side has:

- `level` mirrors ORB's `ReputationSignal` (`"low" | "neutral" | "trusted"` in
  `src/review/submitter-reputation.ts`) 1:1, and AMS can bucket its merge-rate/incident
  summary (`packages/loopover-engine/src/track-record-summary.ts`) onto the same three
  values.
- `sampleSize` maps to ORB's recent-window sample and AMS's merge-rate denominator.
- `source` records provenance without assuming any identity-linkage.
- `asOf` is an ISO-8601 instant so a consumer can reason about staleness (both sides are
  recency-aware).

It deliberately carries no score / ranking / reward fields — only a coarse bucket plus
provenance.

## Scope

Purely additive, type-only. This PR:

- does NOT implement any bridging logic and does NOT decide identity-linkage (that's #6208);
- does NOT change ORB's or AMS's actual internal representations;
- does NOT wire the type into any real call site — #6208 owns how it is produced and read.

## Notes

- Type-only addition: the compiled module is comments + `export {};` (zero runtime
  statements), so it needs no behavioral test per the issue's coverage note — it just has
  to compile and be exported. Verified `npm run build --workspace @loopover/engine` and
  `npm run typecheck` both pass, and the barrel now re-exports `TrustLevel`, `TrustSignal`,
  and `TrustSignalSource`.
- No name collisions: `TrustSignal` / `TrustLevel` / `TrustSignalSource` did not previously
  exist anywhere under `src/` or `packages/`.

Closes #6302
