### PR TITLE
docs(selfhost): document Sentry once, matching the code's own default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -565,7 +565,13 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 
 # --- Sentry error tracking (optional) ---
 # SENTRY_DSN=                                # enables self-host Sentry capture; unset = complete no-op
-# SENTRY_ENVIRONMENT=production
+# SENTRY_DSN_FILE=                           # optional mounted secret file; the generic *_FILE loader
+#                                            #   (src/selfhost/load-file-secrets.ts) resolves it into SENTRY_DSN
+# SENTRY_ENVIRONMENT=production              # the code's own default (src/selfhost/sentry.ts); set any label you
+#                                            #   want to slice by in Sentry (staging, selfhost, ...) — nothing
+#                                            #   behaves differently per value, it only tags the events
+# SENTRY_SERVER_NAME=                        # clean name for THIS instance in Sentry (e.g. loopover-us-east);
+#                                            #   unset defaults to the OS hostname — never the public-origin URL
 # SENTRY_TRACES_SAMPLE_RATE=                 # traces/spans are off when blank/unset; errors still report. Set a LOW
 #                                            #   rate (e.g. 0.05) with SENTRY_DSN to sample review tracing: each
 #                                            #   sampled review emits a connected trace — the queue-job span
@@ -611,16 +617,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # today — every repo shares this one webhook.
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 #
-# Sentry error tracking. OFF when SENTRY_DSN is unset. Official self-host release images bake
-# LOOPOVER_VERSION=gittensory-selfhost@<version>; initSentry uses that as the release id unless
-# SENTRY_RELEASE is set explicitly (useful for custom/local images).
-# SENTRY_DSN=
-# SENTRY_DSN_FILE=                          # optional mounted secret file; existing *_FILE loader reads it
-# SENTRY_ENVIRONMENT=selfhost
-# SENTRY_SERVER_NAME=                       # clean name for THIS instance in Sentry (e.g. gittensory-us-east);
-#                                           #   unset defaults to the OS hostname — never the public-origin URL
-# SENTRY_RELEASE=
-# SENTRY_TRACES_SAMPLE_RATE=
+# Sentry error tracking is documented once, under "--- Sentry error tracking (optional) ---" above (#6289).
 
 # --- AI review backend (optional; without AI_PROVIDER reviews run deterministically) ---
 # AI_SUMMARIES_ENABLED=true


### PR DESCRIPTION
## Summary

Closes #6289

`.env.example` documented `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE` **twice**, and the two blocks disagreed — the first suggested `SENTRY_ENVIRONMENT=production`, the second `selfhost`. An operator wiring Sentry hit both in the same file with no way to tell which was right.

### Which is correct, verified against the code

`production`. `initSentry` reads `nonBlank(env.SENTRY_ENVIRONMENT) ?? "production"` (`src/selfhost/sentry.ts:402`).

But the issue asked me to check whether `selfhost` is *"actually a meaningful distinct option"* before calling either wrong — and it isn't a wrong value, it's a **free-form label**: nothing in `sentry.ts` branches on it; it only tags events. So the consolidated entry documents the real default *and* says any label you want to slice by is fine, rather than implying `selfhost` was a mistake.

### Consolidating without losing anything

Kept the existing `--- Sentry error tracking (optional) ---` section (it had the richer tracing/release guidance) and **carried over the two vars only the duplicate had** — both verified real before keeping:

| Var | Verified |
|---|---|
| `SENTRY_DSN_FILE` | the generic `<NAME>_FILE` loader (`src/selfhost/load-file-secrets.ts`) resolves it into `SENTRY_DSN` |
| `SENTRY_SERVER_NAME` | `sentry.ts:413` — `nonBlank(env.SENTRY_SERVER_NAME) ?? hostname()` |

Result: **every `SENTRY_*` name now appears exactly once** — nothing dropped.

A one-line breadcrumb stays where the duplicate was (next to the alerting vars it sat among) so the block doesn't get re-added there. Also fixes the stale `gittensory-us-east` example → `loopover-us-east`.

## Scope

- [x] Conventional Commit title (`docs(selfhost): …`).
- [x] **Comment-only, one file** (`.env.example`), net −3 lines. Every line is a `#` comment in a sample file.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable`; no changelog edit.
- [x] Linked open issue (Closes #6289, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run typecheck` — **0 errors**.
- [x] **Every suite that reads `.env.example`** — `docker-compose-env-example-parity`, `env-example-metric-names`, `self-host-ops-rename-residue`, `selfhost-preflight`, `setup-wizard-docs-parity`, `miner-docker-compose`, `selfhost-compose-resource-limits`, `selfhost-compose-workflows-storage`, `selfhost-grafana-sentry-datasource` — **61 passed**.
- [x] Verified post-change that **no `SENTRY_*` var is documented more than once, and none was lost**.
- [x] Branch isolation proven: `git log upstream/main..HEAD` is this one commit; `git diff --stat upstream/main..HEAD` is this one file.
- [x] Rebased onto current `main`.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows).
- Two suites report a failure in this environment — `selfhost-grafana-sentry-datasource` (`setup-sentry-datasource.sh is executable`: Windows doesn't preserve the Unix exec bit) and `selfhost-compose-workflows-storage` (`$$` escaping in a compose heredoc). Both confirmed **pre-existing on a clean checkout of `main`**, and both are in files this PR doesn't touch (`scripts/`, `docker-compose.yml`).
- Not linted: CI's only lint step is `npm run ui:lint` (`apps/**`); this touches neither. No Codecov obligation — `.env.example` is outside `coverage.include`.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence. Every added line is a commented sample; no real DSN or value is committed.
- [x] **No behavior change of any kind** — `.env.example` is a sample file and every changed line is a comment. Copying it to `.env` yields byte-identical runtime behavior.
- [x] No auth/cookie/CORS/GitHub App/session change; no code, schema, API, or generated artifact touched.
- [x] **Nothing was dropped while deduplicating** — the risk with a consolidation is silently deleting a variable an operator needs. `SENTRY_DSN_FILE` and `SENTRY_SERVER_NAME` were each traced to their real reader in `src/` before being carried over, and every `SENTRY_*` name is verified present exactly once.
- [x] No UI changes; no changelog edit.
