### PR TITLE
fix(mcp): honor --help for analyze-branch and preflight

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -1957,6 +1957,8 @@ async function runCli(args) {
     const suggestion = suggestCommand(command);
     throw new Error(`Unknown command: ${command}.${suggestion ? ` Did you mean \`${suggestion}\`?` : ""} Run \`loopover-mcp --help\` to list commands.`);
   }
+  // Match every other subcommand: honor --help before requiring --login / hitting git+network (#6256).
+  if (options.help === true) return printHelp();
   const contributorLogin = options.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
   if (!contributorLogin) throw new Error("Pass --login <github-login> or set LOOPOVER_LOGIN.");
   const result = await analyzeCurrentBranch({

--- a/test/unit/mcp-cli-analyze-branch.test.ts
+++ b/test/unit/mcp-cli-analyze-branch.test.ts
@@ -1,6 +1,20 @@
 import { rmSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
-import { closeFixtureServer, createPacketRepo, localBranchAnalysisFixture, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+import { closeFixtureServer, createPacketRepo, localBranchAnalysisFixture, run, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+
+describe("loopover-mcp CLI — analyze-branch / preflight --help (#6256)", () => {
+  it("prints usage for analyze-branch --help without requiring --login or hitting git/network", () => {
+    const help = run(["analyze-branch", "--help"]);
+    expect(help).toMatch(/loopover-mcp analyze-branch/);
+    expect(help).toMatch(/--login <github-login>/);
+  });
+
+  it("prints usage for preflight --help without requiring --login or hitting git/network", () => {
+    const help = run(["preflight", "--help"]);
+    expect(help).toMatch(/loopover-mcp preflight/);
+    expect(help).toMatch(/--login <github-login>/);
+  });
+});
 
 describe("loopover-mcp CLI — analyze-branch --format table", () => {
   let tempDir: string | null = null;


### PR DESCRIPTION
## Summary
- Adds the same `--help` early-return other `loopover-mcp` subcommands already use for `analyze-branch` and `preflight`, before `--login` / git+network work begins.
- `loopover-mcp analyze-branch --help` and `loopover-mcp preflight --help` now print the shared usage text from `printHelp()` instead of failing on a missing login.
- Adds focused CLI regression coverage for both commands (`#6256`).

Closes #6256

## Scope
- [x] Code changes stay inside `packages/loopover-mcp/bin/loopover-mcp.js` + matching unit test
- [x] No other subcommand dispatch changed
- [x] Reuses existing `printHelp()` output (already documents both commands)

## Validation
- [x] Unit tests updated (`test/unit/mcp-cli-analyze-branch.test.ts`)
- [x] Focused coverage for the exact failure mode in `#6256`
- [ ] CI on this PR (will mark ready after green)

## Safety
- [x] Diff is limited to CLI help dispatch for two commands
- [x] No scheme / economics / protocol changes
- [x] Non-help paths are unchanged


Made with [Cursor](https://cursor.com)