### PR TITLE
docs(db): guardrail listInstallations/listRepositories against tenant-facing misuse

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -301,6 +301,12 @@ export async function updateInstallationPermissions(env: Env, installationId: nu
   await db.update(installations).set({ permissionsJson: jsonString(permissions), updatedAt: nowIso() }).where(eq(installations.id, installationId));
 }
 
+/** #4797: NOT tenant-scoped at the query layer -- returns every installation with no filter. Every current
+ *  caller is either internal cross-repo maintenance (backfill/sweep machinery, which legitimately needs the
+ *  fleet-wide view) or an admin/maintainer/owner-role-gated dashboard route (verified via `canSessionAccessPath`
+ *  / `requireAppRole` at each call site, src/api/routes.ts). Do NOT call this from any customer/tenant-facing
+ *  path -- use {@link getInstallation} (single, id-scoped) instead. A future Rent-a-Loop customer endpoint that
+ *  reaches for this function by habit would leak every other tenant's installations. */
 export async function listInstallations(env: Env): Promise<InstallationRecord[]> {
   const db = getDb(env.DB);
   const rows = await db.select().from(installations).orderBy(desc(installations.updatedAt)).limit(100);
@@ -537,6 +543,12 @@ export async function getRepository(env: Env, fullName: string): Promise<Reposit
   return caseInsensitiveRow ? toRepositoryRecord(caseInsensitiveRow) : null;
 }
 
+/** #4797: NOT tenant-scoped at the query layer -- returns every repository (including private ones) with no
+ *  filter. Every current caller is either internal cross-repo maintenance/sweep machinery or an
+ *  admin/maintainer/owner-role-gated dashboard route (verified via `canSessionAccessPath` / `requireAppRole`
+ *  at each call site, src/api/routes.ts) -- e.g. `/v1/repos` requires an authorized admin session. Do NOT call
+ *  this from any customer/tenant-facing path -- use {@link getRepository} (single, fullName-scoped) or
+ *  {@link listInstalledRepoFullNamesForInstallation} (installation-scoped) instead. */
 export async function listRepositories(env: Env): Promise<RepositoryRecord[]> {
   const db = getDb(env.DB);
   const rows = await db.select().from(repositories).orderBy(desc(repositories.isRegistered), repositories.fullName);


### PR DESCRIPTION
## Summary

Closes #4797. Audited every query touching `installations`, `repositories`, and `repository_settings` — the shared tables Rent-a-Loop's architecture (#4783) reuses — for tenant-scoping at the query layer, not just application logic.

**Single-row lookups are correctly scoped:** `getRepositorySettings`, `getRepository`, `getInstallation`, `listInstalledRepoFullNamesForInstallation` all take their scoping key as an explicit function parameter, so the query itself can't return another tenant's row regardless of caller behavior.

**Bulk queries have a real gap, now guardrailed:** `listInstallations`/`listRepositories` have no WHERE clause — every row, every call. Traced all 30+ call sites (`src/queue/**`, `src/review/**`, `src/github/backfill.ts`, `src/api/routes.ts`, `src/services/**`): every one is internal cross-repo maintenance machinery or an admin/maintainer/owner-role-gated dashboard route (verified via `canSessionAccessPath`/`requireAppRole` at each API call site — e.g. `/v1/repos`, `/v1/installations` all require an authorized admin session). No live leak exists today, but the isolation only holds because every current caller happens to be admin-gated, not because the query itself enforces it — exactly the risk class the issue's problem statement calls out. Added doc-comment guardrails on both functions pointing at the correctly-scoped alternatives, so a future customer-facing endpoint doesn't reach for them by habit.

Full audit findings posted on #4797.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:ci` (full local gate incl. drift checks, coverage, engine parity, MCP/miner packs, UI build): green, verified via literal captured exit code
- [x] Confirmed no other stale nested `node_modules/@loopover/*` copies exist in this checkout that could mask a real failure
- [x] Rebased onto latest `origin/main`, no conflicts