### PR TITLE
feat(mcp): compute loopover_check_slop_risk in-process from the shared engine

### DIFF
--- a/packages/loopover-engine/package.json
+++ b/packages/loopover-engine/package.json
@@ -54,6 +54,10 @@
     "./signals/path-matchers": {
       "types": "./dist/signals/path-matchers.d.ts",
       "default": "./dist/signals/path-matchers.js"
+    },
+    "./signals/slop": {
+      "types": "./dist/signals/slop.d.ts",
+      "default": "./dist/signals/slop.js"
     }
   },
   "files": [

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -6,6 +6,7 @@ import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { buildFeasibilityVerdict, buildPrTextLint } from "@loopover/engine";
+import { buildSlopAssessment, SLOP_RUBRIC_MARKDOWN } from "@loopover/engine/signals/slop";
 import { z } from "zod";
 import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 import { formatTable } from "../lib/format-table.js";
@@ -484,7 +485,7 @@ const STDIO_TOOL_DESCRIPTORS = [
   },
   {
     name: "loopover_check_slop_risk",
-    description: "Assess the deterministic slop risk of a planned change from local diff metadata (paths + line counts) + the PR description — an agent-native, source-free quality self-check. Returns slopRisk (0-100), band, findings, and the rubric. No repo data needed.",
+    description: "Assess the deterministic slop risk of a planned change from local diff metadata (paths + line counts) + the PR description — an agent-native, source-free quality self-check. Returns slopRisk (0-100), band, findings, and the rubric. Computed in-process; no repo data and no API round-trip.",
   },
   {
     name: "loopover_check_issue_slop",
@@ -830,7 +831,10 @@ registerStdioTool(
     description: stdioToolDescription("loopover_check_slop_risk"),
     inputSchema: checkSlopRiskShape,
   },
-  async (input) => toolResult("LoopOver slop-risk self-check.", await apiPost("/v1/lint/slop-risk", input)),
+  // Computed in-process from @loopover/engine (#6267) — matches the remote server's own buildSlopAssessment
+  // call (src/mcp/server.ts) and the /v1/lint/slop-risk route's `{ ...assessment, rubric }` shape with no API
+  // round-trip, so slop-risk self-checks work fully offline.
+  (input) => toolResult("LoopOver slop-risk self-check.", { ...buildSlopAssessment(input), rubric: SLOP_RUBRIC_MARKDOWN }),
 );
 
 registerStdioTool(

--- a/test/unit/mcp-local-check-slop-risk.test.ts
+++ b/test/unit/mcp-local-check-slop-risk.test.ts
@@ -1,0 +1,98 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+
+// An unreachable API endpoint with a tight timeout: if the stdio tool ever regressed to proxying over HTTP
+// (`apiPost("/v1/lint/slop-risk", …)`) instead of computing in-process, every call below would error out
+// against this dead address. Their success is what proves the local tool runs fully offline (#6267).
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-check-slop-risk-"));
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...(process.env as Record<string, string>),
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: "http://127.0.0.1:1",
+      LOOPOVER_API_TIMEOUT_MS: "400",
+    },
+  });
+  client = new Client({ name: "check-slop-risk-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+async function disconnect() {
+  await client.close().catch(() => undefined);
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+}
+
+describe("loopover_check_slop_risk stdio tool (#6267)", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("advertises the in-process, no-round-trip behavior in the tool list", async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "loopover_check_slop_risk");
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("no API round-trip");
+  });
+
+  it("regression: flags a low-effort change with band/findings/rubric computed in-process, no network call", async () => {
+    const result = await client.callTool({
+      name: "loopover_check_slop_risk",
+      arguments: {
+        changedFiles: [{ path: "src/foo.ts", additions: 50, deletions: 0 }],
+        description: "",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as {
+      slopRisk: number;
+      band: string;
+      findings: { code: string }[];
+      rubric: string;
+    };
+    // A code file with no test evidence (15) + an empty description (15) = 30 → "low".
+    expect(data.slopRisk).toBe(30);
+    expect(data.band).toBe("low");
+    expect(data.findings.map((f) => f.code).sort()).toEqual(["empty_pr_description", "missing_test_evidence"]);
+    // The local path keeps the /v1/lint/slop-risk route's `{ ...assessment, rubric }` shape byte-for-byte.
+    expect(data.rubric).toContain("LoopOver slop assessment rubric");
+  });
+
+  it("returns a clean band with no findings offline for a substantive, well-described change", async () => {
+    const result = await client.callTool({
+      name: "loopover_check_slop_risk",
+      arguments: {
+        changedFiles: [
+          { path: "src/foo.ts", additions: 40, deletions: 2 },
+          { path: "test/unit/foo.test.ts", additions: 30, deletions: 0 },
+        ],
+        description: "Adds X to support Y because Z, with focused regression coverage.",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { slopRisk: number; band: string; findings: unknown[] };
+    expect(data.slopRisk).toBe(0);
+    expect(data.band).toBe("clean");
+    expect(data.findings).toEqual([]);
+  });
+
+  it("never leaks private financial terminology in the offline response", async () => {
+    const result = await client.callTool({
+      name: "loopover_check_slop_risk",
+      arguments: { changedFiles: [{ path: "src/foo.ts", additions: 50, deletions: 0 }], description: "" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result)).not.toMatch(/hotkey|coldkey|wallet|mnemonic|payout|reward|trust score/i);
+  });
+});


### PR DESCRIPTION
## Summary

Make the local MCP server's `loopover_check_slop_risk` tool compute its result in-process from
`@loopover/engine`, matching the remote server's existing in-process behavior, so slop-risk
self-checks work fully offline instead of proxying over HTTP (`apiPost("/v1/lint/slop-risk", …)`).

`buildSlopAssessment`'s canonical logic already lives in
`packages/loopover-engine/src/signals/slop.ts`, and both the remote MCP server
(`src/mcp/server.ts` `checkSlopRisk`) and the API route (`src/api/routes.ts` `/v1/lint/slop-risk`)
already call it directly. The only blocker for the local CLI was that `@loopover/engine`'s
`exports` map did not expose `./signals/slop`, so the local package could not import the function
and fell back to an HTTP proxy — even though it already depends on `@loopover/engine`.

- Added a `./signals/slop` entry to `packages/loopover-engine/package.json`'s `exports` map,
  pointing at the same built module (`dist/signals/slop.{js,d.ts}`) the barrel and the `src/`
  re-export shim already consume.
- Updated `packages/loopover-mcp/bin/loopover-mcp.js`'s `loopover_check_slop_risk` handler to call
  `buildSlopAssessment(input)` directly and wrap it as `{ ...assessment, rubric: SLOP_RUBRIC_MARKDOWN }`
  — byte-for-byte the shape the `/v1/lint/slop-risk` route returned, so the tool's documented output
  (slopRisk, band, findings, rubric) is unchanged, only computed locally. Refreshed its description
  ("Computed in-process; no repo data and no API round-trip").
- Left the remote server (`src/mcp/server.ts`), the API route, the `slop-risk` CLI subcommand, and
  the `review-pr` composition untouched — this mirrors #6308's identical change for
  `loopover_lint_pr_text`, which converted only the stdio tool handler.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6267`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — full suite green except 3 files that shell out to the
      `sqlite3` CLI (absent in my sandbox, present in CI); none import any file this PR changes. The
      diff touches no `src/**` line, so `codecov/patch` has no changed lines to measure.
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run engine-parity:drift-check`
- [x] `npm run manifest:drift-check`
- [x] `npm run docs:drift-check`
- [x] `npm run command-reference:check`
- [x] `npm audit --audit-level=moderate`
- [x] New regression test drives the real stdio server with an unreachable `LOOPOVER_API_URL` +
      tight timeout, proving the tool runs fully offline (`test/unit/mcp-local-check-slop-risk.test.ts`).

If any required check was skipped, explain why:

- `test:workers` / `ui:*` were not run: this change touches no Cloudflare-worker code and no
  `apps/loopover-ui/**` file, so those jobs cover nothing in this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private
      rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise; the offline response is asserted to never
      leak private financial terminology.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — n/a (no such change).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states — n/a (no UI change).
- [ ] Visible UI changes include a `UI Evidence` section — n/a (no visible UI change).
- [x] Public docs/changelogs are updated where needed; no changelog edit in this PR.

## Notes

- Concrete instance of #6227's shared-core convergence pattern, mirroring #6308 for the sibling
  `loopover_lint_pr_text` tool.

Closes #6267
