### PR TITLE
fix(review): exclude bare .ts app-source files from isVisualPath

### DIFF
--- a/src/review/visual/paths.ts
+++ b/src/review/visual/paths.ts
@@ -6,9 +6,21 @@
 // EMPHATIC gate: screenshots fire ONLY for WEB-VISIBLE changes — any frontend app folder (apps/*/**, e.g.
 // apps/loopover-ui/** or apps/ui/**), a public asset (public/**, e.g. an OG image), or a front-of-house
 // source extension (.tsx/.jsx/.css/.scss/.sass/.less/.html/.svg/.astro/.vue/.svelte/.mdx). A backend change
-// (.ts/.md/.json/.py/...) matches NONE of these, so capture never triggers for it.
+// OUTSIDE an app folder (.ts/.md/.json/.py/... under e.g. src/**) matches NONE of these, so capture never
+// triggers for it.
 //
-// PURE — no imports, no I/O. Callers MUST filter changed files through this before any capture.
+// #6322: pattern 1's app-folder prefix alone is extension-agnostic, so a bare .ts file living INSIDE an app's
+// own src/ tree (a data/logic/hooks/test file — TanStack Router's file-based routes are always .tsx/.jsx, so a
+// bare .ts can never itself be a route) also matched, even though it renders nothing (confirmed live:
+// JSONbored/metagraphed#6036 touched only apps/ui/src/lib/metagraphed/queries.ts + its .test.ts sibling, a
+// non-visual data-layer fix the bot's own screenshot-table-gate correctly called out of scope, yet capture
+// still ran and burned Browser Rendering on a meaningless "before/after of the unchanged homepage"). Excluding
+// apps/*/src/**/*.ts specifically (not .tsx) fixes exactly that case while leaving every existing scope
+// untouched: an app-ROOT .ts config file (tailwind.config.ts, vite.config.ts — genuinely can affect rendered
+// output) still matches pattern 1 since it isn't under src/; README.md/components.json/any non-.ts file
+// anywhere in the app tree still matches (not .ts); every .tsx/.jsx route or component is unaffected (this
+// exclusion only strips bare .ts, never .tsx).
+const NON_VISUAL_APP_SOURCE = /^apps\/[^/]+\/src\/.*\.ts$/i;
 
 const VISUAL_PATTERNS: RegExp[] = [
   /^apps\/[^/]+\//i,
@@ -17,7 +29,10 @@ const VISUAL_PATTERNS: RegExp[] = [
 ];
 
 /** True when `path` is a web-visible change worth screenshotting (frontend page / public OG asset / front-end
- *  source file). Backend .ts/.md/.json/.py paths return false → capture must NOT trigger for them. */
+ *  source file). Backend .ts/.md/.json/.py paths return false → capture must NOT trigger for them, and (#6322)
+ *  so does a bare .ts file under an app's own src/ tree even though it starts with an app-folder prefix — see
+ *  NON_VISUAL_APP_SOURCE's doc comment above for why that specific case is safe to exclude. */
 export function isVisualPath(path: string): boolean {
+  if (NON_VISUAL_APP_SOURCE.test(path)) return false;
   return VISUAL_PATTERNS.some((pattern) => pattern.test(path));
 }

--- a/test/unit/visual-paths.test.ts
+++ b/test/unit/visual-paths.test.ts
@@ -66,4 +66,25 @@ describe("isVisualPath (web-visible-only capture gate)", () => {
     // A .ts (backend) must still be false even upper-cased — it is not a web-visible extension.
     expect(isVisualPath("src/Worker.TS")).toBe(false);
   });
+
+  it("does NOT match a bare .ts file under an app's own src/ tree (#6322 — logic/hooks/tests, never a route)", () => {
+    // The exact JSONbored/metagraphed#6036 case: a non-visual data-layer fix that still burned capture
+    // budget before this fix, on files the bot's own screenshot-table-gate correctly called out of scope.
+    expect(isVisualPath("apps/ui/src/lib/metagraphed/queries.ts")).toBe(false);
+    expect(isVisualPath("apps/ui/src/lib/metagraphed/queries.test.ts")).toBe(false);
+    expect(isVisualPath("apps/loopover-ui/src/hooks/useSession.ts")).toBe(false);
+    expect(isVisualPath("apps/loopover-ui/src/types.ts")).toBe(false);
+    // Case-insensitivity applies to the exclusion too, not just the positive matches above.
+    expect(isVisualPath("APPS/UI/SRC/LIB/QUERIES.TS")).toBe(false);
+  });
+
+  it("still matches everything the exclusion must NOT touch", () => {
+    // A .tsx file under the same src/ tree is a route/component -- the exclusion only strips bare .ts.
+    expect(isVisualPath("apps/ui/src/lib/metagraphed/Queries.tsx")).toBe(true);
+    // An app-ROOT .ts config file (not under src/) can genuinely affect rendered output -- still in scope.
+    expect(isVisualPath("apps/ui/tailwind.config.ts")).toBe(true);
+    expect(isVisualPath("apps/loopover-ui/vite.config.ts")).toBe(true);
+    // A non-.ts file under src/ (docs, json, etc.) is untouched by this exclusion.
+    expect(isVisualPath("apps/ui/src/lib/metagraphed/README.md")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- `isVisualPath`'s app-folder pattern (`apps/*/`) is extension-agnostic, so a bare `.ts` file living inside an app's own `src/` tree — a data/logic/hooks/test file, never a route (TanStack Router's file-based routing is always `.tsx`/`.jsx`) — also matched, triggering the full screenshot-capture pipeline even though it renders nothing.
- Confirmed live on JSONbored/metagraphed#6036: a non-visual data-layer fix touching only `apps/ui/src/lib/metagraphed/queries.ts` + its `.test.ts` sibling burned Browser Rendering on a meaningless before/after of the unchanged homepage, despite the bot's own `screenshot-table-gate.ts` correctly calling this PR out of scope for screenshot evidence.
- New pattern excludes `apps/*/src/**/*.ts` specifically (never `.tsx`) — an app-root `.ts` config file (`tailwind.config.ts`, `vite.config.ts`) still matches since it isn't under `src/`, and every non-`.ts` file anywhere in the app tree is unaffected.

**Course-correction from the issue's original proposal**: #6322 initially proposed requiring a route/page-shape path OR a front-end extension. While investigating, I found the existing test suite (`test/unit/visual-paths.test.ts`) explicitly and intentionally asserts `apps/loopover-ui/README.md` and `apps/ui/components.json` (neither route-shaped, neither a front-end extension) as `true` — that broader proposal would have regressed those. The narrower `apps/*/src/**/*.ts` exclusion implemented here fixes the exact observed bug without touching any existing, intentionally-asserted case.

Closes #6322

## Test plan
- [x] `test/unit/visual-paths.test.ts` extended: the exact JSONbored/metagraphed#6036 file paths now `false`; a sibling `.tsx` under the same `src/` tree, app-root `.ts` config files, and a non-`.ts` file under `src/` all remain `true` (100% stmt/branch/line coverage on the changed file)
- [x] `test/unit/queue-3.test.ts` + `test/unit/queue-4.test.ts` (the integration tests exercising `isVisualPath` end-to-end via `buildCapture`) pass unchanged — both use `.tsx` route fixtures, unaffected by this narrowing
- [x] `npm run typecheck` clean
- [x] Full local `npm run test:ci` gate green