### PR TITLE
feat(registry): add subnet-funded pool association to the repo model (#6320)

### DIFF
--- a/src/registry/normalize.ts
+++ b/src/registry/normalize.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ISSUE_DISCOVERY_SHARE } from "../scoring/model";
-import type { JsonValue, RegistryRepoConfig, RegistrySnapshot, RepoTimeDecayOverrides } from "../types";
+import type { JsonValue, RegistryRepoConfig, RegistrySnapshot, RepoPoolAssociation, RepoTimeDecayOverrides } from "../types";
 
 type RawRepoConfig = Record<string, JsonValue>;
 
@@ -76,8 +76,26 @@ function normalizeRepo(repo: string, config: RawRepoConfig): RegistryRepoConfig 
     fixedBaseScore: numberValue(config.fixed_base_score),
     eligibilityMode: stringValue(config.eligibility_mode),
     timeDecay: parseTimeDecayOverrides(config.scoring),
+    poolAssociation: parsePoolAssociation(config),
     raw: config,
   };
+}
+
+// Subnet-funded pool association (#6099/#6320), from the registry's flat `pool_id`/`subnet_id` fields. Both
+// must be present and well-formed (non-empty pool id, finite subnet netuid) for an association to exist —
+// a repo missing either (i.e. every organic repo) parses to null and stays byte-identical to today.
+function parsePoolAssociation(config: RawRepoConfig): RepoPoolAssociation | null {
+  const poolId = stringValue(config.pool_id);
+  const subnetId = numberValue(config.subnet_id);
+  if (poolId === null || subnetId === null) return null;
+  return { poolId, subnetId };
+}
+
+// Read accessor for a repo's pool association (#6320): returns the association a repo was registered with, or
+// null for an organic repo / a repo with no config. The read side #6314's PayoutEligibleEvent construction and
+// #6099's pool-state reporting UI consume — the single place downstream code asks "is this repo pool-funded?".
+export function getRepoPoolAssociation(config: RegistryRepoConfig | null | undefined): RepoPoolAssociation | null {
+  return config?.poolAssociation ?? null;
 }
 
 // Per-repo time-decay overrides (#703), from the registry's nested `scoring.time_decay` (the same source

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,6 +429,18 @@ export type RepoTimeDecayOverrides = {
   minMultiplier?: number | null | undefined;
 };
 
+/**
+ * Subnet-funded pool association for a registered repo (#6099's entity model; part of #6101). Present only
+ * when the registry marks a repo as backed by a Bittensor subnet's reward pool; `poolId` matches #6098's
+ * `SettlementBackend.poolId`, `subnetId` is the funding subnet's netuid. Both are required for a valid
+ * association — a partial one (only one field) is treated as no association, so an organic (non-pool) repo
+ * carries no pool fields and round-trips byte-identical to today. Read it via `getRepoPoolAssociation`.
+ */
+export type RepoPoolAssociation = {
+  poolId: string;
+  subnetId: number;
+};
+
 export type RegistryRepoConfig = {
   repo: string;
   emissionShare: number;
@@ -441,6 +453,8 @@ export type RegistryRepoConfig = {
   eligibilityMode?: string | null;
   /** Per-repo time-decay curve overrides (#703); null/absent = use the global defaults for every field. */
   timeDecay?: RepoTimeDecayOverrides | null;
+  /** Subnet-funded pool association (#6099); null/absent = an organic repo with no funding pool (#6320). */
+  poolAssociation?: RepoPoolAssociation | null;
   raw: Record<string, JsonValue>;
 };
 

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getRepository, upsertRepositoryFromGitHub } from "../../src/db/repositories";
-import { normalizeRegistryPayload } from "../../src/registry/normalize";
+import { getRepoPoolAssociation, normalizeRegistryPayload } from "../../src/registry/normalize";
 import { DEFAULT_ISSUE_DISCOVERY_SHARE } from "../../src/scoring/model";
 import { getLatestRegistrySnapshot, persistRegistrySnapshot, refreshRegistry } from "../../src/registry/sync";
 import { createTestEnv } from "../helpers/d1";
@@ -94,6 +94,45 @@ describe("registry normalization", () => {
     });
     expect(byName["other/repo"]!.timeDecay ?? null).toBeNull();
     expect(byName["empty/decay"]!.timeDecay ?? null).toBeNull();
+  });
+
+  it("parses a subnet-funded pool association and leaves organic repos with none (#6320)", () => {
+    const snapshot = normalizeRegistryPayload(
+      {
+        // A subnet-funded repo carries both a pool id and a subnet netuid → a full association reads back intact.
+        "JSONbored/funded": { emission_share: 0.02, pool_id: "pool-74", subnet_id: 74 },
+        // An organic repo has no pool fields → no association, byte-identical to today.
+        "JSONbored/organic": { emission_share: 0.01 },
+        // A partial association (pool id but no subnet) is not a valid association → null, not a half-populated object.
+        "JSONbored/pool-only": { emission_share: 0.01, pool_id: "pool-9" },
+        // A partial association (subnet but no pool id) is likewise dropped.
+        "JSONbored/subnet-only": { emission_share: 0.01, subnet_id: 12 },
+      },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+    const byName = Object.fromEntries(snapshot.repositories.map((r) => [r.repo, r]));
+    expect(byName["JSONbored/funded"]!.poolAssociation).toEqual({ poolId: "pool-74", subnetId: 74 });
+    expect(byName["JSONbored/organic"]!.poolAssociation ?? null).toBeNull();
+    expect(byName["JSONbored/pool-only"]!.poolAssociation ?? null).toBeNull();
+    expect(byName["JSONbored/subnet-only"]!.poolAssociation ?? null).toBeNull();
+  });
+
+  it("getRepoPoolAssociation reads a repo's pool association or null (#6320)", () => {
+    const snapshot = normalizeRegistryPayload(
+      {
+        "JSONbored/funded": { emission_share: 0.02, pool_id: "pool-74", subnet_id: 74 },
+        "JSONbored/organic": { emission_share: 0.01 },
+      },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+    const byName = Object.fromEntries(snapshot.repositories.map((r) => [r.repo, r]));
+    expect(getRepoPoolAssociation(byName["JSONbored/funded"])).toEqual({ poolId: "pool-74", subnetId: 74 });
+    expect(getRepoPoolAssociation(byName["JSONbored/organic"])).toBeNull();
+    // A missing/undefined config (an unregistered repo) reads back as no association, never throws.
+    expect(getRepoPoolAssociation(null)).toBeNull();
+    expect(getRepoPoolAssociation(undefined)).toBeNull();
   });
 
   it("normalizes repository-list and array payload shapes defensively", () => {


### PR DESCRIPTION
## Summary

- Adds an optional, additive subnet-funded pool association to the repo-registration data model (`RegistryRepoConfig`), implementing the repo↔pool relationship #6099's entity model needs while leaving organic (non-pool) repo registration byte-identical to today.
- New `RepoPoolAssociation` type (`poolId` — the shape #6098's `SettlementBackend.poolId` uses — plus the funding subnet's `subnetId` netuid) and a nullable `poolAssociation` field on `RegistryRepoConfig`.
- `normalizeRepo` now parses the association from the registry payload's flat `pool_id`/`subnet_id` fields via `parsePoolAssociation`. Both fields must be well-formed (non-empty pool id, finite subnet netuid) or the whole association is dropped to `null`, so an organic repo — and any half-populated one — carries no pool fields and round-trips exactly as before.
- New `getRepoPoolAssociation(config)` read accessor returns a repo's association or `null` (including for a missing/unregistered config) — the single read side #6314's `PayoutEligibleEvent` construction and #6099's pool-state reporting UI will consume.

This mirrors the existing `timeDecay` / `parseTimeDecayOverrides` pattern in the same file (a nullable, defensively-parsed, grouped override that is `null` when absent). No settlement mechanics, no pricing/allocation, no UI — data model only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6320`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `test/unit/registry.test.ts` passes; the diff (both new functions and every `||`/`?.`/`??` branch) is at 100% line and branch coverage. The only failing suites in the full run are `selfhost-ams-reporting`, `miner-discover-cli`, and `miner-live-issue-snapshot`, which shell out to the `sqlite3` CLI binary that is absent from this local sandbox — unrelated to this diff and green on CI.
- [x] `npm run ui:openapi:check` (no drift; `RegistryRepoSchema` is a curated subset that already omits the parallel internal `timeDecay` field, so `poolAssociation` follows that precedent and needs no OpenAPI change).
- [x] New behavior has unit tests for the full association, the organic (no-association) path, both half-populated (partial) paths, and the accessor's null/undefined/absent branches.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and makes no compensation/optimization claims.
- [x] No auth/cookie/CORS/session surface touched.
- [x] No API/OpenAPI/MCP behavior change (verified via `ui:openapi:check`).
- [x] No UI change — `UI Evidence` not applicable (data-model/types only).

## Notes

- Additive and non-breaking: `poolAssociation` is optional and defaults to `null`; existing consumers of `RegistryRepoConfig` are unaffected (repo-wide `typecheck` clean).
</content>
</invoke>


Closes #6320
