### PR TITLE
fix(ci): derive production-smoke MCP versions from package.json

### DIFF
--- a/scripts/smoke-production-versions.d.mts
+++ b/scripts/smoke-production-versions.d.mts
@@ -1,0 +1,9 @@
+export const MINIMUM_SUPPORTED_MCP_VERSION: string;
+
+export type ExpectedMcpVersions = {
+  minimumSupportedVersion: string;
+  latestRecommendedVersion: string;
+};
+
+export function expectedMcpVersions(mcpPackageJson: { version?: unknown } | null | undefined): ExpectedMcpVersions;
+export function loadMcpPackageJson(fromUrl?: string): { version: string; [key: string]: unknown };

--- a/scripts/smoke-production-versions.mjs
+++ b/scripts/smoke-production-versions.mjs
@@ -1,0 +1,29 @@
+// Shared expected MCP versions for production smoke (#6293). Latest tracks packages/loopover-mcp
+// package.json the same way src/services/mcp-compatibility.ts does; the minimum floor stays a
+// deliberate constant (not every release raises the supported floor).
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Matches `MINIMUM_SUPPORTED_MCP_VERSION` in src/services/mcp-compatibility.ts. */
+export const MINIMUM_SUPPORTED_MCP_VERSION = "0.5.0";
+
+/**
+ * @param {{ version?: unknown } | null | undefined} mcpPackageJson
+ * @returns {{ minimumSupportedVersion: string, latestRecommendedVersion: string }}
+ */
+export function expectedMcpVersions(mcpPackageJson) {
+  const version = typeof mcpPackageJson?.version === "string" ? mcpPackageJson.version.trim() : "";
+  if (!version) throw new Error("packages/loopover-mcp/package.json is missing a non-empty version");
+  return {
+    minimumSupportedVersion: MINIMUM_SUPPORTED_MCP_VERSION,
+    latestRecommendedVersion: version,
+  };
+}
+
+/** Load the MCP package.json next to this repo's scripts/ directory. */
+export function loadMcpPackageJson(fromUrl = import.meta.url) {
+  const packagePath = join(dirname(fileURLToPath(fromUrl)), "../packages/loopover-mcp/package.json");
+  return JSON.parse(readFileSync(packagePath, "utf8"));
+}

--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -1,5 +1,11 @@
+import { expectedMcpVersions, loadMcpPackageJson } from "./smoke-production-versions.mjs";
+
 const siteOrigin = normalizeOrigin(process.env.LOOPOVER_SITE_ORIGIN ?? "https://loopover.ai");
 const apiOrigin = normalizeOrigin(process.env.LOOPOVER_API_ORIGIN ?? "https://api.loopover.ai");
+// Latest tracks packages/loopover-mcp/package.json (same source as /health + /v1/mcp/compatibility).
+// This script is maintainer-manual (`npm run test:smoke:production`) — not wired into PR CI — which
+// is why a hardcoded 0.5.0 literal could drift for many releases before anyone noticed (#6293).
+const { minimumSupportedVersion, latestRecommendedVersion } = expectedMcpVersions(loadMcpPackageJson());
 
 const siteRoutes = [
   "/",
@@ -31,12 +37,24 @@ async function main() {
   checks.push(checkStatus(`${siteOrigin}/sitemap.xml`, 200, "sitemap", { contentType: /application\/xml/i }));
   checks.push(checkStatus(`${siteOrigin}/CNAME`, 404, "retired GitHub Pages CNAME"));
 
-  checks.push(checkJson(`${apiOrigin}/health`, "API health", (json) => json.status === "ok" && json.minMcpVersion === "0.5.0" && json.latestRecommendedMcpVersion === "0.5.0"));
+  checks.push(
+    checkJson(
+      `${apiOrigin}/health`,
+      "API health",
+      (json) =>
+        json.status === "ok" &&
+        json.minMcpVersion === minimumSupportedVersion &&
+        json.latestRecommendedMcpVersion === latestRecommendedVersion,
+    ),
+  );
   checks.push(
     checkJson(
       `${apiOrigin}/v1/mcp/compatibility`,
       "MCP compatibility",
-      (json) => json.status === "ok" && json.mcp?.minimumSupportedVersion === "0.5.0" && json.mcp?.latestPackageVersion === "0.5.0",
+      (json) =>
+        json.status === "ok" &&
+        json.mcp?.minimumSupportedVersion === minimumSupportedVersion &&
+        json.mcp?.latestPackageVersion === latestRecommendedVersion,
     ),
   );
   checks.push(checkJson(`${apiOrigin}/v1/auth/session`, "signed-out session", (json) => json.status === "signed_out"));

--- a/test/unit/smoke-production-versions.test.ts
+++ b/test/unit/smoke-production-versions.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  expectedMcpVersions,
+  loadMcpPackageJson,
+  MINIMUM_SUPPORTED_MCP_VERSION,
+} from "../../scripts/smoke-production-versions.mjs";
+
+describe("smoke-production-versions (#6293)", () => {
+  it("derives latest from the MCP package.json and keeps the supported floor fixed", () => {
+    expect(expectedMcpVersions({ version: "3.0.0" })).toEqual({
+      minimumSupportedVersion: "0.5.0",
+      latestRecommendedVersion: "3.0.0",
+    });
+    expect(MINIMUM_SUPPORTED_MCP_VERSION).toBe("0.5.0");
+  });
+
+  it("rejects a missing or blank package version", () => {
+    expect(() => expectedMcpVersions({})).toThrow(/missing a non-empty version/i);
+    expect(() => expectedMcpVersions({ version: "  " })).toThrow(/missing a non-empty version/i);
+  });
+
+  it("loads the real MCP package.json and matches its version field", () => {
+    const loaded = loadMcpPackageJson();
+    const onDisk = JSON.parse(
+      readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../packages/loopover-mcp/package.json"), "utf8"),
+    );
+    expect(loaded.version).toBe(onDisk.version);
+    expect(expectedMcpVersions(loaded).latestRecommendedVersion).toBe(onDisk.version);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace hardcoded `0.5.0` assertions for `latestRecommendedMcpVersion` / `latestPackageVersion` with values read from `packages/loopover-mcp/package.json` (same source as `mcp-compatibility.ts`).
- Keep `minimumSupportedVersion` at `0.5.0` (intentional floor).
- Extract `scripts/smoke-production-versions.mjs` + `.d.mts` typings + unit tests so PR CI covers the contract (`validate-code` needs the declaration file for `.mjs` imports).

**Process gap:** `npm run test:smoke:production` is maintainer-manual in `CONTRIBUTING.md` and not wired into `.github/workflows`, which is why the `0.5.0` drift survived many MCP releases.

Supersedes #6332 (closed for missing `.d.mts` / `validate-code` TS7016).

Closes #6293

## Test plan
- [x] `npx vitest run test/unit/smoke-production-versions.test.ts`
- [x] `tsc` clean for the new module (`.d.mts` present)
- [ ] CI green

Made with [Cursor](https://cursor.com)