### PR TITLE
fix(selfhost): fail fast when a configured _FILE secret is unreadable

### DIFF
--- a/src/selfhost/load-file-secrets.ts
+++ b/src/selfhost/load-file-secrets.ts
@@ -1,6 +1,10 @@
 // Resolve `<NAME>_FILE` env vars (Docker secrets / multi-line keys) into `<NAME>` at self-host startup.
 // Extracted from server.ts (#4403) so this has a real test harness -- server.ts itself boots the whole
 // app on import and is Codecov-ignored, so it has no runtime test coverage of its own.
+//
+// A missing or unreadable `<NAME>_FILE` fails the container fast (throws), matching the miner package's
+// `loadMinerFileSecrets` behavior documented in packages/loopover-miner/DEPLOYMENT.md — rather than
+// silently leaving the target env var unset and proceeding without the credential (#6284).
 import { readFileSync } from "node:fs";
 
 // Docker Compose's OWN reserved `_FILE`-suffixed environment variables -- never loopover's secret-file
@@ -22,15 +26,21 @@ export function loadFileSecrets(
     if (!key.endsWith("_FILE") || !env[key] || COMPOSE_RESERVED_FILE_VARS.has(key)) continue;
     const target = key.slice(0, -"_FILE".length);
     if (env[target]) continue; // an explicit value wins
+    const path = env[key] as string;
     try {
-      env[target] = readFile(env[key] as string).trim();
-    } catch {
+      env[target] = readFile(path).trim();
+    } catch (error) {
       console.error(
         JSON.stringify({
           level: "error",
           event: "selfhost_secret_file_unreadable",
           var: key,
         }),
+      );
+      throw new Error(
+        `Failed to read secret file for ${key} (${path}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
     }
   }

--- a/test/unit/selfhost-load-file-secrets.test.ts
+++ b/test/unit/selfhost-load-file-secrets.test.ts
@@ -49,13 +49,15 @@ describe("loadFileSecrets (#4403)", () => {
     expect(readFile).not.toHaveBeenCalled();
   });
 
-  it("logs a structured error and leaves the target unset when the file read fails, for a genuine secret var", () => {
+  it("REGRESSION (#6284): throws (and logs) when a configured _FILE secret is missing/unreadable, instead of leaving the target unset", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const readFile = vi.fn(() => {
       throw new Error("ENOENT");
     });
     const env: Record<string, string | undefined> = { SENTRY_DSN_FILE: "/run/secrets/missing" };
-    loadFileSecrets(env, readFile);
+    expect(() => loadFileSecrets(env, readFile)).toThrow(
+      "Failed to read secret file for SENTRY_DSN_FILE (/run/secrets/missing): ENOENT",
+    );
     expect(env.SENTRY_DSN).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith(
       JSON.stringify({ level: "error", event: "selfhost_secret_file_unreadable", var: "SENTRY_DSN_FILE" }),
@@ -63,16 +65,42 @@ describe("loadFileSecrets (#4403)", () => {
     errorSpy.mockRestore();
   });
 
+  it("formats a non-Error thrown value into the fail-fast error message", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const readFile = vi.fn(() => {
+      throw "boom";
+    });
+    const env: Record<string, string | undefined> = { TOKEN_ENCRYPTION_SECRET_FILE: "/run/secrets/missing" };
+    expect(() => loadFileSecrets(env, readFile)).toThrow(
+      "Failed to read secret file for TOKEN_ENCRYPTION_SECRET_FILE (/run/secrets/missing): boom",
+    );
+    expect(env.TOKEN_ENCRYPTION_SECRET).toBeUndefined();
+    errorSpy.mockRestore();
+  });
+
+  it("still starts normally when no _FILE secret is configured at all", () => {
+    const readFile = vi.fn(() => {
+      throw new Error("should never be called");
+    });
+    const env: Record<string, string | undefined> = { SENTRY_DSN: "already-set-inline" };
+    expect(() => loadFileSecrets(env, readFile)).not.toThrow();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(env.SENTRY_DSN).toBe("already-set-inline");
+  });
+
   it("defaults to process.env and the real node:fs reader when called with no arguments", () => {
     const original = process.env.NOT_A_REAL_SECRET_FILE;
     process.env.NOT_A_REAL_SECRET_FILE = "/definitely/does/not/exist";
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    loadFileSecrets();
-    expect(errorSpy).toHaveBeenCalledWith(
-      JSON.stringify({ level: "error", event: "selfhost_secret_file_unreadable", var: "NOT_A_REAL_SECRET_FILE" }),
-    );
-    errorSpy.mockRestore();
-    if (original === undefined) delete process.env.NOT_A_REAL_SECRET_FILE;
-    else process.env.NOT_A_REAL_SECRET_FILE = original;
+    try {
+      expect(() => loadFileSecrets()).toThrow(/NOT_A_REAL_SECRET_FILE/);
+      expect(errorSpy).toHaveBeenCalledWith(
+        JSON.stringify({ level: "error", event: "selfhost_secret_file_unreadable", var: "NOT_A_REAL_SECRET_FILE" }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+      if (original === undefined) delete process.env.NOT_A_REAL_SECRET_FILE;
+      else process.env.NOT_A_REAL_SECRET_FILE = original;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- **Root cause:** `loadFileSecrets()` logged `selfhost_secret_file_unreadable` when a configured `<NAME>_FILE` path was missing/unreadable, then continued with the target env var unset — so a broken Docker secret mount could boot ORB without the credential.
- **Fix:** Match the miner’s `loadMinerFileSecrets` fail-fast behavior: keep the structured error log, then throw so container startup exits non-zero. Genuinely omitted secrets (no `_FILE` set) and explicit plain-env overrides are unchanged.
- **Impact:** Operators catch broken high-privilege secret mounts at boot instead of running with silently missing credentials.

Closes #6284

## Test plan
- [x] Unit tests: unreadable `_FILE` throws + logs; omitted `_FILE` still starts; COMPOSE reserved vars unchanged
- [ ] CI validate-code / selfhost path checks

## Risk / tradeoffs
- **Breaking for misconfigured deploys that previously “worked” with missing secrets:** intentional — those were already insecure/incorrect. Correctly mounted secrets and plain-env-only configs are unaffected.