### PR TITLE
fix(ci): exit non-zero when lockfile workspace sync misses

### DIFF
--- a/scripts/sync-release-lockfile-versions.d.mts
+++ b/scripts/sync-release-lockfile-versions.d.mts
@@ -1,0 +1,32 @@
+export type SyncLockfileWorkspace = {
+  workspacePath: string;
+  version: string;
+};
+
+export type SyncLockfileHooks = {
+  onFailure?: (workspacePath: string) => void;
+  onAlready?: (workspacePath: string, version: string) => void;
+  onSynced?: (workspacePath: string, version: string) => void;
+};
+
+export type SyncLockfileResult = {
+  content: string;
+  changed: boolean;
+  failures: string[];
+};
+
+export function syncLockfileVersions(
+  content: string,
+  workspaces: SyncLockfileWorkspace[],
+  hooks?: SyncLockfileHooks,
+): SyncLockfileResult;
+
+export type SyncLockfileIo = {
+  readFileSync: (path: string, encoding: string) => string;
+  writeFileSync: (path: string, content: string) => void;
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  exit: (code: number) => void;
+};
+
+export function main(argv?: string[], io?: SyncLockfileIo): number;

--- a/scripts/sync-release-lockfile-versions.mjs
+++ b/scripts/sync-release-lockfile-versions.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // release-please's `extra-files` JSON-path updater doesn't reliably reach package-lock.json's
 // per-workspace version fields, whose keys contain slashes (e.g. "packages/loopover-engine")
 // nested under a manifest-mode component's own release-please-config.json block -- confirmed
@@ -9,35 +8,90 @@
 // multi-thousand-line lockfile, which would risk reordering/reformatting far beyond the one line
 // that actually changed.
 import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const targets = process.argv.slice(2);
-if (targets.length === 0) {
-  console.error("Usage: node sync-release-lockfile-versions.mjs <workspace-path> [<workspace-path> ...]");
-  process.exit(1);
+/**
+ * Sync each workspace's lockfile block version. Continues past match failures so one broken
+ * workspace doesn't hide others; callers must exit non-zero when `failures` is non-empty (#6296).
+ *
+ * @param {string} content
+ * @param {Array<{ workspacePath: string, version: string }>} workspaces
+ * @param {{
+ *   onFailure?: (workspacePath: string) => void,
+ *   onAlready?: (workspacePath: string, version: string) => void,
+ *   onSynced?: (workspacePath: string, version: string) => void,
+ * }} [hooks]
+ * @returns {{ content: string, changed: boolean, failures: string[] }}
+ */
+export function syncLockfileVersions(content, workspaces, hooks = {}) {
+  let next = content;
+  let changed = false;
+  /** @type {string[]} */
+  const failures = [];
+
+  for (const { workspacePath, version } of workspaces) {
+    const escapedKey = workspacePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Anchors on the workspace's own block header + its "name" line (both stable, unique) so this
+    // can't accidentally match a different package's "version" line elsewhere in the file.
+    const pattern = new RegExp(`("${escapedKey}":\\s*\\{\\s*\\n\\s*"name":[^\\n]*\\n\\s*"version":\\s*")[^"]*(")`);
+    if (!pattern.test(next)) {
+      failures.push(workspacePath);
+      hooks.onFailure?.(workspacePath);
+      continue;
+    }
+    const updated = next.replace(pattern, `$1${version}$2`);
+    if (updated === next) {
+      hooks.onAlready?.(workspacePath, version);
+    } else {
+      next = updated;
+      changed = true;
+      hooks.onSynced?.(workspacePath, version);
+    }
+  }
+
+  return { content: next, changed, failures };
 }
 
-const lockPath = "package-lock.json";
-let content = readFileSync(lockPath, "utf8");
-let changed = false;
+export function main(argv = process.argv.slice(2), io = {
+  readFileSync,
+  writeFileSync,
+  log: console.log.bind(console),
+  error: console.error.bind(console),
+  exit: (code) => process.exit(code),
+}) {
+  const targets = argv;
+  if (targets.length === 0) {
+    io.error("Usage: node sync-release-lockfile-versions.mjs <workspace-path> [<workspace-path> ...]");
+    io.exit(1);
+    return 1;
+  }
 
-for (const workspacePath of targets) {
-  const version = JSON.parse(readFileSync(`${workspacePath}/package.json`, "utf8")).version;
-  const escapedKey = workspacePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Anchors on the workspace's own block header + its "name" line (both stable, unique) so this
-  // can't accidentally match a different package's "version" line elsewhere in the file.
-  const pattern = new RegExp(`("${escapedKey}":\\s*\\{\\s*\\n\\s*"name":[^\\n]*\\n\\s*"version":\\s*")[^"]*(")`);
-  if (!pattern.test(content)) {
-    console.error(`${workspacePath}: pattern not found in ${lockPath} -- nothing changed.`);
-    continue;
+  const lockPath = "package-lock.json";
+  const content = io.readFileSync(lockPath, "utf8");
+  const workspaces = targets.map((workspacePath) => ({
+    workspacePath,
+    version: JSON.parse(io.readFileSync(`${workspacePath}/package.json`, "utf8")).version,
+  }));
+
+  const result = syncLockfileVersions(content, workspaces, {
+    onFailure: (workspacePath) => {
+      io.error(`${workspacePath}: pattern not found in ${lockPath} -- nothing changed.`);
+    },
+    onAlready: (workspacePath, version) => {
+      io.log(`${workspacePath}: already at ${version}.`);
+    },
+    onSynced: (workspacePath, version) => {
+      io.log(`${workspacePath}: synced to ${version}.`);
+    },
+  });
+
+  if (result.changed) io.writeFileSync(lockPath, result.content);
+  if (result.failures.length > 0) {
+    io.exit(1);
+    return 1;
   }
-  const updated = content.replace(pattern, `$1${version}$2`);
-  if (updated === content) {
-    console.log(`${workspacePath}: already at ${version}.`);
-  } else {
-    content = updated;
-    changed = true;
-    console.log(`${workspacePath}: synced to ${version}.`);
-  }
+  return 0;
 }
 
-if (changed) writeFileSync(lockPath, content);
+const invokedDirectly = process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main();

--- a/test/unit/sync-release-lockfile-versions.test.ts
+++ b/test/unit/sync-release-lockfile-versions.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { main, syncLockfileVersions } from "../../scripts/sync-release-lockfile-versions.mjs";
+
+const SAMPLE_LOCK = `{
+  "name": "loopover",
+  "lockfileVersion": 3,
+  "packages": {
+    "packages/loopover-engine": {
+      "name": "@loopover/engine",
+      "version": "1.0.0",
+      "license": "AGPL-3.0-only"
+    },
+    "packages/loopover-mcp": {
+      "name": "@loopover/mcp",
+      "version": "2.0.0",
+      "license": "AGPL-3.0-only"
+    }
+  }
+}
+`;
+
+describe("syncLockfileVersions (#6296)", () => {
+  it("updates a workspace version when the lockfile block matches", () => {
+    const result = syncLockfileVersions(SAMPLE_LOCK, [{ workspacePath: "packages/loopover-engine", version: "1.2.3" }]);
+    expect(result.changed).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.content).toContain('"version": "1.2.3"');
+    expect(result.content).toContain('"name": "@loopover/engine"');
+  });
+
+  it("records a match failure without stopping later workspaces, and leaves content unchanged for misses", () => {
+    const result = syncLockfileVersions(SAMPLE_LOCK, [
+      { workspacePath: "packages/missing-workspace", version: "9.9.9" },
+      { workspacePath: "packages/loopover-mcp", version: "3.0.0" },
+    ]);
+    expect(result.failures).toEqual(["packages/missing-workspace"]);
+    expect(result.changed).toBe(true);
+    expect(result.content).toContain('"version": "3.0.0"');
+    expect(result.content).not.toContain("9.9.9");
+  });
+
+  it("reports already-at when the version is unchanged", () => {
+    const onAlready = vi.fn();
+    const result = syncLockfileVersions(
+      SAMPLE_LOCK,
+      [{ workspacePath: "packages/loopover-engine", version: "1.0.0" }],
+      { onAlready },
+    );
+    expect(result.changed).toBe(false);
+    expect(result.failures).toEqual([]);
+    expect(onAlready).toHaveBeenCalledWith("packages/loopover-engine", "1.0.0");
+  });
+});
+
+describe("sync-release-lockfile-versions main exit code (#6296)", () => {
+  it("exits non-zero when any workspace pattern fails to match", () => {
+    const exit = vi.fn();
+    const error = vi.fn();
+    const log = vi.fn();
+    const writeFileSync = vi.fn();
+    const readFileSync = vi.fn((path: string) => {
+      if (path === "package-lock.json") return SAMPLE_LOCK;
+      if (path === "packages/missing-workspace/package.json") return JSON.stringify({ version: "9.9.9" });
+      if (path === "packages/loopover-mcp/package.json") return JSON.stringify({ version: "3.0.0" });
+      throw new Error(`unexpected read: ${path}`);
+    });
+
+    const code = main(["packages/missing-workspace", "packages/loopover-mcp"], {
+      readFileSync,
+      writeFileSync,
+      log,
+      error,
+      exit,
+    });
+
+    expect(code).toBe(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("packages/missing-workspace: pattern not found"),
+    );
+    // Successful workspaces still sync before the non-zero exit.
+    expect(writeFileSync).toHaveBeenCalledWith("package-lock.json", expect.stringContaining('"version": "3.0.0"'));
+    expect(log).toHaveBeenCalledWith("packages/loopover-mcp: synced to 3.0.0.");
+  });
+
+  it("exits via usage error when no workspace paths are provided", () => {
+    const exit = vi.fn();
+    const error = vi.fn();
+    const code = main([], {
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      log: vi.fn(),
+      error,
+      exit,
+    });
+    expect(code).toBe(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(error).toHaveBeenCalledWith(expect.stringMatching(/Usage:/));
+  });
+});


### PR DESCRIPTION
## Summary
- `sync-release-lockfile-versions.mjs` now continues past per-workspace pattern misses, syncs successful ones, then `exit 1` if any miss occurred (so `set -euo pipefail` in `mcp-release-please.yml` can stop the release branch push).
- Extract `syncLockfileVersions` / injectable `main` for unit tests; add `.d.mts` for `validate-code`.

Closes #6296

## Test plan
- [x] `npx vitest run test/unit/sync-release-lockfile-versions.test.ts` (5 pass)
- [ ] CI green

Made with [Cursor](https://cursor.com)