### PR TITLE
fix(ci): share MCP tarball allowlist including shipped lib files

### DIFF
--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -2,6 +2,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
 
 const result = spawnSync("npm", ["pack", "--workspace", "@loopover/mcp", "--dry-run", "--json"], {
   encoding: "utf8",
@@ -14,7 +15,7 @@ if (result.status !== 0) {
 
 const [pack] = JSON.parse(result.stdout);
 const files = pack.files.map((file) => file.path).sort();
-const allowed = [/^bin\/loopover-mcp\.js$/, /^lib\/cli-error\.js$/, /^lib\/local-branch\.js$/, /^lib\/format-table\.js$/, /^lib\/redact-local-path\.js$/, /^scripts\/gittensor-score-preview\.(mjs|py)$/, /^package\.json$/, /^README\.md$/, /^CHANGELOG\.md$/, /^LICENSE$/];
+const allowed = MCP_PACKAGE_ALLOWED_FILE_PATTERNS;
 const forbiddenPath = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
 const forbiddenContent = /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
 const stalePackageText = /(private beta|zeronode\.workers\.dev|preview URL)/i;

--- a/scripts/mcp-package-allowlist.d.mts
+++ b/scripts/mcp-package-allowlist.d.mts
@@ -1,0 +1,1 @@
+export const MCP_PACKAGE_ALLOWED_FILE_PATTERNS: RegExp[];

--- a/scripts/mcp-package-allowlist.mjs
+++ b/scripts/mcp-package-allowlist.mjs
@@ -1,0 +1,16 @@
+// Canonical MCP published-tarball allowlist (#6291). Shared by check-mcp-package.mjs and
+// mcp-release-candidate-core.mjs so the dry-run gate and the release-candidate tarball check
+// cannot drift (the previous duplicated lists already missed shipped lib/*.js files).
+
+export const MCP_PACKAGE_ALLOWED_FILE_PATTERNS = [
+  /^bin\/loopover-mcp\.js$/,
+  /^lib\/cli-error\.js$/,
+  /^lib\/local-branch\.js$/,
+  /^lib\/format-table\.js$/,
+  /^lib\/redact-local-path\.js$/,
+  /^scripts\/gittensor-score-preview\.(mjs|py)$/,
+  /^package\.json$/,
+  /^README\.md$/,
+  /^CHANGELOG\.md$/,
+  /^LICENSE$/,
+];

--- a/scripts/mcp-release-candidate-core.d.mts
+++ b/scripts/mcp-release-candidate-core.d.mts
@@ -1,4 +1,5 @@
 export const RELEASE_TAG_PATTERN: RegExp;
+export const MCP_PACKAGE_ALLOWED_FILE_PATTERNS: RegExp[];
 
 export type CheckResult = {
   ok: boolean;

--- a/scripts/mcp-release-candidate-core.mjs
+++ b/scripts/mcp-release-candidate-core.mjs
@@ -1,4 +1,5 @@
 import { normalizeNewlines } from "./mcp-release-core.mjs";
+import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
 import YAML from "yaml";
 
 /**
@@ -15,16 +16,9 @@ import YAML from "yaml";
 
 export const RELEASE_TAG_PATTERN = /^mcp-v(\d+)\.(\d+)\.(\d+)$/;
 
-// Kept in sync with scripts/check-mcp-package.mjs and the publish workflow tarball gate.
-const ALLOWED_FILE_PATTERNS = [
-  /^bin\/loopover-mcp\.js$/,
-  /^lib\/local-branch\.js$/,
-  /^scripts\/gittensor-score-preview\.(mjs|py)$/,
-  /^package\.json$/,
-  /^README\.md$/,
-  /^CHANGELOG\.md$/,
-  /^LICENSE$/,
-];
+// Canonical allowlist lives in mcp-package-allowlist.mjs (shared with check-mcp-package.mjs).
+export { MCP_PACKAGE_ALLOWED_FILE_PATTERNS };
+const ALLOWED_FILE_PATTERNS = MCP_PACKAGE_ALLOWED_FILE_PATTERNS;
 const FORBIDDEN_PATH_PATTERN = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
 const SECRET_CONTENT_PATTERN = /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
 const NPM_TOKEN_PATTERN = /(NODE_AUTH_TOKEN|NPM_TOKEN|secrets\.NPM[A-Z_]*|_authToken|npm_[A-Za-z0-9]{20,})/;

--- a/test/unit/mcp-release-candidate.test.ts
+++ b/test/unit/mcp-release-candidate.test.ts
@@ -8,6 +8,7 @@ import {
   checkTokenlessPublish,
   expectedReleaseTag,
   fileLooksLikeSecret,
+  MCP_PACKAGE_ALLOWED_FILE_PATTERNS,
   parseReleaseTag,
   redactSensitive,
   unexpectedTarballFiles,
@@ -15,8 +16,19 @@ import {
 
 const FORBIDDEN_PUBLIC_LANGUAGE = /\b(wallet|hotkey|coldkey|raw trust|trust score|payout|reward estimate|farming|private reviewability|public score estimate)\b/i;
 
-// Mirrors the allowlisted shape of the published tarball.
-const ALLOWED_FILES = ["bin/loopover-mcp.js", "lib/local-branch.js", "scripts/gittensor-score-preview.mjs", "package.json", "README.md", "CHANGELOG.md", "LICENSE"];
+// Mirrors the allowlisted shape of the published tarball (must stay aligned with MCP_PACKAGE_ALLOWED_FILE_PATTERNS).
+const ALLOWED_FILES = [
+  "bin/loopover-mcp.js",
+  "lib/cli-error.js",
+  "lib/local-branch.js",
+  "lib/format-table.js",
+  "lib/redact-local-path.js",
+  "scripts/gittensor-score-preview.mjs",
+  "package.json",
+  "README.md",
+  "CHANGELOG.md",
+  "LICENSE",
+];
 const CHANGELOG = "# Changelog\n\n## mcp-v0.4.0 - 2026-06-02\n\n### Features\n- Add a thing\n";
 
 // A tokenless trusted-publishing workflow fixture (same shape as publish-mcp.yml).
@@ -76,6 +88,14 @@ describe("checkChangelog", () => {
 });
 
 describe("checkTarball", () => {
+  it("accepts every shipped MCP lib file previously missing from the RC allowlist (#6291)", () => {
+    for (const file of ["lib/cli-error.js", "lib/format-table.js", "lib/redact-local-path.js"]) {
+      expect(unexpectedTarballFiles([file])).toEqual([]);
+      expect(MCP_PACKAGE_ALLOWED_FILE_PATTERNS.some((pattern) => pattern.test(file))).toBe(true);
+    }
+    expect(unexpectedTarballFiles(ALLOWED_FILES)).toEqual([]);
+  });
+
   it("passes for an allowlisted file set with no secret-like content (success fixture)", () => {
     const result = checkTarball({ files: ALLOWED_FILES, contentsByFile: { "README.md": "# gittensory-mcp", "package.json": "{}" } });
     expect(result).toMatchObject({ ok: true, code: "tarball_ok" });


### PR DESCRIPTION
## Summary
- Add `lib/cli-error.js`, `lib/format-table.js`, and `lib/redact-local-path.js` to the release-candidate tarball allowlist (they already ship and are allowed by `check-mcp-package.mjs`).
- **Unify** both allowlists into `scripts/mcp-package-allowlist.mjs` so `check-mcp-package.mjs` and `mcp-release-candidate-core.mjs` cannot drift again.
- Update the RC test fixture + a regression that asserts the previously-missing lib files are accepted.

Closes #6291

## Test plan
- [x] `npx vitest run test/unit/mcp-release-candidate.test.ts` (20 pass)
- [ ] CI green

Made with [Cursor](https://cursor.com)