### PR TITLE
docs(ams): port docs/sizing.md to a website docs page (docs.ams-sizing.tsx)

### DIFF
--- a/apps/loopover-ui/content/docs/ams-deployment.mdx
+++ b/apps/loopover-ui/content/docs/ams-deployment.mdx
@@ -240,10 +240,8 @@ sends SIGTERM, which the loop handles cleanly at its next kill-switch check.
 - Operators own secret injection; images and packages ship without embedded tokens.
 
 For operational scenarios (ledger corruption, two miners on one state dir, post-upgrade schema
-migration) and measured CPU/RAM/disk sizing, see
-[`packages/loopover-miner/docs/operations-runbook.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/operations-runbook.md)
-and
-[`packages/loopover-miner/docs/sizing.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/sizing.md).
+migration) see the [AMS operations runbook](/docs/ams-operations-runbook), and for measured
+CPU/RAM/disk sizing see [Resource sizing](/docs/ams-sizing).
 
 ## Optional hosted discovery plane (opt-in)
 

--- a/apps/loopover-ui/content/docs/ams-sizing.mdx
+++ b/apps/loopover-ui/content/docs/ams-sizing.mdx
@@ -1,0 +1,125 @@
+---
+title: Resource sizing
+description: Real, measured CPU/RAM/disk numbers for laptop mode and fleet mode, so an operator can size a host or cluster from data instead of guessing.
+---
+
+Real, measured CPU/RAM/disk numbers for laptop mode and fleet mode, so an operator can size a
+host or cluster from data instead of guessing. Neither the operations runbook nor the local-stores
+documentation commits to this — this doc is scoped strictly to the numbers and how they were
+captured.
+
+## Measurement environment
+
+- Linux x86_64 sandbox, 4 vCPU, 9.5 GiB RAM.
+- Node.js 24 (the version the Dockerfile builds on; the host running the laptop-mode measurements
+  below used the repo's own pinned Node 22.13+ requirement).
+
+<Callout variant="note">
+  Absolute numbers are host-dependent — treat these as a rough sense of scale, not a hard target.
+  Re-run the exact commands below on your own hardware for numbers specific to it.
+</Callout>
+
+## Workload measured
+
+Both modes measure `loopover-miner init` (laptop mode only) followed by `loopover-miner discover <owner/repo> [<owner/repo>...] --json` against real, small public repositories (`octocat/Hello-World`, `octocat/Spoon-Knife`) with **no `GITHUB_TOKEN`** — real, unauthenticated GitHub GET requests, metadata fan-out + deterministic ranking, no writes.
+
+<Callout variant="note" title="Deliberately excluded: a live attempt cycle">
+  Sizing a real coding-agent attempt would need an operator-supplied `GITHUB_TOKEN` and
+  coding-agent CLI credentials, and creates a real branch/PR against a real target repository —
+  not something to spend for a resource-sizing exercise, and not reproducible by a reviewer
+  without supplying their own credentials. `discover` is measured instead because it is the
+  dominant, always-run, network- and CPU-bound phase every mode exercises identically; `attempt`'s
+  resource profile is dominated by the operator's chosen coding-agent CLI process, not by anything
+  this package controls.
+</Callout>
+
+## Methodology
+
+- **Laptop mode CPU/RAM**: GNU `/usr/bin/time -v` around the CLI process directly (no container).
+- **Laptop mode disk**: `du -sh`/`du -ah` on the resolved `LOOPOVER_MINER_CONFIG_DIR` after the
+  run.
+- **Fleet mode CPU/RAM**: `docker stats --no-stream` polled once per second per container while
+  each worker ran `discover` followed by a `sleep` tail (so short-lived containers stay observable
+  long enough to sample); the reported number is the peak observed sample per container.
+- **Fleet mode disk**: `du -sh`/`du -ah` on each worker's mounted `/data/miner` volume after the
+  run, via a disposable `alpine` container mounting the same named volume.
+- **N=4 isolation**: per `docker-compose.miner.yml`'s own documented warning, N replicas sharing
+  one volume corrupt/contend on the SQLite ledgers — so N=4 here means **four separate named
+  volumes** (`docker run -d -v miner-n<i>:/data/miner ...` per worker), the same isolation pattern
+  the compose file itself recommends, not a single shared-volume `--scale`.
+
+**Exact commands (laptop mode):**
+
+<CodeBlock
+  lang="bash"
+  code={`LOOPOVER_MINER_CONFIG_DIR=/tmp/sizing-laptop /usr/bin/time -v \\
+  node packages/loopover-miner/bin/loopover-miner.js init --json
+
+LOOPOVER_MINER_CONFIG_DIR=/tmp/sizing-laptop /usr/bin/time -v \\
+  node packages/loopover-miner/bin/loopover-miner.js discover octocat/Hello-World --dry-run --json
+
+du -sh /tmp/sizing-laptop`}
+/>
+
+**Exact commands (fleet mode, N=1 shown; N=4 repeats the `docker run` with 4 distinct
+names/volumes):**
+
+<CodeBlock
+  lang="bash"
+  code={`docker build -f packages/loopover-miner/Dockerfile -t loopover-miner:sizing .
+
+docker volume create miner-sizing-1
+docker run -d --name miner-sizing-1 -v miner-sizing-1:/data/miner --entrypoint sh loopover-miner:sizing \\
+  -c "loopover-miner discover octocat/Hello-World octocat/Spoon-Knife --json > /tmp/out.json 2>&1; sleep 20"
+
+for i in $(seq 1 20); do
+  docker stats --no-stream --format '{{.Container}}\\t{{.CPUPerc}}\\t{{.MemUsage}}' miner-sizing-1
+done
+
+docker run --rm -v miner-sizing-1:/data alpine du -ah /data`}
+/>
+
+## Results
+
+<FeatureRow
+  items={[
+    {
+      title: "Laptop (init), 1 worker",
+      description:
+        "Peak CPU 125% (short burst, Node startup), peak RAM 74 MB. Sandbox environment above.",
+    },
+    {
+      title: "Laptop (discover, 1 repo, 90 issues), 1 worker",
+      description:
+        "Peak CPU 16% (network-bound), peak RAM 98 MB, disk 100 KB (5 SQLite files after init + discover). Sandbox environment above.",
+    },
+    {
+      title: "Fleet, Docker (discover, 2 repos), 1 worker",
+      description:
+        "Peak CPU 54% (short burst), peak RAM 46 MB, disk 92 KB (4 SQLite files). Sandbox environment above, loopover-miner:sizing image (333 MB).",
+    },
+    {
+      title: "Fleet, Docker (discover, 2 repos), 4 workers (isolated volumes)",
+      description:
+        "Peak CPU 5-38% per worker (bursts did not line up across workers), peak RAM 34-45 MB per worker, disk 92 KB per worker (368 KB total across 4 isolated volumes). Sandbox environment above.",
+    },
+  ]}
+/>
+
+**Takeaways:**
+
+- `discover`'s CPU cost is dominated by waiting on GitHub's API, not local computation — laptop
+  mode measured 16% CPU utilization over a 5.6s wall-clock run.
+- Per-worker memory (46 MB for fleet mode, 74–98 MB for the laptop-mode CLI process) did not
+  measurably change between N=1 and N=4 — each worker is an independent Node process with no
+  shared heap, so four isolated workers cost roughly 4× one worker's footprint, not more.
+- Local SQLite disk usage is small (under 100 KB per worker for this workload) and grows with the
+  number of distinct stores a command touches, not with fan-out volume — `discover` alone never
+  touches the larger per-attempt stores (`attempt-log.sqlite3`, `worktree-allocator.sqlite3`,
+  etc.), which only grow once real attempts run.
+- The 333 MB fleet image is dominated by the Node 24 base image and `node_modules`; `npm prune
+  --omit=dev` in the Dockerfile already strips dev dependencies from the runtime stage.
+
+See the [AMS deployment guide](/docs/ams-deployment) for the laptop-mode and fleet-mode setup
+walkthroughs these numbers apply to, and the [AMS operations
+runbook](/docs/ams-operations-runbook) for operational scenarios beyond initial sizing.

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -79,6 +79,7 @@ export const docsNav: DocsGroup[] = [
           { to: "/docs/ams-operations-runbook", label: "Operations runbook" },
           { to: "/docs/ams-observability", label: "Observing your miner" },
           { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
+          { to: "/docs/ams-sizing", label: "Resource sizing" },
         ],
       },
     ],

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -58,6 +58,7 @@ import { Route as DocsFumadocsSpikeApiReferenceRouteImport } from './routes/docs
 import { Route as DocsBranchAnalysisRouteImport } from './routes/docs.branch-analysis'
 import { Route as DocsBetaOnboardingRouteImport } from './routes/docs.beta-onboarding'
 import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.ams-unattended-scheduling'
+import { Route as DocsAmsSizingRouteImport } from './routes/docs.ams-sizing'
 import { Route as DocsAmsOperationsRunbookRouteImport } from './routes/docs.ams-operations-runbook'
 import { Route as DocsAmsObservabilityRouteImport } from './routes/docs.ams-observability'
 import { Route as DocsAmsDeploymentRouteImport } from './routes/docs.ams-deployment'
@@ -338,6 +339,11 @@ const DocsAmsUnattendedSchedulingRoute =
     path: '/ams-unattended-scheduling',
     getParentRoute: () => DocsRoute,
   } as any)
+const DocsAmsSizingRoute = DocsAmsSizingRouteImport.update({
+  id: '/ams-sizing',
+  path: '/ams-sizing',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsAmsOperationsRunbookRoute =
   DocsAmsOperationsRunbookRouteImport.update({
     id: '/ams-operations-runbook',
@@ -464,6 +470,7 @@ export interface FileRoutesByFullPath {
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
+  '/docs/ams-sizing': typeof DocsAmsSizingRoute
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
@@ -531,6 +538,7 @@ export interface FileRoutesByTo {
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
+  '/docs/ams-sizing': typeof DocsAmsSizingRoute
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
@@ -602,6 +610,7 @@ export interface FileRoutesById {
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
+  '/docs/ams-sizing': typeof DocsAmsSizingRoute
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
@@ -674,6 +683,7 @@ export interface FileRouteTypes {
     | '/docs/ams-deployment'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
+    | '/docs/ams-sizing'
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
@@ -741,6 +751,7 @@ export interface FileRouteTypes {
     | '/docs/ams-deployment'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
+    | '/docs/ams-sizing'
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
@@ -811,6 +822,7 @@ export interface FileRouteTypes {
     | '/docs/ams-deployment'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
+    | '/docs/ams-sizing'
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
@@ -1212,6 +1224,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsAmsUnattendedSchedulingRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/ams-sizing': {
+      id: '/docs/ams-sizing'
+      path: '/ams-sizing'
+      fullPath: '/docs/ams-sizing'
+      preLoaderRoute: typeof DocsAmsSizingRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/ams-operations-runbook': {
       id: '/docs/ams-operations-runbook'
       path: '/ams-operations-runbook'
@@ -1401,6 +1420,7 @@ interface DocsRouteChildren {
   DocsAmsDeploymentRoute: typeof DocsAmsDeploymentRoute
   DocsAmsObservabilityRoute: typeof DocsAmsObservabilityRoute
   DocsAmsOperationsRunbookRoute: typeof DocsAmsOperationsRunbookRoute
+  DocsAmsSizingRoute: typeof DocsAmsSizingRoute
   DocsAmsUnattendedSchedulingRoute: typeof DocsAmsUnattendedSchedulingRoute
   DocsBetaOnboardingRoute: typeof DocsBetaOnboardingRoute
   DocsBranchAnalysisRoute: typeof DocsBranchAnalysisRoute
@@ -1445,6 +1465,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAmsDeploymentRoute: DocsAmsDeploymentRoute,
   DocsAmsObservabilityRoute: DocsAmsObservabilityRoute,
   DocsAmsOperationsRunbookRoute: DocsAmsOperationsRunbookRoute,
+  DocsAmsSizingRoute: DocsAmsSizingRoute,
   DocsAmsUnattendedSchedulingRoute: DocsAmsUnattendedSchedulingRoute,
   DocsBetaOnboardingRoute: DocsBetaOnboardingRoute,
   DocsBranchAnalysisRoute: DocsBranchAnalysisRoute,

--- a/apps/loopover-ui/src/routes/docs.ams-sizing.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-sizing.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { docsClientLoader } from "@/lib/docs-client-loader";
+
+// Rendered from content/docs/ams-sizing.mdx via fumadocs-mdx's browser entry
+// (docsClientLoader), through the existing DocsPage/Callout/CodeBlock/FeatureRow
+// primitives -- not fumadocs-ui's bundled components. See docs-source.ts's comment
+// for why the loader below resolves only a plain, serializable path string.
+export const Route = createFileRoute("/docs/ams-sizing")({
+  loader: async () => {
+    const { docsSource } = await import("@/lib/docs-source");
+    const page = docsSource.getPage(["ams-sizing"]);
+    if (!page) throw notFound();
+    return { path: page.path, title: page.data.title, description: page.data.description };
+  },
+  head: () => ({
+    meta: [
+      { title: "Resource sizing — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "Real, measured CPU/RAM/disk numbers for laptop mode and fleet mode, so an operator can size a host or cluster from data instead of guessing.",
+      },
+      { property: "og:title", content: "Resource sizing — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "Real, measured CPU/RAM/disk numbers for laptop mode and fleet mode, so an operator can size a host or cluster from data instead of guessing.",
+      },
+      { property: "og:url", content: "/docs/ams-sizing" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/ams-sizing" }],
+  }),
+  component: AmsSizing,
+});
+
+function AmsSizing() {
+  const { path, title, description } = Route.useLoaderData();
+  const Content = docsClientLoader.getComponent(path);
+  return (
+    <DocsPage eyebrow="Maintainers" title={title} description={description}>
+      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+        <Content />
+      </Suspense>
+    </DocsPage>
+  );
+}

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -77,6 +77,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/ams-operations-runbook", label: "AMS operations runbook" },
       { to: "/docs/ams-observability", label: "Observing your miner" },
       { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
+      { to: "/docs/ams-sizing", label: "Resource sizing" },
       { to: "/docs/self-hosting-docs-audit", label: "Self-host docs audit" },
       { to: "/docs/maintainer-install-trust", label: "Install & trust guide" },
       { to: "/docs/github-app", label: "GitHub App configuration" },

--- a/packages/loopover-miner/docs/sizing.md
+++ b/packages/loopover-miner/docs/sizing.md
@@ -1,5 +1,9 @@
 # loopover-miner resource sizing
 
+> Also published on the docs website: [Resource sizing](https://loopover.ai/docs/ams-sizing) (same
+> content, rendered with search and the rest of the maintainer docs nav). This file remains the
+> canonical source and ships inside the published `@loopover/miner` package.
+
 Real, measured CPU/RAM/disk numbers for laptop mode and fleet mode, so an operator can size a host or
 cluster from data instead of guessing. Neither the operational-runbook issue nor the local-stores
 documentation commits to this — this doc is scoped strictly to the numbers and how they were captured.


### PR DESCRIPTION
## Summary

- Adds `content/docs/ams-sizing.mdx` porting `packages/loopover-miner/docs/sizing.md` to the website: measured laptop-mode and fleet-mode CPU/RAM/disk numbers, the exact reproduction commands and methodology, and takeaways — rendered via the existing `DocsPage`/`Callout`/`CodeBlock`/`FeatureRow` ui-kit primitives, following the pattern set in #6022/#6023/#6024/#6025. The results table is presented as `FeatureRow` items (no `table`/`th`/`td` mapping is registered in `docs-mdx-components.tsx`, so a raw markdown table would render unstyled).
- Adds `apps/loopover-ui/src/routes/docs.ams-sizing.tsx`, a thin loader + `docsClientLoader` route matching every other migrated docs page.
- Adds the page to `docs-nav.tsx`'s "AMS: deployment" subgroup and to `docs.index.tsx`'s Maintainers audience card.
- Repoints `ams-deployment.mdx`'s `operations-runbook.md` and `sizing.md` cross-references (still GitHub-blob links from before those pages existed) to the in-app `/docs/ams-operations-runbook` and `/docs/ams-sizing` routes, per the epic's "update any internal cross-references" instruction.
- `packages/loopover-miner/docs/sizing.md` stays as the canonical source: it ships inside the published `@loopover/miner` npm package. A short pointer to the new website page was added at the top.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: one new docs page + nav wiring + a cross-reference cleanup in one already-migrated page, under `apps/loopover-ui/**`, plus a documentation pointer in `packages/loopover-miner/docs/sizing.md`.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Closes #6026

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — UI-only page addition under `apps/loopover-ui/**` (outside `coverage.include`); `codecov/patch` does not apply
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` run locally from a clean `npm ci` install, green: 900 test files / 17,233 tests passed
- [x] Caught and fixed a real MDX parse bug during authoring: `<owner/repo>` in prose spanning a line break inside a backtick code span was parsed as an unterminated JSX tag by fumadocs-mdx's build (`npm run ui:build` failed with a clear `TS`-style parse error before the fix); rejoining the sentence onto one line resolved it, confirmed by a clean rebuild

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes in this PR
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP behavior changed
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, static docs content only
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI Evidence table — new content page rendered through the same primitives as every other migrated docs page, no visual redesign.
- Continues the "AMS: deployment" nav-subgroup precedent set by #6022/#6023/#6024/#6025.