### PR TITLE
docs(selfhost): .env.example documents the current Orb collector/broker defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -764,14 +764,14 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # The export carries no shared key; the collector treats it as untrusted, rate-limited, aggregate-only data.
 # ORB_AIR_GAP=false                          # air-gapped/OFFLINE deployments only: compute locally, never send
 # ORB_ANONYMIZE=true                         # HMAC-hash repo/PR before export (default true; false = raw names)
-# ORB_COLLECTOR_URL=https://gittensory-api.aethereal.dev/v1/orb/ingest  # gittensory's hosted collector (default; override for your own)
+# ORB_COLLECTOR_URL=https://api.loopover.ai/v1/orb/ingest  # loopover's hosted collector (default; override for your own)
 # ORB_COLLECTOR_TOKEN=                        # bearer credential for a private/self-hosted collector (ORB_COLLECTOR_URL
-#                                            #   above). Unset when using gittensory's own hosted collector.
+#                                            #   above). Unset when using loopover's own hosted collector.
 #
 # Token broker (optional): get GitHub tokens from the central Orb (you installed the Orb App) instead of running
 # your own GitHub App. Set the enrollment secret the operator issued for your install; unset = use your own App key.
 # ORB_ENROLLMENT_SECRET=                      # one-time enrollment secret (a secret — keep it out of version control)
-# ORB_BROKER_URL=https://gittensory-api.aethereal.dev  # the Orb broker base (default; override for a private deployment)
+# ORB_BROKER_URL=https://api.loopover.ai  # the Orb broker base (default; override for a private deployment)
 # ORB_RELAY_MODE=push                        # push | pull. push registers a public relay URL the broker calls;
 #                                            #   pull is the right fit behind NAT/tailnet — your instance drains
 #                                            #   events outbound instead of exposing an inbound endpoint. Default: push.


### PR DESCRIPTION
## Summary

Closes #6281

- `.env.example` documented the pre-rebrand `https://gittensory-api.aethereal.dev` as the default for `ORB_COLLECTOR_URL` and `ORB_BROKER_URL`. The code disagrees: `src/selfhost/orb-collector.ts:168` defaults the collector to `https://api.loopover.ai/v1/orb/ingest`, and `src/orb/broker-client.ts:13`'s `DEFAULT_BROKER_URL` is `https://api.loopover.ai`. An operator reading the example file was told the wrong default.
- Also updates the adjacent "gittensory's hosted collector" prose on those same lines — `orb-collector.ts:10` already describes it as "loopover's hosted collector", so it was the same rebrand staleness.
- **Checked the other files the issue names**: `.env.selfhost.example` documents no ORB collector/broker default, and `docs/` has none either — so nothing else needed changing.
- **Deliberately scoped**: the remaining `gittensory-api.aethereal.dev` references elsewhere (`wrangler.jsonc`, `src/api/routes.ts`, `README.md`, tests) are the **live API origin**, not a stale ORB default. They are a different concern and are left untouched.
- Doc-only: **1 file, +3/-3, no code changes.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Verified the issue's premise against `main` rather than trusting it: read the two code defaults directly, and grepped the whole repo for the stale domain to separate genuine ORB-default staleness from the live API origin.
- `npm run selfhost:env-reference:check` passes (exit 0, "checked 119 env var references") — this is the drift gate that guards generated env docs, and this edit does not disturb it.
- This is a comment-only diff in an example env file with no executable code, so there is nothing for `codecov/patch` to measure and no behavior to test. No source, API, or UI surface is touched; leaving the remaining suites to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Only two commented-out default URLs change. No credential value is added, and every credential line in the touched block stays blank/commented exactly as it was. `CHANGELOG.md` is untouched.

## Notes

Closes #6281
