### PR TITLE
fix(ci): check-orb-release-due picks the true latest orb tag, not a stale beta

### DIFF
--- a/scripts/check-orb-release-due.mjs
+++ b/scripts/check-orb-release-due.mjs
@@ -4,7 +4,7 @@
 // hidden inside this script. See scripts/orb-release-core.mjs for the underlying logic and rationale.
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { buildOrbReleaseReport } from "./orb-release-core.mjs";
+import { buildOrbReleaseReport, latestOrbTag, latestStableOrbTag } from "./orb-release-core.mjs";
 
 const MANIFEST_PATH = "orb-manifest.json";
 
@@ -13,8 +13,8 @@ function main() {
   const manifestVersion = JSON.parse(readFileSync(MANIFEST_PATH, "utf8")).version;
   const tags = git(["tag", "--list", "orb-v*"]).split("\n").filter(Boolean);
 
-  const stableTagName = latestStableTagName(tags);
-  const anyTagName = latestAnyTagName(tags);
+  const stableTagName = latestStableOrbTag(tags)?.tag ?? null;
+  const anyTagName = latestOrbTag(tags)?.tag ?? null;
 
   const report = buildOrbReleaseReport({
     tags,
@@ -30,25 +30,6 @@ function main() {
   if (!args.json && !args.output) {
     process.stdout.write(report.due ? `ORB beta due: ${report.nextTag}\n` : "No ORB beta due.\n");
   }
-}
-
-// Re-derives the same two "latest tag" views orb-release-core.mjs computes internally, purely so this CLI can
-// pick the right git revision range for each -- kept here (not exported from the core module) since it's a
-// git-log concern, not a pure-logic one.
-function latestStableTagName(tags) {
-  const stable = tags.filter((tag) => /^orb-v\d+\.\d+\.\d+$/.test(tag));
-  return stable.sort(compareTagsDesc)[0] ?? null;
-}
-
-function latestAnyTagName(tags) {
-  const versioned = tags.filter((tag) => /^orb-v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(tag));
-  return versioned.sort(compareTagsDesc)[0] ?? null;
-}
-
-function compareTagsDesc(left, right) {
-  // Lexicographic is good enough here purely to pick a `git log` boundary -- buildOrbReleaseReport does the
-  // real semver-aware comparison for anything that ends up in the report itself.
-  return right.localeCompare(left, undefined, { numeric: true });
 }
 
 function parseArgs(argv) {

--- a/test/unit/orb-release.test.ts
+++ b/test/unit/orb-release.test.ts
@@ -105,6 +105,24 @@ describe("semver helpers", () => {
     expect(latestStableOrbTag(["mcp-v1.0.0", "orb-vgarbage"])).toBeNull();
     expect(latestOrbTag([])).toBeNull();
   });
+
+  // #6294: a same-version beta must never outrank its stable promotion. A lexicographic sort puts
+  // "orb-v1.2.0-beta.10" ahead of "orb-v1.2.0" (the beta suffix string-sorts after its own prefix), which
+  // would pick a stale beta as check-orb-release-due.mjs's git-log boundary once a beta and its stable
+  // promotion point at different commits. Beta tags of a shipped version live in the tag list forever, so
+  // this stays reachable indefinitely.
+  it("latestOrbTag ranks a stable tag ahead of its same-version betas, not lexicographically (#6294)", () => {
+    const tags = ["orb-v1.2.0", "orb-v1.2.0-beta.1", "orb-v1.2.0-beta.10"];
+    expect(latestOrbTag(tags)?.tag).toBe("orb-v1.2.0");
+    // The lexicographic ordering this guards against would have returned the beta instead.
+    expect([...tags].sort((left, right) => right.localeCompare(left, undefined, { numeric: true }))[0]).toBe(
+      "orb-v1.2.0-beta.10",
+    );
+    // A later stable still wins over an earlier version's betas.
+    expect(latestOrbTag([...tags, "orb-v1.3.0"])?.tag).toBe("orb-v1.3.0");
+    // With no stable promotion yet, the highest beta is still the right answer (numeric, not string, order).
+    expect(latestOrbTag(["orb-v1.2.0-beta.1", "orb-v1.2.0-beta.10"])?.tag).toBe("orb-v1.2.0-beta.10");
+  });
 });
 
 describe("buildOrbReleaseReport", () => {


### PR DESCRIPTION
## Summary

Closes #6294

- `check-orb-release-due.mjs`'s `compareTagsDesc` sorted tags **lexicographically**, so a same-version beta outranked its stable promotion. Confirmed the issue's repro locally: sorting `["orb-v1.2.0", "orb-v1.2.0-beta.1", "orb-v1.2.0-beta.10"]` puts `orb-v1.2.0-beta.10` first, because a beta suffix string-sorts *after* its own prefix-matching stable tag. Beta tags of a shipped version live in the tag list forever, so this stays reachable once a beta and its stable promotion point at different commits.
- **Reused the existing utility instead of adding a comparator**, as the issue asks: `orb-release-core.mjs` already exports `latestStableOrbTag`/`latestOrbTag` (declared in `orb-release-core.d.mts`), both built on its real `compareSemver` — which already handles stable-outranks-prerelease and numeric `beta.N` ordering. This script **already imports from that module**, so the fix is a delegation, not a new dependency.
- The two local helpers were duplicates of those exports, and the comment justifying them — "kept here (not exported from the core module)" — was simply **inaccurate**: both are exported and typed. Removing them deletes the duplication along with the bug, rather than leaving a second comparator to drift again.
- Net: **-25/+21**, and the script's public behavior is unchanged apart from now picking the correct boundary.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test/unit/orb-release.test.ts` passes (**40 tests**), including the new `#6294` regression test built from the issue's exact repro. It asserts the stable tag now wins, and **pins the lexicographic ordering being guarded against** (asserting the old sort would have returned `orb-v1.2.0-beta.10`), so a regression to string sorting fails loudly. It also covers a later stable beating an earlier version's betas, and betas-only still ordering numerically.
- The regression test targets `latestOrbTag` — the exported, already-unit-tested function this script now delegates to — because `check-orb-release-due.mjs` exports nothing and calls `main()` on import, so it has no unit-test seam. Adding one would mean changing the script's execution semantics while CI workflows invoke it; reusing the existing tested seam avoids that risk entirely. (That missing seam is its own tracked concern — see #6297 for the sibling script.)
- **Ran the real script end-to-end** (`node scripts/check-orb-release-due.mjs --json`): exits 0 and emits a valid report against this repo's actual tags (`latestStableTag: orb-v2.0.0`), confirming the delegation is a drop-in.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This script is read-only by design — it reports, and the actual `git tag`/`push` stays an explicit step in `orb-beta-release.yml`. That property is unchanged here.

## Notes

Closes #6294
