### PR TITLE
fix(rees): reconstruct trailing-newline patches instead of failing closed (#6254)

### DIFF
--- a/review-enrichment/src/analyzers/reconstruct-old-content.ts
+++ b/review-enrichment/src/analyzers/reconstruct-old-content.ts
@@ -34,6 +34,12 @@
 export function reconstructOldContent(newContent: string, patch: string): string | null {
   const newLines = newContent.split("\n");
   const patchLines = patch.split("\n");
+  // A unified-diff patch conventionally ends in a newline, so `split("\n")` yields a phantom empty final element
+  // that is NOT a real diff line — dropping it keeps the reconstruction loop from treating it as a context line
+  // to match against `newContent[cursor]`, which wrongly discarded otherwise-faithful trailing-newline patches
+  // (#6254). This is safe and scoped: a genuine blank context/added/removed line always carries its " "/"+"/"-"
+  // prefix, so a truly-empty ("") element only ever arises from that trailing split, never from real hunk content.
+  if (patchLines.length > 0 && patchLines[patchLines.length - 1] === "") patchLines.pop();
   const out: string[] = [];
   let cursor = 0; // next unconsumed index into newLines
   let i = 0;

--- a/review-enrichment/test/reconstruct-old-content.test.ts
+++ b/review-enrichment/test/reconstruct-old-content.test.ts
@@ -81,3 +81,13 @@ test("reconstructOldContent: a wholly new file reconstructs to an empty string, 
   assert.equal(old, "");
   assert.ok(!old); // falsy, exactly like null — this is the contract every caller relies on
 });
+
+test("reconstructOldContent: a well-formed patch ending in a trailing newline reconstructs faithfully, not null (#6254)", () => {
+  // `patch.split("\n")` on a trailing-newline patch yields a phantom empty final element. Before #6254 the loop
+  // treated it as a context line requiring a match against a non-existent `newLines[cursor]`, so this fully-
+  // faithful hunk wrongly returned null — silently degrading complexity-/duplication-/doc-comment-/exhaustiveness-
+  // drift to "no signal" on the very common trailing-newline patch. The phantom is now dropped before the loop.
+  assert.equal(reconstructOldContent("a\nb", "@@ -1,2 +1,2 @@\n a\n b\n"), "a\nb");
+  // A real change (a removal) that also ends in a trailing newline still rebuilds the old side correctly.
+  assert.equal(reconstructOldContent("a\nb", "@@ -1,2 +1,2 @@\n-x\n+a\n b\n"), "x\nb");
+});


### PR DESCRIPTION
## Summary

`reconstructOldContent` (`review-enrichment/src/analyzers/reconstruct-old-content.ts`) split the patch on `"\n"`. A patch that ends in a trailing newline — a very common, arguably majority, real-world case — produced a phantom empty final element, which the reconstruction loop treated as a context line requiring an exact match against a non-existent `newLines[cursor]`, so it wrongly returned `null` for an otherwise fully-faithful hunk. Verified: `reconstructOldContent("a\nb", "@@ -1,2 +1,2 @@\n a\n b\n")` returned `null`.

That silently degraded all four consumers (`complexity-delta`, `duplication-delta`, `doc-comment-drift`, `exhaustiveness-drift`) to "no signal" for any file whose patch ends in a trailing newline — despite the module's contract being "never trust a reconstructed result that isn't provably faithful," it was discarding *faithful* reconstructions.

## Fix

Drop the genuinely-empty trailing element from the split result before the reconstruction loop runs:

```ts
if (patchLines.length > 0 && patchLines[patchLines.length - 1] === "") patchLines.pop();
```

Safe and scoped to the trailing-newline case, without weakening the "provably faithful" guarantee: a real blank context/added/removed line always carries its `" "`/`"+"`/`"-"` prefix, so a truly-empty (`""`) element only ever arises from that trailing split, never from real hunk content. A genuinely malformed patch still bails to `null` exactly as before.

`reconstructOldContent("a\nb", "@@ -1,2 +1,2 @@\n a\n b\n")` now returns `"a\nb"`.

## Scope / Validation / Safety

- [x] Conventional Commit title; focused; `Closes #6254`.
- [x] Regression test added for the exact case (plus a trailing-newline patch that carries a real removal), alongside the existing edge-case suite (multi-hunk, out-of-order, `\ No newline`, wholly-new-file). Both branches of the new guard are exercised (existing tests have non-trailing-`\n` patches).
- [x] `npm run rees:test` green — **1333 pass, 0 fail**; `metadata:check` clean; 83 source maps validated.
- [x] No behavior change for any malformed patch; no secrets; no `apps/`/`site/`/`CNAME` changes.

`reconstruct-old-content.ts` isn't in `vitest.config.ts`'s coverage.include (nor imported by any `src/**` file), so it's outside Codecov's collected scope — the regression coverage is provided via the review-enrichment `node:test` suite it lives in, per the issue's Deliverables.

Closes #6254
