### PR TITLE
fix(rees): use the shared diff-file-header predicate in api-break/caller-impact (#6255)

### DIFF
--- a/review-enrichment/src/analyzers/api-break.ts
+++ b/review-enrichment/src/analyzers/api-break.ts
@@ -8,6 +8,7 @@
 // exact whole-name loss is; a non-entrypoint file is out of scope (that is the caller-impact analyzer's job).
 // Deterministic, no network, no token. Reports file, old-file line, and symbol only — never surrounding code.
 import type { ApiBreakFinding, EnrichRequest } from "../types.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const MAX_ENTRYPOINTS = 25; // cap changed entrypoint files scanned per PR
@@ -87,10 +88,14 @@ export function removedExports(patch: string): RemovedExport[] {
     }
     if (!inHunk) continue;
     if (raw.startsWith("+")) {
-      if (raw.startsWith("+++")) continue;
+      // Skip only a real unified-diff file header (`+++ b/path`), not added/removed CONTENT that merely starts
+      // with `++`/`--` (git renders `--x;` as `---x;`) — the bespoke startsWith("+++")/("---") guards mis-flagged
+      // such content as a header, dropping it and mis-numbering every later export (#6255, the fix 7 sibling
+      // analyzers already made via this shared predicate).
+      if (isDiffFileHeaderLine(raw)) continue;
       for (const name of exportedNames(raw.slice(1))) added.add(name);
     } else if (raw.startsWith("-")) {
-      if (raw.startsWith("---")) continue;
+      if (isDiffFileHeaderLine(raw)) continue;
       for (const name of exportedNames(raw.slice(1))) {
         if (!removed.has(name)) removed.set(name, oldLine);
       }

--- a/review-enrichment/src/analyzers/caller-impact.ts
+++ b/review-enrichment/src/analyzers/caller-impact.ts
@@ -29,6 +29,7 @@ import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson, boundedFetchText } from "../external-fetch.js";
 import { githubHeaders } from "../github-headers.js";
 import { exportedNames, isPublicEntrypoint } from "./api-break.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
@@ -180,7 +181,7 @@ export function collectRemovedExports(
   for (const file of files) {
     if (!file.patch) continue;
     for (const raw of file.patch.split("\n")) {
-      if (raw.startsWith("+") && !raw.startsWith("+++")) {
+      if (raw.startsWith("+") && !isDiffFileHeaderLine(raw)) {
         for (const name of exportedNames(raw.slice(1))) added.add(name);
       }
     }
@@ -202,7 +203,9 @@ export function collectRemovedExports(
       if (!inHunk) continue;
       if (raw.startsWith("+")) continue; // added line: does not advance the old-file counter
       if (raw.startsWith("-")) {
-        if (raw.startsWith("---")) continue;
+        // Shared header predicate, not startsWith("---"): a removed line whose content starts with `-` (e.g.
+        // `--counter;` → `---counter;`) is NOT a file header and must still be scanned + advance oldLine (#6255).
+        if (isDiffFileHeaderLine(raw)) continue;
         for (const name of exportedNames(raw.slice(1))) {
           if (name === "default" || name.length < MIN_SYMBOL_LEN || seen.has(name)) continue;
           seen.add(name);

--- a/review-enrichment/test/api-break.test.ts
+++ b/review-enrichment/test/api-break.test.ts
@@ -74,6 +74,14 @@ test("removedExports: flags a rename (old name dropped, new name added)", () => 
   assert.deepEqual(out, [{ symbol: "oldName", line: 1 }]);
 });
 
+test("removedExports: a removed line whose CONTENT starts with `--` still advances oldLine, so a later removed export keeps its correct line (#6255)", () => {
+  // `--counter;` renders in the diff as `---counter;`; the bespoke startsWith("---") guard mis-read it as a diff
+  // file header, skipping it WITHOUT advancing oldLine, so `gone` was reported one line too low. The shared
+  // isDiffFileHeaderLine predicate (which keys on the header's `a/`/`b/`/`dev/null` path form) scans it correctly.
+  const out = removedExports(hunk([["-", "--counter;"], ["-", "export function gone() {}"]], 10));
+  assert.deepEqual(out, [{ symbol: "gone", line: 11 }]);
+});
+
 test("removedExports: flags a name dropped from a re-export list", () => {
   const out = removedExports(
     hunk([["-", 'export { a, b } from "./x";'], ["+", 'export { a } from "./x";']]),

--- a/review-enrichment/test/caller-impact.test.ts
+++ b/review-enrichment/test/caller-impact.test.ts
@@ -111,6 +111,16 @@ test("collectRemovedExports: removed export keyed to old-file line", () => {
   assert.deepEqual(removed, [{ file: "src/utils.ts", symbol: "removedHelper", line: 2 }]);
 });
 
+test("collectRemovedExports: a removed line whose CONTENT starts with `--` advances oldLine, so a later removed export keeps its correct line (#6255)", () => {
+  // Same bug as api-break's removedExports (whose doc collectRemovedExports mirrors): `--counter;` renders as
+  // `---counter;`, which the bespoke startsWith("---") guard skipped WITHOUT advancing oldLine, mis-locating
+  // `removedHelper`. The shared isDiffFileHeaderLine predicate scans the content line and reports the right line.
+  const removed = collectRemovedExports([
+    { path: "src/utils.ts", patch: ["@@ -1,2 +1,0 @@", "---counter;", "-export function removedHelper() {}"].join("\n") },
+  ]);
+  assert.deepEqual(removed, [{ file: "src/utils.ts", symbol: "removedHelper", line: 2 }]);
+});
+
 test("collectRemovedExports: a symbol re-added anywhere in the PR (move/edit) is not removed", () => {
   const removed = collectRemovedExports([
     { path: "src/utils.ts", patch: REMOVED_PATCH.replace("removedHelper", "movedHelper") },


### PR DESCRIPTION
## Summary

`api-break.ts`'s `removedExports` and `caller-impact.ts`'s `collectRemovedExports` still used the bespoke `raw.startsWith("+++")` / `raw.startsWith("---")` checks to skip unified-diff file headers. That misidentifies added/removed **content** whose text starts with `+`/`-` — git renders a removed line whose content is `--counter;` as `---counter;` — as a file header, skipping the line **without advancing the old-file cursor**, so every later removed export in the same hunk is reported at the wrong line number.

`undocumented-export.ts:113-117` documents this exact bug and its fix (the shared `isDiffFileHeaderLine` predicate in `diff-lines.ts`), and 7 sibling analyzers already adopted it — these two never did, even though `collectRemovedExports`'s own doc says it mirrors `api-break`.

## Fix

Replace both bespoke checks in each function with `isDiffFileHeaderLine`, which keys on the header's `a/`/`b/`/`/dev/null` path form (so it matches a true header but never `--`/`++`-prefixed content). The shared helper is unchanged.

Both the added (`+++`) and removed (`---`) checks in each function are switched, matching the sibling pattern.

## Scope / Validation / Safety

- [x] Conventional Commit title; focused; `Closes #6255`.
- [x] Regression test for **each** function using the exact reproduction case (a removed line whose content starts with `--`, immediately followed by a real removed export in the same hunk) — asserting the export is now reported at the correct old-file line, not one too low.
- [x] `npm run rees:test` green — **1335 pass, 0 fail**; `metadata:check` clean; 83 source maps validated.
- [x] Shared helper untouched; no behavior change for any real file header; no secrets; no `apps/`/`site/`/`CNAME` changes.

`api-break.ts`/`caller-impact.ts` aren't in `vitest.config.ts`'s coverage.include (nor imported by any `src/**` file), so they're outside Codecov's collected scope — regression coverage is provided via the review-enrichment `node:test` suite, per the issue's Deliverables.

Closes #6255
