### PR TITLE
chore(selfhost): remove dead nonConsumingRetryDelayMs export

### DIFF
--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -689,10 +689,6 @@ export function githubRateLimitRetryDelayMs(
   return null;
 }
 
-export function nonConsumingRetryDelayMs(error: unknown): number | null {
-  return githubRateLimitRetryDelayMs(error);
-}
-
 export function consumingRetryDelayMs(
   error: unknown,
   defaultDelayMs: number,

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -25,7 +25,6 @@ import {
   jobClaimSortKey,
   jobPriority,
   matchesGitHubRateLimitAdmissionTarget,
-  nonConsumingRetryDelayMs,
   parsePositiveIntEnv,
   queueBackgroundConcurrency,
   queueDeadLetterAutoRetryMaxExtraAttempts,
@@ -1479,25 +1478,6 @@ describe("self-host queue common helpers", () => {
         new Error("openai api rate limit exceeded"),
       ),
     ).toBeNull();
-  });
-
-  it("keeps only GitHub rate limits on the non-consuming retry path", () => {
-    expect(nonConsumingRetryDelayMs(new Error("boom"))).toBeNull();
-    expect(
-      nonConsumingRetryDelayMs({
-        status: 429,
-        response: { headers: new Headers({ "retry-after": "2" }) },
-      }),
-    ).toBe(2_000);
-    expect(
-      nonConsumingRetryDelayMs(
-        new RetryableJobError("AI review pending", {
-          retryAfterMs: 1234,
-          retryKind: "ai_review_public_summary_missing",
-        }),
-      ),
-    ).toBeNull();
-    expect(nonConsumingRetryDelayMs(new Error("openai rate limit"))).toBeNull();
   });
 
   it("uses RetryableJobError delays on the bounded consuming retry path", () => {


### PR DESCRIPTION
Closes #6287

## Summary

- Remove `nonConsumingRetryDelayMs` from `src/selfhost/queue-common.ts` — a trivial pass-through alias to `githubRateLimitRetryDelayMs` with zero real (non-test) callers anywhere in the repo. Its sibling `consumingRetryDelayMs` is the one actually used by both queue backends.
- Remove its dedicated test (`selfhost-queue-common.test.ts`'s "keeps only GitHub rate limits on the non-consuming retry path") and the now-unused import.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6287.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — root `tsc --noEmit` OOMs on this shared sandbox regardless of branch (reproduced identically on a clean `main` checkout via `git stash`). No substitute typecheck was needed here beyond what vitest's esbuild transform already catches, since the change is a pure removal (no new type surface) confirmed by a repo-wide grep showing zero remaining references.
- [x] `npm run test:coverage` — not run repo-wide (same OOM risk), but the full set of tests importing from `queue-common.ts` was run directly and passes: `selfhost-sqlite-queue.test.ts`, `queue-5.test.ts`, `selfhost-queue-common.test.ts`, `queue-2.test.ts`, `selfhost-pg-queue.test.ts`, `queue-4.test.ts`, `queue.test.ts`, `queue-3.test.ts`, `selfhost-installation-concurrency-admission.test.ts`, `queue-lifecycle-guards.test.ts` — 1273/1273 passing. (`index.test.ts` in the same run fails on a pre-existing, unrelated `Cannot find package '@sentry/hono/cloudflare'` module-resolution error in `src/api/routes.ts`/`src/index.ts` — reproduced identically on a clean `main` checkout with this diff stashed, so it predates and is unrelated to this change.) This PR is a pure deletion of dead code and its own test, so patch coverage is inherently 100% (no new lines added).
- [x] `npm run test:workers` — N/A, no Worker-facing behavior changed.
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A, no `@loopover/mcp` changes.
- [x] `npm run ui:openapi:check` — N/A, no API/OpenAPI changes.
- [x] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — N/A, this removes dead code and its dedicated test; no new behavior.

If any required check was skipped, explain why:

- Root `npm run typecheck` / `npm run test:coverage`: this sandbox runs on a machine shared with other concurrent sessions; the root `tsc --noEmit` reliably OOMs under that memory pressure regardless of what changed (reproduced identically with this branch's diff fully stashed against `main`). Substituted with a full repo-wide grep confirming zero remaining references to the removed export, plus every directly-importing test file run and passing (1273/1273).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- Confirmed via `grep -rln "nonConsumingRetryDelayMs" src/` (excluding its own definition file) that no production code imports it, matching the issue's finding exactly.
