### PR TITLE
feat(mcp): instrument the remote tool-dispatch chokepoint with PostHog events

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import {
   runIssueRagRetrieval,
   validateIssueRagInput,
 } from "./issue-rag";
+import { recordMcpToolCall } from "./telemetry";
 import {
   authenticatePrivateToken,
   extractBearerToken,
@@ -1631,6 +1632,9 @@ export async function handleMcpRequest(c: AppContext): Promise<Response> {
   const server = new LoopoverMcp(c.env, identity).createServer();
   try {
     const response = await createMcpHandler(server, { route: "/mcp", enableJsonResponse: true })(c.req.raw, c.env, getExecutionContext(c));
+    if (typeof usageMetadata.toolName === "string") {
+      recordMcpToolTelemetry(c.env, usageMetadata.toolName, response.status < 400, Date.now() - startedAt);
+    }
     await recordProductUsageEvent(c.env, {
       surface: "mcp",
       role: "miner",
@@ -1646,6 +1650,9 @@ export async function handleMcpRequest(c: AppContext): Promise<Response> {
     }).catch(() => undefined);
     return response;
   } catch (error) {
+    if (typeof usageMetadata.toolName === "string") {
+      recordMcpToolTelemetry(c.env, usageMetadata.toolName, false, Date.now() - startedAt);
+    }
     await recordProductUsageEvent(c.env, {
       surface: "mcp",
       role: "miner",
@@ -1660,6 +1667,18 @@ export async function handleMcpRequest(c: AppContext): Promise<Response> {
       metadata: usageMetadata,
     }).catch(() => undefined);
     throw error;
+  }
+}
+
+// Single chokepoint for the #6228 PostHog tool-call telemetry (#6237): every `tools/call` request that
+// reaches handleMcpRequest routes through here exactly once, whether it succeeds or throws. Pure
+// observability -- never lets a telemetry failure reach the caller, matching recordMcpToolCall's own
+// no-op guarantee (#6235) with a second, defensive layer at the actual call site.
+function recordMcpToolTelemetry(env: Env, tool: string, ok: boolean, durationMs: number): void {
+  try {
+    recordMcpToolCall(env, { tool, callerType: "remote", ok, durationMs });
+  } catch {
+    // Telemetry must never affect the tool response (#6237).
   }
 }
 

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -6,6 +6,7 @@ import { createTestEnv } from "../helpers/d1";
 describe("MCP server telemetry", () => {
   afterEach(() => {
     vi.doUnmock("agents/mcp");
+    vi.doUnmock("../../src/mcp/telemetry");
     vi.resetModules();
   });
 
@@ -146,5 +147,79 @@ describe("MCP server telemetry", () => {
         metadata: expect.objectContaining({ rpcMethod: "ping" }),
       }),
     ]);
+  });
+
+  it("records exactly one recordMcpToolCall, tagged callerType remote, on a successful tool invocation (#6237)", async () => {
+    vi.resetModules();
+    vi.doMock("agents/mcp", () => ({
+      createMcpHandler: () => () => Response.json({ ok: true }),
+    }));
+    const recordMcpToolCall = vi.fn();
+    vi.doMock("../../src/mcp/telemetry", () => ({ recordMcpToolCall }));
+    const { handleMcpRequest } = await import("../../src/mcp/server");
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "mcp-remote-telemetry-salt" });
+    const request = new Request("https://api.test/mcp", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "tool-call", method: "tools/call", params: { name: "loopover_local_status" } }),
+    });
+
+    await expect(
+      handleMcpRequest({
+        env,
+        executionCtx: { waitUntil() {}, passThroughOnException() {} },
+        req: {
+          method: "POST",
+          raw: request,
+          header: (name: string) => request.headers.get(name) ?? undefined,
+        },
+        json: (body: unknown, status?: number) => Response.json(body, status === undefined ? undefined : { status }),
+      } as never),
+    ).resolves.toMatchObject({ status: 200 });
+
+    expect(recordMcpToolCall).toHaveBeenCalledTimes(1);
+    expect(recordMcpToolCall).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ tool: "loopover_local_status", callerType: "remote", ok: true, durationMs: expect.any(Number) }),
+    );
+  });
+
+  it("does not let a throwing recordMcpToolCall affect the tool response (#6237)", async () => {
+    vi.resetModules();
+    vi.doMock("agents/mcp", () => ({
+      createMcpHandler: () => () => Response.json({ ok: true, result: "unchanged" }),
+    }));
+    vi.doMock("../../src/mcp/telemetry", () => ({
+      recordMcpToolCall: () => {
+        throw new Error("posthog_unreachable");
+      },
+    }));
+    const { handleMcpRequest } = await import("../../src/mcp/server");
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "mcp-remote-telemetry-throws-salt" });
+    const request = new Request("https://api.test/mcp", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "tool-call", method: "tools/call", params: { name: "loopover_local_status" } }),
+    });
+
+    const response = await handleMcpRequest({
+      env,
+      executionCtx: { waitUntil() {}, passThroughOnException() {} },
+      req: {
+        method: "POST",
+        raw: request,
+        header: (name: string) => request.headers.get(name) ?? undefined,
+      },
+      json: (body: unknown, status?: number) => Response.json(body, status === undefined ? undefined : { status }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.clone().json()).resolves.toEqual({ ok: true, result: "unchanged" });
   });
 });


### PR DESCRIPTION
## Summary

- Part of #6228. `handleMcpRequest` (`src/mcp/server.ts`) is the single chokepoint every remote MCP request — including every `tools/call` invocation — already passes through; it already derives `startedAt`, `usageMetadata.toolName`, and success/failure to record a DB-based product-usage event. This PR reuses those exact same signals to also call the #6235 PostHog wrapper's `recordMcpToolCall` exactly once per real tool call, tagged `callerType: "remote"`.
- Only requests where `usageMetadata.toolName` is a string (i.e. an actual `tools/call`, not `ping`/`tools/list`/etc.) trigger `recordMcpToolCall`, mirroring the existing `eventName: "mcp_tool_called"` vs `"mcp_request"` guard already in this function.
- The call is wrapped in a small `recordMcpToolTelemetry` helper with its own try/catch, so a telemetry failure can never affect the tool response — a second, defensive layer on top of the wrapper's own no-throw guarantee from #6235.
- Zero behavior change to any tool's response: the new code only reads already-computed values (`c.env`, `usageMetadata.toolName`, `response.status`, `startedAt`) and never touches the returned `Response`/thrown `error`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This local Windows dev environment cannot run `wrangler` (`cf-typegen:check` fails with a pre-existing, change-unrelated `spawnSync wrangler ENOENT`), which blocks the chained `npm run test:ci` from reaching later steps locally. Each step was therefore run individually: `git diff --check`, `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `miner:env-reference:check`, `selfhost:validate-observability`, engine build, `typecheck`, `test:engine-parity`, `test:live-gate-parity`, and `test:driver-parity` all pass clean on this branch. Coverage was verified by scoping `--coverage.include` to `src/mcp/server.ts` and running just the touched test file: every new line and both sides of both new `if (typeof usageMetadata.toolName === "string")` branches are fully covered. The broader `test/unit/mcp-*.test.ts` + `test/integration/routes-errors.test.ts` sweep passes cleanly aside from 3 pre-existing, change-unrelated Windows-only symlink-permission failures (`EPERM: operation not permitted, symlink`) in `mcp-cli-lint-pr-text.test.ts`/`mcp-cli-slop-risk.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only observability change, no visible UI change.

## Notes

- Closes #6237
- Depends on the already-merged #6235 (`src/mcp/telemetry.ts`'s `recordMcpToolCall`).
