### PR TITLE
docs(selfhost): document CONFIG_DIR_EMPTY_ACKNOWLEDGED in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,6 +236,11 @@ LOOPOVER_REVIEW_DRAFT=false
 # PORT=8787
 # DATABASE_PATH=/data/loopover.sqlite     # SQLite file on the mounted data volume; all migrations auto-apply
 # LOOPOVER_REPO_CONFIG_DIR=/config           # in-container dir the app reads per-repo .loopover.yml files from
+# CONFIG_DIR_EMPTY_ACKNOWLEDGED=true         # silences the boot-time warning when LOOPOVER_REPO_CONFIG_DIR is set
+#                                            #   but the mounted directory is empty (every per-repo/global setting
+#                                            #   silently falls back to built-in defaults). Set once you've
+#                                            #   confirmed this is intentional, e.g. a fresh install with no
+#                                            #   .loopover.yml written yet. Default false (warning shown).
 # COMPOSE_PROJECT_NAME=loopover              # Docker Compose's own project name; also labels the log stream
 #                                            #   Promtail ships to Loki. Change it to run two stacks on one host.
 # TZ=UTC                                     # timezone passed to n8n (--profile workflows) for cron schedules

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -330,6 +330,11 @@ describe("emptyConfigDirAdvisory (gittensory->loopover rename incident)", () => 
     const message = emptyConfigDirAdvisory({ configured: true, entryCount: 0, acknowledged: false });
     expect(message).toMatch(/mounted directory is empty/);
     expect(message).toMatch(/CONFIG_DIR_EMPTY_ACKNOWLEDGED/);
+  });
+
+  it("regression: CONFIG_DIR_EMPTY_ACKNOWLEDGED is documented in .env.example, not just the generated UI reference (#6286)", () => {
+    const envExample = readFileSync(new URL("../../.env.example", import.meta.url), "utf8");
+    expect(envExample).toMatch(/CONFIG_DIR_EMPTY_ACKNOWLEDGED/);
   });
 });
 


### PR DESCRIPTION
Closes #6286

## Summary

- Document `CONFIG_DIR_EMPTY_ACKNOWLEDGED` in `.env.example`, right after the `LOOPOVER_REPO_CONFIG_DIR` var it governs, matching the existing comment style used for `PUBLIC_ORIGIN_ACKNOWLEDGED`/`BACKUP_ACKNOWLEDGED`.
- Add a regression test (`selfhost-health.test.ts`) proving `.env.example` documents the flag — verified it fails without the fix and passes with it.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6286.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — root `tsc --noEmit` reliably OOMs on this shared sandbox regardless of what changed (confirmed pre-existing on a clean checkout in earlier work this session). This change only adds a comment line to a `.env.example` file and one new test assertion using `readFileSync`, with no new type surface — the affected test file was run directly and passes.
- [x] `npm run test:coverage` — not run repo-wide (same OOM risk). The directly affected test file (`selfhost-health.test.ts`, 37 tests) and the broader set of tests that read `.env.example` content (`docker-compose-env-example-parity.test.ts`, `env-example-metric-names.test.ts`, `selfhost-compose-workflows-storage.test.ts`, `selfhost-compose-resource-limits.test.ts`, `selfhost-grafana-sentry-datasource.test.ts`, `selfhost-preflight.test.ts`, `self-host-ops-rename-residue.test.ts`, `setup-wizard-docs-parity.test.ts`) all pass — 94 tests total. `npm run selfhost:env-reference:check` also passes.
- [x] `npm run test:workers` — N/A, no Worker-facing code changed.
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A, no `@loopover/mcp` changes.
- [x] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — the new regression test was verified to genuinely fail without the `.env.example` addition (via a temporary `git stash` of just that file) before being confirmed passing with it.

If any required check was skipped, explain why:

- Root `npm run typecheck` / `npm run test:coverage`: reliably OOMs on this shared sandbox under memory pressure from concurrent sessions, independent of the diff. Substituted with the directly affected test file plus every test that reads `.env.example` content (94 tests, all passing) and the `selfhost:env-reference:check` script.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- `.env.selfhost.example` (the short/minimal starter env) deliberately omits this class of rare-condition acknowledgment flag — `LOOPOVER_REPO_CONFIG_DIR` itself (the var this flag governs) and `BACKUP_ACKNOWLEDGED` are both absent from that file too, so adding only `CONFIG_DIR_EMPTY_ACKNOWLEDGED` there without its trigger var would be inconsistent with that file's existing minimal-subset convention. `.env.example` (the exhaustive reference the issue also names) is the correct and sufficient location.
