### PR TITLE
fix(mcp): treat a bare `help` positional as --help in parseOptions (#6257)

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2898,7 +2898,15 @@ function parseOptions(args) {
       options.json = true;
       continue;
     }
-    if (!arg?.startsWith("--")) continue;
+    if (!arg?.startsWith("--")) {
+      // A bare `help` positional means the same thing as `--help` (#6257): the option-consuming commands
+      // (decision-pack/repo-decision/review-pr) only check `options.help === true`, so without this a
+      // dashless `loopover-mcp decision-pack help` fell through to a confusing "Pass --login…" error instead
+      // of printing usage — while the raw-args commands (lint-pr-text etc.) already special-cased it. A `help`
+      // consumed as a `--key value` value is skipped via `index += 1` below, so only a STANDALONE `help` here.
+      if (arg === "help") options.help = true;
+      continue;
+    }
     // Support the inline `--key=value` form (e.g. `--format=table`) alongside the space-separated
     // `--key value` form; splitting here keeps every existing space-separated option unchanged (#2231).
     const equals = arg.indexOf("=");

--- a/test/unit/mcp-cli-packets.test.ts
+++ b/test/unit/mcp-cli-packets.test.ts
@@ -80,11 +80,23 @@ describe("loopover-mcp CLI — packets", () => {
     expect(help).toMatch(/contributor decision pack/);
   });
 
+  it("prints decision-pack help for a bare `help` positional too, not a --login error (#6257)", () => {
+    const help = run(["decision-pack", "help"]);
+    expect(help).toMatch(/Usage: loopover-mcp decision-pack/);
+    expect(help).not.toMatch(/Pass --login/);
+  });
+
   it("prints repo-decision help without requiring --login/--repo or making a network call", () => {
     const help = run(["repo-decision", "--help"]);
     expect(help).toMatch(/Usage: loopover-mcp repo-decision/);
     expect(help).toMatch(/loopover_explain_repo_decision/);
     expect(help).toMatch(/repo decision/);
+  });
+
+  it("prints repo-decision help for a bare `help` positional too, not a --login error (#6257)", () => {
+    const help = run(["repo-decision", "help"]);
+    expect(help).toMatch(/Usage: loopover-mcp repo-decision/);
+    expect(help).not.toMatch(/Pass --login/);
   });
 
   it("ignores incompatible decision-pack cache entries and clears cache entries on request", async () => {

--- a/test/unit/mcp-cli-review-pr.test.ts
+++ b/test/unit/mcp-cli-review-pr.test.ts
@@ -400,6 +400,12 @@ describe("loopover-mcp CLI — review-pr", () => {
     expect(help).toMatch(/preflight \+ slop-risk \+ PR-text-lint/);
   });
 
+  it("prints help for a bare `help` positional too, not a --login error (#6257)", () => {
+    const help = run(["review-pr", "help"]);
+    expect(help).toMatch(/Usage: loopover-mcp review-pr/);
+    expect(help).not.toMatch(/Pass --login/);
+  });
+
   it("suggests review-pr for close typos", () => {
     expect(() => run(["review-pr-x"])).toThrow(/Did you mean `review-pr`\?/);
   });


### PR DESCRIPTION
## Summary

`loopover-mcp decision-pack help` (and `repo-decision help` / `review-pr help`) threw a confusing "Pass --login…" error instead of printing usage, because a **bare `help` positional** (no dashes) was silently dropped. These three commands are dispatched with a parsed `options` object and only check `options.help === true`, but `parseOptions` skips any non-`--` argument — so `options.help` was never set. The other four command-dispatch siblings (`lint-pr-text`/`validate-config`/`slop-risk`/`issue-slop`) receive raw `args` and already special-case `args[0] === "help"`.

## Fix

In `parseOptions`, set `options.help = true` for a standalone `help` positional — symmetric with how `--help` already resolves to `options.help = true`, and the DRY equivalent of the sibling `args[0] === "help"` special-case that fixes all three option-consuming commands at once:

```js
if (!arg?.startsWith("--")) {
  if (arg === "help") options.help = true;
  continue;
}
```

A `help` consumed as a `--key value` value (e.g. `--query help`) is skipped via the `--key value` branch's `index += 1` before ever reaching this check, so only a genuinely standalone `help` positional is affected. The four already-correct commands are unchanged (they check `args[0]` before parsing).

`loopover-mcp decision-pack help` now prints usage; verified manually and by tests.

## Scope / Validation / Safety

- [x] Conventional Commit title; focused; `Closes #6257`.
- [x] Added a bare-`help` test for **all three** commands (`decision-pack`/`repo-decision`/`review-pr`), asserting they print `Usage:` and not the `Pass --login` error, alongside their existing `--help` tests.
- [x] **All 172 mcp-cli tests pass** (24 files) — no regression to any other command that shares `parseOptions`; `npm run build:mcp` (syntax) green.
- [x] No behavior change for the already-correct commands or for `help` passed as a flag value; no secrets; no `apps/`/`site/`/`CNAME` changes.

`packages/loopover-mcp/bin/**` isn't in Codecov's collected scope (only `src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**` are); the fix is verified by the `test/unit/mcp-cli-*` suite that invokes the real bin.

Closes #6257
