### PR TITLE
fix(mcp): print unknown API compatibility in status (#6263)

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -3149,6 +3149,9 @@ async function status(options) {
       process.stdout.write(`API compatibility: compatible (minimum ${packageName}@${apiCompatibility.minVersion}).\n`);
     } else if (apiCompatibility.status === "unavailable") {
       process.stdout.write(`API compatibility: unavailable (${apiCompatibility.reason ?? "unknown"}).\n`);
+    } else if (apiCompatibility.status === "unknown") {
+      // Mirror doctor()'s unknown arm (#6263): an unparseable minimum version must still surface in human output.
+      process.stdout.write(`API reported an unsupported minimum client version (${apiCompatibility.minVersion}).\n`);
     }
   }
 }

--- a/test/unit/mcp-cli-doctor.test.ts
+++ b/test/unit/mcp-cli-doctor.test.ts
@@ -308,6 +308,26 @@ describe("loopover-mcp CLI — doctor", () => {
     });
   });
 
+  it("prints API compatibility unknown when the minimum version is unparseable (#6263)", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
+    const url = await startFixtureServer({ minMcpVersion: "not-a-semver" });
+    const env = {
+      LOOPOVER_API_URL: url,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_CONFIG_DIR: tempDir,
+      LOOPOVER_SKIP_NPM_VERSION_CHECK: "true",
+    };
+    const statusJson = JSON.parse(await runAsync(["status", "--json"], env)) as {
+      apiCompatibility: { status: string; minVersion: string };
+    };
+    expect(statusJson.apiCompatibility).toMatchObject({ status: "unknown", minVersion: "not-a-semver" });
+
+    // Human-readable status used to omit this arm entirely; keep it visible like doctor().
+    const statusOutput = await runAsync(["status"], env);
+    expect(statusOutput).toContain("unsupported minimum client version");
+    expect(statusOutput).toContain("not-a-semver");
+  });
+
   it("flags API compatibility mismatches with upgrade guidance", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ minMcpVersion: "9.0.0" });


### PR DESCRIPTION
## Summary

- Human-readable `loopover-mcp status` now covers the `api_compatibility` `unknown` case (unparseable minimum version), matching `doctor()`'s warning instead of omitting compatibility entirely.
- Adds a regression test that feeds an unparseable `minMcpVersion` and asserts both JSON and human status output report it.
- Closes #6263

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran targeted MCP CLI coverage: `npx vitest run test/unit/mcp-cli-doctor.test.ts` (19/19 passed), including the new `#6263` regression. Full `npm run test:ci` not run yet on this Windows checkout (platform-forced `npm ci --force`); run the full gate before push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — CLI-only change.

## Notes

- `doctor()` was left unchanged; only `status()`'s human-readable branch gained the missing `unknown` arm.