### PR TITLE
fix(selfhost): fail open with a metric on a token-cache Redis error

### DIFF
--- a/src/selfhost/redis-token-cache.ts
+++ b/src/selfhost/redis-token-cache.ts
@@ -13,14 +13,24 @@ const REDIS_TOKEN_CACHE_METRIC = "loopover_redis_token_cache_total";
 const keyFor = (installationId: number): string =>
   `gh:insttoken:${installationId}`;
 
-function recordTokenCacheMetric(result: "hit" | "miss"): void {
+function recordTokenCacheMetric(result: "hit" | "miss" | "error"): void {
   incr(REDIS_TOKEN_CACHE_METRIC, { result });
 }
 
 export function createRedisTokenCache(redis: Redis): InstallationTokenStore {
   return {
     async get(installationId: number) {
-      const raw = await redis.get(keyFor(installationId));
+      // Fail open on a connection error, same contract as redis-cache.ts's webhook-dedup cache: the caller
+      // (github/app.ts's readCachedToken -> createInstallationToken) has no try/catch of its own, so an
+      // uncaught error here would hard-fail GitHub App token minting on every Redis hiccup instead of just
+      // costing one extra real mint. Unlike redis-cache.ts, still record a metric so the failure isn't invisible.
+      let raw: string | null;
+      try {
+        raw = await redis.get(keyFor(installationId));
+      } catch {
+        recordTokenCacheMetric("error");
+        return null;
+      }
       if (!raw) {
         recordTokenCacheMetric("miss");
         return null;

--- a/test/unit/selfhost-redis-token-cache.test.ts
+++ b/test/unit/selfhost-redis-token-cache.test.ts
@@ -4,7 +4,7 @@ import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createRedisTokenCache } from "../../src/selfhost/redis-token-cache";
 
 /** Minimal ioredis stand-in that records the TTL passed to set(). */
-function fakeRedis(): {
+function fakeRedis(options: { getThrows?: boolean } = {}): {
   redis: Redis;
   store: Map<string, string>;
   ttl: () => number;
@@ -13,6 +13,7 @@ function fakeRedis(): {
   let lastTtl = -1;
   const redis = {
     async get(k: string) {
+      if (options.getThrows) throw new Error("connection refused");
       return store.get(k) ?? null;
     },
     async set(k: string, v: string, _ex: "EX", ttl: number) {
@@ -94,6 +95,19 @@ describe("createRedisTokenCache (#perf installation-token persistence)", () => {
 
     expect(await renderMetrics()).toContain(
       'loopover_redis_token_cache_total{result="miss"} 1',
+    );
+  });
+
+  it("regression: fails open (returns null) and records an error metric on a Redis connection failure (#6288)", async () => {
+    // Unlike a cache miss/malformed value, a connection failure must never throw uncaught here: the caller
+    // (github/app.ts's readCachedToken -> createInstallationToken) has no try/catch of its own, so an uncaught
+    // rejection would hard-fail GitHub App token minting on every Redis hiccup instead of costing one extra
+    // real mint. This must still be observable, unlike redis-cache.ts's silent fail-open.
+    const { redis } = fakeRedis({ getThrows: true });
+    await expect(createRedisTokenCache(redis).get(9)).resolves.toBeNull();
+
+    expect(await renderMetrics()).toContain(
+      'loopover_redis_token_cache_total{result="error"} 1',
     );
   });
 });


### PR DESCRIPTION
Closes #6288

## Summary

- `redis-token-cache.ts`'s `get()` had no `try/catch` around `redis.get()` itself, so a Redis connection failure threw uncaught with no observability signal — unlike its two sibling wrappers (`redis-response-cache.ts` throws with a `result:"error"` metric, `redis-cache.ts` fails open silently with no metric).
- Verified the actual caller contract before choosing a fix: `github/app.ts`'s `readCachedToken` → `createInstallationToken` has no `try/catch` of its own around this call, so an uncaught rejection here would hard-fail GitHub App token minting on every Redis hiccup instead of just costing one extra real mint. **Fail open** (return `null`, same contract as `redis-cache.ts`) is the correct behavior for this specific caller — but unlike `redis-cache.ts`, this fix also records a `result:"error"` metric so the failure is never silently invisible, matching `redis-response-cache.ts`'s observability discipline. `set()` and the other two Redis wrapper files are untouched — no inconsistency was found in their behavior.
- Added a regression test simulating a Redis connection failure, verified to genuinely fail without the fix (uncaught rejection) before confirming it passes with it.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6288.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — root `tsc --noEmit` reliably OOMs on this shared sandbox regardless of what changed (reproduced repeatedly this session on a clean checkout). Scoped coverage (`npx vitest run ... --coverage --coverage.include="src/selfhost/redis-token-cache.ts"`) confirms 100% statements/branches/functions/lines on the changed file, and the full dedicated test file plus `github-app.test.ts` (98 tests total) pass.
- [x] `npm run test:coverage` — not run repo-wide (same OOM risk). Scoped coverage on the changed file is 100% branches (6/6). `test/unit/selfhost-redis-token-cache.test.ts` (7 tests) and `test/unit/github-app.test.ts` (91 tests, covering the caller side) both pass.
- [x] `npm run test:workers` — N/A, no Worker-facing behavior changed beyond this file's own contract, which is now more resilient (fail-open), not less.
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A, no `@loopover/mcp` changes.
- [x] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — the new regression test was verified to genuinely catch the bug (fails on `main` with the fix stashed) before confirming it passes with the fix applied.

If any required check was skipped, explain why:

- Root `npm run typecheck` / `npm run test:coverage`: reliably OOMs on this shared sandbox under memory pressure from concurrent sessions, independent of the diff. Substituted with scoped 100% coverage on the changed file plus the full caller-side test suite (98 tests, all passing).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — Yes: this IS a negative-path fix for GitHub App token-cache resilience, with a dedicated regression test for the Redis-failure path.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- `set()` in the same file also lacks a `try/catch`, but the issue explicitly scopes to the `get()` path (`redis-token-cache.ts:22-27`) and instructs not to touch the other files "unless a genuine inconsistency in THEIR behavior is also found" — kept this PR focused on the described `get()` gap rather than expanding scope.
