### PR TITLE
docs(selfhost): describe what the starters actually ship for critical secrets

### DIFF
--- a/src/selfhost/preflight.ts
+++ b/src/selfhost/preflight.ts
@@ -77,15 +77,30 @@ function addProblem(
   problems.push({ var: name, message });
 }
 
-// Codex security finding: `.env.selfhost.example` / `.env.example` ship these EXACT literal placeholder
-// values for high-privilege secrets (the webhook HMAC secret, plus the static API/MCP/internal bearer
-// tokens). An operator who copies the starter to `.env` and misses "fill in the placeholders" runs an
-// instance with a PUBLICLY KNOWN webhook secret (forgeable signatures) and PUBLICLY KNOWN bearer tokens
-// (LOOPOVER_API_TOKEN bypasses app-role + per-repo write checks; INTERNAL_JOB_TOKEN gates internal
-// routes) -- silently, with no error. Reject these exact strings at boot rather than trusting every
-// operator to have actually edited the file.
+// Codex security finding: reject the starter files' literal placeholder values at boot, rather than trusting
+// every operator to have actually edited the file. An operator who copies a starter to `.env` and misses "fill
+// in the placeholders" would otherwise run with a PUBLICLY KNOWN secret -- a forgeable webhook HMAC, or bearer
+// tokens that bypass real checks (LOOPOVER_API_TOKEN bypasses app-role + per-repo write checks;
+// INTERNAL_JOB_TOKEN gates internal routes) -- silently, with no error.
+//
+// What the starters ACTUALLY ship today (#6285 -- this comment used to claim both files ship literal values for
+// the webhook secret and all three bearer tokens, which was never true of either). Every var below ships
+// COMMENTED OUT in both files, so the hazard is what an operator finds when they uncomment one:
+//   - `.env.selfhost.example`: all five are commented AND valueless (`# GITHUB_WEBHOOK_SECRET=`) -- uncommenting
+//     yields a blank, which checkCriticalSecrets skips outright and which cannot be a publicly known value.
+//   - `.env.example`: same, except SELFHOST_SETUP_TOKEN's commented line carries a literal
+//     (`# SELFHOST_SETUP_TOKEN=change-this-long-random-value`). Uncommenting THAT -- the obvious way to turn the
+//     first-run wizard on -- hands the operator a published token unless this set stops them.
+// That literal is also the string most likely to reach a var that ships valueless: `.env.example` repeats it on
+// POSTGRES_PASSWORD's commented line, so it reads like the house placeholder rather than one var's.
+//
+// Load-bearing for every var here, not just the one that ships it: this set is matched against whatever the
+// operator SET, not against what the files ship. And at 29 chars the literal sails past MIN_SECRET_LENGTH below,
+// so this exact-match set is the ONLY check that catches it.
 const KNOWN_PLACEHOLDER_SECRETS = new Set([
   "change-this-long-random-value",
+  // Ships in neither starter today. Kept as defence-in-depth: this set is matched against whatever an operator
+  // actually set, not against what the files ship, so retiring a once-published placeholder buys nothing.
   "change-this-32-byte-random-token",
 ]);
 


### PR DESCRIPTION
## Summary

`KNOWN_PLACEHOLDER_SECRETS`'s comment in `src/selfhost/preflight.ts` told the reader that `.env.selfhost.example` / `.env.example` "ship these EXACT literal placeholder values" for the webhook HMAC secret and the static API/MCP/internal bearer tokens. I checked both files: that was never true of either. A reader was being misled about which secrets ship exploitable defaults today.

Comment-only -- no executable line changes.

## What the starters actually ship

Every `CRITICAL_SECRET_VARS` entry ships **commented out** in both files, so the real hazard is what an operator finds when they uncomment one:

| File | Shape |
|---|---|
| `.env.selfhost.example` | All five commented **and valueless** (`# GITHUB_WEBHOOK_SECRET=`, L34-48). Uncommenting yields a blank -- `checkCriticalSecrets` skips a blank outright, and a blank cannot be a publicly known value. |
| `.env.example` | Same, except `SELFHOST_SETUP_TOKEN` (L207), whose commented line carries `change-this-long-random-value`. |

So the one real exposure is `# SELFHOST_SETUP_TOKEN=change-this-long-random-value`: uncommenting it is the obvious way to turn the first-run wizard on, and it hands the operator a published token unless this set stops them. That literal is also the string most likely to reach a var that ships valueless -- `.env.example` repeats it on `POSTGRES_PASSWORD`'s commented line (L242), so it reads like the house placeholder rather than one var's. The comment now records exactly this.

## On the issue's second question -- is the check dead for the four that ship valueless?

**No, and the reason is worth recording, so I put it in the comment rather than dropping entries:**

- The set is matched against whatever the operator actually **SET**, not against what the files ship -- so it still fires wherever that literal is pasted, regardless of which var shipped it.
- It is the **only** check that can catch it: `change-this-long-random-value` is **29 chars**, which passes `MIN_SECRET_LENGTH`'s 20-char bar, so the length heuristic below would wave it straight through.

`change-this-32-byte-random-token` ships in **neither** starter today. Noted inline and kept as defence-in-depth -- retiring a once-published placeholder buys nothing when the match is against operator input.

## Scope

- [x] One coherent change; comment-only, in `src/` (a wanted path).
- [x] No secrets/tokens/wallet/trust-score/reward terms.
- [x] No changelog, `site/`, `CNAME`, or `lovable` changes.

## Validation

- [x] `npm run typecheck` -- 0 errors.
- [x] `npx vitest run test/unit/selfhost-preflight.test.ts` -- **18/18 pass** (the only suite importing `selfhost/preflight`, confirmed by grep).
- [x] `git diff --check` -- clean.
- [x] Verified every changed line is a comment programmatically; verified each claim above by re-parsing both starter files at this branch's rebased base.
- [x] Rebased on latest `upstream/main` -- no base conflict.

## Safety

- [x] Comment-only: no behaviour change, so no auth/CORS path is affected and no coverage surface is added.
- [x] No secrets committed. The placeholder strings quoted here are published starter-file values, already public in-repo -- naming them is the point of the check.

Closes #6285
