### PR TITLE
fix(mcp): redact a parenthesis/bracket/colon-prefixed local path in redactLocalPath

### DIFF
--- a/packages/loopover-mcp/lib/redact-local-path.js
+++ b/packages/loopover-mcp/lib/redact-local-path.js
@@ -23,9 +23,12 @@ export function redactLocalPath(value) {
   // Both `/g` patterns are rebuilt per call so no `lastIndex` state carries between invocations.
   // Delimiter-anchored roots (`~/`, `~\`, `C:\`, `C:/`, `/`) whose interior segments may contain
   // spaces, e.g. `/Users/Alice Smith/project` — the anchoring prefix is preserved, only the path swaps.
-  const pathSegment = "[^\\\\/\\s\"'`,;)]+(?:\\s+[^\\\\/\\s\"'`,;)]+)*(?=[\\\\/])";
-  const pathTail = "[^\\\\/\\s\"'`,;)]+";
-  const rootedPath = new RegExp(`(^|[\\s"'\\\`=])((?:~[\\\\/]|[A-Za-z]:[\\\\/]|/)(?:${pathSegment}[\\\\/])*${pathTail})`, "g");
+  const pathSegment = "[^\\\\/\\s\"'`,;)\\]]+(?:\\s+[^\\\\/\\s\"'`,;)\\]]+)*(?=[\\\\/])";
+  const pathTail = "[^\\\\/\\s\"'`,;)\\]]+";
+  // Prefix delimiters a real path can immediately follow in pasted stack-trace/validation-output text.
+  // `(` is the Node.js stack-frame shape (`at fn (/abs/path:10:5)`); `[` and `:` cover the same "no space
+  // before the path" shape in bracketed log lines and colon-joined messages (e.g. `path:/abs/path`).
+  const rootedPath = new RegExp(`(^|[\\s"'\\\`=(\\[:])((?:~[\\\\/]|[A-Za-z]:[\\\\/]|/)(?:${pathSegment}[\\\\/])*${pathTail})`, "g");
   return text
     .replace(rootedPath, (_, prefix) => `${prefix}<local-path>`)
     // Home/Windows roots that appear mid-token with no leading delimiter (so the anchored pass skips

--- a/test/unit/redact-local-path.test.ts
+++ b/test/unit/redact-local-path.test.ts
@@ -30,6 +30,24 @@ describe("redactLocalPath (heuristic: detect an unknown path in free text)", () 
     expect(redacted).not.toContain("~/private");
   });
 
+  // #6258: a Node.js stack-frame path (`at fn (/abs/path:line:col)`) previously leaked in full because
+  // `(` was missing from the prefix delimiter class -- only a space-prefixed path redacted correctly.
+  it("redacts a parenthesis-prefixed path (the Node.js stack-frame shape)", () => {
+    // The trailing `:10:5` line/column suffix has no path separator before the closing `)`, so it's
+    // swallowed into the same redacted match -- still a full, leak-free redaction either way.
+    expect(redactLocalPath("at Object.<anonymous> (/Users/alice/secretproject/file.js:10:5)")).toBe(
+      "at Object.<anonymous> (<local-path>)",
+    );
+  });
+
+  it("redacts a bracket-prefixed path, preserving the closing bracket", () => {
+    expect(redactLocalPath("[/Users/alice/secretproject/file.js]")).toBe("[<local-path>]");
+  });
+
+  it("redacts a colon-prefixed path with no space (e.g. `label:/abs/path`)", () => {
+    expect(redactLocalPath("error:/Users/alice/secretproject/file.js")).toBe("error:<local-path>");
+  });
+
   it("leaves text with no local path untouched, including a bare slash", () => {
     expect(redactLocalPath("just some text, version 1.2.3")).toBe("just some text, version 1.2.3");
     expect(redactLocalPath("pass --flag / or | here")).toBe("pass --flag / or | here");


### PR DESCRIPTION
Closes #6258

## Summary

- `redactLocalPath`'s prefix delimiter class (`(^|[\s"'\`=])`) omitted `(` — the exact prefix Node.js stack traces use (`at fn (/abs/path:10:5)`). Verified directly: a `(`-prefixed absolute path passed through completely unredacted, while a space-prefixed path redacted correctly.
- This function now lives in one shared module (`packages/loopover-mcp/lib/redact-local-path.js`, consolidated by #6264) rather than the two separately-duplicated copies the issue originally cited (`local-branch.js` / `bin/loopover-mcp.js`) — so this one fix closes the gap for every call site at once, including the validation-summary path that POSTs to the LoopOver API.
- Per the issue's own ask to check for other missed prefix shapes: also found and fixed `[` (bracket-wrapped paths, e.g. `[/abs/path]`) and `:` (colon-joined messages with no space, e.g. `error:/abs/path`) missing from the same class. Also excluded `]` from the path-tail/segment character sets so a bracket-wrapped path redacts cleanly (`[<local-path>]`) instead of swallowing the closing bracket into the match.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full local run; pre-existing Windows-only environment failures unrelated to this change — docker-prune script exec-mode checks, path-separator/CRLF differences — are the only failures present, matching the established baseline on a clean checkout)
- [x] Regression tests added in `test/unit/redact-local-path.test.ts`: the exact reproduced parenthesis-prefixed stack-frame case, plus the two additional gaps found (bracket-prefixed, colon-prefixed-no-space).
- [x] Existing tests for every already-covered prefix/delimiter shape continue to pass unmodified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes in this PR.
- [x] Not applicable: no API/OpenAPI/MCP schema change (internal redaction-regex tightening only).
- [x] Not applicable: no UI change.
- [x] No public docs/changelog changes needed for this fix.