### PR TITLE
feat(mcp): add an opt-in PostHog telemetry wrapper for the local MCP CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20753,6 +20753,7 @@
       "dependencies": {
         "@loopover/engine": "^3.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
+        "posthog-node": "^5.44.0",
         "zod": "^4.4.3"
       },
       "bin": {

--- a/packages/loopover-mcp/lib/telemetry.js
+++ b/packages/loopover-mcp/lib/telemetry.js
@@ -1,0 +1,92 @@
+import { PostHog } from "posthog-node";
+
+// Local MCP telemetry wrapper (#6236, part of #6228). The local-side counterpart of the remote server's
+// wrapper (src/mcp/telemetry.ts, #6235): a thin, typed seam around the PostHog Node SDK so the local
+// tool-dispatch instrumentation has ONE place to record a tool call. The tracked-field allowlist from #6228
+// (tool name + caller type + success + coarse latency, and NOTHING else — no arguments, no source, no
+// wallet/hotkey/trust-score data) is the entire `event` shape below; there is nowhere to smuggle anything else.
+//
+// OPT-IN, DEFAULT OFF: unlike the hosted remote server (opt-out), the local `--stdio` CLI runs on a user's own
+// machine, a materially different trust posture (#6228). So this wrapper gates on an explicit opt-in flag BEFORE
+// anything else — `settings.enabled` must be literally `true` (the persisted `telemetryEnabled` flag surfaced by
+// `telemetryState`, set via `loopover-mcp telemetry enable`, #6239). Until a user opts in, this records nothing.
+//
+// SAFE NO-OP / NEVER THROWS: when telemetry is disabled, unconfigured (no api key), or the PostHog init/capture
+// fails, this records nothing and behaves byte-identically to before the module existed — a telemetry failure can
+// never surface an error into, or otherwise affect, the CLI's actual command behavior (#6236).
+//
+// NOT WIRED YET: per #6236 this module is deliberately NOT called from the tool-dispatch path — wiring the local
+// chokepoint to call it is the separate instrumentation issue's job (#6238).
+
+/** PostHog US-cloud ingestion host — the default when no host is supplied. */
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+
+/** The PostHog event name every MCP tool call is recorded under (shared with the remote wrapper). */
+const MCP_TOOL_CALL_EVENT = "mcp_tool_call";
+
+/** Anonymous, constant distinct id: the fleet telemetry carries NO per-actor identity by design (#6228), so
+ *  every event shares one handle and there is no per-user person to build up. */
+const MCP_TELEMETRY_DISTINCT_ID = "loopover-mcp";
+
+/**
+ * @typedef {Object} McpTelemetrySettings
+ * @property {boolean} [enabled] The persisted opt-in flag (`telemetryState().enabled`). Must be literally
+ *   `true` to send anything — anything else (the default) keeps telemetry off.
+ * @property {string} [apiKey] The PostHog project api key (from `POSTHOG_API_KEY`). Absent/blank ⇒ unconfigured.
+ * @property {string} [host] The PostHog ingestion host (from `POSTHOG_HOST`). Absent/blank ⇒ US-cloud default.
+ */
+
+/**
+ * The COMPLETE, allowlisted shape of an MCP tool-call telemetry event (#6228). These four fields are the only
+ * thing ever sent to PostHog — the shape is the enforcement, mirroring the remote wrapper exactly.
+ * @typedef {Object} McpToolCallEvent
+ * @property {string} tool The MCP tool name, e.g. `"predict_gate"`.
+ * @property {"remote" | "local"} callerType Which MCP surface dispatched the call — always `"local"` here.
+ * @property {boolean} ok Whether the tool call succeeded.
+ * @property {number} durationMs Coarse wall-clock duration of the call, in milliseconds.
+ */
+
+/**
+ * Record a single local MCP tool call to PostHog. Safe no-op unless the user has opted in
+ * (`settings.enabled === true`) AND a PostHog api key is configured; never throws — a disabled, unconfigured, or
+ * failing telemetry path degrades to recording nothing, identical to before this module existed (#6236).
+ * @param {McpTelemetrySettings} settings
+ * @param {McpToolCallEvent} event
+ * @returns {void}
+ */
+export function recordMcpToolCall(settings, event) {
+  // Opt-in gate first: only a literal `true` counts as enabled, so the default (absent/false/any other value)
+  // records nothing without ever touching the api key or the network.
+  if (settings?.enabled !== true) return;
+
+  const apiKey = trimmedOrUndefined(settings.apiKey);
+  // Enabled but unconfigured ⇒ still record nothing, byte-identical to before this module existed.
+  if (!apiKey) return;
+
+  const host = trimmedOrUndefined(settings.host) ?? DEFAULT_POSTHOG_HOST;
+  try {
+    const client = new PostHog(apiKey, { host, flushAt: 1, flushInterval: 0 });
+    client.capture({
+      distinctId: MCP_TELEMETRY_DISTINCT_ID,
+      event: MCP_TOOL_CALL_EVENT,
+      // Exactly the #6228 allowlist — nothing more.
+      properties: {
+        tool: event.tool,
+        caller_type: event.callerType,
+        ok: event.ok,
+        duration_ms: event.durationMs,
+      },
+      // No IP-based geo enrichment: the event is anonymous fleet telemetry, not a user location.
+      disableGeoip: true,
+    });
+  } catch {
+    // Telemetry is best-effort and MUST NOT throw into the CLI (#6236): a PostHog init/capture failure degrades
+    // to recording nothing, identical to the disabled/unconfigured paths above.
+  }
+}
+
+/** Trim a possibly-undefined string, treating blank/whitespace as absent. */
+function trimmedOrUndefined(value) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/packages/loopover-mcp/package.json
+++ b/packages/loopover-mcp/package.json
@@ -35,11 +35,12 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "node --check bin/loopover-mcp.js && node --check lib/cli-error.js && node --check lib/local-branch.js && node --check lib/format-table.js && node --check lib/redact-local-path.js && node --check scripts/gittensor-score-preview.mjs"
+    "build": "node --check bin/loopover-mcp.js && node --check lib/cli-error.js && node --check lib/local-branch.js && node --check lib/format-table.js && node --check lib/redact-local-path.js && node --check lib/telemetry.js && node --check scripts/gittensor-score-preview.mjs"
   },
   "dependencies": {
     "@loopover/engine": "^3.0.0",
     "@modelcontextprotocol/sdk": "1.29.0",
+    "posthog-node": "^5.44.0",
     "zod": "^4.4.3"
   },
   "engines": {

--- a/scripts/mcp-package-allowlist.mjs
+++ b/scripts/mcp-package-allowlist.mjs
@@ -8,6 +8,7 @@ export const MCP_PACKAGE_ALLOWED_FILE_PATTERNS = [
   /^lib\/local-branch\.js$/,
   /^lib\/format-table\.js$/,
   /^lib\/redact-local-path\.js$/,
+  /^lib\/telemetry\.js$/,
   /^scripts\/gittensor-score-preview\.(mjs|py)$/,
   /^package\.json$/,
   /^README\.md$/,

--- a/test/unit/local-telemetry.test.ts
+++ b/test/unit/local-telemetry.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the PostHog Node SDK so nothing hits the network: the class records every constructor + capture call
+// on hoisted spies, and per-test flags let us force an init/capture failure to exercise the never-throw path.
+const h = vi.hoisted(() => ({
+  constructSpy: vi.fn(),
+  captureSpy: vi.fn(),
+  state: { throwOnConstruct: false, throwOnCapture: false },
+}));
+
+vi.mock("posthog-node", () => ({
+  PostHog: class {
+    constructor(apiKey: string, options: unknown) {
+      h.constructSpy(apiKey, options);
+      if (h.state.throwOnConstruct) throw new Error("posthog init failed");
+    }
+    capture(message: unknown): void {
+      h.captureSpy(message);
+      if (h.state.throwOnCapture) throw new Error("posthog capture failed");
+    }
+  },
+}));
+
+// @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
+const { recordMcpToolCall } = await import("../../packages/loopover-mcp/lib/telemetry.js");
+
+// The local wrapper always records a "local" caller (#6236); an opted-in, configured settings object.
+const OPTED_IN = { enabled: true, apiKey: "phc_test" };
+const EVENT = { tool: "predict_gate", callerType: "local", ok: true, durationMs: 42 };
+
+describe("recordMcpToolCall (local, opt-in)", () => {
+  beforeEach(() => {
+    h.constructSpy.mockClear();
+    h.captureSpy.mockClear();
+    h.state.throwOnConstruct = false;
+    h.state.throwOnCapture = false;
+  });
+
+  it("is a safe no-op by default (opt-in flag absent) even when an api key is configured", () => {
+    recordMcpToolCall({ apiKey: "phc_test" }, EVENT);
+    expect(h.constructSpy).not.toHaveBeenCalled();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a safe no-op when telemetry is explicitly disabled", () => {
+    recordMcpToolCall({ enabled: false, apiKey: "phc_test" }, EVENT);
+    expect(h.constructSpy).not.toHaveBeenCalled();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats any non-true enabled value (truthy but not literally true) as opted out", () => {
+    // Only a literal `true` counts as enabled, mirroring how the persisted flag is normalized (#6239).
+    recordMcpToolCall({ enabled: 1 as unknown as boolean, apiKey: "phc_test" }, EVENT);
+    recordMcpToolCall({ enabled: "true" as unknown as boolean, apiKey: "phc_test" }, EVENT);
+    expect(h.constructSpy).not.toHaveBeenCalled();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a safe no-op when settings is missing entirely", () => {
+    recordMcpToolCall(undefined as unknown as { enabled?: boolean }, EVENT);
+    expect(h.constructSpy).not.toHaveBeenCalled();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a safe no-op when opted in but no api key is configured (enabled ≠ configured)", () => {
+    recordMcpToolCall({ enabled: true }, EVENT);
+    expect(h.constructSpy).not.toHaveBeenCalled();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a blank/whitespace api key as unconfigured", () => {
+    recordMcpToolCall({ enabled: true, apiKey: "   " }, EVENT);
+    expect(h.constructSpy).not.toHaveBeenCalled();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("captures exactly the allowlisted fields against the US-cloud default host once opted in", () => {
+    recordMcpToolCall(OPTED_IN, EVENT);
+
+    expect(h.constructSpy).toHaveBeenCalledTimes(1);
+    expect(h.constructSpy).toHaveBeenCalledWith("phc_test", {
+      host: "https://us.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+
+    expect(h.captureSpy).toHaveBeenCalledTimes(1);
+    const message = h.captureSpy.mock.calls[0]![0] as {
+      distinctId: string;
+      event: string;
+      properties: Record<string, unknown>;
+      disableGeoip: boolean;
+    };
+    expect(message.distinctId).toBe("loopover-mcp");
+    expect(message.event).toBe("mcp_tool_call");
+    expect(message.disableGeoip).toBe(true);
+    expect(message.properties).toEqual({
+      tool: "predict_gate",
+      caller_type: "local",
+      ok: true,
+      duration_ms: 42,
+    });
+    // The allowlist is the whole payload — no argument/source/wallet/hotkey/trust-score field can ride along.
+    expect(Object.keys(message.properties).sort()).toEqual(["caller_type", "duration_ms", "ok", "tool"]);
+  });
+
+  it("honors a host override and carries a failed call verbatim", () => {
+    recordMcpToolCall(
+      { enabled: true, apiKey: "phc_test", host: "https://eu.i.posthog.com" },
+      { tool: "check_slop_risk", callerType: "local", ok: false, durationMs: 0 },
+    );
+
+    expect(h.constructSpy).toHaveBeenCalledWith("phc_test", {
+      host: "https://eu.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+    const message = h.captureSpy.mock.calls[0]![0] as { properties: Record<string, unknown> };
+    expect(message.properties).toEqual({
+      tool: "check_slop_risk",
+      caller_type: "local",
+      ok: false,
+      duration_ms: 0,
+    });
+  });
+
+  it("trims surrounding whitespace from the api key and host", () => {
+    recordMcpToolCall({ enabled: true, apiKey: "  phc_test  ", host: "  https://eu.i.posthog.com  " }, EVENT);
+    expect(h.constructSpy).toHaveBeenCalledWith("phc_test", {
+      host: "https://eu.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+  });
+
+  it("falls back to the default host when the host is blank", () => {
+    recordMcpToolCall({ enabled: true, apiKey: "phc_test", host: "   " }, EVENT);
+    expect(h.constructSpy).toHaveBeenCalledWith("phc_test", {
+      host: "https://us.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+  });
+
+  it("never throws when the PostHog client fails to initialize", () => {
+    h.state.throwOnConstruct = true;
+    expect(() => recordMcpToolCall(OPTED_IN, EVENT)).not.toThrow();
+    expect(h.captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("never throws when capture itself fails", () => {
+    h.state.throwOnCapture = true;
+    expect(() => recordMcpToolCall(OPTED_IN, EVENT)).not.toThrow();
+    expect(h.captureSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/mcp-release-candidate.test.ts
+++ b/test/unit/mcp-release-candidate.test.ts
@@ -23,6 +23,7 @@ const ALLOWED_FILES = [
   "lib/local-branch.js",
   "lib/format-table.js",
   "lib/redact-local-path.js",
+  "lib/telemetry.js",
   "scripts/gittensor-score-preview.mjs",
   "package.json",
   "README.md",


### PR DESCRIPTION
feat(mcp): add an opt-in PostHog telemetry wrapper for the local MCP CLI

The local --stdio server needs its own telemetry wrapper, separate from the
remote server's (#6235): per #6228 the local CLI runs on a user's own machine, a
different trust posture, so its telemetry defaults to opt-in rather than opt-out.

Add packages/loopover-mcp/lib/telemetry.js exposing recordMcpToolCall(settings,
event), mirroring the remote wrapper's shape and #6228 field allowlist (tool,
caller_type, ok, duration_ms — nothing else). It gates on the persisted
telemetryEnabled opt-in flag (settings.enabled === true, from telemetryState,
#6239) BEFORE touching the api key or network, so it records nothing until a user
explicitly opts in. Disabled, unconfigured, or a PostHog init/capture failure all
degrade to a safe no-op that never throws into the CLI. Not wired into dispatch
yet — that is #6238.

Ship the new lib file through the MCP package allowlist and release-candidate
fixture, add its node --check to the package build, and depend on posthog-node.

Closes #6236

