### PR TITLE
fix(ci): regenerate fumadocs collections unconditionally in validate-code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,16 @@ jobs:
       - name: Build UI-kit package
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run ui:kit:build
+      # apps/loopover-ui's fumadocs-mdx virtual modules (collections/browser, collections/server, imported by
+      # docs-client-loader.tsx/docs-source.ts) are gitignored generated output, normally produced by npm ci's
+      # own `postinstall` hook -- but "Install dependencies" above is SKIPPED on a node_modules cache hit (the
+      # cached path never includes this output), so a warm-cache run reaches UI lint/typecheck/tests/build with
+      # no collections output at all and fails with "Cannot find module 'collections/browser'". Same class of
+      # gap as "Build UI-kit package" above (a required, gitignored artifact absent on a fresh/cached
+      # checkout); runs unconditionally here so cache hit or miss makes no difference.
+      - name: Generate docs content collections
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
+        run: npm run postinstall --workspace @loopover/ui
       - name: UI lint
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run ui:lint


### PR DESCRIPTION
## Summary
- The push-to-main CI workflow's \`validate-code\` job has been intermittently failing on \`UI typecheck\` with \`Cannot find module 'collections/browser'\`/\`'collections/server'\` -- confirmed present on every recent commit to main, unrelated to any specific PR's own diff.
- Root cause: \`apps/loopover-ui\`'s fumadocs-mdx virtual modules are generated by its own \`postinstall\` hook (\`fumadocs-mdx\`), which only runs as part of \`npm ci\`. The \`Restore node_modules cache\` step skips \`npm ci\` entirely on a cache hit -- but the cached paths cover only \`node_modules\`, not the gitignored \`apps/loopover-ui/.source\` output -- so a warm-cache CI run reaches UI lint/typecheck/tests/build with the collections output completely missing.
- Adds an unconditional \`Generate docs content collections\` step (same class of fix as the existing \`Build UI-kit package\` step, which solves an identical gitignored-artifact gap for a different package), so cache hit or miss makes no difference.

## Test plan
- [x] Reproduced locally: moved \`apps/loopover-ui/.source\` aside (simulating a cache-hit CI run with no postinstall), confirmed \`ui:typecheck\` fails with the exact reported error
- [x] Ran the fix command (\`npm run postinstall --workspace @loopover/ui\`) and confirmed \`ui:typecheck\` passes
- [x] \`npm run actionlint\` clean
- [x] Full \`npm run test:ci\` gate green