### PR TITLE
fix(ci): regenerate fumadocs-mdx doc collections even on a node_modules cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,18 @@ jobs:
       - name: Build UI-kit package
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run ui:kit:build
+      # apps/loopover-ui/.source (the fumadocs-mdx doc collection imported via the "collections/*"
+      # tsconfig path alias) is gitignored, generated-on-install output -- normally produced by
+      # loopover-ui's own `postinstall: fumadocs-mdx` lifecycle script. On a node_modules cache HIT,
+      # "Install dependencies" above is skipped entirely, so that lifecycle script never runs and
+      # .source/ never exists, failing ui:typecheck/ui:build with a `collections/browser` resolution
+      # error -- same class of gap as UI-kit's dist/ above, just sourced from a skipped npm-lifecycle
+      # step instead of a skipped explicit build. Unconditional (not gated on cache-hit) because it's
+      # a fast local codegen pass, not a real install; running it again after a real npm ci is a cheap,
+      # idempotent no-op.
+      - name: Generate fumadocs-mdx doc collections
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
+        run: npm run postinstall --workspace @loopover/ui
       - name: UI lint
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run ui:lint


### PR DESCRIPTION
## Summary
- `main` and several open PRs are currently failing `validate-code`/`validate` CI with `Cannot find module 'collections/browser'`.
- Root cause: `validate-code`'s `node_modules` cache-hit optimization skips `npm ci` entirely when the manifest/lockfile-keyed cache matches, which also skips `apps/loopover-ui`'s own `postinstall: fumadocs-mdx` lifecycle script. That script generates the gitignored `apps/loopover-ui/.source/` directory the `"collections/*"` tsconfig path alias resolves to — on a cache hit, `.source/` never exists, so `ui:typecheck`/`ui:build` fail.
- Fix: add an unconditional (not cache-gated) "Generate fumadocs-mdx doc collections" step right before the UI lint/typecheck/test/build steps that need it, gated the same way those steps already are (`push || ui changed`). The `node_modules` cache itself is untouched — CI speed is preserved, this only backfills the one directory a cache hit was never supposed to skip regenerating.

## Validation
- Reproduced locally: fresh `npm ci` (populates `.source/` correctly) → deleted only `apps/loopover-ui/.source/` to simulate a cache-hit run → `npm run ui:typecheck` fails with the exact same `collections/browser`/`collections/server` errors seen in CI.
- Applied the fix's exact command (`npm run postinstall --workspace @loopover/ui`) → `.source/` regenerated → `npm run ui:typecheck` passes cleanly.
- `npm run actionlint` — clean.

## Safety
- [x] No secrets/wallets/hotkeys/trust scores/reward values
- [x] No changes to `site/`, `CNAME`, `lovable/`
- [x] No `CHANGELOG.md` edit
- [x] `node_modules` caching behavior itself unchanged — only adds a cheap, idempotent codegen step