### PR TITLE
feat(engine): define a shared TrustSignal type for ORB/AMS reputation bridging

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -146,6 +146,13 @@ export {
   type TrackRecordSummaryReadResult,
   type TrackRecordTenure,
 } from "./track-record-summary.js";
+export {
+  TRUST_SIGNAL_LEVELS,
+  TRUST_SIGNAL_SOURCES,
+  type TrustSignal,
+  type TrustSignalLevel,
+  type TrustSignalSource,
+} from "./trust-signal.js";
 export * from "./governor/rate-limit.js";
 export * from "./governor/budget-cap.js";
 export * from "./governor/self-plagiarism.js";

--- a/packages/loopover-engine/src/trust-signal.ts
+++ b/packages/loopover-engine/src/trust-signal.ts
@@ -1,0 +1,34 @@
+// Shared trust-signal vocabulary (#6302), groundwork for #6208's reputation-bridge design.
+//
+// ORB (`src/review/submitter-reputation.ts`, whose `ReputationSignal` is `"trusted" | "neutral" | "low"`) and
+// AMS (`track-record-summary.ts` / `prediction-ledger.js`) each carry their own internal notion of "how
+// trustworthy is this contributor's history" with no shared vocabulary between them. This is a minimal,
+// ADDITIVE type both can converge toward. It is DELIBERATELY not wired into any call site and does not change
+// either system's internal representation — #6208 owns how a TrustSignal is populated, identity-linked, and
+// consumed. Like both source systems, it carries no score/ranking internals, preserving their public-safe
+// boundary.
+
+/** Coarse trust levels, matching ORB's existing `ReputationSignal` buckets so the two systems align. */
+export const TRUST_SIGNAL_LEVELS = ["low", "neutral", "trusted"] as const;
+
+export type TrustSignalLevel = (typeof TRUST_SIGNAL_LEVELS)[number];
+
+/** Which system a signal was derived from. */
+export const TRUST_SIGNAL_SOURCES = ["orb-review-history", "ams-track-record"] as const;
+
+export type TrustSignalSource = (typeof TRUST_SIGNAL_SOURCES)[number];
+
+/**
+ * A minimal, source-tagged trust signal derived from a contributor's public history — the shared vocabulary
+ * #6208 can converge ORB's and AMS's internal representations toward, instead of inventing one mid-implementation.
+ */
+export type TrustSignal = {
+  /** Coarse trust level; the same buckets ORB's `ReputationSignal` already emits. */
+  level: TrustSignalLevel;
+  /** How many public data points (PR outcomes / reviews) the level was derived from. */
+  sampleSize: number;
+  /** Which system produced this signal. */
+  source: TrustSignalSource;
+  /** ISO-8601 timestamp of the underlying data the signal reflects. */
+  asOf: string;
+};

--- a/packages/loopover-engine/test/trust-signal.test.ts
+++ b/packages/loopover-engine/test/trust-signal.test.ts
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { TRUST_SIGNAL_LEVELS, TRUST_SIGNAL_SOURCES, type TrustSignal } from "../dist/index.js";
+
+test("barrel: exports the shared TrustSignal level/source constants (#6302)", () => {
+  assert.deepEqual([...TRUST_SIGNAL_LEVELS], ["low", "neutral", "trusted"]);
+  assert.deepEqual([...TRUST_SIGNAL_SOURCES], ["orb-review-history", "ams-track-record"]);
+});
+
+test("TrustSignal admits a well-formed source-tagged signal from either system (#6302)", () => {
+  const fromAms: TrustSignal = { level: "trusted", sampleSize: 12, source: "ams-track-record", asOf: "2026-07-16T00:00:00.000Z" };
+  const fromOrb: TrustSignal = { level: "low", sampleSize: 3, source: "orb-review-history", asOf: "2026-07-16T00:00:00.000Z" };
+  for (const signal of [fromAms, fromOrb]) {
+    assert.equal(TRUST_SIGNAL_LEVELS.includes(signal.level), true);
+    assert.equal(TRUST_SIGNAL_SOURCES.includes(signal.source), true);
+    assert.equal(typeof signal.sampleSize, "number");
+    assert.equal(typeof signal.asOf, "string");
+  }
+});


### PR DESCRIPTION
## Summary

Groundwork for #6208's reputation-bridge design (part of the #6206 AMS+ORB synergy epic). ORB (`src/review/submitter-reputation.ts`, whose `ReputationSignal` is `trusted|neutral|low`) and AMS (`track-record-summary.ts`/`prediction-ledger.js`) each carry their own internal notion of contributor trustworthiness with no shared vocabulary. This adds a minimal, additive shared type both can converge toward.

- **`TrustSignal`** in `@loopover/engine`: `{ level, sampleSize, source, asOf }`. The `level` buckets (`TRUST_SIGNAL_LEVELS = low|neutral|trusted`) match ORB's existing `ReputationSignal`; `source` (`TRUST_SIGNAL_SOURCES = orb-review-history|ams-track-record`) tags which system produced it.
- **Deliberately not wired** into any call site and does not change either system's internal representation — #6208 owns how a TrustSignal is populated, identity-linked, and consumed. Carries no score/ranking internals, preserving both systems' public-safe boundary.
- Exported from the package barrel.

## Tests
`packages/loopover-engine/test/trust-signal.test.ts` confirms the constants export and that a well-formed signal from either system matches the vocabulary. Verified passing locally via `node --test` (2/2).

Closes #6302.