### PR TITLE
docs: update remaining links/prose from gittensory.aethereal.dev to loopover.ai

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # (case-insensitive); unset, empty, or `false` is OFF. When a flag is OFF its
 # code path is fully inert — the review behaves as if the feature did not exist.
 #
-# See https://gittensory.aethereal.dev/docs/tuning for the full reference
+# See https://loopover.ai/docs/tuning for the full reference
 # (flags, per-repo `.loopover.yml` settings, and secret descriptions).
 
 # =============================================================================

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -7,7 +7,7 @@
 #
 # For the EXHAUSTIVE list of every self-host env var (optional services, observability, backup,
 # every AI provider) see `.env.example`'s "Self-host (Docker) — runtime config" section, or the
-# generated reference table at https://gittensory.aethereal.dev/docs/self-hosting-configuration.
+# generated reference table at https://loopover.ai/docs/self-hosting-configuration.
 # Every value below is a SAMPLE placeholder — never commit real secrets.
 
 # =============================================================================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,9 +249,9 @@ Frontend:
 Cloudflare/deploy:
 
 - Production UI deploys through the `loopover-ui` Cloudflare Worker on
-  `https://gittensory.aethereal.dev/`.
+  `https://loopover.ai/`.
 - Production API deploys through the `loopover-api` Cloudflare Worker on
-  `https://gittensory-api.aethereal.dev/`.
+  `https://api.loopover.ai/`.
 - Cloudflare Workers Builds owns automatic deployments from GitHub for BOTH workers (one connection
   per worker, scoped by build-watch-paths). GitHub Actions are validation/fallback only — do not add
   deploy workflows.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _Formerly Gittensory._
   <a href="https://github.com/JSONbored/loopover/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/JSONbored/loopover/actions/workflows/ci.yml/badge.svg" /></a>
   <a href="https://www.npmjs.com/package/@loopover/mcp"><img alt="MCP package" src="https://img.shields.io/npm/v/@loopover/mcp?label=mcp" /></a>
   <a href="https://github.com/JSONbored/loopover/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/JSONbored/loopover" /></a>
-  <a href="https://gittensory.aethereal.dev/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-gittensory.aethereal.dev-0b6bcb" /></a>
+  <a href="https://loopover.ai/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-loopover.ai-0b6bcb" /></a>
   <a href="https://gittensor.io/miners/repository?name=JSONbored/loopover"><img alt="Gittensor impact" src="https://api.gittensor.io/repos/JSONbored%2Floopover/badge.svg" /></a>
 </p>
 
@@ -27,7 +27,7 @@ LoopOver keeps sensitive context private by default.
 - Optional AI summaries receive compact deterministic signal bundles, not raw source code.
 - Maintainer packets and scoring context stay on protected API/MCP surfaces.
 
-See [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-security) for the full boundary.
+See [Privacy and security](https://loopover.ai/docs/privacy-security) for the full boundary.
 
 ## Review Capabilities
 
@@ -46,29 +46,29 @@ LoopOver CI and LoopOver review score, gate, and comment on pull requests. The r
 - **`LoopOver Context`** (`settings.checkRunMode` / `settings.checkRunDetailLevel`, off by default) — a separate, purely advisory Check Run. At its default `checkRunDetailLevel: minimal` it publishes no findings at all; even at `standard`/`deep` it only re-renders content already shown elsewhere. Never make this one required.
 - **Inline review comments** (`LOOPOVER_REVIEW_INLINE_COMMENTS` + `.loopover.yml`'s `review.inline_comments`, off by both by default) — real, reply-able line-anchored PR review comment threads (CodeRabbit-style). This is the ONLY one of the three that posts an interactive per-line thread; the two check runs above never do. With `.loopover.yml`'s `review.suggestions` also on, a precise line-anchored fix is additionally rendered as a one-click, committable GitHub suggested-change block. With `review.finding_categories` also on (off by default), each finding is additionally tagged with a category — security/correctness/performance/maintainability/tests/style — in both the inline comment label and the unified comment's "Finding categories" collapsible; a deterministic path/keyword fallback covers whatever the model omits.
 
-See [Tuning your reviews](https://gittensory.aethereal.dev/docs/tuning) for the full flag, setting, and `.loopover.yml` reference.
+See [Tuning your reviews](https://loopover.ai/docs/tuning) for the full flag, setting, and `.loopover.yml` reference.
 
 ## Start Here
 
 | Audience                  | Start                                                                    | Useful next links                                                                                                                                                                                                 |
 | ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Miners and contributors   | [Quickstart](https://gittensory.aethereal.dev/docs/quickstart)           | [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients), [Miner workflow](https://gittensory.aethereal.dev/docs/miner-workflow), [Scoreability](https://gittensory.aethereal.dev/docs/scoreability) |
-| Maintainers               | [GitHub App](https://gittensory.aethereal.dev/docs/github-app)           | [Maintainer workflow](https://gittensory.aethereal.dev/docs/maintainer-workflow), [Self-host reviews](https://gittensory.aethereal.dev/docs/maintainer-self-hosting), [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-security)                         |
-| Repo owners and operators | [Beta onboarding](https://gittensory.aethereal.dev/docs/beta-onboarding) | [Upstream drift](https://gittensory.aethereal.dev/docs/upstream-drift), [Troubleshooting](https://gittensory.aethereal.dev/docs/troubleshooting), [Roadmap](https://gittensory.aethereal.dev/roadmap)             |
-| Agent authors             | [Agents](https://gittensory.aethereal.dev/agents)                        | [API browser](https://gittensory.aethereal.dev/api), [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients)                                                                                        |
+| Miners and contributors   | [Quickstart](https://loopover.ai/docs/quickstart)           | [MCP client setup](https://loopover.ai/docs/mcp-clients), [Miner workflow](https://loopover.ai/docs/miner-workflow), [Scoreability](https://loopover.ai/docs/scoreability) |
+| Maintainers               | [GitHub App](https://loopover.ai/docs/github-app)           | [Maintainer workflow](https://loopover.ai/docs/maintainer-workflow), [Self-host reviews](https://loopover.ai/docs/maintainer-self-hosting), [Privacy and security](https://loopover.ai/docs/privacy-security)                         |
+| Repo owners and operators | [Beta onboarding](https://loopover.ai/docs/beta-onboarding) | [Upstream drift](https://loopover.ai/docs/upstream-drift), [Troubleshooting](https://loopover.ai/docs/troubleshooting), [Roadmap](https://loopover.ai/roadmap)             |
+| Agent authors             | [Agents](https://loopover.ai/agents)                        | [API browser](https://loopover.ai/api), [MCP client setup](https://loopover.ai/docs/mcp-clients)                                                                                        |
 
 ## Surfaces
 
 | Surface           | Link                                                                                                                               |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Website           | [gittensory.aethereal.dev](https://gittensory.aethereal.dev/)                                                                      |
-| Docs              | [gittensory.aethereal.dev/docs](https://gittensory.aethereal.dev/docs)                                                             |
+| Website           | [loopover.ai](https://loopover.ai/)                                                                      |
+| Docs              | [loopover.ai/docs](https://loopover.ai/docs)                                                             |
 | MCP package       | [@loopover/mcp](https://www.npmjs.com/package/@loopover/mcp)                                               |
 | Engine package    | [`@loopover/engine`](packages/loopover-engine/README.md) — shared deterministic logic for the review stack and miner |
 | Miner package     | [`@loopover/miner`](packages/loopover-miner/README.md) — local foundation CLI for the autonomous miner runtime        |
-| API               | [API browser](https://gittensory.aethereal.dev/api) and [OpenAPI JSON](https://gittensory-api.aethereal.dev/openapi.json)          |
-| GitHub App        | [Setup docs](https://gittensory.aethereal.dev/docs/github-app) — self-hosting is the only currently available path |
-| Browser extension | [Extension page](https://gittensory.aethereal.dev/extension)                                                                       |
+| API               | [API browser](https://loopover.ai/api) and [OpenAPI JSON](https://api.loopover.ai/openapi.json)          |
+| GitHub App        | [Setup docs](https://loopover.ai/docs/github-app) — self-hosting is the only currently available path |
+| Browser extension | [Extension page](https://loopover.ai/extension)                                                                       |
 
 ## MCP Install
 
@@ -87,7 +87,7 @@ loopover-mcp init-client --print claude
 loopover-mcp init-client --print cursor
 ```
 
-For full editor setup and stdio configuration, use [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients).
+For full editor setup and stdio configuration, use [MCP client setup](https://loopover.ai/docs/mcp-clients).
 
 Run base-agent commands:
 

--- a/apps/loopover-ui/content/docs/self-hosting-release-checklist.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-release-checklist.mdx
@@ -542,7 +542,7 @@ The release workflow's own "GitHub Release" step generates the notes body progra
 docker pull ghcr.io/jsonbored/loopover-selfhost:orb-v0.1.0
 \`\`\`
 
-Multi-arch (linux/amd64 + linux/arm64). See https://gittensory.aethereal.dev/docs/maintainer-self-hosting for setup.
+Multi-arch (linux/amd64 + linux/arm64). See https://loopover.ai/docs/maintainer-self-hosting for setup.
 Includes the Claude Code / Codex subscription CLIs by default; credentials stay runtime-only.
 Sentry release id baked into the image: \`loopover-orb@0.1.0\`.
 
@@ -582,9 +582,9 @@ The \`latest\` tag now points here.
 - \`.env\`, \`loopover-config/\`, and all data volumes (database, Redis, Qdrant, Grafana) — never
   overwritten by an update and never baked into the image.
 - GitHub App credentials or \`ORB_ENROLLMENT_SECRET\`, AI-provider credentials, and any \`SENTRY_DSN\`.
-- Resource limits and profile selection — see [Resource profiles](https://gittensory.aethereal.dev/docs/self-hosting-operations)
+- Resource limits and profile selection — see [Resource profiles](https://loopover.ai/docs/self-hosting-operations)
   for measured CPU/memory guidance per profile.
-- Backup and restore procedure — see [Backup and scaling](https://gittensory.aethereal.dev/docs/self-hosting-backup-scaling).
+- Backup and restore procedure — see [Backup and scaling](https://loopover.ai/docs/self-hosting-backup-scaling).
 
 Full changelog: compare against \`orb-v0.1.0-beta.2\`.`}
 />

--- a/review-enrichment/README.md
+++ b/review-enrichment/README.md
@@ -2,7 +2,7 @@
 
 A standalone microservice that produces a structured **review brief** for the gittensory review engine. Run it
 in-network alongside a self-hosted engine via the repo-root `docker-compose --profile rees` service (the simplest
-path, no separate hosting to manage — see the [self-hosting REES docs](https://gittensory.aethereal.dev/docs/self-hosting-rees)),
+path, no separate hosting to manage — see the [self-hosting REES docs](https://loopover.ai/docs/self-hosting-rees)),
 or deploy it as its own service on any platform that can run a Dockerfile-based Node service — see
 [Deploy (Railway)](#deploy-railway) below for one example.
 
@@ -181,7 +181,7 @@ curl -XPOST localhost:8080/v1/enrich -H 'authorization: Bearer dev' \
 ## Deploy (Railway)
 
 For a self-hosted engine, `docker compose --profile rees up -d` from the repo root (see the
-[self-hosting REES docs](https://gittensory.aethereal.dev/docs/self-hosting-rees)) is the simplest path — no
+[self-hosting REES docs](https://loopover.ai/docs/self-hosting-rees)) is the simplest path — no
 separate service to host. If you'd rather run REES on its own outside that compose network, it's a plain
 Dockerfile-based Node service and can go anywhere that builds one; Railway is one option this repo has release
 tooling for (the Sentry/source-map wiring below). Point **Root Directory = `review-enrichment`** at a `railway.json`

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -2,7 +2,7 @@
 
 Native, orchestrator-managed secret storage for the self-host stack (`docker-compose.yml`'s
 top-level `secrets:` block), per the "Prefer secret files" guidance on
-[/docs/self-hosting-security](https://gittensory.aethereal.dev/docs/self-hosting-security).
+[/docs/self-hosting-security](https://loopover.ai/docs/self-hosting-security).
 
 ## Why
 


### PR DESCRIPTION
## Summary

Doc-only follow-up to #6380 (the functional production cutover) -- updates the remaining
`gittensory.aethereal.dev` / `gittensory-api.aethereal.dev` links and prose to `loopover.ai` /
`api.loopover.ai` across README badges/links, `CONTRIBUTING.md`'s production-URL description,
`.env.example` / `.env.selfhost.example` comments, the self-hosting release checklist, and the
REES / secrets READMEs.

`tasty.aethereal.dev` (Umami analytics upstream) and the "an Aethereal OSS project" footer
attribution link are untouched -- neither is a `loopover.ai` product-domain reference.

## Test plan
- [x] `npm run docs:drift-check` clean
- [x] Confirmed zero remaining `gittensory.aethereal.dev` / `gittensory-api.aethereal.dev`
      references across all 7 touched files
- [x] Prose-only change, no `src/**` diff -- no Codecov patch-coverage impact