### PR TITLE
fix(ci): resolve wrangler via require.resolve, never PATH, for cf-typegen

### DIFF
--- a/scripts/gen-cf-typegen.d.mts
+++ b/scripts/gen-cf-typegen.d.mts
@@ -1,5 +1,7 @@
 export const OUTPUT_PATH: string;
 
+export function resolveLocalWranglerBin(): string;
+
 export function formatCfTypegenOutput(source: string): string;
 
 export function genCfTypegen(options?: { check?: boolean }): { changed: boolean | undefined };

--- a/scripts/gen-cf-typegen.mjs
+++ b/scripts/gen-cf-typegen.mjs
@@ -1,7 +1,27 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+/** Resolves this workspace's own pinned `wrangler` binary via Node's module resolution (walking up
+ *  from this file's node_modules tree), never PATH. `execFileSync("wrangler", ...)` would silently
+ *  fall through to PATH -- and pick up a globally-installed wrangler with a DIFFERENT bundled workerd
+ *  version, with zero warning -- whenever node_modules/.bin/wrangler doesn't exist yet (a fresh clone
+ *  or worktree before `npm ci` has run). require.resolve has no such fallback: it throws immediately
+ *  and loudly if the local package isn't installed, instead of silently generating wrong output.
+ *  wrangler's own package.json restricts its `exports` map, so the bin subpath itself isn't directly
+ *  requireable -- resolve the package root via its (always-exported) package.json instead, then read
+ *  the real bin path from there rather than hand-hardcoding "./bin/wrangler.js". */
+export function resolveLocalWranglerBin() {
+  const pkgJsonPath = require.resolve("wrangler/package.json");
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+  const binRelativePath = typeof pkg.bin === "string" ? pkg.bin : pkg.bin.wrangler;
+  return join(dirname(pkgJsonPath), binRelativePath);
+}
 
 // Cloudflare's own `wrangler types` output packs every declared env var into ONE long single-line
 // `Pick<Cloudflare.Env, "A" | "B" | ...>>` union (the generated ProcessEnv interface). Two independent PRs
@@ -40,7 +60,7 @@ export function formatCfTypegenOutput(source) {
 export function genCfTypegen({ check = false } = {}) {
   const target = check ? TEMP_PATH : OUTPUT_PATH;
   try {
-    execFileSync("wrangler", ["types", target], { stdio: "inherit" });
+    execFileSync(process.execPath, [resolveLocalWranglerBin(), "types", target], { stdio: "inherit" });
     const generated = formatCfTypegenOutput(readFileSync(target, "utf8"));
     if (!check) {
       writeFileSync(OUTPUT_PATH, generated);

--- a/test/unit/ci-cf-typegen.test.ts
+++ b/test/unit/ci-cf-typegen.test.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { formatCfTypegenOutput } from "../../scripts/gen-cf-typegen.mjs";
+import { formatCfTypegenOutput, resolveLocalWranglerBin } from "../../scripts/gen-cf-typegen.mjs";
 
 // #1667-followup: wrangler's own `wrangler types` output packs every declared env var into ONE long
 // single-line `Pick<Cloudflare.Env, "A" | "B" | ...>>` union. Two independent PRs that each add a DIFFERENT
@@ -53,6 +53,16 @@ describe("gen-cf-typegen: formatCfTypegenOutput", () => {
 
   it("throws when the ProcessEnv Pick<Cloudflare.Env, ...> union is not found", () => {
     expect(() => formatCfTypegenOutput("interface Env {}\n")).toThrow(/Could not find the ProcessEnv/);
+  });
+
+  // A stale global `wrangler` install can silently generate types from the WRONG (mismatched) workerd
+  // version with zero warning if resolution falls through to PATH. resolveLocalWranglerBin uses Node's
+  // own require.resolve instead of a bare "wrangler" execFileSync call, so it can only ever find this
+  // workspace's own pinned dependency -- never a same-named binary elsewhere on the machine.
+  it("resolveLocalWranglerBin resolves this workspace's own pinned wrangler binary, not PATH", () => {
+    const resolved = resolveLocalWranglerBin();
+    expect(resolved).toContain(join("node_modules", "wrangler", "bin", "wrangler.js"));
+    expect(existsSync(resolved)).toBe(true);
   });
 
   it("REGRESSION: two independent single-var additions no longer conflict under a real git 3-way merge", () => {


### PR DESCRIPTION
## Summary

Follow-up to #6380: that PR's first commit accidentally regenerated `worker-configuration.d.ts`
using a stale, globally-installed `wrangler` (Homebrew, 4.103.0, bundling `workerd@1.20260617.1`)
instead of this repo's pinned `4.107.0` (`workerd@1.20260701.1`) -- caught and fixed in that PR's
second commit, but the root cause (why that was even possible) is fixed here.

`gen-cf-typegen.mjs` called `execFileSync("wrangler", ...)`, which resolves through PATH. In a
fresh clone or worktree where `npm ci` hasn't run yet, `node_modules/.bin/wrangler` doesn't exist,
so this silently falls through to whatever else is named `wrangler` on the machine -- no error, no
warning, just wrong generated output written straight into a committed file that nobody diffs
line-by-line (11k+ lines).

`resolveLocalWranglerBin()` uses `require.resolve("wrangler/package.json")` (the one subpath
wrangler's own `exports` map always allows) to find this workspace's actual pinned install, reads
its real `bin` field instead of hardcoding a relative path, and joins them into an absolute path
that `execFileSync` invokes directly via `process.execPath`. If wrangler isn't installed at all,
this now throws immediately with a clear `Cannot find package 'wrangler'` error instead of quietly
using the wrong one.

Checked for the same pattern elsewhere in the repo -- `gen-cf-typegen.mjs` was the only script
directly shelling out to a bare `"wrangler"` command; everything else goes through `npm run`
(which correctly prepends `node_modules/.bin` first).

## Test plan
- [x] Added a regression test asserting `resolveLocalWranglerBin()` resolves inside this
      workspace's own `node_modules/wrangler/bin/wrangler.js`, not PATH
- [x] `npm run cf-typegen:check` passes cleanly with the new resolution mechanism
- [x] `npm run typecheck` clean (updated `gen-cf-typegen.d.mts` for the new export)
- [x] `test/unit/ci-cf-typegen.test.ts` + `test/unit/ci-cf-typegen-check.test.ts`: 11/11 pass