### PR TITLE
fix(ci): wait for all 6 test shards before Codecov posts a patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,16 @@
 codecov:
   # Don't post a verdict until the CI run that produced the report has finished.
   require_ci_to_pass: true
+  notify:
+    # The 6 backend test shards (validate-tests matrix, ci.yml) each upload their own lcov.info
+    # directly (flags: shard-N) -- additive by design, but Codecov re-evaluates and re-posts the
+    # status check after EVERY individual upload, not just the last one. Without this, codecov/patch
+    # can report a wildly wrong verdict (as low as ~20% "patch coverage") after only 1-2 of 6 shards
+    # have landed, before self-correcting once the rest arrive -- require_ci_to_pass above only checks
+    # the GH Actions run's own conclusion, it says nothing about upload completeness. Waiting for all
+    # 6 coverage uploads (JUnit test_results uploads are a separate stream and don't count here) before
+    # posting a status removes that premature-fail/premature-pass window entirely.
+    after_n_builds: 6
 
 coverage:
   status:


### PR DESCRIPTION
## Summary
- Each of the 6 backend test shards (`validate-tests` matrix, `ci.yml`) uploads its own `lcov.info` directly to Codecov (`flags: shard-N`) — additive by design, but with no `after_n_builds` setting Codecov re-evaluates and re-posts `codecov/patch` after **every individual upload**, not just the last one.
- Observed live on #6321: `codecov/patch` posted `FAILURE` (~22% patch coverage) after only 2 of 6 shards had landed, before the remaining shards arrived. `require_ci_to_pass` doesn't prevent this — it only checks the upstream GH Actions run's own conclusion, not upload completeness.
- Fix: `codecov.notify.after_n_builds: 6` so Codecov withholds any status until all six coverage uploads for a commit are in.

## Validation
- Validated the resulting `codecov.yml` against Codecov's own public config validator (`curl --data-binary @codecov.yml https://codecov.io/validate`) — `Valid!`, `after_n_builds: 6` parses under `codecov.notify` as expected (first attempt placed it directly under `coverage:`, which the validator correctly rejected as an unknown field).
- No test suite change — this is Codecov-side config only, no `src/` diff.

## Safety
- [x] No secrets/wallets/hotkeys/trust scores/reward values
- [x] No changes to `site/`, `CNAME`, `lovable/`
- [x] No `CHANGELOG.md` edit