### PR TITLE
feat(ui): adopt RefreshMeta on owner, miner, and digest panels

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
@@ -10,6 +10,7 @@ import {
 import { toast } from "sonner";
 
 import { StatusPill } from "@/components/site/control-primitives";
+import { RefreshMeta } from "@/components/site/refresh-meta";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { StateBoundary } from "@/components/site/state-views";
@@ -58,53 +59,59 @@ export function DigestPanel() {
       errorDescription={digest.status === "error" ? digest.error : undefined}
     >
       {data ? (
-        <div className="grid gap-8 lg:grid-cols-[340px_1fr] lg:items-start">
-          <div className="mx-auto w-full max-w-[320px]">
-            <PhoneFrame>
-              <DigestStream items={data.items.slice(0, 4)} compact date={data.date} />
-            </PhoneFrame>
-            <p className="mt-3 text-center text-token-2xs text-muted-foreground">
-              Live in-app digest preview. Email delivery is not enabled.
-            </p>
+        <div className="space-y-6">
+          {/* Dashboard-level refresh metadata (#6181) — same cue as maintainer-panel (#2219). */}
+          <div className="flex items-center justify-end">
+            <RefreshMeta loadedAt={digest.loadedAt} onRefresh={digest.reload} />
           </div>
-
-          <div className="rounded-token border-hairline bg-card p-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                  Today · {data.date}
-                </div>
-                <h2 className="mt-1 font-display text-token-xl font-semibold">
-                  {data.items.length} updates worth looking at
-                </h2>
-              </div>
-              <StatusPill status={data.signal === "ready" ? "ready" : "warn"}>
-                Signal · {data.signal}
-              </StatusPill>
+          <div className="grid gap-8 lg:grid-cols-[340px_1fr] lg:items-start">
+            <div className="mx-auto w-full max-w-[320px]">
+              <PhoneFrame>
+                <DigestStream items={data.items.slice(0, 4)} compact date={data.date} />
+              </PhoneFrame>
+              <p className="mt-3 text-center text-token-2xs text-muted-foreground">
+                Live in-app digest preview. Email delivery is not enabled.
+              </p>
             </div>
-            <ul className="mt-5 divide-hairline">
-              {data.items.map((item, index) => (
-                <li
-                  key={`${item.kind}-${index}`}
-                  className="flex gap-3 rounded-token px-2 py-3.5 transition-colors hover:bg-muted/30 -mx-2"
-                >
-                  <span className="mt-0.5 shrink-0">{ICONS[item.kind]}</span>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline justify-between gap-3">
-                      <h3 className="text-token-sm font-medium text-foreground">{item.title}</h3>
-                      {item.meta && (
-                        <span className="font-mono text-token-2xs text-muted-foreground">
-                          {item.meta}
-                        </span>
-                      )}
-                    </div>
-                    <p className="mt-0.5 text-token-sm text-muted-foreground">{item.detail}</p>
-                  </div>
-                </li>
-              ))}
-            </ul>
 
-            <SubscribeForm subscribed={data.subscriptions.length > 0} onStored={digest.reload} />
+            <div className="rounded-token border-hairline bg-card p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                    Today · {data.date}
+                  </div>
+                  <h2 className="mt-1 font-display text-token-xl font-semibold">
+                    {data.items.length} updates worth looking at
+                  </h2>
+                </div>
+                <StatusPill status={data.signal === "ready" ? "ready" : "warn"}>
+                  Signal · {data.signal}
+                </StatusPill>
+              </div>
+              <ul className="mt-5 divide-hairline">
+                {data.items.map((item, index) => (
+                  <li
+                    key={`${item.kind}-${index}`}
+                    className="flex gap-3 rounded-token px-2 py-3.5 transition-colors hover:bg-muted/30 -mx-2"
+                  >
+                    <span className="mt-0.5 shrink-0">{ICONS[item.kind]}</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <h3 className="text-token-sm font-medium text-foreground">{item.title}</h3>
+                        {item.meta && (
+                          <span className="font-mono text-token-2xs text-muted-foreground">
+                            {item.meta}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-0.5 text-token-sm text-muted-foreground">{item.detail}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+
+              <SubscribeForm subscribed={data.subscriptions.length > 0} onStored={digest.reload} />
+            </div>
           </div>
         </div>
       ) : null}

--- a/apps/loopover-ui/src/components/site/app-panels/miner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/miner-panel.tsx
@@ -5,6 +5,7 @@ import { Check, Copy, Download, History, Loader2, RefreshCw } from "lucide-react
 import { KeyValueGrid, StatusPill, type Status } from "@/components/site/control-primitives";
 import { McpVersionBadge } from "@/components/site/mcp-version-badge";
 import { StatCard } from "@/components/site/primitives";
+import { RefreshMeta } from "@/components/site/refresh-meta";
 import { StateBoundary } from "@/components/site/state-views";
 import {
   Dialog,
@@ -174,6 +175,11 @@ export function MinerPanel() {
           </div>
         ) : data ? (
           <div className="space-y-6">
+            {/* Dashboard-level refresh metadata (#6181) — reloads the GET pack; distinct from the
+                rebuild-via-POST "Refresh" in MinerPanelActions above. */}
+            <div className="flex items-center justify-end">
+              <RefreshMeta loadedAt={dashboard.loadedAt} onRefresh={dashboard.reload} />
+            </div>
             <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
               <StatCard label="Next actions" value={data.nextActions.length} hint={data.status} />
               <StatCard label="Open blockers" value={blockerCount} hint="decision pack" />

--- a/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
@@ -6,6 +6,7 @@ import {
   StatusPill,
   type Status,
 } from "@/components/site/control-primitives";
+import { RefreshMeta } from "@/components/site/refresh-meta";
 import { StateBoundary } from "@/components/site/state-views";
 import { Input } from "@/components/ui/input";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -111,10 +112,17 @@ export function OwnerPanel() {
         emptyDescription="Registration readiness appears after repository intelligence has been generated for this repo."
       >
         {workspace ? (
-          <RegistrationWorkspace
-            workspace={workspace}
-            generatedLabel={formatGeneratedAt(workspace.generatedAt)}
-          />
+          <div className="space-y-6">
+            {/* Dashboard-level refresh metadata (#6181) — readiness is the primary resource;
+                refresh() also reloads the config recommendation sibling. */}
+            <div className="flex items-center justify-end">
+              <RefreshMeta loadedAt={readiness.loadedAt} onRefresh={refresh} />
+            </div>
+            <RegistrationWorkspace
+              workspace={workspace}
+              generatedLabel={formatGeneratedAt(workspace.generatedAt)}
+            />
+          </div>
         ) : null}
         {repoPath && readiness.status === "error" ? (
           <p className="text-token-2xs text-muted-foreground">

--- a/apps/loopover-ui/src/components/site/app-panels/refresh-meta-sibling-panels.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/refresh-meta-sibling-panels.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { useApiResource, useSession } = vi.hoisted(() => ({
+  useApiResource: vi.fn(),
+  useSession: vi.fn(),
+}));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: (...args: unknown[]) => useApiResource(...args),
+}));
+vi.mock("@/lib/api/session", () => ({ useSession: () => useSession() }));
+vi.mock("@/components/site/mcp-version-badge", () => ({
+  McpVersionBadge: () => <span>mcp</span>,
+}));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, ...props }: { children: React.ReactNode; to?: string }) => (
+    <a href={props.to ?? "#"}>{children}</a>
+  ),
+}));
+
+import { DigestPanel } from "@/components/site/app-panels/digest-panel";
+import { MinerPanel } from "@/components/site/app-panels/miner-panel";
+import { OwnerPanel } from "@/components/site/app-panels/owner-panel";
+import type { RegistrationReadinessPayload } from "@/lib/registration-workspace";
+
+function readyRegistrationFixture(): RegistrationReadinessPayload {
+  return {
+    repoFullName: "entrius/gittensor",
+    generatedAt: "2026-07-16T00:00:00.000Z",
+    ready: true,
+    recommendedRegistrationMode: "direct_pr",
+    issuePolicy: "direct_pr_no_issue_required",
+    directPrReadiness: { ready: true, reasons: ["Direct-PR intake is healthy."] },
+    issueDiscoveryReadiness: {
+      ready: false,
+      recommendation: "not_recommended",
+      reasons: ["Issue discovery should stay off until intake is excellent."],
+    },
+    labelPolicy: {
+      autoLabelEnabled: true,
+      label: "gittensor",
+      trustedPipelineReady: true,
+      missingOrUnusedRegistryLabels: [],
+    },
+    maintainerCutReadiness: {
+      ready: true,
+      summary: "Maintainer cut can be reviewed without blocking intake.",
+      reasons: ["Queue burden is low."],
+      warnings: [],
+      recommendedAction: "consider_small_cut",
+    },
+    testCoverageHealth: {
+      status: "gate_ready",
+      trustedLabelPipelineReady: true,
+      checkRunMode: "enabled",
+      requiredGate: ["npm run test:ci"],
+      note: "Use repo CI gates before widening contributor intake.",
+      warnings: [],
+    },
+    queueHealth: {
+      level: "low",
+      burdenScore: 0.2,
+      reviewablePullRequests: 3,
+      summary: "Queue burden is low.",
+    },
+    contributorIntakeHealth: { level: "healthy", summary: "Contributor intake is healthy." },
+    githubApp: {
+      installed: true,
+      publicSurface: "comment_and_label",
+      commentMode: "detected_contributors_only",
+      checkRunMode: "enabled",
+      quietByDefault: true,
+      behavior: "Quiet-by-default GitHub App assistance.",
+      warnings: [],
+    },
+    policyReadiness: null,
+    blockers: [],
+    warnings: [],
+    docsCompleteness: {
+      status: "repo_docs_not_crawled",
+      requiredDocs: ["CONTRIBUTING.md", "README.md"],
+      note: "LoopOver validates public repo docs locally; remote crawl is not enabled yet.",
+    },
+    dataQuality: { status: "complete", partial: false, warnings: [] },
+  };
+}
+
+describe("RefreshMeta adoption on sibling panels (#6181)", () => {
+  it("DigestPanel renders RefreshMeta when digest data is ready", () => {
+    const reload = vi.fn();
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: {
+        date: "2026-07-16",
+        signal: "ready",
+        items: [{ kind: "summary", title: "Quiet day", detail: "No open review work." }],
+        subscriptions: [],
+        delivery: { mode: "store_only", emailDeliveryEnabled: false },
+      },
+      error: null,
+      loadedAt: Date.now() - 60_000,
+      reload,
+    });
+    render(<DigestPanel />);
+    expect(screen.getByText(/last refresh/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /^Refresh$/i }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("MinerPanel renders RefreshMeta when dashboard data is ready", () => {
+    const reload = vi.fn();
+    useSession.mockReturnValue({
+      session: { login: "miner", roles: ["miner"] },
+      hydrated: true,
+    });
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: {
+        status: "ready",
+        login: "miner",
+        nextActions: [{ actionKind: "open_pr", rationale: "Ship the fix.", repoFullName: "acme/widgets" }],
+        blockers: [],
+        projections: [],
+        repoFit: [],
+      },
+      error: null,
+      loadedAt: Date.now() - 120_000,
+      reload,
+    });
+    render(<MinerPanel />);
+    expect(screen.getByText(/last refresh/i)).toBeTruthy();
+    // MinerPanelActions also has a rebuild "Refresh"; RefreshMeta's button is still labeled Refresh.
+    const refreshButtons = screen.getAllByRole("button", { name: /^Refresh$/i });
+    expect(refreshButtons.length).toBeGreaterThanOrEqual(2);
+    fireEvent.click(refreshButtons[refreshButtons.length - 1]!);
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("OwnerPanel renders RefreshMeta when registration workspace is ready", () => {
+    const reload = vi.fn();
+    useApiResource.mockImplementation((_path: string, label: string) => {
+      if (label === "Registration readiness") {
+        return {
+          status: "ready",
+          data: readyRegistrationFixture(),
+          error: null,
+          loadedAt: Date.now() - 30_000,
+          reload,
+        };
+      }
+      return {
+        status: "ready",
+        data: null,
+        error: null,
+        loadedAt: Date.now() - 30_000,
+        reload: vi.fn(),
+      };
+    });
+
+    render(<OwnerPanel />);
+    expect(screen.getByText(/last refresh/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /^Refresh$/i }));
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/refresh-meta-sibling-panels.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/refresh-meta-sibling-panels.test.tsx
@@ -118,7 +118,9 @@ describe("RefreshMeta adoption on sibling panels (#6181)", () => {
       data: {
         status: "ready",
         login: "miner",
-        nextActions: [{ actionKind: "open_pr", rationale: "Ship the fix.", repoFullName: "acme/widgets" }],
+        nextActions: [
+          { actionKind: "open_pr", rationale: "Ship the fix.", repoFullName: "acme/widgets" },
+        ],
         blockers: [],
         projections: [],
         repoFit: [],


### PR DESCRIPTION
## Summary

- Add `RefreshMeta` to `owner-panel.tsx`, `miner-panel.tsx`, and `digest-panel.tsx`, matching `maintainer-panel.tsx`'s `#2219` usage (`loadedAt` + `reload`).
- Owner panel uses readiness `loadedAt` and the existing dual-resource `refresh()` callback.
- Miner panel's `RefreshMeta` reloads the GET dashboard; it is distinct from the rebuild-via-POST "Refresh" in `MinerPanelActions`.
- No changes to `RefreshMeta` itself.

## Scope

- [x] Conventional Commit title
- [x] Focused UI change under `apps/loopover-ui/`
- [x] Linked open issue

Note: this issue carries the `visual` label (owner-led). Expect the loopover gate to **hold** for owner review rather than auto-merge.

## Validation

- [x] `npm --workspace @loopover/ui run test -- src/components/site/app-panels/refresh-meta-sibling-panels.test.tsx` — 3 passed
- Codecov patch N/A for `apps/**`

## Safety

- [x] No secrets / wallets / scoring surfaces
- [x] No changelog / site edits

## UI Evidence

| State / title | JPG evidence |
| ------------- | ------------ |
| Digest panel RefreshMeta | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/digest-refresh-meta.jpg"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/digest-refresh-meta.jpg" alt="Digest RefreshMeta" width="240"></a> |
| Miner panel RefreshMeta | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/miner-refresh-meta.jpg"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/miner-refresh-meta.jpg" alt="Miner RefreshMeta" width="240"></a> |
| Owner panel RefreshMeta | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/owner-refresh-meta.jpg"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/owner-refresh-meta.jpg" alt="Owner RefreshMeta" width="240"></a> |
| Digest mobile | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/digest-refresh-meta-mobile.jpg"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/digest-refresh-meta-mobile.jpg" alt="Digest mobile RefreshMeta" width="240"></a> |

Closes #6181
