### PR TITLE
test(ci): give check-mcp-package.mjs an injectable, unit-testable seam

### DIFF
--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -2,31 +2,63 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
 
-const result = spawnSync("npm", ["pack", "--workspace", "@loopover/mcp", "--dry-run", "--json"], {
-  encoding: "utf8",
-});
+const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
+const FORBIDDEN_CONTENT =
+  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
+const STALE_PACKAGE_TEXT = /(private beta|zeronode\.workers\.dev|preview URL)/i;
 
-if (result.status !== 0) {
-  process.stderr.write(result.stderr || result.stdout);
-  process.exit(result.status ?? 1);
+export function validateMcpPackFileList(files, readContent) {
+  const paths = files.map((file) => (typeof file === "string" ? file : file.path)).sort();
+  for (const file of paths) {
+    if (FORBIDDEN_PATH.test(file)) throw new Error(`Forbidden file in MCP package: ${file}`);
+    if (!MCP_PACKAGE_ALLOWED_FILE_PATTERNS.some((pattern) => pattern.test(file)))
+      throw new Error(`Unexpected file in MCP package: ${file}`);
+    const content = readContent(file);
+    if (FORBIDDEN_CONTENT.test(content)) throw new Error(`Secret-like content found in MCP package file: ${file}`);
+    if (file === "README.md" && STALE_PACKAGE_TEXT.test(content))
+      throw new Error(`Stale public-package wording found in MCP package file: ${file}`);
+  }
+  return paths;
 }
 
-const [pack] = JSON.parse(result.stdout);
-const files = pack.files.map((file) => file.path).sort();
-const allowed = MCP_PACKAGE_ALLOWED_FILE_PATTERNS;
-const forbiddenPath = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
-const forbiddenContent = /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
-const stalePackageText = /(private beta|zeronode\.workers\.dev|preview URL)/i;
-
-for (const file of files) {
-  if (forbiddenPath.test(file)) throw new Error(`Forbidden file in MCP package: ${file}`);
-  if (!allowed.some((pattern) => pattern.test(file))) throw new Error(`Unexpected file in MCP package: ${file}`);
-  const fullPath = join("packages/loopover-mcp", file);
-  const content = readFileSync(fullPath, "utf8");
-  if (forbiddenContent.test(content)) throw new Error(`Secret-like content found in MCP package file: ${file}`);
-  if (file === "README.md" && stalePackageText.test(content)) throw new Error(`Stale public-package wording found in MCP package file: ${file}`);
+export function runMcpPackCheck(options = {}) {
+  const pack = options.pack ?? loadMcpPackFromNpm();
+  const packageRoot = options.packageRoot ?? join(process.cwd(), "packages/loopover-mcp");
+  const readContent =
+    options.readContent ??
+    ((file) => {
+      if (process.env.CHECK_MCP_PACK_TEST_CONTENT !== undefined) return process.env.CHECK_MCP_PACK_TEST_CONTENT;
+      return readFileSync(join(packageRoot, file), "utf8");
+    });
+  const paths = validateMcpPackFileList(pack.files, readContent);
+  return `MCP package dry-run ok: ${paths.join(", ")}\n`;
 }
 
-process.stdout.write(`MCP package dry-run ok: ${files.join(", ")}\n`);
+function loadMcpPackFromNpm() {
+  if (process.env.CHECK_MCP_PACK_TEST_FILES) {
+    const paths = JSON.parse(process.env.CHECK_MCP_PACK_TEST_FILES);
+    return { files: paths.map((path) => ({ path })) };
+  }
+  const result = spawnSync("npm", ["pack", "--workspace", "@loopover/mcp", "--dry-run", "--json"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    const message = result.stderr || result.stdout || "npm pack failed";
+    throw new Error(message.trim());
+  }
+  return JSON.parse(result.stdout)[0];
+}
+
+function main() {
+  try {
+    process.stdout.write(runMcpPackCheck());
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/test/unit/check-mcp-package.test.ts
+++ b/test/unit/check-mcp-package.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function runChecker(env: Record<string, string | undefined> = {}): { status: number; out: string } {
+  try {
+    const stdout = execFileSync(process.execPath, ["scripts/check-mcp-package.mjs"], {
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    });
+    return { status: 0, out: stdout };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+// A complete, valid MCP tarball: a bin, shipped lib modules, the preview scripts, and the package metadata files.
+const FULL_PACKAGE = [
+  "package.json",
+  "README.md",
+  "CHANGELOG.md",
+  "LICENSE",
+  "bin/loopover-mcp.js",
+  "lib/cli-error.js",
+  "lib/telemetry.js",
+  "scripts/gittensor-score-preview.mjs",
+  "scripts/gittensor-score-preview.py",
+];
+
+describe("check-mcp-package script", () => {
+  it("passes on the real MCP workspace package", () => {
+    const result = runChecker();
+    expect(result.status).toBe(0);
+    expect(result.out).toMatch(/^MCP package dry-run ok:/);
+    expect(result.out).toContain("bin/loopover-mcp.js");
+    expect(result.out).toContain("package.json");
+  });
+
+  it("accepts a complete allowlisted package", () => {
+    const result = runChecker({
+      CHECK_MCP_PACK_TEST_FILES: JSON.stringify(FULL_PACKAGE),
+      CHECK_MCP_PACK_TEST_CONTENT: "public docs, nothing secret",
+    });
+    expect(result.status).toBe(0);
+    expect(result.out).toMatch(/^MCP package dry-run ok:/);
+    expect(result.out).toContain("lib/cli-error.js");
+    expect(result.out).toContain("scripts/gittensor-score-preview.mjs");
+  });
+
+  it("rejects a forbidden path", () => {
+    const result = runChecker({ CHECK_MCP_PACK_TEST_FILES: JSON.stringify([".env"]) });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Forbidden file in MCP package: .env");
+  });
+
+  it("rejects an unexpected file", () => {
+    const result = runChecker({ CHECK_MCP_PACK_TEST_FILES: JSON.stringify(["scripts/extra.mjs"]) });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Unexpected file in MCP package: scripts/extra.mjs");
+  });
+
+  it("rejects an unexpected bin that matches the package name prefix", () => {
+    const result = runChecker({
+      CHECK_MCP_PACK_TEST_FILES: JSON.stringify(["package.json", "bin/loopover-mcp-backdoor.js"]),
+      CHECK_MCP_PACK_TEST_CONTENT: "console.log('not secret');",
+    });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Unexpected file in MCP package: bin/loopover-mcp-backdoor.js");
+  });
+
+  it("rejects secret-like content", () => {
+    const probe = ["PROBE", "_", "SECRET", "=", "value"].join("");
+    const result = runChecker({
+      CHECK_MCP_PACK_TEST_FILES: JSON.stringify(["package.json", "bin/loopover-mcp.js"]),
+      CHECK_MCP_PACK_TEST_CONTENT: probe,
+    });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Secret-like content found in MCP package file:");
+  });
+
+  it("rejects stale public-package wording in README.md", () => {
+    const result = runChecker({
+      CHECK_MCP_PACK_TEST_FILES: JSON.stringify(["package.json", "README.md"]),
+      CHECK_MCP_PACK_TEST_CONTENT: "Join the private beta today!",
+    });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Stale public-package wording found in MCP package file: README.md");
+  });
+
+  it("only scopes the stale-wording check to README.md, not other allowlisted files", () => {
+    // The same stale phrase in a non-README file (here CHANGELOG.md) is accepted — the guard is README-only.
+    const result = runChecker({
+      CHECK_MCP_PACK_TEST_FILES: JSON.stringify(["package.json", "CHANGELOG.md"]),
+      CHECK_MCP_PACK_TEST_CONTENT: "Historic note: was once a private beta.",
+    });
+    expect(result.status).toBe(0);
+    expect(result.out).toMatch(/^MCP package dry-run ok:/);
+  });
+});


### PR DESCRIPTION
test(ci): give check-mcp-package.mjs an injectable, unit-testable seam

check-mcp-package.mjs was a monolithic top-level script (spawnSync + throw
at module scope, no exports, no test), so drift in its allowlist and
forbidden-content checks could only be caught by manual review — the same
gap that let its sibling issues slip through.

Refactor it to mirror check-miner-package.mjs: extract validateMcpPackFileList
and runMcpPackCheck with injectable pack/readContent dependencies, load the
real tarball via a guarded main(), and support CHECK_MCP_PACK_TEST_FILES /
CHECK_MCP_PACK_TEST_CONTENT env hooks. Add test/unit/check-mcp-package.test.ts
exercising the allowlist, forbidden-path, secret-content, and README-scoped
stale-wording checks, plus the real workspace package.

Behavior is unchanged.

Closes #6297

