### PR TITLE
docs(ams): port docs/discovery-plane-operator-guide.md to a website docs page (docs.ams-discovery-plane.tsx)

### DIFF
--- a/apps/loopover-ui/content/docs/ams-deployment.mdx
+++ b/apps/loopover-ui/content/docs/ams-deployment.mdx
@@ -247,5 +247,4 @@ CPU/RAM/disk sizing see [Resource sizing](/docs/ams-sizing).
 
 The hosted discovery-index is **off by default** — unlike Orb fleet export (`ORB_AIR_GAP` is the
 only opt-out). Operators who want cross-fleet metadata queries or soft-claim coordination must opt
-in explicitly. See
-[`packages/loopover-miner/docs/discovery-plane-operator-guide.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/discovery-plane-operator-guide.md).
+in explicitly. See the [hosted discovery plane operator guide](/docs/ams-discovery-plane).

--- a/apps/loopover-ui/content/docs/ams-discovery-plane.mdx
+++ b/apps/loopover-ui/content/docs/ams-discovery-plane.mdx
@@ -1,0 +1,195 @@
+---
+title: Hosted discovery plane — operator guide (opt-in)
+description: How a loopover-miner instance opts into the optional hosted discovery-index plane, what it may send, and what never leaves the operator's machine.
+---
+
+Operator-facing guide for the **optional** hosted discovery-index plane. This is the client/miner
+half of that roadmap item: how a `loopover-miner` instance opts in, what it may send, and what
+never leaves the operator's machine.
+
+<Callout variant="warn" title="Provisional: opt-in wiring env vars are still TBD">
+  The request/response **contract shape**, the telemetry event schema, and the client soft-claim
+  request builder have now **shipped** as real, tested modules (see below). What remains
+  **provisional** is only the operator-facing **opt-in wiring** — the env var names further below
+  are still TBD pending the hosted server and the miner-side opt-in. Do not treat those env var
+  names as stable API yet.
+</Callout>
+
+<FeatureRow
+  items={[
+    {
+      title: "Discovery-index API contract",
+      description:
+        "DiscoveryIndexQuery / DiscoveryIndexResponse / DiscoveryIndexCandidate request/response shapes. Shipped, stable at DISCOVERY_INDEX_CONTRACT_VERSION 1 (packages/loopover-engine/src/discovery-index-contract.ts).",
+    },
+    {
+      title: "Telemetry event schema",
+      description:
+        "Anonymized telemetry event schema for the optional hosted plane. Shipped (packages/loopover-engine/src/miner-telemetry.ts).",
+    },
+    {
+      title: "Soft-claim request builder",
+      description:
+        "Client-side soft-claim coordination request builder. Shipped (packages/loopover-engine/src/discovery-soft-claim.ts).",
+    },
+    {
+      title: "Hosted server + opt-in wiring",
+      description:
+        "Still open -- the actual blocker for the opt-in mechanism below; the env var names remain TBD until it lands.",
+    },
+  ]}
+/>
+
+Part of the Miner Wave 2 discovery plane (Phase 6). Distinct from Phase 1's **local-only**
+metadata fan-out — that path never phones home today.
+
+## Default posture: opt-in (not like Orb)
+
+Two telemetry/export surfaces exist in LoopOver, and they intentionally use **opposite
+defaults**:
+
+<FeatureRow
+  items={[
+    {
+      title: "Orb fleet calibration",
+      description:
+        "src/selfhost/orb-collector.ts. Default ON once a GitHub App is configured. Opt out only via ORB_AIR_GAP=true (air-gapped / send-nothing). Precedent: review-stack self-host contract -- export is always on unless air-gapped.",
+    },
+    {
+      title: "Hosted discovery plane (this guide)",
+      description:
+        "Default OFF. Opt in explicitly before any hosted index query or plane telemetry. Precedent: hybrid, self-host-first miner deployment -- participation in a shared hosted plane is never assumed.",
+    },
+  ]}
+/>
+
+<Callout variant="warn">
+  Do **not** copy Orb's wording for this plane. Orb's header comment is explicit: "Export is
+  ALWAYS ON… there is no opt-out flag" aside from `ORB_AIR_GAP`. The discovery plane is the
+  opposite: **no hosted traffic unless the operator turns it on.**
+</Callout>
+
+## What the plane is for
+
+When enabled, a miner may query a **shared, metadata-only** discovery index instead of every
+fleet member independently fanning out GitHub search/listing calls against the same repos —
+mitigating cross-fleet rate-limit pressure.
+
+The plane:
+
+- Serves **public GitHub metadata only** (issue titles, labels, counts, timestamps, URLs — the
+  same class of fields Phase 1 already uses locally).
+- May coordinate **soft claims** across the fleet (server-side dedup is still open; the client
+  request shape has shipped).
+- Never receives source trees, diffs, tokens, or write credentials.
+
+Local discovery (`opportunity-fanout` + `opportunity-ranker`) continues to work with **zero**
+hosted configuration.
+
+## Opt-in mechanism (env var names still TBD)
+
+The request/response contract has now shipped (see the scope table above), but the
+operator-facing opt-in env vars below are **not implemented yet** — treat them as
+**documentation placeholders** for the shape operators should expect once the opt-in wiring
+lands:
+
+<FeatureRow
+  items={[
+    {
+      title: "LOOPOVER_MINER_DISCOVERY_PLANE (provisional)",
+      description:
+        "Default unset / false. Master opt-in. When not truthy (1, true, yes, on), the miner must not call the hosted index or emit discovery-plane telemetry.",
+    },
+    {
+      title: "LOOPOVER_MINER_DISCOVERY_INDEX_URL (provisional)",
+      description:
+        "Default unset. Hosted index base URL. Required when the plane is enabled; ignored when opt-in is off.",
+    },
+    {
+      title: "LOOPOVER_MINER_DISCOVERY_TELEMETRY (provisional)",
+      description:
+        "Default unset / false. Separate opt-in for anonymized operational telemetry. Plane queries can stay on while telemetry stays off.",
+    },
+  ]}
+/>
+
+**Truthy-string convention** (when implemented): `/^(1|true|yes|on)$/i`, matching other
+`LOOPOVER_*` flags in this repo.
+
+**Operator checklist (enabled plane):**
+
+**1.** Set `LOOPOVER_MINER_DISCOVERY_PLANE=true` (exact name may change).
+
+**2.** Set `LOOPOVER_MINER_DISCOVERY_INDEX_URL` to the operator-trusted index endpoint.
+
+**3.** Optionally set `LOOPOVER_MINER_DISCOVERY_TELEMETRY=true` if you want anonymized
+operational events for the hosted service — not required for index queries.
+
+**4.** Keep `GITHUB_TOKEN` (or equivalent) on the instance only; never configure tokens intended
+for the hosted plane to receive.
+
+With opt-in off (default), behavior is byte-identical to today: local SQLite ledgers, local
+fan-out, no hosted calls.
+
+## Contrast with local soft-claims today
+
+`packages/loopover-miner/lib/claim-ledger.js` records soft claims **locally only** ("never
+uploads, syncs, or phones home"). Fleet-wide coordination before work starts is what the hosted
+index adds **on top of** that ledger — only after explicit opt-in.
+
+After-the-fact duplicate adjudication (`isDuplicateClusterWinnerByClaim` in `@loopover/engine`)
+remains separate; it resolves collisions by observing what publicly landed first, not by
+preventing overlap up front.
+
+## Invariants
+
+Mirrors the [AMS deployment guide](/docs/ams-deployment)'s tone — concrete guarantees for
+operators:
+
+- **Default OFF** — no hosted discovery-index traffic and no discovery-plane telemetry unless the
+  operator opts in.
+- **Metadata-only index queries** — responses are issue/listing metadata compatible with local
+  `normalizeCandidate` shape; no source upload, no clone, no repo archive.
+- **Read-only client posture** — the miner uses GET/list/search semantics toward GitHub directly
+  (Phase 1) and toward the hosted index when enabled; the plane does not grant the miner new
+  GitHub write capability.
+- **Credentials stay local** — GitHub tokens, PATs, and actor-capable secrets are injected at
+  runtime on the operator's machine or secret store; they are **never** included in index or
+  telemetry payloads.
+- **No compensation signals in the plane** — raw reward values, wallet addresses, hotkeys, trust
+  scores, or private rankings never cross this boundary.
+- **Telemetry is a second opt-in** — even with the plane enabled, anonymized telemetry remains
+  separately gated.
+- **Anonymized identifiers only** — when telemetry ships, repo/issue correlation uses HMAC-hashed
+  identifiers keyed by a **per-instance dedicated secret** the collector never holds (same
+  posture as `getOrCreateAnonSecret` / `hmacField` in `src/selfhost/orb-collector.ts` — key
+  separation from GitHub App / webhook secrets).
+- **Low-cardinality reason buckets** — any free-text-adjacent telemetry fields use bucketed
+  categories (Orb's `bucketReasonCode` pattern), not raw maintainer or model prose.
+- **Core miner still works offline** — claims, plans, queues, and local ledgers do not require
+  the hosted plane; `loopover-miner doctor` / `status` remain no-network commands.
+
+### Never included (client → hosted plane)
+
+Inventory style matches `src/selfhost/orb-collector.ts` ("No diffs, no code…") adapted for
+discovery-plane domain:
+
+- Source file contents, patches, or diffs
+- Full issue/PR bodies or review comments
+- GitHub tokens, PATs, App private keys, or any actor-capable credential
+- Commit SHAs, branch names tied to unpublished work, or CI log excerpts
+- Operator login identities, emails, or hostnames usable as PII
+- Raw gate reasons, model transcripts, or free-text maintainer notes
+- Reward amounts, wallet addresses, hotkeys, trust scores, or private rankings
+
+### Never retained by the hosted service (server-side)
+
+The server operating doc (maintainer-only) will restate the same boundary: **never holds source
+or actor-capable credentials.** This client guide does not define server retention policy.
+
+## Related docs
+
+- [`packages/loopover-miner/docs/cross-repo-discovery-phase1.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/cross-repo-discovery-phase1.md) — local, metadata-only Phase 1 discovery (no hosted plane)
+- [AMS operations runbook](/docs/ams-operations-runbook) — SQLite concurrency, corruption recovery, multi-process collisions, post-upgrade migration
+- [`packages/loopover-miner/docs/miner-goal-spec.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/miner-goal-spec.md) — per-repo `.loopover-miner.yml` targeting policy
+- [AMS deployment guide](/docs/ams-deployment) — laptop vs fleet deployment and core miner invariants

--- a/apps/loopover-ui/content/docs/ams-operations-runbook.mdx
+++ b/apps/loopover-ui/content/docs/ams-operations-runbook.mdx
@@ -277,4 +277,4 @@ store filename.
 - [`packages/loopover-miner/README.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/README.md#local-storage) — store inventory
 - [AMS environment variable reference](/docs/ams-env-reference) — per-store path overrides
 - [`packages/loopover-miner/docs/coding-agent-driver.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/coding-agent-driver.md) — attempt log semantics
-- [`packages/loopover-miner/docs/discovery-plane-operator-guide.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/discovery-plane-operator-guide.md) — optional hosted plane (distinct from local ledger ops)
+- [Hosted discovery plane operator guide](/docs/ams-discovery-plane) — optional hosted plane (distinct from local ledger ops)

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -82,6 +82,7 @@ export const docsNav: DocsGroup[] = [
           { to: "/docs/ams-sizing", label: "Resource sizing" },
           { to: "/docs/ams-config-precedence", label: "Config precedence" },
           { to: "/docs/ams-env-reference", label: "Env var reference" },
+          { to: "/docs/ams-discovery-plane", label: "Discovery plane (opt-in)" },
         ],
       },
     ],

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -61,6 +61,7 @@ import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.a
 import { Route as DocsAmsSizingRouteImport } from './routes/docs.ams-sizing'
 import { Route as DocsAmsOperationsRunbookRouteImport } from './routes/docs.ams-operations-runbook'
 import { Route as DocsAmsObservabilityRouteImport } from './routes/docs.ams-observability'
+import { Route as DocsAmsEnvReferenceRouteImport } from './routes/docs.ams-env-reference'
 import { Route as DocsAmsDiscoveryPlaneRouteImport } from './routes/docs.ams-discovery-plane'
 import { Route as DocsAmsDeploymentRouteImport } from './routes/docs.ams-deployment'
 import { Route as DocsAmsConfigPrecedenceRouteImport } from './routes/docs.ams-config-precedence'
@@ -357,6 +358,11 @@ const DocsAmsObservabilityRoute = DocsAmsObservabilityRouteImport.update({
   path: '/ams-observability',
   getParentRoute: () => DocsRoute,
 } as any)
+const DocsAmsEnvReferenceRoute = DocsAmsEnvReferenceRouteImport.update({
+  id: '/ams-env-reference',
+  path: '/ams-env-reference',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsAmsDiscoveryPlaneRoute = DocsAmsDiscoveryPlaneRouteImport.update({
   id: '/ams-discovery-plane',
   path: '/ams-discovery-plane',
@@ -482,6 +488,7 @@ export interface FileRoutesByFullPath {
   '/docs/ams-config-precedence': typeof DocsAmsConfigPrecedenceRoute
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
   '/docs/ams-discovery-plane': typeof DocsAmsDiscoveryPlaneRoute
+  '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -552,6 +559,7 @@ export interface FileRoutesByTo {
   '/docs/ams-config-precedence': typeof DocsAmsConfigPrecedenceRoute
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
   '/docs/ams-discovery-plane': typeof DocsAmsDiscoveryPlaneRoute
+  '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -626,6 +634,7 @@ export interface FileRoutesById {
   '/docs/ams-config-precedence': typeof DocsAmsConfigPrecedenceRoute
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
   '/docs/ams-discovery-plane': typeof DocsAmsDiscoveryPlaneRoute
+  '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -701,6 +710,7 @@ export interface FileRouteTypes {
     | '/docs/ams-config-precedence'
     | '/docs/ams-deployment'
     | '/docs/ams-discovery-plane'
+    | '/docs/ams-env-reference'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -771,6 +781,7 @@ export interface FileRouteTypes {
     | '/docs/ams-config-precedence'
     | '/docs/ams-deployment'
     | '/docs/ams-discovery-plane'
+    | '/docs/ams-env-reference'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -844,6 +855,7 @@ export interface FileRouteTypes {
     | '/docs/ams-config-precedence'
     | '/docs/ams-deployment'
     | '/docs/ams-discovery-plane'
+    | '/docs/ams-env-reference'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -1269,6 +1281,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsAmsObservabilityRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/ams-env-reference': {
+      id: '/docs/ams-env-reference'
+      path: '/ams-env-reference'
+      fullPath: '/docs/ams-env-reference'
+      preLoaderRoute: typeof DocsAmsEnvReferenceRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/ams-discovery-plane': {
       id: '/docs/ams-discovery-plane'
       path: '/ams-discovery-plane'
@@ -1458,6 +1477,7 @@ interface DocsRouteChildren {
   DocsAmsConfigPrecedenceRoute: typeof DocsAmsConfigPrecedenceRoute
   DocsAmsDeploymentRoute: typeof DocsAmsDeploymentRoute
   DocsAmsDiscoveryPlaneRoute: typeof DocsAmsDiscoveryPlaneRoute
+  DocsAmsEnvReferenceRoute: typeof DocsAmsEnvReferenceRoute
   DocsAmsObservabilityRoute: typeof DocsAmsObservabilityRoute
   DocsAmsOperationsRunbookRoute: typeof DocsAmsOperationsRunbookRoute
   DocsAmsSizingRoute: typeof DocsAmsSizingRoute
@@ -1505,6 +1525,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAmsConfigPrecedenceRoute: DocsAmsConfigPrecedenceRoute,
   DocsAmsDeploymentRoute: DocsAmsDeploymentRoute,
   DocsAmsDiscoveryPlaneRoute: DocsAmsDiscoveryPlaneRoute,
+  DocsAmsEnvReferenceRoute: DocsAmsEnvReferenceRoute,
   DocsAmsObservabilityRoute: DocsAmsObservabilityRoute,
   DocsAmsOperationsRunbookRoute: DocsAmsOperationsRunbookRoute,
   DocsAmsSizingRoute: DocsAmsSizingRoute,

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -61,7 +61,7 @@ import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.a
 import { Route as DocsAmsSizingRouteImport } from './routes/docs.ams-sizing'
 import { Route as DocsAmsOperationsRunbookRouteImport } from './routes/docs.ams-operations-runbook'
 import { Route as DocsAmsObservabilityRouteImport } from './routes/docs.ams-observability'
-import { Route as DocsAmsEnvReferenceRouteImport } from './routes/docs.ams-env-reference'
+import { Route as DocsAmsDiscoveryPlaneRouteImport } from './routes/docs.ams-discovery-plane'
 import { Route as DocsAmsDeploymentRouteImport } from './routes/docs.ams-deployment'
 import { Route as DocsAmsConfigPrecedenceRouteImport } from './routes/docs.ams-config-precedence'
 import { Route as DocsAiSummariesRouteImport } from './routes/docs.ai-summaries'
@@ -357,9 +357,9 @@ const DocsAmsObservabilityRoute = DocsAmsObservabilityRouteImport.update({
   path: '/ams-observability',
   getParentRoute: () => DocsRoute,
 } as any)
-const DocsAmsEnvReferenceRoute = DocsAmsEnvReferenceRouteImport.update({
-  id: '/ams-env-reference',
-  path: '/ams-env-reference',
+const DocsAmsDiscoveryPlaneRoute = DocsAmsDiscoveryPlaneRouteImport.update({
+  id: '/ams-discovery-plane',
+  path: '/ams-discovery-plane',
   getParentRoute: () => DocsRoute,
 } as any)
 const DocsAmsDeploymentRoute = DocsAmsDeploymentRouteImport.update({
@@ -481,7 +481,7 @@ export interface FileRoutesByFullPath {
   '/docs/ai-summaries': typeof DocsAiSummariesRoute
   '/docs/ams-config-precedence': typeof DocsAmsConfigPrecedenceRoute
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
-  '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
+  '/docs/ams-discovery-plane': typeof DocsAmsDiscoveryPlaneRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -551,7 +551,7 @@ export interface FileRoutesByTo {
   '/docs/ai-summaries': typeof DocsAiSummariesRoute
   '/docs/ams-config-precedence': typeof DocsAmsConfigPrecedenceRoute
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
-  '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
+  '/docs/ams-discovery-plane': typeof DocsAmsDiscoveryPlaneRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -625,7 +625,7 @@ export interface FileRoutesById {
   '/docs/ai-summaries': typeof DocsAiSummariesRoute
   '/docs/ams-config-precedence': typeof DocsAmsConfigPrecedenceRoute
   '/docs/ams-deployment': typeof DocsAmsDeploymentRoute
-  '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
+  '/docs/ams-discovery-plane': typeof DocsAmsDiscoveryPlaneRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -700,7 +700,7 @@ export interface FileRouteTypes {
     | '/docs/ai-summaries'
     | '/docs/ams-config-precedence'
     | '/docs/ams-deployment'
-    | '/docs/ams-env-reference'
+    | '/docs/ams-discovery-plane'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -770,7 +770,7 @@ export interface FileRouteTypes {
     | '/docs/ai-summaries'
     | '/docs/ams-config-precedence'
     | '/docs/ams-deployment'
-    | '/docs/ams-env-reference'
+    | '/docs/ams-discovery-plane'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -843,7 +843,7 @@ export interface FileRouteTypes {
     | '/docs/ai-summaries'
     | '/docs/ams-config-precedence'
     | '/docs/ams-deployment'
-    | '/docs/ams-env-reference'
+    | '/docs/ams-discovery-plane'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -1269,11 +1269,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsAmsObservabilityRouteImport
       parentRoute: typeof DocsRoute
     }
-    '/docs/ams-env-reference': {
-      id: '/docs/ams-env-reference'
-      path: '/ams-env-reference'
-      fullPath: '/docs/ams-env-reference'
-      preLoaderRoute: typeof DocsAmsEnvReferenceRouteImport
+    '/docs/ams-discovery-plane': {
+      id: '/docs/ams-discovery-plane'
+      path: '/ams-discovery-plane'
+      fullPath: '/docs/ams-discovery-plane'
+      preLoaderRoute: typeof DocsAmsDiscoveryPlaneRouteImport
       parentRoute: typeof DocsRoute
     }
     '/docs/ams-deployment': {
@@ -1457,7 +1457,7 @@ interface DocsRouteChildren {
   DocsAiSummariesRoute: typeof DocsAiSummariesRoute
   DocsAmsConfigPrecedenceRoute: typeof DocsAmsConfigPrecedenceRoute
   DocsAmsDeploymentRoute: typeof DocsAmsDeploymentRoute
-  DocsAmsEnvReferenceRoute: typeof DocsAmsEnvReferenceRoute
+  DocsAmsDiscoveryPlaneRoute: typeof DocsAmsDiscoveryPlaneRoute
   DocsAmsObservabilityRoute: typeof DocsAmsObservabilityRoute
   DocsAmsOperationsRunbookRoute: typeof DocsAmsOperationsRunbookRoute
   DocsAmsSizingRoute: typeof DocsAmsSizingRoute
@@ -1504,7 +1504,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAiSummariesRoute: DocsAiSummariesRoute,
   DocsAmsConfigPrecedenceRoute: DocsAmsConfigPrecedenceRoute,
   DocsAmsDeploymentRoute: DocsAmsDeploymentRoute,
-  DocsAmsEnvReferenceRoute: DocsAmsEnvReferenceRoute,
+  DocsAmsDiscoveryPlaneRoute: DocsAmsDiscoveryPlaneRoute,
   DocsAmsObservabilityRoute: DocsAmsObservabilityRoute,
   DocsAmsOperationsRunbookRoute: DocsAmsOperationsRunbookRoute,
   DocsAmsSizingRoute: DocsAmsSizingRoute,

--- a/apps/loopover-ui/src/routes/docs.ams-discovery-plane.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-discovery-plane.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { docsClientLoader } from "@/lib/docs-client-loader";
+
+// Rendered from content/docs/ams-discovery-plane.mdx via fumadocs-mdx's browser entry
+// (docsClientLoader), through the existing DocsPage/Callout/CodeBlock/FeatureRow
+// primitives -- not fumadocs-ui's bundled components. See docs-source.ts's comment
+// for why the loader below resolves only a plain, serializable path string.
+export const Route = createFileRoute("/docs/ams-discovery-plane")({
+  loader: async () => {
+    const { docsSource } = await import("@/lib/docs-source");
+    const page = docsSource.getPage(["ams-discovery-plane"]);
+    if (!page) throw notFound();
+    return { path: page.path, title: page.data.title, description: page.data.description };
+  },
+  head: () => ({
+    meta: [
+      { title: "Hosted discovery plane — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "How a loopover-miner instance opts into the optional hosted discovery-index plane, what it may send, and what never leaves the operator's machine.",
+      },
+      { property: "og:title", content: "Hosted discovery plane — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "How a loopover-miner instance opts into the optional hosted discovery-index plane, what it may send, and what never leaves the operator's machine.",
+      },
+      { property: "og:url", content: "/docs/ams-discovery-plane" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/ams-discovery-plane" }],
+  }),
+  component: AmsDiscoveryPlane,
+});
+
+function AmsDiscoveryPlane() {
+  const { path, title, description } = Route.useLoaderData();
+  const Content = docsClientLoader.getComponent(path);
+  return (
+    <DocsPage eyebrow="Maintainers" title={title} description={description}>
+      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+        <Content />
+      </Suspense>
+    </DocsPage>
+  );
+}

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -80,6 +80,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/ams-sizing", label: "Resource sizing" },
       { to: "/docs/ams-config-precedence", label: "Config precedence" },
       { to: "/docs/ams-env-reference", label: "Env var reference" },
+      { to: "/docs/ams-discovery-plane", label: "Discovery plane (opt-in)" },
       { to: "/docs/self-hosting-docs-audit", label: "Self-host docs audit" },
       { to: "/docs/maintainer-install-trust", label: "Install & trust guide" },
       { to: "/docs/github-app", label: "GitHub App configuration" },

--- a/packages/loopover-miner/docs/discovery-plane-operator-guide.md
+++ b/packages/loopover-miner/docs/discovery-plane-operator-guide.md
@@ -1,5 +1,9 @@
 # Hosted discovery plane — operator guide (opt-in)
 
+> Also published on the docs website: [Hosted discovery plane](https://loopover.ai/docs/ams-discovery-plane)
+> (same content, rendered with search and the rest of the maintainer docs nav). This file remains
+> the canonical source and ships inside the published `@loopover/miner` package.
+
 Operator-facing guide for the **optional** Phase 6 hosted discovery-index plane ([#4250](https://github.com/JSONbored/gittensory/issues/4250)). This is the client/miner half of that roadmap item: how a `loopover-miner` instance opts in, what it may send, and what never leaves the operator's machine.
 
 > **Scope:** the request/response **contract shape**, the telemetry event schema, and the client soft-claim


### PR DESCRIPTION
## Summary

- Adds `content/docs/ams-discovery-plane.mdx` porting `packages/loopover-miner/docs/discovery-plane-operator-guide.md` to the website: the optional hosted discovery-index plane's opt-in-by-default posture (opposite of Orb's opt-out-only export), the shipped request/response contract vs. the still-provisional opt-in env vars, and the never-included/never-retained data boundaries — rendered via the existing `DocsPage`/`Callout`/`CodeBlock`/`FeatureRow` ui-kit primitives, following the pattern set in #6022-#6028.
- Adds `apps/loopover-ui/src/routes/docs.ams-discovery-plane.tsx`, a thin loader + `docsClientLoader` route matching every other migrated docs page.
- Adds the page to `docs-nav.tsx`'s "AMS: deployment" subgroup and to `docs.index.tsx`'s Maintainers audience card, and repoints `ams-deployment.mdx`'s and `ams-operations-runbook.mdx`'s GitHub-blob `discovery-plane-operator-guide.md` cross-references to the new in-app route.
- `packages/loopover-miner/docs/discovery-plane-operator-guide.md` stays as the canonical source (ships inside the published `@loopover/miner` npm package) with a short pointer added to the new website page.
- The provisional/TBD framing (env var names not yet stable API) is preserved with a `warn`-variant `Callout` at the top of the page.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: one new docs page + nav wiring + a cross-reference cleanup in two already-migrated pages.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Closes #6029

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — UI-only page addition under `apps/loopover-ui/**` (outside `coverage.include`); `codecov/patch` does not apply
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` run locally from a clean `npm ci` install, rebased on top of the maintainer's CI cache-hit fix (#6375), green: 906 test files / 17,323 tests passed

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes in this PR
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP behavior changed
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, static docs content only
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI Evidence table — new content page rendered through the same primitives as every other migrated docs page, no visual redesign.
- Continues the "AMS: deployment" nav-subgroup precedent set by #6022-#6028.