### PR TITLE
fix(selfhost): guard pg-adapter's rollback so it can't mask the original batch error

### DIFF
--- a/src/selfhost/pg-adapter.ts
+++ b/src/selfhost/pg-adapter.ts
@@ -71,7 +71,11 @@ export function createPgAdapter(pool: Pool): D1Database {
         await client.query("COMMIT");
         return out;
       } catch (error) {
-        await client.query("ROLLBACK");
+        try {
+          await client.query("ROLLBACK");
+        } catch {
+          /* ignore */
+        }
         throw error;
       } finally {
         client.release();

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -59,6 +59,38 @@ suite("Postgres backend (#977) — real Postgres", () => {
     expect(still?.n).toBe(1); // the DELETE rolled back
   });
 
+  it("regression: a rollback failure never masks the original batch error (#6282)", async () => {
+    // Force the ROLLBACK itself to throw, simulating the exact scenario (a connection failure) where the
+    // original error and a subsequent rollback failure would otherwise race to be the thrown error. Only
+    // ROLLBACK is intercepted -- every other query still runs for real against the live Postgres instance.
+    const realClient = await pool.connect();
+    const originalQuery = realClient.query.bind(realClient);
+    let rollbackAttempted = false;
+    try {
+      // @ts-expect-error -- intentionally narrowing pg's overloaded query() signature for this simulation
+      realClient.query = async (...args: Parameters<typeof originalQuery>) => {
+        if (args[0] === "ROLLBACK") {
+          rollbackAttempted = true;
+          throw new Error("simulated rollback failure");
+        }
+        return originalQuery(...args);
+      };
+      const fakePool = { connect: async () => realClient } as unknown as pg.Pool;
+      const db = createPgAdapter(fakePool);
+
+      await expect(
+        db.batch([
+          db.prepare("INSERT INTO system_flags (key, value) VALUES (?, ?) , bad-sql").bind("z", "1"), // syntax error
+        ]),
+      ).rejects.toThrow(/bad-sql|syntax/i); // the ORIGINAL error surfaces, not "simulated rollback failure"
+      expect(rollbackAttempted).toBe(true);
+    } finally {
+      // batch()'s own `finally` already released this client back to the pool -- just restore the
+      // query override so the shared pool's client isn't left poisoned for later tests.
+      realClient.query = originalQuery;
+    }
+  });
+
   it("prunes rows past the retention window and processJob('prune-retention') does not dead-letter (regression for the live self-host incident: job _selfhost_jobs.id=61132 failed with 'column \"rowid\" does not exist')", async () => {
     const db = createPgAdapter(pool);
     const env = { DB: db } as unknown as Env;


### PR DESCRIPTION
Closes #6282

## Summary

- `pg-adapter.ts`'s `batch()` called `await client.query("ROLLBACK")` unguarded inside its `catch` block — if the rollback itself throws (plausible exactly when the original error was a connection failure), that new error propagated instead of `throw error`, silently discarding the real cause. `d1-adapter.ts`'s `batch()` already wraps its `ROLLBACK` in a defensive `try/catch { /* ignore */ }` for exactly this reason. `pg-adapter.ts` now does the same. `d1-adapter.ts` itself is untouched — it was already correct, per the issue's explicit instruction.
- Added an integration test in `test/integration/selfhost-pg.test.ts` (gated on `PG_TEST_URL`, per the issue's test coverage requirement) that grabs a real client from the pool, intercepts its `ROLLBACK` call to force it to throw, and confirms the original batch error (a real SQL syntax error) still surfaces rather than the synthetic rollback failure.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6282.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — root `tsc --noEmit` reliably OOMs on this shared sandbox regardless of what changed (reproduced repeatedly this session). This change is a 4-line `try/catch` wrap plus a new integration test; ran the whole root diff-check clean and the actual integration test suite against real Postgres (below).
- [x] `npm run test:coverage` — `src/selfhost/pg-adapter.ts` is exempt from Codecov's unit-coverage requirement per `codecov.yml` (validated by the real-Postgres integration test instead, per the issue's own Test Coverage Requirements). **Actually ran the integration test against a real local Postgres 16 container** (`docker run -d -e POSTGRES_PASSWORD=devpw -e POSTGRES_DB=gittensory -p 55432:5432 postgres:16`, per the test file's own header instructions): all 7 tests in `test/integration/selfhost-pg.test.ts` pass, including the new regression test. Verified the new test genuinely catches the bug — reverted just the `pg-adapter.ts` fix via `git stash` and confirmed the test fails (`expected ... to throw error matching /bad-sql|syntax/i but got 'simulated rollback failure'`) before re-confirming it passes with the fix restored.
- [x] `npm run test:workers` — N/A, no Worker-facing code changed (this path is self-host-only).
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A, no `@loopover/mcp` changes.
- [x] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — the new regression test was verified to genuinely fail without the fix (via `git stash`) before confirming it passes with it, against a real Postgres instance, not a mock.

If any required check was skipped, explain why:

- Root `npm run typecheck`: reliably OOMs on this shared sandbox under memory pressure from concurrent sessions, independent of the diff. This is a small, self-contained change (one guarded `try/catch`, no new type surface) verified by real integration testing against actual Postgres instead.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, but this IS a negative-path fix for the self-host Postgres backend, with a dedicated regression test for the failure path.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- The issue's Links & Resources section names the test file as `test/integration/selfhost-pg.ts` — the actual file is `test/integration/selfhost-pg.test.ts` (confirmed via repo search; the `.ts`-only name doesn't exist).
