### PR TITLE
chore(rees): remove dead captureError export in review-enrichment/src/sentry.ts

### DIFF
--- a/review-enrichment/src/sentry.ts
+++ b/review-enrichment/src/sentry.ts
@@ -150,19 +150,6 @@ export async function initSentry(env: NodeJS.ProcessEnv): Promise<boolean> {
   }
 }
 
-export function captureError(error: unknown, context?: Record<string, unknown>): void {
-  captureScopedError(error, {
-    contextName: "rees",
-    context: {
-      ...context,
-      release: activeRelease,
-      environment: activeEnvironment,
-    },
-    fingerprint: ["rees-error"],
-    tags: {},
-  });
-}
-
 export function captureRouteError(
   error: unknown,
   context: { route: string; method: string },


### PR DESCRIPTION
Closes #6253

## Summary

- Remove `captureError` from `review-enrichment/src/sentry.ts` — a generic Sentry-capture wrapper with zero real (non-`dist/`) callers anywhere in the repo. Every real call site already uses one of its more specific siblings instead: `captureRouteError`, `captureUnhandledError`, `captureSourcemapUploadFailure`, `captureAnalyzerDegradation`.
- No test changes needed: `review-enrichment`'s existing tests (`sentry-upload.test.ts`, `sentry-degradation.test.ts`, `sentry-release-validation.test.ts`, and the full `review-enrichment` suite) never referenced `captureError`, so they continue passing unchanged, matching the issue's own deliverable.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6253.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` (root) — root `tsc --noEmit` reliably OOMs on this shared sandbox regardless of what changed (reproduced repeatedly this session). `review-enrichment` has its own independent, much lighter typecheck (`npm --prefix review-enrichment run build`, i.e. `tsc -p tsconfig.json`) — ran it directly and it passes clean, confirming zero type errors from the removal (no lingering references anywhere in `review-enrichment/src/**` or `review-enrichment/test/**`).
- [x] `npm run test:coverage` — not run repo-wide (same OOM risk); this is a pure deletion of dead code with no new lines, so patch coverage is inherently 100% on the diff. `review-enrichment` uses its own `node --test` runner (not vitest) — ran the **full** `review-enrichment` test suite directly: 1335/1335 passing, unchanged.
- [x] `npm run test:workers` — N/A, no Worker-facing code changed.
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A, no `@loopover/mcp` changes.
- [x] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — N/A, this removes dead code only; no behavior changed, confirmed by the full unchanged 1335-test suite still passing.

If any required check was skipped, explain why:

- Root `npm run typecheck` / `npm run test:coverage`: reliably OOMs on this shared sandbox under memory pressure from concurrent sessions, independent of the diff. Substituted with `review-enrichment`'s own independent `tsc` build (clean) and its full `node --test` suite (1335/1335 passing).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- Confirmed via `grep -rn "\bcaptureError\b" review-enrichment/src/ review-enrichment/test/` (excluding the gitignored `dist/` build output) that no code imports it — matching the issue's finding exactly. Note `src/selfhost/sentry.ts`'s own separate `captureError` export (a different, actively-used function in the main repo, not `review-enrichment`) is untouched.
