### PR TITLE
fix(selfhost): raise ollama's default batch size to match bge-m3's context window

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -430,6 +430,12 @@ services:
       # Reviews land in bursts, not constant load -- keep both models warm across typical gaps between
       # bursts instead of Ollama's 5m default forcing a cold-start reload every time.
       OLLAMA_KEEP_ALIVE: "${OLLAMA_KEEP_ALIVE:-30m}"
+      # bge-m3's real context window is 8192 tokens, but Ollama's own default batch size (2048) is well
+      # below that -- confirmed in production logs ("input (N tokens) is too large to process") on RAG
+      # chunks up to ~4991 tokens, each one silently dropped from that PR's review context
+      # (rag_embed_batch_degraded, src/review/rag.ts's per-item fallback). The embed request itself
+      # (src/selfhost/ai.ts) has no way to set this per-call -- it's server-side only.
+      OLLAMA_NUM_BATCH: "${OLLAMA_NUM_BATCH:-8192}"
     # Ollama can load multi-GB models into memory; raised from the single-embedder-era default (8g) now that
     # a vision model (#4335) shares this container's memory ceiling alongside bge-m3 -- still capped so a
     # runaway pull can't exhaust host RAM and take down the core review pipeline (#1828).


### PR DESCRIPTION
## Summary
- Ollama's own default `num_batch` (2048) is well under bge-m3's real 8192-token context window.
- Confirmed live via Loki: RAG chunks up to ~4991 tokens were being rejected by Ollama ("input (N tokens) is too large to process. increase the physical batch size"), 263 occurrences in a 3-hour window on one self-host instance -- silently dropped from that PR's review context by `rag.ts`'s existing per-item degrade-instead-of-fail-whole-batch fallback (working as designed, just papering over an under-provisioned server default).
- The embed request itself (`src/selfhost/ai.ts`, an OpenAI-compatible `/embeddings` call) has no per-call way to set this -- it's Ollama server config only.
- Adds `OLLAMA_NUM_BATCH: "${OLLAMA_NUM_BATCH:-8192}"` alongside the ollama service's existing tuning knobs, same override pattern.

## Test plan
- [x] `docker compose config --quiet` validates cleanly
- [x] Applied live on the affected self-host box (via its own `docker-compose.override.yml` as an immediate stopgap ahead of this PR reaching it through a normal deploy); confirmed the env var is loaded and no new "too large" errors in the minutes after restart
- No application code changed; config-only.