### PR TITLE
fix(ci): check-mcp-package imports the shared secret-shape detector

### DIFF
--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -2,6 +2,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";
 import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
 
 const result = spawnSync("npm", ["pack", "--workspace", "@loopover/mcp", "--dry-run", "--json"], {
@@ -17,7 +18,6 @@ const [pack] = JSON.parse(result.stdout);
 const files = pack.files.map((file) => file.path).sort();
 const allowed = MCP_PACKAGE_ALLOWED_FILE_PATTERNS;
 const forbiddenPath = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
-const forbiddenContent = /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
 const stalePackageText = /(private beta|zeronode\.workers\.dev|preview URL)/i;
 
 for (const file of files) {
@@ -25,7 +25,7 @@ for (const file of files) {
   if (!allowed.some((pattern) => pattern.test(file))) throw new Error(`Unexpected file in MCP package: ${file}`);
   const fullPath = join("packages/loopover-mcp", file);
   const content = readFileSync(fullPath, "utf8");
-  if (forbiddenContent.test(content)) throw new Error(`Secret-like content found in MCP package file: ${file}`);
+  if (FORBIDDEN_CONTENT.test(content)) throw new Error(`Secret-like content found in MCP package file: ${file}`);
   if (file === "README.md" && stalePackageText.test(content)) throw new Error(`Stale public-package wording found in MCP package file: ${file}`);
 }
 

--- a/test/unit/forbidden-content.test.ts
+++ b/test/unit/forbidden-content.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { FORBIDDEN_CONTENT } from "../../scripts/forbidden-content.mjs";
+
+// forbidden-content.mjs calls itself the "single source of truth" for the packaged secret-shape detector, but
+// nothing enforced that: check-mcp-package.mjs re-declared the regex as its own literal and drifted silently
+// (#6290). These assertions are source-level on purpose — both checkers run their `npm pack` dry-run at import
+// time and export nothing, so a test cannot import them to compare the constants by identity.
+const PACKAGE_CHECKERS = ["scripts/check-miner-package.mjs", "scripts/check-mcp-package.mjs"];
+
+describe("FORBIDDEN_CONTENT is the single source of truth (#6290)", () => {
+  it.each(PACKAGE_CHECKERS)("%s imports the shared constant rather than re-declaring it", (checker) => {
+    const source = readFileSync(checker, "utf8");
+    expect(source).toContain('import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";');
+    expect(source).toContain("FORBIDDEN_CONTENT.test(");
+    // A re-declared literal is exactly the drift this guards: a local `const ...Content = /.../` detector.
+    expect(source).not.toMatch(/const\s+\w*[Ff]orbidden[Cc]ontent\s*=\s*\//);
+  });
+
+  it("is a stateless matcher, so both checkers can share the one instance safely", () => {
+    // A /g regex would carry lastIndex across .test() calls and make shared use order-dependent.
+    expect(FORBIDDEN_CONTENT.global).toBe(false);
+    expect(FORBIDDEN_CONTENT.sticky).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6290

- `scripts/forbidden-content.mjs` declares itself the "single source of truth" for the packaged secret-shape detector, and `check-miner-package.mjs` imports it. `check-mcp-package.mjs` instead re-declared the identical regex as its own local literal, so the two could drift apart silently — and nothing asserted they stayed equal.
- `check-mcp-package.mjs` now imports `FORBIDDEN_CONTENT`, matching its sibling. The detector is **stateless** (no `global`/`sticky` flag), so sharing a single instance across both checkers is safe — a `/g` regex would carry `lastIndex` between `.test()` calls and make shared use order-dependent.
- Adds a drift guard covering **both** checkers: each must import the shared constant and declare no local detector of its own.
- **1 file changed + 1 test added; the duplicated literal is deleted, not reworded.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- **Verified the guard actually guards**: temporarily restored `main`'s duplicated version and confirmed the new test *fails* against it, then passes with the fix. It is a real drift guard, not a tautology.
- `npm run test:mcp-pack` passes (exit 0) — the real checker still validates the live MCP package end-to-end through the shared constant, so this is a behaviour-preserving swap.
- Ran the affected suites with vitest, all green (**49 tests**): the new `forbidden-content` guard plus `check-miner-package` and `miner-mcp-contract`, the two existing consumers of this constant.
- The new assertions are **source-level by necessity**: both checkers run their `npm pack` dry-run at import time and export nothing, so a test cannot import them to compare the constants by identity. (The missing env-var test seam is separately tracked in #6297 and deliberately out of scope here.)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This **strengthens** a packaging guard: the MCP package checker is now provably driven by the same detector as the miner one, so a future edit to the shared pattern can no longer protect one package while leaving the other behind. No credential-shaped literal is added anywhere — the new test asserts on the regex's flags and on import structure, never on secret-shaped sample values.

## Notes

Closes #6290
