### PR TITLE
chore(mcp): remove dead referenceScorePreviewCommand export in local-branch.js

### DIFF
--- a/packages/loopover-mcp/lib/local-branch.js
+++ b/packages/loopover-mcp/lib/local-branch.js
@@ -1,14 +1,12 @@
 import { execFileSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isCodeFile, isTestPath as isTestFile } from "@loopover/engine/signals/test-evidence";
 import { redactLocalPath } from "./redact-local-path.js";
 
 export { isCodeFile, isTestFile };
 export { redactLocalPath };
-
-const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 function stripTrailingSlashes(value) {
   let end = value.length;
@@ -199,12 +197,6 @@ export function resolveScorePreviewCommand(input = {}) {
   const explicit = input.scorePreviewCommand ?? process.env.GITTENSOR_SCORE_PREVIEW_CMD;
   if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
   return undefined;
-}
-
-export function referenceScorePreviewCommand(kind = "metadata") {
-  const script = kind === "gittensor" ? "gittensor-score-preview.py" : "gittensor-score-preview.mjs";
-  const interpreter = kind === "gittensor" ? "python3" : "node";
-  return `${interpreter} ${join(packageRoot, "scripts", script)}`;
 }
 
 export function referenceScorePreviewExample(kind = "metadata") {

--- a/test/unit/local-scorer-adapter.test.ts
+++ b/test/unit/local-scorer-adapter.test.ts
@@ -5,6 +5,15 @@ function fixtureCommand(name: string) {
   return `node ${join(process.cwd(), "test/fixtures/local-scorer", name)}`;
 }
 
+// Points at the real bundled scorer script the package ships, so this test exercises it end to end.
+// Lives here (not exported from lib/local-branch.js) since this test is its only real caller (#6259) --
+// production guidance text always uses the intentionally generic, path-redacted referenceScorePreviewExample.
+function packagedScorerCommand(kind: "metadata" | "gittensor" = "metadata") {
+  const script = kind === "gittensor" ? "gittensor-score-preview.py" : "gittensor-score-preview.mjs";
+  const interpreter = kind === "gittensor" ? "python3" : "node";
+  return `${interpreter} ${join(process.cwd(), "packages/loopover-mcp/scripts", script)}`;
+}
+
 describe("local scorer adapter", () => {
   const metadata = {
     repoFullName: "entrius/allways-ui",
@@ -96,8 +105,8 @@ describe("local scorer adapter", () => {
 
   it("runs the packaged reference scorer against metadata only", async () => {
     // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
-    const { referenceScorePreviewCommand, runExternalScorePreview } = await import("../../packages/loopover-mcp/lib/local-branch.js");
-    const result = runExternalScorePreview(metadata, referenceScorePreviewCommand("metadata"));
+    const { runExternalScorePreview } = await import("../../packages/loopover-mcp/lib/local-branch.js");
+    const result = runExternalScorePreview(metadata, packagedScorerCommand("metadata"));
     expect(result.ok).toBe(true);
     expect(result.payload).toMatchObject({
       sourceTokenScore: expect.any(Number),


### PR DESCRIPTION
Closes #6259

## Summary

- Investigated both directions the issue offers before picking one: `referenceScorePreviewCommand` (computes the real, absolute path to the bundled scorer via `packageRoot`) vs. `referenceScorePreviewExample` (a hardcoded `./node_modules/@loopover/mcp/scripts/...` string used in guidance text).
- **Wiring `referenceScorePreviewCommand` into guidance text would have been a regression, not a fix.** `test/unit/local-scorer-adapter.test.ts`'s existing "redacts local paths from scorer diagnostics and setup guidance" test explicitly asserts the guidance text (a) never contains the real local filesystem path and (b) matches `/node_modules\/@loopover\/mcp\/scripts\//` — i.e. the generic relative example is intentional, deliberately avoiding leaking an absolute local path (which could embed a username or other identifying info) into text a user might copy elsewhere. `referenceScorePreviewExample` is correct as-is; left untouched.
- `referenceScorePreviewCommand`'s real (and legitimate) use was as a test helper: `local-scorer-adapter.test.ts`'s "runs the packaged reference scorer against metadata only" test uses it to invoke the actual bundled scorer script end to end — a genuinely valuable smoke test, not dead functionality. Removing it outright would have thrown that test coverage away.
- Resolution: moved the packaged-scorer path resolution into the test file itself (a small local helper using the same `join(process.cwd(), ...)` pattern the test's neighboring `fixtureCommand()` helper already uses), since the test is genuinely its only real caller. Removed the now-orphaned `referenceScorePreviewCommand` export, `packageRoot`, and the resulting unused `dirname` import from `lib/local-branch.js`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6259.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` (root) — reliably OOMs on this shared sandbox regardless of what changed (reproduced repeatedly this session). `packages/loopover-mcp` is plain JS with its own `npm run build` (`node --check` across every lib/bin file) — ran it directly and it passes clean.
- [x] `npm run test:coverage` — not run repo-wide (same OOM risk); this change touches a `packages/loopover-mcp/**` JS file (not `src/**`) and a test file, so `codecov/patch` scope is minimal. Ran the full set of tests that import from `local-branch.js`: `local-scorer-adapter.test.ts` (7), `local-branch.test.ts` (59), `mcp-release-candidate.test.ts` (20) — 86/86 passing, including the "runs the packaged reference scorer against metadata only" smoke test still genuinely invoking the real bundled script, and the redaction test confirming guidance text is unaffected.
- [x] `npm run test:workers` — N/A, no Worker-facing code changed.
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A wiring, but `packages/loopover-mcp`'s own `npm run build` (syntax-checks every lib/bin file including the edited `local-branch.js`) passes clean.
- [x] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — N/A new behavior; this preserves existing test coverage (the real-scorer smoke test) while removing the export it no longer needs to come from production code.

If any required check was skipped, explain why:

- Root `npm run typecheck` / `npm run test:coverage`: reliably OOMs on this shared sandbox under memory pressure from concurrent sessions, independent of the diff. Substituted with `packages/loopover-mcp`'s own lighter build check (clean) and the full set of directly-affected tests (86/86 passing).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no MCP tool surface changed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- Confirmed via `grep -rn "referenceScorePreviewCommand\b"` across the repo (excluding `node_modules`) that zero references remain after the change.
