### PR TITLE
chore(signals): converge change-guardrail.ts and preflight-limits.ts onto their @loopover/engine shims

### DIFF
--- a/src/signals/change-guardrail.ts
+++ b/src/signals/change-guardrail.ts
@@ -1,168 +1,20 @@
-// Convergence safety: the hard-guardrail path check for the auto-maintain layer (#778). Changed paths that
-// match a repo's configured hardGuardrailGlobs force MANUAL review — loopover must never auto-merge OR
-// auto-close a PR that touches a guarded path. Ported verbatim from
-// reviewbot core/change-classifier.ts — the mechanism that prevents the awesome-claude #4196 incident class
-// (a weakened policy script auto-merging because its path wasn't guarded). Pure + dependency-free.
-
-// Canonicalize a path or glob so matching is case- and separator-insensitive: backslashes → `/`, drop a
-// leading `./` or `/`, and case-fold. Mirrors signals/focus-manifest `normalizePathForMatch` — without it a
-// guarded path is evaded with `.github/Workflows/` (capital W), a `./`-prefix, or a `\` separator, turning a
-// mandatory human hold on CI/policy files into an auto-merge.
-export function canonicalize(value: string): string {
-  return value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "").toLowerCase();
-}
-
-// globToRegExp's COMPILATION is linear-time, but the COMPILED pattern's .test() can be polynomial-to-exponential
-// time on an adversarial near-miss input when MULTIPLE wildcard GROUPS chain in one glob (a "group" is one `*`
-// OR one `**` — a `**` pair compiles to a SINGLE `.*`, not two independent wildcards, so it must be counted as
-// ONE group, not two characters; see countWildcardGroups below). Both group TYPES contribute to the same danger
-// once chained — `[^/]*` groups separated by a literal that class doesn't exclude (e.g. "-", not "/") back-
-// track ambiguously, and `.*` groups back-track ambiguously EVEN when "/"-separated, since `.*` crosses `/`
-// freely. Re-benchmarked against `path` lengths GitHub can plausibly deliver via a deeply nested file path in a
-// malicious PR (both `path` and, via `.loopover.yml`'s contentLane.*Glob fields, the glob itself can be
-// attacker-influenced in the same PR):
-//   2 wildcard groups (any mix of `*`/`**`, any arrangement): sub-second even at a wildly implausible 32,000-
-//                       char adversarial path (worst case observed: ~400ms) — quadratic, bounded, never a
-//                       realistic hang.
-//   3 wildcard groups: OVER 2 SECONDS at just ~4,000 chars for one chained-`*` shape, over 100ms at ~1,600
-//                       chars for a chained-`**` shape — already dangerous well within a plausible path length.
-//   4+ wildcard groups: confirmed catastrophic — 35 SECONDS at just 1,614 chars for 4 chained `**` groups.
-// hardGuardrailGlobs are maintainer-configured, and this compiler is also exported for reuse by other
-// maintainer-config-driven consumers (content-lane/spec-resolver.ts, whose real globs like "public/**/*.json" are
-// exactly 2 groups: this cap must stay inclusive of that legitimate shape, not just "safer than before"), so the
-// cap lives INSIDE globToRegExp itself (not just in a wrapper like matchesAny below) — every caller is
-// protected automatically rather than needing to separately remember the risk. The boundary is set at the
-// highest GROUP count proven safe by the benchmark above (2) — a boundary that itself sits inside the
-// empirically dangerous range would defeat the point of a cap.
-const MAX_GLOB_WILDCARD_GROUPS = 2;
-
-/** Count `*` GROUPS in `glob` — a `**` pair is ONE group (it compiles to a single `.*`, see globToRegExp), not
- *  two. Mirrors globToRegExp's own tokenization exactly (including consuming a `**`'s trailing `/`) so the count
- *  reflects the actual number of backtracking-capable groups the compiled RegExp will contain, not raw `*`
- *  character count (which would double-count every globstar and reject legitimate globs like
- *  "public/**\/*.json" — 2 real groups — as if they were 3-groups-dangerous). */
-function countWildcardGroups(glob: string): number {
-  let count = 0;
-  for (let i = 0; i < glob.length; i += 1) {
-    if (glob.charAt(i) !== "*") continue;
-    count += 1;
-    if (glob.charAt(i + 1) === "*") {
-      i += 1; // consume the second star of the "**" pair — one group, not two
-      if (glob.charAt(i + 1) === "/") i += 1; // `**/` also matches zero segments, mirroring globToRegExp
-    }
-  }
-  return count;
-}
-
-/** True if `glob` has more wildcard GROUPS than can be safely compiled to a RegExp without risking catastrophic
- *  backtracking (see the MAX_GLOB_WILDCARD_GROUPS rationale above). Exported so any OTHER glob-accepting config
- *  surface (e.g. focus-manifest.ts's contentLane.*Glob parsing) can reject an over-complex glob using the SAME
- *  predicate globToRegExp itself enforces — a caller with its own, independently-counted threshold could accept
- *  a glob globToRegExp then silently compiles to NEVER_MATCHES, configuring a lane that can never activate. */
-export function hasUnsafeWildcardCount(glob: string): boolean {
-  return countWildcardGroups(glob) > MAX_GLOB_WILDCARD_GROUPS;
-}
-
-// A RegExp that never matches any input, at any position — the safe, conservative compiled form of an
-// over-complex glob. "Never matches" (not "matches everything") is the correct default HERE because
-// globToRegExp has no context on caller intent, and a false "matches everything" would be actively wrong for a
-// non-guardrail caller (e.g. content-lane file-scope matching, where "matches everything" would misclassify
-// every changed file as a registry submission). A caller whose OWN semantics want the opposite fail direction
-// (a security guardrail, where under-protection is worse than an unnecessary hold) checks hasUnsafeWildcardCount
-// itself and overrides — see matchesAny below.
-const NEVER_MATCHES = /^(?!)$/;
-
-/** Convert a path glob (`*` matches within a segment, `**` matches across `/`) to an anchored RegExp. The
- *  glob is canonicalized first, so matching is case-insensitive against a canonicalized path. Exported for
- *  reuse anywhere a maintainer-supplied path pattern needs compiling — never compile a raw regex string from
- *  config (ReDoS risk); this linear-time glob compiler is the one safe path pattern this codebase uses.
+/**
+ * Convergence: the hard-guardrail path check for the auto-maintain layer (#778), extracted to
+ * `@loopover/engine` so the maintainer gate and the miner's own gate-prediction share the identical,
+ * versioned matching logic instead of drifting apart (#6202/#6204). See the engine module's doc
+ * comment for the full incident-prevention rationale (the awesome-claude #4196 class).
  *
- *  An over-complex glob (see MAX_GLOB_WILDCARD_GROUPS) short-circuits to NEVER_MATCHES instead of being compiled —
- *  this function never returns a RegExp that risks catastrophic backtracking on .test(), for any input. */
-export function globToRegExp(glob: string): RegExp {
-  if (hasUnsafeWildcardCount(glob)) return NEVER_MATCHES;
-  const canonical = canonicalize(glob);
-  let re = "";
-  for (let i = 0; i < canonical.length; i += 1) {
-    const c = canonical.charAt(i);
-    if (c === "*") {
-      if (canonical.charAt(i + 1) === "*") {
-        re += ".*";
-        i += 1;
-        if (canonical.charAt(i + 1) === "/") i += 1; // `**/` also matches zero segments
-      } else {
-        re += "[^/]*";
-      }
-    } else if (/[.+?^${}()|[\]\\]/.test(c)) {
-      re += `\\${c}`;
-    } else {
-      re += c;
-    }
-  }
-  return new RegExp(`^${re}$`);
-}
-
-/**
- * True if `path` matches any of the globs (`*` within a segment, `**` across `/`), case-insensitively. A glob
- * with more wildcards than can be safely compiled (see hasUnsafeWildcardCount) is treated as matching EVERY
- * path — fail SAFE TOWARD GUARDING, mirroring isGuardrailHit's own "unknown ⇒ treat as a hit" philosophy (an
- * over-complex guardrail glob still forces manual review) rather than the NEVER_MATCHES default globToRegExp
- * itself falls back to, which would silently disable the maintainer's intended protection — the worse failure
- * mode for a safety guardrail specifically (see globToRegExp's own docstring for why NEVER_MATCHES is still the
- * right default for globToRegExp as a general-purpose compiler).
+ * packages/loopover-engine/src/signals/change-guardrail.ts (imported via relative source path, not
+ * the published module, matching this directory's existing duplicate-winner.ts shim) is the source
+ * of truth.
  */
-export function matchesAny(path: string, globs: string[]): boolean {
-  const canonicalPath = canonicalize(path);
-  return globs.some((g) => hasUnsafeWildcardCount(g) || globToRegExp(g).test(canonicalPath));
-}
-
-/**
- * The changed paths (if any) that trip a hard guardrail. A non-empty result means the PR touches a guarded
- * path and MUST fall through to a human — loopover may neither auto-merge nor auto-close it. Pure.
- */
-export function changedPathsHittingGuardrail(changedPaths: string[], hardGuardrailGlobs: string[]): string[] {
-  if (hardGuardrailGlobs.length === 0) return [];
-  return changedPaths.filter((path) => path.length > 0 && matchesAny(path, hardGuardrailGlobs));
-}
-
-export type GuardrailPathMatch = {
-  path: string;
-  glob: string;
-};
-
-/**
- * Structured guardrail match details for public review output + audit logs. Over-complex globs preserve the
- * same fail-safe direction as {@link matchesAny}: they match every non-empty path rather than silently disabling
- * a maintainer's guardrail. Unknown changed paths are represented by {@link isGuardrailHit}'s boolean path only,
- * so callers can say "paths unavailable" without inventing a fake path.
- */
-export function guardrailPathMatches(changedPaths: string[], hardGuardrailGlobs: string[]): GuardrailPathMatch[] {
-  if (hardGuardrailGlobs.length === 0 || changedPaths.length === 0) return [];
-  const matches: GuardrailPathMatch[] = [];
-  for (const path of changedPaths) {
-    if (path.length === 0) continue;
-    const canonicalPath = canonicalize(path);
-    for (const glob of hardGuardrailGlobs) {
-      if (hasUnsafeWildcardCount(glob)) {
-        matches.push({ path, glob });
-        continue;
-      }
-      if (globToRegExp(glob).test(canonicalPath)) {
-        matches.push({ path, glob });
-      }
-    }
-  }
-  return matches;
-}
-
-/**
- * Whether a PR's diff trips a hard guardrail — the BOOLEAN form shared by the disposition (held for owner
- * review) and the public comment (so the headline reads "held", not "safe to merge"). FAIL-SAFE on unknown
- * paths (#1062): when guardrails ARE configured but the changed-file set is empty (the cache is not yet / no
- * longer populated), we cannot prove the PR avoids a guarded path, so treat it as a hit. No guardrails
- * configured ⇒ never a hit. Pure.
- */
-export function isGuardrailHit(changedPaths: string[], hardGuardrailGlobs: string[]): boolean {
-  if (hardGuardrailGlobs.length === 0) return false;
-  return changedPaths.length === 0 || changedPathsHittingGuardrail(changedPaths, hardGuardrailGlobs).length > 0;
-}
+export {
+  canonicalize,
+  hasUnsafeWildcardCount,
+  globToRegExp,
+  matchesAny,
+  changedPathsHittingGuardrail,
+  type GuardrailPathMatch,
+  guardrailPathMatches,
+  isGuardrailHit,
+} from "../../packages/loopover-engine/src/signals/change-guardrail";

--- a/src/signals/preflight-limits.ts
+++ b/src/signals/preflight-limits.ts
@@ -1,14 +1,8 @@
-export const PREFLIGHT_LIMITS = {
-  repoFullNameChars: 200,
-  contributorLoginChars: 100,
-  titleChars: 300,
-  bodyChars: 20_000,
-  labelChars: 100,
-  changedFileChars: 300,
-  testChars: 300,
-  authorAssociationChars: 100,
-  labels: 50,
-  changedFiles: 200,
-  linkedIssues: 100,
-  tests: 50,
-} as const;
+/**
+ * Convergence (#6202/#6204): extracted to `@loopover/engine` so the maintainer gate and the miner's
+ * own preflight share the identical, versioned limits instead of drifting apart. See this directory's
+ * existing duplicate-winner.ts shim for the same pattern.
+ *
+ * packages/loopover-engine/src/signals/preflight-limits.ts is the source of truth.
+ */
+export { PREFLIGHT_LIMITS } from "../../packages/loopover-engine/src/signals/preflight-limits";

--- a/test/unit/check-engine-parity-script.test.ts
+++ b/test/unit/check-engine-parity-script.test.ts
@@ -95,10 +95,12 @@ describe("check-engine-parity script", () => {
     // Floor tracks the count of still-hand-duplicated in-scope twins, minus a small margin so unrelated
     // additions don't trip it while a broken scanner returning ~0 still does. #6194 converged the last four
     // settings twins (autonomy/command-authorization/contributor-blacklist/pr-type-label) onto their engine
-    // shims, so the floor drops from 14 to 10 — the `.some()` structural checks below are the real guard.
-    expect(pairs.length).toBeGreaterThanOrEqual(10);
+    // shims, dropping the floor from 14 to 10. #6204 converged two more (change-guardrail.ts and
+    // preflight-limits.ts, both in src/signals/) onto their shims, dropping the real count to 9 — the
+    // `.some()` structural checks below are the real guard.
+    expect(pairs.length).toBeGreaterThanOrEqual(9);
     expect(pairs.some((pair: EngineParityPair) => pair.fileName === "guardrail-config.ts")).toBe(true);
-    expect(pairs.some((pair: EngineParityPair) => pair.fileName === "change-guardrail.ts")).toBe(true);
+    expect(pairs.some((pair: EngineParityPair) => pair.fileName === "change-guardrail.ts")).toBe(false);
     expect(pairs.some((pair: EngineParityPair) => pair.fileName === "duplicate-winner.ts")).toBe(false);
     expect(pairs.some((pair: EngineParityPair) => pair.fileName === "check-names.ts")).toBe(false);
   });


### PR DESCRIPTION
Closes #6204

## Summary

- Part of the `src/` ↔ `@loopover/engine` convergence epic (#6202). `src/signals/change-guardrail.ts` and `src/signals/preflight-limits.ts` were byte-identical full duplicates of their `packages/loopover-engine/src/signals/` counterparts (re-confirmed via `diff` immediately before converting, per the issue's own requirement).
- Converted both to thin re-export shims, matching this same directory's already-correct `duplicate-winner.ts` pattern exactly (doc-comment shape, relative-source-path import style).
- The engine-side files (`packages/loopover-engine/src/signals/change-guardrail.ts`, `preflight-limits.ts`) are the canonical implementation and are completely untouched — confirmed via `git diff upstream/main -- packages/loopover-engine/src/signals/change-guardrail.ts packages/loopover-engine/src/signals/preflight-limits.ts` showing zero diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6204.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` (root) — reliably OOMs on this shared sandbox regardless of what changed (reproduced repeatedly this session). Ran `npm run build --workspace @loopover/engine` (the lighter, independent cross-package typecheck) clean, and `npm run engine-parity:drift-check` reports all 14 hand-duplicated (twin) file pairs still agree and the engine version check passes — this convergence doesn't touch the twin-pair list, it converts two *fully-duplicated* files to shims instead.
- [x] `npm run test:coverage` — not run repo-wide (same OOM risk). Ran every real importer's test suite directly: `change-guardrail.test.ts` (20), `agent-guardrail-paths.test.ts` (6), `signals-coverage.test.ts` (50), `predicted-gate-engine-coverage.test.ts` (21), `predicted-gate-engine-branch-coverage.test.ts` (7), `processors-public-comment-merge-facts.test.ts` (13) — 117/117 passing, all unchanged from before the shim conversion (per the issue's own deliverable). Also ran `npm run test:live-gate-parity` (15 tests) and `npm run test:engine-parity` (15 tests) — both pass, directly relevant since this change touches the exact gate-decision logic those contract suites cross-check.
- [x] `npm run test:workers` — N/A, no Worker-facing behavior changed (pure re-export, same runtime values).
- [x] `npm run build:mcp` / `npm run test:mcp-pack` — N/A, no `@loopover/mcp` changes.
- [x] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — N/A, no `apps/loopover-ui` changes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — N/A new behavior (pure convergence to a re-export); the full existing test suite for both files' consumers passes unchanged, confirming the shim is behaviorally identical to the prior full duplicate.

If any required check was skipped, explain why:

- Root `npm run typecheck` / `npm run test:coverage`: reliably OOMs on this shared sandbox under memory pressure from concurrent sessions, independent of the diff. Substituted with `@loopover/engine`'s own build (clean), the engine-parity drift check (clean, 14/14 twin pairs agree), and every real importer's test suite plus both gate-parity contract suites (132 tests total, all passing).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- Both files' full public surface (functions, the `GuardrailPathMatch` type, and `PREFLIGHT_LIMITS`) is re-exported unchanged — every consumer's import statement continues to resolve to the identical runtime values, just sourced from the canonical engine module now.
