### PR TITLE
docs: cover MCP tool-call telemetry in the privacy boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ LoopOver keeps sensitive context private by default.
 - Public GitHub comments never include wallet, hotkey, reward estimate, private ranking, raw trust score, or reviewability context.
 - Optional AI summaries receive compact deterministic signal bundles, not raw source code.
 - Maintainer packets and scoring context stay on protected API/MCP surfaces.
+- MCP tool-call telemetry is an allowlist of four fields, and is anonymous — see below.
+
+### MCP telemetry
+
+A recorded MCP tool call carries exactly four fields, and there is no fifth: the **tool name**, which **surface**
+dispatched it (`remote` or `local`), whether it **succeeded**, and a **coarse duration** in milliseconds. The
+allowlist is the event shape itself rather than a filter over a richer one, so there is nowhere to put anything
+else.
+
+**Never tracked:** tool arguments, source contents, repository or issue text, and wallet, hotkey, coldkey, reward,
+private ranking, or raw trust-score data. Events also carry no per-actor identity — every event shares one
+constant, anonymous handle, so there is no per-user profile to accumulate — and IP-based geo enrichment is
+disabled.
+
+Each surface is controlled separately, and they differ in who holds the switch:
+
+- **Local CLI** (`@loopover/mcp`) — **opt-in, OFF by default.** Nothing is recorded unless you have run
+  `loopover-mcp telemetry enable`; an API key alone is not enough. `loopover-mcp telemetry status` reports the
+  current state, and `disable` removes the flag entirely.
+- **Hosted / remote MCP** — a **deployment** setting, not a per-user one: it records when the operator configures
+  `POSTHOG_API_KEY`, which the hosted service does. A self-hosted deployment that leaves it unset records nothing.
 
 See [Privacy and security](https://loopover.ai/docs/privacy-security) for the full boundary.
 

--- a/packages/loopover-mcp/README.md
+++ b/packages/loopover-mcp/README.md
@@ -285,6 +285,28 @@ loopover-mcp telemetry status
 
 Enabling persists a top-level `telemetryEnabled` flag in the same config file `loopover-mcp login` uses, so the choice survives across CLI invocations. `status`, `doctor`, and `config` all report the current opt-in state. Add `--json` to any of these for machine-readable output.
 
+Opting in is necessary but not sufficient: the CLI also needs `LOOPOVER_MCP_POSTHOG_API_KEY` to be set before
+anything leaves your machine. With the flag off — the default — the key is ignored entirely.
+
+### What a tool call records
+
+Exactly four fields, and there is no fifth:
+
+| Field | Example | What it is |
+|---|---|---|
+| `tool` | `predict_gate` | The MCP tool name. |
+| `caller_type` | `local` | Which surface dispatched it (`local` for this CLI). |
+| `ok` | `true` | Whether the call succeeded. |
+| `duration_ms` | `142` | Coarse wall-clock duration. |
+
+**Never recorded:** your tool arguments, source contents, diffs, repository or issue text, file paths, and any
+wallet, hotkey, coldkey, reward, private ranking, or raw trust-score data. Events carry no identity of yours
+either — every event shares one constant, anonymous handle, and IP-based geo enrichment is disabled — so the data
+is a fleet-level count of which tools get used, not a record of what you did.
+
+Telemetry is best-effort and never affects a command: if PostHog is unreachable or errors, the CLI records nothing
+and behaves exactly as it would with telemetry off.
+
 ## Offline decision-pack fallback
 
 Successful `decision-pack` and MCP `loopover_get_decision_pack` calls store a bounded last-good local cache entry keyed by API version and login. If the API or network is temporarily unavailable, the wrapper can return that last-good guidance as `source: "local_cache"` with `stale: true`, `cachedAt`, and rerun guidance. Auth and permission failures do not use stale fallback data.


### PR DESCRIPTION
## Summary

The Privacy Boundary section documents every other place data leaves a user's machine, but never mentioned MCP telemetry — so the surface added most recently was the one a reader had to read source code to understand. A privacy commitment is only worth what it covers.

**Root `README.md`** gains an `### MCP telemetry` subsection under the existing Privacy Boundary: the four-field allowlist, what is never recorded, and the fact that each surface is controlled separately (with different people holding the switch).

**`packages/loopover-mcp/README.md`** already documented the opt-in default and the exact `enable`/`disable`/`status` syntax — that deliverable was effectively already met. What was missing was *what a call actually records*, so that's added as a field table, plus the second gate: opting in is necessary but **not sufficient**, since the CLI also needs `LOOPOVER_MCP_POSTHOG_API_KEY` before anything leaves the machine.

Documentation only, as the issue requires. No code changes.

## Two places I diverged from the issue, after checking the code

The issue's Expected Outcome asks for a *clear, **accurate*** statement, so where its wording and the code disagreed, I followed the code:

1. **"remote-server telemetry is on by default"** — not as written. `src/mcp/telemetry.ts` gates recording on the **deployment** setting `POSTHOG_API_KEY`; a self-host that leaves it unset records nothing ("SAFE NO-OP WHEN UNCONFIGURED"). "On by default" is true of the hosted service but false of the software, and this section is read by self-hosters too. I documented it as what it is — a **deployment** setting rather than a per-user one — which is also the sharper contrast with the local CLI, where the switch belongs to the user. This is the "trust posture" difference `lib/telemetry.js` names in its own header.
2. **Local CLI opt-in** — the flag alone isn't enough. `lib/telemetry.js` requires **both** `telemetryEnabled === true` **and** `LOOPOVER_MCP_POSTHOG_API_KEY`. Documented as both gates.

I also documented two things from the code that bear directly on the boundary and weren't in the issue: every event carries **one constant anonymous distinct id** (so no per-user profile accumulates), and **`disableGeoip: true`** (no IP-based location enrichment).

## Verified, not restated

Every claim was checked against both modules rather than copied from the issue:

| Claim | Verified against |
|---|---|
| Exactly 4 fields: `tool`, `caller_type`, `ok`, `duration_ms` | identical `properties` blocks in `src/mcp/telemetry.ts` and `packages/loopover-mcp/lib/telemetry.js` |
| Local needs flag **and** key | `if (options?.telemetryEnabled !== true) return;` + `LOOPOVER_MCP_POSTHOG_API_KEY` |
| Remote gated on deployment env only | `POSTHOG_API_KEY` / `if (!apiKey) return;` |
| Anonymous id, no geo | `MCP_TELEMETRY_DISTINCT_ID = "loopover-mcp"`, `disableGeoip: true` (both surfaces) |
| Never affects a command | both wrappers swallow init/capture failures and record nothing |

## Deliberately left alone

`src/mcp/telemetry.ts`'s header still reads "NOT WIRED YET", which #6237 made stale when it wired the remote dispatch chokepoint (`server.ts` imports `recordMcpToolCall` and calls it once per `tools/call`). That's a code comment, and this issue is documentation-only — flagging it here rather than widening the diff.

## Validation

- [x] `npm run docs:drift-check` — ok (21 feature flags, 20 commands, 13 gate-mode fields, 110 RepositorySettings fields, 85 FocusManifest fields all documented).
- [x] `mcp-release` + `miner-mcp-tool-docs-parity` + `miner-mcp-client-config-doc` — **16/16 pass** (the suites that read package READMEs).
- [x] Confirmed no test pins the root README's content, so nothing canaries this section.
- [x] `git diff --check` — clean. No control bytes introduced. Rebased on latest `main` — no base conflict.

## Coverage

No patch surface: documentation only. Coverage is collected over `src/**`, `packages/loopover-engine/src/**`, and `packages/loopover-miner/lib/**`; neither changed file is code.

## Scope

- [x] Two files, both READMEs (`+43/-0`). No code changes, per the issue.
- [x] No secrets. The env var names documented here are already public in `src/env.d.ts` and the CLI's own help output; no key material appears.
- [x] No changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Documentation of an existing boundary — no behaviour change.
- [x] The section understates nothing: it names the allowlist as exhaustive because the code enforces it as the event shape itself, not as a filter over a richer one.

Closes #6240
