### PR TITLE
docs: document OLLAMA_NUM_BATCH in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -671,6 +671,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # OLLAMA_NUM_PARALLEL=2                      # concurrent requests per loaded model
 # OLLAMA_MAX_LOADED_MODELS=2                 # distinct models kept resident at once
 # OLLAMA_KEEP_ALIVE=30m                      # how long an idle model stays loaded before eviction
+# OLLAMA_NUM_BATCH=8192                      # bge-m3's real context window; Ollama's own default (2048) silently
+#                                            #   drops any RAG chunk larger than that ("input (N tokens) is too
+#                                            #   large to process") instead of erroring loudly
 # OLLAMA_FLASH_ATTENTION=1                   # usually auto-enabled already on supported GPUs (check the ollama
 #                                            #   container's boot log for "Flash Attention was auto, set to
 #                                            #   enabled" to confirm) -- set explicitly anyway, because it is


### PR DESCRIPTION
## Summary
- #6394 added `OLLAMA_NUM_BATCH` to `docker-compose.yml` but the matching `.env.example` documentation never landed in that PR, leaving `test/unit/docker-compose-env-example-parity.test.ts` failing against `main`.
- Adds the missing `# OLLAMA_NUM_BATCH=8192` reference line with the same explanatory comment style as its neighbors.

## Test plan
- [x] `npx vitest run test/unit/docker-compose-env-example-parity.test.ts` (5/5 passing)
- [x] Full local gate (`npm run test:ci`) green