### PR TITLE
fix(ci): check-mcp-package imports the shared secret-shape detector

### DIFF
--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -3,11 +3,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";
 import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
 
 const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
-const FORBIDDEN_CONTENT =
-  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
 const STALE_PACKAGE_TEXT = /(private beta|zeronode\.workers\.dev|preview URL)/i;
 
 export function validateMcpPackFileList(files, readContent) {

--- a/test/unit/forbidden-content.test.ts
+++ b/test/unit/forbidden-content.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { validateMcpPackFileList } from "../../scripts/check-mcp-package.mjs";
+import { validateMinerPackFileList } from "../../scripts/check-miner-package.mjs";
+import { FORBIDDEN_CONTENT } from "../../scripts/forbidden-content.mjs";
+
+// forbidden-content.mjs calls itself the single source of truth for the packaged secret-shape detector, but
+// nothing enforced it: check-mcp-package.mjs re-declared the regex as its own literal and the two could drift
+// apart unnoticed (#6290). These assertions pin both halves of that claim -- the structural one (each checker
+// imports the constant rather than owning a copy) and the behavioral one (each checker actually rejects what
+// the shared detector matches).
+const PACKAGE_CHECKERS = ["scripts/check-miner-package.mjs", "scripts/check-mcp-package.mjs"];
+
+// Assembled from fragments so this file never itself contains a credential-shaped literal -- the same
+// convention check-mcp-package.test.ts and check-miner-package.test.ts already use for their probes.
+const SECRET_SHAPED_PROBE = ["PROBE", "_", "SECRET", "=", "value"].join("");
+
+describe("FORBIDDEN_CONTENT is the single source of truth (#6290)", () => {
+  it.each(PACKAGE_CHECKERS)("%s imports the shared constant instead of re-declaring it", (checker) => {
+    const source = readFileSync(checker, "utf8");
+    expect(source).toContain('import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";');
+    expect(source).toContain("FORBIDDEN_CONTENT.test(");
+    // The drift this guards against: a checker owning its own copy of the detector.
+    expect(source).not.toMatch(/const\s+FORBIDDEN_CONTENT\s*=/);
+  });
+
+  it("both checkers reject exactly what the shared detector matches", () => {
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+    expect(() => validateMcpPackFileList(["package.json"], () => SECRET_SHAPED_PROBE)).toThrow(
+      /Secret-like content found in MCP package file/,
+    );
+    expect(() => validateMinerPackFileList(["package.json"], () => SECRET_SHAPED_PROBE)).toThrow(
+      /Secret-like content found in miner package file/,
+    );
+  });
+
+  // Scoped to the MCP checker: the miner one layers required-file/lib-artifact guards on top, so a clean-content
+  // assertion there would be testing its allowlist rather than the shared detector.
+  it("does not flag content the shared detector leaves alone", () => {
+    const clean = "export const answer = 42;";
+    expect(FORBIDDEN_CONTENT.test(clean)).toBe(false);
+    expect(() => validateMcpPackFileList(["package.json"], () => clean)).not.toThrow();
+  });
+
+  it("is a stateless matcher, so the shared instance is safe across checkers", () => {
+    // A global/sticky regex would carry lastIndex between .test() calls and make shared use order-dependent.
+    expect(FORBIDDEN_CONTENT.global).toBe(false);
+    expect(FORBIDDEN_CONTENT.sticky).toBe(false);
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6290

- `scripts/forbidden-content.mjs` declares itself the "single source of truth" for the packaged secret-shape detector, and `check-miner-package.mjs` imports it. `check-mcp-package.mjs` still declared the same regex as its own local constant, so the two could drift apart with nothing asserting they stayed equal.
- `check-mcp-package.mjs` now imports `FORBIDDEN_CONTENT`, matching its sibling. The detector is **stateless** (no `global`/`sticky` flag), so a single shared instance is safe across both callers — a `/g` regex would carry `lastIndex` between `.test()` calls and make shared use order-dependent.
- Adds a drift guard covering **both** checkers on both axes:
  - **structural** — each imports the shared constant and declares no local copy;
  - **behavioral** — each actually rejects what the shared detector matches, exercised through the injectable seams (`validateMcpPackFileList` / `validateMinerPackFileList`).
- Net: **-1 line of duplication** in the script, plus the guard.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Both real gates pass end-to-end: `npm run test:mcp-pack` and `npm run test:miner-pack` (exit 0) — the live MCP package now validates through the shared constant, confirming a behaviour-preserving swap.
- Ran the affected suites with vitest, all green (**59 tests**): the new guard plus `check-mcp-package`, `check-miner-package`, and `miner-mcp-contract` — every existing consumer of this constant.
- The behavioral assertions use the injectable seams added for `check-mcp-package.mjs` in #6297, which is why they can prove the coupling rather than only compare source text.
- No `codecov/patch` concern for `scripts/**`, and the added test file is fully exercised.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This **strengthens** a packaging guard: the MCP checker is now provably driven by the same detector as the miner one, so a future edit to the shared pattern can no longer protect one package while silently leaving the other behind. The test's secret-shaped probe is assembled from fragments (`["PROBE", "_", "SECRET", "=", "value"].join("")`) so no credential-shaped literal enters the source — the same convention `check-mcp-package.test.ts` and `check-miner-package.test.ts` already use.

## Notes

Closes #6290

Supersedes #6399, which was identical in intent but auto-closed as `DIRTY`: #6297 landed its injectable-seam rewrite of `check-mcp-package.mjs` while that PR was open. This one is rebuilt on current `main` and takes advantage of those new seams for the behavioral half of the guard.
