### PR TITLE
fix(ci): import shared secret-shape detector in check-mcp-package

### DIFF
--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -4,10 +4,9 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
+import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";
 
 const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
-const FORBIDDEN_CONTENT =
-  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
 const STALE_PACKAGE_TEXT = /(private beta|zeronode\.workers\.dev|preview URL)/i;
 
 export function validateMcpPackFileList(files, readContent) {

--- a/test/unit/forbidden-content.test.ts
+++ b/test/unit/forbidden-content.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FORBIDDEN_CONTENT } from "../../scripts/forbidden-content.mjs";
+
+// forbidden-content.mjs bills itself as the "single source of truth" for the packaged secret-shape detector.
+// Both package checkers must consume that one exported constant rather than hand-copying the regex literal, or the
+// two can silently drift and protect one package while leaving the other behind. These guards read the checker
+// sources and assert the shared import stays wired up — a source-level check by necessity, since the checkers run
+// their `npm pack` dry-run behind a main-guard and export nothing to compare by identity.
+const CONSUMERS = ["check-mcp-package.mjs", "check-miner-package.mjs"];
+
+// Vitest runs from the repo root, the same convention the sibling check-*-package tests rely on.
+function readScript(name: string): string {
+  return readFileSync(join(process.cwd(), "scripts", name), "utf8");
+}
+
+describe("forbidden-content shared secret-shape detector", () => {
+  it("exports a stateless detector safe to share across checkers", () => {
+    expect(FORBIDDEN_CONTENT).toBeInstanceOf(RegExp);
+    // A /g (or /y) detector would carry lastIndex between .test() calls and make shared use order-dependent.
+    expect(FORBIDDEN_CONTENT.global).toBe(false);
+    expect(FORBIDDEN_CONTENT.sticky).toBe(false);
+  });
+
+  it.each(CONSUMERS)("%s imports FORBIDDEN_CONTENT from the shared module", (name) => {
+    const source = readScript(name);
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bFORBIDDEN_CONTENT\b[^}]*\}\s*from\s*["']\.\/forbidden-content\.mjs["']/,
+    );
+  });
+
+  it.each(CONSUMERS)("%s declares no local FORBIDDEN_CONTENT literal of its own", (name) => {
+    const source = readScript(name);
+    expect(source).not.toMatch(/(?:const|let|var)\s+FORBIDDEN_CONTENT\s*=/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6290

`scripts/forbidden-content.mjs` declares itself the "single source of truth" for the packaged
secret-shape detector, and `check-miner-package.mjs` imports it. `check-mcp-package.mjs` instead
re-declared the identical regex as its own local literal, so the two could drift apart silently —
and nothing asserted they stayed equal.

- `check-mcp-package.mjs` now imports `FORBIDDEN_CONTENT` from `./forbidden-content.mjs`, matching
  its sibling; the duplicated literal is deleted. The detector is **stateless** (no `/g` or `/y`
  flag), so sharing one instance across both checkers is safe — a global/sticky regex would carry
  `lastIndex` between `.test()` calls and make shared use order-dependent.
- Adds a drift guard (`test/unit/forbidden-content.test.ts`) covering **both** consumers: each must
  import the shared constant and declare no local detector of its own, plus a check that the shared
  export stays stateless.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6290`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:mcp-pack` (exit 0 — the live checker still validates the real MCP package through the shared constant)
- [x] Ran the affected suites (`forbidden-content`, `check-mcp-package`, `check-miner-package`, `miner-mcp-contract`) — all green.
- [x] New drift guard has unit tests for both consumers and the shared export's flags.

Notes on scope of checks:

- **Verified the guard actually guards**: temporarily restored the duplicated local literal (dropping
  the shared import) and confirmed the new test *fails* against it, then passes with the fix. It is a
  real drift guard, not a tautology.
- The assertions are **source-level by necessity**: both checkers run their `npm pack` dry-run behind
  an `import.meta.url` main-guard and export nothing, so a test cannot import them to compare the
  constants by identity.
- The change is confined to `scripts/**` and a `test/**` file, so there is no `src/**` diff for
  `codecov/patch` to measure.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, or private
  rankings are exposed. The new test asserts on the regex's flags and on import structure, never on
  secret-shaped sample values.
- [x] Public GitHub text stays sanitized and low-noise.

This **strengthens** a packaging guard: the MCP package checker is now provably driven by the same
detector as the miner one, so a future edit to the shared pattern can no longer protect one package
while leaving the other behind.
