### PR TITLE
fix(engine): exclude lockfiles and dependency manifests from trivial-churn detection

### DIFF
--- a/packages/loopover-engine/src/signals/slop.ts
+++ b/packages/loopover-engine/src/signals/slop.ts
@@ -1,4 +1,4 @@
-import { isCodeFile, isTestFile, classifyChangedFile } from "./path-matchers.js";
+import { isCodeFile, isTestFile, classifyChangedFile, type ChangedFileCategory } from "./path-matchers.js";
 import { hasLocalTestEvidence, isTestPath } from "./test-evidence.js";
 import { isFocusManifestPublicSafe } from "../focus-manifest.js";
 import type { AdvisoryFinding } from "../types/predicted-gate-types.js";
@@ -317,22 +317,33 @@ export function buildTrivialWhitespaceChurnFinding(input: SlopAssessmentInput): 
   return buildTrivialChurnFinding(lineTotals.changedLineCount, lineTotals.nonCodeLineCount);
 }
 
+// Lockfiles and dependency manifests never count toward trivial-churn detection: a routine dependency bump
+// (package-lock.json alone can churn dozens of lines for one nested resolution change) was diluting the
+// substantive-share ratio and falsely flagging an otherwise-small, legitimate accompanying source fix as
+// "trivial whitespace churn" -- neither category is `isCodeFile`, so their lines were previously falling
+// straight into nonCodeLineCount. Deliberately narrower than the sibling buildNonSubstantivePaddingFinding's
+// own carve-out (which also exempts config/docs): whether a large PURE docs/config diff with zero source or
+// test lines should still trip this specific "low-effort churn" detector is a separate product judgment call
+// this fix does not make -- see the existing "still fires for non-code-only high-churn diffs" test below,
+// which this deliberately leaves unchanged.
+const CHURN_EXEMPT_CATEGORIES = new Set<ChangedFileCategory>(["lockfile", "dependency_manifest"]);
+
 function summarizeChangedLines(changedFiles: SlopChangedFile[]): {
   changedLineCount: number;
   sourceLineCount: number;
   testLineCount: number;
   nonCodeLineCount: number;
 } {
-  const changedLineCount = changedFiles.reduce(
-    (sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions),
-    0,
-  );
-  const sourceLineCount = changedFiles
-    .filter((file) => isCodeFile(file.path))
-    .reduce((sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions), 0);
-  const testLineCount = changedFiles
-    .filter((file) => isTestFile(file.path))
-    .reduce((sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions), 0);
+  let changedLineCount = 0;
+  let sourceLineCount = 0;
+  let testLineCount = 0;
+  for (const file of changedFiles) {
+    if (CHURN_EXEMPT_CATEGORIES.has(classifyChangedFile(file.path))) continue;
+    const lines = nonNegative(file.additions) + nonNegative(file.deletions);
+    changedLineCount += lines;
+    if (isCodeFile(file.path)) sourceLineCount += lines;
+    if (isTestFile(file.path)) testLineCount += lines;
+  }
   const nonCodeLineCount = Math.max(0, changedLineCount - sourceLineCount - testLineCount);
   return { changedLineCount, sourceLineCount, testLineCount, nonCodeLineCount };
 }

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -453,6 +453,28 @@ describe("buildTrivialWhitespaceChurnFinding", () => {
       }),
     ).toMatchObject({ code: "trivial_whitespace_churn" });
   });
+
+  it("REGRESSION (audit finding): a lockfile-dominated dependency bump does not dilute a small genuine source fix into a false trivial-churn flag", () => {
+    // A real single-package bump can churn dozens of lockfile lines for nested resolutions -- this is not
+    // "whitespace-only churn", it's normal dependency-bump noise, and previously drowned out the genuine
+    // 3-line source fix required by the version bump.
+    expect(
+      buildTrivialWhitespaceChurnFinding({
+        changedFiles: [
+          { path: "package-lock.json", additions: 42, deletions: 3 },
+          { path: "src/utils/rateLimiter.ts", additions: 3, deletions: 0 },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("still fires when a dependency-manifest-dominated diff has zero actual source lines (the lockfile carve-out doesn't mask genuinely trivial churn)", () => {
+    expect(
+      buildTrivialWhitespaceChurnFinding({
+        changedFiles: [{ path: "package.json", additions: 25, deletions: 20 }],
+      }),
+    ).toBeNull(); // below MIN_CHURN_LINES once the manifest is excluded -- correctly not "churn" at all, not just not "trivial"
+  });
 });
 
 describe("buildIssueSlopAssessment (#533 issue-side triage)", () => {


### PR DESCRIPTION
## Summary
- `buildTrivialWhitespaceChurnFinding`'s `summarizeChangedLines` only special-cased `isCodeFile`/`isTestFile` paths, so a routine dependency bump (`package-lock.json` alone can churn dozens of lines for one nested resolution change) fell into `nonCodeLineCount` and diluted the substantive-share ratio — falsely flagging an otherwise-small, legitimate accompanying source fix as "trivial whitespace churn".
- Its sibling `buildNonSubstantivePaddingFinding` already carves lockfiles/manifests/config/docs out of its own padding-share calculation (see the comment at `slop.ts:142-146`); this detector had no equivalent exception.
- Fix scopes the carve-out to `lockfile`/`dependency_manifest` only (not `config`/`docs`), deliberately narrower than the sibling detector's exemption, to preserve the existing "still fires for non-code-only high-churn diffs with zero source and zero test lines" test's asserted behavior — whether a pure docs/config diff should still trip this specific low-effort-churn detector is a separate product call this PR doesn't make.
- Found via a full-system adversarial audit of the ORB review/scoring engine (2 independent skeptic passes, both voted "confirmed").

Closes #6428

## Test plan
- [x] New regression test: a lockfile-dominated dependency bump + small genuine source fix no longer trips the finding
- [x] New regression test: a dependency-manifest-only diff with zero source lines still correctly returns null (below churn threshold once the manifest is excluded, not just "not trivial")
- [x] All 66 existing/new tests in `test/unit/slop.test.ts` pass
- [x] `packages/loopover-engine/src/signals/slop.ts` at 100% line/branch coverage
- [x] Full local gate (`npm run test:ci`) green