### PR TITLE
fix(extension): handle a rejected sendMessage in loadOpportunityBadge

### DIFF
--- a/apps/loopover-miner-extension/content.js
+++ b/apps/loopover-miner-extension/content.js
@@ -40,12 +40,21 @@ function findIssueSidebar() {
 }
 
 async function loadOpportunityBadge(container, target) {
-  const response = await chrome.runtime.sendMessage({
-    type: "loopover-miner:issue-context",
-    owner: target.owner,
-    repo: target.repo,
-    issueNumber: target.issueNumber,
-  });
+  let response;
+  try {
+    response = await chrome.runtime.sendMessage({
+      type: "loopover-miner:issue-context",
+      owner: target.owner,
+      repo: target.repo,
+      issueNumber: target.issueNumber,
+    });
+  } catch {
+    // sendMessage genuinely rejects under MV3 (service worker asleep/restarting, "Extension context
+    // invalidated"). Clean up the same way every other failure path here does, instead of leaving an
+    // unhandled rejection and a permanently-hidden orphan <aside> in the page.
+    container.remove();
+    return;
+  }
   if (!response?.ok) {
     container.remove();
     return;
@@ -72,6 +81,7 @@ if (globalThis.__LOOPOVER_MINER_EXTENSION_TEST__) {
   globalThis.__loopoverMinerContentInternals = {
     matchGitHubIssueTarget,
     findIssueSidebar,
+    loadOpportunityBadge,
     renderOpportunityBadge,
   };
 }

--- a/apps/loopover-miner-extension/test/content.test.ts
+++ b/apps/loopover-miner-extension/test/content.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type BadgeContainer = { remove: () => void; hidden?: boolean; innerHTML?: string };
+type ContentInternals = {
+  loadOpportunityBadge: (container: BadgeContainer, target: unknown) => Promise<void>;
+};
+
+const TARGET = { owner: "JSONbored", repo: "loopover", issueNumber: 145 };
+
+// content.js mounts the badge at import time only when location.pathname is a GitHub issue URL, so importing it
+// on a non-issue path loads the module without any DOM side effects. That keeps this focused on the
+// sendMessage failure path and needs none of the jsdom mount harness the README defers.
+async function loadContentInternals(sendMessage: () => Promise<unknown>): Promise<ContentInternals> {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  vi.stubGlobal("location", { pathname: "/" });
+  vi.stubGlobal("chrome", { runtime: { sendMessage } });
+  vi.stubGlobal("__LOOPOVER_MINER_EXTENSION_TEST__", true);
+  await import("../content.js");
+  return globalThis.__loopoverMinerContentInternals as ContentInternals;
+}
+
+describe("content.js loadOpportunityBadge (#6189)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("removes the badge container when sendMessage rejects, rather than rejecting itself", async () => {
+    // The real MV3 failure: the service worker is asleep/restarting, or the context was invalidated.
+    const sendMessage = vi.fn().mockRejectedValue(new Error("Extension context invalidated"));
+    const { loadOpportunityBadge } = await loadContentInternals(sendMessage);
+    const container: BadgeContainer = { remove: vi.fn() };
+
+    // Must settle, not reject: mountOpportunityBadge calls this as a floating `void` promise, so a rejection
+    // here surfaces as an unhandled rejection in the page.
+    await expect(loadOpportunityBadge(container, TARGET)).resolves.toBeUndefined();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(container.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("still removes the container on a not-ok response, the pre-existing failure path", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ ok: false, error: "nope" });
+    const { loadOpportunityBadge } = await loadContentInternals(sendMessage);
+    const container: BadgeContainer = { remove: vi.fn() };
+
+    await expect(loadOpportunityBadge(container, TARGET)).resolves.toBeUndefined();
+    expect(container.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not remove the container when the message resolves ok", async () => {
+    // payload is unwatched, so renderOpportunityBadge's own guard owns the cleanup decision -- this asserts the
+    // new catch does not swallow a success into a removal.
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true, payload: { watched: true, badge: null } });
+    const { loadOpportunityBadge } = await loadContentInternals(sendMessage);
+    const container: BadgeContainer = { remove: vi.fn() };
+
+    await expect(loadOpportunityBadge(container, TARGET)).resolves.toBeUndefined();
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: "loopover-miner:issue-context",
+      owner: TARGET.owner,
+      repo: TARGET.repo,
+      issueNumber: TARGET.issueNumber,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6189

- `content.js`'s `loadOpportunityBadge` awaited `chrome.runtime.sendMessage` with **no `try/catch`**, unlike every other message call site in this extension (`background.js:19-21`, `options.js:78-94`, `options.js:99-113`).
- `sendMessage` genuinely rejects under MV3 — service worker asleep/restarting, "Extension context invalidated". Because `mountOpportunityBadge` calls this as a floating `void` promise, a rejection became an **unhandled rejection** and left the badge `<aside>` in the DOM permanently hidden with zero user-visible feedback.
- It now cleans up through the same `container.remove()` the function already uses for its other failure paths — the graceful behaviour the issue asks for.
- `background.js` and `options.js` are **untouched**; their handling was already correct, as the issue states.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` *(this workspace's `typecheck` is its `node --check` lint gate — run and passing)*
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- **Verified the regression test actually catches the bug**: with the `try/catch` reverted (and the test seam left in place, to isolate the fix itself), the new test fails with *"promise rejected 'Error: Extension context invalidated' instead of resolving"* — precisely the unhandled rejection described — and passes with the fix.
- This workspace's own gate is green: `npx vitest run --coverage` passes **22 tests across 4 files**, with coverage **100% statements / 100% functions / 100% lines / 95.79% branches**, all above `vitest.config.ts`'s thresholds (98/98/98/94). `npm run lint` (`node --check` on all five scripts) passes.
- **The measured baseline is unchanged**: `content.js` is deliberately outside `coverage.include` (the README defers it pending a jsdom mount harness), so this adds real regression coverage without touching the thresholds or the deferral policy.
- Root-level UI/MCP/worker suites are untouched by an extension-only change; leaving them to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No `UI Evidence` section: there is no new rendered state to screenshot. This strictly *removes* a broken one — on failure the badge container is now cleanly removed instead of persisting as a hidden orphan element, which is the extension's existing behaviour for every other failure path.

## Notes

`loadOpportunityBadge` is added to the existing `__loopoverMinerContentInternals` test seam so the test can drive it directly. `content.js` mounts the badge at import time only when `location.pathname` is a GitHub issue URL, so importing it on a non-issue path loads the module free of DOM side effects — that keeps this focused on the `sendMessage` failure path and needs none of the jsdom mount harness the README defers.

Closes #6189
