### PR TITLE
chore(engine): remove dead isDuplicateClusterWinner (#6172)

### DIFF
--- a/packages/loopover-engine/src/duplicate-winner.ts
+++ b/packages/loopover-engine/src/duplicate-winner.ts
@@ -36,21 +36,6 @@ export type DuplicateClaimMember = {
 };
 
 /**
- * True iff `prNumber` is the cluster winner: the minimum of `{prNumber} ∪ openSiblingNumbers`. An empty
- * sibling list ⇒ the PR is alone in (or out of) the cluster ⇒ winner. A sibling list that happens to contain
- * `prNumber` itself is harmless — the comparison is still min-based.
- *
- * @deprecated Use {@link isDuplicateClusterWinnerByClaim}. PR-number election is retained only for legacy
- * compatibility callers that do not have claim timestamps.
- */
-export function isDuplicateClusterWinner(prNumber: number, openSiblingNumbers: number[]): boolean {
-  for (const sibling of openSiblingNumbers) {
-    if (sibling < prNumber) return false;
-  }
-  return true;
-}
-
-/**
  * True iff `pr` is the earliest-elected claimant in the open duplicate cluster (see the module doc's
  * "ELECTION ORDER" note). Sparse legacy rows fail closed; ties between equally-ordered members use PR number.
  */

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -703,7 +703,6 @@ export * as scoringModel from "./scoring/model.js";
 export * as scoringPreview from "./scoring/preview.js";
 export * as scoringPendingPrScenarios from "./scoring/pending-pr-scenarios.js";
 export {
-  isDuplicateClusterWinner,
   isDuplicateClusterWinnerByClaim,
   resolveDuplicateClusterWinnerNumber,
   type DuplicateClaimMember,

--- a/packages/loopover-engine/src/predicted-gate.ts
+++ b/packages/loopover-engine/src/predicted-gate.ts
@@ -205,7 +205,7 @@ export function buildPredictedGateVerdict(args: {
   // `duplicateWinnerEnabled` is INTENTIONALLY omitted (#dup-winner): the prospective PR is synthetic #0, but a
   // real new PR opened into an existing duplicate cluster gets the HIGHEST number ⇒ it is always a duplicate
   // LOSER, never the winner. So the predictor must keep showing the duplicate finding (the honest pre-submit
-  // answer). Threading the flag here would let isDuplicateClusterWinner(0, …) treat #0 as the winner and
+  // answer). Threading the flag here would let the winner election treat a placeholder #0 as the winner and
   // falsely suppress the block — a false-optimism regression. Do NOT add it without modeling #0 as the loser.
   // Thread linked-issue authors from the issues snapshot so the predictor surfaces the self-authored-linked-issue
   // finding too — evaluateGateCheck below already receives gate.selfAuthoredLinkedIssue, but without this finding it

--- a/packages/loopover-engine/src/signals/duplicate-winner.ts
+++ b/packages/loopover-engine/src/signals/duplicate-winner.ts
@@ -7,7 +7,6 @@
  * `../signals/duplicate-winner.js` import keeps resolving without a call-site change.
  */
 export {
-  isDuplicateClusterWinner,
   isDuplicateClusterWinnerByClaim,
   resolveDuplicateClusterWinnerNumber,
   type DuplicateClaimMember,

--- a/packages/loopover-engine/test/duplicate-winner-signals-shim.test.ts
+++ b/packages/loopover-engine/test/duplicate-winner-signals-shim.test.ts
@@ -5,7 +5,6 @@ import * as topLevel from "../dist/duplicate-winner.js";
 import * as signalsShim from "../dist/signals/duplicate-winner.js";
 
 test("signals/duplicate-winner is a thin re-export of the top-level module (#4251)", () => {
-  assert.equal(signalsShim.isDuplicateClusterWinner, topLevel.isDuplicateClusterWinner);
   assert.equal(signalsShim.isDuplicateClusterWinnerByClaim, topLevel.isDuplicateClusterWinnerByClaim);
   assert.equal(
     signalsShim.resolveDuplicateClusterWinnerNumber,

--- a/packages/loopover-engine/test/duplicate-winner.test.ts
+++ b/packages/loopover-engine/test/duplicate-winner.test.ts
@@ -2,27 +2,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  isDuplicateClusterWinner,
   isDuplicateClusterWinnerByClaim,
   resolveDuplicateClusterWinnerNumber,
 } from "../dist/index.js";
 
 test("barrel: the public entrypoint re-exports the duplicate-winner adjudication API", () => {
-  assert.equal(typeof isDuplicateClusterWinner, "function");
   assert.equal(typeof isDuplicateClusterWinnerByClaim, "function");
   assert.equal(typeof resolveDuplicateClusterWinnerNumber, "function");
-});
-
-test("isDuplicateClusterWinner: the lowest open sibling number wins", () => {
-  assert.equal(isDuplicateClusterWinner(5, [7, 9]), true);
-});
-
-test("isDuplicateClusterWinner: a lower open sibling beats this PR (loser)", () => {
-  assert.equal(isDuplicateClusterWinner(5, [3, 9]), false);
-});
-
-test("isDuplicateClusterWinner: an empty sibling list is always a winner", () => {
-  assert.equal(isDuplicateClusterWinner(5, []), true);
 });
 
 test("isDuplicateClusterWinnerByClaim: an empty sibling list is always a winner", () => {

--- a/src/queue/duplicate-detection.ts
+++ b/src/queue/duplicate-detection.ts
@@ -65,7 +65,7 @@ export function dupWinnerLinkedDuplicateWinnerNumber(
  * GitHub but is still cached `open` would keep "winning" the duplicate cluster, demoting the real lowest-OPEN PR
  * to a loser and auto-closing it via the `duplicate_pr_risk` blocker. Only a LOWER-numbered overlapping sibling
  * can demote this PR from winner, so re-fetch the LIVE state of just those siblings and drop any that are no
- * longer open. Then the downstream election ({@link isDuplicateClusterWinner}) reflects ground truth.
+ * longer open. Then the downstream election ({@link isDuplicateClusterWinnerByClaim}) reflects ground truth.
  *
  * FAIL-OPEN to the stored state: a sibling is dropped ONLY on a positive "not open" confirmation — an unreadable
  * live fetch keeps it, so a transient GitHub hiccup never newly spares a real loser. Flag-OFF (default), no

--- a/src/services/maintainer-activation.ts
+++ b/src/services/maintainer-activation.ts
@@ -62,7 +62,7 @@ export function buildMaintainerActivationPreview(args: {
   const codeCounts = new Map<string, number>();
   const samples: MaintainerActivationSample[] = recent.map((pr) => {
     const advisory = buildPullRequestAdvisory(args.repo, pr, {
-      // Open-only siblings: a closed/merged PR isn't competing, and isDuplicateClusterWinner's invariant
+      // Open-only siblings: a closed/merged PR isn't competing, and isDuplicateClusterWinnerByClaim's invariant
       // requires open-only numbers — match the live pipeline (processors.ts:559/800), which feeds the
       // winner adjudication the same open-filtered set.
       otherOpenPullRequests: args.pullRequests.filter((other) => other.number !== pr.number && other.state === "open"),

--- a/src/signals/duplicate-winner.ts
+++ b/src/signals/duplicate-winner.ts
@@ -8,7 +8,6 @@
  * module, matching the #2282 scoring-preview extraction) is the source of truth.
  */
 export {
-  isDuplicateClusterWinner,
   isDuplicateClusterWinnerByClaim,
   resolveDuplicateClusterWinnerNumber,
   type DuplicateClaimMember,

--- a/test/unit/duplicate-winner.test.ts
+++ b/test/unit/duplicate-winner.test.ts
@@ -1,39 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isDuplicateClusterWinner, isDuplicateClusterWinnerByClaim, resolveDuplicateClusterWinnerNumber } from "../../src/signals/duplicate-winner";
+import { isDuplicateClusterWinnerByClaim, resolveDuplicateClusterWinnerNumber } from "../../src/signals/duplicate-winner";
 import { dupWinnerLinkedDuplicateCount, dupWinnerLinkedDuplicateWinnerNumber, linkedIssueDuplicatePullRequestsForGate } from "../../src/queue/processors";
 import type { PullRequestRecord } from "../../src/types";
 import { listOtherOpenPullRequests, listOtherOpenPullRequestsForAuthor, upsertPullRequestFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
-
-describe("isDuplicateClusterWinner (#dup-winner)", () => {
-  it("the lowest open sibling number wins", () => {
-    expect(isDuplicateClusterWinner(12, [13, 14])).toBe(true);
-  });
-
-  it("a lower open sibling beats this PR (loser)", () => {
-    expect(isDuplicateClusterWinner(14, [12, 13])).toBe(false);
-  });
-
-  it("an empty sibling list ⇒ winner (alone in/out of the cluster)", () => {
-    expect(isDuplicateClusterWinner(7, [])).toBe(true);
-  });
-
-  it("a sibling list that contains self is still min-based (winner when self is lowest)", () => {
-    expect(isDuplicateClusterWinner(12, [12, 13])).toBe(true);
-  });
-
-  it("a sibling list that contains self plus a lower sibling ⇒ loser", () => {
-    expect(isDuplicateClusterWinner(13, [12, 13])).toBe(false);
-  });
-
-  it("cascade: once the lowest sibling closes (drops out of the open set), the next-lowest becomes the winner", () => {
-    // Cluster {12, 13, 14}. PR 13 is a loser while 12 is still open.
-    expect(isDuplicateClusterWinner(13, [12, 14])).toBe(false);
-    // PR 12 closes (red CI) → it leaves the OPEN sibling set the caller passes. Re-eval of PR 13 now sees only
-    // {14} as the open sibling → 13 is the new winner. No permanently-orphaned cluster.
-    expect(isDuplicateClusterWinner(13, [14])).toBe(true);
-  });
-});
 
 describe("isDuplicateClusterWinnerByClaim (#dup-winner claim election)", () => {
   const claim = (number: number, linkedIssueClaimedAt: string | null) => ({ number, linkedIssueClaimedAt });

--- a/test/unit/predicted-gate-engine-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-coverage.test.ts
@@ -25,7 +25,7 @@ import {
   isGuardrailHit,
   matchesAny,
 } from "../../packages/loopover-engine/src/signals/change-guardrail";
-import { isDuplicateClusterWinner, isDuplicateClusterWinnerByClaim, resolveDuplicateClusterWinnerNumber } from "../../packages/loopover-engine/src/signals/duplicate-winner";
+import { isDuplicateClusterWinnerByClaim, resolveDuplicateClusterWinnerNumber } from "../../packages/loopover-engine/src/signals/duplicate-winner";
 import { buildCollisionReport, buildPreflightResult, buildPublicReadinessScore, buildQueueHealth, classifyBountyLifecycle, itemSharesPlannedLinkedIssue, predictedGateEngineInternals, termOverlap, unionScopedOverlapClusters } from "../../packages/loopover-engine/src/signals/predicted-gate-engine";
 import type { CollisionItem, FocusManifest, IssueQualityReport, PreMergeCheck, PullRequestRecord, RepositoryRecord } from "../../packages/loopover-engine/src/types/predicted-gate-types";
 
@@ -249,9 +249,7 @@ describe("predicted-gate engine module coverage (#2283)", () => {
     expect(blocked.conclusion).toBe("failure");
   });
 
-  it("exercises deprecated duplicate winner helper and lane advice branches", () => {
-    expect(isDuplicateClusterWinner(1, [2, 3])).toBe(true);
-    expect(isDuplicateClusterWinner(3, [1, 2])).toBe(false);
+  it("exercises the inactive lane advice branch", () => {
     const inactive = buildPreflightResult(
       { repoFullName: "acme/widgets", title: "Fix", body: "Closes #7", linkedIssues: [7] },
       { ...REPO, registryConfig: { ...REPO.registryConfig!, emissionShare: 0 } },


### PR DESCRIPTION
## Summary

- `packages/loopover-engine/src/duplicate-winner.ts`'s `isDuplicateClusterWinner` (PR-number election) was JSDoc-`@deprecated` in favor of `isDuplicateClusterWinnerByClaim`, "retained only for legacy compatibility callers that do not have claim timestamps." A fresh repo-wide search confirms those legacy callers do not exist: every real caller (e.g. `advisory/gate-advisory.ts`) uses `isDuplicateClusterWinnerByClaim`; the bare function had only re-exports, tests, and `{@link}` mentions.
- Removed `isDuplicateClusterWinner` and its three re-exports (`packages/loopover-engine/src/index.ts`, `packages/loopover-engine/src/signals/duplicate-winner.ts`, `src/signals/duplicate-winner.ts`). `isDuplicateClusterWinnerByClaim` and `resolveDuplicateClusterWinnerNumber` are untouched.
- Removed the tests that existed only to exercise the deleted function (dedicated cases in `packages/loopover-engine/test/duplicate-winner.test.ts`, the shim-identity assertion in `duplicate-winner-signals-shim.test.ts`, the root cases in `test/unit/duplicate-winner.test.ts`, and the two lines in `test/unit/predicted-gate-engine-coverage.test.ts`); every test for the remaining exports stays.
- Updated the now-stale `{@link isDuplicateClusterWinner}` / prose mentions in `src/queue/duplicate-detection.ts`, `src/services/maintainer-activation.ts`, and `packages/loopover-engine/src/predicted-gate.ts` to reference the surviving election function (or describe it generically) so no comment points at a function that no longer exists.

Closes #6172

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6172`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — this PR only DELETES source lines (no added source lines for `codecov/patch` to fall short on); the surviving `isDuplicateClusterWinnerByClaim`/`resolveDuplicateClusterWinnerNumber` keep their full existing test coverage.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] `@loopover/engine` package tests (567 pass) and the root duplicate-winner / predicted-gate-coverage suites pass with the removed cases gone.

If any required check was skipped, explain why:

- No OpenAPI/`cf-typegen`/migration/env-reference regeneration needed — this removes an internal engine helper with no API, binding, schema, or env surface.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP surface changed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A: no docs/changelog change.

## Notes

- Verified the real duplicate-cluster election path (`isDuplicateClusterWinnerByClaim`, used by `advisory/gate-advisory.ts` through the `signals/duplicate-winner.js` shim) is unaffected — only the unused PR-number-election variant and its own tests/comments are removed.
