### PR TITLE
docs(ams): clarify standalone repo support

### DIFF
--- a/apps/loopover-ui/content/docs/miner-workflow.mdx
+++ b/apps/loopover-ui/content/docs/miner-workflow.mdx
@@ -6,6 +6,12 @@ description: A deterministic four-step loop. Each step is pure metadata; each ou
 If the workflow will spawn Claude Code or Codex, configure that driver first in [Miner
 coding-agent driver](/docs/miner-coding-agent).
 
+<Callout variant="info">
+  AMS is not limited to ORB-managed repos. The miner loop can target any GitHub repository you can
+  access, even when the repo is not gittensor-registered and does not ship a `.loopover.yml`.
+  Autonomous PR writes remain gated separately by AMS live-mode opt-ins.
+</Callout>
+
 ## The mirrored loop
 
 Each step on the left is what the contributor runs; the matching step on the right is what the

--- a/apps/loopover-ui/content/docs/quickstart.mdx
+++ b/apps/loopover-ui/content/docs/quickstart.mdx
@@ -3,6 +3,13 @@ title: Quickstart
 description: Install the MCP, sign in, and run your first analysis. About two minutes.
 ---
 
+<Callout variant="info">
+  AMS also works against ordinary GitHub repositories: ORB is optional, gittensor registration is
+  optional, and a missing `.loopover.yml` does not block discovery, analysis, or attempts. Live PR
+  writes still honor AMS's own live-mode gates (`LOOPOVER_MINER_LIVE_MODE=live` plus the target
+  repo's `.loopover-miner.yml` opt-in).
+</Callout>
+
 ## 1. Install
 
 The MCP is published as `@loopover/mcp`. You can run it with `npx`, or

--- a/test/unit/docs-miner-workflow.test.ts
+++ b/test/unit/docs-miner-workflow.test.ts
@@ -6,13 +6,33 @@ const MINER_WORKFLOW_PATH = resolve(
   import.meta.dirname,
   "../../apps/loopover-ui/content/docs/miner-workflow.mdx",
 );
+const QUICKSTART_PATH = resolve(
+  import.meta.dirname,
+  "../../apps/loopover-ui/content/docs/quickstart.mdx",
+);
 
 describe("docs miner workflow page", () => {
   const source = readFileSync(MINER_WORKFLOW_PATH, "utf8");
   const normalizedSource = source.replace(/\s+/g, " ");
+  const quickstartSource = readFileSync(QUICKSTART_PATH, "utf8");
+  const normalizedQuickstartSource = quickstartSource.replace(/\s+/g, " ");
 
   it("cross-links to the miner coding-agent driver page before the loop steps", () => {
     expect(normalizedSource).toMatch(/Miner coding-agent driver/);
     expect(source).toMatch(/\/docs\/miner-coding-agent/);
+  });
+
+  it("documents that AMS works without ORB registration or a repo manifest", () => {
+    expect(normalizedSource).toMatch(/not limited to ORB-managed repos/i);
+    expect(normalizedSource).toMatch(/any GitHub repository you can access/i);
+    expect(normalizedSource).toMatch(/not gittensor-registered/i);
+    expect(normalizedSource).toMatch(/does not ship a `\.loopover\.yml`/i);
+    expect(normalizedQuickstartSource).toMatch(/ordinary GitHub repositories/i);
+    expect(normalizedQuickstartSource).toMatch(/ORB is optional/i);
+    expect(normalizedQuickstartSource).toMatch(/gittensor registration is optional/i);
+    expect(normalizedQuickstartSource).toMatch(/missing `\.loopover\.yml` does not block discovery, analysis, or attempts/i);
+    expect(normalizedQuickstartSource).toMatch(/LOOPOVER_MINER_LIVE_MODE=live/i);
+    expect(normalizedQuickstartSource).toMatch(/`\.loopover-miner\.yml` opt-in/i);
+    expect(normalizedSource).toMatch(/Autonomous PR writes remain gated separately by AMS live-mode opt-ins/i);
   });
 });


### PR DESCRIPTION
## Summary

- Clarifies in the docs that AMS can target ordinary GitHub repositories without ORB, gittensor registration, or a `.loopover.yml` file.
- Adds a regression test that keeps those standalone AMS docs guarantees explicit.
- Captures the live Thursday, July 16, 2026 sandbox findings that standalone discovery/attempts work, while real PR writes remain gated by AMS live-mode opt-ins.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes JSONbored/loopover#6205

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The focused docs test `vitest run test/unit/docs-miner-workflow.test.ts` passed on Thursday, July 16, 2026.
- Full `npm run test:ci` reruns on Thursday, July 16, 2026 got past `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, and `miner:env-reference:check`, but the clean worktree's improvised local dependency hydration kept failing later steps (`selfhost:validate-observability` initially missed `yaml`; earlier reruns missed `tsx` and `typescript` shims). This looks like local clean-worktree dependency drift on this machine, not a failure caused by the docs diff, so I am keeping the PR as a draft.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title                         | JPG/PNG evidence |
| ------------------------------------- | ---------------- |
| Draft note                            | Pending on this draft — docs text only; I have not attached PNG review screenshots yet. |

## Notes

- Live sandbox verification on Thursday, July 16, 2026 used public repos `james3773/extract`, `james3773/minirouter`, and `james3773/recipe`. All three 404'd on `.loopover.yml`; `james3773/extract` also 404'd on both `.loopover-miner.yml` paths.
- `james3773/minirouter` and `james3773/recipe` have issues disabled, so I used `james3773/extract` for the concrete attempt path and opened `james3773/extract#1` as a legitimate sandbox issue.
- Plain `GITHUB_TOKEN` path:
  - `loopover-miner discover james3773/extract james3773/minirouter james3773/recipe --json` succeeded and ranked `james3773/extract#1`.
  - `loopover-miner attempt james3773/extract 1 --miner-login james3773 --base main --live --json` with `MINER_CODING_AGENT_PROVIDER=noop` reached the attempt pipeline and stopped at the default `submissionMode: observe` gate.
  - Rerunning with a temp operator `.loopover-ams.yml` set to `submissionMode: enforce` progressed to the would-be PR payload, then stopped at governor `dry_run_mode_active`, which matches the documented AND gate of `LOOPOVER_MINER_LIVE_MODE=live` plus target-repo `.loopover-miner.yml` `execution.liveModeOptIn: live`.
- I could not safely complete the `loopover-mcp login` session-path verification on Thursday, July 16, 2026 from this environment: there was no preexisting LoopOver session, and the non-interactive `loopover-mcp login --github-token ...` bootstrap was rejected by tool policy as credential disclosure to an external service. A real browser/device-flow login is still needed to fully satisfy that portion of `JSONbored/loopover#6205`.
