### PR TITLE
chore(miner-ui): move 3 test-only fixture factories out of the lib's public API into their test files

### DIFF
--- a/apps/loopover-miner-ui/src/governor.test.tsx
+++ b/apps/loopover-miner-ui/src/governor.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  defaultGovernorPauseState,
   fetchGovernorPauseState,
   GOVERNOR_PAUSE_API_PATH,
   GOVERNOR_PAUSE_STATE_API_PATH,
@@ -19,6 +18,9 @@ import {
   matchGovernorRoute,
   type GovernorApiDeps,
 } from "../vite-governor-api";
+
+// Test-local fixture factory (was a lib export reachable only from tests; moved here per #6187).
+const defaultGovernorPauseState = (): GovernorPauseState => ({ paused: false, reason: null, pausedAt: null });
 
 const pausedState: GovernorPauseState = {
   paused: true,

--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -1,16 +1,18 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  emptyLedgersSummary,
-  fetchLedgers,
-  LEDGERS_API_PATH,
-  type LedgersResult,
-  type LedgersSummary,
-} from "./lib/ledgers";
-import { defaultGovernorPauseState, type GovernorPauseState, type GovernorPauseStateResult } from "./lib/governor";
+import { fetchLedgers, LEDGERS_API_PATH, type LedgersResult, type LedgersSummary } from "./lib/ledgers";
+import { type GovernorPauseState, type GovernorPauseStateResult } from "./lib/governor";
 import { LedgersPage, LedgersView } from "./routes/ledgers";
 import { handleLedgersRequest, type LedgersApiDeps } from "../vite-ledgers-api";
+
+// Test-local fixture factories (were lib exports reachable only from tests; moved here per #6187).
+const emptyLedgersSummary = (): LedgersSummary => ({
+  claims: { total: 0, byStatus: { active: 0, released: 0, expired: 0 } },
+  events: { total: 0, byType: {}, recent: [] },
+  governor: { total: 0, byEventType: {} },
+});
+const defaultGovernorPauseState = (): GovernorPauseState => ({ paused: false, reason: null, pausedAt: null });
 
 const fixtureSummary: LedgersSummary = {
   claims: { total: 3, byStatus: { active: 2, released: 1, expired: 0 } },

--- a/apps/loopover-miner-ui/src/lib/governor.ts
+++ b/apps/loopover-miner-ui/src/lib/governor.ts
@@ -21,8 +21,6 @@ function isGovernorPauseState(value: unknown): value is GovernorPauseState {
   );
 }
 
-export const defaultGovernorPauseState = (): GovernorPauseState => ({ paused: false, reason: null, pausedAt: null });
-
 async function parseGovernorPauseStateResponse(
   response: Response,
   apiLabel: string,

--- a/apps/loopover-miner-ui/src/lib/ledgers.ts
+++ b/apps/loopover-miner-ui/src/lib/ledgers.ts
@@ -18,12 +18,6 @@ export type LedgersSummary = { claims: ClaimsSummary; events: EventsSummary; gov
 
 export type LedgersResult = { ok: true; summary: LedgersSummary } | { ok: false; error: string };
 
-export const emptyLedgersSummary = (): LedgersSummary => ({
-  claims: { total: 0, byStatus: { active: 0, released: 0, expired: 0 } },
-  events: { total: 0, byType: {}, recent: [] },
-  governor: { total: 0, byEventType: {} },
-});
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }

--- a/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
+++ b/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
@@ -51,13 +51,6 @@ function isPortfolioQueueSummary(value: unknown): value is PortfolioQueueSummary
   );
 }
 
-export const emptyPortfolioQueueSummary = (): PortfolioQueueSummary => ({
-  total: 0,
-  byStatus: { queued: 0, in_progress: 0, done: 0 },
-  repos: [],
-  oldestQueuedAgeMs: null,
-});
-
 /** Fetch the local queue summary; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchPortfolioQueue(fetchImpl: typeof fetch = fetch): Promise<PortfolioQueueResult> {
   try {

--- a/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  emptyPortfolioQueueSummary,
   fetchPortfolioQueue,
   PORTFOLIO_QUEUE_API_PATH,
   type PortfolioQueueResult,
@@ -10,6 +9,14 @@ import {
 } from "./lib/portfolio-queue";
 import { PortfolioPage, PortfolioQueueView } from "./routes/portfolio";
 import { handlePortfolioQueueRequest, type PortfolioQueueApiDeps } from "../vite-portfolio-queue-api";
+
+// Test-local fixture factory (was a lib export reachable only from tests; moved here per #6187).
+const emptyPortfolioQueueSummary = (): PortfolioQueueSummary => ({
+  total: 0,
+  byStatus: { queued: 0, in_progress: 0, done: 0 },
+  repos: [],
+  oldestQueuedAgeMs: null,
+});
 
 const fixtureSummary: PortfolioQueueSummary = {
   total: 4,


### PR DESCRIPTION
## Summary

`emptyPortfolioQueueSummary`, `emptyLedgersSummary`, and `defaultGovernorPauseState` were exported from `apps/loopover-miner-ui/src/lib/{portfolio-queue,ledgers,governor}.ts` but had **zero production/component callers** -- they were reachable only from their own `.test.tsx` files, where they build empty-summary fixtures. Keeping them in the lib's public API is misleading (they read as shipping helpers).

## Changes

- Removed the three factory exports from the three lib modules.
- Moved each into the test file(s) that use it as a small test-local `const` (`defaultGovernorPauseState` is used by both `governor.test.tsx` and `ledgers.test.tsx`, so each defines its own trivial one-liner).
- The result types (`PortfolioQueueSummary`, `LedgersSummary`, `GovernorPauseState`) stay exported from the lib -- they are real production types.
- No production/render behavior changes; only the fixture-builders' home moves out of the shipped lib.

## Confirmation (per the issue)

- Repo-wide search: the three factories had no non-test references (no lib/component/route caller).

## Validation

- [x] `@loopover/ui-miner` typecheck clean (after building `@loopover/ui-kit`).
- [x] `vitest run` on all three affected test files -- 59 passed, using the relocated local fixtures.
- [x] `@loopover/ui-miner` lint -- 0 errors (pre-existing react-refresh warnings only).
- [x] `git diff --check` clean; rebased onto latest `main`.

## Safety

- [x] No secrets/private terms. Removing unused public exports cannot change any rendered UI or API behavior.

Closes #6187