### PR TITLE
fix(miner-ui): render oldestQueuedAgeMs in the portfolio overview card

### DIFF
--- a/apps/loopover-miner-ui/src/app.test.tsx
+++ b/apps/loopover-miner-ui/src/app.test.tsx
@@ -17,6 +17,10 @@ const portfolioOk: PortfolioQueueResult = {
   ok: true,
   summary: { total: 5, byStatus: { queued: 2, in_progress: 1, done: 2 }, repos: [], oldestQueuedAgeMs: null },
 };
+const portfolioWithAge: PortfolioQueueResult = {
+  ok: true,
+  summary: { total: 5, byStatus: { queued: 2, in_progress: 1, done: 2 }, repos: [], oldestQueuedAgeMs: 5_400_000 },
+};
 const claimsOk: LedgersResult = {
   ok: true,
   summary: {
@@ -39,6 +43,16 @@ describe("OverviewView (#4853)", () => {
     expect(statValue("Done")).toBe("2");
     expect(statValue("Active")).toBe("3");
     expect(statValue("Total recorded")).toBe("4");
+  });
+
+  it("renders the oldest-queued age in the CLI's whole-minute format when the queue has a queued item (#6185)", () => {
+    render(<OverviewView runs={runsOk} portfolio={portfolioWithAge} claims={claimsOk} />);
+    expect(statValue("Oldest queued")).toBe("90m");
+  });
+
+  it("omits the oldest-queued stat when nothing is queued (null age), matching the CLI omitting it (#6185)", () => {
+    render(<OverviewView runs={runsOk} portfolio={portfolioOk} claims={claimsOk} />);
+    expect(screen.queryByText("Oldest queued")).toBeNull();
   });
 
   it("shows an independent loading message per card before data arrives", () => {

--- a/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
+++ b/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
@@ -58,6 +58,13 @@ export const emptyPortfolioQueueSummary = (): PortfolioQueueSummary => ({
   oldestQueuedAgeMs: null,
 });
 
+/**
+ * Render an `oldestQueuedAgeMs` value as whole minutes, matching the CLI's `queue dashboard` output
+ * (`packages/loopover-miner/lib/portfolio-dashboard.js`'s `oldest-queued: Xm`) so the web UI honours the
+ * shared-data-path contract this module's header describes rather than only computing the field.
+ */
+export const formatOldestQueuedAge = (ageMs: number): string => `${Math.round(ageMs / 60000)}m`;
+
 /** Fetch the local queue summary; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchPortfolioQueue(fetchImpl: typeof fetch = fetch): Promise<PortfolioQueueResult> {
   try {

--- a/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   emptyPortfolioQueueSummary,
   fetchPortfolioQueue,
+  formatOldestQueuedAge,
   PORTFOLIO_QUEUE_API_PATH,
   type PortfolioQueueResult,
   type PortfolioQueueSummary,
@@ -60,6 +61,15 @@ describe("emptyPortfolioQueueSummary (#4306)", () => {
       repos: [],
       oldestQueuedAgeMs: null,
     });
+  });
+});
+
+describe("formatOldestQueuedAge (#6185)", () => {
+  it("renders whole minutes the same way the CLI's queue dashboard does", () => {
+    // 90 min matches the shared fixtureSummary's 5_400_000ms and the CLI's `Math.round(ms / 60000)m`.
+    expect(formatOldestQueuedAge(5_400_000)).toBe("90m");
+    expect(formatOldestQueuedAge(0)).toBe("0m");
+    expect(formatOldestQueuedAge(89_000)).toBe("1m"); // rounds to the nearest whole minute
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/index.tsx
+++ b/apps/loopover-miner-ui/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
 
 import { fetchLedgers, type LedgersResult } from "../lib/ledgers";
-import { fetchPortfolioQueue, type PortfolioQueueResult } from "../lib/portfolio-queue";
+import { fetchPortfolioQueue, formatOldestQueuedAge, type PortfolioQueueResult } from "../lib/portfolio-queue";
 import { fetchRunStates, type RunHistoryResult } from "../lib/run-history";
 import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
 
@@ -81,6 +81,9 @@ export function OverviewPortfolioCard({ portfolio }: { portfolio: PortfolioQueue
           <Stat label="Queued" value={portfolio.summary.byStatus.queued} />
           <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-[var(--warning)]" />
           <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-[var(--success)]" />
+          {portfolio.summary.oldestQueuedAgeMs !== null ? (
+            <Stat label="Oldest queued" value={formatOldestQueuedAge(portfolio.summary.oldestQueuedAgeMs)} />
+          ) : null}
         </>
       )}
     </SummaryCard>


### PR DESCRIPTION
## Summary

- `apps/loopover-miner-ui/src/lib/portfolio-queue.ts` computes and validates `oldestQueuedAgeMs`, and its own header comment claims the miner-ui "shares one data path with the CLI's `queue dashboard`". The CLI renders that field (`packages/loopover-miner/lib/portfolio-dashboard.js:62`, `oldest-queued: Xm`), but the web UI never read it — so the stated parity was not actually delivered.
- Renders `oldestQueuedAgeMs` in `OverviewPortfolioCard` (`routes/index.tsx`), which already shows the exact sibling summary stats the CLI prints on its dashboard header line (total / queued / in_progress / done), so oldest-queued belongs alongside them.
- Formatting mirrors the CLI's reference exactly (`Math.round(ms / 60000)` whole minutes → `Xm`) via a small shared `formatOldestQueuedAge` helper, and — like the CLI — the stat is omitted when nothing is queued (`oldestQueuedAgeMs === null`).
- The CLI's own rendering (`portfolio-dashboard.js`) is left unchanged; it remains the formatting reference.

Closes #6185

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run ui:lint` (no new errors; only the repo's pre-existing `react-refresh`/`exhaustive-deps` warnings)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `@loopover/ui-miner` Vitest suite (`npm --workspace @loopover/ui-miner run test`): 136 passed; the changed `index.tsx` and `portfolio-queue.ts` are fully covered, both the non-null and null (`oldestQueuedAgeMs`) branches exercised.
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has unit tests: `formatOldestQueuedAge` (minute rounding), the rendered stat when a queued item exists, and its omission when nothing is queued.

If any required check was skipped, explain why:

- This is a UI-only change under `apps/loopover-miner-ui/**`. Backend/MCP/OpenAPI checks (`test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`) are not applicable — no `src/**`, MCP, worker, or OpenAPI surface is touched. `apps/**` is excluded from Codecov instrumentation, so `codecov/patch` does not apply to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session/CORS surface changed.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: consumes the existing `/api/portfolio-queue` shape, no API/MCP change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. The stat reads the live `oldestQueuedAgeMs` from the local portfolio-queue API and degrades with the card's existing loading/error/null states.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

Overview dashboard `Portfolio queue` card now rendering `Oldest queued: 90m` (from a fixture `oldestQueuedAgeMs` of 5,400,000 ms → whole minutes, matching the CLI's `oldest-queued: Xm`), alongside the sibling Total/Queued/In progress/Done stats.

| State / title           | JPG/PNG evidence                                                                                                                                                                                                              |
| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Loaded state (desktop)  | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/oldest-queued-6185-desktop.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/oldest-queued-6185-desktop.png" alt="Desktop overview: Portfolio queue card showing Oldest queued 90m" width="320"></a> |
| Loaded state (mobile)   | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/oldest-queued-6185-mobile.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/oldest-queued-6185-mobile.png" alt="Mobile overview: Portfolio queue card showing Oldest queued 90m" width="200"></a>   |

## Notes

- The stat is intentionally hidden when `oldestQueuedAgeMs` is `null` (no queued items, or unparseable `enqueuedAt`), mirroring the CLI, which appends the `oldest-queued` segment only when the value is non-null. Covered by a dedicated test.
