### PR TITLE
fix(ci): check-mcp-package imports the shared secret-shape detector

### DIFF
--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -3,11 +3,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";
 import { MCP_PACKAGE_ALLOWED_FILE_PATTERNS } from "./mcp-package-allowlist.mjs";
 
 const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
-const FORBIDDEN_CONTENT =
-  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
 const STALE_PACKAGE_TEXT = /(private beta|zeronode\.workers\.dev|preview URL)/i;
 
 export function validateMcpPackFileList(files, readContent) {

--- a/test/unit/forbidden-content.test.ts
+++ b/test/unit/forbidden-content.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { FORBIDDEN_CONTENT } from "../../scripts/forbidden-content.mjs";
+
+// forbidden-content.mjs calls itself the single source of truth for the packaged secret-shape detector, but
+// nothing enforced it: check-mcp-package.mjs re-declared the regex as its own local constant and the two could
+// drift apart unnoticed (#6290). These assertions pin both halves of the claim -- the structural one (each
+// checker imports the constant rather than owning a copy) and the behavioral one (each checker actually rejects
+// what the shared detector matches).
+const PACKAGE_CHECKERS = ["scripts/check-miner-package.mjs", "scripts/check-mcp-package.mjs"];
+
+// A minimal file list that passes each checker's path/allowlist/required-file guards, so the run reaches the
+// shared secret-content read. Mirrors the file lists each checker's own "rejects secret-like content" test uses.
+const REACHABLE_FILES: Record<string, string[]> = {
+  "scripts/check-miner-package.mjs": ["package.json", "bin/loopover-miner.js", "lib/cli.js"],
+  "scripts/check-mcp-package.mjs": ["package.json", "bin/loopover-mcp.js"],
+};
+
+// Assembled from fragments so this file never itself contains a credential-shaped literal -- the same
+// convention check-mcp-package.test.ts and check-miner-package.test.ts already use for their probes.
+const SECRET_SHAPED_PROBE = ["PROBE", "_", "SECRET", "=", "value"].join("");
+
+// Run a checker as a subprocess (never import it): both scripts run `npm pack` at import time, and neither has a
+// .d.mts, so importing them from TS would also break the typecheck gate. Their env seams let a single file drive
+// the whole file list + content.
+function runChecker(
+  checker: string,
+  files: string[],
+  content: string,
+): { status: number; out: string } {
+  const isMiner = checker.includes("miner");
+  const env = {
+    ...process.env,
+    [isMiner ? "CHECK_MINER_PACK_TEST_FILES" : "CHECK_MCP_PACK_TEST_FILES"]: JSON.stringify(files),
+    [isMiner ? "CHECK_MINER_PACK_TEST_CONTENT" : "CHECK_MCP_PACK_TEST_CONTENT"]: content,
+  };
+  try {
+    return { status: 0, out: execFileSync(process.execPath, [checker], { encoding: "utf8", env }) };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+describe("FORBIDDEN_CONTENT is the single source of truth (#6290)", () => {
+  it.each(PACKAGE_CHECKERS)("%s imports the shared constant instead of re-declaring it", (checker) => {
+    const source = readFileSync(checker, "utf8");
+    expect(source).toContain('import { FORBIDDEN_CONTENT } from "./forbidden-content.mjs";');
+    expect(source).toContain("FORBIDDEN_CONTENT.test(");
+    // The drift this guards against: a checker owning its own copy of the detector.
+    expect(source).not.toMatch(/const\s+FORBIDDEN_CONTENT\s*=/);
+  });
+
+  it.each(PACKAGE_CHECKERS)("%s rejects content the shared detector matches", (checker) => {
+    // Sanity-check the probe really is what the shared detector flags, then that the checker enforces it.
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+    const result = runChecker(checker, REACHABLE_FILES[checker]!, SECRET_SHAPED_PROBE);
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Secret-like content found in");
+  });
+
+  // Scoped to the MCP checker: the miner one layers required-file / lib-artifact / docs guards on top of a
+  // minimal file list, so a clean-content pass there would be asserting its allowlist rather than the shared
+  // detector. The reject case above already proves the miner checker runs content through the shared constant.
+  it("scripts/check-mcp-package.mjs accepts content the shared detector leaves alone", () => {
+    const result = runChecker(
+      "scripts/check-mcp-package.mjs",
+      REACHABLE_FILES["scripts/check-mcp-package.mjs"]!,
+      "export const answer = 42;",
+    );
+    expect(result.status).toBe(0);
+    expect(result.out).toMatch(/MCP package dry-run ok:/);
+  });
+
+  it("is a stateless matcher, so the shared instance is safe across checkers", () => {
+    // A global/sticky regex would carry lastIndex between .test() calls and make shared use order-dependent.
+    expect(FORBIDDEN_CONTENT.global).toBe(false);
+    expect(FORBIDDEN_CONTENT.sticky).toBe(false);
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6290

- `scripts/forbidden-content.mjs` declares itself the "single source of truth" for the packaged secret-shape detector, and `check-miner-package.mjs` imports it. `check-mcp-package.mjs` still declared the same regex as its own local constant, so the two could drift apart with nothing asserting they stayed equal.
- `check-mcp-package.mjs` now imports `FORBIDDEN_CONTENT`, matching its sibling. The detector is **stateless** (no `global`/`sticky` flag), so one shared instance is safe across both callers.
- Adds a drift guard covering **both** checkers on both axes:
  - **structural** — each imports the shared constant and declares no local copy;
  - **behavioral** — each actually rejects the secret-shaped probe, driven through the checker's existing env-var seam **as a subprocess** (`execFileSync`), the same way `check-mcp-package.test.ts`/`check-miner-package.test.ts` do.
- Net: **-1 line of duplication** in the script, plus the guard.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` *(module resolution of the new test verified in isolation, exit 0 — see note)*
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- **The test imports only `forbidden-content.mjs`, which ships `scripts/forbidden-content.d.mts`.** The behavioral assertions run each checker as a subprocess through its env seam rather than importing `check-*-package.mjs` — those scripts have no `.d.mts` and importing them from TS would fail the `validate-code` Typecheck step. Verified the test's module resolution typechecks in isolation (exit 0).
- Both real gates pass end-to-end: `npm run test:mcp-pack` and `npm run test:miner-pack` (exit 0) — the live MCP package now validates through the shared constant, confirming a behaviour-preserving swap.
- Ran the affected suites with vitest, all green (**60 tests**): the new guard plus `check-mcp-package`, `check-miner-package`, and `miner-mcp-contract`.
- **Verified the guard catches the bug**: restoring `main`'s duplicated version makes the new test fail; with the fix it passes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This **strengthens** a packaging guard: the MCP checker is now provably driven by the same detector as the miner one. The test's secret-shaped probe is assembled from fragments (`["PROBE", "_", "SECRET", "=", "value"].join("")`) so no credential-shaped literal enters the source — the convention the existing package tests already use.

## Notes

Closes #6290

Supersedes #6426 (auto-closed on a `validate-code` Typecheck failure: that revision imported the untyped `check-*-package.mjs` scripts directly). This revision drives them as subprocesses instead, so it imports only the already-typed `forbidden-content.mjs`. #6399 before it was auto-closed as `DIRTY` when #6297 landed a conflicting rewrite of the same file.
