### PR TITLE
fix(miner-ui): render the events.byType breakdown in the ledgers view

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -93,8 +93,34 @@ describe("LedgersView (#4855)", () => {
     expect(screen.getByText("Active", { selector: "dt" }).nextSibling?.textContent).toBe("2");
     expect(screen.getByText("Released", { selector: "dt" }).nextSibling?.textContent).toBe("1");
     expect(screen.getByText("rate_limit_deferred")).toBeTruthy();
-    expect(screen.getByText("attempt_succeeded")).toBeTruthy();
+    // attempt_succeeded now appears twice: once in the events-by-type breakdown and once in the recent feed.
+    expect(screen.getAllByText("attempt_succeeded").length).toBeGreaterThan(0);
     expect(screen.getAllByText("acme/widgets").length).toBeGreaterThan(0);
+  });
+
+  it("renders an events-by-type breakdown table for events.byType (#6184)", () => {
+    const summary: LedgersSummary = {
+      ...fixtureSummary,
+      events: {
+        total: 5,
+        // attempt_failed is present only in the aggregate breakdown, never in the recent feed below,
+        // so finding it proves the byType table (not the recent-events list) rendered it.
+        byType: { attempt_started: 3, attempt_failed: 2 },
+        recent: [{ eventType: "attempt_started", repoFullName: "acme/widgets", createdAt: "2026-07-10T06:00:00.000Z" }],
+      },
+    };
+    render(<LedgersView result={{ ok: true, summary }} />);
+    expect(screen.getByRole("heading", { name: "Events by type (5)" })).toBeTruthy();
+    expect(screen.getByText("attempt_failed")).toBeTruthy();
+  });
+
+  it("shows the empty breakdown message when no events are recorded but other ledgers have activity", () => {
+    const summary: LedgersSummary = {
+      ...fixtureSummary,
+      events: { total: 0, byType: {}, recent: [] },
+    };
+    render(<LedgersView result={{ ok: true, summary }} />);
+    expect(screen.getByText("No events recorded.")).toBeTruthy();
   });
 
   it("renders the fresh-install empty state when every ledger is empty", () => {

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -162,6 +162,15 @@ export function LedgersView({ result }: { result: LedgersResult | null }) {
       </section>
 
       <section className="grid gap-3">
+        <h3 className="font-display text-token-base font-semibold">Events by type ({events.total})</h3>
+        {events.total === 0 ? (
+          <p className="text-token-sm text-muted-foreground">No events recorded.</p>
+        ) : (
+          <CountTable counts={events.byType} keyLabel="Event type" />
+        )}
+      </section>
+
+      <section className="grid gap-3">
         <h3 className="font-display text-token-base font-semibold">Recent events ({events.total})</h3>
         {events.recent.length === 0 ? (
           <p className="text-token-sm text-muted-foreground">No event-ledger entries recorded.</p>


### PR DESCRIPTION
## Summary

`apps/loopover-miner-ui/src/lib/ledgers.ts` types and validates `EventsSummary.byType`
(`ledgers.ts:15,53`), and `routes/ledgers.tsx:23` even defaults it (`events: { total: 0, byType: {}, recent: [] }`).
But `LedgersView` rendered a `CountTable` for the structurally identical `governor.byEventType`
("Governor events") and never did the same for `events.byType` — the "Recent events" section only listed
individual `events.recent` rows, never an aggregate breakdown. The client fetched and type-guarded `byType`
purely to discard it.

This adds the missing breakdown:

- `LedgersView` now renders an `Events by type ({events.total})` section with a `CountTable` for
  `events.byType`, using the exact same component and layout convention as the existing
  `Governor events` / `governor.byEventType` table (same zero-guard message, same `keyLabel="Event type"`,
  same count-descending sort).
- The "Recent events" list and every other section are unchanged — the new section sits between
  "Governor events" and "Recent events".
- No lib, API, or type changes: this only wires already-fetched, already-validated data to the view.

Closes #6184.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — no `.github/workflows/**` changes.
- [x] `npm run ui:typecheck` (this is a `apps/loopover-miner-ui` change; backend `npm run typecheck` is unaffected)
- [x] `npm run ui:test` — all `loopover-miner-ui` tests pass (135), including the new events-by-type cases. `codecov/patch` does not apply: `apps/**` is Codecov-ignored (`codecov.yml`).
- [ ] `npm run test:workers` — backend-only; untouched here.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — no MCP changes.
- [x] `npm run ui:lint`
- [x] `npm run ui:build` (and `npm --prefix apps/loopover-miner-ui run build`)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit tests: the byType breakdown table renders, an aggregate-only type appears, and the empty-events message shows when other ledgers have activity.

If any required check was skipped, explain why:

- Skipped checks are backend/MCP/actionlint scopes with no changes in this UI-only diff (see notes above).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — none of those changed here.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed — no API/OpenAPI/MCP change; the data was already fetched and validated.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — the table renders `events.byType` from the existing local ledgers summary; no mock/demo data added.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs — no doc/changelog change needed.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Ledgers dashboard — new "Events by type" table between "Governor events" and the unchanged "Recent events" feed | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/events-by-type-6184-desktop.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/events-by-type-6184-desktop.png" alt="Ledgers dashboard showing the new Events by type breakdown table" width="240"></a> |
| "Events by type" section (cropped) — same `CountTable` layout as "Governor events", count-descending | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/events-by-type-6184-desktop-section.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/events-by-type-6184-desktop-section.png" alt="Events by type breakdown table cropped" width="240"></a> |
| Mobile layout (390px) — the breakdown renders in the narrow column | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/events-by-type-6184-mobile.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/events-by-type-6184-mobile.png" alt="Mobile layout of the Events by type breakdown" width="180"></a> |

## Notes

- The breakdown uses the shared `CountTable` already used by "Governor events", so `events.byType` and
  `governor.byEventType` now render identically. The screenshots use non-secret sample data
  (`attempt_started`/`attempt_succeeded`/`attempt_failed`); the summary API never republishes raw payloads.
