### PR TITLE
fix(miner-ui): render oldestQueuedAgeMs in the overview portfolio card (#6185)

### DIFF
--- a/apps/loopover-miner-ui/src/app.test.tsx
+++ b/apps/loopover-miner-ui/src/app.test.tsx
@@ -39,6 +39,18 @@ describe("OverviewView (#4853)", () => {
     expect(statValue("Done")).toBe("2");
     expect(statValue("Active")).toBe("3");
     expect(statValue("Total recorded")).toBe("4");
+    // Oldest-queued age is omitted when null (empty queue), matching the CLI (#6185).
+    expect(screen.queryByText("Oldest queued")).toBeNull();
+  });
+
+  it("renders the oldest-queued age in CLI-parity minutes when the queue has one (#6185)", () => {
+    const portfolioWithAge: PortfolioQueueResult = {
+      ok: true,
+      summary: { total: 3, byStatus: { queued: 3, in_progress: 0, done: 0 }, repos: [], oldestQueuedAgeMs: 5_400_000 },
+    };
+    render(<OverviewView runs={runsOk} portfolio={portfolioWithAge} claims={claimsOk} />);
+    // 5_400_000ms / 60000 = 90m, matching portfolio-dashboard.js's `Math.round(oldestQueuedAgeMs / 60000)m`.
+    expect(statValue("Oldest queued")).toBe("90m");
   });
 
   it("shows an independent loading message per card before data arrives", () => {

--- a/apps/loopover-miner-ui/src/routes/index.tsx
+++ b/apps/loopover-miner-ui/src/routes/index.tsx
@@ -81,6 +81,12 @@ export function OverviewPortfolioCard({ portfolio }: { portfolio: PortfolioQueue
           <Stat label="Queued" value={portfolio.summary.byStatus.queued} />
           <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-[var(--warning)]" />
           <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-[var(--success)]" />
+          {/* Deliver the CLI/web-UI parity the portfolio-queue data path promises (#6185): the CLI's `queue
+              dashboard` renders "oldest-queued: Xm" (portfolio-dashboard.js), and the same minutes-rounded age
+              is shown here. Omitted (like the CLI) when the queue is empty and the age is null. */}
+          {portfolio.summary.oldestQueuedAgeMs !== null && (
+            <Stat label="Oldest queued" value={`${Math.round(portfolio.summary.oldestQueuedAgeMs / 60000)}m`} />
+          )}
         </>
       )}
     </SummaryCard>


### PR DESCRIPTION
## Summary

- `apps/loopover-miner-ui/src/lib/portfolio-queue.ts` computes and validates `oldestQueuedAgeMs`, and the module's own header promises the miner-ui "serves the SAME per-repo dashboard shape the CLI's `queue dashboard` command computes ... so the miner-ui and the CLI share one data path." The CLI renders it (`packages/loopover-miner/lib/portfolio-dashboard.js` → "oldest-queued: Xm"), but the web `OverviewPortfolioCard` never read the field — the parity claim wasn't actually delivered.
- Render `oldestQueuedAgeMs` as an "Oldest queued" stat in `OverviewPortfolioCard` (`routes/index.tsx`), formatted with the CLI's exact `Math.round(oldestQueuedAgeMs / 60000)m` minutes rounding. It's conditionally shown only when the value is non-null, matching the CLI, which omits the age line on an empty queue.
- CLI rendering (`portfolio-dashboard.js`) is untouched — it's the formatting reference. UI-only change under `apps/**`.

Closes #6185

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6185`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (repo-wide) clean.
- [x] `@loopover/ui-miner` workspace: `tsc --noEmit` clean, `vitest run --coverage` green — 134 tests pass (adds a test asserting the "Oldest queued" stat renders "90m" for a 5,400,000 ms age, and that it is omitted when the age is null), coverage stays above the workspace's own 85% thresholds.
- [x] `npm run test:ci` (validates the rest of the repo is unaffected — `apps/**` is excluded from the root coverage suite by design).
- [x] `npm audit --audit-level=moderate`
- [x] Captured the change in a real browser (Vite preview build + Playwright) — see UI Evidence.

If any required check was skipped, explain why:

- No OpenAPI/`cf-typegen`/migration/env-reference regeneration needed — a view-only addition with no API, binding, schema, or generated-doc surface.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP surface changed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the stat reads the live `portfolio.summary.oldestQueuedAgeMs` from the same fetched result the card already renders; the card's existing loading/error/empty states are unchanged.
- [x] Visible UI changes include a `UI Evidence` section below with a captioned JPG/PNG thumbnail.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Overview — Portfolio queue card now shows "Oldest queued: 90m" (desktop, 1280×800) | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6185-desktop.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6185-desktop.png" alt="Overview Portfolio queue card rendering the Oldest queued stat as 90m" width="240"></a> |

## Notes

- The rendered age uses the same minutes rounding as the CLI so the two surfaces read identically; a null age (empty queue) shows no "Oldest queued" row, exactly as the CLI omits its age line.
