### PR TITLE
fix(ui): content-shaped loading skeletons for dead-letter/maintainer/miner panels (#6178)

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.test.tsx
@@ -37,6 +37,19 @@ describe("MaintainerPanel role gate", () => {
     render(<MaintainerPanel />);
     expect(screen.queryByText(/Maintainer access required/i)).toBeNull();
   });
+
+  it("shows a content-shaped skeleton (not the generic spinner) while the dashboard loads (#793)", () => {
+    // Default mock: an admitted maintainer whose dashboard resource is still loading.
+    useSession.mockReturnValue({
+      session: { login: "maint", roles: ["maintainer"] },
+      hydrated: true,
+    });
+    const { container } = render(<MaintainerPanel />);
+    // The custom skeleton replaces the generic LoadingState spinner while the payload is in flight.
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText("Loading maintainer context…")).toBeNull();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(1);
+  });
 });
 
 const emptyGateOutcomeBreakdown = {

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -38,6 +38,7 @@ import { TableScroll } from "@/components/site/data-table";
 import { StatCard } from "@/components/site/primitives";
 import { RefreshMeta } from "@/components/site/refresh-meta";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
+import { Skeleton } from "@/components/ui/skeleton";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -210,6 +211,30 @@ export function MaintainerPanel({
   return <MaintainerDashboardView initialRepoFullName={initialRepoFullName} />;
 }
 
+/** Content-shaped loading placeholder mirroring the maintainer dashboard's top-level layout (refresh
+ *  line, onboarding preview, metric grid, the two-column install/settings row, and the reviewability
+ *  table) so the console doesn't jump once the dashboard payload arrives (#793). */
+function MaintainerDashboardSkeleton() {
+  return (
+    <div className="space-y-6" aria-hidden>
+      <div className="flex items-center justify-end">
+        <Skeleton className="h-6 w-40 rounded-token" />
+      </div>
+      <Skeleton className="h-24 w-full rounded-token" />
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <Skeleton key={index} className="h-24 w-full rounded-token" />
+        ))}
+      </section>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-64 w-full rounded-token" />
+        <Skeleton className="h-64 w-full rounded-token" />
+      </section>
+      <Skeleton className="h-72 w-full rounded-token" />
+    </div>
+  );
+}
+
 function MaintainerDashboardView({
   initialRepoFullName,
 }: {
@@ -229,6 +254,7 @@ function MaintainerDashboardView({
       onRetry={dashboard.reload}
       onRefresh={dashboard.reload}
       loadingTitle="Loading maintainer context…"
+      loadingSkeleton={<MaintainerDashboardSkeleton />}
       emptyTitle="No maintainer data yet"
       emptyDescription="Install health, reviewability, and surface previews appear after repository data is available."
     >

--- a/apps/loopover-ui/src/components/site/app-panels/miner-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/miner-panel.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub the data hook + session so the panel renders without touching the network, and neuter the
+// router Link / MCP badge that the miner dashboard pulls in.
+const { useApiResource, useSession } = vi.hoisted(() => ({
+  useApiResource: vi.fn(),
+  useSession: vi.fn(),
+}));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: (...args: unknown[]) => useApiResource(...args),
+}));
+vi.mock("@/lib/api/session", () => ({ useSession: () => useSession() }));
+vi.mock("@/components/site/mcp-version-badge", () => ({
+  McpVersionBadge: () => <span>mcp</span>,
+}));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, ...props }: { children: React.ReactNode; to?: string }) => (
+    <a href={props.to ?? "#"}>{children}</a>
+  ),
+}));
+
+import { MinerPanel } from "@/components/site/app-panels/miner-panel";
+
+describe("MinerPanel loading skeleton (#793)", () => {
+  it("shows a content-shaped skeleton (not the generic spinner) while the decision pack loads", () => {
+    useSession.mockReturnValue({
+      session: { login: "miner", roles: ["miner"] },
+      hydrated: true,
+    });
+    useApiResource.mockReturnValue({
+      status: "loading",
+      data: null,
+      error: null,
+      loadedAt: null,
+      reload: () => {},
+    });
+
+    const { container } = render(<MinerPanel />);
+    // The custom skeleton replaces the generic LoadingState — neither its title nor its spinner shows.
+    // (A distinct always-present sr-only status live-region in the action bar rules out a role query.)
+    expect(screen.queryByText("Loading miner signals…")).toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    // The placeholder renders animate-pulse blocks approximating the dashboard's metric + card grid.
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(1);
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/miner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/miner-panel.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -85,6 +86,32 @@ type MinerDashboard = {
   >;
   mcp?: { snapshot?: string | null; drift?: string | null; lastRun?: string | null };
 };
+
+/** Content-shaped loading placeholder mirroring the miner dashboard's layout (refresh line, metric
+ *  grid, the next-actions/scoreability two-column row, and the blockers/repo-fit row) so the panel
+ *  doesn't jump once the decision pack arrives (#793). */
+function MinerDashboardSkeleton() {
+  return (
+    <div className="space-y-6" aria-hidden>
+      <div className="flex items-center justify-end">
+        <Skeleton className="h-6 w-40 rounded-token" />
+      </div>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <Skeleton key={index} className="h-24 w-full rounded-token" />
+        ))}
+      </section>
+      <section className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
+        <Skeleton className="h-80 w-full rounded-token" />
+        <Skeleton className="h-80 w-full rounded-token" />
+      </section>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-64 w-full rounded-token" />
+        <Skeleton className="h-64 w-full rounded-token" />
+      </section>
+    </div>
+  );
+}
 
 export function MinerPanel() {
   const { session } = useSession();
@@ -166,6 +193,7 @@ export function MinerPanel() {
         onRetry={dashboard.reload}
         onRefresh={dashboard.reload}
         loadingTitle="Loading miner signals…"
+        loadingSkeleton={<MinerDashboardSkeleton />}
         emptyTitle="No miner actions yet"
         emptyDescription="Once a decision pack or branch analysis exists, ranked next actions and blockers will appear here."
       >

--- a/apps/loopover-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -198,6 +198,17 @@ describe("DeadLetterQueuePanel", () => {
     await screen.findByText("github-webhook");
     expect(screen.getByRole("link", { name: /next/i }).getAttribute("aria-disabled")).toBe("true");
   });
+
+  it("shows a content-shaped skeleton (not the generic spinner) while the queue is loading (#793)", () => {
+    // Keep the request in flight so the boundary stays in its loading branch.
+    apiFetch.mockReturnValue(new Promise<never>(() => {}));
+    const { container } = render(<DeadLetterQueuePanel />);
+    // The custom skeleton replaces the generic LoadingState, so neither its status role nor its title show.
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText("Loading dead-letter queue…")).toBeNull();
+    // The placeholder renders animate-pulse skeleton blocks approximating the table's rows.
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(1);
+  });
 });
 
 describe("DeadLetterQueuePanel row actions and purge", () => {

--- a/apps/loopover-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/loopover-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -30,6 +30,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch } from "@/lib/api/request";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -123,6 +124,7 @@ export function DeadLetterQueuePanel() {
           onRefresh={resource.reload}
           loadingTitle="Loading dead-letter queue…"
           loadingDescription="Fetching failed jobs from the self-host queue backend."
+          loadingSkeleton={<DeadLetterQueueSkeleton />}
           emptyTitle="No dead-letter jobs"
           emptyDescription="Jobs that exhaust their retry budget will appear here."
           errorTitle="Couldn't load the dead-letter queue"
@@ -138,6 +140,31 @@ export function DeadLetterQueuePanel() {
         </StateBoundary>
       </div>
     </section>
+  );
+}
+
+/** Content-shaped loading placeholder for the dead-letter table (bordered table container + a row of
+ *  pagination controls) so the panel doesn't jump once the first page of failed jobs arrives (#793). */
+function DeadLetterQueueSkeleton() {
+  return (
+    <div className="space-y-3" aria-hidden>
+      <div className="overflow-x-auto rounded-token border border-border bg-transparent">
+        <div className="border-b border-border px-4 py-3">
+          <Skeleton className="h-4 w-40" />
+        </div>
+        <div className="divide-y divide-border/60">
+          {Array.from({ length: 5 }, (_, index) => (
+            <div key={index} className="px-4 py-3">
+              <Skeleton className="h-5 w-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-8 w-40 rounded-token" />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

`StateBoundary`'s `loadingSkeleton` prop exists to swap the generic centered spinner for a
content-shaped placeholder so a list/table doesn't visibly jump when its data mounts (#793). Only
`app.runs.tsx`'s `RunsListSkeleton` used it; three structurally similar list/table dashboards still
fell through to the generic `LoadingState` and jumped on first paint.

This adds a content-shaped skeleton for each, following `RunsListSkeleton`'s approach (approximate the
real row/column structure), and wires it as `loadingSkeleton`:

- **`dead-letter-queue-panel.tsx`** — `DeadLetterQueueSkeleton`: the bordered table container (header
  strip + row placeholders) plus the range-text / pagination footer row.
- **`maintainer-panel.tsx`** (drives `ContributorQualityTable`) — `MaintainerDashboardSkeleton`:
  mirrors the dashboard's top-level layout (refresh line, onboarding preview, 4-metric grid, the
  two-column install-health/settings row, and the reviewability table block).
- **`miner-panel.tsx`** — `MinerDashboardSkeleton`: the refresh line, 4-metric grid, the
  next-actions/scoreability two-column row, and the blockers/repo-fit row.

The generic `LoadingState` component is unchanged — it stays correct for boundaries with no fixed
content shape. UI-only, under `apps/**`.

Closes #6178

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm --workspace @loopover/ui run test` (276 passed, incl. the 3 new skeleton tests)
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has unit tests (each panel: content-shaped skeleton shows instead of the generic spinner while loading)

If any required check was skipped, explain why:

- This is a UI-only change under `apps/**` (Codecov-ignored). The backend/MCP checks
  (`actionlint`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`,
  `ui:openapi:check`) don't cover this diff — no `src/**`, worker, MCP, or OpenAPI/schema surface is
  touched — so they were not run locally. The UI lint/typecheck/build/test gates that do cover this
  diff are all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session/CORS surface touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — this improves the real loading state; no mock/demo data added.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A: no doc/changelog change needed.

## UI Evidence

Content-shaped loading skeletons (captured with the data endpoint held pending so the loading branch
stays on screen). Each mirrors its panel's real row/column structure, so no layout jump when data
arrives.

| State / title                           | JPG/PNG evidence                                                                                                                                                                                                          |
| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Dead-letter queue — skeleton (desktop)  | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-dlq-desktop.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-dlq-desktop.png" alt="Dead-letter queue skeleton, desktop" width="240"></a>                   |
| Dead-letter queue — skeleton (mobile)   | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-dlq-mobile.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-dlq-mobile.png" alt="Dead-letter queue skeleton, mobile" width="240"></a>                      |
| Maintainer console — skeleton (desktop) | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-maintainer-desktop.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-maintainer-desktop.png" alt="Maintainer dashboard skeleton, desktop" width="240"></a> |
| Maintainer console — skeleton (mobile)  | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-maintainer-mobile.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-maintainer-mobile.png" alt="Maintainer dashboard skeleton, mobile" width="240"></a>    |
| Miner dashboard — skeleton (desktop)    | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-miner-desktop.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-miner-desktop.png" alt="Miner dashboard skeleton, desktop" width="240"></a>                 |
| Miner dashboard — skeleton (mobile)     | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-miner-mobile.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/skeleton-6178-miner-mobile.png" alt="Miner dashboard skeleton, mobile" width="240"></a>                    |

## Notes

- Follows the existing `RunsListSkeleton` pattern: local component, `aria-hidden` wrapper, `Skeleton`
  from `@/components/ui/skeleton`. Row/section counts are approximate — just enough to fill the
  viewport and match the loaded layout's shape.
