### PR TITLE
fix(ui): adopt TableScroll + caption + scope=col a11y pattern across 8 tables

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/activation-preview.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/activation-preview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the API layer so the component never touches the network.
@@ -56,6 +56,21 @@ describe("ActivationPreview", () => {
       expect.stringContaining("/v1/repos/acme/widgets/activation-preview"),
       expect.objectContaining({ label: "Activation preview" }),
     );
+  });
+
+  it("wraps the sample table in a keyboard-focusable, labelled scroll region with a caption and column-scoped headers (#794 a11y pattern)", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: BASE_PREVIEW });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText("Add cursor pagination")).toBeTruthy());
+    const region = screen.getByRole("region", { name: "Advisory preview sample PRs" });
+    // A bare overflow-hidden div is not a tab stop; TableScroll makes it one (WCAG 2.1.1).
+    expect(region.tabIndex).toBe(0);
+    expect(region.className).toContain("overflow-x-auto");
+    const table = screen.getByRole("table", {
+      name: "Sample pull requests with their title, severity, and finding count.",
+    });
+    expect(within(table).getByRole("columnheader", { name: "PR" })).toBeTruthy();
+    expect(within(table).getByRole("columnheader", { name: "Findings" })).toBeTruthy();
   });
 
   it("renders an error state with the failure message when the preview fails to load", async () => {

--- a/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, Loader2, Rocket } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { StatusPill, type Status } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 import { StateBoundary } from "@/components/site/state-views";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
@@ -250,14 +251,25 @@ function ActivationPreviewBody({
       ) : null}
 
       {preview.samples.length > 0 ? (
-        <div className="overflow-hidden rounded-token border-hairline">
+        <TableScroll className="rounded-token border-hairline" label="Advisory preview sample PRs">
           <table className="w-full text-left text-token-xs">
+            <caption className="sr-only">
+              Sample pull requests with their title, severity, and finding count.
+            </caption>
             <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
               <tr>
-                <th className="px-3 py-2 font-normal">PR</th>
-                <th className="px-3 py-2 font-normal">Title</th>
-                <th className="px-3 py-2 font-normal">Severity</th>
-                <th className="px-3 py-2 font-normal">Findings</th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  PR
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Title
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Severity
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Findings
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -275,7 +287,7 @@ function ActivationPreviewBody({
               ))}
             </tbody>
           </table>
-        </div>
+        </TableScroll>
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">

--- a/apps/loopover-ui/src/components/site/app-panels/miner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/miner-panel.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { Check, Copy, Download, History, Loader2, RefreshCw } from "lucide-react";
 
 import { KeyValueGrid, StatusPill, type Status } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 import { McpVersionBadge } from "@/components/site/mcp-version-badge";
 import { StatCard } from "@/components/site/primitives";
 import { RefreshMeta } from "@/components/site/refresh-meta";
@@ -364,42 +365,54 @@ export function MinerPanel() {
                 <p className="mt-1 text-token-xs text-muted-foreground">
                   Where to spend time, and where not to.
                 </p>
-                <table className="mt-4 w-full text-left text-token-sm">
-                  <thead>
-                    <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                      <th className="py-2 pr-3 font-normal">Repo</th>
-                      <th className="py-2 pr-3 font-normal">Lane</th>
-                      <th className="py-2 font-normal">Why</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.repoFit.map((repo, index) => {
-                      const lane = repo.lane ?? "pursue";
-                      return (
-                        <tr
-                          key={`${repo.repoFullName ?? index}`}
-                          className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
-                        >
-                          <td className="py-2 pr-3 align-top">
-                            <div className="break-all font-mono text-token-xs text-foreground/90">
-                              {repo.repoFullName ?? "repo pending"}
-                            </div>
-                            <RecommendationChangeInline change={repo.change} />
-                          </td>
-                          <td className="py-2 pr-3 align-top">
-                            <StatusPill status={LANE_TONE[lane] ?? "info"}>{lane}</StatusPill>
-                          </td>
-                          <td className="py-2 align-top text-token-xs text-muted-foreground">
-                            {repo.why ??
-                              repo.rationale ??
-                              repo.recommendation ??
-                              "No rationale recorded."}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                <TableScroll className="mt-4" label="Repo fit">
+                  <table className="w-full text-left text-token-sm">
+                    <caption className="sr-only">
+                      Repositories with their recommended lane and rationale for where to spend
+                      time.
+                    </caption>
+                    <thead>
+                      <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                        <th scope="col" className="py-2 pr-3 font-normal">
+                          Repo
+                        </th>
+                        <th scope="col" className="py-2 pr-3 font-normal">
+                          Lane
+                        </th>
+                        <th scope="col" className="py-2 font-normal">
+                          Why
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.repoFit.map((repo, index) => {
+                        const lane = repo.lane ?? "pursue";
+                        return (
+                          <tr
+                            key={`${repo.repoFullName ?? index}`}
+                            className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
+                          >
+                            <td className="py-2 pr-3 align-top">
+                              <div className="break-all font-mono text-token-xs text-foreground/90">
+                                {repo.repoFullName ?? "repo pending"}
+                              </div>
+                              <RecommendationChangeInline change={repo.change} />
+                            </td>
+                            <td className="py-2 pr-3 align-top">
+                              <StatusPill status={LANE_TONE[lane] ?? "info"}>{lane}</StatusPill>
+                            </td>
+                            <td className="py-2 align-top text-token-xs text-muted-foreground">
+                              {repo.why ??
+                                repo.rationale ??
+                                repo.recommendation ??
+                                "No rationale recorded."}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </TableScroll>
               </div>
             </section>
           </div>

--- a/apps/loopover-ui/src/components/site/audit-feed.test.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
@@ -114,6 +114,20 @@ describe("AuditFeed", () => {
       "https://api.test/v1/app/skipped-pr-audit?limit=50",
       expect.objectContaining({ credentials: "include" }),
     );
+  });
+
+  it("wraps the audit table in a keyboard-focusable, labelled scroll region with a caption and column-scoped headers (#794 a11y pattern)", async () => {
+    render(<AuditFeed />);
+    await screen.findByText("repo-owner/owned-repo");
+    const region = screen.getByRole("region", { name: "Skipped PR audit" });
+    // A bare overflow-x-auto div is not a tab stop; TableScroll makes it one (WCAG 2.1.1).
+    expect(region.tabIndex).toBe(0);
+    expect(region.className).toContain("overflow-x-auto");
+    const table = screen.getByRole("table", {
+      name: "Skipped pull requests with the time, repository, pull request, skip reason, and remediation for each.",
+    });
+    expect(within(table).getByRole("columnheader", { name: "Time" })).toBeTruthy();
+    expect(within(table).getByRole("columnheader", { name: "Remediation" })).toBeTruthy();
   });
 
   it("shows an empty state when the audit export has no items", async () => {

--- a/apps/loopover-ui/src/components/site/audit-feed.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.tsx
@@ -14,6 +14,7 @@ import {
   type SkippedPrAuditReason,
 } from "@/components/site/audit-feed-model";
 import { BoundaryBadge, StatusPill } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 import {
   EmptyState,
   ErrorState,
@@ -184,15 +185,32 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
         onReset={resetFilters}
       />
 
-      <div className="overflow-x-auto rounded-token border border-border bg-transparent">
+      <TableScroll
+        className="rounded-token border border-border bg-transparent"
+        label="Skipped PR audit"
+      >
         <table className="w-full min-w-[760px] text-left text-token-sm">
+          <caption className="sr-only">
+            Skipped pull requests with the time, repository, pull request, skip reason, and
+            remediation for each.
+          </caption>
           <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
             <tr>
-              <th className="px-4 py-3 font-medium">Time</th>
-              <th className="px-4 py-3 font-medium">Repository</th>
-              <th className="px-4 py-3 font-medium">Pull request</th>
-              <th className="px-4 py-3 font-medium">Reason</th>
-              <th className="px-4 py-3 font-medium">Remediation</th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Time
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Repository
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Pull request
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Reason
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Remediation
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -228,7 +246,7 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
             ))}
           </tbody>
         </table>
-      </div>
+      </TableScroll>
 
       <div className="flex flex-wrap items-center gap-3">
         {data.hasMore && limit < MAX_LIMIT ? (

--- a/apps/loopover-ui/src/components/site/check-run-readiness-table.test.tsx
+++ b/apps/loopover-ui/src/components/site/check-run-readiness-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { CheckRunReadinessTable } from "@/components/site/check-run-readiness-table";
@@ -53,6 +53,19 @@ describe("CheckRunReadinessTable", () => {
     expect(screen.getByText("Test plan noted but not verified.")).toBeTruthy();
     expect(screen.getByText("Developing")).toBeTruthy();
     expect(screen.getByText("Partial")).toBeTruthy();
+  });
+
+  it("wraps the table in a keyboard-focusable, labelled scroll region with a caption and column-scoped headers (#794 a11y pattern)", () => {
+    render(<CheckRunReadinessTable detailLevel="standard" readiness={SAMPLE} />);
+    const region = screen.getByRole("region", { name: "Context check readiness signals" });
+    // A bare overflow-hidden/overflow-x-auto div is not a tab stop; TableScroll makes it one.
+    expect(region.tabIndex).toBe(0);
+    expect(region.className).toContain("overflow-x-auto");
+    const table = screen.getByRole("table", {
+      name: "Readiness signals with their band, evidence, and recommended action.",
+    });
+    expect(within(table).getByRole("columnheader", { name: "Signal" })).toBeTruthy();
+    expect(within(table).getByRole("columnheader", { name: "Action" })).toBeTruthy();
   });
 
   it("hides the table at minimal detail level", () => {

--- a/apps/loopover-ui/src/components/site/check-run-readiness-table.tsx
+++ b/apps/loopover-ui/src/components/site/check-run-readiness-table.tsx
@@ -1,4 +1,5 @@
 import { StatusPill, type Status } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 import {
   COMPONENT_BAND_LABEL,
   READINESS_BAND_LABEL,
@@ -57,14 +58,28 @@ export function CheckRunReadinessTable({
         </StatusPill>
       </div>
 
-      <div className="overflow-hidden rounded-token border-hairline">
+      <TableScroll
+        className="rounded-token border-hairline"
+        label="Context check readiness signals"
+      >
         <table className="w-full text-left text-token-xs">
+          <caption className="sr-only">
+            Readiness signals with their band, evidence, and recommended action.
+          </caption>
           <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
             <tr>
-              <th className="px-3 py-2 font-normal">Signal</th>
-              <th className="px-3 py-2 font-normal">Band</th>
-              <th className="px-3 py-2 font-normal">Evidence</th>
-              <th className="hidden px-3 py-2 font-normal lg:table-cell">Action</th>
+              <th scope="col" className="px-3 py-2 font-normal">
+                Signal
+              </th>
+              <th scope="col" className="px-3 py-2 font-normal">
+                Band
+              </th>
+              <th scope="col" className="px-3 py-2 font-normal">
+                Evidence
+              </th>
+              <th scope="col" className="hidden px-3 py-2 font-normal lg:table-cell">
+                Action
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -84,7 +99,7 @@ export function CheckRunReadinessTable({
             ))}
           </tbody>
         </table>
-      </div>
+      </TableScroll>
     </section>
   );
 }

--- a/apps/loopover-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
@@ -121,6 +121,20 @@ describe("DeadLetterQueuePanel", () => {
     // A null lastError renders as an em dash, not "null" or an empty cell.
     const dashCells = screen.getAllByText("—");
     expect(dashCells.length).toBeGreaterThan(0);
+  });
+
+  it("wraps the queue table in a keyboard-focusable, labelled scroll region with a caption and column-scoped headers (#794 a11y pattern)", async () => {
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+    const region = screen.getByRole("region", { name: "Dead letter queue" });
+    // A bare overflow-x-auto div is not a tab stop; TableScroll makes it one (WCAG 2.1.1).
+    expect(region.tabIndex).toBe(0);
+    expect(region.className).toContain("overflow-x-auto");
+    const table = screen.getByRole("table", {
+      name: "Failed background jobs with their ID, type, attempt count, last error, timestamps, and retry actions.",
+    });
+    expect(within(table).getByRole("columnheader", { name: "Job ID" })).toBeTruthy();
+    expect(within(table).getByRole("columnheader", { name: "Actions" })).toBeTruthy();
   });
 
   it("shows an empty state when the queue has no dead-letter jobs", async () => {

--- a/apps/loopover-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/loopover-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -11,6 +11,7 @@ import {
   type DeadLetterQueueItem,
 } from "@/components/site/dead-letter-queue-panel-model";
 import { StatusPill } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 import { StateActionButton, StateBoundary } from "@/components/site/state-views";
 import {
   AlertDialog,
@@ -242,17 +243,38 @@ function DeadLetterQueueTable({
 
   return (
     <div className="space-y-3">
-      <div className="overflow-x-auto rounded-token border border-border bg-transparent">
+      <TableScroll
+        className="rounded-token border border-border bg-transparent"
+        label="Dead letter queue"
+      >
         <table className="w-full min-w-[880px] text-left text-token-sm">
+          <caption className="sr-only">
+            Failed background jobs with their ID, type, attempt count, last error, timestamps, and
+            retry actions.
+          </caption>
           <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
             <tr>
-              <th className="px-4 py-3 font-medium">Job ID</th>
-              <th className="px-4 py-3 font-medium">Type</th>
-              <th className="px-4 py-3 font-medium">Attempts</th>
-              <th className="px-4 py-3 font-medium">Last error</th>
-              <th className="px-4 py-3 font-medium">Created</th>
-              <th className="px-4 py-3 font-medium">Died</th>
-              <th className="px-4 py-3 font-medium">Actions</th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Job ID
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Type
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Attempts
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Last error
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Created
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Died
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -329,7 +351,7 @@ function DeadLetterQueueTable({
             })}
           </tbody>
         </table>
-      </div>
+      </TableScroll>
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-token-2xs text-muted-foreground">

--- a/apps/loopover-ui/src/components/site/public-repo-quality-page.tsx
+++ b/apps/loopover-ui/src/components/site/public-repo-quality-page.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch } from "@/lib/api/request";
+import { TableScroll } from "@/components/site/data-table";
 import { Card, Section, SectionTitle } from "@/components/site/primitives";
 
 export type PublicQualityMetrics = {
@@ -152,14 +153,25 @@ export function PublicRepoQualityPage({ owner, repo }: { owner: string; repo: st
 
         <div className="mt-10">
           <h2 className="text-token-lg font-medium">Weekly trend</h2>
-          <div className="mt-4 overflow-x-auto">
+          <TableScroll className="mt-4" label="Weekly trend">
             <table className="w-full min-w-[36rem] text-left text-token-sm">
+              <caption className="sr-only">
+                Weekly gate false-positive rate, merge ratio, and blocked count.
+              </caption>
               <thead className="text-token-xs text-muted-foreground">
                 <tr>
-                  <th className="pb-2 pr-4 font-medium">Week</th>
-                  <th className="pb-2 pr-4 font-medium">Gate FP rate</th>
-                  <th className="pb-2 pr-4 font-medium">Merge ratio</th>
-                  <th className="pb-2 font-medium">Blocks</th>
+                  <th scope="col" className="pb-2 pr-4 font-medium">
+                    Week
+                  </th>
+                  <th scope="col" className="pb-2 pr-4 font-medium">
+                    Gate FP rate
+                  </th>
+                  <th scope="col" className="pb-2 pr-4 font-medium">
+                    Merge ratio
+                  </th>
+                  <th scope="col" className="pb-2 font-medium">
+                    Blocks
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -179,7 +191,7 @@ export function PublicRepoQualityPage({ owner, repo }: { owner: string; repo: st
                 ))}
               </tbody>
             </table>
-          </div>
+          </TableScroll>
         </div>
       </div>
     </Section>

--- a/apps/loopover-ui/src/components/site/usage-analytics-panels.test.tsx
+++ b/apps/loopover-ui/src/components/site/usage-analytics-panels.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CommandUsefulnessPanel } from "@/components/site/usage-analytics-panels";
+
+const TOTALS = {
+  feedbackCount: 6,
+  usefulCount: 4,
+  notUsefulCount: 2,
+  usefulnessRate: 0.6667,
+  answerCount: 9,
+};
+
+const COMMANDS = [
+  {
+    command: "/loopover explain",
+    feedbackCount: 4,
+    usefulCount: 3,
+    notUsefulCount: 1,
+    usefulnessRate: 0.75,
+  },
+  {
+    command: "/loopover check",
+    feedbackCount: 2,
+    usefulCount: 1,
+    notUsefulCount: 1,
+    usefulnessRate: null,
+  },
+];
+
+describe("CommandUsefulnessPanel", () => {
+  it("renders a row per command with its feedback, useful count, and rate", () => {
+    render(<CommandUsefulnessPanel totals={TOTALS} commands={COMMANDS} windowDays={30} />);
+    expect(screen.getByText("/loopover explain")).toBeTruthy();
+    expect(screen.getByText("/loopover check")).toBeTruthy();
+    expect(screen.getByText("75%")).toBeTruthy();
+  });
+
+  it("wraps the command table in a keyboard-focusable, labelled scroll region with a caption and column-scoped headers (#794 a11y pattern)", () => {
+    render(<CommandUsefulnessPanel totals={TOTALS} commands={COMMANDS} windowDays={30} />);
+    const region = screen.getByRole("region", { name: "Command feedback" });
+    // A bare overflow-x-auto div is not a tab stop; TableScroll makes it one (WCAG 2.1.1).
+    expect(region.tabIndex).toBe(0);
+    expect(region.className).toContain("overflow-x-auto");
+    const table = screen.getByRole("table", {
+      name: "Commands with their feedback count, useful count, and usefulness rate.",
+    });
+    expect(within(table).getByRole("columnheader", { name: "Command" })).toBeTruthy();
+    expect(within(table).getByRole("columnheader", { name: "Rate" })).toBeTruthy();
+  });
+
+  it("renders a helper note instead of a table when there is no command feedback in the window", () => {
+    render(<CommandUsefulnessPanel totals={TOTALS} commands={[]} windowDays={30} />);
+    expect(screen.getByText("No command feedback recorded in this window.")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/components/site/usage-analytics-panels.tsx
+++ b/apps/loopover-ui/src/components/site/usage-analytics-panels.tsx
@@ -1,4 +1,5 @@
 import { Stat, StatusPill } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 
 type WeeklyMetric = {
   id: string;
@@ -199,14 +200,25 @@ export function CommandUsefulnessPanel({
         />
       </div>
       {commands.length > 0 ? (
-        <div className="mt-4 overflow-x-auto">
+        <TableScroll className="mt-4" label="Command feedback">
           <table className="w-full min-w-[480px] text-left text-token-sm">
+            <caption className="sr-only">
+              Commands with their feedback count, useful count, and usefulness rate.
+            </caption>
             <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
               <tr>
-                <th className="py-2 pr-4 font-medium">Command</th>
-                <th className="py-2 pr-4 font-medium">Feedback</th>
-                <th className="py-2 pr-4 font-medium">Useful</th>
-                <th className="py-2 font-medium">Rate</th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Command
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Feedback
+                </th>
+                <th scope="col" className="py-2 pr-4 font-medium">
+                  Useful
+                </th>
+                <th scope="col" className="py-2 font-medium">
+                  Rate
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -222,7 +234,7 @@ export function CommandUsefulnessPanel({
               ))}
             </tbody>
           </table>
-        </div>
+        </TableScroll>
       ) : (
         <p className="mt-4 text-token-xs text-muted-foreground">
           No command feedback recorded in this window.

--- a/apps/loopover-ui/src/routes/app.analytics.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Download } from "lucide-react";
 
 import { BoundaryBadge, Stat, StatusPill } from "@/components/site/control-primitives";
+import { TableScroll } from "@/components/site/data-table";
 import { RefreshMeta } from "@/components/site/refresh-meta";
 import { StateActionButton, StateBoundary } from "@/components/site/state-views";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -420,17 +421,34 @@ function ProductAnalytics() {
                   ))}
                 </ul>
               ) : null}
-              <div className="mt-4 overflow-x-auto">
+              <TableScroll className="mt-4" label="Usage rollups">
                 <table className="w-full min-w-[680px] text-left text-token-sm">
+                  <caption className="sr-only">
+                    Daily usage rollups with status and event, actor, repo, and activation counts.
+                  </caption>
                   <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
                     <tr>
-                      <th className="py-2 pr-4 font-medium">Day</th>
-                      <th className="py-2 pr-4 font-medium">Status</th>
-                      <th className="py-2 pr-4 font-medium">Events</th>
-                      <th className="py-2 pr-4 font-medium">Actors</th>
-                      <th className="py-2 pr-4 font-medium">Repos</th>
-                      <th className="py-2 pr-4 font-medium">Activated</th>
-                      <th className="py-2 font-medium">GitHub activated</th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Day
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Status
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Events
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Actors
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Repos
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Activated
+                      </th>
+                      <th scope="col" className="py-2 font-medium">
+                        GitHub activated
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -449,7 +467,7 @@ function ProductAnalytics() {
                     ))}
                   </tbody>
                 </table>
-              </div>
+              </TableScroll>
             </section>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

Adopts the `#794` responsive-table accessibility pattern — `TableScroll` (`role="region"` +
`aria-label` + `tabIndex=0`) plus a `<caption>` and `scope="col"` header cells — across the 8 data
tables that were still on the pre-`#794` bare `overflow-x-auto` (or had no scroll region at all).
This matches the exact pattern already established in `maintainer-panel.tsx` and
`contributor-quality-table.tsx`.

Migrated tables:

- **Bare `overflow-x-auto` → `TableScroll`:** `audit-feed.tsx`, `dead-letter-queue-panel.tsx`,
  `usage-analytics-panels.tsx` (Command feedback), `public-repo-quality-page.tsx` (Weekly trend),
  `routes/app.analytics.tsx` (Usage rollups).
- **No scroll region at all → `TableScroll`:** `app-panels/miner-panel.tsx` (Repo fit),
  `check-run-readiness-table.tsx`, `app-panels/activation-preview.tsx` (sample PRs) — the two
  `overflow-hidden` wrappers become `overflow-x-auto` so overflowing content is reachable by keyboard
  and pointer instead of being clipped.

No table's data or columns change — this is wrapping/accessibility markup only, per the issue. Every
`<caption>` is `sr-only`, so there is no at-rest visual difference; the observable change is the
keyboard-focusable scroll region gaining a focus indicator (WCAG 2.1.1) and, on narrow viewports,
horizontal scrollability. Added/extended unit tests assert the accessibility tree for each migrated
table: the labelled `region`, the caption-derived table accessible name, and `columnheader`-role
headers.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6179`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a UI-only change confined to `apps/loopover-ui/**`. The backend / MCP / OpenAPI checks
  (`typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`,
  `actionlint`) have no changed surface to exercise — no `src/**`, worker, MCP, workflow, or API
  schema files are touched. The UI gates that do apply (`ui:lint`, `ui:typecheck`, `ui:build`) and the
  full `apps/loopover-ui` Vitest suite (280 tests) all pass locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session/CORS surface changed.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP behavior changed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with PNG screenshots arranged as captioned, clickable thumbnails.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

The captions are `sr-only` and the `scope`/`role` attributes are semantic-only, so at rest the tables
are pixel-identical to before. The observable change is the WCAG 2.1.1 fix: the scroll region is now a
keyboard tab stop with a visible focus indicator, and on a narrow viewport the table scrolls
horizontally instead of clipping. Both are shown below on the public Weekly-trend table
(`public-repo-quality-page.tsx`), with the scroll region focused.

| State / title                                          | PNG evidence                                                                                                                                                                                                    |
| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Desktop — focused scroll region (keyboard focus ring)  | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/trend-6179-desktop-focus.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/trend-6179-desktop-focus.png" alt="Desktop focus ring" width="240"></a> |
| Mobile (375px) — focus ring + horizontal scrollability | <a href="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/trend-6179-mobile-focus.png"><img src="https://raw.githubusercontent.com/nghetienhiep/gittensory/screenshots/trend-6179-mobile-focus.png" alt="Mobile focus ring and scroll" width="240"></a> |

## Notes

- Test evidence for the accessibility tree lives in the migrated components' `*.test.tsx` files (new
  a11y assertions in `audit-feed`, `dead-letter-queue-panel`, `check-run-readiness-table`,
  `activation-preview`, and a new `usage-analytics-panels.test.tsx`), each asserting the labelled
  scroll region, caption-derived table name, and `columnheader` scope.


Closes #6179
