### PR TITLE
fix(miner-ui): render the events-by-type breakdown ledgers already fetches

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -88,12 +88,16 @@ describe("emptyLedgersSummary (#4855)", () => {
 });
 
 describe("LedgersView (#4855)", () => {
-  it("renders claim status counts, the governor type table, and the recent-events feed", () => {
+  it("renders claim status counts, the governor type table, the events-by-type table, and the recent-events feed", () => {
     render(<LedgersView result={{ ok: true, summary: fixtureSummary }} />);
     expect(screen.getByText("Active", { selector: "dt" }).nextSibling?.textContent).toBe("2");
     expect(screen.getByText("Released", { selector: "dt" }).nextSibling?.textContent).toBe("1");
     expect(screen.getByText("rate_limit_deferred")).toBeTruthy();
-    expect(screen.getByText("attempt_succeeded")).toBeTruthy();
+    // #6184: byType now renders its own aggregate table, so each event type appears twice -- once in that table
+    // and once in the recent-events feed. getAllByText, not getByText, which would throw on the duplicate.
+    expect(screen.getByText("Events by type (2)")).toBeTruthy();
+    expect(screen.getAllByText("attempt_succeeded").length).toBe(2);
+    expect(screen.getAllByText("attempt_started").length).toBe(2);
     expect(screen.getAllByText("acme/widgets").length).toBeGreaterThan(0);
   });
 

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -162,6 +162,15 @@ export function LedgersView({ result }: { result: LedgersResult | null }) {
       </section>
 
       <section className="grid gap-3">
+        <h3 className="font-display text-token-base font-semibold">Events by type ({events.total})</h3>
+        {events.total === 0 ? (
+          <p className="text-token-sm text-muted-foreground">No events recorded.</p>
+        ) : (
+          <CountTable counts={events.byType} keyLabel="Event type" />
+        )}
+      </section>
+
+      <section className="grid gap-3">
         <h3 className="font-display text-token-base font-semibold">Recent events ({events.total})</h3>
         {events.recent.length === 0 ? (
           <p className="text-token-sm text-muted-foreground">No event-ledger entries recorded.</p>


### PR DESCRIPTION
## Summary

`ledgers.ts` types and validates `EventsSummary.byType`, and `routes/ledgers.tsx` even defaults it, but `LedgersView` never rendered it — the "Recent events" section listed individual `events.recent` rows only, so `byType` was fetched and type-guarded purely to be discarded. The structurally identical `governor.byEventType` already gets its own `CountTable` a few lines up.

This adds the matching **"Events by type"** section: same `CountTable` component, same `total === 0` empty-state guard the "Governor events" section uses, placed directly above "Recent events" so the aggregate reads before the detail feed. The "Recent events" list and every other section are untouched, per the issue.

## Test

The existing render test asserted `getByText("attempt_succeeded")`, a value that was unique to the recent-events feed. Now that each event type also appears in the new `byType` table, that value renders **twice** — so `getByText` would throw on the duplicate. The assertion moves to `getAllByText(...).length === 2` (for both `attempt_succeeded` and `attempt_started`) and additionally asserts the new `"Events by type (2)"` header. This is exactly the kind of break that only surfaces by running the suite, not by eyeballing the diff.

## Validation

- [x] `@loopover/ui-miner` test suite — **133/133 pass**; `ledgers.tsx` reports 100% statement/line coverage.
- [x] `npm run ui:typecheck` — clean (both UI workspaces).
- [x] `@loopover/ui-miner` build — clean.
- [x] `npm run ui:lint` — **0 non-prettier violations**; I ran `prettier` on both files and confirmed it made no substantive reflow (my formatting already matches; the repo-wide `prettier/prettier` errors are Windows CRLF noise, absent on CI's LF checkout).
- [x] `git diff --check` clean; the working tree contains only the two intended files (no generated `routeTree.gen.ts` churn committed). Rebased on latest `main` — no base conflict.

## Coverage

No patch surface: `apps/**` is in Codecov's ignore list. The change is still covered by the render test above.

## Scope

- [x] Two files (component + its test), one coherent change, in a wanted path (`apps/loopover-miner-ui/`). Maintainer-authored issue, so this is approved operator-facing work, not speculative cosmetic churn.
- [x] Uses live, already-fetched API data (`events.byType`) and the existing design-token layout convention — exactly what this repo's UI guidance asks for.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Additive rendering of data the client already fetches and validates — no new fetch, no API change, no change to any existing section's output.

Closes #6184
