### PR TITLE
fix(miner-ui): render events.byType breakdown on ledgers dashboard

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -88,13 +88,22 @@ describe("emptyLedgersSummary (#4855)", () => {
 });
 
 describe("LedgersView (#4855)", () => {
-  it("renders claim status counts, the governor type table, and the recent-events feed", () => {
+  it("renders claim status counts, the governor type table, the events-by-type table, and the recent-events feed", () => {
     render(<LedgersView result={{ ok: true, summary: fixtureSummary }} />);
     expect(screen.getByText("Active", { selector: "dt" }).nextSibling?.textContent).toBe("2");
     expect(screen.getByText("Released", { selector: "dt" }).nextSibling?.textContent).toBe("1");
     expect(screen.getByText("rate_limit_deferred")).toBeTruthy();
+    expect(screen.getByText("attempt_started")).toBeTruthy();
     expect(screen.getByText("attempt_succeeded")).toBeTruthy();
     expect(screen.getAllByText("acme/widgets").length).toBeGreaterThan(0);
+  });
+
+  it("renders an events-by-type breakdown table matching the governor pattern (#6184)", () => {
+    render(<LedgersView result={{ ok: true, summary: fixtureSummary }} />);
+    expect(screen.getByRole("heading", { name: "Events (2)" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Governor events (2)" })).toBeTruthy();
+    const attemptStartedCells = screen.getAllByText("attempt_started");
+    expect(attemptStartedCells.length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders the fresh-install empty state when every ledger is empty", () => {

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -162,6 +162,15 @@ export function LedgersView({ result }: { result: LedgersResult | null }) {
       </section>
 
       <section className="grid gap-3">
+        <h3 className="font-display text-token-base font-semibold">Events ({events.total})</h3>
+        {events.total === 0 ? (
+          <p className="text-token-sm text-muted-foreground">No event-ledger entries recorded.</p>
+        ) : (
+          <CountTable counts={events.byType} keyLabel="Event type" />
+        )}
+      </section>
+
+      <section className="grid gap-3">
         <h3 className="font-display text-token-base font-semibold">Recent events ({events.total})</h3>
         {events.recent.length === 0 ? (
           <p className="text-token-sm text-muted-foreground">No event-ledger entries recorded.</p>


### PR DESCRIPTION
## Summary
- Renders `events.byType` in `LedgersView` using the existing `CountTable` component, matching the `governor.byEventType` section layout.
- The ledgers API already fetches and validates `byType`; this stops discarding it on the client.
- Adds focused regression coverage in `ledgers.test.tsx` (`#6184`).

Closes #6184

## Scope
- [x] UI-only change under `apps/loopover-miner-ui`
- [x] Recent events list unchanged
- [x] Reuses existing `CountTable` — no new layout primitives

## Validation
- [x] Unit tests updated (`apps/loopover-miner-ui/src/ledgers.test.tsx`)
- [ ] CI on this PR (will mark ready after green)

## Safety
- [x] Read-only dashboard; no new API surface
- [x] No scheme / economics / protocol changes


Made with [Cursor](https://cursor.com)