### PR TITLE
fix(review): include the PR body in the AI-review cache fingerprint

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -9084,6 +9084,7 @@ async function maybePublishPrPublicSurface(
             dynamicReviewFeatures.impactMap;
           const inputFingerprint = await aiReviewCacheInputFingerprint({
             title: pr.title,
+            body: pr.body,
             mode: settings.aiReviewMode,
             byok: settings.aiReviewByok,
             provider: settings.aiReviewProvider,

--- a/src/review/ai-review-cache-input.ts
+++ b/src/review/ai-review-cache-input.ts
@@ -7,10 +7,13 @@ import { sha256Hex } from "../utils/crypto";
 
 // Bumped v1→v2 (#2995): `features` gained a `cultureProfile` member. Bumped v2→v3 (#2182-#2186): `features`
 // gained an `impactMap` member. Bumped v3→v4 (#3902): `selfHostAiModelOverride` gained ollamaModel/openaiModel/
-// openaiCompatibleModel/anthropicModel members. Every prior cached review's fingerprint was computed without
-// that key, so bumping the version guarantees a clean cache miss on the first review after upgrade rather than
-// silently reusing a hash computed under a different payload shape.
-export const AI_REVIEW_CACHE_INPUT_VERSION = "ai-review-input:v4";
+// openaiCompatibleModel/anthropicModel members. Bumped v4→v5: added a top-level `body` member (the PR
+// description is threaded into the reviewer prompt exactly like `title`, but was never fingerprinted -- an
+// edited-description webhook with an unchanged head SHA silently replayed the pre-edit review). Every prior
+// cached review's fingerprint was computed without that key, so bumping the version guarantees a clean cache
+// miss on the first review after upgrade rather than silently reusing a hash computed under a different payload
+// shape.
+export const AI_REVIEW_CACHE_INPUT_VERSION = "ai-review-input:v5";
 
 // #regate-churn (root cause, confirmed in production): this fingerprint USED to also hash the PR's live
 // `baseSha`, on the theory that a rebase/retarget can change the diff GitHub reports for an otherwise-unchanged
@@ -27,6 +30,10 @@ export type AiReviewCacheInput = {
   // `edited` event that changes only the title must miss the cache rather than replay a review generated for
   // different prompt metadata.
   title: string;
+  // Same reasoning as `title` immediately above: the PR body is threaded into the reviewer prompt too (see
+  // buildUserPrompt's `input.body`), so a same-head `edited` event that changes only the description must also
+  // miss the cache rather than replay a review generated against a different Description: block.
+  body: string | null | undefined;
   mode: string;
   byok: boolean;
   provider: string | null | undefined;
@@ -123,6 +130,7 @@ export async function aiReviewCacheInputFingerprint(input: AiReviewCacheInput): 
   const payload = {
     version: AI_REVIEW_CACHE_INPUT_VERSION,
     title: input.title,
+    body: input.body ?? null,
     mode: input.mode,
     byok: input.byok,
     provider: input.provider ?? null,

--- a/test/unit/ai-review-cache-input.test.ts
+++ b/test/unit/ai-review-cache-input.test.ts
@@ -6,6 +6,7 @@ import {
 
 const baseInput = (): AiReviewCacheInput => ({
   title: "Fix the retry loop",
+  body: "Fixes the retry loop by adding a backoff.",
   mode: "block",
   byok: false,
   provider: null,
@@ -273,6 +274,26 @@ describe("aiReviewCacheInputFingerprint", () => {
 
     expect(titleChanged).not.toBe(original);
     expect(repeated).toBe(original);
+  });
+
+  it("changes when the PR body changes even though nothing else does (#ai-review-cache-body)", async () => {
+    // The PR description is threaded into the reviewer prompt (buildUserPrompt's `input.body`) exactly like
+    // `title` above, so a same-head `edited` event that changes only the description must miss the cache
+    // rather than replay a review generated against a different Description: block. This regression-tests the
+    // fix: `body` used to be entirely absent from AiReviewCacheInput/the hashed payload, so an edited-body
+    // webhook with an unchanged headSha silently reused the pre-edit AI verdict.
+    const original = await aiReviewCacheInputFingerprint(baseInput());
+    const bodyChanged = await aiReviewCacheInputFingerprint({ ...baseInput(), body: "Completely different description now." });
+    const bodyNull = await aiReviewCacheInputFingerprint({ ...baseInput(), body: null });
+    const bodyUndefined = await aiReviewCacheInputFingerprint({ ...baseInput(), body: undefined });
+    const repeated = await aiReviewCacheInputFingerprint(baseInput());
+
+    expect(bodyChanged).not.toBe(original);
+    expect(repeated).toBe(original);
+    // null and undefined both mean "no body" and must fingerprint identically -- the same normalization every
+    // other nullable field in this payload (provider, model, gatePack, ...) already applies via `?? null`.
+    expect(bodyNull).toBe(bodyUndefined);
+    expect(bodyNull).not.toBe(original);
   });
 
   it("changes when aiReviewAllAuthors, aiReviewCloseConfidence, or gatePack change", async () => {

--- a/test/unit/ai-review-cache.test.ts
+++ b/test/unit/ai-review-cache.test.ts
@@ -5,6 +5,7 @@ import { createTestEnv } from "../helpers/d1";
 
 const baseFingerprintInput = (): AiReviewCacheInput => ({
   title: "Fix the retry loop",
+  body: "Fixes the retry loop.",
   mode: "block",
   byok: false,
   provider: null,

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -243,6 +243,7 @@ describe("queue processors", () => {
   async function cachedSubFloorDefectFingerprint(title: string): Promise<string> {
     return aiReviewCacheInputFingerprint({
       title,
+      body: "Closes #1",
       mode: "block",
       byok: false,
       provider: null,

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -1155,10 +1155,15 @@ describe("queue processors", () => {
     const usage = await env.DB.prepare("select feature, status from ai_usage_events where feature = ?").bind("ai_review_pr").first<{ feature: string; status: string }>();
     expect(usage).toMatchObject({ feature: "ai_review_pr", status: "ok" });
     expect(cacheReadSpy).toHaveBeenCalled();
-    expect(cacheReadSpy.mock.calls[0]?.[5]).toMatch(/^ai-review-input:v4:/);
+    // Pinned to v4 before the fix that added `body` to AiReviewCacheInput (AI_REVIEW_CACHE_INPUT_VERSION
+    // bumped v4->v5, same convention as every prior member addition -- see ai-review-cache-input.ts's version
+    // comment) -- this assertion only cares that a real, current-shape fingerprint was computed and threaded
+    // through, not the exact version number, so it is updated to the new version rather than left pinned to
+    // the pre-fix one.
+    expect(cacheReadSpy.mock.calls[0]?.[5]).toMatch(/^ai-review-input:v5:/);
     expect(cacheWriteSpy).toHaveBeenCalled();
     expect(cacheWriteSpy.mock.calls[0]?.[5]).toMatchObject({
-      metadata: { inputFingerprint: expect.stringMatching(/^ai-review-input:v4:/) },
+      metadata: { inputFingerprint: expect.stringMatching(/^ai-review-input:v5:/) },
     });
     cacheReadSpy.mockRestore();
     cacheWriteSpy.mockRestore();

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -4604,7 +4604,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Clean PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Clean PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -5305,6 +5305,7 @@ describe("queue processors", () => {
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
             title: "Current PR",
+            body: "Closes #1",
             mode: "block",
             byok: false,
             provider: null,
@@ -5396,7 +5397,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Current PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -5453,7 +5454,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Current PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -5509,7 +5510,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Current PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -5562,7 +5563,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Current PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -5611,7 +5612,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Partially published PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Partially published PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -5663,7 +5664,7 @@ describe("queue processors", () => {
         cacheable: true,
         metadata: {
           inputFingerprint: await aiReviewCacheInputFingerprint({
-            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            title: "Current PR", body: "Closes #1", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
             aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, selfHostAiModelOverride: { claudeModel: null, claudeEffort: null, codexModel: null, codexEffort: null, ollamaModel: null, openaiModel: null, openaiCompatibleModel: null, anthropicModel: null },
             reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
             profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], pathFilters: [], changedPaths: ["src/a.ts"],
@@ -7272,6 +7273,7 @@ describe("queue processors", () => {
     // Pre-seed the AI review for this exact head SHA + mode → the sweep's block-mode review must reuse it, not re-run.
     const inputFingerprint = await aiReviewCacheInputFingerprint({
       title: "Stale PR",
+      body: "Closes #1",
       mode: "block",
       byok: false,
       provider: null,


### PR DESCRIPTION
## Summary
Fixes 1 confirmed adversarial-audit finding: `src/review/ai-review-cache-input.ts`'s `AiReviewCacheInput` type includes `title` explicitly (with a doc comment explaining a same-head title-only edit must miss the cache), but had no `body` field — so an edited-description webhook silently reused a stale AI verdict, even though `buildUserPrompt` threads `input.body` into the exact same prompt the fingerprint is meant to protect.

`body` is added as a required, nullable key (`string | null | undefined`, no `?`) matching every sibling field's style (`title`, `provider`, `model`, `gatePack`, etc.), and the fingerprint version is bumped v4→v5 — matching this file's own established, repeatedly-documented convention for every prior payload-shape addition.

**Note:** making `body` required meant every existing call site needed an update: the one production call site in `src/queue/processors.ts` (added `body: pr.body,` next to the existing `title: pr.title,`), plus 4 test files that construct `AiReviewCacheInput` object literals directly to pre-seed cache rows or assert on the version-prefixed fingerprint string.

Closes #6413

## Test plan
- [x] New regression test: a body edit changes the fingerprint even though nothing else does; a repeated identical call is stable; null/undefined body normalize to the same fingerprint (mirroring the existing title-change regression test)
- [x] `test/unit/ai-review-cache-input.test.ts` (16/16), `test/unit/ai-review-cache.test.ts` (35/35), `test/unit/queue.test.ts` + `queue-2.test.ts` + `queue-4.test.ts` (425/425 combined)
- [x] Full local gate (`npm run test:ci`) green
