### PR TITLE
fix(review): honor selftune opt-out and revoked autonomy in override read-back

### DIFF
--- a/src/settings/repository-settings.ts
+++ b/src/settings/repository-settings.ts
@@ -2,6 +2,7 @@ import { getGlobalContributorBlacklist, getRepositorySettings } from "../db/repo
 import { loadOverride, type StorageEnv } from "../review/auto-apply";
 import { resolveEffectiveSettings } from "../signals/focus-manifest";
 import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
+import { isAgentConfigured } from "./autonomy";
 import type { RepositorySettings } from "../types";
 
 /** Default-OFF self-tune flag (mirrors selftune-wire's `isSelfTuneEnabled`; inlined here to avoid a
@@ -30,7 +31,16 @@ export function applySelfTuneOverrideToSettings(
 
 /** Effective repository settings: DB values overlaid with `.loopover.yml` (config-as-code), then — when the
  *  self-improvement loop is enabled (`LOOPOVER_REVIEW_SELFTUNE`, default OFF) — with the repo's promoted,
- *  soak-passed, tightening-only auto-tune override. Flag-OFF (default) ⇒ no override read, byte-identical to before. */
+ *  soak-passed, tightening-only auto-tune override. Flag-OFF (default) ⇒ no override read, byte-identical to before.
+ *
+ *  The override read-back honors the SAME two consent signals `selfTuneRepos` (`review/selftune-wire.ts`) checks
+ *  before ever generating a new recommendation: an explicit per-repo `.loopover.yml` `review.selftune: false`
+ *  opt-out, and the repo's broader acting-autonomy consent (`isAgentConfigured`). Without this, a repo that
+ *  opts out (or has its autonomy fully revoked) AFTER an override was already promoted would keep having that
+ *  stale override silently reapplied to every gate decision forever — the only escape hatch would be the
+ *  maintainer-only DELETE override route, which nothing surfaces to the operator. Opting out here does NOT
+ *  delete the promoted override (a human, or re-opting-in, can still see/clear it) — it just stops it from
+ *  being read back while the opt-out is in effect. */
 export async function resolveRepositorySettings(env: Env, repoFullName: string): Promise<RepositorySettings> {
   const [dbSettings, manifest, globalContributorBlacklist] = await Promise.all([
     getRepositorySettings(env, repoFullName),
@@ -39,6 +49,8 @@ export async function resolveRepositorySettings(env: Env, repoFullName: string):
   ]);
   const effective = resolveEffectiveSettings(dbSettings, manifest, globalContributorBlacklist);
   if (!selfTuneFlagOn(env)) return effective;
+  if (manifest.review.selftune === false) return effective; // explicit per-repo opt-out — same check as selfTuneRepos
+  if (!isAgentConfigured(effective.autonomy)) return effective; // acting-autonomy consent revoked/never granted
   // loadOverride is internally fail-safe (returns null on a DB blip), so this never breaks settings resolution.
   const override = await loadOverride(env as unknown as StorageEnv, repoFullName);
   return applySelfTuneOverrideToSettings(effective, override);

--- a/test/unit/selftune-readback.test.ts
+++ b/test/unit/selftune-readback.test.ts
@@ -33,9 +33,15 @@ describe("applySelfTuneOverrideToSettings — tightening-only live read-back (#s
 
 describe("resolveRepositorySettings — self-tune override overlay (flag-gated)", () => {
   const repo = "acme/widgets";
-  async function seed(env: Env): Promise<void> {
+  // `autonomy: { review: "auto" }` grants acting-autonomy consent (isAgentConfigured) so the happy-path override
+  // read-back is exercised. This wasn't required before the opt-out/consent fix below -- the override used to be
+  // read back unconditionally once the global flag was on, regardless of whether the repo had ANY acting
+  // autonomy configured. Now the read-back honors the same consent `selfTuneRepos` requires before promoting a
+  // NEW override in the first place, so a repo with no acting autonomy (or a revoked one) must not keep having a
+  // stale, already-promoted override silently reapplied either.
+  async function seed(env: Env, autonomy: Record<string, string> = { review: "auto" }): Promise<void> {
     await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, 'acme', 'widgets', 1, 1)").bind(repo).run();
-    await repositories.upsertRepositorySettings(env, { repoFullName: repo, qualityGateMinScore: 50 });
+    await repositories.upsertRepositorySettings(env, { repoFullName: repo, qualityGateMinScore: 50, autonomy });
     await writeLiveOverride(env as unknown as StorageEnv, repo, { confidenceFloor: 0.7 });
   }
 
@@ -48,6 +54,19 @@ describe("resolveRepositorySettings — self-tune override overlay (flag-gated)"
   it("flag OFF (default): the override is never read — settings stay byte-identical (50)", async () => {
     const env = createTestEnv();
     await seed(env);
+    expect((await resolveRepositorySettings(env, repo)).qualityGateMinScore).toBe(50);
+  });
+
+  it("flag ON but per-repo opt-out (`.loopover.yml` review.selftune: false): a previously-promoted override is NOT read back (50, not 70)", async () => {
+    const env = createTestEnv({ LOOPOVER_REVIEW_SELFTUNE: "true" });
+    await seed(env);
+    await upsertRepoFocusManifest(env, repo, { review: { selftune: false } }, "api_record");
+    expect((await resolveRepositorySettings(env, repo)).qualityGateMinScore).toBe(50);
+  });
+
+  it("flag ON but acting-autonomy consent revoked (no acting autonomy level configured): a previously-promoted override is NOT read back (50, not 70)", async () => {
+    const env = createTestEnv({ LOOPOVER_REVIEW_SELFTUNE: "true" });
+    await seed(env, {}); // {} normalizes to every class at "observe" (deny-by-default) -- isAgentConfigured is false
     expect((await resolveRepositorySettings(env, repo)).qualityGateMinScore).toBe(50);
   });
 


### PR DESCRIPTION
## Summary
Fixes 1 confirmed adversarial-audit finding(s) in `src/settings/repository-settings.ts`:

- Live-override read-back ignores per-repo opt-out and revoked autonomy consent — an already-promoted tightening keeps mutating the real gate forever (`src/settings/repository-settings.ts`)

Each fix follows the audit's own verified failure scenario and root-cause analysis (2-independent-skeptic adversarial verification pass, both had to vote "confirmed").

Closes #6415

## Test plan
- [x] Regression test(s) reproducing the audited failure scenario for each finding
- [x] Full local gate (`npm run test:ci`) green
