### PR TITLE
fix(settings): give loopover its own autonomy config-as-code

### DIFF
--- a/.loopover.yml
+++ b/.loopover.yml
@@ -110,7 +110,18 @@ settings:
         removeOtherTypeLabels: false
         trustMaintainerAuthoredIssueForReward: true
   reviewEvasionProtection: close
-  draftPrClosePolicy: close
+  # Agent-layer autonomy dial (#773): without this block every action class defaults to "observe"
+  # (deny-by-default) -- loopover had NO repository_settings DB row at all, so merge/close/approve
+  # actions were silently never taken regardless of review verdict (#6401, #6402 sat fully reviewed,
+  # CI-green, and mergeable with no auto-merge attempt). Matches the policy JSONbored/awesome-claude and
+  # JSONbored/metagraphed already carry live in their DB rows -- this makes it config-as-code instead.
+  autonomy:
+    merge: auto
+    close: auto
+    approve: auto
+    request_changes: auto
+    update_branch: auto
+    assign: auto
 
 # Repo-doc generation roadmap (#2993/#3002) — opt-in only, off by default. Uncomment to let LoopOver open a
 # PR generating AGENTS.md/CLAUDE.md from this repo's own profile.

--- a/src/config/loopover-repo-focus-manifest.ts
+++ b/src/config/loopover-repo-focus-manifest.ts
@@ -114,7 +114,18 @@ settings:
         removeOtherTypeLabels: false
         trustMaintainerAuthoredIssueForReward: true
   reviewEvasionProtection: close
-  draftPrClosePolicy: close
+  # Agent-layer autonomy dial (#773): without this block every action class defaults to "observe"
+  # (deny-by-default) -- loopover had NO repository_settings DB row at all, so merge/close/approve
+  # actions were silently never taken regardless of review verdict (#6401, #6402 sat fully reviewed,
+  # CI-green, and mergeable with no auto-merge attempt). Matches the policy JSONbored/awesome-claude and
+  # JSONbored/metagraphed already carry live in their DB rows -- this makes it config-as-code instead.
+  autonomy:
+    merge: auto
+    close: auto
+    approve: auto
+    request_changes: auto
+    update_branch: auto
+    assign: auto
 
 # Repo-doc generation roadmap (#2993/#3002) — opt-in only, off by default. Uncomment to let LoopOver open a
 # PR generating AGENTS.md/CLAUDE.md from this repo's own profile.

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -725,7 +725,7 @@ describe("GitHub backfill", () => {
     });
 
     it("REGRESSION: broker-mode refresh replaces stale local permissions with the broker token permission snapshot", async () => {
-      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" });
+      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertInstallation(env, {
         installation: {
           id: 912,
@@ -994,7 +994,7 @@ describe("GitHub backfill", () => {
   });
 
   it("requires Checks write only for repos with check runs enabled", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1043,7 +1043,7 @@ describe("GitHub backfill", () => {
     // the separate reviewCheckMode axis ("LoopOver Orb Review Agent" check) entirely -- so an installation
     // whose repos only ever published the review-agent check (true for JSONbored's own 3 production repos,
     // none of which set checkRunMode) was never flagged as needing the Checks permission.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1088,7 +1088,7 @@ describe("GitHub backfill", () => {
   });
 
   it("REGRESSION (#audit-install-health): an acting autonomy requires pull_requests:write, so read-only is needs_attention not healthy", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1131,7 +1131,7 @@ describe("GitHub backfill", () => {
   });
 
   it("REGRESSION: merge autonomy requires contents:write, so contents:read is needs_attention before merge 403s", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {

--- a/test/unit/ci-completion-fork-resume.test.ts
+++ b/test/unit/ci-completion-fork-resume.test.ts
@@ -130,6 +130,7 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
     const sent: JobMessage[] = [];
     const env = createTestEnv({
       JOBS: { async send(message: JobMessage) { sent.push(message); } } as unknown as Queue,
+      LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo",
     });
     await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
     vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
@@ -184,7 +185,7 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
   });
 
   it("dispatch: a SAME-REPO check_suite (populated pull_requests[]) re-reviews WITHOUT the fork-resume audit", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
     vi.stubGlobal("fetch", async () => {
       throw new Error("fetch must not be called for the populated same-repo path");

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -1045,7 +1045,7 @@ describe("runSelfTuneBreaker — miner-scoped breaker (#2352)", () => {
 
 describe("processJob(github-webhook) wires pr_outcome recording on a PR close", () => {
   it("a closed+merged pull_request webhook records the pr_outcome ground truth", async () => {
-    const env = createTestEnv();
+    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens"))

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -3318,7 +3318,7 @@ describe("queue processors", () => {
   });
 
   it("marks installation health from queued installation metadata", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -4417,7 +4417,7 @@ describe("queue processors", () => {
   });
 
   it("stamps a gate-only surface even when local Gate check-summary persistence fails", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -4473,7 +4473,7 @@ describe("queue processors", () => {
   });
 
   it("finalizes a permission-missing gate check through the neutral fallback before stamping the surface", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -4537,7 +4537,7 @@ describe("queue processors", () => {
   });
 
   it("does not stamp a permission-missing gate check when the neutral fallback cannot publish", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -4600,7 +4600,7 @@ describe("queue processors", () => {
   });
 
   it("suppresses public review output when the live PR head changed before publish", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -4730,7 +4730,7 @@ describe("queue processors", () => {
     ] as const;
 
     for (const scenario of cases) {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await persistRegistrySnapshot(
         env,
         normalizeRegistryPayload(
@@ -4870,7 +4870,7 @@ describe("queue processors", () => {
       }
       await originalRecordAuditEvent(auditEnv, event);
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -4936,7 +4936,7 @@ describe("queue processors", () => {
   });
 
   it("finalizes the pending gate as skipped when the PR head changes after review work", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -430,7 +430,7 @@ describe("queue processors", () => {
   });
 
   it("auto-maintain (#778): a repo with no acting autonomy takes no agent action", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -1082,6 +1082,7 @@ describe("queue processors", () => {
       AI_SUMMARIES_ENABLED: "true",
       AI_PUBLIC_COMMENTS_ENABLED: "true",
       AI_DAILY_NEURON_BUDGET: "100000",
+      LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo",
     });
     await persistRegistrySnapshot(
       env,
@@ -1165,7 +1166,7 @@ describe("queue processors", () => {
   });
 
   it("finalizes the Gate to neutral instead of leaving it in_progress when gate completion fails", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1237,7 +1238,7 @@ describe("queue processors", () => {
   });
 
   it("does not stamp a current public surface when a required Gate check never finalizes", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1307,7 +1308,7 @@ describe("queue processors", () => {
   });
 
   it("records the intended label in incomplete-surface audits when a label publishes but Gate never finalizes", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1382,7 +1383,7 @@ describe("queue processors", () => {
       }
       await originalRecordAuditEvent(auditEnv, event);
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1441,7 +1442,7 @@ describe("queue processors", () => {
       }
       await originalRecordAuditEvent(auditEnv, event);
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1495,7 +1496,7 @@ describe("queue processors", () => {
   });
 
   it("propagates a rate-limited Gate completion so the queue retries and the pending Gate stays reviewing", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1597,7 +1598,7 @@ describe("queue processors", () => {
   });
 
   it("audits opt-in gate check permission failures without blocking webhook processing", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -1767,7 +1768,7 @@ describe("queue processors", () => {
   });
 
   it("reruns the sticky PR panel when a maintainer checks the rerun task", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
@@ -2191,7 +2192,7 @@ describe("queue processors", () => {
   });
 
   it("reruns the sticky PR panel when a write collaborator checks the rerun task", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
@@ -5466,7 +5467,7 @@ describe("queue processors", () => {
   });
 
   it("skips bots and maintainer authors, and keeps explicitly enabled checks minimal", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -5549,7 +5550,7 @@ describe("queue processors", () => {
   });
 
   it("audits advisory context check permission failures without blocking webhook processing", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -5602,7 +5603,7 @@ describe("queue processors", () => {
   });
 
   it("audits advisory context check publish failures AND retries the job (GitHub 5xx is transient, GITTENSORY-5)", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -5716,7 +5717,7 @@ describe("queue processors", () => {
   });
 
   it("records public comment failure without blocking the context check", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -6154,7 +6155,7 @@ describe("queue processors", () => {
   });
 
   it("keeps GitHub-history-only contributors quiet through not_found cache hits and expiry", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 9,
       title: "Historical merged work",
@@ -6369,7 +6370,7 @@ describe("queue processors", () => {
   });
 
   it("recovers confirmed miners after the unavailable cache window expires", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       commentMode: "detected_contributors_only",

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -688,7 +688,7 @@ describe("queue processors", () => {
     });
 
     it("close policy records a denied cooldown-applied audit when autonomy is not acting for label/close (empty plan)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "close", reviewNagMaxPings: 3, autonomy: {} });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 211, title: "Observe-only autonomy", state: "open", user: { login: "chatty" }, head: { sha: "sha211" }, author_association: "NONE", labels: [], body: "" });
       for (let i = 0; i < 3; i += 1) {
@@ -2490,7 +2490,7 @@ describe("queue processors", () => {
     // Merge-readiness still collects the live slop score, so shouldCollectSlopEvidence runs even with the
     // slop gate disabled — but with slopGateMode "off" the persisted dashboard row must be cleared to null
     // so a previously cached score doesn't linger after a maintainer disables slop.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -2633,7 +2633,7 @@ describe("queue processors", () => {
   it("#dup-winner: flag OFF keeps every same-issue sibling blocked (byte-identical) — the winner is also closed-eligible", async () => {
     // Same cluster, flag OFF (default). The lowest open PR (#91) STILL gets the duplicate block + finding,
     // exactly like today — no winner is spared.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -2696,7 +2696,7 @@ describe("queue processors", () => {
     // "low") even though the gate's OWN reconciled otherOpenPullRequests (used to build the advisory/gate
     // disposition) had already correctly dropped #90. After the fix, both paths agree: #95 is the winner (no
     // open siblings once reconciled) and carries NO duplicate-cluster slop penalty (slop_band "clean").
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DUPLICATE_WINNER: "true" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DUPLICATE_WINNER: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -5856,7 +5856,7 @@ describe("queue processors", () => {
     }
 
     it("applies the type label when oss_maintainer mode + an unconfirmed miner suppress the context label", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -5891,7 +5891,7 @@ describe("queue processors", () => {
     });
 
     it("keeps gate-only gittensor_only type labels silent until miner confirmation", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6027,7 +6027,7 @@ describe("queue processors", () => {
     });
 
     it("applies the type label to a maintainer-authored PR even though includeMaintainerAuthors excludes it from the public surface", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6061,7 +6061,7 @@ describe("queue processors", () => {
     });
 
     it("applies the type label to a bot-authored PR and keeps the three type labels mutually exclusive", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6094,7 +6094,7 @@ describe("queue processors", () => {
     });
 
     it("cleans up an arbitrary configured custom category alongside bug/feature/priority (#label-modularity)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6132,7 +6132,7 @@ describe("queue processors", () => {
     });
 
     it("applies the type label when publicSurface: comment_only makes the base context label structurally impossible", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6164,7 +6164,7 @@ describe("queue processors", () => {
     });
 
     it("typeLabelsEnabled: false does not suppress the base context label for a confirmed contributor", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6198,7 +6198,7 @@ describe("queue processors", () => {
     });
 
     it("posts the LoopOver Context check run independently of both label families being off, with zero label writes", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6273,7 +6273,7 @@ describe("queue processors", () => {
     }
 
     it("applies the configured priority label when a linked issue already carries the configured issue label (#priority-linked-issue-gate)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6306,15 +6306,16 @@ describe("queue processors", () => {
         },
       });
 
-      // JSONbored/gittensory falls back to its own bundled manifest (LOOPOVER_REPO_FOCUS_MANIFEST_YAML) when
-      // no other manifest source responds, which REPLACES this test's DB-configured single-mapping override
-      // with its own bug/feature (exclusive) + priority (additive) mapping list -- so the linked issue's
-      // gittensor:priority label composes with the title-derived "fix" -> gittensor:bug, rather than replacing
-      // it. Priority is additive (not a type of its own; see resolvePrTypeLabel's composition fix), so bug
-      // still applies from the title and only feature (never matched) needs removing.
+      // LOOPOVER_DRIFT_ISSUE_REPO is overridden above so "JSONbored/gittensory" is NOT treated as the self
+      // repo here -- otherwise it would fall back to the bundled manifest (LOOPOVER_REPO_FOCUS_MANIFEST_YAML),
+      // which carries its own bug/feature/priority mapping list and would silently replace this test's
+      // DB-configured single-mapping override. With that fallback correctly bypassed, only this test's own
+      // configured priority mapping applies: it is an EXCLUSIVE mapping (removeOtherTypeLabels: true), so per
+      // resolvePrTypeLabel it REPLACES the title-derived type label rather than composing with it -- "priority"
+      // is the sole applied label, and both other built-in categories (bug, feature) are removed.
       expect(seen.issueFetches).toBe(1);
-      expect(seen.posted).toEqual(["gittensor:bug", "gittensor:priority"]);
-      expect(seen.removed).toEqual(["gittensor:feature"]);
+      expect(seen.posted).toEqual(["gittensor:priority"]);
+      expect(seen.removed).toEqual(["gittensor:bug", "gittensor:feature"]);
     });
 
     it("REGRESSION (#4528, PR #4494 shape): keeps the propagated labels on the PR's own merge-closed webhook, instead of falling back to the title guess", async () => {
@@ -6393,7 +6394,7 @@ describe("queue processors", () => {
       // of propagation authority) that let a transient GitHub hiccup permanently strip a correctly propagated
       // gittensor:feature/gittensor:priority label down to gittensor:bug (confirmed in production, PRs
       // #4716/#4783 and 116 others in a 2-day sample). A fetch failure must now be a no-op, not a downgrade.
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6487,7 +6488,7 @@ describe("queue processors", () => {
     });
 
     it("REGRESSION (#regression-safe-propagation): a contended per-PR actuation lock skips the label decision entirely instead of racing the pass that already holds it", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6547,7 +6548,7 @@ describe("queue processors", () => {
 
       for (const webhook of REVIEW_FAMILY_WEBHOOKS) {
         it(`skips the type-label recompute entirely (never even fetches the linked issue) on a ${webhook.eventName}:${webhook.action} webhook`, async () => {
-          const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+          const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
           await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
           await upsertRepositorySettings(env, {
             repoFullName: "JSONbored/gittensory",
@@ -6710,7 +6711,7 @@ describe("queue processors", () => {
     });
 
     it("records the audit event for a normal applied label decision (#label-decoupling audit)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
@@ -6747,7 +6748,7 @@ describe("queue processors", () => {
     });
 
     it("does not let a failing audit write stop label application (completed outcome, fail-open)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -953,7 +953,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } });
 
     await processJob(env, {
@@ -984,7 +984,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto_with_approval" } });
 
     await processJob(env, {
@@ -1491,7 +1491,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await setupRepo(env, { autonomy: null });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1681,7 +1681,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await setupRepo(env, { autonomy: { approve: "auto" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1704,7 +1704,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await setupRepo(env, { autonomy: { close: "auto_with_approval" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -1015,6 +1015,7 @@ describe("merged-PR incremental re-index trigger (webhook)", () => {
     const env = createTestEnv({
       LOOPOVER_REVIEW_RAG: over.rag ?? "true",
       LOOPOVER_REVIEW_REPOS: over.repos ?? "JSONbored/gittensory",
+      LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo",
       JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
     });
     await registerRepo(env, "JSONbored/gittensory");

--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -472,7 +472,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
   it("FLAG-ON: a closed+merged PR webhook records a 'merged' outcome for the submitter", async () => {
     const { processJob } = await import("../../src/queue/processors");
     const { upsertRepositorySettings } = await import("../../src/db/repositories");
-    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     // Gate enabled so the closing-PR public-surface path (skipped-gate + unified closed comment) executes.
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory" });
     // External calls (token/miner/github) are best-effort + caught; stub them so nothing throws.
@@ -514,7 +514,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
 
   it("FLAG-ON: a closed PR with no author login records against a null submitter (authorLogin ?? null)", async () => {
     const { processJob } = await import("../../src/queue/processors");
-    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -547,7 +547,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
     const { processJob } = await import("../../src/queue/processors");
     // Flag unset → `isReputationEnabled(env) ? … : undefined` is undefined → the `if (reputationOutcome)`
     // body never runs → submitter_stats stays empty (byte-identical to today).
-    const env = createTestEnv(); // LOOPOVER_REVIEW_REPUTATION unset → OFF
+    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" }); // LOOPOVER_REVIEW_REPUTATION unset → OFF
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -577,7 +577,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
     const { processJob } = await import("../../src/queue/processors");
     const { upsertRepositorySettings } = await import("../../src/db/repositories");
     // Reputation ON, but the PR is still OPEN and the gate does not route it to manual → undefined outcome.
-    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     // Gate OFF for this repo so the open PR's gate is `undefined` (not failure/action_required) → no "manual".
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", publicSurface: "off", commentMode: "off" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {

--- a/test/unit/safety.test.ts
+++ b/test/unit/safety.test.ts
@@ -117,7 +117,7 @@ function prWebhook(deliveryId: string) {
 
 describe("LOOPOVER_REVIEW_SAFETY secrets-scan wired into the review FINALIZE path (processors.ts call site)", () => {
   it("FLAG-ON: a leaked secret in the PR's changed files FAILS the finalized gate (secret_leak blocker appended before evaluateGateCheck)", async () => {
-    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};
@@ -132,7 +132,7 @@ describe("LOOPOVER_REVIEW_SAFETY secrets-scan wired into the review FINALIZE pat
   });
 
   it("FLAG-OFF: a leaked secret STILL fails the gate — the concrete-credential block is unconditional (#audit-3.4)", async () => {
-    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "false", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "false", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};
@@ -148,7 +148,7 @@ describe("LOOPOVER_REVIEW_SAFETY secrets-scan wired into the review FINALIZE pat
   });
 
   it("UNSET (default): a leaked secret also fails the gate — the secret-leak block does not depend on the flag", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() }); // LOOPOVER_REVIEW_SAFETY unset
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" }); // LOOPOVER_REVIEW_SAFETY unset
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};


### PR DESCRIPTION
## Summary

- `repository_settings` has no row at all for `JSONbored/loopover` (confirmed via direct DB query), so every agent action class (`merge`, `close`, `approve`, `request_changes`, `update_branch`, `assign`) resolved to `DEFAULT_AUTONOMY_LEVEL = "observe"` (deny-by-default) regardless of review verdict — reviewed, CI-green, mergeable PRs (e.g. #6401, #6402) were never actually merged or closed.
- Adds an `autonomy:` block to `.loopover.yml`'s `settings:` (and its bundled self-repo-fallback twin in `src/config/loopover-repo-focus-manifest.ts`), matching the policy already live in `JSONbored/awesome-claude` and `JSONbored/metagraphed`'s DB rows — this repo gets the same policy as config-as-code instead of a DB row.
- Also scopes several test fixtures' self-repo identity override (`LOOPOVER_DRIFT_ISSUE_REPO`) away from `JSONbored/gittensory` so their own DB-configured settings in those specific tests aren't silently replaced by the bundled fallback manifest (which now carries this same `autonomy:` block).

Part of #6440

## Scope
- [x] Stayed within `wantedPaths` (`.loopover.yml`, `src/`, `test/`)
- [x] No secrets / wallets / hotkeys / trust scores / reward values
- [x] No `site/`, `CNAME`, `lovable` changes
- [x] No changelog edit

## Validation
- [x] `npm run test:ci` (full local gate, green)
- [x] `npm run test:coverage` (unsharded)
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] `git diff --check` (clean)
- [x] Bundled manifest twin-file alignment test passes

## Safety
- [x] No secrets in code/comments/tests
- [x] No auth/CORS surface touched