### PR TITLE
fix(engine): exempt generated/vendored/minified files from the missing-test-evidence signal

### DIFF
--- a/packages/loopover-engine/src/signals/slop.ts
+++ b/packages/loopover-engine/src/signals/slop.ts
@@ -102,6 +102,10 @@ const MIN_SUBSTANTIVE_TEST_ADDITIONS = 3;
 // A padded diff is one whose churn is dominated by non-substantive output. Set at half the diff so a PR
 // with any meaningful share of real, hand-authored files cannot trip it.
 const PADDING_DOMINANCE_SHARE = 0.5;
+// Categories that are mechanically produced, not hand-authored — shared by buildNonSubstantivePaddingFinding
+// (where this same set of categories counts toward the "padding" share) and buildMissingTestEvidenceFinding
+// (where it exempts codegen-only diffs from the missing-test-evidence signal).
+const PADDING_CATEGORIES = new Set(["minified", "generated", "vendored"]);
 
 export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment {
   const findings: AdvisoryFinding[] = [];
@@ -271,7 +275,11 @@ export function buildNoLinkedIssueRationaleFinding(input: SlopAssessmentInput): 
 export function buildMissingTestEvidenceFinding(input: SlopAssessmentInput): AdvisoryFinding | null {
   const changedFiles = input.changedFiles ?? [];
   const changedPaths = changedFiles.map((file) => file.path).filter(Boolean);
-  const codePaths = changedPaths.filter(isCodeFile);
+  // Generated/vendored/minified output carries source-file extensions (e.g. protoc's `.pb.go` stubs) and
+  // so passes the plain isCodeFile check, but nobody hand-writes tests for mechanically regenerated code.
+  // Mirror buildNonSubstantivePaddingFinding's classifyChangedFile-based exemption so this signal can't
+  // fire on a codegen-only diff.
+  const codePaths = changedPaths.filter((path) => isCodeFile(path) && !PADDING_CATEGORIES.has(classifyChangedFile(path)));
   if (codePaths.length === 0) return null;
 
   // A changed test FILE only counts as real test evidence when it carries substantive content. An empty or

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -403,6 +403,33 @@ describe("buildMissingTestEvidenceFinding", () => {
       }),
     ).toBeNull();
   });
+
+  // Regression for the audited gap: a protoc regen touches only *.pb.go stubs (matched by the .go
+  // extension in isCodeFile), which nobody hand-writes tests for. Mirrors
+  // buildNonSubstantivePaddingFinding's classifyChangedFile-based generated/vendored/minified exemption
+  // so this signal can't fire on a codegen-only diff.
+  it("does not fire on a codegen-only diff (generated .pb.go stubs, no hand-authored source)", () => {
+    expect(
+      buildMissingTestEvidenceFinding({
+        changedFiles: [
+          { path: "proto/gen/service.pb.go", additions: 120, deletions: 80 },
+          { path: "proto/gen/service_grpc.pb.go", additions: 60, deletions: 20 },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("still fires when a hand-authored code file ships alongside the generated stubs", () => {
+    const finding = buildMissingTestEvidenceFinding({
+      changedFiles: [
+        { path: "proto/gen/service.pb.go", additions: 120, deletions: 80 },
+        { path: "src/api/handler.go", additions: 10, deletions: 0 },
+      ],
+    });
+    expect(finding).toMatchObject({ code: "missing_test_evidence" });
+    // Only the hand-authored file counts toward the reported total, not the exempted generated stub.
+    expect(finding?.detail).toContain("1 code file(s)");
+  });
 });
 
 describe("buildTrivialWhitespaceChurnFinding", () => {


### PR DESCRIPTION
## Summary
Fixes 1 confirmed adversarial-audit finding(s) in `packages/loopover-engine/src/signals/slop.ts`:

- buildMissingTestEvidenceFinding counts machine-generated/vendored files as "code" needing test evidence, unlike the sibling padding detector which explicitly excludes them (`packages/loopover-engine/src/signals/slop.ts`)

Each fix follows the audit's own verified failure scenario and root-cause analysis (2-independent-skeptic adversarial verification pass, both had to vote "confirmed").

Closes #6418

## Test plan
- [x] Regression test(s) reproducing the audited failure scenario for each finding
- [x] Full local gate (`npm run test:ci`) green
