### PR TITLE
fix(engine): stop the collision report using unscoped issue.linkedPrs for risk escalation

### DIFF
--- a/packages/loopover-engine/src/signals/engine.ts
+++ b/packages/loopover-engine/src/signals/engine.ts
@@ -845,7 +845,7 @@ export function buildCollisionReport(
     const items = [issueItem(issue), ...linkedPrs.map(prItem)];
     clusters.set(`issue-${issue.number}`, {
       id: `issue-${issue.number}`,
-      risk: linkedPrs.length > 1 || issue.linkedPrs.length > 1 ? "high" : "medium",
+      risk: linkedPrs.length > 1 ? "high" : "medium",
       reason: `Open PR work references issue #${issue.number}.`,
       items,
     });

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -123,6 +123,36 @@ describe("world-class backend signals", () => {
     expect(report.clusters[0]?.items.map((item) => item.number)).toContain(7);
   });
 
+  it("does not escalate a single-real-PR issue cluster to high risk from unscoped issue.linkedPrs text mentions (regression)", () => {
+    // Issue #40 has exactly ONE real open PR (#12) that closes it via `linkedIssues`, but the issue's own
+    // cached `linkedPrs` (parsed from contributor-controlled issue body text, e.g. "see PR #8 and PR #9 for
+    // earlier discussion") mentions two PR numbers that are not actually competing work. The cluster's risk
+    // must be driven only by the genuinely-scoped `linkedPrs` (real open PRs), not this raw text-mention field.
+    const soloIssue: IssueRecord = {
+      repoFullName: repo.fullName,
+      number: 40,
+      title: "Solo-linked issue with unrelated body mentions",
+      state: "open",
+      authorLogin: "reporter",
+      labels: ["bug"],
+      linkedPrs: [8, 9],
+    };
+    const solePr: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 12,
+      title: "Fix solo-linked issue",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      labels: ["bug"],
+      linkedIssues: [40],
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    };
+    const report = buildCollisionReport(repo.fullName, [soloIssue], [solePr]);
+    const cluster = report.clusters.find((entry) => entry.id === "issue-40");
+    expect(cluster?.risk).toBe("medium");
+  });
+
   it("builds maintainer burden from queue hygiene signals", () => {
     const collisions = buildCollisionReport(repo.fullName, issues, pullRequests);
     const health = buildQueueHealth(repo, issues, pullRequests, collisions);


### PR DESCRIPTION
## Summary
Fixes 1 confirmed adversarial-audit finding(s) in `packages/loopover-engine/src/signals/engine.ts`:

- buildCollisionReport upgrades a single-real-PR issue cluster to 'high' risk using the same unscoped issue.linkedPrs text-mention field (`packages/loopover-engine/src/signals/engine.ts`)

Each fix follows the audit's own verified failure scenario and root-cause analysis (2-independent-skeptic adversarial verification pass, both had to vote "confirmed").

Closes #6419

## Test plan
- [x] Regression test(s) reproducing the audited failure scenario for each finding
- [x] Full local gate (`npm run test:ci`) green
