### PR TITLE
feat(ui): add CSV export to the operator dashboard

### DIFF
--- a/apps/loopover-ui/src/routes/app.operator.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { BarChart3, Check, Copy, FileJson } from "lucide-react";
+import { BarChart3, Check, Copy, Download, FileJson } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -11,10 +11,11 @@ import {
 } from "@/components/site/control-primitives";
 import { DeadLetterQueuePanel } from "@/components/site/dead-letter-queue-panel";
 import { NotificationReadinessCard } from "@/components/site/notification-readiness-card";
-import { StateBoundary } from "@/components/site/state-views";
+import { StateActionButton, StateBoundary } from "@/components/site/state-views";
 import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch } from "@/lib/api/request";
 import { useApiResource } from "@/lib/api/use-api-resource";
+import { exportOperatorDashboardCsv } from "@/lib/csv-export";
 
 export const Route = createFileRoute("/app/operator")({
   component: OperatorDashboard,
@@ -155,7 +156,16 @@ function OperatorDashboard() {
                 High-level deployment health and noise-reduction impact across all installations.
               </p>
             </div>
-            <BoundaryBadge boundary="private-api" />
+            <div className="flex items-center gap-2">
+              <BoundaryBadge boundary="private-api" />
+              <StateActionButton
+                onClick={() => exportOperatorDashboardCsv(data)}
+                disabled={data.metrics.length === 0}
+                icon={<Download className="size-3 shrink-0" aria-hidden />}
+              >
+                Export CSV
+              </StateActionButton>
+            </div>
           </header>
 
           <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary

`app.operator.tsx` and `app.analytics.tsx` both fetch the same `/v1/app/operator-dashboard` resource, and `lib/csv-export.ts`'s `exportOperatorDashboardCsv` is named for exactly that resource. But only `app.analytics.tsx` offered an "Export CSV" action — the operator page, the one the helper is named after, exposed only Copy-Markdown and Copy-JSON of its weekly report.

This adds an **"Export CSV"** `StateActionButton` to the operator header, wired the same way `app.analytics.tsx:228-234` wires it: `exportOperatorDashboardCsv(data)`, disabled when there are no metrics to export, with the `Download` icon. The helper is reused **unchanged**, per the issue.

## Type compatibility — checked, not assumed

The helper takes `AnalyticsLedgerCsvInput`; the operator page types its fetch as its own local `OperatorDashboardResponse`. I confirmed the operator's data satisfies the helper's shape before wiring it:

- `AnalyticsLedgerCsvInput.metrics` is `ReadonlyArray<{ label, value, delta }>`; the operator's `metrics` is `Array<{ label, value, delta }>` — assignable.
- The optional `weeklyValueReport` needs `{ metrics: ReadonlyArray<{ id, label, value, detail }> }`; the operator's `weeklyValueReport` carries exactly that `metrics` shape (plus extra fields, which are fine for a typed variable).
- The optional `usageSummary` is simply absent — allowed.

So no data reshaping is needed, and `npm run ui:typecheck` confirms the assignment.

## Validation

- [x] `npm run ui:typecheck` — clean (both UI workspaces); this is what proves the operator payload is assignable to the helper.
- [x] `@loopover/ui` test suite — **273/273 pass** (incl. `csv-export.test.ts`, which already covers the helper's row-flattening).
- [x] `@loopover/ui` build — clean (nitro build completed).
- [x] `npm run ui:lint` — **0 non-prettier violations**; I ran `prettier` on the file and confirmed no substantive reflow (the repo-wide `prettier/prettier` errors are Windows CRLF noise, absent on CI's LF checkout).
- [x] `git diff --check` clean; the tree contains only `app.operator.tsx` (no generated `routeTree.gen.ts` churn committed). Rebased on latest `main` — no base conflict.

No new button-level test: `app.analytics.tsx` ships this same button with no such test either (the helper is covered directly), so mirroring it without one matches the repo's existing convention.

## Coverage

No patch surface: `apps/**` is in Codecov's ignore list, and the helper already has direct test coverage.

## Scope

- [x] One file, one coherent change, in a wanted path (`apps/loopover-ui/`). Maintainer-authored issue → approved operator-facing work.
- [x] Reuses live API data and an existing helper + design-token button component — exactly what this repo's UI guidance asks for; not cosmetic churn.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Additive: a new export control over data the page already fetches. No API change, no change to any existing action or section; the button disables itself when there is nothing to export.

Closes #6180
