### PR TITLE
docs(ui): audit ui-kit for existing chat-adjacent UI primitives

### DIFF
--- a/apps/loopover-ui/src/chat-ui-primitives-audit.md
+++ b/apps/loopover-ui/src/chat-ui-primitives-audit.md
@@ -1,0 +1,85 @@
+# Chat-adjacent UI primitives audit (#6244)
+
+Part of #6230 (chat interface spec — scope/backend/placement still open there). This is groundwork
+only, per the issue's own scope: an inventory of what `apps/loopover-ui/src/components/**` and
+`packages/loopover-ui-kit/src/components/**` already have that a future chat surface could reuse,
+against the four primitives #6230 will eventually need. No code changes accompany this doc.
+
+## What exists and is reusable as-is
+
+- **Loading / empty / error scaffolding** — `apps/loopover-ui/src/components/site/state-views.tsx`
+  exports `LoadingState`, `EmptyState`, `ErrorState`, and the composing `StateBoundary`, plus a bare
+  `Spinner` (a `Loader2` icon with `animate-spin`, disabled under `motion-reduce`). These are already
+  the app-wide convention for "is this panel loading/empty/erroring" and would drop straight into a
+  chat panel's outer shell with no adaptation — see the note below on why `Spinner` is not itself a
+  typing indicator.
+- **Composer building blocks** — `packages/loopover-ui-kit/src/components/textarea.tsx` (a plain
+  `forwardRef` wrapper around `<textarea>`, token-styled, no built-in submit handling) and
+  `input.tsx`/`button.tsx` are the raw primitives a composer would be built from. They carry no
+  keyboard-submit or auto-grow logic themselves — see "entirely absent" below.
+- **Scrollable container** — `packages/loopover-ui-kit/src/components/scroll-area.tsx` wraps
+  Radix's `ScrollArea` with the app's scrollbar styling. This is the direct building block for a
+  scrollable message list's viewport; it renders whatever children are passed, so it doesn't imply
+  message layout on its own.
+- **Avatars** — `packages/loopover-ui-kit/src/components/avatar.tsx` (Radix `Avatar` wrapper,
+  image + fallback) is reusable as-is for per-message sender avatars.
+
+## What's close but would need adaptation
+
+- **`apps/loopover-ui/src/components/site/audit-feed.tsx`** (`AuditFeed`) is structurally the
+  closest existing analog to a filtered, live-data timeline: it owns filter state
+  (`reason`/`repoFullName`/`sinceIso`/`limit`), fetches and re-fetches on filter change, and renders
+  through the same `EmptyState`/`ErrorState`/`LoadingState` scaffolding above. But it renders results
+  as an HTML `<table>` with fixed columns (Time / Repository / Pull request / Reason / Remediation),
+  not a bubble/timeline list — reusing it for chat would mean keeping its data-fetching and state
+  shell but replacing the `<table>` row renderer with a per-message component (sender, bubble,
+  timestamp), which is effectively a rewrite of the view layer, not a prop change.
+- **`apps/loopover-ui/src/components/site/command-palette.tsx`** (`CommandPalette`) has the only
+  bare `<input>` + live-filtered scrollable `<ul>` combination in the app (⌘K-triggered, `Escape`
+  closes it, results navigate on click). It's close to "text input driving a list," but it is a
+  *search-and-navigate* palette, not a composer: there's no `onKeyDown` handling for `Enter` at all
+  (results are selected by click, not by keyboard submit), no multi-line/auto-grow textarea, and no
+  concept of "submit this text as a message." A submit-on-Enter composer would need to be built new,
+  informed by this file's open/close and keyboard-listener patterns rather than by reusing its input.
+- **`apps/loopover-ui/src/components/site/animated-terminal.tsx`** (`AnimatedTerminal`) is the
+  closest existing "reveal text incrementally" precedent: a `setInterval`-driven character-by-character
+  typewriter over `scene.prompt`, a `motion.pre` fade-in reveal for `scene.output` via
+  `AnimatePresence`, and a `useReducedMotion()` escape hatch that skips the animation outright. The
+  reveal mechanics (interval-driven character reveal, reduced-motion handling) are a reasonable
+  starting point for a streaming-text renderer, but the data source is a hardcoded
+  `DEFAULT_SCENES: TerminalScene[]` array timed by a fixed `HOLD` duration — there is no chunked
+  input, no cancellation on new input arriving mid-type, and no backpressure handling. Adapting it to
+  real streaming would mean replacing the `setInterval` scene-walk with a consumer of whatever chunk
+  source #6230 picks (see below), while keeping the reduced-motion and fade-in-reveal behavior.
+
+## What's entirely absent
+
+- **A submit-on-Enter composer.** No component anywhere in `apps/loopover-ui/src/components/**` or
+  `packages/loopover-ui-kit/src/components/**` wires a textarea to `Enter`-to-submit /
+  `Shift+Enter`-for-newline, and none auto-grow. `textarea.tsx` is unstyled-behavior raw material
+  only.
+- **A live streaming-text consumer.** Grepping `apps/loopover-ui/src` for
+  `EventSource|ReadableStream|text/event-stream|streaming` returns exactly one hit outside this
+  audit: a comment in `apps/loopover-ui/src/lib/analytics-proxy.ts` explaining that the analytics
+  proxy buffers its (tiny) request body specifically so it does *not* need a streaming/duplex
+  request — i.e. the one file that mentions "streaming" is explicitly the case of avoiding it. There
+  is no code anywhere in the app that consumes an `EventSource`, a `fetch` response's `ReadableStream`
+  body, or a `text/event-stream` response today. `animated-terminal.tsx` (above) is the closest
+  *rendering* precedent, but it has no real stream to consume from.
+- **A chat-bubble / message-list component.** Nothing pairs an avatar, a role-colored bubble, and a
+  timestamp into a reusable per-message unit. `audit-feed.tsx`'s table rows are the nearest list
+  pattern, but as noted above they're tabular, not conversational.
+- **A typing / "in progress" indicator.** `state-views.tsx`'s `Spinner`/`LoadingState` communicate
+  "this whole panel is loading," not "the other side is composing a response inline in the
+  conversation." There is no dot-pulse, no inline avatar-with-ellipsis, nor any other
+  chat-specific in-progress affordance anywhere in the codebase.
+
+## Summary for #6230's eventual scoping
+
+The reusable pieces (`state-views.tsx`'s state scaffolding, `scroll-area.tsx`, `avatar.tsx`,
+`textarea.tsx`/`input.tsx`/`button.tsx` as raw material) cover the outer shell and building blocks,
+not the chat-specific behavior. The four primitives #6230 will need — message list, composer,
+streaming renderer, typing indicator — are each either absent or only structurally adjacent
+(`audit-feed.tsx` for the list, `command-palette.tsx` for the input, `animated-terminal.tsx` for the
+renderer), so whoever implements #6230 should plan to build all four from scratch, informed by these
+adjacent patterns rather than assuming any can be reused directly.


### PR DESCRIPTION
Closes #6244

## Summary

Research-only groundwork for #6230's eventual chat interface spec (still open). Audits `apps/loopover-ui/src/components/**` and `packages/loopover-ui-kit/src/components/**` for anything already resembling the four primitives a chat surface will need — a scrollable message/timeline list, a text composer with submit-on-enter, a streaming/incremental text renderer, and a typing/in-progress indicator — and writes up what's reusable, what's close but needs adaptation, and what's entirely absent. Per the issue's own scope, no functional code changes accompany this: `apps/loopover-ui/src/chat-ui-primitives-audit.md` is the sole deliverable, following the same design-doc pattern as PR #5794 (#3048).

- **Reusable as-is**: `state-views.tsx`'s `LoadingState`/`EmptyState`/`ErrorState`/`StateBoundary`, `scroll-area.tsx`, `avatar.tsx`, and the raw `textarea.tsx`/`input.tsx`/`button.tsx` primitives.
- **Close but needs adaptation**: `audit-feed.tsx` (filtered, live-fetched list — but table-rendered, not a bubble/timeline layout), `command-palette.tsx` (the only text-input + filtered-list combo in the app — but click-to-navigate, no `Enter`-to-submit handling), `animated-terminal.tsx` (interval-driven typewriter reveal with reduced-motion handling — the closest streaming-text precedent, but over a hardcoded static scene array, not a live stream).
- **Entirely absent**: a submit-on-Enter composer; any real streaming consumer (grepped `apps/loopover-ui/src` for `EventSource|ReadableStream|text/event-stream|streaming` — the one hit is a comment in `analytics-proxy.ts` explaining why it deliberately avoids a streaming request body); a chat-bubble/message-list component; an inline typing indicator.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6244.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run docs:drift-check`
- [x] `npm run manifest:drift-check`
- [x] `npm run command-reference:check`
- [x] `npm run ui:lint` — 0 errors, only pre-existing warnings in unrelated files.
- [ ] `npm run ui:typecheck` / `npm run ui:build` — both fail identically on a clean `main` checkout in this sandbox, verified via `git stash`: `ui:typecheck` can't resolve the codegen modules `collections/browser`/`collections/server` (missing a content-collections build step in this environment), and `ui:build` can't resolve `@scalar/api-reference` from `@scalar/api-reference-react`'s dist output. Neither references this PR's new file (`apps/loopover-ui/src/chat-ui-primitives-audit.md` — a `.md` file not imported anywhere) and both reproduce byte-for-byte on unmodified `main`.
- [ ] Root `npm run typecheck` / `npm run test:coverage` — not run; this sandbox's root typecheck reliably OOMs regardless of diff content (reproduced repeatedly across prior PRs this session via `git stash` comparison), and this PR has no `src/**` code changes for Codecov to measure.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — N/A, pure documentation addition, no code paths added.

If any required check was skipped, explain why:

- `ui:typecheck`/`ui:build`: pre-existing sandbox environment issues (a missing codegen step and an unresolvable third-party subpackage), confirmed unrelated to this diff by reproducing the identical failure on a clean `main` checkout before and after stashing this PR's single new file.
- Root `typecheck`/`test:coverage`: this sandbox's established OOM pattern (unrelated to diff content, confirmed repeatedly this session), and moot here since no `src/**` files changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/MCP surface touched.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI behavior changed; this only documents existing UI primitives.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change (a new internal doc file only).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

- This is the audit/inventory deliverable only, per the issue's explicit instruction ("Do not build anything new — this is a research/audit deliverable only"). #6230 (the parent chat-interface spec) is still open with its own scope/backend/placement decisions unresolved; this doc is intended to inform that eventual implementation, not to prejudge it.
