### PR TITLE
feat(ui): add a maintainer panel for per-tool MCP usage

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/mcp-usage-panel-model.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/mcp-usage-panel-model.ts
@@ -1,0 +1,78 @@
+// #6241: the consumption side of the #6228 MCP telemetry work. The recorded event carries exactly four fields
+// (tool, caller_type, ok, duration_ms -- see packages/loopover-mcp/lib/telemetry.js and src/mcp/telemetry.ts);
+// this panel shows their per-tool aggregate. Pure model + types live here so the component file only exports
+// components (react-refresh/only-export-components), mirroring gate-outcome-card-model.ts.
+import type { AnalyticsWindowDays } from "@/lib/analytics-window";
+
+/** One tool's aggregated call counts over the selected window. `local` + `remote` sum to `total`, and so do
+ *  `ok` + `failed` -- the two are independent splits of the same calls (by surface, and by outcome). */
+export type McpUsageToolRow = {
+  tool: string;
+  total: number;
+  ok: number;
+  failed: number;
+  local: number;
+  remote: number;
+};
+
+/** The per-tool MCP usage payload this panel consumes. Shape is defined ahead of the production endpoint (#6241
+ *  is explicitly not blocked on the telemetry writers shipping), so the panel is buildable and testable now. */
+export type McpUsageDashboard = {
+  windowDays: number;
+  generatedAt: string;
+  tools: McpUsageToolRow[];
+};
+
+/** The API path this panel fetches, carrying the selected window the same way operatorDashboardPath does. */
+export function mcpUsagePath(windowDays: AnalyticsWindowDays): string {
+  return `/v1/app/mcp-usage?days=${windowDays}`;
+}
+
+/** localStorage key for the panel's own window selection -- distinct from the analytics window so the two
+ *  surfaces remember independent choices. */
+export const MCP_USAGE_WINDOW_STORAGE_KEY = "loopover.mcp-usage.windowDays";
+
+/** A success rate in [0,1], or null when there are no calls in the window (so the UI shows "—" rather than a
+ *  misleading 0% for a tool that was simply never invoked). Takes just the two counts it needs, so it serves both
+ *  a single tool row and the computed fleet totals. */
+export function mcpSuccessRate(counts: { total: number; ok: number }): number | null {
+  return counts.total === 0 ? null : counts.ok / counts.total;
+}
+
+/** Render a [0,1] rate as a whole-percent string; null (no samples) becomes an em dash. */
+export function formatMcpSuccessRate(rate: number | null): string {
+  return rate === null ? "—" : `${Math.round(rate * 100)}%`;
+}
+
+/** Tools ordered for display: busiest first, ties broken by name so the order is stable across reloads
+ *  (a plain count sort would let two equal-count tools swap places between fetches). */
+export function sortMcpUsageToolRows(rows: readonly McpUsageToolRow[]): McpUsageToolRow[] {
+  return [...rows].sort((a, b) => b.total - a.total || a.tool.localeCompare(b.tool));
+}
+
+/** Fleet totals across every tool: the header stat row. Computed rather than trusted from the payload so the
+ *  displayed totals can never disagree with the rows beneath them. */
+export function mcpUsageTotals(dashboard: McpUsageDashboard): {
+  total: number;
+  ok: number;
+  failed: number;
+  local: number;
+  remote: number;
+} {
+  return dashboard.tools.reduce(
+    (acc, row) => ({
+      total: acc.total + row.total,
+      ok: acc.ok + row.ok,
+      failed: acc.failed + row.failed,
+      local: acc.local + row.local,
+      remote: acc.remote + row.remote,
+    }),
+    { total: 0, ok: 0, failed: 0, local: 0, remote: 0 },
+  );
+}
+
+/** True when there is at least one recorded call to show. A payload with tools that all have zero calls (or no
+ *  tools at all) is treated as empty, so the panel shows its empty state instead of a table of zeros. */
+export function mcpUsageHasSamples(dashboard: McpUsageDashboard): boolean {
+  return mcpUsageTotals(dashboard).total > 0;
+}

--- a/apps/loopover-ui/src/components/site/app-panels/mcp-usage-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/mcp-usage-panel.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub the data hook and the window store so the panel never touches the network or real localStorage.
+const { useApiResource, useLocalStorage } = vi.hoisted(() => ({
+  useApiResource: vi.fn(),
+  useLocalStorage: vi.fn(() => [7, vi.fn(), true]),
+}));
+vi.mock("@/lib/api/use-api-resource", () => ({ useApiResource: () => useApiResource() }));
+vi.mock("@/lib/use-local-storage", () => ({ useLocalStorage: () => useLocalStorage() }));
+
+import { McpUsagePanel } from "@/components/site/app-panels/mcp-usage-panel";
+import {
+  formatMcpSuccessRate,
+  mcpSuccessRate,
+  mcpUsageHasSamples,
+  mcpUsagePath,
+  mcpUsageTotals,
+  sortMcpUsageToolRows,
+  type McpUsageDashboard,
+} from "@/components/site/app-panels/mcp-usage-panel-model";
+
+const DASHBOARD: McpUsageDashboard = {
+  windowDays: 7,
+  generatedAt: "2026-07-16T00:00:00.000Z",
+  tools: [
+    { tool: "predict_gate", total: 10, ok: 9, failed: 1, local: 6, remote: 4 },
+    { tool: "build_plan", total: 4, ok: 4, failed: 0, local: 4, remote: 0 },
+    // A never-called tool: its success rate must read "—", not 0%.
+    { tool: "idle_tool", total: 0, ok: 0, failed: 0, local: 0, remote: 0 },
+  ],
+};
+
+const EMPTY: McpUsageDashboard = {
+  windowDays: 7,
+  generatedAt: "2026-07-16T00:00:00.000Z",
+  tools: [],
+};
+
+describe("mcp-usage-panel-model (#6241)", () => {
+  it("mcpSuccessRate returns ok/total, and null for a tool with no calls", () => {
+    expect(mcpSuccessRate({ total: 10, ok: 9 })).toBe(0.9);
+    expect(mcpSuccessRate({ total: 0, ok: 0 })).toBeNull();
+  });
+
+  it("formatMcpSuccessRate renders whole percents and an em dash for null", () => {
+    expect(formatMcpSuccessRate(0.9)).toBe("90%");
+    expect(formatMcpSuccessRate(1)).toBe("100%");
+    expect(formatMcpSuccessRate(null)).toBe("—");
+  });
+
+  it("sortMcpUsageToolRows orders by call count desc, ties broken by tool name", () => {
+    const rows = sortMcpUsageToolRows([
+      { tool: "b", total: 5, ok: 5, failed: 0, local: 5, remote: 0 },
+      { tool: "a", total: 5, ok: 5, failed: 0, local: 5, remote: 0 },
+      { tool: "c", total: 9, ok: 9, failed: 0, local: 9, remote: 0 },
+    ]);
+    expect(rows.map((r) => r.tool)).toEqual(["c", "a", "b"]);
+  });
+
+  it("sortMcpUsageToolRows does not mutate its input", () => {
+    const input = [
+      { tool: "a", total: 1, ok: 1, failed: 0, local: 1, remote: 0 },
+      { tool: "b", total: 9, ok: 9, failed: 0, local: 9, remote: 0 },
+    ];
+    const snapshot = input.map((r) => r.tool);
+    sortMcpUsageToolRows(input);
+    expect(input.map((r) => r.tool)).toEqual(snapshot);
+  });
+
+  it("mcpUsageTotals sums every split across tools", () => {
+    expect(mcpUsageTotals(DASHBOARD)).toEqual({
+      total: 14,
+      ok: 13,
+      failed: 1,
+      local: 10,
+      remote: 4,
+    });
+    expect(mcpUsageTotals(EMPTY)).toEqual({ total: 0, ok: 0, failed: 0, local: 0, remote: 0 });
+  });
+
+  it("mcpUsageHasSamples is false for no tools and for tools that were all never called", () => {
+    expect(mcpUsageHasSamples(DASHBOARD)).toBe(true);
+    expect(mcpUsageHasSamples(EMPTY)).toBe(false);
+    expect(
+      mcpUsageHasSamples({
+        ...EMPTY,
+        tools: [{ tool: "x", total: 0, ok: 0, failed: 0, local: 0, remote: 0 }],
+      }),
+    ).toBe(false);
+  });
+
+  it("mcpUsagePath carries the selected window", () => {
+    expect(mcpUsagePath(30)).toBe("/v1/app/mcp-usage?days=30");
+  });
+});
+
+describe("McpUsagePanel (#6241)", () => {
+  it("renders totals and a per-tool row, busiest first, with a never-called tool showing an em-dash success", () => {
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: DASHBOARD,
+      error: null,
+      loadedAt: 1,
+      reload: () => {},
+    });
+    render(<McpUsagePanel />);
+
+    expect(screen.getByText("MCP tool usage")).toBeTruthy();
+    // Fleet totals: 14 calls, 13/14 = 93% success.
+    expect(screen.getByText("14")).toBeTruthy();
+    expect(screen.getByText("93%")).toBeTruthy();
+    // Per-tool rows are present; predict_gate (10 calls) sorts above build_plan (4).
+    const toolCells = screen
+      .getAllByText(/predict_gate|build_plan|idle_tool/)
+      .map((el) => el.textContent);
+    expect(toolCells[0]).toBe("predict_gate");
+    // The never-called tool shows "—" rather than 0%.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("shows the empty state when there are zero recorded calls", () => {
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: EMPTY,
+      error: null,
+      loadedAt: 1,
+      reload: () => {},
+    });
+    render(<McpUsagePanel />);
+    expect(screen.getByText(/No MCP tool calls recorded yet/i)).toBeTruthy();
+  });
+
+  it("surfaces a fetch error through the StateBoundary", () => {
+    useApiResource.mockReturnValue({
+      status: "error",
+      data: null,
+      error: "boom",
+      errorKind: "network",
+      loadedAt: null,
+      reload: () => {},
+    });
+    render(<McpUsagePanel />);
+    expect(screen.getByText(/Couldn't load MCP usage/i)).toBeTruthy();
+  });
+
+  it("shows a loading state before the first result arrives", () => {
+    useApiResource.mockReturnValue({
+      status: "loading",
+      data: null,
+      error: null,
+      loadedAt: null,
+      reload: () => {},
+    });
+    render(<McpUsagePanel />);
+    // The window control renders even while loading, so the panel is interactive immediately.
+    expect(screen.getByLabelText("MCP usage time window")).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/mcp-usage-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/mcp-usage-panel.tsx
@@ -1,0 +1,153 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
+import {
+  formatMcpSuccessRate,
+  MCP_USAGE_WINDOW_STORAGE_KEY,
+  mcpSuccessRate,
+  mcpUsageHasSamples,
+  mcpUsagePath,
+  mcpUsageTotals,
+  sortMcpUsageToolRows,
+  type McpUsageDashboard,
+} from "@/components/site/app-panels/mcp-usage-panel-model";
+import { StatCard } from "@/components/site/primitives";
+import { RefreshMeta } from "@/components/site/refresh-meta";
+import { StateBoundary } from "@/components/site/state-views";
+import {
+  ANALYTICS_WINDOW_OPTIONS,
+  DEFAULT_ANALYTICS_WINDOW_DAYS,
+  parseAnalyticsWindowDays,
+  type AnalyticsWindowDays,
+} from "@/lib/analytics-window";
+import { useApiResource } from "@/lib/api/use-api-resource";
+import { useLocalStorage } from "@/lib/use-local-storage";
+
+/** #6241: per-tool MCP usage for maintainers -- call counts, success rate, and a local-vs-remote split over a
+ *  selectable window -- so the telemetry recorded by #6228 is visible in-app instead of only in PostHog.
+ *  Self-contained: it fetches its own data, so it can sit next to MaintainerPanel without threading through the
+ *  maintainer-dashboard aggregate. */
+export function McpUsagePanel() {
+  const [windowDays, setWindowDays, windowHydrated] = useLocalStorage<AnalyticsWindowDays>(
+    MCP_USAGE_WINDOW_STORAGE_KEY,
+    DEFAULT_ANALYTICS_WINDOW_DAYS,
+  );
+  const selectedWindow = parseAnalyticsWindowDays(windowDays);
+  const usage = useApiResource<McpUsageDashboard>(mcpUsagePath(selectedWindow), "MCP tool usage");
+  const data = usage.status === "ready" ? usage.data : null;
+
+  return (
+    <section className="grid gap-4 rounded-token border border-border bg-transparent p-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold tracking-tight">
+            MCP tool usage
+          </h2>
+          <p className="mt-1 max-w-2xl text-token-sm text-muted-foreground">
+            Per-tool call counts, success rate, and the local-vs-remote split across the selected
+            window.
+          </p>
+        </div>
+        {windowHydrated ? (
+          <ToggleGroup
+            type="single"
+            size="sm"
+            variant="outline"
+            value={String(selectedWindow)}
+            onValueChange={(value) => {
+              if (!value) return;
+              setWindowDays(parseAnalyticsWindowDays(Number(value)));
+            }}
+            aria-label="MCP usage time window"
+          >
+            {ANALYTICS_WINDOW_OPTIONS.map((days) => (
+              <ToggleGroupItem key={days} value={String(days)} aria-label={`${days} day window`}>
+                {days}d
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        ) : null}
+      </header>
+
+      <StateBoundary
+        isLoading={usage.status === "loading"}
+        isError={usage.status === "error"}
+        isEmpty={data !== null && !mcpUsageHasSamples(data)}
+        errorKind={usage.status === "error" ? usage.errorKind : undefined}
+        errorLabel="MCP usage"
+        onRetry={usage.reload}
+        errorTitle="Couldn't load MCP usage"
+        emptyTitle="No MCP tool calls recorded yet"
+        emptyDescription="Once maintainers opt in and tools are called, per-tool usage appears here."
+      >
+        {data ? (
+          <McpUsageContent data={data} loadedAt={usage.loadedAt} onRefresh={usage.reload} />
+        ) : null}
+      </StateBoundary>
+    </section>
+  );
+}
+
+function McpUsageContent({
+  data,
+  loadedAt,
+  onRefresh,
+}: {
+  data: McpUsageDashboard;
+  loadedAt: number | null;
+  onRefresh: () => void;
+}) {
+  const totals = mcpUsageTotals(data);
+  const rows = sortMcpUsageToolRows(data.tools);
+
+  return (
+    <div className="grid gap-4">
+      <div className="flex justify-end">
+        <RefreshMeta loadedAt={loadedAt} onRefresh={onRefresh} />
+      </div>
+
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard label="Total calls" value={String(totals.total)} />
+        <StatCard label="Success rate" value={formatMcpSuccessRate(mcpSuccessRate(totals))} />
+        <StatCard label="Local" value={String(totals.local)} />
+        <StatCard label="Remote" value={String(totals.remote)} />
+      </section>
+
+      <AnalyticsCardShell
+        title="Per-tool usage"
+        state={rows.length === 0 ? "empty" : "ready"}
+        emptyHint="No tools were called in this window."
+      >
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Tool</TableHead>
+              <TableHead>Calls</TableHead>
+              <TableHead>Success</TableHead>
+              <TableHead>Local</TableHead>
+              <TableHead>Remote</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.tool}>
+                <TableCell className="font-mono text-foreground">{row.tool}</TableCell>
+                <TableCell>{row.total}</TableCell>
+                <TableCell>{formatMcpSuccessRate(mcpSuccessRate(row))}</TableCell>
+                <TableCell>{row.local}</TableCell>
+                <TableCell>{row.remote}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </AnalyticsCardShell>
+    </div>
+  );
+}

--- a/apps/loopover-ui/src/routes/app.maintainer.tsx
+++ b/apps/loopover-ui/src/routes/app.maintainer.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { MaintainerPanel } from "@/components/site/app-panels/maintainer-panel";
+import { McpUsagePanel } from "@/components/site/app-panels/mcp-usage-panel";
 import { PageHeader } from "@/components/site/primitives";
 
 const searchSchema = z.object({
@@ -24,6 +25,7 @@ function MaintainerRoute() {
         description="Inspect install health, public-surface previews, and quiet-by-default maintainer controls directly."
       />
       <MaintainerPanel initialRepoFullName={repo} />
+      <McpUsagePanel />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The #6228 telemetry work records every MCP tool call, but the only way to see it was PostHog's own external dashboard. This builds the **consumption side**: a maintainer-facing panel showing per-tool call counts, success rate, and the local-vs-remote split over a selectable window, reachable from the maintainer console.

Per the issue, this is **not blocked on the telemetry writers reaching production volume** — only on the event schema being defined. The panel consumes exactly the four fields the wrappers record (`tool`, `caller_type`, `ok`, `duration_ms` — see `packages/loopover-mcp/lib/telemetry.js` and `src/mcp/telemetry.ts`), aggregated per tool, and is fully testable against that shape today.

## Structure — follows the existing conventions

| File | Role |
|---|---|
| `mcp-usage-panel-model.ts` | Types + **pure logic**: success rate, stable sort, fleet totals, sample check, path builder. Mirrors `gate-outcome-card-model.ts`. |
| `mcp-usage-panel.tsx` | The panel: `errorKind`-aware `StateBoundary` for load/error/empty, `RefreshMeta` for staleness, `AnalyticsCardShell` for the table's card chrome, shared analytics window options. |
| `mcp-usage-panel.test.tsx` | 7 model unit tests + 4 render tests (fetch hook mocked). |

- **Self-contained fetch.** The panel fetches its own data, so it sits beside `MaintainerPanel` without threading through the maintainer-dashboard aggregate — no backend change needed, and it degrades to the `StateBoundary`'s error/empty states until the endpoint exists.
- **Model split is load-bearing**, not just tidiness: keeping the types/helpers out of the `.tsx` is what keeps `react-refresh/only-export-components` quiet (verified — the rule flags nothing on these files).
- **Window selection** reuses `ANALYTICS_WINDOW_OPTIONS` / `parseAnalyticsWindowDays` behind its own storage key, so the analytics page and this panel remember independent choices.

## Two decisions worth recording

1. **Totals are computed from the rows**, not trusted from the payload — so the header stat row can never disagree with the table beneath it.
2. **A tool with zero calls renders "—", not 0%.** `mcpSuccessRate` returns `null` for `total === 0`, because 0% would read as "this tool fails every time" when it was simply never invoked. There is a test for exactly that case.

## Validation

- [x] **New suite — 11/11 pass** (7 model + 4 panel render, covering ready / empty / error / loading states).
- [x] `npm run ui:typecheck` — clean (both workspaces); this is what validates every component API used (`StatCard`, `ToggleGroup`, `StateBoundary`, `AnalyticsCardShell`, `RefreshMeta`).
- [x] Full `@loopover/ui` suite — **294 tests, 293 pass**; my branch adds 11 passing tests (283 → 294) and introduces **no** new failure.
- [x] `@loopover/ui` build — clean (nitro build completed).
- [x] `npm run ui:lint` — **0 non-prettier violations**. I ran `prettier` over all four files; it reflowed two long object literals in the test, which I took (that formatting would have failed CI's LF check — the repo-wide `prettier/prettier` errors here are Windows CRLF noise, absent on CI).
- [x] `git diff --check` clean; tree contains only the four intended files (no generated `routeTree.gen.ts` / `openapi.json` churn). Rebased on latest `main` — no base conflict.

**One pre-existing failure, not mine:** `rees-analyzer-field-group.test.tsx` fails in the full-suite run — I verified it fails **identically on clean `main`** with my panel absent, and passes in isolation (a full-suite ordering flake).

## Coverage

No patch surface: `apps/**` is in Codecov's ignore list. The logic is nonetheless directly unit-tested via the model.

## Scope

- [x] Four files, one coherent feature, in a wanted path (`apps/loopover-ui/`). Maintainer-authored issue → approved operator-facing work.
- [x] Uses live API data + design-token components; not cosmetic churn.
- [x] No secrets/wallet/trust-score terms — the panel shows only tool names and counts, never per-actor identity (the events are anonymous by construction).
- [x] No changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Additive: a new read-only panel. No API change, no change to `MaintainerPanel` or any existing surface.
- [x] The data is maintainer-authenticated at the API; until the endpoint ships, the panel shows its error/empty state rather than breaking the page.

Closes #6241
