### PR TITLE
fix(ui): forward errorKind so dashboards show connectivity-aware errors

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -75,6 +75,7 @@ export function CommandsPanel() {
     <StateBoundary
       isLoading={commands.status === "loading"}
       isError={commands.status === "error"}
+      errorKind={commands.status === "error" ? commands.errorKind : undefined}
       isEmpty={commands.status === "ready" && commands.data.commands.length === 0}
       onRetry={commands.reload}
       onRefresh={commands.reload}

--- a/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
@@ -50,6 +50,7 @@ export function DigestPanel() {
     <StateBoundary
       isLoading={digest.status === "loading"}
       isError={digest.status === "error"}
+      errorKind={digest.status === "error" ? digest.errorKind : undefined}
       isEmpty={digest.status === "ready" && digest.data.items.length === 0}
       onRetry={digest.reload}
       onRefresh={digest.reload}

--- a/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
@@ -99,11 +99,15 @@ export function OwnerPanel() {
         </div>
       </section>
 
+      {/* errorKind (#6176): isError requires BOTH resources to have failed, so readiness is always in its error
+          state here. Its kind is the one to report -- readiness is this panel's primary resource (see the
+          RefreshMeta below), and a connectivity failure that took out both would carry the same kind on either. */}
       <StateBoundary
         isLoading={
           Boolean(repoPath) && (readiness.status === "loading" || config.status === "loading")
         }
         isError={Boolean(repoPath) && readiness.status === "error" && config.status === "error"}
+        errorKind={readiness.status === "error" ? readiness.errorKind : undefined}
         isEmpty={Boolean(repoPath) && readiness.status === "ready" && !workspace}
         onRetry={refresh}
         onRefresh={refresh}

--- a/apps/loopover-ui/src/components/site/app-panels/state-boundary-error-kind.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/state-boundary-error-kind.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// #6176: useApiResource has always exposed errorKind on its error state, and ErrorState has always used it to
+// show connectivity-specific copy (state-views.test.tsx pins that consumer). The missing link was the panels
+// themselves, which never forwarded the field -- so a pure network failure rendered the generic "Couldn't load
+// this" everywhere except app.runs.tsx. These tests pin the wiring: a network-kind failure must now surface the
+// connectivity copy through the panel, and a server-side failure must still get the generic copy.
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({ useApiResource: () => useApiResource() }));
+
+import { CommandsPanel } from "@/components/site/app-panels/commands-panel";
+import { DigestPanel } from "@/components/site/app-panels/digest-panel";
+
+// StateBoundary keeps its own pre-#793 default title for a non-network failure, and passes `undefined` for a
+// network one so ErrorState's connectivity-aware default shows through instead. Forwarding errorKind is what
+// selects between the two, so these are the exact strings the fix moves between.
+const NETWORK_COPY = "Can't reach the server";
+const GENERIC_COPY = "Couldn't load data";
+
+function errorState(errorKind?: string) {
+  return {
+    status: "error",
+    data: null,
+    error: "boom",
+    errorKind,
+    loadedAt: null,
+    reload: () => {},
+  };
+}
+
+const PANELS = [
+  { name: "DigestPanel", render: () => render(<DigestPanel />) },
+  { name: "CommandsPanel", render: () => render(<CommandsPanel />) },
+] as const;
+
+describe("StateBoundary errorKind forwarding (#6176)", () => {
+  for (const panel of PANELS) {
+    it(`${panel.name} shows connectivity copy when the fetch failed with a network kind`, () => {
+      useApiResource.mockReturnValue(errorState("network"));
+      panel.render();
+      expect(screen.getByText(NETWORK_COPY)).toBeTruthy();
+    });
+
+    it(`${panel.name} still shows the generic copy for a server-side failure`, () => {
+      // The point of forwarding the kind is that it DISTINGUISHES the two -- an API error must not start
+      // claiming the server is unreachable.
+      useApiResource.mockReturnValue(errorState("http"));
+      panel.render();
+      expect(screen.getByText(GENERIC_COPY)).toBeTruthy();
+      expect(screen.queryByText(NETWORK_COPY)).toBeNull();
+    });
+  }
+});

--- a/apps/loopover-ui/src/routes/app.analytics.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.tsx
@@ -162,6 +162,7 @@ function ProductAnalytics() {
     <StateBoundary
       isLoading={dashboard.status === "loading"}
       isError={dashboard.status === "error"}
+      errorKind={dashboard.status === "error" ? dashboard.errorKind : undefined}
       isEmpty={dashboard.status === "ready" && dashboard.data.metrics.length === 0}
       onRetry={dashboard.reload}
       onRefresh={dashboard.reload}

--- a/apps/loopover-ui/src/routes/app.operator.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.tsx
@@ -134,6 +134,7 @@ function OperatorDashboard() {
     <StateBoundary
       isLoading={dashboard.status === "loading"}
       isError={dashboard.status === "error"}
+      errorKind={dashboard.status === "error" ? dashboard.errorKind : undefined}
       isEmpty={dashboard.status === "ready" && dashboard.data.metrics.length === 0}
       onRetry={dashboard.reload}
       onRefresh={dashboard.reload}


### PR DESCRIPTION
## Summary

`useApiResource` has always carried `errorKind` on its error state, and `StateBoundary`/`ErrorState` have always used it to distinguish "we never reached the server" from "the server answered with an error". The missing link was the panels themselves: only `app.runs.tsx:246` forwarded the field, so every other dashboard showed the generic **"Couldn't load data"** even on a pure connectivity failure.

This forwards it at the call sites that actually route errors through `StateBoundary`, matching `app.runs.tsx`'s exact pattern. Neither `useApiResource` nor `ErrorState` changes — this is only the wiring, as the issue asks.

| Site | Forwarded |
|---|---|
| `owner-panel.tsx` | `readiness.errorKind` |
| `digest-panel.tsx` | `digest.errorKind` |
| `commands-panel.tsx` | `commands.errorKind` |
| `app.operator.tsx` | `dashboard.errorKind` |
| `app.analytics.tsx` | `dashboard.errorKind` |

`owner-panel` reports **readiness's** kind: its `isError` requires **both** readiness and config to have failed, so readiness is always in its error state there — and it is the panel's primary resource (its own `RefreshMeta` comment already says so).

## Two of the seven named sites are deliberately excluded — please read

`miner-panel.tsx` and `maintainer-panel.tsx` **pass no `isError` at all**. Both catch `status === "error"` themselves and render a soft inline warning ("Miner dashboard is unavailable right now (…)") *inside* the boundary's children, rather than using `StateBoundary`'s `ErrorState`. A forwarded `errorKind` would be **ignored** there — `StateBoundary` only consults it when `isError` is true.

Making those two network-aware means moving their error path onto `StateBoundary`, which replaces a deliberate inline notice with a full-page error state. That is a UX change, not a prop forward, and the issue explicitly scopes this to "purely a 'forward the prop' fix" — so I left them alone rather than quietly changing their behaviour. Happy to do that as its own issue if you want them converted.

## Tests

The new suite pins the **wiring end-to-end**, not the prop:

- A `network`-kind failure must now surface **"Can't reach the server"** through the panel.
- An `http`-kind failure must still get the generic copy — the distinction is the entire point of the fix, so a test that only checked the network case could pass on a change that broke it.

**Both network cases fail against the unforwarded panels** (verified by reverting only the two panels and re-running). `ErrorState`'s own `errorKind` behaviour was already covered by `state-views.test.tsx` (#793); what was untested was that any panel actually reaches it.

One detail worth recording: `StateBoundary` keeps its **own** pre-#793 default title (`"Couldn't load data"`) for a non-network failure, and passes `undefined` for a network one so `ErrorState`'s connectivity default shows through. My first draft asserted `ErrorState`'s string and failed — the test now pins the exact strings the fix moves between.

## Validation

- [x] **New suite — 4/4 pass**; the 2 network cases fail without the forwarding.
- [x] Full `@loopover/ui` suite — **287/287 pass, all 46 files** (no pre-existing failures on this run).
- [x] `npm run ui:typecheck` — clean (both workspaces).
- [x] `@loopover/ui` build — clean.
- [x] `npm run ui:lint` — **0 non-prettier violations**; prettier run over all six files (it reflowed one object literal in the test, which I took). The repo-wide `prettier/prettier` errors are Windows CRLF noise, absent on CI's LF checkout.
- [x] `git diff --check` clean; tree contains only the six intended files (no generated `routeTree.gen.ts` / `openapi.json` churn). Rebased on latest `main` — no base conflict.

## Coverage

No patch surface: `apps/**` is in Codecov's ignore list. The behaviour is covered by the new render tests regardless.

## Scope

- [x] Six files, one coherent change, in a wanted path (`apps/loopover-ui/`). Maintainer-authored issue → approved work.
- [x] Five one-line prop forwards plus one comment and one test file. `useApiResource` and `ErrorState` untouched, per the issue.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Strictly corrective and additive: with no `errorKind` the copy was generic; with it, a connectivity failure says so. Every non-network failure keeps the exact copy it had — asserted.

Closes #6176
