### PR TITLE
fix(test): stop repair diagnostics test racing a live manifest fetch

### DIFF
--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2146,8 +2146,12 @@ describe("api routes", () => {
   });
 
   it("serves installation repair diagnostics and refreshes installation health", async () => {
+    // Deterministic manifest fetch: avoids racing a real network call before the first /repair request below.
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
     const app = createApp();
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    // Must differ from the default self-repo name (test/helpers/d1.ts), or loadRepoFocusManifest's self-repo
+    // fallback still injects the live repo's autonomy:auto block despite the stub above.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     const repoPayload = { name: "gittensory", full_name: "JSONbored/gittensory", private: true, default_branch: "main", owner: { login: "JSONbored" } };
     await upsertInstallation(env, {
       installation: {


### PR DESCRIPTION
## Summary
- The installation-repair integration test's first `/repair` request didn't stub `fetch`, so `loadRepoFocusManifest` could hit the real `raw.githubusercontent.com` endpoint for `JSONbored/gittensory`.
- That repo name also matches this test env's default `LOOPOVER_DRIFT_ISSUE_REPO`, so on any fetcher miss the loader's self-repo fallback injected the live repo's `.loopover.yml` (which carries `autonomy: auto`) regardless of network outcome — making the test fail deterministically in any sandbox with outbound network access, independent of whether the live fetch itself succeeded or failed.
- Stub `fetch` to a deterministic 404 and point `LOOPOVER_DRIFT_ISSUE_REPO` at an unrelated repo name so neither the real network path nor the self-repo fallback fires.

## Test plan
- [x] `npx vitest run test/integration/api.test.ts -t "serves installation repair diagnostics"` — green, 5 consecutive runs
- [x] `npx vitest run test/integration/api.test.ts` — 47/47 passing
- [x] `npm run typecheck` — clean