### PR TITLE
fix(test): stop 3 tests from bleeding real autonomy overrides via self-repo fallback

### DIFF
--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2146,8 +2146,16 @@ describe("api routes", () => {
   });
 
   it("serves installation repair diagnostics and refreshes installation health", async () => {
+    // No repo file mocked (this test only cares about DB-configured settings): stub fetch to a plain 404 so
+    // resolveRepositorySettings's manifest lookup never makes a REAL network call to raw.githubusercontent.com,
+    // which -- being a live, mutable URL that transparently follows the gittensory->loopover rename -- would
+    // silently pick up whatever real .loopover.yml content the actual repo carries today instead of the
+    // deterministic DB-only settings this test asserts against. LOOPOVER_DRIFT_ISSUE_REPO is also overridden
+    // so a 404'd fetch doesn't fall back to the bundled self-repo manifest (LOOPOVER_REPO_FOCUS_MANIFEST_YAML),
+    // which carries its own settings.autonomy block (#773) that would equally clobber this test's DB-only setup.
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
     const app = createApp();
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     const repoPayload = { name: "gittensory", full_name: "JSONbored/gittensory", private: true, default_branch: "main", owner: { login: "JSONbored" } };
     await upsertInstallation(env, {
       installation: {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1173,7 +1173,15 @@ describe("GitHub backfill", () => {
   });
 
   it("marks comment, label, and check repair impacts disabled by repo settings", async () => {
-    const env = createTestEnv();
+    // No repo file mocked (this test only cares about DB-configured settings): stub fetch to a plain 404 so
+    // resolveRepositorySettings's manifest lookup never makes a REAL network call to raw.githubusercontent.com,
+    // which -- being a live, mutable URL that transparently follows the gittensory->loopover rename -- would
+    // silently pick up whatever real .loopover.yml content the actual repo carries today instead of the
+    // deterministic DB-only settings this test asserts against. LOOPOVER_DRIFT_ISSUE_REPO is also overridden
+    // so a 404'd fetch doesn't fall back to the bundled self-repo manifest (LOOPOVER_REPO_FOCUS_MANIFEST_YAML),
+    // which carries its own settings.autonomy block (#773) that would equally clobber this test's DB-only setup.
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
@@ -1245,7 +1253,11 @@ describe("GitHub backfill", () => {
   });
 
   it("repair diagnostics require contents:write for merge autonomy (#audit-install-health display)", async () => {
-    const env = createTestEnv();
+    // See the sibling "marks comment, label, and check repair impacts disabled by repo settings" test above --
+    // stub fetch AND override the self-repo identity so this test's DB-only autonomy override is never
+    // silently overlaid by a real, live fetch or the bundled self-repo manifest's own autonomy block.
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto" } });
 

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -2634,8 +2634,10 @@ describe("queue processors", () => {
     // other slop detector. Asserted via the persisted `pull_requests` slopRisk/slopBand columns
     // (updatePullRequestSlopAssessment runs unconditionally inside shouldCollectSlopEvidence, independent of
     // the publish/comment pipeline), mirroring how "clears the persisted dashboard slop score when the slop
-    // gate is off (#911)" above verifies the same live score.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    // gate is off (#911)" above verifies the same live score. LOOPOVER_DRIFT_ISSUE_REPO is overridden so this
+    // test's 404'd manifest fetch doesn't fall back to the bundled self-repo manifest, which carries its own
+    // settings.autonomy block (#773) unrelated to (and irrelevant for) the slop assessment under test here.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),


### PR DESCRIPTION
## Summary

- Currently on \`main\`, 3 tests fail: \`test/unit/backfill.test.ts\` (x2) and \`test/integration/api.test.ts\` (x1), all in the installation-repair-diagnostics area.
- Root cause: these tests use \`"JSONbored/gittensory"\` (the old pre-rename name) as their fixture repo, set up a DB-only \`autonomy\` override, and assert on the computed required GitHub permissions -- but don't stub \`fetch\`. \`raw.githubusercontent.com\` transparently follows the gittensory->loopover repo rename, so the real, unstubbed \`fetch\` call succeeds and returns the ACTUAL live \`.loopover.yml\` content. That file gained a real \`settings.autonomy\` block in #6468 (fixing the "reviews approved but never merged" production bug), so these 3 tests started silently inheriting real production autonomy config instead of their own deterministic DB-only setup, flipping their expected \`pull_requests\`/\`contents\` permission assertions.
- Fix: stub \`fetch\` to a deterministic 404 in each (removing the live-network dependency), and override \`LOOPOVER_DRIFT_ISSUE_REPO\` so a 404'd fetch doesn't then fall back to the bundled self-repo manifest constant (which carries the same \`autonomy\` block).

## Scope
- [x] Test-only change (\`test/unit/backfill.test.ts\`, \`test/integration/api.test.ts\`, plus a similarly-affected test in \`test/unit/queue-5.test.ts\` found during the same investigation)
- [x] No production code changed

## Validation
- [x] All 3 previously-failing tests pass
- [x] Full \`test/unit\` + \`test/integration\` run is green except for one pre-existing, unrelated migration-number collision (0156, filed separately)