### PR TITLE
fix(ui): render generatedAt on GateOutcomeCard and ActivationPreview

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/activation-preview.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/activation-preview.test.tsx
@@ -160,6 +160,13 @@ describe("ActivationPreview", () => {
     expect(screen.getByText(/Enter an installed repository to preview activation\./i)).toBeTruthy();
   });
 
+  it("renders its generatedAt timestamp once the preview loads (#6174)", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: BASE_PREVIEW });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText(BASE_PREVIEW.summary)).toBeTruthy());
+    expect(screen.getByText("generated 05 Jul 2026 00:00")).toBeTruthy();
+  });
+
   it("shows the 'settings unavailable' copy for a typed repo string that doesn't parse as owner\\/repo", async () => {
     apiFetch.mockResolvedValue({ ok: true, data: BASE_PREVIEW });
     render(<ActivationPreview reviewability={REVIEWABILITY} />);

--- a/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { StatusPill, type Status } from "@/components/site/control-primitives";
 import { TableScroll } from "@/components/site/data-table";
 import { StateBoundary } from "@/components/site/state-views";
+import { formatGeneratedAt } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
@@ -140,9 +141,14 @@ export function ActivationPreview({ reviewability }: { reviewability: Array<{ pr
           </p>
         </div>
         {preview ? (
-          <StatusPill status={preview.recommendedAction === null ? "ready" : "info"}>
-            gate {preview.currentReviewCheckMode}
-          </StatusPill>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-token-2xs text-muted-foreground">
+              generated {formatGeneratedAt(preview.generatedAt)}
+            </span>
+            <StatusPill status={preview.recommendedAction === null ? "ready" : "info"}>
+              gate {preview.currentReviewCheckMode}
+            </StatusPill>
+          </div>
         ) : null}
       </div>
 

--- a/apps/loopover-ui/src/components/site/app-panels/gate-outcome-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/gate-outcome-card.test.tsx
@@ -113,4 +113,9 @@ describe("GateOutcomeCard (#2203)", () => {
     const { container } = render(<GateOutcomeCard breakdown={breakdown()} />);
     expect(container.textContent ?? "").not.toMatch(FORBIDDEN_PUBLIC_TERMS);
   });
+
+  it("renders its generatedAt timestamp (#6174)", () => {
+    render(<GateOutcomeCard breakdown={breakdown({ generatedAt: "2026-07-11T00:00:00.000Z" })} />);
+    expect(screen.getByText("generated 11 Jul 2026 00:00")).toBeTruthy();
+  });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/gate-outcome-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/gate-outcome-card.tsx
@@ -6,6 +6,7 @@ import {
   gateOutcomeSegments,
   type GateOutcomeCardData,
 } from "@/components/site/app-panels/gate-outcome-card-model";
+import { formatGeneratedAt } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
 
 /** Gate-outcome breakdown card (#2203, part of #539): auto-merged / auto-closed / held counts and rates
  *  from repo-scoped gate-outcome audit events. Read-only; public-safe aggregate counts only. */
@@ -23,7 +24,12 @@ export function GateOutcomeCard({ breakdown }: { breakdown: GateOutcomeCardData 
             day(s).
           </p>
         </div>
-        <BoundaryBadge boundary="public" />
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-token-2xs text-muted-foreground">
+            generated {formatGeneratedAt(breakdown.generatedAt)}
+          </span>
+          <BoundaryBadge boundary="public" />
+        </div>
       </div>
 
       <div className="mt-4 grid gap-3 sm:grid-cols-3">


### PR DESCRIPTION
Closes #6174

## Summary

`GateOutcomeCardData` and `ActivationPreviewResponse` both already carry a `generatedAt: string` field on their data model, but neither `GateOutcomeCard` nor `ActivationPreview` ever rendered it — unlike sibling dashboard cards fetching the same kind of payload (`SlopDuplicateTrendCard`, `OwnerPanel`'s `RegistrationWorkspace`), which already show a "generated {label}" freshness indicator.

- `GateOutcomeCard`: added a `generated {formatGeneratedAt(breakdown.generatedAt)}` label next to the existing `BoundaryBadge` in the card header.
- `ActivationPreview`: added the same label next to the existing `gate {mode}` `StatusPill` in the card header, shown once a preview has loaded.
- Both reuse the existing exported `formatGeneratedAt` helper from `slop-duplicate-trend-card-model.ts` rather than introducing a third private duplicate of the same formatting logic.
- No data-fetching or other rendered fields changed on either component, per the issue's own scope.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6174.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run docs:drift-check`
- [x] `npm run manifest:drift-check`
- [x] `npm run command-reference:check`
- [x] `npm run ui:lint` — 0 errors, only pre-existing warnings in unrelated files.
- [ ] `npm run ui:typecheck` / `npm run ui:build` — both fail identically on a clean, unmodified `main` checkout in this sandbox (a missing `collections/browser`/`collections/server` codegen step, and an unresolvable `@scalar/api-reference` subpackage), verified via `git stash` — reproduces byte-for-byte with or without this diff.
- [ ] Root `npm run typecheck` / `npm run test:coverage` — not run; this sandbox's root typecheck reliably OOMs regardless of diff content (reproduced repeatedly across prior PRs this session).
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — added a regression test to each component's existing test file asserting the rendered `generated {label}` text (`gate-outcome-card.test.tsx`, `activation-preview.test.tsx`). Ran the full `app-panels` test directory (25 files, 120 tests) to confirm no regressions.

If any required check was skipped, explain why:

- `ui:typecheck`/`ui:build`: pre-existing sandbox environment issues, confirmed unrelated to this diff by reproducing the identical failure on a clean `main` checkout via `git stash`.
- Root `typecheck`/`test:coverage`: this sandbox's established OOM pattern, unrelated to diff content.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/MCP surface touched; both fields were already present on the existing response types.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — Both cards already render from live API data; this only surfaces an already-fetched field.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — See below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## UI Evidence

Both changes are a single small `font-mono text-token-2xs text-muted-foreground` label ("generated {date}") added next to an existing header pill, matching `SlopDuplicateTrendCard`'s established placement and styling exactly (`slop-duplicate-trend-card.tsx:43-45`) — no new visual pattern introduced. Covered by the new regression tests asserting the exact rendered text (`gate-outcome-card.test.tsx`, `activation-preview.test.tsx`); `ui:build` couldn't run in this sandbox (see Validation) to produce a live screenshot.

## Notes

None.
