### PR TITLE
fix(db): grandfather the 0156 migration-number collision

### DIFF
--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -26,6 +26,9 @@
 //   • 0090 — both 0090_contributor_cap_label (#2479) and 0090_pull_request_detail_sync_head_sha (#2527)
 //     merged with bare ADD COLUMN statements. Preserve both filenames so already-applied databases never
 //     replay either ALTER under a new migration name.
+//   • 0156 — both 0156_draft_pr_close_policy and 0156_pull_request_screenshot_table_presence_satisfied
+//     merged independently from the same base and were both applied to production before the collision
+//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074/0090.
 import { readdirSync, readFileSync } from "node:fs";
 import { detectMigrationCollisions, extractMigrationNumber, KNOWN_MIGRATION_DUPLICATES, MIGRATION_FILENAME_PATTERN } from "../src/db/migration-collisions.ts";
 import { detectColumnCollisions } from "../src/db/migration-column-extraction.ts";

--- a/src/db/migration-collisions.ts
+++ b/src/db/migration-collisions.ts
@@ -27,6 +27,7 @@ export const KNOWN_MIGRATION_DUPLICATES: ReadonlyMap<number, ReadonlySet<string>
   [17, new Set(["0017_agent_recommendation_outcomes.sql", "0017_product_usage_role_retention_rollups.sql"])],
   [74, new Set(["0074_ai_review_cache.sql", "0074_orb_self_enrollment_disabled.sql"])],
   [90, new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"])],
+  [156, new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"])],
 ]);
 
 /**

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -37,7 +37,7 @@ describe("check-migrations script", () => {
   it("reports every grandfathered duplicate migration number in the success summary", () => {
     const output = execFileSync(TSX_BIN, ["scripts/check-migrations.mjs"], { encoding: "utf8" });
 
-    expect(output).toContain("(4 grandfathered duplicates: 0015, 0017, 0074, 0090)");
+    expect(output).toContain("(5 grandfathered duplicates: 0015, 0017, 0074, 0090, 0156)");
   });
 
   it.each([

--- a/test/unit/migration-collisions.test.ts
+++ b/test/unit/migration-collisions.test.ts
@@ -75,7 +75,10 @@ describe("KNOWN_MIGRATION_DUPLICATES (#2550)", () => {
   it("stays byte-identical to scripts/check-migrations.mjs's grandfathered list", () => {
     // A drift here would mean the CI script and the live premerge recheck disagree about what's grandfathered
     // — this pins the exact set so a future addition to one side without the other is caught immediately.
-    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 90]);
+    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 90, 156]);
     expect(KNOWN_MIGRATION_DUPLICATES.get(90)).toEqual(new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"]));
+    expect(KNOWN_MIGRATION_DUPLICATES.get(156)).toEqual(
+      new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `0156_draft_pr_close_policy.sql` (#6454) and `0156_pull_request_screenshot_table_presence_satisfied.sql` (a same-day, independently-merged PR) both grabbed migration number 0156 relative to the same `origin/main` base and merged without a collision being caught.
- Both have already been applied to production D1 under their current filenames (confirmed via `d1_migrations`) — renaming either now would make wrangler try to RE-APPLY it, and both are bare `ALTER TABLE ADD COLUMN` statements SQLite can't guard with `IF NOT EXISTS`, so the re-apply would error and break the next deploy.
- Grandfathers 0156 in `KNOWN_MIGRATION_DUPLICATES`, matching the exact precedent already set by 0015/0017/0074/0090 for the same "already-shipped, can't-be-renumbered" reason.

Found while running the full test suite as part of a broader cleanup pass (see sibling PRs).

## Validation
- [x] `npm run db:migrations:check`
- [x] `npm run test:ci` (relevant subset green)