### PR TITLE
fix(settings): restore draftPrClosePolicy after it was dropped by the autonomy config-as-code PR

### DIFF
--- a/.loopover.yml
+++ b/.loopover.yml
@@ -110,6 +110,7 @@ settings:
         removeOtherTypeLabels: false
         trustMaintainerAuthoredIssueForReward: true
   reviewEvasionProtection: close
+  draftPrClosePolicy: close
   # Agent-layer autonomy dial (#773): without this block every action class defaults to "observe"
   # (deny-by-default) -- loopover had NO repository_settings DB row at all, so merge/close/approve
   # actions were silently never taken regardless of review verdict (#6401, #6402 sat fully reviewed,

--- a/src/config/loopover-repo-focus-manifest.ts
+++ b/src/config/loopover-repo-focus-manifest.ts
@@ -114,6 +114,7 @@ settings:
         removeOtherTypeLabels: false
         trustMaintainerAuthoredIssueForReward: true
   reviewEvasionProtection: close
+  draftPrClosePolicy: close
   # Agent-layer autonomy dial (#773): without this block every action class defaults to "observe"
   # (deny-by-default) -- loopover had NO repository_settings DB row at all, so merge/close/approve
   # actions were silently never taken regardless of review verdict (#6401, #6402 sat fully reviewed,


### PR DESCRIPTION
## Summary

- PR #6468's autonomy config-as-code change replaced the same `settings:` block section in both `.loopover.yml` and its bundled fallback manifest, silently dropping this repo's own `draftPrClosePolicy: close` line in the process — the feature (#6454, merged) has been fully live in code since, just disabled for loopover's own repo because nothing enabled it.
- Re-adds `draftPrClosePolicy: close` alongside (not replacing) the `autonomy:` block, in both the committed `.loopover.yml` and its bundled byte-identical twin.

Found while investigating the repository_settings/config-as-code interaction as part of a broader cleanup pass (see sibling PRs).

## Validation
- [x] `npm run manifest:drift-check`
- [x] Relevant manifest/focus-config tests green