### PR TITLE
fix(ci): repair two functional breaks left by the gittensory->loopover rename

### DIFF
--- a/.github/workflows/orb-beta-release.yml
+++ b/.github/workflows/orb-beta-release.yml
@@ -81,7 +81,7 @@ jobs:
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "$TAG" -m "gittensory-orb ${VERSION}"
+            git tag -a "$TAG" -m "loopover-orb ${VERSION}"
             git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
             gh auth setup-git
             git push origin "$TAG"

--- a/.github/workflows/orb-stable-release-tag.yml
+++ b/.github/workflows/orb-stable-release-tag.yml
@@ -75,7 +75,7 @@ jobs:
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "$TAG" -m "gittensory-orb ${VERSION}"
+            git tag -a "$TAG" -m "loopover-orb ${VERSION}"
             git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
             gh auth setup-git
             git push origin "$TAG"

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -152,7 +152,7 @@ jobs:
           fi
 
       - name: Require Sentry token for official release
-        if: github.repository == 'JSONbored/gittensory' && steps.sentry.outputs.enabled != 'true'
+        if: github.repository == 'JSONbored/loopover' && steps.sentry.outputs.enabled != 'true'
         run: |
           echo "::error::Configure SENTRY_AUTH_TOKEN in the release environment before publishing official Orb images."
           exit 1
@@ -232,7 +232,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/loopover-selfhost
           tags: ${{ steps.tags.outputs.list }}
           labels: |
-            org.opencontainers.image.title=gittensory-orb
+            org.opencontainers.image.title=loopover-orb
             org.opencontainers.image.description=Self-hostable LoopOver review engine
             org.opencontainers.image.version=${{ steps.version.outputs.tag }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -407,13 +407,13 @@ jobs:
 
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-              --title "gittensory-orb ${RELEASE_TAG}" \
+              --title "loopover-orb ${RELEASE_TAG}" \
               --notes "$FULL_NOTES" \
               "${PRERELEASE_ARGS[@]}"
           else
             gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
-              --title "gittensory-orb ${RELEASE_TAG}" \
+              --title "loopover-orb ${RELEASE_TAG}" \
               "${PRERELEASE_ARGS[@]}" \
               --notes "$FULL_NOTES"
           fi

--- a/scripts/smoke-selfhost.sh
+++ b/scripts/smoke-selfhost.sh
@@ -5,22 +5,22 @@
 # (or must not) produce. See docs/self-hosting-release-checklist for the beta smoke matrix built on this.
 #
 # Defaults to a plain SQLite + Redis + direct-App boot:
-#   ./scripts/smoke-selfhost.sh gittensory:selfhost-ci
+#   ./scripts/smoke-selfhost.sh loopover-selfhost:ci
 #
 # Test a specific mode by passing extra env and the events it should produce:
 #   SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=claude-code
 #   CLAUDE_CODE_OAUTH_TOKEN=..." \
 #   SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \
-#   ./scripts/smoke-selfhost.sh gittensory:selfhost-ci
+#   ./scripts/smoke-selfhost.sh loopover-selfhost:ci
 #
 # Assert an event must NOT appear (e.g. no AI-CLI-missing warning, no failed relay registration):
-#   SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" ./scripts/smoke-selfhost.sh gittensory:selfhost-ci
+#   SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" ./scripts/smoke-selfhost.sh loopover-selfhost:ci
 #
 # Visual review (#3608): also boots a browserless/chromium sidecar, wires BROWSER_WS_ENDPOINT +
-# PUBLIC_SITE_ORIGIN automatically, and asserts the on-demand /gittensory/shot?url= route returns a real
+# PUBLIC_SITE_ORIGIN automatically, and asserts the on-demand /loopover/shot?url= route returns a real
 # PNG -- proving captureShot() actually renders through the self-host stub end to end, not just that the
 # app boots. The IMAGE under test must have been built with --build-arg INSTALL_VISUAL_REVIEW=true.
-#   SELFHOST_SMOKE_VISUAL_REVIEW=1 ./scripts/smoke-selfhost.sh gittensory:selfhost-ci-visual
+#   SELFHOST_SMOKE_VISUAL_REVIEW=1 ./scripts/smoke-selfhost.sh loopover-selfhost:ci-visual
 set -euo pipefail
 
 IMAGE="${1:?usage: smoke-selfhost.sh <image>}"
@@ -107,7 +107,7 @@ if [ "$VISUAL_REVIEW" = "1" ]; then
     docker logs "$BROWSERLESS_NAME" >&2 || true
     exit 1
   fi
-  # LOOPOVER_REVIEW_SCREENSHOTS must be on: the /gittensory/shot route itself 404s when it's off
+  # LOOPOVER_REVIEW_SCREENSHOTS must be on: the /loopover/shot route itself 404s when it's off
   # (deliberately "truly inert" by design, src/api/routes.ts), independent of BROWSER_WS_ENDPOINT.
   #
   # SMOKE_SHOT_TARGET must be a REAL, publicly resolvable URL, unlike this script's other *.example
@@ -180,26 +180,26 @@ curl -sf "http://127.0.0.1:${PORT}/ready" | grep -q '"ok":true'
 curl -sf "http://127.0.0.1:${PORT}/metrics" | grep -q 'loopover_uptime_seconds'
 
 if [ "$VISUAL_REVIEW" = "1" ]; then
-  echo "smoke-selfhost: checking /gittensory/shot renders a real PNG through the self-host browser stub"
-  SHOT_URL="http://127.0.0.1:${PORT}/gittensory/shot?url=$(printf '%s' "$SMOKE_SHOT_TARGET" | tr -d '\n')"
-  SHOT_HEADERS="$(curl -sf -D - -o /tmp/gt-smoke-shot.png "$SHOT_URL")"
+  echo "smoke-selfhost: checking /loopover/shot renders a real PNG through the self-host browser stub"
+  SHOT_URL="http://127.0.0.1:${PORT}/loopover/shot?url=$(printf '%s' "$SMOKE_SHOT_TARGET" | tr -d '\n')"
+  SHOT_HEADERS="$(curl -sf -D - -o /tmp/loopover-smoke-shot.png "$SHOT_URL")"
   echo "$SHOT_HEADERS" | grep -qi '^content-type: image/png' || {
-    echo "::error::/gittensory/shot did not return image/png" >&2
+    echo "::error::/loopover/shot did not return image/png" >&2
     echo "$SHOT_HEADERS" >&2
     docker logs "$APP_NAME" >&2 || true
     docker logs "$BROWSERLESS_NAME" >&2 || true
     exit 1
   }
-  SHOT_BYTES="$(wc -c </tmp/gt-smoke-shot.png | tr -d ' ')"
+  SHOT_BYTES="$(wc -c </tmp/loopover-smoke-shot.png | tr -d ' ')"
   # A real rendered page is comfortably more than a placeholder/error graphic would be; catches a "PNG
   # content-type but empty/near-empty body" false pass.
   if [ "$SHOT_BYTES" -lt 1024 ]; then
-    echo "::error::/gittensory/shot returned a suspiciously small PNG (${SHOT_BYTES} bytes)" >&2
+    echo "::error::/loopover/shot returned a suspiciously small PNG (${SHOT_BYTES} bytes)" >&2
     docker logs "$APP_NAME" >&2 || true
     exit 1
   fi
-  echo "smoke-selfhost: /gittensory/shot returned a real PNG (${SHOT_BYTES} bytes)"
-  rm -f /tmp/gt-smoke-shot.png
+  echo "smoke-selfhost: /loopover/shot returned a real PNG (${SHOT_BYTES} bytes)"
+  rm -f /tmp/loopover-smoke-shot.png
 fi
 
 LOGS="$(docker logs "$APP_NAME" 2>&1)"


### PR DESCRIPTION
## Summary

- `scripts/smoke-selfhost.sh` hit the dead `/gittensory/shot` route when `VISUAL_REVIEW=1` — the real registered route is `/loopover/shot` (`src/api/routes.ts`). This 404'd the visual-review smoke check unconditionally.
- `release-selfhost.yml`'s "Require Sentry token for official release" safety gate was guarded by `github.repository == 'JSONbored/gittensory'`. Since the repo renamed, `github.repository` now always resolves to `JSONbored/loopover`, so this condition was permanently false — silently disabling the intended block on publishing an official Orb image without `SENTRY_AUTH_TOKEN` configured.
- Also fixes cosmetic residue in the same release path (OCI image title, GitHub Release titles, git tag annotations) — leaves the Sentry org/project/release naming untouched (maintainer decision, #5333: stays gittensory-prefixed).

Found via a comprehensive discovery sweep as part of a broader gittensory→loopover residue cleanup (see sibling PRs).

## Validation
- [x] `npm run actionlint`
- [x] `bash -n scripts/smoke-selfhost.sh`