### PR TITLE
fix(ui): rename remaining user-visible gittensory branding to LoopOver

### DIFF
--- a/apps/loopover-ui/public/manifest.webmanifest
+++ b/apps/loopover-ui/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Gittensory Control Panel",
-  "short_name": "Gittensory",
+  "name": "LoopOver Control Panel",
+  "short_name": "LoopOver",
   "start_url": "/app",
   "scope": "/",
   "display": "standalone",

--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -242,9 +242,9 @@ function BotReply({ boundary, body }: { boundary: CommandSample["boundary"]; bod
             isPrivate ? "bg-mint text-primary-foreground" : "bg-success text-background",
           )}
         >
-          G
+          L
         </span>
-        <span className="font-mono text-token-xs text-foreground">gittensory[bot]</span>
+        <span className="font-mono text-token-xs text-foreground">loopover[bot]</span>
         <span
           className={cn(
             "ml-auto rounded-token border-hairline px-1.5 py-0.5 font-mono text-token-2xs uppercase tracking-wider",

--- a/apps/loopover-ui/src/components/site/app-panels/playground-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/playground-panel.tsx
@@ -374,7 +374,7 @@ export function PlaygroundPanel({ defaultTool = "preflight-branch" }: { defaultT
               {tool === "public-safe-comment" ? (
                 <div className="mt-4 rounded-token border-hairline bg-background/40 p-4 text-token-sm">
                   <div className="mb-2 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                    gittensory · sticky comment
+                    loopover · sticky comment
                   </div>
                   <pre className="whitespace-pre-wrap font-mono text-token-xs text-foreground/90">
                     {formatPublicPreview(result)}
@@ -577,7 +577,7 @@ function formatOutputForClipboard(tool: Tool, result: unknown): string {
       "Maintainers can run `@loopover blockers` for non-public context.",
     ].join("\n");
   }
-  const header = `// gittensory · ${tool} · preview`;
+  const header = `// loopover · ${tool} · preview`;
   const body = JSON.stringify(result, null, 2);
   // Normalize line endings and ensure trailing newline for terminal pastes.
   return `${header}\n${body}\n`.replace(/\r\n/g, "\n");

--- a/apps/loopover-ui/src/components/site/home/pr-quiet-compare.tsx
+++ b/apps/loopover-ui/src/components/site/home/pr-quiet-compare.tsx
@@ -35,7 +35,7 @@ export function PrQuietCompare() {
           ))}
         </ul>
         <CommentBlock
-          author="gittensory[bot]"
+          author="loopover[bot]"
           body="Confirmed miner. Preflight: ready. One linked issue · one squashed commit. Maintainer packet available on request."
           variant="quiet"
         />

--- a/apps/loopover-ui/src/components/site/site-footer.tsx
+++ b/apps/loopover-ui/src/components/site/site-footer.tsx
@@ -62,7 +62,7 @@ export function SiteFooter() {
           </p>
           <div className="mt-5 flex items-center gap-3">
             <a
-              href="https://github.com/jsonbored/gittensory"
+              href="https://github.com/jsonbored/loopover"
               target="_blank"
               rel="noreferrer"
               className="inline-flex h-8 w-8 items-center justify-center rounded-token border border-border text-muted-foreground transition-colors duration-150 hover:text-foreground hover:border-strong focus-ring"

--- a/apps/loopover-ui/src/routes/changelog.tsx
+++ b/apps/loopover-ui/src/routes/changelog.tsx
@@ -70,7 +70,7 @@ function Changelog() {
           <Rss className="size-3" aria-hidden /> npm package
         </a>
         <a
-          href="https://github.com/jsonbored/gittensory/releases"
+          href="https://github.com/jsonbored/loopover/releases"
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center gap-1.5 rounded-token border-hairline px-2.5 py-1 font-mono text-token-2xs text-muted-foreground transition-colors duration-150 hover:text-mint hover:border-strong focus-ring"

--- a/apps/loopover-ui/src/routes/extension.tsx
+++ b/apps/loopover-ui/src/routes/extension.tsx
@@ -202,7 +202,7 @@ function OverlayDemo() {
           <span className="size-2 rounded-full bg-[oklch(0.8_0.15_85)]/60" />
           <span className="size-2 rounded-full bg-success/60" />
           <span className="ml-2 truncate font-mono text-token-2xs">
-            github.com/jsonbored/gittensory/pull/1218
+            github.com/jsonbored/loopover/pull/1218
           </span>
         </div>
         <div className="grid gap-3 p-3 sm:grid-cols-[1.4fr_1fr]">

--- a/apps/loopover-ui/src/routes/roadmap.tsx
+++ b/apps/loopover-ui/src/routes/roadmap.tsx
@@ -126,7 +126,7 @@ function RoadmapPage() {
           waits until the GitHub project scope is available.
         </p>
         <a
-          href="https://github.com/JSONbored/gittensory/issues/127"
+          href="https://github.com/JSONbored/loopover/issues/127"
           target="_blank"
           rel="noreferrer"
           className="mt-4 inline-flex rounded-token border-hairline px-2.5 py-1 font-mono text-token-2xs text-muted-foreground transition-colors duration-150 hover:border-strong hover:text-mint focus-ring"
@@ -182,7 +182,7 @@ function RoadmapPage() {
                     </div>
                     <p className="mt-1.5 text-token-xs text-muted-foreground">{item.description}</p>
                     <a
-                      href={`https://github.com/JSONbored/gittensory/issues/${item.issue}`}
+                      href={`https://github.com/JSONbored/loopover/issues/${item.issue}`}
                       target="_blank"
                       rel="noreferrer"
                       className="mt-3 inline-flex items-center gap-1 rounded-token text-token-xs font-medium text-muted-foreground transition-colors duration-150 hover:text-mint hover:underline focus-ring"

--- a/apps/loopover-ui/src/styles.css
+++ b/apps/loopover-ui/src/styles.css
@@ -8,7 +8,7 @@
  * Site-only additions on top of the shared design system (imported above
  * from @loopover/ui-kit/theme.css — tokens, base layer, and the
  * border-hairline family the shared components depend on now live there).
- * Everything below is specific to gittensory-ui's own marketing/docs pages
+ * Everything below is specific to loopover-ui's own marketing/docs pages
  * and dashboard chrome — hero flourishes, gradients, nav accents — not
  * needed by a shared component, so it stays local.
  */


### PR DESCRIPTION
## Summary

- `public/manifest.webmanifest`: the PWA name/short_name shown to users who install the site (`"Gittensory Control Panel"` / `"Gittensory"`) — the most user-visible instance of the stale branding in the codebase.
- Site GitHub links (footer, roadmap, changelog) and the extension marketing mockup pointed at `jsonbored/gittensory` URLs.
- Demo/preview bot name and label text in the app-panel mockups (commands-panel, playground-panel, pr-quiet-compare) still said `"gittensory[bot]"` / `"gittensory · ..."`, inconsistent with the same codebase's own `"@loopover blockers"` example text.
- One stale comment in `styles.css`.

Part of a broader gittensory→loopover residue cleanup (see sibling PRs).

## Validation
- [x] `npm run ui:typecheck`
- [x] `npm --workspace @loopover/ui run lint` (0 errors, only pre-existing warnings)
- [x] `npm run ui:build`
- [x] `manifest.webmanifest` parses as valid JSON