### PR TITLE
chore: rename npm package metadata from gittensory to loopover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gittensory",
+  "name": "loopover",
   "version": "0.1.0",
   "private": true,
   "packageManager": "npm@10.9.8",
@@ -168,12 +168,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JSONbored/gittensory.git"
+    "url": "git+https://github.com/JSONbored/loopover.git"
   },
   "keywords": [],
   "author": "",
   "bugs": {
-    "url": "https://github.com/JSONbored/gittensory/issues"
+    "url": "https://github.com/JSONbored/loopover/issues"
   },
-  "homepage": "https://github.com/JSONbored/gittensory#readme"
+  "homepage": "https://github.com/JSONbored/loopover#readme"
 }

--- a/packages/loopover-engine/package.json
+++ b/packages/loopover-engine/package.json
@@ -3,20 +3,19 @@
   "version": "3.1.1",
   "license": "AGPL-3.0-only",
   "type": "module",
-  "description": "Shared deterministic engine logic for the LoopOver review stack and gittensory-miner.",
+  "description": "Shared deterministic engine logic for the LoopOver review stack and loopover-miner.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JSONbored/gittensory.git",
+    "url": "git+https://github.com/JSONbored/loopover.git",
     "directory": "packages/loopover-engine"
   },
-  "homepage": "https://github.com/JSONbored/gittensory#readme",
+  "homepage": "https://github.com/JSONbored/loopover#readme",
   "bugs": {
-    "url": "https://github.com/JSONbored/gittensory/issues"
+    "url": "https://github.com/JSONbored/loopover/issues"
   },
   "keywords": [
     "gittensor",
-    "gittensory",
-    "engine",
+        "engine",
     "deterministic",
     "scoring",
     "signals"

--- a/packages/loopover-mcp/package.json
+++ b/packages/loopover-mcp/package.json
@@ -6,12 +6,12 @@
   "description": "Local stdio MCP wrapper for the LoopOver Gittensor base-agent.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JSONbored/gittensory.git",
+    "url": "git+https://github.com/JSONbored/loopover.git",
     "directory": "packages/loopover-mcp"
   },
-  "homepage": "https://github.com/JSONbored/gittensory#readme",
+  "homepage": "https://github.com/JSONbored/loopover#readme",
   "bugs": {
-    "url": "https://github.com/JSONbored/gittensory/issues"
+    "url": "https://github.com/JSONbored/loopover/issues"
   },
   "keywords": [
     "gittensor",

--- a/packages/loopover-miner/package.json
+++ b/packages/loopover-miner/package.json
@@ -6,17 +6,16 @@
   "description": "Foundation CLI for the local LoopOver miner runtime.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JSONbored/gittensory.git",
+    "url": "git+https://github.com/JSONbored/loopover.git",
     "directory": "packages/loopover-miner"
   },
-  "homepage": "https://github.com/JSONbored/gittensory#readme",
+  "homepage": "https://github.com/JSONbored/loopover#readme",
   "bugs": {
-    "url": "https://github.com/JSONbored/gittensory/issues"
+    "url": "https://github.com/JSONbored/loopover/issues"
   },
   "keywords": [
     "gittensor",
-    "gittensory",
-    "miner",
+        "miner",
     "cli",
     "agent"
   ],

--- a/packages/loopover-ui-kit/package.json
+++ b/packages/loopover-ui-kit/package.json
@@ -3,19 +3,18 @@
   "version": "1.0.0",
   "license": "AGPL-3.0-only",
   "type": "module",
-  "description": "Shared design-system tokens and component primitives for gittensory-ui and gittensory-miner-ui.",
+  "description": "Shared design-system tokens and component primitives for loopover-ui and loopover-miner-ui.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JSONbored/gittensory.git",
+    "url": "git+https://github.com/JSONbored/loopover.git",
     "directory": "packages/loopover-ui-kit"
   },
-  "homepage": "https://github.com/JSONbored/gittensory#readme",
+  "homepage": "https://github.com/JSONbored/loopover#readme",
   "bugs": {
-    "url": "https://github.com/JSONbored/gittensory/issues"
+    "url": "https://github.com/JSONbored/loopover/issues"
   },
   "keywords": [
-    "gittensory",
-    "design-system",
+        "design-system",
     "ui"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Root `package.json`'s `"name"` and repository/bugs/homepage URLs, plus the same metadata (+ descriptions, keywords) across the 4 published workspace packages (`@loopover/engine`, `@loopover/mcp`, `@loopover/miner`, `@loopover/ui-kit`), still said "gittensory". None of these are functional (root is `private:true`; GitHub redirects the old repo URL) but they're metadata a consumer would actually read.
- Leaves the "gittensor" (Bittensor subnet) keyword/term untouched everywhere — that's a different, still-correct word, not old-name residue.

Part of a broader gittensory→loopover residue cleanup (see sibling PRs).

## Validation
- [x] `npm run typecheck`
- [x] `npm run build --workspace @loopover/engine`
- [x] All 5 edited files parse as valid JSON