### PR TITLE
docs: fix stale gittensory references in contributor-facing docs

### DIFF
--- a/.claude/skills/contributing-to-loopover/SKILL.md
+++ b/.claude/skills/contributing-to-loopover/SKILL.md
@@ -81,7 +81,7 @@ opening a **fresh** PR. This is the entire reason to get it right before you pus
 
 ```sh
 # External contributor? Fork JSONbored/loopover on GitHub first, then clone YOUR fork:
-git clone https://github.com/<you>/gittensory && cd gittensory
+git clone https://github.com/<you>/loopover && cd loopover
 git remote add upstream https://github.com/JSONbored/loopover   # to sync main later
 nvm use            # Node 22 (.nvmrc)
 npm ci             # installs the whole workspace, incl. apps/loopover-ui — required before any check
@@ -285,8 +285,8 @@ GitHub's web editor (which needs a human browser session an AI coding tool can't
 3. **Host the images on a dedicated branch in your own fork** — never commit them to your feature
    branch, and never rely on drag-and-drop:
    ```sh
-   git worktree add ../gittensory-screenshots main
-   cd ../gittensory-screenshots
+   git worktree add ../loopover-screenshots main
+   cd ../loopover-screenshots
    git checkout --orphan screenshots       # first time; `git checkout screenshots` if you already have one
    git rm -rf . 2>/dev/null
    cp /path/to/your/*.jpg .                # JPG/PNG only -- SVG is never accepted as review evidence
@@ -294,7 +294,7 @@ GitHub's web editor (which needs a human browser session an AI coding tool can't
    git push origin screenshots
    cd -    # your feature branch's working directory was never touched
    ```
-   Reference each file as `https://raw.githubusercontent.com/<your-fork-owner>/gittensory/screenshots/<file>.jpg`,
+   Reference each file as `https://raw.githubusercontent.com/<your-fork-owner>/loopover/screenshots/<file>.jpg`,
    then embed it with the existing `<a href="URL"><img src="URL" alt="Loaded state" width="240"></a>`
    thumbnail convention.
 4. **Animated evidence — for effects no static screenshot can show** (a hover-triggered element, a

--- a/.claude/skills/contributing-to-loopover/SKILL.md
+++ b/.claude/skills/contributing-to-loopover/SKILL.md
@@ -2,7 +2,7 @@
 name: contributing-to-loopover
 description: >-
   Use when writing, testing, or preparing ANY code contribution or pull request to the
-  JSONbored/gittensory repo — picking/validating an issue, implementing a change, writing tests
+  JSONbored/loopover repo — picking/validating an issue, implementing a change, writing tests
   that pass Codecov, running the local CI gate, predicting the loopover gate, and formatting the
   commit + PR. loopover reviews PRs ONE-SHOT via the loopover gate (a GitHub App / CI) plus a
   strict CI suite with Codecov (99% patch coverage, hard); there is no review back-and-forth, so a
@@ -80,9 +80,9 @@ opening a **fresh** PR. This is the entire reason to get it right before you pus
 **Get a working tree — every local command in this skill needs it:**
 
 ```sh
-# External contributor? Fork JSONbored/gittensory on GitHub first, then clone YOUR fork:
+# External contributor? Fork JSONbored/loopover on GitHub first, then clone YOUR fork:
 git clone https://github.com/<you>/gittensory && cd gittensory
-git remote add upstream https://github.com/JSONbored/gittensory   # to sync main later
+git remote add upstream https://github.com/JSONbored/loopover   # to sync main later
 nvm use            # Node 22 (.nvmrc)
 npm ci             # installs the whole workspace, incl. apps/loopover-ui — required before any check
 ```
@@ -98,7 +98,7 @@ approved, then confirm it's green.
 ```sh
 npm install -g @loopover/mcp@latest
 loopover-mcp login                       # GitHub device flow (for the auth'd preflight tools)
-loopover-mcp init-client --print codex   # prints TOML for ~/.codex/config.toml ([mcp_servers.gittensory])
+loopover-mcp init-client --print codex   # prints TOML for ~/.codex/config.toml ([mcp_servers.loopover])
 loopover-mcp init-client --print claude  # or --print cursor — prints the correct config per tool
 ```
 

--- a/.claude/skills/contributing-to-loopover/reference.md
+++ b/.claude/skills/contributing-to-loopover/reference.md
@@ -3,9 +3,9 @@
 Exhaustive tables and patterns behind the `SKILL.md` playbook. Read the section you need; you don't
 need all of it for every change. All commands run from the repo root unless noted.
 
-**Bootstrap (fresh clone):** external contributors **fork** `JSONbored/gittensory`, then
+**Bootstrap (fresh clone):** external contributors **fork** `JSONbored/loopover`, then
 `git clone` their fork, `nvm use` (Node 22 via `.nvmrc`), and **`npm ci`** (required before any check
-runs). Add the upstream remote — `git remote add upstream https://github.com/JSONbored/gittensory` —
+runs). Add the upstream remote — `git remote add upstream https://github.com/JSONbored/loopover` —
 and `git fetch upstream && git rebase upstream/main` before pushing if `main` moved (a base conflict
 auto-closes a contributor PR). Push to your fork; open the PR from it. A first fork PR's Actions wait
 for maintainer approval (CI shows unverified → the engine **holds**, never closes — this is expected).
@@ -153,7 +153,7 @@ Install + configure (let the CLI print the right config for your tool — **Code
 ```sh
 npm install -g @loopover/mcp@latest
 loopover-mcp login                        # GitHub device flow
-loopover-mcp init-client --print codex    # → ~/.codex/config.toml  ([mcp_servers.gittensory])
+loopover-mcp init-client --print codex    # → ~/.codex/config.toml  ([mcp_servers.loopover])
 loopover-mcp init-client --print claude   # or --print cursor  (→ mcpServers JSON)
 ```
 
@@ -196,11 +196,11 @@ own PR.)
 
 ```ts
 import { createTestEnv } from "../helpers/d1";
-const env = createTestEnv({ LOOPOVER_REVIEW_REPOS: "JSONbored/gittensory" });
+const env = createTestEnv({ LOOPOVER_REVIEW_REPOS: "JSONbored/loopover" });
 await env.DB.prepare(`INSERT INTO repositories (full_name, owner, name) VALUES (?,?,?)`)
-  .bind("JSONbored/gittensory", "JSONbored", "gittensory").run();
+  .bind("JSONbored/loopover", "JSONbored", "loopover").run();
 const row = await env.DB.prepare(`SELECT * FROM repositories WHERE full_name = ?`)
-  .bind("JSONbored/gittensory").first<RepoRow>();
+  .bind("JSONbored/loopover").first<RepoRow>();
 ```
 
 **Route tests:** `createApp()` from `src/api/routes` + `app.request(path, init, env)`. **Fetch stub:**

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -36,10 +36,10 @@ Two products, self-host-first:
   `src/signals`, etc). The maintainer side: automates PR review, merge/close disposition, summaries.
   Self-hosted only today (see `.claude/skills/contributing-to-loopover` / `gittensory-deployment-models`
   equivalent context) — no hosted Orb yet, deliberately, ~1-2 months out at the time of writing.
-- Directory names under `packages/` still say `gittensory-*`; only the npm package **names** have
-  moved to `@loopover/*` so far (as of 2026-07-14). Check both independently, don't assume one implies
-  the other — the repo itself renames `gittensory` → `loopover` on ~2026-07-15; re-verify current
-  naming before hardcoding either name into a new issue body.
+- Directory names under `packages/` and npm package names both moved to `loopover-*` / `@loopover/*`
+  (the repo itself renamed `gittensory` → `loopover` on 2026-07-15). Some tables/audit-log values and
+  historical GitHub content still legitimately reference the old name — re-verify current naming before
+  hardcoding either name into a new issue body rather than assuming either direction.
 
 **Standing priorities named by the maintainer (2026-07-14), not yet issue-backed:**
 - **AMS selfhost hardening, round 2.** Miner Wave 4 ("AMS Hardening & Packaging") fully closed
@@ -65,7 +65,7 @@ Two products, self-host-first:
 | `Miner Wave N — <theme> (maintainer)` | Business/legal/architecture track (currently Wave 5, Rent-a-Loop) | Mostly no — but check individual issues, some concrete implementation sub-tasks are deliberately carved out and unlocked even inside a `(maintainer)`-titled milestone |
 | `Miner Wave 4.5 — AMS Hardening Round 2` | **New, created 2026-07-15.** The home for recurring post-Wave-4 gap-audit findings in `packages/loopover-miner`/`packages/loopover-engine` — correctness bugs, unenforced documented contracts, stale comments, small hardening gaps. Every future "AMS selfhost hardening round N" audit files here, not a fresh milestone each time. | Yes — same shape as Wave 4's own contributor-open issues |
 | `AMS Cloud Readiness (maintainer)` | Hosted **multi-tenant SaaS** AMS — NOT the same thing as "AMS selfhost hardening" despite the name similarity | Mostly no (architecture/billing/SLA decisions) — a handful of pure research-spike/audit/load-test issues are deliberately contributor-eligible; check labels per-issue |
-| `ORB Cloud Readiness (maintainer)` | Same shape, for ORB's hosted SaaS story | Mostly no, same caveat — the first several issues in this milestone (#4878-4884-style, "extract X into gittensory-engine") are often pure refactors miscategorized here, not actually tenant/business-specific — read the body, not just the milestone |
+| `ORB Cloud Readiness (maintainer)` | Same shape, for ORB's hosted SaaS story | Mostly no, same caveat — the first several issues in this milestone (#4878-4884-style, "extract X into loopover-engine") are often pure refactors miscategorized here, not actually tenant/business-specific — read the body, not just the milestone |
 | `ORB - Long Term Features & Improvements` | Grab-bag: some genuine self-host feature/bug work, some product-design epics awaiting maintainer subjective calls | Mixed — read each body |
 | `LoopOver Rebrand Migration (maintainer)` | Brand/infra cutover | No |
 | Unmilestoned | Should be rare — every gardening-generated issue gets a real milestone (see below) | If you find one, fold it into the closest-fitting existing milestone rather than leave it adrift |
@@ -205,7 +205,7 @@ mutation { addSubIssue(input: { issueId: "<parent node id>", subIssueId: "<child
 mutation { addBlockedBy(input: { issueId: "<blocked node id>", blockingIssueId: "<blocker node id>" }) { issue { number } } }
 ```
 
-Get an issue's GraphQL node ID via `gh api graphql -f query='query { repository(owner:"JSONbored", name:"gittensory") { issue(number: N) { id } } }'` (note: literal query strings without file interpolation are fine with `-f`; only the `@file` file-read syntax requires `-F`).
+Get an issue's GraphQL node ID via `gh api graphql -f query='query { repository(owner:"JSONbored", name:"loopover") { issue(number: N) { id } } }'` (note: literal query strings without file interpolation are fine with `-f`; only the `@file` file-read syntax requires `-F`).
 
 ## gh CLI gotchas already hit doing this work
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ Enforcement is proportional and escalates with intent and repetition:
   farming, results in submissions being closed and labeled on sight and a block from contributing.
 - Plagiarism and ban-evasion — copying another contributor's work, or returning under a new account
   after a block — result in an immediate **permanent block from contributing across all of our
-  repositories** (`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
+  repositories** (`JSONbored/loopover`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
 
 ## Contribution Terms
 
@@ -70,6 +70,6 @@ good-faith research is welcome through that channel.
 
 For security issues, use GitHub private vulnerability reporting:
 
-https://github.com/JSONbored/gittensory/security/advisories/new
+https://github.com/JSONbored/loopover/security/advisories/new
 
 For non-sensitive support, use GitHub issues and follow `SUPPORT.md`.

--- a/apps/loopover-miner-extension/README.md
+++ b/apps/loopover-miner-extension/README.md
@@ -1,7 +1,7 @@
 # LoopOver Miner Extension
 
 Contributor-facing browser extension for GitHub **issue** pages. It is intentionally separate from
-[`apps/loopover-extension/`](../gittensory-extension/) (the **Maintainer Overlay**), which injects private PR/issue
+[`apps/loopover-extension/`](../loopover-extension/) (the **Maintainer Overlay**), which injects private PR/issue
 context for maintainers.
 
 ## What it does


### PR DESCRIPTION
## Summary

- `.claude/skills/contributing-to-loopover/SKILL.md` + `reference.md`: fork/clone bootstrap instructions told contributors (and future AI agent sessions, since this skill is auto-loaded by `CLAUDE.md` for every contribution) to clone/add-upstream against `github.com/JSONbored/gittensory`, and the printed MCP client config example said `[mcp_servers.gittensory]` — the real generated key is `[mcp_servers.loopover]` (`packages/loopover-mcp/bin/loopover-mcp.js`).
- `.claude/skills/contributor-pipeline-gardening/reference.md`: a dated note claiming "directory names under `packages/` still say `gittensory-*`" is now false (confirmed renamed) and was actively misleading the gardening automation.
- `CODE_OF_CONDUCT.md`: ban-policy repo list + the private security-advisory URL.
- `apps/loopover-miner-extension/README.md`: a relative link pointed at a nonexistent `../gittensory-extension/` directory (real path is `../loopover-extension/`).

Part of a broader gittensory→loopover residue cleanup (see sibling PRs).

## Validation
- [x] `npm run docs:drift-check`
- [x] `git diff --check`