### PR TITLE
docs(config): fix remaining gittensory residue in shipped config examples

### DIFF
--- a/.github/workflows/gittensor-impact.yml
+++ b/.github/workflows/gittensor-impact.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: 22.23.1
 
       - name: Render impact card
-        run: node scripts/gittensor-impact-card.mjs JSONbored/gittensory gittensor-impact-dark.svg
+        run: node scripts/gittensor-impact-card.mjs JSONbored/loopover gittensor-impact-dark.svg
 
       - name: Publish to gittensor-impact-assets
         env:

--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -256,7 +256,7 @@ gate:
     - build
     - test
 
-  # Third-party check-runs to treat as ADVISORY (#4372). Any GitHub App you install alongside gittensory
+  # Third-party check-runs to treat as ADVISORY (#4372). Any GitHub App you install alongside loopover
   # (a security scanner, a contributor-trust analyzer, a license/CLA bot, ...) can post a check-run whose
   # terminal conclusion is outside GitHub's normal pass/fail vocabulary — most commonly a durable
   # "action_required" that only a human can clear in that app's own UI, never on GitHub. Left alone, such a
@@ -266,7 +266,7 @@ gate:
   # CI pass/fail entirely and never counts as "still running", so it can never block or stall the gate. It is
   # NOT silently swallowed either — a non-passing conclusion routes the PR to the manual-review hold (the
   # manualReviewLabel) with the triggering check/app named, so a maintainer can act on it. Generic: name the
-  # app(s) YOU run; gittensory hardcodes no vendor. List of { name, appSlug }, or omit. Default: not
+  # app(s) YOU run; loopover hardcodes no vendor. List of { name, appSlug }, or omit. Default: not
   # configured (byte-identical behavior for every repo that doesn't opt in). Config-as-code only — no DB
   # column or dashboard toggle.
   advisoryCheckRuns:

--- a/CONVERGENCE_RUNBOOK.md
+++ b/CONVERGENCE_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This runbook records the **post-port** operating model for the reviewbot → gittensory convergence tracked by:
+This runbook records the **post-port** operating model for the reviewbot → loopover convergence tracked by:
 
 - `#983` — parent convergence / migration tracker
 - `#1029` — self-host / packaging layer
@@ -13,16 +13,16 @@ This runbook records the **post-port** operating model for the reviewbot → git
 - `#980` — Docker / compose self-host
 - `#981` — configuration, secrets, onboarding
 - `#982` — dashboard / observability
-- `#1030` — decommission legacy reviewbot identity + repo, keep gittensory as the single project
+- `#1030` — decommission legacy reviewbot identity + repo, keep loopover as the single project
 
-The old vendor/embed plan is obsolete. The review system now lives in **gittensory-native codepaths** guarded by `LOOPOVER_REVIEW_*` flags. There is no `REVIEWBOT_ENGINE_ENABLED` path in this repository.
+The old vendor/embed plan is obsolete. The review system now lives in **loopover-native codepaths** guarded by `LOOPOVER_REVIEW_*` flags. There is no `REVIEWBOT_ENGINE_ENABLED` path in this repository.
 
 ## Current architecture
 
-- **Single project:** gittensory is the only source repo for the converged review system.
+- **Single project:** loopover is the only source repo for the converged review system.
 - **Native port:** review features live under `src/review/**`, `src/queue/processors.ts`, and related first-party modules.
 - **Public comment path:** the unified in-place PR comment is rendered unconditionally by the native bridge — it is the only comment-rendering path (the legacy multi-panel renderer and its `LOOPOVER_REVIEW_UNIFIED_COMMENT` flag were retired).
-- **Infra model:** D1 / Queue / AI / optional Vectorize / optional R2 / optional Browser bindings are declared directly in gittensory.
+- **Infra model:** D1 / Queue / AI / optional Vectorize / optional R2 / optional Browser bindings are declared directly in loopover.
 - **Config model:** rollout is controlled by `LOOPOVER_REVIEW_*` flags plus the per-repo allowlist `LOOPOVER_REVIEW_REPOS`.
 - **Parity model:** parity is measured as a shadow/deploy-time comparison against authoritative legacy audit rows; local checkout validation proves structure and safety, not historical decision identity.
 
@@ -61,7 +61,7 @@ These replace the old notion of a separate reviewbot engine toggle.
 
 ## External decommission checklist
 
-Run these only after parity evidence is preserved and the native gittensory path is holding:
+Run these only after parity evidence is preserved and the native loopover path is holding:
 
 1. **Preserve evidence first**
    - export or snapshot the authoritative audit / parity evidence needed for rollback and analytics
@@ -77,7 +77,7 @@ Run these only after parity evidence is preserved and the native gittensory path
 
 4. **Archive, then delete the legacy repo**
    - archive first for a short confirmation window
-   - delete only after native gittensory behavior is validated and rollback is no longer required
+   - delete only after native loopover behavior is validated and rollback is no longer required
 
 5. **Do not couple deletion to public-OSS expansion**
    - the “hide how it works” design remains a separate gate
@@ -117,7 +117,7 @@ npm run test:ci
 
 ## Repository status after convergence
 
-- gittensory owns the converged implementation
+- loopover owns the converged implementation
 - docs must describe the native-port model only
 - legacy decommission is an operator checklist, not an implicit code path
 - the public-OSS flip remains separately gated
@@ -144,7 +144,7 @@ private operator handoff for #1826 instead of committing it here.
 | Historical visual-audit storage | R2 buckets | Historical screenshot/audit capture storage from earlier Cloudflare-hosted review execution. | No current `r2_buckets` block exists in `wrangler.jsonc`; remaining interfaces are optional compatibility hooks for self-host blob storage. | May contain historical review artifacts; contents were not read or listed during this inventory. | **retire-later / needs owner decision** — confirm retention value and out-of-repo consumers in a private operator follow-up before deletion. |
 | Removed platform capabilities | Workers AI / Browser Rendering | Historical hosted review and visual-capture capabilities. | No current binding blocks exist in `wrangler.jsonc`; optional TypeScript interfaces remain for compatibility adapters. | None at rest in this repo. | **keep code as-is / no action** — these are removed capabilities, not storage resources to retire from this public runbook. |
 | Historical config namespace | KV namespace | Historical per-repo configuration storage predating config-as-code. | No current KV binding remains in `wrangler.jsonc`; current configuration flows use repo config and database-backed settings. | N/A in this public runbook. | **no action needed here** — exact namespace identifiers and account-listing evidence belong in the private operator handoff if needed. |
-| Other account resource classes | Hyperdrive / unrelated projects | Out of scope for gittensory cleanup. | `wrangler.jsonc` declares no binding for these resource classes. | N/A. | **not applicable** — do not enumerate unrelated account resources in this repo. |
+| Other account resource classes | Hyperdrive / unrelated projects | Out of scope for loopover cleanup. | `wrangler.jsonc` declares no binding for these resource classes. | N/A. | **not applicable** — do not enumerate unrelated account resources in this repo. |
 
 ### wrangler.jsonc binding hygiene
 

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -239,10 +239,10 @@ required for either family and applies to nothing on its own.
 
 ## Maintainer-mention nag moderation
 
-`settings.reviewNagMonitoredMentions` extends the `@gittensory`-ping review-nag cooldown
+`settings.reviewNagMonitoredMentions` extends the `@loopover`-ping review-nag cooldown
 (`reviewNagPolicy`/`reviewNagMaxPings`/`reviewNagCooldownDays`/`reviewNagLabel` — same settings,
 one shared policy) to **also** throttle a thread's own author repeatedly @-mentioning a configured
-maintainer login, counted independently per login and independently of the `@gittensory` counter:
+maintainer login, counted independently per login and independently of the `@loopover` counter:
 
 ```yaml
 # .loopover.yml (global default)

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -270,7 +270,7 @@ gate:
     - build
     - test
 
-  # Third-party check-runs to treat as ADVISORY (#4372). Any GitHub App you install alongside gittensory
+  # Third-party check-runs to treat as ADVISORY (#4372). Any GitHub App you install alongside loopover
   # (a security scanner, a contributor-trust analyzer, a license/CLA bot, ...) can post a check-run whose
   # terminal conclusion is outside GitHub's normal pass/fail vocabulary — most commonly a durable
   # "action_required" that only a human can clear in that app's own UI, never on GitHub. Left alone, such a
@@ -280,7 +280,7 @@ gate:
   # CI pass/fail entirely and never counts as "still running", so it can never block or stall the gate. It is
   # NOT silently swallowed either — a non-passing conclusion routes the PR to the manual-review hold (the
   # manualReviewLabel) with the triggering check/app named, so a maintainer can act on it. Generic: name the
-  # app(s) YOU run; gittensory hardcodes no vendor. List of { name, appSlug }, or omit. Default: not
+  # app(s) YOU run; loopover hardcodes no vendor. List of { name, appSlug }, or omit. Default: not
   # configured (byte-identical behavior for every repo that doesn't opt in). Config-as-code only — no DB
   # column or dashboard toggle.
   advisoryCheckRuns:

--- a/wrangler.vitest.jsonc
+++ b/wrangler.vitest.jsonc
@@ -1,15 +1,15 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "gittensory-api-vitest",
+  "name": "loopover-api-vitest",
   "main": "src/index.ts",
   "compatibility_date": "2026-05-26",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "GITHUB_APP_ID": "3824093",
-    "GITHUB_APP_SLUG": "gittensory",
+    "GITHUB_APP_SLUG": "loopover",
     "GITHUB_OAUTH_CLIENT_ID": "Ov23lixYxDzyUKE070sm",
     "GITTENSOR_REGISTRY_URL": "https://raw.githubusercontent.com/entrius/gittensor/test/gittensor/validator/weights/master_repositories.json",
-    "PUBLIC_API_ORIGIN": "https://api.gittensory.aethereal.dev",
+    "PUBLIC_API_ORIGIN": "https://api.loopover.ai",
     "AI_SUMMARIES_ENABLED": "false",
     "AI_PUBLIC_COMMENTS_ENABLED": "false"
   },


### PR DESCRIPTION
## Summary

- `.loopover.yml.example` / `config/examples/loopover.full.yml` / `config/examples/README.md`: comments and the `@gittensory`-ping mention example still said "gittensory" — these ship as the literal example an operator copies into their own `.loopover.yml`, and the codebase's own live mention convention is `@loopover` (see `apps/loopover-ui`'s own demo panel text).
- `CONVERGENCE_RUNBOOK.md`: an operational runbook meant as a live reference described the project's own current identity as "gittensory" throughout. Updates the current-state descriptions to loopover; leaves the historical "reviewbot → loopover convergence" framing intact as naming a specific past migration.
- `.github/workflows/gittensor-impact.yml`: the scheduled README impact-card generator hardcoded the pre-rename repo argument.
- `wrangler.vitest.jsonc`: the vitest-only worker name, `GITHUB_APP_SLUG` default, and `PUBLIC_API_ORIGIN` (pointed at the fully-retired `aethereal.dev` domain, no redirect) were stale test-only config.

Part of a broader gittensory→loopover residue cleanup (see sibling PRs).

## Validation
- [x] `npm run actionlint`
- [x] `npm run docs:drift-check`
- [x] `test/unit/config-templates.test.ts` green
- [x] `npm run test:workers` green