### PR TITLE
fix(ui): wire StateBoundary's errorLabel at the six real dashboard call sites

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -76,6 +76,7 @@ export function CommandsPanel() {
       isLoading={commands.status === "loading"}
       isError={commands.status === "error"}
       errorKind={commands.status === "error" ? commands.errorKind : undefined}
+      errorLabel="Command simulator"
       isEmpty={commands.status === "ready" && commands.data.commands.length === 0}
       onRetry={commands.reload}
       onRefresh={commands.reload}

--- a/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
@@ -51,6 +51,7 @@ export function DigestPanel() {
       isLoading={digest.status === "loading"}
       isError={digest.status === "error"}
       errorKind={digest.status === "error" ? digest.errorKind : undefined}
+      errorLabel="Maintainer digest"
       isEmpty={digest.status === "ready" && digest.data.items.length === 0}
       onRetry={digest.reload}
       onRefresh={digest.reload}

--- a/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
@@ -108,6 +108,7 @@ export function OwnerPanel() {
         }
         isError={Boolean(repoPath) && readiness.status === "error" && config.status === "error"}
         errorKind={readiness.status === "error" ? readiness.errorKind : undefined}
+        errorLabel="Repo owner workspace"
         isEmpty={Boolean(repoPath) && readiness.status === "ready" && !workspace}
         onRetry={refresh}
         onRefresh={refresh}

--- a/apps/loopover-ui/src/components/site/app-panels/state-boundary-error-label.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/state-boundary-error-label.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// #6177: StateBoundary's errorLabel prop (global failure toast via notifyApiFailure) has always worked and been
+// tested (state-views.test.tsx), but no real panel ever passed it -- so a dashboard data-fetch failure never
+// produced the toast this feature exists for. These tests pin the wiring: each panel's StateBoundary must now
+// forward a real, panel-specific label to notifyApiFailure on error.
+const { notifyApiFailure } = vi.hoisted(() => ({ notifyApiFailure: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  notifyApiFailure: (...args: unknown[]) => notifyApiFailure(...args),
+}));
+vi.mock("sonner", () => ({ toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }) }));
+
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({ useApiResource: () => useApiResource() }));
+
+import { CommandsPanel } from "@/components/site/app-panels/commands-panel";
+import { DigestPanel } from "@/components/site/app-panels/digest-panel";
+import { OwnerPanel } from "@/components/site/app-panels/owner-panel";
+
+function errorState() {
+  return {
+    status: "error",
+    data: null,
+    error: "boom",
+    errorKind: "http",
+    loadedAt: null,
+    reload: () => {},
+  };
+}
+
+const PANELS = [
+  { name: "DigestPanel", label: "Maintainer digest", render: () => render(<DigestPanel />) },
+  { name: "CommandsPanel", label: "Command simulator", render: () => render(<CommandsPanel />) },
+  { name: "OwnerPanel", label: "Repo owner workspace", render: () => render(<OwnerPanel />) },
+] as const;
+
+describe("StateBoundary errorLabel forwarding (#6177)", () => {
+  for (const panel of PANELS) {
+    it(`${panel.name} surfaces its own errorLabel to the failure notifier on error`, () => {
+      useApiResource.mockReturnValue(errorState());
+      panel.render();
+      expect(notifyApiFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ label: panel.label }),
+      );
+    });
+  }
+});

--- a/apps/loopover-ui/src/routes/app.analytics.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.tsx
@@ -163,6 +163,7 @@ function ProductAnalytics() {
       isLoading={dashboard.status === "loading"}
       isError={dashboard.status === "error"}
       errorKind={dashboard.status === "error" ? dashboard.errorKind : undefined}
+      errorLabel="Product analytics"
       isEmpty={dashboard.status === "ready" && dashboard.data.metrics.length === 0}
       onRetry={dashboard.reload}
       onRefresh={dashboard.reload}

--- a/apps/loopover-ui/src/routes/app.operator.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.tsx
@@ -135,6 +135,7 @@ function OperatorDashboard() {
       isLoading={dashboard.status === "loading"}
       isError={dashboard.status === "error"}
       errorKind={dashboard.status === "error" ? dashboard.errorKind : undefined}
+      errorLabel="Operator dashboard"
       isEmpty={dashboard.status === "ready" && dashboard.data.metrics.length === 0}
       onRetry={dashboard.reload}
       onRefresh={dashboard.reload}

--- a/apps/loopover-ui/src/routes/app.runs.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.tsx
@@ -244,6 +244,7 @@ function AgentRuns() {
         isLoading={canUseLiveRuns && liveRuns.status === "loading"}
         isError={canUseLiveRuns && liveRuns.status === "error" && liveRuns.error !== "disabled"}
         errorKind={liveRuns.status === "error" ? liveRuns.errorKind : undefined}
+        errorLabel="Agent runs"
         errorDescription={liveRuns.status === "error" ? liveRuns.error : undefined}
         onRetry={liveRuns.reload}
         onRefresh={liveRuns.reload}


### PR DESCRIPTION
Closes #6177

## Summary

`StateBoundary`'s `errorLabel` prop (a global failure toast via `notifyApiFailure`, with a Retry action) has always been implemented and tested (`state-views.test.tsx:103,112`), but no real panel ever passed it — so a dashboard data-fetch failure never produced the toast this feature exists for. Meanwhile a few small standalone widgets (`github-stats-chip.tsx`, `mcp-version-badge.tsx`) call `notifyApiFailure` manually instead of going through this prop.

This forwards `errorLabel` at the same call sites the sibling `errorKind` fix (#6176, PR #6476) wired: `owner-panel.tsx`, `digest-panel.tsx`, `commands-panel.tsx`, `app.analytics.tsx`, `app.operator.tsx`, plus `app.runs.tsx` (which already had `errorKind` wired before #6476, as its own PR notes). Each gets a real, panel-specific label matching its identity elsewhere in the app (`command-palette.tsx`'s existing names, where one exists):

| Site | Label |
|---|---|
| `owner-panel.tsx` | `Repo owner workspace` |
| `digest-panel.tsx` | `Maintainer digest` |
| `commands-panel.tsx` | `Command simulator` |
| `app.analytics.tsx` | `Product analytics` |
| `app.operator.tsx` | `Operator dashboard` |
| `app.runs.tsx` | `Agent runs` |

`state-views.tsx`'s implementation of `errorLabel`/`notifyApiFailure` is untouched, per the issue's own scope.

## Two of the seven named sites are deliberately excluded

Same as #6176's own PR: `miner-panel.tsx` and `maintainer-panel.tsx` pass no `isError` to `StateBoundary` at all. Both catch their error state themselves and render a soft inline notice *inside* the boundary's children rather than using `StateBoundary`'s `ErrorState` — a forwarded `errorLabel` would never fire there, since `StateBoundary` only consults it when `isError` is true. Wiring those two would mean replacing their deliberate inline notice with a full error state, a UX change out of scope for a prop-forwarding fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6177.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run docs:drift-check`
- [x] `npm run manifest:drift-check`
- [x] `npm run command-reference:check`
- [x] `npm run ui:lint` — 0 errors, only pre-existing warnings in unrelated files.
- [ ] `npm run ui:typecheck` / `npm run ui:build` — both fail identically on a clean, unmodified `main` checkout in this sandbox (a missing `collections/browser`/`collections/server` codegen step, and an unresolvable `@scalar/api-reference` subpackage), verified via `git stash` — reproduces byte-for-byte with or without this diff.
- [ ] Root `npm run typecheck` / `npm run test:coverage` — not run; this sandbox's root typecheck reliably OOMs regardless of diff content (reproduced repeatedly across prior PRs this session).
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New/changed behavior has tests — new `state-boundary-error-label.test.tsx` (3 tests, mirroring the sibling `state-boundary-error-kind.test.tsx`'s structure): `DigestPanel`, `CommandsPanel`, and `OwnerPanel` each assert `notifyApiFailure` is called with their real label on error. Verified all three genuinely fail without the fix (`git stash` on the six wired files only, re-ran, restored). Ran the full `app-panels` suite (26 files) plus `app.analytics`/`app.operator`/`app.runs` — 122/123 passing, the one failure (`rees-analyzer-field-group.test.tsx`, unrelated to this change) confirmed flaky by re-running in isolation (passes clean).

If any required check was skipped, explain why:

- `ui:typecheck`/`ui:build`: pre-existing sandbox environment issues, confirmed unrelated to this diff by reproducing the identical failure on a clean `main` checkout via `git stash`.
- Root `typecheck`/`test:coverage`: this sandbox's established OOM pattern, unrelated to diff content.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/MCP surface touched.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — Strictly corrective/additive: with no `errorLabel`, an error fetch produced no toast; with it, a real failure now does. No other rendered state changed.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — See below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## UI Evidence

This change has no visible layout/markup diff — `errorLabel` only affects a side-effect (`notifyApiFailure` firing a toast) inside `StateBoundary`'s existing `useEffect`, not anything rendered inline. `ui:build` couldn't run in this sandbox (see Validation) to produce a live screenshot of the toast; covered instead by the new regression tests asserting the exact `notifyApiFailure` call per site.

## Notes

None.
