### PR TITLE
feat(review): add opt-in AMS→ORB reputation bridge (upgrade-only)

### DIFF
--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -1180,6 +1180,16 @@ settings:
 #   screenshots: false
 #   improvementSignal: false
 
+# AMS -> ORB reputation bridge (#6485) -- DEPLOYMENT env, not a per-repo manifest field (a repo must never be
+# able to point ORB at an arbitrary AMS instance; that is the push/gaming vector #6208's design deliberately
+# rejected). Opt-in, PULL-only, UPGRADE-only: when the operator sets LOOPOVER_REVIEW_AMS_BRIDGE=true AND
+# LOOPOVER_AMS_ENDPOINT to a LOCAL AMS endpoint, ORB pulls a submitter's privacy-safe track-record summary
+# (no score/wallet/hotkey fields) and a strong record can lift their INTERNAL reputation signal toward
+# `trusted` -- never toward `low`. Default OFF (either unset -> a no-op, byte-identical). Fail-safe
+# (unreachable/timeout/malformed -> no bonus, never throws) and STRICTLY INTERNAL (never shown publicly).
+# These are set in the deployment environment, not here -- this note documents them alongside the reputation
+# feature they extend.
+
 # Optional ecosystem/network PLUGINS -- distinct from `features:` above, which only toggles loopover's own
 # converged review capabilities. Each key here couples this instance to an external system and is OFF unless
 # BOTH a deployment-wide LOOPOVER_EXPERIMENTAL_* env kill-switch AND an explicit per-repo `true` are set (no

--- a/apps/loopover-ui/content/docs/privacy-security.mdx
+++ b/apps/loopover-ui/content/docs/privacy-security.mdx
@@ -51,6 +51,7 @@ LOOPOVER_REVIEW_IMPACT_MAP="true"              # deterministic impact map (needs
 LOOPOVER_REVIEW_CULTURE_PROFILE="true"         # repo quality-culture profile (needs review.culture_profile: true)
 LOOPOVER_REVIEW_MEMORY="true"                  # repeat-false-positive suppression (needs review.memory too)
 LOOPOVER_REVIEW_REPUTATION="true"              # submitter-reputation spend control (never shown)
+LOOPOVER_REVIEW_AMS_BRIDGE="true"              # opt-in AMS→ORB reputation bridge, upgrade-only (never shown; needs LOOPOVER_AMS_ENDPOINT)
 LOOPOVER_REVIEW_ENRICHMENT="true"              # external analyzer registry (REES) findings
 LOOPOVER_REVIEW_INLINE_COMMENTS="true"         # diff-anchored inline PR review comments
 LOOPOVER_REVIEW_FIX_HANDOFF="true"             # machine-readable fix-handoff block (contributor-run)

--- a/apps/loopover-ui/content/docs/tuning.mdx
+++ b/apps/loopover-ui/content/docs/tuning.mdx
@@ -128,6 +128,12 @@ any per-PR feature to run on a given repo. So a per-PR feature activates only wh
   burst, or low-reputation submitter is downgraded to a deterministic-only review; good
   reputation proceeds normally. Never surfaced publicly — no comment, label, or check shows
   reputation. Per-PR.
+- `LOOPOVER_REVIEW_AMS_BRIDGE` — opt-in AMS→ORB reputation bridge (#6485). When
+  on (and an operator points `LOOPOVER_AMS_ENDPOINT` at a LOCAL AMS instance), ORB PULLS the
+  submitter's privacy-safe AMS track-record summary and lets a strong record lift their
+  reputation signal toward `trusted` — UPGRADE-only, so it can rescue a good-standing submitter
+  from the deterministic-only downgrade but can never worsen their standing. Default off; a no-op
+  (byte-identical) with no endpoint or no AMS data. Fail-safe and never surfaced publicly. Per-PR.
 - `LOOPOVER_REVIEW_ENRICHMENT` — runs the review-enrichment analyzer registry
   (duplication, churn hotspots, blame links, approval integrity, undocumented exports, and
   more) and folds their findings into the review context. Per-PR.

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -1194,6 +1194,16 @@ settings:
 #   screenshots: false
 #   improvementSignal: false
 
+# AMS -> ORB reputation bridge (#6485) -- DEPLOYMENT env, not a per-repo manifest field (a repo must never be
+# able to point ORB at an arbitrary AMS instance; that is the push/gaming vector #6208's design deliberately
+# rejected). Opt-in, PULL-only, UPGRADE-only: when the operator sets LOOPOVER_REVIEW_AMS_BRIDGE=true AND
+# LOOPOVER_AMS_ENDPOINT to a LOCAL AMS endpoint, ORB pulls a submitter's privacy-safe track-record summary
+# (no score/wallet/hotkey fields) and a strong record can lift their INTERNAL reputation signal toward
+# `trusted` -- never toward `low`. Default OFF (either unset -> a no-op, byte-identical). Fail-safe
+# (unreachable/timeout/malformed -> no bonus, never throws) and STRICTLY INTERNAL (never shown publicly).
+# These are set in the deployment environment, not here -- this note documents them alongside the reputation
+# feature they extend.
+
 # Optional ecosystem/network PLUGINS -- distinct from `features:` above, which only toggles loopover's own
 # converged review capabilities. Each key here couples this instance to an external system and is OFF unless
 # BOTH a deployment-wide LOOPOVER_EXPERIMENTAL_* env kill-switch AND an explicit per-repo `true` are set (no

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -362,6 +362,20 @@ declare global {
      *  unset/false reads NO reputation, records NOTHING, and leaves the AI-spend gate byte-identical (the new
      *  branch is unreachable when off). */
     LOOPOVER_REVIEW_REPUTATION?: string;
+    /** Convergence (AMS→ORB reputation bridge, #6485): when truthy, an opt-in, PULL-only, UPGRADE-only read
+     *  path lets a submitter's genuine AMS track record IMPROVE — never worsen — the INTERNAL reputation signal.
+     *  ORB pulls the versioned track-record summary (no score/wallet/hotkey fields) from the operator-set
+     *  {@link Env.LOOPOVER_AMS_ENDPOINT} and a strong record can lift a `low`/`neutral` signal toward `trusted`,
+     *  rescuing a good-standing submitter from the deterministic-only downgrade — it can NEVER downgrade. Default
+     *  OFF — unset/false (or no endpoint) is an immediate no-op that pulls nothing and leaves the signal
+     *  byte-identical. STRICTLY INTERNAL and fail-safe (any read error/timeout/malformed response → no bonus,
+     *  never throws), inheriting the reputation module's contract as-is. */
+    LOOPOVER_REVIEW_AMS_BRIDGE?: string;
+    /** The operator-configured LOCAL AMS endpoint the {@link Env.LOOPOVER_REVIEW_AMS_BRIDGE} bridge PULLS a
+     *  submitter's track-record summary from (GitHub login passed as a `login` query parameter). Self-host /
+     *  operator-only; unset ⇒ the bridge is a no-op even when the flag is on. Timeout-bounded so a slow or
+     *  unreachable instance never slows gate evaluation. */
+    LOOPOVER_AMS_ENDPOINT?: string;
     /** Convergence (ops / observability): when truthy, loopover's OWN review-outcome data drives two
      *  operator surfaces — (1) on the cron tick, an anomaly scan over the gate-block ledger + recommendation /
      *  slop calibration emits a structured `ops_anomaly` log when something drifts (gate false-positive spike,

--- a/src/review/ams-reputation-bridge.ts
+++ b/src/review/ams-reputation-bridge.ts
@@ -1,0 +1,135 @@
+// AMS → ORB reputation bridge (#6485, implementing the #6208 design decision). An opt-in, PULL-only,
+// UPGRADE-only read path that lets a submitter's genuine AMS (Autonomous Miner Score) track record IMPROVE —
+// never worsen — the INTERNAL reputation signal `submitter-reputation.ts` derives. STRICTLY INTERNAL, exactly
+// like every other reputation input: the AMS bridge NEVER surfaces publicly (no label, comment, or check-run);
+// it only feeds the private AI-spend gate via `reputation-wire.ts`.
+//
+// Why this shape (verbatim from #6208's pinned decision):
+//   • GitHub-login-keyed — reuses the same public `authorLogin` axis the reputation module already keys on; no
+//     new hotkey/wallet identity surface (those are forbidden/redacted terms in this codebase).
+//   • ORB PULLS from AMS (never AMS pushing into ORB) — a push model would let any AMS instance write arbitrary
+//     trust into ORB's store, a direct gaming vector. Pull keeps ORB in control and degrades like every other
+//     optional signal here: AMS unreachable/absent → no bonus, neutral default, NEVER throws into the gate.
+//   • UPGRADE-only — a strong AMS record can move a submitter toward `trusted`, NEVER toward `low`. This closes
+//     the exact gaming vector #6208's Boundaries flagged: an AMS record must never be usable punitively.
+//   • Privacy-safe by construction — consumes the existing, versioned `TrackRecordSummaryReadResult` contract
+//     (#6246), which has no score/ranking/wallet/hotkey fields, so nothing new can cross the public boundary.
+//
+// Config-as-code, DEFAULT OFF: gated behind `LOOPOVER_REVIEW_AMS_BRIDGE` (same on/off regex convention as
+// `isReputationEnabled`) AND an operator-set `LOOPOVER_AMS_ENDPOINT`. With either unset the whole path is an
+// immediate no-op that returns the caller's signal untouched — byte-identical behavior for any repo that has
+// not opted in or has no AMS instance. Timeout-bounded so a slow/unreachable AMS never slows gate evaluation.
+
+import { PRODUCT_USER_AGENT } from "../github/client";
+import { TRACK_RECORD_SUMMARY_READ_VERSION, type TrackRecordSummary, type TrackRecordSummaryReadResult } from "../../packages/loopover-engine/src/track-record-summary";
+import type { ReputationSignal } from "./submitter-reputation";
+
+/** A slow or unreachable AMS instance must never slow gate evaluation — a few hundred ms, consistent with this
+ *  codebase's other fail-safe external-read patterns. The whole feature is off by default, so this only ever
+ *  applies once an operator has explicitly pointed ORB at a LOCAL AMS endpoint. */
+export const AMS_BRIDGE_TIMEOUT_MS = 300;
+
+/** Tunable thresholds for what counts as a "strong" AMS track record worth an upgrade. GENERIC mechanism (it
+ *  reveals no review DIRECTION), so the defaults are committed. Deliberately conservative: only a solid,
+ *  clearly-positive record lifts a signal — a sparse or middling one yields no bonus (neutral). */
+export interface AmsBridgeConfig {
+  /** Need at least this many RESOLVED (merged + closed) public PRs before AMS can lift a signal at all. */
+  minResolved: number;
+  /** A merge ratio at/above this reads as a strong track record → `trusted`. */
+  trustedMergeRatio: number;
+}
+
+/** The committed, behavior-preserving defaults. Mirrors the reputation module's own "solid recent record"
+ *  philosophy (minSample 5 / a clear majority succeeding). */
+export const DEFAULT_AMS_BRIDGE_CONFIG: AmsBridgeConfig = {
+  minResolved: 5,
+  trustedMergeRatio: 0.6,
+};
+
+/** True when the AMS bridge is switched on. Flag-OFF (default) → every helper here is a no-op. Same truthy
+ *  convention as `isReputationEnabled` / `isSafetyEnabled` (`/^(1|true|yes|on)$/i`). */
+export function isAmsBridgeEnabled(env: { LOOPOVER_REVIEW_AMS_BRIDGE?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_REVIEW_AMS_BRIDGE ?? "").trim());
+}
+
+/** The operator-configured LOCAL AMS endpoint base URL, trimmed. Returns `undefined` when unset/blank — the
+ *  bridge then degrades to a no-op (there is nothing to pull from). */
+export function amsEndpointUrl(env: { LOOPOVER_AMS_ENDPOINT?: string | undefined }): string | undefined {
+  const raw = env.LOOPOVER_AMS_ENDPOINT?.trim();
+  return raw ? raw : undefined;
+}
+
+// Ordinal rank of each signal on the neutral-anchored axis the bridge moves along: low < neutral < trusted.
+const SIGNAL_RANK: Record<ReputationSignal, number> = { low: 0, neutral: 1, trusted: 2 };
+
+/** UPGRADE-only merge: the result is whichever of the two signals ranks HIGHER, so an AMS signal can only ever
+ *  lift `current` toward `trusted` and can NEVER downgrade it — even if the AMS signal were somehow `low`. This
+ *  is the single invariant the whole bridge exists to guarantee. Pure + total. */
+export function applyAmsUpgrade(current: ReputationSignal, ams: ReputationSignal): ReputationSignal {
+  return SIGNAL_RANK[ams] > SIGNAL_RANK[current] ? ams : current;
+}
+
+/** Derive the upgrade-only bonus signal from a pulled AMS track-record summary. Returns `trusted` ONLY for a
+ *  clearly-strong, incident-free record (enough resolved PRs AND a high merge ratio); anything else — a public
+ *  conduct incident, too little history, or a weak ratio — yields `neutral` (no bonus). NEVER returns `low`:
+ *  the bridge is upgrade-only and must not manufacture a downgrade. Pure + total. */
+export function amsSignalFromSummary(summary: TrackRecordSummary, cfg: AmsBridgeConfig = DEFAULT_AMS_BRIDGE_CONFIG): "trusted" | "neutral" {
+  if (summary.incidents.hasPublicIncident) return "neutral";
+  const { ratio, denominator } = summary.mergeRate;
+  if (ratio !== null && denominator >= cfg.minResolved && ratio >= cfg.trustedMergeRatio) return "trusted";
+  return "neutral";
+}
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Fail-safe parse of an untrusted AMS response into the versioned {@link TrackRecordSummaryReadResult} read
+ *  contract (#6246). Returns `null` on ANY shape mismatch — not an object, an unexpected/absent envelope
+ *  version, or a summary missing its `mergeRate` / `incidents` blocks — so a malformed response degrades to
+ *  "no bonus" rather than trusting arbitrary caller-supplied fields. */
+export function parseTrackRecordReadResult(value: unknown): TrackRecordSummaryReadResult | null {
+  if (!isRecordObject(value)) return null;
+  if (value.version !== TRACK_RECORD_SUMMARY_READ_VERSION) return null;
+  const summary = value.summary;
+  if (!isRecordObject(summary)) return null;
+  if (!isRecordObject(summary.mergeRate)) return null;
+  if (!isRecordObject(summary.incidents)) return null;
+  return value as unknown as TrackRecordSummaryReadResult;
+}
+
+/** Pull one submitter's AMS track-record summary from the operator's LOCAL endpoint. Fail-safe: any fetch
+ *  error, timeout, non-OK status, or malformed body degrades to `null` (no bonus signal) — it must NEVER throw
+ *  into the gate, matching every other guard in the reputation path. Timeout-bounded by
+ *  {@link AMS_BRIDGE_TIMEOUT_MS}. The login is passed as a `login` query parameter on the operator's base URL. */
+export async function fetchAmsTrackRecord(login: string, endpoint: string): Promise<TrackRecordSummaryReadResult | null> {
+  try {
+    const url = new URL(endpoint);
+    url.searchParams.set("login", login);
+    const response = await fetch(url, {
+      headers: { accept: "application/json", "user-agent": PRODUCT_USER_AGENT },
+      signal: AbortSignal.timeout(AMS_BRIDGE_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    return parseTrackRecordReadResult(await response.json());
+  } catch {
+    return null; // fail-safe — a slow/unreachable/malformed AMS instance yields no bonus, never throws.
+  }
+}
+
+/** The bridge entry point: given a submitter and their already-computed ORB reputation signal, PULL their AMS
+ *  track record and return the (upgrade-only) merged signal. A no-op returning `current` unchanged when the
+ *  bridge is off, unconfigured, the submitter is absent, the signal is already `trusted` (nothing to lift, so
+ *  the external read is skipped entirely), or the AMS read yields nothing. Fully fail-safe — never throws. */
+export async function bridgeAmsReputation(env: Env, args: { submitter: string | null | undefined; current: ReputationSignal }): Promise<ReputationSignal> {
+  const { current } = args;
+  if (!isAmsBridgeEnabled(env)) return current;
+  if (current === "trusted") return current;
+  const endpoint = amsEndpointUrl(env);
+  if (!endpoint) return current;
+  const submitter = args.submitter?.trim();
+  if (!submitter) return current;
+  const read = await fetchAmsTrackRecord(submitter, endpoint);
+  if (!read) return current;
+  return applyAmsUpgrade(current, amsSignalFromSummary(read.summary));
+}

--- a/src/review/reputation-wire.ts
+++ b/src/review/reputation-wire.ts
@@ -15,6 +15,7 @@
 
 import { getRepository } from "../db/repositories";
 import { isConfirmedOfficialMiner } from "../gittensor/miner-detection-cache";
+import { bridgeAmsReputation } from "./ams-reputation-bridge";
 import {
   getSubmitterCadence,
   getSubmitterReputation,
@@ -113,7 +114,13 @@ export async function shouldSkipAiForReputation(
   // (#4513, getEffectiveSubmitterReputation) first, then the cadence check (#4514) as an independent
   // second signal -- neither subsumes the other, so both must run, not just whichever merged more recently.
   const stats = await getEffectiveSubmitterReputation(env, { repoFullName: args.project, submitter: args.submitter });
-  if (shouldDowngradeToDeterministic(stats)) return true;
+  // AMS → ORB reputation bridge (#6485): fold in the submitter's genuine external AMS track record, which can
+  // only ever LIFT the computed signal toward "trusted" (never worsen it), rescuing a good-standing submitter
+  // from the deterministic-only downgrade. Independently flag-gated (LOOPOVER_REVIEW_AMS_BRIDGE + endpoint,
+  // default off) and fail-safe → returns stats.signal unchanged when off, unconfigured, or the AMS read yields
+  // nothing, so this stays byte-identical unless an operator has opted in.
+  const signal = await bridgeAmsReputation(env, { submitter: args.submitter, current: stats.signal });
+  if (shouldDowngradeToDeterministic({ ...stats, signal })) return true;
   const cadence = await getSubmitterCadence(env, args.project, args.submitter ?? undefined);
   return isMachinePacedCadence(cadence);
 }

--- a/test/unit/ams-reputation-bridge.test.ts
+++ b/test/unit/ams-reputation-bridge.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AMS_BRIDGE_TIMEOUT_MS,
+  DEFAULT_AMS_BRIDGE_CONFIG,
+  amsEndpointUrl,
+  amsSignalFromSummary,
+  applyAmsUpgrade,
+  bridgeAmsReputation,
+  fetchAmsTrackRecord,
+  isAmsBridgeEnabled,
+  parseTrackRecordReadResult,
+} from "../../src/review/ams-reputation-bridge";
+import { TRACK_RECORD_SUMMARY_READ_VERSION, type TrackRecordSummary } from "../../packages/loopover-engine/src/track-record-summary";
+import type { ReputationSignal } from "../../src/review/submitter-reputation";
+
+// A minimal, valid TrackRecordSummary with just the fields the bridge reads (mergeRate + incidents) tunable.
+function summary(over: { hasPublicIncident?: boolean; ratio?: number | null; denominator?: number } = {}): TrackRecordSummary {
+  const denominator = over.denominator ?? 0;
+  const ratio = over.ratio ?? null;
+  return {
+    enabled: true,
+    login: "octocat",
+    mergeRate: { numerator: 0, denominator, ratio, percent: null, label: "" },
+    tenure: { firstObservedAt: null, days: null, label: "" },
+    incidents: { hasPublicIncident: over.hasPublicIncident ?? false, checkedPublicRecords: 0, activePublicRecords: 0, label: "", evidenceUrls: [] },
+    outcomes: { merged: 0, closedWithoutMerge: 0, resolved: 0, openIgnored: 0, ignored: 0 },
+    audit: { normalizedLogin: "octocat", consideredOutcomeIds: [], ignoredOutcomeIds: [], firstObservedCandidates: [] },
+  };
+}
+
+function envelope(over?: Parameters<typeof summary>[0]) {
+  return { version: TRACK_RECORD_SUMMARY_READ_VERSION, summary: summary(over) };
+}
+
+function amsEnv(over: { LOOPOVER_REVIEW_AMS_BRIDGE?: string; LOOPOVER_AMS_ENDPOINT?: string } = {}): Env {
+  return { LOOPOVER_REVIEW_AMS_BRIDGE: "true", LOOPOVER_AMS_ENDPOINT: "https://ams.local/track-record", ...over } as unknown as Env;
+}
+
+describe("ams-reputation-bridge", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("isAmsBridgeEnabled", () => {
+    it("is true only for the truthy on-tokens", () => {
+      for (const value of ["1", "true", "TRUE", "yes", "on", " on "]) {
+        expect(isAmsBridgeEnabled({ LOOPOVER_REVIEW_AMS_BRIDGE: value })).toBe(true);
+      }
+    });
+
+    it("is false when off or unset", () => {
+      expect(isAmsBridgeEnabled({ LOOPOVER_REVIEW_AMS_BRIDGE: "false" })).toBe(false);
+      expect(isAmsBridgeEnabled({ LOOPOVER_REVIEW_AMS_BRIDGE: "" })).toBe(false);
+      expect(isAmsBridgeEnabled({})).toBe(false);
+    });
+  });
+
+  describe("amsEndpointUrl", () => {
+    it("returns the trimmed endpoint when set", () => {
+      expect(amsEndpointUrl({ LOOPOVER_AMS_ENDPOINT: "  https://ams.local/x  " })).toBe("https://ams.local/x");
+    });
+
+    it("returns undefined when blank or unset", () => {
+      expect(amsEndpointUrl({ LOOPOVER_AMS_ENDPOINT: "   " })).toBeUndefined();
+      expect(amsEndpointUrl({})).toBeUndefined();
+    });
+  });
+
+  describe("applyAmsUpgrade", () => {
+    it("lifts a lower signal toward trusted", () => {
+      expect(applyAmsUpgrade("low", "trusted")).toBe("trusted");
+      expect(applyAmsUpgrade("neutral", "trusted")).toBe("trusted");
+      expect(applyAmsUpgrade("low", "neutral")).toBe("neutral");
+    });
+
+    it("never downgrades — an equal or lower ams signal is a no-op", () => {
+      expect(applyAmsUpgrade("neutral", "low")).toBe("neutral");
+      expect(applyAmsUpgrade("trusted", "neutral")).toBe("trusted");
+      expect(applyAmsUpgrade("trusted", "low")).toBe("trusted");
+      expect(applyAmsUpgrade("neutral", "neutral")).toBe("neutral");
+    });
+  });
+
+  describe("amsSignalFromSummary", () => {
+    it("returns trusted for a strong, incident-free record", () => {
+      expect(amsSignalFromSummary(summary({ ratio: 0.8, denominator: 10 }))).toBe("trusted");
+    });
+
+    it("returns neutral when a public conduct incident is present, even with a strong ratio", () => {
+      expect(amsSignalFromSummary(summary({ hasPublicIncident: true, ratio: 0.9, denominator: 20 }))).toBe("neutral");
+    });
+
+    it("returns neutral when there is not enough resolved history", () => {
+      expect(amsSignalFromSummary(summary({ ratio: 1, denominator: 2 }))).toBe("neutral");
+    });
+
+    it("returns neutral when the merge ratio is weak", () => {
+      expect(amsSignalFromSummary(summary({ ratio: 0.4, denominator: 10 }))).toBe("neutral");
+    });
+
+    it("returns neutral when there is no resolved history at all (null ratio)", () => {
+      expect(amsSignalFromSummary(summary({ ratio: null, denominator: 0 }))).toBe("neutral");
+    });
+
+    it("honors a custom config", () => {
+      expect(amsSignalFromSummary(summary({ ratio: 0.5, denominator: 3 }), { minResolved: 3, trustedMergeRatio: 0.5 })).toBe("trusted");
+    });
+
+    it("exposes conservative committed defaults", () => {
+      expect(DEFAULT_AMS_BRIDGE_CONFIG).toEqual({ minResolved: 5, trustedMergeRatio: 0.6 });
+    });
+  });
+
+  describe("parseTrackRecordReadResult", () => {
+    it("returns the envelope for a well-formed response", () => {
+      const value = envelope({ ratio: 0.7, denominator: 8 });
+      expect(parseTrackRecordReadResult(value)).toBe(value);
+    });
+
+    it("returns null for a non-object", () => {
+      expect(parseTrackRecordReadResult("nope")).toBeNull();
+      expect(parseTrackRecordReadResult(null)).toBeNull();
+      expect(parseTrackRecordReadResult([envelope()])).toBeNull();
+    });
+
+    it("returns null for a wrong/absent envelope version", () => {
+      expect(parseTrackRecordReadResult({ version: 999, summary: summary() })).toBeNull();
+      expect(parseTrackRecordReadResult({ summary: summary() })).toBeNull();
+    });
+
+    it("returns null when the summary block is missing or malformed", () => {
+      expect(parseTrackRecordReadResult({ version: TRACK_RECORD_SUMMARY_READ_VERSION, summary: "x" })).toBeNull();
+    });
+
+    it("returns null when mergeRate is not an object", () => {
+      const bad = { version: TRACK_RECORD_SUMMARY_READ_VERSION, summary: { ...summary(), mergeRate: null } };
+      expect(parseTrackRecordReadResult(bad)).toBeNull();
+    });
+
+    it("returns null when incidents is not an object", () => {
+      const bad = { version: TRACK_RECORD_SUMMARY_READ_VERSION, summary: { ...summary(), incidents: 5 } };
+      expect(parseTrackRecordReadResult(bad)).toBeNull();
+    });
+  });
+
+  describe("fetchAmsTrackRecord", () => {
+    it("returns the parsed envelope on a 200 with a valid body", async () => {
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        expect(String(input)).toContain("login=octocat");
+        return Response.json(envelope({ ratio: 0.8, denominator: 10 }));
+      });
+      const read = await fetchAmsTrackRecord("octocat", "https://ams.local/track-record");
+      expect(read?.summary.mergeRate.ratio).toBe(0.8);
+    });
+
+    it("returns null on a non-OK status", async () => {
+      vi.stubGlobal("fetch", async () => new Response("nope", { status: 503 }));
+      expect(await fetchAmsTrackRecord("octocat", "https://ams.local/track-record")).toBeNull();
+    });
+
+    it("returns null on a malformed (non-JSON) body — no throw", async () => {
+      vi.stubGlobal("fetch", async () => new Response("<html>not json</html>", { status: 200 }));
+      expect(await fetchAmsTrackRecord("octocat", "https://ams.local/track-record")).toBeNull();
+    });
+
+    it("returns null when the fetch rejects (unreachable/timeout) — no throw", async () => {
+      vi.stubGlobal("fetch", async () => {
+        throw new Error("network down");
+      });
+      expect(await fetchAmsTrackRecord("octocat", "https://ams.local/track-record")).toBeNull();
+    });
+
+    it("returns null for a malformed endpoint URL — no throw", async () => {
+      expect(await fetchAmsTrackRecord("octocat", "not-a-valid-url")).toBeNull();
+    });
+  });
+
+  describe("bridgeAmsReputation", () => {
+    const noFetch = () => vi.stubGlobal("fetch", async () => { throw new Error("must not be called"); });
+
+    it("is a no-op when the bridge is disabled (no external read)", async () => {
+      noFetch();
+      const out = await bridgeAmsReputation(amsEnv({ LOOPOVER_REVIEW_AMS_BRIDGE: "false" }), { submitter: "octocat", current: "low" });
+      expect(out).toBe("low");
+    });
+
+    it("skips the read when the signal is already trusted", async () => {
+      noFetch();
+      expect(await bridgeAmsReputation(amsEnv(), { submitter: "octocat", current: "trusted" })).toBe("trusted");
+    });
+
+    it("is a no-op when no endpoint is configured", async () => {
+      noFetch();
+      const env = { LOOPOVER_REVIEW_AMS_BRIDGE: "true" } as unknown as Env;
+      expect(await bridgeAmsReputation(env, { submitter: "octocat", current: "low" })).toBe("low");
+    });
+
+    it("is a no-op when the submitter is absent", async () => {
+      noFetch();
+      expect(await bridgeAmsReputation(amsEnv(), { submitter: "   ", current: "low" })).toBe("low");
+      expect(await bridgeAmsReputation(amsEnv(), { submitter: null, current: "low" })).toBe("low");
+    });
+
+    it("leaves the signal unchanged when the AMS read yields nothing", async () => {
+      vi.stubGlobal("fetch", async () => new Response("", { status: 500 }));
+      expect(await bridgeAmsReputation(amsEnv(), { submitter: "octocat", current: "low" })).toBe("low");
+    });
+
+    it("upgrades a low signal to trusted on a strong AMS record", async () => {
+      vi.stubGlobal("fetch", async () => Response.json(envelope({ ratio: 0.9, denominator: 12 })));
+      expect(await bridgeAmsReputation(amsEnv(), { submitter: "octocat", current: "low" })).toBe("trusted");
+    });
+
+    it("never downgrades — a weak AMS record leaves a neutral signal neutral", async () => {
+      vi.stubGlobal("fetch", async () => Response.json(envelope({ ratio: 0.1, denominator: 12 })));
+      expect(await bridgeAmsReputation(amsEnv(), { submitter: "octocat", current: "neutral" })).toBe("neutral");
+    });
+  });
+
+  it("bounds the AMS read with a short timeout", () => {
+    expect(AMS_BRIDGE_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(AMS_BRIDGE_TIMEOUT_MS).toBeLessThanOrEqual(1000);
+  });
+});
+
+// Type-only guard: the exported signal type stays a superset of what the bridge can emit.
+const _signals: ReputationSignal[] = ["low", "neutral", "trusted"];
+void _signals;

--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -8,6 +8,7 @@ import {
   shouldSkipAiForReputation,
 } from "../../src/review/reputation-wire";
 import { getSubmitterReputation, recordSubmissionOutcome } from "../../src/review/submitter-reputation";
+import { TRACK_RECORD_SUMMARY_READ_VERSION } from "../../packages/loopover-engine/src/track-record-summary";
 import { isConvergenceRepoAllowed } from "../../src/review/cutover-gate";
 import { evaluateGateCheck } from "../../src/rules/advisory";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
@@ -665,5 +666,61 @@ describe("reputationOutcomeFromTerminalState (pure)", () => {
     // still open, gate did not flag → nothing to record yet.
     const passingGate = evaluateGateCheck(advisory(), { confirmedContributor: true });
     expect(reputationOutcomeFromTerminalState({ state: "open", mergedAt: null }, { merged_at: null }, passingGate)).toBeUndefined();
+  });
+});
+
+describe("AMS -> ORB reputation bridge wiring (#6485)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // A privacy-safe AMS track-record read envelope (#6246 contract) with a strong, incident-free record.
+  function strongAmsEnvelope(login: string) {
+    return {
+      version: TRACK_RECORD_SUMMARY_READ_VERSION,
+      summary: {
+        enabled: true,
+        login,
+        mergeRate: { numerator: 11, denominator: 12, ratio: 11 / 12, percent: 92, label: "92%" },
+        tenure: { firstObservedAt: null, days: null, label: "" },
+        incidents: { hasPublicIncident: false, checkedPublicRecords: 0, activePublicRecords: 0, label: "", evidenceUrls: [] },
+        outcomes: { merged: 11, closedWithoutMerge: 1, resolved: 12, openIgnored: 0, ignored: 0 },
+        audit: { normalizedLogin: login, consideredOutcomeIds: [], ignoredOutcomeIds: [], firstObservedCandidates: [] },
+      },
+    };
+  }
+
+  // Seeds a serial-quality-failure history (recent reviewer rejects, no successes) -- the natural, non-abuse
+  // path to a "low" windowed signal that the AMS bridge is meant to be able to rescue. Submissions are spaced
+  // hours apart (human pace) so ONLY the quality signal reads "low"; the independent cadence signal (#4514),
+  // which the bridge deliberately does NOT rescue, stays clear.
+  async function seedSerialQualityFailures(env: Env, submitter: string, base: number) {
+    const t0 = Date.now() - 20 * 60 * 60_000;
+    for (let i = 0; i < 5; i++) {
+      const createdAt = new Date(t0 + i * 3 * 60 * 60_000).toISOString();
+      await env.DB.prepare(
+        `INSERT INTO review_targets (id, project, kind, repo, number, installation_id, submitter, status, decision_json, terminal_at, created_at)
+         VALUES (?, 'acme/widgets', 'pull_request', 'acme/widgets', ?, 1, ?, 'closed', ?, CURRENT_TIMESTAMP, ?)`,
+      )
+        .bind(`acme/widgets:pull_request:acme/widgets#${base + i}`, base + i, submitter, JSON.stringify({ reasonCode: "dual_review_declined" }), createdAt)
+        .run();
+    }
+  }
+
+  it("rescues a low-signal submitter to no-downgrade when a strong AMS record is pulled", async () => {
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_REVIEW_AMS_BRIDGE: "true", LOOPOVER_AMS_ENDPOINT: "https://ams.local/track-record" });
+    await seedSerialQualityFailures(env, "reformed", 1);
+    // Without the bridge this reads "low" -> downgrade. With it, the strong AMS record lifts the signal to trusted.
+    vi.stubGlobal("fetch", async () => Response.json(strongAmsEnvelope("reformed")));
+    expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "reformed" })).toBe(false);
+  });
+
+  it("leaves the downgrade in place when the bridge is off (byte-identical, no external read)", async () => {
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
+    await seedSerialQualityFailures(env, "reformed", 100);
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("bridge is off — must not read AMS");
+    });
+    expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "reformed" })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Implements the #6208 design decision: an opt-in, **PULL-only, upgrade-only**, GitHub-login-keyed bridge that lets a submitter's genuine AMS track record **improve — never worsen** — the internal ORB reputation signal.
- New sibling module `src/review/ams-reputation-bridge.ts` pulls a submitter's privacy-safe track-record summary (the #6246 `TrackRecordSummaryReadResult` contract — no score/wallet/hotkey fields) from a local, operator-configured AMS endpoint and derives an upgrade-only merge. `applyAmsUpgrade` only ever moves a signal toward `trusted`; it can never downgrade, even if the AMS data were negative.
- Wired into `shouldSkipAiForReputation` (`src/review/reputation-wire.ts`) so a strong AMS record can rescue a `low`-signal submitter from the deterministic-only downgrade. The independent cadence/burst signals are intentionally left untouched.
- **Config-as-code, default OFF:** gated behind `LOOPOVER_REVIEW_AMS_BRIDGE` (same on/off convention as `LOOPOVER_REVIEW_REPUTATION`) **and** an operator-set `LOOPOVER_AMS_ENDPOINT`. With either unset the whole path is an immediate no-op — byte-identical behavior for any repo that has not opted in or has no AMS instance.
- **Fail-safe and timeout-bounded** (`AMS_BRIDGE_TIMEOUT_MS = 300`): any fetch error, timeout, non-OK status, or malformed response degrades to "no bonus signal" and never throws into the gate. Strictly internal — never surfaced in any comment/label/check.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6485`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — **100% statements/branches/functions/lines** on both changed source files (`src/review/ams-reputation-bridge.ts`, `src/review/reputation-wire.ts`), measured unsharded on the new + wiring tests.
- [x] `npm run test:workers`
- [x] `npm run docs:drift-check`, `npm run cf-typegen:check`, and the `config/examples` template-sync test all pass.
- [x] New/changed behavior has unit + integration tests for the off-by-default branch, the timeout/error/malformed branch, and both the upgrade and no-op merge outcomes.

If any required check was skipped, explain why:

- The full `ui:build` / `build:mcp` aggregate was not re-run locally: this change is backend-only apart from two text-only docs-flag additions (see UI Evidence). The MCP package and UI bundles are untouched; the CI suite runs the complete gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, or private rankings are exposed — the bridge reuses the existing privacy-safe `TrackRecordPullRequestOutcome`/summary shape, which has no such fields, and never surfaces the signal publicly.
- [x] Upgrade-only by construction: the merge can only lift a signal toward `trusted`, closing the punitive-use gaming vector #6208 flagged. Fail-safe on every read (error/timeout/malformed → no bonus, never throws into the gate).
- [x] Pull-only (ORB never accepts a push): the AMS endpoint is a deployment env var, never a per-repo manifest field, so a repo cannot point ORB at an arbitrary AMS instance.
- [x] Negative-path tests included: unreachable/timeout/malformed response, non-OK status, disabled flag, missing endpoint, absent submitter, and no-downgrade-on-negative-data.

## UI Evidence

Not applicable — no visual/frontend change. The two `content/docs/*.mdx` edits are **text-only** additions documenting the new `LOOPOVER_REVIEW_AMS_BRIDGE` feature flag, required by the `docs:drift-check` gate for every `LOOPOVER_REVIEW_*` flag (same prose treatment as the existing `LOOPOVER_REVIEW_REPUTATION` / `LOOPOVER_REVIEW_OPS` entries). No layout, component, or route change.

## Notes

- Design source: #6208's pinned decision comment (login-keyed, ORB-pulls-from-AMS, upgrade-only, reusing the #6246 read contract). Parent epic: #6206.


Closes #6485
