### PR TITLE
feat(miner-ui): add a light/dark theme toggle to miner-ui

### DIFF
--- a/apps/loopover-miner-ui/index.html
+++ b/apps/loopover-miner-ui/index.html
@@ -1,9 +1,26 @@
 <!doctype html>
-<html lang="en" class="dark" style="color-scheme: dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gittensory Miner</title>
+    <script>
+      // No-flash theme (#6508): restore the persisted theme before the app bundle loads so there is no flash
+      // of the wrong palette. An unset value — or anything other than "light" — defaults to dark, matching the
+      // look the previously-hardcoded class/style used to give existing and first-time users.
+      (function () {
+        try {
+          var r = document.documentElement;
+          if (localStorage.getItem("loopover.miner_theme") === "light") {
+            r.classList.remove("dark");
+            r.style.colorScheme = "light";
+          } else {
+            r.classList.add("dark");
+            r.style.colorScheme = "dark";
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/loopover-miner-ui/src/components/theme-toggle.tsx
+++ b/apps/loopover-miner-ui/src/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { Button } from "@loopover/ui-kit/components/button";
+
+// Light/dark theme toggle for miner-ui (#6508). The shared @loopover/ui-kit theme.css already ships BOTH
+// palettes (light tokens under :root, dark overrides under .dark), switched purely by whether a `.dark` class
+// is present on <html> — so this control only flips that class, mirrors it into colorScheme (so native form
+// controls follow the theme), and persists the choice. index.html's inline no-flash script reads the same
+// persisted value to restore the theme before first paint.
+const STORAGE_KEY = "loopover.miner_theme";
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(() =>
+    typeof document === "undefined" ? true : document.documentElement.classList.contains("dark"),
+  );
+
+  function toggle() {
+    const nextIsDark = !isDark;
+    const root = document.documentElement;
+    root.classList.toggle("dark", nextIsDark);
+    root.style.colorScheme = nextIsDark ? "dark" : "light";
+    try {
+      localStorage.setItem(STORAGE_KEY, nextIsDark ? "dark" : "light");
+    } catch {
+      // localStorage can throw (private mode / storage disabled); the in-page toggle still works this session.
+    }
+    setIsDark(nextIsDark);
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={toggle}>
+      {isDark ? "Switch to light mode" : "Switch to dark mode"}
+    </Button>
+  );
+}

--- a/apps/loopover-miner-ui/src/routes/__root.tsx
+++ b/apps/loopover-miner-ui/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { Outlet, createRootRoute, Link } from "@tanstack/react-router";
 import { GrafanaFooterLink } from "@/components/grafana-footer-link";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export const Route = createRootRoute({
   component: RootLayout,
@@ -28,6 +29,7 @@ function RootLayout() {
               Ledgers
             </Link>
           </nav>
+          <ThemeToggle />
         </div>
       </header>
       <main className="mx-auto max-w-5xl px-6 py-8">

--- a/apps/loopover-miner-ui/src/styles.css
+++ b/apps/loopover-miner-ui/src/styles.css
@@ -7,10 +7,11 @@
 /*
  * gittensory-miner-ui renders from the same shared design system as
  * gittensory-ui (imported above from @loopover/ui-kit) — no
- * local tokens, colors, or fonts. Dark-only for now (the `.dark` class is
- * hardcoded on <html> in index.html), matching gittensory-ui's current
- * dark-only deployment — the light tokens ship in the shared theme so a
- * toggle can be added later without touching this stylesheet.
+ * local tokens, colors, or fonts. Light and dark both ship in the shared
+ * theme, switched by the `.dark` class on <html>: the inline no-flash script
+ * in index.html restores the persisted choice before first paint, and
+ * src/components/theme-toggle.tsx flips it — so this stylesheet stays
+ * theme-agnostic and needs no per-theme rules.
  */
 
 body {

--- a/apps/loopover-miner-ui/src/theme-toggle.test.tsx
+++ b/apps/loopover-miner-ui/src/theme-toggle.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ThemeToggle } from "./components/theme-toggle";
+
+describe("ThemeToggle (#6508)", () => {
+  beforeEach(() => {
+    // The app boots dark by default (index.html's no-flash script), so start each case from that state.
+    document.documentElement.classList.add("dark");
+    document.documentElement.style.colorScheme = "dark";
+    localStorage.clear();
+  });
+  afterEach(() => {
+    document.documentElement.classList.remove("dark");
+    document.documentElement.style.colorScheme = "";
+    localStorage.clear();
+  });
+
+  it("labels the button to switch AWAY from the current theme (dark shows 'Switch to light mode')", () => {
+    render(<ThemeToggle />);
+    expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
+  });
+
+  it("shows 'Switch to dark mode' when the dark class is absent", () => {
+    document.documentElement.classList.remove("dark");
+    render(<ThemeToggle />);
+    expect(screen.getByRole("button", { name: "Switch to dark mode" })).toBeTruthy();
+  });
+
+  it("on click: toggles the .dark class, colorScheme, persisted value, and label (dark → light → dark)", () => {
+    render(<ThemeToggle />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to light mode" }));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(localStorage.getItem("loopover.miner_theme")).toBe("light");
+    expect(screen.getByRole("button", { name: "Switch to dark mode" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to dark mode" }));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(localStorage.getItem("loopover.miner_theme")).toBe("dark");
+    expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

miner-ui was hard-locked to dark — `apps/loopover-miner-ui/index.html` set `class="dark" style="color-scheme: dark"` on `<html>` with no way to switch — even though the shared `@loopover/ui-kit` `theme.css` already ships **both** palettes, switched purely by whether `.dark` is present on `<html>`. This adds the first real toggle.

## Changes (pure wiring — `theme.css` untouched)

- **`src/components/theme-toggle.tsx`** — self-contained `ThemeToggle` (one `<Button variant="outline" size="sm">` from `@loopover/ui-kit/components/button`, mirroring the `grafana-footer-link.tsx` precedent). Label is `"Switch to light mode"` when dark is active, `"Switch to dark mode"` otherwise. Click toggles the `.dark` class, sets `colorScheme`, and persists `"dark"`/`"light"` to `localStorage["loopover.miner_theme"]`.
- **`src/routes/__root.tsx`** — `<ThemeToggle />` wired into the existing header flex row as a sibling of `<nav>` (no layout restructure).
- **`index.html`** — removed the hardcoded `class`/`style`; added an inline no-flash `<script>` in `<head>` that restores the persisted theme before first paint (unset / any non-`"light"` value defaults to dark, matching the prior look), wrapped in `try/catch`.
- **`src/styles.css`** — updated the now-stale "dark-only for now … toggle can be added later" comment.
- **`src/theme-toggle.test.tsx`** — covers the label in both states, the click toggle (class + colorScheme + persistence + label), all via `getByRole("button", { name: … })`.

No new dependency (no `lucide-react`); `theme.css` is not modified. Local gate: `@loopover/ui-miner` typecheck + 137 tests (incl. 3 new) + eslint (0 errors) + `vite build` all green.

Closes #6508