### PR TITLE
feat(miner-ui): add discover/attempt action-dispatch HTTP routes

### DIFF
--- a/apps/loopover-miner-ui/src/attempt-api.test.ts
+++ b/apps/loopover-miner-ui/src/attempt-api.test.ts
@@ -225,18 +225,28 @@ describe("handleAttemptRequest (#6522)", () => {
     expect(args).not.toContain("--token");
   });
 
-  it("surfaces a CLI-module load failure as a 500 with a safe message", async () => {
-    const handled = await handleAttemptRequest(
-      "POST",
-      "/api/attempt",
-      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" }),
-      {
-        loadAttemptCliModule: async () => {
-          throw new Error("module load boom");
+  it("surfaces a CLI-module load failure as a 500 with a generic token, never leaking the raw error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const handled = await handleAttemptRequest(
+        "POST",
+        "/api/attempt",
+        JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" }),
+        {
+          loadAttemptCliModule: async () => {
+            throw new Error("module load boom /abs/path/attempt-cli.js");
+          },
         },
-      },
-    );
-    expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "module load boom" }) });
+      );
+      // Client sees only a generic token — the raw message (which for a real ERR_MODULE_NOT_FOUND
+      // carries an absolute filesystem path) must not appear in the response body.
+      expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "internal_error" }) });
+      expect(handled?.body).not.toContain("module load boom");
+      // The detail is logged server-side for debugging.
+      expect(errorSpy).toHaveBeenCalledWith("[miner-ui] /api/attempt failed:", expect.any(Error));
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/loopover-miner-ui/src/attempt-api.test.ts
+++ b/apps/loopover-miner-ui/src/attempt-api.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { attemptApiPlugin, handleAttemptRequest, matchAttemptRoute, type AttemptApiDeps } from "../vite-attempt-api";
+import type { AttemptCliResult } from "../../../packages/loopover-miner/lib/attempt-cli.js";
+import { ATTEMPT_API_PATH, runAttemptAction, type AttemptRunResult } from "./lib/attempt";
+
+type FakeReq = { method?: string; url?: string } & NodeJS.ReadableStream;
+
+/** A minimal Node-readable-stream double, mirroring governor.test.tsx's fakeRequest. */
+function fakeRequest(method: string | undefined, url: string | undefined, body = ""): FakeReq {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const req = {
+    method,
+    url,
+    on(event: string, cb: (...args: unknown[]) => void) {
+      (listeners[event] ??= []).push(cb);
+      return req;
+    },
+  };
+  queueMicrotask(() => {
+    if (body) for (const cb of listeners.data ?? []) cb(Buffer.from(body));
+    for (const cb of listeners.end ?? []) cb();
+  });
+  return req as unknown as FakeReq;
+}
+
+function fakeResponse() {
+  let statusCode = 200;
+  let ended: string | undefined;
+  const headers: Record<string, string> = {};
+  const res = {
+    get statusCode() {
+      return statusCode;
+    },
+    set statusCode(value: number) {
+      statusCode = value;
+    },
+    setHeader: (k: string, v: string) => {
+      headers[k] = v;
+    },
+    end: (body: string) => {
+      ended = body;
+    },
+  };
+  return { res, headers, getEnded: () => ended, getStatus: () => statusCode };
+}
+
+type CapturedRequestHandler = (
+  req: FakeReq,
+  res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body: string) => void },
+  next: () => void,
+) => void;
+
+const fakeResult: AttemptRunResult = {
+  outcome: "attempt_submitted",
+  repoFullName: "acme/widgets",
+  issueNumber: 42,
+  minerLogin: "alice",
+  base: "main",
+  mode: "live",
+  attemptId: "acme_widgets-42-1",
+};
+
+/** A fake `runAttempt` that captures the args it received and fires onResult with a structured result, exactly
+ *  like the real one does at each genuine return point. */
+function deps(overrides: Partial<AttemptApiDeps> = {}): { deps: AttemptApiDeps; calls: string[][] } {
+  const calls: string[][] = [];
+  const base: AttemptApiDeps = {
+    loadAttemptCliModule: async () => ({
+      runAttempt: async (args, options) => {
+        calls.push(args);
+        // The fake stands in for the real runAttempt's structured result; the client-facing loose shape is a
+        // structural subset of the CLI's AttemptCliResult.
+        options?.onResult?.(fakeResult as unknown as AttemptCliResult);
+        return 0;
+      },
+    }),
+    ...overrides,
+  };
+  return { deps: base, calls };
+}
+
+describe("matchAttemptRoute (#6522)", () => {
+  it("matches only POST /api/attempt", () => {
+    expect(matchAttemptRoute("POST", "/api/attempt")).toBe("attempt-post");
+  });
+
+  it("returns null for every other method/path, including the sibling routes' own paths", () => {
+    expect(matchAttemptRoute("GET", "/api/attempt")).toBeNull();
+    expect(matchAttemptRoute(undefined, "/api/attempt")).toBeNull();
+    expect(matchAttemptRoute("POST", "/api/attempt/")).toBeNull();
+    expect(matchAttemptRoute("POST", "/api/discover")).toBeNull();
+    expect(matchAttemptRoute("POST", "/api/governor/resume")).toBeNull();
+    expect(matchAttemptRoute("POST", "/api/portfolio-queue/requeue")).toBeNull();
+    expect(matchAttemptRoute("GET", "/api/run-state")).toBeNull();
+  });
+});
+
+describe("handleAttemptRequest (#6522)", () => {
+  it("falls through (null) for a non-matching request without loading the CLI module", async () => {
+    let loaded = false;
+    const handled = await handleAttemptRequest("GET", "/api/attempt", "", {
+      loadAttemptCliModule: async () => {
+        loaded = true;
+        throw new Error("must not load");
+      },
+    });
+    expect(handled).toBeNull();
+    expect(loaded).toBe(false);
+  });
+
+  it("marshals a well-formed body into runAttempt and returns the captured onResult payload plus the exit code", async () => {
+    const { deps: d, calls } = deps();
+    const handled = await handleAttemptRequest(
+      "POST",
+      "/api/attempt",
+      JSON.stringify({
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+        minerLogin: "alice",
+        base: "dev",
+        live: true,
+        dryRun: false,
+        json: true,
+      }),
+      d,
+    );
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ result: fakeResult, exitCode: 0 }) });
+    expect(calls).toEqual([["acme/widgets", "42", "--miner-login", "alice", "--base", "dev", "--live", "--json"]]);
+  });
+
+  it("returns 400 for a malformed/missing-required-field body WITHOUT ever calling runAttempt", async () => {
+    let called = false;
+    const d: AttemptApiDeps = {
+      loadAttemptCliModule: async () => ({
+        runAttempt: async () => {
+          called = true;
+          return 0;
+        },
+      }),
+    };
+    for (const rawBody of [
+      "",
+      "not json",
+      JSON.stringify({}),
+      JSON.stringify({ issueNumber: 42 }),
+      JSON.stringify({ repoFullName: "acme/widgets" }),
+      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 0 }),
+      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 4.2 }),
+      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: "42" }),
+    ]) {
+      const handled = await handleAttemptRequest("POST", "/api/attempt", rawBody, d);
+      expect(handled).toEqual({ status: 400, body: JSON.stringify({ error: "invalid_request_body" }) });
+    }
+    expect(called).toBe(false);
+  });
+
+  it("handles the exit-code-only branch (non-zero exit, onResult never fired) without throwing", async () => {
+    const handled = await handleAttemptRequest(
+      "POST",
+      "/api/attempt",
+      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" }),
+      {
+        loadAttemptCliModule: async () => ({
+          // reportCliFailure path (parse-error/paused/unexpected-error): returns non-zero, never fires onResult.
+          runAttempt: async () => 3,
+        }),
+      },
+    );
+    expect(handled).toEqual({ status: 502, body: JSON.stringify({ error: "attempt_failed", exitCode: 3 }) });
+  });
+
+  it("imposes no artificial timeout — it awaits a slow-resolving runAttempt driven by a manual promise", async () => {
+    let resolveRun: ((exitCode: number) => void) | undefined;
+    const runPromise = new Promise<number>((resolve) => {
+      resolveRun = resolve;
+    });
+    let settled = false;
+    const handledPromise = handleAttemptRequest(
+      "POST",
+      "/api/attempt",
+      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" }),
+      {
+        loadAttemptCliModule: async () => ({
+          runAttempt: async (_args, options) => {
+            options?.onResult?.(fakeResult as unknown as AttemptCliResult);
+            return runPromise;
+          },
+        }),
+      },
+    ).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    // The handler must still be pending until the injected fake resolves — proving no route-layer timeout fired.
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveRun?.(0);
+    const handled = await handledPromise;
+    expect(settled).toBe(true);
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ result: fakeResult, exitCode: 0 }) });
+  });
+
+  it("never threads a caller-supplied githubToken/token/apiKey field through to runAttempt", async () => {
+    const { deps: d, calls } = deps();
+    const handled = await handleAttemptRequest(
+      "POST",
+      "/api/attempt",
+      JSON.stringify({
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+        minerLogin: "alice",
+        githubToken: "ghp_secret",
+        token: "t",
+        apiKey: "k",
+      }),
+      d,
+    );
+    expect(handled?.status).toBe(200);
+    const args = calls[0] ?? [];
+    expect(args).toEqual(["acme/widgets", "42", "--miner-login", "alice"]);
+    expect(args.join(" ")).not.toContain("ghp_secret");
+    expect(args).not.toContain("--token");
+  });
+
+  it("surfaces a CLI-module load failure as a 500 with a safe message", async () => {
+    const handled = await handleAttemptRequest(
+      "POST",
+      "/api/attempt",
+      JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" }),
+      {
+        loadAttemptCliModule: async () => {
+          throw new Error("module load boom");
+        },
+      },
+    );
+    expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "module load boom" }) });
+  });
+});
+
+describe("attemptApiPlugin middleware (#6522)", () => {
+  function captureMiddleware(
+    server: { middlewares: { use: (fn: CapturedRequestHandler) => void } },
+    d: AttemptApiDeps,
+  ) {
+    const plugin = attemptApiPlugin(d);
+    // @ts-expect-error -- the test double only implements the subset of Vite's server this plugin reads.
+    plugin.configureServer(server);
+  }
+
+  it("falls through to next() for a non-matching request without ever reading its body", () => {
+    let captured: CapturedRequestHandler | undefined;
+    captureMiddleware({ middlewares: { use: (fn) => (captured = fn) } }, deps().deps);
+    const { res } = fakeResponse();
+    let calledNext = false;
+    captured?.(fakeRequest("GET", "/api/attempt", "should-not-read"), res, () => {
+      calledNext = true;
+    });
+    expect(calledNext).toBe(true);
+  });
+
+  it("serves POST /api/attempt through the middleware, reading the body and writing a JSON response", async () => {
+    let captured: CapturedRequestHandler | undefined;
+    captureMiddleware({ middlewares: { use: (fn) => (captured = fn) } }, deps().deps);
+    const { res, headers, getEnded, getStatus } = fakeResponse();
+    captured?.(
+      fakeRequest(
+        "POST",
+        "/api/attempt",
+        JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" }),
+      ),
+      res,
+      () => {
+        throw new Error("next() must not be called for a matched route");
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getStatus()).toBe(200);
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(getEnded()).toBe(JSON.stringify({ result: fakeResult, exitCode: 0 }));
+  });
+
+  it("also registers via configurePreviewServer", () => {
+    let captured: CapturedRequestHandler | undefined;
+    const plugin = attemptApiPlugin(deps().deps);
+    // @ts-expect-error -- test double for the preview server's middleware stack only.
+    plugin.configurePreviewServer({ middlewares: { use: (fn: CapturedRequestHandler) => (captured = fn) } });
+    expect(captured).toBeTypeOf("function");
+  });
+});
+
+describe("runAttemptAction client (#6522)", () => {
+  it("posts to the attempt API and returns the typed result on success", async () => {
+    const fetchImpl = vi.fn(async (path: string, init?: RequestInit) => {
+      expect(path).toBe(ATTEMPT_API_PATH);
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+        minerLogin: "alice",
+      });
+      return new Response(JSON.stringify({ result: fakeResult, exitCode: 0 }), { status: 200 });
+    });
+    const result = await runAttemptAction(
+      { repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "alice" },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: true, result: fakeResult, exitCode: 0 });
+  });
+
+  it("returns a typed error (not a throw) for an HTTP-level failure, preferring the server error field", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ error: "attempt_failed", exitCode: 3 }), { status: 502 }),
+    );
+    const result = await runAttemptAction(
+      { repoFullName: "acme/widgets", issueNumber: 42 },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: false, error: "attempt_failed" });
+  });
+
+  it("falls back to a status-derived error when a failed response has no error field", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 500 }));
+    const result = await runAttemptAction(
+      { repoFullName: "acme/widgets", issueNumber: 42 },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: false, error: "local attempt API responded 500" });
+  });
+
+  it("rejects an unexpected success payload shape", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ result: { nope: true }, exitCode: 0 }), { status: 200 }),
+    );
+    const result = await runAttemptAction(
+      { repoFullName: "acme/widgets", issueNumber: 42 },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: false, error: "local attempt API returned an unexpected payload shape" });
+  });
+
+  it("returns a typed error when the fetch itself throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const result = await runAttemptAction(
+      { repoFullName: "acme/widgets", issueNumber: 42 },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: false, error: "connection refused" });
+  });
+});

--- a/apps/loopover-miner-ui/src/discover-api.test.ts
+++ b/apps/loopover-miner-ui/src/discover-api.test.ts
@@ -197,18 +197,28 @@ describe("handleDiscoverRequest (#6522)", () => {
     expect(args).not.toContain("--token");
   });
 
-  it("surfaces a CLI-module load failure as a 500 with a safe message", async () => {
-    const handled = await handleDiscoverRequest(
-      "POST",
-      "/api/discover",
-      JSON.stringify({ targets: ["acme/widgets"] }),
-      {
-        loadDiscoverCliModule: async () => {
-          throw new Error("module load boom");
+  it("surfaces a CLI-module load failure as a 500 with a generic token, never leaking the raw error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const handled = await handleDiscoverRequest(
+        "POST",
+        "/api/discover",
+        JSON.stringify({ targets: ["acme/widgets"] }),
+        {
+          loadDiscoverCliModule: async () => {
+            throw new Error("module load boom /abs/path/discover-cli.js");
+          },
         },
-      },
-    );
-    expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "module load boom" }) });
+      );
+      // Client sees only a generic token — the raw message (which for a real ERR_MODULE_NOT_FOUND
+      // carries an absolute filesystem path) must not appear in the response body.
+      expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "internal_error" }) });
+      expect(handled?.body).not.toContain("module load boom");
+      // The detail is logged server-side for debugging.
+      expect(errorSpy).toHaveBeenCalledWith("[miner-ui] /api/discover failed:", expect.any(Error));
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/loopover-miner-ui/src/discover-api.test.ts
+++ b/apps/loopover-miner-ui/src/discover-api.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  discoverApiPlugin,
+  handleDiscoverRequest,
+  matchDiscoverRoute,
+  type DiscoverApiDeps,
+} from "../vite-discover-api";
+import type { DiscoverResult } from "../../../packages/loopover-miner/lib/discover-cli.js";
+import { DISCOVER_API_PATH, runDiscoverAction, type DiscoverRunResult } from "./lib/discover";
+
+type FakeReq = { method?: string; url?: string } & NodeJS.ReadableStream;
+
+/** A minimal Node-readable-stream double, mirroring governor.test.tsx's fakeRequest: `.on("data"/"end", ...)`
+ *  registration works like a real stream, with the body emitted on a microtask so readRequestBody's listeners
+ *  are attached first. */
+function fakeRequest(method: string | undefined, url: string | undefined, body = ""): FakeReq {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const req = {
+    method,
+    url,
+    on(event: string, cb: (...args: unknown[]) => void) {
+      (listeners[event] ??= []).push(cb);
+      return req;
+    },
+  };
+  queueMicrotask(() => {
+    if (body) for (const cb of listeners.data ?? []) cb(Buffer.from(body));
+    for (const cb of listeners.end ?? []) cb();
+  });
+  return req as unknown as FakeReq;
+}
+
+function fakeResponse() {
+  let statusCode = 200;
+  let ended: string | undefined;
+  const headers: Record<string, string> = {};
+  const res = {
+    get statusCode() {
+      return statusCode;
+    },
+    set statusCode(value: number) {
+      statusCode = value;
+    },
+    setHeader: (k: string, v: string) => {
+      headers[k] = v;
+    },
+    end: (body: string) => {
+      ended = body;
+    },
+  };
+  return { res, headers, getEnded: () => ended, getStatus: () => statusCode };
+}
+
+type CapturedRequestHandler = (
+  req: FakeReq,
+  res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body: string) => void },
+  next: () => void,
+) => void;
+
+const fakeResult: DiscoverRunResult = {
+  fanOutCount: 2,
+  ranked: [{ repoFullName: "acme/widgets", issueNumber: 1, title: "Add retry helper", rankScore: 0.9 }],
+  enqueueSummary: { enqueued: 2, skippedBelowMinRank: 0, skippedInvalid: 0 },
+  warnings: [],
+  rateLimitRemaining: 4987,
+  rateLimitResetAt: "2026-07-09T13:00:00.000Z",
+  usedDefaultGoalSpec: false,
+};
+
+/** A fake `runDiscover` that captures the args it received and fires onResult with a structured result, exactly
+ *  like the real one does at its two success points. */
+function deps(overrides: Partial<DiscoverApiDeps> = {}): { deps: DiscoverApiDeps; calls: string[][] } {
+  const calls: string[][] = [];
+  const base: DiscoverApiDeps = {
+    loadDiscoverCliModule: async () => ({
+      runDiscover: async (args, options) => {
+        calls.push(args);
+        // The fake stands in for the real runDiscover's structured success result; the client-facing loose
+        // shape is a structural subset of the CLI's DiscoverResult.
+        options?.onResult?.(fakeResult as unknown as DiscoverResult);
+        return 0;
+      },
+    }),
+    ...overrides,
+  };
+  return { deps: base, calls };
+}
+
+describe("matchDiscoverRoute (#6522)", () => {
+  it("matches only POST /api/discover", () => {
+    expect(matchDiscoverRoute("POST", "/api/discover")).toBe("discover-post");
+  });
+
+  it("returns null for every other method/path, including the sibling routes' own paths", () => {
+    expect(matchDiscoverRoute("GET", "/api/discover")).toBeNull();
+    expect(matchDiscoverRoute(undefined, "/api/discover")).toBeNull();
+    expect(matchDiscoverRoute("POST", "/api/discover/")).toBeNull();
+    expect(matchDiscoverRoute("POST", "/api/attempt")).toBeNull();
+    expect(matchDiscoverRoute("POST", "/api/governor/pause")).toBeNull();
+    expect(matchDiscoverRoute("POST", "/api/portfolio-queue/release")).toBeNull();
+    expect(matchDiscoverRoute("GET", "/api/run-state")).toBeNull();
+  });
+});
+
+describe("handleDiscoverRequest (#6522)", () => {
+  it("falls through (null) for a non-matching request without loading the CLI module", async () => {
+    let loaded = false;
+    const handled = await handleDiscoverRequest("GET", "/api/discover", "", {
+      loadDiscoverCliModule: async () => {
+        loaded = true;
+        throw new Error("must not load");
+      },
+    });
+    expect(handled).toBeNull();
+    expect(loaded).toBe(false);
+  });
+
+  it("marshals a well-formed body into runDiscover and returns the captured onResult payload plus the exit code", async () => {
+    const { deps: d, calls } = deps();
+    const handled = await handleDiscoverRequest(
+      "POST",
+      "/api/discover",
+      JSON.stringify({
+        targets: ["acme/widgets"],
+        dryRun: true,
+        json: true,
+        apiBaseUrl: "https://api.example.test",
+        tokenEnv: "FORGE_PAT",
+      }),
+      d,
+    );
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ result: fakeResult, exitCode: 0 }) });
+    expect(calls).toEqual([
+      ["acme/widgets", "--dry-run", "--json", "--api-base-url", "https://api.example.test", "--token-env", "FORGE_PAT"],
+    ]);
+  });
+
+  it("marshals a --search body into the --search arg", async () => {
+    const { deps: d, calls } = deps();
+    const handled = await handleDiscoverRequest("POST", "/api/discover", JSON.stringify({ search: "label:bug" }), d);
+    expect(handled?.status).toBe(200);
+    expect(calls).toEqual([["--search", "label:bug"]]);
+  });
+
+  it("returns 400 for a malformed/missing-required-field body WITHOUT ever calling runDiscover", async () => {
+    let called = false;
+    const d: DiscoverApiDeps = {
+      loadDiscoverCliModule: async () => ({
+        runDiscover: async () => {
+          called = true;
+          return 0;
+        },
+      }),
+    };
+    // Empty body, invalid JSON, an object with neither targets nor search, and blank-only targets all fail.
+    for (const rawBody of [
+      "",
+      "not json",
+      JSON.stringify({}),
+      JSON.stringify({ dryRun: true }),
+      JSON.stringify({ targets: ["   "] }),
+    ]) {
+      const handled = await handleDiscoverRequest("POST", "/api/discover", rawBody, d);
+      expect(handled).toEqual({ status: 400, body: JSON.stringify({ error: "invalid_request_body" }) });
+    }
+    expect(called).toBe(false);
+  });
+
+  it("handles the exit-code-only branch (non-zero exit, onResult never fired) without throwing", async () => {
+    const handled = await handleDiscoverRequest(
+      "POST",
+      "/api/discover",
+      JSON.stringify({ targets: ["acme/widgets"] }),
+      {
+        loadDiscoverCliModule: async () => ({
+          // reportCliFailure path: returns non-zero, never fires onResult.
+          runDiscover: async () => 1,
+        }),
+      },
+    );
+    expect(handled).toEqual({ status: 502, body: JSON.stringify({ error: "discover_failed", exitCode: 1 }) });
+  });
+
+  it("never threads a caller-supplied githubToken/token/apiKey field through to runDiscover", async () => {
+    const { deps: d, calls } = deps();
+    const handled = await handleDiscoverRequest(
+      "POST",
+      "/api/discover",
+      JSON.stringify({ targets: ["acme/widgets"], githubToken: "ghp_secret", token: "t", apiKey: "k" }),
+      d,
+    );
+    expect(handled?.status).toBe(200);
+    const args = calls[0] ?? [];
+    expect(args).toEqual(["acme/widgets"]);
+    expect(args.join(" ")).not.toContain("ghp_secret");
+    expect(args).not.toContain("--token");
+  });
+
+  it("surfaces a CLI-module load failure as a 500 with a safe message", async () => {
+    const handled = await handleDiscoverRequest(
+      "POST",
+      "/api/discover",
+      JSON.stringify({ targets: ["acme/widgets"] }),
+      {
+        loadDiscoverCliModule: async () => {
+          throw new Error("module load boom");
+        },
+      },
+    );
+    expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "module load boom" }) });
+  });
+});
+
+describe("discoverApiPlugin middleware (#6522)", () => {
+  function captureMiddleware(
+    server: { middlewares: { use: (fn: CapturedRequestHandler) => void } },
+    deps: DiscoverApiDeps,
+  ) {
+    const plugin = discoverApiPlugin(deps);
+    // @ts-expect-error -- the test double only implements the subset of Vite's server this plugin reads.
+    plugin.configureServer(server);
+  }
+
+  it("falls through to next() for a non-matching request without ever reading its body", () => {
+    let captured: CapturedRequestHandler | undefined;
+    captureMiddleware({ middlewares: { use: (fn) => (captured = fn) } }, deps().deps);
+    const { res } = fakeResponse();
+    let calledNext = false;
+    // A body on a non-matching request would hang readRequestBody's Promise if it were (wrongly) read.
+    captured?.(fakeRequest("GET", "/api/discover", "should-not-read"), res, () => {
+      calledNext = true;
+    });
+    expect(calledNext).toBe(true);
+  });
+
+  it("serves POST /api/discover through the middleware, reading the body and writing a JSON response", async () => {
+    let captured: CapturedRequestHandler | undefined;
+    captureMiddleware({ middlewares: { use: (fn) => (captured = fn) } }, deps().deps);
+    const { res, headers, getEnded, getStatus } = fakeResponse();
+    captured?.(fakeRequest("POST", "/api/discover", JSON.stringify({ targets: ["acme/widgets"] })), res, () => {
+      throw new Error("next() must not be called for a matched route");
+    });
+    // Let the microtask-emitted body + the async handler chain settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getStatus()).toBe(200);
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(getEnded()).toBe(JSON.stringify({ result: fakeResult, exitCode: 0 }));
+  });
+
+  it("also registers via configurePreviewServer", () => {
+    let captured: CapturedRequestHandler | undefined;
+    const plugin = discoverApiPlugin(deps().deps);
+    // @ts-expect-error -- test double for the preview server's middleware stack only.
+    plugin.configurePreviewServer({ middlewares: { use: (fn: CapturedRequestHandler) => (captured = fn) } });
+    expect(captured).toBeTypeOf("function");
+  });
+});
+
+describe("runDiscoverAction client (#6522)", () => {
+  it("posts to the discover API and returns the typed result on success", async () => {
+    const fetchImpl = vi.fn(async (path: string, init?: RequestInit) => {
+      expect(path).toBe(DISCOVER_API_PATH);
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({ targets: ["acme/widgets"], dryRun: true });
+      return new Response(JSON.stringify({ result: fakeResult, exitCode: 0 }), { status: 200 });
+    });
+    const result = await runDiscoverAction(
+      { targets: ["acme/widgets"], dryRun: true },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result).toEqual({ ok: true, result: fakeResult, exitCode: 0 });
+  });
+
+  it("returns a typed error (not a throw) for an HTTP-level failure, preferring the server error field", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ error: "discover_failed", exitCode: 1 }), { status: 502 }),
+    );
+    const result = await runDiscoverAction({ targets: ["acme/widgets"] }, fetchImpl as unknown as typeof fetch);
+    expect(result).toEqual({ ok: false, error: "discover_failed" });
+  });
+
+  it("falls back to a status-derived error when a failed response has no error field", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 500 }));
+    const result = await runDiscoverAction({ targets: ["acme/widgets"] }, fetchImpl as unknown as typeof fetch);
+    expect(result).toEqual({ ok: false, error: "local discover API responded 500" });
+  });
+
+  it("rejects an unexpected success payload shape", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ result: { nope: true }, exitCode: 0 }), { status: 200 }),
+    );
+    const result = await runDiscoverAction({ targets: ["acme/widgets"] }, fetchImpl as unknown as typeof fetch);
+    expect(result).toEqual({ ok: false, error: "local discover API returned an unexpected payload shape" });
+  });
+
+  it("returns a typed error when the fetch itself throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const result = await runDiscoverAction({ targets: ["acme/widgets"] }, fetchImpl as unknown as typeof fetch);
+    expect(result).toEqual({ ok: false, error: "connection refused" });
+  });
+});

--- a/apps/loopover-miner-ui/src/lib/attempt.ts
+++ b/apps/loopover-miner-ui/src/lib/attempt.ts
@@ -1,0 +1,82 @@
+// Client for the local attempt action API (#6522, the attempt half of the miner-ui's chat action-dispatch
+// surface). Mirrors governor.ts / portfolio-queue-actions.ts's shape (a typed discriminated result, never a
+// thrown exception for an HTTP-level failure) via the authenticated dev-server bridge in vite-attempt-api.ts,
+// which is a thin, non-bypassing wrapper around the real `loopover-miner attempt` CLI entry point (and so
+// inherits the Governor chokepoint gate automatically).
+//
+// No credential is ever sent: the miner's local harness runs writes with its own local credentials, resolved
+// server-side. The client only sends non-secret passthrough fields (owner/repo, issue number, minerLogin, base,
+// live, dryRun, json).
+
+export const ATTEMPT_API_PATH = "/api/attempt";
+
+export type AttemptRunRequest = {
+  repoFullName: string;
+  issueNumber: number;
+  minerLogin?: string;
+  base?: string;
+  live?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+/** The structured result runAttempt reports via its onResult hook, surfaced verbatim by the route. The `outcome`
+ *  discriminant (dry_run / blocked_* / attempt_*) is always present; the remaining fields vary by outcome. */
+export type AttemptRunResult = {
+  outcome: string;
+  repoFullName: string;
+  issueNumber: number;
+} & Record<string, unknown>;
+
+export type AttemptActionResult =
+  { ok: true; result: AttemptRunResult; exitCode: number } | { ok: false; error: string };
+
+function isAttemptRunResult(value: unknown): value is AttemptRunResult {
+  if (typeof value !== "object" || value === null) return false;
+  const result = value as Record<string, unknown>;
+  return (
+    typeof result.outcome === "string" &&
+    typeof result.repoFullName === "string" &&
+    typeof result.issueNumber === "number"
+  );
+}
+
+async function parseAttemptResponse(response: Response, label: string): Promise<AttemptActionResult> {
+  if (!response.ok) {
+    const payload: unknown = await response.json().catch(() => ({}));
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string" && error) {
+      return { ok: false, error };
+    }
+    return { ok: false, error: `${label} responded ${response.status}` };
+  }
+  const payload: unknown = await response.json();
+  const result = (payload as { result?: unknown }).result;
+  const exitCode = (payload as { exitCode?: unknown }).exitCode;
+  if (!isAttemptRunResult(result) || typeof exitCode !== "number") {
+    return { ok: false, error: `${label} returned an unexpected payload shape` };
+  }
+  return { ok: true, result, exitCode };
+}
+
+/** Attempt an issue — mirrors `loopover-miner attempt <owner/repo> <issue#> --miner-login <login> ...`. This may
+ *  run for minutes server-side (full worktree + coding-agent iteration); the client simply awaits it. HTTP-level
+ *  failures surface as a typed error result the view renders, never a thrown exception. */
+export async function runAttemptAction(
+  request: AttemptRunRequest,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AttemptActionResult> {
+  try {
+    const response = await fetchImpl(ATTEMPT_API_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    return await parseAttemptResponse(response, "local attempt API");
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "failed to reach the local attempt API",
+    };
+  }
+}

--- a/apps/loopover-miner-ui/src/lib/discover.ts
+++ b/apps/loopover-miner-ui/src/lib/discover.ts
@@ -1,0 +1,79 @@
+// Client for the local discover action API (#6522, the discover half of the miner-ui's chat action-dispatch
+// surface). Mirrors governor.ts / portfolio-queue-actions.ts's shape (a typed discriminated result, never a
+// thrown exception for an HTTP-level failure) via the authenticated dev-server bridge in vite-discover-api.ts,
+// which is a thin, non-bypassing wrapper around the real `loopover-miner discover` CLI entry point.
+//
+// No credential is ever sent: GITHUB_TOKEN / the tenant's token env var is resolved server-side by runDiscover
+// itself. The client only sends non-secret passthrough fields (repo targets, search query, apiBaseUrl, the NAME
+// of a token-env var, dryRun, json).
+
+export const DISCOVER_API_PATH = "/api/discover";
+
+export type DiscoverRunRequest = {
+  targets?: string[];
+  search?: string;
+  dryRun?: boolean;
+  json?: boolean;
+  apiBaseUrl?: string;
+  tokenEnv?: string;
+};
+
+/** The structured result runDiscover reports via its onResult hook (#6522), surfaced verbatim by the route. */
+export type DiscoverRunResult = {
+  fanOutCount: number;
+  ranked: unknown[];
+  enqueueSummary: { enqueued: number } & Record<string, unknown>;
+} & Record<string, unknown>;
+
+export type DiscoverActionResult =
+  { ok: true; result: DiscoverRunResult; exitCode: number } | { ok: false; error: string };
+
+function isDiscoverRunResult(value: unknown): value is DiscoverRunResult {
+  if (typeof value !== "object" || value === null) return false;
+  const result = value as Record<string, unknown>;
+  return (
+    typeof result.fanOutCount === "number" &&
+    Array.isArray(result.ranked) &&
+    typeof result.enqueueSummary === "object" &&
+    result.enqueueSummary !== null
+  );
+}
+
+async function parseDiscoverResponse(response: Response, label: string): Promise<DiscoverActionResult> {
+  if (!response.ok) {
+    const payload: unknown = await response.json().catch(() => ({}));
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string" && error) {
+      return { ok: false, error };
+    }
+    return { ok: false, error: `${label} responded ${response.status}` };
+  }
+  const payload: unknown = await response.json();
+  const result = (payload as { result?: unknown }).result;
+  const exitCode = (payload as { exitCode?: unknown }).exitCode;
+  if (!isDiscoverRunResult(result) || typeof exitCode !== "number") {
+    return { ok: false, error: `${label} returned an unexpected payload shape` };
+  }
+  return { ok: true, result, exitCode };
+}
+
+/** Run discover against repo targets or a search query — mirrors `loopover-miner discover ...`. HTTP-level
+ *  failures surface as a typed error result the view renders, never a thrown exception. */
+export async function runDiscoverAction(
+  request: DiscoverRunRequest,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DiscoverActionResult> {
+  try {
+    const response = await fetchImpl(DISCOVER_API_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    return await parseDiscoverResponse(response, "local discover API");
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "failed to reach the local discover API",
+    };
+  }
+}

--- a/apps/loopover-miner-ui/vite-attempt-api.ts
+++ b/apps/loopover-miner-ui/vite-attempt-api.ts
@@ -137,8 +137,11 @@ async function respondToAttemptRoute(rawBody: string, deps: AttemptApiDeps): Pro
     // error status carrying the raw exit code rather than crashing on an assumed-present result object.
     return { status: 502, body: JSON.stringify({ error: "attempt_failed", exitCode }) };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "failed to run local attempt";
-    return { status: 500, body: JSON.stringify({ error: message }) };
+    // Log the detailed error server-side only; return a generic token to the client. A failed dynamic
+    // import raises ERR_MODULE_NOT_FOUND carrying an absolute filesystem path, so echoing error.message
+    // would leak internal directory structure to API callers.
+    console.error("[miner-ui] /api/attempt failed:", error);
+    return { status: 500, body: JSON.stringify({ error: "internal_error" }) };
   }
 }
 

--- a/apps/loopover-miner-ui/vite-attempt-api.ts
+++ b/apps/loopover-miner-ui/vite-attempt-api.ts
@@ -1,0 +1,190 @@
+import type { Plugin } from "vite";
+
+import type { AttemptCliResult, RunAttemptOptions } from "../../packages/loopover-miner/lib/attempt-cli.js";
+
+// `attempt` action-dispatch surface for the miner-ui (#6522): the sibling of vite-discover-api.ts, and the
+// first HTTP route driving the miner's real coding-agent write path. Until now `attempt` existed only as a CLI
+// subcommand (bin/loopover-miner.js -> runAttempt). This file is a thin bridge to the EXISTING, unmodified
+// `runAttempt` entry point (packages/loopover-miner/lib/attempt-cli.js) -- it marshals a POST JSON body into the
+// same CLI-style `args: string[]` parseAttemptArgs already accepts, calls runAttempt, and marshals its
+// structured result back out. It does NOT reimplement the worktree / coding-agent / chokepoint pipeline: because
+// it calls the real runAttempt, it inherits the full Governor chokepoint gate (kill-switch -> dry-run ->
+// rate-limit -> budget -> non-convergence -> self-reputation -> self-plagiarism) for free, with no bypass path.
+//
+// Structured result capture: runAttempt already fires `options.onResult` with the real structured result at
+// every genuine return point (dry-run, rejected, worktree-failure, infeasible, blocked, final) — never at its
+// three reportCliFailure sites (parse-error, paused, unexpected-error). This route captures that result and, on
+// a captured outcome, returns it (plus the raw exit code, so a caller can tell a governed rejection/paused
+// outcome from a clean success without re-deriving it). When runAttempt returns non-zero WITHOUT ever firing
+// onResult, there is no structured result — the route responds with a clear error status instead of crashing.
+//
+// Runtime: unlike every existing /api/* route (all synchronous local-store reads/writes), /api/attempt may run
+// for MINUTES — it drives a full worktree checkout + coding-agent iteration. This handler imposes no artificial
+// per-request timeout; it simply awaits the real runAttempt.
+//
+// Auth: like every sibling /api/* route this file is registered AFTER authPlugin() in vite.config.ts's plugin
+// list, so vite-auth.ts's cookie gate covers it automatically. No credential is ever read from the request
+// body: the miner's local harness runs writes with its own local credentials (GITHUB_TOKEN / resolveGitHubToken
+// live session), never a caller-supplied one. Only non-secret passthrough fields (owner/repo, issue number,
+// minerLogin, base, live, dryRun, json) are marshaled into the args array.
+
+type AttemptCliModule = {
+  runAttempt: (args: string[], options?: RunAttemptOptions) => Promise<number>;
+};
+
+export type AttemptApiDeps = {
+  /** Import of `packages/loopover-miner/lib/attempt-cli.js` — injectable so tests never touch a real store,
+   *  worktree, coding agent, or network. */
+  loadAttemptCliModule: () => Promise<AttemptCliModule>;
+};
+
+const defaultDeps: AttemptApiDeps = {
+  loadAttemptCliModule: () => import("../../packages/loopover-miner/lib/attempt-cli.js") as Promise<AttemptCliModule>,
+};
+
+/** The non-secret subset of a `/api/attempt` POST body. A caller-supplied `githubToken`/`token`/`apiKey` field
+ *  is never in this shape and is dropped, not threaded through — credentials are resolved server-side only. */
+type AttemptRequestBody = {
+  repoFullName: string;
+  issueNumber: number;
+  minerLogin?: string;
+  base?: string;
+  live: boolean;
+  dryRun: boolean;
+  json: boolean;
+};
+
+export type AttemptRoute = "attempt-post";
+
+/** Pure route matcher, no I/O — safe to call synchronously before deciding whether to read a request body. */
+export function matchAttemptRoute(method: string | undefined, url: string | undefined): AttemptRoute | null {
+  if (url === "/api/attempt" && method === "POST") return "attempt-post";
+  return null;
+}
+
+function readRequestBody(req: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+/** Parses the POST body into the non-secret attempt request shape, or null for a malformed / missing-required
+ *  body (no repo target, or a non-positive-integer issue number). Mirrors parseActionBody: a malformed body
+ *  never reaches runAttempt at all. */
+function parseAttemptBody(rawBody: string): AttemptRequestBody | null {
+  if (!rawBody.trim()) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  const repoFullName =
+    typeof record.repoFullName === "string" && record.repoFullName.trim() ? record.repoFullName.trim() : null;
+  if (!repoFullName) return null;
+  const issueNumber = record.issueNumber;
+  if (typeof issueNumber !== "number" || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
+  const body: AttemptRequestBody = {
+    repoFullName,
+    issueNumber,
+    live: record.live === true,
+    dryRun: record.dryRun === true,
+    json: record.json === true,
+  };
+  if (typeof record.minerLogin === "string" && record.minerLogin.trim()) body.minerLogin = record.minerLogin.trim();
+  if (typeof record.base === "string" && record.base.trim()) body.base = record.base.trim();
+  return body;
+}
+
+/** Builds the CLI-style args array parseAttemptArgs accepts from the parsed body — the only entry point into
+ *  runAttempt is a `string[]`, so the route constructs argv rather than calling a lower-level structured API. */
+function buildAttemptArgs(body: AttemptRequestBody): string[] {
+  const args = [body.repoFullName, String(body.issueNumber)];
+  if (body.minerLogin !== undefined) args.push("--miner-login", body.minerLogin);
+  if (body.base !== undefined) args.push("--base", body.base);
+  if (body.live) args.push("--live");
+  if (body.dryRun) args.push("--dry-run");
+  if (body.json) args.push("--json");
+  return args;
+}
+
+async function respondToAttemptRoute(rawBody: string, deps: AttemptApiDeps): Promise<{ status: number; body: string }> {
+  const body = parseAttemptBody(rawBody);
+  if (!body) {
+    return { status: 400, body: JSON.stringify({ error: "invalid_request_body" }) };
+  }
+  try {
+    const attemptCli = await deps.loadAttemptCliModule();
+    let captured: AttemptCliResult | undefined;
+    // No artificial timeout: /api/attempt legitimately runs for minutes (worktree + coding-agent iteration).
+    const exitCode = await attemptCli.runAttempt(buildAttemptArgs(body), {
+      onResult: (result) => {
+        captured = result;
+      },
+    });
+    if (captured !== undefined) {
+      return { status: 200, body: JSON.stringify({ result: captured, exitCode }) };
+    }
+    // Exit-code-only branch: runAttempt returned non-zero (a reportCliFailure site — parse-error / paused /
+    // unexpected-error) WITHOUT ever firing onResult, so there is no structured result. Respond with a clear
+    // error status carrying the raw exit code rather than crashing on an assumed-present result object.
+    return { status: 502, body: JSON.stringify({ error: "attempt_failed", exitCode }) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "failed to run local attempt";
+    return { status: 500, body: JSON.stringify({ error: message }) };
+  }
+}
+
+/** Request handler factored out for direct unit tests (mirrors vite-governor-api.ts's handleGovernorRequest).
+ *  Returns null when the request is not for the attempt route (caller falls through). */
+export async function handleAttemptRequest(
+  method: string | undefined,
+  url: string | undefined,
+  rawBody: string,
+  deps: AttemptApiDeps = defaultDeps,
+): Promise<{ status: number; body: string } | null> {
+  const route = matchAttemptRoute(method, url);
+  if (!route) return null;
+  return respondToAttemptRoute(rawBody, deps);
+}
+
+/** Vite dev/preview middleware serving the POST /api/attempt action route. */
+export function attemptApiPlugin(deps: AttemptApiDeps = defaultDeps): Plugin {
+  const attach = (middlewares: {
+    use: (
+      fn: (
+        req: { method?: string; url?: string } & NodeJS.ReadableStream,
+        res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body: string) => void },
+        next: () => void,
+      ) => void,
+    ) => void;
+  }) => {
+    middlewares.use((req, res, next) => {
+      const route = matchAttemptRoute(req.method, req.url);
+      if (!route) return next();
+      void readRequestBody(req)
+        .then((rawBody) => respondToAttemptRoute(rawBody, deps))
+        .then((handled) => {
+          res.statusCode = handled.status;
+          res.setHeader("Content-Type", "application/json");
+          res.end(handled.body);
+        });
+    });
+  };
+  return {
+    name: "gittensory-miner-ui:attempt-api",
+    configureServer(server) {
+      attach(server.middlewares);
+    },
+    configurePreviewServer(server) {
+      attach(server.middlewares);
+    },
+  };
+}

--- a/apps/loopover-miner-ui/vite-discover-api.ts
+++ b/apps/loopover-miner-ui/vite-discover-api.ts
@@ -144,8 +144,11 @@ async function respondToDiscoverRoute(
     // exit code rather than crashing on an assumed-present result object.
     return { status: 502, body: JSON.stringify({ error: "discover_failed", exitCode }) };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "failed to run local discover";
-    return { status: 500, body: JSON.stringify({ error: message }) };
+    // Log the detailed error server-side only; return a generic token to the client. A failed dynamic
+    // import raises ERR_MODULE_NOT_FOUND carrying an absolute filesystem path, so echoing error.message
+    // would leak internal directory structure to API callers.
+    console.error("[miner-ui] /api/discover failed:", error);
+    return { status: 500, body: JSON.stringify({ error: "internal_error" }) };
   }
 }
 

--- a/apps/loopover-miner-ui/vite-discover-api.ts
+++ b/apps/loopover-miner-ui/vite-discover-api.ts
@@ -1,0 +1,197 @@
+import type { Plugin } from "vite";
+
+import type { DiscoverResult, RunDiscoverOptions } from "../../packages/loopover-miner/lib/discover-cli.js";
+
+// `discover` action-dispatch surface for the miner-ui (#6522): the first HTTP route mirroring the AMS miner's
+// own action-taking commands, alongside the sibling vite-attempt-api.ts. Until now `discover` existed only as a
+// CLI subcommand (bin/loopover-miner.js -> runDiscover). This file is a thin bridge to the EXISTING, unmodified
+// `runDiscover` entry point (packages/loopover-miner/lib/discover-cli.js) -- it marshals a POST JSON body into
+// the same CLI-style `args: string[]` parseDiscoverArgs already accepts, calls runDiscover, and marshals the
+// structured result back out. It does NOT reimplement fan-out/rank/enqueue: the route's only job is request
+// marshaling, so there is no parallel or bypass discovery path.
+//
+// Structured result capture: runDiscover's only outputs used to be a console.log (stdout) plus a numeric exit
+// code. #6522 added an `options.onResult` hook (mirroring runAttempt's proven convention) that fires with the
+// real structured result at each of its two success points, so this route reads the structured outcome directly
+// instead of scraping stdout.
+//
+// Auth: like every sibling /api/* route this file is registered AFTER authPlugin() in vite.config.ts's plugin
+// list, so vite-auth.ts's same-origin HttpOnly cookie gate covers it automatically -- no per-route auth wiring.
+//
+// No credential is ever read from the request body: GITHUB_TOKEN / the tenant's token env var is resolved
+// server-side by runDiscover itself, exactly as the CLI does. Only non-secret passthrough fields (repo targets,
+// search query, apiBaseUrl, the NAME of a token-env var, dryRun, json) are marshaled into the args array.
+//
+// matchDiscoverRoute() is checked SYNCHRONOUSLY before any body read: every other request this middleware sees
+// must fall through to next() immediately, without this plugin touching a stream it has no business reading.
+
+type DiscoverCliModule = {
+  runDiscover: (args: string[], options?: RunDiscoverOptions) => Promise<number>;
+};
+
+export type DiscoverApiDeps = {
+  /** Import of `packages/loopover-miner/lib/discover-cli.js` — injectable so tests never touch a real store,
+   *  network, or the GitHub fan-out. */
+  loadDiscoverCliModule: () => Promise<DiscoverCliModule>;
+};
+
+const defaultDeps: DiscoverApiDeps = {
+  loadDiscoverCliModule: () =>
+    import("../../packages/loopover-miner/lib/discover-cli.js") as Promise<DiscoverCliModule>,
+};
+
+/** The non-secret subset of a `/api/discover` POST body. A caller-supplied `githubToken`/`token`/`apiKey` field
+ *  is never in this shape and is dropped, not threaded through — credentials are resolved server-side only. */
+type DiscoverRequestBody = {
+  targets: string[];
+  search?: string;
+  dryRun: boolean;
+  json: boolean;
+  apiBaseUrl?: string;
+  tokenEnv?: string;
+};
+
+export type DiscoverRoute = "discover-post";
+
+/** Pure route matcher, no I/O — safe to call synchronously before deciding whether to read a request body. */
+export function matchDiscoverRoute(method: string | undefined, url: string | undefined): DiscoverRoute | null {
+  if (url === "/api/discover" && method === "POST") return "discover-post";
+  return null;
+}
+
+function readRequestBody(req: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+function trimmedStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.trim()) out.push(entry.trim());
+  }
+  return out;
+}
+
+/** Parses the POST body into the non-secret discover request shape, or null for a malformed / missing-required
+ *  body (neither repo targets nor a search query). Mirrors vite-portfolio-queue-actions-api.ts's parseActionBody
+ *  convention: a malformed body never reaches runDiscover at all. */
+function parseDiscoverBody(rawBody: string): DiscoverRequestBody | null {
+  if (!rawBody.trim()) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  const targets = trimmedStringArray(record.targets);
+  const search = typeof record.search === "string" && record.search.trim() ? record.search.trim() : undefined;
+  // Required: at least one repo target OR a search query — the same "either targets or --search" contract the
+  // CLI's parseDiscoverArgs enforces. Neither present is a missing-required-field body → 400.
+  if (targets.length === 0 && search === undefined) return null;
+  const body: DiscoverRequestBody = {
+    targets,
+    dryRun: record.dryRun === true,
+    json: record.json === true,
+  };
+  if (search !== undefined) body.search = search;
+  if (typeof record.apiBaseUrl === "string" && record.apiBaseUrl.trim()) body.apiBaseUrl = record.apiBaseUrl.trim();
+  if (typeof record.tokenEnv === "string" && record.tokenEnv.trim()) body.tokenEnv = record.tokenEnv.trim();
+  return body;
+}
+
+/** Builds the CLI-style args array parseDiscoverArgs accepts from the parsed body — the only entry point into
+ *  runDiscover is a `string[]`, so the route constructs argv rather than calling a lower-level structured API. */
+function buildDiscoverArgs(body: DiscoverRequestBody): string[] {
+  const args = [...body.targets];
+  if (body.search !== undefined) args.push("--search", body.search);
+  if (body.dryRun) args.push("--dry-run");
+  if (body.json) args.push("--json");
+  if (body.apiBaseUrl !== undefined) args.push("--api-base-url", body.apiBaseUrl);
+  if (body.tokenEnv !== undefined) args.push("--token-env", body.tokenEnv);
+  return args;
+}
+
+async function respondToDiscoverRoute(
+  rawBody: string,
+  deps: DiscoverApiDeps,
+): Promise<{ status: number; body: string }> {
+  const body = parseDiscoverBody(rawBody);
+  if (!body) {
+    return { status: 400, body: JSON.stringify({ error: "invalid_request_body" }) };
+  }
+  try {
+    const discoverCli = await deps.loadDiscoverCliModule();
+    let captured: DiscoverResult | undefined;
+    const exitCode = await discoverCli.runDiscover(buildDiscoverArgs(body), {
+      onResult: (result) => {
+        captured = result;
+      },
+    });
+    if (captured !== undefined) {
+      return { status: 200, body: JSON.stringify({ result: captured, exitCode }) };
+    }
+    // Exit-code-only branch: runDiscover returned non-zero (a reportCliFailure site) WITHOUT ever firing
+    // onResult, so there is no structured result to return. Respond with a clear error status carrying the raw
+    // exit code rather than crashing on an assumed-present result object.
+    return { status: 502, body: JSON.stringify({ error: "discover_failed", exitCode }) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "failed to run local discover";
+    return { status: 500, body: JSON.stringify({ error: message }) };
+  }
+}
+
+/** Request handler factored out for direct unit tests (mirrors vite-governor-api.ts's handleGovernorRequest).
+ *  Returns null when the request is not for the discover route (caller falls through). */
+export async function handleDiscoverRequest(
+  method: string | undefined,
+  url: string | undefined,
+  rawBody: string,
+  deps: DiscoverApiDeps = defaultDeps,
+): Promise<{ status: number; body: string } | null> {
+  const route = matchDiscoverRoute(method, url);
+  if (!route) return null;
+  return respondToDiscoverRoute(rawBody, deps);
+}
+
+/** Vite dev/preview middleware serving the POST /api/discover action route. */
+export function discoverApiPlugin(deps: DiscoverApiDeps = defaultDeps): Plugin {
+  const attach = (middlewares: {
+    use: (
+      fn: (
+        req: { method?: string; url?: string } & NodeJS.ReadableStream,
+        res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body: string) => void },
+        next: () => void,
+      ) => void,
+    ) => void;
+  }) => {
+    middlewares.use((req, res, next) => {
+      const route = matchDiscoverRoute(req.method, req.url);
+      if (!route) return next();
+      void readRequestBody(req)
+        .then((rawBody) => respondToDiscoverRoute(rawBody, deps))
+        .then((handled) => {
+          res.statusCode = handled.status;
+          res.setHeader("Content-Type", "application/json");
+          res.end(handled.body);
+        });
+    });
+  };
+  return {
+    name: "gittensory-miner-ui:discover-api",
+    configureServer(server) {
+      attach(server.middlewares);
+    },
+    configurePreviewServer(server) {
+      attach(server.middlewares);
+    },
+  };
+}

--- a/apps/loopover-miner-ui/vite.config.ts
+++ b/apps/loopover-miner-ui/vite.config.ts
@@ -4,7 +4,9 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+import { attemptApiPlugin } from "./vite-attempt-api";
 import { authPlugin } from "./vite-auth";
+import { discoverApiPlugin } from "./vite-discover-api";
 import { governorApiPlugin } from "./vite-governor-api";
 import { ledgersApiPlugin } from "./vite-ledgers-api";
 import { portfolioQueueActionsApiPlugin } from "./vite-portfolio-queue-actions-api";
@@ -27,6 +29,8 @@ export default defineConfig({
     ledgersApiPlugin(),
     governorApiPlugin(),
     rankedCandidatesApiPlugin(),
+    discoverApiPlugin(),
+    attemptApiPlugin(),
   ],
   server: {
     // Offset from gittensory-ui (5173) so both apps can run side-by-side locally.

--- a/packages/loopover-miner/lib/discover-cli.d.ts
+++ b/packages/loopover-miner/lib/discover-cli.d.ts
@@ -85,6 +85,10 @@ export type RunDiscoverOptions = {
     rankedIssues: RankedCandidateIssue[],
     options: { queueStore: PortfolioQueueStore },
   ) => EnqueueRankedDiscoverySummary;
+  /** Invoked with the real structured result at each of runDiscover's two success points (dry-run + full-run),
+   *  in addition to (never instead of) the plain exit-code return -- mirrors RunAttemptOptions.onResult so a
+   *  programmatic caller sees the same structured outcome `--json` prints without scraping stdout. */
+  onResult?: (result: DiscoverResult) => void;
 };
 
 export function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs;

--- a/packages/loopover-miner/lib/discover-cli.js
+++ b/packages/loopover-miner/lib/discover-cli.js
@@ -198,6 +198,11 @@ export async function runDiscover(args, options = {}) {
         console.log(renderDiscoverSummary(result));
         console.log("\nDRY RUN: no portfolio-queue write was made.");
       }
+      // Mirrors attempt-cli.js's onResult convention: fired only at a real structured outcome (here, the two
+      // genuine success points), never at a reportCliFailure site -- so a programmatic caller (the miner-ui's
+      // /api/discover bridge, #6522) sees the same structured result `--json` prints, in addition to the
+      // unchanged exit code bin/loopover-miner.js still relies on.
+      options.onResult?.(result);
       return 0;
     } catch (error) {
       return reportCliFailure(parsed.json, describeCliError(error));
@@ -299,6 +304,7 @@ export async function runDiscover(args, options = {}) {
     } else {
       console.log(renderDiscoverSummary(result));
     }
+    options.onResult?.(result);
     return 0;
   } catch (error) {
     return reportCliFailure(parsed.json, describeCliError(error));

--- a/test/unit/miner-discover-cli.test.ts
+++ b/test/unit/miner-discover-cli.test.ts
@@ -1054,6 +1054,106 @@ describe("runDiscover (#4247)", () => {
   });
 });
 
+describe("runDiscover onResult hook (#6522)", () => {
+  it("fires options.onResult with the real structured result at the full-run success point, alongside the unchanged exit 0", async () => {
+    const portfolioQueue = tempQueueStore();
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
+      issues: [fanOutIssue({ issueNumber: 1, title: "Add retry helper" })],
+      warnings: [],
+      rateLimitRemaining: 4987,
+      rateLimitResetAt: "2026-07-09T13:00:00.000Z",
+    }));
+    const onResult = vi.fn();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const exitCode = await runDiscover(["acme/widgets", "--json"], {
+      nowMs: NOW,
+      initPortfolioQueue: () => portfolioQueue,
+      initPolicyDocCache: () => tempPolicyDocCacheStore(),
+      initPolicyVerdictCache: () => tempPolicyVerdictCacheStore(),
+      initRankedCandidatesStore: () => tempRankedCandidatesStore(),
+      fetchCandidateIssuesWithSummary,
+      onResult,
+    });
+
+    expect(exitCode).toBe(0);
+    // The captured result is the same object `--json` prints — its full-run shape (no `outcome` field).
+    const printed = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(printed.outcome).toBeUndefined();
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fanOutCount: 1,
+        enqueueSummary: expect.objectContaining({ enqueued: 1 }),
+      }),
+    );
+    expect(onResult.mock.calls[0]?.[0]).not.toHaveProperty("outcome");
+  });
+
+  it("fires options.onResult with the dry_run structured result at the dry-run success point, alongside the unchanged exit 0", async () => {
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
+      issues: [fanOutIssue({ issueNumber: 1 })],
+      warnings: [],
+      rateLimitRemaining: 4990,
+      rateLimitResetAt: "2026-07-09T13:00:00.000Z",
+    }));
+    const onResult = vi.fn();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const exitCode = await runDiscover(["acme/widgets", "--dry-run", "--json"], {
+      nowMs: NOW,
+      fetchCandidateIssuesWithSummary,
+      onResult,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ outcome: "dry_run", fanOutCount: 1 }));
+  });
+
+  it("REGRESSION: onResult is additive — omitting it leaves the plain exit-code return unchanged at both success points", async () => {
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
+      issues: [fanOutIssue({ issueNumber: 1 })],
+      warnings: [],
+      rateLimitRemaining: 4990,
+      rateLimitResetAt: null,
+    }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    // Dry-run success point, no onResult supplied (exercises the hook-absent optional-chaining branch).
+    const dryExit = await runDiscover(["acme/widgets", "--dry-run"], { nowMs: NOW, fetchCandidateIssuesWithSummary });
+    expect(dryExit).toBe(0);
+
+    // Full-run success point, no onResult supplied (exercises the hook-absent branch there too).
+    const fullExit = await runDiscover(["acme/widgets"], {
+      nowMs: NOW,
+      initPortfolioQueue: () => tempQueueStore(),
+      initPolicyDocCache: () => tempPolicyDocCacheStore(),
+      initPolicyVerdictCache: () => tempPolicyVerdictCacheStore(),
+      initRankedCandidatesStore: () => tempRankedCandidatesStore(),
+      fetchCandidateIssuesWithSummary,
+    });
+    expect(fullExit).toBe(0);
+  });
+
+  it("does NOT fire options.onResult at a reportCliFailure site (fan-out failure), mirroring attempt-cli's asymmetry", async () => {
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => {
+      throw new Error("github_unreachable");
+    });
+    const onResult = vi.fn();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const exitCode = await runDiscover(["acme/widgets", "--dry-run"], {
+      nowMs: NOW,
+      fetchCandidateIssuesWithSummary,
+      onResult,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(onResult).not.toHaveBeenCalled();
+  });
+});
+
 describe("loopover-miner discover CLI entrypoint (#4247)", () => {
   it("lists the discover command in --help", () => {
     const output = runCapture(["--help", "--no-update-check"]);


### PR DESCRIPTION
feat(miner-ui): add discover/attempt action-dispatch HTTP routes

Add POST /api/discover and POST /api/attempt as thin, authenticated
bridges to the real runDiscover/runAttempt CLI entry points, mirroring
the governor and portfolio-queue action-route shape (route matcher /
injectable deps / factored handler / Vite plugin). Both register after
authPlugin() in vite.config.ts, so they inherit vite-auth.ts's cookie
gate; /api/attempt inherits the Governor chokepoint for free by calling
the unmodified runAttempt, with no parallel or bypass execution path.
Credentials are never read from the request body -- only non-secret
passthrough fields are marshaled into the CLI args array.

runDiscover gains an optional onResult hook fired at its two success
points (dry-run + full-run), mirroring runAttempt's existing convention
and never firing at a reportCliFailure site, so the route returns the
same structured result --json prints instead of scraping stdout. Adds
typed client fetchers (discriminated ok/error result, never a throw) and
covers the route handlers, plugins, the onResult addition, and the
exit-code-only branch.

Closes #6522

