### PR TITLE
refactor(test): move queue.test.ts/queue-5.test.ts's Batch A fields to manifest injection

### DIFF
--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -688,7 +688,7 @@ describe("queue processors", () => {
     });
 
     it("close policy records a denied cooldown-applied audit when autonomy is not acting for label/close (empty plan)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "close", reviewNagMaxPings: 3, autonomy: {} });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 211, title: "Observe-only autonomy", state: "open", user: { login: "chatty" }, head: { sha: "sha211" }, author_association: "NONE", labels: [], body: "" });
       for (let i = 0; i < 3; i += 1) {
@@ -2550,7 +2550,7 @@ describe("queue processors", () => {
     // Merge-readiness still collects the live slop score, so shouldCollectSlopEvidence runs even with the
     // slop gate disabled — but with slopGateMode "off" the persisted dashboard row must be cleared to null
     // so a previously cached score doesn't linger after a maintainer disables slop.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -2558,15 +2558,13 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       slopGateMode: "off", // dashboard slop disabled…
       mergeReadinessGateMode: "advisory", // …but readiness keeps the live score in play
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // Seed the PR row plus a stale dashboard slop score that the slop-off pass must clear.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 91,
@@ -2643,14 +2641,12 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       slopGateMode: "advisory",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 96, title: "Add clamp helper for the volume slider", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "genericsha96" }, labels: [], body: "Bounds the volume slider's raw input to a safe numeric range." });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 97, title: "Restrict pagination cursor offsets to a valid window", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "specificsha97" }, labels: [], body: "Prevents the pagination cursor from resolving to an out-of-range offset." });
 
@@ -2725,10 +2721,7 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       duplicatePrGateMode: "block",
@@ -2736,6 +2729,7 @@ describe("queue processors", () => {
       qualityGateMode: "block",
       qualityGateMinScore: 95,
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // The shared issue + the HIGHER-numbered open sibling (#92) → forms the same-issue duplicate cluster.
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91" }, labels: [], body: "Fixes #1\n\nValidation: npm test" });
@@ -2781,7 +2775,7 @@ describe("queue processors", () => {
   it("#dup-winner: flag OFF keeps every same-issue sibling blocked (byte-identical) — the winner is also closed-eligible", async () => {
     // Same cluster, flag OFF (default). The lowest open PR (#91) STILL gets the duplicate block + finding,
     // exactly like today — no winner is spared.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -2789,15 +2783,13 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       duplicatePrGateMode: "block",
       slopGateMode: "advisory",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 92, title: "Also fix the cache", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib92b" }, labels: [], body: "Fixes #1" });
 
@@ -2844,7 +2836,7 @@ describe("queue processors", () => {
     // "low") even though the gate's OWN reconciled otherOpenPullRequests (used to build the advisory/gate
     // disposition) had already correctly dropped #90. After the fix, both paths agree: #95 is the winner (no
     // open siblings once reconciled) and carries NO duplicate-cluster slop penalty (slop_band "clean").
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DUPLICATE_WINNER: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DUPLICATE_WINNER: "true" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
@@ -2852,15 +2844,13 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       duplicatePrGateMode: "block",
       slopGateMode: "advisory",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
     // Stale-cached-open sibling: the DB still says #90 is open (the closed webhook was missed/delayed).
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 90, title: "Older attempt at the cache fix", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib90" }, labels: [], body: "Fixes #1" });
@@ -2916,13 +2906,11 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 90,
       title: "Override me",
@@ -3011,13 +2999,11 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 94,
       title: "Override me (telemetry write fails)",
@@ -3071,14 +3057,12 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       agentPaused: true,
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 91,
       title: "Override me while paused",
@@ -3142,14 +3126,12 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       agentDryRun: true,
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // No head sha — also exercises the metadata's `?? null` fallback on the skip-path audit/usage records.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 93,
@@ -3213,13 +3195,11 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // The stored row still carries the OLD head; a new commit ("live-sha") landed between the comment and now.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 90,
@@ -3294,13 +3274,11 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // A cached row with no head SHA (never detail-synced); the live fetch also yields no head.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 90,
@@ -3352,13 +3330,11 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 92,
       title: "Edited override",
@@ -3419,13 +3395,11 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 91,
       title: "Cannot override",
@@ -3496,10 +3470,7 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName,
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         requireLinkedIssue: true,
         linkedIssueGateMode: "advisory",
@@ -3524,7 +3495,7 @@ describe("queue processors", () => {
         LOOPOVER_REVIEW_MEMORY: "true",
       });
       await seedResolvePr(env, repoFullName, 1964, "resolve-1964-a");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       const calls = { permission: 0, checkPatches: 0, comments: 0 };
       let confirmationBody = "";
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -3593,7 +3564,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1964-ai-cached";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1974, "resolve-1964-ai-cached");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await putCachedAiReview(env, repoFullName, 1974, "resolve-1964-ai-cached", "advisory", {
         notes: "The cached AI review found a public issue.",
         reviewerCount: 2,
@@ -3636,7 +3607,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1964-ai-published";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1975, "resolve-1964-ai-current");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await putCachedAiReview(env, repoFullName, 1975, "resolve-1964-ai-old", "advisory", {
         notes: "The published AI review found a public consensus defect.",
         reviewerCount: 2,
@@ -3681,7 +3652,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1965-off";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedResolvePr(env, repoFullName, 1965, "resolve-1965-off");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         const method = init?.method ?? "GET";
@@ -3726,7 +3697,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1966-deny";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1966, "resolve-1966-deny");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3767,7 +3738,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1967-skip";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1967, "resolve-1967-skip");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3800,7 +3771,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1968-whole";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1968, "resolve-1968-whole");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         const method = init?.method ?? "GET";
@@ -3836,6 +3807,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1973-plain";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedResolvePr(env, repoFullName, 1973, "resolve-1973-plain");
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       let commentPosts = 0;
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
@@ -3869,6 +3841,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1974-help";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedResolvePr(env, repoFullName, 1974, "resolve-1974-help");
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         if (input.toString().includes("/access_tokens")) return Response.json({ token: "installation-token" });
         return new Response("not found", { status: 404 });
@@ -3942,8 +3915,8 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1970-dry-run";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1970, "resolve-1970-dry-run");
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", agentDryRun: true });
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", agentDryRun: true });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3973,8 +3946,8 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1971-paused";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1971, "resolve-1971-paused");
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", agentPaused: true });
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", agentPaused: true });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -4007,7 +3980,8 @@ describe("queue processors", () => {
       const owner = repoFullName.slice(0, slash);
       const name = repoFullName.slice(slash + 1);
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: prNumber, title: "Explain me", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: headSha }, labels: [], body: "No linked issue on purpose" });
     }
     const explainWebhook = (repoFullName: string, prNumber: number, body: string, actor: string, opts: { association?: string; bot?: boolean; action?: string } = {}) => ({
@@ -4226,7 +4200,7 @@ describe("queue processors", () => {
       const owner = repoFullName.slice(0, slash);
       const name = repoFullName.slice(slash + 1);
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: prNumber, title: "Add retry to checkout", state: "open", user: { login: authorLogin }, author_association: "CONTRIBUTOR", head: { sha: headSha, ref: opts.headRef ?? "feature/checkout-retry" }, labels: [], body: "Retries the payment call once on a 5xx." });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: prNumber, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
       // A renamed-with-no-patch file (GitHub omits `patch` for pure renames) -- exercises the
@@ -4236,7 +4210,7 @@ describe("queue processors", () => {
       // a second separate call REPLACES rather than merges with a prior one (see repo-doc-pr.test.ts).
       await upsertRepoFocusManifest(env, repoFullName, {
         features: { e2eTests: true },
-        ...(opts.e2eTestDelivery ? { review: { e2e_test_delivery: opts.e2eTestDelivery } } : {}),
+        ...(opts.e2eTestDelivery ? { review: { e2e_test_delivery: opts.e2eTestDelivery } } : {}), settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
       });
     }
     const generateTestsWebhook = (repoFullName: string, prNumber: number, actor: string, opts: { association?: string; bot?: boolean; commenterIsAuthor?: boolean } = {}) => ({
@@ -4376,7 +4350,8 @@ describe("queue processors", () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       const slash = repoFullName.indexOf("/");
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: 4198, title: "x", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "gen-tests-4195-disabled" }, labels: [], body: "x" });
       // Deliberately no upsertRepoFocusManifest features.e2eTests override -- stays off (no allowlist either).
       let postedBody = "";
@@ -4495,7 +4470,7 @@ describe("queue processors", () => {
       // aiReviewProvider set AND matching the stored key's provider -- exercises the "explicit provider
       // pin agrees with the stored key" arm, distinct from the (also-tested-elsewhere) "no pin configured"
       // default arm.
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", aiReviewByok: true, aiReviewProvider: "anthropic" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", aiReviewByok: true, aiReviewProvider: "anthropic" });
       await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-byok-gen-tests-9999", model: null });
       let postedBody = "";
       const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -4554,7 +4529,8 @@ describe("queue processors", () => {
       });
       const slash = repoFullName.indexOf("/");
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: 4205, title: "Add retry to checkout", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "gen-tests-4195-allowlist" }, labels: [], body: "x" });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: 4205, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
       let postedBody = "";
@@ -4702,11 +4678,11 @@ describe("queue processors", () => {
         });
         const slash = repoFullName.indexOf("/");
         await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-        await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
         // No head sha/ref cached at all on this PR record.
         await upsertPullRequestFromGitHub(env, repoFullName, { number: 4210, title: "Add retry to checkout", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", labels: [], body: "x" });
         await upsertPullRequestFile(env, { repoFullName, pullNumber: 4210, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
-        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" } });
+        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
         let postedBody = "";
         vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
           const url = input.toString();
@@ -4768,13 +4744,13 @@ describe("queue processors", () => {
         });
         const slash = repoFullName.indexOf("/");
         await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-        await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
         // Deliberately no `user` field at all -- the cached PR's authorLogin resolves to null, exercising the
         // ternary's not-found arm (`pr.authorLogin ? ... : { status: "not_found" }`) instead of ever calling
         // getCachedOfficialMinerDetection.
         await upsertPullRequestFromGitHub(env, repoFullName, { number: 4214, title: "Add retry to checkout", state: "open", author_association: "CONTRIBUTOR", head: { sha: "no-author-head-sha", ref: "feature/checkout-retry" }, labels: [], body: "x" });
         await upsertPullRequestFile(env, { repoFullName, pullNumber: 4214, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
-        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" } });
+        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
         let postedBody = "";
         vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
           const url = input.toString();
@@ -4803,7 +4779,7 @@ describe("queue processors", () => {
         const run = vi.fn();
         const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
         await seedGenerateTestsPr(env, repoFullName, 4211, "dryrun-head-sha", "contributor", { headRef: "feature/checkout-retry", e2eTestDelivery: "commit" });
-        await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", agentDryRun: true });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", agentDryRun: true });
         vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
           const url = input.toString();
           if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -4825,7 +4801,7 @@ describe("queue processors", () => {
         const run = vi.fn();
         const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
         await seedGenerateTestsPr(env, repoFullName, 4212, "paused-head-sha", "contributor", { headRef: "feature/checkout-retry", e2eTestDelivery: "commit" });
-        await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", agentPaused: true });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", agentPaused: true });
         vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
           const url = input.toString();
           if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -4862,10 +4838,7 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName,
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         // reviewCheckMode: "required" (not "disabled") -- gateEnabled (which the whole manifestPolicyGateMode
         // block this auto-trigger lives inside is downstream of) requires a truthy reviewCheckMode + a headSha.
         // With reviewCheckMode: "disabled" the function bails out via its own early-return before ever reaching
@@ -4907,7 +4880,7 @@ describe("queue processors", () => {
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
         features: { e2eTests: opts.e2eTests ?? true },
-        review: { e2e_test_auto_trigger: opts.autoTrigger ?? true, ...(opts.e2eTestDelivery ? { e2e_test_delivery: opts.e2eTestDelivery } : {}) },
+        review: { e2e_test_auto_trigger: opts.autoTrigger ?? true, ...(opts.e2eTestDelivery ? { e2e_test_delivery: opts.e2eTestDelivery } : {}) }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
       });
     }
 
@@ -5184,7 +5157,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedAutoTriggerPr(env, repoFullName, 5008, "auto-4196-paused-sha");
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentPaused: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentPaused: true });
       const posted = { count: 0, body: "" };
       stubAutoTriggerFetch(5008, posted);
 
@@ -5201,7 +5174,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedAutoTriggerPr(env, repoFullName, 5009, "auto-4196-dryrun-sha");
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentDryRun: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentDryRun: true });
       const posted = { count: 0, body: "" };
       stubAutoTriggerFetch(5009, posted);
 
@@ -5224,13 +5197,13 @@ describe("queue processors", () => {
       });
       const slash = repoFullName.indexOf("/");
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off" });
       // Deliberately no `user` field at all -- authorLogin resolves to null, exercising the `author ?? "the PR
       // author"` fallback arm (the explicit command's own `actor` is always a real commenter login, so this
       // branch is reachable only from the auto-trigger, which has no comment-invoker to fall back on).
       await upsertPullRequestFromGitHub(env, repoFullName, { number: 5010, title: "Add retry to checkout", state: "open", author_association: "CONTRIBUTOR", head: { sha: "auto-4196-no-author-sha", ref: "feature/checkout-retry" }, labels: [], body: "No validation evidence mentioned here." });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: 5010, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
-      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, review: { e2e_test_auto_trigger: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, review: { e2e_test_auto_trigger: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       const posted = { count: 0, body: "" };
       stubAutoTriggerFetch(5010, posted);
 
@@ -5274,10 +5247,7 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName,
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         requireLinkedIssue: false,
         linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
@@ -5306,7 +5276,7 @@ describe("queue processors", () => {
       });
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
-        features: { e2eTests: opts.e2eTests ?? true },
+        features: { e2eTests: opts.e2eTests ?? true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
       });
     }
 
@@ -5419,10 +5389,7 @@ describe("queue processors", () => {
       await seedCheckboxPr(env, repoFullName, 6013, "checkbox-4589-widened-sha");
       await upsertRepositorySettings(env, {
         repoFullName,
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         requireLinkedIssue: false,
         linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
@@ -5455,10 +5422,7 @@ describe("queue processors", () => {
       await seedCheckboxPr(env, repoFullName, 6014, "checkbox-4589-clamped-sha");
       await upsertRepositorySettings(env, {
         repoFullName,
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         requireLinkedIssue: false,
         linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
@@ -5598,7 +5562,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedCheckboxPr(env, repoFullName, 6008, "checkbox-4589-paused-sha");
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentPaused: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentPaused: true });
       const posted = { count: 0, body: "" };
       stubCheckboxFetch(6008, "maintainer", "admin", posted);
 
@@ -5617,7 +5581,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedCheckboxPr(env, repoFullName, 6010, "checkbox-4589-dryrun-sha");
-      await upsertRepositorySettings(env, { repoFullName, commentMode: "off", publicSurface: "off", autoLabelEnabled: false, checkRunMode: "off", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentDryRun: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentDryRun: true });
       const posted = { count: 0, body: "" };
       stubCheckboxFetch(6010, "maintainer", "admin", posted);
 
@@ -5696,11 +5660,7 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName,
-        commentMode: "detected_contributors_only",
-        publicAudienceMode: "gittensor_only",
-        publicSurface: "comment_and_label",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         // reviewCheckMode MUST be "required" (not "disabled") -- gateEvaluation is never computed at all when
         // the gate is off (#6103: the renderer then falls back to a synthetic "skipped" gate for rendering
         // purposes only), and this test needs the REAL evaluated gate's data for the checkbox/collapsible to
@@ -5712,7 +5672,7 @@ describe("queue processors", () => {
         aiReviewMode: "off",
         typeLabelsEnabled: false,
       });
-      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true } });
+      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSurface: "comment_and_label", checkRunMode: "off" } });
       // gateEvaluation needs a resolved CI aggregate (mocking the module function directly is far simpler than
       // stubbing every raw status/check-suite endpoint the live CI aggregator would otherwise call) -- but
       // NOT "passed": resolveManifestPassedValidationCount treats a fully-green live CI rollup as validation
@@ -6004,20 +5964,17 @@ describe("queue processors", () => {
     }
 
     it("applies the type label when oss_maintainer mode + an unconfirmed miner suppress the context label", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
-        publicAudienceMode: "oss_maintainer",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off" } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(210, seen);
@@ -6039,20 +5996,17 @@ describe("queue processors", () => {
     });
 
     it("keeps gate-only gittensor_only type labels silent until miner confirmation", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "off",
-        publicAudienceMode: "gittensor_only",
         autoLabelEnabled: false,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", publicAudienceMode: "gittensor_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false, minerList: 0 };
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
@@ -6104,12 +6058,8 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "all_prs",
-        publicSurface: "comment_and_label",
-        publicAudienceMode: "gittensor_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         // The only difference from the pre-existing "keeps GitHub-history-only contributors quiet" test
         // (which has the gate off, so it returns before ever reaching the type-label decision): with the
         // gate ENABLED, the function does NOT bail out early, so this is the only path that actually
@@ -6118,6 +6068,7 @@ describe("queue processors", () => {
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", publicAudienceMode: "gittensor_only", checkRunMode: "off" } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(217, seen);
@@ -6143,17 +6094,14 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
-        publicAudienceMode: "oss_maintainer",
         autoLabelEnabled: true,
         typeLabelsEnabled: false,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off" } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(211, seen);
@@ -6175,20 +6123,17 @@ describe("queue processors", () => {
     });
 
     it("applies the type label to a maintainer-authored PR even though includeMaintainerAuthors excludes it from the public surface", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
-        includeMaintainerAuthors: false,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", includeMaintainerAuthors: false, checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(212, seen);
 
@@ -6209,19 +6154,17 @@ describe("queue processors", () => {
     });
 
     it("applies the type label to a bot-authored PR and keeps the three type labels mutually exclusive", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(213, seen);
 
@@ -6242,15 +6185,12 @@ describe("queue processors", () => {
     });
 
     it("cleans up an arbitrary configured custom category alongside bug/feature/priority (#label-modularity)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6260,6 +6200,7 @@ describe("queue processors", () => {
         // classification moved elsewhere) exactly like the built-in categories.
         typeLabels: { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority", security: "area:security" },
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(218, seen);
 
@@ -6280,19 +6221,17 @@ describe("queue processors", () => {
     });
 
     it("applies the type label when publicSurface: comment_only makes the base context label structurally impossible", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "comment_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "comment_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(214, seen);
 
@@ -6312,20 +6251,18 @@ describe("queue processors", () => {
     });
 
     it("typeLabelsEnabled: false does not suppress the base context label for a confirmed contributor", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         typeLabelsEnabled: false,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(215, seen);
@@ -6346,18 +6283,16 @@ describe("queue processors", () => {
     });
 
     it("posts the LoopOver Context check run independently of both label families being off, with zero label writes", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
         typeLabelsEnabled: false,
-        checkRunMode: "enabled",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "enabled" } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(216, seen);
@@ -6421,15 +6356,12 @@ describe("queue processors", () => {
     }
 
     it("applies the configured priority label when a linked issue already carries the configured issue label (#priority-linked-issue-gate)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6439,6 +6371,7 @@ describe("queue processors", () => {
           mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
         },
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(220, 1, seen, () => Response.json({ number: 1, state: "open", user: { login: "contributor" }, labels: ["gittensor:priority"] }));
 
@@ -6454,13 +6387,13 @@ describe("queue processors", () => {
         },
       });
 
-      // LOOPOVER_DRIFT_ISSUE_REPO is overridden above so "JSONbored/gittensory" is NOT treated as the self
-      // repo here -- otherwise it would fall back to the bundled manifest (LOOPOVER_REPO_FOCUS_MANIFEST_YAML),
-      // which carries its own bug/feature/priority mapping list and would silently replace this test's
-      // DB-configured single-mapping override. With that fallback correctly bypassed, only this test's own
-      // configured priority mapping applies: it is an EXCLUSIVE mapping (removeOtherTypeLabels: true), so per
-      // resolvePrTypeLabel it REPLACES the title-derived type label rather than composing with it -- "priority"
-      // is the sole applied label, and both other built-in categories (bug, feature) are removed.
+      // The upsertRepoFocusManifest call above persists a real manifest row for "JSONbored/gittensory", so the
+      // loader finds it directly and never falls back to the bundled self-repo manifest (LOOPOVER_REPO_FOCUS_MANIFEST_YAML)
+      // -- which carries its own bug/feature/priority mapping list that would otherwise silently replace this
+      // test's DB-configured single-mapping override. Only this test's own configured priority mapping applies:
+      // it is an EXCLUSIVE mapping (removeOtherTypeLabels: true), so per resolvePrTypeLabel it REPLACES the
+      // title-derived type label rather than composing with it -- "priority" is the sole applied label, and
+      // both other built-in categories (bug, feature) are removed.
       expect(seen.issueFetches).toBe(1);
       expect(seen.posted).toEqual(["gittensor:priority"]);
       expect(seen.removed).toEqual(["gittensor:bug", "gittensor:feature"]);
@@ -6471,11 +6404,8 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "disabled",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6494,6 +6424,7 @@ describe("queue processors", () => {
           ],
         },
       });
+      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       // The linked issue is CLOSED, at a timestamp at/after this PR's own merge -- GitHub's standard "Closes #N"
       // auto-close, fired by this very merge. Title deliberately uses a verb ("fold") absent from the
@@ -6542,15 +6473,12 @@ describe("queue processors", () => {
       // of propagation authority) that let a transient GitHub hiccup permanently strip a correctly propagated
       // gittensor:feature/gittensor:priority label down to gittensor:bug (confirmed in production, PRs
       // #4716/#4783 and 116 others in a 2-day sample). A fetch failure must now be a no-op, not a downgrade.
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6560,6 +6488,7 @@ describe("queue processors", () => {
           mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
         },
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(221, 1, seen, () => new Response("server error", { status: 500 }));
 
@@ -6594,11 +6523,8 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6608,6 +6534,7 @@ describe("queue processors", () => {
           mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
         },
       });
+      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       let issueShouldFail = false;
       stubPropagationFetch(4716, 2216, seen, () =>
@@ -6636,15 +6563,12 @@ describe("queue processors", () => {
     });
 
     it("REGRESSION (#regression-safe-propagation): a contended per-PR actuation lock skips the label decision entirely instead of racing the pass that already holds it", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6654,6 +6578,7 @@ describe("queue processors", () => {
           mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
         },
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(223, 1, seen, () => Response.json({ number: 1, state: "open", user: { login: "contributor" }, labels: ["gittensor:priority"] }));
 
@@ -6696,15 +6621,12 @@ describe("queue processors", () => {
 
       for (const webhook of REVIEW_FAMILY_WEBHOOKS) {
         it(`skips the type-label recompute entirely (never even fetches the linked issue) on a ${webhook.eventName}:${webhook.action} webhook`, async () => {
-          const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+          const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
           await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
           await upsertRepositorySettings(env, {
             repoFullName: "JSONbored/gittensory",
-            commentMode: "off",
-            publicSurface: "label_only",
             autoLabelEnabled: true,
             createMissingLabel: false,
-            checkRunMode: "off",
             reviewCheckMode: "required",
             linkedIssueGateMode: "off",
             aiReviewMode: "off",
@@ -6714,6 +6636,7 @@ describe("queue processors", () => {
               mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
             },
           });
+          await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
           const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
           stubPropagationFetch(4818, 2192, seen, () => Response.json({ number: 2192, state: "closed", closed_at: "2026-07-11T02:26:25Z", user: { login: "JSONbored" }, labels: ["gittensor:feature"] }));
 
@@ -6758,11 +6681,8 @@ describe("queue processors", () => {
         await upsertRepositoryFromGitHub(env, { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } }, 123);
         await upsertRepositorySettings(env, {
           repoFullName: "acme/widget",
-          commentMode: "off",
-          publicSurface: "label_only",
           autoLabelEnabled: true,
           createMissingLabel: false,
-          checkRunMode: "off",
           reviewCheckMode: "required",
           linkedIssueGateMode: "off",
           aiReviewMode: "off",
@@ -6772,6 +6692,7 @@ describe("queue processors", () => {
             mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
           },
         });
+        await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
         const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
         stubPropagationFetch(9001, 501, seen, () => Response.json({ number: 501, state: "open", user: { login: "contributor" }, labels: ["gittensor:feature"] }));
 
@@ -6828,16 +6749,14 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
         // linkedIssueLabelPropagation intentionally omitted -- defaults to disabled.
       });
+      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(222, 1, seen, () => Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] }));
 
@@ -6859,19 +6778,17 @@ describe("queue processors", () => {
     });
 
     it("records the audit event for a normal applied label decision (#label-decoupling audit)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(219, seen);
 
@@ -6896,19 +6813,17 @@ describe("queue processors", () => {
     });
 
     it("does not let a failing audit write stop label application (completed outcome, fail-open)", async () => {
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "label_only",
         autoLabelEnabled: true,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(220, seen);
       failAuditEventInsertsContaining(env, "github_app.type_label_decision");
@@ -6934,16 +6849,14 @@ describe("queue processors", () => {
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: true,
         typeLabelsEnabled: false,
         createMissingLabel: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(221, seen);
       failAuditEventInsertsContaining(env, "github_app.type_label_decision");

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1256,10 +1256,8 @@ describe("queue processors", () => {
       aiReviewMode: "advisory",
       gatePack: "oss-anti-slop",
       reviewCheckMode: "required",
-      checkRunMode: "off",
-      commentMode: "off",
-      publicSurface: "off",
     });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "no linked issue here" });
     await upsertPullRequestFile(env, { repoFullName: "owner/agent-repo", pullNumber: 7, path: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const ok = true;" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -1304,10 +1302,8 @@ describe("queue processors", () => {
       aiReviewMode: "block",
       gatePack: "oss-anti-slop",
       reviewCheckMode: "required",
-      checkRunMode: "off",
-      commentMode: "off",
-      publicSurface: "off",
     });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     await upsertPullRequestFile(env, { repoFullName: "owner/agent-repo", pullNumber: 7, path: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const ok = value.length;" } });
     await putCachedAiReview(env, "owner/agent-repo", 7, "a7", "block", {
@@ -1347,7 +1343,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     // STORED head is the stale a7; GitHub's LIVE head is b8 (a push the lost synchronize never delivered).
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     let liveFilesFetched = false;
@@ -1377,7 +1374,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     const resyncUpsertSpy = vi.spyOn(repositoriesModule, "upsertPullRequestFromGitHub");
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -1407,7 +1405,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     // STORED row still reads open — the `closed` webhook was dropped (relay down); GitHub's LIVE state is closed.
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Closed PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     let filesFetched = false;
@@ -1436,7 +1435,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Open PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     let webhookReplayApplied = false;
@@ -1467,7 +1467,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     // Seed an UP-TO-DATE reviews-cache marker so this dedup-focused call-count test stays isolated from the
     // reviews-staleness self-heal (#2537 follow-up) — that behavior has its own dedicated coverage below.
@@ -1547,7 +1548,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     // A sync that predates an invalidation (STALE) and no other refresh trigger in play (slop evidence off,
     // manifest gate off, no pre-merge check paths configured) — proves the sweep's own visit, not some unrelated
@@ -1593,7 +1595,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 8, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a8" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     // No reviewsInvalidatedAt at all -- the marker comparison alone would read this as permanently up to date.
     await upsertPullRequestDetailSyncState(env, {
@@ -1633,7 +1636,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     await upsertPullRequestDetailSyncState(env, { repoFullName: "owner/agent-repo", pullNumber: 7, status: "complete", reviewsSyncedAt: new Date().toISOString() });
     // mockRejectedValue (not -Once): an earlier getPullRequestDetailSyncState read inside the resync/readiness
@@ -1672,7 +1676,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITHUB_PUBLIC_TOKEN: "public-token" });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", approve: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", approve: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     let gateFinalized = false;
     let failedMaintenanceMint = false;
@@ -1726,7 +1731,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Pending CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     const requiredContextsSpy = vi
       .spyOn(backfillModule, "fetchRequiredStatusContexts")
@@ -1771,7 +1777,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Still running CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -1819,7 +1826,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Missing aggregate CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
     const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
@@ -1864,7 +1872,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale optional CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -1925,7 +1934,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Permanently stuck CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -2002,7 +2012,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Permanently stuck CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -2073,7 +2084,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 8, title: "Permanently stuck CI, audit write fails", state: "open", user: { login: "contributor" }, head: { sha: "b8" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -2128,7 +2140,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 9, title: "Permanently stuck CI, repeat defer audit write fails", state: "open", user: { login: "contributor" }, head: { sha: "c9" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -2191,7 +2204,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale missing aggregate CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await env.SELFHOST_TRANSIENT_CACHE?.set(
@@ -2243,7 +2257,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Missing required context, within cap", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     // 1 minute elapsed: under the new 2-minute missing-required-context cap AND under the old 30-minute cap —
@@ -2300,7 +2315,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Missing required context, past short cap", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     // 3 minutes elapsed: past the 2-minute missing-required-context surfacing cap, but nowhere near the old
@@ -2359,7 +2375,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "CI completeness unverified", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
     const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
@@ -2402,7 +2419,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "CI fully verified", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(new Set(["trusted-required-ci"]));
     const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
@@ -2446,8 +2464,12 @@ describe("queue processors", () => {
     // it is exclusively a `.loopover.yml`-driven override (settings/repository-settings.ts's default is
     // always the built-in all-off DEFAULT_LINKED_ISSUE_HARD_RULES; only resolveEffectiveSettings's manifest
     // overlay can turn a rule on). So this scaffold enables it via a stubbed `.loopover.yml` content fetch,
-    // not via upsertRepositorySettings.
-    const HARD_RULE_MANIFEST = JSON.stringify({ settings: { linkedIssueHardRules: { ownerAssignedClose: "block" } } });
+    // not via upsertRepositorySettings. checkRunMode/commentMode/publicSurface are Batch-A fields threaded the
+    // SAME way (via the stubbed live manifest fetch below), NOT via upsertRepoFocusManifest -- pre-seeding a
+    // manifest row in D1 would satisfy loadRepoFocusManifestWithCachePolicy's own freshness cache and skip the
+    // live `.loopover.yml` fetch this whole describe block depends on for every pass.
+    const HARD_RULE_MANIFEST = JSON.stringify({ settings: { linkedIssueHardRules: { ownerAssignedClose: "block" }, checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
+    const NO_HARD_RULE_MANIFEST = JSON.stringify({ settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
 
     async function seedHardRuleRepoAndPr(env: ReturnType<typeof createTestEnv>): Promise<void> {
       await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", issues: "write", checks: "write" }, events: [] } });
@@ -2458,9 +2480,6 @@ describe("queue processors", () => {
         aiReviewMode: "off",
         gatePack: "oss-anti-slop",
         reviewCheckMode: "required",
-        checkRunMode: "off",
-        commentMode: "off",
-        publicSurface: "off",
       });
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Ineligible linked issue", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #9" });
     }
@@ -2493,8 +2512,9 @@ describe("queue processors", () => {
           return new Response(null, { status: 204 });
         }
         // The `.loopover.yml`/`.json` content fetch (raw.githubusercontent.com) is the ONLY place
-        // linkedIssueHardRules can be turned on (see the comment above).
-        if (url.includes("raw.githubusercontent.com")) return opts.ruleEnabled ? new Response(HARD_RULE_MANIFEST, { status: 200 }) : new Response("not found", { status: 404 });
+        // linkedIssueHardRules can be turned on (see the comment above). Batch-A settings ride along on BOTH
+        // arms so their effective value stays "off" regardless of whether the hard rule itself is enabled.
+        if (url.includes("raw.githubusercontent.com")) return new Response(opts.ruleEnabled ? HARD_RULE_MANIFEST : NO_HARD_RULE_MANIFEST, { status: 200 });
         return Response.json({});
       });
     }
@@ -2618,7 +2638,7 @@ describe("queue processors", () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", issues: "write", checks: "write" }, events: [] } });
       await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-      await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { close: "auto", review_state_label: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+      await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { close: "auto", review_state_label: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "No hard rule enabled", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #9" });
       const requiredContextsSpy = requiredContextsMock();
       const liveCiSpy = liveCiMock();
@@ -2652,7 +2672,8 @@ describe("queue processors", () => {
       // keeps both passes comparable: it satisfies isAgentConfigured, but the action executor STAGES the merge
       // for approval instead of ever calling the GitHub merge endpoint, so the PR stays open with the same
       // head_sha across both passes.
-      await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto_with_approval", update_branch: "auto_with_approval" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+      await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto_with_approval", update_branch: "auto_with_approval" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+      await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Cross-job CI cache", state: "open", user: { login: "contributor" }, head: { sha: headSha }, base: { ref: "main" }, labels: [], body: "Closes #1" });
       return { env };
     }
@@ -3032,7 +3053,7 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Fold-all vs configured", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     let branchProtectionGets = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -3062,7 +3083,7 @@ describe("queue processors", () => {
     expect(branchProtectionGets).toBe(1);
 
     // Config change: gate.expectedCiContexts now names a context absent from every check-run/status above.
-    await upsertRepoFocusManifest(env, "owner/agent-repo", { gate: { expectedCiContexts: ["required-build"] } });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" }, gate: { expectedCiContexts: ["required-build"] } });
 
     // Call B: SAME repo/baseRef/headSha/check-run state — only settings.expectedCiContexts changed.
     await processJob(env, { type: "agent-regate-pr", deliveryId: "with-expected-contexts", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
@@ -3091,13 +3112,13 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Configured + clean", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     await upsertPullRequestDetailSyncState(env, { repoFullName: "owner/agent-repo", pullNumber: 7, status: "complete", reviewsSyncedAt: new Date().toISOString() });
     // gate.expectedCiContexts is satisfied by a real, passing check-run — so CI resolves cleanly and the pass
     // proceeds all the way through readiness, public-surface publish, AND auto-maintain (unlike the deferred-pending
     // test above, which deliberately stops at readiness to prove the disposition changes).
-    await upsertRepoFocusManifest(env, "owner/agent-repo", { gate: { expectedCiContexts: ["required-build"] } });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" }, gate: { expectedCiContexts: ["required-build"] } });
     let branchProtectionGets = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -3138,11 +3159,11 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Branch protection drift", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
     // expectedCiContexts is configured ONCE and never changes across the two calls below -- only branch protection
     // (the OTHER input to mergeRequiredCiContexts) drifts between them.
-    await upsertRepoFocusManifest(env, "owner/agent-repo", { gate: { expectedCiContexts: ["lint"] } });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" }, gate: { expectedCiContexts: ["lint"] } });
     let requiredContextsFromBranchProtection: Array<string | null> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -3187,9 +3208,9 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Spaced context drift", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
-    await upsertRepoFocusManifest(env, "owner/agent-repo", { gate: { expectedCiContexts: ["lint"] } });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" }, gate: { expectedCiContexts: ["lint"] } });
     let requiredContextsFromBranchProtection: Array<string | null> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -3232,7 +3253,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     // The live head drifted (b8 ≠ a7), so the resync upsert fires — but it REJECTS. The `.catch(() => undefined)`
     // must swallow it so the sweep proceeds on the stored `pr` rather than stalling (#sweep-resync fail-open).
@@ -3262,7 +3284,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 7, "a7"); // marker says current, but GitHub may still show a stale/partial panel
     let checkRunsFetched = false;
@@ -3287,7 +3310,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_REPOS: "owner/agent-repo" });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 7, "a7");
     let checkRunsFetched = false;
@@ -3365,7 +3389,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     // Links issue #1 — the issue the "labeled" event below fires on.
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1", created_at: "2026-07-03T10:00:00.000Z" });
     let fetchCount = 0;
@@ -3408,7 +3433,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_REPOS: "owner/agent-repo" });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     // Links issue #99 — the "labeled" event below fires on issue #1, which this PR does NOT link.
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Unrelated PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #99" });
     let checkRunsFetched = false;
@@ -3453,7 +3479,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1", created_at: "2026-07-03T10:00:00.000Z" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -3496,7 +3523,8 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
     // Every autonomy class left at the deny-by-default "observe" floor — isAgentConfigured is false, same as
     // isConvergenceRepoAllowed, so this repo has genuinely opted into nothing.
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { review: "observe" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { review: "observe" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -3565,7 +3593,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1", created_at: "2026-07-03T10:00:00.000Z" });
     // A CI completion for this exact PR claimed the CI-completion window moments earlier — a wholly separate
     // trigger from the issue-side label change below.
@@ -3617,7 +3646,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1", created_at: "2026-07-03T10:00:00.000Z" });
     let fetchCallCount = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -3677,7 +3707,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     for (let number = 1; number <= SWEEP_MAX_PRS + 2; number += 1) {
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number, title: `Linking PR ${number}`, state: "open", user: { login: "contributor" }, head: { sha: `a${number}` }, labels: [], body: "Closes #1" });
     }
@@ -3729,7 +3760,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     for (let number = 1; number <= ISSUE_WAKE_MAX_PRS + 2; number += 1) {
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number, title: `Linking PR ${number}`, state: "open", user: { login: "contributor" }, head: { sha: `a${number}` }, labels: [], body: "Closes #1" });
     }
@@ -3770,7 +3802,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     for (const number of [10, 11, 12]) {
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number, title: `Sibling PR ${number}`, state: "open", user: { login: "contributor" }, head: { sha: `sib${number}` }, labels: [], body: "No linked issue.", created_at: `2026-07-0${number - 9}T00:00:00.000Z` });
     }
@@ -3818,7 +3851,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     for (const number of [10, 11, 12]) {
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number, title: `Sibling PR ${number}`, state: "open", user: { login: "contributor" }, head: { sha: `sib${number}` }, labels: [], body: "No linked issue." });
     }
@@ -3861,7 +3895,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     for (let number = 1; number <= MERGE_WAKE_MAX_PRS + 2; number += 1) {
       await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number, title: `Sibling PR ${number}`, state: "open", user: { login: "contributor" }, head: { sha: `sib${number}` }, labels: [], body: "No linked issue." });
     }
@@ -3914,7 +3949,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -3976,7 +4012,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -4027,7 +4064,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Linking PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -4074,7 +4112,8 @@ describe("queue processors", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Rebased PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 7, "a7"); // published at the OLD head a7
     let checkRunsFetchedAtNewHead = false;
@@ -4104,7 +4143,8 @@ describe("queue processors", () => {
   it("#4 over-publish dedup: a failing surface-published stamp is swallowed (fail-open) — the publish still completes", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     const stampSpy = vi.spyOn(repositoriesModule, "markPullRequestSurfacePublished").mockRejectedValueOnce(new Error("D1 stamp failed"));
     let commentPosted = false;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -4144,7 +4184,8 @@ describe("queue processors", () => {
   it("REGRESSION (registry-never-synced lane fix): a contributor PR panel does not show the lane-unavailable hold when no registry snapshot has ever synced", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     let commentBody = "";
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -4207,7 +4248,8 @@ describe("queue processors", () => {
       ),
     );
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     let commentBody = "";
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -4259,7 +4301,8 @@ describe("queue processors", () => {
   it("#regate-churn: a failing markAiReviewPublished stamp is swallowed (fail-open) — the publish still completes", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     const markSpy = vi.spyOn(repositoriesModule, "markAiReviewPublished").mockRejectedValueOnce(new Error("D1 stamp failed"));
     let commentPosted = false;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -4308,16 +4351,24 @@ describe("queue processors", () => {
       );
       await upsertInstallation(env, { action: "created", installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "selected", permissions: {}, events: [] } });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+      // commentMode/publicSurface/checkRunMode are Batch-A fields (config-as-code migration, #6442) -- they no
+      // longer have a backing DB column, so they're pulled out of `overrides` here and threaded through the
+      // manifest overlay below instead of into the DB settings row.
+      const { commentMode: commentModeOverride, publicSurface: publicSurfaceOverride, checkRunMode: checkRunModeOverride, ...dbOverrides } = overrides;
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "all_prs",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         reviewCheckMode: "required",
         aiReviewMode: "block",
         gatePack: "oss-anti-slop",
-        ...overrides,
+        ...dbOverrides,
+      });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+        settings: {
+          commentMode: commentModeOverride ?? "all_prs",
+          publicSurface: publicSurfaceOverride ?? "off",
+          checkRunMode: checkRunModeOverride ?? "off",
+        },
       });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
     }
@@ -4335,7 +4386,7 @@ describe("queue processors", () => {
       // #one-shot-review-cadence: this test is about the non-cacheable-outcome cooldown specifically, not
       // cadence -- opt into continuous so the SAME unchanged-head assertions below exercise that mechanism in
       // isolation, unaffected by the one_shot default now suppressing repeat automatic passes for a different reason.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 60, title: "Quiet PR", state: "open", user: { login: "contributor" }, head: { sha: "a60" }, labels: [], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 60, status: "complete", reviewsSyncedAt: new Date().toISOString() });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -4695,7 +4746,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { skip_drafts: true } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { skip_drafts: true } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 68,
         title: "Draft feature",
@@ -4743,7 +4794,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { skip_drafts: true } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { skip_drafts: true } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 81,
         title: "Draft feature",
@@ -4804,10 +4855,7 @@ describe("queue processors", () => {
       await seedRegateChurnRepo(env);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "off",
-        publicSurface: "off",
         autoLabelEnabled: false,
-        checkRunMode: "enabled",
         reviewCheckMode: "required",
         linkedIssueGateMode: "block",
         requireLinkedIssue: true,
@@ -4815,6 +4863,7 @@ describe("queue processors", () => {
         agentDryRun: false,
       });
       await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+        settings: { commentMode: "off", publicSurface: "off", checkRunMode: "enabled" },
         review: {
           auto_review: { skip_drafts: true },
         },
@@ -4872,7 +4921,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { skip_labels: ["do-not-review"] } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { skip_labels: ["do-not-review"] } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 78,
         title: "Ready feature",
@@ -4918,7 +4967,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { skip_docs_only: true } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { skip_docs_only: true } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 79,
         title: "docs: update readme",
@@ -4967,7 +5016,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { max_added_lines: 1 } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { max_added_lines: 1 } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 80,
         title: "feat: large change",
@@ -5015,7 +5064,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { skip_drafts: true, ignore_authors: ["*[bot]"] } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { skip_drafts: true, ignore_authors: ["*[bot]"] } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 69,
         title: "Ready feature",
@@ -5065,14 +5114,12 @@ describe("queue processors", () => {
       await seedRegateChurnRepo(env);
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
-        commentMode: "all_prs",
-        publicSurface: "comment_only",
         autoLabelEnabled: false,
-        checkRunMode: "enabled",
         reviewCheckMode: "required",
         aiReviewMode: "block",
         gatePack: "oss-anti-slop",
       });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "enabled" } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 83,
         title: "Ready feature",
@@ -5129,6 +5176,7 @@ describe("queue processors", () => {
       });
       await seedRegateChurnRepo(env);
       await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+        settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" },
         review: { ai_model: { claude_model: "claude-haiku-4-5", claude_effort: "low", codex_model: "gpt-5.4-mini", codex_effort: "high" } },
       });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
@@ -5177,7 +5225,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env);
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { auto_pause_after_reviewed_commits: 2 } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { auto_pause_after_reviewed_commits: 2 } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 77,
         title: "Churny feature",
@@ -5234,7 +5282,7 @@ describe("queue processors", () => {
         AI_DAILY_NEURON_BUDGET: "100000",
       });
       await seedRegateChurnRepo(env, { publicSurface: "comment_and_label" });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { auto_pause_after_reviewed_commits: 1 } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "off" }, review: { auto_review: { auto_pause_after_reviewed_commits: 1 } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
         number: 78,
         title: "Stuck-open feature",
@@ -5708,7 +5756,7 @@ describe("queue processors", () => {
       await seedRegateChurnRepo(env);
       // #one-shot-review-cadence: isolate this test to the cooldown-vs-real-state-change mechanism it's actually
       // about (see the PR 60 test above for the identical rationale).
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "off", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 63, title: "Pushed PR", state: "open", user: { login: "contributor" }, head: { sha: "a63" }, labels: [], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 63, status: "complete", reviewsSyncedAt: new Date().toISOString() });
       let liveHeadSha = "a63";
@@ -5881,7 +5929,7 @@ describe("queue processors", () => {
       });
       await seedRegateChurnRepo(env, { publicSurface: "comment_and_label" });
       // #one-shot-review-cadence: isolate this test to the unchanged-head/label-repair mechanism it's about.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 70, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a70" }, labels: [], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 70, status: "complete", reviewsSyncedAt: new Date().toISOString() });
 
@@ -6023,7 +6071,7 @@ describe("queue processors", () => {
       });
       await seedRegateChurnRepo(env, { publicSurface: "comment_only" });
       // #one-shot-review-cadence: isolate this test to the real-code-change-triggers-fresh-review mechanism.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 72, title: "Evolving PR", state: "open", user: { login: "contributor" }, head: { sha: "a72" }, labels: [], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 72, status: "complete", reviewsSyncedAt: new Date().toISOString() });
 
@@ -6706,7 +6754,7 @@ describe("queue processors", () => {
           AI_DAILY_NEURON_BUDGET: "100000",
         });
         await seedRegateChurnRepo(env, { publicSurface: "comment_only" });
-        await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+        await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
         await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 95, title: "Continuous-mode PR", state: "open", user: { login: "contributor" }, head: { sha: "a95-v1" }, labels: [], body: "Closes #1" });
         await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 95, status: "complete", reviewsSyncedAt: new Date().toISOString() });
         await putCachedAiReview(env, "JSONbored/gittensory", 95, "a95-v1", "block", { notes: "Original review.", reviewerCount: 1 });
@@ -6927,7 +6975,7 @@ describe("queue processors", () => {
       // #one-shot-review-cadence: isolate this test to the owner-exemption-from-the-LABEL-freeze mechanism --
       // without this, a prior published review would ALSO be reused by the (correctly firing) one_shot default,
       // for an unrelated reason, masking whether the label-freeze exemption itself actually works.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 79, title: "Owner's held PR", state: "open", user: { login: "JSONbored" }, head: { sha: "a79-v1" }, labels: [{ name: "manual-review" }], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 79, status: "complete", reviewsSyncedAt: new Date().toISOString() });
       await putCachedAiReview(env, "JSONbored/gittensory", 79, "a79-v1", "block", { notes: "Original stale review.", reviewerCount: 1 });
@@ -6968,7 +7016,7 @@ describe("queue processors", () => {
       });
       await seedRegateChurnRepo(env, { publicSurface: "comment_only" });
       // #one-shot-review-cadence: isolate this test to the admin-exemption-from-the-LABEL-freeze mechanism.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 80, title: "Admin's held PR", state: "open", user: { login: "fleet-admin" }, head: { sha: "a80-v1" }, labels: [{ name: "manual-review" }], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 80, status: "complete", reviewsSyncedAt: new Date().toISOString() });
       await putCachedAiReview(env, "JSONbored/gittensory", 80, "a80-v1", "block", { notes: "Original stale review.", reviewerCount: 1 });
@@ -7010,7 +7058,7 @@ describe("queue processors", () => {
       // reReviewStoredPullRequest -- that skip would otherwise short-circuit before ever reaching the freeze
       // logic this test targets, so it's explicitly turned off here too.
       await seedRegateChurnRepo(env, { publicSurface: "comment_only", skipAutomationBotAuthors: "off" });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 81, title: "Bot's held PR", state: "open", user: { login: "dependabot[bot]" }, head: { sha: "a81-v1" }, labels: [{ name: "manual-review" }], body: "Closes #1" });
       await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 81, status: "complete", reviewsSyncedAt: new Date().toISOString() });
       await putCachedAiReview(env, "JSONbored/gittensory", 81, "a81-v1", "block", { notes: "Original stale review.", reviewerCount: 1 });
@@ -7051,7 +7099,7 @@ describe("queue processors", () => {
       // manualReviewLabel is config-as-code only (.loopover.yml), not a DB-backed repository setting.
       // #one-shot-review-cadence: also opts into continuous here so this test stays isolated to the
       // manualReviewLabel-disabled mechanism it's actually about.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { manualReviewLabel: null }, review: { auto_review: { cadence: "continuous" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { manualReviewLabel: null, commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" }, review: { auto_review: { cadence: "continuous" } } });
       // The PR carries the literal "manual-review" text as a label, but with the mechanism disabled repo-wide
       // there is no configured label to match against — the freeze must never engage on text alone.
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 76, title: "Held PR, mechanism disabled", state: "open", user: { login: "contributor" }, head: { sha: "a76" }, labels: [{ name: "manual-review" }], body: "Closes #1" });
@@ -7267,7 +7315,8 @@ describe("queue processors", () => {
     });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
-    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "block", gatePack: "oss-anti-slop", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "block", gatePack: "oss-anti-slop", reviewCheckMode: "required" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
     await upsertPullRequestFile(env, { repoFullName: "owner/agent-repo", pullNumber: 7, path: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const ok = value.length;" } });
     // Pre-seed the AI review for this exact head SHA + mode → the sweep's block-mode review must reuse it, not re-run.
@@ -7354,13 +7403,11 @@ describe("queue processors", () => {
     for (const t of [TENANT_A, TENANT_B]) {
       await upsertRepositorySettings(env, {
         repoFullName: t.repo,
-        commentMode: "all_prs",
-        publicSurface: "comment_only",
         autoLabelEnabled: false,
-        checkRunMode: "off",
         reviewCheckMode: "disabled",
         aiReviewMode: "off",
       });
+      await upsertRepoFocusManifest(env, t.repo, { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     }
 
     const postedComments: Record<string, { body: string; authorization: string }[]> = {


### PR DESCRIPTION
## Summary

Part of the Batch A config-as-code migration (#6442, epic #6440): moves the applicable Batch A fields off DB-backed \`upsertRepositorySettings()\` test fixture calls onto \`upsertRepoFocusManifest()\` manifest injection in \`test/unit/queue.test.ts\` (58 call sites) and \`test/unit/queue-5.test.ts\` (55 call sites). \`resolveEffectiveSettings\` already overlays manifest settings over DB settings unconditionally, so this is a pure plumbing move -- identical resolved test behavior, verified per-test.

Also removes now-redundant \`LOOPOVER_DRIFT_ISSUE_REPO\` overrides that #6493's root-cause fix made obsolete, and corrects two stale comments that referenced that same removed workaround.

## Scope
- [x] Test-only change, two files
- [x] No production code changed

## Validation
- [x] \`npx vitest run test/unit/queue.test.ts test/unit/queue-5.test.ts\` -- 358/358 passed