### PR TITLE
refactor(test): move remaining Batch A fields to manifest injection

### DIFF
--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2173,10 +2173,10 @@ describe("api routes", () => {
     vi.stubGlobal("fetch", async () => new Response("Not Found", { status: 404 }));
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "all_prs",
-      publicSurface: "comment_and_label",
       autoLabelEnabled: true,
-      checkRunMode: "off",
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "off" },
     });
     await upsertInstallationHealth(env, {
       installationId: 777,
@@ -2220,7 +2220,12 @@ describe("api routes", () => {
     expect(repairBody.eventDiagnostics).toEqual(expect.arrayContaining([expect.objectContaining({ event: "issue_comment", missing: true })]));
     expect(JSON.stringify(repairBody)).not.toMatch(/wallet|hotkey|raw trust score|payout|reward estimate|farming|private reviewability|public score estimate|github_pat|private key/i);
 
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", checkRunMode: "enabled" });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory" });
+    // Re-persist the manifest snapshot (it replaces, not merges) carrying forward the unchanged
+    // commentMode/publicSurface fields alongside the updated checkRunMode.
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "enabled" },
+    });
     await upsertInstallationHealth(env, {
       installationId: 777,
       accountLogin: "JSONbored",

--- a/test/integration/public-quality-metrics-route-error.test.ts
+++ b/test/integration/public-quality-metrics-route-error.test.ts
@@ -13,6 +13,12 @@ describe("GET /v1/public/repos/:owner/:repo/quality — error path", () => {
   it("returns 503 when quality metrics computation throws", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "quality", full_name: "acme/quality", private: false, owner: { login: "acme" }, default_branch: "main" }, 560);
+    // NOTE: publicQualityMetrics intentionally stays DB-backed here (not moved to the focus manifest)
+    // because the route under test (`loadPublicRepoQualityMetrics` in src/api/routes.ts) reads
+    // `getRepositorySettings` directly -- the same deliberate raw-DB-row bypass documented on the sibling
+    // `loadPublicRepoBadge` helper -- and never consults `resolveRepositorySettings`/the manifest overlay.
+    // Moving this field to `upsertRepoFocusManifest` would make the route see publicQualityMetrics=false
+    // (404) instead of true (503 via the mocked throw), which is a real behavior difference, not a wiring bug.
     await upsertRepositorySettings(env, { repoFullName: "acme/quality", publicQualityMetrics: true });
 
     const res = await createApp().request("/v1/public/repos/acme/quality/quality", {}, env);

--- a/test/unit/actions-fallback-webhook.test.ts
+++ b/test/unit/actions-fallback-webhook.test.ts
@@ -12,6 +12,7 @@ import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import { clearGitHubResponseCacheForTest } from "../../src/github/client";
 import { fallbackShotR2Key, FALLBACK_ARTIFACT_NAME, isFallbackDispatchInFlight, markFallbackDispatched } from "../../src/review/visual/actions-fallback";
 import { processJob } from "../../src/queue/processors";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 // Mirrors test/unit/queue.test.ts's own generatePrivateKeyPem helper -- createInstallationToken mints a real
@@ -115,9 +116,9 @@ async function seedRepoAndPr(env: ReturnType<typeof createTestEnv>, headSha: str
     autonomy: { merge: "observe", update_branch: "observe" },
     aiReviewMode: "off",
     gatePack: "oss-anti-slop",
-    checkRunMode: "off",
-    commentMode: "off",
-    publicSurface: "off",
+  });
+  await upsertRepoFocusManifest(env, "owner/fallback-repo", {
+    settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" },
   });
   await upsertPullRequestFromGitHub(env, "owner/fallback-repo", {
     number: 55,

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -62,6 +62,7 @@ import {
 } from "../../src/github/client";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createTestEnv } from "../helpers/d1";
 
@@ -725,7 +726,7 @@ describe("GitHub backfill", () => {
     });
 
     it("REGRESSION: broker-mode refresh replaces stale local permissions with the broker token permission snapshot", async () => {
-      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" });
       await upsertInstallation(env, {
         installation: {
           id: 912,
@@ -994,7 +995,7 @@ describe("GitHub backfill", () => {
   });
 
   it("requires Checks write only for repos with check runs enabled", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1008,8 +1009,8 @@ describe("GitHub backfill", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      checkRunMode: "enabled",
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { checkRunMode: "enabled" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.endsWith("/app/installations/123")) {
@@ -1043,7 +1044,7 @@ describe("GitHub backfill", () => {
     // the separate reviewCheckMode axis ("LoopOver Orb Review Agent" check) entirely -- so an installation
     // whose repos only ever published the review-agent check (true for JSONbored's own 3 production repos,
     // none of which set checkRunMode) was never flagged as needing the Checks permission.
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1088,7 +1089,7 @@ describe("GitHub backfill", () => {
   });
 
   it("REGRESSION (#audit-install-health): an acting autonomy requires pull_requests:write, so read-only is needs_attention not healthy", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1131,7 +1132,7 @@ describe("GitHub backfill", () => {
   });
 
   it("REGRESSION: merge autonomy requires contents:write, so contents:read is needs_attention before merge 403s", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedRegisteredRepo(env);
     await upsertInstallation(env, {
       installation: {
@@ -1177,10 +1178,10 @@ describe("GitHub backfill", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
     });
     // Without this, the manifest resolver's live (unmocked) GitHub fetch for "JSONbored/gittensory"'s
     // .loopover.yml actually succeeds -- GitHub's repo-rename redirect resolves it to this same repo's
@@ -1288,17 +1289,17 @@ describe("GitHub backfill", () => {
     await upsertRepositoryFromGitHub(env, { name: "labels", full_name: "JSONbored/labels", private: true, owner: { login: "JSONbored" } }, 124);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/comments",
-      commentMode: "detected_contributors_only",
-      publicSurface: "comment_only",
       autoLabelEnabled: false,
-      checkRunMode: "off",
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/comments", {
+      settings: { commentMode: "detected_contributors_only", publicSurface: "comment_only", checkRunMode: "off" },
     });
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/labels",
-      commentMode: "off",
-      publicSurface: "label_only",
       autoLabelEnabled: true,
-      checkRunMode: "off",
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/labels", {
+      settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" },
     });
 
     const repair = await buildInstallationRepairDiagnostics(env, {
@@ -1423,11 +1424,9 @@ describe("GitHub backfill", () => {
     await seedInstalledAndRegisteredRepo(env);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSignalLevel: "standard",
-      checkRunMode: "enabled",
-      checkRunDetailLevel: "standard",
-      backfillEnabled: false,
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "off", publicSignalLevel: "standard", checkRunMode: "enabled", checkRunDetailLevel: "standard", backfillEnabled: false },
     });
 
     const result = await backfillRegisteredRepositories(env);
@@ -3503,11 +3502,9 @@ describe("GitHub backfill", () => {
     await seedRegisteredRepo(env);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSignalLevel: "standard",
-      checkRunMode: "enabled",
-      checkRunDetailLevel: "standard",
-      backfillEnabled: false,
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "off", publicSignalLevel: "standard", checkRunMode: "enabled", checkRunDetailLevel: "standard", backfillEnabled: false },
     });
 
     await expect(enqueueRepositoryOpenDataBackfill(env, { repoFullName: "missing/repo", requestedBy: "api" })).resolves.toMatchObject({ status: "skipped" });
@@ -3515,11 +3512,9 @@ describe("GitHub backfill", () => {
 
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "off",
-      publicSignalLevel: "standard",
-      checkRunMode: "enabled",
-      checkRunDetailLevel: "standard",
-      backfillEnabled: true,
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "off", publicSignalLevel: "standard", checkRunMode: "enabled", checkRunDetailLevel: "standard", backfillEnabled: true },
     });
     await upsertRepoSyncSegment(env, {
       repoFullName: "JSONbored/gittensory",
@@ -4609,7 +4604,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   }
 
   it("returns fetch_error without ever calling fetch when no token is available", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
     const result = await fetchLinkedIssueClosedByPullRequest(env, "owner/repo", 100, 200, undefined);
@@ -4618,7 +4613,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns fetch_error without ever calling fetch for a malformed repoFullName (no owner/name split)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
     expect(await fetchLinkedIssueClosedByPullRequest(env, "", 100, 200, "test-token")).toBe("fetch_error");
@@ -4627,7 +4622,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns fetch_error when GraphQL responds 200 OK with a top-level errors array (GitHub's REAL response shape for an unresolvable issue number, confirmed via gh api graphql)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql"
         ? Response.json({ data: { repository: { issue: null } }, errors: [{ type: "NOT_FOUND", message: "Could not resolve to an issue." }] })
@@ -4638,7 +4633,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns fetch_error when timelineItems.nodes is missing/non-array (malformed response, no top-level errors)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql"
         ? Response.json({ data: { repository: { issue: { timelineItems: {} } } } })
@@ -4649,7 +4644,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns fetch_error when the GraphQL request itself throws (network failure)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async () => {
       throw new Error("network down");
     });
@@ -4658,7 +4653,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns closed_by_pull_request when the closer is a matching PullRequest", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql" ? Response.json(closerBody({ typename: "PullRequest", number: 200 })) : new Response("not found", { status: 404 }),
     );
@@ -4666,7 +4661,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns not_closed_by_pull_request when the closer is a DIFFERENT PullRequest (anti-spoofing)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql" ? Response.json(closerBody({ typename: "PullRequest", number: 999 })) : new Response("not found", { status: 404 }),
     );
@@ -4674,7 +4669,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns not_closed_by_pull_request when the issue was closed manually with no closer at all (confirmed live shape via gh api graphql against JSONbored/gittensory#5130: closer: null)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql"
         ? Response.json({ data: { repository: { issue: { timelineItems: { nodes: [{ __typename: "ClosedEvent", closer: null }] } } } } })
@@ -4684,7 +4679,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns not_closed_by_pull_request when the closer is a Commit, not a PullRequest (issue closed via a commit message reference)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql" ? Response.json(closerBody({ typename: "Commit" })) : new Response("not found", { status: 404 }),
     );
@@ -4692,7 +4687,7 @@ describe("fetchLinkedIssueClosedByPullRequest (#5385)", () => {
   });
 
   it("returns not_closed_by_pull_request when there is no CLOSED_EVENT at all (nodes is an empty array)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
       input.toString() === "https://api.github.com/graphql" ? Response.json(closerBody(null)) : new Response("not found", { status: 404 }),
     );

--- a/test/unit/ci-completion-fork-resume.test.ts
+++ b/test/unit/ci-completion-fork-resume.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ciCompletionHeadSha, processJob, resolveCiCompletionPrNumbers } from "../../src/queue/processors";
 import { upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 import type { GitHubWebhookPayload, JobMessage } from "../../src/types";
 
@@ -47,7 +48,8 @@ async function seedForkResumeRepo(env: ReturnType<typeof createTestEnv>, repo: s
   await upsertRepositoryFromGitHub(env, { name: repo.split("/")[1] ?? "repo", full_name: repo, private: false, owner: { login: owner ?? "owner" } }, 5001);
   // publicSurface/check/gate all OFF + no autonomy → reReviewStoredPullRequest is a clean no-op (no network),
   // so the test isolates resolution + coalesce + audit, exactly the head-SHA fix surface.
-  await upsertRepositorySettings(env, { repoFullName: repo, publicSurface: "off", checkRunMode: "off", autonomy: {} });
+  await upsertRepositorySettings(env, { repoFullName: repo, autonomy: {} });
+  await upsertRepoFocusManifest(env, repo, { settings: { publicSurface: "off", checkRunMode: "off" } });
   await upsertPullRequestFromGitHub(env, repo, { number: prNumber, title: "Fork PR", state: "open", user: { login: "outside-contributor" }, head: { sha: headSha }, labels: [], body: "fork change" });
 }
 
@@ -69,7 +71,7 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
   });
 
   it("(a) same-repo: populated pull_requests[] is returned verbatim, no head-SHA fallback", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     // A throwing fetch proves the populated path never touches GitHub.
     vi.stubGlobal("fetch", async () => {
       throw new Error("fetch must not be called for the same-repo populated path");
@@ -80,7 +82,7 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
   });
 
   it("(b) fork: empty pull_requests[] → a stored open PR matching the head SHA is resolved (DB fast path)", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
     // A throwing fetch proves the DB fast path resolves without the live commits/pulls call.
     vi.stubGlobal("fetch", async () => {
@@ -118,7 +120,7 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
   });
 
   it("(c2) empty head SHA short-circuits to empty without any lookup", async () => {
-    const env = createTestEnv({});
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async () => {
       throw new Error("fetch must not be called for an empty head SHA");
     });
@@ -130,7 +132,6 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
     const sent: JobMessage[] = [];
     const env = createTestEnv({
       JOBS: { async send(message: JobMessage) { sent.push(message); } } as unknown as Queue,
-      LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo",
     });
     await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
     vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
@@ -185,7 +186,7 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
   });
 
   it("dispatch: a SAME-REPO check_suite (populated pull_requests[]) re-reviews WITHOUT the fork-resume audit", async () => {
-    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv();
     await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
     vi.stubGlobal("fetch", async () => {
       throw new Error("fetch must not be called for the populated same-repo path");

--- a/test/unit/linked-issue-satisfaction-run.test.ts
+++ b/test/unit/linked-issue-satisfaction-run.test.ts
@@ -15,6 +15,7 @@ import { linkedIssueSatisfactionCacheInputFingerprint } from "../../src/review/l
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import type { Advisory, PullRequestFileRecord, RepositorySettings } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
@@ -795,16 +796,16 @@ describe("linked-issue satisfaction wired end-to-end through the real webhook pi
     await upsertRepositoryFromGitHub(env, { name: "metagraphed", full_name: "JSONbored/metagraphed", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/metagraphed",
-      commentMode: "all_prs",
-      publicSurface: "comment_only",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       gatePack: "oss-anti-slop",
       linkedIssueGateMode: "off",
       // The gate under test: off by default, opted into "block" here so an above-floor "unaddressed" verdict
       // becomes a real Gate-check failure -- the exact gap #3906 filed against.
       linkedIssueSatisfactionGateMode: "block",
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/metagraphed", {
+      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
     });
 
     let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
@@ -885,15 +886,15 @@ describe("linked-issue satisfaction wired end-to-end through the real webhook pi
     await upsertRepositoryFromGitHub(env, { name: "metagraphed", full_name: "JSONbored/metagraphed", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/metagraphed",
-      commentMode: "all_prs",
-      publicSurface: "comment_only",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       gatePack: "oss-anti-slop",
       linkedIssueGateMode: "off",
       // No override -- linkedIssueSatisfactionGateMode is omitted, so upsertRepositorySettings persists its
       // default "off".
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/metagraphed", {
+      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
     });
 
     let postedCommentBody = "";
@@ -951,13 +952,13 @@ describe("linked-issue satisfaction wired end-to-end through the real webhook pi
     await upsertRepositoryFromGitHub(env, { name: "metagraphed", full_name: "JSONbored/metagraphed", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/metagraphed",
-      commentMode: "off",
-      publicSurface: "off",
       autoLabelEnabled: false,
-      checkRunMode: "off",
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       linkedIssueSatisfactionGateMode: "advisory",
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/metagraphed", {
+      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
     });
 
     let gatePatchBody: { conclusion?: string } = {};

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -384,16 +384,13 @@ async function seedGateEnabledRepo(env: Env): Promise<void> {
   await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
   await upsertRepositorySettings(env, {
     repoFullName: "JSONbored/gittensory",
-    commentMode: "off",
-    publicSurface: "off",
     autoLabelEnabled: false,
-    checkRunMode: "off",
     reviewCheckMode: "required",
     linkedIssueGateMode: "block",
     requireLinkedIssue: true,
   });
   // .loopover.yml authoritatively sets the linked-issue blocker to "block" (config-as-code).
-  await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" } });
+  await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
 }
 
 // The miner-list/token/check-run endpoints the gate finalize touches; `confirmedAuthor` toggles whether the

--- a/test/unit/repo-profile.test.ts
+++ b/test/unit/repo-profile.test.ts
@@ -249,9 +249,9 @@ describe("extractRepoProfile (#2999)", () => {
     await seedChunk(env, "src/widget.ts", "x");
     await upsertRepositorySettings(env, {
       repoFullName: REPO,
-      checkRunMode: "off",
       reviewCheckMode: "required",
     });
+    await upsertRepoFocusManifest(env, REPO, { settings: { checkRunMode: "off" } });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(true);
@@ -266,9 +266,9 @@ describe("extractRepoProfile (#2999)", () => {
     // gate.checkMode still gets reported as publishing one.
     await upsertRepositorySettings(env, {
       repoFullName: REPO,
-      checkRunMode: "enabled",
       reviewCheckMode: "disabled",
     });
+    await upsertRepoFocusManifest(env, REPO, { settings: { checkRunMode: "enabled" } });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(false);

--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -472,7 +472,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
   it("FLAG-ON: a closed+merged PR webhook records a 'merged' outcome for the submitter", async () => {
     const { processJob } = await import("../../src/queue/processors");
     const { upsertRepositorySettings } = await import("../../src/db/repositories");
-    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
     // Gate enabled so the closing-PR public-surface path (skipped-gate + unified closed comment) executes.
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory" });
     // External calls (token/miner/github) are best-effort + caught; stub them so nothing throws.
@@ -514,7 +514,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
 
   it("FLAG-ON: a closed PR with no author login records against a null submitter (authorLogin ?? null)", async () => {
     const { processJob } = await import("../../src/queue/processors");
-    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -547,7 +547,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
     const { processJob } = await import("../../src/queue/processors");
     // Flag unset → `isReputationEnabled(env) ? … : undefined` is undefined → the `if (reputationOutcome)`
     // body never runs → submitter_stats stays empty (byte-identical to today).
-    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" }); // LOOPOVER_REVIEW_REPUTATION unset → OFF
+    const env = createTestEnv(); // LOOPOVER_REVIEW_REPUTATION unset → OFF
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -577,9 +577,10 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
     const { processJob } = await import("../../src/queue/processors");
     const { upsertRepositorySettings } = await import("../../src/db/repositories");
     // Reputation ON, but the PR is still OPEN and the gate does not route it to manual → undefined outcome.
-    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true", LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
     // Gate OFF for this repo so the open PR's gate is `undefined` (not failure/action_required) → no "manual".
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", publicSurface: "off", commentMode: "off" });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });

--- a/test/unit/safety.test.ts
+++ b/test/unit/safety.test.ts
@@ -9,6 +9,7 @@ import {
   upsertRepositoryFromGitHub,
   upsertRepositorySettings,
 } from "../../src/db/repositories";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 // Drives the LOOPOVER_REVIEW_SAFETY secrets-scan WIRING through the live review finalize path
@@ -63,13 +64,11 @@ async function seedGateEnabledRepo(env: Env): Promise<void> {
   await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
   await upsertRepositorySettings(env, {
     repoFullName: "JSONbored/gittensory",
-    commentMode: "off",
-    publicSurface: "off",
     autoLabelEnabled: false,
-    checkRunMode: "off",
     reviewCheckMode: "required",
     slopGateMode: "advisory", // turns the shared gateFiles load on so the reuse branch is hit
   });
+  await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
   await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: safetyMinerSnapshot("contributor") }, 60_000);
 }
 
@@ -117,7 +116,7 @@ function prWebhook(deliveryId: string) {
 
 describe("LOOPOVER_REVIEW_SAFETY secrets-scan wired into the review FINALIZE path (processors.ts call site)", () => {
   it("FLAG-ON: a leaked secret in the PR's changed files FAILS the finalized gate (secret_leak blocker appended before evaluateGateCheck)", async () => {
-    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};
@@ -132,7 +131,7 @@ describe("LOOPOVER_REVIEW_SAFETY secrets-scan wired into the review FINALIZE pat
   });
 
   it("FLAG-OFF: a leaked secret STILL fails the gate — the concrete-credential block is unconditional (#audit-3.4)", async () => {
-    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "false", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv({ LOOPOVER_REVIEW_SAFETY: "false", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};
@@ -148,7 +147,7 @@ describe("LOOPOVER_REVIEW_SAFETY secrets-scan wired into the review FINALIZE pat
   });
 
   it("UNSET (default): a leaked secret also fails the gate — the secret-leak block does not depend on the flag", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" }); // LOOPOVER_REVIEW_SAFETY unset
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() }); // LOOPOVER_REVIEW_SAFETY unset
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};


### PR DESCRIPTION
## Summary

Part of the Batch A config-as-code migration (#6442, epic #6440): moves the applicable Batch A fields off DB-backed \`upsertRepositorySettings()\` test fixture calls onto \`upsertRepoFocusManifest()\` manifest injection across the 10 remaining Batch A files (\`backfill.test.ts\`, \`api.test.ts\`, \`public-quality-metrics-route-error.test.ts\`, \`ci-completion-fork-resume.test.ts\`, \`safety.test.ts\`, \`reputation-wiring.test.ts\`, \`parity-wire.test.ts\`, \`linked-issue-satisfaction-run.test.ts\`, \`repo-profile.test.ts\`, \`actions-fallback-webhook.test.ts\`). \`resolveEffectiveSettings\` already overlays manifest settings over DB settings unconditionally, so this is a pure plumbing move -- identical resolved test behavior, verified per-test.

**Deliberately left DB-backed:** \`badgeEnabled\`/\`publicQualityMetrics\` in the specific tests exercising \`loadPublicRepoBadge\`/\`loadPublicRepoQualityMetrics\` (\`src/api/routes.ts\`) -- those two routes read \`getRepositorySettings\` directly and bypass the manifest overlay entirely, a deliberate perf tradeoff for unauthenticated, high-frequency public routes. Moving those two fields to manifest-only would silently change what those specific tests exercise.

Also removes now-redundant \`LOOPOVER_DRIFT_ISSUE_REPO\` overrides that #6493's root-cause fix made obsolete.

## Scope
- [x] Test-only change, 10 files
- [x] No production code changed

## Validation
- [x] All 10 files run together -- 349/349 passed