### PR TITLE
chore(test): remove now-redundant self-repo-bleed workaround overrides

### DIFF
--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -1045,7 +1045,7 @@ describe("runSelfTuneBreaker — miner-scoped breaker (#2352)", () => {
 
 describe("processJob(github-webhook) wires pr_outcome recording on a PR close", () => {
   it("a closed+merged pull_request webhook records the pr_outcome ground truth", async () => {
-    const env = createTestEnv({ LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo" });
+    const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens"))

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -1015,7 +1015,6 @@ describe("merged-PR incremental re-index trigger (webhook)", () => {
     const env = createTestEnv({
       LOOPOVER_REVIEW_RAG: over.rag ?? "true",
       LOOPOVER_REVIEW_REPOS: over.repos ?? "JSONbored/gittensory",
-      LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo",
       JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
     });
     await registerRepo(env, "JSONbored/gittensory");


### PR DESCRIPTION
## Summary

#6493 fixed the root cause of the self-repo manifest bleed (\`createTestEnv()\`'s default no longer matches any real fixture repo name), which made the earlier per-test \`LOOPOVER_DRIFT_ISSUE_REPO: "unrelated-org/unrelated-repo"\` workaround in \`test/unit/outcomes-wire.test.ts\` and \`test/unit/rag-index.test.ts\` redundant. These two files aren't part of the Batch A config-as-code migration, just carried the same now-obsolete workaround from an earlier fix.

## Scope
- [x] Test-only change, two files
- [x] No production code changed

## Validation
- [x] \`npx vitest run test/unit/outcomes-wire.test.ts test/unit/rag-index.test.ts\` -- 106/106 passed