### PR TITLE
feat(miner-ui): active-route nav highlighting + fix stale tab title

### DIFF
--- a/apps/loopover-miner-ui/index.html
+++ b/apps/loopover-miner-ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gittensory Miner</title>
+    <title>LoopOver Miner</title>
     <script>
       // No-flash theme (#6508): restore the persisted theme before the app bundle loads so there is no flash
       // of the wrong palette. An unset value — or anything other than "light" — defaults to dark, matching the

--- a/apps/loopover-miner-ui/src/routes/__root.tsx
+++ b/apps/loopover-miner-ui/src/routes/__root.tsx
@@ -16,16 +16,33 @@ function RootLayout() {
             <h1 className="text-token-lg font-display font-semibold">Local dashboard</h1>
           </div>
           <nav className="flex gap-4 text-token-sm text-muted-foreground">
-            <Link to="/" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/"
+              activeOptions={{ exact: true }}
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+            >
               Overview
             </Link>
-            <Link to="/run-history" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/run-history"
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+            >
               Run history
             </Link>
-            <Link to="/portfolio" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/portfolio"
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+            >
               Portfolio
             </Link>
-            <Link to="/ledgers" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/ledgers"
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+            >
               Ledgers
             </Link>
           </nav>


### PR DESCRIPTION
## Summary

The four header nav links in `apps/loopover-miner-ui/src/routes/__root.tsx` (Overview / Run history / Portfolio / Ledgers) had **no active-route indication** — every route looked nav-identical. And `index.html`'s `<title>` still read the pre-rename `Gittensory Miner`.

## Changes (only `__root.tsx` + `index.html`; `theme.css` and layout untouched)

- Each nav `<Link>` gets TanStack Router `activeProps` → the current route's link renders in the existing `--primary` token (`font-medium`) and carries `aria-current="page"`. Overview uses `activeOptions={{ exact: true }}` so it isn't active on every sub-route. No new colors/tokens.
- `index.html` `<title>`: `Gittensory Miner` → `LoopOver Miner`.

## Verification

Ran live against the app (playwright), one shot per route — the matching link highlights + carries `aria-current="page"`, the others stay muted, and the tab title reads **LoopOver Miner** on all four:

| route | active nav | `document.title` |
|---|---|---|
| `/` | Overview | LoopOver Miner |
| `/run-history` | Run history | LoopOver Miner |
| `/portfolio` | Portfolio | LoopOver Miner |
| `/ledgers` | Ledgers | LoopOver Miner |

**`/` (Overview active)**
![overview](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6507-screenshots/.pr-screenshots/overview.png)

**`/run-history` (Run history active)**
![run-history](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6507-screenshots/.pr-screenshots/run-history.png)

**`/portfolio` (Portfolio active)**
![portfolio](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6507-screenshots/.pr-screenshots/portfolio.png)

**`/ledgers` (Ledgers active)**
![ledgers](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6507-screenshots/.pr-screenshots/ledgers.png)

<sub>Screenshots are hosted on a separate `pr-6507-screenshots` branch (evidence only) so this PR's diff stays limited to the two files the issue scopes. `apps/loopover-miner-ui/**` is outside Codecov `coverage.include`, so verification here is visual per house convention; the existing route tests render page components in isolation (no full-router harness), so no new router-mount test was introduced per the issue's guidance. Local gate: `@loopover/ui-miner` typecheck + 137 tests + eslint (0 errors) green.</sub>

Closes #6507