### PR TITLE
feat(miner-ui): active-route nav highlighting + fix stale page title (#6507)

### DIFF
--- a/apps/loopover-miner-ui/index.html
+++ b/apps/loopover-miner-ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gittensory Miner</title>
+    <title>LoopOver Miner</title>
     <script>
       // No-flash theme (#6508): restore the persisted theme before the app bundle loads so there is no flash
       // of the wrong palette. An unset value — or anything other than "light" — defaults to dark, matching the

--- a/apps/loopover-miner-ui/src/routes/__root.tsx
+++ b/apps/loopover-miner-ui/src/routes/__root.tsx
@@ -16,16 +16,37 @@ function RootLayout() {
             <h1 className="text-token-lg font-display font-semibold">Local dashboard</h1>
           </div>
           <nav className="flex gap-4 text-token-sm text-muted-foreground">
-            <Link to="/" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            {/* Active-route styling + aria-current via TanStack Router's activeProps (#6507): the current
+                route's link reads as `text-primary` (the same token the "LoopOver Miner" kicker uses), so
+                "where am I" is both visible and exposed to assistive tech. `/` needs exact matching or it would
+                stay active on every nested route. No new colors -- only existing @loopover/ui-kit tokens. */}
+            <Link
+              to="/"
+              activeOptions={{ exact: true }}
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+            >
               Overview
             </Link>
-            <Link to="/run-history" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/run-history"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+            >
               Run history
             </Link>
-            <Link to="/portfolio" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/portfolio"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+            >
               Portfolio
             </Link>
-            <Link to="/ledgers" className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground">
+            <Link
+              to="/ledgers"
+              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
+              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+            >
               Ledgers
             </Link>
           </nav>


### PR DESCRIPTION
## Summary

- `apps/loopover-miner-ui/src/routes/__root.tsx`'s four header nav links (Overview / Run history / Portfolio / Ledgers) had no active-route styling or `aria-current` — every route looked nav-identical, with no "where am I" cue. Added active styling + `aria-current="page"` via TanStack Router's `activeProps`: the current route's link renders as `text-primary` (the same `@loopover/ui-kit` token the "LoopOver Miner" kicker uses — no new colors). The Overview (`/`) link uses `activeOptions={{ exact: true }}` so it isn't perpetually active on nested routes.
- `apps/loopover-miner-ui/index.html`'s `<title>` still read `Gittensory Miner` (a pre-rename leftover); corrected to `LoopOver Miner`.
- Scoped exactly as the issue requires: no change to `__root.tsx`'s `<main>`/`<Outlet/>` layout, no new wrapper/mount point, no chat-rail stub, no touch of `apps/loopover-ui/**` (the other app), no route/fetcher/page-content changes.

Closes #6507

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (miner-ui header active-nav + page title only).
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6507`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (repo-wide) clean — validates the `activeProps`/`activeOptions` typing.
- [x] `@loopover/ui-miner` workspace: `tsc --noEmit` clean, `vitest run` green (137 tests) — no existing test renders `RootLayout`/the header (the app has no root-layout/router test harness today), so per the issue's guidance I did not introduce a new harness purely for this change; the required verification is the screenshot evidence below (one per route + the corrected title).
- [x] `npm run test:ci` (validates the rest of the repo is unaffected — `apps/**` is excluded from the root coverage suite by design, so `codecov/patch` does not gate this PR).
- [x] `npm audit --audit-level=moderate`
- [x] Drove the built app in a real browser (Vite preview + Playwright): each route shows exactly one nav link with `aria-current="page"` and the primary-token active style; the browser tab title reads "LoopOver Miner".

If any required check was skipped, explain why:

- No OpenAPI/`cf-typegen`/migration/env-reference regeneration needed — a restyle + one-line title change with no API/binding/schema surface.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP surface changed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the header is static chrome; the active state derives from the live router location, not mock data.
- [x] Visible UI changes include a `UI Evidence` section below with captioned PNG thumbnails.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

Active nav link (`text-primary` + `aria-current="page"`) per route; the corrected "LoopOver Miner" title is visible in each shot's origin (browser tab), and every screenshot's active link matches its route.

| Route | Active-nav evidence |
| --- | --- |
| `/` — Overview active | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-overview.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-overview.png" alt="Overview nav link active on the / route" width="240"></a> |
| `/run-history` — Run history active | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-run-history.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-run-history.png" alt="Run history nav link active on the /run-history route" width="240"></a> |
| `/portfolio` — Portfolio active | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-portfolio.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-portfolio.png" alt="Portfolio nav link active on the /portfolio route" width="240"></a> |
| `/ledgers` — Ledgers active | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-ledgers.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/pr6507-ledgers.png" alt="Ledgers nav link active on the /ledgers route" width="240"></a> |

## Notes

- Active styling and `aria-current` both come from TanStack Router's `activeProps`, so the visual and the assistive-tech semantics can never drift apart. Only existing `@loopover/ui-kit` tokens are used — no new hex/oklch values.
