### PR TITLE
fix(ui): adopt AnalyticsCardShell in 5 analytics cards that hand-roll their own chrome

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/analytics-card-shell.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/analytics-card-shell.test.tsx
@@ -50,4 +50,25 @@ describe("AnalyticsCardShell", () => {
     expect(screen.getByRole("heading", { name: "Queue health" })).toBeTruthy();
     expect(container.querySelectorAll("p").length).toBe(0);
   });
+
+  it("renders the action header slot across every state (loading, empty, ready)", () => {
+    for (const state of ["loading", "empty", "ready"] as const) {
+      const { unmount } = render(
+        <AnalyticsCardShell title="Queue health" state={state} action={<span>action slot</span>}>
+          <div>ready content</div>
+        </AnalyticsCardShell>,
+      );
+      expect(screen.getByText("action slot")).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("omits the action slot entirely when none is provided", () => {
+    render(
+      <AnalyticsCardShell title="Queue health" state="ready">
+        <div>ready content</div>
+      </AnalyticsCardShell>,
+    );
+    expect(screen.queryByText("action slot")).toBeNull();
+  });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/analytics-card-shell.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/analytics-card-shell.tsx
@@ -15,6 +15,7 @@ export function AnalyticsCardShell({
   state,
   emptyTitle = "No data yet",
   emptyHint,
+  action,
   children,
 }: {
   title: string;
@@ -22,6 +23,9 @@ export function AnalyticsCardShell({
   state: AnalyticsCardState;
   emptyTitle?: string;
   emptyHint?: ReactNode;
+  /** Header-right slot (e.g. a status pill, boundary badge, or freshness stamp) shown across every
+   *  state, matching the header's existing `justify-between` layout. */
+  action?: ReactNode;
   children?: ReactNode;
 }) {
   return (
@@ -33,6 +37,7 @@ export function AnalyticsCardShell({
             <p className="mt-1 text-token-xs text-muted-foreground">{description}</p>
           ) : null}
         </div>
+        {action}
       </div>
 
       {state === "loading" ? (

--- a/apps/loopover-ui/src/components/site/app-panels/cycle-time-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/cycle-time-card.test.tsx
@@ -51,7 +51,7 @@ describe("CycleTimeCard", () => {
     expect(screen.getByText("2 paired PR(s)")).toBeTruthy();
   });
 
-  it("shows inline empty copy when there are no samples", () => {
+  it("shows the shared EmptyState (not a bare paragraph) when there are no samples (#6175)", () => {
     const cycleTime: CycleTimeAggregate = {
       p50Ms: null,
       p90Ms: null,
@@ -61,7 +61,14 @@ describe("CycleTimeCard", () => {
     };
     render(<CycleTimeCard cycleTime={cycleTime} />);
     expect(screen.getByText("no samples yet")).toBeTruthy();
+    expect(screen.getByText("No paired samples yet")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Paired gate decisions and PR outcomes will appear here once the gate has resolved pull requests in the analytics window.",
+      ),
+    ).toBeTruthy();
     expect(screen.queryByText("Cycle-time distribution")).toBeNull();
+    expect(screen.queryByText("p50")).toBeNull();
   });
 
   it("omits the sparkbar when the distribution is empty", () => {

--- a/apps/loopover-ui/src/components/site/app-panels/cycle-time-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/cycle-time-card.tsx
@@ -1,3 +1,4 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
 import { MiniSparkbar, Stat, StatusPill } from "@/components/site/control-primitives";
 import {
   formatCycleTimeMs,
@@ -5,59 +6,48 @@ import {
 } from "@/components/site/app-panels/cycle-time-card-model";
 
 /** Self-host maintainer analytics card (#2194): PR review cycle-time percentiles (p50/p90/p99) from the stats
- *  feed, read-only over the operator-dashboard payload. Shows an inline empty state when there are no paired
- *  gate_decision → pr_outcome samples in the window. */
+ *  feed, read-only over the operator-dashboard payload. Shows the shared EmptyState (#6175) when there are no
+ *  paired gate_decision → pr_outcome samples in the window. */
 export function CycleTimeCard({ cycleTime }: { cycleTime: CycleTimeAggregate }) {
   const hasSamples = cycleTime.sampleSize > 0;
   const hasDistribution = cycleTime.distribution.length > 0;
 
   return (
-    <section className="rounded-token border border-border bg-transparent p-5">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="font-display text-token-lg font-semibold">Review cycle time</h2>
-          <p className="mt-1 text-token-xs text-muted-foreground">
-            Gate decision → PR outcome duration percentiles from review_audit. Public-safe
-            aggregates only.
-          </p>
-        </div>
+    <AnalyticsCardShell
+      title="Review cycle time"
+      description="Gate decision → PR outcome duration percentiles from review_audit. Public-safe aggregates only."
+      state={hasSamples ? "ready" : "empty"}
+      emptyTitle="No paired samples yet"
+      emptyHint="Paired gate decisions and PR outcomes will appear here once the gate has resolved pull requests in the analytics window."
+      action={
         <StatusPill status={hasSamples ? "ready" : "info"}>
           {hasSamples ? `${cycleTime.sampleSize} paired PR(s)` : "no samples yet"}
         </StatusPill>
+      }
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Stat
+          label="p50"
+          value={formatCycleTimeMs(cycleTime.p50Ms)}
+          hint={<span className="text-muted-foreground">median cycle time</span>}
+        />
+        <Stat
+          label="p90"
+          value={formatCycleTimeMs(cycleTime.p90Ms)}
+          hint={<span className="text-muted-foreground">90th percentile</span>}
+        />
+        <Stat
+          label="p99"
+          value={formatCycleTimeMs(cycleTime.p99Ms)}
+          hint={<span className="text-muted-foreground">99th percentile</span>}
+        />
       </div>
-
-      {hasSamples ? (
-        <>
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <Stat
-              label="p50"
-              value={formatCycleTimeMs(cycleTime.p50Ms)}
-              hint={<span className="text-muted-foreground">median cycle time</span>}
-            />
-            <Stat
-              label="p90"
-              value={formatCycleTimeMs(cycleTime.p90Ms)}
-              hint={<span className="text-muted-foreground">90th percentile</span>}
-            />
-            <Stat
-              label="p99"
-              value={formatCycleTimeMs(cycleTime.p99Ms)}
-              hint={<span className="text-muted-foreground">99th percentile</span>}
-            />
-          </div>
-          {hasDistribution ? (
-            <div className="mt-4 rounded-token border border-border bg-background/40 p-3">
-              <div className="text-token-xs text-muted-foreground">Cycle-time distribution</div>
-              <MiniSparkbar values={cycleTime.distribution} className="mt-2" />
-            </div>
-          ) : null}
-        </>
-      ) : (
-        <p className="mt-4 text-token-sm text-muted-foreground">
-          Paired gate decisions and PR outcomes will appear here once the gate has resolved pull
-          requests in the analytics window.
-        </p>
-      )}
-    </section>
+      {hasDistribution ? (
+        <div className="mt-4 rounded-token border border-border bg-background/40 p-3">
+          <div className="text-token-xs text-muted-foreground">Cycle-time distribution</div>
+          <MiniSparkbar values={cycleTime.distribution} className="mt-2" />
+        </div>
+      ) : null}
+    </AnalyticsCardShell>
   );
 }

--- a/apps/loopover-ui/src/components/site/app-panels/gate-outcome-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/gate-outcome-card.tsx
@@ -1,3 +1,4 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
 import { BoundaryBadge, Stat } from "@/components/site/control-primitives";
 import { EmptyState } from "@/components/site/state-views";
 import {
@@ -9,30 +10,28 @@ import {
 import { formatGeneratedAt } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
 
 /** Gate-outcome breakdown card (#2203, part of #539): auto-merged / auto-closed / held counts and rates
- *  from repo-scoped gate-outcome audit events. Read-only; public-safe aggregate counts only. */
+ *  from repo-scoped gate-outcome audit events. Read-only; public-safe aggregate counts only. The count Stats
+ *  always render regardless of the outcome mix, so this card stays in AnalyticsCardShell's "ready" state and
+ *  keeps its own inner outcome-mix-vs-EmptyState toggle (#6175), matching ReversalHealthCard's shape. */
 export function GateOutcomeCard({ breakdown }: { breakdown: GateOutcomeCardData }) {
   const segments = gateOutcomeSegments(breakdown);
   const hasSamples = gateOutcomeHasSamples(breakdown);
 
   return (
-    <section className="rounded-token border-hairline bg-card p-5">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="font-display text-token-lg font-semibold">Gate outcomes</h2>
-          <p className="mt-1 text-token-xs text-muted-foreground">
-            Terminal gate dispositions from audit events over the last {breakdown.windowDays}{" "}
-            day(s).
-          </p>
-        </div>
+    <AnalyticsCardShell
+      title="Gate outcomes"
+      description={`Terminal gate dispositions from audit events over the last ${breakdown.windowDays} day(s).`}
+      state="ready"
+      action={
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-token-2xs text-muted-foreground">
             generated {formatGeneratedAt(breakdown.generatedAt)}
           </span>
           <BoundaryBadge boundary="public" />
         </div>
-      </div>
-
-      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+      }
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
         <Stat
           label="Auto-merged"
           value={String(breakdown.counts.autoMerged)}
@@ -100,6 +99,6 @@ export function GateOutcomeCard({ breakdown }: { breakdown: GateOutcomeCardData 
           description="Auto-merge, auto-close, and hold audit rows appear here once the agent processes PRs in your scoped repos."
         />
       )}
-    </section>
+    </AnalyticsCardShell>
   );
 }

--- a/apps/loopover-ui/src/components/site/app-panels/gate-precision-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/gate-precision-card.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
 import { Stat, StatusPill } from "@/components/site/control-primitives";
 import { aggregateGateEval, type GateEvalReport } from "./gate-precision-card-model";
 
@@ -8,27 +9,25 @@ const MIN_DECIDED_FLOOR = 10;
 
 /** Self-host maintainer analytics card (#2191): gate merge-precision + the TP/FP/FN/TN confusion matrix from
  *  computeGateEval, read-only over the operator-dashboard payload. Renders nothing when there are no evaluated
- *  projects at all (keeps the analytics page clean until the gate has produced eval rows). */
+ *  projects at all (keeps the analytics page clean until the gate has produced eval rows) -- this early return,
+ *  not AnalyticsCardShell's own "empty" state, is this card's documented no-data behavior (#6175). */
 export function GatePrecisionCard({ report }: { report: GateEvalReport }) {
   if (report.rows.length === 0) return null;
   const matrix = aggregateGateEval(report);
   return (
-    <section className="rounded-token border border-border bg-transparent p-5">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="font-display text-token-lg font-semibold">Gate precision</h2>
-          <p className="mt-1 text-token-xs text-muted-foreground">
-            The gate's merge/close predictions scored against realized PR outcomes. Public-safe
-            counts only.
-          </p>
-        </div>
+    <AnalyticsCardShell
+      title="Gate precision"
+      description="The gate's merge/close predictions scored against realized PR outcomes. Public-safe counts only."
+      state="ready"
+      action={
         <StatusPill status={report.hasSignal ? "ready" : "warn"}>
           {report.hasSignal
             ? `${matrix.decided} decided`
             : `below ${MIN_DECIDED_FLOOR}-sample floor`}
         </StatusPill>
-      </div>
-      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+      }
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
         <Stat
           label="Merge precision"
           value={
@@ -68,7 +67,7 @@ export function GatePrecisionCard({ report }: { report: GateEvalReport }) {
           tone="text-success"
         />
       </div>
-    </section>
+    </AnalyticsCardShell>
   );
 }
 

--- a/apps/loopover-ui/src/components/site/app-panels/reversal-health-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/reversal-health-card.tsx
@@ -1,3 +1,4 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
 import { Stat, StatusPill } from "@/components/site/control-primitives";
 import { EmptyState } from "@/components/site/state-views";
 import {
@@ -8,25 +9,22 @@ import {
 } from "@/components/site/app-panels/reversal-health-card-model";
 
 /** Analytics card (#2193): reversal rate and recent auto-action health from computeAgentHealth — read-only
- *  over the operator-dashboard payload. Lists reversed targets when present; EmptyState when none. */
+ *  over the operator-dashboard payload. Lists reversed targets when present; EmptyState when none. The rate
+ *  Stats always render regardless of the list, so this card stays in AnalyticsCardShell's "ready" state and
+ *  keeps its own inner list-vs-EmptyState toggle (#6175) rather than using the shell's own "empty" state,
+ *  which would also hide the Stats. */
 export function ReversalHealthCard({ health }: { health: ReversalHealth }) {
   const status = reversalHealthStatus(health);
   const reversedTargets = health.reversedTargets ?? [];
 
   return (
-    <section className="rounded-token border border-border bg-transparent p-5">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="font-display text-token-lg font-semibold">Reversal health</h2>
-          <p className="mt-1 text-token-xs text-muted-foreground">
-            How often humans reopened or reverted a bot auto-action in the last 7 days. Public-safe
-            counts only.
-          </p>
-        </div>
-        <StatusPill status={status.tone}>{status.label}</StatusPill>
-      </div>
-
-      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <AnalyticsCardShell
+      title="Reversal health"
+      description="How often humans reopened or reverted a bot auto-action in the last 7 days. Public-safe counts only."
+      state="ready"
+      action={<StatusPill status={status.tone}>{status.label}</StatusPill>}
+    >
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <Stat
           label="Reversal rate"
           value={formatRatePct(health.reversalRate)}
@@ -81,6 +79,6 @@ export function ReversalHealthCard({ health }: { health: ReversalHealth }) {
           description="When a contributor reopens a bot-close or reverts a bot-merge, the pull request will appear here."
         />
       )}
-    </section>
+    </AnalyticsCardShell>
   );
 }

--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
@@ -71,12 +71,15 @@ describe("SlopDuplicateTrendCard", () => {
         })}
       />,
     );
+    expect(screen.getByText("No snapshot history yet")).toBeTruthy();
     expect(
       screen.getByText(
         /Queue-health snapshot history will appear here after signal snapshot jobs run/i,
       ),
     ).toBeTruthy();
     expect(screen.queryByLabelText("Trend chart")).toBeNull();
+    // The header action slot (freshness pill + generated-at stamp) renders in every state (#6175).
+    expect(screen.getByText("fresh snapshot")).toBeTruthy();
   });
 
   it("surfaces the stale snapshot pill when data is old", () => {

--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
@@ -1,3 +1,4 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
 import { StatusPill } from "@/components/site/control-primitives";
 import { TrendChart } from "@/components/site/trend-chart";
 import {
@@ -28,14 +29,13 @@ export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplica
   const latest = latestWeekWithSignal(trend.weeks);
 
   return (
-    <section className="rounded-token border border-border bg-transparent p-5">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="font-display text-token-lg font-semibold">Slop + duplicate trend</h2>
-          <p className="mt-1 text-token-xs text-muted-foreground">
-            Weekly slop-flag and duplicate-flag rates from queue-health snapshots. Band labels only.
-          </p>
-        </div>
+    <AnalyticsCardShell
+      title="Slop + duplicate trend"
+      description="Weekly slop-flag and duplicate-flag rates from queue-health snapshots. Band labels only."
+      state={hasSignal ? "ready" : "empty"}
+      emptyTitle="No snapshot history yet"
+      emptyHint="Queue-health snapshot history will appear here after signal snapshot jobs run for your scoped repositories."
+      action={
         <div className="flex flex-wrap items-center gap-2">
           <StatusPill status={trend.stale ? "warn" : "ready"}>
             {trend.stale ? "stale snapshot" : "fresh snapshot"}
@@ -44,62 +44,53 @@ export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplica
             generated {formatGeneratedAt(trend.generatedAt)}
           </span>
         </div>
+      }
+    >
+      <div className="flex flex-wrap items-center gap-4 text-token-xs">
+        <LegendItem
+          color="var(--mint)"
+          label="Slop flag rate"
+          detail={
+            latest?.slopBandLabel
+              ? `latest band: ${latest.slopBandLabel}`
+              : hasSlop
+                ? `latest: ${formatTrendRatePct(latest?.slopFlagRatePct)}`
+                : "no slop samples"
+          }
+          bandLabel={latest?.slopBandLabel}
+        />
+        <LegendItem
+          color="var(--warning)"
+          label="Duplicate flag rate"
+          detail={
+            hasDuplicate
+              ? `latest: ${formatTrendRatePct(latest?.duplicateFlagRatePct)}`
+              : "no duplicate samples"
+          }
+        />
       </div>
 
-      {hasSignal ? (
-        <>
-          <div className="mt-4 flex flex-wrap items-center gap-4 text-token-xs">
-            <LegendItem
-              color="var(--mint)"
-              label="Slop flag rate"
-              detail={
-                latest?.slopBandLabel
-                  ? `latest band: ${latest.slopBandLabel}`
-                  : hasSlop
-                    ? `latest: ${formatTrendRatePct(latest?.slopFlagRatePct)}`
-                    : "no slop samples"
-              }
-              bandLabel={latest?.slopBandLabel}
-            />
-            <LegendItem
-              color="var(--warning)"
-              label="Duplicate flag rate"
-              detail={
-                hasDuplicate
-                  ? `latest: ${formatTrendRatePct(latest?.duplicateFlagRatePct)}`
-                  : "no duplicate samples"
-              }
-            />
-          </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <TrendPanel
+          title="Slop flag rate"
+          emptyMessage="No slop-flag samples in the snapshot window yet."
+          hasSignal={hasSlop}
+          values={chartValuesForSeries(trend.weeks, "slop")}
+          stroke="var(--mint)"
+          fill="color-mix(in oklab, var(--mint) 18%, transparent)"
+        />
+        <TrendPanel
+          title="Duplicate flag rate"
+          emptyMessage="No duplicate-flag samples in the snapshot window yet."
+          hasSignal={hasDuplicate}
+          values={chartValuesForSeries(trend.weeks, "duplicate")}
+          stroke="var(--warning)"
+          fill="color-mix(in oklab, var(--warning) 18%, transparent)"
+        />
+      </div>
 
-          <div className="mt-4 grid gap-4 lg:grid-cols-2">
-            <TrendPanel
-              title="Slop flag rate"
-              emptyMessage="No slop-flag samples in the snapshot window yet."
-              hasSignal={hasSlop}
-              values={chartValuesForSeries(trend.weeks, "slop")}
-              stroke="var(--mint)"
-              fill="color-mix(in oklab, var(--mint) 18%, transparent)"
-            />
-            <TrendPanel
-              title="Duplicate flag rate"
-              emptyMessage="No duplicate-flag samples in the snapshot window yet."
-              hasSignal={hasDuplicate}
-              values={chartValuesForSeries(trend.weeks, "duplicate")}
-              stroke="var(--warning)"
-              fill="color-mix(in oklab, var(--warning) 18%, transparent)"
-            />
-          </div>
-
-          <p className="mt-3 text-token-xs text-muted-foreground">{trend.summary}</p>
-        </>
-      ) : (
-        <p className="mt-4 text-token-sm text-muted-foreground">
-          Queue-health snapshot history will appear here after signal snapshot jobs run for your
-          scoped repositories.
-        </p>
-      )}
-    </section>
+      <p className="mt-3 text-token-xs text-muted-foreground">{trend.summary}</p>
+    </AnalyticsCardShell>
   );
 }
 


### PR DESCRIPTION
Closes #6175

## Summary

`apps/loopover-ui/src/components/site/app-panels/analytics-card-shell.tsx` is the documented (`#2200`) shared "titled card with loading/empty/ready" treatment. Five sibling analytics cards never adopted it, instead hand-rolling the same `<section className="rounded-token border-hairline...">` header/title markup: `cycle-time-card.tsx`, `gate-precision-card.tsx`, `reversal-health-card.tsx`, `gate-outcome-card.tsx`, `slop-duplicate-trend-card.tsx`. This is the root cause of a real, user-visible bug: `cycle-time-card.tsx`'s no-data case rendered a bare `<p>` instead of the shared `EmptyState` every properly-adopted sibling (`acceptance-rate-card.tsx`, `queue-health-card.tsx`) gets for free from `AnalyticsCardShell`'s `state="empty"`.

Each of the 5 cards has a different relationship to "empty," so each migrates differently rather than mechanically:

- **`CycleTimeCard`** and **`SlopDuplicateTrendCard`** are true binary states — when there's no signal, *nothing else* renders (both previously fell back to a bare `<p>`). Both now use the shell's `state={hasSignal ? "ready" : "empty"}` directly, with the previous `<p>` copy moved into `emptyTitle`/`emptyHint`.
- **`GatePrecisionCard`** keeps its documented "render nothing when there are no evaluated rows" early return (`if (report.rows.length === 0) return null;`) completely unchanged — only the `rows > 0` branch is wrapped in the shell, with `state="ready"` always.
- **`ReversalHealthCard`** and **`GateOutcomeCard`** always render their `Stat` tiles regardless of whether the list/mix content has data — using the shell's own `state="empty"` there would also hide those always-present Stats, which isn't the current (or wanted) behavior. Both stay in `state="ready"` and keep their existing inner list-vs-`EmptyState` toggle exactly as before, the same shape `acceptance-rate-card.tsx`/`queue-health-card.tsx` already established for content that doesn't cleanly fit the shell's binary split.

`AnalyticsCardShell` gains an optional `action` header-right slot (status pill / boundary badge / freshness stamp), rendered across every state via the header's existing `justify-between` layout, so each card keeps its existing header signal instead of losing it in the move.

Data-fetching logic and the shape of ready-state content are unchanged — only the chrome/state-handling wrapper moved.

## Note on the prior closed attempt

#6472 attempted this same issue and was auto-closed: CI genuinely failed (`validate`, `validate-code`, `validate-tests`, and the UI preview build) despite the PR claiming a clean typecheck/lint/test/build. This PR verifies every claim below directly rather than assuming — including deliberately reverting the fix files via `git stash` to confirm the new/strengthened tests actually fail without them before restoring.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (UI-only, under `apps/loopover-ui/**`) and does not mix unrelated backend, MCP, docs, or deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6175.

## Validation

- [x] `npm --workspace @loopover/ui run typecheck` — clean.
- [x] `npm run ui:lint` — 0 errors, only pre-existing warnings in unrelated files.
- [x] `npm --workspace @loopover/ui run test` (full workspace) — **47 files, 294 tests, all passing.**
- [x] Strengthened `cycle-time-card.test.tsx`'s and `slop-duplicate-trend-card.test.tsx`'s empty-state tests to assert the real `EmptyState` title/description (not just the header pill text, which was the only thing the old assertions checked) — verified both genuinely fail without the fix via `git stash` on the three changed component files, then restored and re-confirmed passing.
- [x] Added 2 new tests to `analytics-card-shell.test.tsx` for the new `action` slot: renders across all three states, and is omitted entirely when not provided.
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run docs:drift-check` / `manifest:drift-check` / `command-reference:check`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [ ] `npm run ui:build` — fails in this sandbox on an unrelated, pre-existing issue (`@scalar/api-reference` fails to resolve from `@scalar/api-reference-react`'s dist output), reproduced identically on a clean, unmodified `main` checkout this same session (unrelated to this diff).
- [ ] Root `npm run typecheck` / `npm run test:coverage` — this sandbox's root `tsc --noEmit` reliably OOMs regardless of diff content (reproduced repeatedly this session); the workspace-scoped `@loopover/ui` typecheck (clean) plus the full workspace test run (294/294 passing) cover this diff's actual surface. `apps/**` is excluded from Codecov's `coverage.include`, so no `codecov/patch` check applies to this diff.

If any required check was skipped, explain why:

- `ui:build`: pre-existing sandbox environment issue, confirmed unrelated to this diff.
- Root `typecheck`/`test:coverage`: established OOM pattern in this sandbox, unrelated to diff content; superseded by the scoped checks above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/MCP surface touched; all 5 cards keep the exact same prop/data shape.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — Every card already renders from live dashboard payloads; this only fixes/unifies how each card's existing states are presented, per the issue's own scope.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — See below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## UI Evidence

The visible change is `CycleTimeCard`'s and `SlopDuplicateTrendCard`'s empty states now show the shared `EmptyState` treatment (icon + title + description, matching every sibling card) instead of a bare paragraph. The other 3 cards (`GatePrecisionCard`, `ReversalHealthCard`, `GateOutcomeCard`) render identically to before — only their internal chrome now comes from the shared shell rather than hand-rolled markup. `ui:build` couldn't run in this sandbox (see Validation) to produce a live screenshot; covered instead by the new/strengthened regression tests asserting the exact rendered `EmptyState` title/description text per card.

## Notes

None.
