### PR TITLE
fix(selfhost): stop client-spoofed cf-connecting-ip from bypassing rate limits

### DIFF
--- a/src/selfhost/cf-workers-shim.ts
+++ b/src/selfhost/cf-workers-shim.ts
@@ -1,8 +1,8 @@
 // Minimal stand-in for the `cloudflare:workers` module on the Node self-host runtime. The only import of it
-// in the codebase is `DurableObject` (auth/rate-limit.ts → the RateLimiter DO). That DO is NEVER instantiated
-// on self-host — env.RATE_LIMITER is undefined, so enforceRateLimit returns null before any DO is touched —
-// so this base class only needs to make the import + `extends DurableObject` resolve. The self-host esbuild
-// build aliases `cloudflare:workers` to this file (see the Docker build / build:selfhost script).
+// in the codebase is `DurableObject` (auth/rate-limit.ts → the RateLimiter DO). Self-host binds a Redis
+// RATE_LIMITER (server.ts) that speaks the same DO fetch surface — this base class only needs to make the
+// import + `extends DurableObject` resolve. The self-host esbuild build aliases `cloudflare:workers` to this
+// file (see the Docker build / build:selfhost script).
 export class DurableObject<E = unknown> {
   constructor(
     protected ctx?: unknown,

--- a/src/selfhost/trusted-client-ip.ts
+++ b/src/selfhost/trusted-client-ip.ts
@@ -1,0 +1,96 @@
+// Resolve the real client IP for self-host rate limiting (#critical: cf-connecting-ip spoof).
+//
+// On Cloudflare Workers, `cf-connecting-ip` is edge-set and safe for `clientIp()` in auth/rate-limit.ts.
+// On Node self-host the same header is just another request header — fully attacker-controlled — while
+// Redis RATE_LIMITER IS bound (server.ts). Caddy (caddy/Caddyfile) injects X-Real-IP / X-Forwarded-For
+// from `{remote_host}` but does not set or strip `cf-connecting-ip`.
+//
+// This module overwrites `cf-connecting-ip` at the Node edge before the Worker fetch runs:
+//   • Always delete any client-supplied `cf-connecting-ip` (never trust it on Node).
+//   • If the TCP peer is a private/link-local/loopback hop (compose Caddy → app), prefer Caddy's
+//     X-Real-IP, then the leftmost X-Forwarded-For hop.
+//   • Otherwise use the TCP peer (direct :8787 expose) and ignore proxy headers (client-spoofable).
+// Workers remain unchanged: they never call this helper.
+export function resolveTrustedClientIp(
+  peerAddress: string | undefined,
+  headers: Headers,
+): string {
+  const peer = normalizeIpAddress(stripIpv4MappedPrefix(peerAddress));
+  const xReal = normalizeIpAddress(headers.get("x-real-ip") ?? undefined);
+  const xff = normalizeIpAddress(headers.get("x-forwarded-for")?.split(",")[0]?.trim());
+
+  if (peer && isPrivateOrLinkLocal(peer)) {
+    return xReal ?? xff ?? peer;
+  }
+  return peer ?? "unknown-ip";
+}
+
+/** Return a Request whose `cf-connecting-ip` is the Node-edge-trusted client IP (see resolveTrustedClientIp). */
+export function withTrustedClientIp(request: Request, peerAddress: string | undefined): Request {
+  const headers = new Headers(request.headers);
+  headers.delete("cf-connecting-ip");
+  const clientIp = resolveTrustedClientIp(peerAddress, headers);
+  if (clientIp !== "unknown-ip") headers.set("cf-connecting-ip", clientIp);
+  return new Request(request, { headers });
+}
+
+function stripIpv4MappedPrefix(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.startsWith("::ffff:") ? value.slice("::ffff:".length) : value;
+}
+
+function normalizeIpAddress(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !isValidIpAddress(trimmed)) return undefined;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) return trimmed.slice(1, -1);
+  return trimmed;
+}
+
+function isValidIpAddress(value: string): boolean {
+  return isValidIpv4(value) || isValidIpv6(value);
+}
+
+function isValidIpv4(value: string): boolean {
+  const parts = value.split(".");
+  if (parts.length !== 4) return false;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return false;
+    const octet = Number(part);
+    if (octet < 0 || octet > 255) return false;
+  }
+  return true;
+}
+
+function isValidIpv6(value: string): boolean {
+  let candidate = value;
+  if (candidate.startsWith("[") && candidate.endsWith("]")) candidate = candidate.slice(1, -1);
+  if (!candidate.includes(":") || !/^[0-9a-fA-F:.]+$/.test(candidate)) return false;
+  if (candidate.split("::").length > 2) return false;
+  const segments = candidate.split(":");
+  if (segments.length > 8) return false;
+  let hasHexSegment = false;
+  for (const segment of segments) {
+    if (segment === "") continue;
+    if (!/^[0-9a-fA-F]{1,4}$/.test(segment)) return false;
+    hasHexSegment = true;
+  }
+  return hasHexSegment;
+}
+
+/** RFC1918 / link-local / loopback — the hop we see when Caddy (or another compose proxy) fronts the app. */
+export function isPrivateOrLinkLocal(ip: string): boolean {
+  if (ip === "::1" || ip === "0:0:0:0:0:0:0:1") return true;
+  if (ip.startsWith("fe80:") || ip.startsWith("FE80:")) return true;
+  // Unique-local IPv6 (fc00::/7)
+  if (/^[fF][cCdD]/.test(ip)) return true;
+
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n))) return false;
+  const [a, b] = parts as [number, number, number, number];
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import { createOrbRelayRegistrationState, isOrbBrokerMode, registerOrbRelayTarge
 import { exportOrbBatch } from "./selfhost/orb-collector";
 import { createD1Adapter, nodeSqliteDriver } from "./selfhost/d1-adapter";
 import { loadFileSecrets } from "./selfhost/load-file-secrets";
+import { withTrustedClientIp } from "./selfhost/trusted-client-ip";
 import {
   backupAcknowledgedGaugeValue,
   buildHealthBody,
@@ -890,7 +891,11 @@ async function main(): Promise<void> {
   const port = Number(process.env.PORT ?? 8787);
   const server = serve(
     {
-      fetch: async (request: Request) => {
+      fetch: async (request: Request, nodeEnv?: { incoming?: { socket?: { remoteAddress?: string } } }) => {
+        // Self-host rate limiting keys off cf-connecting-ip (auth/rate-limit.ts). On Workers that header is
+        // edge-set; on Node it is attacker-controlled unless we overwrite it from the TCP peer / Caddy hop
+        // here (see trusted-client-ip.ts). Health/ready/metrics below still see the rewritten request.
+        request = withTrustedClientIp(request, nodeEnv?.incoming?.socket?.remoteAddress);
         const path = new URL(request.url).pathname;
         if (path === "/health")
           return new Response(

--- a/test/unit/trusted-client-ip.test.ts
+++ b/test/unit/trusted-client-ip.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPrivateOrLinkLocal,
+  resolveTrustedClientIp,
+  withTrustedClientIp,
+} from "../../src/selfhost/trusted-client-ip";
+
+describe("trusted-client-ip (self-host rate-limit identity)", () => {
+  it("REGRESSION: ignores client-spoofed cf-connecting-ip when the TCP peer is public (direct expose)", () => {
+    const headers = new Headers({
+      "cf-connecting-ip": "203.0.113.1",
+      "x-real-ip": "198.51.100.9",
+      "x-forwarded-for": "198.51.100.9",
+    });
+    // Public peer → use peer; proxy/CF headers are client-controlled on a direct :8787 path.
+    expect(resolveTrustedClientIp("203.0.113.50", headers)).toBe("203.0.113.50");
+    expect(resolveTrustedClientIp("203.0.113.51", headers)).toBe("203.0.113.51");
+  });
+
+  it("REGRESSION: behind a private proxy hop (Caddy), prefers X-Real-IP over a spoofed cf-connecting-ip", () => {
+    const headers = new Headers({
+      "cf-connecting-ip": "203.0.113.1",
+      "x-real-ip": "198.51.100.20",
+      "x-forwarded-for": "198.51.100.20",
+    });
+    expect(resolveTrustedClientIp("10.0.0.2", headers)).toBe("198.51.100.20");
+    expect(resolveTrustedClientIp("172.16.5.1", headers)).toBe("198.51.100.20");
+    expect(resolveTrustedClientIp("192.168.1.1", headers)).toBe("198.51.100.20");
+  });
+
+  it("falls back to leftmost X-Forwarded-For when X-Real-IP is absent behind a private hop", () => {
+    const headers = new Headers({
+      "cf-connecting-ip": "203.0.113.9",
+      "x-forwarded-for": "198.51.100.30, 10.0.0.2",
+    });
+    expect(resolveTrustedClientIp("10.0.0.2", headers)).toBe("198.51.100.30");
+  });
+
+  it("uses the private peer itself when Caddy headers are missing", () => {
+    expect(resolveTrustedClientIp("10.0.0.2", new Headers({ "cf-connecting-ip": "1.2.3.4" }))).toBe("10.0.0.2");
+  });
+
+  it("returns unknown-ip when no usable peer or proxy header is present", () => {
+    expect(resolveTrustedClientIp(undefined, new Headers({ "cf-connecting-ip": "203.0.113.1" }))).toBe("unknown-ip");
+    expect(resolveTrustedClientIp("not-an-ip", new Headers())).toBe("unknown-ip");
+  });
+
+  it("strips IPv4-mapped IPv6 peer prefixes", () => {
+    expect(resolveTrustedClientIp("::ffff:203.0.113.50", new Headers())).toBe("203.0.113.50");
+    expect(
+      resolveTrustedClientIp("::ffff:10.0.0.2", new Headers({ "x-real-ip": "198.51.100.40" })),
+    ).toBe("198.51.100.40");
+  });
+
+  it("withTrustedClientIp deletes spoofed cf-connecting-ip and sets the trusted value", () => {
+    const original = new Request("https://orb.example/v1/auth/github/session", {
+      headers: {
+        "cf-connecting-ip": "203.0.113.1",
+        "x-real-ip": "198.51.100.55",
+      },
+    });
+    const trusted = withTrustedClientIp(original, "10.0.0.5");
+    expect(trusted.headers.get("cf-connecting-ip")).toBe("198.51.100.55");
+    expect(original.headers.get("cf-connecting-ip")).toBe("203.0.113.1");
+  });
+
+  it("withTrustedClientIp omits cf-connecting-ip when identity is unknown-ip", () => {
+    const trusted = withTrustedClientIp(
+      new Request("https://orb.example/health", { headers: { "cf-connecting-ip": "203.0.113.1" } }),
+      undefined,
+    );
+    expect(trusted.headers.get("cf-connecting-ip")).toBeNull();
+  });
+
+  it("classifies private / link-local / loopback peers", () => {
+    expect(isPrivateOrLinkLocal("10.1.2.3")).toBe(true);
+    expect(isPrivateOrLinkLocal("192.168.0.1")).toBe(true);
+    expect(isPrivateOrLinkLocal("172.16.0.1")).toBe(true);
+    expect(isPrivateOrLinkLocal("172.31.255.255")).toBe(true);
+    expect(isPrivateOrLinkLocal("127.0.0.1")).toBe(true);
+    expect(isPrivateOrLinkLocal("169.254.1.1")).toBe(true);
+    expect(isPrivateOrLinkLocal("::1")).toBe(true);
+    expect(isPrivateOrLinkLocal("fe80::1")).toBe(true);
+    expect(isPrivateOrLinkLocal("fc00::1")).toBe(true);
+    expect(isPrivateOrLinkLocal("203.0.113.1")).toBe(false);
+    expect(isPrivateOrLinkLocal("172.15.0.1")).toBe(false);
+    expect(isPrivateOrLinkLocal("172.32.0.1")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause:** Self-host binds Redis `RATE_LIMITER`, but `clientIp()` still trusts `cf-connecting-ip`. On Node that header is attacker-controlled (Caddy only sets X-Real-IP / X-Forwarded-For). Attackers can rotate it to bypass strict pre-auth buckets; honest clients without it collapse to a shared `unknown-ip` bucket.
- **Fix:** At the Node `serve({ fetch })` edge, overwrite `cf-connecting-ip` via `withTrustedClientIp`: delete any client-supplied value; behind a private/link-local peer (Caddy) prefer X-Real-IP / leftmost XFF; on a public peer use the TCP address. Workers unchanged.
- **Impact:** Self-host auth/webhook rate limits bind to the real client again.

## Test plan
- [x] Unit tests for spoof rejection, Caddy hop preference, IPv4-mapped peers, unknown-ip
- [ ] CI validate + codecov/patch

## Risk / tradeoffs
- Assumes the only public front is Caddy on a private compose network (matches shipped Caddyfile). Direct public expose correctly uses the TCP peer and ignores proxy headers.