### PR TITLE
feat(miner-ui): add ChatComposer input component for the chat rail

### DIFF
--- a/apps/loopover-miner-ui/src/chat-composer.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-composer.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatComposer } from "./components/chat-composer";
+
+// jsdom computes no real layout, so a rendered <textarea>'s scrollHeight is 0. Stub it to a fixed pixel
+// value so the auto-grow branch can be exercised deterministically (per the issue's jsdom gotcha note).
+function stubScrollHeight(el: HTMLElement, value: number) {
+  Object.defineProperty(el, "scrollHeight", { configurable: true, value });
+}
+
+describe("ChatComposer (#6514)", () => {
+  it("submits the typed value on Enter and clears the textarea", () => {
+    const onSubmit = vi.fn();
+    render(<ChatComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "hello fleet" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("hello fleet");
+    expect(textarea.value).toBe(""); // cleared after a successful submit
+  });
+
+  it("inserts a newline on Shift+Enter without submitting", () => {
+    const onSubmit = vi.fn();
+    render(<ChatComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "line one" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("line one"); // not cleared — no submit happened
+  });
+
+  it("submits identically when the Send button is clicked", () => {
+    const onSubmit = vi.fn();
+    render(<ChatComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "via button" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("via button");
+    expect(textarea.value).toBe("");
+  });
+
+  it("does NOT submit whitespace-only content — via Enter", () => {
+    const onSubmit = vi.fn();
+    render(<ChatComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "   " } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("   "); // left intact, not cleared
+  });
+
+  it("does NOT submit whitespace-only content — via the button", () => {
+    const onSubmit = vi.fn();
+    render(<ChatComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "  \n\t " } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("auto-grows to fit content below the height cap (overflow hidden)", () => {
+    render(<ChatComposer onSubmit={vi.fn()} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    stubScrollHeight(textarea, 48);
+    fireEvent.change(textarea, { target: { value: "a\nb" } });
+
+    expect(textarea.style.height).toBe("48px");
+    expect(textarea.style.overflowY).toBe("hidden");
+  });
+
+  it("stops growing and scrolls internally once content exceeds the cap", () => {
+    render(<ChatComposer onSubmit={vi.fn()} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    stubScrollHeight(textarea, 640);
+    fireEvent.change(textarea, { target: { value: "many\nlines\nof\ntext\nhere" } });
+
+    expect(textarea.style.height).toBe("200px"); // pinned at the cap
+    expect(textarea.style.overflowY).toBe("auto"); // internal scroll takes over
+  });
+
+  it("disables both the textarea and the Send button when disabled", () => {
+    render(<ChatComposer onSubmit={vi.fn()} disabled placeholder="Ask a question" />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    const button = screen.getByRole("button", { name: /send/i }) as HTMLButtonElement;
+
+    expect(textarea.disabled).toBe(true);
+    expect(button.disabled).toBe(true);
+    expect(textarea.getAttribute("placeholder")).toBe("Ask a question");
+  });
+});

--- a/apps/loopover-miner-ui/src/components/chat-composer.tsx
+++ b/apps/loopover-miner-ui/src/components/chat-composer.tsx
@@ -1,0 +1,86 @@
+// Chat rail message-input control (#6514). A self-contained, backend-agnostic composer built on the ui-kit's
+// raw `Textarea`/`Button` primitives (which carry no submit/auto-grow behavior of their own). It owns its own
+// draft-value state and is uncontrolled from the caller's perspective: the only behavioral prop is `onSubmit`,
+// invoked with the current textarea value when the user submits a non-empty message. Submit fires on `Enter`
+// (no modifier) or a click of the Send button; `Shift+Enter` inserts a literal newline instead. This component
+// ships UNWIRED — it makes no network/MCP/action-dispatch call; mounting it into the persistent chat rail is a
+// separate, later issue.
+import * as React from "react";
+
+import { Button } from "@loopover/ui-kit/components/button";
+import { Textarea } from "@loopover/ui-kit/components/textarea";
+
+// The textarea auto-grows with its content up to this height; beyond it the height is pinned here and the
+// textarea scrolls internally instead of pushing the rail taller without bound.
+const MAX_TEXTAREA_HEIGHT_PX = 200;
+
+export interface ChatComposerProps {
+  /** Called with the current textarea value on a non-empty submit (Enter or Send click). */
+  onSubmit: (message: string) => void;
+  /** Placeholder shown while the textarea is empty. */
+  placeholder?: string;
+  /** Disables both the textarea and the Send button. */
+  disabled?: boolean;
+  /** Accessible label / visible text for the submit button. */
+  submitLabel?: string;
+}
+
+export function ChatComposer({
+  onSubmit,
+  placeholder = "Type a message…",
+  disabled = false,
+  submitLabel = "Send",
+}: ChatComposerProps) {
+  const [value, setValue] = React.useState("");
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  // Auto-grow: collapse to `auto` so a deleted line lets the box shrink, then grow to fit the content up to
+  // the cap. At/above the cap the height is pinned and internal scrolling takes over (overflowY:auto).
+  const resize = React.useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, MAX_TEXTAREA_HEIGHT_PX)}px`;
+    el.style.overflowY = el.scrollHeight > MAX_TEXTAREA_HEIGHT_PX ? "auto" : "hidden";
+  }, []);
+
+  // useLayoutEffect (not useEffect) so the height is corrected before the browser paints, avoiding a
+  // one-frame flash at the wrong size as the draft grows or is cleared after submit.
+  React.useLayoutEffect(() => {
+    resize();
+  }, [value, resize]);
+
+  const submit = React.useCallback(() => {
+    // Trim only for the emptiness check — a value of "   " is blocked exactly like "". The message passed to
+    // the caller is the current textarea value itself.
+    if (value.trim() === "") return;
+    onSubmit(value);
+    setValue("");
+  }, [value, onSubmit]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Shift+Enter is the newline affordance: let the default insert the line break and do not submit.
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="flex items-end gap-2">
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        className="max-h-[200px] resize-none"
+      />
+      <Button type="button" onClick={submit} disabled={disabled}>
+        {submitLabel}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds the chat rail's message-input control as a self-contained, backend-agnostic component: `apps/loopover-miner-ui/src/components/chat-composer.tsx` exporting `ChatComposer`, plus co-located tests at `apps/loopover-miner-ui/src/chat-composer.test.tsx`.

Resolves #6514.

## Behavior (per the issue's requirements)

- Built from the ui-kit's raw primitives — `Textarea` (`@loopover/ui-kit/components/textarea`) and `Button` (`@loopover/ui-kit/components/button`); no new logic added to `packages/loopover-ui-kit/**`.
- `Enter` (no modifier) submits the current textarea value via `onSubmit(message)`, then clears the draft.
- `Shift+Enter` inserts a literal newline and does **not** submit.
- Clicking the Send button submits identically to `Enter`.
- Empty or whitespace-only content never calls `onSubmit` (trim before the emptiness check) — on both the `Enter` and the button paths.
- The textarea auto-grows to fit typed/pasted content up to a height cap; beyond the cap the height is pinned and it scrolls internally.
- Owns its own draft state (uncontrolled from the caller); the only behavioral prop is `onSubmit`, alongside presentational `placeholder`/`disabled`/`submitLabel`.

## Scope / non-goals

- Ships **unwired**: no change to `apps/loopover-miner-ui/src/routes/__root.tsx` or any route file — mounting into the persistent chat rail is a separate, later issue.
- No `fetch`/API/MCP/action-dispatch call anywhere in the component.
- No change under `packages/loopover-ui-kit/**`.

## Tests

`apps/loopover-miner-ui/src/chat-composer.test.tsx` — fixture-driven (mock `onSubmit`), `getByRole`-based per this app's convention. Covers: Enter-submit vs Shift+Enter-newline; non-empty vs whitespace-only (both the Enter and button paths); textarea clears after submit; auto-grow below the cap vs pinned-with-internal-scroll above it (via the documented jsdom `scrollHeight` stub); and the disabled state.

Locally green: `npm run test` (miner-ui, `--coverage`) — 8/8 pass, coverage 86.8% stmts / 86.09% branch / 79.89% funcs / 88.88% lines (above the app floor); `tsc --noEmit` clean; `eslint` clean.