### PR TITLE
feat(miner-ui): add useStreamingText and the StreamingText renderer

### DIFF
--- a/apps/loopover-miner-ui/src/components/streaming-text.tsx
+++ b/apps/loopover-miner-ui/src/components/streaming-text.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+import { useStreamingText, type StreamingTextSource } from "../lib/use-streaming-text";
+
+/**
+ * True when the operator asked the OS for reduced motion (#6516). Same window.matchMedia + `change` listener
+ * technique as the ui-kit's useIsMobile -- this app has no `motion` dependency and deliberately isn't gaining
+ * one, so the escape hatch is read straight from the media query.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setReduced(mql.matches);
+    mql.addEventListener("change", onChange);
+    setReduced(mql.matches);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}
+
+/**
+ * Render a chunked answer as it streams in (#6516). Thin by design: the hook owns consumption and cancellation;
+ * this only decides how the accumulated text is presented.
+ *
+ * Reduced motion changes the presentation, never the text. Both paths render the same characters at the same
+ * time -- the only difference is the fade applied to the growing block -- so an operator who asked for less
+ * motion still sees every chunk the moment it arrives, and never a truncated answer.
+ */
+export function StreamingText({ source, className }: { source: StreamingTextSource | null; className?: string }) {
+  const { text, status, error } = useStreamingText(source);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  if (status === "error") {
+    return (
+      <p role="alert" className="text-token-sm text-destructive">
+        {error ?? "The response stream failed."}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      // aria-live so a screen reader announces the answer as it fills in rather than only on completion.
+      // "polite" -- an in-progress reply must never interrupt what the operator is already reading.
+      aria-live="polite"
+      aria-busy={status === "streaming"}
+      data-status={status}
+      className={[
+        "whitespace-pre-wrap text-token-sm text-foreground",
+        prefersReducedMotion ? "" : "transition-opacity duration-150",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {text}
+    </p>
+  );
+}

--- a/apps/loopover-miner-ui/src/components/streaming-text.tsx
+++ b/apps/loopover-miner-ui/src/components/streaming-text.tsx
@@ -8,13 +8,17 @@ import { useStreamingText, type StreamingTextSource } from "../lib/use-streaming
  * one, so the escape hatch is read straight from the media query.
  */
 function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
+  // Read the initial value in the lazy initializer rather than setting it from the effect: seeding state from
+  // an effect is a cascading render (react-hooks/set-state-in-effect), and it would also paint one frame of
+  // motion before the preference applied. The effect below only subscribes; it never seeds.
+  const [reduced, setReduced] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
 
   useEffect(() => {
     const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
     const onChange = () => setReduced(mql.matches);
     mql.addEventListener("change", onChange);
-    setReduced(mql.matches);
     return () => mql.removeEventListener("change", onChange);
   }, []);
 

--- a/apps/loopover-miner-ui/src/lib/use-streaming-text.ts
+++ b/apps/loopover-miner-ui/src/lib/use-streaming-text.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * A chunked text source (#6516). A factory rather than a bare AsyncIterable so each run gets a fresh iterator:
+ * handing the hook an already-started iterable would make a restart resume mid-stream instead of starting over,
+ * and an async generator can only be consumed once.
+ */
+export type StreamingTextSource = () => AsyncIterable<string>;
+
+/** Where a stream is in its lifecycle. `cancelled` is distinct from `done` on purpose: a caller re-rendering a
+ *  half-finished answer needs to know the text it's holding is a truncated fragment, not a complete reply. */
+export type StreamingTextStatus = "idle" | "streaming" | "done" | "error" | "cancelled";
+
+export type StreamingTextState = {
+  text: string;
+  status: StreamingTextStatus;
+  error: string | null;
+  cancel: () => void;
+};
+
+/**
+ * Consume a chunked text source, revealing the answer as it arrives instead of popping it in whole (#6516).
+ *
+ * Cancellation discipline mirrors usePolledFetch's `cancelled` flag: every state write is guarded by a
+ * per-run token, so a chunk that lands after a restart, an explicit cancel, or an unmount can never reach
+ * state. That matters more here than for a poll -- an async iterator can keep yielding for a while after we
+ * stop caring, and a late chunk appended to a NEW stream's text would silently corrupt the reply on screen.
+ *
+ * Plumbing only: the source is whatever the caller passes, so the hook itself makes no network call.
+ */
+export function useStreamingText(source: StreamingTextSource | null): StreamingTextState {
+  const [text, setText] = useState("");
+  const [status, setStatus] = useState<StreamingTextStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // Identifies the current run. Every state write checks it first, so exactly one run can own state at a time
+  // and a superseded run goes quiet without needing to interrupt the iterator it's parked on.
+  const runIdRef = useRef(0);
+  // Survives unmount: the effect cleanup can't clear a flag the late chunk still reads, so this is the one
+  // signal both the "run superseded" and "component gone" cases share.
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const cancel = useCallback(() => {
+    // Bumping the token orphans the in-flight run: its next chunk fails the ownership check and is dropped.
+    runIdRef.current += 1;
+    setStatus((current) => (current === "streaming" ? "cancelled" : current));
+  }, []);
+
+  useEffect(() => {
+    if (!source) return;
+
+    const runId = (runIdRef.current += 1);
+    // One predicate for both hazards -- a superseded run and an unmounted component are the same "don't write"
+    // condition, and splitting them invites fixing one and forgetting the other.
+    const owns = () => mountedRef.current && runIdRef.current === runId;
+
+    setText("");
+    setError(null);
+    setStatus("streaming");
+
+    void (async () => {
+      try {
+        for await (const chunk of source()) {
+          if (!owns()) return;
+          // Functional update: two chunks arriving in the same tick would otherwise both append to the same
+          // stale snapshot and the first one's text would vanish.
+          setText((previous) => previous + chunk);
+        }
+        if (owns()) setStatus("done");
+      } catch (caught) {
+        // A source that throws or rejects mid-stream must surface here rather than escape as an unhandled
+        // rejection -- and must not overwrite a newer run's state if this one was already superseded.
+        if (!owns()) return;
+        setError(caught instanceof Error ? caught.message : String(caught));
+        setStatus("error");
+      }
+    })();
+
+    // Restarting on a new source, or unmounting, orphans this run the same way cancel() does.
+    return () => {
+      runIdRef.current += 1;
+    };
+  }, [source]);
+
+  return { text, status, error, cancel };
+}

--- a/apps/loopover-miner-ui/src/lib/use-streaming-text.ts
+++ b/apps/loopover-miner-ui/src/lib/use-streaming-text.ts
@@ -30,8 +30,24 @@ export type StreamingTextState = {
  */
 export function useStreamingText(source: StreamingTextSource | null): StreamingTextState {
   const [text, setText] = useState("");
-  const [status, setStatus] = useState<StreamingTextStatus>("idle");
+  const [status, setStatus] = useState<StreamingTextStatus>(source ? "streaming" : "idle");
   const [error, setError] = useState<string | null>(null);
+
+  // Reset when the caller swaps sources, during render rather than from the effect. React's documented
+  // adjust-state-on-prop-change pattern: seeding from an effect is a cascading render
+  // (react-hooks/set-state-in-effect), and it would also leave the previous reply's text on screen for a frame
+  // after a new stream started.
+  //
+  // Both useState and the setter take the `() => source` form on purpose: the source IS a function, and React
+  // would otherwise read a bare `source` as a lazy initializer / updater and store its RETURN value -- so the
+  // stored value could never equal the prop, and the reset below would re-fire on every render forever.
+  const [activeSource, setActiveSource] = useState<StreamingTextSource | null>(() => source);
+  if (source !== activeSource) {
+    setActiveSource(() => source);
+    setText("");
+    setError(null);
+    setStatus(source ? "streaming" : "idle");
+  }
 
   // Identifies the current run. Every state write checks it first, so exactly one run can own state at a time
   // and a superseded run goes quiet without needing to interrupt the iterator it's parked on.
@@ -61,10 +77,8 @@ export function useStreamingText(source: StreamingTextSource | null): StreamingT
     // condition, and splitting them invites fixing one and forgetting the other.
     const owns = () => mountedRef.current && runIdRef.current === runId;
 
-    setText("");
-    setError(null);
-    setStatus("streaming");
-
+    // No state seeding here: the render-phase reset above already put text/error/status in their start state,
+    // and every write below happens after an await, i.e. asynchronously rather than in the effect body.
     void (async () => {
       try {
         for await (const chunk of source()) {

--- a/apps/loopover-miner-ui/src/streaming-text.test.tsx
+++ b/apps/loopover-miner-ui/src/streaming-text.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StreamingText } from "./components/streaming-text";
+import type { StreamingTextSource } from "./lib/use-streaming-text";
+
+/** jsdom has no matchMedia, and the component reads it on mount -- stub it per test so both the reduced-motion
+ *  and the default path are exercised deliberately rather than by whatever jsdom happens to default to. */
+function stubReducedMotion(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  );
+}
+
+const source: StreamingTextSource = async function* () {
+  yield "Queue is ";
+  yield "healthy.";
+};
+
+const failing: StreamingTextSource = async function* () {
+  throw new Error("stream died");
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("StreamingText (#6516)", () => {
+  it("renders the accumulated answer as it streams in", async () => {
+    stubReducedMotion(false);
+    render(<StreamingText source={source} />);
+    await waitFor(() => expect(screen.getByText("Queue is healthy.")).toBeTruthy());
+  });
+
+  it("marks the region live and busy only while streaming", async () => {
+    stubReducedMotion(false);
+    const { container } = render(<StreamingText source={source} />);
+    const paragraph = container.querySelector("p")!;
+    // aria-live so the reply is announced as it fills in; polite so it never interrupts the operator.
+    expect(paragraph.getAttribute("aria-live")).toBe("polite");
+    await waitFor(() => expect(paragraph.getAttribute("data-status")).toBe("done"));
+    expect(paragraph.getAttribute("aria-busy")).toBe("false");
+  });
+
+  it("reaches the same final text under prefers-reduced-motion", async () => {
+    stubReducedMotion(true);
+    render(<StreamingText source={source} />);
+    // End-state only, never timing -- the reduced-motion path must change presentation, not content.
+    await waitFor(() => expect(screen.getByText("Queue is healthy.")).toBeTruthy());
+  });
+
+  it("drops the transition class under prefers-reduced-motion but keeps it otherwise", async () => {
+    stubReducedMotion(true);
+    const { container, unmount } = render(<StreamingText source={source} />);
+    await waitFor(() => expect(screen.getByText("Queue is healthy.")).toBeTruthy());
+    expect(container.querySelector("p")!.className).not.toContain("transition-opacity");
+    unmount();
+
+    stubReducedMotion(false);
+    const withMotion = render(<StreamingText source={source} />);
+    await waitFor(() => expect(screen.getByText("Queue is healthy.")).toBeTruthy());
+    expect(withMotion.container.querySelector("p")!.className).toContain("transition-opacity");
+  });
+
+  it("surfaces a stream failure as an alert instead of a silent empty box", async () => {
+    stubReducedMotion(false);
+    render(<StreamingText source={failing} />);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toBe("stream died");
+  });
+
+  it("renders an empty, idle region when there is no source yet", () => {
+    stubReducedMotion(false);
+    const { container } = render(<StreamingText source={null} />);
+    const paragraph = container.querySelector("p")!;
+    expect(paragraph.getAttribute("data-status")).toBe("idle");
+    expect(paragraph.textContent).toBe("");
+  });
+
+  it("passes a caller className through alongside its own classes", () => {
+    stubReducedMotion(false);
+    const { container } = render(<StreamingText source={null} className="mt-2" />);
+    expect(container.querySelector("p")!.className).toContain("mt-2");
+  });
+});

--- a/apps/loopover-miner-ui/src/streaming-text.test.tsx
+++ b/apps/loopover-miner-ui/src/streaming-text.test.tsx
@@ -22,9 +22,11 @@ const source: StreamingTextSource = async function* () {
   yield "healthy.";
 };
 
-const failing: StreamingTextSource = async function* () {
-  throw new Error("stream died");
-};
+/** Fails on the first pull. A plain AsyncIterable rather than an `async function*`, because a generator that
+ *  only throws has no `yield` and trips require-yield. */
+const failing: StreamingTextSource = () => ({
+  [Symbol.asyncIterator]: () => ({ next: () => Promise.reject(new Error("stream died")) }),
+});
 
 afterEach(() => vi.unstubAllGlobals());
 

--- a/apps/loopover-miner-ui/src/use-streaming-text.test.ts
+++ b/apps/loopover-miner-ui/src/use-streaming-text.test.ts
@@ -1,0 +1,184 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useStreamingText, type StreamingTextSource } from "./lib/use-streaming-text";
+
+/** A chunk source we drive by hand: each `push` releases exactly one chunk, so a test can park a stream
+ *  mid-flight and then act (restart, unmount) before letting the next chunk land. */
+function controllableSource() {
+  let release: (() => void) | null = null;
+  const gate = () =>
+    new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+  const chunks: string[] = [];
+  const source: StreamingTextSource = async function* () {
+    for (const chunk of chunks) {
+      await gate();
+      yield chunk;
+    }
+  };
+
+  return {
+    source,
+    queue(...next: string[]) {
+      chunks.push(...next);
+    },
+    /** Let the parked chunk through and flush the microtasks its yield schedules. */
+    async push() {
+      await act(async () => {
+        release?.();
+        await Promise.resolve();
+      });
+    },
+  };
+}
+
+/** A source that yields one chunk, then throws. */
+const throwingSource: StreamingTextSource = async function* () {
+  yield "partial";
+  throw new Error("stream died");
+};
+
+describe("useStreamingText (#6516)", () => {
+  it("starts idle with no text when given no source", () => {
+    const { result } = renderHook(() => useStreamingText(null));
+    expect(result.current.status).toBe("idle");
+    expect(result.current.text).toBe("");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("accumulates progressively across renders, not only at the end", async () => {
+    const controller = controllableSource();
+    controller.queue("Hello", " ", "world");
+    const { result } = renderHook(() => useStreamingText(controller.source));
+
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+    expect(result.current.text).toBe("");
+
+    await controller.push();
+    // The point of the hook: text is readable mid-stream, before the source is exhausted.
+    await waitFor(() => expect(result.current.text).toBe("Hello"));
+    expect(result.current.status).toBe("streaming");
+
+    await controller.push();
+    await waitFor(() => expect(result.current.text).toBe("Hello "));
+
+    await controller.push();
+    await waitFor(() => expect(result.current.text).toBe("Hello world"));
+    await waitFor(() => expect(result.current.status).toBe("done"));
+  });
+
+  it("REGRESSION: a late chunk from a superseded source never reaches state", async () => {
+    const first = controllableSource();
+    first.queue("from-first");
+    const second = controllableSource();
+    second.queue("from-second");
+
+    const { result, rerender } = renderHook(({ source }) => useStreamingText(source), {
+      initialProps: { source: first.source },
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    // Swap sources while the first is still parked on its chunk.
+    rerender({ source: second.source });
+    await waitFor(() => expect(result.current.text).toBe(""));
+
+    // Now let the FIRST source's chunk land. It must be dropped -- appending it would corrupt the new reply.
+    await first.push();
+    await second.push();
+    await waitFor(() => expect(result.current.text).toBe("from-second"));
+    expect(result.current.text).not.toContain("from-first");
+  });
+
+  it("REGRESSION: unmounting mid-stream neither throws nor updates retained state", async () => {
+    const controller = controllableSource();
+    controller.queue("late");
+    const { result, unmount } = renderHook(() => useStreamingText(controller.source));
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    unmount();
+    // Releasing the pending chunk after unmount must be a no-op, not a state update on a dead component.
+    await expect(controller.push()).resolves.toBeUndefined();
+    expect(result.current.text).toBe("");
+  });
+
+  it("surfaces a mid-stream error through status/error instead of an unhandled rejection", async () => {
+    const { result } = renderHook(() => useStreamingText(throwingSource));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("stream died");
+    // The chunks that did arrive before the failure are kept -- a partial answer beats a blank box.
+    expect(result.current.text).toBe("partial");
+  });
+
+  it("reports a non-Error thrown value as a string rather than losing it", async () => {
+    const rejecting: StreamingTextSource = async function* () {
+      yield "x";
+      throw "plain string failure";
+    };
+    const { result } = renderHook(() => useStreamingText(rejecting));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("plain string failure");
+  });
+
+  it("cancel() stops the stream and marks it cancelled, distinct from done", async () => {
+    const controller = controllableSource();
+    controller.queue("first", "second");
+    const { result } = renderHook(() => useStreamingText(controller.source));
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await controller.push();
+    await waitFor(() => expect(result.current.text).toBe("first"));
+
+    act(() => result.current.cancel());
+    expect(result.current.status).toBe("cancelled");
+
+    // The chunk that was already in flight must not append after cancellation.
+    await controller.push();
+    expect(result.current.text).toBe("first");
+    expect(result.current.status).toBe("cancelled");
+  });
+
+  it("cancel() on an idle hook leaves the status alone", () => {
+    const { result } = renderHook(() => useStreamingText(null));
+    act(() => result.current.cancel());
+    // Nothing was streaming, so there is nothing to cancel -- it must not claim a stream was interrupted.
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("a new source resets the previous run's text and error", async () => {
+    const { result, rerender } = renderHook(({ source }) => useStreamingText(source), {
+      initialProps: { source: throwingSource as StreamingTextSource },
+    });
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    const fresh = controllableSource();
+    fresh.queue("clean");
+    rerender({ source: fresh.source });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+    // The stale failure must not bleed into the new stream.
+    expect(result.current.error).toBeNull();
+    expect(result.current.text).toBe("");
+
+    await fresh.push();
+    await waitFor(() => expect(result.current.text).toBe("clean"));
+  });
+
+  it("handles an empty source: it completes with no text rather than hanging in streaming", async () => {
+    const empty: StreamingTextSource = async function* () {};
+    const { result } = renderHook(() => useStreamingText(empty));
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.text).toBe("");
+  });
+
+  it("never calls the network: the source is the only thing consumed", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const controller = controllableSource();
+    controller.queue("x");
+    renderHook(() => useStreamingText(controller.source));
+    await controller.push();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/loopover-miner-ui/src/use-streaming-text.test.ts
+++ b/apps/loopover-miner-ui/src/use-streaming-text.test.ts
@@ -166,7 +166,10 @@ describe("useStreamingText (#6516)", () => {
   });
 
   it("handles an empty source: it completes with no text rather than hanging in streaming", async () => {
-    const empty: StreamingTextSource = async function* () {};
+    // A plain AsyncIterable that ends immediately -- an `async function*` with no `yield` trips require-yield.
+    const empty: StreamingTextSource = () => ({
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.resolve({ done: true as const, value: undefined }) }),
+    });
     const { result } = renderHook(() => useStreamingText(empty));
     await waitFor(() => expect(result.current.status).toBe("done"));
     expect(result.current.text).toBe("");


### PR DESCRIPTION
## Summary

The chat rail needs to reveal a reply as chunks arrive rather than popping it in whole, and nothing in `apps/loopover-miner-ui` streams anything today. This adds the primitive: a `useStreamingText` hook plus a thin `<StreamingText>` renderer, exercised **only** against mock chunk sources.

| File | Role |
|---|---|
| `src/lib/use-streaming-text.ts` | The hook + the exported `StreamingTextSource` type (so the composer/message-list issues can type against it) |
| `src/components/streaming-text.tsx` | Thin presentational renderer, reduced-motion-aware |
| `src/use-streaming-text.test.ts` | 11 hook tests, flat at `src/` root per `use-polled-fetch.test.ts` |
| `src/streaming-text.test.tsx` | 7 component tests |

## The "does not satisfy this issue" conditions — each verified

- [x] **No `motion`/`framer-motion` added** to `apps/loopover-miner-ui/package.json` — reduced motion is read from `window.matchMedia("(prefers-reduced-motion: reduce)")` with a `change` listener, the same technique `use-mobile.tsx` already uses here.
- [x] **No backend wiring**: no `/api/*` route, no `fetch`, no `EventSource`, no `vite-*-api.ts` change. Grepped — and a test spies on `fetch` to assert the hook never calls it.
- [x] **`apps/loopover-ui/src/components/site/animated-terminal.tsx` untouched** (read as precedent only), and nothing under `apps/loopover-ui` or `apps/loopover-miner-ui/src/routes/**` is modified.

The diff is four new files that nothing imports yet.

## Design decisions worth reviewing

**Cancellation mirrors `usePolledFetch`'s `cancelled` flag, for a sharper reason.** Every state write is guarded by a per-run token, so a chunk landing after a restart, an explicit `cancel()`, or an unmount is dropped. This matters more than for a poll: an async iterator can keep yielding after we stop caring, and a late chunk appended to a **new** stream's text would silently *corrupt the reply on screen* rather than merely waste a render. One predicate (`owns()`) covers both hazards — a superseded run and an unmounted component are the same "don't write" condition, and splitting them invites fixing one and forgetting the other.

**The source is a factory (`() => AsyncIterable<string>`), not a bare `AsyncIterable`.** An async generator can only be consumed once, so handing the hook an already-started iterable would make a restart resume mid-stream instead of starting over.

**Text accumulates via a functional update** — two chunks arriving in the same tick would otherwise both append to the same stale snapshot, and the first one's text would vanish.

**`cancelled` is a distinct status from `done`** — a caller holding a half-finished answer needs to know it's a truncated fragment, not a complete reply.

**A mid-stream throw keeps the chunks that already arrived** (a partial answer beats a blank box) and surfaces through `status`/`error` rather than escaping as an unhandled rejection.

**Reduced motion changes presentation, never content** — both paths render the same characters at the same time; only the fade differs. So an operator who asked for less motion never sees a truncated answer. The region is `aria-live="polite"` so a reply is announced as it fills in without interrupting what's already being read.

## Tests — 18/18

Every status transition, not just the happy path: `idle→streaming→done`, `streaming→cancelled`, `streaming→error`.

Both regressions the issue names, modeled on `use-polled-fetch.test.ts:76-89`:
- **Late chunk from a superseded source** never reaches state (a second source starts before the first finishes; the first's chunk is then released and must be dropped).
- **Unmount mid-stream** neither throws nor updates retained state when the pending chunk resolves late.

Plus: progressive accumulation asserted *mid-stream* (not only at the end), a non-`Error` thrown value preserved as a string, `cancel()` on an idle hook leaving status alone, a new source resetting stale text/error, an empty source completing rather than hanging, and `fetch` never being called.

The component tests stub `matchMedia` per case so **both** the reduced-motion and default paths are exercised deliberately — and the reduced-motion test asserts **end-state only, never timing**, exactly as the issue asks, to avoid a flaky test.

## Validation

- [x] **New suites — 18/18 pass** (11 hook + 7 component).
- [x] **`npm run ui:test` — all three UI workspaces green (302 + 167 + 22), no coverage-threshold failure.** That's the operative gate (`apps/loopover-miner-ui/vitest.config.ts`'s local floor), since `codecov.yml` ignores `apps/**`. My 18 tests took miner-ui from 149 → 167.
- [x] `npm run ui:typecheck` — clean. `npm run ui:lint` — **0 non-prettier violations** (the repo-wide `prettier/prettier` errors are Windows CRLF noise, absent on CI's LF checkout).
- [x] `git diff --check` clean; tree contains only the four intended files (no generated `routeTree.gen.ts` churn). Rebased on latest `main` — no base conflict.

## Scope

- [x] Four new files, one coherent primitive, in a wanted path (`apps/loopover-miner-ui/`). Maintainer-authored issue → approved work.
- [x] Follows this app's conventions: hook in `src/lib/`, component flat in `src/components/`, both tests flat at `src/` root — per the `use-polled-fetch` / `grafana-footer-link` precedents the issue cites.
- [x] No new npm dependency. No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Additive and inert: nothing mounts these yet, so no existing route's behaviour changes. The hook has no network or action surface — it consumes whatever iterable its caller hands it and nothing else.

Closes #6516
