### PR TITLE
feat(miner-ui): add useStreamingText hook + StreamingText renderer

### DIFF
--- a/apps/loopover-miner-ui/src/components/streaming-text.tsx
+++ b/apps/loopover-miner-ui/src/components/streaming-text.tsx
@@ -1,0 +1,61 @@
+// Thin presentational renderer for a progressively-streamed chat response (#6516). It drives `useStreamingText`
+// and renders the accumulated text; while streaming (and only when the user has NOT asked for reduced motion) it
+// shows an animated caret as the sole visual smoothing on top of raw chunk arrival. Reduced motion is detected
+// with `window.matchMedia("(prefers-reduced-motion: reduce)")` — the same technique `@loopover/ui-kit`'s
+// `useIsMobile` uses — since this app deliberately has no `motion`/`framer-motion` dependency. Ships unwired: no
+// backend call lives here; the only text source is whatever `ChunkSource` the caller passes in.
+import * as React from "react";
+
+import { useStreamingText, type ChunkSource } from "../lib/use-streaming-text";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/** Tracks `prefers-reduced-motion: reduce`, updating live if the OS setting changes. Degrades to `false` in
+ *  any environment without `window.matchMedia` (e.g. a non-DOM test) rather than throwing. */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState<boolean>(() =>
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia(REDUCED_MOTION_QUERY).matches
+      : false,
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia(REDUCED_MOTION_QUERY);
+    const onChange = () => setReduced(query.matches);
+    onChange();
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}
+
+export interface StreamingTextProps {
+  /** The chunked text source to reveal; null renders nothing streaming (idle). */
+  source: ChunkSource | null;
+  className?: string;
+}
+
+export function StreamingText({ source, className }: StreamingTextProps) {
+  const { text, status } = useStreamingText(source);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const showCaret = status === "streaming" && !prefersReducedMotion;
+
+  return (
+    <div
+      className={className}
+      role="log"
+      aria-live={prefersReducedMotion ? "off" : "polite"}
+      aria-busy={status === "streaming"}
+      data-status={status}
+    >
+      {text}
+      {showCaret ? (
+        <span aria-hidden="true" className="ml-0.5 inline-block animate-pulse">
+          ▋
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/loopover-miner-ui/src/lib/use-streaming-text.ts
+++ b/apps/loopover-miner-ui/src/lib/use-streaming-text.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * A chunked text source: a factory that returns a fresh `AsyncIterable<string>` each time streaming starts
+ * (#6516). A factory — rather than a bare iterable — so restarting (a new source supplied, or the same one
+ * re-run) always consumes from the beginning rather than a half-drained iterator. A composer/message-list
+ * issue can type its real backend adapter against this exported name.
+ */
+export type ChunkSource = () => AsyncIterable<string>;
+
+/** Lifecycle of a single stream. `idle` = no source yet; terminal states are `done`/`error`/`cancelled`. */
+export type StreamStatus = "idle" | "streaming" | "done" | "error" | "cancelled";
+
+export interface StreamingTextState {
+  /** The text accumulated from every chunk seen so far. */
+  text: string;
+  status: StreamStatus;
+  /** The error a source threw/rejected with mid-stream; null unless `status === "error"`. */
+  error: unknown;
+  /** Stop consuming the in-flight source; transitions `streaming` → `cancelled` (a no-op once terminal). */
+  cancel: () => void;
+}
+
+/**
+ * Reveal a chat response's text progressively as chunks arrive, instead of popping the whole message in at
+ * once. Consuming the source starts when a non-null `source` is supplied and restarts whenever the `source`
+ * reference changes — so, like `usePolledFetch`, the caller must pass a STABLE/memoized source, or each render
+ * would restart the stream.
+ *
+ * Cancellation discipline mirrors `usePolledFetch`'s `cancelled`-flag pattern exactly: supplying a new source
+ * (or unmounting) stops consumption of the previous source, and no chunk arriving from it after that point may
+ * reach returned state. A source that throws or rejects mid-stream surfaces through `status`/`error` rather
+ * than as an unhandled rejection, and is never silently swallowed.
+ */
+export function useStreamingText(source: ChunkSource | null): StreamingTextState {
+  const [text, setText] = useState("");
+  const [status, setStatus] = useState<StreamStatus>("idle");
+  const [error, setError] = useState<unknown>(null);
+  // Points at the ACTIVE run's canceller so the stable `cancel()` below always stops the current stream.
+  const cancelRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    if (!source) return;
+
+    let cancelled = false;
+    cancelRef.current = () => {
+      cancelled = true;
+    };
+
+    // Fresh stream: reset accumulation/error and enter the streaming state.
+    setText("");
+    setError(null);
+    setStatus("streaming");
+
+    void (async () => {
+      try {
+        for await (const chunk of source()) {
+          if (cancelled) return; // a late chunk after cancel/unmount/source-swap must not touch state
+          setText((prev) => prev + chunk);
+        }
+        if (cancelled) return;
+        setStatus("done");
+      } catch (err) {
+        if (cancelled) return;
+        setError(err);
+        setStatus("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source]);
+
+  const cancel = useCallback(() => {
+    cancelRef.current();
+    // Only a running stream is cancellable; leave done/error/idle untouched.
+    setStatus((prev) => (prev === "streaming" ? "cancelled" : prev));
+  }, []);
+
+  return { text, status, error, cancel };
+}

--- a/apps/loopover-miner-ui/src/streaming-text.test.tsx
+++ b/apps/loopover-miner-ui/src/streaming-text.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StreamingText } from "./components/streaming-text";
+import type { ChunkSource } from "./lib/use-streaming-text";
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("StreamingText (#6516)", () => {
+  it("renders the accumulated streamed text and marks completion", async () => {
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "Hel";
+        yield "lo";
+      })();
+
+    render(<StreamingText source={source} />);
+    const log = screen.getByRole("log");
+
+    await waitFor(() => expect(log.textContent).toContain("Hello"));
+    await waitFor(() => expect(log.getAttribute("data-status")).toBe("done"));
+  });
+
+  it("stays idle and renders no text when the source is null", () => {
+    render(<StreamingText source={null} />);
+    const log = screen.getByRole("log");
+
+    expect(log.getAttribute("data-status")).toBe("idle");
+    expect(log.textContent).toBe("");
+    expect(log.getAttribute("aria-busy")).toBe("false");
+  });
+
+  it("shows an animated caret only while streaming when motion is allowed", async () => {
+    const held = new Promise<void>(() => {}); // never resolves — keeps the stream open
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "typing";
+        await held;
+      })();
+
+    render(<StreamingText source={source} />);
+    const log = screen.getByRole("log");
+
+    await waitFor(() => expect(log.textContent).toContain("typing"));
+    expect(log.getAttribute("aria-busy")).toBe("true");
+    expect(log.querySelector("[aria-hidden='true']")).not.toBeNull(); // caret present mid-stream
+    expect(log.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("reaches the same final text under prefers-reduced-motion, with the live cue disabled", async () => {
+    stubMatchMedia(true);
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "Quiet ";
+        yield "reveal";
+      })();
+
+    render(<StreamingText source={source} />);
+    const log = screen.getByRole("log");
+
+    await waitFor(() => expect(log.textContent).toBe("Quiet reveal")); // no caret text appended
+    expect(log.getAttribute("data-status")).toBe("done");
+    expect(log.getAttribute("aria-live")).toBe("off"); // reduced motion turns the live region off
+  });
+});

--- a/apps/loopover-miner-ui/src/use-streaming-text.test.ts
+++ b/apps/loopover-miner-ui/src/use-streaming-text.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useStreamingText, type ChunkSource } from "./lib/use-streaming-text";
+
+// A promise the test resolves by hand, to gate a generator between chunks so intermediate stream state is
+// observable deterministically (no timers, just microtask ordering) — the streaming analogue of
+// use-polled-fetch.test.ts's manually-resolved in-flight fetches.
+function gate(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+describe("useStreamingText (#6516)", () => {
+  it("accumulates chunks incrementally across renders, not only at the end", async () => {
+    const second = gate();
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "Hel";
+        await second.promise;
+        yield "lo";
+      })();
+
+    const { result } = renderHook(() => useStreamingText(source));
+
+    await waitFor(() => expect(result.current.text).toBe("Hel")); // partial, before the 2nd chunk
+    expect(result.current.status).toBe("streaming");
+
+    second.release();
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.text).toBe("Hello");
+  });
+
+  it("stops consuming a previous source when a new one is supplied — no late chunk from the old source lands", async () => {
+    const oldLate = gate();
+    const source1: ChunkSource = () =>
+      (async function* () {
+        yield "one";
+        await oldLate.promise;
+        yield "LATE";
+      })();
+    const source2: ChunkSource = () =>
+      (async function* () {
+        yield "two";
+      })();
+
+    const { result, rerender } = renderHook(({ src }) => useStreamingText(src), {
+      initialProps: { src: source1 as ChunkSource },
+    });
+
+    await waitFor(() => expect(result.current.text).toBe("one"));
+
+    rerender({ src: source2 });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.text).toBe("two"); // reset to source2; source1 abandoned
+
+    oldLate.release(); // source1's tail chunk fires AFTER the swap
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.text).toBe("two"); // "LATE" never appended
+  });
+
+  it("does not update state after unmount, even if a pending chunk resolves late", async () => {
+    const late = gate();
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "start";
+        await late.promise;
+        yield "END";
+      })();
+
+    const { result, unmount } = renderHook(() => useStreamingText(source));
+    await waitFor(() => expect(result.current.text).toBe("start"));
+
+    unmount();
+    late.release();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result.current.text).toBe("start"); // frozen at unmount; "END" never applied
+  });
+
+  it("surfaces a mid-stream error through status/error and keeps the partial text", async () => {
+    const boom = new Error("stream exploded");
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "part";
+        throw boom;
+      })();
+
+    const { result } = renderHook(() => useStreamingText(source));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(boom);
+    expect(result.current.text).toBe("part");
+  });
+
+  it("cancel() halts an in-flight stream and ignores later chunks", async () => {
+    const second = gate();
+    const source: ChunkSource = () =>
+      (async function* () {
+        yield "a";
+        await second.promise;
+        yield "b";
+      })();
+
+    const { result } = renderHook(() => useStreamingText(source));
+    await waitFor(() => expect(result.current.text).toBe("a"));
+
+    act(() => result.current.cancel());
+    expect(result.current.status).toBe("cancelled");
+
+    second.release();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.text).toBe("a"); // "b" ignored after cancel
+    expect(result.current.status).toBe("cancelled");
+  });
+
+  it("stays idle with a null source and cancel() is a no-op", () => {
+    const { result } = renderHook(() => useStreamingText(null));
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.text).toBe("");
+    expect(result.current.error).toBeNull();
+
+    act(() => result.current.cancel()); // must not throw or change state
+    expect(result.current.status).toBe("idle");
+  });
+});


### PR DESCRIPTION
## What

Adds the chat rail's progressive-reveal primitive as tested, **unwired** plumbing:

- `apps/loopover-miner-ui/src/lib/use-streaming-text.ts` — `useStreamingText(source)`
- `apps/loopover-miner-ui/src/components/streaming-text.tsx` — the `<StreamingText>` renderer

Resolves #6516.

## The hook

- Accepts a `ChunkSource` — a factory returning `AsyncIterable<string>` (exported by name from the same file so a later composer/message-list issue can type against it).
- Returns the accumulated `text`, a `status` (`idle`/`streaming`/`done`/`error`/`cancelled`), the surfaced `error`, and `cancel()`.
- Supplying a **new source** while one is streaming — or **unmounting** — stops consuming the previous source, and no chunk arriving from it afterward reaches returned state (the same `cancelled`-flag discipline `usePolledFetch` uses).
- A source that **throws/rejects mid-stream** surfaces through `status`/`error` — never an unhandled rejection, never silently swallowed.

## The renderer

- Thin `<StreamingText>` drives the hook and reveals the accumulated text; an animated caret is the only visual smoothing.
- Reduced motion is detected via `window.matchMedia("(prefers-reduced-motion: reduce)")` — the same technique `@loopover/ui-kit`'s `useIsMobile` uses — so **no `motion`/`framer-motion` dependency is added**.

## Scope / non-goals

- No new npm dependency; no `/api/*` route, live `fetch`, or `EventSource` anywhere in the PR. Every test drives the hook through an in-test mock chunk source only.
- Not wired into `__root.tsx` / any route — that's separate, later work.
- `apps/loopover-ui`'s `animated-terminal.tsx` was read for precedent only and is not touched.

## Tests (co-located per this app's convention)

- `src/use-streaming-text.test.ts` — incremental accumulation across renders; cancel-on-new-source and cancel-on-unmount late-chunk regressions; mid-stream error path; `cancel()`; idle-with-null-source.
- `src/streaming-text.test.tsx` — populated render + completion; idle/null source; caret shown only while streaming; identical final text under `prefers-reduced-motion` (end-state asserted, not timing).

Locally green: miner-ui `npm run test` (`--coverage`) — full suite 155/155 pass, coverage 87.53% stmts / 86.37% branch / 81.37% funcs / 89.69% lines (above the app floor); `tsc --noEmit` clean; `eslint` clean.