### PR TITLE
refactor(settings): drop Batch A's 9 config-as-code-only DB columns

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
@@ -37,7 +37,6 @@ type ActivationPreviewResponse = {
 type ActivationResponse = {
   repoFullName: string;
   reviewCheckMode: string;
-  checkRunMode: string;
   linkedIssueGateMode: string;
   duplicatePrGateMode: string;
   qualityGateMode: string;

--- a/apps/loopover-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
@@ -21,12 +21,6 @@ import { GateRampControl } from "@/components/site/app-panels/gate-ramp-control"
 const REVIEWABILITY = [{ pr: "acme/widgets#1" }];
 
 const ADVISORY_SETTINGS = {
-  commentMode: "detected_contributors_only" as const,
-  publicAudienceMode: "oss_maintainer" as const,
-  publicSignalLevel: "standard" as const,
-  publicSurface: "comment_and_label" as const,
-  checkRunMode: "enabled" as const,
-  checkRunDetailLevel: "standard" as const,
   reviewCheckMode: "required" as const,
   gatePack: "gittensor" as const,
   linkedIssueGateMode: "advisory" as const,
@@ -42,7 +36,6 @@ const ADVISORY_SETTINGS = {
   autoLabelEnabled: true,
   gittensorLabel: "gittensor",
   createMissingLabel: true,
-  includeMaintainerAuthors: false,
   requireLinkedIssue: false,
   badgeEnabled: false,
   publicQualityMetrics: false,
@@ -108,7 +101,7 @@ describe("GateRampControl (#2218)", () => {
     expect(body.linkedIssueGateMode).toBe("block");
     expect(body.duplicatePrGateMode).toBe("block");
     expect(body.qualityGateMode).toBe("block");
-    expect(body.commentMode).toBe("detected_contributors_only");
+    expect(body.gittensorLabel).toBe("gittensor");
   });
 
   it("closes confirm without saving when cancel is clicked", async () => {

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -142,65 +142,10 @@ const SLOP_FIELDS: FieldDef[] = [
   },
 ];
 
+// commentMode/publicSurface/publicSignalLevel/publicAudienceMode/checkRunMode/checkRunDetailLevel/
+// includeMaintainerAuthors moved off the dashboard entirely (Batch A, loopover#6442) -- configure them via
+// this repo's own .loopover.yml settings.* block instead.
 const SURFACE_FIELDS: FieldDef[] = [
-  {
-    key: "commentMode",
-    label: "Comment mode",
-    kind: "select",
-    options: [
-      ["off", "off"],
-      ["detected_contributors_only", "detected contributors only"],
-      ["all_prs", "all PRs"],
-    ],
-  },
-  {
-    key: "publicSurface",
-    label: "Public surface",
-    kind: "select",
-    options: [
-      ["off", "off"],
-      ["comment_and_label", "comment + label"],
-      ["comment_only", "comment only"],
-      ["label_only", "label only"],
-    ],
-  },
-  {
-    key: "publicSignalLevel",
-    label: "Public signal level",
-    kind: "select",
-    options: [
-      ["minimal", "minimal"],
-      ["standard", "standard"],
-    ],
-  },
-  {
-    key: "publicAudienceMode",
-    label: "Audience",
-    kind: "select",
-    options: [
-      ["oss_maintainer", "OSS maintainer"],
-      ["gittensor_only", "gittensor only"],
-    ],
-  },
-  {
-    key: "checkRunMode",
-    label: "Context check run",
-    kind: "select",
-    options: [
-      ["off", "off"],
-      ["enabled", "enabled"],
-    ],
-  },
-  {
-    key: "checkRunDetailLevel",
-    label: "Check detail",
-    kind: "select",
-    options: [
-      ["minimal", "minimal"],
-      ["standard", "standard"],
-    ],
-  },
-  { key: "includeMaintainerAuthors", label: "Include maintainer-authored PRs", kind: "toggle" },
   { key: "requireLinkedIssue", label: "Require a linked issue", kind: "toggle" },
   { key: "badgeEnabled", label: "Repo badge", kind: "toggle" },
   { key: "publicQualityMetrics", label: "Public quality page", kind: "toggle" },

--- a/apps/loopover-ui/src/lib/maintainer-settings-editable.test.ts
+++ b/apps/loopover-ui/src/lib/maintainer-settings-editable.test.ts
@@ -7,12 +7,6 @@ import {
 } from "@/lib/maintainer-settings-editable";
 
 const SETTINGS: MaintainerSettingsEditable = {
-  commentMode: "detected_contributors_only",
-  publicAudienceMode: "oss_maintainer",
-  publicSignalLevel: "standard",
-  publicSurface: "comment_and_label",
-  checkRunMode: "enabled",
-  checkRunDetailLevel: "standard",
   reviewCheckMode: "required",
   gatePack: "gittensor",
   linkedIssueGateMode: "advisory",
@@ -28,7 +22,6 @@ const SETTINGS: MaintainerSettingsEditable = {
   autoLabelEnabled: true,
   gittensorLabel: "gittensor",
   createMissingLabel: true,
-  includeMaintainerAuthors: false,
   requireLinkedIssue: false,
   badgeEnabled: false,
   publicQualityMetrics: false,
@@ -44,7 +37,7 @@ describe("maintainer-settings-editable (#2218)", () => {
     const payload = buildMaintainerSettingsSavePayload(SETTINGS);
     expect(Object.keys(payload).sort()).toEqual([...MAINTAINER_SETTINGS_EDITABLE_KEYS].sort());
     expect(payload.linkedIssueGateMode).toBe("advisory");
-    expect(payload.commentMode).toBe("detected_contributors_only");
+    expect(payload.gittensorLabel).toBe("gittensor");
   });
 
   it("buildMaintainerSettingsSavePayload merges a partial patch over the base settings", () => {
@@ -56,7 +49,7 @@ describe("maintainer-settings-editable (#2218)", () => {
     expect(payload.duplicatePrGateMode).toBe("block");
     // Untouched fields pass through unchanged.
     expect(payload.qualityGateMode).toBe("advisory");
-    expect(payload.commentMode).toBe("detected_contributors_only");
+    expect(payload.gittensorLabel).toBe("gittensor");
   });
 
   it("an empty patch object is a no-op (same as omitting it)", () => {

--- a/apps/loopover-ui/src/lib/maintainer-settings-editable.ts
+++ b/apps/loopover-ui/src/lib/maintainer-settings-editable.ts
@@ -18,12 +18,6 @@ export type AgentActionClass =
 export type AutoMergeMethod = "merge" | "squash" | "rebase";
 
 export type MaintainerSettingsEditable = {
-  commentMode: "off" | "detected_contributors_only" | "all_prs";
-  publicAudienceMode: "oss_maintainer" | "gittensor_only";
-  publicSignalLevel: "minimal" | "standard";
-  publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
-  checkRunMode: "off" | "enabled";
-  checkRunDetailLevel: "minimal" | "standard";
   // #4618/#5373: a prior gateCheckMode field was a deprecated computed read-back, since removed entirely --
   // reviewCheckMode is the real, writable authority for whether the review-agent check-run publishes.
   reviewCheckMode: "required" | "visible" | "disabled";
@@ -41,7 +35,6 @@ export type MaintainerSettingsEditable = {
   autoLabelEnabled: boolean;
   gittensorLabel: string;
   createMissingLabel: boolean;
-  includeMaintainerAuthors: boolean;
   requireLinkedIssue: boolean;
   badgeEnabled: boolean;
   publicQualityMetrics: boolean;
@@ -54,12 +47,6 @@ export type MaintainerSettingsEditable = {
 
 // The maintainer-editable subset, sent verbatim to PUT /settings (which merges onto current settings).
 export const MAINTAINER_SETTINGS_EDITABLE_KEYS: Array<keyof MaintainerSettingsEditable> = [
-  "commentMode",
-  "publicAudienceMode",
-  "publicSignalLevel",
-  "publicSurface",
-  "checkRunMode",
-  "checkRunDetailLevel",
   "reviewCheckMode",
   "gatePack",
   "linkedIssueGateMode",
@@ -75,7 +62,6 @@ export const MAINTAINER_SETTINGS_EDITABLE_KEYS: Array<keyof MaintainerSettingsEd
   "autoLabelEnabled",
   "gittensorLabel",
   "createMissingLabel",
-  "includeMaintainerAuthors",
   "requireLinkedIssue",
   "badgeEnabled",
   "publicQualityMetrics",

--- a/migrations/0158_drop_batch_a_config_as_code_columns.sql
+++ b/migrations/0158_drop_batch_a_config_as_code_columns.sql
@@ -1,0 +1,20 @@
+-- Config-as-code migration (Batch A, loopover#6442/epic #6440): these 9 fields already parse correctly
+-- from .loopover.yml's settings: block (confirmed via audit, zero silent-discard bugs) and resolveEffectiveSettings
+-- already overlays manifest settings over the DB value unconditionally -- so once the DB value itself
+-- stops carrying a real per-repo override (getRepositorySettings now returns the same built-in default for
+-- every repo instead of a live column), the effective behavior collapses to "manifest override, else
+-- built-in default": genuine config-as-code, no more DB-vs-yml dual-source ambiguity for these fields.
+-- badgeEnabled/publicQualityMetrics are DELIBERATELY excluded and stay DB-only forever: src/api/routes.ts's
+-- loadPublicRepoBadge/loadPublicRepoQualityMetrics read them via a direct getRepositorySettings call that
+-- bypasses the manifest overlay entirely, a documented perf tradeoff for two unauthenticated, high-frequency
+-- public routes (no manifest-cache lookup, no possible cold-cache GitHub fetch, on every image/API load).
+-- SQLite 3.35+ / D1 supports DROP COLUMN directly (same precedent as 0122/0146/0150).
+ALTER TABLE repository_settings DROP COLUMN comment_mode;
+ALTER TABLE repository_settings DROP COLUMN public_audience_mode;
+ALTER TABLE repository_settings DROP COLUMN public_signal_level;
+ALTER TABLE repository_settings DROP COLUMN check_run_mode;
+ALTER TABLE repository_settings DROP COLUMN check_run_detail_level;
+ALTER TABLE repository_settings DROP COLUMN regate_sweep_order_mode;
+ALTER TABLE repository_settings DROP COLUMN public_surface;
+ALTER TABLE repository_settings DROP COLUMN include_maintainer_authors;
+ALTER TABLE repository_settings DROP COLUMN backfill_enabled;

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2753,10 +2753,12 @@ export function createApp() {
     if (gate instanceof Response) return gate;
     const current = await getRepositorySettings(c.env, fullName);
     const updated = await upsertRepositorySettings(c.env, { ...current, ...recommendedAdvisoryActivationSettings() });
+    // checkRunMode dropped (Batch A, loopover#6442): recommendedAdvisoryActivationSettings() no longer sets
+    // it (writing it is now a no-op), so echoing updated.checkRunMode here would just always report the
+    // hardcoded default regardless of what this activation actually did.
     return c.json({
       repoFullName: fullName,
       reviewCheckMode: updated.reviewCheckMode,
-      checkRunMode: updated.checkRunMode,
       linkedIssueGateMode: updated.linkedIssueGateMode,
       duplicatePrGateMode: updated.duplicatePrGateMode,
       qualityGateMode: updated.qualityGateMode,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -277,7 +277,7 @@ import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from ".
 import { buildMaintainerSlopDuplicateTrend, SLOP_DUPLICATE_TREND_SNAPSHOT_LIMIT } from "../services/maintainer-slop-duplicate-trend";
 import { buildGateOutcomeBreakdown, GATE_OUTCOME_BREAKDOWN_WINDOW_DAYS } from "../services/gate-outcome-breakdown";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
-import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, normalizeReadinessGateMode } from "../signals/focus-manifest";
+import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, normalizeReadinessGateMode, resolveEffectiveSettings } from "../signals/focus-manifest";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
@@ -663,15 +663,6 @@ const agentPlanSchema = z
 const agentExplainBlockersSchema = z.union([localBranchAnalysisSchema, agentPlanSchema]);
 
 const repositorySettingsSchema = z.object({
-  commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]).default("detected_contributors_only"),
-  publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]).default("oss_maintainer"),
-  publicSignalLevel: z.enum(["minimal", "standard"]).default("standard"),
-  checkRunMode: z.enum(["off", "enabled"]).default("off"),
-  // Matches repository_settings.check_run_detail_level's own column default (#2907) -- the Context check's
-  // public output is intentionally minimal by design (see formatCheckRunOutput's doc comment), so a caller of
-  // this full-replace route that omits this field must land on the same safe default as a never-configured row.
-  checkRunDetailLevel: z.enum(["minimal", "standard"]).default("minimal"),
-  regateSweepOrderMode: z.enum(["staleness", "oldest-first"]).default("staleness"),
   // #4618/#5373: this write schema never accepted a gateCheckMode field -- it was a deprecated computed
   // read-back of reviewCheckMode, removed from RepositorySettings entirely in #5373. Set reviewCheckMode
   // directly.
@@ -692,10 +683,7 @@ const repositorySettingsSchema = z.object({
   gittensorLabel: z.string().trim().min(1).max(50).default("gittensor"),
   blacklistLabel: z.string().trim().min(1).max(50).default("slop"),
   createMissingLabel: z.boolean().default(true),
-  publicSurface: z.enum(["off", "comment_and_label", "comment_only", "label_only"]).default("comment_and_label"),
-  includeMaintainerAuthors: z.boolean().default(false),
   requireLinkedIssue: z.boolean().default(false),
-  backfillEnabled: z.boolean().default(true),
   badgeEnabled: z.boolean().default(false),
   publicQualityMetrics: z.boolean().default(false),
   commandAuthorization: z
@@ -719,13 +707,6 @@ const repositorySettingsSchema = z.object({
 // rather than preserving it.
 const maintainerSettingsSchema = z
   .object({
-    commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
-    publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
-    publicSignalLevel: z.enum(["minimal", "standard"]),
-    publicSurface: z.enum(["off", "comment_and_label", "comment_only", "label_only"]),
-    checkRunMode: z.enum(["off", "enabled"]),
-    checkRunDetailLevel: z.enum(["minimal", "standard"]),
-    regateSweepOrderMode: z.enum(["staleness", "oldest-first"]),
     reviewCheckMode: z.enum(["required", "visible", "disabled"]),
     gatePack: z.enum(["gittensor", "oss-anti-slop"]),
     linkedIssueGateMode: z.enum(["off", "advisory", "block"]),
@@ -747,7 +728,6 @@ const maintainerSettingsSchema = z
     gittensorLabel: z.string().trim().min(1).max(50),
     blacklistLabel: z.string().trim().min(1).max(50),
     createMissingLabel: z.boolean(),
-    includeMaintainerAuthors: z.boolean(),
     closeOwnerAuthors: z.boolean(),
     requireLinkedIssue: z.boolean(),
     badgeEnabled: z.boolean(),
@@ -2534,7 +2514,10 @@ export function createApp() {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
     const gate = await requireRepoMaintainer(c, fullName);
     if (gate instanceof Response) return gate;
-    return c.json(await getRepositorySettings(c.env, fullName));
+    // resolveRepositorySettings (not the raw getRepositorySettings row), so this reflects the true EFFECTIVE
+    // value -- a config-as-code-only field (Batch A, loopover#6442) would otherwise always show its hardcoded
+    // default here regardless of what the repo's .loopover.yml actually configures.
+    return c.json(await resolveRepositorySettings(c.env, fullName));
   });
 
   // #130 maintainer settings editor: PATCH-style save of the gate / slop / label / surface / command-auth
@@ -4208,12 +4191,6 @@ export function createApp() {
     return c.json(
       await upsertRepositorySettings(c.env, {
         repoFullName: fullName,
-        commentMode: parsed.data.commentMode,
-        publicAudienceMode: parsed.data.publicAudienceMode,
-        publicSignalLevel: parsed.data.publicSignalLevel,
-        checkRunMode: parsed.data.checkRunMode,
-        checkRunDetailLevel: parsed.data.checkRunDetailLevel,
-        regateSweepOrderMode: parsed.data.regateSweepOrderMode,
         reviewCheckMode: parsed.data.reviewCheckMode,
         gatePack: parsed.data.gatePack,
         linkedIssueGateMode: parsed.data.linkedIssueGateMode,
@@ -4231,10 +4208,7 @@ export function createApp() {
         gittensorLabel: parsed.data.gittensorLabel,
         blacklistLabel: parsed.data.blacklistLabel,
         createMissingLabel: parsed.data.createMissingLabel,
-        publicSurface: parsed.data.publicSurface,
-        includeMaintainerAuthors: parsed.data.includeMaintainerAuthors,
         requireLinkedIssue: parsed.data.requireLinkedIssue,
-        backfillEnabled: parsed.data.backfillEnabled,
         badgeEnabled: parsed.data.badgeEnabled,
         publicQualityMetrics: parsed.data.publicQualityMetrics,
         commandAuthorization: normalizeCommandAuthorizationPolicy(parsed.data.commandAuthorization).policy,
@@ -5064,6 +5038,28 @@ async function buildRepoOutcomePatternsResponse(env: Env, fullName: string) {
   return attachDataQuality(response as unknown as Record<string, unknown>, dataQuality);
 }
 
+// Batch A (loopover#6442): these 9 fields moved off the DB entirely -- rawSettings (getRepositorySettings)
+// always returns the same hardcoded default for them now, so a "DB vs yml" comparison built on rawSettings
+// alone would be comparing a constant against yml, never reflecting a repo's real .loopover.yml-driven
+// behavior. Overlays the true EFFECTIVE value for just these 9 fields onto an otherwise-raw-DB settings
+// object, preserving the #2912 DB-vs-yml comparison intent for every other (still DB-backed) field.
+const CONFIG_AS_CODE_ONLY_FIELDS = [
+  "commentMode",
+  "publicAudienceMode",
+  "publicSignalLevel",
+  "checkRunMode",
+  "checkRunDetailLevel",
+  "regateSweepOrderMode",
+  "publicSurface",
+  "includeMaintainerAuthors",
+  "backfillEnabled",
+] as const satisfies ReadonlyArray<keyof RepositorySettings>;
+function applyConfigAsCodeOnlyFields(rawSettings: RepositorySettings, resolvedSettings: RepositorySettings): RepositorySettings {
+  const settings = { ...rawSettings };
+  for (const field of CONFIG_AS_CODE_ONLY_FIELDS) (settings[field] as unknown) = resolvedSettings[field];
+  return settings;
+}
+
 export async function buildRegistrationReadinessResponse(env: Env, fullName: string) {
   /* v8 ignore start -- Registration readiness route-level shaping over covered signal helpers. */
   // Intentionally the raw DB `settings` alongside the raw (cache-only, never live-fetched) `focusManifest`,
@@ -5071,12 +5067,17 @@ export async function buildRegistrationReadinessResponse(env: Env, fullName: str
   // relationship between the two config layers (e.g. "your yml sets X but the currently active settings say
   // Y"), which requires seeing them unmerged (#2912). See buildRegistrationReadiness's use of `focusManifest`
   // for the yml-compiled policy section, separate from `settings` for the currently-active-behavior section.
-  const [intelligence, settings, upstreamReports, focusManifest] = await Promise.all([
+  const [intelligence, rawSettings, upstreamReports, focusManifest] = await Promise.all([
     buildRepoIntelligenceResponse(env, fullName),
     getRepositorySettings(env, fullName),
     listUpstreamDriftReports(env, 20),
     loadRepoFocusManifest(env, fullName, { fetcher: async () => null }),
   ]);
+  // Batch A (loopover#6442): the 9 config-as-code-only fields no longer have an independent DB value to
+  // compare against yml (#2912's rationale doesn't apply to them anymore -- `rawSettings` would always show
+  // the same hardcoded default), so overlay the real EFFECTIVE value for those specific fields onto the raw
+  // DB settings used for everything else.
+  const settings = applyConfigAsCodeOnlyFields(rawSettings, resolveEffectiveSettings(rawSettings, focusManifest));
   const repo = intelligence.repo;
   const installation = await loadInstallationHealthSummary(env, repo);
   const report = buildRegistrationReadiness({
@@ -5128,8 +5129,13 @@ export async function buildGittensorConfigRecommendationResponse(env: Env, fullN
   // to ADD to .loopover.yml based on the repo's currently-active (dashboard/API-configured) behavior — using
   // the yml-merged view here would be comparing the recommendation against itself once a yml override exists
   // (#2912).
-  const intelligence = await buildRepoIntelligenceResponse(env, fullName);
-  const settings = await getRepositorySettings(env, fullName);
+  const [intelligence, rawSettings, resolvedSettings] = await Promise.all([
+    buildRepoIntelligenceResponse(env, fullName),
+    getRepositorySettings(env, fullName),
+    resolveRepositorySettings(env, fullName),
+  ]);
+  // Batch A (loopover#6442): see buildRegistrationReadinessResponse's identical comment above.
+  const settings = applyConfigAsCodeOnlyFields(rawSettings, resolvedSettings);
   const repo = intelligence.repo;
   const recommendation = buildGittensorConfigRecommendation({
     repoFullName: fullName,

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -656,12 +656,15 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
   }
   return {
     repoFullName: row.repoFullName,
-    commentMode: parseCommentMode(row.commentMode),
-    publicAudienceMode: parsePublicAudienceMode(row.publicAudienceMode),
-    publicSignalLevel: row.publicSignalLevel === "minimal" ? "minimal" : "standard",
-    checkRunMode: parseCheckRunMode(row.checkRunMode),
-    checkRunDetailLevel: parseCheckRunDetailLevel(row.checkRunDetailLevel),
-    regateSweepOrderMode: parseRegateSweepOrderMode(row.regateSweepOrderMode),
+    // Config-as-code only (Batch A, loopover#6442): no DB column backs these 9 fields anymore -- the
+    // built-in default here is unconditional (not row-dependent), matching the !row branch above.
+    // resolveEffectiveSettings still overlays a repo's .loopover.yml settings.* value over this default.
+    commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
+    publicSignalLevel: "standard",
+    checkRunMode: "off",
+    checkRunDetailLevel: "minimal",
+    regateSweepOrderMode: "staleness",
     reviewCheckMode: parseReviewCheckMode(row.reviewCheckMode),
     autoProjectMilestoneMatch: parseProjectMilestoneMatchMode(row.projectMilestoneMatchMode),
     autoProjectMilestoneMatchBackend: parseProjectMilestoneMatchBackend(row.autoProjectMilestoneMatchBackend),
@@ -693,10 +696,11 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     gittensorLabel: row.gittensorLabel,
     blacklistLabel: row.blacklistLabel,
     createMissingLabel: row.createMissingLabel,
-    publicSurface: parsePublicSurface(row.publicSurface),
-    includeMaintainerAuthors: row.includeMaintainerAuthors,
+    // Config-as-code only (Batch A, loopover#6442): see the comment on the reviewCheckMode block above.
+    publicSurface: "comment_and_label",
+    includeMaintainerAuthors: false,
     requireLinkedIssue: row.requireLinkedIssue,
-    backfillEnabled: row.backfillEnabled,
+    backfillEnabled: true,
     badgeEnabled: row.badgeEnabled,
     publicQualityMetrics: row.publicQualityMetrics,
     agentPaused: row.agentPaused,
@@ -773,12 +777,16 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
   // write path, can express "close without any label" via an explicit null; see focus-manifest.ts).
   const resolved = {
     repoFullName: settings.repoFullName,
-    commentMode: settings.commentMode ?? "detected_contributors_only",
-    publicAudienceMode: settings.publicAudienceMode ?? "oss_maintainer",
-    publicSignalLevel: settings.publicSignalLevel ?? "standard",
-    checkRunMode: settings.checkRunMode ?? "off",
-    checkRunDetailLevel: settings.checkRunDetailLevel ?? "minimal",
-    regateSweepOrderMode: settings.regateSweepOrderMode ?? "staleness",
+    // Config-as-code only (Batch A, loopover#6442): no DB column backs these 9 fields anymore -- any
+    // caller-supplied value is a silent no-op (there is nothing left to persist it to), so this always
+    // returns the same built-in default getRepositorySettings would, regardless of `settings.X` input.
+    // Configure these via a repo's .loopover.yml settings.* block instead.
+    commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
+    publicSignalLevel: "standard",
+    checkRunMode: "off",
+    checkRunDetailLevel: "minimal",
+    regateSweepOrderMode: "staleness",
     reviewCheckMode: settings.reviewCheckMode ?? "disabled",
     autoProjectMilestoneMatch: settings.autoProjectMilestoneMatch ?? "off",
     autoProjectMilestoneMatchBackend: settings.autoProjectMilestoneMatchBackend ?? "github",
@@ -809,10 +817,11 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     gittensorLabel: settings.gittensorLabel ?? "gittensor",
     blacklistLabel: settings.blacklistLabel ?? "slop",
     createMissingLabel: settings.createMissingLabel ?? true,
-    publicSurface: settings.publicSurface ?? "comment_and_label",
-    includeMaintainerAuthors: settings.includeMaintainerAuthors ?? false,
+    // Config-as-code only (Batch A, loopover#6442): see the comment on the reviewCheckMode block above.
+    publicSurface: "comment_and_label",
+    includeMaintainerAuthors: false,
     requireLinkedIssue: settings.requireLinkedIssue ?? false,
-    backfillEnabled: settings.backfillEnabled ?? true,
+    backfillEnabled: true,
     badgeEnabled: settings.badgeEnabled ?? false,
     publicQualityMetrics: settings.publicQualityMetrics ?? false,
     agentPaused: settings.agentPaused ?? false,
@@ -855,12 +864,6 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     .insert(repositorySettings)
     .values({
       repoFullName: resolved.repoFullName,
-      commentMode: resolved.commentMode,
-      publicAudienceMode: resolved.publicAudienceMode,
-      publicSignalLevel: resolved.publicSignalLevel,
-      checkRunMode: resolved.checkRunMode,
-      checkRunDetailLevel: resolved.checkRunDetailLevel,
-      regateSweepOrderMode: resolved.regateSweepOrderMode,
       reviewCheckMode: resolved.reviewCheckMode,
       projectMilestoneMatchMode: resolved.autoProjectMilestoneMatch,
       autoProjectMilestoneMatchBackend: resolved.autoProjectMilestoneMatchBackend,
@@ -891,10 +894,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
       gittensorLabel: resolved.gittensorLabel,
       blacklistLabel: resolved.blacklistLabel,
       createMissingLabel: resolved.createMissingLabel,
-      publicSurface: resolved.publicSurface,
-      includeMaintainerAuthors: resolved.includeMaintainerAuthors,
       requireLinkedIssue: resolved.requireLinkedIssue,
-      backfillEnabled: resolved.backfillEnabled,
       badgeEnabled: resolved.badgeEnabled,
       publicQualityMetrics: resolved.publicQualityMetrics,
       agentPaused: resolved.agentPaused,
@@ -943,12 +943,6 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     .onConflictDoUpdate({
       target: repositorySettings.repoFullName,
       set: {
-        commentMode: resolved.commentMode,
-        publicAudienceMode: resolved.publicAudienceMode,
-        publicSignalLevel: resolved.publicSignalLevel,
-        checkRunMode: resolved.checkRunMode,
-        checkRunDetailLevel: resolved.checkRunDetailLevel,
-        regateSweepOrderMode: resolved.regateSweepOrderMode,
         reviewCheckMode: resolved.reviewCheckMode,
       projectMilestoneMatchMode: resolved.autoProjectMilestoneMatch,
       autoProjectMilestoneMatchBackend: resolved.autoProjectMilestoneMatchBackend,
@@ -981,10 +975,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
         gittensorLabel: resolved.gittensorLabel,
         blacklistLabel: resolved.blacklistLabel,
         createMissingLabel: resolved.createMissingLabel,
-        publicSurface: resolved.publicSurface,
-        includeMaintainerAuthors: resolved.includeMaintainerAuthors,
         requireLinkedIssue: resolved.requireLinkedIssue,
-        backfillEnabled: resolved.backfillEnabled,
         badgeEnabled: resolved.badgeEnabled,
         publicQualityMetrics: resolved.publicQualityMetrics,
         agentPaused: resolved.agentPaused,
@@ -7762,29 +7753,6 @@ function parseAgentRecommendationOutcomeConfidence(value: string): AgentRecommen
   return "medium";
 }
 
-function parseCommentMode(value: string): RepositorySettings["commentMode"] {
-  if (value === "detected_contributors_only" || value === "all_prs") return value;
-  return "off";
-}
-
-function parsePublicAudienceMode(value: string): RepositorySettings["publicAudienceMode"] {
-  return value === "gittensor_only" ? "gittensor_only" : "oss_maintainer";
-}
-
-function parseCheckRunMode(value: string): RepositorySettings["checkRunMode"] {
-  return value === "enabled" ? "enabled" : "off";
-}
-
-function parseCheckRunDetailLevel(value: string): RepositorySettings["checkRunDetailLevel"] {
-  // #4620: a pre-#4620 row persisted as "deep" degrades to "standard" here -- the two were always
-  // behaviorally identical (see the type's own doc comment), so this is a display-only fallback.
-  return value === "minimal" ? "minimal" : "standard";
-}
-
-function parseRegateSweepOrderMode(value: string): RepositorySettings["regateSweepOrderMode"] {
-  return value === "oldest-first" ? "oldest-first" : "staleness";
-}
-
 function parseReviewCheckMode(value: string): RepositorySettings["reviewCheckMode"] {
   return value === "required" || value === "visible" ? value : "disabled";
 }
@@ -7842,11 +7810,6 @@ function normalizePositiveIntOrNull(value: number | null | undefined): number | 
 function normalizeOpenItemCap(value: number | null | undefined): number | null {
   const parsed = normalizePositiveIntOrNull(value);
   return parsed === null ? null : Math.min(parsed, MAX_CONTRIBUTOR_OPEN_ITEM_CAP);
-}
-
-function parsePublicSurface(value: string): RepositorySettings["publicSurface"] {
-  if (value === "comment_only" || value === "label_only" || value === "off") return value;
-  return "comment_and_label";
 }
 
 function parseCommandAuthorizationPolicy(value: string): RepositorySettings["commandAuthorization"] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,14 +45,6 @@ export const repositories = sqliteTable("repositories", {
 
 export const repositorySettings = sqliteTable("repository_settings", {
   repoFullName: text("repo_full_name").primaryKey(),
-  commentMode: text("comment_mode").notNull().default("detected_contributors_only"),
-  publicAudienceMode: text("public_audience_mode").notNull().default("oss_maintainer"),
-  publicSignalLevel: text("public_signal_level").notNull().default("standard"),
-  checkRunMode: text("check_run_mode").notNull().default("off"),
-  checkRunDetailLevel: text("check_run_detail_level").notNull().default("minimal"),
-  // Scheduled re-gate sweep candidate ordering (#3815). staleness | oldest-first. Default staleness — see
-  // RepositorySettings["regateSweepOrderMode"] for the full convergence-guarantee rationale.
-  regateSweepOrderMode: text("regate_sweep_order_mode").notNull().default("staleness"),
   reviewCheckMode: text("review_check_mode").notNull().default("disabled"),
   projectMilestoneMatchMode: text("project_milestone_match_mode").notNull().default("off"),
   autoProjectMilestoneMatchBackend: text("auto_project_milestone_match_backend").notNull().default("github"),
@@ -110,10 +102,7 @@ export const repositorySettings = sqliteTable("repository_settings", {
   // Linked-issue label propagation (#priority-linked-issue-gate): the only mechanism that can select the
   // configured priority label -- never inferred from title/files/AI/PR-labels. Default disabled, no mappings.
   linkedIssueLabelPropagationJson: text("linked_issue_label_propagation_json").notNull().default("{}"),
-  publicSurface: text("public_surface").notNull().default("comment_and_label"),
-  includeMaintainerAuthors: integer("include_maintainer_authors", { mode: "boolean" }).notNull().default(false),
   requireLinkedIssue: integer("require_linked_issue", { mode: "boolean" }).notNull().default(false),
-  backfillEnabled: integer("backfill_enabled", { mode: "boolean" }).notNull().default(true),
   badgeEnabled: integer("badge_enabled", { mode: "boolean" }).notNull().default(false),
   publicQualityMetrics: integer("public_quality_metrics", { mode: "boolean" }).notNull().default(false),
   commandAuthorizationJson: text("command_authorization_json").notNull().default("{}"),

--- a/src/services/maintainer-activation.ts
+++ b/src/services/maintainer-activation.ts
@@ -115,11 +115,14 @@ function buildSummary(evaluated: number, withFindings: number, currentlyActive: 
  */
 export function recommendedAdvisoryActivationSettings(): Pick<
   RepositorySettings,
-  "reviewCheckMode" | "checkRunMode" | "linkedIssueGateMode" | "duplicatePrGateMode" | "qualityGateMode"
+  "reviewCheckMode" | "linkedIssueGateMode" | "duplicatePrGateMode" | "qualityGateMode"
 > {
+  // checkRunMode moved off the DB entirely (Batch A, loopover#6442) -- writing it via upsertRepositorySettings
+  // is now a silent no-op, so it's dropped from this one-click patch rather than pretending to activate it.
+  // Turning check-run mode on now requires a repo's own .loopover.yml settings.checkRunMode -- there is no
+  // config-as-code write mechanism this one-click action can use to set that on the maintainer's behalf.
   return {
     reviewCheckMode: "required",
-    checkRunMode: "enabled",
     linkedIssueGateMode: "advisory",
     duplicatePrGateMode: "advisory",
     qualityGateMode: "advisory",

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -411,18 +411,6 @@ describe("api routes", () => {
     await expect(response.json()).resolves.toMatchObject({ repoFullName: "acme/badged", badgeEnabled: true });
   });
 
-  it("REGRESSION (#2907): defaults checkRunDetailLevel to minimal, matching the DB column's own default, when omitted", async () => {
-    const app = createApp();
-    const env = createTestEnv();
-    const response = await app.request(
-      "/v1/internal/repos/acme/detail-level-default/settings",
-      { method: "POST", headers: { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ checkRunMode: "enabled" }) },
-      env,
-    );
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({ checkRunMode: "enabled", checkRunDetailLevel: "minimal" });
-  });
-
   it("downgrades qualityGateMode: block to advisory through the internal settings write endpoint too (#2267)", async () => {
     // Readiness/quality can never hard-block a PR — the internal full-settings write path (used by tooling,
     // not just the maintainer dashboard) gets the identical downgrade so it can't persist "block" either.
@@ -2171,6 +2159,10 @@ describe("api routes", () => {
     // .loopover.yml succeeds via GitHub's repo-rename redirect and returns the CURRENT (broader) autonomy
     // grant, which would upgrade requiredPermissions beyond what this test asserts.
     vi.stubGlobal("fetch", async () => new Response("Not Found", { status: 404 }));
+    // commentMode/publicSurface/checkRunMode moved off the DB entirely (Batch A, loopover#6442) -- the
+    // hardcoded defaults (commentMode: detected_contributors_only, publicSurface: comment_and_label,
+    // checkRunMode: off) already satisfy usesCommentMode/usesLabelMode's conditions below, so no manifest
+    // override is needed for this first assertion block.
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
@@ -4621,7 +4613,7 @@ describe("api routes", () => {
     expect(queuedBurden.status).toBe(202);
     const queuedSignals = await app.request("/v1/internal/jobs/generate-signal-snapshots", { method: "POST", headers: internalHeaders, body: JSON.stringify({ repoFullName: "owner/repo" }) }, env);
     expect(queuedSignals.status).toBe(202);
-    expect((await app.request("/v1/internal/repos/owner/repo/settings", { method: "POST", headers: internalHeaders, body: JSON.stringify({ commentMode: "bad" }) }, env)).status).toBe(400);
+    expect((await app.request("/v1/internal/repos/owner/repo/settings", { method: "POST", headers: internalHeaders, body: JSON.stringify({ reviewCheckMode: "bad" }) }, env)).status).toBe(400);
   });
 
   it("settings-preview never mutates GitHub state", async () => {
@@ -6066,12 +6058,13 @@ describe("api routes", () => {
 
     await upsertRepositorySettings(env, {
       repoFullName: "entrius/allways-ui",
-      publicSurface: "off",
       requireLinkedIssue: true,
       autoLabelEnabled: false,
       createMissingLabel: false,
       gittensorLabel: "gittensor-miner",
     });
+    // publicSurface moved off the DB entirely (Batch A, loopover#6442) -- set via manifest injection instead.
+    await upsertRepoFocusManifest(env, "entrius/allways-ui", { settings: { publicSurface: "off" } });
     const directReadiness = await app.request("/v1/repos/entrius/allways-ui/registration-readiness", { headers: apiHeaders(env) }, env);
     expect(directReadiness.status).toBe(200);
     await expect(directReadiness.json()).resolves.toMatchObject({
@@ -6086,6 +6079,7 @@ describe("api routes", () => {
       maintainerNotes: [
         "Private reviewability note with wallet, hotkey, raw trust, and farming details.",
       ],
+      settings: { publicSurface: "off" },
     });
     const policyReadiness = await app.request("/v1/repos/entrius/allways-ui/registration-readiness", { headers: apiHeaders(env) }, env);
     expect(policyReadiness.status).toBe(200);
@@ -6457,7 +6451,7 @@ describe("api routes", () => {
     expect(signalsOne.status).toBe(202);
     const invalidSettings = await app.request(
       "/v1/internal/repos/owner/repo/settings",
-      { method: "POST", headers: { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}` }, body: JSON.stringify({ commentMode: "loud" }) },
+      { method: "POST", headers: { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}` }, body: JSON.stringify({ reviewCheckMode: "loud" }) },
       env,
     );
     expect(invalidSettings.status).toBe(400);
@@ -6539,7 +6533,7 @@ describe("api routes", () => {
       "/v1/internal/repos/entrius/allways-ui/settings",
       {
         method: "POST",
-        body: JSON.stringify({ commentMode: "detected_contributors_only", publicSignalLevel: "minimal" }),
+        body: JSON.stringify({ gatePack: "oss-anti-slop" }),
       },
       env,
     );
@@ -6551,8 +6545,6 @@ describe("api routes", () => {
         method: "POST",
         headers: { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}` },
         body: JSON.stringify({
-          commentMode: "detected_contributors_only",
-          publicSignalLevel: "minimal",
           gatePack: "oss-anti-slop",
           commandAuthorization: { default: ["maintainer"], commands: { preflight: ["pr_author"], "queue-summary": ["maintainer", "collaborator"] } },
         }),
@@ -6561,15 +6553,13 @@ describe("api routes", () => {
     );
     expect(updated.status).toBe(200);
     await expect(updated.json()).resolves.toMatchObject({
-      commentMode: "detected_contributors_only",
-      publicSignalLevel: "minimal",
       gatePack: "oss-anti-slop",
       commandAuthorization: { default: ["maintainer"], commands: expect.objectContaining({ preflight: ["pr_author"] }) },
     });
 
     const settings = await app.request("/v1/repos/entrius/allways-ui/settings", { headers: apiHeaders(env) }, env);
     expect(settings.status).toBe(200);
-    await expect(settings.json()).resolves.toMatchObject({ commentMode: "detected_contributors_only", gatePack: "oss-anti-slop", commandAuthorization: { commands: expect.objectContaining({ preflight: ["pr_author"] }) } });
+    await expect(settings.json()).resolves.toMatchObject({ gatePack: "oss-anti-slop", commandAuthorization: { commands: expect.objectContaining({ preflight: ["pr_author"] }) } });
 
     const preview = await app.request(
       "/v1/repos/entrius/allways-ui/settings-preview",

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -1095,7 +1095,7 @@ describe("api route guards and error branches", () => {
         await app.request("/v1/internal/repos/JSONbored/gittensory/settings", {
           method: "POST",
           headers: internalHeaders(env),
-          body: JSON.stringify({ commentMode: "bad" }),
+          body: JSON.stringify({ reviewCheckMode: "bad" }),
         }, env)
       ).status,
     ).toBe(400);
@@ -1184,16 +1184,15 @@ describe("api route guards and error branches", () => {
         method: "POST",
         headers: internalHeaders(env),
         body: JSON.stringify({
-          commentMode: "all_prs",
-          publicSignalLevel: "minimal",
-          checkRunDetailLevel: "standard",
-          backfillEnabled: false,
+          gatePack: "oss-anti-slop",
+          createMissingLabel: false,
+          badgeEnabled: true,
         }),
       },
       env,
     );
     expect(updated.status).toBe(200);
-    await expect(updated.json()).resolves.toMatchObject({ commentMode: "all_prs", checkRunDetailLevel: "standard", backfillEnabled: false });
+    await expect(updated.json()).resolves.toMatchObject({ gatePack: "oss-anti-slop", createMissingLabel: false, badgeEnabled: true });
   });
 
   it("exposes and clears self-tune overrides for operators, rejecting unauthorized callers (#6168)", async () => {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -63,7 +63,6 @@ import {
 } from "../../src/github/client";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
-import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createTestEnv } from "../helpers/d1";
 

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -30,6 +30,7 @@ import {
   upsertRepositoryFromGitHub,
   upsertRepositorySettings,
 } from "../../src/db/repositories";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import {
   backfillOpenPullRequestDetails,
   backfillRegisteredRepositories,
@@ -1010,6 +1011,7 @@ describe("GitHub backfill", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
     });
+    // checkRunMode moved off the DB entirely (Batch A, loopover#6442) -- set via manifest injection instead.
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { checkRunMode: "enabled" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -1180,13 +1182,10 @@ describe("GitHub backfill", () => {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
-      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
-    });
-    // Without this, the manifest resolver's live (unmocked) GitHub fetch for "JSONbored/gittensory"'s
-    // .loopover.yml actually succeeds -- GitHub's repo-rename redirect resolves it to this same repo's
-    // CURRENT .loopover.yml, which now grants full agent autonomy -- silently upgrading the required
-    // permissions this test asserts are absent. Force the fetch to a deterministic 404 instead.
+    // commentMode/publicSurface/checkRunMode moved off the DB entirely (Batch A, loopover#6442) -- set via
+    // manifest injection instead. The pre-cached row means the loader never calls fetch for this repo, but
+    // stub it defensively anyway so this test never depends on live network either way.
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async () => new Response("Not Found", { status: 404 }));
 
     const repair = await buildInstallationRepairDiagnostics(env, {
@@ -1425,6 +1424,8 @@ describe("GitHub backfill", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
     });
+    // commentMode/publicSignalLevel/checkRunMode/checkRunDetailLevel/backfillEnabled moved off the DB
+    // entirely (Batch A, loopover#6442) -- set via manifest injection instead.
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       settings: { commentMode: "off", publicSignalLevel: "standard", checkRunMode: "enabled", checkRunDetailLevel: "standard", backfillEnabled: false },
     });

--- a/test/unit/maintainer-activation.test.ts
+++ b/test/unit/maintainer-activation.test.ts
@@ -239,7 +239,6 @@ describe("recommendedAdvisoryActivationSettings", () => {
   it("enables the gate + deterministic rules in advisory (non-blocking) mode", () => {
     expect(recommendedAdvisoryActivationSettings()).toEqual({
       reviewCheckMode: "required",
-      checkRunMode: "enabled",
       linkedIssueGateMode: "advisory",
       duplicatePrGateMode: "advisory",
       qualityGateMode: "advisory",

--- a/test/unit/repo-identity-rename.test.ts
+++ b/test/unit/repo-identity-rename.test.ts
@@ -97,21 +97,21 @@ describe("renameRepositoryIdentity", () => {
     // these assert on the raw row directly to distinguish "no row" / "renamed row" / "folded row".
     it("renames the settings row's repo_full_name", async () => {
       const env = createTestEnv();
-      await upsertRepositorySettings(env, { repoFullName: OLD, commentMode: "off" });
+      await upsertRepositorySettings(env, { repoFullName: OLD, gittensorLabel: "marker-old" });
       await renameRepositoryIdentity(env, OLD, NEW);
       const oldRow = await env.DB.prepare("select count(*) as n from repository_settings where repo_full_name = ?").bind(OLD).first<{ n: number }>();
       expect(oldRow?.n).toBe(0);
       const settings = await getRepositorySettings(env, NEW);
-      expect(settings.commentMode).toBe("off");
+      expect(settings.gittensorLabel).toBe("marker-old");
     });
 
     it("REGRESSION (#repo-rename-migration): folds away a stray new-name settings row, keeping the pre-existing configured settings", async () => {
       const env = createTestEnv();
-      await upsertRepositorySettings(env, { repoFullName: OLD, commentMode: "detected_contributors_only" });
-      await upsertRepositorySettings(env, { repoFullName: NEW, commentMode: "off" }); // stray, should be discarded
+      await upsertRepositorySettings(env, { repoFullName: OLD, gittensorLabel: "marker-configured" });
+      await upsertRepositorySettings(env, { repoFullName: NEW, gittensorLabel: "marker-stray" }); // stray, should be discarded
       await renameRepositoryIdentity(env, OLD, NEW);
       const settings = await getRepositorySettings(env, NEW);
-      expect(settings.commentMode).toBe("detected_contributors_only");
+      expect(settings.gittensorLabel).toBe("marker-configured");
       const newRowCount = await env.DB.prepare("select count(*) as n from repository_settings where repo_full_name = ?").bind(NEW).first<{ n: number }>();
       expect(newRowCount?.n).toBe(1); // exactly one surviving row, not two
     });


### PR DESCRIPTION
## Summary

Batch A Phase 2 (#6442, epic #6440): drops the 9 fields confirmed safe to migrate off `repository_settings` entirely -- `commentMode`, `publicAudienceMode`, `publicSignalLevel`, `checkRunMode`, `checkRunDetailLevel`, `regateSweepOrderMode`, `publicSurface`, `includeMaintainerAuthors`, `backfillEnabled` (migration 0158).

`resolveEffectiveSettings` needed **zero changes**: its existing `{...dbSettings, ...manifestSettings}` spread already overlays manifest over DB unconditionally. Once `dbSettings` itself just returns the same built-in default for these fields (no real column to read), the merge collapses to "manifest override, else built-in default" -- genuine config-as-code, no dual-source ambiguity.

**Deliberately excluded, stay DB-only forever:** `badgeEnabled`/`publicQualityMetrics`. `loadPublicRepoBadge`/`loadPublicRepoQualityMetrics` (`src/api/routes.ts`) read them via a direct `getRepositorySettings` call that bypasses the manifest overlay entirely -- a documented perf tradeoff for two unauthenticated, high-frequency public routes (no manifest-cache lookup, no possible cold-cache GitHub fetch, on every image/API load).

## Changes
- Drops the 9 columns from `src/db/schema.ts` + a real migration; removes their read/write/default-fill logic from `src/db/repositories.ts` and the now-dead `parseX` helpers.
- Removes the 9 fields from `repositorySettingsSchema`/`maintainerSettingsSchema` and the internal/maintainer settings write paths (a caller-supplied value is now a silent no-op, since there's nothing left to persist it to).
- Switches `GET /v1/repos/:owner/:repo/settings` to `resolveRepositorySettings` (was the raw DB row, which would otherwise always show the hardcoded default regardless of a repo's real `.loopover.yml`).
- Overlays the true effective value for just these 9 fields onto the registration-readiness / gittensor-config-recommendation "DB vs yml" advisory builders, preserving their #2912 comparison intent for every other still-DB-backed field.
- Drops `checkRunMode` from the one-click "enable advisory mode" activation patch (writing it is now a no-op), with a comment explaining why.
- Updates the maintainer dashboard UI (removes 7 dead form fields/editable keys) and every affected test (converted to manifest-based fixture setup where the field's own behavior was under test; swapped to a still-real marker field where it was only probing unrelated DB-identity mechanics).

## Scope
- [x] Stayed within `wantedPaths`
- [x] No secrets/wallets/hotkeys/trust scores/reward values
- [x] Regenerated `apps/loopover-ui/public/openapi.json`
- [x] New migration `0158_drop_batch_a_config_as_code_columns.sql`, next contiguous number

## Validation
- [x] `npm run test:ci` (full local gate, green)
- [x] `npm run typecheck` (backend + UI, clean)
- [x] `npm run ui:test` (292/292 passed)
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] Patch coverage verified CLEAN on every changed line/branch in `src/api/routes.ts`, `src/db/repositories.ts`, `src/db/schema.ts`, `src/services/maintainer-activation.ts` (cross-referenced `coverage/lcov.info` against the diff)