### PR TITLE
feat(review): add a read-only endpoint exposing ORB's live self-tuned gate thresholds

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -13945,6 +13945,32 @@
           "maintainerNextSteps",
           "privateSummary"
         ]
+      },
+      "LiveGateThresholdsResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "confidence_floor": {
+            "type": "number",
+            "nullable": true
+          },
+          "scope_cap_files": {
+            "type": "integer",
+            "nullable": true
+          },
+          "scope_cap_lines": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "repoFullName",
+          "confidence_floor",
+          "scope_cap_files",
+          "scope_cap_lines"
+        ]
       }
     },
     "parameters": {},
@@ -17943,6 +17969,55 @@
           },
           "429": {
             "description": "Rate limited"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/live-gate-thresholds": {
+      "get": {
+        "summary": "Live self-tuned gate thresholds for AMS probe (#6486)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Field-limited live (or soaking-shadow) TunableOverride values — confidence_floor / scope_cap_files / scope_cap_lines only",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LiveGateThresholdsResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
+          },
+          "404": {
+            "description": "No live or shadow gate override is active for this repo"
           }
         },
         "security": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -264,7 +264,7 @@ import { buildMaintainerActivationPreview, recommendedAdvisoryActivationSettings
 import { buildRepoOutcomeCalibration } from "../services/outcome-calibration";
 import { loadGatePrecisionReport } from "../services/gate-precision";
 import { computeOpsStats, isOpsEnabled, resolveOpsManifestOverride } from "../review/ops-wire";
-import { deleteLiveOverride, listOverrideAudit, loadOverride, loadShadowOverride, sanitizeOverridePayload, type StorageEnv } from "../review/auto-apply";
+import { authoritativeGateOverride, deleteLiveOverride, listOverrideAudit, loadOverride, loadShadowOverride, sanitizeOverridePayload, toLiveGateThresholdFields, type StorageEnv } from "../review/auto-apply";
 import { handleInternalCalibration, handleInternalDecision, type OpsAgentConfig } from "../review/ops";
 import { computeParityReadiness, isParityAuditEnabled } from "../review/parity-wire";
 import { computePredictedGateAgreement } from "../review/predicted-gate-agreement";
@@ -3016,6 +3016,25 @@ export function createApp() {
       },
       shadowPending: shadow !== null,
     });
+  });
+
+  // AMS probe surface for a repo's live self-tuned gate thresholds (#6486, implementing #6209's decision).
+  // Distinct from gate-config/effective above: a field-limited, snake_case-only payload (no shadowPending, no
+  // nested effective object) matching tunables_overrides' own column names 1:1, and the live row wins but a
+  // soaking shadow's queued value fills in when live is absent -- #6209 decided AMS should see a pending
+  // tightening too, not just a promoted one. Never includes applied_at/clear_at or override_audit history.
+  app.get("/v1/repos/:owner/:repo/live-gate-thresholds", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const identity = await authenticateRequestIdentity(c);
+    // Only the shared, end-user-obtainable static `mcp` token is allowlist-scoped; every other identity
+    // (an authenticated session, or an operator-only api/internal static token) stays trusted, matching the
+    // intelligence/issue-quality/reviewability precedent routes above.
+    if (identity?.kind === "static" && identity.actor === "mcp" && !(await import("../auth/security")).isMcpReadRepoAllowed(c.env.MCP_READ_REPO_ALLOWLIST, fullName)) return c.json({ error: "forbidden_repo" }, 403);
+    const storageEnv = c.env as unknown as StorageEnv;
+    const [live, shadow] = await Promise.all([loadOverride(storageEnv, fullName), loadShadowOverride(storageEnv, fullName)]);
+    const fields = toLiveGateThresholdFields(authoritativeGateOverride(live, shadow));
+    if (!fields) return c.json({ error: "live_gate_thresholds_not_found", repoFullName: fullName }, 404);
+    return c.json({ repoFullName: fullName, ...fields });
   });
 
   app.get("/v1/repos/:owner/:repo/outcome-patterns", async (c) => {

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1739,6 +1739,17 @@ export const IssueQualityResponseSchema = z
   })
   .openapi("IssueQualityResponse");
 
+/** Field-limited AMS/MCP probe payload for a repo's live gate thresholds (#6486) — snake_case column names
+ *  matching `tunables_overrides` 1:1; deliberately excludes applied_at/clear_at and override_audit history. */
+export const LiveGateThresholdsResponseSchema = z
+  .object({
+    repoFullName: z.string(),
+    confidence_floor: z.number().nullable(),
+    scope_cap_files: z.number().int().nullable(),
+    scope_cap_lines: z.number().int().nullable(),
+  })
+  .openapi("LiveGateThresholdsResponse");
+
 export const BurdenForecastSchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -33,6 +33,7 @@ import {
   IssueQualityResponseSchema,
   LabelAuditSchema,
   LaneAdviceSchema,
+  LiveGateThresholdsResponseSchema,
   LocalBranchAnalysisSchema,
   LocalDiffPreflightResultSchema,
   MaintainerPacketSchema,
@@ -148,6 +149,7 @@ export function buildOpenApiSpec() {
   registry.register("ScorePreview", ScorePreviewSchema);
   registry.register("IssueQualityReport", IssueQualityReportSchema);
   registry.register("IssueQualityResponse", IssueQualityResponseSchema);
+  registry.register("LiveGateThresholdsResponse", LiveGateThresholdsResponseSchema);
   registry.register("BurdenForecast", BurdenForecastSchema);
   registry.register("ContributorScoringProfile", ContributorScoringProfileSchema);
   registry.register("ContributorStrategy", ContributorStrategySchema);
@@ -417,6 +419,17 @@ export function buildOpenApiSpec() {
     responses: {
       200: { description: "Cached or computed issue quality report for the repo", content: { "application/json": { schema: IssueQualityResponseSchema } } },
       404: { description: "Repo is unknown or has no issue-quality coverage yet" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/live-gate-thresholds",
+    summary: "Live self-tuned gate thresholds for AMS probe (#6486)",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: { description: "Field-limited live (or soaking-shadow) TunableOverride values — confidence_floor / scope_cap_files / scope_cap_lines only", content: { "application/json": { schema: LiveGateThresholdsResponseSchema } } },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
+      404: { description: "No live or shadow gate override is active for this repo" },
     },
   });
   registry.registerPath({

--- a/src/review/auto-apply.ts
+++ b/src/review/auto-apply.ts
@@ -276,6 +276,33 @@ export async function deleteShadowOverride(env: StorageEnv, project: string): Pr
   await storage(env).prepare("DELETE FROM tunables_overrides_shadow WHERE project = ?").bind(project).run();
 }
 
+/** PURE: prefer a project's LIVE override; when absent, fall through to a soaking SHADOW override's queued
+ *  value (#6486/#6209 — AMS probes this so a repo mid-soak still reports its pending threshold, not "none"). */
+export function authoritativeGateOverride(live: TunableOverride | null, shadow: ShadowOverride | null): TunableOverride | null {
+  return live ?? shadow?.override ?? null;
+}
+
+/** Field-limited AMS/MCP payload for a repo's live gate thresholds (#6486). Snake_case names match the
+ *  tunables_overrides column names AMS probes for; deliberately excludes applied_at/clear_at and the
+ *  override_audit history — only the resolved effective values ever leave this projection. */
+export type LiveGateThresholdFields = {
+  confidence_floor: number | null;
+  scope_cap_files: number | null;
+  scope_cap_lines: number | null;
+};
+
+/** PURE: project an authoritative TunableOverride into the exact snake_case allowlist, or null when the
+ *  override carries neither a confidenceFloor nor a scopeCap (nothing to report). */
+export function toLiveGateThresholdFields(override: TunableOverride | null): LiveGateThresholdFields | null {
+  if (!override) return null;
+  if (override.confidenceFloor === undefined && override.scopeCap === undefined) return null;
+  return {
+    confidence_floor: override.confidenceFloor ?? null,
+    scope_cap_files: override.scopeCap?.files ?? null,
+    scope_cap_lines: override.scopeCap?.lines ?? null,
+  };
+}
+
 /** Record one override-lifecycle event to the dedicated (target-free) audit table. Fail-safe: a write error
  *  never breaks the apply path, but it IS surfaced at error level (this is the operator's ONLY visibility
  *  into an autonomous config change — a silently-dropped log line here defeats that entirely). */

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -6787,6 +6787,72 @@ describe("api routes", () => {
     const unauth = await app.request("/v1/repos/entrius/allways-ui/gate-config/effective", {}, env);
     expect(unauth.status).toBe(401);
   });
+
+  it("exposes field-limited snake_case live gate thresholds for the AMS probe (#6486)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    // No live or shadow override yet → not-found, matching the issue-quality-route not-found convention.
+    const missing = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", { headers: apiHeaders(env) }, env);
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toEqual({ error: "live_gate_thresholds_not_found", repoFullName: "entrius/allways-ui" });
+
+    // A live override surfaces as flat snake_case fields; audit rows and shadow queue detail must never leak.
+    const storageEnv = env as unknown as StorageEnv;
+    await writeLiveOverride(storageEnv, "entrius/allways-ui", { confidenceFloor: 0.91, scopeCap: { files: 8, lines: 250 } });
+    await writeShadowOverride(storageEnv, "entrius/allways-ui", { confidenceFloor: 0.4 }, "2099-01-01T00:00:00.000Z");
+    await recordOverrideAudit(storageEnv, "entrius/allways-ui", "apply", { note: "must-never-surface-on-6486" });
+    const live = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", { headers: apiHeaders(env) }, env);
+    expect(live.status).toBe(200);
+    const liveBody = (await live.json()) as unknown;
+    expect(liveBody).toEqual({
+      repoFullName: "entrius/allways-ui",
+      confidence_floor: 0.91,
+      scope_cap_files: 8,
+      scope_cap_lines: 250,
+    });
+    expect(JSON.stringify(liveBody)).not.toMatch(/override_audit|applied_at|clear_at|must-never-surface|shadowPending|effective/i);
+
+    // A soaking shadow's queued override fills in when live is absent (#6209's decision: AMS should see a
+    // pending tightening too, not just a promoted one) — and a floor-only override nulls both scope_cap fields.
+    const shadowOnlyEnv = createTestEnv();
+    await writeShadowOverride(shadowOnlyEnv as unknown as StorageEnv, "entrius/allways-ui", { confidenceFloor: 0.66 }, "2099-01-01T00:00:00.000Z");
+    const shadowed = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", { headers: apiHeaders(shadowOnlyEnv) }, shadowOnlyEnv);
+    expect(shadowed.status).toBe(200);
+    await expect(shadowed.json()).resolves.toEqual({
+      repoFullName: "entrius/allways-ui",
+      confidence_floor: 0.66,
+      scope_cap_files: null,
+      scope_cap_lines: null,
+    });
+
+    // A live override carrying only a scope cap (no confidence floor) still resolves confidence_floor to null.
+    const scopeCapOnlyEnv = createTestEnv();
+    await writeLiveOverride(scopeCapOnlyEnv as unknown as StorageEnv, "entrius/allways-ui", { scopeCap: { files: 4, lines: 120 } });
+    const scopeCapOnly = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", { headers: apiHeaders(scopeCapOnlyEnv) }, scopeCapOnlyEnv);
+    expect(scopeCapOnly.status).toBe(200);
+    await expect(scopeCapOnly.json()).resolves.toEqual({
+      repoFullName: "entrius/allways-ui",
+      confidence_floor: null,
+      scope_cap_files: 4,
+      scope_cap_lines: 120,
+    });
+
+    // A static mcp credential within the allowlist reads successfully (default MCP_READ_REPO_ALLOWLIST is "*").
+    const mcpAllowed = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", { headers: mcpHeaders(env) }, env);
+    expect(mcpAllowed.status).toBe(200);
+    await expect(mcpAllowed.json()).resolves.toMatchObject({ confidence_floor: 0.91 });
+
+    // The shared static mcp credential is scoped to MCP_READ_REPO_ALLOWLIST, same precedent as gate-config/effective.
+    const forbiddenEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await writeLiveOverride(forbiddenEnv as unknown as StorageEnv, "entrius/allways-ui", { confidenceFloor: 0.9 });
+    const forbidden = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", { headers: mcpHeaders(forbiddenEnv) }, forbiddenEnv);
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    // Unauthenticated calls are rejected before any repo lookup.
+    const unauth = await app.request("/v1/repos/entrius/allways-ui/live-gate-thresholds", {}, env);
+    expect(unauth.status).toBe(401);
+  });
 });
 
 async function signWebhook(body: string, secret: string | undefined): Promise<string> {

--- a/test/unit/auto-apply.test.ts
+++ b/test/unit/auto-apply.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type AutoApplyContext,
   applyOverrideRecommendation,
+  authoritativeGateOverride,
   deleteLiveOverride,
   deleteShadowOverride,
   describeOverride,
@@ -16,13 +17,66 @@ import {
   runAutoApplyRecommendations,
   sanitizeOverridePayload,
   SHADOW_PROMOTION_MIN_DECIDED,
+  type ShadowOverride,
   type StorageEnv,
   type StorageLike,
+  toLiveGateThresholdFields,
   type TunableOverride,
   writeLiveOverride,
   writeShadowOverride,
 } from "../../src/review/auto-apply";
 import type { TuningRec } from "../../src/review/auto-tune";
+
+describe("authoritativeGateOverride (#6486)", () => {
+  const live: TunableOverride = { confidenceFloor: 0.9 };
+  const shadow: ShadowOverride = { override: { confidenceFloor: 0.5 }, validatedUntil: null };
+
+  it("prefers a present live override over a present shadow override", () => {
+    expect(authoritativeGateOverride(live, shadow)).toBe(live);
+  });
+
+  it("falls through to the shadow's queued override when live is absent", () => {
+    expect(authoritativeGateOverride(null, shadow)).toBe(shadow.override);
+  });
+
+  it("returns null when neither a live nor a shadow override is active", () => {
+    expect(authoritativeGateOverride(null, null)).toBeNull();
+  });
+});
+
+describe("toLiveGateThresholdFields (#6486)", () => {
+  it("returns null for a null override", () => {
+    expect(toLiveGateThresholdFields(null)).toBeNull();
+  });
+
+  it("returns null for an override with neither confidenceFloor nor scopeCap set", () => {
+    expect(toLiveGateThresholdFields({})).toBeNull();
+  });
+
+  it("projects confidenceFloor-only into confidence_floor, nulling both scope_cap fields", () => {
+    expect(toLiveGateThresholdFields({ confidenceFloor: 0.85 })).toEqual({
+      confidence_floor: 0.85,
+      scope_cap_files: null,
+      scope_cap_lines: null,
+    });
+  });
+
+  it("projects scopeCap-only into scope_cap_files/scope_cap_lines, nulling confidence_floor", () => {
+    expect(toLiveGateThresholdFields({ scopeCap: { files: 6, lines: 180 } })).toEqual({
+      confidence_floor: null,
+      scope_cap_files: 6,
+      scope_cap_lines: 180,
+    });
+  });
+
+  it("projects both fields when both confidenceFloor and scopeCap are set", () => {
+    expect(toLiveGateThresholdFields({ confidenceFloor: 0.7, scopeCap: { files: 3, lines: 90 } })).toEqual({
+      confidence_floor: 0.7,
+      scope_cap_files: 3,
+      scope_cap_lines: 90,
+    });
+  });
+});
 
 describe("rowToOverride (#273 — D1 row → validated override)", () => {
   it("maps a full row", () => {


### PR DESCRIPTION
Closes #6486

## Summary

#6209 decided the design (see its pinned decision comment): AMS probes a new read-only ORB endpoint for a repo's live self-tuned gate thresholds before falling back to static-file reconstruction (the AMS-side consumer is a separate, blocked-on-this sibling issue, #6487). This PR is the ORB-side endpoint only.

New `GET /v1/repos/:owner/:repo/live-gate-thresholds`:

- **Field allowlist is exact**, per #6209's decision: only `confidence_floor`, `scope_cap_files`, `scope_cap_lines` — no `applied_at`/`clear_at`, no `override_audit` history. These are the live `TunableOverride` fields already defined in `src/review/auto-apply.ts`.
- **Live wins; a soaking shadow fills in when live is absent** — #6209's decision explicitly wants AMS to see a pending tightening too, not just an already-promoted one.
- **404** with `{ error: "live_gate_thresholds_not_found", repoFullName }` when neither a live nor a shadow override is active — matching the existing not-found convention `/issue-quality`'s route already uses (`issue_quality_not_found`), per the issue's own "follow existing convention, don't invent a new response shape" requirement.
- **Auth**: `isMcpReadRepoAllowed` + `MCP_READ_REPO_ALLOWLIST` gates a static `mcp`-actor identity; every other identity (an authenticated session, or an operator-only static token) is trusted — the exact same gate already used on `src/api/routes.ts:2354`/`2368`/`2959`. This is deliberately the simpler pattern, not the stricter `requireStaticProtectedApiToken`-gated shape the sibling `/gate-config/effective` route (#6247) uses — #6209's decision comment names this specific gate ("the exact same gate already used on ~6 existing MCP-facing read routes"), and `/gate-config/effective` predates #6209's decision and has a different (nested camelCase, `shadowPending`-flagged) response shape serving a different UI consumer, so this is intentionally a distinct route, not a duplicate.

Two new pure helpers in `auto-apply.ts`:

- `authoritativeGateOverride(live, shadow)`: `live ?? shadow?.override ?? null` — live wins, shadow is the fallback.
- `toLiveGateThresholdFields(override)`: projects into the exact snake_case allowlist, returning `null` when the override carries neither a `confidenceFloor` nor a `scopeCap`.

## Note on a prior closed attempt

A previous PR for this issue (#6545) was auto-closed on `codecov/patch` failing at 95.45% (1 uncovered line). I did not blindly reuse that PR's diff — I re-derived the implementation from #6209's decision comment and the existing precedent routes, then wrote my own test suite and specifically traced every branch by hand before writing tests, including the exact combination that's easy to miss in a `??`-heavy projection function (a `confidenceFloor`-absent-but-`scopeCap`-present override, and vice versa — see `toLiveGateThresholdFields`'s 5 dedicated unit tests). I also caught and removed a `v8 ignore` comment I'd initially misattributed to the wrong line while drafting (copied from an adjacent "unauthenticated requests never reach here" precedent that doesn't actually apply to the mcp-allowlist check) — verified via `lcov` line/branch hit-count output that the real conditional is genuinely, fully exercised by the test suite with no coverage exemption needed at all.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #6486.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run db:migrations:check` / `db:schema-drift:check` — N/A, no migration or schema change (reuses the existing `tunables_overrides`/`tunables_overrides_shadow` tables as-is).
- [x] `npm run selfhost:env-reference:check` / `selfhost:validate-observability`
- [x] `npm run docs:drift-check` / `manifest:drift-check` / `command-reference:check`
- [x] `npm run ui:openapi` (regenerated) / `npm run ui:openapi:check` (clean) / `npm run ui:openapi:settings-parity` (clean) — new `LiveGateThresholdsResponseSchema` + path registered in `src/openapi/schemas.ts`/`spec.ts`, `apps/loopover-ui/public/openapi.json` regenerated and committed.
- [x] `test/unit/auto-apply.test.ts` (full file, 103 tests) and `test/integration/api.test.ts` (full file, 48 tests) — both 100% passing.
- [x] Broader regression sweep: `auto-apply`/`auto-tune`/`reputation-wiring` test files together — 190 tests, all passing.
- [x] **Coverage verified directly, not assumed**: ran a scoped `vitest --coverage` against just `src/review/auto-apply.ts` and `src/api/routes.ts` with only my 2 changed test files. `auto-apply.ts` — 100% statements/functions/lines, 98.72% branch with the single remaining gap confirmed pre-existing and unrelated (`runAutoApplyRecommendations`, an untouched function, in a partial 2-file run — the full suite covers it). My new route's exact lines, verified via the `lcov` report's per-line `DA:`/`BRDA:` hit counts: every line has a non-zero hit count, and both sides of every branch (the `identity?.kind === "static" && identity.actor === "mcp" && !isMcpReadRepoAllowed(...)` chain, and the `if (!fields)` 404 check) show non-zero counts on both outcomes.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [ ] Root `npm run typecheck` / unsharded `npm run test:coverage` — this sandbox's root `tsc --noEmit` reliably OOMs regardless of diff content (reproduced repeatedly this session, confirmed again on this diff — the failure trace shows the standard V8 heap-limit abort, not a real type error). Substituted with careful manual type review of every new line (documented above) plus `npm run ui:openapi`'s own `tsx`-driven type-check of the new Zod schemas passing clean, plus the scoped coverage run's line-by-line confirmation that the actual runtime code paths execute exactly as written.

If any required check was skipped, explain why:

- Root `typecheck`/unsharded `test:coverage`: established OOM pattern in this sandbox (2.3GB free RAM, no swap headroom), unrelated to diff content. Substituted with the scoped, file-targeted coverage verification above, which is the specific signal Codecov's `codecov/patch` gate actually measures for this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — Not an auth-model change (reuses the existing `isMcpReadRepoAllowed` gate verbatim), but the negative path (403 forbidden_repo, 401 unauthenticated) is explicitly tested in the integration test.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — New route, schema, and path registered; `ui:openapi:check` clean.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.

## Notes

The AMS-side consumer (`self-review-context.js` probing this endpoint, #6487) is explicitly a separate, blocked-on-this sibling issue and is not built here.
