### PR TITLE
feat(miner): gate iterate-loop pass->handoff on selfLoopAutonomy

### DIFF
--- a/packages/loopover-engine/src/miner/iterate-loop.ts
+++ b/packages/loopover-engine/src/miner/iterate-loop.ts
@@ -28,6 +28,7 @@
 // return value. A logging failure never alters the loop's decision (mirrors the governor-ledger and
 // pretooluse-hook append-failure handling elsewhere in this package).
 
+import type { AutonomyLevel } from "../types/manifest-deps-types.js";
 import type { CodingAgentDriver, CodingAgentDriverResult, CodingAgentDriverTask } from "./coding-agent-driver.js";
 import { codingAgentModeExecutes, type CodingAgentExecutionMode } from "./coding-agent-mode.js";
 import { invokeCodingAgentDriver } from "./coding-agent-invoke.js";
@@ -86,6 +87,12 @@ export type IterateLoopInput = {
    *  automated contributions -- resolved by the caller (AI-policy-map / rejection-state-machine), consumed
    *  as-is. See iterate-policy.ts's own `IterationState.rejectionSignaled` doc comment. */
   rejectionSignaled: boolean;
+
+  /** The operator's configured self-loop autonomy level (#6560), resolved by the caller from
+   *  `AmsPolicySpec.selfLoopAutonomy` and passed through unchanged to each iteration's `IterationState`. Gates
+   *  ONLY the pass->handoff transition; omitted defaults to treated-as-`"auto"`. See iterate-policy.ts's own
+   *  `IterationState.autonomyLevel` doc comment. */
+  autonomyLevel?: AutonomyLevel | undefined;
 };
 
 /** Optional cooperative abort probed BEFORE every driver invocation (#5670). A bare `true` or
@@ -452,6 +459,7 @@ async function runIterateLoopCore(input: IterateLoopInput, deps: IterateLoopDeps
       selfReview,
       previousBlockerCodes,
       rejectionSignaled: input.rejectionSignaled,
+      autonomyLevel: input.autonomyLevel,
     };
     const decision = decideNextActionWithReason(state);
     logDecision(input, deps, iterationNumber, decision, []);

--- a/packages/loopover-engine/src/miner/iterate-policy.ts
+++ b/packages/loopover-engine/src/miner/iterate-policy.ts
@@ -20,6 +20,7 @@
 // once `.loopover-miner.yml` defines autonomy fields -- that wiring is explicitly left to a later phase; this
 // module's `decideNextAction` is autonomy-level-agnostic today.
 
+import type { AutonomyLevel } from "../types/manifest-deps-types.js";
 import type { SelfReviewVerdict } from "./self-review-adapter.js";
 
 /** The three outcomes `decideNextAction` may reach. */
@@ -35,7 +36,11 @@ export type AbandonReason =
   | "no_progress"
   /** Mid-attempt emergency stop (#5670): kill-switch (or operator pause acting as a stop signal) tripped
    *  between iterate-loop iterations — cooperative, not a hard SIGKILL of an in-flight driver call. */
-  | "kill_switch_engaged";
+  | "kill_switch_engaged"
+  /** A clean predicted-gate pass WAS reached, but the operator's configured self-loop autonomy level is
+   *  `"observe"` -- loopover watches without handing off (#6560). Distinct from any failing/ambiguous
+   *  self-review abandon: nothing was wrong with the attempt, the level simply keeps the loop observe-only. */
+  | "autonomy_observe_only";
 
 /**
  * The self-review outcome as the policy needs it -- narrower than the full {@link SelfReviewVerdict} (self-
@@ -75,6 +80,12 @@ export type IterationState = {
    *  tracks. Optional and defaults to not-reached, so `IterationState` fixtures that predate this field remain
    *  valid. */
   costCeilingReached?: boolean | undefined;
+  /** The operator's configured self-loop autonomy level (#6560), resolved by the caller from
+   *  `AmsPolicySpec.selfLoopAutonomy` and threaded through unchanged. Gates ONLY the pass->handoff
+   *  transition (step 3): `"observe"` abandons observe-only, `"auto_with_approval"` hands off pending
+   *  approval, `"auto"` hands off unconditionally. Optional and defaults to treated-as-`"auto"` when
+   *  `undefined`, so `IterationState` fixtures that predate this field remain valid with unchanged output. */
+  autonomyLevel?: AutonomyLevel | undefined;
   selfReview: SelfReviewOutcome;
   /** The prior iteration's `fail` blocker codes, for the no-progress detector -- `null` when there is no prior
    *  iteration to compare (the first iteration, or the prior iteration did not reach a `fail` outcome). */
@@ -115,6 +126,10 @@ export type IterateLoopDecision = {
   reason: string;
   /** Populated only when `action === "abandon"`. */
   abandonReason?: AbandonReason | undefined;
+  /** Populated only for a `"handoff"` reached under `autonomyLevel === "auto_with_approval"` (#6560): the
+   *  handoff is authorized but must clear a human approval gate before it submits, mirroring
+   *  `autonomyRequiresApproval` (settings/autonomy.ts). Absent (`undefined`) means no approval gate. */
+  requiresApproval?: true | undefined;
 };
 
 function blockerSetsEqual(current: readonly string[], previous: readonly string[]): boolean {
@@ -132,7 +147,11 @@ function blockerSetsEqual(current: readonly string[], previous: readonly string[
  * Precedence (each check short-circuits the ones below it):
  * 1. `rejectionSignaled` -- ALWAYS abandons, even over an otherwise-passing self-review (disengage silently).
  * 2. `selfReview.kind === "ambiguous"` -- abandons; never optimistically continues or hands off on ambiguity.
- * 3. `selfReview.kind === "pass"` -- the ONLY path to `"handoff"`.
+ * 3. `selfReview.kind === "pass"` -- the ONLY path to `"handoff"`, narrowed by the effective autonomy level
+ *    (`state.autonomyLevel ?? "auto"`, #6560): `"auto"` hands off unconditionally, `"auto_with_approval"`
+ *    hands off with `requiresApproval: true`, `"observe"` abandons observe-only (`autonomy_observe_only`).
+ *    Steps 1 and 2 still win over any autonomy level, so a pass is never even consulted after a rejection or
+ *    ambiguity.
  * 4. `iterationNumber >= maxIterations` -- abandons at the hard ceiling regardless of whether the blocker set
  *    was still changing (genuine incremental progress does not buy unlimited iterations).
  * 5. `costCeilingReached` -- abandons at the hard cost ceiling, same rationale as the iteration ceiling above.
@@ -152,6 +171,17 @@ export function decideNextActionWithReason(state: IterationState): IterateLoopDe
     };
   }
   if (state.selfReview.kind === "pass") {
+    const effectiveLevel: AutonomyLevel = state.autonomyLevel ?? "auto";
+    if (effectiveLevel === "observe") {
+      return {
+        action: "abandon",
+        abandonReason: "autonomy_observe_only",
+        reason: "Self-review reached a clean predicted-gate pass, but the configured self-loop autonomy level is observe-only; watching without handing off.",
+      };
+    }
+    if (effectiveLevel === "auto_with_approval") {
+      return { action: "handoff", requiresApproval: true, reason: "Self-review reached a clean predicted-gate pass; handing off pending human approval." };
+    }
     return { action: "handoff", reason: "Self-review reached a clean predicted-gate pass." };
   }
   if (state.iterationNumber >= state.maxIterations) {

--- a/packages/loopover-engine/test/iterate-policy.test.ts
+++ b/packages/loopover-engine/test/iterate-policy.test.ts
@@ -50,6 +50,52 @@ test("handoff: the ONLY path is a clean self-review pass", () => {
   assert.ok(decision.reason.length > 0);
 });
 
+test("autonomy (#6560) auto: a passing self-review hands off unconditionally, no requiresApproval", () => {
+  const decision = decideNextActionWithReason(baseState({ selfReview: { kind: "pass" }, autonomyLevel: "auto" }));
+  assert.equal(decision.action, "handoff");
+  assert.equal(decision.requiresApproval, undefined);
+});
+
+test("autonomy (#6560) auto_with_approval: a passing self-review still hands off, but with requiresApproval:true", () => {
+  const decision = decideNextActionWithReason(baseState({ selfReview: { kind: "pass" }, autonomyLevel: "auto_with_approval" }));
+  assert.equal(decision.action, "handoff");
+  assert.equal(decision.requiresApproval, true);
+  assert.ok(decision.reason.length > 0);
+});
+
+test("autonomy (#6560) observe: a passing self-review abandons observe-only with autonomy_observe_only", () => {
+  const decision = decideNextActionWithReason(baseState({ selfReview: { kind: "pass" }, autonomyLevel: "observe" }));
+  assert.equal(decision.action, "abandon");
+  assert.equal(decision.abandonReason, "autonomy_observe_only");
+  assert.equal(decision.requiresApproval, undefined);
+  // The reason must note the pass WAS reached (distinct from the ambiguous/other abandon wording).
+  assert.match(decision.reason, /clean predicted-gate pass/);
+  assert.match(decision.reason, /observe-only/);
+});
+
+test("autonomy (#6560) REGRESSION: an unset autonomyLevel is byte-identical to an explicit \"auto\" on a passing self-review", () => {
+  const omitted = decideNextActionWithReason(baseState({ selfReview: { kind: "pass" } }));
+  const explicitAuto = decideNextActionWithReason(baseState({ selfReview: { kind: "pass" }, autonomyLevel: "auto" }));
+  assert.equal(omitted.action, "handoff");
+  assert.deepEqual(omitted, explicitAuto);
+});
+
+test("autonomy (#6560): rejectionSignaled wins over ANY autonomy level, including observe (step 1 unreachable-by-autonomy)", () => {
+  for (const autonomyLevel of ["auto", "auto_with_approval", "observe"] as const) {
+    const decision = decideNextActionWithReason(baseState({ selfReview: { kind: "pass" }, rejectionSignaled: true, autonomyLevel }));
+    assert.equal(decision.action, "abandon");
+    assert.equal(decision.abandonReason, "rejection_signaled");
+  }
+});
+
+test("autonomy (#6560): an ambiguous self-review wins over ANY autonomy level, including observe (step 2 unreachable-by-autonomy)", () => {
+  for (const autonomyLevel of ["auto", "auto_with_approval", "observe"] as const) {
+    const decision = decideNextActionWithReason(baseState({ selfReview: { kind: "ambiguous" }, autonomyLevel }));
+    assert.equal(decision.action, "abandon");
+    assert.equal(decision.abandonReason, "self_review_ambiguous");
+  }
+});
+
 test("abandon (rejection_signaled): wins over EVERYTHING else, including an otherwise-passing self-review", () => {
   const state = baseState({ selfReview: { kind: "pass" }, rejectionSignaled: true });
   const decision = decideNextActionWithReason(state);

--- a/packages/loopover-miner/lib/attempt-input-builder.js
+++ b/packages/loopover-miner/lib/attempt-input-builder.js
@@ -99,5 +99,10 @@ export function buildAttemptLoopInput(input) {
     branchRef: input.branchRef,
     reviewContext: input.reviewContext,
     rejectionSignaled: input.rejectionSignaled,
+    // The operator's own `.loopover-ams.yml` self-loop autonomy level (#6560): threaded straight through the
+    // same as rejectionSignaled above, so a clean self-review pass hands off unconditionally / pending approval
+    // / stays observe-only per what the operator configured. Unset (older config) stays undefined, which
+    // iterate-policy treats as "auto" -- byte-identical to pre-this-field behavior.
+    autonomyLevel: input.amsPolicySpec.selfLoopAutonomy,
   };
 }

--- a/test/unit/iterate-policy-autonomy.test.ts
+++ b/test/unit/iterate-policy-autonomy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { decideNextActionWithReason, type IterationState } from "../../packages/loopover-engine/src/index";
+
+// Codecov measures packages/loopover-engine/src/** ONLY through root vitest (never the engine's own node:test
+// suite), so the #6560 autonomy narrowing of decideNextAction's step-3 pass->handoff branch is exercised here
+// as well as in packages/loopover-engine/test/iterate-policy.test.ts.
+
+function passingState(overrides: Partial<IterationState> = {}): IterationState {
+  return {
+    iterationNumber: 1,
+    maxIterations: 5,
+    selfReview: { kind: "pass" },
+    previousBlockerCodes: null,
+    rejectionSignaled: false,
+    ...overrides,
+  };
+}
+
+describe("decideNextActionWithReason autonomy narrowing (#6560)", () => {
+  it("auto: a clean pass hands off unconditionally, no requiresApproval", () => {
+    const decision = decideNextActionWithReason(passingState({ autonomyLevel: "auto" }));
+    expect(decision.action).toBe("handoff");
+    expect(decision.requiresApproval).toBeUndefined();
+  });
+
+  it("auto_with_approval: a clean pass still hands off, but flags requiresApproval:true", () => {
+    const decision = decideNextActionWithReason(passingState({ autonomyLevel: "auto_with_approval" }));
+    expect(decision.action).toBe("handoff");
+    expect(decision.requiresApproval).toBe(true);
+    expect(decision.reason.length).toBeGreaterThan(0);
+  });
+
+  it("observe: a clean pass abandons observe-only with autonomy_observe_only", () => {
+    const decision = decideNextActionWithReason(passingState({ autonomyLevel: "observe" }));
+    expect(decision.action).toBe("abandon");
+    expect(decision.abandonReason).toBe("autonomy_observe_only");
+    expect(decision.requiresApproval).toBeUndefined();
+    // The reason must note the pass WAS reached but the level keeps the loop observe-only.
+    expect(decision.reason).toMatch(/clean predicted-gate pass/);
+    expect(decision.reason).toMatch(/observe-only/);
+  });
+
+  it("REGRESSION: an omitted autonomyLevel is deep-equal to an explicit \"auto\" on the same passing state", () => {
+    const omitted = decideNextActionWithReason(passingState());
+    const explicitAuto = decideNextActionWithReason(passingState({ autonomyLevel: "auto" }));
+    expect(omitted.action).toBe("handoff");
+    expect(omitted).toEqual(explicitAuto);
+  });
+
+  it("REGRESSION: an explicitly-undefined autonomyLevel is deep-equal to an explicit \"auto\"", () => {
+    const explicitUndefined = decideNextActionWithReason(passingState({ autonomyLevel: undefined }));
+    const explicitAuto = decideNextActionWithReason(passingState({ autonomyLevel: "auto" }));
+    expect(explicitUndefined).toEqual(explicitAuto);
+  });
+
+  it("rejectionSignaled wins over ANY autonomy level, including observe (step 1 is unreachable-by-autonomy)", () => {
+    for (const autonomyLevel of ["auto", "auto_with_approval", "observe"] as const) {
+      const decision = decideNextActionWithReason(passingState({ rejectionSignaled: true, autonomyLevel }));
+      expect(decision.action).toBe("abandon");
+      expect(decision.abandonReason).toBe("rejection_signaled");
+    }
+  });
+
+  it("an ambiguous self-review wins over ANY autonomy level, including observe (step 2 is unreachable-by-autonomy)", () => {
+    for (const autonomyLevel of ["auto", "auto_with_approval", "observe"] as const) {
+      const decision = decideNextActionWithReason(passingState({ selfReview: { kind: "ambiguous" }, autonomyLevel }));
+      expect(decision.action).toBe("abandon");
+      expect(decision.abandonReason).toBe("self_review_ambiguous");
+    }
+  });
+});

--- a/test/unit/miner-attempt-input-builder.test.ts
+++ b/test/unit/miner-attempt-input-builder.test.ts
@@ -5,7 +5,7 @@ vi.mock("@loopover/engine", async () => {
 });
 
 import { buildAttemptGovernorContext, buildAttemptLoopInput } from "../../packages/loopover-miner/lib/attempt-input-builder.js";
-import { DEFAULT_AMS_POLICY_SPEC, evaluateGovernorChokepoint, parseFocusManifest } from "../../packages/loopover-engine/src/index";
+import { DEFAULT_AMS_POLICY_SPEC, evaluateGovernorChokepoint, parseFocusManifest, type AmsPolicySpec } from "../../packages/loopover-engine/src/index";
 
 function codingTaskSpec(overrides: Record<string, unknown> = {}) {
   return {
@@ -177,6 +177,38 @@ describe("buildAttemptLoopInput (#5132)", () => {
     });
     expect(loopInput.rejectionSignaled).toBe(true);
     expect(loopInput.mode).toBe("live");
+  });
+
+  it("threads amsPolicySpec.selfLoopAutonomy through to IterateLoopInput.autonomyLevel unchanged (#6560)", () => {
+    const loopInput = buildAttemptLoopInput({
+      codingTaskSpec: codingTaskSpec(),
+      reviewContext: reviewContext(),
+      worktreePath: "/fake",
+      attemptId: "a1",
+      mode: "live",
+      repoFullName: "acme/widgets",
+      minerLogin: "alice",
+      rejectionSignaled: false,
+      // selfLoopAutonomy is the sibling config-schema issue's addition to AmsPolicySpec; this issue only reads
+      // it, so cast the operator-configured value onto the spec until that field lands on the type.
+      amsPolicySpec: { ...DEFAULT_AMS_POLICY_SPEC, selfLoopAutonomy: "observe" } as AmsPolicySpec,
+    });
+    expect(loopInput.autonomyLevel).toBe("observe");
+  });
+
+  it("leaves autonomyLevel undefined when amsPolicySpec has no selfLoopAutonomy set (#6560)", () => {
+    const loopInput = buildAttemptLoopInput({
+      codingTaskSpec: codingTaskSpec(),
+      reviewContext: reviewContext(),
+      worktreePath: "/fake",
+      attemptId: "a1",
+      mode: "dry_run",
+      repoFullName: "acme/widgets",
+      minerLogin: "alice",
+      rejectionSignaled: false,
+      amsPolicySpec: DEFAULT_AMS_POLICY_SPEC,
+    });
+    expect(loopInput.autonomyLevel).toBeUndefined();
   });
 
   it("uses AmsPolicySpec's real maxIterations/maxTurnsPerIteration, not hardcoded literals", () => {


### PR DESCRIPTION
## What

Wires the operator's self-loop autonomy setting into `decideNextAction`'s pass→handoff step (#6560). Until now the policy's step-3 clean-pass branch was autonomy-level-agnostic (its header called this out as a deferred gap): a passing self-review always handed off unconditionally.

## Changes

- `iterate-policy.ts`
  - `IterationState.autonomyLevel?: AutonomyLevel` (imported the same way `settings/autonomy.ts` does). Optional, defaults to treated-as-`"auto"` when unset — same shape/precedent as `costCeilingReached`.
  - `IterateLoopDecision.requiresApproval?: true` (additive; mirrors `autonomyRequiresApproval`).
  - New `AbandonReason` variant `"autonomy_observe_only"`.
  - Narrowed **only** the step-3 `selfReview.kind === "pass"` branch, resolving `state.autonomyLevel ?? "auto"`:
    - `"auto"` (or unset): unchanged `{ action: "handoff" }`, no `requiresApproval`.
    - `"auto_with_approval"`: `{ action: "handoff", requiresApproval: true }`.
    - `"observe"`: `{ action: "abandon", abandonReason: "autonomy_observe_only" }`, reason notes the clean pass WAS reached but the level keeps the loop observe-only.
  - Steps 1 (`rejectionSignaled`) and 2 (`ambiguous`) untouched — they still win over any level.
- `iterate-loop.ts`: `IterateLoopInput.autonomyLevel?` (same optional/doc shape as `rejectionSignaled`), copied verbatim into the per-iteration `IterationState`.
- `attempt-input-builder.js`: `buildAttemptLoopInput` maps `amsPolicySpec.selfLoopAutonomy → autonomyLevel`, the same pass-through pattern as `rejectionSignaled`.

`maxIterations`/`capLimits` remain the only iteration/budget controls; this field gates ONLY the pass→handoff transition.

## Tests

- Root vitest `test/unit/iterate-policy-autonomy.test.ts` (Codecov-measured) + engine `iterate-policy.test.ts`:
  - all three levels against a passing state (`auto`→handoff, `auto_with_approval`→handoff+`requiresApproval:true`, `observe`→abandon+`autonomy_observe_only`);
  - byte-identical regression: omitted / explicit-`undefined` / explicit-`"auto"` all deep-equal on the same passing state;
  - `rejectionSignaled` and `ambiguous` still win over every level including `"observe"`.
- `test/unit/miner-attempt-input-builder.test.ts`: `selfLoopAutonomy` flows through to `autonomyLevel`, and stays `undefined` when unset.

A repo that leaves the field unset behaves byte-identically to pre-this-change code.

Closes #6560
