### PR TITLE
feat(engine): add selfLoopAutonomy to AmsPolicySpec

### DIFF
--- a/packages/loopover-engine/src/ams-policy-spec.ts
+++ b/packages/loopover-engine/src/ams-policy-spec.ts
@@ -1,6 +1,12 @@
 import { parse as parseYaml } from "yaml";
 
 import { DEFAULT_PORTFOLIO_CONVERGENCE_THRESHOLDS, type PortfolioConvergenceThresholds } from "./portfolio/non-convergence.js";
+import { AUTONOMY_LEVELS } from "./settings/autonomy.js";
+import type { AutonomyLevel } from "./types/manifest-deps-types.js";
+
+// Re-exported so the barrel can surface it from this module's own export block, alongside every other
+// AmsPolicySpec field type (AmsSubmissionMode/AmsSlopThreshold/AmsCapLimits) rather than from a second place.
+export type { AutonomyLevel };
 
 // AmsPolicySpec (#5132, Wave 3.5 follow-up). The type surface for `.loopover-ams.yml` -- the OPERATOR's own
 // execution-risk policy for their miner (AMS: the autonomous mining system this file's fields configure), as
@@ -51,6 +57,14 @@ export type AmsPolicySpec = {
   /** Per-iteration turn budget passed to the coding-agent driver (IterateLoopInput.maxTurnsPerIteration).
    *  Default: 6. */
   maxTurnsPerIteration: number;
+  /** How much autonomy the iterate loop has over its OWN self-directed pass -> handoff transition (#6559).
+   *
+   *  Default: "auto" -- deliberately NOT settings/autonomy.ts's own DEFAULT_AUTONOMY_LEVEL of "observe". That
+   *  default is right for the maintainer auto-maintain dial, which gates a capability with no prior acting
+   *  behavior. This field gates something that already happens unconditionally today (a clean self-review pass
+   *  hands off), so defaulting to "observe" would silently change behavior for every operator who leaves the
+   *  field unset. Inert until the consultation issue reads it. */
+  selfLoopAutonomy: AutonomyLevel;
 };
 
 /** The tolerant parser result for `.loopover-ams.yml`. Mirrors `ParsedMinerGoalSpec`'s present/warnings shape. */
@@ -71,6 +85,7 @@ export const DEFAULT_AMS_POLICY_SPEC: Readonly<AmsPolicySpec> = Object.freeze({
   convergenceThresholds: Object.freeze({ ...DEFAULT_PORTFOLIO_CONVERGENCE_THRESHOLDS }),
   maxIterations: 3,
   maxTurnsPerIteration: 6,
+  selfLoopAutonomy: "auto",
 });
 
 const MAX_AMS_POLICY_SPEC_BYTES = 8_192;
@@ -83,6 +98,7 @@ function cloneDefaultAmsPolicySpec(): AmsPolicySpec {
     convergenceThresholds: { ...DEFAULT_AMS_POLICY_SPEC.convergenceThresholds },
     maxIterations: DEFAULT_AMS_POLICY_SPEC.maxIterations,
     maxTurnsPerIteration: DEFAULT_AMS_POLICY_SPEC.maxTurnsPerIteration,
+    selfLoopAutonomy: DEFAULT_AMS_POLICY_SPEC.selfLoopAutonomy,
   };
 }
 
@@ -94,6 +110,17 @@ function normalizeSubmissionMode(value: unknown, fallback: AmsSubmissionMode, wa
   if (value === undefined || value === null) return fallback;
   if (value === "observe" || value === "enforce") return value;
   warnings.push(`AmsPolicySpec field "submissionMode" must be one of observe, enforce; falling back to "${fallback}".`);
+  return fallback;
+}
+
+function normalizeSelfLoopAutonomy(value: unknown, fallback: AutonomyLevel, warnings: string[]): AutonomyLevel {
+  if (value === undefined || value === null) return fallback;
+  // Validated against AUTONOMY_LEVELS rather than a literal list so this can't drift from the vocabulary the
+  // rest of the codebase resolves against.
+  if (typeof value === "string" && (AUTONOMY_LEVELS as readonly string[]).includes(value)) return value as AutonomyLevel;
+  warnings.push(
+    `AmsPolicySpec field "selfLoopAutonomy" must be one of ${AUTONOMY_LEVELS.join(", ")}; falling back to "${fallback}".`,
+  );
   return fallback;
 }
 
@@ -166,7 +193,8 @@ function hasConfiguredPolicyFields(spec: AmsPolicySpec): boolean {
     spec.convergenceThresholds.maxConsecutiveFailures !== DEFAULT_AMS_POLICY_SPEC.convergenceThresholds.maxConsecutiveFailures ||
     spec.convergenceThresholds.maxReenqueues !== DEFAULT_AMS_POLICY_SPEC.convergenceThresholds.maxReenqueues ||
     spec.maxIterations !== DEFAULT_AMS_POLICY_SPEC.maxIterations ||
-    spec.maxTurnsPerIteration !== DEFAULT_AMS_POLICY_SPEC.maxTurnsPerIteration
+    spec.maxTurnsPerIteration !== DEFAULT_AMS_POLICY_SPEC.maxTurnsPerIteration ||
+    spec.selfLoopAutonomy !== DEFAULT_AMS_POLICY_SPEC.selfLoopAutonomy
   );
 }
 
@@ -207,6 +235,11 @@ export function parseAmsPolicySpec(raw: unknown): ParsedAmsPolicySpec {
       record.maxTurnsPerIteration,
       "maxTurnsPerIteration",
       DEFAULT_AMS_POLICY_SPEC.maxTurnsPerIteration,
+      warnings,
+    ),
+    selfLoopAutonomy: normalizeSelfLoopAutonomy(
+      record.selfLoopAutonomy,
+      DEFAULT_AMS_POLICY_SPEC.selfLoopAutonomy,
       warnings,
     ),
   };

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -525,6 +525,7 @@ export {
   type AmsPolicySpec,
   type AmsSlopThreshold,
   type AmsSubmissionMode,
+  type AutonomyLevel,
   type ParsedAmsPolicySpec,
 } from "./ams-policy-spec.js";
 export {

--- a/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
+++ b/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
@@ -40,6 +40,7 @@ test("parseAmsPolicySpec: valid raw config normalizes every field and keeps non-
     convergenceThresholds: { maxConsecutiveFailures: 5, maxReenqueues: 2 },
     maxIterations: 5,
     maxTurnsPerIteration: 10,
+    selfLoopAutonomy: "observe",
   });
 
   assert.equal(parsed.present, true);
@@ -50,8 +51,45 @@ test("parseAmsPolicySpec: valid raw config normalizes every field and keeps non-
     convergenceThresholds: { maxConsecutiveFailures: 5, maxReenqueues: 2 },
     maxIterations: 5,
     maxTurnsPerIteration: 10,
+    selfLoopAutonomy: "observe",
   });
   assert.deepEqual(parsed.warnings, []);
+});
+
+test("parseAmsPolicySpec: selfLoopAutonomy defaults to auto when omitted (#6559)", () => {
+  // "auto" is today's implicit behavior -- a clean self-review pass already hands off unconditionally -- so
+  // this default is what keeps an unset field from silently changing an existing operator's loop.
+  assert.equal(DEFAULT_AMS_POLICY_SPEC.selfLoopAutonomy, "auto");
+  assert.equal(parseAmsPolicySpec({}).spec.selfLoopAutonomy, "auto");
+});
+
+test("parseAmsPolicySpec: selfLoopAutonomy accepts every valid level (#6559)", () => {
+  // maxIterations rides along so the spec has a non-default field: with only selfLoopAutonomy: "auto" nothing
+  // is configured, and the parser's own "nothing recognized" warning would mask the level's own parse.
+  for (const level of ["observe", "auto_with_approval", "auto"]) {
+    const parsed = parseAmsPolicySpec({ selfLoopAutonomy: level, maxIterations: 5 });
+    assert.equal(parsed.spec.selfLoopAutonomy, level);
+    assert.deepEqual(parsed.warnings, []);
+  }
+});
+
+test("parseAmsPolicySpec: a non-default selfLoopAutonomy alone marks the spec present (#6559)", () => {
+  const parsed = parseAmsPolicySpec({ selfLoopAutonomy: "observe" });
+  assert.equal(parsed.present, true);
+});
+
+test("parseAmsPolicySpec: the default selfLoopAutonomy does not count as configured (#6559)", () => {
+  const parsed = parseAmsPolicySpec({ selfLoopAutonomy: "auto" });
+  assert.equal(parsed.present, false);
+  assert.deepEqual(parsed.spec, DEFAULT_AMS_POLICY_SPEC);
+});
+
+test("parseAmsPolicySpec: an invalid selfLoopAutonomy falls back to auto with a warning (#6559)", () => {
+  for (const value of ["yolo", 3, true, { level: "auto" }]) {
+    const parsed = parseAmsPolicySpec({ selfLoopAutonomy: value, maxIterations: 5 });
+    assert.equal(parsed.spec.selfLoopAutonomy, "auto");
+    assert.match(parsed.warnings.join(" "), /selfLoopAutonomy/);
+  }
 });
 
 test("parseAmsPolicySpec: maxIterations/maxTurnsPerIteration floor to whole counts and reject negative/non-numeric values", () => {

--- a/test/unit/ams-policy-spec-parser.test.ts
+++ b/test/unit/ams-policy-spec-parser.test.ts
@@ -42,6 +42,7 @@ describe("AmsPolicySpec parser (#5132)", () => {
       convergenceThresholds: { maxConsecutiveFailures: 5, maxReenqueues: 2 },
       maxIterations: 5,
       maxTurnsPerIteration: 10,
+      selfLoopAutonomy: "observe",
     });
     expect(parsed.present).toBe(true);
     expect(parsed.spec).toEqual({
@@ -51,8 +52,73 @@ describe("AmsPolicySpec parser (#5132)", () => {
       convergenceThresholds: { maxConsecutiveFailures: 5, maxReenqueues: 2 },
       maxIterations: 5,
       maxTurnsPerIteration: 10,
+      selfLoopAutonomy: "observe",
     });
     expect(parsed.warnings).toEqual([]);
+  });
+
+  describe("selfLoopAutonomy (#6559)", () => {
+    it("defaults to auto when omitted -- NOT observe, which would change today's behavior", () => {
+      // The loop already hands off unconditionally on a clean pass, so an "observe" default would silently
+      // stop that for every operator who never set the field. This assertion is the guard on that decision.
+      expect(DEFAULT_AMS_POLICY_SPEC.selfLoopAutonomy).toBe("auto");
+      expect(parseAmsPolicySpec({}).spec.selfLoopAutonomy).toBe("auto");
+      expect(parseAmsPolicySpec({ maxIterations: 5 }).spec.selfLoopAutonomy).toBe("auto");
+    });
+
+    // A non-default sibling field rides along on purpose: with ONLY selfLoopAutonomy: "auto" the spec has no
+    // non-default field at all, so the parser's own "nothing recognized" warning fires and would drown out
+    // whether the level itself parsed cleanly. maxIterations keeps the spec present so this asserts one thing.
+    it.each(["observe", "auto_with_approval", "auto"])("accepts the valid level %s", (level) => {
+      const parsed = parseAmsPolicySpec({ selfLoopAutonomy: level, maxIterations: 5 });
+      expect(parsed.spec.selfLoopAutonomy).toBe(level);
+      expect(parsed.warnings).toEqual([]);
+    });
+
+    it("marks a non-default level as configured, so the file isn't dismissed as empty", () => {
+      // selfLoopAutonomy alone must be enough to make the spec present -- if hasConfiguredPolicyFields missed
+      // it, an operator whose only setting is this one would be told their file had nothing recognized in it.
+      const parsed = parseAmsPolicySpec({ selfLoopAutonomy: "observe" });
+      expect(parsed.present).toBe(true);
+      expect(parsed.warnings).toEqual([]);
+    });
+
+    it("REGRESSION: the default level does NOT count as configured", () => {
+      // The mirror of the case above: hasConfiguredPolicyFields' new clause must not false-positive on the
+      // default, or an empty file would suddenly report itself as present.
+      const parsed = parseAmsPolicySpec({ selfLoopAutonomy: "auto" });
+      expect(parsed.present).toBe(false);
+      expect(parsed.spec).toEqual(DEFAULT_AMS_POLICY_SPEC);
+    });
+
+    it("REGRESSION: a zero-field input still returns the full, unmodified default spec", () => {
+      const parsed = parseAmsPolicySpec({});
+      expect(parsed.present).toBe(false);
+      expect(parsed.spec).toEqual(DEFAULT_AMS_POLICY_SPEC);
+    });
+
+    it.each([
+      ["an unknown string", "yolo"],
+      ["a near-miss level", "auto-with-approval"],
+      ["a number", 3],
+      ["a boolean", true],
+      ["an object", { level: "auto" }],
+    ])("falls back to auto with a warning for %s", (_label, value) => {
+      const parsed = parseAmsPolicySpec({ selfLoopAutonomy: value, maxIterations: 5 });
+      expect(parsed.spec.selfLoopAutonomy).toBe("auto");
+      const warning = parsed.warnings.join(" ");
+      expect(warning).toMatch(/selfLoopAutonomy/);
+      // The warning must name the allowed values, or an operator can't tell what to type instead.
+      expect(warning).toMatch(/observe.*auto_with_approval.*auto/);
+    });
+
+    it("treats an explicit null as unset rather than invalid", () => {
+      // Same reason as above for the sibling field: null must produce NO warning of its own, which is only
+      // observable once the spec has something else configured.
+      const parsed = parseAmsPolicySpec({ selfLoopAutonomy: null, maxIterations: 5 });
+      expect(parsed.spec.selfLoopAutonomy).toBe("auto");
+      expect(parsed.warnings).toEqual([]);
+    });
   });
 
   it("maxIterations/maxTurnsPerIteration floor to whole counts, allow zero, and reject negative/non-numeric values", () => {


### PR DESCRIPTION
## Summary

The config-schema half of the #6060 ADR: `.loopover-ams.yml` now accepts `selfLoopAutonomy: observe|auto_with_approval|auto`, parsed, defaulted and warned-on like every other `AmsPolicySpec` field. **The field is inert** — `decideNextAction`/`iterate-policy.ts` are untouched, per the issue; the follow-up consultation issue consumes it.

## The default is `"auto"`, deliberately

Not `settings/autonomy.ts`'s own `DEFAULT_AUTONOMY_LEVEL = "observe"`. That default is right for the maintainer auto-maintain dial, which gates a capability with **no prior acting behavior**. This field gates something that **already happens unconditionally today** — a clean self-review pass hands off (`iterate-policy.ts:154-156`) — so defaulting to `"observe"` would silently stop that for every operator who leaves the field unset. A test pins `DEFAULT_AMS_POLICY_SPEC.selfLoopAutonomy === "auto"` so this can't be "tidied" into consistency with the other dial later.

## Wiring

Threaded through the full surface the way every sibling field is: the type, `DEFAULT_AMS_POLICY_SPEC`, `cloneDefaultAmsPolicySpec`, `hasConfiguredPolicyFields`, and `parseAmsPolicySpec`'s assignment.

- `normalizeSelfLoopAutonomy` mirrors `normalizeSubmissionMode`'s shape but validates against **`AUTONOMY_LEVELS`** rather than a literal list, so it can't drift from the vocabulary the rest of the codebase resolves against. The warning names the allowed values — an operator who typo'd one needs to know what to type instead.
- `AutonomyLevel` is re-exported from `ams-policy-spec.ts` so the barrel surfaces it from **that module's own export block**, alongside every other `AmsPolicySpec` field type, rather than from a second place.

## Both suites updated — for the two different reasons the issue sets out

- **`test/unit/ams-policy-spec-parser.test.ts`** (root, vitest) — what Codecov measures this diff by.
- **`packages/loopover-engine/test/ams-policy-spec-parser.test.ts`** (package-local, `node --test` against `dist/`) — keeps `npm run test --workspace @loopover/engine` (part of `test:ci`) green.

Both already had a `deepEqual` on the **full spec** that my new field broke. Neither is a type error — `npm run typecheck` was clean while both suites were red — so only running them surfaced it.

Coverage includes **both sides of `hasConfiguredPolicyFields`' new clause**: a non-default level alone must mark the spec `present` (otherwise an operator whose only setting is this one would be told their file had nothing recognized in it), and the default must **not** (otherwise an empty file would report itself as configured). Plus: all 3 valid levels, an unknown string, a near-miss (`auto-with-approval`), a number, a boolean, an object, an explicit `null` treated as unset, and the zero-field regression returning the full unmodified default.

One detail worth recording: the valid-level cases pass a non-default sibling field (`maxIterations: 5`) alongside. With only `selfLoopAutonomy: "auto"` the spec has no non-default field at all, so the parser's own "nothing recognized" warning fires and would mask whether the level itself parsed cleanly. My first draft asserted `warnings === []` without it and failed — the tests now isolate one thing each.

## Validation

- [x] **Engine `node --test` — 572/572 pass** (was 1 failing before I updated its deep-equal).
- [x] **Root vitest — 93/93** across `ams-policy-spec-parser` plus every `AmsPolicySpec` consumer (`miner-ams-policy`, `miner-loop-cli`, `miner-governor-metrics-cli`, `miner-attempt-input-builder`).
- [x] **Patch coverage 100%** — measured from the v8 JSON report against my 34 changed lines: zero uncovered statements, **zero partial branches**, zero uncovered functions. Clears the 99% `codecov/patch` gate on `packages/loopover-engine/src/**`.
- [x] `npm run typecheck` — 0 errors. Engine build clean. `git diff --check` clean. Rebased on latest `main` — no base conflict.

Pre-existing, not mine: two `miner-attempt-cli` cases (`#5185 appendAttemptLogEvent`, `allocator failure`) fail identically on clean `main`.

## Scope

- [x] Four files, one coherent change: the field + its validator, the barrel export, and both parser suites. Wanted paths (`packages/`, `test/`).
- [x] No behaviour change: `decideNextAction`/`iterate-policy.ts` untouched, the field inert until the follow-up.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] The `"auto"` default is precisely what makes this a zero-behaviour-change addition — every existing operator's loop keeps doing exactly what it does today.
- [x] Tolerant parsing: any invalid value falls back to the default with a named warning rather than throwing, matching every sibling field.

Closes #6559
