### PR TITLE
test(settings): inject Batch B config-as-code fields via the manifest

### DIFF
--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -6064,6 +6064,10 @@ describe("api routes", () => {
       gittensorLabel: "gittensor-miner",
     });
     // publicSurface moved off the DB entirely (Batch A, loopover#6442) -- set via manifest injection instead.
+    // createMissingLabel/gittensorLabel stay DB-injected here: buildRegistrationReadinessResponse's
+    // applyConfigAsCodeOnlyFields only overlays the effective value for Batch A's 9 fields (#6442) -- every
+    // other field, including these two, is intentionally the RAW DB value (the #2912 raw-vs-manifest
+    // comparison design), so a manifest override here would NOT show up in this response.
     await upsertRepoFocusManifest(env, "entrius/allways-ui", { settings: { publicSurface: "off" } });
     const directReadiness = await app.request("/v1/repos/entrius/allways-ui/registration-readiness", { headers: apiHeaders(env) }, env);
     expect(directReadiness.status).toBe(200);

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -195,7 +195,8 @@ describe("agent approval queue (#779)", () => {
 
   it("accept holds a staged merge behind a still-open, OVERLAPPING older sibling under mergeTrainMode: enforce (#selfhost-merge-train-overlap)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" }, mergeTrainMode: "enforce" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" } });
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { mergeTrainMode: "enforce" } });
     await seedInstallation(env);
     // Relative to Date.now() (this file never pins the system clock) so the sibling is unambiguously OLDER
     // than the current PR but still well within the 24h merge-train staleness cap.
@@ -212,7 +213,8 @@ describe("agent approval queue (#779)", () => {
 
   it("accept does NOT hold a staged merge behind an older sibling sharing no linked issue or file, even under mergeTrainMode: enforce", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" }, mergeTrainMode: "enforce" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" } });
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { mergeTrainMode: "enforce" } });
     await seedInstallation(env);
     const olderCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     const newerCreatedAt = new Date(Date.now() - 30 * 60 * 1000).toISOString();
@@ -321,8 +323,8 @@ describe("agent approval queue (#779)", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "owner/repo",
       autonomy: { close: "auto_with_approval" },
-      contributorBlacklist: [{ login: "plagiarist", reason: "plagiarism" }],
     });
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { contributorBlacklist: [{ login: "plagiarist", reason: "plagiarism" }] } });
     await seedInstallation(env);
     await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "plagiarist" }, head: { sha: "h7" }, labels: [], body: "x" });
     const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "blocked", closeKind: "blacklist", expectedHeadSha: "h7" }, reason: "blacklisted contributor" });
@@ -337,7 +339,8 @@ describe("agent approval queue (#779)", () => {
   it("REGRESSION: accept rechecks blacklist closes against the effective global blacklist", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await Promise.all([
-      upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, contributorBlacklist: [] }),
+      upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } }),
+      upsertRepoFocusManifest(env, "owner/repo", { settings: { contributorBlacklist: [] } }),
       upsertGlobalContributorBlacklist(env, { contributorBlacklist: [{ login: "fleet-banned", reason: "global" }] }),
     ]);
     await seedInstallation(env);
@@ -356,7 +359,8 @@ describe("agent approval queue (#779)", () => {
     // passes cleanly -- only re-resolving blacklist membership against the CURRENT repo settings (not the
     // plan-time snapshot baked into the sticky pending row) detects that the maintainer removed the entry.
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, contributorBlacklist: [] });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { contributorBlacklist: [] } });
     await seedInstallation(env);
     await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "reformed" }, head: { sha: "h7" }, labels: [], body: "x" });
     const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "blocked", closeKind: "blacklist", expectedHeadSha: "h7" }, reason: "blacklisted contributor" });

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -3708,9 +3708,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false } });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 43,
@@ -3793,9 +3792,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false } });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 44,
@@ -3881,7 +3879,6 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
     // wantedPaths configured + a changed file outside it produces manifest_off_focus (NOT one of the three
     // enforceable codes); testExpectations configured + no evidence produces manifest_missing_tests (IS
@@ -3889,7 +3886,7 @@ describe("queue processors", () => {
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       wantedPaths: ["docs/"],
       testExpectations: ["Run npm run test:ci."],
-      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
     });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
@@ -3975,9 +3972,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false } });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 45,
@@ -4063,9 +4059,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { linkedIssuePolicy: "required", settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { linkedIssuePolicy: "required", settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false } });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 46,
@@ -4151,9 +4146,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { linkedIssuePolicy: "required", settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { linkedIssuePolicy: "required", settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false } });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 47,
@@ -4239,9 +4233,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { testExpectations: ["Run npm run test:ci."], settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false } });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 46,
@@ -4330,12 +4323,11 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       manifestPolicyGateMode: "block",
       requireLinkedIssue: false,
-      typeLabelsEnabled: false,
     });
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       testExpectations: ["Run npm run test:ci."],
       review: { auto_review: { ignore_authors: ["*[bot]"] } },
-      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
     });
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",

--- a/test/unit/queue-3.test.ts
+++ b/test/unit/queue-3.test.ts
@@ -1273,12 +1273,15 @@ describe("queue processors", () => {
       reviewCheckMode: "required",
       aiReviewMode: "advisory",
       autonomy: { close: "auto", label: "auto" },
-      // The banned login is per-repo DB config; the label is the configurable `.loopover.yml` value below —
-      // nothing is hard-coded.
-      contributorBlacklist: [{ login: "baduser", reason: "plagiarism" }],
     });
+    // contributorBlacklist moved off the DB entirely (Batch B, loopover#6443) -- set via manifest injection.
     // The label is configurable via `.loopover.yml` (default "slop"); set a custom one to prove it's not hardcoded.
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", blacklistLabel: "spam" } }, "repo_file");
+    await upsertRepoFocusManifest(
+      env,
+      "JSONbored/gittensory",
+      { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", blacklistLabel: "spam", contributorBlacklist: [{ login: "baduser", reason: "plagiarism" }] } },
+      "repo_file",
+    );
     const seen = { closed: false, labels: [] as string[], comments: [] as string[] };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -1289,12 +1289,11 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      createMissingLabel: false,
       reviewCheckMode: "required",
       linkedIssueGateMode: "off",
       aiReviewMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
     await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
     let labelPosts = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -5559,9 +5558,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      createMissingLabel: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicSurface: "comment_only", checkRunMode: "enabled", checkRunDetailLevel: "standard" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "detected_contributors_only", publicSurface: "comment_only", checkRunMode: "enabled", checkRunDetailLevel: "standard", createMissingLabel: true },
+    });
     const calls = { checks: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -5828,9 +5828,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      createMissingLabel: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicSurface: "label_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "detected_contributors_only", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false },
+    });
     const calls = { comments: 0, labels: 0, minerList: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -5910,9 +5911,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      createMissingLabel: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicSurface: "label_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "detected_contributors_only", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false },
+    });
     const calls = { comments: 0, labels: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -6184,9 +6186,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      createMissingLabel: false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicSurface: "label_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: { commentMode: "detected_contributors_only", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false },
+    });
     let officialSource: "down" | "confirmed" = "down";
     const calls = { minerList: 0, labels: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -6263,10 +6266,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      createMissingLabel: false,
       agentPaused: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "comment_and_label", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "comment_and_label", checkRunMode: "off", createMissingLabel: false } });
     const calls = { labels: 0, comments: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -4851,7 +4851,6 @@ describe("queue processors", () => {
         linkedIssueGateMode: "off",
         manifestPolicyGateMode: opts.manifestPolicyGateMode ?? "advisory",
         aiReviewMode: "off",
-        typeLabelsEnabled: false,
       });
       await upsertPullRequestFromGitHub(env, repoFullName, {
         number: prNumber,
@@ -4883,7 +4882,7 @@ describe("queue processors", () => {
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
         features: { e2eTests: opts.e2eTests ?? true },
-        review: { e2e_test_auto_trigger: opts.autoTrigger ?? true, ...(opts.e2eTestDelivery ? { e2e_test_delivery: opts.e2eTestDelivery } : {}) }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+        review: { e2e_test_auto_trigger: opts.autoTrigger ?? true, ...(opts.e2eTestDelivery ? { e2e_test_delivery: opts.e2eTestDelivery } : {}) }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
       });
     }
 
@@ -5255,7 +5254,6 @@ describe("queue processors", () => {
         linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
         aiReviewMode: "off",
-        typeLabelsEnabled: false,
       });
       await upsertPullRequestFromGitHub(env, repoFullName, {
         number: prNumber,
@@ -5279,7 +5277,7 @@ describe("queue processors", () => {
       });
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
-        features: { e2eTests: opts.e2eTests ?? true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+        features: { e2eTests: opts.e2eTests ?? true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
       });
     }
 
@@ -5673,9 +5671,8 @@ describe("queue processors", () => {
         linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
         aiReviewMode: "off",
-        typeLabelsEnabled: false,
       });
-      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSurface: "comment_and_label", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSurface: "comment_and_label", checkRunMode: "off", typeLabelsEnabled: false } });
       // gateEvaluation needs a resolved CI aggregate (mocking the module function directly is far simpler than
       // stubbing every raw status/check-suite endpoint the live CI aggregator would otherwise call) -- but
       // NOT "passed": resolveManifestPassedValidationCount treats a fully-green live CI rollup as validation
@@ -5972,12 +5969,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off", createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(210, seen);
@@ -6004,12 +6000,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: false,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", publicAudienceMode: "gittensor_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", publicAudienceMode: "gittensor_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false, minerList: 0 };
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
@@ -6062,7 +6057,6 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         // The only difference from the pre-existing "keeps GitHub-history-only contributors quiet" test
         // (which has the gate off, so it returns before ever reaching the type-label decision): with the
         // gate ENABLED, the function does NOT bail out early, so this is the only path that actually
@@ -6071,7 +6065,7 @@ describe("queue processors", () => {
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", publicAudienceMode: "gittensor_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", publicAudienceMode: "gittensor_only", checkRunMode: "off", createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(217, seen);
@@ -6098,13 +6092,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        typeLabelsEnabled: false,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(211, seen);
@@ -6131,12 +6123,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", includeMaintainerAuthors: false, checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", includeMaintainerAuthors: false, checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(212, seen);
 
@@ -6162,12 +6153,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(213, seen);
 
@@ -6193,17 +6183,15 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
-        // A self-host taxonomy well beyond the built-in bug/feature/priority triad (#label-modularity):
-        // `security` is a registered category with no title-classification rule of its own, so it is
-        // never CHOSEN here, but it must still be a cleanup CANDIDATE (never left dangling on a PR whose
-        // classification moved elsewhere) exactly like the built-in categories.
-        typeLabels: { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority", security: "area:security" },
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+      // A self-host taxonomy well beyond the built-in bug/feature/priority triad (#label-modularity):
+      // `security` is a registered category with no title-classification rule of its own, so it is
+      // never CHOSEN here, but it must still be a cleanup CANDIDATE (never left dangling on a PR whose
+      // classification moved elsewhere) exactly like the built-in categories.
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false, typeLabels: { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority", security: "area:security" } } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(218, seen);
 
@@ -6229,12 +6217,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "comment_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "comment_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(214, seen);
 
@@ -6259,13 +6246,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        typeLabelsEnabled: false,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(215, seen);
@@ -6291,11 +6276,10 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: false,
-        typeLabelsEnabled: false,
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "enabled" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "enabled", typeLabelsEnabled: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(216, seen);
@@ -6364,17 +6348,23 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
-        linkedIssueLabelPropagation: {
-          enabled: true,
-          mode: "exclusive_type_label",
-          mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
+      });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+        settings: {
+          commentMode: "off",
+          publicSurface: "label_only",
+          checkRunMode: "off",
+          createMissingLabel: false,
+          linkedIssueLabelPropagation: {
+            enabled: true,
+            mode: "exclusive_type_label",
+            mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
+          },
         },
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(220, 1, seen, () => Response.json({ number: 1, state: "open", user: { login: "contributor" }, labels: ["gittensor:priority"] }));
 
@@ -6408,7 +6398,6 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "disabled",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
@@ -6418,16 +6407,23 @@ describe("queue processors", () => {
         // to do and bails before the label block. `label: "auto"` is the minimal opt-in that reproduces this
         // without pulling in merge/close autonomy's own CI-wait/rebase machinery.
         autonomy: { label: "auto" },
-        linkedIssueLabelPropagation: {
-          enabled: true,
-          mode: "exclusive_type_label",
-          mappings: [
-            { issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true },
-            { issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: false },
-          ],
+      });
+      await upsertRepoFocusManifest(env, "acme/widget", {
+        settings: {
+          commentMode: "off",
+          publicSurface: "label_only",
+          checkRunMode: "off",
+          createMissingLabel: false,
+          linkedIssueLabelPropagation: {
+            enabled: true,
+            mode: "exclusive_type_label",
+            mappings: [
+              { issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true },
+              { issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: false },
+            ],
+          },
         },
       });
-      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       // The linked issue is CLOSED, at a timestamp at/after this PR's own merge -- GitHub's standard "Closes #N"
       // auto-close, fired by this very merge. Title deliberately uses a verb ("fold") absent from the
@@ -6481,17 +6477,23 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
-        linkedIssueLabelPropagation: {
-          enabled: true,
-          mode: "exclusive_type_label",
-          mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
+      });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+        settings: {
+          commentMode: "off",
+          publicSurface: "label_only",
+          checkRunMode: "off",
+          createMissingLabel: false,
+          linkedIssueLabelPropagation: {
+            enabled: true,
+            mode: "exclusive_type_label",
+            mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
+          },
         },
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(221, 1, seen, () => new Response("server error", { status: 500 }));
 
@@ -6527,17 +6529,23 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
-        linkedIssueLabelPropagation: {
-          enabled: true,
-          mode: "exclusive_type_label",
-          mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+      });
+      await upsertRepoFocusManifest(env, "acme/widget", {
+        settings: {
+          commentMode: "off",
+          publicSurface: "label_only",
+          checkRunMode: "off",
+          createMissingLabel: false,
+          linkedIssueLabelPropagation: {
+            enabled: true,
+            mode: "exclusive_type_label",
+            mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+          },
         },
       });
-      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       let issueShouldFail = false;
       stubPropagationFetch(4716, 2216, seen, () =>
@@ -6571,17 +6579,23 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
-        linkedIssueLabelPropagation: {
-          enabled: true,
-          mode: "exclusive_type_label",
-          mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
+      });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+        settings: {
+          commentMode: "off",
+          publicSurface: "label_only",
+          checkRunMode: "off",
+          createMissingLabel: false,
+          linkedIssueLabelPropagation: {
+            enabled: true,
+            mode: "exclusive_type_label",
+            mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }],
+          },
         },
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(223, 1, seen, () => Response.json({ number: 1, state: "open", user: { login: "contributor" }, labels: ["gittensor:priority"] }));
 
@@ -6629,17 +6643,23 @@ describe("queue processors", () => {
           await upsertRepositorySettings(env, {
             repoFullName: "JSONbored/gittensory",
             autoLabelEnabled: true,
-            createMissingLabel: false,
             reviewCheckMode: "required",
             linkedIssueGateMode: "off",
             aiReviewMode: "off",
-            linkedIssueLabelPropagation: {
-              enabled: true,
-              mode: "exclusive_type_label",
-              mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+          });
+          await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+            settings: {
+              commentMode: "off",
+              publicSurface: "label_only",
+              checkRunMode: "off",
+              createMissingLabel: false,
+              linkedIssueLabelPropagation: {
+                enabled: true,
+                mode: "exclusive_type_label",
+                mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+              },
             },
           });
-          await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
           const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
           stubPropagationFetch(4818, 2192, seen, () => Response.json({ number: 2192, state: "closed", closed_at: "2026-07-11T02:26:25Z", user: { login: "JSONbored" }, labels: ["gittensor:feature"] }));
 
@@ -6685,17 +6705,23 @@ describe("queue processors", () => {
         await upsertRepositorySettings(env, {
           repoFullName: "acme/widget",
           autoLabelEnabled: true,
-          createMissingLabel: false,
           reviewCheckMode: "required",
           linkedIssueGateMode: "off",
           aiReviewMode: "off",
-          linkedIssueLabelPropagation: {
-            enabled: true,
-            mode: "exclusive_type_label",
-            mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+        });
+        await upsertRepoFocusManifest(env, "acme/widget", {
+          settings: {
+            commentMode: "off",
+            publicSurface: "label_only",
+            checkRunMode: "off",
+            createMissingLabel: false,
+            linkedIssueLabelPropagation: {
+              enabled: true,
+              mode: "exclusive_type_label",
+              mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+            },
           },
         });
-        await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
         const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
         stubPropagationFetch(9001, 501, seen, () => Response.json({ number: 501, state: "open", user: { login: "contributor" }, labels: ["gittensor:feature"] }));
 
@@ -6753,13 +6779,12 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
         // linkedIssueLabelPropagation intentionally omitted -- defaults to disabled.
       });
-      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(222, 1, seen, () => Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] }));
 
@@ -6786,12 +6811,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(219, seen);
 
@@ -6821,12 +6845,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(220, seen);
       failAuditEventInsertsContaining(env, "github_app.type_label_decision");
@@ -6853,13 +6876,11 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        typeLabelsEnabled: false,
-        createMissingLabel: false,
         reviewCheckMode: "required",
         linkedIssueGateMode: "off",
         aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(221, seen);
       failAuditEventInsertsContaining(env, "github_app.type_label_decision");

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -1783,14 +1783,24 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       },
       repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
     });
+    // reviewEvasionProtection is manifest-only now (Batch B, loopover#6443); pull any test override out of
+    // `overrides` before it reaches the DB write below so a per-test `{ reviewEvasionProtection: "off" }` still
+    // takes effect via the manifest overlay instead of being silently outranked by the "close" default.
+    const { reviewEvasionProtection, ...dbOverrides } = overrides;
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autonomy: { close: "auto" },
       agentPaused: false,
-      reviewEvasionProtection: "close",
-      ...overrides,
+      ...dbOverrides,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: {
+        publicSurface: "off",
+        commentMode: "off",
+        checkRunMode: "off",
+        reviewEvasionProtection: (reviewEvasionProtection as "off" | "close" | undefined) ?? "close",
+      },
+    });
   }
 
   // Generic GitHub fetch stub covering every endpoint the evasion handlers (and the surrounding webhook
@@ -2094,8 +2104,8 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         },
         repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
       });
-      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false, reviewEvasionProtection: "close" });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off", reviewEvasionProtection: "close" } });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
       await processJob(env, { type: "github-webhook", deliveryId: "self-close-no-write", eventName: "pull_request", payload: closedPayload("contributor") });
@@ -2690,8 +2700,8 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         },
         repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
       });
-      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false, reviewEvasionProtection: "close" });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off", reviewEvasionProtection: "close" } });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-evasion-no-write", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3159,8 +3169,8 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         },
         repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
       });
-      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false, reviewEvasionProtection: "close" });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { publicSurface: "off", commentMode: "off", checkRunMode: "off", reviewEvasionProtection: "close" } });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-no-write-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-no-write-2", eventName: "pull_request", payload: draftEvasionPayload("contributor") });


### PR DESCRIPTION
## Summary
- Prep step for loopover#6443 (Batch B of the repository_settings config-as-code migration, #6440): converts tests that exercise `gittensorLabel`, `createMissingLabel`, `typeLabelsEnabled`, `typeLabels`, `linkedIssueLabelPropagation`, `contributorBlacklist`, `reviewEvasionProtection`, and `mergeTrainMode` through `resolveRepositorySettings` from DB-based injection (`upsertRepositorySettings`) to manifest-based injection (`upsertRepoFocusManifest`), mirroring the same pattern already landed for Batch A (loopover#6442).
- No production code changes — test files only. This is the same "Phase 1" pattern as Batch A: stop relying on the soon-to-be-dropped DB write path in tests, before the columns are actually dropped in a follow-up Phase 2 PR.
- Left untouched by design: DB-round-trip tests for these fields (`moderation-config-db.test.ts`, `repository-settings-merge-train-mode.test.ts`, `contributor-blacklist.test.ts`) and tests using a field purely as an "unrelated setting preserved" marker in a write-merge route (`routes-ai-byok.test.ts`, and the `createMissingLabel`/`gittensorLabel` site in `api.test.ts`'s registration-readiness test, since that endpoint deliberately shows the raw DB value for those two fields today).

## Scope
- [x] Stayed within `test/**`
- [x] No `src/**`, `packages/**`, or generated-artifact changes
- [x] No secrets/wallets/hotkeys/trust-scores/reward values touched

## Validation
- `npx tsc --noEmit` — clean
- `npx vitest run` (full unsharded suite) — 923/925 files, 17636/17649 tests passed (pre-existing skips unchanged)
- `npm run ui:lint && npm run ui:typecheck && npm run ui:test && npm run ui:build` — all green
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- Test-only change — Codecov `codecov/patch` has no `src/**` lines to measure

## Safety
- [x] No auth/CORS/session changes
- [x] No secrets in code, comments, or tests