### PR TITLE
feat(miner-ui): adopt StateBoundary + skeletons on the Overview route

### DIFF
--- a/apps/loopover-miner-ui/src/app.test.tsx
+++ b/apps/loopover-miner-ui/src/app.test.tsx
@@ -53,14 +53,17 @@ describe("OverviewView (#4853)", () => {
     expect(statValue("Oldest queued")).toBe("90m");
   });
 
-  it("shows an independent loading message per card before data arrives", () => {
+  it("shows an independent content-shaped loading skeleton per card before data arrives (#6509)", () => {
     render(<OverviewView runs={null} portfolio={null} claims={null} />);
-    expect(screen.getByText(/Loading run state/i)).toBeTruthy();
-    expect(screen.getByText(/Loading the portfolio queue/i)).toBeTruthy();
-    expect(screen.getByText(/Loading the claim ledger/i)).toBeTruthy();
+    // Each card's loading surface is now a role="status" Skeleton placeholder, not a flat gray sentence.
+    expect(screen.getByRole("status", { name: /loading run activity/i })).toBeTruthy();
+    expect(screen.getByRole("status", { name: /loading the portfolio queue/i })).toBeTruthy();
+    expect(screen.getByRole("status", { name: /loading the claim ledger/i })).toBeTruthy();
+    // The pre-#6509 hand-rolled "Loading …" text is gone.
+    expect(screen.queryByText(/Loading run state/i)).toBeNull();
   });
 
-  it("degrades each card independently: an errored source shows an alert while the others still render", () => {
+  it("degrades each card independently: an errored source shows a StateBoundary alert while the others still render", () => {
     render(
       <OverviewView
         runs={{ ok: false, error: "down" }}
@@ -69,6 +72,9 @@ describe("OverviewView (#4853)", () => {
       />,
     );
     expect(screen.getAllByRole("alert")).toHaveLength(2); // runs + claims errored
+    // The shared StateBoundary error surface, with this route's per-card copy (#6509).
+    expect(screen.getByText(/Couldn't read run state/i)).toBeTruthy();
+    expect(screen.getByText(/Couldn't read the claim ledger/i)).toBeTruthy();
     expect(statValue("Total items")).toBe("5"); // portfolio still renders
   });
 });

--- a/apps/loopover-miner-ui/src/routes/index.tsx
+++ b/apps/loopover-miner-ui/src/routes/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
+import { Skeleton } from "@loopover/ui-kit/components/skeleton";
+import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 
 import { fetchLedgers, type LedgersResult } from "../lib/ledgers";
 import { fetchPortfolioQueue, type PortfolioQueueResult } from "../lib/portfolio-queue";
@@ -14,7 +16,13 @@ export const Route = createFileRoute("/")({
 // Overview dashboard (#4853): replaces the Phase-6 placeholder with a live, at-a-glance summary of real miner
 // state — run activity, portfolio queue, and claims — aggregated from the same local read-only APIs the dedicated
 // views use (run-state, portfolio-queue, ledgers). Each card degrades independently: it shows its own loading or
-// error message without taking the others down. Live-refreshed on the shared poll cadence (#4856).
+// error surface without taking the others down. Live-refreshed on the shared poll cadence (#4856).
+//
+// #6509: the per-card loading/error surface is the shared `StateBoundary` + content-shaped `Skeleton` from
+// @loopover/ui-kit (the same primitives the main app's routes already use), replacing this route's own
+// hand-rolled "Loading …" / "Could not read …" text. The skeleton mirrors each card's Stat rows so the layout
+// doesn't shift once data arrives, and — unlike a flat gray sentence re-rendered every 10s poll — reads as a
+// live placeholder. Errors auto-recover on the next successful poll, so no manual retry action is wired.
 
 /** One metric line inside a summary card. */
 function Stat({ label, value, tone }: { label: string; value: string | number; tone?: string }) {
@@ -37,33 +45,43 @@ function SummaryCard({ title, children }: { title: string; children: React.React
   );
 }
 
-function Fallback({ state, subject }: { state: "loading" | "error"; subject: string }) {
-  return state === "loading" ? (
-    <p className="text-token-sm text-muted-foreground">Loading {subject}…</p>
-  ) : (
-    <p role="alert" className="text-token-sm text-[var(--danger)]">
-      Could not read {subject}.
-    </p>
+/** Content-shaped loading placeholder for a summary card: `rows` shimmer lines mirroring the `Stat` label/value
+ *  layout, so the card keeps its height and the content doesn't jump once the poll resolves. `role="status"`
+ *  keeps the loading state announced to assistive tech (the flat "Loading …" text it replaces was announced too). */
+function CardStatsSkeleton({ rows, label }: { rows: number; label: string }) {
+  return (
+    <div className="grid gap-2" role="status" aria-label={label}>
+      {Array.from({ length: rows }).map((_, index) => (
+        <div key={index} className="flex items-baseline justify-between gap-4">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-5 w-12" />
+        </div>
+      ))}
+    </div>
   );
 }
 
 export function OverviewRunsCard({ runs }: { runs: RunHistoryResult | null }) {
   return (
     <SummaryCard title="Run activity">
-      {runs === null ? (
-        <Fallback state="loading" subject="run state" />
-      ) : !runs.ok ? (
-        <Fallback state="error" subject="run state" />
-      ) : (
-        <>
-          <Stat label="Repositories tracked" value={runs.rows.length} />
-          <Stat
-            label="Currently working"
-            value={runs.rows.filter((row) => row.state !== "idle").length}
-            tone="text-[var(--success)]"
-          />
-        </>
-      )}
+      <StateBoundary
+        isLoading={runs === null}
+        isError={runs !== null && !runs.ok}
+        loadingSkeleton={<CardStatsSkeleton rows={2} label="Loading run activity" />}
+        errorTitle="Couldn't read run state"
+        errorDescription="The local run-state API didn't respond. This refreshes automatically."
+      >
+        {runs?.ok && (
+          <>
+            <Stat label="Repositories tracked" value={runs.rows.length} />
+            <Stat
+              label="Currently working"
+              value={runs.rows.filter((row) => row.state !== "idle").length}
+              tone="text-[var(--success)]"
+            />
+          </>
+        )}
+      </StateBoundary>
     </SummaryCard>
   );
 }
@@ -71,24 +89,28 @@ export function OverviewRunsCard({ runs }: { runs: RunHistoryResult | null }) {
 export function OverviewPortfolioCard({ portfolio }: { portfolio: PortfolioQueueResult | null }) {
   return (
     <SummaryCard title="Portfolio queue">
-      {portfolio === null ? (
-        <Fallback state="loading" subject="the portfolio queue" />
-      ) : !portfolio.ok ? (
-        <Fallback state="error" subject="the portfolio queue" />
-      ) : (
-        <>
-          <Stat label="Total items" value={portfolio.summary.total} />
-          <Stat label="Queued" value={portfolio.summary.byStatus.queued} />
-          <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-[var(--warning)]" />
-          <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-[var(--success)]" />
-          {/* Deliver the CLI/web-UI parity the portfolio-queue data path promises (#6185): the CLI's `queue
-              dashboard` renders "oldest-queued: Xm" (portfolio-dashboard.js), and the same minutes-rounded age
-              is shown here. Omitted (like the CLI) when the queue is empty and the age is null. */}
-          {portfolio.summary.oldestQueuedAgeMs !== null && (
-            <Stat label="Oldest queued" value={`${Math.round(portfolio.summary.oldestQueuedAgeMs / 60000)}m`} />
-          )}
-        </>
-      )}
+      <StateBoundary
+        isLoading={portfolio === null}
+        isError={portfolio !== null && !portfolio.ok}
+        loadingSkeleton={<CardStatsSkeleton rows={4} label="Loading the portfolio queue" />}
+        errorTitle="Couldn't read the portfolio queue"
+        errorDescription="The local portfolio-queue API didn't respond. This refreshes automatically."
+      >
+        {portfolio?.ok && (
+          <>
+            <Stat label="Total items" value={portfolio.summary.total} />
+            <Stat label="Queued" value={portfolio.summary.byStatus.queued} />
+            <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-[var(--warning)]" />
+            <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-[var(--success)]" />
+            {/* Deliver the CLI/web-UI parity the portfolio-queue data path promises (#6185): the CLI's `queue
+                dashboard` renders "oldest-queued: Xm" (portfolio-dashboard.js), and the same minutes-rounded age
+                is shown here. Omitted (like the CLI) when the queue is empty and the age is null. */}
+            {portfolio.summary.oldestQueuedAgeMs !== null && (
+              <Stat label="Oldest queued" value={`${Math.round(portfolio.summary.oldestQueuedAgeMs / 60000)}m`} />
+            )}
+          </>
+        )}
+      </StateBoundary>
     </SummaryCard>
   );
 }
@@ -96,16 +118,20 @@ export function OverviewPortfolioCard({ portfolio }: { portfolio: PortfolioQueue
 export function OverviewClaimsCard({ claims }: { claims: LedgersResult | null }) {
   return (
     <SummaryCard title="Claims">
-      {claims === null ? (
-        <Fallback state="loading" subject="the claim ledger" />
-      ) : !claims.ok ? (
-        <Fallback state="error" subject="the claim ledger" />
-      ) : (
-        <>
-          <Stat label="Active" value={claims.summary.claims.byStatus.active} tone="text-[var(--success)]" />
-          <Stat label="Total recorded" value={claims.summary.claims.total} />
-        </>
-      )}
+      <StateBoundary
+        isLoading={claims === null}
+        isError={claims !== null && !claims.ok}
+        loadingSkeleton={<CardStatsSkeleton rows={2} label="Loading the claim ledger" />}
+        errorTitle="Couldn't read the claim ledger"
+        errorDescription="The local ledgers API didn't respond. This refreshes automatically."
+      >
+        {claims?.ok && (
+          <>
+            <Stat label="Active" value={claims.summary.claims.byStatus.active} tone="text-[var(--success)]" />
+            <Stat label="Total recorded" value={claims.summary.claims.total} />
+          </>
+        )}
+      </StateBoundary>
     </SummaryCard>
   );
 }


### PR DESCRIPTION
## Summary

Closes #6509

- The Overview route's three summary cards (Run activity, Portfolio queue, Claims) each rendered their loading/error surface with a **hand-rolled `Fallback` helper** — a flat gray "Loading …" sentence and an inline error line, re-rendered every 10s poll. This route had no skeleton anywhere.
- Adopts the shared **`StateBoundary` + `Skeleton`** primitives from `@loopover/ui-kit` — the same ones the main app's routes (`app.analytics.tsx`, `app.operator.tsx`) already use. Each card now wraps its `Stat`s in `<StateBoundary>` with a **content-shaped skeleton that mirrors the card's Stat rows**, so the layout no longer shifts when data arrives and the loading state reads as a live shimmer rather than static text. Error surfaces use StateBoundary's shared alert.
- **Behavior and data are unchanged**: the same three read-only sources, the same Stats, the same oldest-queued CLI-parity minutes (#6185). Each card still degrades independently, and errors auto-recover on the next successful poll — so no manual retry action is wired (matching the existing poll-driven UX).

## UI Evidence

This change is to the **loading and error placeholder states** (transient, poll-driven), not a static layout redesign — so the "visible" delta is best described precisely and is fully asserted by the tests below (#6509 is not `visual`-labeled).

**Run activity / Portfolio queue / Claims cards — loading state:**
- Before: a single line `Loading run state…` / `Loading the portfolio queue…` / `Loading the claim ledger…` (flat `text-muted-foreground` text), replaced abruptly by content on first poll.
- After: 2 / 4 / 2 shimmer rows (`@loopover/ui-kit` `Skeleton`, `animate-pulse`) laid out exactly like the card's `Stat` rows (a label-width bar + a value-width bar per row), inside a `role="status"` region labelled e.g. "Loading run activity". The card keeps its height, so no layout shift when data arrives. Respects `prefers-reduced-motion` (the ui-kit Skeleton/animation primitives already do).

**Cards — error state:**
- Before: an inline `role="alert"` line `Could not read run state.`
- After: the shared `StateBoundary` error surface (`ErrorState`) with per-card copy ("Couldn't read run state", "…the portfolio queue", "…the claim ledger") and a warning icon, consistent with the rest of the app. Still `role="alert"`; each card errors independently while the others render.

**Data state (unchanged):** identical Stats and values; verified by the pre-existing "summarizes … from live data" and "#6185 oldest-queued minutes" tests, which pass unmodified.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` *(miner-ui `tsc --noEmit`: 0 errors on the touched files — see note)*
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint` *(eslint on the changed files: 0 errors)*
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build` *(vitest build/transform of the route succeeds)*
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran this app's own gate: `vitest run --coverage` — **183 tests pass across 16 files**, with coverage **87.8% statements / 86.7% branches / 81.1% functions / 89.8% lines**, above `vitest.config.ts`'s thresholds (85/85/75/85). The `src/routes` group is 97%+; the new `StateBoundary`/`CardStatsSkeleton` paths are exercised by the loading-skeleton test (role="status" per card), the error test (2 independent alerts), and the unchanged data tests.
- `npx tsc --noEmit` on `apps/loopover-miner-ui` reports **0 errors** across the touched files. (It surfaces one pre-existing error in `vite-chat-api.ts`, which this PR does not touch, only when `packages/loopover-engine`'s `dist` is stale; a fresh engine build — which CI does — clears it.)
- `eslint` on both changed files: 0 errors. `prettier --check`: clean.
- Root-level suites (workers/mcp/openapi/audit) are untouched by an Overview-route-only change; leaving them to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with organized before/after detail. This change is to transient loading/error states (not a static visual), and #6509 is not `visual`-labeled; the states are fully asserted by tests. No SVG/committed review screenshots.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Read-only Overview route: no auth/API/data-source change. The cards render live local API data with real loading/error/empty states via the shared `StateBoundary` — no mock/demo fallback.

## Notes

Adopts existing shared components (`StateBoundary`, `Skeleton` from `@loopover/ui-kit`) — nothing new is built. Establishes the pattern for the sibling route redesigns (#6510/#6511/#6512).

Closes #6509
