### PR TITLE
refactor(miner-ui): adopt shared StateBoundary in the portfolio route

### DIFF
--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -42,7 +42,9 @@ const doneItem: PortfolioQueueActionItem = {
 };
 
 describe("PortfolioQueueActionsSection (#4857)", () => {
-  it("renders the loading state before the first result arrives", () => {
+  it("renders a content-shaped skeleton before the first result arrives", () => {
+    // #6511: StateBoundary renders the skeleton INSTEAD of a loading title, so the old
+    // "Loading actionable queue items…" text is intentionally gone; assert the placeholder instead.
     render(
       <PortfolioQueueActionsSection
         result={null}
@@ -52,7 +54,27 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
         onRequeue={() => undefined}
       />,
     );
-    expect(screen.getByText(/Loading actionable queue items/i)).toBeTruthy();
+    expect(screen.getByTestId("queue-actions-skeleton")).toBeTruthy();
+    // Shaped like the real content, not one generic bar: the real table is not rendered yet.
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders the empty-state sentence verbatim, with no extra copy from the shared boundary", () => {
+    // #6511: the whole original sentence is the EmptyState title and the description is suppressed, so the
+    // rendered copy is byte-identical to the <p> it replaced -- not a reworded title/description split, and
+    // none of StateBoundary's own default "This view has no records to show." boilerplate.
+    render(
+      <PortfolioQueueActionsSection
+        result={{ ok: true, items: [] }}
+        actionResult={null}
+        pending={false}
+        onRelease={() => undefined}
+        onRequeue={() => undefined}
+      />,
+    );
+    expect(screen.getByText("No in-progress or completed items to release or requeue right now.")).toBeTruthy();
+    expect(screen.queryByText(/This view has no records to show/i)).toBeNull();
+    expect(screen.queryByRole("table")).toBeNull();
   });
 
   it("renders an error message when the local API is unreachable", () => {

--- a/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
@@ -90,7 +90,13 @@ describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
 
   it("renders the fresh-install empty state without erroring", () => {
     render(<PortfolioQueueView result={{ ok: true, summary: emptyPortfolioQueueSummary() }} />);
-    expect(screen.getByText(/No queued work yet/i)).toBeTruthy();
+    // #6511: asserted as the exact sentence, not a loose regex -- the whole original string is the EmptyState
+    // title with the description suppressed, so the rendered copy is byte-identical to the <p> it replaced.
+    expect(
+      screen.getByText("No queued work yet — the cards fill in once the miner enqueues its first portfolio item."),
+    ).toBeTruthy();
+    // And none of StateBoundary's own default empty boilerplate leaks in alongside it.
+    expect(screen.queryByText(/This view has no records to show/i)).toBeNull();
     expect(screen.queryByRole("table")).toBeNull();
   });
 
@@ -99,9 +105,23 @@ describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
     expect(screen.getByRole("alert").textContent).toContain("connection refused");
   });
 
-  it("renders the loading state before the first result arrives", () => {
+  it("renders a content-shaped skeleton before the first result arrives", () => {
+    // #6511: StateBoundary renders the skeleton INSTEAD of a loading title, so the old
+    // "Loading local portfolio queue…" text is intentionally gone; assert the placeholder instead.
     render(<PortfolioQueueView result={null} />);
-    expect(screen.getByText(/Loading local portfolio queue/i)).toBeTruthy();
+    expect(screen.getByTestId("portfolio-queue-skeleton")).toBeTruthy();
+    // Shaped like the real content, not one generic bar: the real table is not rendered yet.
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders the error sentence verbatim, with no extra copy from the shared boundary", () => {
+    // #6511: same whole-sentence treatment on the error path -- one string, description suppressed, so none of
+    // ErrorState's own "Something went wrong fetching this data." default appears next to it.
+    render(<PortfolioQueueView result={{ ok: false, error: "connection refused" }} />);
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Could not read the local portfolio queue: connection refused",
+    );
+    expect(screen.queryByText(/Something went wrong fetching this data/i)).toBeNull();
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@loopover/ui-kit/components/button";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
+import { Skeleton } from "@loopover/ui-kit/components/skeleton";
+import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
 
 import {
@@ -35,61 +37,100 @@ const STATUS_TONE: Record<QueueStatus, string> = {
   done: "text-[var(--success)]",
 };
 
-export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | null }) {
-  if (result === null) {
-    return <p className="text-token-sm text-muted-foreground">Loading local portfolio queue…</p>;
-  }
-  if (!result.ok) {
-    return (
-      <p role="alert" className="text-token-sm text-[var(--danger)]">
-        Could not read the local portfolio queue: {result.error}
-      </p>
-    );
-  }
-  const summary = result.summary;
-  if (summary.total === 0) {
-    return (
-      <p className="text-token-sm text-muted-foreground">
-        No queued work yet — the cards fill in once the miner enqueues its first portfolio item.
-      </p>
-    );
-  }
+/** Placeholder shaped like the real summary -- three status cards over the repo table -- so the layout doesn't
+ *  jump when the 10s poll lands. A single generic bar would just move the jump later. */
+function PortfolioQueueSkeleton() {
   return (
-    <div className="grid gap-6">
+    <div className="grid gap-6" data-testid="portfolio-queue-skeleton">
       <dl className="grid gap-4 sm:grid-cols-3">
         {(Object.keys(STATUS_LABELS) as QueueStatus[]).map((status) => (
           <Card key={status}>
             <CardContent className="p-4">
-              <dt className="text-token-2xs uppercase tracking-wider text-muted-foreground">{STATUS_LABELS[status]}</dt>
-              <dd className={`mt-1 text-token-3xl font-display font-semibold ${STATUS_TONE[status]}`}>
-                {summary.byStatus[status]}
-              </dd>
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="mt-2 h-8 w-12" />
             </CardContent>
           </Card>
         ))}
       </dl>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Repository</TableHead>
-            <TableHead>Queued</TableHead>
-            <TableHead>In progress</TableHead>
-            <TableHead>Done</TableHead>
-            <TableHead>Total</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {summary.repos.map((repo) => (
-            <TableRow key={repo.repoFullName}>
-              <TableCell className="font-mono text-foreground">{repo.repoFullName}</TableCell>
-              <TableCell>{repo.byStatus.queued}</TableCell>
-              <TableCell>{repo.byStatus.in_progress}</TableCell>
-              <TableCell>{repo.byStatus.done}</TableCell>
-              <TableCell>{repo.total}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <div className="grid gap-2">
+        {[0, 1, 2].map((row) => (
+          <Skeleton key={`repo-row-${row}`} className="h-8 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | null }) {
+  const summary = result?.ok ? result.summary : null;
+  return (
+    <StateBoundary
+      isLoading={result === null}
+      isError={result !== null && !result.ok}
+      isEmpty={summary !== null && summary.total === 0}
+      loadingSkeleton={<PortfolioQueueSkeleton />}
+      // Each message is passed as the WHOLE original sentence with the description suppressed, rather than
+      // split across title/description: the issue requires the user-visible strings not be reworded, and Shell
+      // renders `{description && ...}` so an empty one adds nothing. The rendered text is byte-identical to the
+      // <p> tags this replaces. ErrorState emits role="alert" itself, so failures still announce the same way.
+      errorTitle={
+        result !== null && !result.ok ? `Could not read the local portfolio queue: ${result.error}` : undefined
+      }
+      errorDescription=""
+      emptyTitle="No queued work yet — the cards fill in once the miner enqueues its first portfolio item."
+      emptyDescription={null}
+    >
+      {summary === null ? null : (
+        <div className="grid gap-6">
+          <dl className="grid gap-4 sm:grid-cols-3">
+            {(Object.keys(STATUS_LABELS) as QueueStatus[]).map((status) => (
+              <Card key={status}>
+                <CardContent className="p-4">
+                  <dt className="text-token-2xs uppercase tracking-wider text-muted-foreground">
+                    {STATUS_LABELS[status]}
+                  </dt>
+                  <dd className={`mt-1 text-token-3xl font-display font-semibold ${STATUS_TONE[status]}`}>
+                    {summary.byStatus[status]}
+                  </dd>
+                </CardContent>
+              </Card>
+            ))}
+          </dl>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Repository</TableHead>
+                <TableHead>Queued</TableHead>
+                <TableHead>In progress</TableHead>
+                <TableHead>Done</TableHead>
+                <TableHead>Total</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {summary.repos.map((repo) => (
+                <TableRow key={repo.repoFullName}>
+                  <TableCell className="font-mono text-foreground">{repo.repoFullName}</TableCell>
+                  <TableCell>{repo.byStatus.queued}</TableCell>
+                  <TableCell>{repo.byStatus.in_progress}</TableCell>
+                  <TableCell>{repo.byStatus.done}</TableCell>
+                  <TableCell>{repo.total}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </StateBoundary>
+  );
+}
+
+/** Placeholder shaped like the queue-actions table's rows, for the same reason as the summary's. */
+function QueueActionsSkeleton() {
+  return (
+    <div className="grid gap-2" data-testid="queue-actions-skeleton">
+      {[0, 1, 2].map((row) => (
+        <Skeleton key={`action-row-${row}`} className="h-8 w-full" />
+      ))}
     </div>
   );
 }
@@ -115,48 +156,54 @@ export function PortfolioQueueActionsSection({
           Queue action failed: {actionResult.error}
         </p>
       ) : null}
-      {result === null ? (
-        <p className="text-token-sm text-muted-foreground">Loading actionable queue items…</p>
-      ) : !result.ok ? (
-        <p role="alert" className="text-token-sm text-[var(--danger)]">
-          Could not read actionable queue items: {result.error}
-        </p>
-      ) : result.items.length === 0 ? (
-        <p className="text-token-sm text-muted-foreground">
-          No in-progress or completed items to release or requeue right now.
-        </p>
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Repository</TableHead>
-              <TableHead>Identifier</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Action</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {result.items.map((item) => (
-              <TableRow key={`${item.apiBaseUrl}:${item.repoFullName}:${item.identifier}`}>
-                <TableCell className="font-mono text-foreground">{item.repoFullName}</TableCell>
-                <TableCell className="font-mono">{item.identifier}</TableCell>
-                <TableCell>{STATUS_LABELS[item.status]}</TableCell>
-                <TableCell>
-                  {item.status === "in_progress" ? (
-                    <Button size="sm" variant="outline" disabled={pending} onClick={() => onRelease(item)}>
-                      Release
-                    </Button>
-                  ) : (
-                    <Button size="sm" variant="outline" disabled={pending} onClick={() => onRequeue(item)}>
-                      Requeue
-                    </Button>
-                  )}
-                </TableCell>
+      {/* Its own boundary, deliberately: this fetch is independent of the summary above, so a failure here
+          must not blank the summary -- and a summary failure must not hide the actions. Same whole-sentence
+          treatment as above, so the empty/error copy stays byte-identical to the <p> tags it replaces. */}
+      <StateBoundary
+        isLoading={result === null}
+        isError={result !== null && !result.ok}
+        isEmpty={result !== null && result.ok && result.items.length === 0}
+        loadingSkeleton={<QueueActionsSkeleton />}
+        errorTitle={
+          result !== null && !result.ok ? `Could not read actionable queue items: ${result.error}` : undefined
+        }
+        errorDescription=""
+        emptyTitle="No in-progress or completed items to release or requeue right now."
+        emptyDescription={null}
+      >
+        {result === null || !result.ok || result.items.length === 0 ? null : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Repository</TableHead>
+                <TableHead>Identifier</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Action</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
+            </TableHeader>
+            <TableBody>
+              {result.items.map((item) => (
+                <TableRow key={`${item.apiBaseUrl}:${item.repoFullName}:${item.identifier}`}>
+                  <TableCell className="font-mono text-foreground">{item.repoFullName}</TableCell>
+                  <TableCell className="font-mono">{item.identifier}</TableCell>
+                  <TableCell>{STATUS_LABELS[item.status]}</TableCell>
+                  <TableCell>
+                    {item.status === "in_progress" ? (
+                      <Button size="sm" variant="outline" disabled={pending} onClick={() => onRelease(item)}>
+                        Release
+                      </Button>
+                    ) : (
+                      <Button size="sm" variant="outline" disabled={pending} onClick={() => onRequeue(item)}>
+                        Requeue
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </StateBoundary>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Both components in this route hand-rolled the same loading/error/empty triple as literal `<p>` tags, and the loading branch was a flat sentence re-rendered on every 10s poll. This swaps both onto the ui-kit's `StateBoundary` plus its `Skeleton` primitive — which this app already depends on but had never imported.

**Prerequisite confirmed before starting**, as the issue requires: the `state-views.tsx` port has landed — `@loopover/ui-kit/components/state-views` exports `StateBoundary`/`LoadingState`/`ErrorState`/`EmptyState`. I import the real component from the package; nothing is forked, copied, or reached into from `apps/loopover-ui`.

## Design decisions

- **Each async flow keeps its OWN boundary**, deliberately. The summary read and the queue-actions read are independent fetches; one shared boundary would let a queue-actions failure blank the summary, or a summary failure hide the actions.
- **Skeletons are shaped like the real content** — three status cards over table rows, and rows for the actions table — so the layout settles when the poll lands instead of jumping. A single generic bar would just move the jump later.
- **Every user-visible sentence is preserved exactly, character for character.** This is the one part worth scrutinising, because the obvious way to adopt this primitive gets it wrong. `StateBoundary` wants a `title` + a `description`, which invites splitting each existing sentence across the two — a rewrite, however reasonable, of copy the issue says not to reword. Instead each **whole original sentence is passed as the title** and the description is **suppressed**, so the rendered text is identical to the `<p>` it replaces. The suppression is not symmetric, and the difference matters:
  - `EmptyState` has no default description and `Shell` renders `{description && …}`, so `emptyDescription={null}` renders nothing.
  - `ErrorState` resolves `description ?? <default>`, so `null` would **restore** its default copy — it needs `errorDescription=""` to stay suppressed.

  The result: none of `StateBoundary`'s own boilerplate ("This view has no records to show.", "Something went wrong fetching this data.") reaches the user. `ErrorState` emits `role="alert"` itself, so failures keep announcing exactly as the hand-rolled `<p role="alert">` did.

## Frozen underneath — the part worth checking

Per the issue, the action surface is behaviourally untouched, and the diff proves it:

- `lib/portfolio-queue.ts`, `lib/portfolio-queue-actions.ts`, `lib/use-polled-fetch.ts` — **unchanged** (`git diff` against `main` for `src/lib/` is empty).
- The Release/Requeue `Button`s and their `onClick`/`disabled={pending}` wiring to `onRelease`/`onRequeue` → `releaseItem`/`requeueItem` — unchanged. Only the chrome around them moved.

The strongest evidence is the tests: **every pre-existing assertion in both suites passes unmodified**, including the release/requeue POST-wiring tests, the pending-disable test, and the **#6090 regression** (a failing release renders the error without a false re-fetch). Those untouched tests are what prove the action surface really didn't move.

## Tests

The two loading assertions had to change, because `StateBoundary` renders `loadingSkeleton ?? <LoadingState>` — with a skeleton supplied, the literal "Loading local portfolio queue…" / "Loading actionable queue items…" text is intentionally gone. Both now assert the skeleton placeholder instead, exactly as the issue directs.

Beyond that, **each of the four boundary branches is now pinned to its exact rendered sentence**, since preserving that copy is the main risk in this change and a loose regex would not have caught a reworded split:

| Suite | Branch | Asserts |
|---|---|---|
| `portfolio-queue.test.tsx` | loading | skeleton present, real table not yet rendered |
| | empty | the exact sentence, **and** no `This view has no records to show` |
| | error | the exact sentence, **and** no `Something went wrong fetching this data` |
| `portfolio-queue-actions.test.tsx` | loading | skeleton present, real table not yet rendered |
| | **empty (new)** | the exact sentence, **and** no boilerplate — this branch had no test at all before |
| | error | the exact sentence (existing assertion, unmodified) |

## Validation

- [x] **Both portfolio suites — 36/36 pass**, with every pre-existing assertion unmodified.
- [x] **Whole miner-ui app — 223/223 pass** via `npm --workspace @loopover/ui-miner run test` (`vitest run --coverage`), **no coverage-threshold failure**. That's the operative local gate.
- [x] `eslint` — **0 errors** on my three files. The 3 remaining warnings (`react-refresh/only-export-components`, two `react-hooks/exhaustive-deps`) are **pre-existing on `main`**, not introduced here. `prettier --write` applied.
- [x] `git diff --check` clean; the tree contains only the three permitted files (no generated `routeTree.gen.ts` churn). Rebased on latest `main` — no base conflict.

**One pre-existing failure, not mine:** `ui:typecheck` reports `vite-chat-api.ts(43,34) TS2352`. I verified it fails **identically on clean `main`** with my work stashed.

## Coverage

Not scored by `codecov/patch`: `apps/loopover-miner-ui` sits under `apps/**`, which `codecov.yml`'s `ignore:` list excludes (Codecov collects only `src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**`). Flagging that explicitly so a reviewer isn't confused by the absent check — the app's own local coverage floor above is the real gate, and it's green.

## Scope

- [x] Exactly the three files the issue permits: `routes/portfolio.tsx`, `portfolio-queue.test.tsx`, `portfolio-queue-actions.test.tsx`. `run-history.tsx`, `ledgers.tsx`, `index.tsx`, `__root.tsx` untouched — they're separate issues.
- [x] No new component library, no ad-hoc CSS, no new design tokens — only existing `@loopover/ui-kit` primitives.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Rendering-only: no fetcher, endpoint, poll-cadence, or button semantic changes, so there is exactly one write path into the portfolio queue (the existing one) both before and after.

Closes #6511
