### PR TITLE
docs(config): note settings.* as a legacy alias for 11 gate/AI-review fields

### DIFF
--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -730,6 +730,26 @@ review:
 # Everything a maintainer can toggle in the dashboard can be set here as code.
 # All values shown are the safe defaults; delete any line to inherit it.
 settings:
+  # The 11 fields below each have a friendlier `gate.<name>` alias documented in section 2 above
+  # (`gate.checkMode`/`gate.enabled`, `gate.linkedIssue`, `gate.duplicates`, `gate.readiness.mode`/
+  # `gate.readiness.minScore`, `gate.selfAuthoredLinkedIssue`, `gate.aiReview.mode`/`.byok`/`.provider`/
+  # `.model`/`.allAuthors`). `gate.*` is the RECOMMENDED spelling going forward and wins whenever both
+  # forms are set for the same field (see PRECEDENCE at the top of this file). The generic names below
+  # remain fully supported (no functional deprecation, still DB-backed) and are shown here, commented
+  # out, only so this reference stays discoverable for a config written before the `gate:` alias
+  # existed. Prefer `gate.*` above for anything new.
+  # reviewCheckMode: visible                   # alias of gate.checkMode / gate.enabled
+  # linkedIssueGateMode: advisory               # alias of gate.linkedIssue
+  # duplicatePrGateMode: block                  # alias of gate.duplicates
+  # qualityGateMode: advisory                   # alias of gate.readiness.mode
+  # qualityGateMinScore: null                   # alias of gate.readiness.minScore
+  # selfAuthoredLinkedIssueGateMode: advisory   # alias of gate.selfAuthoredLinkedIssue
+  # aiReviewMode: off                           # alias of gate.aiReview.mode
+  # aiReviewByok: false                         # alias of gate.aiReview.byok
+  # aiReviewProvider: null                      # alias of gate.aiReview.provider
+  # aiReviewModel: null                         # alias of gate.aiReview.model
+  # aiReviewAllAuthors: false                   # alias of gate.aiReview.allAuthors
+
   # Who receives the public PR comment.
   # off | detected_contributors_only | all_prs. Default: detected_contributors_only.
   commentMode: detected_contributors_only

--- a/apps/loopover-ui/content/docs/tuning.mdx
+++ b/apps/loopover-ui/content/docs/tuning.mdx
@@ -205,6 +205,12 @@ gate evaluation, comments, labels, audit, or autonomous merge/close on or off �
 dimension modes below directly, and set `gate.checkMode` explicitly instead of
 the ambiguous `gate.enabled`. The main dimensions:
 
+Several of these also have a generic `settings.<field>` spelling (for example
+`settings.linkedIssueGateMode`, `settings.qualityGateMode`,
+`settings.aiReviewMode`) — that spelling remains fully supported for backward
+compatibility, but the `gate.*` form shown below is the recommended one going
+forward and wins whenever both are set for the same field.
+
 - `gate.pack` — the policy pack: `gittensor` (default; registry-aware,
   tracks confirmed-Gittensor-contributor status for scoring) or `oss-anti-slop`
   (runs the deterministic rules against any author on any repo, with no

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -744,6 +744,26 @@ review:
 # Everything a maintainer can toggle in the dashboard can be set here as code.
 # All values shown are the safe defaults; delete any line to inherit it.
 settings:
+  # The 11 fields below each have a friendlier `gate.<name>` alias documented in section 2 above
+  # (`gate.checkMode`/`gate.enabled`, `gate.linkedIssue`, `gate.duplicates`, `gate.readiness.mode`/
+  # `gate.readiness.minScore`, `gate.selfAuthoredLinkedIssue`, `gate.aiReview.mode`/`.byok`/`.provider`/
+  # `.model`/`.allAuthors`). `gate.*` is the RECOMMENDED spelling going forward and wins whenever both
+  # forms are set for the same field (see PRECEDENCE at the top of this file). The generic names below
+  # remain fully supported (no functional deprecation, still DB-backed) and are shown here, commented
+  # out, only so this reference stays discoverable for a config written before the `gate:` alias
+  # existed. Prefer `gate.*` above for anything new.
+  # reviewCheckMode: visible                   # alias of gate.checkMode / gate.enabled
+  # linkedIssueGateMode: advisory               # alias of gate.linkedIssue
+  # duplicatePrGateMode: block                  # alias of gate.duplicates
+  # qualityGateMode: advisory                   # alias of gate.readiness.mode
+  # qualityGateMinScore: null                   # alias of gate.readiness.minScore
+  # selfAuthoredLinkedIssueGateMode: advisory   # alias of gate.selfAuthoredLinkedIssue
+  # aiReviewMode: off                           # alias of gate.aiReview.mode
+  # aiReviewByok: false                         # alias of gate.aiReview.byok
+  # aiReviewProvider: null                      # alias of gate.aiReview.provider
+  # aiReviewModel: null                         # alias of gate.aiReview.model
+  # aiReviewAllAuthors: false                   # alias of gate.aiReview.allAuthors
+
   # Who receives the public PR comment.
   # off | detected_contributors_only | all_prs. Default: detected_contributors_only.
   commentMode: detected_contributors_only


### PR DESCRIPTION
## Summary
- Part of loopover#6444 (Batch C of the repository_settings config-as-code migration, #6440). Confirms `gate.*` is already the sole documented form for `reviewCheckMode`, `linkedIssueGateMode`, `duplicatePrGateMode`, `qualityGateMode`, `qualityGateMinScore`, `selfAuthoredLinkedIssueGateMode`, and the five `aiReview*` fields across every `.loopover.yml` example and self-hosting doc checked (`.loopover.yml`, `.loopover.minimal.yml`, `config/examples/*.yml`, `src/config/loopover-repo-focus-manifest.ts`, `apps/loopover-ui/content/docs/self-hosting-configuration.mdx`) — no conversion needed there.
- Adds the still-supported `settings.*` legacy-alias spellings to the two exhaustive "every field" reference files (`.loopover.yml.example`, `config/examples/loopover.full.yml`, kept byte-identical to each other) and a short note in `apps/loopover-ui/content/docs/tuning.mdx`, since those files previously didn't mention this alias for these 11 fields at all.
- No functional change — `gate.*` already wins over `settings.*` on conflict (`applyGateConfigOverrides` in `src/signals/focus-manifest.ts`).

## Scope
- [x] `.loopover.yml.example`, `config/examples/loopover.full.yml`, `apps/loopover-ui/content/docs/tuning.mdx` only
- [x] No `src/**`/`packages/**`/`test/**` changes

## Validation
- `npm run docs:drift-check` — ok
- `npm run manifest:drift-check` — ok (`.loopover.yml` and the bundled manifest agree)
- `npx tsc --noEmit` — clean
- `npm run ui:build` — clean (docs mdx compiles)

## Safety
- [x] No secrets/wallets/hotkeys/trust-scores/reward values touched