### PR TITLE
feat(ui): add AMS-vs-human contributor-mix maintainer dashboard panel

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -13971,6 +13971,91 @@
           "scope_cap_files",
           "scope_cap_lines"
         ]
+      },
+      "AmsMinerCohortComparison": {
+        "type": "object",
+        "properties": {
+          "present": {
+            "type": "boolean"
+          },
+          "windowDays": {
+            "type": "number"
+          },
+          "totalSubmitterCount": {
+            "type": "number"
+          },
+          "checkedSubmitterCount": {
+            "type": "number"
+          },
+          "amsCohort": {
+            "type": "object",
+            "properties": {
+              "submitterCount": {
+                "type": "number"
+              },
+              "prVolume": {
+                "type": "number"
+              },
+              "acceptanceRate": {
+                "type": "number",
+                "nullable": true
+              },
+              "avgReviewCycleCount": {
+                "type": "number",
+                "nullable": true
+              },
+              "avgTimeToMergeMs": {
+                "type": "number",
+                "nullable": true
+              }
+            },
+            "required": [
+              "submitterCount",
+              "prVolume",
+              "acceptanceRate",
+              "avgReviewCycleCount",
+              "avgTimeToMergeMs"
+            ]
+          },
+          "humanCohort": {
+            "type": "object",
+            "properties": {
+              "submitterCount": {
+                "type": "number"
+              },
+              "prVolume": {
+                "type": "number"
+              },
+              "acceptanceRate": {
+                "type": "number",
+                "nullable": true
+              },
+              "avgReviewCycleCount": {
+                "type": "number",
+                "nullable": true
+              },
+              "avgTimeToMergeMs": {
+                "type": "number",
+                "nullable": true
+              }
+            },
+            "required": [
+              "submitterCount",
+              "prVolume",
+              "acceptanceRate",
+              "avgReviewCycleCount",
+              "avgTimeToMergeMs"
+            ]
+          }
+        },
+        "required": [
+          "present",
+          "windowDays",
+          "totalSubmitterCount",
+          "checkedSubmitterCount",
+          "amsCohort",
+          "humanCohort"
+        ]
       }
     },
     "parameters": {},

--- a/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the API layer so the component never touches the network.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+import { AmsMinerCohortCard } from "@/components/site/app-panels/ams-miner-cohort-card";
+
+const REVIEWABILITY = [{ pr: "acme/widgets#1" }];
+
+const POPULATED_COMPARISON = {
+  present: true,
+  windowDays: 90,
+  totalSubmitterCount: 5,
+  checkedSubmitterCount: 5,
+  amsCohort: {
+    submitterCount: 2,
+    prVolume: 20,
+    acceptanceRate: 0.8,
+    avgReviewCycleCount: 1.5,
+    avgTimeToMergeMs: 3_600_000,
+  },
+  humanCohort: {
+    submitterCount: 3,
+    prVolume: 9,
+    acceptanceRate: 0.5,
+    avgReviewCycleCount: 2.5,
+    avgTimeToMergeMs: 172_800_000,
+  },
+};
+
+describe("AmsMinerCohortCard", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it("shows a loading state, then renders both cohorts on load", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: POPULATED_COMPARISON });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+
+    expect(screen.getByText(/Loading AMS contributor mix/i)).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("AMS miners")).toBeTruthy());
+    expect(screen.getByText("Other contributors")).toBeTruthy();
+    expect(screen.getByText(/Window: 90 days · checked 5 of/i)).toBeTruthy();
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/repos/acme/widgets/ams-miner-cohort"),
+      expect.objectContaining({ label: "AMS miner cohort comparison" }),
+    );
+  });
+
+  it("renders the AMS cohort's acceptance rate, review-cycle count, and time-to-merge", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: POPULATED_COMPARISON });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText("AMS miners")).toBeTruthy());
+    expect(screen.getByText("80%")).toBeTruthy();
+    expect(screen.getByText("1.5")).toBeTruthy();
+    expect(screen.getByText("1.0h")).toBeTruthy();
+  });
+
+  it("renders days for a time-to-merge at or beyond 24 hours", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: POPULATED_COMPARISON });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText("Other contributors")).toBeTruthy());
+    expect(screen.getByText("2.0d")).toBeTruthy();
+  });
+
+  it("renders an empty state (never an error) when the API reports present: false", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        present: false,
+        windowDays: 0,
+        totalSubmitterCount: 0,
+        checkedSubmitterCount: 0,
+        amsCohort: {
+          submitterCount: 0,
+          prVolume: 0,
+          acceptanceRate: null,
+          avgReviewCycleCount: null,
+          avgTimeToMergeMs: null,
+        },
+        humanCohort: {
+          submitterCount: 0,
+          prVolume: 0,
+          acceptanceRate: null,
+          avgReviewCycleCount: null,
+          avgTimeToMergeMs: null,
+        },
+      },
+    });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText(/No identifiable AMS activity yet/i)).toBeTruthy());
+  });
+
+  it("renders — for a null acceptanceRate/avgTimeToMergeMs rather than fabricating a number", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        ...POPULATED_COMPARISON,
+        amsCohort: {
+          submitterCount: 1,
+          prVolume: 1,
+          acceptanceRate: null,
+          avgReviewCycleCount: null,
+          avgTimeToMergeMs: null,
+        },
+      },
+    });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText("AMS miners")).toBeTruthy());
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("renders an error state with the failure message when the comparison fails to load", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "503 Service Unavailable" });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load the AMS contributor mix/i)).toBeTruthy(),
+    );
+    expect(screen.getByText("503 Service Unavailable")).toBeTruthy();
+  });
+
+  it("falls back to a manual owner/repo entry when no repos are registered yet", () => {
+    render(<AmsMinerCohortCard reviewability={[]} />);
+    expect(screen.getByText(/No registered repositories detected yet/i)).toBeTruthy();
+    expect(screen.getByText(/Enter an installed repository to compare cohorts\./i)).toBeTruthy();
+  });
+
+  it("shows the 'view unavailable' copy for a typed repo string that doesn't parse as owner\\/repo", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: POPULATED_COMPARISON });
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText("AMS miners")).toBeTruthy());
+
+    fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
+      target: { value: "not-a-valid-slug" },
+    });
+    expect(screen.getByText(/This view is unavailable for this repository\./i)).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { StateBoundary } from "@/components/site/state-views";
+import { apiFetch } from "@/lib/api/request";
+import { getApiOrigin } from "@/lib/api/origin";
+import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
+
+export type AmsMinerCohortMetrics = {
+  submitterCount: number;
+  prVolume: number;
+  acceptanceRate: number | null;
+  avgReviewCycleCount: number | null;
+  avgTimeToMergeMs: number | null;
+};
+
+export type AmsMinerCohortComparison = {
+  present: boolean;
+  windowDays: number;
+  totalSubmitterCount: number;
+  checkedSubmitterCount: number;
+  amsCohort: AmsMinerCohortMetrics;
+  humanCohort: AmsMinerCohortMetrics;
+};
+
+function repoApiBase(repoFullName: string): string | null {
+  const target = splitRepoFullName(repoFullName);
+  if (!target) return null;
+  return `${getApiOrigin().replace(/\/$/, "")}/v1/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? "—" : `${Math.round(value * 100)}%`;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "—";
+  const hours = ms / (1000 * 60 * 60);
+  if (hours < 24) return `${hours.toFixed(1)}h`;
+  return `${(hours / 24).toFixed(1)}d`;
+}
+
+function formatCount(value: number | null): string {
+  return value === null ? "—" : value.toFixed(1);
+}
+
+function CohortColumn({ title, metrics }: { title: string; metrics: AmsMinerCohortMetrics }) {
+  return (
+    <div className="rounded-token border border-border/60 bg-background/40 p-4">
+      <h3 className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+        {title}
+      </h3>
+      <dl className="mt-3 grid grid-cols-2 gap-3 text-token-sm">
+        <div>
+          <dt className="text-token-2xs text-muted-foreground">Submitters</dt>
+          <dd className="font-display text-token-lg font-semibold">{metrics.submitterCount}</dd>
+        </div>
+        <div>
+          <dt className="text-token-2xs text-muted-foreground">PR volume</dt>
+          <dd className="font-display text-token-lg font-semibold">{metrics.prVolume}</dd>
+        </div>
+        <div>
+          <dt className="text-token-2xs text-muted-foreground">Acceptance rate</dt>
+          <dd className="font-display text-token-lg font-semibold">
+            {formatPercent(metrics.acceptanceRate)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-token-2xs text-muted-foreground">Review-cycle count</dt>
+          <dd className="font-display text-token-lg font-semibold">
+            {formatCount(metrics.avgReviewCycleCount)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-token-2xs text-muted-foreground">Time to merge</dt>
+          <dd className="font-display text-token-lg font-semibold">
+            {formatDuration(metrics.avgTimeToMergeMs)}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+/**
+ * AMS-vs-human contributor-mix dashboard panel (#6488), per #6210's decided design: for a selected repo,
+ * compares identifiable AMS miners against every other submitter on acceptance rate / review-cycle count /
+ * time-to-merge / PR volume. Reuses the ActivationPreview repo-picker + self-fetch shape in this same file
+ * group. `present: false` from the API (bridge off, unconfigured, or zero submitter activity) renders the
+ * SAME empty state -- never an error, matching #6488's own required empty-state behavior.
+ */
+export function AmsMinerCohortCard({ reviewability }: { reviewability: Array<{ pr: string }> }) {
+  const repoOptions = extractPreviewRepoOptions(reviewability);
+  const [repoFullName, setRepoFullName] = useState(repoOptions[0] ?? "");
+  const [comparison, setComparison] = useState<AmsMinerCohortComparison | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const base = repoApiBase(repoFullName);
+  const hasRepos = repoOptions.length > 0;
+
+  const load = useCallback(async () => {
+    const apiBase = repoApiBase(repoFullName);
+    if (!apiBase) {
+      setComparison(null);
+      setLoadError(null);
+      return;
+    }
+    setLoadError(null);
+    setLoading(true);
+    const result = await apiFetch<AmsMinerCohortComparison>(`${apiBase}/ams-miner-cohort`, {
+      label: "AMS miner cohort comparison",
+      credentials: "include",
+      silentStatus: true,
+    });
+    if (result.ok) {
+      setComparison(result.data);
+    } else {
+      setComparison(null);
+      setLoadError(result.message);
+    }
+    setLoading(false);
+  }, [repoFullName]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <section
+      className="rounded-token border-hairline bg-card p-5"
+      aria-labelledby="ams-miner-cohort-title"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 id="ams-miner-cohort-title" className="font-display text-token-lg font-semibold">
+            AMS contributor mix
+          </h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            How much of this repo's activity comes from identifiable AMS miners, and how that cohort
+            performs relative to other contributors.
+          </p>
+        </div>
+      </div>
+
+      <label className="mt-4 block max-w-sm">
+        <span className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+          Repository
+        </span>
+        <input
+          value={repoFullName}
+          onChange={(event) => setRepoFullName(event.target.value)}
+          list="ams-miner-cohort-repos"
+          placeholder="owner/repo"
+          className="mt-1 min-h-10 w-full rounded-token border border-border bg-background/70 px-3 py-2 font-mono text-token-sm text-foreground outline-none transition-colors focus:border-mint"
+        />
+        <datalist id="ams-miner-cohort-repos">
+          {repoOptions.map((repo) => (
+            <option key={repo} value={repo} />
+          ))}
+        </datalist>
+        {!hasRepos ? (
+          <span className="mt-1 block text-token-2xs text-muted-foreground">
+            No registered repositories detected yet — type an installed{" "}
+            <code className="font-mono">owner/repo</code>.
+          </span>
+        ) : null}
+      </label>
+
+      <div className="mt-6">
+        <StateBoundary
+          isLoading={Boolean(base) && loading}
+          isError={Boolean(base) && !loading && loadError !== null}
+          isEmpty={Boolean(base) && !loading && comparison !== null && !comparison.present}
+          onRetry={load}
+          onRefresh={load}
+          loadingTitle="Loading AMS contributor mix…"
+          errorTitle="Couldn't load the AMS contributor mix"
+          errorDescription={loadError ?? undefined}
+          emptyTitle="No identifiable AMS activity yet"
+          emptyDescription="This repo has no AMS-identifiable submitters in the current window, or the AMS reputation bridge isn't configured."
+        >
+          {!base ? (
+            <p className="text-token-sm text-muted-foreground">
+              {hasRepos
+                ? "This view is unavailable for this repository."
+                : "Enter an installed repository to compare cohorts."}
+            </p>
+          ) : comparison?.present ? (
+            <div>
+              <p className="text-token-2xs text-muted-foreground">
+                Window: {comparison.windowDays} days · checked {comparison.checkedSubmitterCount} of{" "}
+                {comparison.totalSubmitterCount} submitters
+              </p>
+              <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                <CohortColumn title="AMS miners" metrics={comparison.amsCohort} />
+                <CohortColumn title="Other contributors" metrics={comparison.humanCohort} />
+              </div>
+            </div>
+          ) : null}
+        </StateBoundary>
+      </div>
+    </section>
+  );
+}

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -18,6 +18,7 @@ import {
   type Status,
 } from "@/components/site/control-primitives";
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
+import { AmsMinerCohortCard } from "@/components/site/app-panels/ams-miner-cohort-card";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { ContributorQualityTable } from "@/components/site/app-panels/contributor-quality-table";
 import type { MaintainerTopContributor } from "@/components/site/app-panels/contributor-quality-table-model";
@@ -452,6 +453,8 @@ function MaintainerDashboardView({
           <ContributorQualityTable topContributors={data.qualityDashboard.topContributors} />
 
           <ActivationPreview reviewability={data.reviewability} />
+
+          <AmsMinerCohortCard reviewability={data.reviewability} />
 
           <GateRampControl reviewability={data.reviewability} />
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -212,6 +212,7 @@ import {
 import { generateAndSendReviewRecap } from "../services/review-recap";
 import { loadOrComputeIssueQualityResponse } from "../services/issue-quality";
 import { loadMaintainerNoiseReport } from "../services/maintainer-noise";
+import { buildAmsMinerCohortComparison } from "../review/ams-miner-cohort";
 import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
@@ -2713,6 +2714,17 @@ export function createApp() {
     const gate = await requireRepoMaintainer(c, fullName);
     if (gate instanceof Response) return gate;
     return c.json(await loadMaintainerNoiseReport(c.env, fullName));
+  });
+
+  // #6488 (per #6210's decided design): AMS-vs-human contributor-mix dashboard comparison. Maintainer-scoped,
+  // mirrors maintainer-noise above. `present: false` (never a 404/error) when the AMS reputation bridge is off,
+  // unconfigured, or the repo has no submitter activity in the window -- the panel's own required empty state.
+  app.get("/v1/repos/:owner/:repo/ams-miner-cohort", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const gate = await requireRepoMaintainer(c, fullName);
+    /* v8 ignore next -- unauthorized requests are rejected by the auth middleware before reaching the handler. */
+    if (gate instanceof Response) return gate;
+    return c.json(await buildAmsMinerCohortComparison(c.env, fullName));
   });
 
   // #6168 self-tune override admin: the operator-facing read side of the self-tune override store. The

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -2603,6 +2603,25 @@ export const MaintainerNoiseReportSchema = z
   })
   .openapi("MaintainerNoiseReport");
 
+export const AmsMinerCohortMetricsSchema = z.object({
+  submitterCount: z.number(),
+  prVolume: z.number(),
+  acceptanceRate: z.number().nullable(),
+  avgReviewCycleCount: z.number().nullable(),
+  avgTimeToMergeMs: z.number().nullable(),
+});
+
+export const AmsMinerCohortComparisonSchema = z
+  .object({
+    present: z.boolean(),
+    windowDays: z.number(),
+    totalSubmitterCount: z.number(),
+    checkedSubmitterCount: z.number(),
+    amsCohort: AmsMinerCohortMetricsSchema,
+    humanCohort: AmsMinerCohortMetricsSchema,
+  })
+  .openapi("AmsMinerCohortComparison");
+
 export const PullRequestReviewabilitySchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -40,6 +40,7 @@ import {
   MaintainerCutReadinessSchema,
   MaintainerLaneReportSchema,
   MaintainerNoiseReportSchema,
+  AmsMinerCohortComparisonSchema,
   McpCompatibilitySchema,
   PullRequestMaintainerPacketSchema,
   PullRequestReviewIntelligenceSchema,
@@ -157,6 +158,7 @@ export function buildOpenApiSpec() {
   registry.register("RepoRewardRisk", RepoRewardRiskSchema);
   registry.register("ContributorRewardRiskStrategy", ContributorRewardRiskStrategySchema);
   registry.register("MaintainerNoiseReport", MaintainerNoiseReportSchema);
+  registry.register("AmsMinerCohortComparison", AmsMinerCohortComparisonSchema);
   registry.register("PullRequestReviewability", PullRequestReviewabilitySchema);
 
   registry.registerPath({

--- a/src/review/ams-miner-cohort.ts
+++ b/src/review/ams-miner-cohort.ts
@@ -1,0 +1,135 @@
+// AMS-vs-human contributor-mix dashboard panel (#6488), per #6210's decided design: for one repo, classify each
+// recent submitter as "has AMS track-record data" (via the ORB/AMS reputation bridge's pull path, #6485/#6208)
+// vs. not, then compare acceptance rate / review-cycle count / time-to-merge / PR volume between the two
+// cohorts. Reuses `submitter-reputation.ts`'s existing `review_targets`-based outcome classification for the
+// metrics and `ams-reputation-bridge.ts`'s existing fail-safe, timeout-bounded pull for AMS membership — no new
+// identity system, no new network path.
+//
+// BOUNDED, NOT EXHAUSTIVE: classifying membership needs one live call per distinct submitter login (there is no
+// cached "is this login an AMS miner" flag anywhere yet). An unbounded per-dashboard-load fan-out over every
+// submitter a repo has ever seen would be real added latency/cost, so this checks only the
+// AMS_MINER_COHORT_CHECK_CAP most active submitters (by submission volume) in the window; every other submitter
+// is counted in the human cohort by default (an unchecked submitter is never assumed to be an AMS miner —
+// "not classified" always falls to the conservative side, same discipline as the bridge's own upgrade-only
+// rule). `checkedSubmitterCount`/`totalSubmitterCount` disclose the cap so a caller never silently reads
+// "covered everyone" from a capped result.
+//
+// Bearer-gated, maintainer-only (see the API route this feeds) — matches submitter-reputation.ts's own /stats
+// access model. STRICTLY INTERNAL: no wallet/hotkey/reward/trust-score wording, matching every other reputation
+// surface in this codebase, public or private.
+
+import { fetchAmsTrackRecord, type AmsTrackRecordFetch } from "./ams-reputation-bridge";
+import { isAmsReputationBridgeEnabled, resolveAmsTrackRecordEndpoint } from "./ams-reputation-bridge-wire";
+import { listSubmitterCohortRows, REPUTATION_WINDOW_DAYS, type SubmitterCohortRow } from "./submitter-reputation";
+
+/** How many of a repo's most active submitters (by submission volume) get a live AMS track-record check.
+ *  Bounds per-dashboard-load network fan-out; see this module's own header comment for the classification
+ *  fallback when a repo has more distinct submitters than this. */
+export const AMS_MINER_COHORT_CHECK_CAP = 25;
+
+export type AmsMinerCohortMetrics = {
+  submitterCount: number;
+  prVolume: number;
+  /** merged / (merged + closed) over the cohort's terminal rows, `null` when the cohort has no terminal rows
+   *  to divide by (never fabricated as 0, which would misleadingly read as "0% acceptance"). */
+  acceptanceRate: number | null;
+  /** Mean of each submitter's own average `attempt_count` (the gate's re-review counter, reused as the
+   *  review-cycle-count proxy per #6488's requirements) — `null` when the cohort is empty. */
+  avgReviewCycleCount: number | null;
+  /** Mean time-to-merge in ms across the cohort's MERGED rows only, `null` when the cohort has no merges. */
+  avgTimeToMergeMs: number | null;
+};
+
+export type AmsMinerCohortComparison = {
+  present: boolean;
+  windowDays: number;
+  totalSubmitterCount: number;
+  checkedSubmitterCount: number;
+  amsCohort: AmsMinerCohortMetrics;
+  humanCohort: AmsMinerCohortMetrics;
+};
+
+const EMPTY_METRICS: AmsMinerCohortMetrics = { submitterCount: 0, prVolume: 0, acceptanceRate: null, avgReviewCycleCount: null, avgTimeToMergeMs: null };
+
+const ABSENT_COMPARISON: AmsMinerCohortComparison = {
+  present: false,
+  windowDays: 0,
+  totalSubmitterCount: 0,
+  checkedSubmitterCount: 0,
+  amsCohort: EMPTY_METRICS,
+  humanCohort: EMPTY_METRICS,
+};
+
+function average(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/** PURE: aggregate one cohort's rows into the four #6488-required metrics. */
+export function computeCohortMetrics(rows: readonly SubmitterCohortRow[]): AmsMinerCohortMetrics {
+  if (rows.length === 0) return EMPTY_METRICS;
+  const prVolume = rows.reduce((sum, row) => sum + row.submissions, 0);
+  const merged = rows.reduce((sum, row) => sum + row.merged, 0);
+  const closed = rows.reduce((sum, row) => sum + row.closed, 0);
+  const terminal = merged + closed;
+  const mergeDurations = rows.filter((row) => row.avgMergeMs !== null).map((row) => row.avgMergeMs as number);
+  return {
+    submitterCount: rows.length,
+    prVolume,
+    acceptanceRate: terminal > 0 ? merged / terminal : null,
+    avgReviewCycleCount: average(rows.map((row) => row.avgAttemptCount)),
+    avgTimeToMergeMs: average(mergeDurations),
+  };
+}
+
+/** PURE: split cohort rows by AMS-track-record membership. `amsLogins` is case-insensitive, matching GitHub
+ *  login semantics (mirrors `ams-reputation-bridge.ts`'s own `outcomesForLogin`). */
+export function splitCohortRows(rows: readonly SubmitterCohortRow[], amsLogins: ReadonlySet<string>): { ams: SubmitterCohortRow[]; human: SubmitterCohortRow[] } {
+  const ams: SubmitterCohortRow[] = [];
+  const human: SubmitterCohortRow[] = [];
+  for (const row of rows) {
+    (amsLogins.has(row.submitter.trim().toLowerCase()) ? ams : human).push(row);
+  }
+  return { ams, human };
+}
+
+export type AmsMinerCohortOptions = {
+  windowDays?: number | undefined;
+  fetchImpl?: AmsTrackRecordFetch | undefined;
+  timeoutMs?: number | undefined;
+};
+
+/**
+ * Build the AMS-vs-human cohort comparison for one repo (#6488). `present: false` — never an error state — when
+ * the bridge feature is off, no AMS endpoint is configured, or the repo has no submitter activity in the
+ * window: every one of those reads as "no identifiable AMS activity" to the caller, exactly per this issue's
+ * required empty state. Never throws: `listSubmitterCohortRows`/`fetchAmsTrackRecord` are already fail-safe.
+ */
+export async function buildAmsMinerCohortComparison(env: Env, repoFullName: string, options: AmsMinerCohortOptions = {}): Promise<AmsMinerCohortComparison> {
+  if (!isAmsReputationBridgeEnabled(env)) return ABSENT_COMPARISON;
+  const endpoint = resolveAmsTrackRecordEndpoint(env);
+  if (!endpoint) return ABSENT_COMPARISON;
+
+  const windowDays = options.windowDays ?? REPUTATION_WINDOW_DAYS;
+  const rows = await listSubmitterCohortRows(env, repoFullName, windowDays);
+  if (rows.length === 0) return { ...ABSENT_COMPARISON, windowDays };
+
+  const checked = [...rows].sort((a, b) => b.submissions - a.submissions).slice(0, AMS_MINER_COHORT_CHECK_CAP);
+  const bridgeOptions = { endpoint, fetchImpl: options.fetchImpl, timeoutMs: options.timeoutMs };
+  const lookups = await Promise.all(checked.map((row) => fetchAmsTrackRecord(row.submitter, bridgeOptions)));
+  const amsLogins = new Set<string>();
+  checked.forEach((row, index) => {
+    const outcomes = lookups[index];
+    if (outcomes !== null && outcomes !== undefined && outcomes.length > 0) amsLogins.add(row.submitter.trim().toLowerCase());
+  });
+
+  const { ams, human } = splitCohortRows(rows, amsLogins);
+  return {
+    present: true,
+    windowDays,
+    totalSubmitterCount: rows.length,
+    checkedSubmitterCount: checked.length,
+    amsCohort: computeCohortMetrics(ams),
+    humanCohort: computeCohortMetrics(human),
+  };
+}

--- a/src/review/submitter-reputation.ts
+++ b/src/review/submitter-reputation.ts
@@ -313,6 +313,52 @@ export async function getSubmitterReputation(env: Env, project: string, submitte
   return { ...agg, closeRate: decided > 0 ? agg.closed / decided : 0, signal };
 }
 
+/** One submitter's raw, recency-windowed terminal-outcome tally for a repo (#6488) — the same `review_targets`
+ *  source {@link getSubmitterReputation} reads, but grouped by submitter instead of scoped to one. `avgAttemptCount`
+ *  reuses `attempt_count` (the gate's own re-review counter) as the review-cycle-count proxy; `avgMergeMs` is
+ *  `AVG(terminal_at - created_at)` over MERGED rows only (`null` when this submitter has no merges in the window). */
+export interface SubmitterCohortRow {
+  submitter: string;
+  submissions: number;
+  merged: number;
+  closed: number;
+  avgAttemptCount: number;
+  avgMergeMs: number | null;
+}
+
+/** Per-submitter cohort tally for a repo over the recency window (#6488, AMS-vs-human dashboard comparison).
+ *  Reuses the SAME `review_targets` terminal-row convention {@link getSubmitterReputation} does (terminal_at
+ *  within `windowDays`), just grouped by submitter instead of read for one. Fail-safe: any read error degrades
+ *  to an empty array (never throws — the caller treats that identically to "no activity in the window"). */
+export async function listSubmitterCohortRows(env: Env, project: string, windowDays: number = REPUTATION_WINDOW_DAYS): Promise<SubmitterCohortRow[]> {
+  try {
+    const result = await storage(env)
+      .prepare(
+        `SELECT submitter,
+                COUNT(*) AS submissions,
+                SUM(CASE WHEN status = 'merged' THEN 1 ELSE 0 END) AS merged,
+                SUM(CASE WHEN status = 'closed' THEN 1 ELSE 0 END) AS closed,
+                AVG(attempt_count) AS avgAttemptCount,
+                AVG(CASE WHEN status = 'merged' THEN (julianday(terminal_at) - julianday(created_at)) * 86400000 ELSE NULL END) AS avgMergeMs
+           FROM review_targets
+          WHERE project = ? AND submitter IS NOT NULL AND submitter != '' AND terminal_at IS NOT NULL AND terminal_at >= datetime('now', ?)
+          GROUP BY submitter`,
+      )
+      .bind(project, `-${windowDays} days`)
+      .all<{ submitter: string; submissions: number; merged: number; closed: number; avgAttemptCount: number; avgMergeMs: number | null }>();
+    return (result?.results ?? []).map((row) => ({
+      submitter: row.submitter,
+      submissions: row.submissions,
+      merged: row.merged,
+      closed: row.closed,
+      avgAttemptCount: row.avgAttemptCount,
+      avgMergeMs: row.avgMergeMs,
+    }));
+  } catch {
+    return []; // fail-safe — never throw; the caller reads this identically to "no activity in the window".
+  }
+}
+
 /** Install-wide sibling of {@link getSubmitterReputation} (#4513): the SAME quality-weighted, recency-windowed
  *  signal derivation, but aggregated across EVERY repo `review_targets` has recorded for this installation_id
  *  (migrations/0050), not just one project. Closes a real blind spot: a fleet identity spreading thin across

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -953,6 +953,14 @@ describe("api routes", () => {
       noiseSources: expect.any(Array),
     });
 
+    // #6488: AMS-vs-human contributor-mix dashboard comparison, maintainer-scoped like maintainer-noise above.
+    // present: false here (never a 404/error) since the test env has no AMS reputation bridge configured.
+    const amsMinerCohortUnauthenticated = await app.request("/v1/repos/entrius/allways-ui/ams-miner-cohort", {}, env);
+    expect(amsMinerCohortUnauthenticated.status).toBe(401);
+    const amsMinerCohort = await app.request("/v1/repos/entrius/allways-ui/ams-miner-cohort", { headers: apiHeaders(env) }, env);
+    expect(amsMinerCohort.status).toBe(200);
+    await expect(amsMinerCohort.json()).resolves.toMatchObject({ present: false });
+
     const settingsPreviewUnauthenticated = await app.request("/v1/repos/entrius/allways-ui/settings-preview", { method: "POST", body: "{}" }, env);
     expect(settingsPreviewUnauthenticated.status).toBe(401);
 

--- a/test/unit/ams-miner-cohort.test.ts
+++ b/test/unit/ams-miner-cohort.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { AMS_MINER_COHORT_CHECK_CAP, buildAmsMinerCohortComparison, computeCohortMetrics, splitCohortRows } from "../../src/review/ams-miner-cohort";
+import { REPUTATION_WINDOW_DAYS, type SubmitterCohortRow } from "../../src/review/submitter-reputation";
+import type { AmsTrackRecordFetch } from "../../src/review/ams-reputation-bridge";
+
+const ENDPOINT = "https://ams.internal";
+
+function row(overrides: Partial<SubmitterCohortRow> = {}): SubmitterCohortRow {
+  return { submitter: "alice", submissions: 10, merged: 7, closed: 3, avgAttemptCount: 1.5, avgMergeMs: 3_600_000, ...overrides };
+}
+
+/** A fetchImpl returning `outcomesByLogin[login] ?? []` as the { pullRequests } envelope, matching
+ *  ams-reputation-bridge.test.ts's own jsonFetch convention. */
+function trackRecordFetch(outcomesByLogin: Record<string, unknown[]>): AmsTrackRecordFetch {
+  return async (url: string) => {
+    const login = decodeURIComponent(url.split("/track-record/")[1] ?? "");
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ pullRequests: outcomesByLogin[login] ?? [] }),
+    } as unknown as Response;
+  };
+}
+
+function amsOutcome(login: string) {
+  return { repoFullName: "acme/widgets", authorLogin: login, state: "merged" };
+}
+
+describe("computeCohortMetrics (pure) (#6488)", () => {
+  it("returns the empty-metrics shape for zero rows", () => {
+    expect(computeCohortMetrics([])).toEqual({ submitterCount: 0, prVolume: 0, acceptanceRate: null, avgReviewCycleCount: null, avgTimeToMergeMs: null });
+  });
+
+  it("aggregates prVolume, acceptanceRate, and both averages across multiple submitters", () => {
+    const rows = [row({ submitter: "alice", submissions: 10, merged: 7, closed: 3, avgAttemptCount: 1.5, avgMergeMs: 1_000 }), row({ submitter: "bob", submissions: 4, merged: 1, closed: 1, avgAttemptCount: 2.5, avgMergeMs: 3_000 })];
+    const metrics = computeCohortMetrics(rows);
+    expect(metrics.submitterCount).toBe(2);
+    expect(metrics.prVolume).toBe(14);
+    expect(metrics.acceptanceRate).toBeCloseTo(8 / 12); // merged 7+1 / terminal (7+3)+(1+1)
+    expect(metrics.avgReviewCycleCount).toBeCloseTo(2); // mean of 1.5 and 2.5
+    expect(metrics.avgTimeToMergeMs).toBeCloseTo(2_000); // mean of 1000 and 3000
+  });
+
+  it("acceptanceRate is null (never fabricated 0) when the cohort has zero terminal rows", () => {
+    const metrics = computeCohortMetrics([row({ merged: 0, closed: 0 })]);
+    expect(metrics.acceptanceRate).toBeNull();
+  });
+
+  it("avgTimeToMergeMs is null when no row in the cohort has a merge", () => {
+    const metrics = computeCohortMetrics([row({ merged: 0, closed: 3, avgMergeMs: null })]);
+    expect(metrics.avgTimeToMergeMs).toBeNull();
+  });
+});
+
+describe("splitCohortRows (pure) (#6488)", () => {
+  it("splits rows by membership, case-insensitively", () => {
+    const rows = [row({ submitter: "Alice" }), row({ submitter: "bob" }), row({ submitter: "carol" })];
+    const { ams, human } = splitCohortRows(rows, new Set(["alice"]));
+    expect(ams.map((r) => r.submitter)).toEqual(["Alice"]);
+    expect(human.map((r) => r.submitter)).toEqual(["bob", "carol"]);
+  });
+
+  it("an empty membership set puts every row in the human cohort", () => {
+    const rows = [row({ submitter: "alice" }), row({ submitter: "bob" })];
+    const { ams, human } = splitCohortRows(rows, new Set());
+    expect(ams).toEqual([]);
+    expect(human).toHaveLength(2);
+  });
+});
+
+describe("buildAmsMinerCohortComparison (#6488)", () => {
+  const enabledEnv = { LOOPOVER_REVIEW_AMS_REPUTATION_BRIDGE: "true", LOOPOVER_AMS_TRACK_RECORD_URL: ENDPOINT } as unknown as Env;
+
+  it("present: false when the bridge feature flag is off (no DB read attempted)", async () => {
+    const env = { DB: { prepare: () => { throw new Error("should not query when the bridge is off"); } } } as unknown as Env;
+    await expect(buildAmsMinerCohortComparison(env, "acme/widgets")).resolves.toEqual({
+      present: false,
+      windowDays: 0,
+      totalSubmitterCount: 0,
+      checkedSubmitterCount: 0,
+      amsCohort: { submitterCount: 0, prVolume: 0, acceptanceRate: null, avgReviewCycleCount: null, avgTimeToMergeMs: null },
+      humanCohort: { submitterCount: 0, prVolume: 0, acceptanceRate: null, avgReviewCycleCount: null, avgTimeToMergeMs: null },
+    });
+  });
+
+  it("present: false when the bridge is on but no endpoint is configured", async () => {
+    const env = { LOOPOVER_REVIEW_AMS_REPUTATION_BRIDGE: "true", DB: { prepare: () => { throw new Error("should not query"); } } } as unknown as Env;
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets");
+    expect(result.present).toBe(false);
+  });
+
+  it("present: false (empty state, not an error) when the repo has no submitter activity in the window", async () => {
+    const env = { ...enabledEnv, DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }) } } as unknown as Env;
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets");
+    expect(result.present).toBe(false);
+    expect(result.windowDays).toBe(REPUTATION_WINDOW_DAYS);
+  });
+
+  it("classifies submitters into AMS vs human cohorts using the bridge's own live lookup", async () => {
+    const rows = [row({ submitter: "alice", submissions: 10, merged: 7, closed: 3 }), row({ submitter: "bob", submissions: 4, merged: 1, closed: 1 })];
+    const env = { ...enabledEnv, DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: rows }) }) }) } } as unknown as Env;
+    const fetchImpl = trackRecordFetch({ alice: [amsOutcome("alice")] }); // alice has AMS data, bob does not
+
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets", { fetchImpl });
+
+    expect(result.present).toBe(true);
+    expect(result.totalSubmitterCount).toBe(2);
+    expect(result.checkedSubmitterCount).toBe(2);
+    expect(result.amsCohort.submitterCount).toBe(1);
+    expect(result.amsCohort.prVolume).toBe(10);
+    expect(result.humanCohort.submitterCount).toBe(1);
+    expect(result.humanCohort.prVolume).toBe(4);
+  });
+
+  it("a login the bridge fails to resolve (null, fail-safe) is never counted as AMS", async () => {
+    const rows = [row({ submitter: "alice" })];
+    const env = { ...enabledEnv, DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: rows }) }) }) } } as unknown as Env;
+    const fetchImpl: AmsTrackRecordFetch = async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response;
+
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets", { fetchImpl });
+
+    expect(result.amsCohort.submitterCount).toBe(0);
+    expect(result.humanCohort.submitterCount).toBe(1);
+  });
+
+  it("a login the bridge resolves with zero matching outcomes is not counted as AMS", async () => {
+    const rows = [row({ submitter: "alice" })];
+    const env = { ...enabledEnv, DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: rows }) }) }) } } as unknown as Env;
+    const fetchImpl = trackRecordFetch({}); // alice resolves, but with no outcomes
+
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets", { fetchImpl });
+
+    expect(result.amsCohort.submitterCount).toBe(0);
+    expect(result.humanCohort.submitterCount).toBe(1);
+  });
+
+  it("REGRESSION: caps live lookups at AMS_MINER_COHORT_CHECK_CAP, defaulting every unchecked submitter to the human cohort", async () => {
+    const rowCount = AMS_MINER_COHORT_CHECK_CAP + 5;
+    const rows = Array.from({ length: rowCount }, (_unused, i) => row({ submitter: `submitter-${i}`, submissions: rowCount - i }));
+    const env = { ...enabledEnv, DB: { prepare: () => ({ bind: () => ({ all: async () => ({ results: rows }) }) }) } } as unknown as Env;
+    let calls = 0;
+    const fetchImpl: AmsTrackRecordFetch = async () => {
+      calls += 1;
+      return { ok: true, status: 200, json: async () => ({ pullRequests: [] }) } as unknown as Response;
+    };
+
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets", { fetchImpl });
+
+    expect(calls).toBe(AMS_MINER_COHORT_CHECK_CAP);
+    expect(result.totalSubmitterCount).toBe(rowCount);
+    expect(result.checkedSubmitterCount).toBe(AMS_MINER_COHORT_CHECK_CAP);
+    expect(result.humanCohort.submitterCount).toBe(rowCount); // none matched AMS, so all land in human
+  });
+
+  it("threads a custom windowDays option through to the underlying query and the response", async () => {
+    const seenBindArgs: unknown[][] = [];
+    const env = {
+      ...enabledEnv,
+      DB: {
+        prepare: () => ({
+          bind: (...args: unknown[]) => {
+            seenBindArgs.push(args);
+            return { all: async () => ({ results: [] }) };
+          },
+        }),
+      },
+    } as unknown as Env;
+
+    const result = await buildAmsMinerCohortComparison(env, "acme/widgets", { windowDays: 14 });
+
+    expect(seenBindArgs[0]).toEqual(["acme/widgets", "-14 days"]);
+    expect(result.windowDays).toBe(14);
+  });
+});

--- a/test/unit/submitter-reputation.test.ts
+++ b/test/unit/submitter-reputation.test.ts
@@ -8,6 +8,7 @@ import {
   getSubmitterReputation,
   getSubmitterReputationAcrossInstall,
   isMachinePacedCadence,
+  listSubmitterCohortRows,
   recordSubmissionOutcome,
   REPUTATION_WINDOW_DAYS,
   type ReputationConfig,
@@ -280,6 +281,77 @@ describe("recordSubmissionOutcome / getSubmitterReputation (D1, fail-safe)", () 
     const rep = await getSubmitterReputation(env, "p", "u");
     expect(rep.signal).toBe("neutral");
     expect(rep.closeRate).toBeCloseTo(1 / 3); // closed 1 / (merged 2 + closed 1)
+  });
+});
+
+describe("listSubmitterCohortRows (D1, fail-safe) (#6488)", () => {
+  it("passes the project + window-days binding and maps the aggregate row shape through unchanged", async () => {
+    const seen: { sql: string; bindArgs: unknown[] }[] = [];
+    const env = {
+      DB: {
+        prepare: (sql: string) => ({
+          bind: (...bindArgs: unknown[]) => {
+            seen.push({ sql, bindArgs });
+            return {
+              all: async () => ({
+                results: [
+                  { submitter: "alice", submissions: 10, merged: 7, closed: 3, avgAttemptCount: 1.5, avgMergeMs: 3_600_000 },
+                  { submitter: "bob", submissions: 2, merged: 0, closed: 2, avgAttemptCount: 3, avgMergeMs: null },
+                ],
+              }),
+            };
+          },
+        }),
+      },
+    } as unknown as Env;
+
+    const rows = await listSubmitterCohortRows(env, "acme/widgets", 30);
+
+    expect(seen[0]?.bindArgs).toEqual(["acme/widgets", "-30 days"]);
+    expect(seen[0]?.sql).toContain("GROUP BY submitter");
+    expect(rows).toEqual([
+      { submitter: "alice", submissions: 10, merged: 7, closed: 3, avgAttemptCount: 1.5, avgMergeMs: 3_600_000 },
+      { submitter: "bob", submissions: 2, merged: 0, closed: 2, avgAttemptCount: 3, avgMergeMs: null },
+    ]);
+  });
+
+  it("defaults windowDays to REPUTATION_WINDOW_DAYS when omitted", async () => {
+    const seen: unknown[][] = [];
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: (...bindArgs: unknown[]) => {
+            seen.push(bindArgs);
+            return { all: async () => ({ results: [] }) };
+          },
+        }),
+      },
+    } as unknown as Env;
+
+    await listSubmitterCohortRows(env, "acme/widgets");
+
+    expect(seen[0]).toEqual(["acme/widgets", `-${REPUTATION_WINDOW_DAYS} days`]);
+  });
+
+  it("degrades to an empty array (never throws) when the query itself throws", async () => {
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => {
+              throw new Error("D1 boom");
+            },
+          }),
+        }),
+      },
+    } as unknown as Env;
+
+    await expect(listSubmitterCohortRows(env, "acme/widgets")).resolves.toEqual([]);
+  });
+
+  it("degrades to an empty array when the query resolves malformed (no results key, ?? [] fallback)", async () => {
+    const env = { DB: { prepare: () => ({ bind: () => ({ all: async () => undefined }) }) } } as unknown as Env;
+    await expect(listSubmitterCohortRows(env, "acme/widgets")).resolves.toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Per #6210's decided design: a maintainer-only dashboard panel comparing identifiable AMS miners
against a repo's other contributors on acceptance rate, review-cycle count, time-to-merge, and PR
volume.

- **Backend (`src/review/ams-miner-cohort.ts`, new):** classifies a repo's recent submitters into an
  AMS cohort vs. a human cohort and computes the four required metrics per cohort. Membership ("has
  AMS track-record data") reuses the existing ORB/AMS reputation bridge's pull path
  (`fetchAmsTrackRecord`, #6485); the metrics reuse `submitter-reputation.ts`'s existing
  `review_targets` outcome classification via a new `listSubmitterCohortRows` grouped-by-submitter
  aggregate query, rather than re-deriving anything.
- **Bounded, not exhaustive:** classifying membership needs one live call per distinct submitter login
  (there's no cached "is this an AMS miner" flag anywhere). To bound per-dashboard-load network
  fan-out, only the repo's `AMS_MINER_COHORT_CHECK_CAP` (25) most active submitters get a live check;
  every unchecked submitter defaults to the human cohort (never assumed AMS — same conservative-default
  discipline as the bridge's own upgrade-only rule). The response discloses
  `checkedSubmitterCount`/`totalSubmitterCount` so a caller never reads a capped result as exhaustive.
- **Route:** `GET /v1/repos/:owner/:repo/ams-miner-cohort`, maintainer-gated identically to the
  existing `maintainer-noise` route (`requireRepoMaintainer`). `present: false` (never a 404/error)
  when the AMS bridge is off, unconfigured, or the repo has no submitter activity in the window — the
  panel's required empty state.
- **UI:** new `AmsMinerCohortCard` in `apps/loopover-ui/src/components/site/app-panels/`, wired into
  `maintainer-panel.tsx` next to `ActivationPreview`. Self-contained repo picker + self-fetch, mirroring
  `ActivationPreview`'s exact shape (this repo's established precedent for a maintainer-panel card that
  needs its own single-repo data, distinct from the multi-repo `qualityDashboard` aggregate).
- **OpenAPI:** new `AmsMinerCohortComparison` schema, registered the same way `MaintainerNoiseReport`
  is (schema only, no `registerPath` — matches the maintainer-only, non-MCP-facing route convention).

No wallet/hotkey/reward/trust-score wording anywhere in the panel or backend, matching this repo's
existing constraints for private-only surfaces.

## Test plan

- [x] `test/unit/ams-miner-cohort.test.ts` (new): pure `computeCohortMetrics`/`splitCohortRows` cases
  (empty cohort, multi-submitter aggregation, `null` acceptanceRate/avgTimeToMergeMs never fabricated),
  plus the full `buildAmsMinerCohortComparison` orchestrator (bridge off, no endpoint, empty-window,
  AMS/human classification via a mocked bridge fetch, a fail-safe null lookup never counting as AMS, the
  `AMS_MINER_COHORT_CHECK_CAP` regression, and a custom `windowDays` threading through) — 14/14 passing
- [x] `test/unit/submitter-reputation.test.ts`: added `listSubmitterCohortRows` D1 fail-safe tests
  (binding shape, default window, throw → `[]`, malformed result → `[]`) — 51/51 passing
- [x] `test/integration/api.test.ts`: added the new route's 401/200 + `present: false` empty-state case
  — 142/142 passing across the full integration suite
- [x] `apps/loopover-ui/.../ams-miner-cohort-card.test.tsx` (new, 8 tests) + `maintainer-panel.test.tsx`
  regression (7/7) — both passing
- [x] Verified 100% statement/branch/function/line coverage locally on both new/changed `src/**` files
  (`ams-miner-cohort.ts`, `submitter-reputation.ts`) via scoped `vitest --coverage`, and zero uncovered
  lines/branches on the new route's changed lines in `routes.ts` via direct lcov `DA:`/`BRDA:`
  inspection (one line needed a `v8 ignore next`, matching the exact, already-established precedent at
  3 other `requireRepoMaintainer` call sites in this same file — unauthenticated requests are rejected
  by the auth middleware before the handler runs, so that in-handler branch is genuinely unreachable)
- [x] `npm run build --workspace @loopover/engine`, `npm run ui:lint`, `npm run ui:typecheck`,
  `npm run ui:openapi` + `ui:openapi:check` + `ui:openapi:settings-parity`, `npm run docs:drift-check`,
  `npm run manifest:drift-check`, `npm run engine-parity:drift-check`, `git diff --check`,
  `npm run actionlint` — all clean
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Root `npm run typecheck` OOMs in this sandbox regardless of diff content (pre-existing environment
  limitation, unrelated to this change); substituted the scoped engine build plus careful manual
  line-by-line type review of every changed `src/**` file

Closes #6488