### PR TITLE
refactor(settings): drop Batch B's 15 config-as-code-only DB columns

### DIFF
--- a/apps/loopover-ui/content/docs/tuning.mdx
+++ b/apps/loopover-ui/content/docs/tuning.mdx
@@ -311,8 +311,10 @@ path holds are configured only through `settings.hardGuardrailGlobs`.
 
 ## Other repo settings
 
-Anything you can toggle in the dashboard can also be set as code under
-`settings:` in `.loopover.yml`. Common ones, all defaulting to the
+Everything you can toggle in the dashboard can also be set as code under
+`settings:` in `.loopover.yml` — plus a growing set of config-as-code-only
+fields with no dashboard control at all (moved off the DB entirely; `.loopover.yml`
+is the only way to set them). Common ones, all defaulting to the
 safe values shown:
 
 - `commentMode` — comment audience: `off` /

--- a/apps/loopover-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
@@ -34,8 +34,6 @@ const ADVISORY_SETTINGS = {
   slopGateMinScore: null,
   slopAiAdvisory: false,
   autoLabelEnabled: true,
-  gittensorLabel: "gittensor",
-  createMissingLabel: true,
   requireLinkedIssue: false,
   badgeEnabled: false,
   publicQualityMetrics: false,
@@ -101,7 +99,8 @@ describe("GateRampControl (#2218)", () => {
     expect(body.linkedIssueGateMode).toBe("block");
     expect(body.duplicatePrGateMode).toBe("block");
     expect(body.qualityGateMode).toBe("block");
-    expect(body.gittensorLabel).toBe("gittensor");
+    // gittensorLabel moved off the dashboard (Batch B, loopover#6443) -- no longer in the PUT payload.
+    expect(body.gittensorLabel).toBeUndefined();
   });
 
   it("closes confirm without saving when cancel is clicked", async () => {

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -302,25 +302,14 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
           />
           <div>
             <h3 className={LABEL_CLASS}>Labels</h3>
+            {/* #6443: "Label name" / "Create label if missing" removed -- gittensorLabel/createMissingLabel
+                are no longer DB-backed, config-as-code only via .loopover.yml's settings: block now. */}
             <div className="mt-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <ToggleControl
                 label="Auto-label PRs"
                 hint="Only the base context label below — type labels have their own toggle"
                 value={settings.autoLabelEnabled}
                 onChange={(v) => setField("autoLabelEnabled", v)}
-              />
-              <label className="block">
-                <span className={LABEL_CLASS}>Label name</span>
-                <input
-                  value={settings.gittensorLabel}
-                  onChange={(event) => setField("gittensorLabel", event.target.value)}
-                  className={FIELD_CLASS}
-                />
-              </label>
-              <ToggleControl
-                label="Create label if missing"
-                value={settings.createMissingLabel}
-                onChange={(v) => setField("createMissingLabel", v)}
               />
             </div>
           </div>

--- a/apps/loopover-ui/src/lib/maintainer-settings-editable.test.ts
+++ b/apps/loopover-ui/src/lib/maintainer-settings-editable.test.ts
@@ -20,8 +20,6 @@ const SETTINGS: MaintainerSettingsEditable = {
   slopGateMinScore: null,
   slopAiAdvisory: false,
   autoLabelEnabled: true,
-  gittensorLabel: "gittensor",
-  createMissingLabel: true,
   requireLinkedIssue: false,
   badgeEnabled: false,
   publicQualityMetrics: false,
@@ -37,7 +35,7 @@ describe("maintainer-settings-editable (#2218)", () => {
     const payload = buildMaintainerSettingsSavePayload(SETTINGS);
     expect(Object.keys(payload).sort()).toEqual([...MAINTAINER_SETTINGS_EDITABLE_KEYS].sort());
     expect(payload.linkedIssueGateMode).toBe("advisory");
-    expect(payload.gittensorLabel).toBe("gittensor");
+    expect(payload.badgeEnabled).toBe(false);
   });
 
   it("buildMaintainerSettingsSavePayload merges a partial patch over the base settings", () => {
@@ -49,7 +47,7 @@ describe("maintainer-settings-editable (#2218)", () => {
     expect(payload.duplicatePrGateMode).toBe("block");
     // Untouched fields pass through unchanged.
     expect(payload.qualityGateMode).toBe("advisory");
-    expect(payload.gittensorLabel).toBe("gittensor");
+    expect(payload.badgeEnabled).toBe(false);
   });
 
   it("an empty patch object is a no-op (same as omitting it)", () => {

--- a/apps/loopover-ui/src/lib/maintainer-settings-editable.ts
+++ b/apps/loopover-ui/src/lib/maintainer-settings-editable.ts
@@ -33,8 +33,8 @@ export type MaintainerSettingsEditable = {
   slopGateMinScore: number | null;
   slopAiAdvisory: boolean;
   autoLabelEnabled: boolean;
-  gittensorLabel: string;
-  createMissingLabel: boolean;
+  // #6443: gittensorLabel/createMissingLabel removed -- no longer DB-backed, config-as-code only via
+  // .loopover.yml's settings: block now (the dashboard can no longer write them).
   requireLinkedIssue: boolean;
   badgeEnabled: boolean;
   publicQualityMetrics: boolean;
@@ -60,8 +60,6 @@ export const MAINTAINER_SETTINGS_EDITABLE_KEYS: Array<keyof MaintainerSettingsEd
   "slopGateMinScore",
   "slopAiAdvisory",
   "autoLabelEnabled",
-  "gittensorLabel",
-  "createMissingLabel",
   "requireLinkedIssue",
   "badgeEnabled",
   "publicQualityMetrics",

--- a/migrations/0158_drop_batch_b_config_as_code_columns.sql
+++ b/migrations/0158_drop_batch_b_config_as_code_columns.sql
@@ -1,0 +1,27 @@
+-- Config-as-code migration (Batch B, loopover#6443/epic #6440): these 15 fields already parse correctly
+-- from .loopover.yml's settings: block (confirmed via audit, including the sparse-merge composite fields
+-- typeLabels/linkedIssueLabelPropagation, which resolveEffectiveSettings merges a manifest partial onto a
+-- base -- that base now always resolves to the built-in default (DEFAULT_TYPE_LABELS/
+-- DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION) rather than a stale DB customization, since getRepositorySettings
+-- no longer reads a real per-repo value for these columns). Same dead-column-cleanup shape as Batch A
+-- (migration 0157) and the earlier 0122/0146/0150 precedents. SQLite 3.35+ / D1 supports DROP COLUMN
+-- directly.
+--
+-- contributor_blacklist_json here is the PER-REPO override column on repository_settings -- distinct from
+-- the separate global_contributor_blacklist table (untouched by this migration), which still has its own
+-- contributor_blacklist_json column and its own parseContributorBlacklist read path.
+ALTER TABLE repository_settings DROP COLUMN gittensor_label;
+ALTER TABLE repository_settings DROP COLUMN blacklist_label;
+ALTER TABLE repository_settings DROP COLUMN create_missing_label;
+ALTER TABLE repository_settings DROP COLUMN type_labels_enabled;
+ALTER TABLE repository_settings DROP COLUMN type_labels_json;
+ALTER TABLE repository_settings DROP COLUMN linked_issue_label_propagation_json;
+ALTER TABLE repository_settings DROP COLUMN contributor_blacklist_json;
+ALTER TABLE repository_settings DROP COLUMN moderation_gate_mode;
+ALTER TABLE repository_settings DROP COLUMN moderation_rules_json;
+ALTER TABLE repository_settings DROP COLUMN moderation_warning_label;
+ALTER TABLE repository_settings DROP COLUMN moderation_banned_label;
+ALTER TABLE repository_settings DROP COLUMN review_evasion_protection;
+ALTER TABLE repository_settings DROP COLUMN review_evasion_label;
+ALTER TABLE repository_settings DROP COLUMN review_evasion_comment;
+ALTER TABLE repository_settings DROP COLUMN merge_train_mode;

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -30,7 +30,6 @@ import {
 } from "../auth/security";
 import { normalizeGittBountySnapshot } from "../bounties/ingest";
 import { DEFAULT_COMMAND_AUTHORIZATION_POLICY, normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
-import { normalizeContributorBlacklist } from "../settings/contributor-blacklist";
 import { isDuplicateWinnerEnabledGlobally, resolveDuplicateWinnerEnabled } from "../settings/duplicate-winner-mode";
 import { SCENARIO_MAX_BRANCH_REF_CHARS, SCENARIO_MAX_LINKED_ISSUE_NUMBERS, SCENARIO_MAX_REPO_FULL_NAME_CHARS } from "../scenarios/input-model";
 import {
@@ -680,9 +679,8 @@ const repositorySettingsSchema = z.object({
   aiReviewLowConfidenceDisposition: z.enum(["one_shot", "hold_for_review", "advisory_only"]).default("hold_for_review"),
   closeOwnerAuthors: z.boolean().default(false),
   autoLabelEnabled: z.boolean().default(true),
-  gittensorLabel: z.string().trim().min(1).max(50).default("gittensor"),
-  blacklistLabel: z.string().trim().min(1).max(50).default("slop"),
-  createMissingLabel: z.boolean().default(true),
+  // #6443: gittensorLabel/blacklistLabel/createMissingLabel/contributorBlacklist removed -- no longer
+  // DB-backed, config-as-code only via .loopover.yml's settings: block now.
   requireLinkedIssue: z.boolean().default(false),
   badgeEnabled: z.boolean().default(false),
   publicQualityMetrics: z.boolean().default(false),
@@ -692,12 +690,6 @@ const repositorySettingsSchema = z.object({
       commands: z.record(z.string().trim().min(1).max(64), z.array(z.enum(["maintainer", "collaborator", "pr_author", "confirmed_miner"])).max(4)).optional(),
     })
     .default(DEFAULT_COMMAND_AUTHORIZATION_POLICY),
-  // Per-repo contributor blacklist (#1425). Loose by design — the DB layer normalizes/validates each entry
-  // (login pattern, public-safe metadata, de-dup, caps), so invalid entries are dropped on persist.
-  contributorBlacklist: z
-    .array(z.object({ login: z.string(), reason: z.string().optional(), evidence: z.array(z.string()).optional(), addedAt: z.string().optional() }))
-    .max(1000)
-    .default([]),
 });
 
 // #130 maintainer self-serve settings editor. A PATCH-style subset: every field optional so the maintainer
@@ -717,7 +709,8 @@ const maintainerSettingsSchema = z
     manifestPolicyGateMode: z.enum(["off", "advisory", "block"]),
     selfAuthoredLinkedIssueGateMode: z.enum(["off", "advisory", "block"]),
     linkedIssueSatisfactionGateMode: z.enum(["off", "advisory", "block"]),
-    mergeTrainMode: z.enum(["off", "audit", "enforce"]),
+    // #6443: mergeTrainMode/gittensorLabel/blacklistLabel/createMissingLabel removed -- no longer DB-backed,
+    // config-as-code only via .loopover.yml's settings: block now.
     firstTimeContributorGrace: z
       .boolean()
       .describe("Reserved (#2266) -- the gate evaluator never reads this field. Currently has no effect on gate decisions."),
@@ -725,9 +718,6 @@ const maintainerSettingsSchema = z
     slopGateMinScore: z.number().int().min(0).max(100).nullable(),
     slopAiAdvisory: z.boolean(),
     autoLabelEnabled: z.boolean(),
-    gittensorLabel: z.string().trim().min(1).max(50),
-    blacklistLabel: z.string().trim().min(1).max(50),
-    createMissingLabel: z.boolean(),
     closeOwnerAuthors: z.boolean(),
     requireLinkedIssue: z.boolean(),
     badgeEnabled: z.boolean(),
@@ -4228,14 +4218,10 @@ export function createApp() {
         aiReviewLowConfidenceDisposition: parsed.data.aiReviewLowConfidenceDisposition,
         closeOwnerAuthors: parsed.data.closeOwnerAuthors,
         autoLabelEnabled: parsed.data.autoLabelEnabled,
-        gittensorLabel: parsed.data.gittensorLabel,
-        blacklistLabel: parsed.data.blacklistLabel,
-        createMissingLabel: parsed.data.createMissingLabel,
         requireLinkedIssue: parsed.data.requireLinkedIssue,
         badgeEnabled: parsed.data.badgeEnabled,
         publicQualityMetrics: parsed.data.publicQualityMetrics,
         commandAuthorization: normalizeCommandAuthorizationPolicy(parsed.data.commandAuthorization).policy,
-        contributorBlacklist: normalizeContributorBlacklist(parsed.data.contributorBlacklist).entries,
       }),
     );
   });
@@ -5061,12 +5047,14 @@ async function buildRepoOutcomePatternsResponse(env: Env, fullName: string) {
   return attachDataQuality(response as unknown as Record<string, unknown>, dataQuality);
 }
 
-// Batch A (loopover#6442): these 9 fields moved off the DB entirely -- rawSettings (getRepositorySettings)
-// always returns the same hardcoded default for them now, so a "DB vs yml" comparison built on rawSettings
-// alone would be comparing a constant against yml, never reflecting a repo's real .loopover.yml-driven
-// behavior. Overlays the true EFFECTIVE value for just these 9 fields onto an otherwise-raw-DB settings
-// object, preserving the #2912 DB-vs-yml comparison intent for every other (still DB-backed) field.
+// Batch A (loopover#6442) + Batch B (loopover#6443): these fields moved off the DB entirely -- rawSettings
+// (getRepositorySettings) always returns the same hardcoded default for them now, so a "DB vs yml" comparison
+// built on rawSettings alone would be comparing a constant against yml, never reflecting a repo's real
+// .loopover.yml-driven behavior. Overlays the true EFFECTIVE value for just these fields onto an otherwise-
+// raw-DB settings object, preserving the #2912 DB-vs-yml comparison intent for every other (still DB-backed)
+// field.
 const CONFIG_AS_CODE_ONLY_FIELDS = [
+  // Batch A (loopover#6442)
   "commentMode",
   "publicAudienceMode",
   "publicSignalLevel",
@@ -5076,6 +5064,22 @@ const CONFIG_AS_CODE_ONLY_FIELDS = [
   "publicSurface",
   "includeMaintainerAuthors",
   "backfillEnabled",
+  // Batch B (loopover#6443)
+  "gittensorLabel",
+  "blacklistLabel",
+  "createMissingLabel",
+  "typeLabelsEnabled",
+  "typeLabels",
+  "linkedIssueLabelPropagation",
+  "contributorBlacklist",
+  "moderationGateMode",
+  "moderationRules",
+  "moderationWarningLabel",
+  "moderationBannedLabel",
+  "reviewEvasionProtection",
+  "reviewEvasionLabel",
+  "reviewEvasionComment",
+  "mergeTrainMode",
 ] as const satisfies ReadonlyArray<keyof RepositorySettings>;
 function applyConfigAsCodeOnlyFields(rawSettings: RepositorySettings, resolvedSettings: RepositorySettings): RepositorySettings {
   const settings = { ...rawSettings };

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -171,8 +171,8 @@ import { normalizeContributorBlacklist } from "../settings/contributor-blacklist
 import { normalizeAutoCloseExemptLogins } from "../settings/auto-close-exempt";
 import { DEFAULT_GLOBAL_MODERATION_CONFIG, MAX_MODERATION_VIOLATION_DECAY_DAYS, normalizeModerationLabel, normalizeModerationRules, type GlobalModerationConfig, type ModerationRuleType } from "../settings/moderation-rules";
 import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy, DEFAULT_AUTO_MAINTAIN_POLICY } from "../settings/autonomy";
-import { DEFAULT_TYPE_LABELS, normalizeTypeLabelSet } from "../settings/pr-type-label";
-import { DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, normalizeLinkedIssueLabelPropagationConfig } from "../review/linked-issue-label-propagation";
+import { DEFAULT_TYPE_LABELS } from "../settings/pr-type-label";
+import { DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION } from "../review/linked-issue-label-propagation";
 import { DEFAULT_LINKED_ISSUE_HARD_RULES } from "../review/linked-issue-hard-rules-config";
 import { DEFAULT_SCREENSHOT_TABLE_GATE, isScreenshotTableGateAction, normalizeScreenshotTableGateConfig } from "../review/screenshot-table-gate";
 import { decryptSecret, encryptSecret, sha256Hex } from "../utils/crypto";
@@ -646,7 +646,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
       moderationWarningLabel: undefined,
       moderationBannedLabel: undefined,
       skipAutomationBotAuthors: "inherit",
-      reviewEvasionProtection: "close", // #4011: default-ON -- see normalizeReviewEvasionProtection's doc comment
+      reviewEvasionProtection: "close", // #4011/#6443: default-ON, always -- a repo protects itself from self-close/draft-dodge gaming unless it explicitly opts out via .loopover.yml
       reviewEvasionLabel: DEFAULT_REVIEW_EVASION_LABEL,
       reviewEvasionComment: true,
       draftPrClosePolicy: "off",
@@ -689,13 +689,17 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     aiReviewLowConfidenceDisposition: parseAiReviewLowConfidenceDisposition(row.aiReviewLowConfidenceDisposition),
     closeOwnerAuthors: row.closeOwnerAuthors,
     autoLabelEnabled: row.autoLabelEnabled,
-    typeLabelsEnabled: row.typeLabelsEnabled,
-    typeLabels: parseTypeLabelSet(row.typeLabelsJson),
-    linkedIssueLabelPropagation: parseLinkedIssueLabelPropagationConfig(row.linkedIssueLabelPropagationJson),
+    // Config-as-code only (Batch B, loopover#6443): no DB column backs these 12 fields anymore -- unconditional
+    // built-in defaults, matching the !row branch above. resolveEffectiveSettings still overlays a repo's
+    // .loopover.yml settings.* value over these (the sparse-merge base for typeLabels/
+    // linkedIssueLabelPropagation now always resolves to the built-in default, never a stale DB customization).
+    typeLabelsEnabled: true,
+    typeLabels: { ...DEFAULT_TYPE_LABELS },
+    linkedIssueLabelPropagation: { ...DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, mappings: [] },
     linkedIssueHardRules: { ...DEFAULT_LINKED_ISSUE_HARD_RULES, pointBearingLabels: [], maintainerOnlyLabels: [] },
-    gittensorLabel: row.gittensorLabel,
-    blacklistLabel: row.blacklistLabel,
-    createMissingLabel: row.createMissingLabel,
+    gittensorLabel: "gittensor",
+    blacklistLabel: "slop",
+    createMissingLabel: true,
     // Config-as-code only (Batch A, loopover#6442): see the comment on the reviewCheckMode block above.
     publicSurface: "comment_and_label",
     includeMaintainerAuthors: false,
@@ -706,7 +710,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     agentPaused: row.agentPaused,
     agentDryRun: row.agentDryRun,
     commandAuthorization: parseCommandAuthorizationPolicy(row.commandAuthorizationJson),
-    contributorBlacklist: parseContributorBlacklist(row.contributorBlacklistJson),
+    contributorBlacklist: [],
     autonomy: parseAutonomyPolicy(row.autonomyJson),
     autoMaintain: parseAutoMaintainPolicy(row.autoMaintainJson),
     contributorOpenPrCap: normalizeOpenItemCap(row.contributorOpenPrCap),
@@ -726,16 +730,17 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     commandRateLimitMaxPerWindow: normalizePositiveIntWithDefault(row.commandRateLimitMaxPerWindow, 20),
     commandRateLimitAiMaxPerWindow: normalizePositiveIntWithDefault(row.commandRateLimitAiMaxPerWindow, 5),
     commandRateLimitWindowHours: normalizePositiveIntWithDefault(row.commandRateLimitWindowHours, 24),
-    moderationGateMode: normalizeModerationGateMode(row.moderationGateMode),
-    moderationRules: parseModerationRulesColumn(row.moderationRulesJson),
-    moderationWarningLabel: normalizeModerationLabel(row.moderationWarningLabel),
-    moderationBannedLabel: normalizeModerationLabel(row.moderationBannedLabel),
+    // Config-as-code only (Batch B, loopover#6443): see the comment on the typeLabelsEnabled block above.
+    moderationGateMode: "inherit",
+    moderationRules: undefined,
+    moderationWarningLabel: undefined,
+    moderationBannedLabel: undefined,
     skipAutomationBotAuthors: normalizeSkipAutomationBotAuthors(row.skipAutomationBotAuthors),
-    reviewEvasionProtection: normalizeReviewEvasionProtection(row.reviewEvasionProtection),
-    reviewEvasionLabel: row.reviewEvasionLabel,
-    reviewEvasionComment: row.reviewEvasionComment,
+    reviewEvasionProtection: "close", // #4011/#6443: default-ON, always -- a repo protects itself from self-close/draft-dodge gaming unless it explicitly opts out via .loopover.yml
+    reviewEvasionLabel: DEFAULT_REVIEW_EVASION_LABEL,
+    reviewEvasionComment: true,
     draftPrClosePolicy: normalizeDraftPrClosePolicy(row.draftPrClosePolicy),
-    mergeTrainMode: normalizeMergeTrainMode(row.mergeTrainMode),
+    mergeTrainMode: "off",
     screenshotTableGate: parseScreenshotTableGateRow(row),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -811,12 +816,15 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     aiReviewLowConfidenceDisposition: parseAiReviewLowConfidenceDisposition(settings.aiReviewLowConfidenceDisposition),
     closeOwnerAuthors: settings.closeOwnerAuthors ?? false,
     autoLabelEnabled: settings.autoLabelEnabled ?? true,
-    typeLabelsEnabled: settings.typeLabelsEnabled ?? true,
-    typeLabels: normalizeTypeLabelSet(settings.typeLabels, []),
-    linkedIssueLabelPropagation: normalizeLinkedIssueLabelPropagationConfig(settings.linkedIssueLabelPropagation, []),
-    gittensorLabel: settings.gittensorLabel ?? "gittensor",
-    blacklistLabel: settings.blacklistLabel ?? "slop",
-    createMissingLabel: settings.createMissingLabel ?? true,
+    // Config-as-code only (Batch B, loopover#6443): hardcoded, not `settings.xxx ?? default`, so a caller
+    // passing one of these through this API is silently ignored rather than appearing to persist when
+    // there's no column to write it to.
+    typeLabelsEnabled: true,
+    typeLabels: { ...DEFAULT_TYPE_LABELS },
+    linkedIssueLabelPropagation: { ...DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, mappings: [] },
+    gittensorLabel: "gittensor",
+    blacklistLabel: "slop",
+    createMissingLabel: true,
     // Config-as-code only (Batch A, loopover#6442): see the comment on the reviewCheckMode block above.
     publicSurface: "comment_and_label",
     includeMaintainerAuthors: false,
@@ -827,7 +835,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     agentPaused: settings.agentPaused ?? false,
     agentDryRun: settings.agentDryRun ?? false,
     commandAuthorization: normalizeCommandAuthorizationPolicy(settings.commandAuthorization).policy,
-    contributorBlacklist: normalizeContributorBlacklist(settings.contributorBlacklist).entries,
+    contributorBlacklist: [] as RepositorySettings["contributorBlacklist"],
     autonomy: normalizeAutonomyPolicy(settings.autonomy),
     autoMaintain: normalizeAutoMaintainPolicy(settings.autoMaintain),
     contributorOpenPrCap: normalizeOpenItemCap(settings.contributorOpenPrCap),
@@ -847,16 +855,17 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     commandRateLimitMaxPerWindow: normalizePositiveIntWithDefault(settings.commandRateLimitMaxPerWindow, 20),
     commandRateLimitAiMaxPerWindow: normalizePositiveIntWithDefault(settings.commandRateLimitAiMaxPerWindow, 5),
     commandRateLimitWindowHours: normalizePositiveIntWithDefault(settings.commandRateLimitWindowHours, 24),
-    moderationGateMode: normalizeModerationGateMode(settings.moderationGateMode),
-    moderationRules: settings.moderationRules,
-    moderationWarningLabel: normalizeModerationLabel(settings.moderationWarningLabel),
-    moderationBannedLabel: normalizeModerationLabel(settings.moderationBannedLabel),
+    // Config-as-code only (Batch B, loopover#6443): see the comment on the typeLabelsEnabled block above.
+    moderationGateMode: "inherit" as const,
+    moderationRules: undefined,
+    moderationWarningLabel: undefined,
+    moderationBannedLabel: undefined,
     skipAutomationBotAuthors: normalizeSkipAutomationBotAuthors(settings.skipAutomationBotAuthors),
-    reviewEvasionProtection: normalizeReviewEvasionProtection(settings.reviewEvasionProtection),
-    reviewEvasionLabel: settings.reviewEvasionLabel ?? DEFAULT_REVIEW_EVASION_LABEL,
-    reviewEvasionComment: settings.reviewEvasionComment ?? true,
+    reviewEvasionProtection: "close" as const,
+    reviewEvasionLabel: DEFAULT_REVIEW_EVASION_LABEL,
+    reviewEvasionComment: true,
     draftPrClosePolicy: normalizeDraftPrClosePolicy(settings.draftPrClosePolicy),
-    mergeTrainMode: normalizeMergeTrainMode(settings.mergeTrainMode),
+    mergeTrainMode: "off" as const,
     screenshotTableGate: normalizeScreenshotTableGateConfig(settings.screenshotTableGate, []),
   } satisfies RepositorySettings;
   const db = getDb(env.DB);
@@ -888,19 +897,12 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
       aiReviewLowConfidenceDisposition: resolved.aiReviewLowConfidenceDisposition,
       closeOwnerAuthors: resolved.closeOwnerAuthors,
       autoLabelEnabled: resolved.autoLabelEnabled,
-      typeLabelsEnabled: resolved.typeLabelsEnabled,
-      typeLabelsJson: jsonString(resolved.typeLabels),
-      linkedIssueLabelPropagationJson: jsonString(resolved.linkedIssueLabelPropagation),
-      gittensorLabel: resolved.gittensorLabel,
-      blacklistLabel: resolved.blacklistLabel,
-      createMissingLabel: resolved.createMissingLabel,
       requireLinkedIssue: resolved.requireLinkedIssue,
       badgeEnabled: resolved.badgeEnabled,
       publicQualityMetrics: resolved.publicQualityMetrics,
       agentPaused: resolved.agentPaused,
       agentDryRun: resolved.agentDryRun,
       commandAuthorizationJson: jsonString(resolved.commandAuthorization),
-      contributorBlacklistJson: jsonString(resolved.contributorBlacklist),
       autonomyJson: jsonString(resolved.autonomy),
       autoMaintainJson: jsonString(resolved.autoMaintain),
       contributorOpenPrCap: resolved.contributorOpenPrCap,
@@ -920,16 +922,8 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
       commandRateLimitMaxPerWindow: resolved.commandRateLimitMaxPerWindow,
       commandRateLimitAiMaxPerWindow: resolved.commandRateLimitAiMaxPerWindow,
       commandRateLimitWindowHours: resolved.commandRateLimitWindowHours,
-      moderationGateMode: resolved.moderationGateMode,
-      moderationRulesJson: resolved.moderationRules === undefined ? null : jsonString(resolved.moderationRules),
-      moderationWarningLabel: resolved.moderationWarningLabel ?? null,
-      moderationBannedLabel: resolved.moderationBannedLabel ?? null,
       skipAutomationBotAuthors: resolved.skipAutomationBotAuthors,
-      reviewEvasionProtection: resolved.reviewEvasionProtection,
-      reviewEvasionLabel: resolved.reviewEvasionLabel,
-      reviewEvasionComment: resolved.reviewEvasionComment,
       draftPrClosePolicy: resolved.draftPrClosePolicy,
-      mergeTrainMode: resolved.mergeTrainMode,
       screenshotTableGateEnabled: resolved.screenshotTableGate.enabled,
       screenshotTableGateWhenLabelsJson: jsonString(resolved.screenshotTableGate.whenLabels),
       screenshotTableGateWhenPathsJson: jsonString(resolved.screenshotTableGate.whenPaths),
@@ -969,19 +963,12 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
         aiReviewLowConfidenceDisposition: resolved.aiReviewLowConfidenceDisposition,
         closeOwnerAuthors: resolved.closeOwnerAuthors,
         autoLabelEnabled: resolved.autoLabelEnabled,
-        typeLabelsEnabled: resolved.typeLabelsEnabled,
-        typeLabelsJson: jsonString(resolved.typeLabels),
-        linkedIssueLabelPropagationJson: jsonString(resolved.linkedIssueLabelPropagation),
-        gittensorLabel: resolved.gittensorLabel,
-        blacklistLabel: resolved.blacklistLabel,
-        createMissingLabel: resolved.createMissingLabel,
         requireLinkedIssue: resolved.requireLinkedIssue,
         badgeEnabled: resolved.badgeEnabled,
         publicQualityMetrics: resolved.publicQualityMetrics,
         agentPaused: resolved.agentPaused,
         agentDryRun: resolved.agentDryRun,
         commandAuthorizationJson: jsonString(resolved.commandAuthorization),
-        contributorBlacklistJson: jsonString(resolved.contributorBlacklist),
         autonomyJson: jsonString(resolved.autonomy),
         autoMaintainJson: jsonString(resolved.autoMaintain),
         contributorOpenPrCap: resolved.contributorOpenPrCap,
@@ -1001,16 +988,8 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
         commandRateLimitMaxPerWindow: resolved.commandRateLimitMaxPerWindow,
         commandRateLimitAiMaxPerWindow: resolved.commandRateLimitAiMaxPerWindow,
         commandRateLimitWindowHours: resolved.commandRateLimitWindowHours,
-        moderationGateMode: resolved.moderationGateMode,
-        moderationRulesJson: resolved.moderationRules === undefined ? null : jsonString(resolved.moderationRules),
-        moderationWarningLabel: resolved.moderationWarningLabel ?? null,
-        moderationBannedLabel: resolved.moderationBannedLabel ?? null,
         skipAutomationBotAuthors: resolved.skipAutomationBotAuthors,
-        reviewEvasionProtection: resolved.reviewEvasionProtection,
-        reviewEvasionLabel: resolved.reviewEvasionLabel,
-        reviewEvasionComment: resolved.reviewEvasionComment,
         draftPrClosePolicy: resolved.draftPrClosePolicy,
-        mergeTrainMode: resolved.mergeTrainMode,
         screenshotTableGateEnabled: resolved.screenshotTableGate.enabled,
         screenshotTableGateWhenLabelsJson: jsonString(resolved.screenshotTableGate.whenLabels),
         screenshotTableGateWhenPathsJson: jsonString(resolved.screenshotTableGate.whenPaths),
@@ -7816,14 +7795,6 @@ function parseCommandAuthorizationPolicy(value: string): RepositorySettings["com
   return normalizeCommandAuthorizationPolicy(parseJson<unknown>(value, null)).policy;
 }
 
-function parseTypeLabelSet(value: string): RepositorySettings["typeLabels"] {
-  return normalizeTypeLabelSet(parseJson<unknown>(value, null), []);
-}
-
-function parseLinkedIssueLabelPropagationConfig(value: string): RepositorySettings["linkedIssueLabelPropagation"] {
-  return normalizeLinkedIssueLabelPropagationConfig(parseJson<unknown>(value, null), []);
-}
-
 function parseContributorBlacklist(value: string): RepositorySettings["contributorBlacklist"] {
   return normalizeContributorBlacklist(parseJson<unknown>(value, null)).entries;
 }
@@ -7836,30 +7807,8 @@ function normalizeReviewNagPolicy(value: string | null | undefined): "off" | "ho
   return value === "hold" || value === "close" ? value : "off";
 }
 
-// Review-evasion protection (#review-evasion-protection): binary off|close, mirroring reviewNagPolicy's
-// shape minus the "hold" tier (an evasion attempt is always re-closed as the App when enabled, never merely
-// held -- there is no partial-enforcement mode).
-//
-// #4011: default-ON, the deliberate exception to every other field in this file defaulting conservatively
-// (off/false/advisory). A repo that hasn't discovered and explicitly set this field got ZERO self-close/
-// draft-dodge/repeated-cycling protection under the old "off" default -- a real, already-exploited gaming
-// vector (see loopover-ai-review-repeat-spend-and-draft-gaming-fix). Any value other than the explicit
-// opt-out "off" (including undefined/garbage) now resolves to "close": protected unless a repo deliberately
-// turns it off, not unprotected unless a repo discovers and turns it on. This is the ONLY reachable default
-// for this field -- the raw schema.ts column-level DEFAULT and the SQLite DDL default are never reached by
-// any live write path (upsertRepositorySettings always resolves and supplies an explicit value through this
-// exact function; see migration 0102's doc comment for the same lesson learned on a sibling field), so
-// changing them would have zero effect and was deliberately left alone.
-function normalizeReviewEvasionProtection(value: string | null | undefined): "off" | "close" {
-  return value === "off" ? "off" : "close";
-}
-
 function normalizeDraftPrClosePolicy(value: string | null | undefined): "off" | "close" {
   return value === "close" ? "close" : "off";
-}
-
-function normalizeMergeTrainMode(value: string | null | undefined): "off" | "audit" | "enforce" {
-  return value === "audit" || value === "enforce" ? value : "off";
 }
 
 // Config-driven before/after screenshot-table gate (#2006): the row stores whenLabels/whenPaths as JSON string
@@ -7892,21 +7841,8 @@ function normalizeCommandRateLimitPolicy(value: string | null | undefined): "off
   return value === "hold" ? value : "off";
 }
 
-function normalizeModerationGateMode(value: string | null | undefined): "inherit" | "off" | "enabled" {
-  return value === "off" || value === "enabled" ? value : "inherit";
-}
-
 function normalizeSkipAutomationBotAuthors(value: string | null | undefined): "inherit" | "off" | "enabled" {
   return value === "off" || value === "enabled" ? value : "inherit";
-}
-
-// NULL means "inherit the global rule set" (undefined), distinct from a normalized-but-empty list -- a repo
-// that explicitly configured an empty moderationRules override (opting every rule out) must stay empty, not
-// be coerced back to "inherit". Mirrors parseContributorBlacklist/parseAutoCloseExemptLogins's JSON-parse
-// shape, except the column itself (not just malformed JSON) can be genuinely absent.
-function parseModerationRulesColumn(value: string | null | undefined): RepositorySettings["moderationRules"] {
-  if (value === null || value === undefined) return undefined;
-  return normalizeModerationRules(parseJson<unknown>(value, null)).rules;
 }
 
 // A review-nag threshold/window is a discrete positive count, not a score — reuses the same non-clamping,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -89,25 +89,10 @@ export const repositorySettings = sqliteTable("repository_settings", {
   aiReviewLowConfidenceDisposition: text("ai_review_low_confidence_disposition").notNull().default("hold_for_review"),
   closeOwnerAuthors: integer("close_owner_authors", { mode: "boolean" }).notNull().default(false),
   autoLabelEnabled: integer("auto_label_enabled", { mode: "boolean" }).notNull().default(true),
-  gittensorLabel: text("gittensor_label").notNull().default("gittensor"),
-  // Label applied to a blacklisted contributor's PR/issue (#1425); configurable so the disposition works
-  // regardless of the label a repo uses.
-  blacklistLabel: text("blacklist_label").notNull().default("slop"),
-  createMissingLabel: integer("create_missing_label", { mode: "boolean" }).notNull().default(true),
-  // #label-decoupling: independently gates the per-PR TYPE label (gittensor:bug/feature/priority),
-  // distinct from autoLabelEnabled (the base gittensor context label) and the public-surface gate.
-  typeLabelsEnabled: integer("type_labels_enabled", { mode: "boolean" }).notNull().default(true),
-  // Per-repo override of the three TYPE label NAMES (#priority-linked-issue-gate): { bug, feature, priority }.
-  typeLabelsJson: text("type_labels_json").notNull().default("{}"),
-  // Linked-issue label propagation (#priority-linked-issue-gate): the only mechanism that can select the
-  // configured priority label -- never inferred from title/files/AI/PR-labels. Default disabled, no mappings.
-  linkedIssueLabelPropagationJson: text("linked_issue_label_propagation_json").notNull().default("{}"),
   requireLinkedIssue: integer("require_linked_issue", { mode: "boolean" }).notNull().default(false),
   badgeEnabled: integer("badge_enabled", { mode: "boolean" }).notNull().default(false),
   publicQualityMetrics: integer("public_quality_metrics", { mode: "boolean" }).notNull().default(false),
   commandAuthorizationJson: text("command_authorization_json").notNull().default("{}"),
-  // Per-repo contributor blacklist (#1425): a JSON array of { login, reason?, evidence?, addedAt? } entries.
-  contributorBlacklistJson: text("contributor_blacklist_json").notNull().default("[]"),
   autonomyJson: text("autonomy_json").notNull().default("{}"),
   autoMaintainJson: text("auto_maintain_json").notNull().default("{}"),
   agentPaused: integer("agent_paused", { mode: "boolean" }).notNull().default(false),
@@ -144,34 +129,10 @@ export const repositorySettings = sqliteTable("repository_settings", {
   commandRateLimitMaxPerWindow: integer("command_rate_limit_max_per_window").notNull().default(20),
   commandRateLimitAiMaxPerWindow: integer("command_rate_limit_ai_max_per_window").notNull().default(5),
   commandRateLimitWindowHours: integer("command_rate_limit_window_hours").notNull().default(24),
-  // Moderation-rules engine (#selfhost-mod-engine): per-repo overrides layered over global_moderation_config.
-  // 'inherit' (default) defers to the global master switch; 'off'/'enabled' force this repo regardless of it.
-  moderationGateMode: text("moderation_gate_mode").notNull().default("inherit"),
-  // Nullable: null = inherit the global rule set / label text, never "unset to empty".
-  moderationRulesJson: text("moderation_rules_json"),
-  moderationWarningLabel: text("moderation_warning_label"),
-  moderationBannedLabel: text("moderation_banned_label"),
-  // Review-evasion protection (#review-evasion-protection). reviewEvasionLabel mirrors blacklistLabel/
-  // reviewNagLabel's shape -- NOT NULL with a string default; "no label" is a `.loopover.yml`-only
-  // override, never persisted here.
-  //
-  // #4011: this raw column-level DEFAULT ('off') is intentionally left unchanged even though the actual
-  // resolved default is now 'close' (protection ON) -- upsertRepositorySettings is the ONLY writer and
-  // always resolves an explicit value through normalizeReviewEvasionProtection (its own doc comment has
-  // the full reasoning), so this raw default never fires through any live write path. Rebuilding it would
-  // need a full create-copy-drop-rename table migration for zero behavioral effect (SQLite has no ALTER
-  // COLUMN SET DEFAULT) -- see migration 0102's doc comment for the identical lesson already learned on
-  // linked_issue_gate_mode. Don't "fix" this value without re-reading that reasoning first.
-  reviewEvasionProtection: text("review_evasion_protection").notNull().default("off"),
-  reviewEvasionLabel: text("review_evasion_label").notNull().default("review-evasion"),
-  reviewEvasionComment: integer("review_evasion_comment", { mode: "boolean" }).notNull().default(true),
-  // Draft-PR close policy (#draft-pr-close-policy): off by default -- unlike reviewEvasionProtection above,
-  // this enforces on ANY draft (including the first one, before a review has run), so a maintainer opts in
-  // deliberately rather than getting it on by default.
+  // Draft-PR close policy (#draft-pr-close-policy): off by default -- enforces on ANY draft (including the
+  // first one, before a review has run), so a maintainer opts in deliberately rather than getting it on by
+  // default.
   draftPrClosePolicy: text("draft_pr_close_policy").notNull().default("off"),
-  // Merge-train FIFO gate (#selfhost-merge-train): off by default, same "opt-in, no surprise behavior change"
-  // shape as reviewEvasionProtection above.
-  mergeTrainMode: text("merge_train_mode").notNull().default("off"),
   // Config-driven before/after screenshot-table gate (#2006): off by default. whenLabels/whenPaths are JSON
   // string arrays (mirrors contributorBlacklistJson's shape); screenshotTableGateMessage is nullable ("no
   // override" is a `.loopover.yml`-only concept -- null here means "use the built-in default message").

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8042,9 +8042,9 @@ async function maybePublishPrPublicSurface(
       try {
         // Same reasoning as `typeLabelsEnabled` above: `settings.typeLabels` is optional only for
         // RepositorySettings-fixture-construction backward compat -- getRepositorySettings always
-        // resolves it to a concrete, complete PrTypeLabelSet (parseTypeLabelSet never returns
-        // undefined), so the `?? DEFAULT_TYPE_LABELS` fallback is unreachable on this webhook-
-        // integration path.
+        // resolves it to a concrete, complete PrTypeLabelSet (config-as-code only as of #6443 --
+        // hardcoded to DEFAULT_TYPE_LABELS, never undefined), so the `?? DEFAULT_TYPE_LABELS` fallback
+        // is unreachable on this webhook-integration path.
         /* v8 ignore next -- see the comment above */
         const typeLabels = settings.typeLabels ?? DEFAULT_TYPE_LABELS;
         const propagation = settings.linkedIssueLabelPropagation;
@@ -8123,8 +8123,10 @@ async function maybePublishPrPublicSurface(
             targetKey: `${repoFullName}#${pr.number}`,
             outcome: "completed",
             // `|| "none"` is unreachable: resolvePrTypeLabel's "title" source always resolves a non-empty
-            // label (deriveKindFromTitle only ever returns "bug"/"feature", and parseTypeLabelSet always
-            // falls back a built-in category to its default rather than an empty string), and its
+            // label (deriveKindFromTitle only ever returns "bug"/"feature", and a built-in category always
+            // falls back to its default rather than an empty string -- either DEFAULT_TYPE_LABELS directly
+            // for the config-as-code-only DB base (#6443), or normalizeTypeLabelSet's own fallback for a
+            // manifest override), and its
             // propagation sources only ever use a mapping's `prLabel`, which normalizeMapping drops
             // entirely when empty -- applyLabels can never be [] here.
             /* v8 ignore next */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1247,8 +1247,10 @@ export type RepositorySettings = {
   plannerMode?: "inherit" | "off" | "enabled" | undefined;
   /** Review-evasion protection (#review-evasion-protection): a contributor closing or converting their OWN
    *  PR to draft while loopover has an ACTIVE review pass running against it is dodging the one-shot
-   *  review process. The effective default is `"close"` as of #4011 (see `normalizeReviewEvasionProtection`
-   *  in `db/repositories.ts`) -- `"off"` is now an explicit opt-out, not the default. `"close"` reopens (if
+   *  review process. The effective default is `"close"` as of #4011 (config-as-code only as of #6443 --
+   *  `db/repositories.ts`'s `getRepositorySettings`/`upsertRepositorySettings` always resolve this hardcoded
+   *  default now; only `.loopover.yml`'s `settings.reviewEvasionProtection` can override it) -- `"off"` is
+   *  now an explicit opt-out, not the default. `"close"` reopens (if
    *  needed) and re-closes as the App -- a close the contributor cannot themselves reopen (#one-shot-reopen)
    *  -- applies the configured label/comment, and records a `review_evasion` moderation strike. Note:
    *  `"off"` only suppresses this ENFORCEMENT -- the ready&harr;draft cycling COUNTER (`processors.ts`'s

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2624,7 +2624,9 @@ describe("api routes", () => {
         // have. slopGateMode: "block" is a DIFFERENT, legitimately-blockable dimension and is left untouched.
         // #4618/#5373: gateCheckMode is an unknown key with no effect here (removed from RepositorySettings
         // entirely) -- included to confirm it is silently ignored, not to drive reviewCheckMode.
-        body: JSON.stringify({ gateCheckMode: "enabled", reviewCheckMode: "required", slopGateMode: "block", slopGateMinScore: 55, qualityGateMode: "block", mergeTrainMode: "enforce", autonomy: { merge: "auto_with_approval", deploy: "auto" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" }, agentPaused: true, agentDryRun: true }),
+        // mergeTrainMode moved off the DB entirely (Batch B, loopover#6443) -- no longer a writable key on this
+        // route, config-as-code only via .loopover.yml now.
+        body: JSON.stringify({ gateCheckMode: "enabled", reviewCheckMode: "required", slopGateMode: "block", slopGateMinScore: 55, qualityGateMode: "block", autonomy: { merge: "auto_with_approval", deploy: "auto" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" }, agentPaused: true, agentDryRun: true }),
       },
       ownerEnv,
     );
@@ -2634,7 +2636,6 @@ describe("api routes", () => {
       slopGateMode: "block",
       slopGateMinScore: 55,
       qualityGateMode: "advisory", // #2267: downgraded, not persisted as "block"
-      mergeTrainMode: "enforce",
       autonomy: { merge: "auto_with_approval" }, // unknown action class dropped by the DB normalizer
       autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" },
       agentPaused: true, // #776 kill-switch
@@ -6060,15 +6061,12 @@ describe("api routes", () => {
       repoFullName: "entrius/allways-ui",
       requireLinkedIssue: true,
       autoLabelEnabled: false,
-      createMissingLabel: false,
-      gittensorLabel: "gittensor-miner",
     });
-    // publicSurface moved off the DB entirely (Batch A, loopover#6442) -- set via manifest injection instead.
-    // createMissingLabel/gittensorLabel stay DB-injected here: buildRegistrationReadinessResponse's
-    // applyConfigAsCodeOnlyFields only overlays the effective value for Batch A's 9 fields (#6442) -- every
-    // other field, including these two, is intentionally the RAW DB value (the #2912 raw-vs-manifest
-    // comparison design), so a manifest override here would NOT show up in this response.
-    await upsertRepoFocusManifest(env, "entrius/allways-ui", { settings: { publicSurface: "off" } });
+    // publicSurface (Batch A, loopover#6442) and createMissingLabel/gittensorLabel (Batch B, loopover#6443)
+    // all moved off the DB entirely -- set via manifest injection instead. buildRegistrationReadinessResponse's
+    // applyConfigAsCodeOnlyFields overlays the effective value for both batches' fields, so only a manifest
+    // override (not a DB write) shows up in this response for any of them now.
+    await upsertRepoFocusManifest(env, "entrius/allways-ui", { settings: { publicSurface: "off", createMissingLabel: false, gittensorLabel: "gittensor-miner" } });
     const directReadiness = await app.request("/v1/repos/entrius/allways-ui/registration-readiness", { headers: apiHeaders(env) }, env);
     expect(directReadiness.status).toBe(200);
     await expect(directReadiness.json()).resolves.toMatchObject({
@@ -6083,7 +6081,9 @@ describe("api routes", () => {
       maintainerNotes: [
         "Private reviewability note with wallet, hotkey, raw trust, and farming details.",
       ],
-      settings: { publicSurface: "off" },
+      // upsertRepoFocusManifest replaces the stored manifest wholesale, so gittensorLabel needs repeating here
+      // -- the gittensor-config-recommendation check further below (confirmedMinerLabel) still depends on it.
+      settings: { publicSurface: "off", gittensorLabel: "gittensor-miner" },
     });
     const policyReadiness = await app.request("/v1/repos/entrius/allways-ui/registration-readiness", { headers: apiHeaders(env) }, env);
     expect(policyReadiness.status).toBe(200);

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -1185,14 +1185,13 @@ describe("api route guards and error branches", () => {
         headers: internalHeaders(env),
         body: JSON.stringify({
           gatePack: "oss-anti-slop",
-          createMissingLabel: false,
           badgeEnabled: true,
         }),
       },
       env,
     );
     expect(updated.status).toBe(200);
-    await expect(updated.json()).resolves.toMatchObject({ gatePack: "oss-anti-slop", createMissingLabel: false, badgeEnabled: true });
+    await expect(updated.json()).resolves.toMatchObject({ gatePack: "oss-anti-slop", badgeEnabled: true });
   });
 
   it("exposes and clears self-tune overrides for operators, rejecting unauthorized callers (#6168)", async () => {

--- a/test/unit/contributor-blacklist.test.ts
+++ b/test/unit/contributor-blacklist.test.ts
@@ -1,14 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { findBlacklistEntry, isAuthorBlacklisted, mergeContributorBlacklists, normalizeContributorBlacklist } from "../../src/settings/contributor-blacklist";
 import { getGlobalContributorBlacklist, getRepositorySettings, upsertGlobalContributorBlacklist, upsertRepositorySettings } from "../../src/db/repositories";
+import { resolveRepositorySettings } from "../../src/settings/repository-settings";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 import type { ContributorBlacklistEntry } from "../../src/types";
 
-describe("contributor blacklist DB round-trip (#1425)", () => {
-  it("persists + resolves the per-repo blacklist through the DB, dropping invalid entries", async () => {
+describe("per-repo contributor blacklist config-as-code (#1425, Batch B loopover#6443)", () => {
+  it("getRepositorySettings ignores a caller-supplied override on upsert -- moved off the DB entirely, config-as-code only via .loopover.yml now", async () => {
     const env = createTestEnv();
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", contributorBlacklist: [{ login: "plagiarist", reason: "plagiarism" }, { login: "-invalid" }, { login: "farmer" }] });
     const settings = await getRepositorySettings(env, "owner/repo");
+    expect(settings.contributorBlacklist).toEqual([]);
+  });
+
+  it("resolveRepositorySettings honors an explicit per-repo blacklist from .loopover.yml's settings: block, dropping invalid entries", async () => {
+    const env = createTestEnv();
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
+    await upsertRepoFocusManifest(env, "owner/repo", {
+      settings: { contributorBlacklist: [{ login: "plagiarist", reason: "plagiarism" }, { login: "-invalid" }, { login: "farmer" }] },
+    });
+    const settings = await resolveRepositorySettings(env, "owner/repo");
     expect(settings.contributorBlacklist?.map((e) => e.login)).toEqual(["plagiarist", "farmer"]);
     expect(settings.contributorBlacklist?.[0]).toEqual({ login: "plagiarist", reason: "plagiarism" });
   });

--- a/test/unit/moderation-config-db.test.ts
+++ b/test/unit/moderation-config-db.test.ts
@@ -8,7 +8,10 @@ import {
   upsertGlobalModerationConfig,
   upsertRepositorySettings,
 } from "../../src/db/repositories";
+import { resolveRepositorySettings } from "../../src/settings/repository-settings";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
+import { DEFAULT_REVIEW_EVASION_LABEL } from "../../src/settings/agent-actions";
 import { DEFAULT_GLOBAL_MODERATION_CONFIG, MAX_MODERATION_VIOLATION_DECAY_DAYS, MODERATION_VIOLATION_EVENT_TYPE } from "../../src/settings/moderation-rules";
 
 describe("global moderation config DB round-trip (#selfhost-mod-engine)", () => {
@@ -187,7 +190,7 @@ describe("moderation violation ledger (#selfhost-mod-engine)", () => {
   });
 });
 
-describe("per-repo moderation settings DB round-trip (#selfhost-mod-engine)", () => {
+describe("per-repo moderation settings config-as-code (#selfhost-mod-engine, Batch B loopover#6443)", () => {
   it("defaults to 'inherit' gate mode and undefined overrides for an unconfigured repo", async () => {
     const settings = await getRepositorySettings(createTestEnv(), "owner/none");
     expect(settings.moderationGateMode).toBe("inherit");
@@ -196,7 +199,7 @@ describe("per-repo moderation settings DB round-trip (#selfhost-mod-engine)", ()
     expect(settings.moderationBannedLabel).toBeUndefined();
   });
 
-  it("persists an explicit gate mode + rule override + custom labels", async () => {
+  it("getRepositorySettings ignores a caller-supplied override on upsert -- these fields moved off the DB entirely, config-as-code only via .loopover.yml now", async () => {
     const env = createTestEnv();
     await upsertRepositorySettings(env, {
       repoFullName: "owner/repo",
@@ -206,87 +209,90 @@ describe("per-repo moderation settings DB round-trip (#selfhost-mod-engine)", ()
       moderationBannedLabel: "repo:ban",
     });
     const settings = await getRepositorySettings(env, "owner/repo");
+    expect(settings.moderationGateMode).toBe("inherit");
+    expect(settings.moderationRules).toBeUndefined();
+    expect(settings.moderationWarningLabel).toBeUndefined();
+    expect(settings.moderationBannedLabel).toBeUndefined();
+  });
+
+  it("resolveRepositorySettings honors an explicit gate mode + rule override + custom labels from .loopover.yml's settings: block", async () => {
+    const env = createTestEnv();
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
+    await upsertRepoFocusManifest(env, "owner/repo", {
+      settings: {
+        moderationGateMode: "enabled",
+        moderationRules: ["blacklist"],
+        moderationWarningLabel: "repo:warn",
+        moderationBannedLabel: "repo:ban",
+      },
+    });
+    const settings = await resolveRepositorySettings(env, "owner/repo");
     expect(settings.moderationGateMode).toBe("enabled");
     expect(settings.moderationRules).toEqual(["blacklist"]);
     expect(settings.moderationWarningLabel).toBe("repo:warn");
     expect(settings.moderationBannedLabel).toBe("repo:ban");
   });
 
-  it("persists an explicit EMPTY moderationRules override distinctly from 'not configured' (undefined)", async () => {
+  it("resolveRepositorySettings honors an explicit EMPTY moderationRules override distinctly from 'not configured' (undefined)", async () => {
     const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", moderationRules: [] });
-    const settings = await getRepositorySettings(env, "owner/repo");
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { moderationRules: [] } });
+    const settings = await resolveRepositorySettings(env, "owner/repo");
     expect(settings.moderationRules).toEqual([]);
-  });
-
-  it("round-trips through an UPDATE (not just the initial INSERT)", async () => {
-    const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", moderationGateMode: "off" });
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", moderationGateMode: "enabled", moderationWarningLabel: "updated:warn" });
-    const settings = await getRepositorySettings(env, "owner/repo");
-    expect(settings.moderationGateMode).toBe("enabled");
-    expect(settings.moderationWarningLabel).toBe("updated:warn");
   });
 
   it("moderationRules accepts review_evasion alongside the original three (#review-evasion-protection)", async () => {
     const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", moderationRules: ["review_evasion", "blacklist"] });
-    const settings = await getRepositorySettings(env, "owner/repo");
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { moderationRules: ["review_evasion", "blacklist"] } });
+    const settings = await resolveRepositorySettings(env, "owner/repo");
     expect(settings.moderationRules).toEqual(["review_evasion", "blacklist"]);
   });
 });
 
-describe("per-repo review-evasion protection settings DB round-trip (#review-evasion-protection)", () => {
+describe("per-repo review-evasion protection settings config-as-code (#review-evasion-protection, Batch B loopover#6443)", () => {
   it("defaults to close/review-evasion/true for an unconfigured repo (#4011: default-ON)", async () => {
     const settings = await getRepositorySettings(createTestEnv(), "owner/none");
     expect(settings.reviewEvasionProtection).toBe("close");
-    expect(settings.reviewEvasionLabel).toBe("review-evasion");
+    expect(settings.reviewEvasionLabel).toBe(DEFAULT_REVIEW_EVASION_LABEL);
     expect(settings.reviewEvasionComment).toBe(true);
   });
 
-  it("persists an explicit protection mode + custom label + comment toggle", async () => {
+  it("getRepositorySettings ignores a caller-supplied override on upsert -- these fields moved off the DB entirely, config-as-code only via .loopover.yml now", async () => {
     const env = createTestEnv();
     await upsertRepositorySettings(env, {
       repoFullName: "owner/repo",
-      reviewEvasionProtection: "close",
+      reviewEvasionProtection: "off",
       reviewEvasionLabel: "repo:evasion",
       reviewEvasionComment: false,
     });
     const settings = await getRepositorySettings(env, "owner/repo");
     expect(settings.reviewEvasionProtection).toBe("close");
+    expect(settings.reviewEvasionLabel).toBe(DEFAULT_REVIEW_EVASION_LABEL);
+    expect(settings.reviewEvasionComment).toBe(true);
+  });
+
+  it("resolveRepositorySettings honors an explicit protection mode + custom label + comment toggle from .loopover.yml's settings: block", async () => {
+    const env = createTestEnv();
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
+    await upsertRepoFocusManifest(env, "owner/repo", {
+      settings: {
+        reviewEvasionProtection: "close",
+        reviewEvasionLabel: "repo:evasion",
+        reviewEvasionComment: false,
+      },
+    });
+    const settings = await resolveRepositorySettings(env, "owner/repo");
+    expect(settings.reviewEvasionProtection).toBe("close");
     expect(settings.reviewEvasionLabel).toBe("repo:evasion");
     expect(settings.reviewEvasionComment).toBe(false);
   });
 
-  it("an explicit null label falls back to the default (#label-scoping: the DB column has no true-null state, mirroring blacklistLabel)", async () => {
-    const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", reviewEvasionLabel: null });
-    const settings = await getRepositorySettings(env, "owner/repo");
-    expect(settings.reviewEvasionLabel).toBe("review-evasion");
-  });
-
-  it("round-trips through an UPDATE (not just the initial INSERT)", async () => {
-    const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", reviewEvasionProtection: "off" });
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", reviewEvasionProtection: "close", reviewEvasionComment: false });
-    const settings = await getRepositorySettings(env, "owner/repo");
-    expect(settings.reviewEvasionProtection).toBe("close");
-    expect(settings.reviewEvasionComment).toBe(false);
-  });
-
-  it("a malformed raw DB value for review_evasion_protection normalizes to 'close' on read (#4011: only the explicit opt-out 'off' is honored; anything else, including a bypassed-validation bogus value, fails safe to protected)", async () => {
+  it("the explicit opt-out 'off' is honored via the manifest overlay (#4011)", async () => {
     const env = createTestEnv();
     await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
-    await env.DB.prepare("UPDATE repository_settings SET review_evasion_protection = 'bogus' WHERE repo_full_name = ?").bind("owner/repo").run();
-    const settings = await getRepositorySettings(env, "owner/repo");
-    expect(settings.reviewEvasionProtection).toBe("close");
-  });
-
-  it("the explicit opt-out 'off' is honored on read even after a direct SQL write (#4011)", async () => {
-    const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo" });
-    await env.DB.prepare("UPDATE repository_settings SET review_evasion_protection = 'off' WHERE repo_full_name = ?").bind("owner/repo").run();
-    const settings = await getRepositorySettings(env, "owner/repo");
+    await upsertRepoFocusManifest(env, "owner/repo", { settings: { reviewEvasionProtection: "off" } });
+    const settings = await resolveRepositorySettings(env, "owner/repo");
     expect(settings.reviewEvasionProtection).toBe("off");
   });
 });

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -1783,10 +1783,11 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       },
       repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
     });
-    // reviewEvasionProtection is manifest-only now (Batch B, loopover#6443); pull any test override out of
-    // `overrides` before it reaches the DB write below so a per-test `{ reviewEvasionProtection: "off" }` still
-    // takes effect via the manifest overlay instead of being silently outranked by the "close" default.
-    const { reviewEvasionProtection, ...dbOverrides } = overrides;
+    // reviewEvasionProtection/reviewEvasionComment are manifest-only now (Batch B, loopover#6443); pull any
+    // test override out of `overrides` before it reaches the DB write below so a per-test
+    // `{ reviewEvasionProtection: "off" }`/`{ reviewEvasionComment: false }` still takes effect via the
+    // manifest overlay instead of being silently outranked by the hardcoded default.
+    const { reviewEvasionProtection, reviewEvasionComment, ...dbOverrides } = overrides;
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autonomy: { close: "auto" },
@@ -1799,6 +1800,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         commentMode: "off",
         checkRunMode: "off",
         reviewEvasionProtection: (reviewEvasionProtection as "off" | "close" | undefined) ?? "close",
+        ...(reviewEvasionComment !== undefined ? { reviewEvasionComment: reviewEvasionComment as boolean } : {}),
       },
     });
   }

--- a/test/unit/repo-identity-rename.test.ts
+++ b/test/unit/repo-identity-rename.test.ts
@@ -97,21 +97,24 @@ describe("renameRepositoryIdentity", () => {
     // these assert on the raw row directly to distinguish "no row" / "renamed row" / "folded row".
     it("renames the settings row's repo_full_name", async () => {
       const env = createTestEnv();
-      await upsertRepositorySettings(env, { repoFullName: OLD, gittensorLabel: "marker-old" });
+      // #6443: gittensorLabel is about to leave the DB too (config-as-code only via .loopover.yml now) --
+      // autoLabelEnabled is a core dashboard-editable field with no config-as-code migration plans, so it's
+      // a stable distinguishing marker that won't need updating again by a future migration in this epic.
+      await upsertRepositorySettings(env, { repoFullName: OLD, autoLabelEnabled: false });
       await renameRepositoryIdentity(env, OLD, NEW);
       const oldRow = await env.DB.prepare("select count(*) as n from repository_settings where repo_full_name = ?").bind(OLD).first<{ n: number }>();
       expect(oldRow?.n).toBe(0);
       const settings = await getRepositorySettings(env, NEW);
-      expect(settings.gittensorLabel).toBe("marker-old");
+      expect(settings.autoLabelEnabled).toBe(false);
     });
 
     it("REGRESSION (#repo-rename-migration): folds away a stray new-name settings row, keeping the pre-existing configured settings", async () => {
       const env = createTestEnv();
-      await upsertRepositorySettings(env, { repoFullName: OLD, gittensorLabel: "marker-configured" });
-      await upsertRepositorySettings(env, { repoFullName: NEW, gittensorLabel: "marker-stray" }); // stray, should be discarded
+      await upsertRepositorySettings(env, { repoFullName: OLD, autoLabelEnabled: false });
+      await upsertRepositorySettings(env, { repoFullName: NEW, autoLabelEnabled: true }); // stray, should be discarded
       await renameRepositoryIdentity(env, OLD, NEW);
       const settings = await getRepositorySettings(env, NEW);
-      expect(settings.gittensorLabel).toBe("marker-configured");
+      expect(settings.autoLabelEnabled).toBe(false);
       const newRowCount = await env.DB.prepare("select count(*) as n from repository_settings where repo_full_name = ?").bind(NEW).first<{ n: number }>();
       expect(newRowCount?.n).toBe(1); // exactly one surviving row, not two
     });

--- a/test/unit/repository-settings-merge-train-mode.test.ts
+++ b/test/unit/repository-settings-merge-train-mode.test.ts
@@ -1,54 +1,41 @@
 import { describe, expect, it } from "vitest";
 import { getRepositorySettings, upsertRepositorySettings } from "../../src/db/repositories";
+import { resolveRepositorySettings } from "../../src/settings/repository-settings";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
-// #selfhost-merge-train: mergeTrainMode ("off" | "audit" | "enforce") was added to the schema/type/openapi
-// layer but the INSERT and UPDATE column lists in upsertRepositorySettings never actually included it -- the
-// resolved value was computed correctly but silently never written, so setting it via the settings API/
-// dashboard (or any upsertRepositorySettings caller) was completely inert; the column stayed at its SQL
-// DEFAULT 'off' forever, on both a brand-new row (INSERT) and an existing one (UPDATE via onConflictDoUpdate).
-// Caught only by an integration-level merge-train test wired through the settings-resolution path, not by
-// the pure decision function's own unit tests (merge-train.test.ts), which never touch the DB at all.
-describe("repository_settings: mergeTrainMode persistence (#selfhost-merge-train)", () => {
+// #selfhost-merge-train: mergeTrainMode ("off" | "audit" | "enforce") moved off the DB entirely (Batch B,
+// config-as-code migration, loopover#6443) -- it's config-as-code only via .loopover.yml's settings: block
+// now. getRepositorySettings always resolves the conservative "off" default regardless of any DB write
+// (upsertRepositorySettings silently ignores a caller-supplied mergeTrainMode, and there is no longer a
+// column for a direct SQL write to land in); resolveRepositorySettings is the only path that honors an
+// explicit per-repo override, via the manifest overlay.
+describe("repository_settings: mergeTrainMode config-as-code (#selfhost-merge-train)", () => {
   it("getRepositorySettings returns off for a repo with no DB row at all (conservative default)", async () => {
     const env = createTestEnv();
     const settings = await getRepositorySettings(env, "acme/brand-new-repo");
     expect(settings.mergeTrainMode).toBe("off");
   });
 
-  it("REGRESSION: an explicit mergeTrainMode persists on the FIRST upsert (INSERT path)", async () => {
+  it("getRepositorySettings ignores a caller-supplied mergeTrainMode on upsert -- always off (no DB column to persist it in)", async () => {
     const env = createTestEnv();
     await upsertRepositorySettings(env, { repoFullName: "acme/fresh-insert", mergeTrainMode: "enforce" });
     const settings = await getRepositorySettings(env, "acme/fresh-insert");
+    expect(settings.mergeTrainMode).toBe("off");
+  });
+
+  it("resolveRepositorySettings honors an explicit mergeTrainMode from .loopover.yml's settings: block", async () => {
+    const env = createTestEnv();
+    await upsertRepositorySettings(env, { repoFullName: "acme/manifest-driven" });
+    await upsertRepoFocusManifest(env, "acme/manifest-driven", { settings: { mergeTrainMode: "enforce" } });
+    const settings = await resolveRepositorySettings(env, "acme/manifest-driven");
     expect(settings.mergeTrainMode).toBe("enforce");
   });
 
-  it("REGRESSION: an explicit mergeTrainMode persists on a SECOND upsert of an already-existing row (UPDATE path)", async () => {
+  it("resolveRepositorySettings falls back to off when no manifest override is present", async () => {
     const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "acme/existing-row" });
-    const before = await getRepositorySettings(env, "acme/existing-row");
-    expect(before.mergeTrainMode).toBe("off");
-
-    await upsertRepositorySettings(env, { repoFullName: "acme/existing-row", mergeTrainMode: "audit" });
-    const after = await getRepositorySettings(env, "acme/existing-row");
-    expect(after.mergeTrainMode).toBe("audit");
-  });
-
-  it("a true read-modify-write caller (spread current settings, then re-upsert) carries mergeTrainMode forward explicitly", async () => {
-    const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "acme/round-trip", mergeTrainMode: "enforce" });
-    const settings = await getRepositorySettings(env, "acme/round-trip");
-    expect(settings.mergeTrainMode).toBe("enforce");
-    await upsertRepositorySettings(env, { ...settings, repoFullName: "acme/round-trip" });
-    const after = await getRepositorySettings(env, "acme/round-trip");
-    expect(after.mergeTrainMode).toBe("enforce");
-  });
-
-  it("an invalid persisted DB value fails closed to off on read", async () => {
-    const env = createTestEnv();
-    await upsertRepositorySettings(env, { repoFullName: "acme/malformed" });
-    await env.DB.prepare("UPDATE repository_settings SET merge_train_mode = ? WHERE repo_full_name = ?").bind("sometimes", "acme/malformed").run();
-    const settings = await getRepositorySettings(env, "acme/malformed");
+    await upsertRepositorySettings(env, { repoFullName: "acme/no-manifest" });
+    const settings = await resolveRepositorySettings(env, "acme/no-manifest");
     expect(settings.mergeTrainMode).toBe("off");
   });
 });

--- a/test/unit/routes-ai-byok.test.ts
+++ b/test/unit/routes-ai-byok.test.ts
@@ -32,7 +32,7 @@ describe("maintainer AI-review config route", () => {
   it("sets mode/byok/provider/model and preserves unrelated settings", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
-    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", gittensorLabel: "custom-label", blacklistLabel: "abuse" });
+    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", autoLabelEnabled: false });
     const res = await app.request(
       `/v1/repos/${REPO}/ai-review`,
       { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ mode: "block", byok: true, provider: "anthropic", model: "claude-3-5-sonnet-latest", allAuthors: true, closeOwnerAuthors: true }) },
@@ -45,8 +45,7 @@ describe("maintainer AI-review config route", () => {
     expect(settings.aiReviewAllAuthors).toBe(true); // persisted + read back (DB column round-trip)
     expect(settings.closeOwnerAuthors).toBe(true); // persisted + read back (DB column round-trip)
     expect(settings.reviewCheckMode).toBe("required"); // preserved
-    expect(settings.gittensorLabel).toBe("custom-label"); // preserved
-    expect(settings.blacklistLabel).toBe("abuse"); // #1425 round-trips through the DB
+    expect(settings.autoLabelEnabled).toBe(false); // preserved
   });
 
   it("defaults closeOwnerAuthors off when the AI-review config omits it", async () => {
@@ -96,7 +95,7 @@ describe("maintainer AI-review config route", () => {
   it("sets aiReviewLowConfidenceDisposition (#4603) and preserves unrelated settings", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
-    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", gittensorLabel: "custom-label" });
+    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", autoLabelEnabled: false });
     const res = await app.request(
       `/v1/repos/${REPO}/ai-review`,
       { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ mode: "block", byok: false, lowConfidenceDisposition: "advisory_only" }) },
@@ -107,7 +106,7 @@ describe("maintainer AI-review config route", () => {
     const settings = await getRepositorySettings(env, REPO);
     expect(settings.aiReviewLowConfidenceDisposition).toBe("advisory_only"); // persisted + read back (DB column round-trip)
     expect(settings.reviewCheckMode).toBe("required"); // preserved
-    expect(settings.gittensorLabel).toBe("custom-label"); // preserved
+    expect(settings.autoLabelEnabled).toBe(false); // preserved
   });
 
   it("defaults aiReviewLowConfidenceDisposition to hold_for_review when the AI-review config omits it (fresh repo, no row)", async () => {
@@ -149,10 +148,10 @@ describe("maintainer AI-review config route", () => {
   it("lets maintainer settings set closeOwnerAuthors without resetting unrelated fields", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
-    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", gittensorLabel: "custom-label" });
+    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", autoLabelEnabled: false });
     const res = await app.request(`/v1/repos/${REPO}/settings`, { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ closeOwnerAuthors: true }) }, env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ closeOwnerAuthors: true, reviewCheckMode: "required", gittensorLabel: "custom-label" });
+    expect(await res.json()).toMatchObject({ closeOwnerAuthors: true, reviewCheckMode: "required", autoLabelEnabled: false });
     const settings = await getRepositorySettings(env, REPO);
     expect(settings.closeOwnerAuthors).toBe(true);
     expect(settings.reviewCheckMode).toBe("required");


### PR DESCRIPTION
## Summary

- Drops `gittensorLabel`, `blacklistLabel`, `createMissingLabel`, `typeLabelsEnabled`, `typeLabels`, `linkedIssueLabelPropagation`, `contributorBlacklist`, `moderationGateMode`, `moderationRules`, `moderationWarningLabel`, `moderationBannedLabel`, `reviewEvasionProtection`, `reviewEvasionLabel`, `reviewEvasionComment`, and `mergeTrainMode` from `repository_settings` (migration 0158) — all 15 already resolved correctly from `.loopover.yml`'s `settings:` block via `resolveEffectiveSettings`'s manifest overlay, making the DB column a redundant, never-authoritative second source of truth.
- `getRepositorySettings`/`upsertRepositorySettings` now treat these as fixed built-in defaults (a caller-supplied value on upsert is a silent no-op, matching Batch A's #6442 precedent); removes the 5 of the 15 that had a dashboard/internal-API write path (`gittensorLabel`, `blacklistLabel`, `createMissingLabel`, `contributorBlacklist`, `mergeTrainMode`) from `repositorySettingsSchema`/`maintainerSettingsSchema` and the maintainer settings panel.
- Extends `CONFIG_AS_CODE_ONLY_FIELDS` (previously Batch A's 9 fields only) to also cover these 15, so `buildRegistrationReadinessResponse`/`buildGittensorConfigRecommendationResponse` keep showing the real manifest-resolved value instead of the now-constant raw DB row — this was a genuine regression I caught and fixed during review, not part of the original plan.
- The sparse-merge composite fields (`typeLabels`, `linkedIssueLabelPropagation`) need no changes to `resolveEffectiveSettings`: their merge base just always resolves to the built-in default now instead of a possible stale DB customization.

Closes #6443, part of epic #6440.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused on the single DB-removal migration described in #6443; touches DB/schema/API/dashboard/tests together because they can't ship independently without breaking the gate.
- [x] Follows `CONTRIBUTING.md`.
- [x] Closes #6443 (open, assigned to the maintainer).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 100% patch coverage confirmed by hand-checking every added line in `src/api/routes.ts` and `src/db/repositories.ts` against `coverage/lcov.info` (zero 0-hit lines in the diff).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` — not run (no dependency changes in this PR).
- [x] New/changed behavior has tests: rewrote the DB-round-trip tests that this migration made obsolete (`moderation-config-db.test.ts`, `repository-settings-merge-train-mode.test.ts`, `contributor-blacklist.test.ts`) to instead verify (a) `getRepositorySettings` ignores a caller-supplied override and (b) `resolveRepositorySettings` honors a `.loopover.yml` manifest override — plus fixed the resulting fixture breakage across `routes-ai-byok.test.ts`, `repo-identity-rename.test.ts`, `queue-lifecycle-guards.test.ts`, `test/integration/api.test.ts`, `test/integration/routes-errors.test.ts`, and `gate-ramp-control.test.tsx`.

Full local `npm run test:ci` passed clean twice (once pre-rebase, once post-rebase onto the latest `main`).

## Safety

- [x] No secrets/wallet/hotkey/PAT/trust-score exposure.
- [x] Public GitHub text unaffected.
- [x] No auth/cookie/CORS/session changes.
- [x] OpenAPI verified unchanged (`ui:openapi:settings-parity`: RepositorySettingsSchema still matches the 111-field RepositorySettings type — only the DB source moved, the type didn't).
- [x] Dashboard change (removing the now-non-functional "Label name"/"Create label if missing" controls) uses live data, no mock fallback.
- N/A UI Evidence — maintainer-authored PR, per standing team convention the screenshot-table requirement doesn't bind owner PRs.
- [x] Docs updated (`tuning.mdx`'s "Other repo settings" intro corrected — it previously implied every field listed there was also dashboard-toggleable, which is no longer true for `gittensorLabel`/`createMissingLabel`/`typeLabelsEnabled`/`typeLabels`).

## Notes

- Rebased onto `main` mid-implementation after discovering active concurrent work in this exact area: PR #6585 (an outside contributor's independent attempt at this same issue, via Cursor) was auto-closed by LoopOver's own review bot because #6443 is maintainer-assigned — correct behavior, not a bug. Their implementation independently validated this approach and also caught that `badgeEnabled`/`publicQualityMetrics` are risky "still DB-backed" test markers right now (a separate in-flight branch is targeting them too); switched my test fixture markers to `autoLabelEnabled` to match their safer choice.
- Migration renumbered from 0159 to 0158 after rebasing past an unrelated upstream fix that closed a gap at 0157.