### PR TITLE
fix(ui): self-heal the Cloudflare Pages build's incomplete workspace install

### DIFF
--- a/apps/loopover-ui/package.json
+++ b/apps/loopover-ui/package.json
@@ -10,7 +10,7 @@
     "postinstall": "fumadocs-mdx",
     "dev": "vite dev",
     "build": "vite build",
-    "build:cloudflare": "npm --prefix ../.. run ui:build",
+    "build:cloudflare": "npm --prefix ../.. ci && npm --prefix ../.. run ui:build",
     "build:dev": "vite build --mode development",
     "bundle-analysis": "bundle-analyzer ./dist/client --bundle-name=loopover-ui --upload-token=$CODECOV_TOKEN",
     "deploy:built": "wrangler deploy --config dist/server/wrangler.json",


### PR DESCRIPTION
## Summary
- The Cloudflare Pages project's root directory is `apps/loopover-ui`, so its automatic `npm clean-install` step only installs that workspace's own declared dependencies (957 packages), never reaching sibling workspace packages (the full monorepo installs ~1316).
- This silently worked until `packages/loopover-engine` gained two new direct dependencies (`@anthropic-ai/claude-agent-sdk`, `web-tree-sitter`) for its miner chat-grounding work — the Cloudflare build now fails with `TS2307: Cannot find module` on those, breaking the preview build for **every** PR that touches `apps/loopover-ui/**`.
- `build:cloudflare` already `cd`s to the monorepo root (`npm --prefix ../.. run ui:build`) to run the real build; this extends the same pattern one step earlier — `npm --prefix ../.. ci && npm --prefix ../.. run ui:build` — so the build is self-sufficient regardless of what Cloudflare's own auto-detected install step covered, with no Cloudflare dashboard changes needed.

## Scope
- [x] `apps/loopover-ui/package.json` only (one script line)
- [x] No `src/**` changes

## Validation
- Ran `npm run build:cloudflare` from inside `apps/loopover-ui` (the exact CWD Cloudflare invokes it from) — full root `npm ci` + `ui:build` (engine + ui + ui-miner) all succeed.
- `npx tsc --noEmit` — clean
- `npm run actionlint` — clean (no workflow changes, just confirming nothing else drifted)

## Safety
- [x] No secrets touched