### PR TITLE
fix(auth): send the canonical PRODUCT_USER_AGENT from github-oauth.ts

### DIFF
--- a/src/auth/github-oauth.ts
+++ b/src/auth/github-oauth.ts
@@ -5,7 +5,7 @@ import {
   timingSafeEqual,
 } from "./security";
 import { getDecryptedSessionGitHubTokenBundle, recordAuditEvent, storeSessionGitHubToken } from "../db/repositories";
-import { timeoutFetch } from "../github/client";
+import { PRODUCT_USER_AGENT, timeoutFetch } from "../github/client";
 import type { JsonValue } from "../types";
 
 type GitHubDeviceCodeResponse = {
@@ -47,7 +47,7 @@ export async function startGitHubDeviceFlow(env: Env): Promise<GitHubDeviceCodeR
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "loopover-api",
+      "user-agent": PRODUCT_USER_AGENT,
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -73,7 +73,7 @@ export async function pollGitHubDeviceFlow(env: Env, deviceCode: string) {
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "loopover-api",
+      "user-agent": PRODUCT_USER_AGENT,
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -137,7 +137,7 @@ export async function completeGitHubWebOAuth(
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "loopover-api",
+      "user-agent": PRODUCT_USER_AGENT,
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -195,7 +195,7 @@ export async function createSessionFromGitHubToken(
     headers: {
       accept: "application/vnd.github+json",
       authorization: `Bearer ${githubToken}`,
-      "user-agent": "loopover-api",
+      "user-agent": PRODUCT_USER_AGENT,
       "x-github-api-version": "2022-11-28",
     },
   });
@@ -234,7 +234,7 @@ async function verifyTokenBelongsToApp(env: Env, githubToken: string): Promise<b
       accept: "application/vnd.github+json",
       authorization: `Basic ${btoa(`${env.GITHUB_OAUTH_CLIENT_ID}:${env.GITHUB_OAUTH_CLIENT_SECRET}`)}`,
       "content-type": "application/json",
-      "user-agent": "loopover-api",
+      "user-agent": PRODUCT_USER_AGENT,
       "x-github-api-version": "2022-11-28",
     },
     body: JSON.stringify({ access_token: githubToken }),
@@ -324,7 +324,7 @@ async function refreshGitHubUserToken(
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "loopover-api",
+      "user-agent": PRODUCT_USER_AGENT,
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { completeGitHubWebOAuth, createSessionFromGitHubToken, pollGitHubDeviceFlow, startGitHubDeviceFlow, startGitHubWebOAuth } from "../../src/auth/github-oauth";
 import { enforceRateLimit, RateLimiter, routeClassForPath } from "../../src/auth/rate-limit";
 import { authenticatePrivateToken, buildBrowserSessionCookie, createSessionForGitHubUser, extractCookieValue, isAuthorizedGitHubSessionLogin, isMcpActuationRepoAllowed, revokeSession, timingSafeEqual } from "../../src/auth/security";
+import { PRODUCT_USER_AGENT } from "../../src/github/client";
 import { createTestEnv } from "../helpers/d1";
 
 describe("private-beta auth and rate limiting", () => {
@@ -675,6 +676,20 @@ describe("private-beta auth and rate limiting", () => {
       }),
     );
     await expect(startGitHubDeviceFlow(env)).resolves.not.toHaveProperty("interval");
+  });
+
+  it("REGRESSION (#6610): sends the canonical PRODUCT_USER_AGENT, not a drifted 'loopover-api' literal", async () => {
+    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id" });
+    let seenUserAgent: string | undefined;
+    vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenUserAgent = (init?.headers as Record<string, string> | undefined)?.["user-agent"];
+      return Response.json({ device_code: "device-code", user_code: "USER-CODE", verification_uri: "https://github.com/login/device", expires_in: 900 });
+    });
+
+    await startGitHubDeviceFlow(env);
+
+    expect(seenUserAgent).toBe(PRODUCT_USER_AGENT);
+    expect(seenUserAgent).not.toBe("loopover-api");
   });
 
   it("starts and completes GitHub web OAuth with signed state", async () => {


### PR DESCRIPTION
## Summary

- `src/auth/github-oauth.ts` hardcoded a stale `"loopover-api"` user-agent literal on all six of its
  outbound GitHub calls (device flow start/poll, OAuth code exchange, token verification, app-token
  introspection, refresh-token exchange) instead of importing and using `PRODUCT_USER_AGENT` from
  `src/github/client.ts` — the single canonical constant every sibling GitHub-calling module in
  `src/github/` already uses. This meant GitHub saw two different product identities depending on
  which code path made the request.
- Fixed by importing `PRODUCT_USER_AGENT` alongside the already-imported `timeoutFetch` and replacing
  the literal at all six call sites. Header-value-only change — no other behavior touched.
- Left `service: "loopover-api"` literals in `src/api/routes.ts`/`src/openapi/schemas.ts` and the
  separate `user-agent` literal in `src/services/draft.ts` untouched, per the issue's explicit scope
  boundaries (a distinct concept and a distinct subsystem respectively).

## Test plan

- [x] Added a regression test to `test/unit/auth.test.ts` asserting the outbound `fetch` call's
  `init.headers["user-agent"]` is `PRODUCT_USER_AGENT` (and explicitly not `"loopover-api"`), following
  the file's existing `vi.stubGlobal("fetch", ...)` mocking pattern
- [x] `npx vitest run test/unit/auth.test.ts test/unit/auth-github-token.test.ts` — 61/61 passing
- [x] Verified 96.68%/97.84%/96.66%/98.3% (stmt/branch/func/line) coverage on `github-oauth.ts` via
  scoped `vitest --coverage` across both test files together; confirmed via direct lcov `DA:`
  inspection that none of this diff's 7 changed lines are among the file's few remaining pre-existing
  uncovered lines (372, 398 — both outside this diff)
  the two changed lines
- [x] `git diff --check`, `npm run actionlint`, `npm audit --audit-level=moderate` — all clean
- [x] No manifest/OpenAPI/schema/DB changes needed — pure `src/**` + `test/**` diff

Closes #6610