### PR TITLE
fix(github): reject a malformed three-segment repoFullName in comments.ts

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -50,8 +50,13 @@ async function createOrUpdateIssueCommentWithMarker(
   marker: string,
   options: { createIfMissing?: boolean | undefined; mode?: AgentActionMode } = {},
 ): Promise<{ id: number; html_url?: string } | null> {
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  // Reject anything that is not exactly two non-empty segments -- "owner/repo/extra" would otherwise pass
+  // (the destructure silently drops the extra segment), issuing a call against a repo the caller never
+  // specified. Matches the segment-count guard in parseRepoFullName (assignees.ts / labels.ts).
+  if (parts.length !== 2 || !owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
 
   return await withInstallationTokenRetry(env, installationId, async (token) => {
     // Non-live mode suppresses the comment create/update writes; the GET marker-search probe below still runs.

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -379,6 +379,14 @@ describe("GitHub PR intelligence comments", () => {
   it("rejects invalid repository names before calling GitHub", async () => {
     await expect(createOrUpdatePrIntelligenceComment(createTestEnv(), 123, "invalid", 12, "body")).rejects.toThrow(/Invalid repository full name/);
   });
+
+  it("rejects a malformed three-segment repository name instead of silently truncating it", async () => {
+    // "owner/repo/extra" splits into three segments; the extra one must be rejected, not dropped, so no
+    // GitHub call is ever made against the truncated "owner/repo".
+    await expect(createOrUpdatePrIntelligenceComment(createTestEnv(), 123, "owner/repo/extra", 12, "body")).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+  });
 });
 
 async function generatePrivateKeyPem(): Promise<string> {


### PR DESCRIPTION
## What

`createOrUpdateIssueCommentWithMarker` in `src/github/comments.ts` validated `repoFullName` with `const [owner, repo] = repoFullName.split("/")` + a truthiness check. `"owner/repo/extra"` passed it — the destructure silently dropped the extra segment, and the GitHub API call was issued against `owner/repo`, a repo the caller never specified.

Resolves #6612.

## Fix

Add the missing `parts.length !== 2` segment-count check inline, matching the guard already in `parseRepoFullName` (`assignees.ts` / `labels.ts`):

```ts
const parts = repoFullName.split("/");
const owner = parts[0];
const repo = parts[1];
if (parts.length !== 2 || !owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
```

- No-slash (`"invalid"`) and empty-segment (`"owner/"`, `"/repo"`) inputs are still rejected exactly as before.
- Whitespace handling is intentionally left unchanged (a separate issue, #6613, covers per-segment padding in a different file).
- Both exported wrappers (`createOrUpdatePrIntelligenceComment`, `createOrUpdateAgentCommandComment`) continue to propagate the thrown error unchanged.

## Test

`test/unit/github-comments.test.ts` gains a case asserting `"owner/repo/extra"` is rejected via `createOrUpdatePrIntelligenceComment`, mirroring the precedent in `github-assignees.test.ts`. The new `parts.length !== 2` branch is exercised by it.

Locally green: `npx vitest run test/unit/github-comments.test.ts` → 14/14 pass; the new branch is covered (diff patch-coverage complete).