### PR TITLE
fix(review): trim whitespace on three truthy env flag checks

### DIFF
--- a/src/review/gittensor-wire.ts
+++ b/src/review/gittensor-wire.ts
@@ -20,7 +20,7 @@ import { resolveManifestOnlyFeature } from "./feature-activation";
  *  {@link gittensorEnabledRepoFullNames} short-circuits before reading a single manifest. Truthy follows the
  *  codebase convention (`/^(1|true|yes|on)$/i`, same as isImpactMapEnabled / isSelfTuneEnabled). */
 export function isGittensorPluginEnabled(env: { LOOPOVER_EXPERIMENTAL_GITTENSOR?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.LOOPOVER_EXPERIMENTAL_GITTENSOR ?? "");
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_EXPERIMENTAL_GITTENSOR ?? "").trim());
 }
 
 /** Resolve whether the gittensor plugin is active for THIS repo: the operator's global env kill-switch AND an

--- a/src/review/maintainer-recap-wire.ts
+++ b/src/review/maintainer-recap-wire.ts
@@ -28,7 +28,7 @@ export function isRecapEnabled(
   manifestOverride?: MaintainerRecapManifestOverride | undefined,
 ): boolean {
   if (manifestOverride?.present) return manifestOverride.enabled;
-  return /^(1|true|yes|on)$/i.test(env.LOOPOVER_MAINTAINER_RECAP ?? "");
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_MAINTAINER_RECAP ?? "").trim());
 }
 
 export type RecapCadence = "daily" | "weekly";

--- a/src/review/pr-reconciliation.ts
+++ b/src/review/pr-reconciliation.ts
@@ -37,7 +37,7 @@ export function isPrReconciliationEnabled(
   manifestOverride?: PrReconciliationManifestOverride | undefined,
 ): boolean {
   if (manifestOverride?.present) return manifestOverride.enabled;
-  return /^(1|true|yes|on)$/i.test(env.LOOPOVER_PR_RECONCILIATION ?? "");
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_PR_RECONCILIATION ?? "").trim());
 }
 
 // Short in-isolate TTL cache for resolvePrReconciliationManifestOverride, mirroring ops-wire.ts /

--- a/test/unit/gittensor-wire.test.ts
+++ b/test/unit/gittensor-wire.test.ts
@@ -38,6 +38,12 @@ describe("isGittensorPluginEnabled", () => {
     expect(isGittensorPluginEnabled({ LOOPOVER_EXPERIMENTAL_GITTENSOR: "on" })).toBe(true);
     expect(isGittensorPluginEnabled({ LOOPOVER_EXPERIMENTAL_GITTENSOR: "yes" })).toBe(true);
   });
+
+  it("REGRESSION (#6635): whitespace-padded truthy values still activate (matches isRagEnabled)", () => {
+    expect(isGittensorPluginEnabled({ LOOPOVER_EXPERIMENTAL_GITTENSOR: "true\n" })).toBe(true);
+    expect(isGittensorPluginEnabled({ LOOPOVER_EXPERIMENTAL_GITTENSOR: " 1 " })).toBe(true);
+    expect(isGittensorPluginEnabled({ LOOPOVER_EXPERIMENTAL_GITTENSOR: "\ton\t" })).toBe(true);
+  });
 });
 
 describe("shouldEnableGittensorForRepo", () => {

--- a/test/unit/maintainer-recap-wire.test.ts
+++ b/test/unit/maintainer-recap-wire.test.ts
@@ -68,6 +68,12 @@ describe("isRecapEnabled — default OFF, truthy convention", () => {
     for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isRecapEnabled({ LOOPOVER_MAINTAINER_RECAP: on })).toBe(true);
   });
 
+  it("REGRESSION (#6635): whitespace-padded truthy values still activate (matches isRagEnabled)", () => {
+    expect(isRecapEnabled({ LOOPOVER_MAINTAINER_RECAP: "true\n" })).toBe(true);
+    expect(isRecapEnabled({ LOOPOVER_MAINTAINER_RECAP: " 1 " })).toBe(true);
+    expect(isRecapEnabled({ LOOPOVER_MAINTAINER_RECAP: "\ton\t" })).toBe(true);
+  });
+
   it("a present manifest override wins outright over the env flag, in both directions (#2250)", () => {
     expect(isRecapEnabled({ LOOPOVER_MAINTAINER_RECAP: "false" }, { present: true, enabled: true, cadence: "weekly" })).toBe(true);
     expect(isRecapEnabled({ LOOPOVER_MAINTAINER_RECAP: "true" }, { present: true, enabled: false, cadence: "weekly" })).toBe(false);

--- a/test/unit/pr-reconciliation.test.ts
+++ b/test/unit/pr-reconciliation.test.ts
@@ -21,6 +21,12 @@ describe("isPrReconciliationEnabled — default OFF, truthy convention", () => {
     for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isPrReconciliationEnabled({ LOOPOVER_PR_RECONCILIATION: on })).toBe(true);
   });
 
+  it("REGRESSION (#6635): whitespace-padded truthy values still activate (matches isRagEnabled)", () => {
+    expect(isPrReconciliationEnabled({ LOOPOVER_PR_RECONCILIATION: "true\n" })).toBe(true);
+    expect(isPrReconciliationEnabled({ LOOPOVER_PR_RECONCILIATION: " 1 " })).toBe(true);
+    expect(isPrReconciliationEnabled({ LOOPOVER_PR_RECONCILIATION: "\ton\t" })).toBe(true);
+  });
+
   it("a present manifest override wins outright over the env flag, in both directions (#6558)", () => {
     expect(isPrReconciliationEnabled({ LOOPOVER_PR_RECONCILIATION: "false" }, { present: true, enabled: true })).toBe(true);
     expect(isPrReconciliationEnabled({ LOOPOVER_PR_RECONCILIATION: "true" }, { present: true, enabled: false })).toBe(false);


### PR DESCRIPTION
## Summary
- Adds `.trim()` to the env truthy checks in `gittensor-wire.ts`, `maintainer-recap-wire.ts`, and `pr-reconciliation.ts`, matching `isRagEnabled` / sibling `*-wire.ts` flags.
- Adds regression tests asserting whitespace-padded truthy values (e.g. `true\n`, ` 1 `) still activate each flag.

Closes #6635

## Test plan
- [ ] Unit tests for the three files pass on CI (incl. new #6635 cases)
- [ ] Codecov patch green for the three env-check lines

Made with [Cursor](https://cursor.com)