### PR TITLE
refactor(signals): reuse slop.ts's canonical clamp in improvement.ts

### DIFF
--- a/src/signals/improvement.ts
+++ b/src/signals/improvement.ts
@@ -26,7 +26,7 @@
 // live source for complexityDeltas, duplicationDeltas, or patchCoverageDeltaPercent — all three are honest
 // gaps, not yet wired by design (a later sub-issue's job), and this module must degrade cleanly when they're
 // absent (see "insufficient signal" below) rather than fabricate a neutral score.
-import { buildMissingTestEvidenceFinding, type SlopChangedFile } from "./slop";
+import { buildMissingTestEvidenceFinding, clamp, type SlopChangedFile } from "./slop";
 import { isCodeFile } from "./path-matchers";
 import type { SignalFinding } from "./engine";
 
@@ -252,8 +252,4 @@ function improvementBandFor(improvementScore: number, hasSignal: boolean): Impro
   if (improvementScore < 31) return "minor";
   if (improvementScore < 60) return "moderate";
   return "significant";
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }


### PR DESCRIPTION
## Summary

`src/signals/improvement.ts` defined its own private `clamp` helper, byte-identical in signature and
body to the `clamp` already re-exported from `src/signals/slop.ts` (sourced from
`packages/loopover-engine/src/signals/slop.ts`). `improvement.ts` already imports from `./slop` for
`buildMissingTestEvidenceFinding`, so the dependency was already established — `clamp` just wasn't
added to that same import. Sibling file `src/signals/issue-slop.ts` already imports `clamp` from
`./slop` the same way this PR now does.

Pure refactor: removed the local `clamp` function and added `clamp` to the existing `./slop` import.
`improvementScore`'s computed value (and every `build*Finding` helper's output) is byte-identical to
before this change, since both implementations share the exact same signature and body.

## Test plan

- [x] `npx vitest run test/unit/improvement.test.ts test/unit/improvement-signal-wiring.test.ts test/unit/mcp-check-improvement-potential.test.ts`
  — 52/52 passing unmodified, confirming byte-identical behavior
- [x] Verified 100% statement/branch/function/line coverage on `improvement.ts` via scoped
  `vitest --coverage` across all three test files
- [x] `git diff --check`, `npm run actionlint`, `npm audit --audit-level=moderate` — all clean
- [x] No manifest/OpenAPI/schema/DB changes needed — a single-file `src/**` diff (removed function +
  one import line)

Closes #6607