### PR TITLE
refactor(signals): reuse slop.ts's canonical clamp in improvement.ts

### DIFF
--- a/src/signals/improvement.ts
+++ b/src/signals/improvement.ts
@@ -26,7 +26,7 @@
 // live source for complexityDeltas, duplicationDeltas, or patchCoverageDeltaPercent — all three are honest
 // gaps, not yet wired by design (a later sub-issue's job), and this module must degrade cleanly when they're
 // absent (see "insufficient signal" below) rather than fabricate a neutral score.
-import { buildMissingTestEvidenceFinding, type SlopChangedFile } from "./slop";
+import { buildMissingTestEvidenceFinding, clamp, type SlopChangedFile } from "./slop";
 import { isCodeFile } from "./path-matchers";
 import type { SignalFinding } from "./engine";
 
@@ -252,8 +252,4 @@ function improvementBandFor(improvementScore: number, hasSignal: boolean): Impro
   if (improvementScore < 31) return "minor";
   if (improvementScore < 60) return "moderate";
   return "significant";
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }


### PR DESCRIPTION
## What

`src/signals/improvement.ts` defined its own private `clamp(value, min, max)` whose body is identical to the `clamp` already re-exported from `./slop` (sourced from `packages/loopover-engine/src/signals/slop.ts`). The file already imports from `./slop`, so `clamp` was simply never added to that import.

Resolves #6607.

## Change

- Add `clamp` to the existing `./slop` import.
- Delete the local duplicate `clamp` function.

This matches the sibling `src/signals/issue-slop.ts`, which already imports `clamp` from `./slop`. Behavior is unchanged — same signature, same body, same single call site (`buildStructuralImprovementAssessment`).

Net diff: +1/-5. Locally green: `npx vitest run test/unit/improvement.test.ts test/unit/improvement-signal-wiring.test.ts` → 47/47 pass.