### PR TITLE
fix(engine): honor no-issue rationale in predicted preflight

### DIFF
--- a/packages/loopover-engine/src/signals/predicted-gate-engine.ts
+++ b/packages/loopover-engine/src/signals/predicted-gate-engine.ts
@@ -412,7 +412,7 @@ export function buildPreflightResult(
       action: maintainerAuthored ? "No action." : "Refresh registry data or choose a registered active repo.",
     });
   }
-  if (linkedIssues.length === 0 && lane.lane !== "issue_discovery") {
+  if (linkedIssues.length === 0 && lane.lane !== "issue_discovery" && !hasClearNoIssueRationale({ title: input.title, body: input.body })) {
     findings.push({
       code: "missing_linked_issue",
       severity: "warning",

--- a/test/unit/predicted-gate-engine-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-coverage.test.ts
@@ -360,6 +360,25 @@ describe("predicted-gate engine module coverage (#2283)", () => {
     expect(observed.findings.some((f) => f.code === "missing_linked_issue")).toBe(true);
   });
 
+  it("REGRESSION (#6628): predicted preflight honors a clear no-issue rationale like the live gate", () => {
+    const docsOnly = buildPreflightResult(
+      { repoFullName: REPO.fullName, title: "docs-only: fix typo", body: "", linkedIssues: [] },
+      REPO,
+      [],
+      [],
+    );
+    expect(docsOnly.lane.lane).not.toBe("issue_discovery");
+    expect(docsOnly.findings.some((finding) => finding.code === "missing_linked_issue")).toBe(false);
+
+    const unexplained = buildPreflightResult(
+      { repoFullName: REPO.fullName, title: "Fix upload behavior", body: "", linkedIssues: [] },
+      REPO,
+      [],
+      [],
+    );
+    expect(unexplained.findings.some((finding) => finding.code === "missing_linked_issue")).toBe(true);
+  });
+
   it("exercises gate holds, readiness score branches, and linked-issue advisory paths", () => {
     const advisory = buildPullRequestAdvisory(REPO, PR, { requireLinkedIssue: true, confirmedNoOpenLinkedIssue: true, linkedIssueAuthorLogins: ["miner1"] });
     expect(advisory.findings.some((f) => f.code === "missing_linked_issue")).toBe(true);


### PR DESCRIPTION
## Summary

- Add the missing `!hasClearNoIssueRationale(...)` check to `buildPreflightResult` in `predicted-gate-engine.ts`, matching the live gate in `engine.ts`.
- Add a regression test asserting docs-only PRs with no linked issue do not produce a spurious `missing_linked_issue` finding, while unexplained PRs still do.

Closes #6628

## Test plan

- [x] `npx vitest run test/unit/predicted-gate-engine-coverage.test.ts -t 6628`
- [x] `npx vitest run test/unit/predicted-gate-engine-coverage.test.ts test/unit/predicted-gate-engine-branch-coverage.test.ts --coverage --coverage.include=packages/loopover-engine/src/signals/predicted-gate-engine.ts`