### PR TITLE
feat(miner-ui): redesign ledgers route with StateBoundary + skeletons (#6512)

### DIFF
--- a/apps/loopover-miner-ui/src/governor.test.tsx
+++ b/apps/loopover-miner-ui/src/governor.test.tsx
@@ -35,11 +35,12 @@ describe("defaultGovernorPauseState (#4857)", () => {
 });
 
 describe("GovernorControlSection (#4857)", () => {
-  it("renders the loading state before the first result arrives", () => {
+  it("renders a content-shaped loading skeleton (role=status), not the old flat loading text (#6512)", () => {
     render(
       <GovernorControlSection result={null} pending={false} onPause={() => undefined} onResume={() => undefined} />,
     );
-    expect(screen.getByText(/Loading governor state/i)).toBeTruthy();
+    expect(screen.getByRole("status", { name: /loading governor state/i })).toBeTruthy();
+    expect(screen.queryByText("Loading governor state…")).toBeNull(); // the pre-#6512 sentence is gone
   });
 
   it("renders an error message when the local API is unreachable", () => {

--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -112,9 +112,10 @@ describe("LedgersView (#4855)", () => {
     expect(screen.getByRole("alert").textContent).toContain("connection refused");
   });
 
-  it("renders the loading state before the first result arrives", () => {
+  it("renders a content-shaped loading skeleton (role=status), not the old flat loading text (#6512)", () => {
     render(<LedgersView result={null} />);
-    expect(screen.getByText(/Loading local ledgers/i)).toBeTruthy();
+    expect(screen.getByRole("status", { name: /loading local ledgers/i })).toBeTruthy();
+    expect(screen.queryByText("Loading local ledgers…")).toBeNull(); // the pre-#6512 sentence is gone
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -4,9 +4,17 @@ import { useEffect, useState } from "react";
 import { Button } from "@loopover/ui-kit/components/button";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
 import { Input } from "@loopover/ui-kit/components/input";
+import { Skeleton } from "@loopover/ui-kit/components/skeleton";
+import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
 
-import { CLAIM_STATUSES, fetchLedgers, type ClaimStatus, type LedgersResult } from "../lib/ledgers";
+import {
+  CLAIM_STATUSES,
+  fetchLedgers,
+  type ClaimStatus,
+  type LedgersResult,
+  type LedgersSummary,
+} from "../lib/ledgers";
 import { fetchGovernorPauseState, pauseGovernor, resumeGovernor, type GovernorPauseStateResult } from "../lib/governor";
 
 export const Route = createFileRoute("/ledgers")({
@@ -15,8 +23,15 @@ export const Route = createFileRoute("/ledgers")({
 
 // Read-only views over the miner's local claim / event / governor ledgers (#4855). All three are aggregated
 // server-side (see vite-ledgers-api.ts) to status/type counts plus a small feed of SAFE columns — raw payloads
-// and the free-text claim note never reach this component. Same 4-state pattern as the portfolio/run-history
-// views (loading / error / fresh-install empty / populated).
+// and the free-text claim note never reach this component.
+//
+// #6512: the two hand-rolled loading/error/empty `<p>` blocks (the read-only ledger summary, and the SEPARATE
+// governor control section) are each replaced by the shared @loopover/ui-kit `StateBoundary`, with a
+// content-shaped `Skeleton` placeholder for the loading state so the layout doesn't jump when the poll resolves.
+// The two flows keep their OWN independent boundary — a governor-state fetch failure must not blank the ledger
+// summary, and vice-versa. Purely presentational: `lib/ledgers.ts`/`lib/governor.ts`, the two fetch loops, and
+// the pause/resume Button wiring are untouched; only the loading/error chrome and the governor-control layout
+// change.
 //
 // The governor control section below is a SEPARATE fetch/action loop from the read-only ledger summary above
 // (#4857, the governor half): it reads/writes the governor's pause state via vite-governor-api.ts, the
@@ -57,81 +72,54 @@ function CountTable({ counts, keyLabel }: { counts: Record<string, number>; keyL
   );
 }
 
-export function GovernorControlSection({
-  result,
-  pending,
-  onPause,
-  onResume,
-}: {
-  result: GovernorPauseStateResult | null;
-  pending: boolean;
-  onPause: (reason?: string) => void;
-  onResume: () => void;
-}) {
-  // Optional pause reason, mirroring the CLI's `governor pause [--reason <text>]`; an empty field
-  // is passed through as `undefined` so it matches the CLI's own optional-flag behavior.
-  const [reason, setReason] = useState("");
+/** Card+table-shaped loading placeholder for the ledger summary: mirrors the 3 status cards and the stacked
+ *  count/feed tables below them, so the summary keeps its shape while the first fetch resolves. `role="status"`
+ *  keeps the loading state announced to assistive tech (as the flat "Loading local ledgers…" text it replaces
+ *  was). */
+function LedgerSummarySkeleton() {
   return (
-    <section className="grid gap-3">
-      <h3 className="font-display text-token-base font-semibold">Governor control</h3>
-      {result === null ? (
-        <p className="text-token-sm text-muted-foreground">Loading governor state…</p>
-      ) : !result.ok ? (
-        <p role="alert" className="text-token-sm text-[var(--danger)]">
-          Could not read the local governor state: {result.error}
-        </p>
-      ) : (
-        <div className="flex flex-wrap items-center gap-3">
-          <p className="text-token-sm text-muted-foreground">
-            {result.pauseState.paused
-              ? `Paused since ${result.pauseState.pausedAt}${result.pauseState.reason ? ` (${result.pauseState.reason})` : ""}`
-              : "Not paused"}
-          </p>
-          {result.pauseState.paused ? (
-            <Button size="sm" variant="outline" disabled={pending} onClick={onResume}>
-              Resume governor
-            </Button>
-          ) : (
-            <>
-              <Input
-                type="text"
-                value={reason}
-                onChange={(event) => setReason(event.target.value)}
-                disabled={pending}
-                placeholder="Reason (optional)"
-                aria-label="Pause reason"
-                className="w-auto flex-1 min-w-[12rem]"
-              />
-              <Button size="sm" variant="destructive" disabled={pending} onClick={() => onPause(reason || undefined)}>
-                Pause governor
-              </Button>
-            </>
-          )}
+    <div className="grid gap-6" role="status" aria-label="Loading local ledgers">
+      <section className="grid gap-3">
+        <Skeleton className="h-5 w-28" />
+        <div className="grid gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Card key={index}>
+              <CardContent className="p-4">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="mt-2 h-8 w-12" />
+              </CardContent>
+            </Card>
+          ))}
         </div>
-      )}
-    </section>
+      </section>
+      {Array.from({ length: 2 }).map((_, index) => (
+        <section key={index} className="grid gap-3">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-24 w-full" />
+        </section>
+      ))}
+    </div>
   );
 }
 
-export function LedgersView({ result }: { result: LedgersResult | null }) {
-  if (result === null) {
-    return <p className="text-token-sm text-muted-foreground">Loading local ledgers…</p>;
-  }
-  if (!result.ok) {
-    return (
-      <p role="alert" className="text-token-sm text-[var(--danger)]">
-        Could not read the local ledgers: {result.error}
-      </p>
-    );
-  }
-  const { claims, events, governor } = result.summary;
-  if (claims.total === 0 && events.total === 0 && governor.total === 0) {
-    return (
-      <p className="text-token-sm text-muted-foreground">
-        No ledger activity yet — claims, events, and governor entries appear here once the miner starts working.
-      </p>
-    );
-  }
+/** Row-shaped loading placeholder for the governor control section: a status line plus an action-sized block,
+ *  matching the "Not paused / Resume" row it stands in for. Its own `role="status"` announces this flow
+ *  independently of the ledger-summary skeleton above. */
+function GovernorControlSkeleton() {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 rounded-token-sm bg-muted/40 p-3"
+      role="status"
+      aria-label="Loading governor state"
+    >
+      <Skeleton className="h-5 w-40" />
+      <Skeleton className="h-9 w-28" />
+    </div>
+  );
+}
+
+function LedgersSummaryContent({ summary }: { summary: LedgersSummary }) {
+  const { claims, events, governor } = summary;
   return (
     <div className="grid gap-6">
       <section className="grid gap-3">
@@ -196,6 +184,86 @@ export function LedgersView({ result }: { result: LedgersResult | null }) {
         )}
       </section>
     </div>
+  );
+}
+
+export function GovernorControlSection({
+  result,
+  pending,
+  onPause,
+  onResume,
+}: {
+  result: GovernorPauseStateResult | null;
+  pending: boolean;
+  onPause: (reason?: string) => void;
+  onResume: () => void;
+}) {
+  // Optional pause reason, mirroring the CLI's `governor pause [--reason <text>]`; an empty field
+  // is passed through as `undefined` so it matches the CLI's own optional-flag behavior.
+  const [reason, setReason] = useState("");
+  const errorText = result !== null && !result.ok ? result.error : undefined;
+  return (
+    <section className="grid gap-3">
+      <h3 className="font-display text-token-base font-semibold">Governor control</h3>
+      <StateBoundary
+        isLoading={result === null}
+        isError={result !== null && !result.ok}
+        loadingSkeleton={<GovernorControlSkeleton />}
+        errorTitle="Couldn't read the local governor state"
+        errorDescription={errorText}
+      >
+        {result?.ok && (
+          <div className="flex flex-wrap items-center gap-3 rounded-token-sm bg-muted/40 p-3">
+            <p className="text-token-sm text-muted-foreground">
+              {result.pauseState.paused
+                ? `Paused since ${result.pauseState.pausedAt}${result.pauseState.reason ? ` (${result.pauseState.reason})` : ""}`
+                : "Not paused"}
+            </p>
+            {result.pauseState.paused ? (
+              <Button size="sm" variant="outline" disabled={pending} onClick={onResume} className="ml-auto">
+                Resume governor
+              </Button>
+            ) : (
+              <div className="ml-auto flex flex-wrap items-center gap-3">
+                <Input
+                  type="text"
+                  value={reason}
+                  onChange={(event) => setReason(event.target.value)}
+                  disabled={pending}
+                  placeholder="Reason (optional)"
+                  aria-label="Pause reason"
+                  className="w-auto flex-1 min-w-[12rem]"
+                />
+                <Button size="sm" variant="destructive" disabled={pending} onClick={() => onPause(reason || undefined)}>
+                  Pause governor
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </StateBoundary>
+    </section>
+  );
+}
+
+export function LedgersView({ result }: { result: LedgersResult | null }) {
+  const summary = result?.ok ? result.summary : null;
+  const isEmpty =
+    summary !== null && summary.claims.total === 0 && summary.events.total === 0 && summary.governor.total === 0;
+  const errorText = result !== null && !result.ok ? result.error : undefined;
+  return (
+    <StateBoundary
+      isLoading={result === null}
+      isError={result !== null && !result.ok}
+      isEmpty={isEmpty}
+      loadingSkeleton={<LedgerSummarySkeleton />}
+      errorTitle="Couldn't read the local ledgers"
+      errorDescription={errorText}
+      emptyTitle="No ledger activity yet"
+      emptyDescription="Claims, events, and governor entries appear here once the miner starts working."
+    >
+      {summary && <LedgersSummaryContent summary={summary} />}
+    </StateBoundary>
   );
 }
 


### PR DESCRIPTION
Closes #6512.

Redesigns the **Ledgers** miner-ui route so its two async flows each render through the shared `@loopover/ui-kit` `StateBoundary` with content-shaped `Skeleton` placeholders, replacing the two hand-rolled `<p>` loading/error/empty blocks.

### What changed
- **Ledger summary** (`LedgersView`): wrapped in its own `StateBoundary` — `LedgerSummarySkeleton` (3 status cards + two table blocks) while loading, ui-kit error surface on failure, ui-kit empty surface on a fresh install.
- **Governor control** (`GovernorControlSection`): wrapped in a **separate, independent** `StateBoundary` — a governor pause-state fetch failure no longer blanks the ledger summary, and vice-versa. Its row is regrouped into a single muted surface container (`rounded-token-sm bg-muted/40`) with the Reason input + action button right-aligned, using existing design tokens only.
- `GovernorControlSkeleton` gives the governor row its own loading placeholder.

### Explicitly untouched (out of scope)
`lib/ledgers.ts`, `lib/governor.ts`, both `useEffect` fetch loops, and the pause/resume `Button` `onClick`/`disabled` wiring into `POST /api/governor/{pause,resume}` are byte-for-byte unchanged — this is purely presentational.

### Verification
- `apps/loopover-miner-ui/**` is outside `src/**`, so **Codecov's patch-coverage gate does not apply** to this change (no Codecov check will appear).
- Extended the existing route test harness: the two loading-state assertions in `ledgers.test.tsx` and `governor.test.tsx` now assert the `role="status"` skeleton instead of the removed flat text; every other assertion (error `role="alert"` surfaces, empty state, pause/resume wiring, `#6186`) passes unchanged.
- Full miner-ui gate green: **236 tests pass**, `typecheck`, `lint` (0 errors), `build`.

### Before / after — both flows, all three states
**Loading (both skeletons):**
![loading](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6512-screenshots/.pr-screenshots/ledgers-loading-skeletons.png)

**Populated (restyled governor control + full summary):**
![populated](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6512-screenshots/.pr-screenshots/ledgers-populated.png)

**Error (two independent boundaries fail separately):**
![error](https://raw.githubusercontent.com/jaytbarimbao-collab/gittensory/pr-6512-screenshots/.pr-screenshots/ledgers-error-states.png)