### PR TITLE
test(ui): guard the Cloudflare build's self-heal step against regression

### DIFF
--- a/test/unit/ui-cloudflare-build-self-heal.test.ts
+++ b/test/unit/ui-cloudflare-build-self-heal.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => JSON.parse(readFileSync(path, "utf8"));
+
+// #6642: the Cloudflare Pages project for loopover-ui has its root directory set to apps/loopover-ui, so
+// Cloudflare's own automatic `npm clean-install` step only installs THIS workspace's own declared
+// dependencies -- it never reaches sibling workspace packages (proved live: it silently under-installed
+// until packages/loopover-engine gained @anthropic-ai/claude-agent-sdk/web-tree-sitter, then every PR
+// touching apps/loopover-ui/** started failing `Workers Builds: loopover-ui` with TS2307). #6624 fixed
+// this by making build:cloudflare self-sufficient: it runs a full monorepo-root `npm ci` itself before
+// building, so it no longer depends on what Cloudflare's own scoped install covered.
+//
+// A CI job cannot actually reproduce Cloudflare's scoped-install behavior to regression-test this end to
+// end -- confirmed empirically that a plain `npm ci` run from apps/loopover-ui in a normal git checkout
+// correctly finds and installs the FULL workspace tree (Cloudflare's specific build sandbox does
+// something else, not reproducible via plain npm/git commands). The reliable, cheap guard is asserting
+// the self-heal step itself is still present -- this is what actually prevents the regression from
+// recurring, regardless of whether the original failure mode can be simulated in CI.
+describe("apps/loopover-ui's Cloudflare build stays self-sufficient (#6642)", () => {
+  it("build:cloudflare runs a full monorepo-root npm ci before building, not just the build script alone", () => {
+    const pkg = read("apps/loopover-ui/package.json");
+    const script = pkg.scripts["build:cloudflare"];
+    expect(script).toBeTypeOf("string");
+    // Order matters: the root install must happen BEFORE ui:build, so build:cloudflare is
+    // self-sufficient regardless of what Cloudflare's own root-scoped install step already did.
+    expect(script).toMatch(/^npm --prefix \.\.\/\.\. ci\s*&&\s*npm --prefix \.\.\/\.\. run ui:build$/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #6642.

- #6642 asked for a CI check exercising `apps/loopover-ui`'s `build:cloudflare` script (scoped to that directory) so a future regression of #6624's class is caught before merge.
- I tested that approach empirically first: a plain `npm ci` run from `apps/loopover-ui` in a normal git checkout correctly finds and installs the **full** workspace tree (confirmed live — it reaches for the root `node_modules/sharp` and attempts to build it). Cloudflare's actual build sandbox does something else to produce its partial 957-package install, which isn't reproducible via plain npm/git commands in GitHub Actions. A CI job that just `cd`s into `apps/loopover-ui` and runs `npm ci` would always pass, giving false confidence rather than a real regression test.
- The reliable, cheap invariant that actually prevents this regression: `build:cloudflare` must keep running a full monorepo-root `npm ci` before `ui:build` (that's what #6624 added). This adds a unit test asserting that exact script shape, mirroring the existing `test/unit/ci-ui-build-openapi.test.ts` convention of testing critical build-recipe content directly rather than trying to functionally simulate an external platform's build sandbox.
- Verified the test actually catches the regression: reverted `build:cloudflare` locally to the pre-#6624 shape, confirmed the test goes red, restored it.

## Scope
- [x] `test/unit/ui-cloudflare-build-self-heal.test.ts` only (new file)
- [x] No `src/**` changes

## Validation
- `npx vitest run test/unit/ui-cloudflare-build-self-heal.test.ts` — passes
- Manually reverted `build:cloudflare`'s content and re-ran — test fails as expected, confirming it's a real guard
- `npx vitest run` (full unsharded suite) — 930/932 files, 17826/17839 tests passed (pre-existing skips unchanged)
- `npx tsc --noEmit` — clean

## Safety
- [x] No secrets touched