### PR TITLE
docs(selfhost): document the GPU-reservation force-recreate gotcha for ollama

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -402,6 +402,24 @@ services:
   # After `docker compose --profile ollama up -d`, pull a model:
   #   docker compose exec ollama ollama pull llama3.2
   # Then set AI_PROVIDER=ollama and OLLAMA_AI_BASE_URL=http://ollama:11434/v1 in .env.
+  #
+  # GPU hosts: request the device via a local override (gitignored), e.g. docker-compose.local-gpu.yml:
+  #   services:
+  #     ollama:
+  #       deploy:
+  #         resources:
+  #           reservations:
+  #             devices:
+  #               - driver: nvidia
+  #                 count: all
+  #                 capabilities: [gpu]
+  # A device reservation only takes effect on container CREATION -- `docker compose restart ollama` reuses
+  # the existing container's already-baked-in config and will NOT pick it up, even after adding the file to
+  # COMPOSE_FILE. Confirmed in production (#gittensory-4327): the override existed for days while the
+  # running container's `docker inspect --format '{{json .HostConfig.DeviceRequests}}'` stayed `null`, and
+  # `ollama ps` kept reporting 100% CPU. Use `docker compose up -d --force-recreate ollama` (or any change
+  # that forces a recreate) after adding or editing a device reservation, then re-check `ollama ps` for
+  # "100% GPU" and/or `docker inspect`'s DeviceRequests to confirm it actually took.
   ollama:
     image: ollama/ollama:0.30.10
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Found live on edge-nl-01 (#gittensory-4327): a GPU device reservation for the `ollama` service was added via `docker-compose.local-gpu.yml` days ago and correctly listed in `COMPOSE_FILE`, but the running container was never actually recreated with it — `docker inspect`'s `HostConfig.DeviceRequests` stayed `null` and `ollama ps` kept reporting 100% CPU the whole time, causing RAG embedding timeouts (`rag_embed_item_error`/`review_context_fetch_failed`) under review load.
- A device reservation only takes effect at container *creation*; `restart` (or whatever restarted it previously) reuses the existing container's already-baked-in config and silently no-ops. `docker compose up -d --force-recreate ollama` picked it up immediately — confirmed via `ollama ps` reporting "100% GPU" and full layer offload (`load_tensors: offloaded 25/25 layers to GPU`) in the container's own startup logs.
- This documents the override pattern and the gotcha directly on the `ollama` service in `docker-compose.yml` so the next GPU host doesn't lose the same embedding throughput to a silent no-op.

## Test plan
- [x] Comment-only change to `docker-compose.yml` — no functional/behavioral change, nothing to test beyond the file still parsing (`docker compose config` validated clean on the live server after this exact text was applied there manually)