### PR TITLE
test(settings): inject Batch C gate/AI-review fields via the manifest (queue rest)

### DIFF
--- a/test/unit/mcp-pr-ai-review-findings.test.ts
+++ b/test/unit/mcp-pr-ai-review-findings.test.ts
@@ -7,10 +7,10 @@ import {
   putCachedAiReview,
   upsertPullRequestFromGitHub,
   upsertRepositoryFromGitHub,
-  upsertRepositorySettings,
 } from "../../src/db/repositories";
 import { LoopoverMcp } from "../../src/mcp/server";
 import { INLINE_FINDINGS_METADATA_KEY } from "../../src/mcp/pr-ai-review-findings";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
@@ -29,7 +29,7 @@ const inlineFindings = [
 
 async function seedPublishedReview(env: Env): Promise<void> {
   await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-  await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "block" });
+  await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "block" } });
   await upsertPullRequestFromGitHub(env, "acme/widgets", {
     number: 42,
     title: "Fix widget cache",
@@ -73,7 +73,7 @@ describe("MCP loopover_get_pr_ai_review_findings (#4519)", () => {
   it("returns not_found when no published AI review exists", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "block" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "block" } });
     await upsertPullRequestFromGitHub(env, "acme/widgets", {
       number: 7,
       title: "Draft",
@@ -112,7 +112,7 @@ describe("MCP loopover_get_pr_ai_review_findings (#4519)", () => {
   it("returns a zero-finding ready summary when the published review has no inline findings", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "block" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "block" } });
     await upsertPullRequestFromGitHub(env, "acme/widgets", {
       number: 99,
       title: "Clean",
@@ -136,7 +136,7 @@ describe("MCP loopover_get_pr_ai_review_findings (#4519)", () => {
   it("returns ai_review_off when the repo has AI review disabled", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "off" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "off" } });
     await upsertPullRequestFromGitHub(env, "acme/widgets", {
       number: 8,
       title: "Draft",
@@ -186,7 +186,7 @@ describe("MCP loopover_get_pr_ai_review_findings (#4519)", () => {
       private: true,
       owner: { login: "victimco" },
     });
-    await upsertRepositorySettings(env, { repoFullName: "victimco/private-roadmap", aiReviewMode: "block" });
+    await upsertRepoFocusManifest(env, "victimco/private-roadmap", { settings: { aiReviewMode: "block" } });
     await upsertPullRequestFromGitHub(env, "victimco/private-roadmap", {
       number: 1,
       title: "Secret",

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -261,11 +261,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: over.autonomy ?? { merge: "auto", update_branch: "auto" },
       agentPaused: over.agentPaused ?? false,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
   }
 
   function behindWebhook() {
@@ -398,8 +397,8 @@ describe("queue processors", () => {
     // #4603 sub-floor-defect test's settings shape in queue-2.test.ts). copycatGateMode is config-as-code ONLY
     // (no DB column, per RepositorySettings.copycatGateMode's own doc comment) -- setting it on upsertRepositorySettings
     // is silently ignored; it must go through the focus-manifest (.loopover.yml) loader instead, below.
-    await upsertRepositorySettings(env, { repoFullName: "owner/copycat-repo", autonomy: { close: "auto" }, gatePack: "oss-anti-slop", reviewCheckMode: "required" });
-    await upsertRepoFocusManifest(env, "owner/copycat-repo", { gate: { copycat: { mode: "warn" } }, settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/copycat-repo", autonomy: { close: "auto" }, gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "owner/copycat-repo", { gate: { copycat: { mode: "warn" } }, settings: { reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" } });
     // An earlier open sibling PR whose added code the new PR (below) reproduces verbatim.
     const sourceLines = "function add(a, b) {\nconst total = a + b;\nlogger.debug(total);\nreturn total;\n}\nexport default add;";
     const sourcePatch = sourceLines.split("\n").map((line) => `+${line}`).join("\n");
@@ -439,12 +438,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
       requireLinkedIssue: true,
       autonomy: { label: "observe" }, // not acting → agent never runs
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
@@ -481,14 +478,13 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { review_state_label: "auto", request_changes: "auto" },
     });
     // No confirmed-miner seed → author is unconfirmed; the manifest's linkedIssue:block + no issue fires a
     // blocker, so the gate now FAILS the author normally (#gate-nonconfirmed — confirmed status no longer
     // neutralizes the verdict). But this repo grants only review_state_label/request_changes autonomy — NOT
     // merge/close/approve — so the failing gate yields a request-changes/label action at most, never a terminal action.
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
@@ -528,10 +524,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { label: "auto" },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
@@ -568,11 +563,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { review_state_label: "auto" },
       agentDryRun: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
@@ -615,8 +609,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
     });
     const calls = { gateChecks: 0, comments: 0, minerList: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -649,7 +641,7 @@ describe("queue processors", () => {
       return new Response("not found", { status: 404 });
     });
 
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "gate-bot-public-skip",
@@ -683,8 +675,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
     });
     const calls = { gateChecks: 0, comments: 0, minerList: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -723,7 +713,7 @@ describe("queue processors", () => {
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       gate: { linkedIssue: "block" },
       review: { auto_review: { ignore_authors: ["renovate*"] } },
-      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
+      settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
     });
     await processJob(env, {
       type: "github-webhook",
@@ -759,8 +749,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "disabled",
-      linkedIssueGateMode: "off",
     });
     const calls = { github: 0, minerList: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -772,7 +760,7 @@ describe("queue processors", () => {
 
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       review: { auto_review: { ignore_authors: ["release-please*"] } },
-      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
+      settings: { reviewCheckMode: "disabled", linkedIssueGateMode: "off", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
     });
     await processJob(env, {
       type: "github-webhook",
@@ -808,14 +796,12 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "disabled",
-      linkedIssueGateMode: "off",
     });
     vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
 
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       review: { auto_review: { ignore_authors: ["renovate*"] } },
-      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+      settings: { reviewCheckMode: "disabled", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" },
     });
     await processJob(env, {
       type: "github-webhook",
@@ -853,8 +839,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
     });
     const calls = { minerList: 0, gateChecks: 0, comments: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -887,7 +871,7 @@ describe("queue processors", () => {
       return new Response("not found", { status: 404 });
     });
 
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "all_prs", publicAudienceMode: "gittensor_only", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "all_prs", publicAudienceMode: "gittensor_only", publicSurface: "comment_only", checkRunMode: "off" } });
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "gate-unconfirmed-miner-public-skip",
@@ -921,8 +905,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
     });
 
     const calls = { minerList: 0, gateChecks: 0, comments: 0 };
@@ -950,7 +932,7 @@ describe("queue processors", () => {
       return new Response("not found", { status: 404 });
     });
 
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "all_prs", publicAudienceMode: "gittensor_only", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "all_prs", publicAudienceMode: "gittensor_only", publicSurface: "comment_only", checkRunMode: "off" } });
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "gate-unavailable-miner-public-skip",
@@ -984,8 +966,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
     });
     const calls = { minerList: 0, gateChecks: 0 };
     let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
@@ -1017,7 +997,7 @@ describe("queue processors", () => {
       return new Response("not found", { status: 404 });
     });
 
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "off", publicAudienceMode: "oss_maintainer", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "off", publicAudienceMode: "oss_maintainer", publicSurface: "off", checkRunMode: "off" } });
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "gate-confirmed-block",
@@ -1065,16 +1045,13 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      aiReviewMode: "block",
       // Also exercise the opt-in slop advisory in the same surface pass: it persists a per-PR assessment
       // and runs the (advisory-only) AI slop pass, but never blocks — the gate still fails on the AI
       // consensus defect alone.
       slopGateMode: "advisory",
       slopAiAdvisory: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "block", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
     const cacheReadSpy = vi
       .spyOn(repositoriesModule, "getCachedAiReview")
@@ -1151,10 +1128,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     const patchBodies: Array<{ status?: string; conclusion?: string; output?: { title?: string } }> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -1221,11 +1196,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      aiReviewMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     let commentPosts = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -1289,11 +1261,18 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      aiReviewMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      settings: {
+        commentMode: "off",
+        publicSurface: "label_only",
+        checkRunMode: "off",
+        createMissingLabel: false,
+        reviewCheckMode: "required",
+        linkedIssueGateMode: "off",
+        aiReviewMode: "off",
+      },
+    });
     await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
     let labelPosts = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1361,11 +1340,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      aiReviewMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       const method = init?.method ?? "GET";
@@ -1418,11 +1394,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      aiReviewMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       const method = init?.method ?? "GET";
@@ -1470,10 +1443,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     const patchBodies: Array<{ status?: string; conclusion?: string; output?: { title?: string } }> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -1520,12 +1491,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block",
       requireLinkedIssue: true,
     });
     // Config turns the gate OFF even though repo settings have reviewCheckMode: required (the gate check-run publishing).
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { enabled: false }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { enabled: false }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "block", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     const calls = { gateChecks: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -1567,10 +1536,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       requireLinkedIssue: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -1618,9 +1586,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     const calls = { gateWrites: 0, commentGets: 0, commentPosts: 0 };
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -1676,9 +1643,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     let commentGets = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -1835,11 +1801,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { merge: "auto" },
       commandAuthorization: { default: ["maintainer"], commands: { "review-now": ["maintainer"] } },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", includeMaintainerAuthors: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", includeMaintainerAuthors: true } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 46,
       title: "Pending CI rerun",
@@ -2378,7 +2343,6 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: true,
-      reviewCheckMode: "required",
     });
     let publicCalls = 0;
     vi.stubGlobal("fetch", async () => {
@@ -2386,7 +2350,7 @@ describe("queue processors", () => {
       return new Response("unexpected public call", { status: 500 });
     });
 
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "enabled" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "enabled" } });
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "pr-labeled-noisy",
@@ -2644,10 +2608,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     let postedBody = "";
     const calls = { comments: 0, gateChecks: 0 };
     let gateFinalized = false;
@@ -2826,10 +2789,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     let postedBody = "";
     const calls = { comments: 0, gateChecks: 0 };
     let gateFinalized = false;
@@ -2998,14 +2960,13 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
       // The only delta from the #4744 test above: turns on slop evidence collection so `slopBand` is populated
       // this pass. "advisory" never blocks (only "block" mode does, at the configured threshold) -- this test
       // is exercising the quadrant label, not the slop gate.
       slopGateMode: "advisory",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     let postedBody = "";
     const calls = { comments: 0, gateChecks: 0 };
     let gateFinalized = false;
@@ -3160,10 +3121,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     let mergeableStateReads = 0;
     // No mockRejectedValueOnce here -- unlike the "renders the unified PR-review comment" test above, every call
     // succeeds identically, isolating the "both refreshes succeed" case this fix targets (a prior-call failure
@@ -3277,10 +3237,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     let postedBody = "";
     const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
       ciState: "passed",
@@ -3418,6 +3377,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode stays DB-backed here (not moved to upsertRepoFocusManifest) because this test
+      // exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would poison the
+      // 6h manifest cache and skip that fetch entirely -- see the comment on the fetch mock below.
       reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
@@ -3560,6 +3522,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode stays DB-backed here (not moved to upsertRepoFocusManifest) -- this test
+      // exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would poison
+      // the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
@@ -3726,6 +3691,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode stays DB-backed here (not moved to upsertRepoFocusManifest) -- this test
+      // exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would poison
+      // the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
@@ -3901,6 +3869,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode stays DB-backed here (not moved to upsertRepoFocusManifest) -- this test
+      // exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would poison
+      // the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
     });
@@ -4082,6 +4053,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode/aiReviewMode stay DB-backed here (not moved to upsertRepoFocusManifest) --
+      // this test exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would
+      // poison the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       aiReviewMode: "block",
       gatePack: "oss-anti-slop",
@@ -4160,6 +4134,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode also stays DB-backed here (not moved to upsertRepoFocusManifest) -- this
+      // test exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would
+      // poison the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       // advisory (NOT block): block mode always reviews the full diff, ignoring exclude_paths/path_filters, so
       // only advisory mode exercises the filterReviewFilesForAi branch (src/queue/processors.ts).
@@ -4236,6 +4213,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode/linkedIssueGateMode stay DB-backed here (not moved to upsertRepoFocusManifest) --
+      // this test exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would
+      // poison the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
       linkedIssueGateMode: "block",
@@ -4394,13 +4374,13 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { update_branch: "auto" },
-      qualityGateMode: "advisory",
-      qualityGateMinScore: 100,
     });
     await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
       settings: {
+        reviewCheckMode: "required",
+        qualityGateMode: "advisory",
+        qualityGateMinScore: 100,
         commentMode: "detected_contributors_only",
         publicAudienceMode: "gittensor_only",
         publicSignalLevel: "standard",
@@ -4641,8 +4621,8 @@ describe("queue processors", () => {
   it("swallows an estimateReviewEffort failure when persisting the public-stats minutes — the publish still completes", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "off", gatePack: "oss-anti-slop" });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", aiReviewMode: "off", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     const estimateSpy = vi.spyOn(reviewEffortModule, "estimateReviewEffort").mockImplementationOnce(() => {
       throw new Error("estimator blew up");
     });
@@ -4726,6 +4706,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
+      // Batch-C: reviewCheckMode/aiReviewMode stay DB-backed here (not moved to upsertRepoFocusManifest) --
+      // this test exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would
+      // poison the 6h manifest cache and skip that fetch entirely.
       reviewCheckMode: "required",
       aiReviewMode: "block",
       gatePack: "oss-anti-slop",
@@ -4797,8 +4780,8 @@ describe("queue processors", () => {
     });
     await persistRegistrySnapshot(env, normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"));
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "block", gatePack: "oss-anti-slop" });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", aiReviewMode: "block", commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 77, title: "Held PR", state: "open", user: { login: "contributor" }, head: { sha: "a77" }, labels: [{ name: "manual-review" }], body: "Closes #1" });
     await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 77, status: "complete", reviewsSyncedAt: new Date().toISOString() });
     // A prior PUBLISHED review for this exact head — the freeze path reuses it (aiReview = frozenReview) instead of
@@ -4857,6 +4840,9 @@ describe("queue processors", () => {
       AI_DAILY_NEURON_BUDGET: "100000",
     });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    // Batch-C: reviewCheckMode/aiReviewMode stay DB-backed here (not moved to upsertRepoFocusManifest) --
+    // this test exercises the real .loopover.yml raw-fetch path below, and upsertRepoFocusManifest would
+    // poison the 6h manifest cache and skip that fetch entirely.
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, reviewCheckMode: "required", aiReviewMode: "block", gatePack: "oss-anti-slop" });
     let unifiedCommentBody = "";
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -4925,9 +4911,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     // Seed a FAILED check summary with a per-check WHY (codecov-style) so listCheckSummaries returns it and the
     // unified site populates failingDetails. (The PR row + headSha must match for the check to associate.)
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
@@ -5076,9 +5061,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 6,
       title: "Fix flaky retry test",
@@ -5218,9 +5202,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSignalLevel: "standard", publicSurface: "comment_and_label", checkRunMode: "off", checkRunDetailLevel: "minimal", backfillEnabled: true } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 7,
       title: "Bump lockfile",

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -2559,12 +2559,10 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
       slopGateMode: "off", // dashboard slop disabled…
       mergeReadinessGateMode: "advisory", // …but readiness keeps the live score in play
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // Seed the PR row plus a stale dashboard slop score that the slop-off pass must clear.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 91,
@@ -2645,11 +2643,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
       slopGateMode: "advisory",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 96, title: "Add clamp helper for the volume slider", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "genericsha96" }, labels: [], body: "Bounds the volume slider's raw input to a safe numeric range." });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 97, title: "Restrict pagination cursor offsets to a valid window", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "specificsha97" }, labels: [], body: "Prevents the pagination cursor from resolving to an out-of-range offset." });
 
@@ -2725,14 +2721,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      duplicatePrGateMode: "block",
       slopGateMode: "advisory",
-      qualityGateMode: "block",
-      qualityGateMinScore: 95,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", duplicatePrGateMode: "block", qualityGateMode: "block", qualityGateMinScore: 95, commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // The shared issue + the HIGHER-numbered open sibling (#92) → forms the same-issue duplicate cluster.
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91" }, labels: [], body: "Fixes #1\n\nValidation: npm test" });
@@ -2787,12 +2778,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      duplicatePrGateMode: "block",
       slopGateMode: "advisory",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", duplicatePrGateMode: "block", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 92, title: "Also fix the cache", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib92b" }, labels: [], body: "Fixes #1" });
 
@@ -2848,12 +2836,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
-      duplicatePrGateMode: "block",
       slopGateMode: "advisory",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", duplicatePrGateMode: "block", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
     // Stale-cached-open sibling: the DB still says #90 is open (the closed webhook was missed/delayed).
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 90, title: "Older attempt at the cache fix", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib90" }, labels: [], body: "Fixes #1" });
@@ -2907,6 +2892,10 @@ describe("queue processors", () => {
   it("overrides the Gate to neutral for THIS commit only when a real write/admin maintainer runs gate-override", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    // NOT manifest-converted: this test asserts directly on the raw repository_settings.review_check_mode
+    // DB column below (a bypassing raw SQL read, not resolveRepositorySettings/resolveEffectiveSettings),
+    // to prove the gate-override doesn't persist a permanent state change -- a manifest override wouldn't
+    // be reflected in that raw column read, so reviewCheckMode/linkedIssueGateMode stay DB-injected here.
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
@@ -3003,10 +2992,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 94,
       title: "Override me (telemetry write fails)",
@@ -3061,11 +3048,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
       agentPaused: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 91,
       title: "Override me while paused",
@@ -3130,11 +3115,9 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
       agentDryRun: true,
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // No head sha — also exercises the metadata's `?? null` fallback on the skip-path audit/usage records.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 93,
@@ -3199,10 +3182,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // The stored row still carries the OLD head; a new commit ("live-sha") landed between the comment and now.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 90,
@@ -3278,10 +3259,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     // A cached row with no head SHA (never detail-synced); the live fetch also yields no head.
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 90,
@@ -3334,10 +3313,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 92,
       title: "Edited override",
@@ -3399,10 +3376,8 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
       number: 91,
       title: "Cannot override",
@@ -3474,10 +3449,7 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName,
         autoLabelEnabled: false,
-        reviewCheckMode: "required",
         requireLinkedIssue: true,
-        linkedIssueGateMode: "advisory",
-        aiReviewMode: "advisory",
       });
       await upsertPullRequestFromGitHub(env, repoFullName, {
         number: prNumber,
@@ -3498,7 +3470,7 @@ describe("queue processors", () => {
         LOOPOVER_REVIEW_MEMORY: "true",
       });
       await seedResolvePr(env, repoFullName, 1964, "resolve-1964-a");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       const calls = { permission: 0, checkPatches: 0, comments: 0 };
       let confirmationBody = "";
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -3567,7 +3539,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1964-ai-cached";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1974, "resolve-1964-ai-cached");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await putCachedAiReview(env, repoFullName, 1974, "resolve-1964-ai-cached", "advisory", {
         notes: "The cached AI review found a public issue.",
         reviewerCount: 2,
@@ -3610,7 +3582,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1964-ai-published";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1975, "resolve-1964-ai-current");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await putCachedAiReview(env, repoFullName, 1975, "resolve-1964-ai-old", "advisory", {
         notes: "The published AI review found a public consensus defect.",
         reviewerCount: 2,
@@ -3655,7 +3627,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1965-off";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedResolvePr(env, repoFullName, 1965, "resolve-1965-off");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         const method = init?.method ?? "GET";
@@ -3700,7 +3672,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1966-deny";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1966, "resolve-1966-deny");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3741,7 +3713,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1967-skip";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1967, "resolve-1967-skip");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3774,7 +3746,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1968-whole";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1968, "resolve-1968-whole");
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         const method = init?.method ?? "GET";
@@ -3810,7 +3782,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1973-plain";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedResolvePr(env, repoFullName, 1973, "resolve-1973-plain");
-      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       let commentPosts = 0;
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
@@ -3844,7 +3816,7 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1974-help";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedResolvePr(env, repoFullName, 1974, "resolve-1974-help");
-      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         if (input.toString().includes("/access_tokens")) return Response.json({ token: "installation-token" });
         return new Response("not found", { status: 404 });
@@ -3918,8 +3890,8 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1970-dry-run";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1970, "resolve-1970-dry-run");
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", agentDryRun: true });
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: true, agentDryRun: true });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3949,8 +3921,8 @@ describe("queue processors", () => {
       const repoFullName = "JSONbored/resolve-1971-paused";
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_MEMORY: "true" });
       await seedResolvePr(env, repoFullName, 1971, "resolve-1971-paused");
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", agentPaused: true });
-      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: true, agentPaused: true });
+      await upsertRepoFocusManifest(env, repoFullName, { review: { memory: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -3983,8 +3955,8 @@ describe("queue processors", () => {
       const owner = repoFullName.slice(0, slash);
       const name = repoFullName.slice(slash + 1);
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: true, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
-      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: true });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: prNumber, title: "Explain me", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: headSha }, labels: [], body: "No linked issue on purpose" });
     }
     const explainWebhook = (repoFullName: string, prNumber: number, body: string, actor: string, opts: { association?: string; bot?: boolean; action?: string } = {}) => ({
@@ -4151,7 +4123,7 @@ describe("queue processors", () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       // Register the repo + settings but NOT the PR row, so getPullRequest returns null.
       await upsertRepositoryFromGitHub(env, { name: "explain-2169-nopr", full_name: repoFullName, private: false, owner: { login: "JSONbored" } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, reviewCheckMode: "required", aiReviewMode: "advisory" });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { reviewCheckMode: "required", aiReviewMode: "advisory" } });
       let posted = false;
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         if (input.toString().includes("/comments")) posted = true;
@@ -4203,7 +4175,7 @@ describe("queue processors", () => {
       const owner = repoFullName.slice(0, slash);
       const name = repoFullName.slice(slash + 1);
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: prNumber, title: "Add retry to checkout", state: "open", user: { login: authorLogin }, author_association: "CONTRIBUTOR", head: { sha: headSha, ref: opts.headRef ?? "feature/checkout-retry" }, labels: [], body: "Retries the payment call once on a 5xx." });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: prNumber, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
       // A renamed-with-no-patch file (GitHub omits `patch` for pure renames) -- exercises the
@@ -4213,7 +4185,7 @@ describe("queue processors", () => {
       // a second separate call REPLACES rather than merges with a prior one (see repo-doc-pr.test.ts).
       await upsertRepoFocusManifest(env, repoFullName, {
         features: { e2eTests: true },
-        ...(opts.e2eTestDelivery ? { review: { e2e_test_delivery: opts.e2eTestDelivery } } : {}), settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+        ...(opts.e2eTestDelivery ? { review: { e2e_test_delivery: opts.e2eTestDelivery } } : {}), settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" },
       });
     }
     const generateTestsWebhook = (repoFullName: string, prNumber: number, actor: string, opts: { association?: string; bot?: boolean; commenterIsAuthor?: boolean } = {}) => ({
@@ -4353,8 +4325,8 @@ describe("queue processors", () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       const slash = repoFullName.indexOf("/");
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
-      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: 4198, title: "x", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "gen-tests-4195-disabled" }, labels: [], body: "x" });
       // Deliberately no upsertRepoFocusManifest features.e2eTests override -- stays off (no allowlist either).
       let postedBody = "";
@@ -4473,7 +4445,13 @@ describe("queue processors", () => {
       // aiReviewProvider set AND matching the stored key's provider -- exercises the "explicit provider
       // pin agrees with the stored key" arm, distinct from the (also-tested-elsewhere) "no pin configured"
       // default arm.
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", aiReviewByok: true, aiReviewProvider: "anthropic" });
+      // NOTE: this SECOND upsertRepoFocusManifest call (after seedGenerateTestsPr's own) REPLACES that
+      // manifest snapshot wholesale, so it re-states features.e2eTests + every settings.* field the helper
+      // already set, alongside the aiReviewByok/aiReviewProvider fields unique to this test.
+      await upsertRepoFocusManifest(env, repoFullName, {
+        features: { e2eTests: true },
+        settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", aiReviewByok: true, aiReviewProvider: "anthropic", commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+      });
       await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-byok-gen-tests-9999", model: null });
       let postedBody = "";
       const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -4532,8 +4510,8 @@ describe("queue processors", () => {
       });
       const slash = repoFullName.indexOf("/");
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
-      await upsertRepoFocusManifest(env, repoFullName, { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false });
+      await upsertRepoFocusManifest(env, repoFullName, { settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       await upsertPullRequestFromGitHub(env, repoFullName, { number: 4205, title: "Add retry to checkout", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "gen-tests-4195-allowlist" }, labels: [], body: "x" });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: 4205, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
       let postedBody = "";
@@ -4681,11 +4659,11 @@ describe("queue processors", () => {
         });
         const slash = repoFullName.indexOf("/");
         await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false });
         // No head sha/ref cached at all on this PR record.
         await upsertPullRequestFromGitHub(env, repoFullName, { number: 4210, title: "Add retry to checkout", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", labels: [], body: "x" });
         await upsertPullRequestFile(env, { repoFullName, pullNumber: 4210, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
-        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
         let postedBody = "";
         vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
           const url = input.toString();
@@ -4747,13 +4725,13 @@ describe("queue processors", () => {
         });
         const slash = repoFullName.indexOf("/");
         await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory" });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false });
         // Deliberately no `user` field at all -- the cached PR's authorLogin resolves to null, exercising the
         // ternary's not-found arm (`pr.authorLogin ? ... : { status: "not_found" }`) instead of ever calling
         // getCachedOfficialMinerDetection.
         await upsertPullRequestFromGitHub(env, repoFullName, { number: 4214, title: "Add retry to checkout", state: "open", author_association: "CONTRIBUTOR", head: { sha: "no-author-head-sha", ref: "feature/checkout-retry" }, labels: [], body: "x" });
         await upsertPullRequestFile(env, { repoFullName, pullNumber: 4214, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
-        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+        await upsertRepoFocusManifest(env, repoFullName, { features: { e2eTests: true }, review: { e2e_test_delivery: "commit" }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "advisory", aiReviewMode: "advisory", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
         let postedBody = "";
         vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
           const url = input.toString();
@@ -4782,7 +4760,7 @@ describe("queue processors", () => {
         const run = vi.fn();
         const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
         await seedGenerateTestsPr(env, repoFullName, 4211, "dryrun-head-sha", "contributor", { headRef: "feature/checkout-retry", e2eTestDelivery: "commit" });
-        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", agentDryRun: true });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, agentDryRun: true });
         vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
           const url = input.toString();
           if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -4804,7 +4782,7 @@ describe("queue processors", () => {
         const run = vi.fn();
         const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
         await seedGenerateTestsPr(env, repoFullName, 4212, "paused-head-sha", "contributor", { headRef: "feature/checkout-retry", e2eTestDelivery: "commit" });
-        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "advisory", aiReviewMode: "advisory", agentPaused: true });
+        await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, agentPaused: true });
         vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
           const url = input.toString();
           if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -4842,15 +4820,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName,
         autoLabelEnabled: false,
-        // reviewCheckMode: "required" (not "disabled") -- gateEnabled (which the whole manifestPolicyGateMode
-        // block this auto-trigger lives inside is downstream of) requires a truthy reviewCheckMode + a headSha.
-        // With reviewCheckMode: "disabled" the function bails out via its own early-return before ever reaching
-        // guidance.
-        reviewCheckMode: "required",
         requireLinkedIssue: false,
-        linkedIssueGateMode: "off",
         manifestPolicyGateMode: opts.manifestPolicyGateMode ?? "advisory",
-        aiReviewMode: "off",
       });
       await upsertPullRequestFromGitHub(env, repoFullName, {
         number: prNumber,
@@ -4879,10 +4850,15 @@ describe("queue processors", () => {
       // to exercise the auto-trigger's own behavior -- the one test that cares about the real production
       // default (OFF) passes `autoTrigger: false` explicitly, mirroring how the `e2eTests: false` case above
       // already tests ITS OWN negative default the same way.
+      // reviewCheckMode: "required" (not "disabled") -- gateEnabled (which the whole manifestPolicyGateMode
+      // block this auto-trigger lives inside is downstream of) requires a truthy reviewCheckMode + a headSha.
+      // With reviewCheckMode: "disabled" the function bails out via its own early-return before ever reaching
+      // guidance.
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
         features: { e2eTests: opts.e2eTests ?? true },
-        review: { e2e_test_auto_trigger: opts.autoTrigger ?? true, ...(opts.e2eTestDelivery ? { e2e_test_delivery: opts.e2eTestDelivery } : {}) }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
+        review: { e2e_test_auto_trigger: opts.autoTrigger ?? true, ...(opts.e2eTestDelivery ? { e2e_test_delivery: opts.e2eTestDelivery } : {}) },
+        settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
       });
     }
 
@@ -5159,7 +5135,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedAutoTriggerPr(env, repoFullName, 5008, "auto-4196-paused-sha");
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentPaused: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, manifestPolicyGateMode: "advisory", agentPaused: true });
       const posted = { count: 0, body: "" };
       stubAutoTriggerFetch(5008, posted);
 
@@ -5176,7 +5152,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedAutoTriggerPr(env, repoFullName, 5009, "auto-4196-dryrun-sha");
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentDryRun: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, manifestPolicyGateMode: "advisory", agentDryRun: true });
       const posted = { count: 0, body: "" };
       stubAutoTriggerFetch(5009, posted);
 
@@ -5199,13 +5175,13 @@ describe("queue processors", () => {
       });
       const slash = repoFullName.indexOf("/");
       await upsertRepositoryFromGitHub(env, { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } }, 123);
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, reviewCheckMode: "required", requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off" });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, manifestPolicyGateMode: "advisory" });
       // Deliberately no `user` field at all -- authorLogin resolves to null, exercising the `author ?? "the PR
       // author"` fallback arm (the explicit command's own `actor` is always a real commenter login, so this
       // branch is reachable only from the auto-trigger, which has no comment-invoker to fall back on).
       await upsertPullRequestFromGitHub(env, repoFullName, { number: 5010, title: "Add retry to checkout", state: "open", author_association: "CONTRIBUTOR", head: { sha: "auto-4196-no-author-sha", ref: "feature/checkout-retry" }, labels: [], body: "No validation evidence mentioned here." });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: 5010, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
-      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, review: { e2e_test_auto_trigger: true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, review: { e2e_test_auto_trigger: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
       const posted = { count: 0, body: "" };
       stubAutoTriggerFetch(5010, posted);
 
@@ -5251,9 +5227,7 @@ describe("queue processors", () => {
         repoFullName,
         autoLabelEnabled: false,
         requireLinkedIssue: false,
-        linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
-        aiReviewMode: "off",
       });
       await upsertPullRequestFromGitHub(env, repoFullName, {
         number: prNumber,
@@ -5277,7 +5251,8 @@ describe("queue processors", () => {
       });
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
-        features: { e2eTests: opts.e2eTests ?? true }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
+        features: { e2eTests: opts.e2eTests ?? true },
+        settings: { linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false },
       });
     }
 
@@ -5392,9 +5367,7 @@ describe("queue processors", () => {
         repoFullName,
         autoLabelEnabled: false,
         requireLinkedIssue: false,
-        linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
-        aiReviewMode: "off",
         commandAuthorization: { default: ["maintainer"], commands: { "generate-tests": ["maintainer", "collaborator"] } },
       });
       const posted = { count: 0, body: "" };
@@ -5425,9 +5398,7 @@ describe("queue processors", () => {
         repoFullName,
         autoLabelEnabled: false,
         requireLinkedIssue: false,
-        linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
-        aiReviewMode: "off",
         // A repo attempting to grant its own PR authors unconditional access -- normalizeCommandRoleList drops
         // the spoofable raw pr_author role for any MAINTAINER_ONLY_DEFAULT_COMMANDS entry (generate-tests is
         // one), re-clamped at the point of use regardless of what's stored here.
@@ -5563,7 +5534,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedCheckboxPr(env, repoFullName, 6008, "checkbox-4589-paused-sha");
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentPaused: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, manifestPolicyGateMode: "advisory", agentPaused: true });
       const posted = { count: 0, body: "" };
       stubCheckboxFetch(6008, "maintainer", "admin", posted);
 
@@ -5582,7 +5553,7 @@ describe("queue processors", () => {
       const run = vi.fn();
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AI: { run } as unknown as Ai, LOOPOVER_REVIEW_E2E_TESTS: "true", AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
       await seedCheckboxPr(env, repoFullName, 6010, "checkbox-4589-dryrun-sha");
-      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, linkedIssueGateMode: "off", manifestPolicyGateMode: "advisory", aiReviewMode: "off", agentDryRun: true });
+      await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false, manifestPolicyGateMode: "advisory", agentDryRun: true });
       const posted = { count: 0, body: "" };
       stubCheckboxFetch(6010, "maintainer", "admin", posted);
 
@@ -5606,10 +5577,14 @@ describe("queue processors", () => {
         AI_PUBLIC_COMMENTS_ENABLED: "true",
       });
       await seedCheckboxPr(env, repoFullName, 6011, "checkbox-4589-commit-sha");
+      // This SECOND upsertRepoFocusManifest call (after seedCheckboxPr's own) REPLACES that manifest snapshot
+      // wholesale, so it must re-state the settings.* fields seedCheckboxPr already set (linkedIssueGateMode,
+      // aiReviewMode) alongside the testExpectations/features/review this test itself needs.
       await upsertRepoFocusManifest(env, repoFullName, {
         testExpectations: ["Run npm run test:ci."],
         features: { e2eTests: true },
         review: { e2e_test_delivery: "commit" },
+        settings: { linkedIssueGateMode: "off", aiReviewMode: "off" },
       });
       const posted = { count: 0, body: "" };
       const gitWrites: string[] = [];
@@ -5662,17 +5637,14 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName,
         autoLabelEnabled: false,
-        // reviewCheckMode MUST be "required" (not "disabled") -- gateEvaluation is never computed at all when
-        // the gate is off (#6103: the renderer then falls back to a synthetic "skipped" gate for rendering
-        // purposes only), and this test needs the REAL evaluated gate's data for the checkbox/collapsible to
-        // render. Mirrors the settings shape of the pre-existing "renders the unified PR-review comment..." test above.
-        reviewCheckMode: "required",
         requireLinkedIssue: false,
-        linkedIssueGateMode: "off",
         manifestPolicyGateMode: "advisory",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, settings: { commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSurface: "comment_and_label", checkRunMode: "off", typeLabelsEnabled: false } });
+      // reviewCheckMode MUST be "required" (not "disabled") -- gateEvaluation is never computed at all when
+      // the gate is off (#6103: the renderer then falls back to a synthetic "skipped" gate for rendering
+      // purposes only), and this test needs the REAL evaluated gate's data for the checkbox/collapsible to
+      // render. Mirrors the settings shape of the pre-existing "renders the unified PR-review comment..." test above.
+      await upsertRepoFocusManifest(env, repoFullName, { testExpectations: ["Run npm run test:ci."], features: { e2eTests: true }, settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "detected_contributors_only", publicAudienceMode: "gittensor_only", publicSurface: "comment_and_label", checkRunMode: "off", typeLabelsEnabled: false } });
       // gateEvaluation needs a resolved CI aggregate (mocking the module function directly is far simpler than
       // stubbing every raw status/check-suite endpoint the live CI aggregator would otherwise call) -- but
       // NOT "passed": resolveManifestPassedValidationCount treats a fully-green live CI rollup as validation
@@ -5991,11 +5963,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off", createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(210, seen);
@@ -6022,11 +5991,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: false,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", publicAudienceMode: "gittensor_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", publicAudienceMode: "gittensor_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false, minerList: 0 };
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
@@ -6083,11 +6049,8 @@ describe("queue processors", () => {
         // (which has the gate off, so it returns before ever reaching the type-label decision): with the
         // gate ENABLED, the function does NOT bail out early, so this is the only path that actually
         // exercises `decision.skipReason === "not_official_gittensor_miner"` at the type-label gate.
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", publicAudienceMode: "gittensor_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "all_prs", publicSurface: "comment_and_label", publicAudienceMode: "gittensor_only", checkRunMode: "off", createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(217, seen);
@@ -6114,11 +6077,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", publicAudienceMode: "oss_maintainer", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "not_found" }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(211, seen);
@@ -6145,11 +6105,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", includeMaintainerAuthors: false, checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", includeMaintainerAuthors: false, checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(212, seen);
 
@@ -6175,11 +6132,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(213, seen);
 
@@ -6205,15 +6159,12 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
       // A self-host taxonomy well beyond the built-in bug/feature/priority triad (#label-modularity):
       // `security` is a registered category with no title-classification rule of its own, so it is
       // never CHOSEN here, but it must still be a cleanup CANDIDATE (never left dangling on a PR whose
       // classification moved elsewhere) exactly like the built-in categories.
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false, typeLabels: { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority", security: "area:security" } } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false, typeLabels: { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority", security: "area:security" } } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(218, seen);
 
@@ -6239,11 +6190,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "comment_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "comment_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(214, seen);
 
@@ -6268,11 +6216,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(215, seen);
@@ -6298,10 +6243,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: false,
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "enabled", typeLabelsEnabled: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "enabled", typeLabelsEnabled: false } });
       await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(216, seen);
@@ -6370,12 +6313,12 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
       await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
         settings: {
+          reviewCheckMode: "required",
+          linkedIssueGateMode: "off",
+          aiReviewMode: "off",
           commentMode: "off",
           publicSurface: "label_only",
           checkRunMode: "off",
@@ -6420,9 +6363,6 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
         autoLabelEnabled: true,
-        reviewCheckMode: "disabled",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
         // Real-world shape: the type-label decision runs regardless of the check-run/gate publish mode, but
         // the SURROUNDING function only reaches that far for an already-closed PR when the agent layer is
         // configured (autonomyNeedsGateEvaluation) -- an unconfigured repo's closed-PR pass has nothing else
@@ -6432,6 +6372,9 @@ describe("queue processors", () => {
       });
       await upsertRepoFocusManifest(env, "acme/widget", {
         settings: {
+          reviewCheckMode: "disabled",
+          linkedIssueGateMode: "off",
+          aiReviewMode: "off",
           commentMode: "off",
           publicSurface: "label_only",
           checkRunMode: "off",
@@ -6499,12 +6442,12 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
       await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
         settings: {
+          reviewCheckMode: "required",
+          linkedIssueGateMode: "off",
+          aiReviewMode: "off",
           commentMode: "off",
           publicSurface: "label_only",
           checkRunMode: "off",
@@ -6551,12 +6494,12 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
       await upsertRepoFocusManifest(env, "acme/widget", {
         settings: {
+          reviewCheckMode: "required",
+          linkedIssueGateMode: "off",
+          aiReviewMode: "off",
           commentMode: "off",
           publicSurface: "label_only",
           checkRunMode: "off",
@@ -6601,12 +6544,12 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
       await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
         settings: {
+          reviewCheckMode: "required",
+          linkedIssueGateMode: "off",
+          aiReviewMode: "off",
           commentMode: "off",
           publicSurface: "label_only",
           checkRunMode: "off",
@@ -6665,12 +6608,12 @@ describe("queue processors", () => {
           await upsertRepositorySettings(env, {
             repoFullName: "JSONbored/gittensory",
             autoLabelEnabled: true,
-            reviewCheckMode: "required",
-            linkedIssueGateMode: "off",
-            aiReviewMode: "off",
           });
           await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
             settings: {
+              reviewCheckMode: "required",
+              linkedIssueGateMode: "off",
+              aiReviewMode: "off",
               commentMode: "off",
               publicSurface: "label_only",
               checkRunMode: "off",
@@ -6727,12 +6670,12 @@ describe("queue processors", () => {
         await upsertRepositorySettings(env, {
           repoFullName: "acme/widget",
           autoLabelEnabled: true,
-          reviewCheckMode: "required",
-          linkedIssueGateMode: "off",
-          aiReviewMode: "off",
         });
         await upsertRepoFocusManifest(env, "acme/widget", {
           settings: {
+            reviewCheckMode: "required",
+            linkedIssueGateMode: "off",
+            aiReviewMode: "off",
             commentMode: "off",
             publicSurface: "label_only",
             checkRunMode: "off",
@@ -6801,12 +6744,9 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "acme/widget",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
         // linkedIssueLabelPropagation intentionally omitted -- defaults to disabled.
       });
-      await upsertRepoFocusManifest(env, "acme/widget", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "acme/widget", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
       stubPropagationFetch(222, 1, seen, () => Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] }));
 
@@ -6833,11 +6773,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(219, seen);
 
@@ -6867,11 +6804,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "label_only", checkRunMode: "off", createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(220, seen);
       failAuditEventInsertsContaining(env, "github_app.type_label_decision");
@@ -6898,11 +6832,8 @@ describe("queue processors", () => {
       await upsertRepositorySettings(env, {
         repoFullName: "JSONbored/gittensory",
         autoLabelEnabled: true,
-        reviewCheckMode: "required",
-        linkedIssueGateMode: "off",
-        aiReviewMode: "off",
       });
-      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", linkedIssueGateMode: "off", aiReviewMode: "off", commentMode: "off", publicSurface: "off", checkRunMode: "off", typeLabelsEnabled: false, createMissingLabel: false } });
       const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false };
       stubTypeLabelFetch(221, seen);
       failAuditEventInsertsContaining(env, "github_app.type_label_decision");

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -257,10 +257,9 @@ describe("agentMaintenanceHeadMatchesGate", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       autonomy: { merge: "auto", approve: "auto", close: "auto" },
     });
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", reviewCheckMode: "required" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
@@ -1045,11 +1044,11 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     });
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      reviewCheckMode: "required",
       autonomy: { close: "auto" },
       agentPaused: false,
       ...overrides,
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required" } });
   }
 
   it("closes a PR immediately when the contributor converts to draft after a gate failure on the same headSha", async () => {
@@ -1173,7 +1172,8 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       },
       repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
     });
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewCheckMode: "required", autonomy: { close: "auto" }, agentPaused: false });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
     await processJob(env, { type: "github-webhook", deliveryId: "draft-dodge-no-write", eventName: "pull_request", payload: draftPayload("contributor") });
@@ -1203,7 +1203,8 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     // No installations row pre-seeded. processGitHubWebhook auto-upserts one from the payload's bare
     // `installation: { id: 123 }` (no permissions field, as a real pull_request payload carries), so the
     // resulting row has no explicit pull_requests:write grant — the permission check must fail CLOSED (deny).
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewCheckMode: "required", autonomy: { close: "auto" }, agentPaused: false });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
     await processJob(env, { type: "github-webhook", deliveryId: "draft-dodge-no-install-row", eventName: "pull_request", payload: draftPayload("contributor") });
@@ -1237,7 +1238,8 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       },
       repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
     });
-    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewCheckMode: "required", autonomy: { close: "auto" }, agentPaused: false });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     // First getInstallation call in processGitHubWebhook (installationActor derivation, unrelated to this fix)
     // resolves normally; the SECOND call is the draft-dodge readiness check itself -- that one is a genuine D1
@@ -1623,10 +1625,10 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     });
     await upsertRepositorySettings(env, {
       repoFullName: "noslash",
-      reviewCheckMode: "required",
       autonomy: { close: "auto" },
       agentPaused: false,
     });
+    await upsertRepoFocusManifest(env, "noslash", { settings: { reviewCheckMode: "required" } });
     await recordGateBlockOutcome(env, { repoFullName: "noslash", pullNumber: 77, headSha: "sha-noslash", blockerCodes: ["missing_linked_issue"] });
 
     const noslashPayload = {
@@ -4405,11 +4407,9 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
       },
       repositories: [{ name: "gittensory", full_name: REPO, private: false, owner: { login: "JSONbored" } }],
     });
-    const { commentMode, publicSurface, checkRunMode, ...restSettingsOverrides } = settingsOverrides;
+    const { commentMode, publicSurface, checkRunMode, reviewCheckMode, linkedIssueGateMode, ...restSettingsOverrides } = settingsOverrides;
     await upsertRepositorySettings(env, {
       repoFullName: REPO,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "block", // the default blocker mechanism for these tests: missing linked issue -> gate failure
       ...restSettingsOverrides,
     });
     await upsertRepoFocusManifest(env, REPO, {
@@ -4417,6 +4417,9 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
         commentMode: commentMode ?? "off",
         publicSurface: publicSurface ?? "off",
         checkRunMode: checkRunMode ?? "off",
+        reviewCheckMode: reviewCheckMode ?? "required",
+        // the default blocker mechanism for these tests: missing linked issue -> gate failure
+        linkedIssueGateMode: linkedIssueGateMode ?? "block",
       },
     });
     // Without a registry snapshot the gate reports a "repo_unregistered" warning finding, which keeps the

--- a/test/unit/repo-profile.test.ts
+++ b/test/unit/repo-profile.test.ts
@@ -42,8 +42,8 @@ describe("extractRepoProfile (#2999)", () => {
         scripts: { test: "vitest run", "test:coverage": "vitest run --coverage", lint: "eslint .", build: "tsc" },
       }),
     );
-    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "required", requireLinkedIssue: true });
-    await upsertRepoFocusManifest(env, REPO, { linkedIssuePolicy: "required" });
+    await upsertRepositorySettings(env, { repoFullName: REPO, requireLinkedIssue: true });
+    await upsertRepoFocusManifest(env, REPO, { linkedIssuePolicy: "required", settings: { reviewCheckMode: "required" } });
 
     const profile = await extractRepoProfile(env, REPO, { now: "2026-07-05T00:00:00.000Z" });
 
@@ -249,9 +249,8 @@ describe("extractRepoProfile (#2999)", () => {
     await seedChunk(env, "src/widget.ts", "x");
     await upsertRepositorySettings(env, {
       repoFullName: REPO,
-      reviewCheckMode: "required",
     });
-    await upsertRepoFocusManifest(env, REPO, { settings: { checkRunMode: "off" } });
+    await upsertRepoFocusManifest(env, REPO, { settings: { checkRunMode: "off", reviewCheckMode: "required" } });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(true);
@@ -266,9 +265,8 @@ describe("extractRepoProfile (#2999)", () => {
     // gate.checkMode still gets reported as publishing one.
     await upsertRepositorySettings(env, {
       repoFullName: REPO,
-      reviewCheckMode: "disabled",
     });
-    await upsertRepoFocusManifest(env, REPO, { settings: { checkRunMode: "enabled" } });
+    await upsertRepoFocusManifest(env, REPO, { settings: { checkRunMode: "enabled", reviewCheckMode: "disabled" } });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(false);
@@ -277,7 +275,7 @@ describe("extractRepoProfile (#2999)", () => {
   it("reflects gatePublishesCheck true when reviewCheckMode is visible", async () => {
     const env = createTestEnv({});
     await seedChunk(env, "src/widget.ts", "x");
-    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "visible" });
+    await upsertRepoFocusManifest(env, REPO, { settings: { reviewCheckMode: "visible" } });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(true);


### PR DESCRIPTION
## Summary
- Part of the Batch C test-suite conversion (loopover#6444, epic #6440). Converts `test/unit/queue-4.test.ts`, `queue-5.test.ts`, `queue-lifecycle-guards.test.ts`, `mcp-pr-ai-review-findings.test.ts`, and `repo-profile.test.ts`'s DB-based injection of `reviewCheckMode`, `linkedIssueGateMode`, `duplicatePrGateMode`, `qualityGateMode`, `qualityGateMinScore`, `aiReviewMode`, `aiReviewAllAuthors` (whichever apply per file) to manifest-based injection via `upsertRepoFocusManifest`, mirroring the established Batch A/B pattern.
- No production code changes — test files only.

## Scope
- [x] `test/unit/queue-4.test.ts`, `queue-5.test.ts`, `queue-lifecycle-guards.test.ts`, `mcp-pr-ai-review-findings.test.ts`, `repo-profile.test.ts` only
- [x] No `src/**` changes

## Validation
- `npx tsc --noEmit` — clean
- `npx vitest run test/unit/queue-4.test.ts test/unit/queue-5.test.ts test/unit/queue-lifecycle-guards.test.ts test/unit/mcp-pr-ai-review-findings.test.ts test/unit/repo-profile.test.ts` — 520/520 passed
- Test-only change — Codecov `codecov/patch` has no `src/**` lines to measure

## Safety
- [x] No secrets touched