### PR TITLE
fix(github): resolve GraphQL cache TTL per cache class

### DIFF
--- a/src/github/graphql-cache.ts
+++ b/src/github/graphql-cache.ts
@@ -53,7 +53,10 @@ function positiveEnvSeconds(env: Record<string, string | undefined>, name: strin
 }
 
 export function githubGraphQlCacheTtlSeconds(cls: GitHubGraphQlCacheClass, env: Record<string, string | undefined> = process.env): number {
-  return positiveEnvSeconds(env, "GITHUB_GRAPHQL_CACHE_TTL_SECONDS", DEFAULT_GRAPHQL_TTL_SECONDS);
+  if (cls === "repo_totals") {
+    return positiveEnvSeconds(env, "GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS", DEFAULT_GRAPHQL_TTL_SECONDS);
+  }
+  return positiveEnvSeconds(env, "GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS", DEFAULT_GRAPHQL_TTL_SECONDS);
 }
 
 async function sha256Hex(value: string): Promise<string> {

--- a/test/unit/github-graphql-cache.test.ts
+++ b/test/unit/github-graphql-cache.test.ts
@@ -87,7 +87,8 @@ describe("graphql cache allowlist", () => {
     expect(graphqlOperationName(`query LoopOverContributorActivity { rateLimit { remaining } }`)).toBe("LoopOverContributorActivity");
     expect(graphqlCacheClassForQuery(`query LoopOverContributorActivity { x: rateLimit { remaining } }`)).toBe("contributor_activity");
     expect(githubGraphQlCacheTtlSeconds("contributor_activity")).toBe(600);
-    vi.stubEnv("GITHUB_GRAPHQL_CACHE_TTL_SECONDS", "   ");
+    vi.stubEnv("GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS", "   ");
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity")).toBe(600);
     expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(600);
 
     expect(isCacheableGraphQlQuery(MUTABLE_QUERY)).toBe(false);
@@ -102,13 +103,27 @@ describe("graphql cache allowlist", () => {
     expect(isCacheableGraphQlResponseBody("not-json")).toBe(false);
   });
 
-  it("honors GITHUB_GRAPHQL_CACHE_TTL_SECONDS with a positive fallback", () => {
-    vi.stubEnv("GITHUB_GRAPHQL_CACHE_TTL_SECONDS", "120");
-    expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(120);
-    vi.stubEnv("GITHUB_GRAPHQL_CACHE_TTL_SECONDS", "0");
-    expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(600);
-    vi.stubEnv("GITHUB_GRAPHQL_CACHE_TTL_SECONDS", "not-a-number");
-    expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(600);
+  it("resolves per-class GraphQL cache TTL env overrides with safe fallbacks", () => {
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", {})).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", {})).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "120" })).toBe(120);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "90.8" })).toBe(90);
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "3600" })).toBe(3600);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "300" })).toBe(300);
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "0" })).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "" })).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "0" })).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "0.5" })).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "not-a-number" })).toBe(600);
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "Infinity" })).toBe(600);
+    expect(
+      githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "900" }),
+    ).toBe(900);
+    expect(githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS: "900" })).toBe(600);
+    expect(
+      githubGraphQlCacheTtlSeconds("contributor_activity", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "180" }),
+    ).toBe(180);
+    expect(githubGraphQlCacheTtlSeconds("repo_totals", { GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS: "180" })).toBe(600);
   });
 });
 


### PR DESCRIPTION
## Summary

- Branch `githubGraphQlCacheTtlSeconds` on `repo_totals` vs `contributor_activity`, mirroring `githubResponseCacheTtlSeconds`.
- Add `GITHUB_GRAPHQL_REPO_TOTALS_CACHE_TTL_SECONDS` and `GITHUB_GRAPHQL_CONTRIBUTOR_ACTIVITY_CACHE_TTL_SECONDS` (default 600s each when unset).
- Remove the shared `GITHUB_GRAPHQL_CACHE_TTL_SECONDS` env var so each class has exactly one configuration knob.

Closes #6609

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally on `test/unit/github-graphql-cache.test.ts` (22 tests pass; per-class TTL branches covered)
- [ ] `npm run test:workers` (no worker binding changes)
- [ ] `npm run build:mcp` (no MCP changes)
- [ ] `npm run test:mcp-pack` (no MCP changes)
- [ ] `npm run ui:openapi:check` (no API/schema changes)
- [ ] `npm run ui:lint` (no UI changes)
- [ ] `npm run ui:typecheck` (no UI changes)
- [ ] `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only TTL resolver change; skipped UI/MCP/workers checks and full unsharded `test:ci` (local Windows env has unrelated pre-existing failures in miner/selfhost script tests).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change.

## Notes

- Operators who previously set `GITHUB_GRAPHQL_CACHE_TTL_SECONDS` must migrate to the two class-specific vars; there is no silent alias by design (matches REST cache one-var-per-class model).
