### PR TITLE
test(settings): inject Batch C gate/AI-review fields via the manifest (small files)

### DIFF
--- a/test/unit/actions-fallback-webhook.test.ts
+++ b/test/unit/actions-fallback-webhook.test.ts
@@ -114,11 +114,10 @@ async function seedRepoAndPr(env: ReturnType<typeof createTestEnv>, headSha: str
   await upsertRepositorySettings(env, {
     repoFullName: "owner/fallback-repo",
     autonomy: { merge: "observe", update_branch: "observe" },
-    aiReviewMode: "off",
     gatePack: "oss-anti-slop",
   });
   await upsertRepoFocusManifest(env, "owner/fallback-repo", {
-    settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off" },
+    settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off", aiReviewMode: "off" },
   });
   await upsertPullRequestFromGitHub(env, "owner/fallback-repo", {
     number: 55,

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1057,10 +1057,8 @@ describe("GitHub backfill", () => {
       },
     });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
-    await upsertRepositorySettings(env, {
-      repoFullName: "JSONbored/gittensory",
-      reviewCheckMode: "required", // checkRunMode left at its default ("off")
-    });
+    // checkRunMode left at its default ("off")
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required" } });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.endsWith("/app/installations/123")) {

--- a/test/unit/data-spine.test.ts
+++ b/test/unit/data-spine.test.ts
@@ -270,6 +270,9 @@ describe("data spine repositories", () => {
     // gatePack (#692) round-trips and defaults to gittensor.
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", gatePack: "oss-anti-slop" });
     expect((await getRepositorySettings(env, "owner/repo")).gatePack).toBe("oss-anti-slop");
+    // Left DB-based (not manifest injection): this exercises getRepositorySettings's own raw DB round-trip
+    // directly -- it has no manifest overlay (that's resolveRepositorySettings/resolveEffectiveSettings) --
+    // so a manifest-only write here would never be observed by the assertion below.
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", gatePack: "gittensor", linkedIssueGateMode: "block" });
     expect(await getRepositorySettings(env, "owner/repo")).toMatchObject({ gatePack: "gittensor", linkedIssueGateMode: "block" });
     await upsertRepositorySettings(env, { repoFullName: "owner/defaultpack" });

--- a/test/unit/linked-issue-satisfaction-run.test.ts
+++ b/test/unit/linked-issue-satisfaction-run.test.ts
@@ -797,15 +797,13 @@ describe("linked-issue satisfaction wired end-to-end through the real webhook pi
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/metagraphed",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       gatePack: "oss-anti-slop",
-      linkedIssueGateMode: "off",
       // The gate under test: off by default, opted into "block" here so an above-floor "unaddressed" verdict
       // becomes a real Gate-check failure -- the exact gap #3906 filed against.
       linkedIssueSatisfactionGateMode: "block",
     });
     await upsertRepoFocusManifest(env, "JSONbored/metagraphed", {
-      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
+      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", reviewCheckMode: "required", linkedIssueGateMode: "off" },
     });
 
     let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
@@ -887,14 +885,12 @@ describe("linked-issue satisfaction wired end-to-end through the real webhook pi
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/metagraphed",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
       gatePack: "oss-anti-slop",
-      linkedIssueGateMode: "off",
       // No override -- linkedIssueSatisfactionGateMode is omitted, so upsertRepositorySettings persists its
       // default "off".
     });
     await upsertRepoFocusManifest(env, "JSONbored/metagraphed", {
-      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off" },
+      settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", reviewCheckMode: "required", linkedIssueGateMode: "off" },
     });
 
     let postedCommentBody = "";
@@ -953,12 +949,10 @@ describe("linked-issue satisfaction wired end-to-end through the real webhook pi
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/metagraphed",
       autoLabelEnabled: false,
-      reviewCheckMode: "required",
-      linkedIssueGateMode: "off",
       linkedIssueSatisfactionGateMode: "advisory",
     });
     await upsertRepoFocusManifest(env, "JSONbored/metagraphed", {
-      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" },
+      settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", reviewCheckMode: "required", linkedIssueGateMode: "off" },
     });
 
     let gatePatchBody: { conclusion?: string } = {};

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -385,12 +385,13 @@ async function seedGateEnabledRepo(env: Env): Promise<void> {
   await upsertRepositorySettings(env, {
     repoFullName: "JSONbored/gittensory",
     autoLabelEnabled: false,
-    reviewCheckMode: "required",
-    linkedIssueGateMode: "block",
     requireLinkedIssue: true,
   });
   // .loopover.yml authoritatively sets the linked-issue blocker to "block" (config-as-code).
-  await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" }, settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+  await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+    gate: { linkedIssue: "block" },
+    settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", reviewCheckMode: "required", linkedIssueGateMode: "block" },
+  });
 }
 
 // The miner-list/token/check-run endpoints the gate finalize touches; `confirmedAuthor` toggles whether the

--- a/test/unit/pr-ai-review-findings.test.ts
+++ b/test/unit/pr-ai-review-findings.test.ts
@@ -8,9 +8,10 @@ import {
   orderedFindingCategoryCountRows,
   parseStoredInlineFindings,
 } from "../../src/mcp/pr-ai-review-findings";
-import { markAiReviewPublished, putCachedAiReview, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { markAiReviewPublished, putCachedAiReview, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { buildFindingCategoryCollapsible } from "../../src/review/unified-comment-bridge";
 import type { InlineFinding } from "../../src/services/ai-review";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 const sampleFindings: InlineFinding[] = [
@@ -117,7 +118,7 @@ describe("loadPrAiReviewFindings", () => {
   it("returns ready with empty findings when a published review has no inline metadata", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "advisory" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "advisory" } });
     await putCachedAiReview(env, "acme/widgets", 11, "sha-empty", "advisory", { notes: "Clean review.", reviewerCount: 1 });
     await markAiReviewPublished(env, "acme/widgets", 11, "sha-empty");
 
@@ -135,14 +136,14 @@ describe("loadPrAiReviewFindings", () => {
   it("returns ai_review_off and not_found on the expected branches", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "off" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "off" } });
     expect(await loadPrAiReviewFindings(env, { repoFullName: "acme/widgets", pullNumber: 12, login: "miner1" })).toMatchObject({
       status: "ai_review_off",
       findings: [],
       categoryCounts: {},
     });
 
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "block" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "block" } });
     expect(await loadPrAiReviewFindings(env, { repoFullName: "acme/widgets", pullNumber: 12, login: "miner1" })).toMatchObject({
       status: "not_found",
       findings: [],
@@ -153,7 +154,7 @@ describe("loadPrAiReviewFindings", () => {
   it("nulls headSha when the published row omits it from the repository read", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
-    await upsertRepositorySettings(env, { repoFullName: "acme/widgets", aiReviewMode: "block" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "block" } });
     await env.DB.prepare(
       `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json, metadata_json, cacheable, published_at, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/test/unit/safety.test.ts
+++ b/test/unit/safety.test.ts
@@ -65,10 +65,9 @@ async function seedGateEnabledRepo(env: Env): Promise<void> {
   await upsertRepositorySettings(env, {
     repoFullName: "JSONbored/gittensory",
     autoLabelEnabled: false,
-    reviewCheckMode: "required",
     slopGateMode: "advisory", // turns the shared gateFiles load on so the reuse branch is hit
   });
-  await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+  await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "off", publicSurface: "off", checkRunMode: "off", reviewCheckMode: "required" } });
   await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: safetyMinerSnapshot("contributor") }, 60_000);
 }
 

--- a/test/unit/selftune-readback.test.ts
+++ b/test/unit/selftune-readback.test.ts
@@ -41,7 +41,8 @@ describe("resolveRepositorySettings — self-tune override overlay (flag-gated)"
   // stale, already-promoted override silently reapplied either.
   async function seed(env: Env, autonomy: Record<string, string> = { review: "auto" }): Promise<void> {
     await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, 'acme', 'widgets', 1, 1)").bind(repo).run();
-    await repositories.upsertRepositorySettings(env, { repoFullName: repo, qualityGateMinScore: 50, autonomy });
+    await repositories.upsertRepositorySettings(env, { repoFullName: repo, autonomy });
+    await upsertRepoFocusManifest(env, repo, { settings: { qualityGateMinScore: 50 } });
     await writeLiveOverride(env as unknown as StorageEnv, repo, { confidenceFloor: 0.7 });
   }
 
@@ -60,7 +61,9 @@ describe("resolveRepositorySettings — self-tune override overlay (flag-gated)"
   it("flag ON but per-repo opt-out (`.loopover.yml` review.selftune: false): a previously-promoted override is NOT read back (50, not 70)", async () => {
     const env = createTestEnv({ LOOPOVER_REVIEW_SELFTUNE: "true" });
     await seed(env);
-    await upsertRepoFocusManifest(env, repo, { review: { selftune: false } }, "api_record");
+    // Replaces the manifest snapshot seed() just persisted (upsertRepoFocusManifest is a wholesale
+    // REPLACE, not a merge) -- re-include settings.qualityGateMinScore here so the value survives.
+    await upsertRepoFocusManifest(env, repo, { review: { selftune: false }, settings: { qualityGateMinScore: 50 } }, "api_record");
     expect((await resolveRepositorySettings(env, repo)).qualityGateMinScore).toBe(50);
   });
 
@@ -75,9 +78,9 @@ describe("resolveRepositorySettings — self-tune override overlay (flag-gated)"
     const repoFullName = "acme/blacklist";
     await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, 'acme', 'blacklist', 1, 1)").bind(repoFullName).run();
     await Promise.all([
-      repositories.upsertRepositorySettings(env, { repoFullName, qualityGateMinScore: 50 }),
+      repositories.upsertRepositorySettings(env, { repoFullName }),
       repositories.upsertGlobalContributorBlacklist(env, { contributorBlacklist: [{ login: "GlobalBad", reason: "global" }] }),
-      upsertRepoFocusManifest(env, repoFullName, { settings: { contributorBlacklist: [{ login: "ManifestBad" }] } }, "api_record"),
+      upsertRepoFocusManifest(env, repoFullName, { settings: { contributorBlacklist: [{ login: "ManifestBad" }], qualityGateMinScore: 50 } }, "api_record"),
     ]);
 
     const settings = await resolveRepositorySettings(env, repoFullName);


### PR DESCRIPTION
## Summary
- Part of the Batch C test-suite conversion (loopover#6444, epic #6440). Converts 8 smaller test files (`actions-fallback-webhook.test.ts`, `backfill.test.ts`, `data-spine.test.ts`, `linked-issue-satisfaction-run.test.ts`, `parity-wire.test.ts`, `pr-ai-review-findings.test.ts`, `safety.test.ts`, `selftune-readback.test.ts`) DB-based injection of `reviewCheckMode`/`qualityGateMinScore` (whichever apply per file) to manifest-based injection via `upsertRepoFocusManifest`, mirroring Batch A/B.
- One site in `data-spine.test.ts` stays DB-based, with an explanatory comment: it asserts via `getRepositorySettings` directly, a raw DB reader with no manifest overlay, so a manifest override wouldn't be visible there.
- No production code changes — test files only.

## Scope
- [x] The 8 listed test files only
- [x] No `src/**` changes

## Validation
- `npx tsc --noEmit` — clean
- `npx vitest run` on all 8 files — 260/260 passed
- Test-only change — Codecov `codecov/patch` has no `src/**` lines to measure

## Safety
- [x] No secrets touched