### PR TITLE
fix(mcp): honor free-text tests evidence in loopover_check_test_evidence

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -155,7 +155,7 @@ import {
   buildTestGenSpec,
   type LocalWriteActionSpec,
 } from "./local-write-tools";
-import { classifyTestCoverage, isCodeFile, isTestPath, TEST_FRAMEWORKS } from "../signals/test-evidence";
+import { classifyTestCoverage, hasLocalTestEvidence, isCodeFile, isTestPath, TEST_FRAMEWORKS } from "../signals/test-evidence";
 import { applyStepResult, buildPlanDag, nextReadySteps, planProgress, validatePlanDag, type PlanDag } from "../services/plan-dag";
 import { buildFocusManifestValidation } from "../services/focus-manifest-validation";
 import { isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
@@ -1182,6 +1182,7 @@ const checkImprovementPotentialOutputSchema = {
 const checkTestEvidenceShape = {
   changedPaths: z.array(z.string().min(1).max(400)).max(2000),
   testFiles: z.array(z.string().min(1).max(400)).max(2000).optional(),
+  tests: z.array(z.string().max(400)).max(2000).optional(),
 };
 
 const checkTestEvidenceOutputSchema = {
@@ -3640,12 +3641,24 @@ export class LoopoverMcp {
   private async checkTestEvidence(input: z.infer<z.ZodObject<typeof checkTestEvidenceShape>>): Promise<ToolPayload> {
     await this.enforceToolRateLimit("loopover_check_test_evidence");
     const allPaths = [...input.changedPaths, ...(input.testFiles ?? [])];
-    const classification = classifyTestCoverage(allPaths);
     const codeFileCount = input.changedPaths.filter(isCodeFile).length;
-    const testFileCount = allPaths.filter(isTestPath).length;
+    let classification = classifyTestCoverage(allPaths);
+    let testFileCount = allPaths.filter(isTestPath).length;
+    // Credit free-text `tests` evidence (e.g. "ran `go test ./...` locally, no new file") the same way the
+    // sibling tools loopover_check_slop_risk / loopover_suggest_boundary_tests already do via
+    // hasLocalTestEvidence. Only ever LIFT an otherwise-"absent" verdict -- never make this more lenient than
+    // the path-based signal once real test-file evidence (weak/adequate/strong) already exists.
+    const creditedByFreeTextTests =
+      classification === "absent" && hasLocalTestEvidence({ tests: input.tests, testFiles: input.testFiles });
+    if (creditedByFreeTextTests) {
+      classification = "adequate";
+      testFileCount = Math.max(testFileCount, 1);
+    }
     const guidance: string[] = [];
     if (codeFileCount === 0) {
       guidance.push("No hand-authored code files changed, so the missing-test-evidence signal does not apply (e.g. a docs- or config-only change).");
+    } else if (creditedByFreeTextTests) {
+      guidance.push("No test file was detected among the changed paths, but the free-text `tests` evidence you supplied is credited as test evidence (the same way check_slop_risk and suggest_boundary_tests treat it).");
     } else if (classification === "absent") {
       guidance.push("Changed code files carry no test evidence — add or update a test that exercises the change before opening the PR.");
     } else if (classification === "strong") {

--- a/test/unit/mcp-check-test-evidence.test.ts
+++ b/test/unit/mcp-check-test-evidence.test.ts
@@ -63,4 +63,44 @@ describe("MCP loopover_check_test_evidence (#2235)", () => {
     expect(data.codeFileCount).toBe(0);
     expect(data.guidance.join(" ")).toMatch(/does not apply/i);
   });
+
+  it("credits free-text tests evidence when no test file is present, lifting absent to adequate (#6618)", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "loopover_check_test_evidence",
+      arguments: { changedPaths: ["src/a.ts", "src/b.ts"], tests: ["ran `go test ./internal/entity` locally, no new file"] },
+    });
+    const data = result.structuredContent as Result;
+    expect(data.classification).toBe("adequate"); // lifted from the path-based "absent"
+    expect(data.testFileCount).toBeGreaterThanOrEqual(1);
+    expect(data.guidance.join(" ")).toMatch(/free-text `tests`/i); // distinct wording, not the path-derived lines
+    expect(data.guidance.join(" ")).not.toMatch(/looks strong/i);
+  });
+
+  it("does not credit an empty tests array — classification stays absent (#6618)", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "loopover_check_test_evidence",
+      arguments: { changedPaths: ["src/a.ts", "src/b.ts"], tests: [] },
+    });
+    const data = result.structuredContent as Result;
+    expect(data.classification).toBe("absent");
+    expect(data.testFileCount).toBe(0);
+    expect(data.guidance.join(" ")).toMatch(/no test evidence/i);
+  });
+
+  it("does not apply the override above absent — a weak path classification stays weak (#6618)", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "loopover_check_test_evidence",
+      arguments: {
+        changedPaths: ["src/a.ts", "src/b.ts", "src/c.ts", "src/d.ts", "src/e.ts"],
+        testFiles: ["test/a.test.ts"],
+        tests: ["ran the full suite locally"],
+      },
+    });
+    const data = result.structuredContent as Result;
+    expect(data.classification).toBe("weak"); // real path evidence already present → override must not fire
+    expect(data.guidance.join(" ")).toMatch(/weak/i);
+  });
 });


### PR DESCRIPTION
## What

`loopover_check_test_evidence` (`checkTestEvidenceShape` / `checkTestEvidence`, `src/mcp/server.ts`) is documented as modeled on `checkSlopRisk`, but its shape only had `changedPaths`/`testFiles` and its handler called `classifyTestCoverage(allPaths)` directly — it never consulted `hasLocalTestEvidence`. So a caller whose only test evidence is free-text (e.g. *"ran `go test ./...` locally, no new file"*) got an `"absent"` verdict, even though `loopover_check_slop_risk` and `loopover_suggest_boundary_tests` correctly credit the exact same evidence via the shared `hasLocalTestEvidence` helper.

Resolves #6618.

## Fix

- Add an optional `tests` field to `checkTestEvidenceShape`, same bounds as the sibling shapes: `z.array(z.string().max(400)).max(2000).optional()`.
- Import `hasLocalTestEvidence` from `../signals/test-evidence`.
- In the handler, override an otherwise-`"absent"` classification to `"adequate"` (with `testFileCount >= 1`) **only** when `hasLocalTestEvidence({ tests, testFiles })` returns true, and add a distinct guidance line noting the evidence came from the free-text field (not path-derived).
- The override applies **only above `"absent"`**: `weak`/`adequate`/`strong` path-based classifications are returned unchanged, so the tool never becomes more lenient than the path signal once real test-file evidence exists.

## Tests

Three new cases in `test/unit/mcp-check-test-evidence.test.ts`: free-text-only evidence lifts `absent`→`adequate` with distinct guidance; an empty `tests: []` stays `absent` (matching `hasLocalTestEvidence({ tests: [] }) === false`); and a `weak` path classification stays `weak` (override does not fire above absent). Each new branch is exercised.

Locally: typecheck clean for the changed files; `hasLocalTestEvidence` semantics the override relies on verified via `test/unit/test-evidence.test.ts` (23/23). The full MCP integration suite runs in CI.