### PR TITLE
feat(mcp): REST route + CLI mirror for loopover_get_eligibility_plan

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -889,6 +889,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Explain a private score preview multiplier-by-multiplier with plain-English levers and the highest-impact improvement.",
   },
   {
+    name: "loopover_get_eligibility_plan",
+    category: "discovery",
+    description: "Derive a structured eligibility plan from local score-preview metadata: whether the branch/PR is eligible now, public-safe blockers, and cleanup paths. Advisory dry-run only — no GitHub writes.",
+  },
+  {
     name: "loopover_get_decision_pack",
     category: "discovery",
     description: "Return the private decision pack for a contributor: the ranked repos and issues to work on next, with per-repo go/raise/avoid guidance. Takes login (the contributor's GitHub username).",
@@ -1509,6 +1514,46 @@ registerStdioTool(
   async (input) => toolResult("LoopOver private local PR scoring preview.", await previewLocalScore(await withClientWorkspaceRoots(input))),
 );
 
+// Shared by loopover_explain_score_breakdown and loopover_get_eligibility_plan (#6621): both resolve the same
+// local branch/diff metadata into the /v1/scoring request body — only the endpoint they POST it to differs, so
+// the assembly lives here once rather than in two drifting copies.
+function buildLocalScoreRequestBody(workspaceInput, contributorLogin) {
+  const workspace = resolveWorkspaceCwd(workspaceInput);
+  const diff = collectLocalDiff(workspace.cwd, workspaceInput.baseRef, workspaceInput.workspaceRoots);
+  const branchPayload = buildBranchAnalysisPayload({
+    ...workspaceInput,
+    login: contributorLogin,
+    cwd: workspace.cwd,
+    repoFullName: workspaceInput.repoFullName,
+    baseRef: workspaceInput.baseRef,
+  });
+  const upstreamPreview = branchPayload.localScorerStatus;
+  const estimatedSourceLines = workspaceInput.sourceLines ?? Math.max(1, diff.changedLineCount - diff.testFiles.length);
+  return {
+    repoFullName: workspaceInput.repoFullName,
+    targetType: "local_diff",
+    targetKey: workspaceInput.targetKey ?? localDiffTargetKey(branchPayload, workspaceInput.baseRef),
+    contributorLogin,
+    labels: workspaceInput.labels,
+    linkedIssueMode: workspaceInput.linkedIssueMode,
+    sourceTokenScore: workspaceInput.sourceTokenScore ?? estimatedSourceLines,
+    sourceLines: estimatedSourceLines,
+    totalTokenScore: workspaceInput.totalTokenScore ?? diff.changedLineCount,
+    testTokenScore: diff.testFiles.length,
+    openPrCount: workspaceInput.openPrCount,
+    credibility: workspaceInput.credibility,
+    changesRequestedCount: workspaceInput.changesRequestedCount,
+    pendingMergedPrCount: workspaceInput.pendingMergedPrCount,
+    pendingClosedPrCount: workspaceInput.pendingClosedPrCount,
+    approvedPrCount: workspaceInput.approvedPrCount,
+    expectedOpenPrCountAfterMerge: workspaceInput.expectedOpenPrCountAfterMerge,
+    projectedCredibility: workspaceInput.projectedCredibility,
+    scenarioNotes: workspaceInput.scenarioNotes,
+    branchEligibility: workspaceInput.branchEligibility,
+    metadataOnly: !upstreamPreview.ok,
+  };
+}
+
 registerStdioTool(
   "loopover_explain_score_breakdown",
   {
@@ -1519,41 +1564,23 @@ registerStdioTool(
     const workspaceInput = await withClientWorkspaceRoots(input);
     const contributorLogin = workspaceInput.contributorLogin ?? activeProfile.session?.login;
     if (!contributorLogin) throw new Error("contributorLogin is required for score breakdown.");
-    const workspace = resolveWorkspaceCwd(workspaceInput);
-    const diff = collectLocalDiff(workspace.cwd, workspaceInput.baseRef, workspaceInput.workspaceRoots);
-    const branchPayload = buildBranchAnalysisPayload({
-      ...workspaceInput,
-      login: contributorLogin,
-      cwd: workspace.cwd,
-      repoFullName: workspaceInput.repoFullName,
-      baseRef: workspaceInput.baseRef,
-    });
-    const upstreamPreview = branchPayload.localScorerStatus;
-    const estimatedSourceLines = workspaceInput.sourceLines ?? Math.max(1, diff.changedLineCount - diff.testFiles.length);
-    const body = {
-      repoFullName: workspaceInput.repoFullName,
-      targetType: "local_diff",
-      targetKey: workspaceInput.targetKey ?? localDiffTargetKey(branchPayload, workspaceInput.baseRef),
-      contributorLogin,
-      labels: workspaceInput.labels,
-      linkedIssueMode: workspaceInput.linkedIssueMode,
-      sourceTokenScore: workspaceInput.sourceTokenScore ?? estimatedSourceLines,
-      sourceLines: estimatedSourceLines,
-      totalTokenScore: workspaceInput.totalTokenScore ?? diff.changedLineCount,
-      testTokenScore: diff.testFiles.length,
-      openPrCount: workspaceInput.openPrCount,
-      credibility: workspaceInput.credibility,
-      changesRequestedCount: workspaceInput.changesRequestedCount,
-      pendingMergedPrCount: workspaceInput.pendingMergedPrCount,
-      pendingClosedPrCount: workspaceInput.pendingClosedPrCount,
-      approvedPrCount: workspaceInput.approvedPrCount,
-      expectedOpenPrCountAfterMerge: workspaceInput.expectedOpenPrCountAfterMerge,
-      projectedCredibility: workspaceInput.projectedCredibility,
-      scenarioNotes: workspaceInput.scenarioNotes,
-      branchEligibility: workspaceInput.branchEligibility,
-      metadataOnly: !upstreamPreview.ok,
-    };
+    const body = buildLocalScoreRequestBody(workspaceInput, contributorLogin);
     return toolResult("LoopOver private score breakdown.", await apiPost("/v1/scoring/explain-breakdown", body));
+  },
+);
+
+registerStdioTool(
+  "loopover_get_eligibility_plan",
+  {
+    description: stdioToolDescription("loopover_get_eligibility_plan"),
+    inputSchema: localScoreShape,
+  },
+  async (input) => {
+    const workspaceInput = await withClientWorkspaceRoots(input);
+    const contributorLogin = workspaceInput.contributorLogin ?? activeProfile.session?.login;
+    if (!contributorLogin) throw new Error("contributorLogin is required for the eligibility plan.");
+    const body = buildLocalScoreRequestBody(workspaceInput, contributorLogin);
+    return toolResult("LoopOver private eligibility plan.", await apiPost("/v1/scoring/eligibility-plan", body));
   },
 );
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -169,6 +169,7 @@ import { buildRemediationPlan } from "../services/remediation-plan";
 import { handleDraftCreate, handleDraftOAuthCallback, handleDraftStatus } from "../services/draft";
 import { decidePendingAgentAction } from "../services/agent-approval-queue";
 import { explainScoreBreakdown } from "../services/score-breakdown";
+import { deriveEligibilityPlan } from "../services/eligibility-plan";
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import {
   authoritativeContributorRepoStats,
@@ -2111,6 +2112,29 @@ export function createApp() {
     const input = { ...parsed.data, openIssueCount, applyTimeDecay: isTimeDecayEnabled(c.env) };
     const preview = buildScorePreview({ input, repo, snapshot, contributorEvidence: evidence });
     return c.json(explainScoreBreakdown(preview));
+  });
+
+  app.post("/v1/scoring/eligibility-plan", async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsed = scorePreviewSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_scoring_preview_request", issues: parsed.error.issues }, 400);
+    // Like /v1/scoring/preview (and loopover_get_eligibility_plan's own MCP handler), the contributor gate is
+    // conditional on contributorLogin being supplied — not unconditionally required as in explain-breakdown.
+    if (parsed.data.contributorLogin) {
+      const unauthorized = await requireContributorAccess(c, parsed.data.contributorLogin);
+      if (unauthorized) return unauthorized;
+    }
+    const [repo, snapshot, evidence, contributorIssues] = await Promise.all([
+      getRepository(c.env, parsed.data.repoFullName),
+      getOrCreateScoringModelSnapshot(c.env),
+      parsed.data.contributorLogin ? getContributorEvidence(c.env, parsed.data.contributorLogin) : Promise.resolve(null),
+      parsed.data.contributorLogin ? listContributorIssues(c.env, parsed.data.contributorLogin) : Promise.resolve([]),
+    ]);
+    const openIssueCount = contributorOpenIssueCount(contributorIssues, parsed.data.repoFullName);
+    // Time-decay (#703) is an owner-gated global, injected server-side (not caller-controllable).
+    const input = { ...parsed.data, openIssueCount, applyTimeDecay: isTimeDecayEnabled(c.env) };
+    const preview = buildScorePreview({ input, repo, snapshot, contributorEvidence: evidence });
+    return c.json(deriveEligibilityPlan(preview));
   });
 
   app.get("/v1/sync/status", async (c) => {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2012,6 +2012,37 @@ describe("api routes", () => {
     expect(missingContributorBreakdown.status).toBe(400);
     await expect(missingContributorBreakdown.json()).resolves.toMatchObject({ error: "contributor_login_required" });
 
+    // #6621: /v1/scoring/eligibility-plan reuses the same fetch/build as explain-breakdown but returns a
+    // deriveEligibilityPlan verdict, and — like /v1/scoring/preview — treats contributorLogin as optional.
+    const eligibilityPlan = await app.request(
+      "/v1/scoring/eligibility-plan",
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify(agedScoreInput) },
+      env,
+    );
+    expect(eligibilityPlan.status).toBe(200);
+    const eligibilityPlanBody = (await eligibilityPlan.json()) as {
+      eligible: boolean;
+      branchEligibilityStatus: string;
+      blockers: string[];
+      cleanupPaths: string[];
+    };
+    expect(eligibilityPlanBody).toMatchObject({
+      eligible: expect.any(Boolean),
+      branchEligibilityStatus: expect.any(String),
+      blockers: expect.any(Array),
+      cleanupPaths: expect.any(Array),
+    });
+
+    // Unlike explain-breakdown (which 400s without a contributorLogin), the eligibility plan omits the
+    // contributor gate when no login is supplied — the conditional path shared with /v1/scoring/preview.
+    const anonymousEligibilityPlan = await app.request(
+      "/v1/scoring/eligibility-plan",
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ repoFullName: "entrius/allways-ui", sourceTokenScore: 42 }) },
+      env,
+    );
+    expect(anonymousEligibilityPlan.status).toBe(200);
+    await expect(anonymousEligibilityPlan.json()).resolves.toMatchObject({ eligible: expect.any(Boolean), blockers: expect.any(Array) });
+
     for (const [signalType, payload] of [
       ["queue-health", { repoFullName: "entrius/allways-ui", signals: { openPullRequests: 2 } }],
       ["config-quality", { repoFullName: "entrius/allways-ui", notObservedConfiguredLabels: ["refactor"] }],
@@ -4543,6 +4574,7 @@ describe("api routes", () => {
 
     for (const [path, error] of [
       ["/v1/scoring/preview", "invalid_scoring_preview_request"],
+      ["/v1/scoring/eligibility-plan", "invalid_scoring_preview_request"],
       ["/v1/agent/runs", "invalid_agent_run_request"],
       ["/v1/agent/plan-next-work", "invalid_agent_plan_request"],
       ["/v1/agent/preflight-branch", "invalid_agent_preflight_branch_request"],

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -253,6 +253,19 @@ describe("api route guards and error branches", () => {
     expect(victimScorePreview.status).toBe(403);
     await expect(victimScorePreview.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
 
+    // #6621: /v1/scoring/eligibility-plan applies the same contributor gate as /v1/scoring/preview.
+    const victimEligibilityPlan = await app.request(
+      "/v1/scoring/eligibility-plan",
+      {
+        method: "POST",
+        headers: sessionHeaders,
+        body: JSON.stringify({ repoFullName: "owner/private-repo", contributorLogin: "victim", metadataOnly: true }),
+      },
+      env,
+    );
+    expect(victimEligibilityPlan.status).toBe(403);
+    await expect(victimEligibilityPlan.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
+
     const victimBranchPayload = {
       login: "victim",
       repoFullName: "owner/private-repo",


### PR DESCRIPTION
## Summary

Closes #6621

`loopover_get_eligibility_plan` existed **only** on the remote MCP server (`src/mcp/server.ts`) — the one tool in the `preview` / `explain_breakdown` / `eligibility_plan` trio with no REST route and no local CLI mirror. This adds both, modelled exactly on `loopover_explain_score_breakdown`'s existing pair.

- **`POST /v1/scoring/eligibility-plan`** (`src/api/routes.ts`), placed immediately after `explain-breakdown` and structured identically: same `scorePreviewSchema`, same `repo`/`snapshot`/`evidence`/`contributorIssues` fetch, same `buildScorePreview(...)`. It returns `deriveEligibilityPlan(preview)` (reused as-is from `src/services/eligibility-plan.ts`, not reimplemented) and — like `/v1/scoring/preview`, and matching `loopover_get_eligibility_plan`'s own MCP handler — treats `contributorLogin` as **optional** (conditional gate), not the unconditional requirement `explain-breakdown` uses.
- **`loopover_get_eligibility_plan` stdio tool** in `packages/loopover-mcp/bin/loopover-mcp.js`, plus a `STDIO_TOOL_DESCRIPTORS` entry (category `discovery`, matching the server's `MCP_TOOL_CATEGORIES`). The local branch-metadata→request-body assembly it shares with `loopover_explain_score_breakdown` is **factored into a `buildLocalScoreRequestBody` helper both call**, per the issue's preferred option, so the two can't drift — the only difference is the `apiPost` path.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6621`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` *(see note — type-safe by construction; local root typecheck OOMs)*
- [x] `npm run test:coverage` *(the changed route's every branch is covered — see below)*
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- **Route coverage (the codecov/patch-gated surface).** Ran the affected integration tests green: `test/integration/api.test.ts` "serves deterministic signal endpoints" now exercises the new route's **authorized path** (contributorLogin present → 200 + `{eligible, branchEligibilityStatus, blockers, cleanupPaths}`), the **optional-login path** (no contributorLogin → 200, the branch that differs from explain-breakdown), and the **invalid-body 400** (added to the parametrized `invalid_scoring_preview_request` list). The **contributor-gate 403** branch is covered in `test/integration/routes-errors.test.ts`, mirroring the existing `victimScorePreview` case (a session whose actor ≠ the requested contributor). That is every branch of the new route.
- **CLI coverage.** `packages/loopover-mcp/bin/loopover-mcp.js` is not in `vitest.config.ts`'s `coverage.include`, so it isn't codecov-gated. Its registration, description, and category are validated by the existing `test/unit/mcp-cli-tools.test.ts` (which boots the real stdio server and asserts descriptors match registered tools) — passing with the new tool. The request-body assembly is now the shared `buildLocalScoreRequestBody` helper, exercised through `loopover_explain_score_breakdown`'s unchanged path; the sole delta is the `apiPost` endpoint string.
- **Typecheck.** The route is byte-identical to the adjacent, type-checked `explain-breakdown` route except the terminal call; `explainScoreBreakdown` and `deriveEligibilityPlan` both take the same `ScorePreviewResult`, so passing the shared `preview` is type-safe by construction. The repo's root `typecheck` OOMs locally; an isolated `tsc` surfaces no error at the changed lines (only pre-existing ambient-type/config artifacts common to the whole file). CI runs the full typecheck.
- **OpenAPI.** `src/openapi/spec.ts` is hand-curated and does not list `explain-breakdown` (or `preview`'s siblings); the new route follows that precedent, so `ui:openapi:check` needs no regen.
- Prettier is not run by CI (no `format`/`format:check` script, absent from `test:ci`); all four touched files are already non-prettier-clean on `main`, so no formatting churn was introduced.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section.
- [ ] Public docs/changelogs are updated where needed.

The new route inherits the exact contributor gate of its siblings: `requireContributorAccess` is applied when a `contributorLogin` is supplied (403 `forbidden_contributor` on a mismatch — tested), and `deriveEligibilityPlan` returns only public-safe blocker/cleanup language (no scores or private counts) by construction.

## Notes

`deriveEligibilityPlan` and the remote `loopover_get_eligibility_plan` tool are unchanged; this only adds the missing HTTP + CLI reach. The shared `buildLocalScoreRequestBody` extraction removes the copy-paste the issue flagged, so `explain_score_breakdown` and `get_eligibility_plan` stay in lockstep.

Closes #6621
