### PR TITLE
fix(github): compare the bot login case-insensitively when dismissing its approval

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -132,7 +132,12 @@ export async function dismissLatestBotApproval(env: Env, installationId: number,
     const { owner, repo } = splitRepo(repoFullName);
     return await withInstallationTokenRetry(env, installationId, async (token) => {
       const octokit = makeInstallationOctokit(env, token, "live", githubRateLimitAdmissionKeyForInstallation(installationId));
-      const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
+      // Compared case-INSENSITIVELY, like every other bot-login check in this subsystem
+      // (isLoopOverBotComment in comments.ts:104, normalizeGitHubSlug/isBotActor in self-authored.ts). GitHub's
+      // canonical casing for the login need not match however GITHUB_APP_SLUG happens to be configured, and a
+      // case-sensitive === would degrade to a silent no-op: no match, no error, a stale bot approval simply
+      // never dismissed (#6614).
+      const botLogin = `${env.GITHUB_APP_SLUG}[bot]`.toLowerCase();
       // Reviews are returned oldest-first; the LAST matching entry across ALL pages is the bot's most recent
       // APPROVE. Stopping at page 1 would find (or miss) the wrong review on a PR with >100 total reviews.
       let latestApprovalId: number | undefined;
@@ -140,7 +145,7 @@ export async function dismissLatestBotApproval(env: Env, installationId: number,
         const response = await octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", { owner, repo, pull_number: pullNumber, per_page: REVIEW_PAGE_SIZE, page });
         const batch = response.data as Array<{ id: number; state?: string; user?: { login?: string | null } | null }>;
         for (const review of batch) {
-          if (review.user?.login === botLogin && review.state === "APPROVED") latestApprovalId = review.id;
+          if (review.user?.login?.toLowerCase() === botLogin && review.state === "APPROVED") latestApprovalId = review.id;
         }
         if (batch.length < REVIEW_PAGE_SIZE) break;
       }

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -567,6 +567,51 @@ describe("GitHub PR action primitives (#778)", () => {
     expect(calls[0]?.body).toMatchObject({ message: "stale approval retracted", event: "DISMISS" });
   });
 
+  it("dismisses the bot's approve review when GitHub returns a different login casing than GITHUB_APP_SLUG (#6614)", async () => {
+    // The regression: `Gittensory[bot]` vs the default GITHUB_APP_SLUG of `gittensory` matched nothing under
+    // the old case-sensitive ===, so this returned { dismissed: false } — a SILENT no-op, no error, leaving a
+    // stale bot approval standing. The human reviewer whose login differs only in case must still be ignored.
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/11/reviews") && !url.includes("/dismissals") && method === "GET") {
+        return Response.json([
+          { id: 1, state: "APPROVED", user: { login: "Human-Reviewer" } },
+          { id: 2, state: "APPROVED", user: { login: "Gittensory[bot]" } }, // an EARLIER bot approve, mixed case
+          { id: 3, state: "CHANGES_REQUESTED", user: { login: "GITTENSORY[BOT]" } },
+          { id: 4, state: "APPROVED", user: { login: "GitTensory[Bot]" } }, // the LATEST bot approve — this one
+        ]);
+      }
+      if (url.includes("/pulls/11/reviews/4/dismissals") && method === "PUT") {
+        calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+        return Response.json({ id: 4, state: "DISMISSED" });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    const result = await dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 11, "stale approval retracted");
+    expect(result).toEqual({ dismissed: true });
+    expect(calls).toHaveLength(1); // the mixed-case human's approve (id 1) was never dismissed
+  });
+
+  it("still ignores a review whose author is missing a login entirely (#6614)", async () => {
+    // The optional-chain's nullish side: `review.user?.login?.toLowerCase()` must not throw on a null author
+    // (a ghosted/deleted account) and must not match the bot.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/12/reviews")) {
+        return Response.json([
+          { id: 1, state: "APPROVED", user: null },
+          { id: 2, state: "APPROVED", user: { login: null } },
+        ]);
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 12, "retract")).resolves.toEqual({ dismissed: false });
+  });
+
   it("is a no-op when the bot never approved this PR", async () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();


### PR DESCRIPTION
## Summary

`dismissLatestBotApproval` matched the review author against `` `${env.GITHUB_APP_SLUG}[bot]` `` with a case-sensitive `===`. Every other bot-login comparison in this subsystem lowercases first — `isLoopOverBotComment` (`comments.ts:104-106`), and `normalizeGitHubSlug`/`isBotActor` (`self-authored.ts:23-29`, `:36-40`). This one didn't.

**Why it matters more than a cosmetic inconsistency:** GitHub's canonical casing for the login need not match however an operator configured `GITHUB_APP_SLUG`. On a mismatch the loop found nothing, `latestApprovalId` stayed `undefined`, and the function returned `{ dismissed: false }` — the *same value it legitimately returns when the bot never approved*. No error, no throw, no log: a stale bot approval would simply never be dismissed for a review-evasion or re-review flow that depends on it, and the failure is indistinguishable from the healthy no-op.

## The fix

Lowercase both sides, mirroring `isLoopOverBotComment` exactly:

```ts
const botLogin = `${env.GITHUB_APP_SLUG}[bot]`.toLowerCase();
...
if (review.user?.login?.toLowerCase() === botLogin && review.state === "APPROVED") latestApprovalId = review.id;
```

Note `?.toLowerCase()` rather than `.toLowerCase()`: `login` is typed `string | null | undefined`, so the optional chain keeps a ghosted/deleted author from throwing — the old `===` tolerated that and the fix must too.

**Scoped to the login comparison only**, per the issue: pagination, the latest-across-all-pages selection, the best-effort `try/catch`, and the dismissal write are untouched.

## Tests

- **The regression test genuinely reproduces the bug — verified, not assumed.** With the fix stashed and only the test applied, it **fails**; with the fix, it passes. A test that passed either way would have pinned nothing.
- It mirrors the existing `"dismisses the bot's own LATEST approve review…"` case the issue points at, using `Gittensory[bot]` / `GITTENSORY[BOT]` / `GitTensory[Bot]` against the default `GITHUB_APP_SLUG: "gittensory"` — and keeps a **`Human-Reviewer`** approve in the fixture so the assertion still proves the fix didn't over-match into dismissing a human's review. The earlier mixed-case bot approve is also still correctly skipped in favour of the latest.
- A second case covers the **nullish side** of the new optional chain (`user: null` and `login: null`), so both sides of the branch I introduced are exercised rather than just the happy one.

## Validation

- [x] **Patch coverage 100%, measured** from the v8 JSON report against my changed lines (135–140, 148): **zero uncovered statements, zero partial branches**. Clears the 99% `codecov/patch` wall on `src/**`.
- [x] **289/289 pass** across every suite that reaches this function: `github-pr-actions`, `agent-action-executor`, `agent-approval-queue` (the full consumer set of `dismissLatestBotApproval`).
- [x] `npm run typecheck` — 0 errors · `eslint` — 0 errors/0 warnings · `git diff --check` clean · rebased on latest `main`, no base conflict.

## Scope

- [x] Two files: the one-line comparison fix and its regression tests. Wanted paths (`src/`, `test/`).
- [x] No behavior change for the matching-case path that works today — only the mismatched-case path stops silently no-op'ing.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Strictly widening: a login that matched before still matches (lowercasing both sides is stable for already-equal strings). The only newly-matched reviews are the bot's own approvals that differ solely in case — which is precisely the bug.
- [x] Cannot over-match a human: the comparison is still a full-string equality against `<slug>[bot]`, not a substring or prefix, and the test pins that a mixed-case human reviewer's approve is left alone.

Closes #6614
