### PR TITLE
fix(review): align lockfile-tamper finding text with lockfile-entry check

### DIFF
--- a/src/review/lockfile-tamper.ts
+++ b/src/review/lockfile-tamper.ts
@@ -224,7 +224,7 @@ export function lockfileTamperRiskFinding(files: PullRequestFileRecord[]): Advis
   const hasUnbumped = flagged.some((f) => f.reason === "unbumped_resolved");
   const detailParts: string[] = [];
   if (hasOffRegistry) detailParts.push("a resolved URL points outside registry.npmjs.org");
-  if (hasUnbumped) detailParts.push("a resolved/integrity value changed without a matching package.json version bump");
+  if (hasUnbumped) detailParts.push("a resolved/integrity value changed without a matching version bump in the lockfile entry itself");
 
   return {
     code: "lockfile_tamper_risk",

--- a/test/unit/lockfile-tamper.test.ts
+++ b/test/unit/lockfile-tamper.test.ts
@@ -56,7 +56,7 @@ describe("lockfileTamperRiskFinding", () => {
     expect(finding).toBeNull();
   });
 
-  it("triggers on a hand-edited resolved/integrity with NO corresponding package.json version bump", () => {
+  it("triggers on a hand-edited resolved/integrity with NO corresponding lockfile-entry version bump", () => {
     const lockPatch = [
       '@@ -100,8 +100,8 @@',
       '     "node_modules/lodash": {',


### PR DESCRIPTION
## Summary
- Corrects the user-facing lockfile-tamper finding text so it describes comparing the lockfile entry's own `version` field (the #2676 redesign), not the abandoned package.json cross-reference.
- Updates the matching test description so it doesn't perpetuate the stale framing.

Closes #6633

## Test plan
- [ ] Existing `lockfile-tamper` unit suite still passes
- [ ] Finding detail for an unbumped resolved/integrity case mentions the lockfile entry version, not package.json

Made with [Cursor](https://cursor.com)