### PR TITLE
fix(github): reject per-segment whitespace in splitRepo

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -21,11 +21,11 @@ const COMMIT_MESSAGES_PAGE_SIZE = 100;
 // recorded, not swallowed.
 
 function splitRepo(repoFullName: string): { owner: string; repo: string } {
-  if (repoFullName !== repoFullName.trim()) {
-    throw new Error(`Invalid repository full name: ${repoFullName}`);
-  }
+  // Reject any whitespace (leading, trailing, or per-segment like `owner/ repo`) so a padded slug can never
+  // reach a GitHub call — a valid owner/repo name never contains spaces. Mirrors parseRepoFullName in
+  // assignees.ts / labels.ts (#6613).
   const parts = repoFullName.split("/");
-  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+  if (parts.length !== 2 || !parts[0] || !parts[1] || /\s/.test(repoFullName)) {
     throw new Error(`Invalid repository full name: ${repoFullName}`);
   }
   return { owner: parts[0], repo: parts[1] };

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -21,6 +21,12 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(closePullRequest(createTestEnv(), 1, " owner/repo ", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
+    // Per-segment padding (#6613) — mirrors assignees.ts parseRepoFullName coverage.
+    for (const padded of ["owner/ repo", "owner /repo"]) {
+      await expect(closePullRequest(createTestEnv(), 1, padded, 4)).rejects.toThrow(
+        /Invalid repository full name/,
+      );
+    }
     let called = false;
     vi.stubGlobal("fetch", async () => {
       called = true;
@@ -32,6 +38,11 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(closePullRequest(envWithKey(), 1, " owner/repo ", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
+    for (const padded of ["owner/ repo", "owner /repo"]) {
+      await expect(closePullRequest(envWithKey(), 1, padded, 4)).rejects.toThrow(
+        /Invalid repository full name/,
+      );
+    }
     expect(called).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- `splitRepo` now rejects any whitespace in `repoFullName` (including `owner/ repo` / `owner /repo`), matching `parseRepoFullName` in assignees/labels.
- Extends the existing validation test to cover per-segment padding.

Closes #6613

## Test plan
- [ ] `github-pr-actions` validation test rejects `owner/ repo` and `owner /repo` before any GitHub call
- [ ] Existing whole-string padding / malformed name cases still throw the same message shape
- [ ] codecov/patch green

Made with [Cursor](https://cursor.com)