### PR TITLE
fix(engine): align predicted-gate collision risk with live gate

### DIFF
--- a/packages/loopover-engine/src/signals/predicted-gate-engine.ts
+++ b/packages/loopover-engine/src/signals/predicted-gate-engine.ts
@@ -136,7 +136,7 @@ export function buildCollisionReport(
     const items = [issueItem(issue), ...linkedPrs.map(prItem)];
     clusters.set(`issue-${issue.number}`, {
       id: `issue-${issue.number}`,
-      risk: linkedPrs.length > 1 || issue.linkedPrs.length > 1 ? "high" : "medium",
+      risk: linkedPrs.length > 1 ? "high" : "medium",
       reason: `Open PR work references issue #${issue.number}.`,
       items,
     });

--- a/test/contract/predicted-gate-engine-collision-parity.test.ts
+++ b/test/contract/predicted-gate-engine-collision-parity.test.ts
@@ -88,6 +88,17 @@ describe("predicted-gate engine collision parity (#2283)", () => {
     expect(collisions.clusters).toHaveLength(0);
   });
 
+  it("REGRESSION (#6629): risk uses freshly-computed linkedPrs only — stale issue.linkedPrs cannot inflate to high", () => {
+    const directRepo = repo("owner/parity");
+    // Exactly one open PR actually references the issue; the issue's own linkedPrs field is stale/inflated.
+    const shared = issue(directRepo.fullName, 7, "Auth token refresh race", { linkedPrs: [50, 51, 52] });
+    const onlyLocal = pr(directRepo.fullName, 50, "Guard the token refresh race", { linkedIssues: [7] });
+    const collisions = buildCollisionReport(directRepo.fullName, [shared], [onlyLocal]);
+    const cluster = collisions.clusters.find((c) => c.id === "issue-7");
+    expect(cluster).toBeDefined();
+    expect(cluster?.risk).toBe("medium");
+  });
+
   it("buildQueueHealth counts draft PRs and fires inactive_draft_prs finding when stale", () => {
     const directRepo = repo("owner/draft-test");
     const collisions = buildCollisionReport(directRepo.fullName, [], []);


### PR DESCRIPTION
## Summary
- Removes the extra `issue.linkedPrs.length > 1` clause from predicted-gate `buildCollisionReport` risk so it matches the canonical live-gate twin in `engine.ts`.
- Adds a regression test: a single freshly-linked PR stays `medium` risk even when the issue's stale `linkedPrs` field lists multiple PRs.

Closes #6629

## Test plan
- [ ] New #6629 collision-parity regression passes
- [ ] Existing predicted-gate collision parity suite still green
- [ ] codecov/patch green

Made with [Cursor](https://cursor.com)