### PR TITLE
fix(review): guard fix-handoff suggestion blocks against an embedded code fence

### DIFF
--- a/src/review/fix-handoff-render.ts
+++ b/src/review/fix-handoff-render.ts
@@ -58,7 +58,10 @@ export function buildFixHandoffBlock(finding: InlineFinding): FixHandoffBlock {
   const location = hasLine ? `${safePath}:${line}` : `${safePath} (no specific line)`;
   const label = finding.severity === "blocker" ? "Blocker" : "Nit";
   const suggestedChange = finding.suggestion?.trim() || undefined;
-  const suggestionBlock = suggestedChange ? `\n\nSuggested change:\n\`\`\`\n${suggestedChange}\n\`\`\`` : "";
+  // Skip the fenced block when the suggestion itself contains a ``` sequence, which would close the outer fence
+  // early and break the rendered markdown -- matching inline-suggestion-anchor.ts's safeSuggestionBlock guard.
+  const suggestionBlock =
+    suggestedChange && !suggestedChange.includes("```") ? `\n\nSuggested change:\n\`\`\`\n${suggestedChange}\n\`\`\`` : "";
   const body = [
     FIX_HANDOFF_MARKER,
     `**Fix handoff — ${label} at \`${location}\`**`,
@@ -106,7 +109,9 @@ function fixHandoffAggregateItem(finding: InlineFinding, index: number): string 
   const location = hasLine ? `${safePath}:${finding.line}` : `${safePath} (no specific line)`;
   const label = finding.severity === "blocker" ? "Blocker" : "Nit";
   const suggestion = finding.suggestion?.trim();
-  const suggestionBlock = suggestion ? `\n   \`\`\`\n   ${suggestion.replace(/\n/g, "\n   ")}\n   \`\`\`` : "";
+  // Same fence-safety guard as buildFixHandoffBlock / safeSuggestionBlock: an embedded ``` would break the block.
+  const suggestionBlock =
+    suggestion && !suggestion.includes("```") ? `\n   \`\`\`\n   ${suggestion.replace(/\n/g, "\n   ")}\n   \`\`\`` : "";
   return `${index + 1}. **${label} at \`${location}\`** — ${finding.body}${suggestionBlock}`;
 }
 

--- a/test/unit/fix-handoff-render.test.ts
+++ b/test/unit/fix-handoff-render.test.ts
@@ -39,6 +39,14 @@ describe("buildFixHandoffBlock (#2175)", () => {
     expect(block.body).not.toContain("Suggested change:");
   });
 
+  it("skips the fenced block when the suggestion itself contains a ``` sequence (#6632)", () => {
+    const block = buildFixHandoffBlock(finding({ suggestion: "Replace with:\n```\nconst x = 1;\n```" }));
+    // The embedded fence would close the outer block early, so the fenced rendering is skipped entirely
+    // (matching safeSuggestionBlock); no stray ``` leaks into the rendered markdown.
+    expect(block.body).not.toContain("Suggested change:");
+    expect(block.body).not.toContain("```");
+  });
+
   it("yields a path-only block (line 0) when the finding has no commentable line (line <= 0)", () => {
     const block = buildFixHandoffBlock(finding({ line: 0 }));
     expect(block.line).toBe(0);
@@ -121,6 +129,11 @@ describe("buildFixHandoffAggregateBlock (#5102)", () => {
   it("omits the suggestion block entirely when absent or whitespace-only", () => {
     expect(buildFixHandoffAggregateBlock([finding()])?.body).not.toContain("```");
     expect(buildFixHandoffAggregateBlock([finding({ suggestion: "   " })])?.body).not.toContain("```");
+  });
+
+  it("skips the fenced suggestion block when the suggestion contains a ``` sequence (#6632)", () => {
+    const block = buildFixHandoffAggregateBlock([finding({ suggestion: "```\nconst x = 1;\n```" })]);
+    expect(block?.body).not.toContain("```"); // embedded fence would break the item's block; skipped entirely
   });
 
   it("always includes the exact LOCAL_WRITE_BOUNDARY text (boundary-safe)", () => {


### PR DESCRIPTION
## What

`buildFixHandoffBlock` and `fixHandoffAggregateItem` in `src/review/fix-handoff-render.ts` splice a finding's suggestion text into a fenced code block without checking whether the suggestion itself contains a ` ``` ` sequence. A suggestion demonstrating a fenced code example would **close the outer fence early and break the rendered markdown**.

Resolves #6632.

## Fix

Add the same guard the sibling renderer `src/review/inline-suggestion-anchor.ts`'s `safeSuggestionBlock` already uses — skip the fenced block entirely when the suggestion contains ` ``` ` — to **both** call sites (`buildFixHandoffBlock` and `fixHandoffAggregateItem`). No third convention is invented.

The structured `suggestedChange` field (raw data consumed programmatically, not a fenced block) is unchanged; only the markdown rendering is guarded, matching the precedent.

## Tests

`test/unit/fix-handoff-render.test.ts` gains a regression for each function: a suggestion containing a ` ``` ` fence renders no fenced block (no stray ` ``` ` leaks into the output), while the existing present/absent/whitespace-only cases keep their behavior. The new guard branch is covered.

Locally green: `npx vitest run test/unit/fix-handoff-render.test.ts` → 22/22; eslint clean; the new branch is covered on the diff.