### PR TITLE
fix(agent-actions): cancel in-flight CI on a blacklist close too (#6659)

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -534,13 +534,20 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     try {
       const detailOverride = await performAction(env, ctx, action);
       await audit("completed", detailOverride ?? action.reason);
-      // CI-run cancellation on a contributor_cap close (#2462, anti-abuse): stop burning CI minutes on a PR
-      // that was just closed for exceeding the contributor cap. Best-effort, AFTER the close already
+      // CI-run cancellation on an anti-abuse close (#2462 contributor_cap; extended to blacklist #6659): stop
+      // burning CI minutes on a PR that was just closed for exceeding the contributor cap, or for a banned
+      // login. contributor_cap stays opt-in (contributorCapCancelCi) since a repo may want the cap to bite
+      // without touching CI; blacklist is unconditional -- there is no scenario where a maintainer wants a
+      // permanently-banned login's CI to keep running after the close. Best-effort, AFTER the close already
       // succeeded -- cancelInFlightWorkflowRunsForHeadSha never throws, so a missing actions:write grant (or
       // any other failure here) can never retroactively turn this already-successful close into a recorded
       // "error" by escaping into the catch block below.
-      if (action.actionClass === "close" && action.closeKind === "contributor_cap" && ctx.contributorCapCancelCi && ctx.headSha) {
-        await recordContributorCapCiCancelOutcome(env, ctx, ctx.headSha);
+      if (action.actionClass === "close" && ctx.headSha) {
+        if (action.closeKind === "contributor_cap" && ctx.contributorCapCancelCi) {
+          await recordCiCancelOutcome(env, "contributor_cap", ctx, ctx.headSha);
+        } else if (action.closeKind === "blacklist") {
+          await recordCiCancelOutcome(env, "blacklist", ctx, ctx.headSha);
+        }
       }
       // Re-approval idempotency: record the head SHA we just approved so the planner skips re-approving this
       // exact commit on the next sweep (a GitHub App's own approval does not reliably flip reviewDecision to
@@ -680,14 +687,22 @@ async function maybeEscalateModeration(
   });
 }
 
-/** CI-run cancellation on a contributor_cap close (#2462): runs cancelInFlightWorkflowRunsForHeadSha and
- *  records exactly one of two audit outcomes, mirroring the established `github_app.*_permission_missing`
- *  convention (processors.ts's check-run/gate-check permission-missing audits) so a fleet-wide actions:write
- *  scope gap surfaces the same way those already do. Never throws -- both recordAuditEvent calls are
- *  best-effort (`.catch(() => undefined)`), since a failure to WRITE the audit record must not retroactively
- *  affect the close this already ran after. */
-async function auditContributorCapCiCancelled(
+// CI-run cancellation on an anti-abuse close (#2462 contributor_cap, extended to blacklist #6659): the two
+// closeKinds that share this behavior. contributor_cap keeps its original event-type spelling below (an
+// existing Grafana/audit convention other tooling already queries by -- never renamed); blacklist gets its
+// own parallel spelling rather than reusing contributor_cap's, so the audit trail never mislabels WHY a
+// PR's CI was cancelled.
+type CiCancelReasonKind = "contributor_cap" | "blacklist";
+
+/** CI-run cancellation on an anti-abuse close: runs cancelInFlightWorkflowRunsForHeadSha and records exactly
+ *  one of two audit outcomes, mirroring the established `github_app.*_permission_missing` convention
+ *  (processors.ts's check-run/gate-check permission-missing audits) so a fleet-wide actions:write scope gap
+ *  surfaces the same way those already do. Never throws -- both recordAuditEvent calls are best-effort
+ *  (`.catch(() => undefined)`), since a failure to WRITE the audit record must not retroactively affect the
+ *  close this already ran after. */
+async function auditCiCancelled(
   env: Env,
+  reasonKind: CiCancelReasonKind,
   targetKey: string,
   repoFullName: string,
   headSha: string,
@@ -695,38 +710,40 @@ async function auditContributorCapCiCancelled(
 ): Promise<void> {
   const detail = `cancelled ${outcome.cancelledCount} of ${outcome.totalFound} in-flight workflow run(s)`;
   const metadata = { repoFullName, headSha, cancelledCount: outcome.cancelledCount, totalFound: outcome.totalFound };
-  const write = recordAuditEvent(env, { eventType: "github_app.contributor_cap_ci_cancelled", actor: AGENT_ACTOR, targetKey, outcome: "completed", detail, metadata });
+  const eventType = reasonKind === "blacklist" ? "github_app.blacklist_ci_cancelled" : "github_app.contributor_cap_ci_cancelled";
+  const write = recordAuditEvent(env, { eventType, actor: AGENT_ACTOR, targetKey, outcome: "completed", detail, metadata });
   await write.catch(() => undefined);
 }
 
 // #gate finding: a genuine cancel error (network/create-token/list-run failure -- reason "error") is not a
 // permission gap; recording it under the permission-missing event type mislabels it for anyone
 // querying/dashboarding by eventType, even though metadata.reason already carries the real outcome.kind.
-async function auditContributorCapCiCancelFailed(env: Env, targetKey: string, repoFullName: string, headSha: string, reason: string, warning: string): Promise<void> {
+async function auditCiCancelFailed(env: Env, reasonKind: CiCancelReasonKind, targetKey: string, repoFullName: string, headSha: string, reason: string, warning: string): Promise<void> {
   const metadata = { repoFullName, headSha, reason };
-  const eventType = reason === "permission_missing" ? "github_app.contributor_cap_ci_cancel_permission_missing" : "github_app.contributor_cap_ci_cancel_failed";
+  const prefix = reasonKind === "blacklist" ? "blacklist" : "contributor_cap";
+  const eventType = reason === "permission_missing" ? `github_app.${prefix}_ci_cancel_permission_missing` : `github_app.${prefix}_ci_cancel_failed`;
   const write = recordAuditEvent(env, { eventType, actor: AGENT_ACTOR, targetKey, outcome: "error", detail: warning, metadata });
   await write.catch(() => undefined);
 }
 
-async function recordContributorCapCiCancelOutcome(env: Env, ctx: AgentActionExecutionContext, headSha: string): Promise<void> {
+async function recordCiCancelOutcome(env: Env, reasonKind: CiCancelReasonKind, ctx: AgentActionExecutionContext, headSha: string): Promise<void> {
   const targetKey = `${ctx.repoFullName}#${ctx.pullNumber}`;
   const outcome = await cancelInFlightWorkflowRunsForHeadSha(env, ctx.installationId, ctx.repoFullName, headSha, ctx.pullNumber);
   if (outcome.kind === "cancelled") {
-    await auditContributorCapCiCancelled(env, targetKey, ctx.repoFullName, headSha, outcome);
+    await auditCiCancelled(env, reasonKind, targetKey, ctx.repoFullName, headSha, outcome);
     return;
   }
   console.error(
     JSON.stringify({
       level: "error",
-      event: "contributor_cap_ci_cancel_failed",
+      event: `${reasonKind}_ci_cancel_failed`,
       reason: outcome.kind,
       repository: ctx.repoFullName,
       pullNumber: ctx.pullNumber,
       message: outcome.warning,
     }),
   );
-  await auditContributorCapCiCancelFailed(env, targetKey, ctx.repoFullName, headSha, outcome.kind, outcome.warning);
+  await auditCiCancelFailed(env, reasonKind, targetKey, ctx.repoFullName, headSha, outcome.kind, outcome.warning);
 }
 
 export type IssueActionExecutionContext = {

--- a/test/unit/queue-3.test.ts
+++ b/test/unit/queue-3.test.ts
@@ -1335,6 +1335,120 @@ describe("queue processors", () => {
     expect(seen.comments.some((c) => c.includes("blocked from contributing"))).toBe(true);
   });
 
+  it("blacklist (#6659): a banned author's close also cancels the PR's in-flight CI runs, unconditionally (no config toggle)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto", label: "auto" } });
+    // contributorBlacklist moved off the DB entirely (Batch B, loopover#6443) -- set via manifest injection,
+    // same as the deterministic-close test above. No contributorCapCancelCi anywhere -- CI-cancel on a
+    // blacklist close is unconditional, unlike contributor_cap's opt-in toggle.
+    await upsertRepoFocusManifest(
+      env,
+      "JSONbored/gittensory",
+      { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", contributorBlacklist: [{ login: "baduser", reason: "force-push CI churn" }], reviewCheckMode: "required", aiReviewMode: "advisory" } },
+      "repo_file",
+    );
+    const seen = { closed: false, cancelledIds: [] as number[], listedStatuses: [] as string[] };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
+      if (url.includes("/pulls/55/reviews")) return Response.json([]);
+      if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
+      if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "baduser" }, head: { sha: "bl55" }, mergeable_state: "clean" });
+      if (url.includes("/commits/bl55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/bl55/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/55/labels")) return Response.json([]);
+      if (url.includes("/issues/55/comments")) return Response.json([]);
+      if (url.includes("/actions/runs?head_sha=bl55&status=in_progress")) { seen.listedStatuses.push("in_progress"); return Response.json({ workflow_runs: [{ id: 301, event: "pull_request", pull_requests: [{ number: 55 }] }] }); }
+      if (url.includes("/actions/runs?head_sha=bl55&status=queued")) { seen.listedStatuses.push("queued"); return Response.json({ workflow_runs: [{ id: 302, event: "pull_request", pull_requests: [{ number: 55 }] }] }); }
+      if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") {
+        seen.cancelledIds.push(Number(url.match(/\/actions\/runs\/(\d+)\/cancel/)?.[1]));
+        return new Response(null, { status: 202 });
+      }
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "blacklist-close-cancel-ci",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 55, title: "Banned author PR", state: "open", user: { login: "baduser" }, head: { sha: "bl55" }, labels: [], body: "Closes #1", mergeable_state: "clean", reviewDecision: "APPROVED" },
+      },
+    });
+
+    expect(seen.closed).toBe(true);
+    expect(seen.listedStatuses.sort()).toEqual(["in_progress", "queued"]);
+    expect(seen.cancelledIds.sort()).toEqual([301, 302]);
+    const cancelAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.blacklist_ci_cancelled'").first<{ n: number }>();
+    expect(cancelAudit?.n).toBeGreaterThanOrEqual(1);
+  });
+
+  it("blacklist (#6659): a failed CI-cancel attempt degrades gracefully — the close still succeeds and a blacklist-specific failure audit is recorded", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto", label: "auto" } });
+    await upsertRepoFocusManifest(
+      env,
+      "JSONbored/gittensory",
+      { settings: { commentMode: "all_prs", publicSurface: "comment_only", checkRunMode: "off", contributorBlacklist: [{ login: "baduser", reason: "force-push CI churn" }], reviewCheckMode: "required", aiReviewMode: "advisory" } },
+      "repo_file",
+    );
+    const seen = { closed: false, cancelledIds: [] as number[] };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
+      if (url.includes("/pulls/55/reviews")) return Response.json([]);
+      if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
+      if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "baduser" }, head: { sha: "bl55" }, mergeable_state: "clean" });
+      if (url.includes("/commits/bl55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/bl55/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/55/labels")) return Response.json([]);
+      if (url.includes("/issues/55/comments")) return Response.json([]);
+      // A genuine cancel error (not a permission gap) -- both branches of that inner distinction are already
+      // covered by the contributor_cap tests above; this just needs to hit the new blacklist-prefixed event.
+      if (url.includes("/actions/runs?head_sha=bl55&status=in_progress")) return Response.json({ workflow_runs: [{ id: 303, event: "pull_request", pull_requests: [{ number: 55 }] }] });
+      if (url.includes("/actions/runs?head_sha=bl55&status=queued")) return Response.json({ workflow_runs: [] });
+      if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") { seen.cancelledIds.push(303); return new Response(null, { status: 500 }); }
+      return Response.json({});
+    });
+
+    await expect(
+      processJob(env, {
+        type: "github-webhook",
+        deliveryId: "blacklist-close-cancel-ci-failed",
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 55, title: "Banned author PR", state: "open", user: { login: "baduser" }, head: { sha: "bl55" }, labels: [], body: "Closes #1", mergeable_state: "clean", reviewDecision: "APPROVED" },
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(seen.closed).toBe(true);
+    const failedAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.blacklist_ci_cancel_failed'").first<{ n: number }>();
+    expect(failedAudit?.n).toBeGreaterThanOrEqual(1);
+  });
+
   it("screenshot-table gate (#2006): an in-scope contributor PR missing a before/after table is closed deterministically regardless of the (unrelated, still-running) AI review and no merit merge", async () => {
     let aiCalls = 0;
     const env = createTestEnv({


### PR DESCRIPTION
## Summary

- The contributor_cap close disposition (#2462) already cancels queued/in-progress GitHub Actions runs for a closed PR's head SHA when `contributorCapCancelCi` is enabled. The blacklist close disposition (#1425) never did — a permanently-banned login's CI kept running to completion even though the PR was closed deterministically ahead of any review.
- Extends the same cancellation to `closeKind: "blacklist"`, unconditionally (no new config toggle) — there's no legitimate reason to keep burning CI on a banned login's PR once it's closed.
- Refactored the shared CI-cancel helpers (`recordContributorCapCiCancelOutcome` → `recordCiCancelOutcome`, parameterized by a `CiCancelReasonKind`) so both closeKinds share one implementation. The existing `contributor_cap` audit event-type strings are unchanged (other tooling queries by those exact names); blacklist gets its own parallel event types (`github_app.blacklist_ci_cancelled`, `github_app.blacklist_ci_cancel_failed`, `github_app.blacklist_ci_cancel_permission_missing`) so the audit trail never mislabels why a PR's CI was cancelled.

Closes #6659

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full unsharded run, 930 files / 17843 tests, 0 failures) — the new/changed lines in `agent-action-executor.ts` show 100% line+branch coverage (verified via the v8 report's Uncovered Line #s, which lists only pre-existing unrelated lines).
- [x] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches exactly 2 files (`src/services/agent-action-executor.ts`, `test/unit/queue-3.test.ts`) — no MCP, UI, engine, or miner package files. Also ran and confirmed green locally: `db:migrations:check`, `db:schema-drift:check`, `cf-typegen:check`, `selfhost:env-reference:check`, `miner:env-reference:check`, `docs:drift-check`, `manifest:drift-check`, `engine-parity:drift-check`, `command-reference:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `test:engine-parity`, `test:live-gate-parity`, `test:driver-parity`. Skipped the MCP/miner pack builds and UI lint/typecheck/build locally (unaffected by this diff, and the full local `test:ci` run exceeded the 10-minute tool timeout) — deferring to CI's `validate` check for final confirmation on those steps.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No UI/frontend changes in this PR.

## Notes

- Backend-only anti-abuse fix, no UI/API-schema/DB changes, so no generated artifacts needed regeneration.