### PR TITLE
refactor(engine): consolidate plan step readiness helpers

### DIFF
--- a/packages/loopover-engine/src/plan-blocked.ts
+++ b/packages/loopover-engine/src/plan-blocked.ts
@@ -1,13 +1,5 @@
-import type { PlanDag, PlanStep, PlanStepStatus } from "./plan-export.js";
-
-const isDone = (status: PlanStepStatus): boolean => status === "completed" || status === "skipped";
-
-function nextReadySteps(plan: PlanDag): PlanStep[] {
-  const statusById = new Map(plan.steps.map((step) => [step.id, step.status]));
-  return plan.steps.filter(
-    (step) => step.status === "pending" && step.dependsOn.every((dep) => isDone(statusById.get(dep) ?? "pending")),
-  );
-}
+import type { PlanDag } from "./plan-export.js";
+import { nextReadySteps } from "./plan-step-readiness.js";
 
 /**
  * Return whether the plan is deadlocked: pending steps remain but none are runnable. Mirrors the `blocked`

--- a/packages/loopover-engine/src/plan-overall-status.ts
+++ b/packages/loopover-engine/src/plan-overall-status.ts
@@ -1,15 +1,7 @@
-import type { PlanDag, PlanStep, PlanStepStatus } from "./plan-export.js";
+import type { PlanDag } from "./plan-export.js";
+import { nextReadySteps } from "./plan-step-readiness.js";
 
 export type PlanOverallStatus = "pending" | "running" | "completed" | "failed" | "blocked";
-
-const isDone = (status: PlanStepStatus): boolean => status === "completed" || status === "skipped";
-
-function nextReadySteps(plan: PlanDag): PlanStep[] {
-  const statusById = new Map(plan.steps.map((step) => [step.id, step.status]));
-  return plan.steps.filter(
-    (step) => step.status === "pending" && step.dependsOn.every((dep) => isDone(statusById.get(dep) ?? "pending")),
-  );
-}
 
 /**
  * Resolve the coarse plan status matching hosted `planProgress`'s `status` field. Pure — reads the plan DAG only.

--- a/packages/loopover-engine/src/plan-ready.ts
+++ b/packages/loopover-engine/src/plan-ready.ts
@@ -1,13 +1,5 @@
-import type { PlanDag, PlanStep, PlanStepStatus } from "./plan-export.js";
-
-const isDone = (status: PlanStepStatus): boolean => status === "completed" || status === "skipped";
-
-function nextReadySteps(plan: PlanDag): PlanStep[] {
-  const statusById = new Map(plan.steps.map((step) => [step.id, step.status]));
-  return plan.steps.filter(
-    (step) => step.status === "pending" && step.dependsOn.every((dep) => isDone(statusById.get(dep) ?? "pending")),
-  );
-}
+import type { PlanDag } from "./plan-export.js";
+import { nextReadySteps } from "./plan-step-readiness.js";
 
 /**
  * Return whether any step is runnable now: `pending` with every dependency `completed` or `skipped`. Mirrors hosted

--- a/packages/loopover-engine/src/plan-step-readiness.ts
+++ b/packages/loopover-engine/src/plan-step-readiness.ts
@@ -1,0 +1,12 @@
+import type { PlanDag, PlanStep, PlanStepStatus } from "./plan-export.js";
+
+export function isDone(status: PlanStepStatus): boolean {
+  return status === "completed" || status === "skipped";
+}
+
+export function nextReadySteps(plan: PlanDag): PlanStep[] {
+  const statusById = new Map(plan.steps.map((step) => [step.id, step.status]));
+  return plan.steps.filter(
+    (step) => step.status === "pending" && step.dependsOn.every((dep) => isDone(statusById.get(dep) ?? "pending")),
+  );
+}

--- a/test/unit/plan-step-readiness.test.ts
+++ b/test/unit/plan-step-readiness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { isDone, nextReadySteps } from "../../packages/loopover-engine/src/plan-step-readiness";
+import type { PlanStep, PlanStepStatus } from "../../packages/loopover-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("isDone", () => {
+  it.each<PlanStepStatus>(["pending", "running", "failed"])("returns false for %s", (status) => {
+    expect(isDone(status)).toBe(false);
+  });
+
+  it.each<PlanStepStatus>(["completed", "skipped"])("returns true for %s", (status) => {
+    expect(isDone(status)).toBe(true);
+  });
+});
+
+describe("nextReadySteps", () => {
+  it("returns a pending step with no dependencies", () => {
+    const ready = step({ id: "a", title: "Build", status: "pending" });
+    expect(nextReadySteps({ steps: [ready] })).toEqual([ready]);
+  });
+
+  it("returns a pending step when its dependency is completed", () => {
+    const dep = step({ id: "a", title: "Build", status: "completed" });
+    const ready = step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] });
+    expect(nextReadySteps({ steps: [dep, ready] })).toEqual([ready]);
+  });
+
+  it("returns a pending step when its dependency is skipped", () => {
+    const dep = step({ id: "a", title: "Build", status: "skipped" });
+    const ready = step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] });
+    expect(nextReadySteps({ steps: [dep, ready] })).toEqual([ready]);
+  });
+
+  it.each<PlanStepStatus>(["running", "failed"])("returns no ready steps when a dependency is %s", (status) => {
+    const dep = step({ id: "a", title: "Build", status });
+    const blocked = step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] });
+    expect(nextReadySteps({ steps: [dep, blocked] })).toEqual([]);
+  });
+
+  it("returns no ready steps when a dependency is still pending", () => {
+    const dep = step({ id: "a", title: "Build", status: "pending", dependsOn: ["ghost"] });
+    const blocked = step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] });
+    expect(nextReadySteps({ steps: [dep, blocked] })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `packages/loopover-engine/src/plan-step-readiness.ts` with shared `isDone` and `nextReadySteps`.
- Update `plan-blocked.ts`, `plan-overall-status.ts`, and `plan-ready.ts` to import from the shared module instead of maintaining three byte-identical copies.
- Add direct unit tests for the consolidated helpers.

Closes #6626

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes)
- [x] `npm run typecheck`
- [x] Targeted `npm run test` on plan readiness/blocked/overall-status/ready suites (36 tests pass)
- [ ] `npm run test:workers` (no worker binding changes)
- [ ] `npm run build:mcp` (no MCP changes)
- [ ] `npm run test:mcp-pack` (no MCP changes)
- [ ] `npm run ui:openapi:check` (no API/schema changes)
- [ ] `npm run ui:lint` (no UI changes)
- [ ] `npm run ui:typecheck` (no UI changes)
- [ ] `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Pure internal refactor with no API/schema/UI changes; skipped unrelated validation jobs.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — engine-internal refactor only.

## Notes

- No public barrel export changes; `isDone`/`nextReadySteps` remain internal to `@loopover/engine`.
