### PR TITLE
test(review): cover extractReviewSummary suggestions-merge and sole-reviewer-consensus branches

### DIFF
--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -727,6 +727,26 @@ describe("buildUnifiedReviewInput", () => {
     expect(deriveUnifiedStatus(input)).toBe("held");
   });
 
+  it("merges a reviewer's free-form suggestions into the nits list (#6634)", () => {
+    const input = buildUnifiedReviewInput({
+      changedFiles: 1,
+      reviews: [reviewNote("merge", { nits: ["Rename foo"], suggestions: ["Consider extracting the parser"] })],
+    });
+    expect(input.nits).toContain("Consider extracting the parser"); // free-form suggestion merged in
+    expect(input.nits).toContain("Rename foo"); // alongside the explicit nit
+  });
+
+  it("a sole valid reviewer's blocker still counts as consensus (#6634)", () => {
+    const input = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("close", { blockers: ["Real defect"] })] });
+    expect(input.consensusBlocker).toBe(true); // valid.length === 1 && reviewersWithBlockers === 1
+    expect(deriveUnifiedStatus(input)).toBe("blocked");
+  });
+
+  it("consensusBlocker is false when no reviewer reports a blocker (#6634)", () => {
+    const input = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge"), reviewNote("merge")] });
+    expect(input.consensusBlocker).toBe(false);
+  });
+
   it("counts reviewers that produced no verdict (partial review)", () => {
     const input = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge"), { model: "m2", notes: null }] });
     expect(input.failedCount).toBe(1);


### PR DESCRIPTION
## What

`extractReviewSummary` (`src/review/unified-comment.ts`, lines 130-143) had two untested branches:

- **Line 136** merges each reviewer's `suggestions` array into the rendered `nits` list — never exercised, because the shared test helper always defaulted `suggestions: []`.
- **Line 140**'s documented "a sole reviewer's blocker still counts as consensus" rule (`valid.length === 1 && reviewersWithBlockers === 1`) was reachable but never asserted on `.consensusBlocker`.

Resolves #6634. **Test-only — no production code change** (`extractReviewSummary`'s logic is not in question, only its coverage).

## Tests added (`test/unit/unified-comment.test.ts`)

- A reviewer's non-empty `suggestions` array is merged into the output `nits` (alongside an explicit nit).
- A sole valid reviewer reporting a blocker yields `consensusBlocker: true` (and a `blocked` status).
- `consensusBlocker` stays `false` when no reviewer reports a blocker.

Locally green: `npx vitest run test/unit/unified-comment.test.ts` → 101/101. Since there's no `src/**` change, the codecov patch gate has no diff to score; these tests close the coverage gap on the already-shipped branches.