### PR TITLE
test(review): cover extractReviewSummary suggestions-merge + sole-reviewer consensus (#6634)

### DIFF
--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -727,6 +727,38 @@ describe("buildUnifiedReviewInput", () => {
     expect(deriveUnifiedStatus(input)).toBe("held");
   });
 
+  it("a SOLE reviewer's blocker still counts as a consensus blocker (#6634)", () => {
+    // The one-reviewer case exercises the `valid.length === 1 && reviewersWithBlockers === 1` arm of
+    // consensusBlocker — a lone blocker in a DUAL review is a split (above), but the sole reviewer IS the
+    // consensus, so its blocker hard-blocks.
+    const input = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("request_changes", { blockers: ["Real defect"] })] });
+    expect(input.consensusBlocker).toBe(true);
+    expect(deriveUnifiedStatus(input)).toBe("blocked");
+  });
+
+  it("a sole reviewer with no blocker is not a consensus blocker (#6634)", () => {
+    const input = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge")] });
+    expect(input.consensusBlocker).toBe(false);
+  });
+
+  it("merges a reviewer's free-form suggestions into the rendered nits, deduped alongside explicit nits (#6634)", () => {
+    // extractReviewSummary folds each reviewer's non-blocking `suggestions` into `nits` (both are non-blocking).
+    // The shared helper defaults `suggestions: []`, so this is the first case to push a non-empty array through.
+    const input = buildUnifiedReviewInput({
+      changedFiles: 1,
+      reviews: [
+        reviewNote("merge", { nits: ["Document the new property."], suggestions: ["Consider extracting a helper.", "document the new property."] }),
+        reviewNote("merge", { suggestions: ["Add a changeset entry."] }),
+      ],
+    });
+    // The free-form suggestions surface in nits...
+    const nits = input.nits ?? [];
+    expect(nits).toContain("Consider extracting a helper.");
+    expect(nits).toContain("Add a changeset entry.");
+    // ...alongside the explicit nit, and the case-insensitive duplicate of it is deduped away (only one survives).
+    expect(nits.filter((n) => n.toLowerCase() === "document the new property.")).toEqual(["Document the new property."]);
+  });
+
   it("counts reviewers that produced no verdict (partial review)", () => {
     const input = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge"), { model: "m2", notes: null }] });
     expect(input.failedCount).toBe(1);


### PR DESCRIPTION
## Summary

`extractReviewSummary` (`src/review/unified-comment.ts:130-143`) had two already-shipped branches with no test coverage:

- **Line 136** folds each reviewer's free-form `suggestions` array into the rendered `nits` (both are non-blocking). The shared `reviewNote` test helper only ever passed the default `suggestions: []`, so the merge was never exercised through the sole entry point `buildUnifiedReviewInput`.
- **Line 140** computes `consensusBlocker = reviewersWithBlockers >= 2 || (valid.length === 1 && reviewersWithBlockers === 1)` — the documented "a sole reviewer's blocker still counts as consensus" rule. The existing single-reviewer-with-blocker case never asserted on `.consensusBlocker`, leaving that arm unverified.

This adds three cases through `buildUnifiedReviewInput` (the sole entry point that reaches `extractReviewSummary`):

- a non-empty `suggestions` array surfaces in `nits`, deduped case-insensitively against an explicit nit;
- a **sole** reviewer's blocker → `consensusBlocker: true` (and derived status `blocked`) — the `valid.length === 1 && reviewersWithBlockers === 1` arm, distinct from the existing dual-review "lone blocker is a split → held" case;
- a sole reviewer with no blocker → `consensusBlocker: false`.

**No production code change** — `extractReviewSummary`'s logic is not in question; this only closes the coverage gap on documented behavior.

Closes #6634

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6634`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/unified-comment.test.ts` — 101 passing (3 new)

If any required check was skipped, explain why:

- The change is confined to `test/unit/unified-comment.test.ts`; no `src/**` line changes, so `codecov/patch` has no patch surface to gate, and no OpenAPI/`cf-typegen`/migration/UI regeneration applies.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No visible UI changes.
- [x] No docs/changelog changes.

## Notes

- Test-only coverage closure for an existing branch pair; behavior is unchanged.
