### PR TITLE
fix(engine): drop stale issue.linkedPrs clause from buildCollisionReport risk

### DIFF
--- a/packages/loopover-engine/src/signals/predicted-gate-engine.ts
+++ b/packages/loopover-engine/src/signals/predicted-gate-engine.ts
@@ -136,7 +136,7 @@ export function buildCollisionReport(
     const items = [issueItem(issue), ...linkedPrs.map(prItem)];
     clusters.set(`issue-${issue.number}`, {
       id: `issue-${issue.number}`,
-      risk: linkedPrs.length > 1 || issue.linkedPrs.length > 1 ? "high" : "medium",
+      risk: linkedPrs.length > 1 ? "high" : "medium",
       reason: `Open PR work references issue #${issue.number}.`,
       items,
     });

--- a/test/contract/predicted-gate-engine-collision-parity.test.ts
+++ b/test/contract/predicted-gate-engine-collision-parity.test.ts
@@ -53,6 +53,21 @@ describe("predicted-gate engine collision parity (#2283)", () => {
     expect(sharedLinkedIssue.findings.map((finding) => finding.code)).toContain("possible_duplicate_work");
   });
 
+  it("classifies a single-linked-PR cluster as medium risk even when the issue's own linkedPrs field is stale (>1), matching engine.ts's canonical version", () => {
+    const directRepo = repo("owner/direct");
+    // The issue's own linkedPrs field is a pre-populated/possibly-stale count of 2,
+    // but exactly ONE open PR actually references the issue. The live gate (engine.ts)
+    // classifies this on the freshly-computed linkedPrs only -> "medium"; the miner
+    // preview must match, not inflate to "high" off the stale issue.linkedPrs count.
+    const staleIssue = issue(directRepo.fullName, 7, "Token refresh race in the auth middleware", { linkedPrs: [101, 102] });
+    const singleLinkingPr = pr(directRepo.fullName, 50, "Guard the token refresh race", { linkedIssues: [7] });
+
+    const collisions = buildCollisionReport(directRepo.fullName, [staleIssue], [singleLinkingPr]);
+    const cluster = collisions.clusters.find((c) => c.id === "issue-7");
+    expect(cluster).toBeDefined();
+    expect(cluster?.risk).toBe("medium");
+  });
+
   it("itemSharesPlannedLinkedIssue intersects linked-issue sets and tolerates missing linkedIssues", () => {
     const prItemValue: CollisionItem = { type: "pull_request", number: 42, title: "Unrelated PR", linkedIssues: [9] };
     expect(itemSharesPlannedLinkedIssue(prItemValue, [9])).toBe(true);


### PR DESCRIPTION
## Summary

`buildCollisionReport` in `packages/loopover-engine/src/signals/predicted-gate-engine.ts` (the miner's local predicted-gate preview) computed the issue/linked-PR cluster risk as:

```ts
risk: linkedPrs.length > 1 || issue.linkedPrs.length > 1 ? "high" : "medium",
```

Its canonical twin of the same name in `engine.ts` (the live ORB gate) uses only:

```ts
risk: linkedPrs.length > 1 ? "high" : "medium",
```

The extra `|| issue.linkedPrs.length > 1` clause reads the caller-supplied, possibly-stale `issue.linkedPrs` field (distinct from the freshly-computed `linkedPrs` derived from the actual open-PR list). So the miner preview could classify a cluster as `"high"` purely off a cached `issue.linkedPrs` count where the live gate would report `"medium"` — inflating the miner-facing risk relative to what the gate actually applies post-submission, breaking `predicted-gate.ts`'s documented pre/post parity contract.

## Fix

Remove the extra clause so `predicted-gate-engine.ts` matches `engine.ts` exactly. `engine.ts` is untouched (it's the canonical, already-correct version). No other part of `buildCollisionReport` changes.

## Test

Extends `test/contract/predicted-gate-engine-collision-parity.test.ts`: a cluster with exactly one open PR referencing an issue whose own `linkedPrs` field is stale (`[101, 102]`, length 2) now resolves to `"medium"`, not `"high"`. The existing `sharedIssuePair` case (two PRs → one issue) still exercises the `"high"` branch via `linkedPrs.length`. Both branches of the changed line are covered.

Closes #6629