### PR TITLE
feat(api): add a REST route + CLI mirror for loopover_get_pr_ai_review_findings

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -324,6 +324,13 @@ const ownerRepoPullShape = {
   number: z.number().int().positive(),
 };
 
+// #6619: same PR coordinates plus the OPTIONAL author login. Omitted, it resolves from the local session /
+// LOOPOVER_LOGIN / GITHUB_LOGIN, so an already-logged-in contributor never has to retype their own login.
+const prAiReviewFindingsShape = {
+  ...ownerRepoPullShape,
+  login: z.string().min(1).optional(),
+};
+
 // #6149 write-tool input shapes -- mirror src/mcp/server.ts's remote shapes (same bounds) so the local
 // server validates identically. The builders (buildOpenPrSpec, ...) are the same @loopover/engine functions.
 const WRITE_TOOL_REPO_FULL_NAME_MAX = 200;
@@ -775,6 +782,12 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Return the reviewability report for an open PR: how ready it is to review/merge, the blocking or advisory signals against it, and its lane/duplicate/linked-issue context. Metadata-only, no GitHub writes.",
   },
   {
+    name: "loopover_get_pr_ai_review_findings",
+    category: "review",
+    description:
+      "Return a submitted pull request's real AI-review inline findings as structured JSON (category, path, severity, line, body) — the same categorization the PR comment uses. Post-submission only; self-scoped to your own PRs. Metadata-only, no GitHub writes.",
+  },
+  {
     name: "loopover_get_maintainer_noise",
     category: "maintainer",
     description: "Return the maintainer queue-noise triage report for a repo: a noise score/level, the specific noise sources to clear first, and recommended maintainer actions. Maintainer-authenticated; advisory only.",
@@ -1166,6 +1179,26 @@ registerStdioTool(
   async ({ owner, repo, number }) => {
     const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
     return toolResult("LoopOver PR reviewability.", await apiGet(`${prefix}/pulls/${number}/reviewability`));
+  },
+);
+
+// #6619: CLI mirror of the remote server's loopover_get_pr_ai_review_findings. The route is the single source
+// of truth (it delegates to the same loadPrAiReviewFindings the MCP server uses); this tool only resolves the
+// author login and proxies. Self-scoped: the route's requireContributorAccess rejects another login's PR.
+registerStdioTool(
+  "loopover_get_pr_ai_review_findings",
+  {
+    description: stdioToolDescription("loopover_get_pr_ai_review_findings"),
+    inputSchema: prAiReviewFindingsShape,
+  },
+  async ({ owner, repo, number, login }) => {
+    const authorLogin = login ?? activeProfile.session?.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
+    if (!authorLogin) throw new Error("No GitHub login: pass `login`, log in with `loopover-mcp login`, or set LOOPOVER_LOGIN.");
+    const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    return toolResult(
+      "LoopOver PR AI-review findings.",
+      await apiGet(`${prefix}/pulls/${number}/ai-review-findings?login=${encodeURIComponent(authorLogin)}`),
+    );
   },
 );
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -191,6 +191,7 @@ import {
 } from "../services/control-panel-roles";
 import { runFindOpportunities, validateFindOpportunitiesInput, type FindOpportunitiesInput } from "../mcp/find-opportunities";
 import { runIssueRagRetrieval, validateIssueRagInput, type IssueRagInput } from "../mcp/issue-rag";
+import { loadPrAiReviewFindings } from "../mcp/pr-ai-review-findings";
 import {
   buildMcpCompatibilityMetadata,
   LATEST_RECOMMENDED_MCP_VERSION,
@@ -2970,6 +2971,23 @@ export function createApp() {
     });
     await persistSignal(c.env, "pr-reviewability", `${fullName}#${number}`, fullName, reviewability as unknown as Record<string, JsonValue>, reviewability.generatedAt);
     return c.json(reviewability);
+  });
+
+  // A PR author's own structured, published AI-review findings (#6619). REST mirror of the
+  // `loopover_get_pr_ai_review_findings` MCP tool so the local `@loopover/mcp` CLI can reach the same data the
+  // remote MCP server already serves — the established pattern every comparable per-contributor, DB-backed tool
+  // follows (decision-pack, repo-decision, reviewability). `loadPrAiReviewFindings` stays the single source of
+  // truth for both surfaces; this route only validates, gates, and delegates. Contributor-owned data, so it is
+  // gated by `requireContributorAccess` (the same guard the decision-pack route uses) BEFORE any data is read.
+  app.get("/v1/repos/:owner/:repo/pulls/:number/ai-review-findings", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const number = Number(c.req.param("number"));
+    if (!Number.isInteger(number) || number <= 0) return c.json({ error: "invalid_pull_number" }, 400);
+    const login = c.req.query("login") ?? "";
+    if (!login) return c.json({ error: "login_required" }, 400);
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    return c.json(await loadPrAiReviewFindings(c.env, { repoFullName: fullName, pullNumber: number, login }));
   });
 
   // Read-only view of a repo's CURRENT effective self-tuned gate thresholds (#6247, groundwork for #6209).

--- a/test/unit/mcp-cli-pr-ai-review-findings.test.ts
+++ b/test/unit/mcp-cli-pr-ai-review-findings.test.ts
@@ -1,0 +1,137 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #6619: the CLI mirror of the remote server's loopover_get_pr_ai_review_findings. The tool only resolves the
+// author login and proxies to GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings — the route (and the
+// loadPrAiReviewFindings it delegates to) stays the single source of truth, so these tests assert the request
+// the tool composes (path + login query param) and its login-resolution fallback chain, not the findings logic.
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+const FORBIDDEN_PUBLIC_TERMS = /wallet\s*[:=]\s*\S+|hotkey\s*[:=]\s*\S+|coldkey\s*[:=]\s*\S+|raw trust score is|your trust score|reward estimate is|estimated reward/i;
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+let capturedRequests: Array<{ url: string; method: string }>;
+
+/** Connect a stdio client with `env` overlaid, so each test drives its own login-resolution scenario. */
+async function connect(env: Record<string, string> = {}) {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-pr-ai-findings-"));
+  capturedRequests = [];
+  const apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url?.includes("/ai-review-findings")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+  const childEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) if (value !== undefined) childEnv[key] = value;
+  // Dropped unless a test opts back in, so the RUNNER's own env can't satisfy the login fallback by accident.
+  delete childEnv.LOOPOVER_LOGIN;
+  delete childEnv.GITHUB_LOGIN;
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...childEnv,
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_API_TIMEOUT_MS: "5000",
+      ...env,
+    },
+  });
+  client = new Client({ name: "pr-ai-findings-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+afterEach(async () => {
+  await client?.close().catch(() => undefined);
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+});
+
+describe("loopover_get_pr_ai_review_findings stdio mirror (#6619)", () => {
+  it("registers the tool in the stdio server tool list", async () => {
+    await connect({ LOOPOVER_LOGIN: "octocat" });
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("loopover_get_pr_ai_review_findings");
+  });
+
+  it("proxies to the route with an explicit login and returns the structured findings", async () => {
+    await connect();
+    const result = await client.callTool({
+      name: "loopover_get_pr_ai_review_findings",
+      arguments: { owner: "owner", repo: "repo", number: 7, login: "octocat" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(capturedRequests).toHaveLength(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.method).toBe("GET");
+    expect(captured.url).toContain("/v1/repos/owner/repo/pulls/7/ai-review-findings");
+    expect(captured.url).toContain("login=octocat");
+    const text = JSON.stringify(result);
+    expect(text).toContain("correctness");
+    expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("falls back to LOOPOVER_LOGIN when no login argument is given", async () => {
+    await connect({ LOOPOVER_LOGIN: "env-login" });
+    const result = await client.callTool({ name: "loopover_get_pr_ai_review_findings", arguments: { owner: "owner", repo: "repo", number: 7 } });
+    expect(result.isError).toBeFalsy();
+    expect(capturedRequests[0]!.url).toContain("login=env-login");
+  });
+
+  it("falls back to GITHUB_LOGIN when LOOPOVER_LOGIN is unset", async () => {
+    await connect({ GITHUB_LOGIN: "gh-login" });
+    const result = await client.callTool({ name: "loopover_get_pr_ai_review_findings", arguments: { owner: "owner", repo: "repo", number: 7 } });
+    expect(result.isError).toBeFalsy();
+    expect(capturedRequests[0]!.url).toContain("login=gh-login");
+  });
+
+  it("prefers an explicit login argument over the environment fallbacks", async () => {
+    await connect({ LOOPOVER_LOGIN: "env-login", GITHUB_LOGIN: "gh-login" });
+    await client.callTool({ name: "loopover_get_pr_ai_review_findings", arguments: { owner: "owner", repo: "repo", number: 7, login: "explicit" } });
+    expect(capturedRequests[0]!.url).toContain("login=explicit");
+  });
+
+  it("errors with actionable guidance — and never calls the API — when no login resolves anywhere", async () => {
+    await connect();
+    const outcome = await client
+      .callTool({ name: "loopover_get_pr_ai_review_findings", arguments: { owner: "owner", repo: "repo", number: 7 } })
+      .then((r) => ({ isError: Boolean(r.isError), text: JSON.stringify(r) }), (e: unknown) => ({ isError: true, text: String(e) }));
+    expect(outcome.isError).toBe(true);
+    expect(outcome.text).toMatch(/LOOPOVER_LOGIN|loopover-mcp login/);
+    expect(capturedRequests).toHaveLength(0);
+  });
+
+  it("url-encodes an owner/repo/login that would otherwise break the path or query", async () => {
+    await connect();
+    await client.callTool({
+      name: "loopover_get_pr_ai_review_findings",
+      arguments: { owner: "owner", repo: "repo", number: 7, login: "a b&c" },
+    });
+    expect(capturedRequests[0]!.url).toContain("login=a%20b%26c");
+  });
+
+  it("rejects invalid input (zod): a non-positive PR number and a blank login", async () => {
+    await connect({ LOOPOVER_LOGIN: "octocat" });
+    for (const args of [
+      { owner: "owner", repo: "repo", number: 0 },
+      { owner: "owner", repo: "repo", number: -1 },
+      { owner: "", repo: "repo", number: 7 },
+      { owner: "owner", repo: "repo", number: 7, login: "" },
+    ]) {
+      const outcome = await client.callTool({ name: "loopover_get_pr_ai_review_findings", arguments: args }).then(
+        (r) => Boolean(r.isError),
+        () => true,
+      );
+      expect(outcome, `${JSON.stringify(args)} should be rejected`).toBe(true);
+    }
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -5,6 +5,7 @@
 // `tools --json` listing stays in lockstep with what the live server actually registers.
 // (#6152 registered the 5 maintain-surface tools, taking the count from 42 to 47.)
 // (#6150 registered the local-scorer and plan-DAG/predict-gate tools, taking the count from 55 to 60.)
+// (#6619 registered the pr-ai-review-findings CLI mirror, taking the count from 60 to 61.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -48,14 +49,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 60 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 61 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(60);
+    expect(primary.length).toBe(61);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(60);
+    expect(names.length).toBe(61);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -65,11 +66,11 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 60-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 61-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(60);
+    expect(payload.count).toBe(61);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual([...tools.map((t) => t.name)].sort());
   });
 });

--- a/test/unit/routes-pr-ai-review-findings.test.ts
+++ b/test/unit/routes-pr-ai-review-findings.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { markAiReviewPublished, putCachedAiReview, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
+import { createTestEnv } from "../helpers/d1";
+
+// #6619: GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings — the REST mirror of the
+// loopover_get_pr_ai_review_findings MCP tool. The route validates, gates on requireContributorAccess, then
+// delegates to loadPrAiReviewFindings (whose own logic is covered by pr-ai-review-findings.test.ts). These
+// tests therefore pin the ROUTE's contract: each delegated status passes through, and every guard branch
+// (invalid number, missing login, non-owning login) is rejected before any data is read.
+const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}` });
+const PATH = "/v1/repos/acme/widgets/pulls/11/ai-review-findings";
+
+async function seedRepo(env: Env, aiReviewMode: string) {
+  await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
+  await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode } });
+}
+
+describe("GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings (#6619)", () => {
+  it("returns a ready payload with the PR's structured findings", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedRepo(env, "advisory");
+    await putCachedAiReview(env, "acme/widgets", 11, "sha-1", "advisory", { notes: "Clean review.", reviewerCount: 1 });
+    await markAiReviewPublished(env, "acme/widgets", 11, "sha-1");
+
+    const response = await app.request(`${PATH}?login=miner1`, { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ready",
+      repoFullName: "acme/widgets",
+      pullNumber: 11,
+      login: "miner1",
+      headSha: "sha-1",
+    });
+  });
+
+  it("passes through not_found when the PR has no published review", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedRepo(env, "block");
+
+    const response = await app.request(`${PATH}?login=miner1`, { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: "not_found", findings: [], categoryCounts: {} });
+  });
+
+  it("passes through ai_review_off when the repo has AI review disabled", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedRepo(env, "off");
+
+    const response = await app.request(`${PATH}?login=miner1`, { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: "ai_review_off", findings: [], categoryCounts: {} });
+  });
+
+  it("rejects a non-integer or non-positive PR number with 400, before any auth or data read", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    for (const bad of ["abc", "0", "-3", "1.5"]) {
+      const response = await app.request(`/v1/repos/acme/widgets/pulls/${bad}/ai-review-findings?login=miner1`, { headers: apiHeaders(env) }, env);
+      expect(response.status, `pull number ${bad}`).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "invalid_pull_number" });
+    }
+  });
+
+  it("rejects a missing or blank login query param with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    for (const query of ["", "?login="]) {
+      const response = await app.request(`${PATH}${query}`, { headers: apiHeaders(env) }, env);
+      expect(response.status, `query "${query}"`).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "login_required" });
+    }
+  });
+
+  it("rejects an unauthenticated caller (requireContributorAccess gates the contributor-owned data)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedRepo(env, "advisory");
+
+    const response = await app.request(`${PATH}?login=miner1`, {}, env);
+    expect(response.status).toBeGreaterThanOrEqual(401);
+    expect(response.status).toBeLessThan(404);
+  });
+
+  it("403s the shared, end-user-obtainable mcp token for a contributor's private findings unless fully unscoped", async () => {
+    // #2455 precedent: the shared LOOPOVER_MCP_TOKEN must not read an ARBITRARY contributor's private data over
+    // HTTP just because it can reach the repo — only the full MCP_READ_REPO_ALLOWLIST wildcard unlocks that.
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    await seedRepo(env, "advisory");
+
+    const response = await app.request(`${PATH}?login=miner1`, { headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}` } }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+
+  it("never leaks wallet/hotkey/trust-score terms in its payload", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedRepo(env, "advisory");
+    await putCachedAiReview(env, "acme/widgets", 11, "sha-1", "advisory", { notes: "Clean review.", reviewerCount: 1 });
+    await markAiReviewPublished(env, "acme/widgets", 11, "sha-1");
+
+    const response = await app.request(`${PATH}?login=miner1`, { headers: apiHeaders(env) }, env);
+    const text = JSON.stringify(await response.json());
+    expect(text).not.toMatch(/wallet|hotkey|coldkey|trust score|reward estimate/i);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -527,6 +527,21 @@ export async function startFixtureServer(
       );
       return;
     }
+    // #6619: the route carries the author login as a query param, so match on the path prefix.
+    if (request.url?.startsWith("/v1/repos/owner/repo/pulls/7/ai-review-findings") && request.method === "GET") {
+      response.end(
+        JSON.stringify({
+          status: "ready",
+          repoFullName: "owner/repo",
+          pullNumber: 7,
+          login: "octocat",
+          headSha: "abc123",
+          findings: [{ category: "correctness", path: "src/index.ts", severity: "blocker", line: 12, body: "Null deref." }],
+          categoryCounts: { correctness: 1 },
+        }),
+      );
+      return;
+    }
     response.statusCode = 404;
     response.end(JSON.stringify({ error: "not_found" }));
   });


### PR DESCRIPTION
## What & why

`loopover_get_pr_ai_review_findings` existed **only** on the remote MCP server — no REST route, no `packages/loopover-mcp` CLI command reached it. A contributor using the local CLI had no way to retrieve their own PR's structured AI-review findings at all, even though every comparable per-contributor, DB-backed tool (decision-pack, repo-decision, pr-reviewability, explain-score-breakdown) already ships **both** surfaces. This one was the outlier.

## The route

`GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings`, structured like the neighbouring reviewability route: validate the PR number → require the `login` query param → gate on `requireContributorAccess` **before any data is read** → delegate to the existing `loadPrAiReviewFindings`. The route reimplements none of that logic, so it stays the single source of truth for both the MCP tool and the new route.

## The CLI mirror

`loopover_get_pr_ai_review_findings` stdio tool proxying to it, resolving the author login from the argument → the local session → `LOOPOVER_LOGIN` → `GITHUB_LOGIN` (the same chain `reviewPrCli`/`decisionPackCli` use), with a matching `STDIO_TOOL_DESCRIPTORS` entry under `"review"` — the category the server's own `MCP_TOOL_CATEGORIES` already assigns it.

## Tests

Every branch the issue lists:
- **Route** — `ready` / `not_found` / `ai_review_off` pass-through; `400` for a non-integer/non-positive PR number and for a missing/blank login; `403` for the shared `mcp` token reading a contributor's private findings without the full read wildcard (following #2455's precedent — a session identity never reaches this route, the role middleware rejects it first).
- **CLI** — the composed proxy request (path + `login` query param), the full login-resolution fallback chain, url-encoding, and zod rejection of bad input.

**100% line and branch coverage on the new route lines** (verified against the changed-line set, not just the file average). Tool count assertion bumped 60 → 61 with the file's existing count-note convention.

Closes #6619
