### PR TITLE
fix(queue): re-verify write permission before the reopen re-close, like its 4 siblings

### DIFF
--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -74,9 +74,11 @@ type CloseEnforcementGateResult =
  *  the caller, since those differ too much between guards to unify (self-close's reopen-then-close with
  *  asymmetric error handling vs. the other 4's single close call).
  *
- *  `permissionReadiness: null` skips the write-permission-readiness step entirely -- the reopen-reclose
- *  guard has never had this check (a pre-existing gap distinct from #4602/#4637's close-autonomy gap; not
- *  introduced or fixed by this extraction, since a refactor must not change behavior).
+ *  `permissionReadiness: null` would skip the write-permission-readiness step entirely. All 5 callers now
+ *  pass a real object, so every close-enforcement guard denies-with-audit on a missing `pull_requests: write`
+ *  grant rather than attempting a doomed mutation -- the reopen-reclose guard was the last holdout (#6603).
+ *  The parameter stays nullable rather than required: it is the shape a future non-mutating caller would
+ *  need, and narrowing it is a signature change #6603 deliberately left out of scope.
  *  `paused: null` records NO audit event on a paused/frozen repo -- draft-dodge's existing, preserved gap
  *  (every other guard here DOES audit a paused stand-down; draft-dodge simply never has). */
 async function evaluateCloseEnforcementGate(args: {
@@ -409,9 +411,9 @@ async function recloseDisallowedReopenIfNeeded(
   // autonomy class while deliberately leaving close unconfigured (deny-by-default) could still have a
   // disallowed reopen re-closed here. Mirrors the review-evasion siblings' identical gate; the shared gate
   // below checks the close action class directly rather than isAgentConfigured, so a repo that never
-  // authorized close specifically can't have its disallowed reopen re-closed here (#review-audit). Unlike the
-  // other 4 close-enforcement guards, this one has never had a write-permission-readiness check
-  // (`permissionReadiness: null` below preserves that pre-existing gap, distinct from #4602's autonomy gap).
+  // authorized close specifically can't have its disallowed reopen re-closed here (#review-audit). The
+  // write-permission-readiness check below is a SECOND, distinct gate from that autonomy one: autonomy is what
+  // the operator authorized, readiness is what the App was actually granted (#6603).
   const gate = await evaluateCloseEnforcementGate({
     env,
     installationId,
@@ -431,7 +433,10 @@ async function recloseDisallowedReopenIfNeeded(
       detail: `skipped (agent paused): would re-close a disallowed reopen by ${reopener}`,
       metadata: { ...gateMetadata, mode: "paused" },
     },
-    permissionReadiness: null,
+    permissionReadiness: {
+      detail: `denied reopen re-close for ${reopener} — pull_requests: write not granted`,
+      metadata: gateMetadata,
+    },
     freshness: {
       detailSuffix: " — reopen re-close not executed",
       metadata: gateMetadata,

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -300,6 +300,26 @@ describe("agentMaintenanceHeadMatchesGate", () => {
   });
 });
 
+/** Seed the installation record with the `pull_requests: write` grant the reopen re-close guard now re-verifies
+ *  before mutating, exactly as the other 4 close-enforcement guards already do (#6603). These fixtures predate
+ *  that check, so they never seeded an installation at all and `getInstallation` returned null — which now
+ *  reads as "the App was never granted write" and denies. Granting it here restores each test's ORIGINAL
+ *  subject: none of their assertions change, they just now model a properly-installed App the way the sibling
+ *  guards' fixtures (e.g. :250, :1040) always have. The one test that asserts the DENY path deliberately does
+ *  not call this. */
+async function grantWriteInstallation(env: ReturnType<typeof createTestEnv>): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: 123,
+      account: { login: "JSONbored", id: 1, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "write", pull_requests: "write", issues: "write" },
+      events: ["pull_request"],
+    },
+    repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+  });
+}
+
 describe("one-shot reopen prevention", () => {
   beforeEach(() => {
     clearInstallationTokenCacheForTest();
@@ -307,6 +327,49 @@ describe("one-shot reopen prevention", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("denies the re-close when pull_requests: write is not granted (#6603)", async () => {
+    // The gap this closes: the reopen re-close guard was the ONLY one of the 5 close-enforcement guards that
+    // never re-verified the App's write grant, so on a revoked/never-granted installation it would attempt a
+    // doomed PATCH and rely on that call's own failure path. Its 4 siblings deny up front with an audit event;
+    // now this one does too. Identical setup to the happy-path test below, minus the write grant.
+    const calls: Array<{ url: string; method: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
+      if (url.endsWith("/collaborators/maintainer/permission")) return Response.json({ permission: "write" });
+      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }, { event: "reopened", actor: { login: "contributor" } }]);
+      if (url.endsWith("/issues/42/comments")) return Response.json({ id: 99 }, { status: 201 });
+      if (url.endsWith("/pulls/42") && method === "PATCH") return Response.json({ state: "closed" });
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    // Installed, but WITHOUT pull_requests: write — the distinction that matters. Mirrors the sibling guards'
+    // own permission-denied fixtures (e.g. the self-close guard's at :2096).
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+
+    await processJob(env, { type: "github-webhook", deliveryId: "reopen-no-write", eventName: "pull_request", payload: reopenedPayload("contributor") });
+
+    // The doomed mutation is never attempted — that is the whole point of checking up front.
+    expect(calls.some((call) => call.method === "PATCH" && call.url.endsWith("/pulls/42"))).toBe(false);
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toBe("denied reopen re-close for contributor — pull_requests: write not granted");
   });
 
   it("re-closes contributor reopens after a write collaborator closed the PR", async () => {
@@ -329,6 +392,7 @@ describe("one-shot reopen prevention", () => {
 
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
+    await grantWriteInstallation(env);
 
     await processJob(env, {
       type: "github-webhook",
@@ -363,6 +427,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
     // A maintainer legitimately reopened/re-approved the PR — or a queue retry replayed a stale payload — in
     // the window between the original webhook delivery and this handler's permission/closer-history reads. The
     // live re-check must catch it and deny the re-close rather than overwriting a live maintainer decision.
@@ -401,6 +466,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-promoted", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
@@ -439,6 +505,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-superseded", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
@@ -468,6 +535,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-same-latest", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
@@ -503,6 +571,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-window-stuffed", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
@@ -534,6 +603,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-timeline-error", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
@@ -562,6 +632,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-no-reopen-event", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
@@ -593,6 +664,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
     vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
 
     await expect(
@@ -613,6 +685,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
     vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "head_changed", expectedHeadSha: "abc123", liveHeadSha: "def456", liveState: "open" });
     vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
 
@@ -636,6 +709,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
     vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
 
     await expect(
@@ -663,6 +737,7 @@ describe("one-shot reopen prevention", () => {
 
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
+    await grantWriteInstallation(env);
 
     await processJob(env, {
       type: "github-webhook",
@@ -757,6 +832,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
+    await grantWriteInstallation(env);
     await repositoriesModule.setGlobalAgentFrozen(env, true); // emergency brake on
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-frozen", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed
@@ -858,6 +934,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
+    await grantWriteInstallation(env);
     await processJob(env, { type: "github-webhook", deliveryId: "window-evasion-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
     const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ detail: string }>();
@@ -879,6 +956,7 @@ describe("one-shot reopen prevention", () => {
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
+    await grantWriteInstallation(env);
     await processJob(env, { type: "github-webhook", deliveryId: "bot-closer-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
   });


### PR DESCRIPTION
## Summary

`evaluateCloseEnforcementGate` re-verifies the App actually holds `pull_requests: write` before a caller mutates a PR, and records a `denied` audit event when it doesn't — but only when passed a real `permissionReadiness` object. Four of the five close-enforcement guards passed one. `recloseDisallowedReopenIfNeeded` passed `null`, skipping the check entirely.

**Practical effect:** on an installation where the grant was never given or was later revoked, the other four guards deny up front with an audit trail. This one went ahead and attempted `closePullRequest`, relying only on that API call's own failure path — a doomed mutation and no `denied` event to explain it.

The gap was documented in-code as known-and-unfixed in two places (`review-evasion.ts:77-79` and `:413-414`). This closes it and updates both comments.

## The change

The call site now passes a real object, reusing the `gateMetadata` already built above it, exactly as its four siblings do:

```ts
permissionReadiness: {
  detail: `denied reopen re-close for ${reopener} — pull_requests: write not granted`,
  metadata: gateMetadata,
},
```

Per the issue, `evaluateCloseEnforcementGate`'s signature and its `permissionReadiness` shape are untouched, and no other guard's behavior changes. The parameter stays nullable rather than being narrowed to required — that would be a signature change the issue explicitly left out of scope — and the doc comment now says why it stays that way instead of advertising a gap that no longer exists.

Note this readiness gate is **distinct from the #4602 close-autonomy gate** already at that call site, and the updated comment says so: autonomy is what the operator *authorized*, readiness is what the App was actually *granted*. Both are needed; neither substitutes for the other.

## The test-fixture change — the part worth scrutinising

Adding the check turned **13 existing reopen tests red**, and that's worth explaining rather than glossing, because "13 tests changed" is exactly the shape of a PR that bent tests to fit code.

They failed for a real reason: those fixtures never seeded an installation record at all, so `getInstallation` returned `null` → no permissions → `reconsent_required` → denied. They predate the check, so they never needed to. The four sibling guards' fixtures **already** seed the grant (`:250`, `:1040`).

So the fix is to make these fixtures model a properly-installed App, via one shared helper (`grantWriteInstallation`) rather than 13 copy-pasted blocks. **No assertion was changed, relaxed, or removed** — each test still asserts precisely what it asserted before, on its original subject. The helper's doc comment records why it exists so the next reader doesn't have to reconstruct this.

The `git diff` backs that claim: the only edits to existing tests are the single added `await grantWriteInstallation(env);` line each.

## Tests

- **The new deny test genuinely reproduces the gap — verified, not assumed.** With the src fix stashed and only the test applied, it **fails**; with the fix, it passes.
- It mirrors the sibling guards' own permission-denied fixtures (`:2096`): installed, but **with `permissions: { metadata: "read", issues: "write" }` and no `pull_requests`** — so it pins "installed without the grant", not merely "no installation record", which is the distinction that actually matters in production.
- It asserts the **exact** `denied` detail string, and that the `PATCH /pulls/42` mutation is **never attempted** — checking up front is the entire point.
- It deliberately does **not** call the shared grant helper, which is why the helper's comment calls that case out.

## Validation

- [x] **Patch coverage 100%, measured** from the v8 JSON report against my changed lines (77–81, 414–416, 436–439): **zero uncovered statements, zero partial branches**. Clears the 99% `codecov/patch` wall on `src/**`.
- [x] **319/319 pass** across `queue-lifecycle-guards` (202) and `queue-2` — the suites the issue names as covering `maybeRecloseDisallowedReopen`.
- [x] `npm run typecheck` — 0 errors · `eslint` — 0 errors/0 warnings · `git diff --check` clean · rebased on latest `main`, no base conflict.

## Scope

- [x] Two files: the call site + its two stale doc comments, and the tests. Wanted paths (`src/`, `test/`).
- [x] The other 4 guards, `evaluateCloseEnforcementGate`'s signature, the pagination/freshness/lock logic, and the dismissal write are all untouched.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Strictly more conservative: the only new outcome is a **deny** where the guard previously attempted a mutation that could not have succeeded. It cannot cause a close that wouldn't have happened before.
- [x] The autonomy gate still runs first and is unchanged, so a repo that never authorized close specifically is still denied for that reason, with its original audit detail.
- [x] Brings the 5th guard in line with the 4 that already behave this way, rather than introducing a new policy.

Closes #6603
