### PR TITLE
fix(github): tighten ConfigurationCommandRequest.reason to a literal union

### DIFF
--- a/src/github/configuration-command.ts
+++ b/src/github/configuration-command.ts
@@ -7,7 +7,13 @@ import type { GitHubWebhookPayload } from "../types";
  *  the issue-only planner, configuration is repo-level and answers on either a PR or an issue thread. (#2168) */
 export type ConfigurationCommandRequest =
   | { ok: true; repoFullName: string; installationId: number; actor: string; issueNumber: number }
-  | { ok: false; reason: string; repoFullName: string | null; actor: string | null; targetKey: string | null };
+  | {
+      ok: false;
+      reason: "unsupported_comment_action_or_bot" | "missing_repo_issue_installation_or_actor";
+      repoFullName: string | null;
+      actor: string | null;
+      targetKey: string | null;
+    };
 
 export function classifyConfigurationCommandRequest(
   payload: GitHubWebhookPayload,


### PR DESCRIPTION
## What

`ConfigurationCommandRequest`'s failure `reason` field (`src/github/configuration-command.ts`) was typed as a bare `string`, unlike its sibling `PrCommandRequest`, whose `reason` is a proper string-literal union. `classifyConfigurationCommandRequest` only ever returns two literals — `"unsupported_comment_action_or_bot"` and `"missing_repo_issue_installation_or_actor"` — so the loose type meant a future typo (or an ad hoc third value) would type-check silently instead of being caught by `tsc`.

Resolves #6616.

## Change

Narrow `reason` to the exact literal union of those two values, matching the pattern already used by `PrCommandRequest["reason"]` in `src/github/pr-command-request.ts`.

**Type-only** — `classifyConfigurationCommandRequest`'s runtime behavior, return values, and every existing assertion in `test/unit/configuration-command.test.ts` are unaffected. The narrowing is a subtype of `string`, so no consumer (e.g. `src/queue/processors.ts`) needed a fix.

## Validation

- `test/unit/configuration-command.test.ts` passes unmodified (7/7) — the two literal reasons are already pinned by its `toMatchObject` assertions.
- `tsc --noEmit` surfaces no new configuration-command/`reason` errors — the stricter type is compatible everywhere it's consumed.
- eslint clean. No new tests required (type-annotation-only change, no new runtime branch).