### PR TITLE
fix(ci): stop draft PRs from wasting CI/review-pipeline resources (#6670)

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -20,6 +20,10 @@ on:
       - "test/integration/selfhost-pg*"
       - ".github/workflows/selfhost.yml"
   pull_request:
+    # Explicit list because the default (opened/synchronize/reopened) omits ready_for_review -- once
+    # build-boot below skips draft PRs, marking a PR ready must itself trigger a real run (#6670), not
+    # wait for the next push. Mirrors ci.yml's pull_request.types comment/list exactly.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "src/selfhost/**"
       - "src/server.ts"
@@ -49,6 +53,12 @@ concurrency:
 jobs:
   build-boot:
     name: build + boot smoke test
+    # Skip draft PRs (#6670, anti-abuse): this job boots a real Postgres service, does a full npm ci, and
+    # runs two docker buildx builds plus a container smoke test -- real minutes on every push, including a
+    # force-push, to a PR nobody has marked ready for review yet. Mirrors ci.yml's validate-code guard;
+    # draft != true also gates push runs correctly (github.event.pull_request is unset there, so the
+    # property access evaluates to null, and null != true is true).
+    if: ${{ github.event_name == 'push' || github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -12,7 +12,10 @@ name: UI Preview Build
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # Explicit list because the default (opened/synchronize/reopened) omits ready_for_review -- once the
+    # build job below skips draft PRs, marking a PR ready must itself trigger a real preview build (#6670),
+    # not wait for the next push. Mirrors ci.yml's pull_request.types comment/list exactly.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "apps/loopover-ui/**"
       - "packages/**"
@@ -27,6 +30,12 @@ concurrency:
 jobs:
   build:
     name: Build UI preview artifact
+    # Skip draft PRs (#6670, anti-abuse): a full npm ci + UI build on every push, including a force-push, to
+    # a PR nobody has marked ready for review yet. Mirrors ci.yml's validate-code guard; draft != true also
+    # gates push runs correctly (github.event.pull_request is unset there, so the property access evaluates
+    # to null, and null != true is true) -- kept even though this workflow has no push trigger today, so the
+    # condition stays correct if one is ever added.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -123,6 +123,7 @@ import {
   type OfficialGittensorMinerDetection,
 } from "../gittensor/api";
 import {
+  cancelInFlightWorkflowRunsForHeadSha,
   createInstallationToken,
   createOrUpdateCheckRun,
   createOrUpdateErroredGateCheckRun,
@@ -5584,6 +5585,48 @@ async function maybeHandleIssueCommentCommandWebhookEvent(
   return false;
 }
 
+/** CI-run cancellation on a draft conversion (#6670, anti-abuse/resource-waste): a PR converted to draft
+ *  stops burning CI minutes on whatever was already queued/in-progress for its current head SHA, mirroring
+ *  the contributor_cap/blacklist close-time cancellation in agent-action-executor.ts (#2462/#6659) --
+ *  duplicated rather than shared because this fires on the webhook path itself, before any planner/executor
+ *  action exists to hang the cancel off of. Respects the same global-freeze/agentPaused/dry-run mode every
+ *  other mutating action in this file respects (#2130 follow-up: "this close path previously bypassed
+ *  pause/freeze/dry-run entirely" in review-evasion.ts is exactly the bug class a real GitHub-mutating
+ *  side effect here must not reintroduce) -- a paused/frozen/dry-run install records what WOULD have been
+ *  cancelled instead of actually calling the Actions API. Never throws -- every recordAuditEvent call is
+ *  best-effort (`.catch(() => undefined)`), since a failure to WRITE the audit record must not affect the
+ *  rest of this webhook delivery's processing. */
+async function recordDraftConversionCiCancelOutcome(env: Env, installationId: number, repoFullName: string, pullNumber: number, headSha: string, settings: RepositorySettings): Promise<void> {
+  const targetKey = `${repoFullName}#${pullNumber}`;
+  const mode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)), agentPaused: settings.agentPaused, agentDryRun: settings.agentDryRun });
+  if (mode !== "live") {
+    await recordAuditEvent(env, {
+      eventType: "github_app.draft_convert_ci_cancel_skipped",
+      actor: "loopover",
+      targetKey,
+      outcome: "completed",
+      detail: `dry-run: would cancel in-flight CI for headSha ${headSha}`,
+      metadata: { repoFullName, headSha, mode },
+    }).catch(() => undefined);
+    return;
+  }
+  const outcome = await cancelInFlightWorkflowRunsForHeadSha(env, installationId, repoFullName, headSha, pullNumber);
+  if (outcome.kind === "cancelled") {
+    const detail = `cancelled ${outcome.cancelledCount} of ${outcome.totalFound} in-flight workflow run(s)`;
+    await recordAuditEvent(env, {
+      eventType: "github_app.draft_convert_ci_cancelled",
+      actor: "loopover",
+      targetKey,
+      outcome: "completed",
+      detail,
+      metadata: { repoFullName, headSha, cancelledCount: outcome.cancelledCount, totalFound: outcome.totalFound },
+    }).catch(() => undefined);
+    return;
+  }
+  const eventType = outcome.kind === "permission_missing" ? "github_app.draft_convert_ci_cancel_permission_missing" : "github_app.draft_convert_ci_cancel_failed";
+  await recordAuditEvent(env, { eventType, actor: "loopover", targetKey, outcome: "error", detail: outcome.warning, metadata: { repoFullName, headSha, reason: outcome.kind } }).catch(() => undefined);
+}
+
 /**
  * Handles a webhook payload that carries a `pull_request` object: PR-outcome/reversal signal recording,
  * reviews-cache invalidation, mergeable-state cache invalidation, review-evasion-tracking invalidation,
@@ -5912,6 +5955,16 @@ async function handlePullRequestWebhookEvent(
         settings,
         draftConversionCount,
       );
+    }
+    // CI-run cancellation on a draft conversion (#6670, resource-waste): converting an already-open PR to
+    // draft stops burning CI minutes on whatever GitHub Actions already queued for its current head SHA --
+    // unconditional (no config toggle), fires regardless of whether any of the review-evasion guards above
+    // also acted, and independent of pr.state (a PR the guards above just closed still had CI queued for
+    // its head SHA the moment this webhook fired, so the cancel is still worth attempting). Best-effort:
+    // cancelInFlightWorkflowRunsForHeadSha never throws, so a missing actions:write grant never affects the
+    // rest of this webhook delivery's processing.
+    if (payload.action === "converted_to_draft" && installationId && pr.headSha) {
+      await recordDraftConversionCiCancelOutcome(env, installationId, repoFullName, pr.number, pr.headSha, settings);
     }
     // Review-evasion protection: the "closed" half of the active-review-tracking cleanup (the
     // "synchronize" half runs earlier, alongside invalidatePrStateCache). Deliberately placed AFTER the

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -151,9 +151,14 @@ export type AutoReviewEligibilityInput = {
   reviewedCommitCount: number;
 };
 
-/** Evaluate `review.auto_review` eligibility. Returns a quiet skip reason string, or null when AI review should proceed. (#1954) */
+/** Evaluate `review.auto_review` eligibility. Returns a quiet skip reason string, or null when AI review should proceed. (#1954)
+ *  `skipDrafts` defaults to ON fleet-wide as of #6670 (resource-waste): `null`/unset now skips the AI-review
+ *  call the same as an explicit `true` -- only an explicit `skip_drafts: false` in a repo's manifest opts
+ *  back into reviewing drafts. This is the AI-review call ONLY; gate evaluation and check-run creation
+ *  always run regardless (#3698/#security) -- a contributor cannot use draft status to dodge a real gate
+ *  verdict, only to skip the (non-authoritative) AI commentary. */
 export function evaluateAutoReviewSkipReason(config: AutoReviewConfig, input: AutoReviewEligibilityInput): string | null {
-  if (config.skipDrafts === true && input.isDraft) return "review skipped (draft)";
+  if (config.skipDrafts !== false && input.isDraft) return "review skipped (draft)";
   if (input.author && config.ignoreAuthors.length > 0) {
     const author = input.author.toLowerCase();
     if (config.ignoreAuthors.some((glob) => matchesManifestPath(author, glob.toLowerCase()))) {

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -4610,10 +4610,15 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
     expect(resolveAutoReviewConfig(null)).toEqual({ ...EMPTY_AUTO_REVIEW_CONFIG });
   });
 
-  it("evaluateAutoReviewSkipReason: byte-identical when unset; skips with deterministic reasons when configured", () => {
+  it("evaluateAutoReviewSkipReason: byte-identical when unset (except skipDrafts, on-by-default since #6670); skips with deterministic reasons when configured", () => {
     const empty = { ...EMPTY_AUTO_REVIEW_CONFIG };
-    const input = { isDraft: true, author: "dependabot[bot]", title: "WIP: bump deps", labels: [] as string[], changedPaths: [] as string[], addedLineCount: 0, changedFileCount: 0, baseRef: "develop", reviewedCommitCount: 0 };
+    // isDraft: false here so every OTHER assertion below (which reuses this fixture without overriding
+    // isDraft) reaches its own intended check instead of short-circuiting on the now-default-on draft skip.
+    const input = { isDraft: false, author: "dependabot[bot]", title: "WIP: bump deps", labels: [] as string[], changedPaths: [] as string[], addedLineCount: 0, changedFileCount: 0, baseRef: "develop", reviewedCommitCount: 0 };
     expect(evaluateAutoReviewSkipReason(empty, input)).toBeNull();
+    // #6670: an unset skipDrafts (null) now skips a draft PR's AI-review call the same as an explicit
+    // `true` -- only an explicit `skip_drafts: false` opts back in (covered two assertions below).
+    expect(evaluateAutoReviewSkipReason(empty, { ...input, isDraft: true })).toBe("review skipped (draft)");
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: true })).toBe("review skipped (draft)");
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: false })).toBeNull();
     expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["*[bot]"] }, input)).toBe("review skipped (ignored author)");

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -1765,6 +1765,149 @@ function closedPayload(sender: string, author = sender, headSha = "abc123"): any
   };
 }
 
+describe("converted_to_draft CI-cancel (#6670, resource-waste)", () => {
+  beforeEach(() => clearInstallationTokenCacheForTest());
+  afterEach(() => {
+    clearInstallationTokenCacheForTest();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function draftConvertPayload(headSha = "abc123"): any {
+    return {
+      action: "converted_to_draft",
+      installation: { id: 123 },
+      repository: { id: 1, name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", owner: { login: "JSONbored" } },
+      sender: { login: "contributor", type: "User" },
+      pull_request: {
+        id: 4242,
+        number: 42,
+        state: "open",
+        title: "Some PR",
+        body: "Body.",
+        user: { login: "contributor" },
+        head: { sha: headSha, ref: "fix", repo: { full_name: "contributor/gittensory", owner: { login: "contributor" } } },
+        base: { sha: "base123", ref: "main", repo: { full_name: "JSONbored/gittensory", owner: { login: "JSONbored" } } },
+        draft: true,
+        merged: false,
+        mergeable_state: "clean",
+        created_at: "2026-05-27T00:00:00Z",
+        updated_at: "2026-05-27T00:00:00Z",
+      },
+    };
+  }
+
+  async function setupRepo(env: ReturnType<typeof createTestEnv>, overrides: Record<string, unknown> = {}): Promise<void> {
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" }, agentPaused: false, ...overrides });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required" } });
+  }
+
+  function stubDraftCiCancelFetch(seen: { cancelledIds: number[]; listedStatuses: string[] }, runListResponses: { in_progress?: number[]; queued?: number[] } = {}, cancelResponse: () => Response = () => new Response(null, { status: 202 })) {
+    return async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/actions/runs?head_sha=abc123&status=in_progress")) { seen.listedStatuses.push("in_progress"); return Response.json({ workflow_runs: (runListResponses.in_progress ?? []).map((id) => ({ id, event: "pull_request", pull_requests: [{ number: 42 }] })) }); }
+      if (url.includes("/actions/runs?head_sha=abc123&status=queued")) { seen.listedStatuses.push("queued"); return Response.json({ workflow_runs: (runListResponses.queued ?? []).map((id) => ({ id, event: "pull_request", pull_requests: [{ number: 42 }] })) }); }
+      if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") {
+        seen.cancelledIds.push(Number(url.match(/\/actions\/runs\/(\d+)\/cancel/)?.[1]));
+        return cancelResponse();
+      }
+      return new Response("not found", { status: 404 });
+    };
+  }
+
+  it("cancels in-flight CI runs for the PR's head SHA when it is converted to draft", async () => {
+    const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
+    vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [401], queued: [402] }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await setupRepo(env);
+
+    await processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel", eventName: "pull_request", payload: draftConvertPayload() });
+
+    expect(seen.listedStatuses.sort()).toEqual(["in_progress", "queued"]);
+    expect(seen.cancelledIds.sort()).toEqual([401, 402]);
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.draft_convert_ci_cancelled").first<{ detail: string }>();
+    expect(audit?.detail).toContain("cancelled 2 of 2");
+  });
+
+  it("degrades gracefully when the cancel attempt fails — a genuine error is recorded, nothing throws", async () => {
+    const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
+    vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [403] }, () => new Response(null, { status: 500 })));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await setupRepo(env);
+
+    await expect(
+      processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel-failed", eventName: "pull_request", payload: draftConvertPayload() }),
+    ).resolves.toBeUndefined();
+
+    const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("github_app.draft_convert_ci_cancel_failed").first<{ n: number }>();
+    expect(audit?.n).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not attempt to cancel CI while the agent is paused — records a dry-run-shaped skip instead", async () => {
+    const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
+    vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [404] }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await setupRepo(env, { agentPaused: true });
+
+    await processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel-paused", eventName: "pull_request", payload: draftConvertPayload() });
+
+    expect(seen.listedStatuses).toEqual([]);
+    expect(seen.cancelledIds).toEqual([]);
+    const audit = await env.DB.prepare("select detail, outcome from audit_events where event_type = ?").bind("github_app.draft_convert_ci_cancel_skipped").first<{ detail: string; outcome: string }>();
+    expect(audit?.outcome).toBe("completed");
+    expect(audit?.detail).toContain("dry-run: would cancel");
+  });
+
+  it("swallows a failing audit write on the paused/dry-run skip path — the handler still completes without throwing", async () => {
+    const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
+    vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [405] }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await setupRepo(env, { agentPaused: true });
+    const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
+    const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockImplementation(async (auditEnv, event) => {
+      if (event.eventType === "github_app.draft_convert_ci_cancel_skipped") throw new Error("audit DB down");
+      await originalRecordAuditEvent(auditEnv, event);
+    });
+
+    await expect(
+      processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel-paused-audit-fail", eventName: "pull_request", payload: draftConvertPayload() }),
+    ).resolves.toBeUndefined();
+    auditSpy.mockRestore();
+    expect(seen.listedStatuses).toEqual([]);
+  });
+
+  it("swallows a failing audit write on the successful-cancel path — the handler still completes without throwing", async () => {
+    const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
+    vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [406] }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await setupRepo(env);
+    const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
+    const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockImplementation(async (auditEnv, event) => {
+      if (event.eventType === "github_app.draft_convert_ci_cancelled") throw new Error("audit DB down");
+      await originalRecordAuditEvent(auditEnv, event);
+    });
+
+    await expect(
+      processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel-success-audit-fail", eventName: "pull_request", payload: draftConvertPayload() }),
+    ).resolves.toBeUndefined();
+    auditSpy.mockRestore();
+    expect(seen.cancelledIds).toEqual([406]);
+  });
+});
+
 describe("review-evasion protection (#review-evasion-protection)", () => {
   beforeEach(() => clearInstallationTokenCacheForTest());
   afterEach(() => {


### PR DESCRIPTION
## Summary

- `.github/workflows/selfhost.yml`'s `build-boot` job (Postgres service container, 2 docker buildx builds, boot smoke test, 20min timeout) and `.github/workflows/ui-preview.yml`'s `build` job (full UI build) had no draft guard — unlike `ci.yml`'s heaviest jobs, which already skip drafts via `github.event.pull_request.draft != true`. Added the same guard to both, plus `ready_for_review` to each workflow's `pull_request.types` list (mirroring `ci.yml`'s own comment/list) so marking a PR ready still triggers a real run instead of waiting for the next push.
- Converting an already-open PR to draft (`converted_to_draft`) didn't cancel any GitHub Actions runs already queued/in-progress for its head SHA. Added `recordDraftConversionCiCancelOutcome` in `src/queue/processors.ts`, reusing `cancelInFlightWorkflowRunsForHeadSha` (the same mechanism the `contributor_cap`/`blacklist` close-time cancellation in `agent-action-executor.ts` uses). Respects the same global-freeze/`agentPaused`/dry-run mode every other mutating action in this file respects — a paused/frozen/dry-run install records what *would* have been cancelled instead of calling the Actions API.
- `review.auto_review.skip_drafts` (gates only the AI-review LLM call) was opt-in per repo. Flipped its default to on fleet-wide in `evaluateAutoReviewSkipReason` (`src/signals/focus-manifest.ts`) — an unset value now behaves the same as an explicit `true`; a repo can still opt back in to reviewing drafts with an explicit `skip_drafts: false`.
- **Deliberately out of scope**: gate evaluation and check-run creation still run unconditionally on draft PRs regardless of `skip_drafts` — that's an existing, deliberate anti-gaming invariant (`#3698/#security` in `processors.ts`) preventing a contributor from using draft status (something they fully control) to dodge a real gate failure. Extending the skip to cover that would reopen exactly the hole `review-evasion.ts`'s draft guards exist to close.

Closes #6670

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full unsharded run, 931 files / 17904 tests, 0 failures) — every new/changed line in `processors.ts` and `signals/focus-manifest.ts` shows 100% line+branch coverage (verified via lcov cross-referencing against the diff's exact line ranges).
- [x] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches 6 files — 2 workflow YAML files, 2 backend TS files, 2 test files — no MCP, UI source, engine, or miner package files. Also ran and confirmed green locally: `db:migrations:check`, `docs:drift-check`, `manifest:drift-check`, `engine-parity:drift-check`, `command-reference:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `test:engine-parity`, `test:live-gate-parity`, `test:driver-parity`. Skipped the MCP/miner pack builds and UI lint/typecheck/build locally (unaffected by this diff, and the full local `test:ci` run exceeds this tool's 10-minute per-command limit) — deferring to CI's `validate` check for final confirmation on those steps.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No UI/frontend changes in this PR.

## Notes

- Follow-up to #6669 (blacklist CI-cancel) from the same anti-abuse/resource-waste investigation.
- No generated artifacts needed regeneration — no API/schema, DB, or wrangler binding changes.