### PR TITLE
refactor(signals): share resolveIssuePolicy between readiness reports (#6606)

### DIFF
--- a/src/signals/registration-readiness.ts
+++ b/src/signals/registration-readiness.ts
@@ -4,10 +4,16 @@ import { nowIso } from "../utils/json";
 import type { ConfigQuality, ContributorIntakeHealth, LabelAudit, LaneAdvice, MaintainerCutReadiness, QueueHealth } from "./engine";
 import { compileFocusManifestPolicy, type FocusManifest } from "./focus-manifest";
 import { buildRepoOnboardingPackPreview, focusManifestPolicyToCompilerOutput, type RepoOnboardingPackPreview } from "./onboarding-pack";
-import { buildRepoPolicyReadiness, policyReadinessWarningText, type RepoPolicyReadinessReport } from "./repo-policy-readiness";
+import {
+  buildRepoPolicyReadiness,
+  policyReadinessWarningText,
+  resolveIssuePolicy,
+  type IssuePolicy,
+  type RepoPolicyReadinessReport,
+} from "./repo-policy-readiness";
 
 export type RegistrationMode = "direct_pr" | "issue_discovery" | "split";
-export type IssuePolicy = "issue_discovery_enabled" | "split_pr_and_issue_discovery_enabled" | "direct_pr_requires_linked_issue" | "direct_pr_no_issue_required";
+export type { IssuePolicy };
 
 export type InstallationHealthSummary = {
   status: "healthy" | "needs_attention" | "broken";
@@ -90,12 +96,6 @@ const COVERAGE_GATE = ["npm run test:ci", "global coverage >= 95% (lines, statem
 
 function laneToMode(lane: LaneAdvice): RegistrationMode {
   return lane.lane === "issue_discovery" ? "issue_discovery" : lane.lane === "split" ? "split" : "direct_pr";
-}
-
-function resolveIssuePolicy(lane: LaneAdvice, settings: RepositorySettings): IssuePolicy {
-  if (lane.lane === "issue_discovery") return "issue_discovery_enabled";
-  if (lane.lane === "split") return "split_pr_and_issue_discovery_enabled";
-  return settings.requireLinkedIssue ? "direct_pr_requires_linked_issue" : "direct_pr_no_issue_required";
 }
 
 function buildTestCoverageHealth(labelAudit: LabelAudit, settings: RepositorySettings): TestCoverageHealth {

--- a/src/signals/repo-policy-readiness.ts
+++ b/src/signals/repo-policy-readiness.ts
@@ -2,6 +2,12 @@ import type { RepositorySettings } from "../types";
 import { isFocusManifestPublicSafe, type FocusManifest } from "./focus-manifest";
 import type { ConfigQuality, ContributorIntakeHealth, LabelAudit, LaneAdvice, QueueHealth } from "./engine";
 
+export type IssuePolicy =
+  | "issue_discovery_enabled"
+  | "split_pr_and_issue_discovery_enabled"
+  | "direct_pr_requires_linked_issue"
+  | "direct_pr_no_issue_required";
+
 export type RepoPolicyReadinessWarningCategory =
   | "contribution_flow"
   | "direct_pr_policy"
@@ -46,7 +52,7 @@ export type RepoPolicyReadinessReport = {
     queueLevel: QueueHealth["level"];
     contributorIntakeLevel: ContributorIntakeHealth["level"];
     configLevel: ConfigQuality["level"];
-    issuePolicy: string;
+    issuePolicy: IssuePolicy;
     issueDiscoveryPolicy: FocusManifest["issueDiscoveryPolicy"];
   };
   droppedPublicWarnings: Array<{
@@ -231,7 +237,10 @@ export function policyReadinessWarningText(warning: RepoPolicyReadinessWarning):
   return `${warning.title}: ${warning.detail} ${warning.action}`;
 }
 
-function resolveIssuePolicy(lane: LaneAdvice, settings: RepositorySettings): string {
+/** Shared by {@link buildRegistrationReadiness} so both readiness reports classify the same
+ *  lane/settings pair to the same issue-policy string (#6606). registration-readiness imports
+ *  this module already; exporting here avoids a second hand-maintained copy. */
+export function resolveIssuePolicy(lane: LaneAdvice, settings: RepositorySettings): IssuePolicy {
   if (lane.lane === "issue_discovery") return "issue_discovery_enabled";
   if (lane.lane === "split") return "split_pr_and_issue_discovery_enabled";
   return settings.requireLinkedIssue ? "direct_pr_requires_linked_issue" : "direct_pr_no_issue_required";


### PR DESCRIPTION
## Summary

- Move the duplicated `IssuePolicy` type and `resolveIssuePolicy` helper into `repo-policy-readiness.ts` and export them as the single source of truth.
- Have `registration-readiness.ts` import the shared implementation instead of maintaining a byte-identical private copy (same pattern as `labelPolicyNote` in #5943).
- Pure refactor: `buildRegistrationReadiness` / `buildRepoPolicyReadiness` output is unchanged.

Closes #6606

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Pure internal move of already-covered helpers; ran `npx vitest run test/unit/registration-readiness.test.ts test/unit/repo-policy-readiness.test.ts` (33 passed). Full `npm run test:ci` / coverage still needed before push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI/frontend/docs change.

## Notes

-