### PR TITLE
fix(queue): audit draft-dodge stand-down when paused or frozen

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -5866,15 +5866,15 @@ async function handlePullRequestWebhookEvent(
     // Draft-dodge guard (#converted-to-draft): a contributor converting an OPEN PR to draft cannot use
     // draft state to keep a gate-rejected PR alive. When a prior gate failure exists for the PR's current
     // headSha (and the block has not been maintainer-overridden), close the PR immediately — the gate
-    // verdict stands and does not reset on draft conversion. Skipped when the agent is unconfigured or
-    // paused (the gate doesn't act on paused repos) and for owner / automation PRs.
+    // verdict stands and does not reset on draft conversion. Skipped when the agent is unconfigured and for
+    // owner / automation PRs. Pause/freeze/dry-run are enforced inside evaluateCloseEnforcementGate (same as
+    // the other 4 close-enforcement guards) so a paused stand-down is audited (#6604), not silently skipped.
     if (
       payload.action === "converted_to_draft" &&
       installationId &&
       pr.headSha &&
       pr.state === "open" &&
       isAgentConfigured(settings.autonomy) &&
-      !settings.agentPaused &&
       !isProtectedAutomationAuthor(pr.authorLogin)
     ) {
       // Deliberately UNCAUGHT here: closeDraftDodgeAttemptIfBlocked catches every operation that should

--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -77,8 +77,8 @@ type CloseEnforcementGateResult =
  *  `permissionReadiness: null` skips the write-permission-readiness step entirely -- the reopen-reclose
  *  guard has never had this check (a pre-existing gap distinct from #4602/#4637's close-autonomy gap; not
  *  introduced or fixed by this extraction, since a refactor must not change behavior).
- *  `paused: null` records NO audit event on a paused/frozen repo -- draft-dodge's existing, preserved gap
- *  (every other guard here DOES audit a paused stand-down; draft-dodge simply never has). */
+ *  Every caller passes a real `paused` object so a paused/frozen stand-down is audited the same way for all
+ *  five close-enforcement guards (#6604). */
 async function evaluateCloseEnforcementGate(args: {
   env: Env;
   installationId: number;
@@ -276,9 +276,10 @@ async function closeDraftDodgeAttemptIfBlocked(
         detail: `dry-run: would close draft-dodge attempt by ${draftDodgeAuthor} — prior gate failure on headSha ${pr.headSha} stands`,
         metadata: { ...gateMetadata, mode: "dry_run" },
       },
-      // Draft-dodge is the one guard of the 5 that records NO audit event on a paused/frozen repo -- a
-      // pre-existing gap this extraction preserves rather than fixes (a refactor must not change behavior).
-      paused: null,
+      paused: {
+        detail: `agent actions paused -- draft-dodge close not enforced for ${draftDodgeAuthor}`,
+        metadata: gateMetadata,
+      },
       permissionReadiness: {
         detail: `denied draft-dodge close for ${draftDodgeAuthor} — pull_requests: write not granted`,
         metadata: gateMetadata,

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -1289,7 +1289,9 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     await repositoriesModule.setGlobalAgentFrozen(env, true);
     await processJob(env, { type: "github-webhook", deliveryId: "draft-frozen", eventName: "pull_request", payload: draftPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed under freeze
-    expect(await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("github_app.draft_dodge_closed").first<{ n: number }>()).toMatchObject({ n: 0 });
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.draft_dodge_closed").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toContain("agent actions paused -- draft-dodge close not enforced for contributor");
   });
 
   it("dry-run: audits a would-be draft-dodge close without touching GitHub (#killswitch-gap)", async () => {
@@ -1464,7 +1466,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     expect(calls.some((c) => c.includes("PATCH") && c.includes("/pulls/42"))).toBe(false);
   });
 
-  it("no-ops when the agent is paused (agentPaused=true)", async () => {
+  it("no-ops when the agent is paused (agentPaused=true) and audits the paused stand-down (#6604)", async () => {
     const calls: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -1480,6 +1482,9 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     await processJob(env, { type: "github-webhook", deliveryId: "draft-paused", eventName: "pull_request", payload: draftPayload("contributor") });
 
     expect(calls.some((c) => c.includes("PATCH") && c.includes("/pulls/42"))).toBe(false);
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.draft_dodge_closed").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toContain("agent actions paused -- draft-dodge close not enforced for contributor");
   });
 
   it("no-ops when the agent autonomy is not configured (autonomy=null)", async () => {


### PR DESCRIPTION
## Summary
- `closeDraftDodgeAttemptIfBlocked` now passes a real `paused` object to `evaluateCloseEnforcementGate`, matching its 4 sibling close-enforcement guards.
- Updates the helper/call-site docs that previously documented the intentional no-audit gap.
- Extends lifecycle-guard tests so paused and frozen draft-dodge paths record a `denied` audit with the new detail string.

Closes #6604

## Test plan
- [ ] Draft-dodge under `agentPaused` / global freeze does not close the PR
- [ ] Both paths record `github_app.draft_dodge_closed` with `outcome: denied` and the paused detail
- [ ] codecov/patch green

Made with [Cursor](https://cursor.com)