### PR TITLE
fix(signals): advertise the real 99% patch coverage gate

### DIFF
--- a/src/signals/registration-readiness.ts
+++ b/src/signals/registration-readiness.ts
@@ -86,7 +86,7 @@ export type RegistrationReadinessInput = {
 };
 
 const REQUIRED_DOCS = ["README", "CONTRIBUTING", "SECURITY", "SUPPORT"];
-const COVERAGE_GATE = ["npm run test:ci", "global coverage >= 95% (lines, statements, functions, branches)"];
+const COVERAGE_GATE = ["npm run test:ci", "patch (changed-lines) coverage >= 99%"];
 
 function laneToMode(lane: LaneAdvice): RegistrationMode {
   return lane.lane === "issue_discovery" ? "issue_discovery" : lane.lane === "split" ? "split" : "direct_pr";

--- a/test/unit/registration-readiness.test.ts
+++ b/test/unit/registration-readiness.test.ts
@@ -106,6 +106,8 @@ describe("buildRegistrationReadiness", () => {
     });
     expect(report.queueHealth.level).toBe("low");
     expect(report.testCoverageHealth.requiredGate).toContain("npm run test:ci");
+    expect(report.testCoverageHealth.requiredGate).toContain("patch (changed-lines) coverage >= 99%");
+    expect(report.testCoverageHealth.requiredGate).not.toContain("global coverage >= 95%");
     expect(report.blockers).toHaveLength(0);
     expect(report.githubApp.warnings).toHaveLength(0);
     expect(report.labelPolicy.trustedPipelineReady).toBe(true);


### PR DESCRIPTION
## Summary
- Updates `COVERAGE_GATE` in registration readiness from the stale `global coverage >= 95%` wording to `patch (changed-lines) coverage >= 99%`, matching `codecov.yml`.
- Pins the corrected `requiredGate` string in unit tests so it cannot silently drift again.

Closes #6605

## Test plan
- [ ] Registration readiness report `testCoverageHealth.requiredGate` includes the 99% patch wording
- [ ] codecov/patch green

Made with [Cursor](https://cursor.com)