### PR TITLE
fix(signals): align registration-readiness coverage gate with 99% patch (#6605)

### DIFF
--- a/src/signals/registration-readiness.ts
+++ b/src/signals/registration-readiness.ts
@@ -86,7 +86,7 @@ export type RegistrationReadinessInput = {
 };
 
 const REQUIRED_DOCS = ["README", "CONTRIBUTING", "SECURITY", "SUPPORT"];
-const COVERAGE_GATE = ["npm run test:ci", "global coverage >= 95% (lines, statements, functions, branches)"];
+const COVERAGE_GATE = ["npm run test:ci", "patch (changed-lines) coverage >= 99%"];
 
 function laneToMode(lane: LaneAdvice): RegistrationMode {
   return lane.lane === "issue_discovery" ? "issue_discovery" : lane.lane === "split" ? "split" : "direct_pr";

--- a/test/unit/registration-readiness.test.ts
+++ b/test/unit/registration-readiness.test.ts
@@ -105,7 +105,10 @@ describe("buildRegistrationReadiness", () => {
       githubApp: { installed: true, quietByDefault: true },
     });
     expect(report.queueHealth.level).toBe("low");
-    expect(report.testCoverageHealth.requiredGate).toContain("npm run test:ci");
+    expect(report.testCoverageHealth.requiredGate).toEqual([
+      "npm run test:ci",
+      "patch (changed-lines) coverage >= 99%",
+    ]);
     expect(report.blockers).toHaveLength(0);
     expect(report.githubApp.warnings).toHaveLength(0);
     expect(report.labelPolicy.trustedPipelineReady).toBe(true);


### PR DESCRIPTION
## Summary
- Correct `COVERAGE_GATE` in registration-readiness so it advertises the real CI bar: 99% patch (changed-lines) coverage, not a stale 95% global gate.
- Pin the exact `requiredGate` wording in the unit test so this string cannot drift again without failing CI.

Closes #6605

## Test plan
- [x] `npx vitest run test/unit/registration-readiness.test.ts`
- [ ] `npm run test:ci`
- [ ] Confirm registration-readiness / self-dogfood pack / registration-workspace surfaces show `patch (changed-lines) coverage >= 99%`