### PR TITLE
fix(review): wire resolveDispositionReason into the action-executor notification (#6636)

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -17,6 +17,7 @@ import {
 import { isAuthorBlacklisted } from "../settings/contributor-blacklist";
 import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
+import { resolveDispositionReason } from "../review/outcomes-wire";
 import { cancelInFlightWorkflowRunsForHeadSha, createInstallationToken, githubErrorStatus, isGitHubRateLimitedError } from "../github/app";
 import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequestState, fetchLiveReviewThreadBlockers, refreshInstallationHealthForInstallation } from "../github/backfill";
 import { githubRateLimitAdmissionKeyForToken } from "../github/client";
@@ -562,7 +563,12 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       const notifyOutcome: NotifyOutcome | null =
         action.actionClass === "merge" ? "merged" : action.actionClass === "close" ? "closed" : action.actionClass === "request_changes" ? "manual" : null;
       if (notifyOutcome) {
-        const notifyParams = { repoFullName: ctx.repoFullName, pullNumber: ctx.pullNumber, outcome: notifyOutcome, summary: action.reason, submitter: ctx.authorLogin };
+        // #6636: enrich the notification with the AI's actual gate-verdict reasoning (the latest recorded
+        // gate_decision summary for this PR) instead of only the plain disposition reason — resolveDispositionReason
+        // falls back to `action.reason` when no verdict is on record or the read fails, so this is byte-identical
+        // when there's nothing to enrich with. review_audit keys gate_decision rows by `${repoFullName}#${number}`.
+        const summary = await resolveDispositionReason(env, `${ctx.repoFullName}#${ctx.pullNumber}`, action.reason);
+        const notifyParams = { repoFullName: ctx.repoFullName, pullNumber: ctx.pullNumber, outcome: notifyOutcome, summary, submitter: ctx.authorLogin };
         await notifyActionToDiscord(env, notifyParams).catch(() => undefined);
         await notifyActionToSlack(env, notifyParams).catch(() => undefined);
       }

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as notifyDiscordModule from "../../src/services/notify-discord";
 
 vi.mock("../../src/github/pr-actions", () => ({
   createPullRequestReview: vi.fn(async () => ({ id: 1 })),
@@ -221,6 +222,25 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     const outcomes = await executeAgentMaintenanceActions(env, ctx(), [close]);
     expect(outcomes[0]?.detail).toBe("noise");
     expect(outcomes[0]?.detail.endsWith("…")).toBe(false);
+  });
+
+  it("enriches the disposition notification with the recorded gate verdict, falling back to the plain reason when none is on record (#6636)", async () => {
+    const env = createTestEnv({});
+    const notifySpy = vi.spyOn(notifyDiscordModule, "notifyActionToDiscord").mockResolvedValue(undefined);
+
+    // PR #7 HAS a recorded gate_decision verdict → the notification carries the enriched (verdict) reason, not
+    // the plain disposition reason ("noise"). review_audit keys the row by `${repoFullName}#${pullNumber}`.
+    await env.DB.prepare(
+      "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+    )
+      .bind("gv7", "owner/repo", "owner/repo#7", "gate_decision", "close", "gittensory-native", "sha7", "An AI reviewer flagged a likely blocking defect", "2026-07-16T00:00:00.000Z")
+      .run();
+    await executeAgentMaintenanceActions(env, ctx(), [close]);
+    expect(notifySpy).toHaveBeenCalledWith(env, expect.objectContaining({ pullNumber: 7, summary: "An AI reviewer flagged a likely blocking defect" }));
+
+    // PR #8 has NO recorded verdict → resolveDispositionReason falls back to the plain disposition reason.
+    await executeAgentMaintenanceActions(env, ctx({ pullNumber: 8, headSha: "sha8" }), [close]);
+    expect(notifySpy).toHaveBeenCalledWith(env, expect.objectContaining({ pullNumber: 8, summary: "noise" }));
   });
 
   it("records every structured close reason in audit metadata instead of only the flattened detail", async () => {


### PR DESCRIPTION
## Summary

`resolveDispositionReason` (`src/review/outcomes-wire.ts`) was fully implemented and had a dedicated test suite, but **zero call sites** — the action executor emitted its Discord/Slack disposition notification with only the plain `action.reason`, so the enriched, verdict-aware reason the function was built to supply never reached users. Its own doc comment has promised that behavior since it was built. Closes #6636.

## Fix

At the notify site in `src/services/agent-action-executor.ts`, resolve the enriched reason before building the notification params:

```ts
const summary = await resolveDispositionReason(env, `${ctx.repoFullName}#${ctx.pullNumber}`, action.reason);
```

`resolveDispositionReason` returns the latest recorded `gate_decision` summary for the PR (`review_audit` keys those rows by `${repoFullName}#${pullNumber}`), and **falls back to `action.reason`** when no verdict is on record or the read fails — so the notification is byte-identical when there's nothing to enrich with. `resolveDispositionReason`'s own logic is unchanged (it's already correct + tested); this is purely the missing wire-up.

## Scope / Validation / Safety

- [x] Conventional Commit; focused; `Closes #6636`.
- [x] `npm run typecheck` (0 errors), engine build clean, `git diff --check` clean, no attribution/secrets.
- [x] Regression test: spies on `notifyActionToDiscord` and asserts the notification carries the **enriched** gate-verdict summary for a PR with a recorded verdict, and the **plain** disposition reason for a PR without one — covering both branches at the new call site.
- [x] The changed source line is covered (hit via existing merge/close executor tests + the new regression test); `test/unit/agent-action-executor.test.ts` + `outcomes-wire.test.ts` green (219 tests).
- [x] `resolveDispositionReason`'s logic untouched; no behavior change when no verdict is recorded.

Closes #6636
