### PR TITLE
feat(openapi): document GET /v1/repos/:owner/:repo/gate-config/effective

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14056,6 +14056,52 @@
           "amsCohort",
           "humanCohort"
         ]
+      },
+      "GateConfigEffectiveResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "effective": {
+            "type": "object",
+            "properties": {
+              "confidenceFloor": {
+                "type": "number",
+                "nullable": true
+              },
+              "scopeCap": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "type": "integer",
+                    "nullable": true
+                  },
+                  "lines": {
+                    "type": "integer",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "files",
+                  "lines"
+                ]
+              }
+            },
+            "required": [
+              "confidenceFloor",
+              "scopeCap"
+            ]
+          },
+          "shadowPending": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "repoFullName",
+          "effective",
+          "shadowPending"
+        ]
       }
     },
     "parameters": {},
@@ -18103,6 +18149,55 @@
           },
           "404": {
             "description": "No live or shadow gate override is active for this repo"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/gate-config/effective": {
+      "get": {
+        "summary": "Current effective self-tuned gate config for a repo (#6247)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Effective TunableOverride values (confidenceFloor / scopeCap.files / scopeCap.lines) with a shadowPending flag — never the raw override_audit history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GateConfigEffectiveResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid static protected API token"
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
           }
         },
         "security": [

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1749,6 +1749,20 @@ export const LiveGateThresholdsResponseSchema = z
   })
   .openapi("LiveGateThresholdsResponse");
 
+export const GateConfigEffectiveResponseSchema = z
+  .object({
+    repoFullName: z.string(),
+    effective: z.object({
+      confidenceFloor: z.number().nullable(),
+      scopeCap: z.object({
+        files: z.number().int().nullable(),
+        lines: z.number().int().nullable(),
+      }),
+    }),
+    shadowPending: z.boolean(),
+  })
+  .openapi("GateConfigEffectiveResponse");
+
 export const BurdenForecastSchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -31,6 +31,7 @@ import {
   InstallationRepairSchema,
   IssueQualityReportSchema,
   IssueQualityResponseSchema,
+  GateConfigEffectiveResponseSchema,
   LabelAuditSchema,
   LaneAdviceSchema,
   LiveGateThresholdsResponseSchema,
@@ -150,6 +151,7 @@ export function buildOpenApiSpec() {
   registry.register("ScorePreview", ScorePreviewSchema);
   registry.register("IssueQualityReport", IssueQualityReportSchema);
   registry.register("IssueQualityResponse", IssueQualityResponseSchema);
+  registry.register("GateConfigEffectiveResponse", GateConfigEffectiveResponseSchema);
   registry.register("LiveGateThresholdsResponse", LiveGateThresholdsResponseSchema);
   registry.register("BurdenForecast", BurdenForecastSchema);
   registry.register("ContributorScoringProfile", ContributorScoringProfileSchema);
@@ -421,6 +423,20 @@ export function buildOpenApiSpec() {
     responses: {
       200: { description: "Cached or computed issue quality report for the repo", content: { "application/json": { schema: IssueQualityResponseSchema } } },
       404: { description: "Repo is unknown or has no issue-quality coverage yet" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/gate-config/effective",
+    summary: "Current effective self-tuned gate config for a repo (#6247)",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: {
+        description: "Effective TunableOverride values (confidenceFloor / scopeCap.files / scopeCap.lines) with a shadowPending flag — never the raw override_audit history",
+        content: { "application/json": { schema: GateConfigEffectiveResponseSchema } },
+      },
+      401: { description: "Missing or invalid static protected API token" },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
     },
   });
   registry.registerPath({

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -14,6 +14,7 @@ describe("OpenAPI contract", () => {
     expect(spec.paths["/v1/repos/{owner}/{repo}/intelligence"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/issue-quality"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/outcome-patterns"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/gate-config/effective"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/registration-readiness"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/gittensor-config-recommendation"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/pulls/{number}/maintainer-packet"]).toBeDefined();


### PR DESCRIPTION
## What

`GET /v1/repos/:owner/:repo/gate-config/effective` (`src/api/routes.ts`) is the direct sibling of `live-gate-thresholds` — back-to-back handlers sharing the exact same auth (`requireStaticProtectedApiToken` + the `mcp`-allowlist check) — but was **missing from the OpenAPI contract entirely**: no schema, no `registerPath`, no test assertion. So it never appeared in the generated `openapi.json` (or `apps/loopover-ui/public/openapi.json`), even though its live sibling did, leaving API consumers to reverse-engineer it from the route implementation.

Resolves #6611.

## Change

- **`src/openapi/schemas.ts`**: add `GateConfigEffectiveResponseSchema` matching the handler's inline response shape — `{ repoFullName, effective: { confidenceFloor, scopeCap: { files, lines } }, shadowPending }` — with the same `.openapi(...)` convention as the adjacent `LiveGateThresholdsResponseSchema`.
- **`src/openapi/spec.ts`**: register the schema and add a `registry.registerPath` for `GET /v1/repos/{owner}/{repo}/gate-config/effective`, adjacent to `live-gate-thresholds`. The handler always returns data (nulls when no override) rather than 404-ing, and returns 401 (bad token) / 403 (not allowlisted) / 200 — so those are the documented statuses.
- **`test/unit/openapi.test.ts`**: `.toBeDefined()` assertion for the new path, so a future regression is caught by CI.
- Regenerated `apps/loopover-ui/public/openapi.json` (`ui:openapi:check` passes).

Scoped to `gate-config/effective` only — no other undocumented route is touched.

Locally green: `npx vitest run test/unit/openapi.test.ts` → 3/3; `tsx scripts/write-ui-openapi.ts --check` passes; spec.ts coverage 100% lines; eslint clean.