### PR TITLE
docs(review): correct grounding activation comment for features.grounding (#6623)

### DIFF
--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -3,9 +3,12 @@
 // CI outcomes ("this will break CI" on a green PR) and undefined symbols ("X is not defined" when it's
 // defined 10 lines outside the visible hunk) — the #967 class of false blockers.
 //
-// Every review lane calls these helpers; ACTIVATION is per-project via features.ciGrounding /
-// features.fullFileContext (default OFF — wire once here, flip on per chain from its config). Fully
-// fail-safe: any fetch error degrades to "no grounding" and the review proceeds on the diff alone.
+// Every review lane calls these helpers; ACTIVATION is a single `features.grounding` ConvergedFeatureKey
+// (resolved via resolveConvergedFeature / convergedFeatureActive) plus the LOOPOVER_REVIEW_GROUNDING env
+// kill-switch (default OFF). `ciGrounding` / `fullFileContext` below are internal GroundingFlags fields —
+// today's one real caller (groundingFlags() in ./grounding-wire) always sets both identically; they are
+// not independently-settable `.loopover.yml` keys. Fully fail-safe: any fetch error degrades to "no
+// grounding" and the review proceeds on the diff alone.
 //
 // SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence): every type + helper this module needs is
 // defined HERE. No imports from reviewbot. The logic is byte-faithful to the reviewbot source
@@ -59,7 +62,10 @@ const MAX_SINGLE_FILE = 24_000; // a file larger than this is marked truncated (
 // Binary / generated / lockfile paths carry no review signal as full text — skip inlining them.
 const SKIP_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|heic|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|tgz|wasm)$/i;
 
-/** The grounding feature flags (subset of reviewbot's FeatureToggles). */
+/** The grounding feature flags (subset of reviewbot's FeatureToggles). Two internal booleans of one
+ *  GroundingFlags value — the type permits independent values so a future caller could split CI-summary
+ *  vs full-file gathering, but today's only caller (`groundingFlags()` in `./grounding-wire`) always sets
+ *  both from the single `features.grounding` / LOOPOVER_REVIEW_GROUNDING activation path. */
 export interface GroundingFlags {
   ciGrounding: boolean;
   fullFileContext: boolean;


### PR DESCRIPTION
## Summary

- Correct `src/review/review-grounding.ts`'s module header so activation is described as the real single `features.grounding` ConvergedFeatureKey path (via `resolveConvergedFeature` / `convergedFeatureActive`) plus the `LOOPOVER_REVIEW_GROUNDING` env kill-switch — not the non-existent `features.ciGrounding` / `features.fullFileContext` keys.
- Clarify on `GroundingFlags` that `ciGrounding` / `fullFileContext` are internal fields of one flags value; today's only caller (`groundingFlags()` in `grounding-wire.ts`) always sets both identically. Comment-only; no runtime changes.

Closes #6623

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Comment-only docs fix (no executable code touched). Codecov patch gate does not apply. Ran `npx vitest run test/unit/review-grounding.test.ts test/unit/grounding-wiring.test.ts` (80 passed) to confirm no runtime behavior changed. Remaining `test:ci` steps are unchanged by this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — comment-only change; no visible UI.

## Notes

-