### PR TITLE
fix(engine): render a sub-365-day full-year tenure as months, not "0y 12m"

### DIFF
--- a/packages/loopover-engine/src/track-record-summary.ts
+++ b/packages/loopover-engine/src/track-record-summary.ts
@@ -226,7 +226,10 @@ function formatTenure(days: number | null): string {
   if (days === 1) return "1 day";
   if (days < 30) return `${days} days`;
   const months = Math.floor(days / 30);
-  if (months < 12) return months === 1 ? "1 month" : `${months} months`;
+  // Cut over to the year format at the same 365-day boundary the year branch below uses. Gating on
+  // `months < 12` treats a year as 360 days (12×30), so 360–364 days failed this check yet still yielded
+  // `years = floor(days/365) === 0`, rendering the nonsensical "0y 12m" instead of "12 months".
+  if (days < 365) return months === 1 ? "1 month" : `${months} months`;
   const years = Math.floor(days / 365);
   const remainderMonths = Math.floor((days % 365) / 30);
   if (remainderMonths === 0) return years === 1 ? "1 year" : `${years} years`;

--- a/packages/loopover-engine/test/track-record-summary.test.ts
+++ b/packages/loopover-engine/test/track-record-summary.test.ts
@@ -377,6 +377,7 @@ test("computeTrackRecordSummary renders month and year tenure labels determinist
     ["2026-07-03T18:00:00Z", "1 day"],
     ["2026-06-25T18:00:00Z", "9 days"],
     ["2026-03-01T18:00:00Z", "4 months"],
+    ["2025-07-09T18:00:00Z", "12 months"], // 360 days: a sub-365-day full year renders as months, not "0y 12m"
     ["2024-12-01T18:00:00Z", "1y 7m"],
   ].map(([createdAt, expected]) => {
     const summary = computeTrackRecordSummary({
@@ -401,6 +402,7 @@ test("computeTrackRecordSummary renders month and year tenure labels determinist
     ["2026-07-03T18:00:00Z", "1 day", "1 day"],
     ["2026-06-25T18:00:00Z", "9 days", "9 days"],
     ["2026-03-01T18:00:00Z", "4 months", "4 months"],
+    ["2025-07-09T18:00:00Z", "12 months", "12 months"],
     ["2024-12-01T18:00:00Z", "1y 7m", "1y 7m"],
   ]);
 });


### PR DESCRIPTION
## Bug (self-found, no issue)

`formatTenure` in `packages/loopover-engine/src/track-record-summary.ts` renders a nonsensical **`"0y 12m"`** for any public tenure of **360–364 days**.

The month/year cutover is gated on `months < 12` where `months = Math.floor(days / 30)` — i.e. it treats a year as 360 days. But the year branch computes `years = Math.floor(days / 365)`. So for 360–364 days:
- `months` is `12` → the `months < 12` branch is skipped,
- `years` is `0` → control falls into the year-formatting branch, which is written assuming `years >= 1`,
- result: `` `${years}y ${remainderMonths}m` `` → **`"0y 12m"`**.

This label is user-visible: `renderTrackRecordSummaryMarkdown` emits `- Public tenure: ${summary.tenure.label}` into a public PR body.

### Demonstration (current behavior)
```
359 => "11 months"
360 => "0y 12m"   ← wrong
364 => "0y 12m"   ← wrong
365 => "1 year"
```

## Fix

Align the month/year cutover with the **same 365-day boundary the year branch already uses**, by gating the month branch on `days < 365` instead of `months < 12`:

```
360..364 => "12 months"   (was "0y 12m")
365       => "1 year"      (unchanged)
```

Every other range is unchanged — `days`, single `"1 month"`, `"N months"`, `"1 year"`, `"N years"`, and `"Ny Mm"` all render exactly as before (verified: 29→"29 days", 30→"1 month", 359→"11 months", 395→"1y 1m", 730→"2 years").

## Test

Extends the existing deterministic `computeTrackRecordSummary renders month and year tenure labels deterministically` table with a **360-day** case asserting `"12 months"` — a regression guard on the exact boundary. The pre-existing 365-day `"1 year"` test covers the other side of the changed branch, so the patch is fully covered.

Full `track-record-summary` suite: **30/30 pass**.