### PR TITLE
fix(agent-actions): never approve a repeat unlinked-issue offender's PR it is closing

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -1206,8 +1206,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // Never APPROVE a base-conflicting PR: it is closed below (willClose on isConflict), so a "LoopOver approves —
   // safe to merge" review on a PR we're about to close is incoherent (and a stale approval strands the PR if it
   // later goes green). A `behind`/`blocked` PR is fine to approve (it is rebased pre-review or the approval clears
-  // the block); only a hard `dirty` conflict is excluded here. (#ready-needs-mergeable, the #4220 report) */
-  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && !isConflict && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
+  // the block); only a hard `dirty` conflict is excluded here. (#ready-needs-mergeable, the #4220 report)
+  // The same coherence rule applies to a confirmed repeat unlinked-issue offender (`unlinkedIssueMatchViolated`),
+  // whose own CLOSE branch fires below — approving a PR being closed as a repeat violation is equally incoherent.
+  // The sibling close paths already exclude it (lines 1092, 1128-1134); this guard omitted it, so a green,
+  // not-yet-approved repeat offender's PR was planned as an incoherent approve+close pair. */
+  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && !unlinkedIssueMatchViolated && !isConflict && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -728,6 +728,23 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan.find((a) => a.actionClass === "close")?.expectedHeadSha).toBe("abc123");
     });
 
+    it("never ALSO approves the repeat offender's PR it is closing — no incoherent approve+close pair", () => {
+      // A green, clean, not-yet-approved PR from a confirmed repeat unlinked-issue offender, with BOTH approve
+      // and close autonomy acting. The dedicated close branch fires on unlinkedIssueMatchViolated; the approve
+      // guard must suppress here too (like every sibling close path) — approving a PR we're about to close is
+      // incoherent (function contract: "never both merge and close"; the approve guard's own comment).
+      const plan = planAgentMaintenanceActions(
+        input({
+          conclusion: "success",
+          autonomy: { approve: "auto", close: "auto" },
+          ...repeated,
+          pr: { labels: [], mergeableState: "clean" }, // reviewDecision unset: the APPROVED short-circuit is absent
+        }),
+      );
+      expect(classes(plan)).toContain("close");
+      expect(classes(plan)).not.toContain("approve");
+    });
+
     it("cites the repeat-specific reason and the standard close message template, tagged closeKind: heuristic (subject to the precision breaker)", () => {
       const action = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ...repeated, pr: { labels: [] } })).find((a) => a.actionClass === "close");
       expect(action?.reason).toContain("#42");


### PR DESCRIPTION
## Bug (self-found, no issue)

`planAgentMaintenanceActions` (`src/settings/agent-actions.ts`) documents that it returns a **coherent** disposition set — its contract comment: *"never both merge and close"*, and the approve guard's own comment: approving *"a PR we're about to close is incoherent (and a stale approval strands the PR if it later goes green)."*

The approve guard excludes two of the three close paths that can coexist with a review-good PR — `!linkedIssueCloseInFlight` and `!isConflict` — but **omits the third**: a confirmed repeat unlinked-issue offender, `unlinkedIssueMatchViolated` (which fires its own one-shot `close`).

### Triggering input
A green, gate-passing, **not-yet-approved** PR from a **confirmed repeat** unlinked-issue offender, with both `approve` and `close` autonomy acting:
- `conclusion: "success"` → `reviewGood === true`
- `autonomy: { approve: "auto", close: "auto" }`
- `unlinkedIssueMatchClose` set, `mergeableState: "clean"`, `reviewDecision` unset

**Result:** the plan is `["approve", "close"]` — the bot **approves the very PR it is closing** as a repeat violation, and leaves a stale approval behind.

`heldForManualReview` does not catch this: its unlinked term is `input.unlinkedIssueMatchClose !== undefined && !acting("close")`, which is deliberately false exactly when `close` is acting — the scenario here.

## Fix

Add `!unlinkedIssueMatchViolated` to the approve guard — the same term the **sibling close paths already carry** (lines 1092 and 1128–1134). The one place that checked `!linkedIssueCloseInFlight` but forgot `!unlinkedIssueMatchViolated` is now consistent, so a repeat offender's PR gets a single `close` and no approval.

Every other approve / merge / close / hold disposition is unchanged.

## Test

Adds a regression test to the *"unlinked-issue-match CLOSE"* suite asserting the plan **contains `close` and not `approve`** for the triggering input. Verified it **fails on the current code** (plan is `["approve","close"]`) and **passes with the fix**.

- Full `agent-actions` suite: **287/287 pass**.
- `src/settings/agent-actions.ts`: statements/lines 100%, and the changed guard line's new branch is covered on both outcomes (repeat-offender → approve suppressed; normal → approve proceeds), so the patch is fully covered.