### PR TITLE
feat(mcp): register close PR write tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -10,6 +10,7 @@ import { buildFeasibilityVerdict, buildPrTextLint } from "@loopover/engine";
 // registering them locally is just importing the same engine builders the remote server uses.
 import {
   buildApplyLabelsSpec,
+  buildClosePrSpec,
   buildCreateBranchSpec,
   buildDeleteBranchSpec,
   buildFileIssueSpec,
@@ -361,6 +362,11 @@ const applyLabelsShape = {
   repoFullName: writeToolRepoFullName,
   number: z.number().int().positive(),
   labels: z.array(z.string().min(1).max(100)).min(1).max(20),
+};
+const closePrShape = {
+  repoFullName: writeToolRepoFullName,
+  number: z.number().int().positive(),
+  comment: z.string().max(WRITE_TOOL_BODY_MAX).optional(),
 };
 const postEligibilityCommentShape = {
   repoFullName: writeToolRepoFullName,
@@ -1060,6 +1066,12 @@ const STDIO_TOOL_DESCRIPTORS = [
     category: "agent",
     description:
       "Build a LOCAL-execution spec to add labels to an issue or PR (run it with your own gh creds; loopover never performs the write).",
+  },
+  {
+    name: "loopover_close_pr",
+    category: "agent",
+    description:
+      "Build a LOCAL-execution spec to close a pull request (run it with your own gh creds; loopover never performs the write).",
   },
   {
     name: "loopover_post_eligibility_comment",
@@ -2091,6 +2103,15 @@ registerStdioTool(
     inputSchema: applyLabelsShape,
   },
   (input) => localWriteSpecResult(buildApplyLabelsSpec(input)),
+);
+
+registerStdioTool(
+  "loopover_close_pr",
+  {
+    description: stdioToolDescription("loopover_close_pr"),
+    inputSchema: closePrShape,
+  },
+  (input) => localWriteSpecResult(buildClosePrSpec(input)),
 );
 
 registerStdioTool(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -146,6 +146,7 @@ import { computeLocalScorerTokens } from "../signals/local-scorer";
 import { buildPullRequestReviewability, type PullRequestReviewability } from "../signals/reward-risk";
 import {
   buildApplyLabelsSpec,
+  buildClosePrSpec,
   buildCreateBranchSpec,
   buildDeleteBranchSpec,
   buildFileIssueSpec,
@@ -421,6 +422,11 @@ const applyLabelsShape = {
   repoFullName: z.string().min(3).max(SCENARIO_MAX_REPO_FULL_NAME_CHARS),
   number: z.number().int().positive(),
   labels: z.array(z.string().min(1).max(100)).min(1).max(20),
+};
+const closePrShape = {
+  repoFullName: z.string().min(3).max(SCENARIO_MAX_REPO_FULL_NAME_CHARS),
+  number: z.number().int().positive(),
+  comment: z.string().max(WRITE_TOOL_BODY_MAX).optional(),
 };
 const postEligibilityCommentShape = {
   repoFullName: z.string().min(3).max(SCENARIO_MAX_REPO_FULL_NAME_CHARS),
@@ -1767,6 +1773,7 @@ export const MCP_TOOL_CATEGORIES: Record<string, McpToolCategory> = {
   loopover_open_pr: "agent",
   loopover_file_issue: "agent",
   loopover_apply_labels: "agent",
+  loopover_close_pr: "agent",
   loopover_post_eligibility_comment: "agent",
   loopover_create_branch: "agent",
   loopover_delete_branch: "agent",
@@ -2393,6 +2400,11 @@ export class LoopoverMcp {
       "loopover_apply_labels",
       { description: "Build a LOCAL-execution spec to add labels to an issue or PR (run it with your own gh creds; loopover never performs the write).", inputSchema: applyLabelsShape, outputSchema: localWriteActionOutputSchema },
       async (input) => this.toolResult(this.localWriteSpec(buildApplyLabelsSpec(input))),
+    );
+    register(
+      "loopover_close_pr",
+      { description: "Build a LOCAL-execution spec to close a pull request (run it with your own gh creds; loopover never performs the write).", inputSchema: closePrShape, outputSchema: localWriteActionOutputSchema },
+      async (input) => this.toolResult(this.localWriteSpec(buildClosePrSpec(input))),
     );
     register(
       "loopover_post_eligibility_comment",

--- a/test/unit/mcp-cli-write-tools.test.ts
+++ b/test/unit/mcp-cli-write-tools.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-// #6149: the 8 miner write-tools are PURE local-execution spec builders (loopover never performs the write);
+// #6149: the miner write-tools are PURE local-execution spec builders (loopover never performs the write);
 // each returns a { action, command, boundary } spec the caller runs with its OWN gh/git creds. These tests
 // drive the real local stdio server and assert the composed spec, plus a zod-rejection failure path per tool.
 const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
@@ -35,6 +35,7 @@ const WRITE_TOOLS = [
   "loopover_open_pr",
   "loopover_file_issue",
   "loopover_apply_labels",
+  "loopover_close_pr",
   "loopover_post_eligibility_comment",
   "loopover_create_branch",
   "loopover_delete_branch",
@@ -47,7 +48,7 @@ function spec(result: unknown): { action: string; command: string; boundary: str
 }
 
 describe("loopover-mcp write-tools (#6149)", () => {
-  it("registers all 8 write-tools on the local stdio server", async () => {
+  it("registers all 9 write-tools on the local stdio server", async () => {
     const names = new Set((await client.listTools()).tools.map((t) => t.name));
     for (const name of WRITE_TOOLS) expect(names, `missing ${name}`).toContain(name);
   });
@@ -84,6 +85,27 @@ describe("loopover-mcp write-tools (#6149)", () => {
     expect(spec(result).action).toBe("apply_labels");
     expect(spec(result).command).toContain("gh issue edit 7 --repo 'acme/widgets'");
     expect(spec(result).command).toContain("--add-label");
+  });
+
+  it("loopover_close_pr composes a gh pr close spec with and without a comment", async () => {
+    const withComment = await client.callTool({
+      name: "loopover_close_pr",
+      arguments: { repoFullName: "acme/widgets", number: 7, comment: "Closing duplicate" },
+    });
+    expect(withComment.isError).toBeFalsy();
+    expect(spec(withComment).action).toBe("close_pr");
+    expect(spec(withComment).command).toBe(
+      "gh pr close 7 --repo 'acme/widgets' && gh pr comment 7 --repo 'acme/widgets' --body 'Closing duplicate'",
+    );
+    expect(spec(withComment).boundary).toMatch(/your OWN GitHub credentials/i);
+    expect(spec(withComment).boundary).toMatch(/never performs the write/i);
+
+    const withoutComment = await client.callTool({
+      name: "loopover_close_pr",
+      arguments: { repoFullName: "acme/widgets", number: 7 },
+    });
+    expect(withoutComment.isError).toBeFalsy();
+    expect(spec(withoutComment).command).toBe("gh pr close 7 --repo 'acme/widgets'");
   });
 
   it("loopover_post_eligibility_comment composes a gh issue comment spec", async () => {
@@ -137,6 +159,7 @@ describe("loopover-mcp write-tools (#6149)", () => {
       loopover_open_pr: { repoFullName: "acme/widgets", base: "main", head: "feat-x", title: "", body: "b" }, // title min(1)
       loopover_file_issue: { repoFullName: "ab", title: "T", body: "b" }, // repoFullName min(3)
       loopover_apply_labels: { repoFullName: "acme/widgets", number: 7, labels: [] }, // labels min(1)
+      loopover_close_pr: { repoFullName: "acme/widgets", number: 0 }, // number positive
       loopover_post_eligibility_comment: { repoFullName: "acme/widgets", number: 0, body: "b" }, // number positive
       loopover_create_branch: { base: "main" }, // branch required
       loopover_delete_branch: { branch: "" }, // branch min(1)

--- a/test/unit/mcp-write-tools.test.ts
+++ b/test/unit/mcp-write-tools.test.ts
@@ -46,6 +46,29 @@ describe("MCP miner write-tools (#780)", () => {
     }
   });
 
+  it("close_pr returns the existing local-execution spec with and without a comment", async () => {
+    const client = await connect();
+    const withComment = await client.callTool({
+      name: "loopover_close_pr",
+      arguments: { repoFullName: "o/r", number: 7, comment: "Closing: lost the claim to #5" },
+    });
+    expect(withComment.isError).toBeFalsy();
+    const withCommentSpec = withComment.structuredContent as Spec;
+    expect(withCommentSpec.action).toBe("close_pr");
+    expect(withCommentSpec.command).toBe(
+      "gh pr close 7 --repo 'o/r' && gh pr comment 7 --repo 'o/r' --body 'Closing: lost the claim to #5'",
+    );
+    expect(withCommentSpec.boundary).toMatch(/your OWN GitHub credentials/i);
+    expect(withCommentSpec.boundary).toMatch(/never performs the write/i);
+
+    const withoutComment = await client.callTool({
+      name: "loopover_close_pr",
+      arguments: { repoFullName: "o/r", number: 7 },
+    });
+    expect(withoutComment.isError).toBeFalsy();
+    expect((withoutComment.structuredContent as Spec).command).toBe("gh pr close 7 --repo 'o/r'");
+  });
+
   // #2188 (boundary-safe test-generation slice of #1972).
   it("generate_tests returns a local-execution spec naming the framework and target files; gittensory performs no write", async () => {
     const client = await connect();


### PR DESCRIPTION
## Summary

- Register `loopover_close_pr` on the remote MCP server and local stdio MCP server.
- Reuse `buildClosePrSpec` so the tool returns the same local-execution command and boundary as the existing engine/miner consumer.
- Cover registration, category metadata, validation, and exact commands with and without an optional comment.

Closes #6615

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:ci` was attempted. Its unsharded coverage phase hit pre-existing Windows-only executable-bit and subprocess failures before later jobs could run. The three affected MCP suites pass (20 tests), including both optional-comment branches and tool-category parity. `npm run test:mcp-pack` also hits the Windows executable-bit check; `npm pack --dry-run --json` succeeds and lists the expected package.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

- The tool only builds a command for the caller to run locally with its own credentials; LoopOver does not perform the write.
