### PR TITLE
docs(mcp): fix stale 'NOT WIRED YET' comment in telemetry.ts (#6617)

### DIFF
--- a/src/mcp/telemetry.ts
+++ b/src/mcp/telemetry.ts
@@ -11,8 +11,10 @@ import { PostHog } from "posthog-node";
 // The wrapper also never throws: a PostHog init/capture failure degrades to recording nothing, exactly like
 // the unconfigured path, so it can never surface an error into the MCP tool caller.
 //
-// NOT WIRED YET: per #6235 this module is deliberately NOT called from the tool-dispatch path — that (and the
-// client lifecycle/flush strategy a live Worker needs) is the separate instrumentation issue's job.
+// WIRED into the remote tool-dispatch path (#6237, merged PR #6358): {@link recordMcpToolCall} is invoked from
+// `recordMcpToolTelemetry` in src/mcp/server.ts — the single chokepoint every `tools/call` request that reaches
+// handleMcpRequest routes through exactly once, whether it succeeds or throws. (The local/CLI-side counterpart,
+// packages/loopover-mcp/lib/telemetry.js, has its own separate wiring status per #6236/#6238.)
 
 /** PostHog US-cloud ingestion host — the default when POSTHOG_HOST isn't set. */
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";


### PR DESCRIPTION
## Summary

- `src/mcp/telemetry.ts`'s header carried a stale `NOT WIRED YET` note saying `recordMcpToolCall` is deliberately not called from the tool-dispatch path.
- It IS wired now: #6237 (merged PR #6358) added `recordMcpToolTelemetry` in `src/mcp/server.ts` — the single chokepoint every `tools/call` routes through — which calls `recordMcpToolCall` directly.
- Comment-only correction citing the real chokepoint + issue/PR; no runtime change (the exported signature, no-op-when-unconfigured, and never-throw guarantees are byte-identical). The local/CLI counterpart (`packages/loopover-mcp/lib/telemetry.js`) is untouched.

Closes #6617

## Test plan

- [x] Comment-only diff; existing `test/unit/mcp-telemetry.test.ts` + `test/unit/mcp-server-telemetry.test.ts` pass unchanged (no logic touched).
