### PR TITLE
feat(api): add a REST route + CLI mirror for loopover_get_eligibility_plan

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -902,6 +902,12 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Explain a private score preview multiplier-by-multiplier with plain-English levers and the highest-impact improvement.",
   },
   {
+    name: "loopover_get_eligibility_plan",
+    category: "discovery",
+    description:
+      "Derive a structured eligibility plan from local score-preview metadata: whether the branch/PR is eligible now, public-safe blockers, and cleanup paths. Advisory dry-run only — no GitHub writes.",
+  },
+  {
     name: "loopover_get_decision_pack",
     category: "discovery",
     description: "Return the private decision pack for a contributor: the ranked repos and issues to work on next, with per-repo go/raise/avoid guidance. Takes login (the contributor's GitHub username).",
@@ -1542,52 +1548,70 @@ registerStdioTool(
   async (input) => toolResult("LoopOver private local PR scoring preview.", await previewLocalScore(await withClientWorkspaceRoots(input))),
 );
 
+// #6621: the local-branch -> scoring-request body BOTH local scoring tools post. Extracted from
+// loopover_explain_score_breakdown so its eligibility-plan sibling sends a byte-identical request instead of a
+// second, drifting copy of this assembly. `purpose` only shapes the missing-login error message.
+async function buildLocalScoreRequestBody(input, purpose) {
+  const workspaceInput = await withClientWorkspaceRoots(input);
+  const contributorLogin = workspaceInput.contributorLogin ?? activeProfile.session?.login;
+  if (!contributorLogin) throw new Error(`contributorLogin is required for ${purpose}.`);
+  const workspace = resolveWorkspaceCwd(workspaceInput);
+  const diff = collectLocalDiff(workspace.cwd, workspaceInput.baseRef, workspaceInput.workspaceRoots);
+  const branchPayload = buildBranchAnalysisPayload({
+    ...workspaceInput,
+    login: contributorLogin,
+    cwd: workspace.cwd,
+    repoFullName: workspaceInput.repoFullName,
+    baseRef: workspaceInput.baseRef,
+  });
+  const upstreamPreview = branchPayload.localScorerStatus;
+  const estimatedSourceLines = workspaceInput.sourceLines ?? Math.max(1, diff.changedLineCount - diff.testFiles.length);
+  return {
+    repoFullName: workspaceInput.repoFullName,
+    targetType: "local_diff",
+    targetKey: workspaceInput.targetKey ?? localDiffTargetKey(branchPayload, workspaceInput.baseRef),
+    contributorLogin,
+    labels: workspaceInput.labels,
+    linkedIssueMode: workspaceInput.linkedIssueMode,
+    sourceTokenScore: workspaceInput.sourceTokenScore ?? estimatedSourceLines,
+    sourceLines: estimatedSourceLines,
+    totalTokenScore: workspaceInput.totalTokenScore ?? diff.changedLineCount,
+    testTokenScore: diff.testFiles.length,
+    openPrCount: workspaceInput.openPrCount,
+    credibility: workspaceInput.credibility,
+    changesRequestedCount: workspaceInput.changesRequestedCount,
+    pendingMergedPrCount: workspaceInput.pendingMergedPrCount,
+    pendingClosedPrCount: workspaceInput.pendingClosedPrCount,
+    approvedPrCount: workspaceInput.approvedPrCount,
+    expectedOpenPrCountAfterMerge: workspaceInput.expectedOpenPrCountAfterMerge,
+    projectedCredibility: workspaceInput.projectedCredibility,
+    scenarioNotes: workspaceInput.scenarioNotes,
+    branchEligibility: workspaceInput.branchEligibility,
+    metadataOnly: !upstreamPreview.ok,
+  };
+}
+
 registerStdioTool(
   "loopover_explain_score_breakdown",
   {
     description: stdioToolDescription("loopover_explain_score_breakdown"),
     inputSchema: localScoreShape,
   },
-  async (input) => {
-    const workspaceInput = await withClientWorkspaceRoots(input);
-    const contributorLogin = workspaceInput.contributorLogin ?? activeProfile.session?.login;
-    if (!contributorLogin) throw new Error("contributorLogin is required for score breakdown.");
-    const workspace = resolveWorkspaceCwd(workspaceInput);
-    const diff = collectLocalDiff(workspace.cwd, workspaceInput.baseRef, workspaceInput.workspaceRoots);
-    const branchPayload = buildBranchAnalysisPayload({
-      ...workspaceInput,
-      login: contributorLogin,
-      cwd: workspace.cwd,
-      repoFullName: workspaceInput.repoFullName,
-      baseRef: workspaceInput.baseRef,
-    });
-    const upstreamPreview = branchPayload.localScorerStatus;
-    const estimatedSourceLines = workspaceInput.sourceLines ?? Math.max(1, diff.changedLineCount - diff.testFiles.length);
-    const body = {
-      repoFullName: workspaceInput.repoFullName,
-      targetType: "local_diff",
-      targetKey: workspaceInput.targetKey ?? localDiffTargetKey(branchPayload, workspaceInput.baseRef),
-      contributorLogin,
-      labels: workspaceInput.labels,
-      linkedIssueMode: workspaceInput.linkedIssueMode,
-      sourceTokenScore: workspaceInput.sourceTokenScore ?? estimatedSourceLines,
-      sourceLines: estimatedSourceLines,
-      totalTokenScore: workspaceInput.totalTokenScore ?? diff.changedLineCount,
-      testTokenScore: diff.testFiles.length,
-      openPrCount: workspaceInput.openPrCount,
-      credibility: workspaceInput.credibility,
-      changesRequestedCount: workspaceInput.changesRequestedCount,
-      pendingMergedPrCount: workspaceInput.pendingMergedPrCount,
-      pendingClosedPrCount: workspaceInput.pendingClosedPrCount,
-      approvedPrCount: workspaceInput.approvedPrCount,
-      expectedOpenPrCountAfterMerge: workspaceInput.expectedOpenPrCountAfterMerge,
-      projectedCredibility: workspaceInput.projectedCredibility,
-      scenarioNotes: workspaceInput.scenarioNotes,
-      branchEligibility: workspaceInput.branchEligibility,
-      metadataOnly: !upstreamPreview.ok,
-    };
-    return toolResult("LoopOver private score breakdown.", await apiPost("/v1/scoring/explain-breakdown", body));
+  async (input) =>
+    toolResult("LoopOver private score breakdown.", await apiPost("/v1/scoring/explain-breakdown", await buildLocalScoreRequestBody(input, "score breakdown"))),
+);
+
+// #6621: CLI mirror of the remote server's loopover_get_eligibility_plan — the one tool in the
+// preview/breakdown/eligibility trio that had no REST route or CLI mirror. Same local-branch request body as
+// the breakdown tool above; only the endpoint differs. deriveEligibilityPlan runs server-side.
+registerStdioTool(
+  "loopover_get_eligibility_plan",
+  {
+    description: stdioToolDescription("loopover_get_eligibility_plan"),
+    inputSchema: localScoreShape,
   },
+  async (input) =>
+    toolResult("LoopOver eligibility plan.", await apiPost("/v1/scoring/eligibility-plan", await buildLocalScoreRequestBody(input, "an eligibility plan"))),
 );
 
 registerStdioTool(

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -169,6 +169,7 @@ import { buildRemediationPlan } from "../services/remediation-plan";
 import { handleDraftCreate, handleDraftOAuthCallback, handleDraftStatus } from "../services/draft";
 import { decidePendingAgentAction } from "../services/agent-approval-queue";
 import { explainScoreBreakdown } from "../services/score-breakdown";
+import { deriveEligibilityPlan } from "../services/eligibility-plan";
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import {
   authoritativeContributorRepoStats,
@@ -2112,6 +2113,33 @@ export function createApp() {
     const input = { ...parsed.data, openIssueCount, applyTimeDecay: isTimeDecayEnabled(c.env) };
     const preview = buildScorePreview({ input, repo, snapshot, contributorEvidence: evidence });
     return c.json(explainScoreBreakdown(preview));
+  });
+
+  // #6621: the eligibility-plan sibling of /v1/scoring/explain-breakdown — same scorePreviewSchema body, same
+  // repo/snapshot/evidence fetch, same buildScorePreview, then a different pure derivation on top
+  // (deriveEligibilityPlan instead of explainScoreBreakdown). Mirrors the loopover_get_eligibility_plan MCP
+  // handler exactly; deriveEligibilityPlan stays the single source of truth and is not reimplemented here.
+  // contributorLogin is OPTIONAL and gated only when supplied — matching /v1/scoring/preview (and this tool's
+  // own MCP handler), NOT explain-breakdown's unconditional-required version.
+  app.post("/v1/scoring/eligibility-plan", async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsed = scorePreviewSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_scoring_preview_request", issues: parsed.error.issues }, 400);
+    if (parsed.data.contributorLogin) {
+      const unauthorized = await requireContributorAccess(c, parsed.data.contributorLogin);
+      if (unauthorized) return unauthorized;
+    }
+    const [repo, snapshot, evidence, contributorIssues] = await Promise.all([
+      getRepository(c.env, parsed.data.repoFullName),
+      getOrCreateScoringModelSnapshot(c.env),
+      parsed.data.contributorLogin ? getContributorEvidence(c.env, parsed.data.contributorLogin) : Promise.resolve(null),
+      parsed.data.contributorLogin ? listContributorIssues(c.env, parsed.data.contributorLogin) : Promise.resolve([]),
+    ]);
+    const openIssueCount = contributorOpenIssueCount(contributorIssues, parsed.data.repoFullName);
+    // Time-decay (#703) is an owner-gated global, injected server-side (not caller-controllable).
+    const input = { ...parsed.data, openIssueCount, applyTimeDecay: isTimeDecayEnabled(c.env) };
+    const preview = buildScorePreview({ input, repo, snapshot, contributorEvidence: evidence });
+    return c.json(deriveEligibilityPlan(preview));
   });
 
   app.get("/v1/sync/status", async (c) => {

--- a/test/unit/mcp-cli-eligibility-plan-tool.test.ts
+++ b/test/unit/mcp-cli-eligibility-plan-tool.test.ts
@@ -1,0 +1,73 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+// #6621: loopover_get_eligibility_plan was the one tool in the preview/breakdown/eligibility trio with no CLI
+// mirror. It shares loopover_explain_score_breakdown's request-body assembly via buildLocalScoreRequestBody, so
+// what is worth pinning here is the tool's own surface: that it is registered under the right schema, that its
+// zod shape rejects bad input, and that the shared helper's contributorLogin guard fires BEFORE any workspace
+// or network work. The composed body + apiPost round-trip is covered server-side by routes-eligibility-plan.
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+
+describe("loopover_get_eligibility_plan stdio mirror (#6621)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let configDir: string;
+
+  async function connect() {
+    configDir = mkdtempSync(join(tmpdir(), "loopover-eligibility-plan-"));
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v;
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [bin, "--stdio"],
+      env: { ...env, LOOPOVER_CONFIG_DIR: configDir, LOOPOVER_TOKEN: "session-token", LOOPOVER_API_TIMEOUT_MS: "5000" },
+    });
+    client = new Client({ name: "eligibility-plan-tool-test", version: "0.0.1" });
+    await client.connect(transport);
+  }
+
+  afterEach(async () => {
+    await client?.close().catch(() => undefined);
+    if (configDir) rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it("registers the tool alongside its explain_score_breakdown sibling", async () => {
+    await connect();
+    const names = new Set((await client.listTools()).tools.map((t) => t.name));
+    expect(names).toContain("loopover_get_eligibility_plan");
+    expect(names).toContain("loopover_explain_score_breakdown");
+  });
+
+  it("advertises the same input schema as its sibling (both take localScoreShape)", async () => {
+    await connect();
+    const { tools } = await client.listTools();
+    const plan = tools.find((t) => t.name === "loopover_get_eligibility_plan");
+    const breakdown = tools.find((t) => t.name === "loopover_explain_score_breakdown");
+    expect(plan?.inputSchema).toEqual(breakdown?.inputSchema);
+    expect(plan?.description).toMatch(/eligib/i);
+  });
+
+  it("fails fast when no contributorLogin resolves — the shared helper guards before any workspace/network work", async () => {
+    await connect();
+    const outcome = await client
+      .callTool({ name: "loopover_get_eligibility_plan", arguments: { repoFullName: "acme/widgets" } })
+      .then((r) => ({ isError: Boolean(r.isError), text: JSON.stringify(r) }), (e: unknown) => ({ isError: true, text: String(e) }));
+    expect(outcome.isError).toBe(true);
+    expect(outcome.text).toMatch(/contributorLogin is required for an eligibility plan/);
+  });
+
+  it("rejects invalid input (zod input-schema validation)", async () => {
+    await connect();
+    for (const args of [{}, { repoFullName: "" }, { repoFullName: "acme/widgets", linkedIssueMode: "bogus" }]) {
+      const rejected = await client.callTool({ name: "loopover_get_eligibility_plan", arguments: args }).then(
+        (r) => Boolean(r.isError),
+        () => true,
+      );
+      expect(rejected, `${JSON.stringify(args)} should be rejected`).toBe(true);
+    }
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -5,6 +5,7 @@
 // `tools --json` listing stays in lockstep with what the live server actually registers.
 // (#6152 registered the 5 maintain-surface tools, taking the count from 42 to 47.)
 // (#6150 registered the local-scorer and plan-DAG/predict-gate tools, taking the count from 55 to 60.)
+// (#6621 registered the eligibility-plan CLI mirror, taking the count from 61 to 62.)
 // (#6619 registered the pr-ai-review-findings CLI mirror, taking the count from 60 to 61.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -49,14 +50,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 61 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 62 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(61);
+    expect(primary.length).toBe(62);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(61);
+    expect(names.length).toBe(62);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -66,11 +67,11 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 61-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 62-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(61);
+    expect(payload.count).toBe(62);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual([...tools.map((t) => t.name)].sort());
   });
 });

--- a/test/unit/routes-eligibility-plan.test.ts
+++ b/test/unit/routes-eligibility-plan.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+// #6621: POST /v1/scoring/eligibility-plan — the eligibility-plan sibling of /v1/scoring/explain-breakdown.
+// It shares that route's body schema, fetch, and buildScorePreview, then applies deriveEligibilityPlan (whose
+// own logic is covered by eligibility-plan's unit tests). These tests pin the ROUTE contract: the derivation is
+// returned, contributorLogin is OPTIONAL but gated when supplied, and a bad body is rejected.
+const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" });
+const PATH = "/v1/scoring/eligibility-plan";
+
+const post = (app: ReturnType<typeof createApp>, env: Env, body: unknown, headers = apiHeaders(env)) =>
+  app.request(PATH, { method: "POST", headers, body: JSON.stringify(body) }, env);
+
+async function seed(env: Env) {
+  await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
+}
+
+describe("POST /v1/scoring/eligibility-plan (#6621)", () => {
+  it("returns an eligibility plan for a branch that needs no linked issue", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seed(env);
+    const response = await post(app, env, { repoFullName: "acme/widgets", linkedIssueMode: "none", sourceTokenScore: 40, totalTokenScore: 60 });
+    expect(response.status).toBe(200);
+    const plan = await response.json();
+    expect(plan).toMatchObject({
+      eligible: expect.any(Boolean),
+      linkedIssueStatus: expect.any(String),
+      branchEligibilityStatus: expect.any(String),
+    });
+  });
+
+  it("reports an ineligible plan with public-safe blockers when a standard linked issue is unvalidated", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seed(env);
+    const response = await post(app, env, { repoFullName: "acme/widgets", linkedIssueMode: "standard", sourceTokenScore: 40, totalTokenScore: 60 });
+    expect(response.status).toBe(200);
+    const plan = (await response.json()) as { eligible: boolean; blockers?: unknown[] };
+    expect(plan.eligible).toBe(false);
+    expect(Array.isArray(plan.blockers)).toBe(true);
+    // Advisory, public-safe output only — never private scoring internals.
+    expect(JSON.stringify(plan)).not.toMatch(/wallet|hotkey|coldkey|trust score|reward estimate/i);
+  });
+
+  it("accepts a request with NO contributorLogin — it is optional here, unlike explain-breakdown", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seed(env);
+    const response = await post(app, env, { repoFullName: "acme/widgets" });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ eligible: expect.any(Boolean) });
+  });
+
+  it("fetches contributor evidence + issues when an AUTHORIZED contributorLogin is supplied", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seed(env);
+    // The operator api token is trusted, so this passes the gate and exercises the contributor-scoped fetches
+    // (evidence + open issues) that the no-login path deliberately skips.
+    const response = await post(app, env, { repoFullName: "acme/widgets", contributorLogin: "miner1", linkedIssueMode: "none", sourceTokenScore: 40, totalTokenScore: 60 });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ eligible: expect.any(Boolean), branchEligibilityStatus: expect.any(String) });
+  });
+
+  it("gates on requireContributorAccess ONLY when contributorLogin is supplied", async () => {
+    const app = createApp();
+    // The shared mcp token may not read an arbitrary contributor's data without the full read wildcard (#2455).
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    await seed(env);
+    const mcpHeaders = { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`, "content-type": "application/json" };
+
+    const gated = await post(app, env, { repoFullName: "acme/widgets", contributorLogin: "miner1" }, mcpHeaders);
+    expect(gated.status).toBe(403);
+
+    // …and the very same token succeeds when it asks for nothing contributor-scoped.
+    const ungated = await post(app, env, { repoFullName: "acme/widgets" }, mcpHeaders);
+    expect(ungated.status).toBe(200);
+  });
+
+  it("rejects an invalid or unparseable body with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    for (const body of [{ repoFullName: "ab" }, { repoFullName: "acme/widgets", linkedIssueMode: "bogus" }, { notARepo: true }]) {
+      const response = await post(app, env, body);
+      expect(response.status, JSON.stringify(body)).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: "invalid_scoring_preview_request" });
+    }
+    const malformed = await app.request(PATH, { method: "POST", headers: apiHeaders(env), body: "{not json" }, env);
+    expect(malformed.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## What & why

`loopover_get_eligibility_plan` was the **only** tool in the preview/breakdown/eligibility trio with neither a REST route nor a CLI mirror. A contributor on the local CLI could already fetch a raw score preview (`/v1/scoring/preview`) and its breakdown explanation (`/v1/scoring/explain-breakdown`) — but had no way to get an eligibility verdict at all.

## The route

`POST /v1/scoring/eligibility-plan`, placed immediately after `/v1/scoring/explain-breakdown` and structured identically: same `scorePreviewSchema` body, same repo/snapshot/evidence/contributorIssues fetch, same `buildScorePreview` — then `deriveEligibilityPlan` instead of `explainScoreBreakdown`. `deriveEligibilityPlan` is reused as-is, never reimplemented in the route.

`contributorLogin` is **optional** and gated only when supplied — matching `/v1/scoring/preview` and this tool's own MCP handler, not explain-breakdown's unconditional-required version (as the issue specifies).

## The CLI mirror + a de-duplication

The issue offered a choice: factor the shared body-assembly into a helper, or copy it verbatim and file a follow-up. **I factored it.** The breakdown tool's ~40-line local-branch → request-body assembly is now `buildLocalScoreRequestBody()`, called by both tools, so the two requests cannot drift — the only difference is the endpoint they post to. Existing breakdown tests pass unchanged against the refactor.

Descriptor added under `"discovery"`, matching the server's own `MCP_TOOL_CATEGORIES`. Tool count 61 → 62, with the file's existing count-note convention.

## Tests

- **Route** — eligible and ineligible-with-blockers plans; the `contributorLogin`-optional path; an **authorized** `contributorLogin` (exercising the contributor-scoped evidence/issue fetches the no-login path deliberately skips); the 403 for a token that may not read another contributor's data; and 400s for invalid + unparseable bodies.
- **CLI** — registration, input-schema parity with its sibling, the shared helper's fail-fast login guard (it fires before any workspace/network work), and zod rejection.

**100% line and branch coverage on the new route lines**, measured against the changed-line set. No OpenAPI entry — consistent with its `/v1/scoring/explain-breakdown` sibling, which has none either; `ui:openapi:check` stays green.

Closes #6621
