### PR TITLE
refactor(queue): delegate the two duplicate bounded-concurrency helpers to the canonical one (#6602)

### DIFF
--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -1,5 +1,6 @@
 import type { FileFetcher } from "../review/review-grounding";
 import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
+import { mapWithConcurrency } from "./map-with-concurrency";
 
 /** Per-file cap when synthesizing a patch for GitHub's patch-less (binary/large) PR files. */
 export const SECRET_SCAN_PATCH_FALLBACK_MAX_CHARS = 512_000;
@@ -154,22 +155,13 @@ export function incompletePatchLessSecretScanFinding(
   };
 }
 
+// #6602: delegate to the canonical bounded-concurrency helper instead of hand-duplicating the worker-pool loop.
 async function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
   items: T[],
   limit: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /** When GitHub omits inline `patch` (binary/large files), fetch post-change content and synthesize `+` lines so

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -3,6 +3,7 @@ import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { contentLaneConfigToJson, experimentalConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, maintainerRecapConfigToJson, opsConfigToJson, publicStatsConfigToJson, draftFlowConfigToJson, upstreamDriftIssuesConfigToJson, sweepWatchdogConfigToJson, prReconciliationConfigToJson, federatedIntelligenceConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
 import { LOOPOVER_REPO_FOCUS_MANIFEST_YAML, resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 import type { LocalManifestLoadResult } from "../selfhost/private-config";
 
 export const REPO_FOCUS_MANIFEST_SIGNAL = "repo-focus-manifest";
@@ -235,19 +236,11 @@ async function readBoundedResponseText(response: Response): Promise<string | nul
   }
 }
 
-/** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899). */
+/** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899).
+ *  Thin delegation to the canonical `mapWithConcurrency` (#6602) — kept as a named wrapper so every existing
+ *  `(items, limit, mapper)` call site keeps compiling and behaving unchanged, without a second copy of the loop. */
 export async function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
-  const results: U[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /**


### PR DESCRIPTION
## Summary

`src/queue/map-with-concurrency.ts`'s `mapWithConcurrency` is the canonical bounded-concurrency worker-pool helper (already reused by `duplicate-detection.ts`, `job-dispatch.ts`, `processors.ts`). Two files independently re-implemented the identical loop:

- `src/signals/focus-manifest-loader.ts`'s exported `mapWithConcurrencyLimit`
- `src/queue/patchless-secret-scan.ts`'s private `mapPatchLessSecretScanFilesWithConcurrency`

Closes #6602. Both bodies now delegate to `mapWithConcurrency`, keeping each wrapper's name and `(items, limit, mapper)` signature so every existing call site (including the two in `processors.ts`) compiles and behaves unchanged. `map-with-concurrency.ts` is now the single implementation of the loop under `src/queue/` and `src/signals/`.

The canonical helper is behavior-identical for valid inputs (and marginally safer — it clamps the worker count to at least 1). Net −15 lines.

## Scope / Validation / Safety

- [x] Conventional Commit; focused; `Closes #6602`.
- [x] Pure internal consolidation — no public behavior, call signatures, or export names changed.
- [x] `npm run typecheck` (0 errors), `git diff --check` clean, no attribution/secrets, no circular import (`map-with-concurrency` is a leaf util).
- [x] Both delegating lines covered by the existing caller suites (per the issue, no new test required); `patchless-secret-scan` / `focus-manifest-loader` / `map-with-concurrency` + `queue`/`queue-4`/`queue-2` all green (463 tests across the affected suites).

Closes #6602
