### PR TITLE
fix(miner): open the worktree allocator through local-store's openLocalStoreDb

### DIFF
--- a/packages/loopover-miner/lib/worktree-allocator.js
+++ b/packages/loopover-miner/lib/worktree-allocator.js
@@ -1,11 +1,19 @@
-import { chmodSync, mkdirSync } from "node:fs";
+// mkdirSync is still needed for the git-worktree CHECKOUT dirs below (resolveWorktreeBaseDir's tree) — that is
+// a filesystem directory, not a store DB path, and is deliberately out of this migration's scope. Only the DB
+// handle's own mkdir/chmod moved into openLocalStoreDb.
+import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import { join } from "node:path";
+import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 
 // Git-worktree-per-attempt allocator (#4297): durable local bookkeeping for which worktree paths are
-// allocated to which fleet attempts. Mirrors the package's existing local-store pattern (run-state.js,
-// claim-ledger.js, portfolio-queue.js) — plain JS + node:sqlite, never phones home.
+// allocated to which fleet attempts. Opens its handle through local-store.js's openLocalStoreDb (#4272), the
+// same call run-state.js / claim-ledger.js / portfolio-queue.js use — plain JS + node:sqlite, never phones
+// home. Going through openLocalStoreDb is what registers the handle for crash-safe cleanup
+// (process-lifecycle.js, #4826), which matters most for exactly this store: a SIGINT/SIGTERM mid-write is what
+// leaves a worktree slot leased to a process that no longer exists (#6600). It previously hand-rolled the
+// identical mkdirSync/chmodSync/PRAGMA sequence and so was never registered, despite this comment already
+// claiming to mirror those three files.
 
 const defaultDbFileName = "worktree-allocator.sqlite3";
 const defaultWorktreeDirName = "worktrees";
@@ -13,20 +21,7 @@ const defaultMaxConcurrency = 2;
 let defaultWorktreeAllocator = null;
 
 export function resolveWorktreeAllocatorDbPath(env = process.env) {
-  const explicitPath = typeof env.LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB === "string"
-    ? env.LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB.trim()
-    : "";
-  if (explicitPath) return explicitPath;
-
-  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
-    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
-    : "";
-  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
-
-  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
-    ? env.XDG_CONFIG_HOME.trim()
-    : join(homedir(), ".config");
-  return join(configHome, "loopover-miner", defaultDbFileName);
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB", env);
 }
 
 export function resolveWorktreeBaseDir(env = process.env) {
@@ -47,9 +42,7 @@ export function resolveWorktreeBaseDir(env = process.env) {
 }
 
 function normalizeDbPath(dbPath) {
-  const path = (dbPath ?? resolveWorktreeAllocatorDbPath()).trim();
-  if (!path) throw new Error("invalid_worktree_allocator_db_path");
-  return path;
+  return normalizeLocalStoreDbPath(dbPath, resolveWorktreeAllocatorDbPath(), "invalid_worktree_allocator_db_path");
 }
 
 function normalizeWorktreeBaseDir(worktreeBaseDir) {
@@ -154,10 +147,7 @@ export function openWorktreeAllocator(options = {}) {
   const maxConcurrency = normalizeMaxConcurrency(options.maxConcurrency);
   const processPid = Number.isInteger(options.processPid) ? options.processPid : process.pid;
 
-  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
-  const db = new DatabaseSync(resolvedPath);
-  chmodSync(resolvedPath, 0o600);
-  db.exec("PRAGMA busy_timeout = 5000");
+  const db = openLocalStoreDb(resolvedPath);
   ensureSlotTable(db);
   ensureSlots(db, worktreeBaseDir, maxConcurrency);
   reclaimOrphanedAllocations(db);

--- a/test/unit/miner-worktree-allocator.test.ts
+++ b/test/unit/miner-worktree-allocator.test.ts
@@ -9,9 +9,23 @@ import {
   resolveWorktreeAllocatorDbPath,
   resolveWorktreeBaseDir,
 } from "../../packages/loopover-miner/lib/worktree-allocator.js";
+import {
+  cleanupResourceCount,
+  closeAllCleanupResources,
+  resetProcessLifecycleForTesting,
+} from "../../packages/loopover-miner/lib/process-lifecycle.js";
 
 const roots: string[] = [];
 const allocators: Array<{ close(): void }> = [];
+
+/** Opt an allocator out of the shared afterEach close, for a test that closes the handle itself. `close()` is
+ *  not idempotent (node:sqlite throws "database is not open"), so a test asserting the close path must own the
+ *  handle's lifetime outright rather than be closed a second time on the way out. */
+function ownClose<T extends { close(): void }>(allocator: T): T {
+  const index = allocators.indexOf(allocator);
+  if (index >= 0) allocators.splice(index, 1);
+  return allocator;
+}
 
 function tempAllocator(options: { maxConcurrency?: number; processPid?: number } = {}) {
   const root = mkdtempSync(join(tmpdir(), "loopover-miner-worktree-allocator-"));
@@ -97,5 +111,28 @@ describe("loopover-miner worktree allocator scaffolding (#4298)", () => {
     const first = allocator.acquire("attempt-a", "acme/widgets");
     const second = allocator.acquire("attempt-a", "acme/widgets");
     expect(second.worktreePath).toBe(first.worktreePath);
+  });
+
+  it("registers the store for crash-safe cleanup and unregisters it on close (#6600)", () => {
+    // The whole point of routing through openLocalStoreDb: a SIGINT/SIGTERM mid-write is what leaves a worktree
+    // slot leased to a dead process, so this store must be closed by the signal handlers like its 3 siblings.
+    // Hand-rolling `new DatabaseSync(...)` registered nothing, so this count stayed at 0.
+    resetProcessLifecycleForTesting();
+    expect(cleanupResourceCount()).toBe(0);
+    const allocator = ownClose(tempAllocator({ maxConcurrency: 1 }));
+    expect(cleanupResourceCount()).toBe(1);
+    allocator.close();
+    // The normal close() unregisters, so a long-running loop doesn't accumulate stale handles or double-close.
+    expect(cleanupResourceCount()).toBe(0);
+  });
+
+  it("is closed by closeAllCleanupResources when the process dies mid-write (#6600)", () => {
+    resetProcessLifecycleForTesting();
+    const allocator = ownClose(tempAllocator({ maxConcurrency: 1 }));
+    allocator.acquire("attempt-a", "acme/widgets");
+    expect(cleanupResourceCount()).toBe(1);
+
+    closeAllCleanupResources(); // what installCliSignalHandlers invokes on SIGINT/SIGTERM
+    expect(cleanupResourceCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

`worktree-allocator.js`'s header comment claimed it "Mirrors the package's existing local-store pattern (`run-state.js`, `claim-ledger.js`, `portfolio-queue.js`)". Since #4272 those three open through `local-store.js`'s `openLocalStoreDb`; this one still hand-rolled the identical `mkdirSync`/`new DatabaseSync(...)`/`chmodSync`/`PRAGMA busy_timeout` sequence they used to have.

**That's not cosmetic.** `openLocalStoreDb` is what calls `registerCleanupResource` (#4826), so a SIGINT/SIGTERM/crash mid-write is flushed and closed by `installCliSignalHandlers`. Because the allocator never called it, it was **not registered** — and it is precisely the store where that matters most: it tracks which worktree paths are leased to which attempts, so a killed process is exactly what strands a slot leased to a PID that no longer exists. The comment asserting it mirrored those three files is what made the gap easy to miss.

## The change

- Opens via `openLocalStoreDb(resolvedPath)`; the hand-rolled mkdir/DatabaseSync/chmod/PRAGMA block is gone.
- `resolveWorktreeAllocatorDbPath` → `resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB", env)`, and `normalizeDbPath` → `normalizeLocalStoreDbPath(...)`, matching `run-state.js`/`claim-ledger.js` exactly.
- Header comment rewritten to say what it now does, and why routing through the helper is the point (registration), rather than claiming a resemblance.

**Env-var resolution is unchanged**: the inline resolver I deleted was line-for-line what `resolveLocalStoreDbPath` already does, so `LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB`, `LOOPOVER_MINER_CONFIG_DIR` and `XDG_CONFIG_HOME` still resolve identically, in the same precedence order.

`close()` needed no change: `openLocalStoreDb` wraps `db.close` to unregister first, so the existing `close()` unregisters for free.

## Two things worth a reviewer's eye

- **`resolveWorktreeBaseDir` is untouched**, per the issue — it resolves a git-worktree *checkout directory*, not a store DB path. `mkdirSync` therefore stays imported and is still used for that tree; only the DB handle's own mkdir/chmod moved into the helper. The import carries a comment saying so, since "why is `node:fs` still here?" is the obvious next question.
- **`normalizeDbPath` gets slightly stricter, deliberately.** The old code did `(dbPath ?? resolve()).trim()`, which threw a `TypeError` on a non-string; the shared helper type-checks and throws the same `invalid_worktree_allocator_db_path` the empty-string case already threw. That's the sibling stores' behavior and a strictly better error, not a behavior regression on any valid input.

## Tests

- **Both new tests fail on the unmigrated source and pass with the migration — verified, not assumed.** They'd be worthless otherwise: the whole defect is an absent side effect, so a test that passes either way would pin nothing.
- One asserts `cleanupResourceCount()` goes `0 → 1` on open and back to `0` on `close()`; the other asserts `closeAllCleanupResources()` — what `installCliSignalHandlers` invokes on SIGINT/SIGTERM — actually closes an allocator left open mid-write. That second one is the real user-facing guarantee, not just the registration bookkeeping.
- They mirror `miner-local-store.test.ts`'s existing `#4826` block.
- Both opt out of the suite's shared `afterEach` close via a small `ownClose` helper: `close()` is not idempotent (node:sqlite throws "database is not open"), so a test that closes the handle itself must own its lifetime. The helper documents that so the next person doesn't rediscover it via a confusing failure.

## Validation

- [x] **Patch coverage 100%, measured** from the v8 JSON report against my 16 changed lines: **zero uncovered statements, zero partial branches**. Clears the 99% `codecov/patch` wall on `packages/loopover-miner/lib/**`.
- [x] Both new tests pass; `npm run build:miner` (`node --check` across every lib file) passes.
- [x] Ran every consumer suite: `miner-worktree-allocator`, `miner-worktree-allocator-collisions`, `miner-concurrent-store-races`, `miner-local-store-readme`, `miner-local-store`.

**The remaining local failures are pre-existing and not mine — verified, not assumed.** The same 4 tests fail identically on clean `main` with my work stashed: `miner-local-store`'s and `miner-worktree-allocator`'s DB-path and file-mode cases. They're Windows-only (`\` vs `/` separators, and `statSync().mode & 0o077` returning `54` rather than `0`, since Windows has no POSIX permission bits). Same count, same tests, before and after.

## Scope

- [x] Two files: the migration and its tests. Wanted paths (`packages/`, `test/`).
- [x] Public API, schema, `resolveWorktreeBaseDir`, and the honored env vars are all unchanged.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Strictly additive at runtime: the same file is opened with the same permissions and the same busy-timeout; the only new behavior is that the handle is now registered for cleanup and unregistered on close.
- [x] Deduplicating onto the shared helper means the allocator can't drift from the three stores its comment points at — which is how this gap opened in the first place.

Closes #6600
