### PR TITLE
refactor(miner): open worktree-allocator through openLocalStoreDb for crash-safe cleanup

### DIFF
--- a/packages/loopover-miner/lib/worktree-allocator.js
+++ b/packages/loopover-miner/lib/worktree-allocator.js
@@ -1,11 +1,12 @@
-import { chmodSync, mkdirSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import { join } from "node:path";
+import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 
 // Git-worktree-per-attempt allocator (#4297): durable local bookkeeping for which worktree paths are
-// allocated to which fleet attempts. Mirrors the package's existing local-store pattern (run-state.js,
-// claim-ledger.js, portfolio-queue.js) — plain JS + node:sqlite, never phones home.
+// allocated to which fleet attempts. Opens its SQLite handle through local-store.js's openLocalStoreDb (like
+// run-state.js, claim-ledger.js, portfolio-queue.js), so the handle is registered for crash-safe cleanup
+// (#4826) — a SIGINT/SIGTERM/crash mid-write is flushed/closed cleanly. Plain JS + node:sqlite, never phones home.
 
 const defaultDbFileName = "worktree-allocator.sqlite3";
 const defaultWorktreeDirName = "worktrees";
@@ -13,20 +14,7 @@ const defaultMaxConcurrency = 2;
 let defaultWorktreeAllocator = null;
 
 export function resolveWorktreeAllocatorDbPath(env = process.env) {
-  const explicitPath = typeof env.LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB === "string"
-    ? env.LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB.trim()
-    : "";
-  if (explicitPath) return explicitPath;
-
-  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
-    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
-    : "";
-  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
-
-  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
-    ? env.XDG_CONFIG_HOME.trim()
-    : join(homedir(), ".config");
-  return join(configHome, "loopover-miner", defaultDbFileName);
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB", env);
 }
 
 export function resolveWorktreeBaseDir(env = process.env) {
@@ -47,9 +35,7 @@ export function resolveWorktreeBaseDir(env = process.env) {
 }
 
 function normalizeDbPath(dbPath) {
-  const path = (dbPath ?? resolveWorktreeAllocatorDbPath()).trim();
-  if (!path) throw new Error("invalid_worktree_allocator_db_path");
-  return path;
+  return normalizeLocalStoreDbPath(dbPath, resolveWorktreeAllocatorDbPath(), "invalid_worktree_allocator_db_path");
 }
 
 function normalizeWorktreeBaseDir(worktreeBaseDir) {
@@ -154,10 +140,7 @@ export function openWorktreeAllocator(options = {}) {
   const maxConcurrency = normalizeMaxConcurrency(options.maxConcurrency);
   const processPid = Number.isInteger(options.processPid) ? options.processPid : process.pid;
 
-  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
-  const db = new DatabaseSync(resolvedPath);
-  chmodSync(resolvedPath, 0o600);
-  db.exec("PRAGMA busy_timeout = 5000");
+  const db = openLocalStoreDb(resolvedPath);
   ensureSlotTable(db);
   ensureSlots(db, worktreeBaseDir, maxConcurrency);
   reclaimOrphanedAllocations(db);

--- a/test/unit/miner-worktree-allocator.test.ts
+++ b/test/unit/miner-worktree-allocator.test.ts
@@ -9,6 +9,7 @@ import {
   resolveWorktreeAllocatorDbPath,
   resolveWorktreeBaseDir,
 } from "../../packages/loopover-miner/lib/worktree-allocator.js";
+import { cleanupResourceCount, resetProcessLifecycleForTesting } from "../../packages/loopover-miner/lib/process-lifecycle.js";
 
 const roots: string[] = [];
 const allocators: Array<{ close(): void }> = [];
@@ -97,5 +98,23 @@ describe("loopover-miner worktree allocator scaffolding (#4298)", () => {
     const first = allocator.acquire("attempt-a", "acme/widgets");
     const second = allocator.acquire("attempt-a", "acme/widgets");
     expect(second.worktreePath).toBe(first.worktreePath);
+  });
+
+  it("registers the opened store for crash-safe cleanup and unregisters it on close (#6600)", () => {
+    // Opening through local-store.js's openLocalStoreDb registers the handle so a SIGINT/SIGTERM/crash
+    // mid-write is flushed by installCliSignalHandlers — exactly as the three sibling stores already are.
+    resetProcessLifecycleForTesting();
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-worktree-cleanup-"));
+    roots.push(root);
+
+    expect(cleanupResourceCount()).toBe(0);
+    const allocator = openWorktreeAllocator({
+      dbPath: join(root, "worktree-allocator.sqlite3"),
+      worktreeBaseDir: join(root, "worktrees"),
+      maxConcurrency: 1,
+    });
+    expect(cleanupResourceCount()).toBe(1);
+    allocator.close();
+    expect(cleanupResourceCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## What

`packages/loopover-miner/lib/worktree-allocator.js`'s header comment claimed to mirror the package's local-store pattern (`run-state.js` / `claim-ledger.js` / `portfolio-queue.js`), but those three migrated to `local-store.js`'s `openLocalStoreDb` (#4272/#4826) — which, beyond deduplicating the `mkdirSync`/`chmodSync`/`PRAGMA busy_timeout` boilerplate, **registers the handle via `registerCleanupResource`** so a SIGINT/SIGTERM/crash mid-write is flushed/closed cleanly. `worktree-allocator.js` still hand-rolled its open and was therefore **not** registered — despite tracking exactly the kind of leased-slot state a killed process leaves stuck.

Resolves #6600.

## Change

- Open via `openLocalStoreDb(resolvedPath)` instead of the hand-rolled `mkdirSync`/`new DatabaseSync`/`chmodSync`/`PRAGMA` sequence.
- Resolve/normalize the DB path via `resolveLocalStoreDbPath` / `normalizeLocalStoreDbPath` — the same env vars (`LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB`, `LOOPOVER_MINER_CONFIG_DIR`, `XDG_CONFIG_HOME`, home default) resolve identically — matching `claim-ledger.js` / `run-state.js`.
- `resolveWorktreeBaseDir` (the git-worktree checkout directory, not the DB path) is left untouched, per scope.
- Header comment updated to state it now opens through `openLocalStoreDb`.

## Test

Adds a case asserting opening the allocator increases `process-lifecycle.js`'s `cleanupResourceCount()` by one and its own `close()` decreases it back — the crash-safe-registration guarantee the three sibling stores already have.

Locally green: the new test passes; the existing behavioral tests are unchanged. (The only failures in this file are 2 pre-existing Windows-only cases — POSIX path separators and Unix file-mode bits — unrelated to this change and green on CI's Linux.) LF-clean, eslint clean.