### PR TITLE
feat(miner): catch real env vars undocumented in DEPLOYMENT.md

### DIFF
--- a/packages/loopover-miner/DEPLOYMENT.md
+++ b/packages/loopover-miner/DEPLOYMENT.md
@@ -79,6 +79,30 @@ For provider selection and the CLI-specific model/timeout overrides, see
 
 4. Optional per-repo miner goals: copy [`.loopover-miner.yml.example`](../../.loopover-miner.yml.example) to a target repo as `.loopover-miner.yml`. See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md).
 
+## Additional environment variables
+
+Beyond `LOOPOVER_MINER_CONFIG_DIR`/`XDG_CONFIG_HOME` and each store's own `LOOPOVER_MINER_<NAME>_DB`
+override (above), the CLI also honors:
+
+- `LOOPOVER_MINER_AMS_COLLECTOR_TOKEN`, `LOOPOVER_MINER_AMS_COLLECTOR_URL` — the opt-in Orb telemetry
+  export's network-send destination and bearer token (`orb-export.js`).
+- `LOOPOVER_MINER_AMS_POLICY_PATH` — overrides the default `.loopover-ams.yml` lookup path for the
+  operator's local execution-risk policy (`ams-policy.js`).
+- `LOOPOVER_MINER_CHAT_ACTIONS` — feature flag gating the chat-surface's action-dispatch capability
+  (`chat-action-dispatch.js`).
+- `LOOPOVER_MINER_LEDGER_RETENTION_DAYS`, `LOOPOVER_MINER_LEDGER_RETENTION_MAX_ROWS` — opt-in
+  age/size-bounded pruning for the local ledgers (`store-maintenance.js`). Unset by default: no pruning.
+- `LOOPOVER_MINER_LOG_LEVEL` — overrides the CLI's default log verbosity (`logger.js`).
+- `LOOPOVER_MINER_NO_UPDATE_CHECK` — disables the CLI's background update-check ping (`update-check.js`).
+- `LOOPOVER_MINER_REPO_CLONE_DIR` — overrides the default directory a target repo is cloned into before
+  an attempt (`repo-clone.js`).
+- `LOOPOVER_MINER_SENTRY_DSN`, `LOOPOVER_MINER_SENTRY_ENVIRONMENT` — opt-in crash/error reporting
+  destination and environment tag (`sentry.js`). Unset by default: no reporting.
+- `LOOPOVER_MINER_VERSION` — overrides the release identifier the CLI reports (`version.js`), mainly for
+  test/CI harnesses that need a deterministic version string.
+- `LOOPOVER_MINER_WORKTREE_DIR` — overrides the default base directory attempt worktrees are allocated
+  under (`worktree-allocator.js`).
+
 ## Fleet mode walkthrough
 
 Build the fleet image from the **monorepo root** (the Dockerfile needs the full workspace on disk before `npm ci` — see comments in [`Dockerfile`](Dockerfile)):

--- a/packages/loopover-miner/lib/deployment-docs-audit.d.ts
+++ b/packages/loopover-miner/lib/deployment-docs-audit.d.ts
@@ -5,9 +5,12 @@ export type DeploymentDocsClaims = {
   subcommands: string[];
 };
 
-/** Filesystem-independent view of the live source tree the parsed claims are checked against. */
+/** Filesystem-independent view of the live source tree the parsed claims are checked against.
+ *  `envReads` is the full set of real env-var-read tokens (#6601), enumerable for the reverse
+ *  (undocumented-in-reality) direction -- `hasEnvRead` alone only supports a one-name-at-a-time test. */
 export type DeploymentDocsReality = {
   hasEnvRead: (name: string) => boolean;
+  envReads: Iterable<string>;
   pathExists: (relativePath: string) => boolean;
   isRegisteredCommand: (name: string) => boolean;
 };

--- a/packages/loopover-miner/lib/deployment-docs-audit.js
+++ b/packages/loopover-miner/lib/deployment-docs-audit.js
@@ -74,12 +74,28 @@ export function scanRegisteredCommands(binSource) {
   return commands;
 }
 
+/** Prefix the reverse (undocumented-in-reality) check requires -- the bare `MINER_*` alias namespace also
+ *  matches non-env-var exported identifiers (event-type/metric/filename constants), so it is not a reliable
+ *  signal for this direction on its own; only the fully-qualified `LOOPOVER_MINER_` namespace is checked. */
+const REVERSE_CHECK_PREFIX = "LOOPOVER_MINER_";
+/** `DEPLOYMENT.md` documents the whole `LOOPOVER_MINER_<NAME>_DB` family generically via one sentence rather
+ *  than enumerating every store's override by name -- excluded from the reverse check so that deliberate
+ *  documentation choice is never flagged as drift. */
+const REVERSE_CHECK_DB_SUFFIX = "_DB";
+
 /**
- * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies three predicates so this
- * comparison stays pure and filesystem-independent: `hasEnvRead(name)` (a read of that env var exists
- * under packages/loopover-miner/**), `pathExists(relativePath)` (the doc-relative path is on disk),
- * and `isRegisteredCommand(name)` (the subcommand is dispatched by the CLI). Returns the drift findings,
- * each failure naming the specific stale claim rather than a generic mismatch.
+ * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies `hasEnvRead(name)` (a read of
+ * that env var exists under packages/loopover-miner/**), `pathExists(relativePath)` (the doc-relative path is
+ * on disk), `isRegisteredCommand(name)` (the subcommand is dispatched by the CLI), and `envReads` (the full
+ * iterable set of real env-var-read tokens, for the reverse direction below) -- so this comparison stays pure
+ * and filesystem-independent. Returns the drift findings, each failure naming the specific stale claim rather
+ * than a generic mismatch.
+ *
+ * The reverse direction (#6601): a real, currently-read `LOOPOVER_MINER_*` env var with zero mentions in
+ * DEPLOYMENT.md is just as much drift as a documented-but-dead one, but was previously invisible to this
+ * audit. Scoped to the `LOOPOVER_MINER_` prefix (the bare `MINER_*` alias namespace is too noisy, see
+ * REVERSE_CHECK_PREFIX) and excludes the `_DB` suffix family (documented generically, see
+ * REVERSE_CHECK_DB_SUFFIX).
  */
 export function auditDeploymentDocs(claims, reality) {
   const failures = [];
@@ -89,6 +105,13 @@ export function auditDeploymentDocs(claims, reality) {
         `env var "${name}" is documented in DEPLOYMENT.md but no read of it exists under packages/loopover-miner/**`,
       );
     }
+  }
+  const documentedEnvVars = new Set(claims.envVars);
+  for (const name of reality.envReads) {
+    if (!name.startsWith(REVERSE_CHECK_PREFIX)) continue;
+    if (name.endsWith(REVERSE_CHECK_DB_SUFFIX)) continue;
+    if (documentedEnvVars.has(name)) continue;
+    failures.push(`env var "${name}" is read under packages/loopover-miner/** but is not documented in DEPLOYMENT.md`);
   }
   for (const path of claims.filePaths) {
     if (!reality.pathExists(path)) {

--- a/scripts/check-miner-deployment-docs.d.mts
+++ b/scripts/check-miner-deployment-docs.d.mts
@@ -1,5 +1,6 @@
 export type MinerDeploymentReality = {
   hasEnvRead: (name: string) => boolean;
+  envReads: Iterable<string>;
   pathExists: (relativePath: string) => boolean;
   isRegisteredCommand: (name: string) => boolean;
 };

--- a/scripts/check-miner-deployment-docs.mjs
+++ b/scripts/check-miner-deployment-docs.mjs
@@ -39,6 +39,7 @@ export function buildLiveMinerDeploymentReality() {
   const registered = scanRegisteredCommands(readFileSync(BIN_ENTRY, "utf8"));
   return {
     hasEnvRead: (name) => envReads.has(name),
+    envReads,
     pathExists: (relativePath) => existsSync(resolve(MINER_DIR, relativePath)),
     isRegisteredCommand: (name) => registered.has(name),
   };

--- a/test/unit/check-miner-deployment-docs.test.ts
+++ b/test/unit/check-miner-deployment-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildLiveMinerDeploymentReality,
   main,
   runMinerDeploymentDocsAudit,
 } from "../../scripts/check-miner-deployment-docs.mjs";
@@ -30,6 +31,16 @@ describe("check-miner-deployment-docs (#6158)", () => {
     expect(exit).toHaveBeenCalledWith(1);
     expect(error).toHaveBeenCalledWith(expect.stringMatching(/DEPLOYMENT\.md is out of sync/i));
     expect(log).not.toHaveBeenCalled();
+  });
+
+  it("buildLiveMinerDeploymentReality populates the enumerable envReads field (#6601)", () => {
+    const reality = buildLiveMinerDeploymentReality();
+    const envReads = [...reality.envReads];
+    expect(envReads.length).toBeGreaterThan(0);
+    expect(envReads).toContain("LOOPOVER_MINER_LOG_LEVEL");
+    // Every token reality.hasEnvRead reports true for must also appear in the enumerable set -- the two
+    // must agree, since hasEnvRead is just a membership test over the same underlying set.
+    expect(reality.hasEnvRead("LOOPOVER_MINER_LOG_LEVEL")).toBe(true);
   });
 
   it("main prints ok and returns 0 on the live tree", () => {

--- a/test/unit/miner-deployment-docs-audit.test.ts
+++ b/test/unit/miner-deployment-docs-audit.test.ts
@@ -43,6 +43,7 @@ function buildLiveReality(): DeploymentDocsReality {
   const registered = scanRegisteredCommands(readFileSync(BIN_ENTRY, "utf8"));
   return {
     hasEnvRead: (name) => envReads.has(name),
+    envReads,
     pathExists: (relativePath) => existsSync(resolve(MINER_DIR, relativePath)),
     isRegisteredCommand: (name) => registered.has(name),
   };
@@ -50,6 +51,7 @@ function buildLiveReality(): DeploymentDocsReality {
 
 const ALWAYS_IN_SYNC: DeploymentDocsReality = {
   hasEnvRead: () => true,
+  envReads: [],
   pathExists: () => true,
   isRegisteredCommand: () => true,
 };
@@ -188,7 +190,7 @@ describe("loopover-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
     expect(() =>
       assertDeploymentDocsInSync(
         { envVars: ["LOOPOVER_MINER_GONE"], filePaths: ["gone.yml"], subcommands: ["gone"] },
-        { hasEnvRead: () => false, pathExists: () => false, isRegisteredCommand: () => false },
+        { hasEnvRead: () => false, envReads: [], pathExists: () => false, isRegisteredCommand: () => false },
       ),
     ).toThrow(/LOOPOVER_MINER_GONE[\s\S]*gone\.yml[\s\S]*loopover-miner gone/);
   });
@@ -200,5 +202,52 @@ describe("loopover-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
     );
     expect(result.ok).toBe(true);
     expect(result.failures).toEqual([]);
+  });
+
+  describe("auditDeploymentDocs — reverse direction (#6601): real reads undocumented in DEPLOYMENT.md", () => {
+    it("flags a real, undocumented, non-_DB LOOPOVER_MINER_* read by name", () => {
+      const result = auditDeploymentDocs(
+        { envVars: [], filePaths: [], subcommands: [] },
+        { ...ALWAYS_IN_SYNC, envReads: ["LOOPOVER_MINER_LOG_LEVEL"] },
+      );
+      expect(result.ok).toBe(false);
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain("LOOPOVER_MINER_LOG_LEVEL");
+      expect(result.failures[0]).toContain("not documented");
+    });
+
+    it("does not flag a real read that is already documented", () => {
+      const result = auditDeploymentDocs(
+        { envVars: ["LOOPOVER_MINER_LOG_LEVEL"], filePaths: [], subcommands: [] },
+        { ...ALWAYS_IN_SYNC, envReads: ["LOOPOVER_MINER_LOG_LEVEL"] },
+      );
+      expect(result).toEqual({ ok: true, failures: [] });
+    });
+
+    it("does not flag an undocumented LOOPOVER_MINER_*_DB token -- documented generically", () => {
+      const result = auditDeploymentDocs(
+        { envVars: [], filePaths: [], subcommands: [] },
+        { ...ALWAYS_IN_SYNC, envReads: ["LOOPOVER_MINER_SOME_NEW_STORE_DB"] },
+      );
+      expect(result).toEqual({ ok: true, failures: [] });
+    });
+
+    it("does not flag an undocumented bare MINER_* token (no LOOPOVER_MINER_ prefix) -- too noisy a signal", () => {
+      const result = auditDeploymentDocs(
+        { envVars: [], filePaths: [], subcommands: [] },
+        { ...ALWAYS_IN_SYNC, envReads: ["MINER_PACKAGE_VERSION"] },
+      );
+      expect(result).toEqual({ ok: true, failures: [] });
+    });
+
+    it("REGRESSION: the live DEPLOYMENT.md documents every real, non-_DB LOOPOVER_MINER_* env var it reads", () => {
+      // The precise assertion this issue's own fix targets: run the reverse direction against the real,
+      // built-from-source tree (not a synthetic fixture), so a future undocumented var fails this test the
+      // same way the CI-wired script does.
+      const reality = buildLiveReality();
+      const result = auditDeploymentDocs(claims, reality);
+      expect(result.ok).toBe(true);
+      expect(result.failures).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`packages/loopover-miner/lib/deployment-docs-audit.js`'s `auditDeploymentDocs` only checked one
direction: a documented env var/path/subcommand that no longer matches reality. A real, currently-read
`LOOPOVER_MINER_*` env var missing from `DEPLOYMENT.md` entirely went uncaught.

- Adds the reverse check: every real env-var read starting with `LOOPOVER_MINER_` that does **not**
  end with `_DB` (that family is documented generically via one existing sentence, not per-store
  enumeration) and is not present in the doc's claims produces a named failure. The bare `MINER_*`
  alias namespace is excluded from this direction — it also matches non-env-var identifiers already in
  the tree (event-type/metric/filename constants), so including it would produce false positives.
- `reality` gains a new enumerable `envReads` field (an iterable of strings) alongside the existing
  `hasEnvRead(name)` membership test, since the reverse direction needs to enumerate reality's own vars
  rather than test one name at a time.
- `scripts/check-miner-deployment-docs.mjs`'s `buildLiveMinerDeploymentReality` now exposes that field
  from the `scanEnvVarTokens` scan it already runs — no new source-scanning logic.
- `packages/loopover-miner/DEPLOYMENT.md` now documents the thirteen real env vars this surfaced as
  genuinely undocumented (`LOOPOVER_MINER_AMS_COLLECTOR_TOKEN`/`_URL`, `_AMS_POLICY_PATH`,
  `_CHAT_ACTIONS`, `_LEDGER_RETENTION_DAYS`/`_MAX_ROWS`, `_LOG_LEVEL`, `_NO_UPDATE_CHECK`,
  `_REPO_CLONE_DIR`, `_SENTRY_DSN`/`_ENVIRONMENT`, `_VERSION`, `_WORKTREE_DIR`) — verified each against
  its real source-code read before documenting it.
- Existing forward-direction checks (documented-but-dead env var/path/subcommand) are unchanged.

## Test plan

- [x] `test/unit/miner-deployment-docs-audit.test.ts`: new describe block covering — an undocumented
  non-`_DB` `LOOPOVER_MINER_*` real read is flagged by name; a documented one is not flagged; an
  undocumented `LOOPOVER_MINER_*_DB` token is not flagged (generic-pattern exemption); an undocumented
  bare `MINER_*` token is not flagged; and a regression test running the reverse check against the
  real, built-from-source tree confirming `DEPLOYMENT.md` documents every real non-`_DB`
  `LOOPOVER_MINER_*` var it reads — 23/23 passing (all pre-existing tests updated with the new
  `envReads` field and pass unmodified otherwise)
- [x] `test/unit/check-miner-deployment-docs.test.ts`: new test asserting
  `buildLiveMinerDeploymentReality`'s `envReads` field is populated and agrees with `hasEnvRead` — 5/5
  passing
- [x] `npm run test:miner-deployment-docs-audit` (the CI-wired entrypoint) — passes cleanly against the
  updated `DEPLOYMENT.md`: "16 env vars, 15 paths, 4 subcommands"
- [x] Verified zero uncovered lines/branches on this diff's exact changed-line ranges in
  `deployment-docs-audit.js` (the Codecov-gated file) via scoped `vitest --coverage` + direct lcov
  `DA:`/`BRDA:` inspection — 100% covered. `scripts/check-miner-deployment-docs.mjs` is outside
  `src/**`/`packages/**` and excluded from Codecov's patch gate per `codecov.yml`; its one changed line
  (`envReads,`) is exercised by the new `check-miner-deployment-docs.test.ts` assertion regardless.
- [x] Manually verified each of the thirteen newly-documented env vars against its real source-code
  read before adding it to `DEPLOYMENT.md`
- [x] `node --check` on both changed `.js`/`.mjs` files, `npm run docs:drift-check`, `git diff --check`,
  `npm run actionlint`, `npm audit --audit-level=moderate` — all clean
- [x] No other file in the repo references `deployment-docs-audit.js`/`buildLiveMinerDeploymentReality`/
  `DeploymentDocsReality` beyond what's covered above (confirmed via grep)

Closes #6601