### PR TITLE
refactor(queue): consolidate the duplicated bounded-concurrency helpers onto mapWithConcurrency

### DIFF
--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -1,4 +1,5 @@
 import type { FileFetcher } from "../review/review-grounding";
+import { mapWithConcurrency } from "./map-with-concurrency";
 import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
 
 /** Per-file cap when synthesizing a patch for GitHub's patch-less (binary/large) PR files. */
@@ -154,22 +155,14 @@ export function incompletePatchLessSecretScanFinding(
   };
 }
 
-async function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
+/** Bounded-concurrency fan-out over the patch-less files, delegating to the canonical worker pool in
+ *  `./map-with-concurrency` rather than re-implementing it (#6602). */
+function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
   items: T[],
   limit: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /** When GitHub omits inline `patch` (binary/large files), fetch post-change content and synthesize `+` lines so

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -1,4 +1,5 @@
 import { listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { contentLaneConfigToJson, experimentalConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, maintainerRecapConfigToJson, opsConfigToJson, publicStatsConfigToJson, draftFlowConfigToJson, upstreamDriftIssuesConfigToJson, sweepWatchdogConfigToJson, prReconciliationConfigToJson, federatedIntelligenceConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
@@ -235,19 +236,14 @@ async function readBoundedResponseText(response: Response): Promise<string | nul
   }
 }
 
-/** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899). */
-export async function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
-  const results: U[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+/** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899).
+ *
+ *  Delegates to the canonical worker pool in `src/queue/map-with-concurrency.ts` rather than re-implementing it
+ *  (#6602) — this file's own copy had already drifted from it, and `processors.ts` imported BOTH side by side.
+ *  Kept as a named wrapper rather than re-pointing its call sites: the name and `(items, limit, mapper)` shape
+ *  are what every existing caller uses, and preserving them is what makes this a no-op consolidation. */
+export function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /**


### PR DESCRIPTION
## Summary

`src/queue/map-with-concurrency.ts` exports the canonical bounded-concurrency worker pool, already reused by `duplicate-detection.ts`, `job-dispatch.ts`, and `processors.ts`. Two files re-implemented the same loop by hand:

- `focus-manifest-loader.ts`'s exported `mapWithConcurrencyLimit`
- `patchless-secret-scan.ts`'s private `mapPatchLessSecretScanFilesWithConcurrency`

The drift was already visible: `processors.ts` imported **both** `mapWithConcurrency` (`:369`) and `mapWithConcurrencyLimit` (`:509`) side by side and used each at different call sites for the same job.

Both now delegate to the canonical helper. Exported names and `(items, limit, mapper)` signatures are unchanged, so every existing caller compiles and behaves identically.

## The one real behavioral difference — and why it's safe

This looked like three identical copies. It wasn't, and the difference is worth stating plainly rather than describing this as a pure no-op:

```ts
// canonical:  always at least one worker
const workerCount = Math.max(1, Math.min(concurrency, items.length || 1));
// both copies: zero workers when limit <= 0
Array.from({ length: Math.min(limit, items.length) }, ...)
```

For `limit <= 0` the copies spawned **zero** workers and returned `new Array(items.length)` of holes **without ever calling `mapper`** — silently, no error. The canonical clamps to ≥1 and processes everything.

**That path is unreachable.** All three call sites pass a hardcoded constant `4`:
- `processors.ts:889` and `:1592` → `SWEEP_FANOUT_RESOLUTION_CONCURRENCY = 4` (`processors.ts:838`)
- `focus-manifest-loader.ts:202` → `REPO_FOCUS_MANIFEST_MAX_CONCURRENT_LOADS = 4` (`:11`)
- `patchless-secret-scan.ts:196` → `SECRET_SCAN_PATCH_FALLBACK_MAX_CONCURRENT = 4` (`:11`)

None is env-derived or caller-supplied, so no current caller can reach the divergence and behavior is identical for every real input. For empty `items` both shapes already agreed (`[]`). Where they differ, the canonical is the safer of the two — silently skipping all work is a worse failure than clamping to one worker — so consolidating onto it also removes a latent trap for any future caller that computes its limit.

I'm flagging this rather than burying it: "identical algorithm" was the issue's premise, and it's *almost* true. The delegation is behavior-preserving where it counts, and strictly better where it isn't.

## Why the wrappers stay

Both keep their names and signatures rather than re-pointing call sites at `mapWithConcurrency` directly. That's what makes this a no-op consolidation the reviewer can verify by inspection: the diff is confined to two function bodies, and no call site moves. `mapWithConcurrencyLimit` in particular is exported and used from `processors.ts`, so preserving it keeps the change contained.

## Validation

- [x] **`map-with-concurrency.ts` is now the only file under `src/queue/` or `src/signals/` implementing the loop** — verified mechanically (`grep -rln "nextIndex += 1" src/queue/ src/signals/` returns exactly that one file). That's the issue's acceptance criterion.
- [x] **Patch coverage 100%, measured** from the v8 JSON report against my changed lines — `focus-manifest-loader.ts` (9) and `patchless-secret-scan.ts` (5): **zero uncovered statements, zero partial branches**. Clears the 99% `codecov/patch` wall on `src/**`.
- [x] **629 tests pass** across every consumer: `patchless-secret-scan` + `focus-manifest-loader` (89), and `queue-2`/`queue-3`/`queue-4`/`queue-5` (540) — the suites that drive both `processors.ts` call sites.
- [x] `npm run typecheck` — 0 errors · `eslint` — 0 errors/0 warnings · `git diff --check` clean · rebased on latest `main`, no base conflict.

No new tests: as the issue notes, both wrappers are already exercised transitively by their callers' suites, and adding a test for a one-line delegation would pin the wrapper rather than the behavior.

## Scope

- [x] Two files, two function bodies plus two imports. Wanted paths (`src/`).
- [x] `map-with-concurrency.ts` itself is untouched — it was already correct; this deletes the copies rather than changing the original.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] No public behavior, call-signature, or export-name change for any existing caller.
- [x] The deleted copies' only divergence (`limit <= 0`) is unreachable from all three call sites, each passing a hardcoded `4`.
- [x] One implementation means the three can no longer silently drift apart — which is exactly what had already happened here.

Closes #6602
