### PR TITLE
refactor: consolidate duplicate bounded-concurrency helpers onto mapWithConcurrency (#6602)

### DIFF
--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -1,4 +1,5 @@
 import type { FileFetcher } from "../review/review-grounding";
+import { mapWithConcurrency } from "./map-with-concurrency";
 import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
 
 /** Per-file cap when synthesizing a patch for GitHub's patch-less (binary/large) PR files. */
@@ -154,22 +155,14 @@ export function incompletePatchLessSecretScanFinding(
   };
 }
 
+// Bounded-concurrency fan-out over the patch-less files. Delegates to the canonical `mapWithConcurrency`
+// (#6602) — the worker-pool loop lives in exactly one place under src/queue and src/signals.
 async function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
   items: T[],
   limit: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /** When GitHub omits inline `patch` (binary/large files), fetch post-change content and synthesize `+` lines so

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -1,4 +1,5 @@
 import { listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { contentLaneConfigToJson, experimentalConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, maintainerRecapConfigToJson, opsConfigToJson, publicStatsConfigToJson, draftFlowConfigToJson, upstreamDriftIssuesConfigToJson, sweepWatchdogConfigToJson, prReconciliationConfigToJson, federatedIntelligenceConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
@@ -235,19 +236,11 @@ async function readBoundedResponseText(response: Response): Promise<string | nul
   }
 }
 
-/** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899). */
+/** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899).
+ *  Delegates to the canonical `mapWithConcurrency` (#6602) so the worker-pool loop lives in exactly one place;
+ *  the name and `(items, limit, mapper)` signature are preserved for existing callers. */
 export async function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
-  const results: U[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /**


### PR DESCRIPTION
Closes #6602.

`src/queue/map-with-concurrency.ts`'s `mapWithConcurrency` is the canonical bounded-concurrency worker-pool helper, but two hand-duplicated copies of the same loop had drifted in beside it (visibly so in `processors.ts`, which imports **both** `mapWithConcurrency` and `mapWithConcurrencyLimit` and uses each at different call sites):

- `src/signals/focus-manifest-loader.ts` — exported `mapWithConcurrencyLimit`
- `src/queue/patchless-secret-scan.ts` — private `mapPatchLessSecretScanFilesWithConcurrency`

### Change
Both now **delegate** to `mapWithConcurrency`, preserving their existing names and `(items, limit, mapper)` signatures so every current caller compiles and behaves unchanged. After this, `map-with-concurrency.ts` is the **only** file under `src/queue/` or `src/signals/` that implements the worker-pool loop itself.

Pure internal consolidation — no change to public behavior, call signatures, or export names.

### Tests / coverage
Per the issue, no new test file is required: both wrappers are already exercised transitively by their existing caller suites — `test/unit/patchless-secret-scan.test.ts` (54 tests, incl. the patch-less fallback path that calls the private helper) and `test/unit/focus-manifest-loader.test.ts` + the processors suites that drive `mapWithConcurrencyLimit`. Confirmed green locally, and the changed delegation lines are covered (focus-manifest-loader's uncovered set is 59-88, not the delegation).