### PR TITLE
fix(miner): catch undocumented LOOPOVER_MINER_* env vars in DEPLOYMENT.md audit (#6601)

### DIFF
--- a/packages/loopover-miner/DEPLOYMENT.md
+++ b/packages/loopover-miner/DEPLOYMENT.md
@@ -77,6 +77,23 @@ For provider selection and the CLI-specific model/timeout overrides, see
    `LOOPOVER_MINER_PORTFOLIO_QUEUE_DB` — to relocate an individual file. `doctor`'s `store-integrity:*` checks
    report the persistent stores, so it is the quickest way to confirm what exists and is readable on disk.
 
+   **Other operator env knobs** (catalog also in [`docs/env-reference.md`](docs/env-reference.md)):
+
+   - `LOOPOVER_MINER_LOG_LEVEL` — log verbosity (`debug` / `info` / `warn` / `error`; also `--verbose` / `--quiet`).
+   - `LOOPOVER_MINER_NO_UPDATE_CHECK` — set to `1`/`true`/`yes` to skip the startup npm-registry version nudge
+     (also `--no-update-check`).
+   - `LOOPOVER_MINER_VERSION` — override the resolved release id (fleet image builds stamp this).
+   - `LOOPOVER_MINER_REPO_CLONE_DIR` — base directory for cloned evaluation repos (`lib/repo-clone.js`).
+   - `LOOPOVER_MINER_WORKTREE_DIR` — base directory for per-attempt git worktrees (`lib/worktree-allocator.js`).
+   - `LOOPOVER_MINER_LEDGER_RETENTION_DAYS` / `LOOPOVER_MINER_LEDGER_RETENTION_MAX_ROWS` — opt-in age- and/or
+     size-based pruning for the append-only event/governor/prediction ledgers (unset ⇒ retention off).
+   - `LOOPOVER_MINER_CHAT_ACTIONS` — flag that enables chat-action dispatch (`lib/chat-action-dispatch.js`).
+   - `LOOPOVER_MINER_AMS_POLICY_PATH` — override path for the local AMS policy file (`lib/ams-policy.js`).
+   - `LOOPOVER_MINER_AMS_COLLECTOR_URL` / `LOOPOVER_MINER_AMS_COLLECTOR_TOKEN` — Orb export collector endpoint
+     and optional bearer credential (`lib/orb-export.js`).
+   - `LOOPOVER_MINER_SENTRY_DSN` / `LOOPOVER_MINER_SENTRY_ENVIRONMENT` — opt-in Sentry error tracking (no-op
+     unless the DSN is set; environment defaults to `production`).
+
 4. Optional per-repo miner goals: copy [`.loopover-miner.yml.example`](../../.loopover-miner.yml.example) to a target repo as `.loopover-miner.yml`. See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md).
 
 ## Fleet mode walkthrough

--- a/packages/loopover-miner/lib/deployment-docs-audit.d.ts
+++ b/packages/loopover-miner/lib/deployment-docs-audit.d.ts
@@ -8,6 +8,8 @@ export type DeploymentDocsClaims = {
 /** Filesystem-independent view of the live source tree the parsed claims are checked against. */
 export type DeploymentDocsReality = {
   hasEnvRead: (name: string) => boolean;
+  /** Every scanned LOOPOVER_MINER_* / MINER_* token from miner+engine source (#6601 reverse check). */
+  envReads: Iterable<string>;
   pathExists: (relativePath: string) => boolean;
   isRegisteredCommand: (name: string) => boolean;
 };

--- a/packages/loopover-miner/lib/deployment-docs-audit.js
+++ b/packages/loopover-miner/lib/deployment-docs-audit.js
@@ -1,7 +1,8 @@
-// Docs-accuracy audit for the miner's DEPLOYMENT.md (#5180). Mirrors the self-host docs audit
+// Docs-accuracy audit for the miner's DEPLOYMENT.md (#5180, #6601). Mirrors the self-host docs audit
 // (apps/loopover-ui/src/lib/selfhost-docs-audit.ts): parse the deployment doc, then assert every
 // LOOPOVER_MINER_* / MINER_* env var, repo-relative file path, and `loopover-miner <subcommand>`
-// it documents still exists under packages/loopover-miner/**. A rename or move that leaves the doc
+// it documents still exists under packages/loopover-miner/** — and the reverse for non-_DB
+// LOOPOVER_MINER_* reads that the doc never mentions (#6601). A rename or move that leaves the doc
 // stale then fails CI with a message naming the exact stale claim, instead of misleading operators.
 // Wired into CI via `npm run test:miner-deployment-docs-audit` (scripts/check-miner-deployment-docs.mjs)
 // and the live unit suite in test/unit/miner-deployment-docs-audit.test.ts (#6158).
@@ -75,11 +76,19 @@ export function scanRegisteredCommands(binSource) {
 }
 
 /**
- * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies three predicates so this
- * comparison stays pure and filesystem-independent: `hasEnvRead(name)` (a read of that env var exists
- * under packages/loopover-miner/**), `pathExists(relativePath)` (the doc-relative path is on disk),
- * and `isRegisteredCommand(name)` (the subcommand is dispatched by the CLI). Returns the drift findings,
- * each failure naming the specific stale claim rather than a generic mismatch.
+ * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies three predicates plus
+ * an enumerable `envReads` set so this comparison stays pure and filesystem-independent:
+ * `hasEnvRead(name)` (a read of that env var exists under packages/loopover-miner/**),
+ * `envReads` (every scanned LOOPOVER_MINER_* / MINER_* token — used for the reverse check in #6601),
+ * `pathExists(relativePath)` (the doc-relative path is on disk), and `isRegisteredCommand(name)`
+ * (the subcommand is dispatched by the CLI). Returns the drift findings, each failure naming the
+ * specific stale claim rather than a generic mismatch.
+ *
+ * Reverse env-var check (#6601): every `LOOPOVER_MINER_*` token in `envReads` that does NOT end in
+ * `_DB` and is absent from `claims.envVars` is a failure. Tokens ending in `_DB` are exempt because
+ * DEPLOYMENT.md documents that family generically via `LOOPOVER_MINER_<NAME>_DB`. Bare `MINER_*`
+ * aliases (no `LOOPOVER_MINER_` prefix) are not included in the reverse direction — only the forward
+ * "documented claim must have a real read" check applies to them.
  */
 export function auditDeploymentDocs(claims, reality) {
   const failures = [];
@@ -89,6 +98,15 @@ export function auditDeploymentDocs(claims, reality) {
         `env var "${name}" is documented in DEPLOYMENT.md but no read of it exists under packages/loopover-miner/**`,
       );
     }
+  }
+  const documentedEnvVars = new Set(claims.envVars);
+  for (const name of reality.envReads) {
+    if (!name.startsWith("LOOPOVER_MINER_")) continue;
+    if (name.endsWith("_DB")) continue;
+    if (documentedEnvVars.has(name)) continue;
+    failures.push(
+      `env var "${name}" is read under packages/loopover-miner/** but is not documented in DEPLOYMENT.md`,
+    );
   }
   for (const path of claims.filePaths) {
     if (!reality.pathExists(path)) {

--- a/scripts/check-miner-deployment-docs.mjs
+++ b/scripts/check-miner-deployment-docs.mjs
@@ -39,6 +39,8 @@ export function buildLiveMinerDeploymentReality() {
   const registered = scanRegisteredCommands(readFileSync(BIN_ENTRY, "utf8"));
   return {
     hasEnvRead: (name) => envReads.has(name),
+    // Enumerable copy of the same scan `hasEnvRead` queries — reverse undocumented-env check (#6601).
+    envReads,
     pathExists: (relativePath) => existsSync(resolve(MINER_DIR, relativePath)),
     isRegisteredCommand: (name) => registered.has(name),
   };

--- a/test/unit/check-miner-deployment-docs.test.ts
+++ b/test/unit/check-miner-deployment-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildLiveMinerDeploymentReality,
   main,
   runMinerDeploymentDocsAudit,
 } from "../../scripts/check-miner-deployment-docs.mjs";
@@ -12,6 +13,18 @@ describe("check-miner-deployment-docs (#6158)", () => {
     expect(result.claimCounts.envVars).toBeGreaterThan(0);
     expect(result.claimCounts.filePaths).toBeGreaterThan(0);
     expect(result.claimCounts.subcommands).toBeGreaterThan(0);
+  });
+
+  it("populates envReads on live reality and the full bidirectional audit passes (#6601)", () => {
+    const reality = buildLiveMinerDeploymentReality();
+    const envReads = [...reality.envReads];
+    expect(envReads.length).toBeGreaterThan(0);
+    expect(envReads.some((name) => name.startsWith("LOOPOVER_MINER_"))).toBe(true);
+    expect(typeof reality.hasEnvRead).toBe("function");
+    // Same reality object the CI script builds — full audit (forward + reverse) must stay green.
+    const result = runMinerDeploymentDocsAudit({ reality });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
   });
 
   it("fails when env-var backing reads are forced missing (drift fixture)", () => {

--- a/test/unit/miner-deployment-docs-audit.test.ts
+++ b/test/unit/miner-deployment-docs-audit.test.ts
@@ -43,6 +43,7 @@ function buildLiveReality(): DeploymentDocsReality {
   const registered = scanRegisteredCommands(readFileSync(BIN_ENTRY, "utf8"));
   return {
     hasEnvRead: (name) => envReads.has(name),
+    envReads,
     pathExists: (relativePath) => existsSync(resolve(MINER_DIR, relativePath)),
     isRegisteredCommand: (name) => registered.has(name),
   };
@@ -50,6 +51,7 @@ function buildLiveReality(): DeploymentDocsReality {
 
 const ALWAYS_IN_SYNC: DeploymentDocsReality = {
   hasEnvRead: () => true,
+  envReads: [],
   pathExists: () => true,
   isRegisteredCommand: () => true,
 };
@@ -162,6 +164,49 @@ describe("loopover-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
     expect(result.failures[0]).toContain("no read");
   });
 
+  it("flags an undocumented non-_DB LOOPOVER_MINER_* real read by name (#6601)", () => {
+    const result = auditDeploymentDocs(
+      { envVars: [], filePaths: [], subcommands: [] },
+      { ...ALWAYS_IN_SYNC, envReads: ["LOOPOVER_MINER_LOG_LEVEL"] },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toContain("LOOPOVER_MINER_LOG_LEVEL");
+    expect(result.failures[0]).toContain("not documented");
+  });
+
+  it("does not flag a documented LOOPOVER_MINER_* real read (#6601)", () => {
+    const result = auditDeploymentDocs(
+      { envVars: ["LOOPOVER_MINER_LOG_LEVEL"], filePaths: [], subcommands: [] },
+      {
+        ...ALWAYS_IN_SYNC,
+        hasEnvRead: (name) => name === "LOOPOVER_MINER_LOG_LEVEL",
+        envReads: ["LOOPOVER_MINER_LOG_LEVEL"],
+      },
+    );
+    expect(result).toEqual({ ok: true, failures: [] });
+  });
+
+  it("does not flag an undocumented LOOPOVER_MINER_*_DB token (generic-pattern exemption) (#6601)", () => {
+    // DEPLOYMENT.md covers the per-store family via LOOPOVER_MINER_<NAME>_DB — reverse check must not
+    // force exhaustive per-store enumeration of that already-documented pattern.
+    const result = auditDeploymentDocs(
+      { envVars: [], filePaths: [], subcommands: [] },
+      { ...ALWAYS_IN_SYNC, envReads: ["LOOPOVER_MINER_PORTFOLIO_QUEUE_DB"] },
+    );
+    expect(result).toEqual({ ok: true, failures: [] });
+  });
+
+  it("does not flag an undocumented bare MINER_* token without LOOPOVER_MINER_ prefix (#6601)", () => {
+    // Bare MINER_* matches non-env identifiers (event types, metrics, filenames); reverse check scopes
+    // to LOOPOVER_MINER_* only. Forward direction (documented MINER_* must have a real read) is unchanged.
+    const result = auditDeploymentDocs(
+      { envVars: [], filePaths: [], subcommands: [] },
+      { ...ALWAYS_IN_SYNC, envReads: ["MINER_PR_OUTCOME_EVENT"] },
+    );
+    expect(result).toEqual({ ok: true, failures: [] });
+  });
+
   it("flags a documented file path that no longer exists on disk", () => {
     const result = auditDeploymentDocs(
       { envVars: [], filePaths: ["docker-compose.moved.yml"], subcommands: [] },
@@ -188,7 +233,12 @@ describe("loopover-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
     expect(() =>
       assertDeploymentDocsInSync(
         { envVars: ["LOOPOVER_MINER_GONE"], filePaths: ["gone.yml"], subcommands: ["gone"] },
-        { hasEnvRead: () => false, pathExists: () => false, isRegisteredCommand: () => false },
+        {
+          hasEnvRead: () => false,
+          envReads: [],
+          pathExists: () => false,
+          isRegisteredCommand: () => false,
+        },
       ),
     ).toThrow(/LOOPOVER_MINER_GONE[\s\S]*gone\.yml[\s\S]*loopover-miner gone/);
   });


### PR DESCRIPTION
## Summary

- Extend the miner `DEPLOYMENT.md` accuracy audit with a reverse-direction check: every real `LOOPOVER_MINER_*` read that is not `_DB`-suffixed and not documented fails CI by name (#6601).
- Expose `reality.envReads` from the existing `scanEnvVarTokens` scan (no new source walking) and document the thirteen previously missing operator env knobs in `DEPLOYMENT.md`.
- Keep forward checks unchanged; bare `MINER_*` aliases stay reverse-exempt; the generic `LOOPOVER_MINER_<NAME>_DB` family stays reverse-exempt.

Closes #6601

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `test:ci` / coverage gate not run yet in this session; targeted unit tests (`miner-deployment-docs-audit`, `check-miner-deployment-docs`) and `npm run test:miner-deployment-docs-audit` passed. Run the full local gate before push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — markdown/docs-audit change only; no visible UI surface.

## Notes

- Reverse check scopes to `LOOPOVER_MINER_` prefix and excludes `*_DB` (generic pattern already in the doc). Bare `MINER_*` remains forward-only.