### PR TITLE
fix(queue): consolidate duplicate mapWithConcurrency helpers

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -194,8 +194,6 @@ import {
 } from "../services/control-panel-roles";
 import { runFindOpportunities, validateFindOpportunitiesInput, type FindOpportunitiesInput } from "../mcp/find-opportunities";
 import { runIssueRagRetrieval, validateIssueRagInput, type IssueRagInput } from "../mcp/issue-rag";
-import { buildFindingTaxonomyDocument } from "../review/finding-taxonomy";
-import { buildEnrichmentAnalyzersTaxonomyDocument } from "../review/enrichment-analyzers-taxonomy";
 import { loadPrAiReviewFindings } from "../mcp/pr-ai-review-findings";
 import {
   buildMcpCompatibilityMetadata,

--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -1,5 +1,6 @@
 import type { FileFetcher } from "../review/review-grounding";
 import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
+import { mapWithConcurrency } from "./map-with-concurrency";
 
 /** Per-file cap when synthesizing a patch for GitHub's patch-less (binary/large) PR files. */
 export const SECRET_SCAN_PATCH_FALLBACK_MAX_CHARS = 512_000;
@@ -159,17 +160,7 @@ async function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
   limit: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /** When GitHub omits inline `patch` (binary/large files), fetch post-change content and synthesize `+` lines so

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -1,4 +1,5 @@
 import { listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { contentLaneConfigToJson, experimentalConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, maintainerRecapConfigToJson, opsConfigToJson, publicStatsConfigToJson, draftFlowConfigToJson, upstreamDriftIssuesConfigToJson, sweepWatchdogConfigToJson, prReconciliationConfigToJson, federatedIntelligenceConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
@@ -237,17 +238,7 @@ async function readBoundedResponseText(response: Response): Promise<string | nul
 
 /** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899). */
 export async function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
-  const results: U[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Delegate `mapWithConcurrencyLimit` and `mapPatchLessSecretScanFilesWithConcurrency` to the canonical `mapWithConcurrency` helper so the bounded-concurrency worker-pool loop lives in one place.
- Preserve existing export names and call signatures; no behavior change for callers.

Closes #6602

## Test plan
- [ ] Existing `patchless-secret-scan` / focus-manifest / processors suites pass
- [ ] Codecov patch gate green on changed lines