### PR TITLE
refactor(queue): consolidate bounded-concurrency helpers onto mapWithConcurrency

### DIFF
--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -1,5 +1,6 @@
 import type { FileFetcher } from "../review/review-grounding";
 import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
+import { mapWithConcurrency } from "./map-with-concurrency";
 
 /** Per-file cap when synthesizing a patch for GitHub's patch-less (binary/large) PR files. */
 export const SECRET_SCAN_PATCH_FALLBACK_MAX_CHARS = 512_000;
@@ -159,17 +160,7 @@ async function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
   limit: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /** When GitHub omits inline `patch` (binary/large files), fetch post-change content and synthesize `+` lines so

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -3,6 +3,7 @@ import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { contentLaneConfigToJson, experimentalConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, maintainerRecapConfigToJson, opsConfigToJson, publicStatsConfigToJson, draftFlowConfigToJson, upstreamDriftIssuesConfigToJson, sweepWatchdogConfigToJson, prReconciliationConfigToJson, federatedIntelligenceConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
 import { LOOPOVER_REPO_FOCUS_MANIFEST_YAML, resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 import type { LocalManifestLoadResult } from "../selfhost/private-config";
 
 export const REPO_FOCUS_MANIFEST_SIGNAL = "repo-focus-manifest";
@@ -237,17 +238,7 @@ async function readBoundedResponseText(response: Response): Promise<string | nul
 
 /** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899). */
 export async function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
-  const results: U[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /**


### PR DESCRIPTION
## What

`src/queue/map-with-concurrency.ts` is the canonical bounded-concurrency worker-pool helper, already reused across `src/queue`. Two files re-implemented the identical loop instead of importing it:

- `src/signals/focus-manifest-loader.ts` — `mapWithConcurrencyLimit`
- `src/queue/patchless-secret-scan.ts` — `mapPatchLessSecretScanFilesWithConcurrency`

Both now delegate to `mapWithConcurrency`, keeping their exported names and `(items, limit, mapper)` signatures unchanged, so every call site (including the two in `src/queue/processors.ts`) compiles and behaves exactly as before.

## Why

Three copies of the same fan-out loop can silently drift. After this change `map-with-concurrency.ts` is the single implementation under `src/queue/` and `src/signals/`; the other two just call into it.

## Scope

Pure internal consolidation — no change to public behavior, call signatures, or export names. The two delegating wrappers are already exercised transitively by their callers' existing suites (`test/unit/patchless-secret-scan.test.ts`, the focus-manifest-loader / processors tests that drive `mapWithConcurrencyLimit`), so no new test is added.

Fixes #6602
