### PR TITLE
fix(api): remove duplicate finding-taxonomy/enrichment-analyzers imports

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -194,8 +194,6 @@ import {
 } from "../services/control-panel-roles";
 import { runFindOpportunities, validateFindOpportunitiesInput, type FindOpportunitiesInput } from "../mcp/find-opportunities";
 import { runIssueRagRetrieval, validateIssueRagInput, type IssueRagInput } from "../mcp/issue-rag";
-import { buildFindingTaxonomyDocument } from "../review/finding-taxonomy";
-import { buildEnrichmentAnalyzersTaxonomyDocument } from "../review/enrichment-analyzers-taxonomy";
 import { loadPrAiReviewFindings } from "../mcp/pr-ai-review-findings";
 import {
   buildMcpCompatibilityMetadata,


### PR DESCRIPTION
## Summary

- `src/api/routes.ts` imported `buildFindingTaxonomyDocument` and `buildEnrichmentAnalyzersTaxonomyDocument` twice — once near the top of the import block, again a bit lower (introduced by #6709). This breaks `tsc --noEmit` with TS2300 duplicate-identifier errors, which red-CIs typecheck for any branch currently built on top of `main`.
- Removes the duplicate pair of import lines. No behavior change — both route handlers (`/v1/mcp/finding-taxonomy`, `/v1/finding-taxonomy`, `/v1/mcp/enrichment-analyzers`, `/v1/enrichment-analyzers`) are unaffected; they still resolve to the same single import.

## Scope

- [x] Conventional Commit title.
- [x] Focused, single-purpose fix.
- [x] No linked issue — trivial, obvious CI-breaking duplicate-import fix with zero behavior change (maintainer PR).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (was failing with TS2300 before this fix, clean after)
- [x] `npx vitest run test/integration/api.test.ts test/unit/mcp-pr-ai-review-findings.test.ts` (routes touching the affected imports, all green)

## Safety

- [x] No secrets/behavior changes; pure duplicate-import removal.