### PR TITLE
test: scratch verification for draft-conversion CI-cancel (#6670)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,5 +1,6 @@
 declare global {
   interface Env {
+    // (no-op comment: scratch verification touch for the #6670 draft-conversion CI-cancel test)
     DB: D1Database;
     JOBS: Queue;
     /** Self-host webhook queue binding. Cloudflare no longer binds this because hosted reviews are retired. */


### PR DESCRIPTION
Throwaway verification PR — confirming #6670's converted_to_draft CI-cancel actually cancels a real in-flight run, not just a clean no-op. Will be closed immediately once confirmed.