### PR TITLE
fix(review): strip NUL bytes from RAG chunk text before the storage INSERT

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -433,6 +433,19 @@ export async function embedTexts(
 }
 
 // ── Index write (used by ingestion): embed + vector upsert + chunk-text store ─────────────────────
+/** #6685-followup (review_context_fetch_failed/rag_upsert_error, 538 occurrences over 2+ weeks): a chunk's
+ *  source text can legitimately contain a raw NUL byte (binary content misdetected as text, a corrupted
+ *  file, certain generated/minified output) -- Postgres's `text` type rejects it outright ("invalid byte
+ *  sequence for encoding UTF8: 0x00"), unlike SQLite's more permissive TEXT columns, which is why this only
+ *  ever surfaced on the Postgres-backed self-host deployment. `db.batch` runs the whole statement list as
+ *  one transaction, so a single NUL byte anywhere in a batch previously poisoned every other, otherwise-fine
+ *  chunk's upsert too. Strips only U+0000 (Postgres's actual constraint) rather than the broader control-
+ *  character ranges other sanitizers in this codebase use for *display* text -- this is source code being
+ *  embedded/retrieved, where a real tab/newline/other control character can be meaningful. */
+function stripNullBytes(text: string): string {
+  return text.includes("\u0000") ? text.replaceAll("\u0000", "") : text;
+}
+
 /** Upsert chunks: write text to the storage table (source of truth) + vectors+light metadata to the vector
  *  index. Returns the number upserted (0 on any failure — ingestion treats that as "try again later").
  *  `blobSha` (#4365) is the source file's git blob SHA at index time, stamped onto every chunk row for
@@ -465,7 +478,7 @@ export async function upsertChunks(infra: RagInfra, project: string, repo: strin
       db.prepare(
         "INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text, blob_sha) VALUES (?,?,?,?,?,?,?,?) " +
           "ON CONFLICT(id) DO UPDATE SET text=excluded.text, kind=excluded.kind, chunk_index=excluded.chunk_index, blob_sha=excluded.blob_sha, updated_at=CURRENT_TIMESTAMP",
-      ).bind(c.id, project, repo, c.path, c.chunkIndex, c.kind, c.text, blobSha ?? null),
+      ).bind(c.id, project, repo, c.path, c.chunkIndex, c.kind, stripNullBytes(c.text), blobSha ?? null),
     );
     await db.batch(stmts);
     return embedded.length;

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -654,6 +654,32 @@ describe("rag: upsertChunks (embed + vector upsert + chunk-text store)", () => {
     expect(bindCalls[0]?.at(-1)).toBeNull();
   });
 
+  it("REGRESSION (#6685-followup): strips a NUL byte from chunk text before the storage INSERT (Postgres invalid-byte-sequence crash)", async () => {
+    const vector = { upsert: async () => undefined } as unknown as VectorAdapter;
+    const bindCalls: unknown[][] = [];
+    const storage = {
+      prepare: () => ({
+        bind: (...args: unknown[]) => {
+          bindCalls.push(args);
+          return { run: async () => undefined } as unknown as BoundStatement;
+        },
+      }),
+      batch: async () => undefined,
+    } as unknown as StorageAdapter;
+    const dirtyChunks: RagChunk[] = [
+      { id: "ns|src/a.ts::0", path: "src/a.ts", chunkIndex: 0, kind: "code", text: "before\u0000after" },
+      { id: "ns|src/b.ts::0", path: "src/b.ts", chunkIndex: 0, kind: "code", text: "clean, no NUL here" },
+    ];
+    const inference: InferenceAdapter = { run: async (_model, opts) => ({ data: (opts.text as string[]).map(() => Array(1024).fill(0.1)) }) };
+
+    const n = await upsertChunks({ storage, vector, inference }, "gittensory", "o/r", dirtyChunks);
+
+    expect(n).toBe(2);
+    // text is the 7th bind() argument -- id, project, repo, path, chunkIndex, kind, text, blobSha.
+    expect(bindCalls[0]?.[6]).toBe("beforeafter"); // the NUL byte is gone, the surrounding text is untouched
+    expect(bindCalls[1]?.[6]).toBe("clean, no NUL here"); // no NUL present -> byte-identical passthrough
+  });
+
   it("returns 0 with no vector / no inference / empty chunks (the fail-safe guard)", async () => {
     const vector = { upsert: async () => undefined } as unknown as VectorAdapter;
     const storage = storageStub();


### PR DESCRIPTION
## Summary
- Postgres's `text` type rejects a raw NUL byte outright (`invalid byte sequence for encoding "UTF8": 0x00`) — unlike SQLite's more permissive TEXT columns, which is why this only ever surfaced on the Postgres-backed self-host deployment, never in tests. A chunk's source text can legitimately contain one (binary content misdetected as text, a corrupted file, certain generated/minified output): [538 occurrences](https://jsonbored.sentry.io/issues/GITTENSORY-D) of `review_context_fetch_failed`/`rag_upsert_error` over 2+ weeks in production.
- `db.batch` runs the whole INSERT statement list for a batch as one transaction, so a single NUL byte anywhere in the batch previously poisoned every other, otherwise-fine chunk's upsert too — not just the one dirty chunk.
- Strips only `U+0000` (Postgres's actual constraint), not the broader control-character ranges the codebase's other sanitizers use for *display* text — this is source code being embedded/retrieved, where a real tab/newline/other control character can be meaningful.

Found via Sentry issue triage, not a linked contributor issue — maintainer PR.

## Validation
- [x] `npm run typecheck`
- [x] `npm run test:ci` (full gate, green end to end)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New regression test proves both branches: a chunk with an embedded NUL has it stripped while surrounding text is untouched, and a clean chunk passes through byte-identical