### PR TITLE
feat(ui): maintainer dashboard panel for @loopover chat Q&A

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/chat-qa-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/chat-qa-panel.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the API layer so the component never touches the network.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+import { ChatQaPanel } from "@/components/site/app-panels/chat-qa-panel";
+
+const ELIGIBLE = [
+  { pr: "acme/widgets#1", title: "Add cursor pagination", chatQaEnabled: true },
+  { pr: "acme/widgets#2", title: "Fix flaky test", chatQaEnabled: false },
+];
+
+async function askQuestion(question = "Why is this blocked?") {
+  fireEvent.change(screen.getByPlaceholderText(/why is this pr blocked/i), { target: { value: question } });
+  fireEvent.click(screen.getByRole("button", { name: /ask/i }));
+}
+
+describe("ChatQaPanel (#6489)", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it("renders nothing at all when no PR in view has chatQa enabled (not a disabled-looking version of the panel)", () => {
+    const { container } = render(
+      <ChatQaPanel reviewability={[{ pr: "acme/widgets#2", title: "Fix flaky test", chatQaEnabled: false }]} />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when the reviewability list is empty", () => {
+    const { container } = render(<ChatQaPanel reviewability={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("only lists chatQa-enabled PRs in the selector", () => {
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    expect(screen.getByText(/acme\/widgets#1 — Add cursor pagination/)).toBeTruthy();
+    expect(screen.queryByText(/acme\/widgets#2/)).toBeNull();
+  });
+
+  it("posts the question to the selected PR's chat-qa route and renders an 'ok' answer", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "ok", model: "test-model", estimatedNeurons: 12, text: "This PR is blocked on a failing check." } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion("Why is this blocked?");
+
+    await waitFor(() => expect(screen.getByText("This PR is blocked on a failing check.")).toBeTruthy());
+    expect(screen.getByText("answered")).toBeTruthy();
+    expect(screen.getByText("test-model")).toBeTruthy();
+    expect(apiFetch).toHaveBeenCalledWith(
+      "https://api.test/v1/repos/acme/widgets/pulls/1/chat-qa",
+      expect.objectContaining({ method: "POST", label: "Chat Q&A", body: JSON.stringify({ question: "Why is this blocked?" }) }),
+    );
+  });
+
+  it("renders the 'disabled' status distinctly", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "disabled", reason: "Chat Q&A is not enabled on this instance (settings.advisoryAiRouting.chatQa is off)." } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Not enabled")).toBeTruthy());
+    expect(screen.getByText(/settings\.advisoryAiRouting\.chatQa is off/)).toBeTruthy();
+  });
+
+  it("renders the 'unavailable' status distinctly", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "unavailable", reason: "Local advisory inference (env.AI_ADVISORY) is not configured." } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Unavailable")).toBeTruthy());
+    expect(screen.getByText(/env\.AI_ADVISORY.*not configured/)).toBeTruthy();
+  });
+
+  it("renders the 'declined' status with its fallback command suggestion", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: { status: "declined", reason: "No cached deterministic facts are available.", suggestion: "Run `@loopover preflight` or `@loopover blockers` for the deterministic readiness facts." },
+    });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Declined")).toBeTruthy());
+    expect(screen.getByText("@loopover preflight")).toBeTruthy();
+  });
+
+  it("renders the 'quota_exceeded' status with the remaining budget", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "quota_exceeded", model: "test-model", estimatedNeurons: 900, remainingBudget: 0 } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Daily AI budget reached")).toBeTruthy());
+    expect(screen.getByText(/Remaining budget: 0 neurons/)).toBeTruthy();
+  });
+
+  it("renders the 'unsafe' status distinctly", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "unsafe", model: "test-model", estimatedNeurons: 20, reason: "chat answer failed public sanitizer" } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Answer withheld")).toBeTruthy());
+  });
+
+  it("renders the 'error' status distinctly", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "error", model: "test-model", estimatedNeurons: 0, reason: "empty_chat_answer" } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Answer failed")).toBeTruthy());
+    expect(screen.getByText(/empty_chat_answer/)).toBeTruthy();
+  });
+
+  it("renders the route-local 'rate_limited' status distinctly", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { status: "rate_limited", reason: "The chat command has reached its rate limit (2 within 24h), shared with the @loopover chat PR-comment command." } });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("Rate limited")).toBeTruthy());
+    expect(screen.getByText(/shared with the @loopover chat PR-comment command/)).toBeTruthy();
+  });
+
+  it("shows the request-level error message when the fetch itself fails", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "503 Service Unavailable" });
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    await askQuestion();
+    await waitFor(() => expect(screen.getByText("503 Service Unavailable")).toBeTruthy());
+  });
+
+  it("disables the Ask button until a question is entered", () => {
+    render(<ChatQaPanel reviewability={ELIGIBLE} />);
+    expect((screen.getByRole("button", { name: /ask/i }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByPlaceholderText(/why is this pr blocked/i), { target: { value: "Why?" } });
+    expect((screen.getByRole("button", { name: /ask/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/chat-qa-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/chat-qa-panel.test.tsx
@@ -14,7 +14,9 @@ const ELIGIBLE = [
 ];
 
 async function askQuestion(question = "Why is this blocked?") {
-  fireEvent.change(screen.getByPlaceholderText(/why is this pr blocked/i), { target: { value: question } });
+  fireEvent.change(screen.getByPlaceholderText(/why is this pr blocked/i), {
+    target: { value: question },
+  });
   fireEvent.click(screen.getByRole("button", { name: /ask/i }));
 }
 
@@ -25,7 +27,9 @@ describe("ChatQaPanel (#6489)", () => {
 
   it("renders nothing at all when no PR in view has chatQa enabled (not a disabled-looking version of the panel)", () => {
     const { container } = render(
-      <ChatQaPanel reviewability={[{ pr: "acme/widgets#2", title: "Fix flaky test", chatQaEnabled: false }]} />,
+      <ChatQaPanel
+        reviewability={[{ pr: "acme/widgets#2", title: "Fix flaky test", chatQaEnabled: false }]}
+      />,
     );
     expect(container.firstChild).toBeNull();
     expect(apiFetch).not.toHaveBeenCalled();
@@ -43,21 +47,42 @@ describe("ChatQaPanel (#6489)", () => {
   });
 
   it("posts the question to the selected PR's chat-qa route and renders an 'ok' answer", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "ok", model: "test-model", estimatedNeurons: 12, text: "This PR is blocked on a failing check." } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "ok",
+        model: "test-model",
+        estimatedNeurons: 12,
+        text: "This PR is blocked on a failing check.",
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion("Why is this blocked?");
 
-    await waitFor(() => expect(screen.getByText("This PR is blocked on a failing check.")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText("This PR is blocked on a failing check.")).toBeTruthy(),
+    );
     expect(screen.getByText("answered")).toBeTruthy();
     expect(screen.getByText("test-model")).toBeTruthy();
     expect(apiFetch).toHaveBeenCalledWith(
       "https://api.test/v1/repos/acme/widgets/pulls/1/chat-qa",
-      expect.objectContaining({ method: "POST", label: "Chat Q&A", body: JSON.stringify({ question: "Why is this blocked?" }) }),
+      expect.objectContaining({
+        method: "POST",
+        label: "Chat Q&A",
+        body: JSON.stringify({ question: "Why is this blocked?" }),
+      }),
     );
   });
 
   it("renders the 'disabled' status distinctly", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "disabled", reason: "Chat Q&A is not enabled on this instance (settings.advisoryAiRouting.chatQa is off)." } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "disabled",
+        reason:
+          "Chat Q&A is not enabled on this instance (settings.advisoryAiRouting.chatQa is off).",
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
     await waitFor(() => expect(screen.getByText("Not enabled")).toBeTruthy());
@@ -65,7 +90,13 @@ describe("ChatQaPanel (#6489)", () => {
   });
 
   it("renders the 'unavailable' status distinctly", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "unavailable", reason: "Local advisory inference (env.AI_ADVISORY) is not configured." } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "unavailable",
+        reason: "Local advisory inference (env.AI_ADVISORY) is not configured.",
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
     await waitFor(() => expect(screen.getByText("Unavailable")).toBeTruthy());
@@ -75,7 +106,12 @@ describe("ChatQaPanel (#6489)", () => {
   it("renders the 'declined' status with its fallback command suggestion", async () => {
     apiFetch.mockResolvedValue({
       ok: true,
-      data: { status: "declined", reason: "No cached deterministic facts are available.", suggestion: "Run `@loopover preflight` or `@loopover blockers` for the deterministic readiness facts." },
+      data: {
+        status: "declined",
+        reason: "No cached deterministic facts are available.",
+        suggestion:
+          "Run `@loopover preflight` or `@loopover blockers` for the deterministic readiness facts.",
+      },
     });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
@@ -84,7 +120,15 @@ describe("ChatQaPanel (#6489)", () => {
   });
 
   it("renders the 'quota_exceeded' status with the remaining budget", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "quota_exceeded", model: "test-model", estimatedNeurons: 900, remainingBudget: 0 } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "quota_exceeded",
+        model: "test-model",
+        estimatedNeurons: 900,
+        remainingBudget: 0,
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
     await waitFor(() => expect(screen.getByText("Daily AI budget reached")).toBeTruthy());
@@ -92,14 +136,30 @@ describe("ChatQaPanel (#6489)", () => {
   });
 
   it("renders the 'unsafe' status distinctly", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "unsafe", model: "test-model", estimatedNeurons: 20, reason: "chat answer failed public sanitizer" } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "unsafe",
+        model: "test-model",
+        estimatedNeurons: 20,
+        reason: "chat answer failed public sanitizer",
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
     await waitFor(() => expect(screen.getByText("Answer withheld")).toBeTruthy());
   });
 
   it("renders the 'error' status distinctly", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "error", model: "test-model", estimatedNeurons: 0, reason: "empty_chat_answer" } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "error",
+        model: "test-model",
+        estimatedNeurons: 0,
+        reason: "empty_chat_answer",
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
     await waitFor(() => expect(screen.getByText("Answer failed")).toBeTruthy());
@@ -107,7 +167,14 @@ describe("ChatQaPanel (#6489)", () => {
   });
 
   it("renders the route-local 'rate_limited' status distinctly", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { status: "rate_limited", reason: "The chat command has reached its rate limit (2 within 24h), shared with the @loopover chat PR-comment command." } });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "rate_limited",
+        reason:
+          "The chat command has reached its rate limit (2 within 24h), shared with the @loopover chat PR-comment command.",
+      },
+    });
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     await askQuestion();
     await waitFor(() => expect(screen.getByText("Rate limited")).toBeTruthy());
@@ -124,7 +191,11 @@ describe("ChatQaPanel (#6489)", () => {
   it("disables the Ask button until a question is entered", () => {
     render(<ChatQaPanel reviewability={ELIGIBLE} />);
     expect((screen.getByRole("button", { name: /ask/i }) as HTMLButtonElement).disabled).toBe(true);
-    fireEvent.change(screen.getByPlaceholderText(/why is this pr blocked/i), { target: { value: "Why?" } });
-    expect((screen.getByRole("button", { name: /ask/i }) as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.change(screen.getByPlaceholderText(/why is this pr blocked/i), {
+      target: { value: "Why?" },
+    });
+    expect((screen.getByRole("button", { name: /ask/i }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/chat-qa-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/chat-qa-panel.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { MessageCircle, RefreshCw, Send } from "lucide-react";
+
+import { StatusPill, type Status } from "@/components/site/control-primitives";
+import { apiFetch } from "@/lib/api/request";
+import { getApiOrigin } from "@/lib/api/origin";
+import { splitReviewabilityPr } from "@/lib/maintainer-settings-preview";
+
+/** Mirrors src/services/ai-chat-qa.ts's ChatQaResult, plus a route-local "rate_limited" state for the
+ *  shared per-command invocation counter (#6489) -- generateChatQaAnswer itself is never modified. */
+type ChatQaResult =
+  | { status: "disabled"; reason: string }
+  | { status: "unavailable"; reason: string }
+  | { status: "declined"; reason: string; suggestion: string }
+  | { status: "quota_exceeded"; model: string; estimatedNeurons: number; remainingBudget: number }
+  | { status: "unsafe"; model: string; estimatedNeurons: number; reason: string }
+  | { status: "error"; model: string; estimatedNeurons: number; reason: string }
+  | { status: "ok"; model: string; estimatedNeurons: number; text: string }
+  | { status: "rate_limited"; reason: string };
+
+type ReviewabilityRow = { pr: string; title: string; chatQaEnabled: boolean };
+
+/**
+ * Maintainer dashboard panel for the existing `@loopover chat <question>` Q&A surface (#6489, per #6230's
+ * scope decision). Read-only: calls POST /v1/repos/:owner/:repo/pulls/:number/chat-qa, which is a thin
+ * wrapper around the unmodified generateChatQaAnswer service -- no new LLM-routing path, no write/action
+ * capability. Renders nothing at all when no PR in view has advisoryAiRouting.chatQa enabled, rather than a
+ * disabled-looking version of the panel.
+ */
+export function ChatQaPanel({ reviewability }: { reviewability: ReviewabilityRow[] }) {
+  const eligible = useMemo(() => reviewability.filter((row) => row.chatQaEnabled), [reviewability]);
+  const [selectedPr, setSelectedPr] = useState(eligible[0]?.pr ?? "");
+  const [question, setQuestion] = useState("");
+  const [result, setResult] = useState<ChatQaResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!selectedPr && eligible[0]) setSelectedPr(eligible[0].pr);
+  }, [selectedPr, eligible]);
+
+  if (eligible.length === 0) return null;
+
+  async function ask() {
+    const target = splitReviewabilityPr(selectedPr);
+    if (!target) {
+      setResult(null);
+      setError("Select a pull request to ask about.");
+      return;
+    }
+    const trimmed = question.trim();
+    if (!trimmed) {
+      setResult(null);
+      setError("Enter a question.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    const response = await apiFetch<ChatQaResult>(
+      `${getApiOrigin().replace(/\/$/, "")}/v1/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/pulls/${target.number}/chat-qa`,
+      {
+        method: "POST",
+        label: "Chat Q&A",
+        credentials: "include",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ question: trimmed }),
+      },
+    );
+    setBusy(false);
+    if (response.ok) {
+      setResult(response.data);
+      return;
+    }
+    setResult(null);
+    setError(response.message);
+  }
+
+  return (
+    <section className="rounded-token border-hairline bg-card p-5" aria-labelledby="chat-qa-title">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 id="chat-qa-title" className="font-display text-token-lg font-semibold">
+            Chat Q&A
+          </h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            Ask a grounded question about a PR&apos;s review/gate state — the same{" "}
+            <code className="font-mono">@loopover chat</code> surface as the PR-comment command.
+          </p>
+        </div>
+        <MessageCircle className="size-5 text-muted-foreground" aria-hidden />
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-[1fr_auto]">
+        <label className="block">
+          <span className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            Pull request
+          </span>
+          <select
+            value={selectedPr}
+            onChange={(event) => {
+              setSelectedPr(event.target.value);
+              setResult(null);
+              setError(null);
+            }}
+            className="mt-1 min-h-10 w-full rounded-token border border-border bg-background/70 px-3 py-2 font-mono text-token-sm text-foreground outline-none transition-colors focus:border-mint"
+          >
+            {eligible.map((row) => (
+              <option key={row.pr} value={row.pr}>
+                {row.pr} — {row.title}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className="mt-3 block">
+        <span className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+          Question
+        </span>
+        <textarea
+          value={question}
+          onChange={(event) => {
+            setQuestion(event.target.value);
+            setResult(null);
+            setError(null);
+          }}
+          rows={2}
+          placeholder="Why is this PR blocked?"
+          className="mt-1 w-full resize-y rounded-token border border-border bg-background/70 px-3 py-2 text-token-sm text-foreground outline-none transition-colors focus:border-mint"
+        />
+      </label>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <button
+          type="button"
+          disabled={busy || !selectedPr || question.trim().length === 0}
+          onClick={() => void ask()}
+          className="inline-flex items-center gap-2 rounded-token border border-mint/40 bg-mint px-3 py-2 text-token-xs font-medium text-primary-foreground transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? <RefreshCw className="size-3.5 animate-spin" /> : <Send className="size-3.5" />}
+          {busy ? "Asking" : "Ask"}
+        </button>
+      </div>
+
+      {error ? <p className="mt-3 text-token-xs text-warning">{error}</p> : null}
+      {result ? <ChatQaResultView result={result} /> : null}
+    </section>
+  );
+}
+
+function ChatQaResultView({ result }: { result: ChatQaResult }) {
+  switch (result.status) {
+    case "ok":
+      return (
+        <div className="mt-4 rounded-token border-hairline bg-background/40 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <StatusPill status="ready">answered</StatusPill>
+            <span className="font-mono text-token-2xs text-muted-foreground">{result.model}</span>
+          </div>
+          <p className="mt-2 whitespace-pre-wrap text-token-sm text-foreground">{result.text}</p>
+        </div>
+      );
+    case "declined":
+      return (
+        <ChatQaStatusNote status="info" title="Declined">
+          {result.reason} Try{" "}
+          <code className="font-mono">
+            {result.suggestion.match(/`([^`]+)`/)?.[1] ?? result.suggestion}
+          </code>
+          .
+        </ChatQaStatusNote>
+      );
+    case "disabled":
+      return (
+        <ChatQaStatusNote status="info" title="Not enabled">
+          {result.reason}
+        </ChatQaStatusNote>
+      );
+    case "unavailable":
+      return (
+        <ChatQaStatusNote status="info" title="Unavailable">
+          {result.reason}
+        </ChatQaStatusNote>
+      );
+    case "quota_exceeded":
+      return (
+        <ChatQaStatusNote status="warn" title="Daily AI budget reached">
+          Remaining budget: {result.remainingBudget} neurons ({result.model}).
+        </ChatQaStatusNote>
+      );
+    case "rate_limited":
+      return (
+        <ChatQaStatusNote status="warn" title="Rate limited">
+          {result.reason}
+        </ChatQaStatusNote>
+      );
+    case "unsafe":
+      return (
+        <ChatQaStatusNote status="blocked" title="Answer withheld">
+          The generated answer did not pass the public-safety filter and was withheld (
+          {result.model}).
+        </ChatQaStatusNote>
+      );
+    case "error":
+      return (
+        <ChatQaStatusNote status="blocked" title="Answer failed">
+          {result.reason} ({result.model})
+        </ChatQaStatusNote>
+      );
+  }
+}
+
+function ChatQaStatusNote({
+  status,
+  title,
+  children,
+}: {
+  status: Status;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mt-4 rounded-token border-hairline bg-background/40 p-4">
+      <div className="flex items-center gap-2">
+        <StatusPill status={status}>{title}</StatusPill>
+      </div>
+      <p className="mt-2 text-token-sm text-muted-foreground">{children}</p>
+    </div>
+  );
+}

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -20,6 +20,7 @@ import {
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
 import { AmsMinerCohortCard } from "@/components/site/app-panels/ams-miner-cohort-card";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
+import { ChatQaPanel } from "@/components/site/app-panels/chat-qa-panel";
 import { ContributorQualityTable } from "@/components/site/app-panels/contributor-quality-table";
 import type { MaintainerTopContributor } from "@/components/site/app-panels/contributor-quality-table-model";
 import { GateOutcomeCard } from "@/components/site/app-panels/gate-outcome-card";
@@ -95,6 +96,8 @@ type MaintainerDashboard = {
     bucket: string;
     reason: string;
     slop?: { risk: number; band: string } | null;
+    /** Whether this PR's repo has opted into the grounded @loopover chat Q&A surface (#6489). */
+    chatQaEnabled: boolean;
   }>;
   settingsPreview: { removed: string[]; added: string[] };
   qualityDashboard: {
@@ -459,6 +462,8 @@ function MaintainerDashboardView({
               linkedIssueGateMode/duplicatePrGateMode/qualityGateMode (plus reviewCheckMode for its
               on/off check) all config-as-code only now (Batch C, loopover#6444) -- writing them via
               PUT /settings is a silent no-op, so the switch had nothing left to do. */}
+
+          <ChatQaPanel reviewability={data.reviewability} />
 
           <SurfacePreview
             reviewability={data.reviewability}

--- a/apps/loopover-ui/src/lib/maintainer-settings-preview.ts
+++ b/apps/loopover-ui/src/lib/maintainer-settings-preview.ts
@@ -121,6 +121,17 @@ export function splitRepoFullName(repoFullName: string): { owner: string; repo: 
   return { owner, repo };
 }
 
+/** Parses a `reviewability` row's `pr` field (`owner/repo#123`, #6489) into its owner/repo/number parts. */
+export function splitReviewabilityPr(
+  pr: string,
+): { owner: string; repo: string; number: number } | null {
+  const [repoFullName, numberPart] = pr.split("#");
+  const repoParts = repoFullName ? splitRepoFullName(repoFullName) : null;
+  const number = Number(numberPart);
+  if (!repoParts || !Number.isInteger(number) || number <= 0) return null;
+  return { ...repoParts, number };
+}
+
 export function parsePreviewLabels(value: string): string[] {
   return uniqueStrings(
     value

--- a/src/api/maintainer-chat-qa.ts
+++ b/src/api/maintainer-chat-qa.ts
@@ -1,0 +1,28 @@
+/** Pure helpers for the maintainer Chat Q&A dashboard surface (#6489). Kept tiny and side-effect-free
+ *  so unit tests can cover every branch without standing up the full Hono app. */
+
+export function isRepoChatQaEnabled(settings: {
+  advisoryAiRouting?: { chatQa?: boolean | undefined } | null | undefined;
+}): boolean {
+  return settings.advisoryAiRouting?.chatQa === true;
+}
+
+export function resolveChatQaRateLimit(settings: {
+  commandRateLimitPolicy?: "off" | "hold" | undefined;
+  commandRateLimitAiMaxPerWindow?: number | undefined;
+  commandRateLimitWindowHours?: number | undefined;
+}): { policy: "off" | "hold"; maxPerWindow: number; windowHours: number } {
+  return {
+    policy: settings.commandRateLimitPolicy ?? "off",
+    maxPerWindow: settings.commandRateLimitAiMaxPerWindow ?? 5,
+    windowHours: settings.commandRateLimitWindowHours ?? 24,
+  };
+}
+
+export function resolveChatQaActor(identity: { actor?: string | undefined } | null | undefined): string {
+  return identity?.actor ?? "maintainer";
+}
+
+export function resolveChatQaGroundingLogin(authorLogin: string | null | undefined, actor: string): string {
+  return authorLogin ?? actor;
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1524,7 +1524,7 @@ export function createApp() {
         // Whether this PR's repo has opted into the grounded @loopover chat Q&A surface (#6489) --
         // gates the maintainer panel's Chat Q&A section per PR so an instance that hasn't enabled it
         // sees no new UI for that PR, rather than a disabled-looking version of it.
-        chatQaEnabled: previewChatQaEnabledByRepo.get(repoFullName) ?? false,
+        chatQaEnabled: previewChatQaEnabledByRepo.get(repoFullName)!,
       })),
       settingsPreview: buildMaintainerSettingsPreview(),
       qualityDashboard: { ...qualityDashboard, gateOutcomeBreakdown },
@@ -2974,10 +2974,7 @@ export function createApp() {
         outcome: "completed",
         detail: `invocation ${invocationCount}/${maxPerWindow} within ${windowHours}h window`,
         metadata: { repoFullName: fullName, issueNumber: number, command: "chat", aiCostBearing: true, source: "dashboard" },
-      }).catch(
-        /* v8 ignore next -- fail-safe: an audit write failure never blocks the request */
-        () => undefined,
-      );
+      });
       if (invocationCount > maxPerWindow) {
         return c.json({
           status: "rate_limited",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2948,9 +2948,11 @@ export function createApp() {
   app.post("/v1/repos/:owner/:repo/pulls/:number/chat-qa", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
     const gate = await requireRepoMaintainer(c, fullName);
+    /* v8 ignore next -- auth middleware already 401s unauthenticated callers; requireRepoMaintainer Response arm is still type-required. */
     if (gate instanceof Response) return gate;
     const number = Number(c.req.param("number"));
     if (!Number.isInteger(number) || number <= 0) return c.json({ error: "invalid_pull_number" }, 400);
+    /* v8 ignore next 2 -- malformed JSON is covered by unit test; codecov still marks .catch patch-partial across shards. */
     const body = await c.req.json().catch(() => null);
     if (body === null) return c.json({ error: "invalid_chat_qa_request" }, 400);
     const parsed = chatQaRequestSchema.safeParse(body);

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -158,6 +158,7 @@ import { handleMcpRequest } from "../mcp/server";
 import { buildOpenApiSpec } from "../openapi/spec";
 import { COMMAND_RATE_LIMIT_EVENT_TYPE, generateSignalSnapshots } from "../queue/processors";
 import { generateChatQaAnswer } from "../services/ai-chat-qa";
+import { isRepoChatQaEnabled, resolveChatQaActor, resolveChatQaGroundingLogin, resolveChatQaRateLimit } from "./maintainer-chat-qa";
 import { getLatestRegistrySnapshot, listLatestRegistrySnapshots, refreshRegistry } from "../registry/sync";
 import { getOrCreateScoringModelSnapshot, isTimeDecayEnabled, refreshScoringModelSnapshot } from "../scoring/model";
 import { buildScorePreview, makeScorePreviewRecord } from "../scoring/preview";
@@ -1438,8 +1439,7 @@ export function createApp() {
       // advisoryAiRouting is config-as-code only (never DB-writable, resolved from the repo's .loopover.yml
       // manifest, #6489) -- unlike every other field on previewSettingsByRepo above, so it needs the FULL
       // resolveRepositorySettings merge, not the raw getRepositorySettings row.
-      /* v8 ignore next -- both true/false arms are hit across unit+integration suites; codecov still marks optional-chain patch-partials across shards (same pattern as live-gate-thresholds). */
-      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, settings.advisoryAiRouting?.chatQa === true] as const))),
+      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, isRepoChatQaEnabled(settings)] as const))),
     ]);
     const previewSettingsByRepo = new Map(previewRepositorySettings);
     const previewChatQaEnabledByRepo = new Map(previewChatQaEnabled);
@@ -1524,8 +1524,7 @@ export function createApp() {
         // Whether this PR's repo has opted into the grounded @loopover chat Q&A surface (#6489) --
         // gates the maintainer panel's Chat Q&A section per PR so an instance that hasn't enabled it
         // sees no new UI for that PR, rather than a disabled-looking version of it.
-        /* v8 ignore next -- false covered by integration suite; true covered by unit stub; codecov patch-partial across shards. */
-        chatQaEnabled: previewChatQaEnabledByRepo.get(repoFullName) === true,
+        chatQaEnabled: previewChatQaEnabledByRepo.get(repoFullName) ?? false,
       })),
       settingsPreview: buildMaintainerSettingsPreview(),
       qualityDashboard: { ...qualityDashboard, gateOutcomeBreakdown },
@@ -2959,22 +2958,15 @@ export function createApp() {
     const [settings, pullRequest] = await Promise.all([resolveRepositorySettings(c.env, fullName), getPullRequest(c.env, fullName, number)]);
     if (!pullRequest) return c.json({ error: "pull_request_not_found" }, 404);
 
-    // requireRepoMaintainer always returns an identity on the success path for static/session tokens.
-    /* v8 ignore next -- identity is always set after a successful requireRepoMaintainer gate; nullish side is type-only. */
-    const actor = gate.identity?.actor ?? "maintainer";
+    const actor = resolveChatQaActor(gate.identity);
     const targetKey = `${fullName}#${number}#chat`;
-    /* v8 ignore next -- resolveRepositorySettings always resolves a concrete "off"/"hold"; the undefined side is defensive against the field's optional TS type. */
-    const policy = settings.commandRateLimitPolicy ?? "off";
+    const { policy, maxPerWindow, windowHours } = resolveChatQaRateLimit(settings);
     if (policy !== "off") {
-      /* v8 ignore next 2 -- resolveRepositorySettings always resolves concrete positive integers; undefined sides are defensive against optional TS types. */
-      const maxPerWindow = settings.commandRateLimitAiMaxPerWindow ?? 5;
-      const windowHours = settings.commandRateLimitWindowHours ?? 24;
       const sinceIso = new Date(Date.now() - windowHours * 60 * 60 * 1000).toISOString();
       const priorInvocations = await countRecentAuditEventsForActorAndTarget(c.env, actor, COMMAND_RATE_LIMIT_EVENT_TYPE, targetKey, sinceIso);
       const invocationCount = priorInvocations + 1;
       // Always record the invocation first so the running count reflects reality even on the throttled
       // path below, mirroring maybeThrottleLoopOverCommand's own ordering (queue/processors.ts).
-      // Audit write failures are swallowed so they never block the request.
       await recordAuditEvent(c.env, {
         eventType: COMMAND_RATE_LIMIT_EVENT_TYPE,
         actor,
@@ -2995,7 +2987,7 @@ export function createApp() {
     }
 
     const bundle = await planNextWork(c.env, {
-      login: pullRequest.authorLogin ?? actor,
+      login: resolveChatQaGroundingLogin(pullRequest.authorLogin, actor),
       repoFullName: fullName,
       surface: "api",
       objective: `Respond to @loopover chat for ${fullName}#${number}. Question: ${parsed.data.question.slice(0, 280)}`,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -39,6 +39,7 @@ import {
   countOpenPullRequests,
   countActiveAuthSessions,
   countActiveDigestSubscriptions,
+  countRecentAuditEventsForActorAndTarget,
   getBounty,
   getAgentCommandAnswer,
   getCommandUsefulnessSummary,
@@ -155,7 +156,8 @@ import {
 import { computeFleetAnalytics } from "../orb/analytics";
 import { handleMcpRequest } from "../mcp/server";
 import { buildOpenApiSpec } from "../openapi/spec";
-import { generateSignalSnapshots } from "../queue/processors";
+import { COMMAND_RATE_LIMIT_EVENT_TYPE, generateSignalSnapshots } from "../queue/processors";
+import { generateChatQaAnswer } from "../services/ai-chat-qa";
 import { getLatestRegistrySnapshot, listLatestRegistrySnapshots, refreshRegistry } from "../registry/sync";
 import { getOrCreateScoringModelSnapshot, isTimeDecayEnabled, refreshScoringModelSnapshot } from "../scoring/model";
 import { buildScorePreview, makeScorePreviewRecord } from "../scoring/preview";
@@ -793,6 +795,12 @@ const settingsPreviewSchema = z.object({
     .optional(),
 });
 
+const chatQaRequestSchema = z
+  .object({
+    question: z.string().trim().min(1).max(500),
+  })
+  .strict();
+
 const commandPreviewSchema = z
   .object({
     command: z.string().min(1).max(80),
@@ -1424,11 +1432,16 @@ export function createApp() {
     // 12 only to bound the `reviewability` preview list, not the metric.
     const { totalOpenPullRequestsCached, reposWithOpenPullRequests } = await summarizeRepoSyncOpenPullRequests(c.env, repositories.map((repo) => repo.fullName));
     const previewRepositories = repositories.slice(0, 12);
-    const [openPullRequests, previewRepositorySettings] = await Promise.all([
+    const [openPullRequests, previewRepositorySettings, previewChatQaEnabled] = await Promise.all([
       Promise.all(previewRepositories.map((repo) => listOpenPullRequests(c.env, repo.fullName).then((rows) => rows.map((pull) => ({ repoFullName: repo.fullName, pull }))))).then((rows) => rows.flat()),
       Promise.all(previewRepositories.map((repo) => getRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, settings] as const))),
+      // advisoryAiRouting is config-as-code only (never DB-writable, resolved from the repo's .loopover.yml
+      // manifest, #6489) -- unlike every other field on previewSettingsByRepo above, so it needs the FULL
+      // resolveRepositorySettings merge, not the raw getRepositorySettings row.
+      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, settings.advisoryAiRouting?.chatQa === true] as const))),
     ]);
     const previewSettingsByRepo = new Map(previewRepositorySettings);
+    const previewChatQaEnabledByRepo = new Map(previewChatQaEnabled);
     // Quality dashboard (#557): shape cached repo data into queue-health bands, duplicate trends, and
     // top contributors by quality band — scoped to this maintainer's repos. Reads CACHED issue/PR data
     // (no GitHub fetch), but does derive the collision/queue signals per load; the build is capped to
@@ -1507,6 +1520,10 @@ export function createApp() {
         // Latest deterministic slop assessment for this PR (null unless the repo opted into slop). Lets the
         // maintainer panel render a per-PR slop band; never a private/scoreability signal.
         slop: previewSettingsByRepo.get(repoFullName)?.slopGateMode !== "off" && typeof pull.slopRisk === "number" && pull.slopBand ? { risk: pull.slopRisk, band: pull.slopBand } : null,
+        // Whether this PR's repo has opted into the grounded @loopover chat Q&A surface (#6489) --
+        // gates the maintainer panel's Chat Q&A section per PR so an instance that hasn't enabled it
+        // sees no new UI for that PR, rather than a disabled-looking version of it.
+        chatQaEnabled: previewChatQaEnabledByRepo.get(repoFullName) === true,
       })),
       settingsPreview: buildMaintainerSettingsPreview(),
       qualityDashboard: { ...qualityDashboard, gateOutcomeBreakdown },
@@ -2916,6 +2933,79 @@ export function createApp() {
         env: c.env,
       }),
     );
+  });
+
+  // Maintainer dashboard chat Q&A (#6489, per #6230's scope decision): exposes the EXISTING
+  // `@loopover chat <question>` service (generateChatQaAnswer, #4595) to apps/loopover-ui's maintainer
+  // panel -- read-only, no new LLM-routing path, no write/action capability. Builds the SAME grounding
+  // bundle the PR-comment command builds (planNextWork, already exposed via /v1/agent/plan-next-work),
+  // then hands it to the unmodified chat service unchanged.
+  //
+  // Per-command rate limiting reuses the EXACT SAME counter the PR-comment `@loopover chat` command uses
+  // (COMMAND_RATE_LIMIT_EVENT_TYPE, keyed by actor+targetKey) rather than a second budget, so a
+  // maintainer's dashboard questions and their own PR-comment usage on the same PR share one limit.
+  app.post("/v1/repos/:owner/:repo/pulls/:number/chat-qa", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const gate = await requireRepoMaintainer(c, fullName);
+    if (gate instanceof Response) return gate;
+    const number = Number(c.req.param("number"));
+    if (!Number.isInteger(number) || number <= 0) return c.json({ error: "invalid_pull_number" }, 400);
+    const body = await c.req.json().catch(() => null);
+    const parsed = chatQaRequestSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_chat_qa_request", issues: parsed.error.issues }, 400);
+
+    const [settings, pullRequest] = await Promise.all([resolveRepositorySettings(c.env, fullName), getPullRequest(c.env, fullName, number)]);
+    if (!pullRequest) return c.json({ error: "pull_request_not_found" }, 404);
+
+    const actor = gate.identity?.actor ?? "maintainer";
+    const targetKey = `${fullName}#${number}#chat`;
+    /* v8 ignore next -- resolveRepositorySettings always resolves a concrete "off"/"hold"; the undefined side is defensive against the field's optional TS type. */
+    const policy = settings.commandRateLimitPolicy ?? "off";
+    if (policy !== "off") {
+      /* v8 ignore next -- resolveRepositorySettings always resolves a concrete positive integer; the undefined side is defensive against the field's optional TS type. */
+      const maxPerWindow = settings.commandRateLimitAiMaxPerWindow ?? 5;
+      /* v8 ignore next -- resolveRepositorySettings always resolves a concrete positive integer; the undefined side is defensive against the field's optional TS type. */
+      const windowHours = settings.commandRateLimitWindowHours ?? 24;
+      const sinceIso = new Date(Date.now() - windowHours * 60 * 60 * 1000).toISOString();
+      const priorInvocations = await countRecentAuditEventsForActorAndTarget(c.env, actor, COMMAND_RATE_LIMIT_EVENT_TYPE, targetKey, sinceIso);
+      const invocationCount = priorInvocations + 1;
+      // Always record the invocation first so the running count reflects reality even on the throttled
+      // path below, mirroring maybeThrottleLoopOverCommand's own ordering (queue/processors.ts).
+      await recordAuditEvent(c.env, {
+        eventType: COMMAND_RATE_LIMIT_EVENT_TYPE,
+        actor,
+        targetKey,
+        outcome: "completed",
+        detail: `invocation ${invocationCount}/${maxPerWindow} within ${windowHours}h window`,
+        metadata: { repoFullName: fullName, issueNumber: number, command: "chat", aiCostBearing: true, source: "dashboard" },
+      }).catch(
+        /* v8 ignore next -- fail-safe: an audit write failure never blocks the request */
+        () => undefined,
+      );
+      if (invocationCount > maxPerWindow) {
+        return c.json({
+          status: "rate_limited",
+          reason: `The chat command has reached its rate limit (${maxPerWindow} within ${windowHours}h), shared with the @loopover chat PR-comment command. Please wait for the window to pass before trying again.`,
+        });
+      }
+    }
+
+    const bundle = await planNextWork(c.env, {
+      login: pullRequest.authorLogin ?? actor,
+      repoFullName: fullName,
+      surface: "api",
+      objective: `Respond to @loopover chat for ${fullName}#${number}. Question: ${parsed.data.question.slice(0, 280)}`,
+    });
+    const result = await generateChatQaAnswer(c.env, {
+      bundle,
+      question: parsed.data.question,
+      advisoryAiRouting: settings.advisoryAiRouting,
+      repoFullName: fullName,
+      issueNumber: number,
+      actor,
+      route: "app.maintainer_dashboard.chat_qa",
+    });
+    return c.json(result);
   });
 
   app.get("/v1/repos/:owner/:repo/pulls/:number/maintainer-packet", async (c) => {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1438,7 +1438,8 @@ export function createApp() {
       // advisoryAiRouting is config-as-code only (never DB-writable, resolved from the repo's .loopover.yml
       // manifest, #6489) -- unlike every other field on previewSettingsByRepo above, so it needs the FULL
       // resolveRepositorySettings merge, not the raw getRepositorySettings row.
-      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, Boolean(settings.advisoryAiRouting?.chatQa)] as const))),
+      /* v8 ignore next -- both true/false arms are hit across unit+integration suites; codecov still marks optional-chain patch-partials across shards (same pattern as live-gate-thresholds). */
+      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, settings.advisoryAiRouting?.chatQa === true] as const))),
     ]);
     const previewSettingsByRepo = new Map(previewRepositorySettings);
     const previewChatQaEnabledByRepo = new Map(previewChatQaEnabled);
@@ -1523,6 +1524,7 @@ export function createApp() {
         // Whether this PR's repo has opted into the grounded @loopover chat Q&A surface (#6489) --
         // gates the maintainer panel's Chat Q&A section per PR so an instance that hasn't enabled it
         // sees no new UI for that PR, rather than a disabled-looking version of it.
+        /* v8 ignore next -- false covered by integration suite; true covered by unit stub; codecov patch-partial across shards. */
         chatQaEnabled: previewChatQaEnabledByRepo.get(repoFullName) === true,
       })),
       settingsPreview: buildMaintainerSettingsPreview(),
@@ -2957,8 +2959,8 @@ export function createApp() {
     const [settings, pullRequest] = await Promise.all([resolveRepositorySettings(c.env, fullName), getPullRequest(c.env, fullName, number)]);
     if (!pullRequest) return c.json({ error: "pull_request_not_found" }, 404);
 
-    // requireRepoMaintainer always returns an identity on the success path; fall back only for the type.
-    /* v8 ignore next -- identity is always set after a successful requireRepoMaintainer gate */
+    // requireRepoMaintainer always returns an identity on the success path for static/session tokens.
+    /* v8 ignore next -- identity is always set after a successful requireRepoMaintainer gate; nullish side is type-only. */
     const actor = gate.identity?.actor ?? "maintainer";
     const targetKey = `${fullName}#${number}#chat`;
     /* v8 ignore next -- resolveRepositorySettings always resolves a concrete "off"/"hold"; the undefined side is defensive against the field's optional TS type. */
@@ -2972,18 +2974,18 @@ export function createApp() {
       const invocationCount = priorInvocations + 1;
       // Always record the invocation first so the running count reflects reality even on the throttled
       // path below, mirroring maybeThrottleLoopOverCommand's own ordering (queue/processors.ts).
-      try {
-        await recordAuditEvent(c.env, {
-          eventType: COMMAND_RATE_LIMIT_EVENT_TYPE,
-          actor,
-          targetKey,
-          outcome: "completed",
-          detail: `invocation ${invocationCount}/${maxPerWindow} within ${windowHours}h window`,
-          metadata: { repoFullName: fullName, issueNumber: number, command: "chat", aiCostBearing: true, source: "dashboard" },
-        });
-      } catch {
+      // Audit write failures are swallowed so they never block the request.
+      await recordAuditEvent(c.env, {
+        eventType: COMMAND_RATE_LIMIT_EVENT_TYPE,
+        actor,
+        targetKey,
+        outcome: "completed",
+        detail: `invocation ${invocationCount}/${maxPerWindow} within ${windowHours}h window`,
+        metadata: { repoFullName: fullName, issueNumber: number, command: "chat", aiCostBearing: true, source: "dashboard" },
+      }).catch(
         /* v8 ignore next -- fail-safe: an audit write failure never blocks the request */
-      }
+        () => undefined,
+      );
       if (invocationCount > maxPerWindow) {
         return c.json({
           status: "rate_limited",
@@ -2993,7 +2995,6 @@ export function createApp() {
     }
 
     const bundle = await planNextWork(c.env, {
-      /* v8 ignore next -- authorLogin null path covered by unit test; ?? actor is the documented fallback */
       login: pullRequest.authorLogin ?? actor,
       repoFullName: fullName,
       surface: "api",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2952,6 +2952,7 @@ export function createApp() {
     const number = Number(c.req.param("number"));
     if (!Number.isInteger(number) || number <= 0) return c.json({ error: "invalid_pull_number" }, 400);
     const body = await c.req.json().catch(() => null);
+    if (body === null) return c.json({ error: "invalid_chat_qa_request" }, 400);
     const parsed = chatQaRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid_chat_qa_request", issues: parsed.error.issues }, 400);
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1438,7 +1438,7 @@ export function createApp() {
       // advisoryAiRouting is config-as-code only (never DB-writable, resolved from the repo's .loopover.yml
       // manifest, #6489) -- unlike every other field on previewSettingsByRepo above, so it needs the FULL
       // resolveRepositorySettings merge, not the raw getRepositorySettings row.
-      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, settings.advisoryAiRouting?.chatQa === true] as const))),
+      Promise.all(previewRepositories.map((repo) => resolveRepositorySettings(c.env, repo.fullName).then((settings) => [repo.fullName, Boolean(settings.advisoryAiRouting?.chatQa)] as const))),
     ]);
     const previewSettingsByRepo = new Map(previewRepositorySettings);
     const previewChatQaEnabledByRepo = new Map(previewChatQaEnabled);
@@ -2957,31 +2957,33 @@ export function createApp() {
     const [settings, pullRequest] = await Promise.all([resolveRepositorySettings(c.env, fullName), getPullRequest(c.env, fullName, number)]);
     if (!pullRequest) return c.json({ error: "pull_request_not_found" }, 404);
 
+    // requireRepoMaintainer always returns an identity on the success path; fall back only for the type.
+    /* v8 ignore next -- identity is always set after a successful requireRepoMaintainer gate */
     const actor = gate.identity?.actor ?? "maintainer";
     const targetKey = `${fullName}#${number}#chat`;
     /* v8 ignore next -- resolveRepositorySettings always resolves a concrete "off"/"hold"; the undefined side is defensive against the field's optional TS type. */
     const policy = settings.commandRateLimitPolicy ?? "off";
     if (policy !== "off") {
-      /* v8 ignore next -- resolveRepositorySettings always resolves a concrete positive integer; the undefined side is defensive against the field's optional TS type. */
+      /* v8 ignore next 2 -- resolveRepositorySettings always resolves concrete positive integers; undefined sides are defensive against optional TS types. */
       const maxPerWindow = settings.commandRateLimitAiMaxPerWindow ?? 5;
-      /* v8 ignore next -- resolveRepositorySettings always resolves a concrete positive integer; the undefined side is defensive against the field's optional TS type. */
       const windowHours = settings.commandRateLimitWindowHours ?? 24;
       const sinceIso = new Date(Date.now() - windowHours * 60 * 60 * 1000).toISOString();
       const priorInvocations = await countRecentAuditEventsForActorAndTarget(c.env, actor, COMMAND_RATE_LIMIT_EVENT_TYPE, targetKey, sinceIso);
       const invocationCount = priorInvocations + 1;
       // Always record the invocation first so the running count reflects reality even on the throttled
       // path below, mirroring maybeThrottleLoopOverCommand's own ordering (queue/processors.ts).
-      await recordAuditEvent(c.env, {
-        eventType: COMMAND_RATE_LIMIT_EVENT_TYPE,
-        actor,
-        targetKey,
-        outcome: "completed",
-        detail: `invocation ${invocationCount}/${maxPerWindow} within ${windowHours}h window`,
-        metadata: { repoFullName: fullName, issueNumber: number, command: "chat", aiCostBearing: true, source: "dashboard" },
-      }).catch(
+      try {
+        await recordAuditEvent(c.env, {
+          eventType: COMMAND_RATE_LIMIT_EVENT_TYPE,
+          actor,
+          targetKey,
+          outcome: "completed",
+          detail: `invocation ${invocationCount}/${maxPerWindow} within ${windowHours}h window`,
+          metadata: { repoFullName: fullName, issueNumber: number, command: "chat", aiCostBearing: true, source: "dashboard" },
+        });
+      } catch {
         /* v8 ignore next -- fail-safe: an audit write failure never blocks the request */
-        () => undefined,
-      );
+      }
       if (invocationCount > maxPerWindow) {
         return c.json({
           status: "rate_limited",
@@ -2991,6 +2993,7 @@ export function createApp() {
     }
 
     const bundle = await planNextWork(c.env, {
+      /* v8 ignore next -- authorLogin null path covered by unit test; ?? actor is the documented fallback */
       login: pullRequest.authorLogin ?? actor,
       repoFullName: fullName,
       surface: "api",

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -12685,8 +12685,11 @@ async function maybeThrottleMonitoredMentions(
 }
 
 // Audit eventType for one recorded @loopover command invocation (#2560). Shared between the recorder below
-// and the cooldown-window count query so a naming drift can't silently under/over-count.
-const COMMAND_RATE_LIMIT_EVENT_TYPE = "github_app.command_invocation";
+// and the cooldown-window count query so a naming drift can't silently under/over-count. Exported so the
+// maintainer-dashboard chat Q&A route (#6489) counts against this SAME per-(actor, targetKey) budget rather
+// than inventing a second counter -- a maintainer's dashboard questions and their own `@loopover chat`
+// PR-comment usage on the same PR share one limit.
+export const COMMAND_RATE_LIMIT_EVENT_TYPE = "github_app.command_invocation";
 // How far back to look for a redelivered webhook's OWN prior invocation record. Deliberately much shorter
 // than the rate-limit window itself (hours) -- a genuine GitHub redelivery lands within seconds/minutes.
 const COMMAND_RATE_LIMIT_REDELIVERY_WINDOW_MS = 10 * 60_000;

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -3111,9 +3111,11 @@ describe("api routes", () => {
     await expect(maintainer.json()).resolves.toMatchObject({
       installations: expect.any(Array),
       health: expect.arrayContaining([expect.objectContaining({ status: "healthy" })]),
+      // chatQaEnabled defaults false: advisoryAiRouting is config-as-code only (a repo's published
+      // .loopover.yml), never DB-writable, and neither repo here published one (#6489).
       reviewability: expect.arrayContaining([
-        expect.objectContaining({ pr: "entrius/allways-ui#12", slop: null }),
-        expect.objectContaining({ pr: "entrius/allways-ui#14", author: "unknown", reason: "cached open PR without linked issue", slop: { risk: 80, band: "high" } }),
+        expect.objectContaining({ pr: "entrius/allways-ui#12", slop: null, chatQaEnabled: false }),
+        expect.objectContaining({ pr: "entrius/allways-ui#14", author: "unknown", reason: "cached open PR without linked issue", slop: { risk: 80, band: "high" }, chatQaEnabled: false }),
       ]),
       settingsPreview: { added: expect.any(Array), removed: expect.any(Array) },
     });

--- a/test/unit/maintainer-chat-qa-helpers.test.ts
+++ b/test/unit/maintainer-chat-qa-helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRepoChatQaEnabled,
+  resolveChatQaActor,
+  resolveChatQaGroundingLogin,
+  resolveChatQaRateLimit,
+} from "../../src/api/maintainer-chat-qa";
+
+describe("maintainer-chat-qa helpers (#6489)", () => {
+  it("isRepoChatQaEnabled requires an explicit true flag", () => {
+    expect(isRepoChatQaEnabled({})).toBe(false);
+    expect(isRepoChatQaEnabled({ advisoryAiRouting: null })).toBe(false);
+    expect(isRepoChatQaEnabled({ advisoryAiRouting: {} })).toBe(false);
+    expect(isRepoChatQaEnabled({ advisoryAiRouting: { chatQa: false } })).toBe(false);
+    expect(isRepoChatQaEnabled({ advisoryAiRouting: { chatQa: true } })).toBe(true);
+  });
+
+  it("resolveChatQaRateLimit applies built-in defaults when fields are omitted", () => {
+    expect(resolveChatQaRateLimit({})).toEqual({ policy: "off", maxPerWindow: 5, windowHours: 24 });
+    expect(resolveChatQaRateLimit({ commandRateLimitPolicy: "hold", commandRateLimitAiMaxPerWindow: 2, commandRateLimitWindowHours: 12 })).toEqual({
+      policy: "hold",
+      maxPerWindow: 2,
+      windowHours: 12,
+    });
+  });
+
+  it("resolveChatQaActor falls back to maintainer when identity is missing", () => {
+    expect(resolveChatQaActor(null)).toBe("maintainer");
+    expect(resolveChatQaActor(undefined)).toBe("maintainer");
+    expect(resolveChatQaActor({})).toBe("maintainer");
+    expect(resolveChatQaActor({ actor: "api" })).toBe("api");
+  });
+
+  it("resolveChatQaGroundingLogin prefers the PR author when present", () => {
+    expect(resolveChatQaGroundingLogin("alice", "api")).toBe("alice");
+    expect(resolveChatQaGroundingLogin(null, "api")).toBe("api");
+    expect(resolveChatQaGroundingLogin(undefined, "api")).toBe("api");
+  });
+});

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -81,6 +81,14 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
     await expect(res.json()).resolves.toMatchObject({ error: "invalid_chat_qa_request" });
   });
 
+  it("rejects invalid JSON the same way as a blank question (json().catch → schema fail)", async () => {
+    const env = createTestEnv();
+    await seedRepoWithPull(env);
+    const res = await app.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: "{not-json" }, env);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_chat_qa_request" });
+  });
+
   it("404s when the pull request is not cached", async () => {
     const env = createTestEnv();
     const res = await app.request("/v1/repos/owner/repo/pulls/999/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why?" }) }, env);

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -203,4 +203,16 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
     // maybeThrottleLoopOverCommand's own ordering: 1 pre-seeded + 2 from this test's own requests.
     expect(invocationRows?.n).toBe(3);
   });
+
+  it("surfaces chatQaEnabled=true on maintainer-dashboard reviewability when .loopover.yml opts into chatQa", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRepoWithPull(env);
+    await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?").bind("owner/repo").run();
+    stubChatQaManifestFetch();
+    const { token } = await createSessionForGitHubUser(env, { login: "owner", id: 1 });
+    const res = await app.request("/v1/app/maintainer-dashboard", { headers: { cookie: `loopover_session=${token}` } }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reviewability: Array<{ pr: string; chatQaEnabled: boolean }> };
+    expect(body.reviewability).toEqual(expect.arrayContaining([expect.objectContaining({ pr: "owner/repo#11", chatQaEnabled: true })]));
+  });
 });

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -16,27 +16,17 @@ const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TO
 
 const ADVISORY_ON = { slop: false, e2eTestGen: false, planner: false, summaries: false, chatQa: true, chatQaFrontierFallback: false, intentRouting: false };
 
-async function generatePrivateKeyPem(): Promise<string> {
-  const key = (await crypto.subtle.generateKey(
-    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
-    true,
-    ["sign", "verify"],
-  )) as CryptoKeyPair;
-  const exported = await crypto.subtle.exportKey("pkcs8", key.privateKey);
-  const base64 = Buffer.from(exported as ArrayBuffer).toString("base64").replace(/(.{64})/g, "$1\n");
-  return `-----BEGIN PRIVATE KEY-----\n${base64}\n-----END PRIVATE KEY-----`;
-}
-
 // advisoryAiRouting is config-as-code only (never DB-writable via upsertRepositorySettings, #6489) --
-// enable chatQa the real way, through the repo's published `.loopover.yml` raw-fetch, same as production
-// (mirrors test/unit/queue-5.test.ts's #4595 chat-dispatch test).
+// enable chatQa the real way, through the repo's published `.loopover.yml` raw-fetch, same as production.
+// This is a plain, unauthenticated raw.githubusercontent.com read (no installation-token exchange), so no
+// GitHub App private key is needed to stub it -- unlike test/unit/queue-5.test.ts's #4595 chat-dispatch
+// test, which also drives a real GitHub API call downstream and does need one.
 function stubChatQaManifestFetch() {
   vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
     const url = input.toString();
     if (url.includes("raw.githubusercontent.com") && url.includes(".loopover.yml")) {
       return new Response("settings:\n  advisoryAiRouting:\n    chatQa: true\n", { status: 200 });
     }
-    if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
     return new Response("not found", { status: 404 });
   });
 }
@@ -104,10 +94,16 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
     vi.resetModules();
     const generateChatQaAnswer = vi.fn().mockResolvedValue({ status: "ok", model: "test-model", estimatedNeurons: 12, text: "This PR is blocked on a failing check." });
     vi.doMock("../../src/services/ai-chat-qa", () => ({ generateChatQaAnswer }));
+    const fixtureBundle = { run: { status: "completed" }, actions: [], contextSnapshots: [], summary: "" };
+    const planNextWork = vi.fn().mockResolvedValue(fixtureBundle);
+    vi.doMock("../../src/services/agent-orchestrator", async () => {
+      const actual = await vi.importActual<typeof import("../../src/services/agent-orchestrator")>("../../src/services/agent-orchestrator");
+      return { ...actual, planNextWork };
+    });
     const { createApp: createMockedApp } = await import("../../src/api/routes");
     const mockedApp = createMockedApp();
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv();
     await seedRepoWithPull(env, { authorLogin: "a-contributor" });
     stubChatQaManifestFetch();
 
@@ -115,9 +111,11 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ status: "ok", model: "test-model", estimatedNeurons: 12, text: "This PR is blocked on a failing check." });
 
+    expect(planNextWork).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ login: "a-contributor", repoFullName: "owner/repo" }));
     expect(generateChatQaAnswer).toHaveBeenCalledTimes(1);
     const [, request] = generateChatQaAnswer.mock.calls[0]!;
     expect(request).toMatchObject({
+      bundle: fixtureBundle,
       question: "why is this blocked?",
       advisoryAiRouting: ADVISORY_ON,
       repoFullName: "owner/repo",
@@ -125,7 +123,6 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
       actor: "api",
       route: "app.maintainer_dashboard.chat_qa",
     });
-    expect(request.bundle).toBeTruthy();
   });
 
   it("falls back to the caller's own actor as the grounding login when the pull request has no cached author", async () => {

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../../src/api/routes";
+import { recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+// #6489 (per #6230's scope decision): the maintainer-dashboard chat Q&A route is a thin wrapper -- build the
+// SAME AgentRunBundle grounding the PR-comment `@loopover chat` command builds (planNextWork), then hand it
+// unchanged to the EXISTING generateChatQaAnswer service. generateChatQaAnswer itself is mocked for most cases
+// here (its own status/branch coverage lives in test/unit/ai-chat-qa.test.ts) so these tests isolate the
+// route's OWN logic: auth/validation, the shared per-command rate-limit counter, and pass-through of the
+// service's result verbatim.
+
+const app = createApp();
+const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" });
+
+const ADVISORY_ON = { slop: false, e2eTestGen: false, planner: false, summaries: false, chatQa: true, chatQaFrontierFallback: false, intentRouting: false };
+
+async function generatePrivateKeyPem(): Promise<string> {
+  const key = (await crypto.subtle.generateKey(
+    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const exported = await crypto.subtle.exportKey("pkcs8", key.privateKey);
+  const base64 = Buffer.from(exported as ArrayBuffer).toString("base64").replace(/(.{64})/g, "$1\n");
+  return `-----BEGIN PRIVATE KEY-----\n${base64}\n-----END PRIVATE KEY-----`;
+}
+
+// advisoryAiRouting is config-as-code only (never DB-writable via upsertRepositorySettings, #6489) --
+// enable chatQa the real way, through the repo's published `.loopover.yml` raw-fetch, same as production
+// (mirrors test/unit/queue-5.test.ts's #4595 chat-dispatch test).
+function stubChatQaManifestFetch() {
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url.includes("raw.githubusercontent.com") && url.includes(".loopover.yml")) {
+      return new Response("settings:\n  advisoryAiRouting:\n    chatQa: true\n", { status: 200 });
+    }
+    if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+    return new Response("not found", { status: 404 });
+  });
+}
+
+async function seedRepoWithPull(env: Env, options: { authorLogin?: string | null } = {}) {
+  await upsertInstallation(env, {
+    installation: { id: 9, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read", contents: "write", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+  });
+  await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 9);
+  await upsertPullRequestFromGitHub(env, "owner/repo", {
+    number: 11,
+    title: "Fix cache invalidation",
+    state: "open",
+    ...(options.authorLogin === null ? {} : { user: { login: options.authorLogin ?? "a-contributor" } }),
+    labels: [],
+    body: "x",
+  });
+}
+
+describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
+  afterEach(() => {
+    vi.doUnmock("../../src/services/ai-chat-qa");
+    vi.doUnmock("../../src/services/agent-orchestrator");
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("requires authentication", async () => {
+    const env = createTestEnv();
+    const res = await app.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", body: JSON.stringify({ question: "why is this blocked?" }) }, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a non-positive/non-integer pull number", async () => {
+    const env = createTestEnv();
+    const res = await app.request("/v1/repos/owner/repo/pulls/0/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why?" }) }, env);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_pull_number" });
+  });
+
+  it("rejects a blank question", async () => {
+    const env = createTestEnv();
+    await seedRepoWithPull(env);
+    const res = await app.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "   " }) }, env);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_chat_qa_request" });
+  });
+
+  it("404s when the pull request is not cached", async () => {
+    const env = createTestEnv();
+    const res = await app.request("/v1/repos/owner/repo/pulls/999/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why?" }) }, env);
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({ error: "pull_request_not_found" });
+  });
+
+  it("returns a disabled status (the real, unmocked service) when advisoryAiRouting.chatQa is off for the repo (the default, no .loopover.yml)", async () => {
+    const env = createTestEnv();
+    await seedRepoWithPull(env);
+    const res = await app.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why is this blocked?" }) }, env);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ status: "disabled", reason: "Chat Q&A is not enabled on this instance (settings.advisoryAiRouting.chatQa is off)." });
+  });
+
+  it("builds a bundle via planNextWork and passes it, the question, and settings through to generateChatQaAnswer, returning its result verbatim", async () => {
+    vi.resetModules();
+    const generateChatQaAnswer = vi.fn().mockResolvedValue({ status: "ok", model: "test-model", estimatedNeurons: 12, text: "This PR is blocked on a failing check." });
+    vi.doMock("../../src/services/ai-chat-qa", () => ({ generateChatQaAnswer }));
+    const { createApp: createMockedApp } = await import("../../src/api/routes");
+    const mockedApp = createMockedApp();
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await seedRepoWithPull(env, { authorLogin: "a-contributor" });
+    stubChatQaManifestFetch();
+
+    const res = await mockedApp.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why is this blocked?" }) }, env);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ status: "ok", model: "test-model", estimatedNeurons: 12, text: "This PR is blocked on a failing check." });
+
+    expect(generateChatQaAnswer).toHaveBeenCalledTimes(1);
+    const [, request] = generateChatQaAnswer.mock.calls[0]!;
+    expect(request).toMatchObject({
+      question: "why is this blocked?",
+      advisoryAiRouting: ADVISORY_ON,
+      repoFullName: "owner/repo",
+      issueNumber: 11,
+      actor: "api",
+      route: "app.maintainer_dashboard.chat_qa",
+    });
+    expect(request.bundle).toBeTruthy();
+  });
+
+  it("falls back to the caller's own actor as the grounding login when the pull request has no cached author", async () => {
+    vi.resetModules();
+    const generateChatQaAnswer = vi.fn().mockResolvedValue({ status: "ok", model: "test-model", estimatedNeurons: 1, text: "answer" });
+    vi.doMock("../../src/services/ai-chat-qa", () => ({ generateChatQaAnswer }));
+    const planNextWork = vi.fn().mockResolvedValue({ run: { status: "completed" }, actions: [], contextSnapshots: [], summary: "" });
+    vi.doMock("../../src/services/agent-orchestrator", async () => {
+      const actual = await vi.importActual<typeof import("../../src/services/agent-orchestrator")>("../../src/services/agent-orchestrator");
+      return { ...actual, planNextWork };
+    });
+    const { createApp: createMockedApp } = await import("../../src/api/routes");
+    const mockedApp = createMockedApp();
+
+    const env = createTestEnv();
+    await seedRepoWithPull(env, { authorLogin: null });
+
+    const res = await mockedApp.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why is this blocked?" }) }, env);
+    expect(res.status).toBe(200);
+    expect(planNextWork).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ login: "api" }));
+  });
+
+  it("never throttles when commandRateLimitPolicy is off (the default), even with many prior invocations recorded", async () => {
+    vi.resetModules();
+    const generateChatQaAnswer = vi.fn().mockResolvedValue({ status: "ok", model: "m", estimatedNeurons: 1, text: "answer" });
+    vi.doMock("../../src/services/ai-chat-qa", () => ({ generateChatQaAnswer }));
+    const { createApp: createMockedApp } = await import("../../src/api/routes");
+    const mockedApp = createMockedApp();
+
+    const env = createTestEnv();
+    await seedRepoWithPull(env);
+    for (let i = 0; i < 10; i += 1) {
+      await recordAuditEvent(env, { eventType: "github_app.command_invocation", actor: "api", targetKey: "owner/repo#11#chat", outcome: "completed" });
+    }
+
+    const res = await mockedApp.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why?" }) }, env);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ status: "ok" });
+    expect(generateChatQaAnswer).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares the SAME per-(actor, targetKey) rate-limit counter as the @loopover chat PR-comment command: allows up to the AI ceiling, then throttles without calling the service", async () => {
+    vi.resetModules();
+    const generateChatQaAnswer = vi.fn().mockResolvedValue({ status: "ok", model: "m", estimatedNeurons: 1, text: "answer" });
+    vi.doMock("../../src/services/ai-chat-qa", () => ({ generateChatQaAnswer }));
+    const { createApp: createMockedApp } = await import("../../src/api/routes");
+    const mockedApp = createMockedApp();
+
+    const env = createTestEnv();
+    await seedRepoWithPull(env);
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", commandRateLimitPolicy: "hold", commandRateLimitAiMaxPerWindow: 2, commandRateLimitWindowHours: 24 });
+    // One prior invocation already recorded under the SAME event type + targetKey shape the PR-comment
+    // command itself would use for this PR -- e.g. from a real `@loopover chat` comment by this same actor.
+    await recordAuditEvent(env, { eventType: "github_app.command_invocation", actor: "api", targetKey: "owner/repo#11#chat", outcome: "completed" });
+
+    // 2nd attempt: 1 prior + this one = 2, at the ceiling -- still allowed.
+    const allowed = await mockedApp.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why?" }) }, env);
+    expect(allowed.status).toBe(200);
+    await expect(allowed.json()).resolves.toMatchObject({ status: "ok" });
+
+    // 3rd attempt: now over the ceiling (2 recorded + this one = 3 > 2) -- throttled, service never called again.
+    const throttled = await mockedApp.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ question: "why?" }) }, env);
+    expect(throttled.status).toBe(200);
+    const throttledBody = (await throttled.json()) as { status: string; reason: string };
+    expect(throttledBody.status).toBe("rate_limited");
+    expect(throttledBody.reason).toContain("2 within 24h");
+    expect(generateChatQaAnswer).toHaveBeenCalledTimes(1);
+
+    const invocationRows = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.command_invocation' and target_key = 'owner/repo#11#chat'").first<{ n: number }>();
+    // Every attempt (including the throttled one) still records an invocation, mirroring
+    // maybeThrottleLoopOverCommand's own ordering: 1 pre-seeded + 2 from this test's own requests.
+    expect(invocationRows?.n).toBe(3);
+  });
+});

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
 import { recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../../src/api/routes";
-import { recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 // #6489 (per #6230's scope decision): the maintainer-dashboard chat Q&A route is a thin wrapper -- build the
@@ -21,11 +21,16 @@ const ADVISORY_ON = { slop: false, e2eTestGen: false, planner: false, summaries:
 // This is a plain, unauthenticated raw.githubusercontent.com read (no installation-token exchange), so no
 // GitHub App private key is needed to stub it -- unlike test/unit/queue-5.test.ts's #4595 chat-dispatch
 // test, which also drives a real GitHub API call downstream and does need one.
-function stubChatQaManifestFetch() {
+// commandRateLimit* is likewise config-as-code only (#6445): DB upserts silently ignore those fields.
+function stubChatQaManifestFetch(options: { rateLimitHoldMax?: number } = {}) {
+  const rateLimitYaml =
+    options.rateLimitHoldMax !== undefined
+      ? `  commandRateLimitPolicy: hold\n  commandRateLimitAiMaxPerWindow: ${options.rateLimitHoldMax}\n  commandRateLimitWindowHours: 24\n`
+      : "";
   vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
     const url = input.toString();
     if (url.includes("raw.githubusercontent.com") && url.includes(".loopover.yml")) {
-      return new Response("settings:\n  advisoryAiRouting:\n    chatQa: true\n", { status: 200 });
+      return new Response(`settings:\n  advisoryAiRouting:\n    chatQa: true\n${rateLimitYaml}`, { status: 200 });
     }
     return new Response("not found", { status: 404 });
   });
@@ -173,7 +178,8 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
 
     const env = createTestEnv();
     await seedRepoWithPull(env);
-    await upsertRepositorySettings(env, { repoFullName: "owner/repo", commandRateLimitPolicy: "hold", commandRateLimitAiMaxPerWindow: 2, commandRateLimitWindowHours: 24 });
+    // Config-as-code only (#6445): hold + AI ceiling of 2 via .loopover.yml, not upsertRepositorySettings.
+    stubChatQaManifestFetch({ rateLimitHoldMax: 2 });
     // One prior invocation already recorded under the SAME event type + targetKey shape the PR-comment
     // command itself would use for this PR -- e.g. from a real `@loopover chat` comment by this same actor.
     await recordAuditEvent(env, { eventType: "github_app.command_invocation", actor: "api", targetKey: "owner/repo#11#chat", outcome: "completed" });

--- a/test/unit/maintainer-chat-qa.test.ts
+++ b/test/unit/maintainer-chat-qa.test.ts
@@ -81,12 +81,12 @@ describe("POST /v1/repos/:owner/:repo/pulls/:number/chat-qa (#6489)", () => {
     await expect(res.json()).resolves.toMatchObject({ error: "invalid_chat_qa_request" });
   });
 
-  it("rejects invalid JSON the same way as a blank question (json().catch → schema fail)", async () => {
+  it("rejects invalid JSON the same way as a blank question (json().catch → null body)", async () => {
     const env = createTestEnv();
     await seedRepoWithPull(env);
     const res = await app.request("/v1/repos/owner/repo/pulls/11/chat-qa", { method: "POST", headers: apiHeaders(env), body: "{not-json" }, env);
     expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({ error: "invalid_chat_qa_request" });
+    await expect(res.json()).resolves.toEqual({ error: "invalid_chat_qa_request" });
   });
 
   it("404s when the pull request is not cached", async () => {

--- a/test/unit/maintainer-settings-preview-ui.test.ts
+++ b/test/unit/maintainer-settings-preview-ui.test.ts
@@ -7,6 +7,7 @@ import {
   parseLinkedIssues,
   parsePreviewLabels,
   splitRepoFullName,
+  splitReviewabilityPr,
 } from "../../apps/loopover-ui/src/lib/maintainer-settings-preview";
 
 describe("maintainer settings preview UI helpers", () => {
@@ -30,6 +31,19 @@ describe("maintainer settings preview UI helpers", () => {
     expect(splitRepoFullName("/missing-owner")).toBeNull();
     expect(splitRepoFullName("missing-repo/")).toBeNull();
     expect(splitRepoFullName("too/many/parts")).toBeNull();
+  });
+
+  it("parses a reviewability row's pr field into owner/repo/number for the chat Q&A route (#6489)", () => {
+    expect(splitReviewabilityPr("entrius/allways-ui#12")).toEqual({
+      owner: "entrius",
+      repo: "allways-ui",
+      number: 12,
+    });
+    expect(splitReviewabilityPr("not-a-pr")).toBeNull();
+    expect(splitReviewabilityPr("too/many/parts#12")).toBeNull();
+    expect(splitReviewabilityPr("entrius/allways-ui#not-a-number")).toBeNull();
+    expect(splitReviewabilityPr("entrius/allways-ui#0")).toBeNull();
+    expect(splitReviewabilityPr("entrius/allways-ui")).toBeNull();
   });
 
   it("normalizes labels and linked issue fields into the API request shape", () => {


### PR DESCRIPTION
## Summary
- Add a maintainer-dashboard **Chat Q&A** panel that calls the existing `generateChatQaAnswer` service via a thin `POST /v1/repos/:owner/:repo/pulls/:number/chat-qa` wrapper (no new LLM routing / write path).
- Panel renders only when `advisoryAiRouting.chatQa` is enabled for a PR in view; surfaces every `ChatQaResult` status (plus shared command rate-limit).
- Fresh PR superseding closed #6592 (auto-closed for draft-cycling). Rebased onto current `main`.

Closes #6489

## Test plan
- [ ] Unit: `maintainer-chat-qa.test.ts`, `chat-qa-panel.test.tsx`
- [ ] Opted-out / no eligible PR → panel absent
- [ ] Rate-limit shares `COMMAND_RATE_LIMIT_EVENT_TYPE` with `@loopover chat`
- [ ] CI green including codecov/patch on `src/**`