### PR TITLE
fix(review): don't count a byte-identical republish toward review-burst (#6724)

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -26,7 +26,7 @@ export async function createOrUpdatePrIntelligenceComment(
   pullNumber: number,
   body: string,
   options: { createIfMissing?: boolean | undefined; mode?: AgentActionMode } = {},
-): Promise<{ id: number; html_url?: string } | null> {
+): Promise<{ id: number; html_url?: string; changed: boolean } | null> {
   return createOrUpdateIssueCommentWithMarker(env, installationId, repoFullName, pullNumber, body, PR_INTELLIGENCE_COMMENT_MARKER, options);
 }
 
@@ -37,10 +37,15 @@ export async function createOrUpdateAgentCommandComment(
   issueNumber: number,
   body: string,
   mode: AgentActionMode = "live",
-): Promise<{ id: number; html_url?: string } | null> {
+): Promise<{ id: number; html_url?: string; changed: boolean } | null> {
   return createOrUpdateIssueCommentWithMarker(env, installationId, repoFullName, issueNumber, body, AGENT_COMMAND_COMMENT_MARKER, { mode });
 }
 
+// #6724 (review-burst): `changed` distinguishes a genuine no-op (the rendered body was byte-identical to what's
+// already posted, PATCH skipped -- see the idempotency comment below) from a real create/update, so a caller can
+// avoid double-counting a republish that produced no visible change. `false` ONLY on the proven-identical path;
+// every other return (created, updated, or `createIfMissing: false` returning null) is `true`/absent because
+// there's no cheap, safe way to prove those didn't change anything.
 async function createOrUpdateIssueCommentWithMarker(
   env: Env,
   installationId: number,
@@ -49,7 +54,7 @@ async function createOrUpdateIssueCommentWithMarker(
   body: string,
   marker: string,
   options: { createIfMissing?: boolean | undefined; mode?: AgentActionMode } = {},
-): Promise<{ id: number; html_url?: string } | null> {
+): Promise<{ id: number; html_url?: string; changed: boolean } | null> {
   const parts = repoFullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
@@ -84,7 +89,7 @@ async function createOrUpdateIssueCommentWithMarker(
       // marker — also collapses a duplicate webhook delivery for the same commit.
       if (canonical.body === body) {
         await deleteDuplicateMarkerComments(octokit, owner, repo, existing, canonical.id);
-        return { id: canonical.id, ...(canonical.html_url !== undefined ? { html_url: canonical.html_url } : {}) };
+        return { id: canonical.id, ...(canonical.html_url !== undefined ? { html_url: canonical.html_url } : {}), changed: false };
       }
       const response = await octokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
         owner,
@@ -93,7 +98,7 @@ async function createOrUpdateIssueCommentWithMarker(
         body,
       });
       await deleteDuplicateMarkerComments(octokit, owner, repo, existing, canonical.id);
-      return response.data as { id: number; html_url?: string };
+      return { ...(response.data as { id: number; html_url?: string }), changed: true };
     }
     if (options.createIfMissing === false) return null;
     const response = await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
@@ -102,7 +107,7 @@ async function createOrUpdateIssueCommentWithMarker(
       issue_number: issueNumber,
       body,
     });
-    return response.data as { id: number; html_url?: string };
+    return { ...(response.data as { id: number; html_url?: string }), changed: true };
   });
 }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8303,6 +8303,12 @@ async function maybePublishPrPublicSurface(
   let autoReviewSkipReasonForPublish: string | null = null;
   const publishedOutputs: PublicSurfaceOutput[] = [];
   const failedOutputs: PublicSurfaceOutputFailure[] = [];
+  // #6724 (review-burst): true until a comment/label publish proves itself a no-op (byte-identical body / label
+  // already present) -- read by finishPublicSurfacePublication's final call below to avoid double-counting a
+  // republish that changed nothing on GitHub. Stay true (the safe default) for any output this pass doesn't
+  // attempt, and for output kinds with no cheap no-op signal (gate_check_run, check_run).
+  let commentContentChanged = true;
+  let labelContentChanged = true;
   const reviewedHeadSha = reviewedPullRequestHeadSha(pr.headSha, advisory.headSha);
   const freshnessForReviewOutput = (phase: string): Promise<PullRequestFreshness> =>
     reviewTargetFreshness(env, {
@@ -8352,7 +8358,10 @@ async function maybePublishPrPublicSurface(
       });
     return reviewFiles;
   };
-  const finishPublicSurfacePublication = async (): Promise<
+  // #6724 (review-burst): contentChanged defaults true so every existing caller (the three early-return call
+  // sites below, none of which reach the comment/label publish steps) keeps recording pr_public_surface_published
+  // exactly as before -- only the final "full" call site computes and passes the real value.
+  const finishPublicSurfacePublication = async (contentChanged = true): Promise<
     ReturnType<typeof evaluateGateCheck> | undefined
   > => {
     const gateSurfaceIncomplete = gateEnabled && !gateFinalized;
@@ -8467,41 +8476,61 @@ async function maybePublishPrPublicSurface(
           .then((startedAt) => reviewDurationMsSince(startedAt, Date.now()))
           .catch(() => undefined)
       : undefined;
-    await recordAuditEvent(env, {
-      eventType: "github_app.pr_public_surface_published",
-      actor: author,
-      targetKey: `${repoFullName}#${pr.number}`,
-      outcome: "completed",
-      metadata: {
-        deliveryId: webhook.deliveryId,
-        publicSurface: settings.publicSurface,
-        label: decision.willLabel ? settings.gittensorLabel : null,
-        checkRunMode: settings.checkRunMode,
-        reviewCheckMode: settings.reviewCheckMode,
-        publicAudienceMode: settings.publicAudienceMode,
-        publishedOutputs,
-        failedOutputs,
-        gateCheckFinalized: gateFinalized,
-        ...(reviewEffortMinutesForStats !== undefined ? { reviewEffortMinutes: reviewEffortMinutesForStats } : {}),
-        ...(reviewDurationMsForStats !== undefined ? { reviewDurationMs: reviewDurationMsForStats } : {}),
-      },
-    });
-    await recordGithubProductUsage(env, "pr_public_surface_published", {
-      actor: author,
-      repoFullName,
-      targetKey: `${repoFullName}#${pr.number}`,
-      outcome: "completed",
-      metadata: {
-        publicSurface: settings.publicSurface,
-        labelApplied: decision.willLabel,
-        checkRunMode: settings.checkRunMode,
-        reviewCheckMode: settings.reviewCheckMode,
-        publicAudienceMode: settings.publicAudienceMode,
-        publishedOutputs,
-        failedOutputs,
-        gateCheckFinalized: gateFinalized,
-      },
-    });
+    // #6724 (review-burst): a proven no-op republish (comment byte-identical, label already present) still
+    // completes every side effect below (surface-published stamp, AI-review-published stamp) -- those ARE
+    // accurate on a no-op, since the head genuinely is current -- but skips the two DURABLE "a review was
+    // published" records (this event feeds public-stats.ts/services/public-review-volume-trend.ts and is
+    // exempt from retention pruning, db/retention.ts), so a CI-flap/retry-storm that keeps re-rendering the
+    // same content stops inflating both the public "reviews completed" count and the review-burst anomaly
+    // counter (findHottestReviewTargetForRepo, db/repositories.ts) that reads this exact event type. A narrower
+    // event records the no-op instead, mirroring the existing github_app.public_surface_publish_skipped_current
+    // precedent (#6685) for the same "provably nothing changed" shape.
+    if (contentChanged) {
+      await recordAuditEvent(env, {
+        eventType: "github_app.pr_public_surface_published",
+        actor: author,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "completed",
+        metadata: {
+          deliveryId: webhook.deliveryId,
+          publicSurface: settings.publicSurface,
+          label: decision.willLabel ? settings.gittensorLabel : null,
+          checkRunMode: settings.checkRunMode,
+          reviewCheckMode: settings.reviewCheckMode,
+          publicAudienceMode: settings.publicAudienceMode,
+          publishedOutputs,
+          failedOutputs,
+          gateCheckFinalized: gateFinalized,
+          ...(reviewEffortMinutesForStats !== undefined ? { reviewEffortMinutes: reviewEffortMinutesForStats } : {}),
+          ...(reviewDurationMsForStats !== undefined ? { reviewDurationMs: reviewDurationMsForStats } : {}),
+        },
+      });
+      await recordGithubProductUsage(env, "pr_public_surface_published", {
+        actor: author,
+        repoFullName,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "completed",
+        metadata: {
+          publicSurface: settings.publicSurface,
+          labelApplied: decision.willLabel,
+          checkRunMode: settings.checkRunMode,
+          reviewCheckMode: settings.reviewCheckMode,
+          publicAudienceMode: settings.publicAudienceMode,
+          publishedOutputs,
+          failedOutputs,
+          gateCheckFinalized: gateFinalized,
+        },
+      });
+    } else {
+      await recordAuditEvent(env, {
+        eventType: "github_app.pr_public_surface_republish_noop",
+        actor: author,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "completed",
+        detail: "republish produced no visible change (comment byte-identical / label already present)",
+        metadata: { deliveryId: webhook.deliveryId, repoFullName, publishedOutputs },
+      }).catch(() => undefined);
+    }
     // Stamp the head SHA only after every required public surface for this repo completed. For gate-enabled repos,
     // a comment/label without a finalized Orb gate check is incomplete and must stay repair-visible to the sweep.
     await markPullRequestSurfacePublished(env, repoFullName, pr.number, advisory.headSha).catch((error) => {
@@ -10551,7 +10580,7 @@ async function maybePublishPrPublicSurface(
       });
     }
     try {
-      await withReviewPipelineSpan(
+      const commentResult = await withReviewPipelineSpan(
         "selfhost.review.publish.comment",
         {
           installationId,
@@ -10570,6 +10599,10 @@ async function maybePublishPrPublicSurface(
             { mode },
           ),
       );
+      // #6724 (review-burst): only a proven byte-identical no-op (createOrUpdatePrIntelligenceComment's own
+      // idempotency check) sets this false -- a real create/update, or the createIfMissing:false null case
+      // (not reachable on this call site, which never sets that option), both default true.
+      commentContentChanged = commentResult?.changed ?? true;
       publishedOutputs.push("comment");
       incr("loopover_reviews_published_total", { repo: repoFullName });
       // Real end-to-end review latency (#review-latency-metric): pr.headShaObservedAt is the moment THIS
@@ -10616,7 +10649,7 @@ async function maybePublishPrPublicSurface(
   }
   if (decision.willLabel) {
     try {
-      await withReviewPipelineSpan(
+      const labelResult = await withReviewPipelineSpan(
         "selfhost.review.publish.label",
         {
           installationId,
@@ -10638,6 +10671,9 @@ async function maybePublishPrPublicSurface(
             },
           ),
       );
+      // #6724 (review-burst): applied:false means the label was already present -- a proven no-op, same idea
+      // as commentContentChanged above.
+      labelContentChanged = labelResult.applied;
       publishedOutputs.push("label");
     } catch (error) {
       const message = errorMessage(error);
@@ -10654,7 +10690,15 @@ async function maybePublishPrPublicSurface(
       if (isGitHubRateLimitedError(error)) throw error;
     }
   }
-  return finishPublicSurfacePublication();
+  // #6724 (review-burst): only a PUBLISHED-OUTPUTS SET of exactly comment/label (both proven no-ops, or absent
+  // entirely) counts as a no-op pass. Any other output kind in this pass (gate_check_run, check_run) has no
+  // cheap no-op signal, so its mere presence keeps this true -- conservative by design, this can only ever
+  // suppress a pr_public_surface_published record for a pass PROVEN to have changed nothing, never the reverse.
+  const surfaceContentChanged =
+    publishedOutputs.some((output) => output !== "comment" && output !== "label") ||
+    (publishedOutputs.includes("comment") && commentContentChanged) ||
+    (publishedOutputs.includes("label") && labelContentChanged);
+  return finishPublicSurfacePublication(surfaceContentChanged);
 }
 
 async function recordPublicSurfaceOutputFailure(

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -352,7 +352,7 @@ describe("GitHub PR intelligence comments", () => {
 
     const result = await createOrUpdatePrIntelligenceComment(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "JSONbored/gittensory", 12, body);
 
-    expect(result).toEqual({ id: 101, html_url: "https://github.com/comment/101" }); // html_url-present branch of the early return
+    expect(result).toEqual({ id: 101, html_url: "https://github.com/comment/101", changed: false }); // html_url-present branch of the early return; changed:false is the #6724 no-op signal
     expect(calls.some((call) => call.startsWith("PATCH "))).toBe(false); // identical body → NO GitHub write
   });
 
@@ -372,7 +372,7 @@ describe("GitHub PR intelligence comments", () => {
 
     const result = await createOrUpdatePrIntelligenceComment(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "JSONbored/gittensory", 12, body);
 
-    expect(result).toEqual({ id: 202 }); // html_url-absent branch → no html_url key on the early return
+    expect(result).toEqual({ id: 202, changed: false }); // html_url-absent branch → no html_url key; changed:false is the #6724 no-op signal
     expect(calls.some((call) => call.startsWith("PATCH "))).toBe(false);
   });
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync } from "node:crypto";
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import { clearReviewSuppressionCacheForTest } from "../../src/review/review-memory-wire";
 import { PR_PANEL_COMMENT_MARKER } from "../../src/github/comments";
+import * as commentsModule from "../../src/github/comments";
 import * as backfillModule from "../../src/github/backfill";
 import * as rateLimitModule from "../../src/github/rate-limit";
 import * as repositoriesModule from "../../src/db/repositories";
@@ -6009,6 +6010,202 @@ describe("queue processors", () => {
         .bind("github_app.ai_review_cache_hit", "JSONbored/gittensory#70")
         .first<{ n: number }>();
       expect(reuseAudit?.n).toBe(2); // both later passes explicitly reused the durable cache
+    });
+
+    it("#6724 (review-burst): a genuinely full no-op republish (comment byte-identical AND label already present) records republish_noop instead of a fresh pr_public_surface_published", async () => {
+      let aiCalls = 0;
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => { aiCalls += 1; return { response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }; } } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env, { publicSurface: "comment_and_label" });
+      // reviewCheckMode: "disabled" isolates the comment/label no-op path this test is about -- with the gate
+      // check-run enabled (as most gateEnabled repos are), gate_check_run publishes fresh every pass regardless
+      // of comment/label content, which correctly keeps surfaceContentChanged true by this fix's own conservative
+      // design (only a PUBLISHED-OUTPUTS SET of exactly comment/label can ever be marked unchanged). Extending a
+      // similar no-op signal to gate_check_run is a separate, not-yet-implemented scope -- see the PR description.
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "off", reviewCheckMode: "disabled", aiReviewMode: "block" }, review: { auto_review: { cadence: "continuous" } } });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 71, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a71" }, labels: [], body: "Closes #1" });
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 71, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+
+      const stickyComment: { current: { id: number; body: string } | null } = { current: null };
+      let commentPatches = 0;
+      let labelPosts = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/71/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/71")) return Response.json({ number: 71, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a71" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a71/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+        if (url.includes("/commits/a71/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/issues/71/comments") && method === "GET") {
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+        }
+        if (url.includes("/issues/71/comments") && method === "POST") {
+          const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+          stickyComment.current = { id: 1, body };
+          return Response.json({ id: 1 }, { status: 201 });
+        }
+        if (url.includes("/issues/comments/1") && method === "PATCH") {
+          commentPatches += 1;
+          const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+          stickyComment.current = { id: 1, body };
+          return Response.json({ id: 1 }, { status: 200 });
+        }
+        // Unlike the #3379 reproduction above, EVERY label this PR would ever get (gittensorLabel's own "gittensor"
+        // AND the separate type-label decision's "gittensor:bug", inferred from the title) is ALREADY present from
+        // the first pass onward -- proving the genuinely-nothing-changed case this test targets, not the
+        // perpetual-label-repair case that one covers.
+        if (url.includes("/issues/71/labels") && method === "GET") return Response.json([{ name: "gittensor" }, { name: "gittensor:bug" }]);
+        if (url.includes("/issues/71/labels") && method === "POST") {
+          labelPosts += 1;
+          return Response.json([]);
+        }
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        return Response.json({});
+      });
+
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "webhook-open", repoFullName: "JSONbored/gittensory", prNumber: 71, installationId: 123 });
+      expect(aiCalls).toBeGreaterThan(0);
+      const publishedAfterFirst = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_published", "JSONbored/gittensory#71")
+        .first<{ n: number }>();
+      expect(publishedAfterFirst?.n).toBe(1); // the first pass IS a real publish (brand-new comment)
+      expect(labelPosts).toBe(0); // label was already present from the very first GET -- never posted
+      const patchesAfterFirst = commentPatches; // the first pass's own placeholder->final PATCH, same as #3379 above
+
+      // A later scheduled regate-sweep pass over the SAME unchanged head: AI cache hit, comment PATCH skipped
+      // (byte-identical), label already present -- nothing on GitHub actually changes this pass.
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "regate-sweep:JSONbored/gittensory#71:1", repoFullName: "JSONbored/gittensory", prNumber: 71, installationId: 123 });
+
+      expect(commentPatches).toBe(patchesAfterFirst); // no additional PATCH -- the re-render is byte-identical
+      expect(labelPosts).toBe(0);
+      const publishedAfterSecond = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_published", "JSONbored/gittensory#71")
+        .first<{ n: number }>();
+      expect(publishedAfterSecond?.n).toBe(1); // NOT a second durable publish record -- the burst counter's exact fix target
+      const noopAudit = await env.DB.prepare("select count(*) as n, detail from audit_events where event_type = ? and target_key = ? group by detail")
+        .bind("github_app.pr_public_surface_republish_noop", "JSONbored/gittensory#71")
+        .first<{ n: number; detail: string }>();
+      expect(noopAudit?.n).toBe(1);
+      expect(noopAudit?.detail).toContain("no visible change");
+    });
+
+    it("#6724 (review-burst): a comment-unchanged pass that newly applies a previously-missing label still records a fresh pr_public_surface_published", async () => {
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => ({ response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }) } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env, { publicSurface: "comment_and_label" });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "off", reviewCheckMode: "required", aiReviewMode: "block" }, review: { auto_review: { cadence: "continuous" } } });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 72, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a72" }, labels: [], body: "Closes #1" });
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 72, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+
+      const stickyComment: { current: { id: number; body: string } | null } = { current: null };
+      let labelPresent = false;
+      let labelPosts = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/72/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/72")) return Response.json({ number: 72, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a72" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a72/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+        if (url.includes("/commits/a72/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/issues/72/comments") && method === "GET") {
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+        }
+        if (url.includes("/issues/72/comments") && method === "POST") {
+          const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+          stickyComment.current = { id: 1, body };
+          return Response.json({ id: 1 }, { status: 201 });
+        }
+        if (url.includes("/issues/comments/1") && method === "PATCH") {
+          const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+          stickyComment.current = { id: 1, body };
+          return Response.json({ id: 1 }, { status: 200 });
+        }
+        // The label is missing on the first pass (proving the FIRST publish is real), then present by the second
+        // -- but this test simulates it being manually removed again right before the second pass, so the second
+        // pass's own POST is what flips labelPresent back to true, proving a genuinely NEW label application
+        // still counts as a real change even though the comment itself renders byte-identical.
+        if (url.includes("/issues/72/labels") && method === "GET") return Response.json(labelPresent ? [{ name: "gittensor" }] : []);
+        if (url.includes("/issues/72/labels") && method === "POST") {
+          labelPosts += 1;
+          labelPresent = true;
+          return Response.json([]);
+        }
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        return Response.json({});
+      });
+
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "webhook-open", repoFullName: "JSONbored/gittensory", prNumber: 72, installationId: 123 });
+      expect(labelPosts).toBe(1);
+      labelPresent = false; // simulate a maintainer/bot removing the label between passes
+
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "regate-sweep:JSONbored/gittensory#72:1", repoFullName: "JSONbored/gittensory", prNumber: 72, installationId: 123 });
+      expect(labelPosts).toBe(2); // label repair re-applied it -- a real change this pass
+
+      const published = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_published", "JSONbored/gittensory#72")
+        .first<{ n: number }>();
+      expect(published?.n).toBe(2); // both passes are real publishes -- comment unchanged, but the label DID change
+      const noopAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_republish_noop", "JSONbored/gittensory#72")
+        .first<{ n: number }>();
+      expect(noopAudit?.n).toBe(0);
+    });
+
+    it("#6724 (review-burst): a null comment-publish result (the createIfMissing:false shape, structurally unreachable at this call site but still part of the return type) defaults commentContentChanged to true, not a false no-op", async () => {
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => ({ response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }) } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env, { publicSurface: "comment_and_label" });
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { commentMode: "all_prs", publicSurface: "comment_and_label", checkRunMode: "off", reviewCheckMode: "disabled", aiReviewMode: "block" }, review: { auto_review: { cadence: "continuous" } } });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 73, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a73" }, labels: [], body: "Closes #1" });
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 73, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/73/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/73")) return Response.json({ number: 73, title: "Fix the retry loop", state: "open", user: { login: "contributor" }, head: { sha: "a73" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a73/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+        if (url.includes("/commits/a73/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/issues/73/labels") && method === "GET") return Response.json([{ name: "gittensor" }, { name: "gittensor:bug" }]);
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        return Response.json({});
+      });
+      // The real return type of createOrUpdatePrIntelligenceComment is `{...} | null` (null on createIfMissing:
+      // false, never passed at this call site) -- mocking null here proves the `?? true` fallback keeps a
+      // never-actually-happens shape from EVER being misread as a proven no-op.
+      const commentSpy = vi.spyOn(commentsModule, "createOrUpdatePrIntelligenceComment").mockResolvedValue(null);
+
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "webhook-open", repoFullName: "JSONbored/gittensory", prNumber: 73, installationId: 123 });
+      commentSpy.mockRestore();
+
+      const published = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_published", "JSONbored/gittensory#73")
+        .first<{ n: number }>();
+      expect(published?.n).toBe(1); // defaulted to changed:true, not misclassified as a no-op
+      const noopAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_republish_noop", "JSONbored/gittensory#73")
+        .first<{ n: number }>();
+      expect(noopAudit?.n).toBe(0);
     });
 
     it("REGRESSION (#6685): a draft PR's repeat fork-CI-completion triggers stop republishing once the head is already current", async () => {


### PR DESCRIPTION
## Summary

- The `github_app.pr_public_surface_published` audit event (recorded once per successful publish pass in `maybePublishPrPublicSurface`) fed the review-burst anomaly counter (`findHottestReviewTargetForRepo`), public-facing review stats (`public-stats.ts`, `services/public-review-volume-trend.ts`), and an `orb/outcomes.ts` disposition ledger. It's also explicitly marked `DURABLE` in `db/retention.ts`.
- During a CI-flap/retry-storm (confirmed live: `JSONbored/loopover#6641` at 6 republishes, `JSONbored/metagraphed#6264` at 22, both in 2h), the finalize pipeline legitimately re-runs and this event fires every time — even though `createOrUpdateIssueCommentWithMarker` already dedupes the actual GitHub PATCH when the rendered body is byte-identical. That dedup was invisible to the audit layer, so a no-op republish still counted as a fresh "review completed."
- `createOrUpdateIssueCommentWithMarker` (`src/github/comments.ts`) now returns `changed: boolean` — `false` only on the proven byte-identical PATCH-skip path. Threaded through `createOrUpdatePrIntelligenceComment`/`createOrUpdateAgentCommandComment`'s return types.
- `maybePublishPrPublicSurface` (`src/queue/processors.ts`) combines that with `ensurePullRequestLabel`'s existing `applied` flag: when a pass's `publishedOutputs` is exactly `comment`/`label` and both are proven no-ops, it records a narrower `github_app.pr_public_surface_republish_noop` event instead of the durable `pr_public_surface_published` — mirroring the existing `public_surface_publish_skipped_current` precedent (#6685) for the same "provably nothing changed" shape. Every other side effect (`markPullRequestSurfacePublished`, `markAiReviewPublished`) still runs unconditionally, since those remain correct on a no-op.
- **Deliberately conservative, and deliberately NOT extended to `gate_check_run`/`check_run`**: any output besides comment/label in the same pass keeps the pass counted as changed, since there's no cheap "was this actually different" signal for those yet. This can only ever suppress a record for a pass *proven* to have changed nothing — never the reverse. A repo with `reviewCheckMode` enabled (gate check-run publishes every pass) won't see this fix's benefit until/unless a similar no-op signal is added for check-runs — flagged as separate, unimplemented scope, not silently glossed over.

Closes #6724

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (no workflow changes in this PR, ran anyway)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — ran the full suite once clean (935 files / 17963 tests, 0 failures) before the final commit, then re-verified the affected files (`queue.test.ts` + `queue-2/3/4/5.test.ts` + `queue-lifecycle-guards.test.ts` + `github-comments.test.ts` + the public-stats/retention/product-usage/ops-wire consumer suites, 246 tests) after the last change. Every new/changed line in `src/github/comments.ts` and `src/queue/processors.ts` shows 100% line+branch coverage via lcov cross-referencing against the diff's exact hunks — the one remaining uncovered branch in the scanned range (`processors.ts:10690`) is pre-existing, unmodified code outside this diff.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check` (no schema changes, ran anyway)
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 3 new tests covering the full-no-op path, the label-changed-but-comment-unchanged path, and the structurally-unreachable-but-type-required null-comment-result fallback.

If any required check was skipped, explain why:

- This diff touches exactly 4 files (`src/github/comments.ts`, `src/queue/processors.ts`, `test/unit/github-comments.test.ts`, `test/unit/queue.test.ts`) — no MCP, UI, engine, or miner package files. Also ran and confirmed green locally: `docs:drift-check`, `manifest:drift-check`, `engine-parity:drift-check`. Skipped the MCP/miner pack builds and UI lint/typecheck/build locally (unaffected by this diff, and a full local `test:ci` run exceeds this tool's 10-minute per-command limit) — deferring to CI's `validate` check for final confirmation on those steps.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No UI/frontend changes in this PR.

## Notes

- Same anti-abuse/resource-waste investigation as #6669/#6679, discovered while live-verifying those fixes on the production instance.
- No generated artifacts needed regeneration — no API/schema, DB, or wrangler binding changes.