### PR TITLE
feat(mcp): mirror contributor-issue-drafts/generate over MCP + CLI

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -87,7 +87,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision"],
+  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "generate-issue-drafts"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -2691,6 +2691,8 @@ function printMaintainHelp() {
       `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
       `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
       "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
+      "  generate-issue-drafts        Preview contributor-issue drafts (dry-run). Pass --create to actually file",
+      "                               them, --limit N to cap how many (default 5).",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -2797,7 +2799,24 @@ async function maintainCli(args) {
     emit(payload, lines.join("\n"));
     return;
   }
-  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision.`);
+  if (subcommand === "generate-issue-drafts") {
+    // #6757 — mirror of POST /v1/repos/:owner/:repo/contributor-issue-drafts/generate. Dry-run by default: the
+    // preview never writes. `--create` is the only way to actually file, and it always pairs create with
+    // dryRun:false so the request itself can never trip the route's explicit-create safety guard. The API still
+    // enforces write access + the paused/frozen kill-switch; the CLI never decides locally.
+    const create = options.create === true;
+    const body = { dryRun: !create, create };
+    const limit = Number(options.limit);
+    if (Number.isFinite(limit)) body.limit = limit;
+    const payload = await apiPost(`${repoBase}/contributor-issue-drafts/generate`, body);
+    const drafts = payload.drafts ?? [];
+    emit(
+      payload,
+      `${payload.dryRun ? "Previewed" : "Generated"} ${drafts.length} contributor issue draft(s) for ${repoFullName}: ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created.`,
+    );
+    return;
+  }
+  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | generate-issue-drafts.`);
 }
 
 async function runCli(args) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -96,6 +96,7 @@ import {
 } from "../services/agent-orchestrator";
 import { authoritativeContributorRepoStats, loadContributorDecisionPackForServing, repoDecisionFromPack } from "../services/decision-pack";
 import { buildPublicPrBodyDraft } from "../services/pr-body-draft";
+import { generateContributorIssueDrafts } from "../services/contributor-issue-draft";
 import { buildRemediationPlan } from "../services/remediation-plan";
 import { deriveEligibilityPlan } from "../services/eligibility-plan";
 import { explainScoreBreakdown } from "../services/score-breakdown";
@@ -631,6 +632,44 @@ const refreshRepoDocsOutputSchema = {
   pullNumber: z.number().optional(),
   url: z.string().optional(),
   reason: z.string().optional(),
+};
+
+// #6757 — MCP mirror of the contributor-issue-drafts/generate REST route (src/api/routes.ts). Delegates to the
+// SAME generateContributorIssueDrafts service, so the dry-run-by-default / explicit-create-requires-dryRun-false
+// safety guard is shared, not re-implemented. dryRun/create/limit mirror contributorIssueDraftGenerateSchema's
+// bounds; leaving them unset takes the service defaults (dryRun true, create false, limit 5).
+const generateContributorIssueDraftsShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  dryRun: z.boolean().optional(),
+  create: z.boolean().optional(),
+  limit: z.number().int().min(1).max(20).optional(),
+};
+
+const contributorIssueDraftEntrySchema = z.object({
+  fingerprint: z.string(),
+  topic: z.string(),
+  title: z.string(),
+  body: z.string(),
+  labels: z.array(z.string()),
+  status: z.string(),
+  duplicateOf: z.object({ number: z.number(), title: z.string(), reason: z.string() }).optional(),
+  declinedBy: z.object({ number: z.number(), title: z.string(), reason: z.string() }).optional(),
+  issue: z.object({ number: z.number(), url: z.string() }).optional(),
+});
+
+const generateContributorIssueDraftsOutputSchema = {
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  dryRun: z.boolean().optional(),
+  createRequested: z.boolean().optional(),
+  proposed: z.number().optional(),
+  skippedDuplicate: z.number().optional(),
+  skippedDeclined: z.number().optional(),
+  skippedUnsafe: z.number().optional(),
+  created: z.number().optional(),
+  skippedCreateFailed: z.number().optional(),
+  drafts: z.array(contributorIssueDraftEntrySchema).optional(),
 };
 
 // #784 (MCP slice) — the agent audit feed: executed actions + approval decisions for a repo.
@@ -1789,6 +1828,7 @@ export const MCP_TOOL_CATEGORIES: Record<string, McpToolCategory> = {
   loopover_list_pending_actions: "agent",
   loopover_decide_pending_action: "agent",
   loopover_refresh_repo_docs: "maintainer",
+  loopover_generate_contributor_issue_drafts: "maintainer",
   loopover_get_agent_audit_feed: "agent",
   loopover_explain_score_breakdown: "review",
   loopover_explain_review_risk: "review",
@@ -2540,6 +2580,17 @@ export class LoopoverMcp {
         outputSchema: refreshRepoDocsOutputSchema,
       },
       async (input) => this.toolResult(await this.refreshRepoDocs(input)),
+    );
+
+    register(
+      "loopover_generate_contributor_issue_drafts",
+      {
+        description:
+          "Generate contributor-issue drafts for a repo -- the MCP mirror of the web dashboard's contributor-issue-drafts/generate call. Dry-run by default: it only PREVIEWS drafts unless create:true is paired with dryRun:false, and even then a paused/frozen agent is never allowed to file. It never silently opens issues. Maintainer access required.",
+        inputSchema: generateContributorIssueDraftsShape,
+        outputSchema: generateContributorIssueDraftsOutputSchema,
+      },
+      async (input) => this.toolResult(await this.generateContributorIssueDraftsTool(input)),
     );
 
     register(
@@ -4220,6 +4271,31 @@ export class LoopoverMcp {
     return {
       summary: `${result.reused ? "Found the already-open" : "Opened a new"} repo-doc pull request for ${fullName}: ${result.url}`,
       data: { opened: true, reused: result.reused, pullNumber: result.pullNumber, url: result.url },
+    };
+  }
+
+  // #6757 — MCP mirror of POST /v1/repos/:owner/:repo/contributor-issue-drafts/generate. requireRepoManageAccess
+  // is the write-manage gate (the same authority the route's create path additionally demands via
+  // requireRepoWriteAccess), checked FIRST. The explicit-create guard is re-asserted here so an implicit/default
+  // dry run can never be turned into a silent create, exactly mirroring the route; the deeper kill-switch brake
+  // (paused/frozen agent) lives inside generateContributorIssueDrafts and applies to every caller.
+  private async generateContributorIssueDraftsTool(
+    input: z.infer<z.ZodObject<typeof generateContributorIssueDraftsShape>>,
+  ): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoManageAccess(fullName);
+    if (input.create && input.dryRun !== false) {
+      throw new Error("explicit_create_requires_dry_run_false");
+    }
+    const result = await generateContributorIssueDrafts(this.env, fullName, {
+      dryRun: input.dryRun,
+      create: input.create,
+      limit: input.limit,
+      requestedBy: this.identity.actor,
+    });
+    return {
+      summary: `${result.dryRun ? "Previewed" : "Generated"} ${result.drafts.length} contributor issue draft(s) for ${fullName}: ${result.proposed} proposed, ${result.created} created.`,
+      data: result as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -220,7 +220,7 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("Register-ArgumentCompleter -Native -CommandName loopover-mcp");
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
-    expect(ps).toContain("'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision')");
+    expect(ps).toContain("'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'generate-issue-drafts')");
   });
 
   it("emits completion as machine-readable json", () => {

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -95,6 +95,27 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(scoped).toMatch(/Gate precision for owner\/repo \(last 30d\)/);
   });
 
+  it("generate-issue-drafts previews by default and files with --create (#6757)", async () => {
+    const e = await env();
+    const preview = await runAsync(["maintain", "generate-issue-drafts", "--repo", "owner/repo"], e);
+    expect(preview).toMatch(/Previewed 2 contributor issue draft\(s\) for owner\/repo: 2 proposed, 0 created\./);
+    const previewJson = JSON.parse(await runAsync(["maintain", "generate-issue-drafts", "--repo", "owner/repo", "--json"], e)) as {
+      dryRun: boolean;
+      createRequested: boolean;
+      created: number;
+    };
+    expect(previewJson).toMatchObject({ dryRun: true, createRequested: false, created: 0 });
+
+    const created = await runAsync(["maintain", "generate-issue-drafts", "--repo", "owner/repo", "--create"], e);
+    expect(created).toMatch(/Generated 2 contributor issue draft\(s\) for owner\/repo: 0 proposed, 2 created\./);
+    const createdJson = JSON.parse(await runAsync(["maintain", "generate-issue-drafts", "--repo", "owner/repo", "--create", "--limit", "1", "--json"], e)) as {
+      dryRun: boolean;
+      createRequested: boolean;
+      created: number;
+    };
+    expect(createdJson).toMatchObject({ dryRun: false, createRequested: true, created: 1 });
+  });
+
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {
     const e = await env();
     await expect(runAsync(["maintain", "status"], e)).rejects.toThrow(/Pass --repo/);

--- a/test/unit/mcp-generate-contributor-issue-drafts.test.ts
+++ b/test/unit/mcp-generate-contributor-issue-drafts.test.ts
@@ -1,0 +1,105 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { LoopoverMcp } from "../../src/mcp/server";
+import type { AuthIdentity } from "../../src/auth/security";
+import { createTestEnv } from "../helpers/d1";
+
+const REPO = "JSONbored/gittensory";
+const API_IDENTITY: AuthIdentity = { kind: "static", actor: "api" };
+
+async function connect(env: Env, identity?: AuthIdentity) {
+  const server = (identity ? new LoopoverMcp(env, identity) : new LoopoverMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-generate-drafts-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+// #6757 — the MCP mirror of contributor-issue-drafts/generate. The safety guard and dry-run-by-default posture
+// are the contract; these tests pin both, plus the manage-access gate and REST parity.
+describe("MCP loopover_generate_contributor_issue_drafts (#6757)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("previews contributor issue drafts as a dry run by default (no create, no GitHub write)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const client = await connect(createTestEnv(), API_IDENTITY);
+    const result = await client.callTool({ name: "loopover_generate_contributor_issue_drafts", arguments: { owner: "JSONbored", repo: "gittensory", limit: 2 } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({ repoFullName: REPO, dryRun: true, createRequested: false, created: 0 });
+    expect(Array.isArray(data.drafts)).toBe(true);
+    expect((data.drafts as unknown[]).length).toBeGreaterThan(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit create that is not paired with dryRun:false (the safety guard is preserved)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const client = await connect(createTestEnv(), API_IDENTITY);
+    const result = await client.callTool({ name: "loopover_generate_contributor_issue_drafts", arguments: { owner: "JSONbored", repo: "gittensory", create: true } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/explicit_create_requires_dry_run_false/);
+    // The guard trips before any GitHub write is attempted.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("creates issues when create:true is paired with dryRun:false", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ number: 501, html_url: "https://github.com/JSONbored/gittensory/issues/501" })),
+    );
+    const env = createTestEnv({ LOOPOVER_CONTRIBUTOR_ISSUE_TOKEN: "token" });
+    const client = await connect(env, API_IDENTITY);
+    const result = await client.callTool({
+      name: "loopover_generate_contributor_issue_drafts",
+      arguments: { owner: "JSONbored", repo: "gittensory", create: true, dryRun: false, limit: 1 },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({ repoFullName: REPO, dryRun: false, createRequested: true });
+    expect((result.content as Array<{ text: string }>)[0]?.text).toMatch(/^Generated /);
+  });
+
+  it("denies a static MCP-token caller when the repo is not in MCP_ACTUATION_REPO_ALLOWLIST", async () => {
+    const client = await connect(createTestEnv({ MCP_ACTUATION_REPO_ALLOWLIST: "" })); // default identity: static mcp
+    const result = await client.callTool({ name: "loopover_generate_contributor_issue_drafts", arguments: { owner: "JSONbored", repo: "gittensory" } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toMatch(/MCP_ACTUATION_REPO_ALLOWLIST/);
+  });
+
+  it("allows the static MCP-token caller once the repo is explicitly allowlisted", async () => {
+    const client = await connect(createTestEnv({ MCP_ACTUATION_REPO_ALLOWLIST: REPO }));
+    const result = await client.callTool({ name: "loopover_generate_contributor_issue_drafts", arguments: { owner: "JSONbored", repo: "gittensory", limit: 1 } });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({ repoFullName: REPO, dryRun: true });
+  });
+
+  // The issue's explicit parity requirement: the MCP tool and the REST route are two faces of the same service,
+  // so identical input must yield identical output (bar the wall-clock generatedAt stamp).
+  it("returns output identical to the REST route for identical input", async () => {
+    const env = createTestEnv();
+    const args = { owner: "JSONbored", repo: "gittensory", dryRun: true, limit: 3 };
+
+    const client = await connect(env, API_IDENTITY);
+    const toolResult = await client.callTool({ name: "loopover_generate_contributor_issue_drafts", arguments: args });
+    expect(toolResult.isError).toBeFalsy();
+    const toolData = { ...(toolResult.structuredContent as Record<string, unknown>) };
+
+    const app = createApp();
+    const response = await app.request(
+      `/v1/repos/${REPO}/contributor-issue-drafts/generate`,
+      { method: "POST", headers: { authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ dryRun: true, limit: 3 }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    const routeData = (await response.json()) as Record<string, unknown>;
+
+    delete toolData.generatedAt;
+    delete routeData.generatedAt;
+    expect(toolData).toEqual(routeData);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -420,6 +420,39 @@ export async function startFixtureServer(
       response.end(JSON.stringify({ repoFullName: "owner/repo", agentPaused: body.agentPaused === true, ...(body.autonomy ? { autonomy: body.autonomy } : {}) }));
       return;
     }
+    // #6757 contributor-issue-draft generation. Echoes dryRun/create so the CLI's preview-vs-create wiring is
+    // testable; the fixture never trips the route's explicit-create guard because the CLI always pairs them.
+    if (request.url === "/v1/repos/owner/repo/contributor-issue-drafts/generate" && request.method === "POST") {
+      const body = (await readJsonRequest(request)) as { dryRun?: boolean; create?: boolean; limit?: number };
+      const dryRun = body.dryRun !== false;
+      const createRequested = body.create === true;
+      const willCreate = !dryRun && createRequested;
+      const limit = body.limit ?? 2;
+      const drafts = Array.from({ length: Math.min(limit, 2) }, (_, index) => ({
+        fingerprint: `fp-${index}`,
+        topic: "focus:wanted_path:src/",
+        title: `Draft ${index}`,
+        body: "Draft body",
+        labels: ["help wanted"],
+        status: willCreate ? "created" : "proposed",
+      }));
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          generatedAt: "2026-06-01T00:00:00.000Z",
+          dryRun,
+          createRequested,
+          proposed: willCreate ? 0 : drafts.length,
+          skippedDuplicate: 0,
+          skippedDeclined: 0,
+          skippedUnsafe: 0,
+          created: willCreate ? drafts.length : 0,
+          skippedCreateFailed: 0,
+          drafts,
+        }),
+      );
+      return;
+    }
     // #554 gate precision telemetry (read-only). Echoes ?windowDays so the CLI window pass-through is testable.
     if (request.url?.startsWith("/v1/repos/owner/repo/gate-precision") && request.method === "GET") {
       const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");


### PR DESCRIPTION
## Summary

- Exposes contributor issue-draft generation over MCP and the CLI, closing the gap where `POST /v1/repos/:owner/:repo/contributor-issue-drafts/generate` was reachable only from the web dashboard's REST call.
- Adds the `loopover_generate_contributor_issue_drafts` remote MCP tool (`requireRepoManageAccess`-gated, categorized `maintainer`) and a `maintain generate-issue-drafts [--create] [--limit N] --repo owner/repo` CLI subcommand.
- Both surfaces delegate to the same `generateContributorIssueDrafts` service as the route, so the **dry-run-by-default** posture and the **`explicit_create_requires_dry_run_false`** safety guard are shared, not re-implemented — the tool never silently files issues. The deeper paused/frozen-agent kill-switch inside the service still applies to every caller.
- The CLI previews by default and only writes with `--create`, which always pairs `create` with `dryRun:false` so the request itself can never trip the route's create guard; the API still enforces write access and the kill-switch.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #6757`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new/changed `src/` lines and branches in `src/mcp/server.ts` are 100% covered (dry-run preview, explicit-create guard both arms, create path, manage-access allow/deny, and REST↔MCP output parity).
- [x] `npm run build:mcp` + `npm run test:mcp-pack` (CLI subcommand added to `packages/loopover-mcp`).
- [x] `npm run command-reference:check` / `npm run docs:drift-check`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)

Environment note: `test/unit/selfhost-ams-reporting.test.ts`, `mcp-cli-doctor`, `miner-discover-cli`, and `miner-live-issue-snapshot` fail identically on a clean base checkout in this sandbox (missing `sqlite3` binary / network fixtures) — unrelated to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise (the service's existing public-safe/redaction path is reused; the MCP result runs through `redactSensitiveForMcp`).
- [x] Access changes include negative-path tests: static `mcp` identity denied without `MCP_ACTUATION_REPO_ALLOWLIST`, allowed once allowlisted, and the explicit-create guard is asserted to trip before any GitHub write.
- [x] MCP behavior is updated and tested (tool registration, category map, output schema, and call-level tests).

## Notes

- No UI/frontend/docs/extension surface changed, so no UI Evidence is applicable.
- Deliverables: `loopover_generate_contributor_issue_drafts` MCP tool; `maintain generate-issue-drafts` CLI subcommand; unit test asserting the dry-run-by-default guard is preserved plus a REST↔MCP output-parity test for identical input.


Closes #6757
