### PR TITLE
fix(mcp): rename enrichment-analyzers resource URI to loopover://

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2252,7 +2252,7 @@ server.registerResource(
 
 server.registerResource(
   "loopover_enrichment_analyzers",
-  "gittensory://enrichment-analyzers",
+  "loopover://enrichment-analyzers",
   {
     title: "LoopOver Enrichment Analyzers",
     description: "Static taxonomy of REES enrichment analyzers: names, categories, and cost classes.",
@@ -2265,7 +2265,7 @@ server.registerResource(
     } catch {
       data = { status: "unavailable" };
     }
-    return { contents: [{ uri: "gittensory://enrichment-analyzers", mimeType: "application/json", text: JSON.stringify(data, null, 2) }] };
+    return { contents: [{ uri: "loopover://enrichment-analyzers", mimeType: "application/json", text: JSON.stringify(data, null, 2) }] };
   },
 );
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2044,7 +2044,7 @@ export function createApp() {
 
   app.get("/v1/scoring/model", async (c) => c.json(await getOrCreateScoringModelSnapshot(c.env)));
 
-  // #6593: REST mirrors of the `loopover://finding-taxonomy` / `gittensory://enrichment-analyzers` MCP
+  // #6593: REST mirrors of the `loopover://finding-taxonomy` / `loopover://enrichment-analyzers` MCP
   // resources, so a plain HTTP client (a dashboard, a non-MCP integration) can discover the same static
   // documents. Both builders are pure, argument-free, and return no PR/user/private data — the same class of
   // public static discovery data as /v1/scoring/model and /v1/upstream/ruleset alongside them, so they carry no

--- a/src/review/enrichment-analyzers-taxonomy.ts
+++ b/src/review/enrichment-analyzers-taxonomy.ts
@@ -1,7 +1,7 @@
 import analyzerMetadata from "../../review-enrichment/analyzer-metadata.json";
 
 /** MCP resource URI for the REES enrichment analyzer taxonomy (#2226). */
-export const ENRICHMENT_ANALYZERS_URI = "gittensory://enrichment-analyzers" as const;
+export const ENRICHMENT_ANALYZERS_URI = "loopover://enrichment-analyzers" as const;
 
 type AnalyzerMetadataFile = {
   defaultProfile: string;

--- a/test/unit/enrichment-analyzers-taxonomy.test.ts
+++ b/test/unit/enrichment-analyzers-taxonomy.test.ts
@@ -44,7 +44,7 @@ describe("enrichment analyzers taxonomy document", () => {
   });
 
   it("uses the stable MCP resource URI", () => {
-    expect(ENRICHMENT_ANALYZERS_URI).toBe("gittensory://enrichment-analyzers");
+    expect(ENRICHMENT_ANALYZERS_URI).toBe("loopover://enrichment-analyzers");
   });
 });
 

--- a/test/unit/mcp-discovery.test.ts
+++ b/test/unit/mcp-discovery.test.ts
@@ -117,7 +117,7 @@ describe("MCP resource discovery", () => {
     expect(uris).toContain("loopover://compatibility");
     // #6620: the two static-document mirrors, using the same URIs the remote server registers.
     expect(uris).toContain("loopover://finding-taxonomy");
-    expect(uris).toContain("gittensory://enrichment-analyzers");
+    expect(uris).toContain("loopover://enrichment-analyzers");
   });
 
   it("resource descriptions do not expose forbidden public terms", async () => {
@@ -154,7 +154,7 @@ describe("MCP resource discovery", () => {
     expect(() => JSON.parse(content.text ?? "")).not.toThrow();
   });
 
-  it.each(["loopover://finding-taxonomy", "gittensory://enrichment-analyzers"])(
+  it.each(["loopover://finding-taxonomy", "loopover://enrichment-analyzers"])(
     "can read the %s resource and get structured JSON (#6620)",
     async (uri) => {
       const result = await client.readResource({ uri });

--- a/test/unit/mcp-enrichment-analyzers.test.ts
+++ b/test/unit/mcp-enrichment-analyzers.test.ts
@@ -13,7 +13,7 @@ async function connectTestClient() {
   const mcpServer = new LoopoverMcp(createTestEnv()).createServer();
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await mcpServer.connect(serverTransport);
-  const client = new Client({ name: "gittensory-enrichment-analyzers-test", version: "0.1.0" }, { capabilities: {} });
+  const client = new Client({ name: "loopover-enrichment-analyzers-test", version: "0.1.0" }, { capabilities: {} });
   await client.connect(clientTransport);
   return { client, mcpServer };
 }

--- a/test/unit/routes-taxonomy-mirrors.test.ts
+++ b/test/unit/routes-taxonomy-mirrors.test.ts
@@ -4,7 +4,7 @@ import { buildEnrichmentAnalyzersTaxonomyDocument } from "../../src/review/enric
 import { buildFindingTaxonomyDocument } from "../../src/review/finding-taxonomy";
 import { createTestEnv } from "../helpers/d1";
 
-// #6593: REST mirrors of the `loopover://finding-taxonomy` / `gittensory://enrichment-analyzers` MCP resources.
+// #6593: REST mirrors of the `loopover://finding-taxonomy` / `loopover://enrichment-analyzers` MCP resources.
 // Both delegate to a pure, argument-free builder, so these tests pin the ROUTE contract — served byte-identical
 // to the document the MCP resource already returns, and gated exactly like the sibling static-data routes it
 // sits with (no new auth middleware of its own) — rather than re-testing the builders themselves.


### PR DESCRIPTION
## Summary
- `ENRICHMENT_ANALYZERS_URI` was still `gittensory://enrichment-analyzers`, while its sibling `FINDING_TAXONOMY_URI` (added in the same #6620 PR) already uses `loopover://finding-taxonomy` — a straggler from the rebrand, not an intentional legacy reference (unlike the `GITTENSORY_LEGACY_*` check-run-name constants, nothing here is annotated as pre-rename/compat).
- Fixed in both the main server (`src/review/enrichment-analyzers-taxonomy.ts`, `src/mcp/server.ts` already referenced the constant so no change needed there) and the standalone `@loopover/mcp` CLI package (`packages/loopover-mcp/bin/loopover-mcp.js`), which independently registers the same resource.
- Updated the 4 test files whose assertions were pinned to the old literal value, plus two doc comments for consistency.
- Confirmed via `git grep` that zero references to the old URI remain anywhere in the tracked repo.

## Scope
- [x] Narrow, single-purpose change
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `npx vitest run test/unit/enrichment-analyzers-taxonomy.test.ts test/unit/mcp-discovery.test.ts test/unit/mcp-enrichment-analyzers.test.ts test/unit/routes-taxonomy-mirrors.test.ts` — 34/34 passing
- `npm run typecheck` — clean
- `git grep -n "gittensory://enrichment-analyzers"` — zero hits repo-wide