### PR TITLE
chore(ci): regenerate the branding-drift baseline after #6786

### DIFF
--- a/scripts/branding-drift-baseline.json
+++ b/scripts/branding-drift-baseline.json
@@ -1,7 +1,7 @@
 {
   "packages/loopover-engine/src/signals/engine.ts": 2,
-  "packages/loopover-mcp/bin/loopover-mcp.js": 5,
-  "src/api/routes.ts": 3,
+  "packages/loopover-mcp/bin/loopover-mcp.js": 3,
+  "src/api/routes.ts": 2,
   "src/db/repositories.ts": 1,
   "src/github/app.ts": 11,
   "src/github/backfill.ts": 7,
@@ -12,7 +12,6 @@
   "src/queue/processors.ts": 6,
   "src/review/check-names.ts": 8,
   "src/review/contributor-calibration.ts": 2,
-  "src/review/enrichment-analyzers-taxonomy.ts": 1,
   "src/review/enrichment-wire.ts": 1,
   "src/review/ops-wire.ts": 3,
   "src/review/outcomes-wire.ts": 2,


### PR DESCRIPTION
## Summary
- #6786 (enrichment-analyzers URI rename) merged after #6788's (branding-drift guardrail) baseline was generated, so `main`'s own `branding-drift:check` has been red since both landed — exactly the "decreased" scenario the check is designed to catch, working as intended.
- Regenerated via `npm run branding-drift:update`. Diff is minimal: `loopover-mcp.js` 5→3, `routes.ts` 3→2, `enrichment-analyzers-taxonomy.ts` 1→0 (removed entirely, now clean).

## Scope
- [x] Narrow, single-purpose change (generated artifact only)
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `npm run branding-drift:check` — passes against the regenerated baseline