### PR TITLE
fix(engine): floor percentComplete at 0 so it stays in its documented 0-100 range (#6773)

### DIFF
--- a/packages/loopover-engine/src/loop-progress.ts
+++ b/packages/loopover-engine/src/loop-progress.ts
@@ -40,8 +40,12 @@ export type ProgressSnapshot = {
 /** Build a customer-facing progress snapshot from already-computed loop state (#4800). Pure. */
 export function buildProgressSnapshot(state: LoopProgressState): ProgressSnapshot {
   const maxIterations = state.maxIterations ?? null;
+  // Clamp BOTH ends (#6773): `iteration` is an unvalidated caller-supplied number, so a negative one (an
+  // upstream bookkeeping bug) would otherwise produce a negative percent, contradicting the documented 0-100.
   const percentComplete =
-    maxIterations !== null && maxIterations > 0 ? Math.min(100, Math.round((state.iteration / maxIterations) * 100)) : null;
+    maxIterations !== null && maxIterations > 0
+      ? Math.max(0, Math.min(100, Math.round((state.iteration / maxIterations) * 100)))
+      : null;
   return {
     phase: state.phase,
     status: state.status,

--- a/test/unit/loop-progress.test.ts
+++ b/test/unit/loop-progress.test.ts
@@ -28,6 +28,13 @@ describe("buildProgressSnapshot (#4800)", () => {
     expect(buildProgressSnapshot(running({ iteration: 7, maxIterations: 5 })).percentComplete).toBe(100);
   });
 
+  it("REGRESSION (#6773): floors percent-complete at 0 for a negative iteration, never below the documented range", () => {
+    // `iteration` is an unvalidated caller-supplied number: an upstream bookkeeping bug producing a negative
+    // one must not surface as a negative percent (the upper bound was clamped, the lower one was not).
+    expect(buildProgressSnapshot(running({ iteration: -1, maxIterations: 5 })).percentComplete).toBe(0);
+    expect(buildProgressSnapshot(running({ iteration: -100, maxIterations: 5 })).percentComplete).toBe(0);
+  });
+
   it("defaults recent activity to empty and caps the tail at MAX_PROGRESS_ACTIVITY", () => {
     expect(buildProgressSnapshot(running()).recentActivity).toEqual([]); // omitted
     const many = Array.from({ length: MAX_PROGRESS_ACTIVITY + 4 }, (_, i) => ({ step: `s${i}` }));


### PR DESCRIPTION
## Summary

- `packages/loopover-engine/src/loop-progress.ts` documents `percentComplete` as "0-100, or null when the budget is unknown", but `buildProgressSnapshot` clamped only the upper bound (`Math.min(100, ...)`).
- `LoopProgressState.iteration` is a plain, unvalidated `number`, so a negative `iteration` (from an upstream bookkeeping bug) produced a **negative** `percentComplete` — outside the documented range, on a customer-facing progress surface.
- Clamp both ends: `Math.max(0, Math.min(100, ...))`. No other behavior changes (the null-budget path and the upper clamp are untouched).

Closes #6773

## Test plan

- [x] Regression test: a negative `iteration` (`-1` and `-100`) floors `percentComplete` to `0`.
- [x] The existing upper-bound (`100`), exact-percent, and null-budget cases still pass unchanged — `test/unit/loop-progress.test.ts` green (13 tests).
- [x] Coverage on the changed file: **100% statements (16/16), 100% branches (21/21)**.
- [x] `npm run typecheck` clean.
