### PR TITLE
docs(engine): correct normalizeNonNegativeInteger's floor in its doc comment (#6775)

### DIFF
--- a/packages/loopover-engine/src/ams-policy-spec.ts
+++ b/packages/loopover-engine/src/ams-policy-spec.ts
@@ -141,7 +141,9 @@ function normalizePositiveNumber(value: unknown, field: string, fallback: number
 }
 
 /** Like normalizePositiveNumber, but floors to a whole count -- for fields that are semantically integer
- *  counts (an iteration/turn budget), matching MinerGoalSpec's own normalizePositiveInteger convention. */
+ *  counts (an iteration/turn budget). Its floor is >= 0: unlike MinerGoalSpec's normalizePositiveInteger
+ *  (which rejects anything < 1 after flooring), 0 is deliberately accepted here (see the parser test's
+ *  zero-budget case) -- a 0 budget is a meaningful "do nothing" setting, not a malformed value. */
 function normalizeNonNegativeInteger(value: unknown, field: string, fallback: number, warnings: string[]): number {
   const normalized = normalizePositiveNumber(value, field, fallback, warnings);
   return Math.floor(normalized);


### PR DESCRIPTION
## Summary

- `normalizeNonNegativeInteger`'s doc comment claimed it matches "MinerGoalSpec's own normalizePositiveInteger convention" — but that sibling rejects any value `< 1` after flooring, while this one only rejects `< 0` and **deliberately accepts `0`** (already-tested behavior: a 0 budget is a meaningful "do nothing" setting).
- Corrected the comment to describe its own `>= 0` floor and why `0` is accepted, so it can't mislead a contributor into believing `0` is rejected here the way it is in `miner-goal-spec.ts`.
- Comment-only — no behavior change (the logic is correct as-is, per the issue).

Closes #6775

## Test plan

- [x] Comment-only diff (verified: no non-comment lines changed).
- [x] `npm run test --workspace @loopover/engine` green — 588 pass / 0 fail, including the existing `ams-policy-spec-parser` zero-budget case that pins the real `>= 0` behavior.
- [x] `npm run typecheck` clean.
