### PR TITLE
docs(selfhost): fix stale gittensory-selfhost self-host doc defaults

### DIFF
--- a/apps/loopover-ui/content/docs/self-hosting-configuration.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-configuration.mdx
@@ -216,7 +216,7 @@ Tune `MAINTENANCE_ADMISSION_MAX_LIVE_PENDING` (default `5`), `MAINTENANCE_ADMISS
 
 ## Tracing and telemetry env
 
-`OTEL_EXPORTER_OTLP_ENDPOINT` overrides the OpenTelemetry collector target only if you're routing to an external collector instead of the bundled one (default `http://otel-collector:4318` under the `observability` profile). `OTEL_SERVICE_NAME` (default `gittensory-selfhost`) is the service name traces and metrics are tagged with — set a distinct value per instance if you run more than one and want to tell them apart in Grafana/Tempo. `OTEL_TRACES_SAMPLER` (default `parentbased_traceidratio`) picks the sampling strategy for app job/provider traces; pair it with `OTEL_TRACES_SAMPLER_ARG` (for example `0.05` to sample 5% of root traces).
+`OTEL_EXPORTER_OTLP_ENDPOINT` overrides the OpenTelemetry collector target only if you're routing to an external collector instead of the bundled one (default `http://otel-collector:4318` under the `observability` profile). `OTEL_SERVICE_NAME` (default `loopover-selfhost`) is the service name traces and metrics are tagged with — set a distinct value per instance if you run more than one and want to tell them apart in Grafana/Tempo. `OTEL_TRACES_SAMPLER` (default `parentbased_traceidratio`) picks the sampling strategy for app job/provider traces; pair it with `OTEL_TRACES_SAMPLER_ARG` (for example `0.05` to sample 5% of root traces).
 
 ## Generated env reference
 

--- a/apps/loopover-ui/content/docs/self-hosting-operations.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-operations.mdx
@@ -606,8 +606,8 @@ captures use a `kind` or review `operation` tag instead.
 />
 
 Cron monitor slugs follow
-`gittensory-selfhost-{environment}-{loop}` (for example
-`gittensory-selfhost-production-scheduled-loop`). Pair monitor alerts with queue
+`loopover-selfhost-{environment}-{loop}` (for example
+`loopover-selfhost-production-scheduled-loop`). Pair monitor alerts with queue
 depth, dead-job counts, and the matching structured log event.
 
 ## Sentry alert classes and runbook

--- a/test/unit/self-host-ops-rename-residue.test.ts
+++ b/test/unit/self-host-ops-rename-residue.test.ts
@@ -10,6 +10,10 @@ const SELF_HOSTING_OPS_DOC = join(
   process.cwd(),
   "apps/loopover-ui/content/docs/self-hosting-operations.mdx",
 );
+const SELF_HOSTING_CONFIGURATION_DOC = join(
+  process.cwd(),
+  "apps/loopover-ui/content/docs/self-hosting-configuration.mdx",
+);
 const TERRAFORM_MAIN = join(process.cwd(), "packages/loopover-miner/terraform/main.tf");
 const CAPABILITY_AUDIT_DOC = join(process.cwd(), "src/review/repo-agnostic-capability-audit.md");
 
@@ -18,6 +22,25 @@ describe("self-host ops docs rename residue (#5937)", () => {
     const doc = readFileSync(SELF_HOSTING_OPS_DOC, "utf8");
     expect(doc).not.toContain("loopover-docker-safe-prune");
     expect(doc).toContain("loopover-docker-prune");
+  });
+
+  it("documents the real loopover-selfhost-{environment}-{loop} cron monitor slug, not the pre-rename prefix", () => {
+    // resolveSentryMonitorSlug (src/selfhost/sentry.ts) has emitted "loopover-selfhost-..." slugs since the
+    // Sentry monitor-naming rebrand; this doc paragraph was left describing the pre-rename "gittensory-selfhost-..."
+    // pattern. Unlike the SENTRY_RELEASE default (scripts/deploy-selfhost-prebuilt.sh, deliberately still
+    // "gittensory-selfhost@..." per test/unit/selfhost-sentry-release.test.ts), the monitor slug has no such
+    // pinned exception -- it's a plain doc/code mismatch.
+    const doc = readFileSync(SELF_HOSTING_OPS_DOC, "utf8");
+    expect(doc).not.toContain("gittensory-selfhost-{environment}-{loop}");
+    expect(doc).toContain("loopover-selfhost-{environment}-{loop}");
+  });
+
+  it("documents the real loopover-selfhost OTEL_SERVICE_NAME default, not the pre-rename value", () => {
+    // src/selfhost/otel.ts falls back to "loopover-selfhost" when OTEL_SERVICE_NAME is unset; this doc line
+    // still described the pre-rename default.
+    const doc = readFileSync(SELF_HOSTING_CONFIGURATION_DOC, "utf8");
+    expect(doc).not.toContain("`OTEL_SERVICE_NAME` (default `gittensory-selfhost`)");
+    expect(doc).toContain("`OTEL_SERVICE_NAME` (default `loopover-selfhost`)");
   });
 
   it("points the terraform module's header comment at the real env filename, not .gittensory-miner.env", () => {


### PR DESCRIPTION
## Summary

- Part of the repo-wide gittensory -> loopover rebrand cleanup (owner-requested follow-up sweep over the long tail of remaining references). Two self-hosting doc paragraphs described pre-rename defaults that the underlying code has since moved off of:
  - `self-hosting-configuration.mdx`: documented the `OTEL_SERVICE_NAME` default as `gittensory-selfhost`, but `src/selfhost/otel.ts` has fallen back to `loopover-selfhost` for a while now.
  - `self-hosting-operations.mdx`: documented the Sentry cron monitor slug format as `gittensory-selfhost-{environment}-{loop}`, but `resolveSentryMonitorSlug` (`src/selfhost/sentry.ts`) has emitted `loopover-selfhost-...` slugs for a while now (also covered by `test/unit/selfhost-sentry.test.ts`'s existing assertions).
  - Extended the existing `#5937` rename-residue regression test (`test/unit/self-host-ops-rename-residue.test.ts`) with both cases so this doesn't drift again.
- Deliberately did **not** touch the `SENTRY_RELEASE` default in `scripts/deploy-selfhost-prebuilt.sh` (`gittensory-selfhost@<sha>`) or its doc mention -- `test/unit/selfhost-sentry-release.test.ts` pins that exact literal on purpose, unlike the monitor slug. Verified this is intentional (not drift) before leaving it alone.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- **no issue linked**: this is a repo-owner-requested maintainer-equivalent cleanup pass over the long tail of remaining `gittensory` references left from the ongoing rebrand, not a contributor-facing fix tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (docs + test file only; no `src/**` lines changed, so Codecov patch coverage does not apply)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` run green end to end (all 18001 tests, 13 intentionally skipped, 0 failed)
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- N/A, no runtime code changed; added a regression test for the two doc-drift facts instead.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- N/A, no such change.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A, docs-content-only change, no UI code touched.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, this is a docs-content text fix (a paragraph on an existing docs page), not a visual/layout change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- First of a small series of PRs sweeping the remaining `gittensory` references (~410 files) left over from the rebrand, split by area per repo convention (small, focused PRs). This one covers self-hosting docs describing OTEL/Sentry monitor defaults specifically.