### PR TITLE
docs(ams): document AMS's verified standalone, ORB/gittensor-optional capability

### DIFF
--- a/apps/loopover-ui/content/docs/ams-deployment.mdx
+++ b/apps/loopover-ui/content/docs/ams-deployment.mdx
@@ -237,6 +237,18 @@ sends SIGTERM, which the loop handles cleanly at its next kill-switch check.
 - Discovery/ranking primitives that touch GitHub only run when explicitly invoked and only perform
   documented GETs unless a future command says otherwise.
 - Operators own secret injection; images and packages ship without embedded tokens.
+- AMS works against **any** GitHub repository — it does not require ORB installed, gittensor
+  registration, or a `.loopover.yml` file on the target repo to function.
+
+<Callout variant="note" title="Verified against a real, non-gittensor repo">
+  `loopover-miner init`, `doctor`, and `discover <owner/repo>` were run end to end against real
+  public GitHub repositories with no `.loopover.yml` and no gittensor registration, using only a
+  plain `GITHUB_TOKEN` — every step worked as documented, including correctly returning zero
+  candidates on a repo with no open issues and ranking real issues on repos that had them. The
+  `loopover-mcp login` device-flow session path (a separate mechanism from AMS's own credential
+  resolution) currently has a known reliability issue independent of AMS itself — see the linked
+  issue tracker for status before relying on it for unattended AMS setups.
+</Callout>
 
 For operational scenarios (ledger corruption, two miners on one state dir, post-upgrade schema
 migration) see the [AMS operations runbook](/docs/ams-operations-runbook), and for measured

--- a/packages/loopover-miner/DEPLOYMENT.md
+++ b/packages/loopover-miner/DEPLOYMENT.md
@@ -180,6 +180,7 @@ Want the dashboard too? [`systemd/loopover-miner-ui.service.example`](../../syst
 - `loopover-miner status` and `loopover-miner doctor` make **no network calls**.
 - Discovery/ranking primitives that touch GitHub only run when explicitly invoked and only perform documented GETs unless a future command says otherwise.
 - Operators own secret injection; images and packages ship without embedded tokens.
+- AMS works against **any** GitHub repository — it does not require ORB installed, gittensor registration, or a `.loopover.yml` file on the target repo to function. Verified end to end (`init`, `doctor`, `discover <owner/repo>`) against real public repositories with no `.loopover.yml` and no gittensor registration, using only a plain `GITHUB_TOKEN`.
 
 See [`docs/operations-runbook.md`](docs/operations-runbook.md) for operational scenarios: ledger corruption, two miners on one state dir, and post-upgrade schema migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
 


### PR DESCRIPTION
## Summary

Documents AMS's verified standalone, ORB/gittensor-optional capability in the AMS deployment guide, per the full end-to-end verification below.

Closes #6205

## Verified: plain GITHUB_TOKEN path

Ran `@loopover/miner` (`npm install -g @loopover/miner@latest`) on a real machine, using only a plain `GITHUB_TOKEN` (no `loopover-mcp login`):

- `loopover-miner status` / `doctor` / `init --verify-token` — all correct, offline where documented, token validated where not.
- `loopover-miner discover <owner/repo>` against several real, public, non-gittensor repos with no `.loopover.yml`:
  - Repos with zero open issues correctly returned "no candidates found" (not an error).
  - A repo with only maintainer-tracking/Renovate meta-issues correctly surfaced them, scored appropriately low.
  - A repo with 79 real open issues correctly fanned out, ranked, and enqueued all 79, with sensible top candidates.
- `loopover-miner attempt <owner/repo> <issue#> --miner-login <login> --live` against two real, well-scoped issues on a repo I have contributor standing on:
  - The first was correctly auto-avoided by AMS's own feasibility gate (`duplicate_cluster_high`) rather than blindly attempted — the gate is doing its job.
  - The second reproducibly failed before any real driver work happened. Root-caused and filed separately as #6840 (the `claude-cli` driver's `--permission-mode acceptEdits` denies every `Read`/`Bash` tool call, so it can never actually read a file or run a test non-interactively) — confirmed via manual reproduction with and without the fix (`bypassPermissions`: 0 denials, real fix + regression test produced; `acceptEdits`: 19/19 denials, zero real work, 31 turns and real $ spent for nothing).

**Conclusion:** the standalone `GITHUB_TOKEN` path works exactly as designed through `discover` and attempt orchestration; the coding-agent driver itself has a real, now-documented bug (#6840) that currently blocks it from completing real work, independent of the standalone-repo story this issue set out to verify.

## Verified: device-flow paths

Two distinct device-flow mechanisms exist and were both tested:

- **`loopover-miner init --interactive`'s own "Authorize with GitHub" option** (`LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID`) — works end to end once pointed at the already-deployed classic OAuth App (`GITHUB_OAUTH_CLIENT_ID` in `wrangler.jsonc`, currently used for dashboard login). No dedicated `loopover-ams` App exists yet, contra the code's own comments/docs, which describe a not-yet-registered App as the intended target — worth a design decision on whether to keep reusing the dashboard's App or register a dedicated one (flagged separately, not fixed here).
- **`loopover-mcp login`'s own device-flow** (a completely separate mechanism — logs into LoopOver's own backend, which `resolveGitHubToken` then calls `/v1/auth/github/token` against) — reproducibly broken. Filed as #6792: the polling route falls under a blanket 10-req/60s rate-limit class that a spec-compliant device-flow poller reliably exhausts within seconds.

## Docs updated

`apps/loopover-ui/content/docs/ams-deployment.mdx` (+ its DEPLOYMENT.md source) rather than `docs.miner-workflow.tsx`/`docs.quickstart.tsx` named in the issue — neither of those actually covers `@loopover/miner`'s autonomous discover/attempt loop (`miner-workflow.mdx` is about the separate, semi-autonomous `@loopover/mcp` copilot tool; `quickstart.mdx` is `@loopover/mcp`-only). `ams-deployment.mdx` is the doc that actually corresponds to what was tested.

## Other findings (not fixed here, noted for awareness)

- The published `@loopover/miner` (2.0.0) and `@loopover/mcp` (0.9.0) npm packages are both meaningfully stale relative to `main` (currently 3.0.0 for both) — `@loopover/mcp`'s published `bin` field is still `gittensor-mcp`, not `loopover-mcp` at all, and its current source can't even resolve its own `@loopover/engine@^3.0.0` dependency against what's published. Not filed as its own issue since it's a release/publish-process gap rather than a code bug, but worth knowing before recommending `npm install -g @loopover/mcp` to anyone right now.

## Test plan
- [x] `npm run docs:drift-check`
- [x] `npm run test:miner-deployment-docs-audit`
- [x] `npm --workspace @loopover/ui run build`
