### PR TITLE
feat(ui): add a copy button to the run drawer's Inputs JSON block

### DIFF
--- a/apps/loopover-ui/src/routes/app.runs.test.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the toast layer so the copy handlers' user-facing signal can be asserted directly.
+const { success, error } = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success, error } }));
+
+import { DrawerSurface } from "./app.runs";
+
+const run = {
+  id: "run_1",
+  source: "mcp",
+  kind: "plan-next-work",
+  repo: "JSONbored/loopover",
+  ranked_actions: 3,
+  ruleset_snapshot: "rs_2026_07",
+  signal_fidelity: "ready",
+  boundary: "advisory",
+  created_at: "2026-07-17T00:00:00.000Z",
+  snapshotReplays: [],
+} as unknown as Parameters<typeof DrawerSurface>[0]["run"];
+
+// The exact text the drawer renders into its Inputs <pre> -- the copy button must hand the clipboard
+// this and nothing else.
+const expectedJson = JSON.stringify(
+  { repo: "JSONbored/loopover", source: "mcp", kind: "plan-next-work" },
+  null,
+  2,
+);
+
+function renderDrawer() {
+  return render(
+    <DrawerSurface
+      run={run}
+      filtered={[run]}
+      onSelect={() => {}}
+      onClose={() => {}}
+      onRerun={() => {}}
+    />,
+  );
+}
+
+function mockClipboard(writeText: () => Promise<void>) {
+  const spy = vi.fn(writeText);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: spy },
+    configurable: true,
+    writable: true,
+  });
+  return spy;
+}
+
+describe("run drawer Inputs copy button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a copy affordance for the Inputs JSON block", () => {
+    renderDrawer();
+    // The regression this guards: the Inputs <pre> shipped with no copy button at all, unlike every
+    // other code/JSON block in the app.
+    expect(screen.getByRole("button", { name: "Copy inputs JSON" })).toBeTruthy();
+  });
+
+  it("copies exactly the JSON shown in the Inputs block", async () => {
+    const writeText = mockClipboard(() => Promise.resolve());
+    const { container } = renderDrawer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy inputs JSON" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expectedJson));
+    // The rendered <pre> and the clipboard payload come from one hoisted string, so they cannot drift.
+    // Compared against textContent rather than getByText because the latter collapses the JSON's
+    // newlines and indentation, which is precisely what must match here.
+    expect(container.querySelector("pre")?.textContent).toBe(expectedJson);
+  });
+
+  it("reports success through the same toast channel as the drawer's other copy actions", async () => {
+    mockClipboard(() => Promise.resolve());
+    renderDrawer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy inputs JSON" }));
+
+    await waitFor(() =>
+      expect(success).toHaveBeenCalledWith("Inputs copied", {
+        description: "plan-next-work inputs are ready to paste.",
+      }),
+    );
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a toast instead of throwing when the clipboard write is rejected", async () => {
+    // A permission-denied clipboard rejects; the handler's catch arm is the branch that keeps a denied
+    // copy from becoming an unhandled rejection.
+    mockClipboard(() => Promise.reject(new Error("denied")));
+    renderDrawer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy inputs JSON" }));
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith("Couldn't copy inputs"));
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  it("leaves the existing Permalink copy action untouched", async () => {
+    const writeText = mockClipboard(() => Promise.resolve());
+    renderDrawer();
+
+    fireEvent.click(screen.getByRole("button", { name: /permalink/i }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("selected=run_1")),
+    );
+    expect(success).toHaveBeenCalledWith("Permalink copied", expect.anything());
+  });
+});

--- a/apps/loopover-ui/src/routes/app.runs.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "motion/react";
 import {
   ChevronLeft,
   ChevronRight,
+  Copy,
   Filter,
   Link2,
   RotateCw,
@@ -686,7 +687,9 @@ function RunDrawer({
   );
 }
 
-function DrawerSurface({
+// Exported for unit tests: the drawer body is only ever reached through the route's data-fetching
+// component, so mounting it directly is what lets its copy affordances be asserted without a router.
+export function DrawerSurface({
   run,
   filtered,
   onSelect,
@@ -710,6 +713,22 @@ function DrawerSurface({
       toast.success("Permalink copied", { description: url });
     } catch {
       toast.error("Couldn't copy permalink");
+    }
+  };
+
+  // Rendered into the <pre> below *and* handed to the clipboard, so the copied text can never drift
+  // from the text on screen.
+  const inputsJson = JSON.stringify(
+    { repo: run.repo, source: run.source, kind: run.kind },
+    null,
+    2,
+  );
+  const copyInputs = async () => {
+    try {
+      await navigator.clipboard.writeText(inputsJson);
+      toast.success("Inputs copied", { description: `${run.kind} inputs are ready to paste.` });
+    } catch {
+      toast.error("Couldn't copy inputs");
     }
   };
   const closeRef = useRef<HTMLButtonElement | null>(null);
@@ -813,11 +832,22 @@ function DrawerSurface({
         </div>
 
         <div>
-          <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-            Inputs
+          <div className="flex items-center justify-between gap-2">
+            <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+              Inputs
+            </div>
+            <button
+              type="button"
+              onClick={copyInputs}
+              aria-label="Copy inputs JSON"
+              className="inline-flex items-center justify-center gap-1.5 rounded-token border border-border px-2 py-1 text-token-2xs text-foreground/90 transition-colors hover:bg-accent focus-ring"
+            >
+              <Copy className="size-3" />
+              Copy
+            </button>
           </div>
           <pre className="mt-2 overflow-x-auto rounded-token border border-border bg-background/60 p-3 font-mono text-token-2xs text-foreground/90">
-            {JSON.stringify({ repo: run.repo, source: run.source, kind: run.kind }, null, 2)}
+            {inputsJson}
           </pre>
         </div>
 


### PR DESCRIPTION
## What

`app.runs.tsx`'s run drawer rendered its **Inputs** JSON into a bare `<pre>` with no copy affordance, while every other code/JSON block in the app ships one — `CodeBlock`'s hover-revealed button, the Playground panel's "Copy output", and this same drawer's own **Permalink** action ~120 lines below. The Inputs block was the odd one out.

This adds an icon button beside the `Inputs` label that copies the block.

## How

- **Mirrors the existing Permalink action** in the same drawer: same `rounded-token border border-border … hover:bg-accent focus-ring` markup, scaled to `px-2 py-1` / `size-3` to sit on the label row, and the same `toast.success` / `toast.error` signalling used by every copy call site in this file.
- **The JSON is hoisted to one `inputsJson` const** that feeds both the `<pre>` and the clipboard write. Previously the object literal lived inline in the JSX; had the copy handler re-stringified it, the copied text could silently drift from the text on screen. One source of truth makes that unrepresentable.
- `DrawerSurface` is exported so the drawer body can be mounted directly in a unit test — it is otherwise only reachable through the route's data-fetching component, which would require a router and a live API to exercise.

## Testing

`apps/loopover-ui/src/routes/app.runs.test.tsx` (new, 5 cases): the button renders; it copies **exactly** the JSON shown in the `<pre>` (compared against `textContent`, since `getByText` collapses the newlines and indentation that are the point here); success toasts; a rejected clipboard write surfaces `toast.error` rather than an unhandled rejection; and the pre-existing Permalink action still works.

**The regression is proven, not assumed.** Against this component without the fix (export added so the suite can mount it at all), the 4 copy-button cases fail with `Unable to find an accessible element with the role "button" and name "Copy inputs JSON"`, while the Permalink case still passes — confirming the suite pins the new behaviour and does not merely restate the diff.

Full gate green locally at this base: `ui:typecheck`, `ui:lint`, `ui:test` (**77 files / 590 tests**), `ui:build`, plus `selfhost:env-reference:check`, `command-reference:check`, `docs:drift-check`, `ui:openapi:check`, `ui:openapi:settings-parity`, `ui:version-audit`.

On the issue's coverage note: `vitest.config.ts` sets `coverage.exclude: ["src/env.d.ts", "apps/**"]`, so the Codecov patch gate does not measure this path — the test above is included because the behaviour is worth pinning, not to satisfy that gate. No screenshot table: the change adds a standard icon button to an existing label row and ships no other visual change.

Closes #6815
