### PR TITLE
chore(config): fix stale gittensory prose in wrangler.jsonc comments

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -90,7 +90,7 @@
     // NEVER surfaced publicly. Default OFF — flag-OFF reads nothing, records nothing, and leaves the AI-spend
     // gate byte-identical.
     "LOOPOVER_REVIEW_REPUTATION": "false",
-    // Convergence (ops / observability): drive two OPERATOR surfaces off gittensory's own review-outcome data
+    // Convergence (ops / observability): drive two OPERATOR surfaces off loopover's own review-outcome data
     // — (1) a cron-tick anomaly scan over the gate-block ledger + recommendation/slop calibration that emits a
     // structured `ops_anomaly` log on drift, and (2) a bearer-gated GET /v1/internal/ops/stats outcome
     // aggregate. Read-only observability; the auto-tune/config-mutation self-improve loop is NOT wired here.
@@ -149,7 +149,7 @@
     // identical until deliberately enabled per-repo. See review/content-lane-wire.
     "LOOPOVER_REVIEW_CONTENT_LANE": "false",
     // Convergence (self-improve / auto-tune): run the ported self-improvement loop on the cron tick over
-    // gittensory's own review-outcome data — compute tuning recommendations, SHADOW-SOAK any strictly-
+    // loopover's own review-outcome data — compute tuning recommendations, SHADOW-SOAK any strictly-
     // tightening one, and AUTO-PROMOTE it to live ONLY after the soak window passes the gate; every action is
     // audited. It can ONLY EVER tighten the gate (a loosening recommendation is never applied). Default OFF —
     // flag-OFF the cron enqueues no selftune job, does zero tuning work, reads/writes no override, byte-
@@ -157,14 +157,14 @@
     // follow-up — see src/review/selftune-wire.ts.
     "LOOPOVER_REVIEW_SELFTUNE": "false",
     // Experimental `gittensor` plugin (the `experimental:` manifest block, first key): the operator-level
-    // kill-switch for gittensory's original subnet mining-registry/scoring integration, now opt-in rather than
+    // kill-switch for loopover's original subnet mining-registry/scoring integration, now opt-in rather than
     // a core dependency. ANDed with the per-repo `.loopover.yml experimental.gittensor` opt-in — neither
     // alone is sufficient, and unlike `features:` there is no LOOPOVER_REVIEW_REPOS allowlist fallback.
     // Default OFF — flag-OFF (or every repo unset), refresh-registry is never enqueued (see src/index.ts),
     // registry/sync.ts persists nothing for this instance, and a self-host box makes zero outbound contact
     // with the gittensor subnet registry. See src/review/gittensor-wire.ts.
     "LOOPOVER_EXPERIMENTAL_GITTENSOR": "false",
-    // Maintainer recap digest (#1963, #2248): deliver a cross-repo RecapReport -- gittensory's own gate-
+    // Maintainer recap digest (#1963, #2248): deliver a cross-repo RecapReport -- loopover's own gate-
     // precision + outcome-calibration data folded across every scanned repo -- to Discord on a cron cadence
     // (LOOPOVER_RECAP_CADENCE=daily|weekly, default weekly; LOOPOVER_RECAP_HOUR / LOOPOVER_RECAP_DAY
     // pick when). Default OFF — flag-OFF the cron enqueues no recap job, byte-identical to today.
@@ -175,7 +175,7 @@
     // ON, the GraphQL path reuses the REST-resolved required contexts and still falls back to REST on any error,
     // unexpected shape, or >100 rollup contexts.
     "GITHUB_STATUS_ROLLUP_GRAPHQL": "false",
-    // Convergence (#issue-coding-plan): the `@gittensory plan` command. Default OFF — `@gittensory plan` falls
+    // Convergence (#issue-coding-plan): the `@loopover plan` command. Default OFF — `@loopover plan` falls
     // through to the existing mention path (byte-identical). Hosted planning is retired with the Cloudflare AI
     // binding; self-host can run planning through the configured self-host AI provider.
     "LOOPOVER_REVIEW_PLANNER": "false",
@@ -192,7 +192,7 @@
     // Convergence (cutover): comma-separated allowlist of repo full-names ("owner/repo") that may run the
     // PER-PR converged review features (safety, grounding, RAG, reputation, unified comment). A feature
     // activates for a repo ONLY when its global flag above is ON AND the repo is listed here — so the cutover
-    // rolls forward one repo at a time (e.g. "JSONbored/gittensory,JSONbored/awesome-claude"). Default "" →
+    // rolls forward one repo at a time (e.g. "JSONbored/loopover,JSONbored/awesome-claude"). Default "" →
     // NO repos converged → the per-PR converged path stays dormant for every repo regardless of the global
     // flags (byte-identical to today). The cron/endpoint flags (ops/selftune/parity/draft) stay global.
     "LOOPOVER_REVIEW_REPOS": "",


### PR DESCRIPTION
## Summary

- Continues the repo-wide gittensory -> loopover rebrand cleanup sweep. `wrangler.jsonc` is the live Cloudflare Worker config, so this is deliberately its own small, isolated PR (comment-only, nothing else bundled in).
- Five self-referential comments in the `vars` block still said "gittensory" meaning "this app" (e.g. "drive two OPERATOR surfaces off gittensory's own review-outcome data"), and one described a since-renamed mention-command prefix ("the `@gittensory plan` command" -- `src/github/commands.ts`'s actual mention regex has matched `@loopover` for a while now, verified directly). Also fixed one illustrative repo-list example in a comment.
- **No `vars` values changed** -- verified with `npm run cf-typegen:check` that `worker-configuration.d.ts` is still up to date (the generated types only capture binding/var shapes, not comments), and checked that none of the handful of tests referencing `"wrangler.jsonc"` inspect this file's actual comment prose (they only use the string as a path/guardrail-classification fixture).
- Explicitly re-verified and left untouched:
  - The unrelated `gittensor` (Bittensor subnet) naming at a few nearby lines -- a different term entirely, not part of this rebrand.
  - The `gittensory-native` DB source-column literal and its explanatory comment -- a real value compared against historical rows.
  - The `JSONbored/gittensory` entry in `LOOPOVER_PUBLIC_STATS_REPOS` -- explicitly justified by the adjacent comment (this repo's own pre-rename `audit_events` rows are still stored under the old `full_name`).
  - The queue-rename and domain-retirement history comments -- accurate past-tense descriptions of things already renamed/retired.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- **no issue linked**: repo-owner-requested maintainer-equivalent cleanup pass, not a contributor fix tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (comment-only change; no `vars`/binding shape touched)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] Full `npm run test:ci` green end to end, exit code captured directly (0)
- [x] `npm run cf-typegen:check` passes -- confirms `worker-configuration.d.ts` is unaffected
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- N/A, comment-only change, no runtime behavior touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- N/A, no such change (comments only).
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, no visible change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Third in a small series of PRs sweeping the remaining `gittensory` references left over from the rebrand (#6826 self-hosting docs, #6841 root/infra config). This is deliberately the smallest, most isolated one given the file's stakes.