### PR TITLE
fix(auth): give device-flow polling its own rate-limit budget

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -3921,7 +3921,20 @@ async function loginWithDeviceFlow() {
   let intervalMs = Math.max(5, Number(start.interval ?? 5)) * 1000;
   while (Date.now() < deadline) {
     await sleep(intervalMs);
-    const result = await apiFetch("/v1/auth/github/device/poll", { method: "POST", body: JSON.stringify({ deviceCode: start.deviceCode }) }, { auth: false });
+    let result;
+    try {
+      result = await apiFetch("/v1/auth/github/device/poll", { method: "POST", body: JSON.stringify({ deviceCode: start.deviceCode }) }, { auth: false });
+    } catch (error) {
+      // A transient 429 from our own rate limiter (#6792) is not a GitHub-reported device-flow status --
+      // back off using the server's Retry-After and keep polling within the deadline, the same posture
+      // already applied to GitHub's own "slow_down" status below, instead of aborting the whole attempt.
+      if (error?.status === 429) {
+        const retryAfterSeconds = Number(/retry-after=(\d+)s/.exec(error.message)?.[1]);
+        intervalMs = Math.max(intervalMs, (Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : 5) * 1000);
+        continue;
+      }
+      throw error;
+    }
     if (result.token) return result;
     if (result.status === "slow_down") intervalMs += 5000;
     if (result.status && result.status !== "authorization_pending" && result.status !== "slow_down") throw new Error(`GitHub OAuth failed: ${result.status}`);

--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -122,6 +122,13 @@ export function routeClassForPath(path: string): RateLimitClass {
   // self-host instances. Strict (10/min per IP) caps abuse — legitimate instances export hourly.
   if (path === "/v1/orb/ingest") return "strict";
   if (path === "/v1/auth/session" || path === "/v1/auth/logout") return "normal";
+  // GitHub's OAuth Device Authorization Grant (RFC 8628) is polling-by-design: a client polls
+  // /device/poll at a server-specified interval (this repo's own default is 5s) for up to the device
+  // code's full expiry window (900s / 15 minutes here) -- normal human completion time alone can
+  // exceed the blanket strict class's 10-req/60s budget well before the code even expires (#6792).
+  // /device/start shares the same generous class since a retried/failed start attempt shouldn't eat
+  // into the same tight budget a poll loop needs.
+  if (path === "/v1/auth/github/device/poll" || path === "/v1/auth/github/device/start") return "normal";
   if (path.startsWith("/v1/auth/")) return "strict";
   if (path === "/loopover/shot") return "expensive";
   if (

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -466,9 +466,11 @@ describe("api route guards and error branches", () => {
     expect(noOriginPreflight.headers.get("access-control-allow-origin")).toBeNull();
 
     const limitedEnv = createTestEnv({ RATE_LIMITER: denyAllRateLimiter() as unknown as DurableObjectNamespace });
+    // #6792: device/start (and device/poll) get the "normal" class, not the blanket /v1/auth/* strict
+    // one -- a spec-compliant device-flow poller needs a budget sized for its own polling cadence.
     const limited = await app.request("/v1/auth/github/device/start", { method: "POST" }, limitedEnv);
     expect(limited.status).toBe(429);
-    await expect(limited.json()).resolves.toMatchObject({ error: "rate_limited", routeClass: "strict" });
+    await expect(limited.json()).resolves.toMatchObject({ error: "rate_limited", routeClass: "normal" });
     expect((await app.request("/v1/repos", { headers: apiHeaders(limitedEnv) }, limitedEnv)).status).toBe(429);
 
     const allowedRateEnv = createTestEnv({ RATE_LIMITER: allowRateLimiter() as unknown as DurableObjectNamespace });

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -112,7 +112,11 @@ describe("private-beta auth and rate limiting", () => {
   it("classifies rate-limit route costs", () => {
     expect(routeClassForPath("/v1/github/webhook")).toBe("strict");
     expect(routeClassForPath("/v1/orb/ingest")).toBe("strict"); // open telemetry ingest — abuse-capped per IP
-    expect(routeClassForPath("/v1/auth/github/device/start")).toBe("strict");
+    // #6792: device-flow start/poll get the same generous "normal" budget as /v1/auth/session and
+    // /v1/auth/logout, not the blanket /v1/auth/* strict class — a spec-compliant poller (RFC 8628)
+    // exhausts a 10-req/60s budget well within a human's normal completion time otherwise.
+    expect(routeClassForPath("/v1/auth/github/device/start")).toBe("normal");
+    expect(routeClassForPath("/v1/auth/github/device/poll")).toBe("normal");
     expect(routeClassForPath("/v1/auth/github/token")).toBe("strict"); // #6117: same strict cap as the rest of /v1/auth/*
     expect(routeClassForPath("/v1/local/branch-analysis")).toBe("expensive");
     expect(routeClassForPath("/loopover/shot")).toBe("expensive");

--- a/test/unit/mcp-cli-profiles.test.ts
+++ b/test/unit/mcp-cli-profiles.test.ts
@@ -227,4 +227,25 @@ describe("loopover-mcp CLI — profiles", () => {
     expect(telemetryHeaders).not.toContain("session-token");
     expect(telemetryHeaders).not.toContain(tempDir);
   });
+
+  it("#6792: loginWithDeviceFlow backs off and keeps polling through a transient 429 from our own rate limiter instead of aborting", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
+    const url = await startFixtureServer({
+      deviceFlowStart: { deviceCode: "device-code-1", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", interval: 0 },
+      deviceFlowPollResponses: [
+        { status: 429, retryAfterSeconds: 1, body: { error: "rate_limited", routeClass: "normal" } },
+        { body: { token: "device-session-token", login: "JSONbored", expiresAt: "2026-06-02T00:00:00.000Z", scopes: ["repo"] } },
+      ],
+    });
+
+    const login = JSON.parse(
+      await runAsync(["login", "--json"], {
+        LOOPOVER_API_URL: url,
+        LOOPOVER_CONFIG_DIR: tempDir,
+        LOOPOVER_SKIP_NPM_VERSION_CHECK: "true",
+      }),
+    ) as { status: string; login: string };
+
+    expect(login).toMatchObject({ status: "authenticated", login: "JSONbored" });
+  }, 20000);
 });

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -156,8 +156,14 @@ export async function startFixtureServer(
     openPrMonitor?: Record<string, unknown>;
     intakeStatus?: number;
     localBranchAnalysisStatus?: number;
+    /** #6792: queued /v1/auth/github/device/poll responses, consumed one per request -- the last entry
+     *  repeats once exhausted. Lets a test simulate a transient 429 (or GitHub's own slow_down/pending
+     *  statuses) before the device flow eventually resolves. Requires deviceFlowStart to be set too. */
+    deviceFlowStart?: { deviceCode: string; userCode: string; verificationUri: string; expiresIn?: number; interval?: number };
+    deviceFlowPollResponses?: Array<{ status?: number; retryAfterSeconds?: number; body: unknown }>;
   } = {},
 ) {
+  let deviceFlowPollCallCount = 0;
   server = createServer(async (request, response) => {
     options.onApiRequest?.(request);
     response.setHeader("content-type", "application/json");
@@ -232,6 +238,21 @@ export async function startFixtureServer(
     }
     if (request.url === "/v1/auth/logout" && request.method === "POST") {
       response.end(JSON.stringify({ status: "logged_out" }));
+      return;
+    }
+    if (request.url === "/v1/auth/github/device/start" && request.method === "POST" && options.deviceFlowStart) {
+      const start = options.deviceFlowStart;
+      response.end(JSON.stringify({ status: "pending", deviceCode: start.deviceCode, userCode: start.userCode, verificationUri: start.verificationUri, expiresIn: start.expiresIn ?? 900, interval: start.interval ?? 5 }));
+      return;
+    }
+    if (request.url === "/v1/auth/github/device/poll" && request.method === "POST" && options.deviceFlowPollResponses) {
+      await readJsonRequest(request);
+      const responses = options.deviceFlowPollResponses;
+      const next = responses[Math.min(deviceFlowPollCallCount, responses.length - 1)];
+      deviceFlowPollCallCount += 1;
+      response.statusCode = next?.status ?? 200;
+      if (next?.retryAfterSeconds !== undefined) response.setHeader("retry-after", String(next.retryAfterSeconds));
+      response.end(JSON.stringify(next?.body ?? {}));
       return;
     }
     if (request.url === "/v1/contributors/JSONbored/decision-pack" && request.method === "GET") {


### PR DESCRIPTION
## Summary
- `/v1/auth/github/device/poll` (and `/device/start`) inherited the blanket `/v1/auth/*` strict class (10 req/60s), but GitHub's OAuth Device Authorization Grant (RFC 8628) is polling-by-design at a server-specified interval for up to the code's full expiry window — a spec-compliant poller reliably exhausts that budget within seconds, well before a human can realistically complete authorization.
- Reclassifies both routes to the same "normal" (120 req/60s) budget `/v1/auth/session` and `/v1/auth/logout` already use.
- Makes `loopover-mcp`'s own `loginWithDeviceFlow` resilient to a transient 429 from this same rate limiter — backs off using the server's `Retry-After` the same way it already handles GitHub's own `slow_down` status, instead of aborting the whole login attempt.

Closes #6792

## Test plan
- [x] `npm run test:ci` — full local gate green
- [x] New regression test: a real `loopover-mcp login` run (no `--github-token`) through the CLI harness's fixture server, simulating a 429-then-success poll sequence
- [x] Updated existing `routeClassForPath`/rate-limit assertions for the reclassified routes