### PR TITLE
fix(signals): make shouldPublishPrIntelligenceComment respect commentMode for oss_maintainer (#6776)

### DIFF
--- a/packages/loopover-engine/src/signals/engine.ts
+++ b/packages/loopover-engine/src/signals/engine.ts
@@ -1419,7 +1419,11 @@ export function detectGittensorContributor(
 export function shouldPublishPrIntelligenceComment(settings: RepositorySettings, detection: ContributorDetection): boolean {
   if (settings.commentMode === "off") return false;
   if (settings.publicSurface !== "comment_and_label" && settings.publicSurface !== "comment_only") return false;
-  if (settings.publicAudienceMode === "oss_maintainer") return settings.commentMode === "all_prs" || detection.detected || detection.source !== "official_gittensor_api";
+  // #6776: gate on commentMode, not the audience. The dropped `detection.source !== "official_gittensor_api"`
+  // disjunct was a tautology -- source is only ever "official_gittensor_api" (paired with detected: true) or
+  // undefined, so it was true whenever `detected` was false, making the whole branch unconditionally true and
+  // silently treating `detected_contributors_only` as `all_prs` for every oss_maintainer repo.
+  if (settings.publicAudienceMode === "oss_maintainer") return settings.commentMode === "all_prs" || detection.detected;
   return detection.detected && detection.source === "official_gittensor_api";
 }
 

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -820,6 +820,19 @@ describe("world-class backend signals", () => {
     expect(shouldPublishPrIntelligenceComment({ ...settings, commentMode: "all_prs" }, undetected)).toBe(false);
     expect(shouldPublishPrIntelligenceComment({ ...settings, commentMode: "all_prs" }, cachedDetected)).toBe(false);
     expect(shouldPublishPrIntelligenceComment({ ...settings, commentMode: "all_prs" }, { ...cachedDetected, source: "official_gittensor_api" })).toBe(true);
+
+    // #6776: the oss_maintainer branch must respect commentMode, not silently treat detected_contributors_only
+    // as all_prs. (The dropped `source !== "official_gittensor_api"` disjunct was a tautology making it always true.)
+    const ossSettings = { ...settings, publicAudienceMode: "oss_maintainer" as const };
+    // commentMode: all_prs short-circuits true even for an undetected contributor.
+    expect(shouldPublishPrIntelligenceComment({ ...ossSettings, commentMode: "all_prs" }, undetected)).toBe(true);
+    // REGRESSION: detected_contributors_only + an undetected contributor → false (previously an always-true tautology).
+    expect(shouldPublishPrIntelligenceComment({ ...ossSettings, commentMode: "detected_contributors_only" }, undetected)).toBe(false);
+    // A detected (even non-official) contributor still comments: the gate is now commentMode + detected, with no
+    // audience/source carve-out — locking in the intended, tautology-free semantics.
+    expect(cachedDetected.detected).toBe(true);
+    expect(cachedDetected.source).not.toBe("official_gittensor_api");
+    expect(shouldPublishPrIntelligenceComment({ ...ossSettings, commentMode: "detected_contributors_only" }, cachedDetected)).toBe(true);
   });
 
   it("returns hold/caution opportunities for inactive and issue-discovery lanes", () => {


### PR DESCRIPTION
## Summary

`shouldPublishPrIntelligenceComment` (`packages/loopover-engine/src/signals/engine.ts`) gated the
`oss_maintainer` audience on:

```ts
return settings.commentMode === "all_prs" || detection.detected || detection.source !== "official_gittensor_api";
```

The third disjunct is a **tautology**. `detection.source` is only ever `"official_gittensor_api"` (always
paired with `detected: true`) or `undefined` — no construction path produces `detected: false` with
`source: "official_gittensor_api"`. So `detection.source !== "official_gittensor_api"` is `true` exactly when
`detected` is `false`, making the whole expression **unconditionally true**. For every `oss_maintainer`-audience
repo, `commentMode: "detected_contributors_only"` silently behaved identically to `"all_prs"`, defeating the gate.

This drops the tautological disjunct:

```ts
return settings.commentMode === "all_prs" || detection.detected;
```

so the branch now respects `commentMode` (matching the documented single source of truth,
`shouldPublishPrComment` in `src/signals/settings-preview.ts`, which gates on `commentMode` with no audience
carve-out). The function has zero production callers today — it's a superseded duplicate — so this only removes a
latent trap for a future caller; live behavior is unchanged.

Adds the previously-absent `oss_maintainer`-branch test coverage, including the two regression cases the issue
calls for.

Closes #6776

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6776`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the one changed executable line (the `oss_maintainer` return) is exercised on **both** branches (`commentMode: all_prs` short-circuit true; `detected_contributors_only` with an undetected contributor → false; with a detected contributor → true), verified via `coverage-final.json`.
- [x] `npx vitest run test/unit/signals.test.ts test/unit/signals-coverage.test.ts` (92 passing)
- [x] engine `build` + `node --test` (588 passing) + `engine-parity:drift-check`

If any required check was skipped, explain why:

- No UI/OpenAPI/MCP/migration surface changed (a single backend predicate + its unit test), so `ui:*` / `ui:openapi:check` / `cf-typegen` / migration checks are N/A to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/MCP surface changed.
- [x] No visible UI changes (backend predicate only), so no `UI Evidence` section is required.
- [x] Public docs/changelogs: none needed; no changelog edited.

## Notes

- `shouldPublishPrIntelligenceComment` has zero production callers in `src/` (verified), so this is behavior-preserving for the live webhook/preview paths — it removes a tautology that would otherwise mislead any future caller relying on `commentMode` for an `oss_maintainer` repo.
