### PR TITLE
docs(miner): fix stale gittensory prose and broken links in loopover-miner docs

### DIFF
--- a/packages/loopover-miner/DEPLOYMENT.md
+++ b/packages/loopover-miner/DEPLOYMENT.md
@@ -126,7 +126,7 @@ fails the container fast with a clear error naming the file path, rather than si
 credential. The same `<NAME>_FILE` convention works for any credential the miner reads from a plain env var —
 not only `GITHUB_TOKEN`.
 
-The repo-root [`docker-compose.yml`](../../docker-compose.yml) documents the **self-hosted review stack** (the `gittensory` API/orb), not the miner CLI. Miners are clients of that stack (or of github.com directly) and do not require it to run locally.
+The repo-root [`docker-compose.yml`](../../docker-compose.yml) documents the **self-hosted review stack** (the `loopover` API/orb), not the miner CLI. Miners are clients of that stack (or of github.com directly) and do not require it to run locally.
 
 ### Docker Compose (fleet mode)
 

--- a/packages/loopover-miner/Dockerfile
+++ b/packages/loopover-miner/Dockerfile
@@ -9,8 +9,8 @@ ARG LOOPOVER_VERSION=
 FROM public.ecr.aws/docker/library/node:24-slim AS build
 WORKDIR /app
 # Full source BEFORE `npm ci`: npm workspaces only symlinks packages that already exist on disk.
-# Same ordering fix as the root gittensory-api Dockerfile — @loopover/engine must be
-# present when `npm ci` runs or gittensory-miner's workspace dependency cannot resolve.
+# Same ordering fix as the root loopover-api Dockerfile — @loopover/engine must be
+# present when `npm ci` runs or loopover-miner's workspace dependency cannot resolve.
 COPY . .
 RUN npm ci --ignore-scripts
 RUN npm --workspace @loopover/engine run build

--- a/packages/loopover-miner/README.md
+++ b/packages/loopover-miner/README.md
@@ -39,7 +39,7 @@ It never clones source and never writes to GitHub.
 
 Discovery is per-tenant, not github.com-specific (#4784): `lib/forge-config.js` (`resolveForgeConfig`) holds the
 forge base URL, API version, request headers, repo path, search endpoint/qualifiers, user-agent, and credential env
-var behind one resolver with gittensory's github.com values as the only defaults, so the fan-out targets another
+var behind one resolver with loopover's github.com values as the only defaults, so the fan-out targets another
 forge unchanged. `loopover-miner discover` surfaces `--api-base-url <url>` and `--token-env <VAR>` and forwards a
 tenant goal spec to the ranker, printing `usedDefaultGoalSpec` so a fall-back to the built-in rubric is explicit
 rather than silent. See [`docs/repo-agnostic-capability-audit.md`](docs/repo-agnostic-capability-audit.md) for the
@@ -53,7 +53,7 @@ throws, and per its acceptance criteria **fails closed** — a repo with no reco
 `{ detected: false, reason }` and a command that can't be inferred without guessing stays `null`, rather than being
 assumed. The attempt path consumes it: `buildCodingTaskSpec` appends the real stack summary (and any
 confidently-inferred build/test/lint/format commands) to the coding-agent instructions so validation uses
-the target repo's own tooling rather than assuming LoopOver/gittensory CI ([#4786](https://github.com/JSONbored/gittensory/issues/4786)). (#4785)
+the target repo's own tooling rather than assuming LoopOver's own CI conventions ([#4786](https://github.com/JSONbored/gittensory/issues/4786)). (#4785)
 
 The package also includes an append-only governor decision ledger: `initGovernorLedger` / `appendGovernorEvent`
 persist structured allow/deny/throttle/kill-switch outcomes in local SQLite for contributor audit. Insert-only —
@@ -79,7 +79,7 @@ deleted. (#2322)
 
 The package also records local PR outcomes: `recordPrOutcomeSnapshot` / `readPrOutcomes` write and reduce the
 miner's OWN record of the outcomes of its OWN PRs (merged / closed, with an optional rejection-reason bucket) over
-the append-only event ledger above. This is DISTINCT from the gittensory server's `recordPrOutcome`
+the append-only event ledger above. This is DISTINCT from the loopover server's `recordPrOutcome`
 (`src/review/outcomes-wire.ts`), which writes hosted-backend audit rows from the GitHub App's webhook stream — same
 concept name, different codebase layer, no shared code (a laptop-mode miner may have no webhook relay at all). (#4274)
 

--- a/packages/loopover-miner/docs/ams-auth-identity-research.md
+++ b/packages/loopover-miner/docs/ams-auth-identity-research.md
@@ -2,7 +2,7 @@
 
 Research spike for **#5217**. AMS has no auth/identity layer today — self-host is single-operator, single-machine,
 with no login concept at all. A hosted AMS needs one. This document surveys realistic approaches, evaluated
-**against the installation-token / GitHub App patterns gittensory already operates** (ORB's token-broker,
+**against the installation-token / GitHub App patterns loopover already operates** (ORB's token-broker,
 `src/orb/broker.ts`), so the eventual auth/identity design issue starts from a baseline consistent with existing
 infrastructure rather than an unrelated auth stack. **Research and writeup only — no auth flow, token exchange,
 or provider integration is implemented or decided here; the output is a non-binding input to the maintainer-owned

--- a/packages/loopover-miner/docs/coding-agent-driver.md
+++ b/packages/loopover-miner/docs/coding-agent-driver.md
@@ -6,7 +6,7 @@ provider-agnostic contract, so the rest of the miner — planning, attempt loggi
 has to know which backend actually did the work.
 
 The interface itself lives in `@loopover/engine`
-([`packages/loopover-engine/src/miner/coding-agent-driver.ts`](../../gittensory-engine/src/miner/coding-agent-driver.ts));
+([`packages/loopover-engine/src/miner/coding-agent-driver.ts`](../../loopover-engine/src/miner/coding-agent-driver.ts));
 the orchestration around it (mode gating, invocation, the factory) lives in the sibling modules described below.
 
 > **See also:** [Observing your miner](observability.md) — point Grafana at the miner's local SQLite ledgers

--- a/packages/loopover-miner/docs/cross-repo-evaluation.md
+++ b/packages/loopover-miner/docs/cross-repo-evaluation.md
@@ -1,7 +1,7 @@
 # Cross-repo evaluation harness
 
 The **cross-repo evaluation harness** (#4788) is a repeatable readiness check that asks whether the miner can
-approach a diverse benchmark repo set **without gittensory-specific target-repo configuration** (no
+approach a diverse benchmark repo set **without loopover-specific target-repo configuration** (no
 `.loopover-miner.yml` required in the benchmark repos). It exercises the same offline path a real attempt uses
 before the coding agent runs:
 
@@ -9,7 +9,7 @@ before the coding agent runs:
 2. **Stack auto-detection** (`detectRepoStack`, #4785)
 3. **Coding-task spec composition** (`buildCodingTaskSpec`, #4786) including validation guidance derived from the
    detected stack
-4. **Assumption scan** — agent instructions must not positively mandate LoopOver/gittensory CI conventions
+4. **Assumption scan** — agent instructions must not positively mandate LoopOver's own CI conventions
 
 Each benchmark repo receives a **pass/fail** line. Failures are categorized:
 
@@ -17,7 +17,7 @@ Each benchmark repo receives a **pass/fail** line. Failures are categorized:
 | --- | --- |
 | `stack_detection_gap` | No recognized manifest / stack could not be inferred |
 | `execution_gap` | Stack detected but the coding-task path is not ready (e.g. missing inferred test command when required) |
-| `gittensory_assumption` | Agent instructions leak gittensory-specific CI assumptions |
+| `loopover_assumption` | Agent instructions leak loopover-specific CI assumptions |
 | `clone_setup` | The repo has not been cloned to the expected cache path |
 | `other` | Unexpected errors |
 

--- a/packages/loopover-miner/docs/miner-selfimprove-calibration.md
+++ b/packages/loopover-miner/docs/miner-selfimprove-calibration.md
@@ -14,7 +14,7 @@ that could do it would defeat the safety it exists to provide.
 ## What calibration measures
 
 The engine contract is `Phase7CalibrationLoopResult`
-([`packages/loopover-engine/src/phase7-calibration-loop.ts`](../../gittensory-engine/src/phase7-calibration-loop.ts)):
+([`packages/loopover-engine/src/phase7-calibration-loop.ts`](../../loopover-engine/src/phase7-calibration-loop.ts)):
 it combines the **historical-replay** composite score with the passive **`pr_outcome`** signal and tracks accuracy
 against the documented **`DOCUMENTED_CALIBRATION_BASELINE = 0.62`** (the 62% self-review baseline from the Phase 7
 roadmap). The engine owns the deterministic combine / freshness / threshold / hold-reason logic; the miner runtime
@@ -120,7 +120,7 @@ From any contributor-safe tool in this batch:
 
 ## References
 
-- [`packages/loopover-engine/src/phase7-calibration-loop.ts`](../../gittensory-engine/src/phase7-calibration-loop.ts) — the calibration-loop contract + `DOCUMENTED_CALIBRATION_BASELINE`.
+- [`packages/loopover-engine/src/phase7-calibration-loop.ts`](../../loopover-engine/src/phase7-calibration-loop.ts) — the calibration-loop contract + `DOCUMENTED_CALIBRATION_BASELINE`.
 - `src/review/parity.ts` — `GateEvalRow` (the confusion matrix) and `REVERSAL_DISCOUNT_WEIGHT` (value-weighting).
 - `src/review/auto-tune.ts` — the existing hold-only accuracy circuit-breaker (#2352's eventual consumer).
 - `src/selfhost/orb-collector.ts` — the anonymized HMAC-with-local-secret telemetry pattern.

--- a/packages/loopover-miner/docs/observability.md
+++ b/packages/loopover-miner/docs/observability.md
@@ -91,7 +91,7 @@ family's metrics are simply omitted from the file for that run (logged to stderr
 
 ```sh
 # crontab -e
-*/5 * * * * LOOPOVER_MINER_CONFIG_DIR=/data/miner sh /path/to/gittensory/scripts/export-miner-prometheus-textfile.sh
+*/5 * * * * LOOPOVER_MINER_CONFIG_DIR=/data/miner sh /path/to/loopover/scripts/export-miner-prometheus-textfile.sh
 ```
 
 Then point your own `prometheus.yml` at node_exporter as usual — no changes to this repo's `prometheus/` config
@@ -102,7 +102,7 @@ alert rules that already target these exact metric names.
 ## Anonymized central telemetry (opt-in, off by default)
 
 Everything above stays entirely on your own machine. Separately, the miner can send a small, anonymized batch
-of its own PR-outcome history to gittensory's hosted AMS collector — the same fleet-growth/usage telemetry Orb's
+of its own PR-outcome history to loopover's hosted AMS collector — the same fleet-growth/usage telemetry Orb's
 self-host collector already sends for maintainers, mirrored for contributors:
 
 ```sh
@@ -124,6 +124,6 @@ maintainer-side collector) — every invocation requires `--enable --send` expli
 
 | Variable | Purpose |
 | --- | --- |
-| `LOOPOVER_MINER_AMS_COLLECTOR_URL` | Override the collector endpoint (default: gittensory's hosted collector). |
+| `LOOPOVER_MINER_AMS_COLLECTOR_URL` | Override the collector endpoint (default: loopover's hosted collector). |
 | `LOOPOVER_MINER_AMS_COLLECTOR_TOKEN` | Optional bearer credential, only needed if your collector requires one. |
 | `LOOPOVER_MINER_ORB_EXPORT_DB` | Override the local secret+cursor store path (default: `orb-export.sqlite3` under `LOOPOVER_MINER_CONFIG_DIR`). |

--- a/packages/loopover-miner/docs/repo-agnostic-capability-audit.md
+++ b/packages/loopover-miner/docs/repo-agnostic-capability-audit.md
@@ -100,8 +100,8 @@ redo them:
 
 ## Resolution (#4784)
 
-All five checklist items are resolved (or, where noted, explicitly deferred with a reason); gittensory's
-own github.com conventions survive only as defaults, and the existing gittensory discovery path is
+All five checklist items are resolved (or, where noted, explicitly deferred with a reason); loopover's
+own github.com conventions survive only as defaults, and the existing loopover discovery path is
 unchanged (`resolveForgeConfig()` with no overrides is byte-identical to the pre-#4784 hardcoded
 behavior).
 
@@ -120,7 +120,7 @@ behavior).
   reads a non-`GITHUB_TOKEN` variable, defaulting to `GITHUB_TOKEN`.
 - **Tenant goal spec through — resolved.** `runDiscover` forwards `goalSpecsByRepo` /
   `goalSpecContentByRepo` to the ranker and surfaces `usedDefaultGoalSpec` in both the JSON and the
-  human-readable summary, so the fall-back to gittensory's built-in rubric is explicit rather than
+  human-readable summary, so the fall-back to loopover's built-in rubric is explicit rather than
   silent. The **discovery** label taxonomy is the goal spec's generic `preferredLabels` /
   `blockedLabels` (already per-tenant). The engine's `DEFAULT_TYPE_LABELS` (`gittensor:*`) is a
   **review-stack** default (overridable per repo via the focus manifest) that the miner discovery

--- a/packages/loopover-miner/schema/miner-goal-spec.schema.json
+++ b/packages/loopover-miner/schema/miner-goal-spec.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://jsonbored.dev/schemas/gittensory-miner-goal-spec.json",
+  "$id": "https://jsonbored.dev/schemas/loopover-miner-goal-spec.json",
   "title": "MinerGoalSpec",
-  "description": "Per-repo miner configuration parsed from `.gittensory-miner.yml` (see packages/loopover-miner/docs/miner-goal-spec.md).",
+  "description": "Per-repo miner configuration parsed from `.loopover-miner.yml` (see packages/loopover-miner/docs/miner-goal-spec.md).",
   "type": "object",
   "additionalProperties": true,
   "properties": {


### PR DESCRIPTION
## Summary

- Continues the repo-wide gittensory -> loopover rebrand cleanup sweep, covering `packages/loopover-miner/`'s remaining stale "gittensory" self-references:
  - Two broken relative links to `packages/gittensory-engine/...` (the package was renamed to `loopover-engine`) in `docs/coding-agent-driver.md` and `docs/miner-selfimprove-calibration.md` (both occurrences in the latter).
  - `docs/cross-repo-evaluation.md`'s `gittensory_assumption` failure-category table entry was factually wrong -- the real constant's value (`lib/cross-repo-evaluation.js`'s `CROSS_REPO_FAILURE_CATEGORY.GITTENSOR_ASSUMPTION`) is literally `"loopover_assumption"`, verified directly against source.
  - `schema/miner-goal-spec.schema.json`'s `$id` and `description` referenced a `.gittensory-miner.yml` filename that never existed under that name -- the real, only-ever config filename is `.loopover-miner.yml` (verified against `packages/loopover-engine/src/miner-goal-spec.ts`'s file-discovery list).
  - Self-referential prose describing loopover's own current conventions, hosted AMS collector, and API/orb across `README.md`, `DEPLOYMENT.md`, `Dockerfile`, `docs/ams-auth-identity-research.md`, `docs/observability.md`.
  - `docs/repo-agnostic-capability-audit.md`'s `## Resolution (#4784)` section, which states current post-fix truth -- left the earlier "Findings by file/module" checklist section's own "gittensory"-as-concept prose alone, since that section is a deliberately-preserved pre-fix historical snapshot the Resolution section explicitly supersedes (mirrors the same judgment call already applied to the sibling `src/review/repo-agnostic-capability-audit.md` doc, not touched in this PR).
- Left every `github.com/JSONbored/gittensory/issues/NNNN` historical citation untouched -- confirmed this is an established, repo-wide convention (GitHub's rename redirect keeps them resolving; no other file anywhere in the repo rewrites this class of link), and left the Findings-section "gittensory"-as-concept prose in the audit doc alone for the same historical-snapshot reason.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- **no issue linked**: repo-owner-requested maintainer-equivalent cleanup pass, not a contributor fix tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (docs/schema-only change; no `src/**` lines touched)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] Full `npm run test:ci` green end to end, exit code captured directly (0). Note: two earlier attempts on this same diff transiently failed on one unrelated, pre-existing test (`test/unit/ai-summaries.test.ts`'s 30s-timeout AI-rewrite-iteration test) -- root-caused to concurrent CPU contention from another active local session's own full test run happening at the same time (confirmed via `ps`/`uptime`; load average was 40-75 during both failures), not this diff (it passes reliably in isolation and touches zero files this change relates to). Third attempt, after the contention subsided, was clean.
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- N/A, no runtime code changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, no visible change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Fourth in a small series of PRs sweeping the remaining `gittensory` references left over from the rebrand (#6826 self-hosting docs, #6841 root/infra config, #6849 wrangler.jsonc comments).