### PR TITLE
fix(miner): scope the managed-PR queue row to the polled forge host

### DIFF
--- a/packages/loopover-miner/lib/manage-poll.js
+++ b/packages/loopover-miner/lib/manage-poll.js
@@ -5,6 +5,7 @@ import {
   formatManagedPrIdentifier,
 } from "./manage-status.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
 
@@ -105,13 +106,27 @@ export function parseManagePollArgs(args = []) {
   };
 }
 
-function ensureManagedPrRow(portfolioQueue, repoFullName, prNumber) {
+/** The forge host a managed-PR row belongs to. Mirrors portfolio-queue-manager.js's own fold (and every
+ *  store's `normalizeApiBaseUrl`): omitted/blank → the github.com default, so a single-forge caller is
+ *  unaffected. Used only to COMPARE hosts here; `enqueue` still does its own normalization/validation. */
+function resolveManagedRowApiBaseUrl(apiBaseUrl) {
+  return typeof apiBaseUrl === "string" && apiBaseUrl.trim() ? apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
+}
+
+function ensureManagedPrRow(portfolioQueue, repoFullName, prNumber, apiBaseUrl) {
   const identifier = formatManagedPrIdentifier(prNumber);
+  // `listQueue(repoFullName)` is forge-BLIND, so the existence check has to compare the host too: the queue's
+  // composite (api_base_url, repo_full_name, identifier) key exists precisely so two hosts serving the same
+  // owner/repo name never collide (#5563). Without this scoping, the same repo+PR-number already tracked on
+  // ANOTHER host suppresses this host's row entirely.
+  const targetApiBaseUrl = resolveManagedRowApiBaseUrl(apiBaseUrl);
   const exists = portfolioQueue
     .listQueue(repoFullName)
-    .some((entry) => entry.identifier === identifier);
+    .some((entry) => entry.identifier === identifier && resolveManagedRowApiBaseUrl(entry.apiBaseUrl) === targetApiBaseUrl);
   if (!exists) {
-    portfolioQueue.enqueue({ repoFullName, identifier, priority: 0 });
+    // Thread the SAME apiBaseUrl the CI poll above used, so the row is scoped to the host it was polled from
+    // instead of silently defaulting to github.com.
+    portfolioQueue.enqueue({ repoFullName, identifier, priority: 0, apiBaseUrl });
   }
 }
 
@@ -155,7 +170,7 @@ export async function recordManagePollSnapshot(input, options = {}) {
   });
 
   if ((options.ensurePortfolioRow ?? true) && portfolioQueue) {
-    ensureManagedPrRow(portfolioQueue, repoFullName, input.prNumber);
+    ensureManagedPrRow(portfolioQueue, repoFullName, input.prNumber, options.apiBaseUrl);
   }
 
   const event = eventLedger.appendEvent({

--- a/test/unit/miner-manage-poll.test.ts
+++ b/test/unit/miner-manage-poll.test.ts
@@ -23,6 +23,7 @@ import {
   closeDefaultPortfolioQueueStore,
   initPortfolioQueueStore,
 } from "../../packages/loopover-miner/lib/portfolio-queue.js";
+import { DEFAULT_FORGE_CONFIG } from "../../packages/loopover-miner/lib/forge-config.js";
 
 const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
@@ -136,6 +137,47 @@ describe("loopover-miner manage poll (#2323/#2325)", () => {
         queueStatus: "queued",
       }),
     ]);
+  });
+
+  it("REGRESSION: scopes the managed-PR queue row to the polled forge host instead of silently defaulting to github.com (#6764)", async () => {
+    const { portfolioQueue, eventLedger } = tempStores();
+    const apiBaseUrl = "https://ghe.acme.example/api/v3";
+    const pollCheckRuns = vi.fn().mockResolvedValue(pollResult("success"));
+
+    await recordManagePollSnapshot(
+      { repoFullName: "acme/widgets", prNumber: 12, branch: "fix/ci" },
+      { eventLedger, portfolioQueue, pollCheckRuns, githubToken: "token", apiBaseUrl },
+    );
+
+    // The CI poll is already host-scoped two lines away; the queue row it ensures must match it.
+    expect(pollCheckRuns).toHaveBeenCalledWith("acme/widgets", 12, expect.objectContaining({ apiBaseUrl }));
+    expect(portfolioQueue.listQueue("acme/widgets")).toEqual([
+      expect.objectContaining({ apiBaseUrl, identifier: "pr:12", status: "queued", priority: 0 }),
+    ]);
+  });
+
+  it("REGRESSION: a same-named repo+PR already tracked on ANOTHER forge host does not suppress this host's row (#6764)", async () => {
+    const { portfolioQueue, eventLedger } = tempStores();
+    const otherHost = "https://ghe.acme.example/api/v3";
+    // The SAME owner/repo + PR number, already queued against a DIFFERENT forge host. The queue's composite
+    // (api_base_url, repo_full_name, identifier) key exists precisely so these two never collide (#5563).
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "pr:12", priority: 0, apiBaseUrl: otherHost });
+
+    await recordManagePollSnapshot(
+      { repoFullName: "acme/widgets", prNumber: 12, branch: "fix/ci" },
+      {
+        eventLedger,
+        portfolioQueue,
+        pollCheckRuns: vi.fn().mockResolvedValue(pollResult("success")),
+        githubToken: "token",
+      },
+    );
+
+    // Before the fix, the forge-blind existence check matched the other host's row on identifier alone and
+    // skipped creating this host's row entirely.
+    const rows = portfolioQueue.listQueue("acme/widgets");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.apiBaseUrl).sort()).toEqual([DEFAULT_FORGE_CONFIG.apiBaseUrl, otherHost].sort());
   });
 
   it("runManagePoll prints summary and JSON output with injected stores", async () => {


### PR DESCRIPTION
Closes #6764

## Problem

`ensureManagedPrRow` (`packages/loopover-miner/lib/manage-poll.js`) enqueues `{ repoFullName, identifier, priority: 0 }` with **no `apiBaseUrl`**, so `portfolio-queue.js`'s `normalizeApiBaseUrl` silently defaults the row to github.com — even when the poll two lines away ran against a different forge host (`recordManagePollSnapshot` already threads `options.apiBaseUrl` into `pollCheckRuns`). The queue's composite `(api_base_url, repo_full_name, identifier)` primary key exists specifically so two hosts serving the same owner/repo name never collide (#5563); this write path violates that invariant.

The "already exists" check is forge-blind for the same reason: `listQueue(repoFullName)` returns rows across **every** host, so the same repo + PR-number already tracked on **another** host suppresses row creation for this one entirely.

## Fix

- Thread `options.apiBaseUrl` from `recordManagePollSnapshot` into `ensureManagedPrRow` and pass it to `enqueue`, so the row is scoped to the host it was actually polled from. `enqueue` still performs its own normalization/validation.
- Scope the existence check to the same forge host, comparing through a small `resolveManagedRowApiBaseUrl` fold that mirrors `portfolio-queue-manager.js`'s existing one (omitted/blank → the github.com default, so every pre-existing single-forge caller is byte-identical).

## Tests

Two regression tests in `test/unit/miner-manage-poll.test.ts` (which previously had **zero** `apiBaseUrl` references), both failing before the fix:

1. polling a non-default `apiBaseUrl` → the resulting queue row is scoped to **that host** (before: silently github.com);
2. the exact reported failure mode — a same-named repo + PR already queued on **another** host no longer suppresses this host's row (before: `expected length 2 but got 1`).

## Validation

- `npx vitest run test/unit/miner-manage-poll.test.ts` → **11/11 pass** (9 existing + 2 new)
- `npm run typecheck` → **clean (0 errors)**
- Scope: 1 source file + 1 test file
