### PR TITLE
docs(packages): fix stale gittensory prose and audit citations

### DIFF
--- a/packages/loopover-engine/README.md
+++ b/packages/loopover-engine/README.md
@@ -1,6 +1,6 @@
 # @loopover/engine
 
-Shared, deterministic engine logic for the LoopOver review stack and the `gittensory-miner`.
+Shared, deterministic engine logic for the LoopOver review stack and the `loopover-miner`.
 
 This package houses pure, side-effect-free logic (scoring preview/model, predicted-gate types, reward-risk,
 slop signals, focus-manifest parse/compile core, duplicate-winner adjudication, and their engine-parity

--- a/packages/loopover-mcp/README.md
+++ b/packages/loopover-mcp/README.md
@@ -129,7 +129,7 @@ loopover-mcp analyze-branch --login jsonbored \
 ## Review your PR locally before you push
 
 `loopover-mcp review-pr` composes the existing preflight, slop-risk, and PR-text-lint checks into
-ONE report, so your own local agent (Claude Code, Codex, etc.) can see everything the gittensory gate
+ONE report, so your own local agent (Claude Code, Codex, etc.) can see everything the loopover gate
 would flag before you ever open a PR. It is a thin composition layer — it calls the same checks
 `preflight`, `slop-risk`, and `lint-pr-text` already run and merges their output; it does not
 reimplement any of them.

--- a/packages/loopover-ui-kit/src/theme.css
+++ b/packages/loopover-ui-kit/src/theme.css
@@ -1,7 +1,7 @@
 /*
- * Gittensory design system — shared tokens + base layer.
+ * LoopOver design system — shared tokens + base layer.
  * Extracted from apps/loopover-ui/src/styles.css so every consuming app
- * (gittensory-ui, gittensory-miner-ui) renders from one source of truth.
+ * (loopover-ui, loopover-miner-ui) renders from one source of truth.
  * Palette: Lovable Lime — AA-tuned citron/lime (#c4f24c family), light + dark
  * are first-class, toggled via .dark on documentElement. All colors in oklch.
  * Fonts: Space Grotesk (headings) + DM Sans (body) + JetBrains Mono (code).
@@ -291,8 +291,8 @@
   }
 }
 
-/* Shared focus + hover utilities — generic enough that both gittensory-ui
-   and gittensory-miner-ui use them directly, unlike the hero/marketing-only
+/* Shared focus + hover utilities — generic enough that both loopover-ui
+   and loopover-miner-ui use them directly, unlike the hero/marketing-only
    flourishes (aurora-glow, bg-grid, gradient-border) that stay app-local. */
 @layer utilities {
   .focus-ring {

--- a/review-enrichment/Dockerfile
+++ b/review-enrichment/Dockerfile
@@ -1,4 +1,4 @@
-# Gittensory review-enrichment service (REES). Lean two-stage Node build; analyzers are pure-JS diff-hunk
+# LoopOver review-enrichment service (REES). Lean two-stage Node build; analyzers are pure-JS diff-hunk
 # heuristics with no external CLI tools (#1477 scoped this to the cheap, no-checkout path -- see
 # review-enrichment/src/analyzers/complexity.ts's header for why a real linter/AST toolchain is out of scope).
 # Build context = the review-enrichment/ directory (Railway "Root Directory" = review-enrichment).

--- a/review-enrichment/README.md
+++ b/review-enrichment/README.md
@@ -1,6 +1,6 @@
 # Review-enrichment service (REES)
 
-A standalone microservice that produces a structured **review brief** for the gittensory review engine. Run it
+A standalone microservice that produces a structured **review brief** for the loopover review engine. Run it
 in-network alongside a self-hosted engine via the repo-root `docker-compose --profile rees` service (the simplest
 path, no separate hosting to manage — see the [self-hosting REES docs](https://loopover.ai/docs/self-hosting-rees)),
 or deploy it as its own service on any platform that can run a Dockerfile-based Node service — see
@@ -247,7 +247,7 @@ Set these Railway service variables:
 | `SENTRY_TRACES_SAMPLE_RATE`    | Optional; defaults to `0`, so errors report without tracing.            |
 | `SENTRY_RELEASE`               | Optional override. Only set it when that exact REES bundle is uploaded. |
 | `SENTRY_URL`                   | Optional Sentry API URL; defaults to `https://sentry.io`.               |
-| `SENTRY_REPOSITORY`            | Optional; defaults to `JSONbored/gittensory` for commit association.    |
+| `SENTRY_REPOSITORY`            | Optional; defaults to `JSONbored/loopover` for commit association.      |
 | `REES_SENTRY_UPLOAD_STRICT`    | Optional. Set `true` to fail startup if source-map upload fails.        |
 | `REES_SENTRY_VALIDATE_RELEASE` | Optional. Set `false` only to disable post-upload release validation.   |
 
@@ -296,7 +296,7 @@ Useful production queries:
   - `event:rees_route_error route:/v1/enrich method:POST`
 - Analyzer failures grouped by analyzer:
   - `event:rees_analyzer_degraded analyzer:history`
-  - `event:rees_analyzer_degraded analyzer:dependency repo:JSONbored/gittensory`
+  - `event:rees_analyzer_degraded analyzer:dependency repo:JSONbored/loopover`
 - Source-map upload/startup failures on a Railway deploy:
   - `event:rees_sourcemap_upload_failed railwayDeploymentId:<deploy-id>`
 - Process-level crashes:

--- a/src/review/repo-agnostic-capability-audit.md
+++ b/src/review/repo-agnostic-capability-audit.md
@@ -115,8 +115,8 @@ is a generic role vocabulary, not a gittensory assumption — no change needed.
 
 | Location | Assumption | Category | Should become |
 | --- | --- | --- | --- |
-| `maintainer-recap-wire.ts:203` | `actor: "gittensory"` | (7) branding | Per-tenant actor identity string. |
-| `parity.ts:254`, `stats.ts:112`, `parity-wire.ts:218` | shadow-writer default `"gittensory"` (parity self-join compares `reviewbot` vs `gittensory`) | (7) branding | Per-tenant shadow-writer name; the parity comparison is otherwise generic. |
+| `maintainer-recap-wire.ts:203` | `actor: "loopover"` | (7) branding | Per-tenant actor identity string. |
+| `parity.ts:254`, `stats.ts:112` | shadow-writer default `"loopover"` (parity self-join compares `reviewbot` vs `loopover`) | (7) branding | Per-tenant shadow-writer name; the parity comparison is otherwise generic. (`parity-wire.ts:218`'s `computeParityReadiness` deliberately overrides this default to the preserved `gittensory-native` DB-source literal instead -- a historical-compat value, not a per-tenant branding default.) |
 
 ### `src/review/check-names.ts` and `src/review/unified-comment*.ts` — check-run + comment branding
 
@@ -138,8 +138,8 @@ These were checked and are already tenant-agnostic / config-driven; call them ou
 implementation issue doesn't redo them:
 
 - **`src/rules/` gate logic** — `predicted-gate.ts` re-exports the engine's `predicted-gate.js` wholesale,
-  and `advisory.ts` contains only generic gate-decision logic (the `gittensory`/`loopover` mentions at
-  `advisory.ts:563/895/911/945` are explanatory comments, not hardcoded identity). The rules layer is
+  and `advisory.ts` contains only generic gate-decision logic (the `loopover` mentions at
+  `advisory.ts:580/919/935/969` are explanatory comments, not hardcoded identity). The rules layer is
   already repo-agnostic.
 - **Label propagation** — `linked-issue-label-propagation.ts` / `-fetch.ts` drive their mappings from a
   configurable `linkedIssueLabelPropagation` setting (`DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION` fallback);
@@ -150,7 +150,7 @@ implementation issue doesn't redo them:
   (the finding above), not the mechanism.
 - **Signals maintainer-lane / role model** — `signals/engine.ts:1642` uses a generic forge role vocabulary
   (`owner`/`org_member`/`collaborator`/`repo_maintainer`), not gittensory-specific roles.
-- **`cutover-gate.ts` repo list** — the `"JSONbored/gittensory,..."` string at `cutover-gate.ts:8` is a
+- **`cutover-gate.ts` repo list** — the `"JSONbored/loopover,..."` string at `cutover-gate.ts:8` is a
   comment example of the `owner/repo` env format; the actual list is env-supplied, not hardcoded.
 
 ## Prioritized checklist for the follow-up implementation issue


### PR DESCRIPTION
## Summary

- Continues the repo-wide gittensory -> loopover rebrand cleanup sweep. Fixes self-referential prose in `packages/loopover-engine/README.md`, `packages/loopover-mcp/README.md`, `packages/loopover-ui-kit/src/theme.css`, and `review-enrichment/Dockerfile`/`README.md` describing loopover's own current gate/design-system/review-engine identity, plus a `review-enrichment/README.md` `SENTRY_REPOSITORY` default that had drifted from the real current default in `review-enrichment/src/upload-sourcemaps.ts` (verified: `JSONbored/loopover`, not `JSONbored/gittensory`).
- Re-verifies and fixes four citations in `src/review/repo-agnostic-capability-audit.md` that had gone stale since the audit was written, each checked directly against the real current source line:
  - `maintainer-recap-wire.ts:203`'s `actor` is now `"loopover"`, not `"gittensory"`.
  - `parity.ts`/`stats.ts`'s shadow-writer default is now `"loopover"`, not `"gittensory"` -- `parity-wire.ts:218`'s own `computeParityReadiness` call is the one place that still deliberately reaches the preserved `gittensory-native` DB literal, by explicitly *overriding* that default, so it's called out separately now rather than folded into the same (now-incorrect) "shared gittensory default" framing.
  - `advisory.ts`'s brand-mention line numbers had drifted (563/895/911/945 -> 580/919/935/969) and the content itself no longer contains any "gittensory" mention at all, only "loopover".
  - `cutover-gate.ts:8`'s own comment-example string is now `"JSONbored/loopover,..."`.
- Left the audit doc's earlier "Findings by file/module" checklist section alone -- it's a deliberately-preserved historical snapshot of what was hardcoded when issue #5744's audit was written (describing "gittensory" as a concept, not quoting a literal current value) -- only fixed citations that assert a specific, now-verifiably-wrong fact about current source.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- **no issue linked**: repo-owner-requested maintainer-equivalent cleanup pass, not a contributor fix tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (docs-only change; no `src/**` runtime lines touched, only a `.md` file under `src/review/`)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] Full `npm run test:ci` green end to end, exit code captured directly (0)
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- N/A, no runtime code changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, no visible change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Fifth in a small series of PRs sweeping the remaining `gittensory` references left over from the rebrand (#6826, #6841, #6849, #6859).