### PR TITLE
fix(miner): release the primed portfolio claim when --max-cycles is exhausted

### DIFF
--- a/packages/loopover-miner/lib/loop-cli.js
+++ b/packages/loopover-miner/lib/loop-cli.js
@@ -561,6 +561,14 @@ export async function runLoop(args, options = {}) {
 
     if (haltReason === null && parsed.maxCycles !== undefined) {
       haltReason = "max_cycles_reached";
+      // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
+      // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
+      // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
+      // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
+      // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
+      if (claimed) {
+        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      }
     }
 
     const summary = { haltReason, cyclesRun: cycles.length, cycles };

--- a/test/unit/miner-loop-cli.test.ts
+++ b/test/unit/miner-loop-cli.test.ts
@@ -242,6 +242,38 @@ describe("runLoop (#5135)", () => {
     expect(printed).toContain("No discovery, queue, or ledger writes were made.");
   });
 
+  it("REGRESSION: exhausting --max-cycles releases the primed claim instead of stranding it in_progress (#6763)", async () => {
+    const { eventLedger, governorLedger, portfolioQueue, runState, governorState, paths } = tempStores();
+    // A non-empty queue: the initial priming dequeues this item (flipping it to 'in_progress') BEFORE the
+    // while-condition rejects maxCycles=0, so no cycle ever processes or releases it.
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 0 });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const runAttemptSpy = vi.fn();
+
+    const exitCode = await runLoop(["acme/widgets", "--miner-login", "alice", "--json", "--max-cycles", "0"], {
+      openGovernorState: () => governorState,
+      initEventLedger: () => eventLedger,
+      initGovernorLedger: () => governorLedger,
+      initPortfolioQueue: () => portfolioQueue,
+      initRunStateStore: () => runState,
+      runDiscover: vi.fn(async () => 0),
+      runAttempt: runAttemptSpy,
+      ...readyLoopOptions(),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runAttemptSpy).not.toHaveBeenCalled();
+    const printed = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(printed.haltReason).toBe("max_cycles_reached");
+
+    // Before the fix the row stayed 'in_progress' forever: dequeueNext() only pulls 'queued' rows, so no
+    // future loop/attempt run could ever see it again (only an out-of-band stale-lease sweep could).
+    const after = reopenAfterRun(paths);
+    expect(after.portfolioQueue.listQueue("acme/widgets")).toEqual([
+      expect.objectContaining({ identifier: "issue:1", status: "queued" }),
+    ]);
+  });
+
   it("halts immediately on an active kill switch, before running discovery or any attempt", async () => {
     const { eventLedger, governorLedger, portfolioQueue, runState, governorState } = tempStores();
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);


### PR DESCRIPTION
Closes #6763

## Problem

`loop-cli.js` primes the next claim at the tail of every non-halting path (and once before the loop), *before* the `while` condition re-checks `cycleIndex < parsed.maxCycles`. When that check fails, the freshly-dequeued `claimed` item — already flipped to `status = 'in_progress'` by `dequeueStatement` — is discarded with no release: the `max_cycles_reached` halt has no `markFailed`, and the `finally` block only closes DB handles.

Because `dequeueNext()` only pulls `status = 'queued'` rows, that item becomes **invisible to every future `loop`/`attempt` invocation** until an out-of-band stale-lease sweep reclaims it. `normalizeOptionalPositiveInt` explicitly accepts `0`, so `--max-cycles 0` against a non-empty queue claims-and-abandons an item on the very first priming.

The kill-switch and pause halts both already `markFailed` the in-flight claim before breaking — only this halt was missing the equivalent release.

## Fix

Release the leftover claim on normal max-cycles exhaustion, mirroring those existing halt paths:

```js
if (haltReason === null && parsed.maxCycles !== undefined) {
  haltReason = "max_cycles_reached";
  if (claimed) portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
}
```

`claimed` at that point is always the primed-but-never-processed item (each cycle re-assigns it at the tail), and `markFailed` returns it to `queued`. A `null` claim (empty queue) is a no-op.

## Tests

`test/unit/miner-loop-cli.test.ts` adds a regression test reproducing the exact failure mode: `--max-cycles 0` against a non-empty queue halts `max_cycles_reached` without running any attempt, and the item is left **`queued`** — not stranded `in_progress`. It fails before the fix.

## Validation

- `npx vitest run test/unit/miner-loop-cli.test.ts` → **32/32 pass** (31 existing + 1 new)
- `npx vitest run test/unit/miner-loop-closure.test.ts test/unit/miner-loop-reentry.test.ts` → **18/18 pass** (no sibling regressions)
- `npm run typecheck` → **clean (0 errors)**
- Scope: 1 source file + 1 test file
