### PR TITLE
fix(track-record): exempt the GitHub login line from the public-field blocklist scan (#6772)

### DIFF
--- a/packages/loopover-engine/src/track-record-summary.ts
+++ b/packages/loopover-engine/src/track-record-summary.ts
@@ -423,10 +423,7 @@ export function shouldIncludeTrackRecordSummary(
  */
 export function renderTrackRecordSummaryMarkdown(summary: TrackRecordSummary): string {
   if (!summary.enabled) return "";
-  const lines = [
-    "### Public contributor record",
-    "",
-    `- GitHub login: ${markdownSafe(summary.login)}`,
+  const bodyLines = [
     `- Resolved public PRs: ${summary.outcomes.resolved} (${summary.outcomes.merged} merged, ${summary.outcomes.closedWithoutMerge} closed without merge)`,
     `- Public merge rate: ${summary.mergeRate.label}`,
     `- Public tenure: ${summary.tenure.label}`,
@@ -434,15 +431,25 @@ export function renderTrackRecordSummaryMarkdown(summary: TrackRecordSummary): s
   ];
 
   if (summary.outcomes.openIgnored > 0) {
-    lines.push(`- Open PRs ignored for rate: ${summary.outcomes.openIgnored}`);
+    bodyLines.push(`- Open PRs ignored for rate: ${summary.outcomes.openIgnored}`);
   }
   if (summary.incidents.hasPublicIncident && summary.incidents.evidenceUrls.length > 0) {
-    lines.push(
+    bodyLines.push(
       `- Public evidence: ${summary.incidents.evidenceUrls.map((url) => markdownSafe(url)).join(", ")}`,
     );
   }
 
-  const rendered = `${lines.join("\n")}\n`;
-  assertPublicSummaryText(rendered);
-  return rendered;
+  // #6772: fail-closed on the COMPUTED fields only -- a blocklisted term there would be a genuine leak. The
+  // GitHub login is caller-provided identity (already markdown-escaped below), not computed private data, so a
+  // legitimate username that merely contains a blocklisted word bounded by hyphens (e.g. "team-wallet") must
+  // NOT crash rendering. Scanning the whole block including the identity line was the bug.
+  assertPublicSummaryText(bodyLines.join("\n"));
+
+  const lines = [
+    "### Public contributor record",
+    "",
+    `- GitHub login: ${markdownSafe(summary.login)}`,
+    ...bodyLines,
+  ];
+  return `${lines.join("\n")}\n`;
 }

--- a/test/unit/track-record-summary-login-blocklist.test.ts
+++ b/test/unit/track-record-summary-login-blocklist.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { computeTrackRecordSummary, renderTrackRecordSummaryMarkdown } from "../../packages/loopover-engine/src/track-record-summary";
+
+// #6772: `renderTrackRecordSummaryMarkdown` used to scan the ENTIRE rendered block -- including the caller-
+// provided `GitHub login:` identity line -- against PUBLIC_FIELD_BLOCKLIST, so a genuine username that merely
+// contains a blocklisted word bounded by hyphens (e.g. "team-wallet") crashed rendering. The fix scans only the
+// computed fields. This is a ROOT vitest suite (not the engine's node:test one) so the changed lines land in the
+// Codecov patch measurement for `packages/loopover-engine/src/**`.
+const NOW = "2026-07-04T18:00:00.000Z";
+const config = { includeTrackRecordSummary: true, warnings: [] as string[] };
+
+describe("renderTrackRecordSummaryMarkdown login vs public-field blocklist (#6772)", () => {
+  it("REGRESSION: renders a genuine GitHub login containing a blocklisted word (team-wallet) instead of throwing", () => {
+    const summary = computeTrackRecordSummary({ login: "team-wallet", now: NOW, config, outcomes: [] });
+    const md = renderTrackRecordSummaryMarkdown(summary);
+    expect(md).toContain("- GitHub login: team-wallet");
+  });
+
+  it("still fails closed when a COMPUTED field carries a blocklisted term (the exemption is identity-line-only)", () => {
+    const summary = computeTrackRecordSummary({ login: "miner", now: NOW, config, outcomes: [] });
+    expect(() =>
+      renderTrackRecordSummaryMarkdown({ ...summary, incidents: { ...summary.incidents, label: "trust score leaked" } }),
+    ).toThrow(/blocked public field/u);
+  });
+
+  it("returns an empty string for a disabled summary (no rendering, no scan)", () => {
+    const base = computeTrackRecordSummary({ login: "miner", now: NOW, config, outcomes: [] });
+    expect(renderTrackRecordSummaryMarkdown({ ...base, enabled: false })).toBe("");
+  });
+
+  it("renders the optional open-ignored and public-evidence lines when present (both conditional branches)", () => {
+    const base = computeTrackRecordSummary({ login: "octocat", now: NOW, config, outcomes: [] });
+    const md = renderTrackRecordSummaryMarkdown({
+      ...base,
+      outcomes: { ...base.outcomes, openIgnored: 3 },
+      incidents: { ...base.incidents, hasPublicIncident: true, evidenceUrls: ["https://example.test/record"] },
+    });
+    expect(md).toContain("- Open PRs ignored for rate: 3");
+    expect(md).toMatch(/- Public evidence: .*example\.test\/record/u);
+  });
+});


### PR DESCRIPTION
## Summary

`renderTrackRecordSummaryMarkdown` (`packages/loopover-engine/src/track-record-summary.ts`) built the full
Markdown block — **including the caller-provided `- GitHub login: <login>` identity line** — and then ran
`assertPublicSummaryText` over the whole thing, which throws if any `PUBLIC_FIELD_BLOCKLIST` pattern (`/\bwallet\b/`,
`/\breward\b/`, `/\branking\b/`, `/\bhotkey\b/`, …) matches anywhere.

A hyphen is a legal GitHub username character and a word boundary, so a **genuine** login like `team-wallet`,
`reward-hunter`, or `top-ranking` matched the blocklist and **crashed rendering entirely** — no track-record
summary could be produced for that contributor.

The blocklist exists to keep **computed private fields** (trust score, reward, ranking, wallet/hotkey/coldkey
data) off public surfaces. The login is caller-provided *identity*, not computed private data, and is already
markdown-escaped. This fix scans **only the computed body lines** and renders the login line outside the scan:

- output is **byte-identical** to before (same header, login, and body lines, same order);
- fail-closed behavior is **preserved** — a genuinely-injected blocklisted term in a computed field (e.g. an
  incident label of `"trust score leaked"`) still throws.

Closes #6772

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6772`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the rewritten `renderTrackRecordSummaryMarkdown` is exercised on **every** line and branch (disabled early-return; both optional-line conditionals true/false; the `assertPublicSummaryText` throw path; the login-excluded regression), verified via `coverage-final.json`. The render path was previously covered only by the engine's `node:test`, which is **outside** the Codecov patch measurement — this adds a ROOT vitest suite so the changed lines are measured.
- [x] engine `build` + `node --test` (**588** passing, incl. the existing "fails closed if a blocked public field is introduced") + `engine-parity:drift-check`

If any required check was skipped, explain why:

- Single engine predicate/render change + its unit test; no UI/OpenAPI/MCP/migration surface, so those checks are N/A to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session surface.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/MCP surface changed.
- [x] No visible UI changes (backend render helper only), so no `UI Evidence` section is required.
- [x] Public docs/changelogs: none needed.

## Notes

- The exemption is **identity-line-only**: every computed/user-derived field (merge rate, tenure, conduct label, evidence URLs) is still scanned, so this narrows the check to exactly the line that can never be a private-data leak, rather than weakening the safety net.
