### PR TITLE
fix(miner): open doctor's laptop-state check read-only (camelCase readOnly)

### DIFF
--- a/packages/loopover-miner/lib/laptop-init.js
+++ b/packages/loopover-miner/lib/laptop-init.js
@@ -63,7 +63,10 @@ export function checkLaptopStateSqlite(env = process.env) {
     };
   }
   try {
-    const db = new DatabaseSync(dbPath, { readonly: true });
+    // `readOnly` (camelCase) -- node:sqlite silently IGNORES `readonly` (lowercase) as an unrecognized option
+    // and opens read-write anyway, which would break doctor's own "no writes, no network" contract. Same
+    // footgun already documented in claim-ledger.js's openClaimLedgerReadOnly and purge-cli.js.
+    const db = new DatabaseSync(dbPath, { readOnly: true });
     db.prepare("SELECT 1").get();
     db.close();
     return { name: "laptop-state-sqlite", ok: true, detail: dbPath };

--- a/test/unit/miner-laptop-init.test.ts
+++ b/test/unit/miner-laptop-init.test.ts
@@ -9,7 +9,26 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+/** Records every `new DatabaseSync(path, options)` the module under test performs, so a test can assert the
+ *  OPTIONS it opens with (#6765) -- checkLaptopStateSqlite never exposes its own handle. The subclass just
+ *  records and delegates, so every other test's behavior is unchanged. */
+const { databaseSyncOptions } = vi.hoisted(() => ({ databaseSyncOptions: [] as Array<Record<string, unknown> | undefined> }));
+
+vi.mock("node:sqlite", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:sqlite")>();
+  class RecordingDatabaseSync extends actual.DatabaseSync {
+    // Rest-args forwarding: passing an explicit `undefined` options arg is NOT the same as omitting it, so
+    // every existing `new DatabaseSync(path)` caller must reach super with its original arity.
+    constructor(...args: ConstructorParameters<typeof actual.DatabaseSync>) {
+      databaseSyncOptions.push(args[1] as Record<string, unknown> | undefined);
+      super(...args);
+    }
+  }
+  return { ...actual, DatabaseSync: RecordingDatabaseSync };
+});
 import {
   checkDockerPresent,
   checkLaptopStateSqlite,
@@ -79,6 +98,31 @@ describe("loopover-miner laptop init (#2329)", () => {
     const check = checkLaptopStateSqlite(env);
     expect(check.ok).toBe(false);
     expect(check.detail).toContain("loopover-miner init");
+  });
+
+  it("REGRESSION: doctor's laptop-state check opens a driver-enforced read-only connection (#6765)", () => {
+    const root = tempRoot();
+    const env = { LOOPOVER_MINER_CONFIG_DIR: join(root, "state") };
+    initLaptopState(env);
+    const dbPath = resolveLaptopStateDbPath(env);
+    databaseSyncOptions.length = 0;
+
+    expect(checkLaptopStateSqlite(env).ok).toBe(true);
+    // The check must open with camelCase `readOnly`. node:sqlite silently IGNORES the lowercase `readonly`
+    // key as an unrecognized option and opens read-write anyway -- which is what this used to pass, breaking
+    // doctor's own documented "no writes, no network" contract.
+    expect(databaseSyncOptions).toEqual([{ readOnly: true }]);
+
+    // ...and that option is what makes the connection driver-enforced: a write through it throws, whereas the
+    // silently-ignored lowercase spelling happily writes.
+    const enforced = new DatabaseSync(dbPath, { readOnly: true });
+    expect(() => enforced.exec("CREATE TABLE probe_camel (id INTEGER)")).toThrow();
+    enforced.close();
+
+    const ignored = new DatabaseSync(dbPath, { readonly: true } as never);
+    expect(() => ignored.exec("CREATE TABLE probe_lower (id INTEGER)")).not.toThrow();
+    ignored.exec("DROP TABLE probe_lower");
+    ignored.close();
   });
 
   it("doctor sqlite check reports unreadable files", () => {


### PR DESCRIPTION
Closes #6765

## Problem

`checkLaptopStateSqlite` (`packages/loopover-miner/lib/laptop-init.js:66`) opened its connection with `{ readonly: true }`. `node:sqlite`'s `DatabaseSync` only recognizes the **camelCase** `readOnly` option — the lowercase key is silently ignored as unrecognized, so the connection opened **read-write**. This check is wired into `doctor` (`status.js`), whose own header states the contract it violates: *"no writes, no network."*

The same footgun is already documented in this package by `claim-ledger.js`'s `openClaimLedgerReadOnly` (*"node:sqlite silently IGNORES `readonly` (lowercase) … and opens read-write anyway"*) and `purge-cli.js`.

## Fix

Use the camelCase `{ readOnly: true }`, with a comment pointing at the sibling precedent.

**Deliverable — grep confirmation:** `laptop-init.js:66` was the **only** remaining lowercase instance in `packages/loopover-miner/lib/**`. Every other `DatabaseSync` read-only open already uses the camelCase form:

| file | option |
|---|---|
| `claim-ledger.js:270` | `{ readOnly: true }` ✅ |
| `migrate-cli.js:37` | `{ readOnly: true }` ✅ |
| `purge-cli.js:94` | `{ readOnly: true }` ✅ |
| `store-maintenance.js:74` | `{ readOnly: true }` ✅ |
| `laptop-init.js:66` | `{ readonly: true }` ❌ → fixed here |

## Tests

`test/unit/miner-laptop-init.test.ts` adds a regression test that:
1. records the options `checkLaptopStateSqlite` actually opens with (the function never exposes its own handle) and asserts they are `{ readOnly: true }` — this fails before the fix with `expected [ { readonly: true } ] to deeply equal [ { readOnly: true } ]`;
2. proves *why* the casing matters, mirroring `claim-ledger.js`'s read-only tests: a write through a `{ readOnly: true }` connection **throws**, while the silently-ignored lowercase spelling happily writes.

The recording subclass forwards constructor rest-args (an explicit `undefined` options arg is not the same as omitting it), so every existing test's behavior is unchanged.

## Validation

- `npx vitest run test/unit/miner-laptop-init.test.ts` → **10 passed, 12 total**; the 2 failures are **pre-existing on Windows only** and identical to the baseline before this change (POSIX path-separator + `chmod` permission semantics) — **zero net-new failures**.
- `npm run typecheck` → **clean (0 errors)**
- Scope: 1 source file + 1 test file
