### PR TITLE
fix(miner): retain a crashed attempt's worktree for post-mortem

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -513,23 +513,33 @@ export async function runAttempt(args, options = {}) {
     claimedIssue = true;
 
     const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
-    const result = await runAttemptPipeline(
-      {
-        loopInput,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        killSwitchScope,
-        slopThreshold: amsPolicy.spec.slopThreshold,
-        submissionMode: amsPolicy.spec.submissionMode,
-        governor,
-      },
-      {
-        ...deps,
-        shouldAbort,
-        resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
-      },
-    );
+    let result;
+    try {
+      result = await runAttemptPipeline(
+        {
+          loopInput,
+          issueNumber: parsed.issueNumber,
+          minerLogin: parsed.minerLogin,
+          base: parsed.base,
+          killSwitchScope,
+          slopThreshold: amsPolicy.spec.slopThreshold,
+          submissionMode: amsPolicy.spec.submissionMode,
+          governor,
+        },
+        {
+          ...deps,
+          shouldAbort,
+          resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
+        },
+      );
+    } catch (error) {
+      // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
+      // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
+      // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
+      // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
+      worktreeResult.attemptOk = false;
+      throw error;
+    }
 
     worktreeResult.attemptOk = result.outcome === "submitted";
 
@@ -670,8 +680,10 @@ export async function runAttempt(args, options = {}) {
     return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
-    // happens; every earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since
-    // nothing ran in the worktree to postmortem -- those default to `true` (nothing to retain), matching
+    // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
+    // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
+    // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
+    // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
     // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
     if (worktreeResult?.ok) {
       const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -1541,6 +1541,33 @@ describe("runAttempt: real claim-ledger wiring (#5393)", () => {
     expect(releaseClaimSpy).toHaveBeenCalledWith("acme/widgets", 7);
   });
 
+  it("REGRESSION: retains the worktree when runMinerAttempt throws — a crashed attempt is what needs post-mortem (#6759)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const cleanupAttemptWorktreeSpy = vi.fn().mockResolvedValue({ ok: true, removed: false });
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({
+        cleanupAttemptWorktree: cleanupAttemptWorktreeSpy,
+        runMinerAttempt: async () => {
+          throw new Error("boom");
+        },
+      }),
+    });
+
+    expect(exitCode).toBe(2);
+    // attemptOk MUST be false: shouldRetainWorktree(attemptOk) === !attemptOk, so a crashed attempt's
+    // worktree is retained for inspection. Before the fix, the throw skipped the `attemptOk` assignment
+    // entirely and the finally block's `?? true` default deleted exactly the worktree worth keeping.
+    expect(cleanupAttemptWorktreeSpy).toHaveBeenCalledWith(expect.any(String), expect.any(String), false);
+  });
+
   it("never claims when the attempt is blocked before feasibility is even checked (rejection-signaled)", async () => {
     const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
     vi.spyOn(console, "error").mockImplementation(() => undefined);


### PR DESCRIPTION
Closes #6759

## Problem

`attempt-cli.js` only set `worktreeResult.attemptOk = result.outcome === "submitted"` **after** `runAttemptPipeline` returned normally. When it **throws**, execution jumps straight to the outer catch and that line never runs, leaving `attemptOk` `undefined`. The `finally` block then calls:

```js
await cleanupWorktree(..., worktreeResult.attemptOk ?? true);
```

so the `?? true` default **deletes** the worktree of a genuinely crashed attempt — precisely the one that most needs post-mortem inspection. `shouldRetainWorktree(attemptOk)` (`packages/loopover-engine/src/miner/worktree-plan.ts`) returns `!attemptOk`, and its header explicitly states a FAILED attempt's worktree is retained for inspection. The existing throw-path test exercised this route but only asserted the claim release, never what `cleanupAttemptWorktree` received.

## Fix

- Wrap the `runAttemptPipeline` call so an uncaught exception records `attemptOk = false` (retain) before rethrowing. The `?? true` default is left intact for the *earlier blocked paths* (rejection / worktree-prep-failure / infeasible) it was actually written for — nothing ran in those worktrees to postmortem.
- Correct the stale `finally`-block comment, which described only the "earlier blocked path" cases and never the exception case.

## Tests

`test/unit/miner-attempt-cli.test.ts` adds a regression test asserting `cleanupAttemptWorktree` is called with `attemptOk === false` when `runMinerAttempt` throws. It fails before the fix (the call arrived with `true`).

## Validation

- `npx vitest run test/unit/miner-attempt-cli.test.ts` → **68 passed, 70 total**. The 2 failures are **pre-existing on Windows only** and byte-identical to the pristine baseline (`2 failed | 67 passed` before this change, `2 failed | 68 passed` after) — **zero net-new failures**, +1 new passing test.
- `npm run typecheck` → **clean (0 errors)**
- Scope: 1 source file + 1 test file
