### PR TITLE
test(services): fix stale actor/repo-key assertions left by the rebrand

### DIFF
--- a/test/unit/notify-pagerduty.test.ts
+++ b/test/unit/notify-pagerduty.test.ts
@@ -235,7 +235,7 @@ describe("triggerPagerDutyIncident — cooldown gate (alert fatigue control #2)"
     const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
     await recordAuditEvent(env, {
       eventType: "external_notification.pagerduty",
-      actor: "loopover",
+      actor: "gittensory",
       targetKey: "ops_anomaly:acme/widgets",
       outcome: "completed",
       detail: "triggered",

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -72,8 +72,8 @@ describe("registry normalization", () => {
   it("parses per-repo time-decay overrides from the registry scoring.time_decay block (#703)", () => {
     const snapshot = normalizeRegistryPayload(
       {
-        // JSONbored/gittensory's real master_repositories.json shape: a partial override (no steepness).
-        "JSONbored/gittensory": {
+        // JSONbored/loopover's real master_repositories.json shape: a partial override (no steepness).
+        "JSONbored/loopover": {
           emission_share: 0.01,
           scoring: { pr_lookback_days: 45, time_decay: { grace_period_hours: 24, sigmoid_midpoint_days: 10, min_multiplier: 0.05 } },
         },
@@ -86,7 +86,7 @@ describe("registry normalization", () => {
       "2026-05-22T00:00:00.000Z",
     );
     const byName = Object.fromEntries(snapshot.repositories.map((r) => [r.repo, r]));
-    expect(byName["JSONbored/gittensory"]!.timeDecay).toEqual({
+    expect(byName["JSONbored/loopover"]!.timeDecay).toEqual({
       gracePeriodHours: 24,
       sigmoidMidpointDays: 10,
       sigmoidSteepness: null, // absent → falls back to the global default at resolve time

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1880,7 +1880,7 @@ NOVELTY_BONUS_SCALAR = 3
       const c = DEFAULT_SCORING_CONSTANTS;
       // No overrides → all snapshot defaults.
       expect(resolveTimeDecay(c, null)).toEqual({ gracePeriodHours: 12, sigmoidMidpointDays: 10, sigmoidSteepness: 0.4, minMultiplier: 0.05 });
-      // Partial override (JSONbored/gittensory's real config: grace 24, midpoint 10, min 0.05, no steepness)
+      // Partial override (JSONbored/loopover's real config: grace 24, midpoint 10, min 0.05, no steepness)
       // → overridden fields apply, the absent steepness falls back to the default.
       expect(resolveTimeDecay(c, { gracePeriodHours: 24, sigmoidMidpointDays: 10, minMultiplier: 0.05 })).toEqual({
         gracePeriodHours: 24,
@@ -1938,7 +1938,7 @@ NOVELTY_BONUS_SCALAR = 3
 
     it("applies each live repo's resolved curve in the preview (per-repo, not global)", () => {
       const input: ScorePreviewInput = { repoFullName: repo.fullName, sourceTokenScore: 58, totalTokenScore: 600, sourceLines: 60, openPrCount: 0, credibility: 1, applyTimeDecay: true, prAgeHours: 18 };
-      // Repo with a 24h grace override (like JSONbored/gittensory) → an 18h-old PR is still fresh.
+      // Repo with a 24h grace override (like JSONbored/loopover) → an 18h-old PR is still fresh.
       const repo24: RepositoryRecord = { ...repo, registryConfig: { ...repo.registryConfig!, timeDecay: { gracePeriodHours: 24 } } };
       expect(buildScorePreview({ repo: repo24, snapshot, input }).scoreEstimate.timeDecayMultiplier).toBe(1);
       // Same PR on a repo using the default 12h grace → past grace, so it decays.


### PR DESCRIPTION
## Summary

- Continues the repo-wide gittensory -> loopover rebrand cleanup sweep. Two genuine test-correctness bugs, both introduced by the rename and not caught before:
  - `notify-pagerduty.test.ts`: the test titled "a recent page recorded under the pre-rebrand 'gittensory' actor still suppresses a duplicate" was inserting `actor: "loopover"` into its fixture -- the wrong value for what it claims to test. `src/services/notify-pagerduty.ts`'s `trigger()` path deliberately queries **both** the `"loopover"` and `"gittensory"` actors (a dual-actor OR-query, so a page recorded under the old actor value just before the rebrand deployed still suppresses a duplicate after it). Verified: no other test anywhere in the suite exercises the `"gittensory"` side of that query, so this branch had zero coverage despite this test's stated purpose. Flipped the fixture to `actor: "gittensory"` so the test actually covers the branch it's named for.
  - `registry.test.ts` / `scoring.test.ts`: two comments claimed to mirror "JSONbored/gittensory's real `master_repositories.json` shape" -- verified directly against the live upstream registry (`entrius/gittensor`) that the real key is now `JSONbored/loopover`. Fixed both comments; in `registry.test.ts` the comment's own fixture block used the same stale key as its literal input/lookup value in that one self-contained test case, so updated that too for internal consistency. Every other `"JSONbored/gittensory"` fixture elsewhere in that file is an unrelated, arbitrary placeholder repo name with no connection to the real upstream shape, and is left alone.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- **no issue linked**: repo-owner-requested maintainer-equivalent cleanup pass, not a contributor fix tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- targeted run of the three changed test files is green (`test/unit/notify-pagerduty.test.ts`, `test/unit/registry.test.ts`, `test/unit/scoring.test.ts`); test-only change, exempt from Codecov patch coverage.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [~] `npm run test:ci`: the three changed test files pass cleanly, individually and alongside each other. The **full** local run flagged 4 unrelated failures this attempt (`ai-summaries.test.ts`'s 30s-timeout AI-rewrite test, and two real-git-subprocess tests in `miner-attempt-worktree.test.ts`/`miner-repo-clone.test.ts`), all traced to severe local machine contention, not this diff: `uptime` showed a load average of 118-193 during this run (multiple concurrent local sessions were independently running their own heavy `npm run test:coverage`/git-clone workloads on this same shared machine at the time -- confirmed via `ps`). None of the 4 failing files overlap this diff's 3 files at all, and re-running all 4 in isolation (away from the full-parallel-suite contention) passed cleanly, including the two git-subprocess tests, which are exactly the kind of test that's fragile under heavy concurrent I/O/CPU load. Given the repeated, targeted, isolated confirmation and the zero file-path overlap, I'm proceeding rather than continuing to re-run the full heavy suite against an already critically-loaded shared machine. Flagging this transparently rather than silently rerunning until it happens to go green.
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- N/A, test-only change (these test files gained coverage of an existing branch, no new production code).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Sixth in a small series of PRs sweeping the remaining `gittensory` references left over from the rebrand (#6826, #6841, #6849, #6859, #6863). This one is the only one so far that fixes a genuine bug (a test-coverage gap) rather than pure prose/comment drift.