### PR TITLE
fix(test): widen timeouts on real-git miner clone/worktree tests

### DIFF
--- a/test/unit/miner-attempt-worktree.test.ts
+++ b/test/unit/miner-attempt-worktree.test.ts
@@ -57,6 +57,11 @@ describe("createRealWorktreeExec (#5132)", () => {
 
 describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
   it("REGRESSION: worktreePath is a real, checked-out git repo on a real branch, not an empty directory", async () => {
+    // Six real, sequential git subprocess spawns (origin init/add/commit, the clone inside
+    // prepareAttemptWorktree, its `git worktree add`, and this test's own rev-parse) -- legitimately more
+    // wall-clock latency than the default 15s test timeout reliably covers under concurrent full-suite
+    // load (passes in well under 1s in isolation; the same class of flake fixed for
+    // test/unit/agent-sdk-driver.test.ts's real-git-subprocess test).
     const root = tempRoot("loopover-miner-attempt-worktree-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -72,9 +77,11 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
     // And it's a real, distinct branch -- not just a copy of main.
     const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: result.worktreePath, encoding: "utf8" }).trim();
     expect(branch).toBe("loopover/attempt/attempt-1");
-  });
+  }, 60000);
 
   it("removes a succeeded attempt's worktree but retains a failed one's, per the engine's own retention policy", async () => {
+    // Real git subprocess round trip -- two full prepareAttemptWorktree/cleanupAttemptWorktree cycles, more
+    // real spawns than the REGRESSION test above. See its comment for why this needs an explicit timeout.
     const root = tempRoot("loopover-miner-attempt-worktree-cleanup-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -90,7 +97,7 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
     const retainedResult = await cleanupAttemptWorktree(failed.repoPath, failed.worktreePath, false);
     expect(retainedResult).toEqual({ ok: true, removed: false });
     expect(existsSync(failed.worktreePath)).toBe(true);
-  });
+  }, 60000);
 
   it("returns ok:false when the base clone cannot be prepared, without attempting git worktree add", async () => {
     const root = tempRoot("loopover-miner-attempt-worktree-clonefail-");
@@ -111,6 +118,8 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
   });
 
   it("returns ok:false with git's real stderr when git worktree add fails (e.g. an unknown base branch)", async () => {
+    // Real git subprocess round trip (origin init + a real clone + a failing `git worktree add`). See the
+    // REGRESSION test above for why this needs an explicit timeout.
     const root = tempRoot("loopover-miner-attempt-worktree-addfail-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -121,5 +130,5 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
     if (result.ok) throw new Error("expected failure");
     expect(result.repoPath).toBe(join(cloneBaseDir, "acme", "widgets"));
     expect(result.error).toBeTruthy();
-  });
+  }, 60000);
 });

--- a/test/unit/miner-repo-clone.test.ts
+++ b/test/unit/miner-repo-clone.test.ts
@@ -62,6 +62,11 @@ describe("resolveRepoCloneBaseDir / resolveRepoCloneDir (#5132)", () => {
 
 describe("ensureRepoCloned (#5132)", () => {
   it("clones a real repo on first use, and fetches + hard-resets an existing clone to pick up new commits", async () => {
+    // Nine real, sequential git subprocess spawns (origin init/add/commit, the first ensureRepoCloned's
+    // clone, a second origin commit, and the second ensureRepoCloned's fetch+checkout+reset) --
+    // legitimately more wall-clock latency than the default 15s test timeout reliably covers under
+    // concurrent full-suite load (passes in well under 1s in isolation; the same class of flake fixed for
+    // test/unit/agent-sdk-driver.test.ts's real-git-subprocess test).
     const root = tempRoot("loopover-miner-repo-clone-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -80,9 +85,14 @@ describe("ensureRepoCloned (#5132)", () => {
     expect(second.ok).toBe(true);
     expect(readFileSync(join(second.repoPath, "README.md"), "utf8")).toBe("hello\n");
     expect(readFileSync(join(second.repoPath, "second.txt"), "utf8")).toBe("second file\n");
-  });
+  }, 60000);
 
   it("respects a non-default baseBranch on the fetch+reset path", async () => {
+    // Ten real, sequential git subprocess spawns (origin init/add/commit, the branch checkout, the first
+    // ensureRepoCloned's clone, the second commitFile's add/commit, and the second ensureRepoCloned's
+    // fetch+checkout+reset) -- legitimately more wall-clock latency than the default 15s test timeout
+    // reliably covers under concurrent full-suite load (passes in well under 1s in isolation; the same
+    // class of flake fixed for test/unit/agent-sdk-driver.test.ts's real-git-subprocess test).
     const root = tempRoot("loopover-miner-repo-clone-branch-");
     const originPath = initOriginRepo(root);
     execFileSync("git", ["checkout", "-b", "develop"], { cwd: originPath, stdio: "ignore" });
@@ -95,7 +105,7 @@ describe("ensureRepoCloned (#5132)", () => {
     const second = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath, baseBranch: "develop" });
     expect(second.ok).toBe(true);
     expect(readFileSync(join(second.repoPath, "develop-only.txt"), "utf8")).toBe("develop content\n");
-  });
+  }, 60000);
 
   it("rejects a malformed repoFullName", async () => {
     await expect(ensureRepoCloned("not-a-repo")).rejects.toThrow("invalid_repo_full_name");
@@ -110,6 +120,8 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("returns ok:false on a fetch failure without touching the existing clone (injected runGit)", async () => {
+    // Real origin init + a real clone before the injected-runGit assertion. See the first test in this
+    // block for why this needs an explicit timeout.
     const root = tempRoot("loopover-miner-repo-clone-fetchfail-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -120,9 +132,11 @@ describe("ensureRepoCloned (#5132)", () => {
     const second = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath, runGit });
     expect(second.ok).toBe(false);
     expect(second.error).toBe("network unreachable");
-  });
+  }, 60000);
 
   it("returns ok:false on a checkout failure and a reset failure (injected runGit)", async () => {
+    // Real origin init + a real clone before the injected-runGit assertions. See the first test in this
+    // block for why this needs an explicit timeout.
     const root = tempRoot("loopover-miner-repo-clone-checkoutfail-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -137,7 +151,7 @@ describe("ensureRepoCloned (#5132)", () => {
     const resetResult = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath, runGit: resetFails });
     expect(resetResult.ok).toBe(false);
     expect(resetResult.error).toBe("git_reset_failed");
-  });
+  }, 60000);
 
   it("returns ok:false with a fallback error message on a clone failure with no stderr (injected runGit)", async () => {
     const root = tempRoot("loopover-miner-repo-clone-nostderr-");
@@ -149,6 +163,8 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("rejects a dash-prefixed baseBranch before invoking git (#5923)", async () => {
+    // Real origin init + a real clone before the injected-runGit assertion. See the first test in this
+    // block for why this needs an explicit timeout.
     const root = tempRoot("loopover-miner-repo-clone-unsafe-branch-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
@@ -163,7 +179,7 @@ describe("ensureRepoCloned (#5132)", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBe("invalid_base_branch");
     expect(runGitCalls).toBe(0);
-  });
+  }, 60000);
 
   it("rejects a dash-prefixed remoteUrl before invoking git (#5923)", async () => {
     const root = tempRoot("loopover-miner-repo-clone-unsafe-url-");


### PR DESCRIPTION
## Summary

- `test/unit/miner-attempt-worktree.test.ts` and `test/unit/miner-repo-clone.test.ts` (the `#5132` miner clone/worktree suite) run 4-10 real, sequential `git` subprocess spawns per test (init/add/commit an origin repo, then clone/fetch/checkout/reset/`worktree add` against it) to exercise genuine behavior rather than mocks.
- Under concurrent full-suite load this reliably exceeds the default 15s vitest test timeout on the heaviest tests -- confirmed as a timing issue, not a logic failure: every test passes in well under 1s in isolation, and every assertion that runs passes.
- Widens every real-git test in both files to an explicit `60000`ms timeout, matching the existing convention already used for this same class of test in `test/unit/agent-sdk-driver.test.ts` (a real-git-subprocess test hardened the same way).
- Discovered as a byproduct of investigating and fixing an unrelated flaky-test report (`test/unit/ai-summaries.test.ts`, separate PR) -- running the full suite to verify that fix surfaced these two files' pre-existing flakiness too.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- not applicable; this is a maintainer-authored test-reliability fix discovered during unrelated work, not a contributor PR under the linked-issue policy.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- test-only change to `test/**`, which Codecov does not measure, so there is no patch-coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- not applicable; no production code changed.

Additional validation beyond the standard checklist: both files' own tests were run 5x under simulated heavy CPU contention (16 CPU-bound processes oversubscribing a 12-core machine) with zero outright failures. A full local `npm run test:ci` run also passed both fixed files cleanly (`miner-repo-clone.test.ts` and `miner-attempt-worktree.test.ts` both green), though that run also surfaced two additional, unrelated flakes (`test/unit/github-labels.test.ts`, `test/unit/github-pr-actions.test.ts`) that only appeared while two full 18k-test suites were running concurrently on the same machine -- self-inflicted, unrealistic contention well beyond normal CI conditions, not something observed under a single full-suite run. Flagging separately rather than expanding this PR's scope further.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Not applicable -- test-only change.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable -- no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not applicable -- no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (Not applicable -- no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below. (Not applicable -- no visible/UI changes.)
- [x] Public docs/changelogs are updated where needed. (Not applicable.)

## UI Evidence

Not applicable -- test-only change, no UI/frontend/docs surface touched.

## Notes

- Companion PRs from the same investigation: the originally-reported `test/unit/ai-summaries.test.ts` flake, and a same-pattern fix for `test/unit/agent-sdk-driver.test.ts` discovered along the way.