### PR TITLE
fix(discovery-index): cap the untrusted response candidate list (#6774)

### DIFF
--- a/packages/loopover-engine/src/discovery-index-contract.ts
+++ b/packages/loopover-engine/src/discovery-index-contract.ts
@@ -224,8 +224,17 @@ export function normalizeDiscoveryIndexResponse(raw: unknown): ParsedDiscoveryIn
     warnings.push("DiscoveryIndexResponse must be a mapping; falling back to an empty candidate list.");
   }
   const rawCandidates = record && Array.isArray(record.candidates) ? record.candidates : [];
+  // #6774: the request side clamps page size to MAX_PAGE_LIMIT, but this response comes from the OPTIONAL,
+  // only-partially-trusted hosted index (see this module's header). A misbehaving or compromised host could
+  // otherwise return an arbitrarily large `candidates` array and force unbounded client-side normalization. Cap
+  // it, dropping the overflow with a warning; the retained page and `nextCursor` still round-trip so pagination
+  // continues from the truncated page.
+  const boundedCandidates = rawCandidates.length > MAX_PAGE_LIMIT ? rawCandidates.slice(0, MAX_PAGE_LIMIT) : rawCandidates;
+  if (boundedCandidates.length < rawCandidates.length) {
+    warnings.push(`DiscoveryIndexResponse returned ${rawCandidates.length} candidates; capping to ${MAX_PAGE_LIMIT} and dropping the rest.`);
+  }
   const candidates: DiscoveryIndexCandidate[] = [];
-  for (const entry of rawCandidates) {
+  for (const entry of boundedCandidates) {
     const normalized = normalizeDiscoveryIndexCandidate(entry);
     if (normalized === null) {
       warnings.push("DiscoveryIndexResponse dropped an invalid or boundary-violating candidate.");

--- a/test/unit/discovery-index-contract.test.ts
+++ b/test/unit/discovery-index-contract.test.ts
@@ -173,5 +173,14 @@ describe("discovery-index API contract (#4300)", () => {
       expect(empty.warnings.join(" ")).toMatch(/must be a mapping/);
       expect(normalizeDiscoveryIndexResponse({ candidates: "nope", nextCursor: "  " }).response).toMatchObject({ candidates: [], nextCursor: null });
     });
+
+    it("caps an oversized candidate array at MAX_PAGE_LIMIT (200) with a warning, and still round-trips nextCursor for the truncated page (#6774)", () => {
+      // A misbehaving/compromised discovery-index host returns far more than the request-side page cap allows.
+      const oversized = Array.from({ length: 250 }, (_, i) => ({ ...VALID_CANDIDATE, issueNumber: i + 1 }));
+      const parsed = normalizeDiscoveryIndexResponse({ candidates: oversized, nextCursor: "page2==" });
+      expect(parsed.response.candidates).toHaveLength(200); // dropped the overflow rather than processing 250
+      expect(parsed.warnings.some((w) => /returned 250 candidates; capping to 200/.test(w))).toBe(true);
+      expect(parsed.response.nextCursor).toBe("page2=="); // truncation must not break forward pagination
+    });
   });
 });


### PR DESCRIPTION
## Summary

`normalizeDiscoveryIndexResponse` (`packages/loopover-engine/src/discovery-index-contract.ts`) looped over the
response's `candidates` array with **no length cap**. The request side already clamps page size to
`MAX_PAGE_LIMIT` (200) via `clampLimit`, but the *response* comes from the **OPTIONAL, only-partially-trusted
hosted discovery-index service** — this module's own header frames it as an external boundary
("NO raw scores / rewards / wallet / hotkey data / source contents crossing the public boundary"). A misbehaving
or compromised host could return an arbitrarily large `candidates` array and force unbounded client-side
normalization.

This caps the array at `MAX_PAGE_LIMIT`, dropping the overflow with a warning:

```ts
const boundedCandidates = rawCandidates.length > MAX_PAGE_LIMIT ? rawCandidates.slice(0, MAX_PAGE_LIMIT) : rawCandidates;
if (boundedCandidates.length < rawCandidates.length) {
  warnings.push(`DiscoveryIndexResponse returned ${rawCandidates.length} candidates; capping to ${MAX_PAGE_LIMIT} and dropping the rest.`);
}
```

The retained page and `nextCursor` still round-trip, so forward pagination continues from the truncated page.
Consistent with the module's tolerant-parser convention (degrade with a warning, never throw).

Closes #6774

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6774`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new cap lines are exercised on both branches (oversized → truncate + warn; the `≤ cap` path is covered by the existing response test), verified via `coverage-final.json`.
- [x] `npx vitest run test/unit/discovery-index-contract.test.ts` (17 passing, incl. the new 250→200 truncation regression asserting the warning + preserved `nextCursor`)
- [x] engine `build` + `node --test` (588 passing) + `engine-parity:drift-check`

If any required check was skipped, explain why:

- Single engine parser change + its unit test; no UI/OpenAPI/MCP/migration surface, so those checks are N/A to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session surface; this hardens an untrusted-input parse path with a test.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/MCP surface changed (schema/shape module only, no endpoint).
- [x] No visible UI changes (backend parser only), so no `UI Evidence` section is required.
- [x] Public docs/changelogs: none needed.

## Notes

- The cap reuses the existing `MAX_PAGE_LIMIT` (200) — a well-behaved host can never return more than one page's worth, so this only ever drops data an over-limit/hostile host tried to push. `nextCursor` is parsed independently of the candidate list, so truncating a page does not break pagination.
