### PR TITLE
fix(test): reduce and widen the agent-sdk-driver real-git test timeout

### DIFF
--- a/test/unit/agent-sdk-driver.test.ts
+++ b/test/unit/agent-sdk-driver.test.ts
@@ -88,19 +88,28 @@ describe("createAgentSdkCodingAgentDriver", () => {
   });
 
   it("enumerates tracked and untracked worktree changes with git", async () => {
-    // Real subprocess spawns (init, 2x config, add, commit, plus the driver's own diff enumeration) --
-    // legitimately more wall-clock latency than the default 15s test timeout reliably covers under
-    // concurrent CI shard/system load (observed timing out under heavy parallel contention with no logic
-    // failure; passes in well under 1s in isolation). An explicit timeout says so instead of relying on
-    // ambient headroom.
+    // Real subprocess spawns (init, add, commit, plus the driver's own diff enumeration) -- legitimately
+    // more wall-clock latency than the default 15s test timeout reliably covers under concurrent CI
+    // shard/system load (passes in well under 1s in isolation). Commit identity goes through
+    // GIT_AUTHOR_*/GIT_COMMITTER_* env vars on the commit call instead of two separate `git config`
+    // subprocess spawns, cutting setup from 5 sequential git invocations to 3 -- but each remaining spawn
+    // still waits on real OS process-scheduling under load, which a smaller loop-body trim can reduce but
+    // not eliminate. Reproduced under simulated contention (16 CPU-bound processes oversubscribing a
+    // 12-core machine): clean single-attempt runs ranged ~0.3-20s, with one run exceeding 30s outright.
+    // 60s covers the observed range with headroom instead of relying on ambient timing.
     const dir = await mkdtemp(join(tmpdir(), "gittensory-agent-sdk-"));
+    const commitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test User",
+      GIT_AUTHOR_EMAIL: "test@example.invalid",
+      GIT_COMMITTER_NAME: "Test User",
+      GIT_COMMITTER_EMAIL: "test@example.invalid",
+    };
     try {
       await execFileAsync("git", ["init"], { cwd: dir });
-      await execFileAsync("git", ["config", "user.email", "test@example.invalid"], { cwd: dir });
-      await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: dir });
       await writeFile(join(dir, "tracked.ts"), "export const value = 1;\n");
       await execFileAsync("git", ["add", "tracked.ts"], { cwd: dir });
-      await execFileAsync("git", ["commit", "-m", "init"], { cwd: dir });
+      await execFileAsync("git", ["commit", "-m", "init"], { cwd: dir, env: commitEnv });
 
       const driver = createAgentSdkCodingAgentDriver({
         query: queryYielding([
@@ -119,7 +128,7 @@ describe("createAgentSdkCodingAgentDriver", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  }, 30000);
+  }, 60000);
 
   it("derives changed files from the worktree after untracked mutating tools", async () => {
     const driver = driverWith({


### PR DESCRIPTION
## Summary

- `test/unit/agent-sdk-driver.test.ts`'s real-git-subprocess test (`enumerates tracked and untracked worktree changes with git`) spawns `git init`, two `git config` calls, `git add`, `git commit`, and the driver's own diff enumeration (two more, parallelized) against a real temp repo.
- Under concurrent full-suite load this reliably exceeded its existing explicit 30s timeout (added previously in commit `534dad77` alongside the sibling fix now being applied to `test/unit/ai-summaries.test.ts` in a separate PR).
- Commit identity now goes through `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env vars on the commit call instead of two separate `git config` subprocess spawns, cutting setup from 5 sequential git invocations to 3.
- The remaining spawns still wait on real OS process scheduling under load, so the timeout is also widened to 60s -- based on repeated measurement under simulated CPU contention (16 processes oversubscribing a 12-core machine): clean single-attempt runs ranged ~0.3-20s across 10 runs, with one outlier at ~54s and none exceeding 60s.
- Discovered as a byproduct of investigating and fixing an unrelated flaky-test report (`test/unit/ai-summaries.test.ts`, separate PR) -- both tests were widened in the same historical commit for the same reason, and a full-suite verification run for that fix surfaced this one still flaking.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- not applicable; this is a maintainer-authored test-reliability fix discovered during unrelated work, not a contributor PR under the linked-issue policy.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- test-only change to `test/**`, which Codecov does not measure, so there is no patch-coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- not applicable; no production code changed.

Additional validation beyond the standard checklist: the fixed test was run 10x under simulated heavy CPU contention (16 CPU-bound processes oversubscribing a 12-core machine) with zero outright failures (see timing data above). A full local `npm run test:ci` run also passed this file cleanly (`agent-sdk-driver.test.ts`, 9.3s, no retry needed), though that run also showed `test/unit/ai-summaries.test.ts` failing (expected -- its fix lives in a separate, not-yet-merged PR; this worktree branched before that fix existed) and surfaced two additional, unrelated flakes (`test/unit/github-labels.test.ts`, `test/unit/github-pr-actions.test.ts`) that only appeared while two full 18k-test suites were running concurrently on the same machine -- self-inflicted, unrealistic contention well beyond normal CI conditions. Flagging separately rather than expanding this PR's scope further.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Not applicable -- test-only change.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable -- no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not applicable -- no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (Not applicable -- no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below. (Not applicable -- no visible/UI changes.)
- [x] Public docs/changelogs are updated where needed. (Not applicable.)

## UI Evidence

Not applicable -- test-only change, no UI/frontend/docs surface touched.

## Notes

- Companion PRs from the same investigation: the originally-reported `test/unit/ai-summaries.test.ts` flake, and a same-pattern timeout fix for the `#5132` miner clone/worktree test suite.