### PR TITLE
fix(miner): cover every local store in doctor's and migrate's sweeps

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.js
+++ b/packages/loopover-miner/lib/migrate-cli.js
@@ -18,6 +18,10 @@ import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./predictio
 import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
 import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
 import { openPlanStore, resolvePlanStoreDbPath } from "./plan-store.js";
+import { openGovernorState, resolveGovernorStateDbPath } from "./governor-state.js";
+import { initAttemptLog, resolveAttemptLogDbPath } from "./attempt-log.js";
+import { openReplaySnapshotStore, resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
+import { openWorktreeAllocator, resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 
 const MIGRATE_USAGE = "Usage: loopover-miner migrate [--json]";
 
@@ -29,6 +33,12 @@ const STORES = [
   { name: "claim-ledger", resolveDbPath: resolveClaimLedgerDbPath, open: openClaimLedger },
   { name: "run-state", resolveDbPath: resolveRunStateDbPath, open: initRunStateStore },
   { name: "plan-store", resolveDbPath: resolvePlanStoreDbPath, open: openPlanStore },
+  { name: "governor-state", resolveDbPath: resolveGovernorStateDbPath, open: openGovernorState },
+  { name: "attempt-log", resolveDbPath: resolveAttemptLogDbPath, open: initAttemptLog },
+  { name: "replay-snapshot", resolveDbPath: resolveReplaySnapshotDbPath, open: openReplaySnapshotStore },
+  // openWorktreeAllocator takes an options object rather than a bare dbPath, so it's adapted to this list's
+  // `open(dbPath)` contract; its other options keep their own documented defaults.
+  { name: "worktree-allocator", resolveDbPath: resolveWorktreeAllocatorDbPath, open: (dbPath) => openWorktreeAllocator({ dbPath }) },
 ];
 
 /** Read a store file's stamped schema version without ever creating it -- matches checkStoreIntegrity's

--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -19,6 +19,10 @@ import { hasGitHubTokenSource } from "./github-token-resolution.js";
 import { resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
 import { resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
 import { resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import { resolveGovernorStateDbPath } from "./governor-state.js";
+import { resolveAttemptLogDbPath } from "./attempt-log.js";
+import { resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
+import { resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { resolveRunStateDbPath } from "./run-state.js";
 import { resolvePlanStoreDbPath } from "./plan-store.js";
 
@@ -307,6 +311,10 @@ function storeIntegrityChecks(env) {
     ["claim-ledger", resolveClaimLedgerDbPath(env)],
     ["run-state", resolveRunStateDbPath(env)],
     ["plan-store", resolvePlanStoreDbPath(env)],
+    ["governor-state", resolveGovernorStateDbPath(env)],
+    ["attempt-log", resolveAttemptLogDbPath(env)],
+    ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
+    ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
   ];
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -24,6 +24,11 @@ const STORE_NAMES = [
   "claim-ledger",
   "run-state",
   "plan-store",
+  // #6768: the four stores that were previously migrated/checked only lazily, never by the proactive sweep.
+  "governor-state",
+  "attempt-log",
+  "replay-snapshot",
+  "worktree-allocator",
 ];
 
 afterEach(() => {

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -125,6 +125,11 @@ describe("loopover-miner status/doctor (#2288)", () => {
       "store-integrity:claim-ledger",
       "store-integrity:run-state",
       "store-integrity:plan-store",
+      // #6768: doctor's sweep now covers every real local store, not just the original seven.
+      "store-integrity:governor-state",
+      "store-integrity:attempt-log",
+      "store-integrity:replay-snapshot",
+      "store-integrity:worktree-allocator",
     ]);
     expect(runDoctor([], env, cwd)).toBe(0);
     expect(log).toHaveBeenCalled();


### PR DESCRIPTION
Closes #6768

## Problem

`status.js`'s `storeIntegrityChecks` and `migrate-cli.js`'s `STORES` both enumerated the same **seven** stores — and `migrate-cli.js`'s own header states its list deliberately mirrors `status.js`'s. But four other real, independent local SQLite stores using the same `resolveLocalStoreDbPath`/`openLocalStoreDb` convention were in **neither** list:

- `governor-state.js`
- `attempt-log.js`
- `replay-snapshot.js`
- `worktree-allocator.js`

So neither `doctor`'s corruption sweep nor an operator's proactive `migrate` — whose stated purpose is to bring *"every known store's EXISTING on-disk file up to date"* — ever touched these four. They were only migrated/checked lazily, whenever some command happened to open them first.

## Fix

Add the same four stores to **both** lists, preserving the mirror invariant:

- `status.js` → `store-integrity:{governor-state,attempt-log,replay-snapshot,worktree-allocator}`
- `migrate-cli.js` → the same four in the same order.

`openWorktreeAllocator` takes an options object rather than a bare `dbPath`, so it's adapted to the `STORES` list's `open(dbPath)` contract (`(dbPath) => openWorktreeAllocator({ dbPath })`); its other options keep their own documented defaults.

Disposable/cache-only stores are deliberately left out, consistent with their own documented design.

## Tests

Both list-shape tests are updated to the now-**eleven**-store surface:
- `test/unit/miner-migrate-cli.test.ts` — `STORE_NAMES` (the sweep asserts name + order, and that a fresh env skips all eleven);
- `test/unit/miner-status.test.ts` — `doctor`'s `--json` check-name list.

## Validation

- `npx vitest run test/unit/miner-migrate-cli.test.ts test/unit/miner-status.test.ts` → **43 passed, 44 total**. The single failure (`resolves the state dir…`) is **pre-existing on Windows only** — the pristine baseline fails it identically (`1 failed | 32 passed`) — POSIX path-separator semantics; **zero net-new failures**.
- `npm run typecheck` → **clean (0 errors)**
- Scope: 2 source files + 2 test files (+28/−0)
