### PR TITLE
fix(test): stop ai-summaries forbidden-word sweep timing out under load

### DIFF
--- a/test/unit/ai-summaries.test.ts
+++ b/test/unit/ai-summaries.test.ts
@@ -409,16 +409,22 @@ describe("optional deterministic-summary rewrite layer", () => {
   });
 
   it("routes every forbidden public term through the canonical sanitizer and falls back when AI is unsafe", async () => {
-    // Iterates every entry in FORBIDDEN_PUBLIC_COMMENT_WORDS (40+ words) as its own real round trip through
-    // rewriteSignalBundleWithAi -- legitimately more work than the default 15s test timeout reliably covers
-    // under load (observed timing out under concurrent CI shard contention, not a logic failure: every
-    // assertion that DID run passed). An explicit timeout says so instead of relying on ambient headroom.
+    // Iterates every entry in FORBIDDEN_PUBLIC_COMMENT_WORDS as its own real round trip through
+    // rewriteSignalBundleWithAi, sharing one env/D1 database across all of them instead of building a
+    // fresh one per word: createTestEnv() replays every migrations/*.sql file per call (test/helpers/d1.ts),
+    // so N fresh in-memory databases -- not rewriteSignalBundleWithAi itself -- was what previously pushed
+    // this test past vitest's default timeout under load. Sharing is safe here: every iteration lands on
+    // the "unsafe" branch, and sumAiEstimatedNeuronsSince only sums status "ok" rows (src/db/repositories.ts),
+    // so the shared daily neuron budget never accumulates across words.
+    let currentWord = "";
+    const run = vi.fn(async () => ({ response: `Looks great, includes ${currentWord} detail.` }));
+    const env = publicEnv({}, run);
     for (const word of FORBIDDEN_PUBLIC_COMMENT_WORDS) {
-      const run = vi.fn(async () => ({ response: `Looks great, includes ${word} detail.` }));
-      const result = await rewriteSignalBundleWithAi(publicEnv({}, run), rewriteReq());
+      currentWord = word;
+      const result = await rewriteSignalBundleWithAi(env, rewriteReq());
       expect(result, `forbidden word: ${word}`).toMatchObject({ status: "unsafe", text: DETERMINISTIC_BODY });
     }
-  }, 30000);
+  });
 
   it("rejects reward, ranking, scoreability, and reviewability variants in public AI rewrites", async () => {
     const unsafeOutputs = [


### PR DESCRIPTION
## Summary

- `test/unit/ai-summaries.test.ts`'s "routes every forbidden public term through the canonical sanitizer and falls back when AI is unsafe" test iterates all 33 entries in `FORBIDDEN_PUBLIC_COMMENT_WORDS`, building a fresh `createTestEnv()` (via `publicEnv()`) on every single iteration.
- `createTestEnv()` constructs a new in-memory SQLite database and replays every `migrations/*.sql` file (166 of them) on construction (`test/helpers/d1.ts`) -- so the loop was rebuilding a fully-migrated database 33 times over for a test that only needs one shared database.
- This was previously masked by widening the timeout to an explicit 30s (commit `534dad77`, alongside two sibling tests with the same symptom), but under sufficiently heavy concurrent load even 30s wasn't enough -- reproduced locally: an isolated run that normally passes in ~9s took 72s+ and failed on both the initial attempt and vitest's automatic retry.
- Fix: hoist the shared env/mock out of the loop so the database is built once, not 33 times. This is safe -- every iteration is expected to land on the `"unsafe"` branch, and `sumAiEstimatedNeuronsSince` only sums `status: "ok"` rows (`src/db/repositories.ts`), so the shared daily neuron budget never accumulates across words.
- Result: isolated runs dropped from ~9s (up to 72s+ under load) to under 1s (3 consecutive runs: 619ms, 318ms, 297ms), and a full unsharded `npm run test:coverage` pass (18,027 tests) shows no timeout on this test.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- not applicable; this is a maintainer-authored test-reliability fix, not a contributor PR under the linked-issue policy.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- test-only change to `test/**`, which Codecov does not measure, so there is no patch-coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- not applicable; no production code changed.

Additional validation beyond the standard checklist: ran the fixed test in isolation 3x consecutively (all under 1s, see Summary), ran the full `test/unit/ai-summaries.test.ts` file (all 47 tests pass), and ran a full local `npm run test:ci` pass -- fully green for this file. That gate run separately surfaced two unrelated, pre-existing flakes in `test/unit/miner-attempt-worktree.test.ts` and `test/unit/miner-repo-clone.test.ts` (same root class: real git subprocess work exceeding the default timeout under load), which are fixed in a separate companion PR rather than folded into this one.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Not applicable -- test-only change.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable -- no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not applicable -- no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (Not applicable -- no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below. (Not applicable -- no visible/UI changes.)
- [x] Public docs/changelogs are updated where needed. (Not applicable.)

## UI Evidence

Not applicable -- test-only change, no UI/frontend/docs surface touched.

## Notes

- Companion PRs from the same investigation: a same-pattern timeout fix for `test/unit/agent-sdk-driver.test.ts`, and a same-pattern fix for the `#5132` miner clone/worktree test suite.