### PR TITLE
fix(ci): update remaining gittensory references in workflow files

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -51,7 +51,7 @@ jobs:
     environment: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]' && github.ref_type == 'tag' && inputs.create_github_release && contains(inputs.version, '-beta.') && 'release-beta' || 'release' }}
     env:
       SENTRY_ORG: jsonbored
-      SENTRY_PROJECT: gittensory
+      SENTRY_PROJECT: loopover
       SENTRY_CLI_PACKAGE: "@sentry/cli@3.6.0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -114,7 +114,7 @@ jobs:
           {
             echo "v=${VERSION}"
             echo "tag=orb-v${VERSION}"
-            echo "release=gittensory-orb@${VERSION}"
+            echo "release=loopover-orb@${VERSION}"
             echo "prerelease=${PRERELEASE}"
           } >> "$GITHUB_OUTPUT"
 
@@ -162,7 +162,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG || 'jsonbored' }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT || 'gittensory' }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT || 'loopover' }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_RELEASE: ${{ steps.version.outputs.release }}
           SENTRY_REPOSITORY: ${{ github.repository }}
@@ -275,7 +275,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG || 'jsonbored' }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT || 'gittensory' }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT || 'loopover' }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_RELEASE: ${{ steps.version.outputs.release }}
         run: |
@@ -287,7 +287,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG || 'jsonbored' }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT || 'gittensory' }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT || 'loopover' }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_RELEASE: ${{ steps.version.outputs.release }}
           SENTRY_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -66,7 +66,7 @@ jobs:
         image: postgres:18-alpine
         env:
           POSTGRES_PASSWORD: devpw
-          POSTGRES_DB: gittensory
+          POSTGRES_DB: loopover
         ports:
           - 5432:5432
         options: >-
@@ -94,7 +94,7 @@ jobs:
         run: npm run build --workspace @loopover/engine
 
       - name: Postgres integration test (real PG)
-        run: PG_TEST_URL=postgres://postgres:devpw@localhost:5432/gittensory npx vitest run test/integration/selfhost-pg.test.ts
+        run: PG_TEST_URL=postgres://postgres:devpw@localhost:5432/loopover npx vitest run test/integration/selfhost-pg.test.ts
 
       - name: Build the self-host bundle
         run: node scripts/build-selfhost.mjs
@@ -115,11 +115,11 @@ jobs:
             --cache-from type=gha \
             --cache-to type=gha,mode=max \
             --load \
-            -t gittensory:selfhost-ci .
+            -t loopover:selfhost-ci .
 
       - name: Smoke-test bundled AI CLIs
         run: |
-          docker run --rm --entrypoint sh gittensory:selfhost-ci -c \
+          docker run --rm --entrypoint sh loopover:selfhost-ci -c \
             'command -v claude && claude --version && command -v codex && codex --version'
 
       - name: Free disk before visual-review image build
@@ -134,10 +134,10 @@ jobs:
             --build-context selfhost_dist=./dist \
             --build-arg INSTALL_VISUAL_REVIEW=true \
             --load \
-            -t gittensory:selfhost-prebuilt-visual-ci .
-          docker run --rm --entrypoint node gittensory:selfhost-prebuilt-visual-ci \
+            -t loopover:selfhost-prebuilt-visual-ci .
+          docker run --rm --entrypoint node loopover:selfhost-prebuilt-visual-ci \
             -e "import('puppeteer-core').then(() => console.log('puppeteer-core ok'))"
-          docker rmi gittensory:selfhost-prebuilt-visual-ci || true
+          docker rmi loopover:selfhost-prebuilt-visual-ci || true
           docker image prune -f
 
       - name: Boot the container + smoke-test /health, /ready, /metrics, migrations
@@ -153,7 +153,7 @@ jobs:
             -e REDIS_URL=redis://gt-redis:6379 \
             -e SELFHOST_SETUP_TOKEN=selfhost-ci-setup-token \
             -e PUBLIC_API_ORIGIN=https://selfhost-ci.example \
-            gittensory:selfhost-ci
+            loopover:selfhost-ci
           ok=0
           for _ in $(seq 1 30); do
             if curl -sf http://127.0.0.1:8787/health >/dev/null; then ok=1; break; fi

--- a/.github/workflows/visual-capture-fallback.yml
+++ b/.github/workflows/visual-capture-fallback.yml
@@ -1,13 +1,13 @@
 name: LoopOver Visual Capture Fallback
 
 # GitHub-Actions build-and-serve FALLBACK for a repo with no CI-produced preview deploy (#4112, part of the
-# #3607 visual-capture convergence epic). gittensory's preview-url.ts discovery chain (Deployments API ->
+# #3607 visual-capture convergence epic). loopover's preview-url.ts discovery chain (Deployments API ->
 # commit-check scan -> bot PR-comment scan) only ever finds a preview that SOME OTHER CI already produced;
 # this workflow is what lets a self-hosted repo with none of that still get an automated "after" screenshot,
 # by having Actions itself build, serve, and capture the PR's own code.
 #
 # Mirrors this repo's OWN ui-preview.yml fork-safety discipline: `contents: read` only, NO secrets anywhere in
-# this job. It is triggered ONLY by `workflow_dispatch`, and ONLY gittensory's own backend dispatches it
+# this job. It is triggered ONLY by `workflow_dispatch`, and ONLY loopover's own backend dispatches it
 # (src/review/visual/actions-fallback.ts, dispatchVisualCaptureFallback) -- always against `ref:
 # <default-branch>`. A `workflow_dispatch` call always runs the DISPATCHED ref's copy of this file, so a
 # contributor can never smuggle a modified workflow definition through their own PR branch (unlike a
@@ -24,13 +24,13 @@ name: LoopOver Visual Capture Fallback
 # regardless of how trusted its source is.
 #
 # Handoff: this job uploads its captured PNGs as a GitHub Actions artifact (`loopover-visual-fallback`) and
-# stops -- it never talks to gittensory directly and holds no credential to do so. On completion, GitHub
-# delivers a `workflow_run` webhook; gittensory's backend then lists + downloads that run's artifact using its
+# stops -- it never talks to loopover directly and holds no credential to do so. On completion, GitHub
+# delivers a `workflow_run` webhook; loopover's backend then lists + downloads that run's artifact using its
 # OWN, already-trusted GitHub App installation token -- never a token that passed through this job.
 #
 # Setup (self-hosted repos only -- NOT needed for loopover-ui / metagraphed, which already have their own
 # preview-deploy pipeline): copy this file, unmodified, into the target repo's `.github/workflows/` at this
-# EXACT path and name (`visual-capture-fallback.yml` / "LoopOver Visual Capture Fallback") -- gittensory's
+# EXACT path and name (`visual-capture-fallback.yml` / "LoopOver Visual Capture Fallback") -- loopover's
 # dispatch call and workflow_run listener both key off this fixed name. Then set `review.visual.actions_fallback:
 # true` in that repo's `.loopover.yml` (see .loopover.yml.example) to opt in; it activates ONLY when the
 # existing discovery chain finds no preview at all, so a repo with its own CI-produced preview is unaffected.
@@ -163,7 +163,7 @@ jobs:
         if: always()
         run: kill "$(cat serve.pid)" 2>/dev/null || true
 
-      # gittensory's backend downloads this by name via its OWN installation token (never a token from this
+      # loopover's backend downloads this by name via its OWN installation token (never a token from this
       # job) once the `workflow_run` completion webhook arrives -- see fetchFallbackArtifactShots.
       - name: Upload captured screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- `release-selfhost.yml` carried a real bug, not just stale naming: `SENTRY_PROJECT` isn't set as a repo variable (confirmed via `gh variable get`), so every release build was falling back to the hardcoded default `'gittensory'` — the Sentry project's pre-rename slug — for all Sentry API calls. Separately, the `release=gittensory-orb@${VERSION}` step output feeds `SENTRY_RELEASE` (3 places) and `LOOPOVER_VERSION` on every release, meaning this workflow was actively *regenerating* the exact stale value I found and removed from the server's `.env` earlier this session, not just leaving an old leftover. Fixed the job-level default, all 3 step-level `vars.SENTRY_PROJECT ||` fallbacks, and the release-string template.
- `selfhost.yml` and `visual-capture-fallback.yml` had only cosmetic references: a throwaway CI-only test Postgres DB name, Docker image tags scoped to a single job run, and prose comments describing current backend behavior. Updated for consistency/clarity.
- Left untouched: the two comments in `release-selfhost.yml` (lines 8, 224) that correctly document a past Docker-image-naming decision (#4777) in historical-past-tense framing — those are legitimate history, not drift.

## Scope
- [x] Narrow, single-purpose change (workflow files only)
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `npm run actionlint` — clean
- `git diff --check` — clean
- Confirmed via `git grep` that only the 2 legitimate historical comments remain across all 3 files