### PR TITLE
fix(miner): retry GitHub rate-limit responses in http-retry instead of aborting the poll (#6761)

### DIFF
--- a/packages/loopover-miner/lib/http-retry.js
+++ b/packages/loopover-miner/lib/http-retry.js
@@ -1,10 +1,12 @@
 // Bounded retry-with-backoff around a single HTTP call (#4829). The miner's pollers (ci-poller and others)
 // previously let a single brief 5xx from GitHub kill the whole poll loop, because their own attempt loop
 // only re-polls while a conclusion is genuinely "pending", never after a server error. This wraps ONE fetch so a
-// transient SERVER error (a 5xx RESPONSE) is retried a bounded number of times, DISTINCT from that pending-
-// polling, sleeping an exponential backoff between attempts and giving up after `maxAttempts`. A 2xx/3xx/4xx
-// response is returned immediately, and a THROWN error (a network-level failure) propagates unchanged rather than
-// being retried — the pollers' existing failure-mode contract (#4281) deliberately bubbles those to the caller.
+// transient SERVER error (a 5xx RESPONSE) or a transient GitHub RATE-LIMIT response (429 / secondary-403, #6761)
+// is retried a bounded number of times, DISTINCT from that pending-polling, sleeping an exponential backoff (or
+// the response's `Retry-After`, whichever is longer) between attempts and giving up after `maxAttempts`. Any other
+// 2xx/3xx/4xx response — including a plain permission 403 — is returned immediately, and a THROWN error (a network-
+// level failure) propagates unchanged rather than being retried — the pollers' existing failure-mode contract
+// (#4281) deliberately bubbles those to the caller.
 // Pure control flow over injected `fetchFn`/`sleepFn`/`backoffMs` — no real network or timers in tests.
 
 const DEFAULT_MAX_ATTEMPTS = 3;
@@ -25,10 +27,50 @@ export function defaultRetryBackoffMs(attempt) {
 
 const defaultSleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs));
 
+/** Read a response header defensively — works with a real `Headers` object or a test stub exposing `.get()`. */
+function readHeader(response, name) {
+  const headers = response && response.headers;
+  return headers && typeof headers.get === "function" ? headers.get(name) : null;
+}
+
 /**
- * Perform `fetchFn(url, init)` with bounded retry on a transient 5xx response. A 5xx is retried (sleeping
- * `backoffMs(attempt)` between attempts) up to `maxAttempts`; a 2xx/3xx/4xx response is returned immediately, and
- * after the last attempt a lingering 5xx is returned as-is (the caller's own error handling still runs). A THROWN
+ * A transient GitHub rate-limit response the poll should ride out rather than abort on (#6761): a 429 (primary
+ * rate limit / abuse), or a SECONDARY-rate-limit 403 — identified by a `Retry-After` header or `x-ratelimit-
+ * remaining: 0`. A plain permission-denied 403 carries neither signal and is deliberately NOT treated as a rate
+ * limit: it can never succeed, so retrying it would only burn the bounded attempt budget.
+ */
+function isRateLimitStatus(response) {
+  if (response.status === 429) return true;
+  if (response.status !== 403) return false;
+  if (readHeader(response, "retry-after") != null) return true;
+  const remaining = readHeader(response, "x-ratelimit-remaining");
+  return remaining != null && Number(remaining) === 0;
+}
+
+/** Retry a transient SERVER error (5xx) OR a transient rate-limit response (429 / secondary-403). (#6761) */
+function isRetryableStatus(response) {
+  return response.status >= 500 || isRateLimitStatus(response);
+}
+
+/**
+ * Delay before the next attempt. Honor a `Retry-After` header (delta-seconds) when GitHub sends one — but never
+ * below the computed exponential backoff (so a tiny/zero value can't hammer) and never above MAX_BACKOFF_MS;
+ * otherwise fall back to the exponential backoff alone. (#6761)
+ */
+function retryDelayMs(response, attempt, backoffMs) {
+  const base = backoffMs(attempt);
+  const retryAfterSeconds = Number(readHeader(response, "retry-after"));
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return Math.min(MAX_BACKOFF_MS, Math.max(base, retryAfterSeconds * 1000));
+  }
+  return base;
+}
+
+/**
+ * Perform `fetchFn(url, init)` with bounded retry on a transient 5xx OR rate-limit (429 / secondary-403) response.
+ * A retryable status is retried (sleeping `Retry-After` or `backoffMs(attempt)`, whichever is longer, between
+ * attempts) up to `maxAttempts`; any other 2xx/3xx/4xx response is returned immediately, and after the last attempt
+ * a lingering retryable status is returned as-is (the caller's own error handling still runs). A THROWN
  * error is NOT retried — it propagates to the caller (the pollers' #4281 failure-mode contract). When `timeoutMs`
  * is given, each attempt gets its own fresh abort timeout (a stalled connection is exactly the kind of network-
  * level failure #4281 already bubbles unretried, so a timed-out attempt propagates the same way).
@@ -46,10 +88,11 @@ export async function fetchWithRetry(fetchFn, url, init, options = {}) {
   for (let attempt = 1; ; attempt += 1) {
     // A thrown error is intentionally NOT caught here — it propagates to the caller unchanged.
     const response = await fetchOnce(fetchFn, url, init, options.timeoutMs);
-    // Retry only transient SERVER errors (5xx). Return 2xx/3xx/4xx immediately; on the final attempt a lingering
-    // 5xx is returned as-is.
-    if (response.status < 500 || attempt >= maxAttempts) return response;
-    await sleepFn(backoffMs(attempt));
+    // Retry transient SERVER errors (5xx) AND transient GitHub rate-limit responses (429 / secondary-403, #6761).
+    // Everything else (2xx/3xx/other 4xx incl. a plain permission 403) is returned immediately; on the final
+    // attempt a lingering retryable status is returned as-is so the caller's own error handling still runs.
+    if (!isRetryableStatus(response) || attempt >= maxAttempts) return response;
+    await sleepFn(retryDelayMs(response, attempt, backoffMs));
   }
 }
 

--- a/test/unit/miner-ci-poller-failure-modes.test.ts
+++ b/test/unit/miner-ci-poller-failure-modes.test.ts
@@ -20,28 +20,39 @@ function checkRun(name: string, status: string, conclusion: string | null = null
   };
 }
 
-// Three transient-failure modes the existing miner-ci-poller.test.ts (#2323) does not exercise (#4281). Because
-// pollCheckRuns' attempt loop (ci-poller.js:200-225) wraps NO try/catch around fetchHeadSha/fetchCheckRuns, a single
-// thrown error on attempt 1 aborts the whole poll immediately — it does not consume a backoff attempt and retry.
-// These pin that current behavior (no silent retry, no swallow, no hang) rather than changing it; if the poll should
-// instead retry on a 429, that is a separate feat/fix, deliberately not done here under a test-prefixed change.
-describe("miner CI poller transient-failure modes (#4281)", () => {
-  it.each([403, 429])(
-    "propagates a %d response as github_<status> and does NOT retry through the remaining attempts",
-    async (status) => {
-      const sleepFn = vi.fn(async () => {});
-      const fetchFn = vi.fn(async () => jsonResponse({ message: "API rate limit exceeded" }, { status }));
+// Transient-failure modes the happy-path miner-ci-poller.test.ts (#2323) does not exercise (#4281). pollCheckRuns'
+// attempt loop wraps NO try/catch around fetchHeadSha/fetchCheckRuns, so a THROWN error on attempt 1 aborts the
+// whole poll immediately. #6761 refined the RESPONSE side: fetchWithRetry now rides out a transient RATE-LIMIT
+// response (429, or a secondary-rate-limit 403 with a Retry-After / x-ratelimit-remaining: 0 header) within its
+// bounded budget, but a PLAIN permission 403 (no rate-limit signal) is still not retried, and a thrown network
+// error still propagates unretried. These pin those distinctions.
+describe("miner CI poller transient-failure modes (#4281, #6761)", () => {
+  it("propagates a plain permission 403 (no rate-limit headers) as github_403 without retrying", async () => {
+    const sleepFn = vi.fn(async () => {});
+    const fetchFn = vi.fn(async () => jsonResponse({ message: "Resource not accessible by integration" }, { status: 403 }));
 
-      await expect(
-        pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
-      ).rejects.toMatchObject({ code: `github_${status}` });
+    await expect(
+      pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
+    ).rejects.toMatchObject({ code: "github_403" });
 
-      // The error surfaces on attempt 1's first request (the PR head-SHA fetch) and aborts the poll: no backoff
-      // sleep is consumed and none of the remaining four attempts run.
-      expect(fetchFn).toHaveBeenCalledTimes(1);
-      expect(sleepFn).not.toHaveBeenCalled();
-    },
-  );
+    // Not a rate limit → not retried: the error surfaces on the very first (PR head-SHA) request and aborts the poll.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("retries a persistent 429 within fetchWithRetry's bounded budget, then surfaces github_429 (#6761)", async () => {
+    const sleepFn = vi.fn(async () => {});
+    const fetchFn = vi.fn(async () => jsonResponse({ message: "API rate limit exceeded" }, { status: 429 }));
+
+    await expect(
+      pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
+    ).rejects.toMatchObject({ code: "github_429" });
+
+    // The head-SHA fetch's fetchWithRetry now exhausts its default 3 attempts (2 backoff sleeps) on the persistent
+    // 429 before the still-429 surfaces — a single transient spike would instead have been ridden out to success.
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
 
   it("propagates a fetchFn promise rejection (network timeout) during the PR head-SHA fetch", async () => {
     const sleepFn = vi.fn(async () => {});

--- a/test/unit/miner-ci-poller.test.ts
+++ b/test/unit/miner-ci-poller.test.ts
@@ -90,6 +90,28 @@ describe("miner CI check-run poller (#2323)", () => {
     expect(result.conclusion).toBe("success"); // the poll completed despite the transient 5xx
   });
 
+  it("retries a transient 429 rate-limit from GitHub during the poll and completes (#6761)", async () => {
+    let checkRunsAttempts = 0;
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/repos/acme/widgets/pulls/42")) return prResponse("head-sha");
+      if (url.includes("/check-runs")) {
+        checkRunsAttempts += 1;
+        if (checkRunsAttempts === 1) return jsonResponse({ message: "API rate limit exceeded" }, { status: 429 }); // a transient rate limit
+        return checksResponse([checkRun("validate", "completed", "success")]);
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+    const result = await pollCheckRuns("acme/widgets", 42, {
+      apiBaseUrl: API,
+      githubToken: "github-token",
+      fetchFn,
+      sleepFn: () => Promise.resolve(), // no real backoff delay in the test
+    });
+    expect(checkRunsAttempts).toBe(2); // the 429 was retried within the bounded budget, then succeeded
+    expect(result.conclusion).toBe("success"); // the poll completed instead of aborting on the rate limit
+  });
+
   it("rejects untrusted apiBaseUrl values before any token-bearing request", async () => {
     const fetchFn = vi.fn();
     for (const apiBaseUrl of [

--- a/test/unit/miner-http-retry.test.ts
+++ b/test/unit/miner-http-retry.test.ts
@@ -83,6 +83,85 @@ describe("fetchWithRetry (#4829)", () => {
   });
 });
 
+/** A response with case-insensitive header lookup, mirroring a real `Headers` object's `.get()`. */
+function resp(status: number, headers: Record<string, string> = {}) {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return { status, headers: { get: (name: string) => (name.toLowerCase() in lower ? lower[name.toLowerCase()] : null) } };
+}
+
+/** A fetchFn driven by a scripted list of response objects (the last one repeats). */
+function seqFetch(responses: Array<ReturnType<typeof resp>>) {
+  let call = 0;
+  return async (_url?: unknown, _init?: unknown) => responses[Math.min(call++, responses.length - 1)]!;
+}
+
+describe("fetchWithRetry rate-limit retry (#6761)", () => {
+  it("retries a 429 (primary rate limit) and returns the eventual success", async () => {
+    const f = seqFetch([resp(429), resp(200)]);
+    const res = await fetchWithRetry(f, "u", undefined, { maxAttempts: 3, sleepFn: noSleep });
+    expect(res.status).toBe(200);
+  });
+
+  it("retries a secondary-rate-limit 403 (Retry-After header present)", async () => {
+    const f = seqFetch([resp(403, { "retry-after": "1" }), resp(200)]);
+    const res = await fetchWithRetry(f, "u", undefined, { maxAttempts: 3, sleepFn: noSleep });
+    expect(res.status).toBe(200);
+  });
+
+  it("retries a primary-rate-limit 403 (x-ratelimit-remaining: 0)", async () => {
+    const f = seqFetch([resp(403, { "x-ratelimit-remaining": "0" }), resp(200)]);
+    const res = await fetchWithRetry(f, "u", undefined, { maxAttempts: 3, sleepFn: noSleep });
+    expect(res.status).toBe(200);
+  });
+
+  it("does NOT retry a plain permission 403 (no rate-limit signal) — returns it immediately", async () => {
+    let calls = 0;
+    const f = async () => {
+      calls += 1;
+      return resp(403, { "x-ratelimit-remaining": "4999" });
+    };
+    const res = await fetchWithRetry(f, "u", undefined, { maxAttempts: 3, sleepFn: noSleep });
+    expect(res.status).toBe(403);
+    expect(calls).toBe(1);
+  });
+
+  it("does NOT retry a 403 with no headers at all (defensive header read)", async () => {
+    let calls = 0;
+    const f = async () => {
+      calls += 1;
+      return { status: 403 }; // no `headers` property
+    };
+    const res = await fetchWithRetry(f, "u", undefined, { maxAttempts: 3, sleepFn: noSleep });
+    expect(res.status).toBe(403);
+    expect(calls).toBe(1);
+  });
+
+  it("honors Retry-After (delta-seconds), never below the backoff, and caps at MAX_BACKOFF_MS", async () => {
+    const delays: number[] = [];
+    const sleepFn = (ms: number) => {
+      delays.push(ms);
+      return Promise.resolve();
+    };
+    // attempt 1: Retry-After 2s > backoff 500 → 2000ms; attempt 2: Retry-After 3600s → capped to 10_000ms.
+    const f = seqFetch([resp(429, { "retry-after": "2" }), resp(429, { "retry-after": "3600" }), resp(200)]);
+    await fetchWithRetry(f, "u", undefined, { maxAttempts: 5, sleepFn, backoffMs: () => 500 });
+    expect(delays).toEqual([2000, 10_000]);
+  });
+
+  it("falls back to the exponential backoff when Retry-After is smaller, zero, or non-numeric", async () => {
+    const delays: number[] = [];
+    const sleepFn = (ms: number) => {
+      delays.push(ms);
+      return Promise.resolve();
+    };
+    // Retry-After "0" → max(800, 0) = 800; "nope" → NaN → backoff 800.
+    const f = seqFetch([resp(429, { "retry-after": "0" }), resp(429, { "retry-after": "nope" }), resp(200)]);
+    await fetchWithRetry(f, "u", undefined, { maxAttempts: 5, sleepFn, backoffMs: () => 800 });
+    expect(delays).toEqual([800, 800]);
+  });
+});
+
 describe("fetchWithRetry timeoutMs (#miner-github-read-timeouts)", () => {
   it("does not inject a signal when timeoutMs is absent (undefined)", async () => {
     const f = scriptedFetch([200]);

--- a/test/unit/miner-pr-disposition-poller.test.ts
+++ b/test/unit/miner-pr-disposition-poller.test.ts
@@ -47,6 +47,24 @@ describe("PR disposition poller (#5135)", () => {
     expect(result).toMatchObject({ state: "closed", merged: true });
   });
 
+  it("retries a transient 429 rate-limit from the GitHub API during a poll and completes (#6761)", async () => {
+    let attempts = 0;
+    const fetchFn = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) return jsonResponse({ message: "API rate limit exceeded" }, { status: 429 }); // a transient rate limit
+      return prResponse({ state: "closed", merged: true, closed_at: "2026-07-12T00:00:00Z" });
+    });
+
+    const result = await pollPrDisposition("acme/widgets", 42, {
+      apiBaseUrl: API,
+      fetchFn,
+      sleepFn: async () => {}, // keep the per-call retry backoff instant
+    });
+
+    expect(attempts).toBe(2); // the 429 was retried, then succeeded — not surfaced as an immediate failure
+    expect(result).toMatchObject({ state: "closed", merged: true });
+  });
+
   it("returns terminal merged disposition immediately, without further polling", async () => {
     const fetchFn = vi.fn(async () =>
       prResponse({ state: "closed", merged: true, closed_at: "2026-07-12T00:00:00Z" }),


### PR DESCRIPTION
## Summary

`packages/loopover-miner/lib/http-retry.js`'s `fetchWithRetry` retried only transient **5xx** responses
(`if (response.status < 500 || attempt >= maxAttempts) return response;`). A GitHub **429** (or a
secondary-rate-limit **403**) therefore fell straight through to the pollers' `githubGetJsonResponse` /
`fetchPullRequest`, which throw on any non-2xx — and neither poller wraps that call in try/catch, so a single
transient rate-limit response **aborted the whole poll on attempt 1** (and, by extension, the miner run) instead
of riding out the spike.

This extends the retry predicate to also retry:

- a **429** (primary rate limit / abuse detection), and
- a **secondary-rate-limit 403** — identified by a `Retry-After` header or `x-ratelimit-remaining: 0`.

A **plain permission 403** carries neither signal and is deliberately **not** retried — it can never succeed, so
retrying would only burn the bounded attempt budget. `Retry-After` (delta-seconds) is honored for the
inter-attempt delay, never below the existing exponential backoff and capped at `MAX_BACKOFF_MS`. Thrown
network errors still propagate unretried (the #4281 contract). The fix lives in the shared helper, so every
`fetchWithRetry` caller (both pollers + `opportunity-fanout`) gets the hardened behavior.

Closes #6761

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6761`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `http-retry.js` is **fully covered** (all statements + branches: 429, secondary-403 via `Retry-After` and via `x-ratelimit-remaining: 0`, plain-403 no-retry, headerless-403 no-retry, and every `Retry-After` path — honored / below-backoff / non-numeric / capped), verified via `coverage-final.json`.
- [x] `npm run build:miner` (node --check)
- [x] `npx vitest run` for the 4 affected suites (59 passing): new rate-limit unit tests, 429-retried-to-success regressions for **both** `ci-poller` and `pr-disposition-poller`, and the updated `miner-ci-poller-failure-modes` pinning test (429 now retries; a plain 403 still aborts). `opportunity-fanout` (the other `fetchWithRetry` caller) suites still pass.

If any required check was skipped, explain why:

- Single miner-lib change + its tests; no UI/OpenAPI/MCP/migration/engine surface, so those checks are N/A to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — the retry predicate's negative path (a plain 403 is NOT retried) is explicitly tested so a permanent auth failure can't be mistaken for a transient one.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/MCP surface changed.
- [x] No visible UI changes (miner retry helper only), so no `UI Evidence` section is required.
- [x] Public docs/changelogs: none needed.

## Notes

- The 403 decision (per the issue's "explicitly decide and document" ask): a 403 is retried **only** when it looks like a secondary rate limit (`Retry-After` present, or `x-ratelimit-remaining: 0`); a bare permission 403 is returned immediately. This mirrors GitHub's own guidance that secondary-rate-limit 403s carry `Retry-After`.
