### PR TITLE
fix(test): stop rebuilding env/keys per iteration in repo-name validation tests

### DIFF
--- a/test/unit/github-labels.test.ts
+++ b/test/unit/github-labels.test.ts
@@ -11,12 +11,19 @@ describe("GitHub PR labels", () => {
   });
 
   it("rejects invalid repository names before making GitHub calls", async () => {
-    await expect(ensurePullRequestLabel(createTestEnv(), 123, "invalid", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(/Invalid repository full name/);
-    await expect(ensurePullRequestLabel(createTestEnv(), 123, "owner/repo/extra", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
+    // Every malformed name below is rejected by parseRepoFullName() (src/github/labels.ts) before
+    // ensurePullRequestLabel ever touches `env`, so one shared env per env-shape covers every case
+    // without rebuilding a fresh in-memory SQLite database (166-migration replay, see
+    // test/helpers/d1.ts) or generating a fresh RSA-2048 key (real synchronous CPU work) on every
+    // iteration -- that redundant setup, not the code under test, is what timed this test out under
+    // concurrent full-suite load.
+    const env = createTestEnv();
+    await expect(ensurePullRequestLabel(env, 123, "invalid", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(/Invalid repository full name/);
+    await expect(ensurePullRequestLabel(env, 123, "owner/repo/extra", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
       /Invalid repository full name/,
     );
     for (const padded of [" owner/repo ", "owner/ repo", "owner /repo", "own er/repo"]) {
-      await expect(ensurePullRequestLabel(createTestEnv(), 123, padded, 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
+      await expect(ensurePullRequestLabel(env, 123, padded, 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
         /Invalid repository full name/,
       );
     }
@@ -25,10 +32,11 @@ describe("GitHub PR labels", () => {
       called = true;
       return Response.json({ token: "t" });
     });
+    const keyedEnv = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
     for (const malformed of ["owner/repo/extra", "owner/ repo", "owner /repo"]) {
       await expect(
         ensurePullRequestLabel(
-          createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }),
+          keyedEnv,
           123,
           malformed,
           4,

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -14,16 +14,22 @@ describe("GitHub PR action primitives (#778)", () => {
   });
 
   it("validates the repo name before any GitHub call", async () => {
-    await expect(closePullRequest(createTestEnv(), 1, "invalid", 4)).rejects.toThrow(/Invalid repository full name/);
-    await expect(closePullRequest(createTestEnv(), 1, "owner/repo/extra", 4)).rejects.toThrow(
+    // Every malformed name below is rejected by splitRepo() (src/github/pr-actions.ts) before
+    // closePullRequest ever touches `env`, so one shared env per env-shape covers every case without
+    // rebuilding a fresh in-memory SQLite database (166-migration replay, see test/helpers/d1.ts) or
+    // generating a fresh RSA-2048 key (real synchronous CPU work) on every call -- that redundant
+    // setup, not the code under test, is what timed this test out under concurrent full-suite load.
+    const env = createTestEnv();
+    await expect(closePullRequest(env, 1, "invalid", 4)).rejects.toThrow(/Invalid repository full name/);
+    await expect(closePullRequest(env, 1, "owner/repo/extra", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
-    await expect(closePullRequest(createTestEnv(), 1, " owner/repo ", 4)).rejects.toThrow(
+    await expect(closePullRequest(env, 1, " owner/repo ", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
     // Per-segment padding (#6613) — mirrors assignees.ts parseRepoFullName coverage.
     for (const padded of ["owner/ repo", "owner /repo"]) {
-      await expect(closePullRequest(createTestEnv(), 1, padded, 4)).rejects.toThrow(
+      await expect(closePullRequest(env, 1, padded, 4)).rejects.toThrow(
         /Invalid repository full name/,
       );
     }
@@ -32,14 +38,15 @@ describe("GitHub PR action primitives (#778)", () => {
       called = true;
       return Response.json({ token: "t" });
     });
-    await expect(closePullRequest(envWithKey(), 1, "owner/repo/extra", 4)).rejects.toThrow(
+    const keyedEnv = envWithKey();
+    await expect(closePullRequest(keyedEnv, 1, "owner/repo/extra", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
-    await expect(closePullRequest(envWithKey(), 1, " owner/repo ", 4)).rejects.toThrow(
+    await expect(closePullRequest(keyedEnv, 1, " owner/repo ", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
     for (const padded of ["owner/ repo", "owner /repo"]) {
-      await expect(closePullRequest(envWithKey(), 1, padded, 4)).rejects.toThrow(
+      await expect(closePullRequest(keyedEnv, 1, padded, 4)).rejects.toThrow(
         /Invalid repository full name/,
       );
     }


### PR DESCRIPTION
## Summary

- `test/unit/github-labels.test.ts`'s "rejects invalid repository names before making GitHub calls" and `test/unit/github-pr-actions.test.ts`'s "validates the repo name before any GitHub call" each called `createTestEnv()` up to 9 times, and generated a fresh RSA-2048 key (`generateRsaPrivateKeyPem()`, real synchronous CPU work) up to 4 times -- once per malformed-name case in a loop.
- `ensurePullRequestLabel`/`closePullRequest` reject on `parseRepoFullName()`/`splitRepo()` before ever touching `env` (`src/github/labels.ts`, `src/github/pr-actions.ts`), so none of that setup was needed more than once per env-shape (plain vs. keyed).
- These were reported as timing out alongside three already-merged sibling fixes for the same general class of problem (real subprocess/DB setup work exceeding vitest's timeout under heavy concurrent load): `test/unit/ai-summaries.test.ts` (#6874), `test/unit/agent-sdk-driver.test.ts` (#6871), and the `#5132` miner clone/worktree suite (#6869).
- **This pair didn't reproduce under realistic load**, though: 3x isolated runs and 3x runs under simulated CPU contention (16 processes oversubscribing a 12-core machine) all passed cleanly, with neither target test ever appearing among the slowest tests in its file. The original failure was traced to two full ~18k-test suites running concurrently on one machine (two worktrees' `npm run test:ci` backgrounded at the same time) -- a self-inflicted, unrealistic doubling of load, not a normal-load risk.
- Fixing the confirmed redundant setup anyway since it's the exact same safe, zero-behavior-change pattern already proven on the three sibling PRs, and it measurably speeds up the suite regardless: ~20% faster on both files together under sustained load (44.7s/45.4s/40.9s fixed vs. 56.0s/56.4s/54.8s baseline, 3 runs each, same continued CPU-contention conditions). No timeout was widened -- there was nothing to widen; this is purely eliminating unnecessary setup.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- not applicable; this is a maintainer-authored test-reliability fix, not a contributor PR under the linked-issue policy.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- test-only change to `test/**`, which Codecov does not measure, so there is no patch-coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- not applicable; no production code changed, and both files' full 58 tests still pass unchanged.

Additional validation beyond the standard checklist: both target tests run 3x in isolation and 3x under simulated heavy CPU contention with zero failures (see timing data in Summary). A full local `npm run test:ci` run (single suite, not concurrent with anything else) shows both `github-labels.test.ts` and `github-pr-actions.test.ts` fully clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Not applicable -- test-only change.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable -- no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not applicable -- no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (Not applicable -- no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below. (Not applicable -- no visible/UI changes.)
- [x] Public docs/changelogs are updated where needed. (Not applicable.)

## UI Evidence

Not applicable -- test-only change, no UI/frontend/docs surface touched.

## Notes

- Follow-up from the same investigation as #6874, #6871, and #6869. A separate, unrelated bug (a stale `gittensory-orb` string in `test/unit/release-selfhost-prerelease.test.ts`, left behind by commit `7c5965d8`'s otherwise-correct rebrand of `.github/workflows/release-selfhost.yml`) was also surfaced by this PR's `npm run test:ci` run and is being fixed in its own separate PR.