### PR TITLE
fix(scripts): update remaining gittensory references, fix stale Sentry release default

### DIFF
--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -13,7 +13,7 @@ if (invalidArgs.length > 0) {
   process.exit(1);
 }
 
-const tempDir = mkdtempSync(join(tmpdir(), "gittensory-changelog-"));
+const tempDir = mkdtempSync(join(tmpdir(), "loopover-changelog-"));
 
 try {
   const checks = [

--- a/scripts/deploy-selfhost-prebuilt.sh
+++ b/scripts/deploy-selfhost-prebuilt.sh
@@ -7,7 +7,7 @@
 #   ./scripts/deploy-selfhost-prebuilt.sh
 #
 # Optional knobs:
-#   SENTRY_RELEASE=gittensory-selfhost@edge-abc123 ./scripts/deploy-selfhost-prebuilt.sh
+#   SENTRY_RELEASE=loopover-selfhost@edge-abc123 ./scripts/deploy-selfhost-prebuilt.sh
 #   SELFHOST_COMPOSE_FILES="docker-compose.yml docker-compose.override.yml" ./scripts/deploy-selfhost-prebuilt.sh
 #   SELFHOST_SKIP_SENTRY_UPLOAD=1 ./scripts/deploy-selfhost-prebuilt.sh
 #   SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh   # opt-in Infisical secrets (#5120), see docs
@@ -74,7 +74,7 @@ run_sentry_upload() {
     -v "$PWD:/work" \
     -w /work \
     "$NODE_IMAGE" \
-    sh -lc 'apt-get update >/dev/null && apt-get install -y --no-install-recommends ca-certificates git >/dev/null && git config --global --add safe.directory /work && (npx -y "$SENTRY_CLI_PACKAGE" releases new "$SENTRY_RELEASE" >/tmp/gittensory-sentry-release-new.log 2>&1 || true) && npx -y "$SENTRY_CLI_PACKAGE" releases set-commits "$SENTRY_RELEASE" --auto && npx -y "$SENTRY_CLI_PACKAGE" sourcemaps inject dist && node scripts/validate-selfhost-sourcemap.mjs && npx -y "$SENTRY_CLI_PACKAGE" sourcemaps upload --release="$SENTRY_RELEASE" dist && npx -y "$SENTRY_CLI_PACKAGE" releases finalize "$SENTRY_RELEASE" && chown -R "$HOST_UID:$HOST_GID" dist node_modules package-lock.json'
+    sh -lc 'apt-get update >/dev/null && apt-get install -y --no-install-recommends ca-certificates git >/dev/null && git config --global --add safe.directory /work && (npx -y "$SENTRY_CLI_PACKAGE" releases new "$SENTRY_RELEASE" >/tmp/loopover-sentry-release-new.log 2>&1 || true) && npx -y "$SENTRY_CLI_PACKAGE" releases set-commits "$SENTRY_RELEASE" --auto && npx -y "$SENTRY_CLI_PACKAGE" sourcemaps inject dist && node scripts/validate-selfhost-sourcemap.mjs && npx -y "$SENTRY_CLI_PACKAGE" sourcemaps upload --release="$SENTRY_RELEASE" dist && npx -y "$SENTRY_CLI_PACKAGE" releases finalize "$SENTRY_RELEASE" && chown -R "$HOST_UID:$HOST_GID" dist node_modules package-lock.json'
 }
 
 run_init_secrets() {
@@ -125,7 +125,7 @@ fi
 # Default to the current checkout on every deploy. Do not reuse a persisted .env value here:
 # that value is written by the previous deploy and would make future updates report stale
 # release/version metadata unless the operator remembered to override it manually.
-SENTRY_RELEASE="${SENTRY_RELEASE:-gittensory-selfhost@$(git rev-parse --short=8 HEAD)}"
+SENTRY_RELEASE="${SENTRY_RELEASE:-loopover-selfhost@$(git rev-parse --short=8 HEAD)}"
 export SENTRY_RELEASE
 
 env_put SENTRY_RELEASE "$SENTRY_RELEASE"

--- a/scripts/export-ams-reporting-db.sh
+++ b/scripts/export-ams-reporting-db.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-# AMS (gittensory-miner) redacted reporting export (#5184 follow-up; closes the gap PR #5471 flagged: Grafana must
+# AMS (loopover-miner) redacted reporting export (#5184 follow-up; closes the gap PR #5471 flagged: Grafana must
 # never mount the miner's live LOOPOVER_MINER_CONFIG_DIR ledgers directly -- attempt_log_events.reason and
 # .payload_json are free-form and can carry arbitrary internal detail). Mirrors export-grafana-reporting-db.sh's
 # shape (incremental fingerprint fast-path, atomic tmp-then-move, fail-open on a missing/unreadable source) but is

--- a/scripts/export-miner-prometheus-textfile.sh
+++ b/scripts/export-miner-prometheus-textfile.sh
@@ -20,7 +20,7 @@ set -eu
 # export is strictly better than a stale-forever or entirely-missing one.
 
 MINER_BIN="${LOOPOVER_MINER_BIN:-loopover-miner}"
-OUT_FILE="${LOOPOVER_MINER_PROMETHEUS_TEXTFILE:-/var/lib/node_exporter/textfile_collector/gittensory_miner.prom}"
+OUT_FILE="${LOOPOVER_MINER_PROMETHEUS_TEXTFILE:-/var/lib/node_exporter/textfile_collector/loopover_miner.prom}"
 TMP_FILE="${OUT_FILE}.tmp"
 
 mkdir -p "$(dirname "$OUT_FILE")"


### PR DESCRIPTION
## Summary
- `deploy-selfhost-prebuilt.sh` carried the same live bug just fixed in `release-selfhost.yml` (#6876): `SENTRY_RELEASE` defaulted to `gittensory-selfhost@<sha>` when unset, so a manual/prebuilt deploy tags Sentry with the pre-rename project's release format on every run. Fixed the default, its log-file path, and the usage-example comment.
- `check-changelog.mjs`, `export-ams-reporting-db.sh`, `export-miner-prometheus-textfile.sh` had cosmetic-only references (a temp-dir prefix, a stale parenthetical, a default output filename) — updated for consistency with the already-renamed `LOOPOVER_MINER_*` env vars around them.
- Audited every other `gittensor(y)` hit in `scripts/**` and deliberately left several untouched (full reasoning in the commit message): a wiki-link to an external doc I can't verify the real name of, a `--db gittensory` usage example that's now confirmed correct against the live Cloudflare account (the production D1 database is genuinely still named `gittensory`, kept by explicit decision — no in-place rename support in `wrangler d1`/`wrangler r2 bucket`, and a live-data migration isn't worth it for a cosmetic label), a stored DB discriminant value, an unrelated external `gittensor.io` service integration, and `gittensor:bug`/`feature`/`priority` — real, current GitHub label names on this repo, a deliberate naming choice separate from the old `gittensory` product name (confirmed against `src/config/loopover-repo-focus-manifest.ts`).

## Scope
- [x] Narrow, single-purpose change (scripts only)
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `bash -n` on all 3 shell scripts, `node --check` on the one `.mjs` — all clean
- `git diff --check` — clean