### PR TITLE
fix(test): match release-selfhost-prerelease.test.ts to the loopover-orb rename

### DIFF
--- a/test/unit/release-selfhost-prerelease.test.ts
+++ b/test/unit/release-selfhost-prerelease.test.ts
@@ -55,7 +55,7 @@ describe("release-selfhost.yml \"Resolve version\" step (#1937)", () => {
   it("accepts a stable semver tag and marks it non-prerelease", () => {
     const r = resolveVersion({ EVENT_NAME: "push", INPUT_VERSION: "", REF_NAME: "orb-v0.1.0" });
     expect(r.status).toBe(0);
-    expect(r.outputs).toMatchObject({ v: "0.1.0", tag: "orb-v0.1.0", release: "gittensory-orb@0.1.0", prerelease: "false" });
+    expect(r.outputs).toMatchObject({ v: "0.1.0", tag: "orb-v0.1.0", release: "loopover-orb@0.1.0", prerelease: "false" });
   });
 
   it.each(["rc", "beta"])("accepts an -%s.N prerelease tag and marks it prerelease", (kind) => {


### PR DESCRIPTION
## Summary

- Commit `7c5965d8` ("fix(ci): update remaining gittensory references in workflow files") correctly changed `.github/workflows/release-selfhost.yml`'s "Resolve version" step to emit `release=loopover-orb@${VERSION}` instead of the pre-rename `gittensory-orb@${VERSION}` -- a real bug fix, not just cosmetic naming (an unset `SENTRY_PROJECT` was defaulting release builds to the deleted Sentry project's old slug, per that commit's own detailed message).
- `test/unit/release-selfhost-prerelease.test.ts` executes that exact bash step (extracted straight out of the committed workflow YAML, not a re-derived copy) and asserts on its real output -- it wasn't updated to match, so it started failing deterministically: expected `"gittensory-orb@0.1.0"`, received `"loopover-orb@0.1.0"`.
- Discovered while running the full local gate for an unrelated PR (#6880). Confirmed this is the only stale reference in this specific file (`grep -n "gittensory-orb" test/unit/release-selfhost-prerelease.test.ts` -- one hit) and confirmed via `git show 7c5965d8` that the production-side change was intentional and correct, not itself a bug to revert.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- not applicable; this is a maintainer-authored test-reliability fix, not a contributor PR under the linked-issue policy.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- test-only change to `test/**`, which Codecov does not measure, so there is no patch-coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- not applicable; no production code changed, this is a one-line expected-value correction.

Additional validation: a full local `npm run test:ci` run is fully green with this change (all steps, zero failures).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Not applicable -- test-only change.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable -- no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not applicable -- no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (Not applicable -- no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below. (Not applicable -- no visible/UI changes.)
- [x] Public docs/changelogs are updated where needed. (Not applicable.)

## UI Evidence

Not applicable -- test-only change, no UI/frontend/docs surface touched.

## Notes

- A broader, related cleanup (other stale `gittensory`/`gittensory-orb` bot-identity references across ~15 test files, including `test/helpers/d1.ts`'s `createTestEnv()` default) is being investigated and will follow in a separate PR.