### PR TITLE
fix(miner): give the coding-agent CLI subprocess an env it can authenticate with

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -353,6 +353,7 @@ export {
   type LintGuardSpawnFn,
 } from "./miner/lint-guard.js";
 export {
+  CODING_AGENT_CLI_CREDENTIAL_ENV,
   CODING_AGENT_DRIVER_CONFIG_ENV,
   CODING_AGENT_DRIVER_NAMES,
   createCodingAgentDriver,

--- a/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
+++ b/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
@@ -3,7 +3,11 @@ import type {
   CodingAgentDriverResult,
   CodingAgentDriverTask,
 } from "./coding-agent-driver.js";
-import { buildAllowlistedEnv, redactSecrets } from "../subprocess-env.js";
+import {
+  SUBPROCESS_CLI_ENV_ALLOWLIST,
+  buildAllowlistedEnv,
+  redactSecrets,
+} from "../subprocess-env.js";
 
 // CLI-subprocess CodingAgentDriver (#4266). Implements the CodingAgentDriver seam (#4262) by running the coding
 // agent (`claude`/`codex`) as a subprocess in the attempt's scoped working directory. The spawn primitive is
@@ -68,21 +72,14 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TRANSCRIPT_CHARS = 8000;
 const MAX_ERROR_DETAIL_CHARS = 500;
 
-const CODING_AGENT_ENV_ALLOWLIST = [
-  "HTTPS_PROXY",
-  "HTTP_PROXY",
-  "LANG",
-  "LC_ALL",
-  "NODE_EXTRA_CA_CERTS",
-  "NO_PROXY",
-  "PATH",
-  "SSL_CERT_DIR",
-  "SSL_CERT_FILE",
-  "TERM",
-  "https_proxy",
-  "http_proxy",
-  "no_proxy",
-] as const;
+// The child env comes from `SUBPROCESS_CLI_ENV_ALLOWLIST` (#6875). This module previously kept its own
+// `CODING_AGENT_ENV_ALLOWLIST`, which had drifted into a strict SUBSET of the shared list: identical except
+// that it dropped `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME` and `XDG_STATE_HOME`. `claude`/`codex` locate
+// their persisted credential under `HOME`/`XDG_CONFIG_HOME`, so a subprocess spawned without them could never
+// authenticate -- it answered every task with `"Not logged in · Please run /login"` behind an `is_error: true`
+// + `subtype: "success"` envelope, i.e. `claude_code_error_success` with zero turns. The shared list is the
+// module header's stated intent ("Two safety primitives are reused from subprocess-env.ts rather than
+// re-implemented"); the local copy was the drift.
 
 /** Real, verified `claude -p` non-interactive argv (confirmed against `claude --help` and a live invocation,
  *  #5135 follow-up -- the previous default argv here used `--max-turns`/`--acceptance-criteria`, neither of
@@ -266,7 +263,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
   const knownSecrets = options.knownSecrets ?? [];
   return {
     async run(task: CodingAgentDriverTask): Promise<CodingAgentDriverResult> {
-      const env = buildAllowlistedEnv(options.parentEnv ?? {}, CODING_AGENT_ENV_ALLOWLIST, options.env ?? {});
+      const env = buildAllowlistedEnv(options.parentEnv ?? {}, SUBPROCESS_CLI_ENV_ALLOWLIST, options.env ?? {});
       const spawned = await options.spawn(options.command, buildArgs(task), {
         cwd: task.workingDirectory,
         env,

--- a/packages/loopover-engine/src/miner/driver-factory.ts
+++ b/packages/loopover-engine/src/miner/driver-factory.ts
@@ -43,13 +43,34 @@ export type CodingAgentDriverName = (typeof CODING_AGENT_DRIVER_NAMES)[number];
  *  misleading config-as-code surface. Deliberately NOT declared: a max-turns key (the turn budget is task-level
  *  input — `CodingAgentDriverTask.maxTurns` — set by the orchestrator per attempt, not per-provider config) and
  *  an agent-sdk model key (the SDK session uses the account/CLI default; it exposes no model option on the
- *  driver today). */
+ *  driver today). A CLI provider's own credential env is NOT declared here either — it is not a per-provider
+ *  "companion var" an operator sets, and this map's one-kind-to-one-env-var-NAME shape is relied on by generic
+ *  consumers (`init-wizard.js`'s `promptCompanionVars`); see `CODING_AGENT_CLI_CREDENTIAL_ENV` below. */
 export const CODING_AGENT_DRIVER_CONFIG_ENV: Readonly<Record<CodingAgentDriverName, { model?: string; timeoutMs?: string }>> =
   Object.freeze({
     noop: {},
     "claude-cli": { model: "MINER_CODING_AGENT_CLAUDE_MODEL", timeoutMs: "MINER_CODING_AGENT_TIMEOUT_MS" },
     "codex-cli": { model: "MINER_CODING_AGENT_CODEX_MODEL", timeoutMs: "MINER_CODING_AGENT_TIMEOUT_MS" },
     "agent-sdk": {},
+  });
+
+/** The credential env var each CLI provider authenticates with, in preference order (#6875). Kept OUT of
+ *  `CODING_AGENT_DRIVER_CONFIG_ENV` deliberately: that map's contract is one `kind -> single env var NAME`, and
+ *  its generic consumers rely on it — `init-wizard.js`'s `promptCompanionVars` iterates its entries and prompts
+ *  once per value, so a list-valued entry there renders as
+ *  `Optional undefined for claude-cli (env CLAUDE_CODE_OAUTH_TOKEN,ANTHROPIC_API_KEY)` and writes a junk .env
+ *  line if answered. These are also not "companion vars" an operator sets per provider — they are the upstream
+ *  CLI's own credential, which is why they are declared here instead.
+ *
+ *  Keyed by the CLI `command` rather than the driver name because only the two spawning providers have one:
+ *  `agent-sdk` authenticates in-process and `noop` runs nothing, so neither can appear here, and the lookup is
+ *  total (no unreachable fallback branch). Order is preference order — the first configured key wins, mirroring
+ *  `firstConfiguredEnvValue`. Not a REQUIREMENT: `isConfiguredCodingAgentDriver` treats CLI providers as
+ *  locally-authenticated, so a credential persisted under `HOME` is the equally-valid other path. */
+export const CODING_AGENT_CLI_CREDENTIAL_ENV: Readonly<Record<"claude" | "codex", readonly string[]>> =
+  Object.freeze({
+    claude: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+    codex: ["OPENAI_API_KEY", "CODEX_ACCESS_TOKEN"],
   });
 
 /** `firstConfigured` (src/selfhost/ai.ts:117-134) pattern: a set-and-non-empty env value, else undefined. */
@@ -144,6 +165,22 @@ function buildCliArgsWithConfiguredModel(
   };
 }
 
+/** Resolve the ONE credential the selected CLI actually authenticates with, as a `{key: value}` overlay for the
+ *  driver's `env` (#6875). Returns `{}` when none is configured — a CLI provider is locally-authenticated, so a
+ *  credential persisted under `HOME` is the equally-valid other path and an absent key must not fail closed
+ *  here. Only the FIRST configured key of that command's own list is returned: forwarding every credential an
+ *  operator happens to have exported would hand a prompt-injectable subprocess keys it has no use for. */
+function resolveProviderCredentialEnv(
+  command: "claude" | "codex",
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  for (const key of CODING_AGENT_CLI_CREDENTIAL_ENV[command]) {
+    const value = firstConfiguredEnvValue(env[key]);
+    if (value !== undefined) return { [key]: value };
+  }
+  return {};
+}
+
 function createCliProvider(
   command: "claude" | "codex",
   modelEnvKey: string,
@@ -164,13 +201,27 @@ function createCliProvider(
   const model = firstConfiguredEnvValue(env[modelEnvKey]);
   const timeoutMs = configuredTimeoutMs(env);
   const buildArgs = buildCliArgsWithConfiguredModel(command, model);
+  // The credential rides in as the driver's `env` OVERLAY rather than as an allowlist entry (#6875). This is
+  // the pattern `createClaudeCodeAi` (src/selfhost/ai.ts) already uses for the REVIEWER CLI, for the reason
+  // stated there verbatim: threaded "explicitly here ... rather than widening SUBSCRIPTION_CLI_ENV_ALLOWLIST
+  // itself (which also gates the codex subprocess and should stay minimal)". Identical logic applies here --
+  // the allowlist is shared and provider-agnostic, so putting credential names in it would hand codex's key to
+  // a claude subprocess and vice versa. Resolving the overlay per provider is what keeps this least-privilege.
+  // `buildAllowlistedEnv` applies `extra` last, so it wins over any allowlisted parent value.
+  const credentialEnv = resolveProviderCredentialEnv(command, env);
+  // Anything we deliberately hand the child must also be redactable out of anything the child says back: the
+  // subprocess is prompt-injectable, and its stdout becomes a stored transcript and an error detail. The driver
+  // already redacts `knownSecrets` from both -- it just never had this value to redact. Merged with (not
+  // replacing) a caller's own list.
+  const knownSecrets = [...(options.knownSecrets ?? []), ...Object.values(credentialEnv)];
   return createCliSubprocessCodingAgentDriver({
     command,
     spawn: options.spawn,
     parentEnv: env,
+    ...(Object.keys(credentialEnv).length > 0 ? { env: credentialEnv } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(buildArgs !== undefined ? { buildArgs } : {}),
-    ...(options.knownSecrets !== undefined ? { knownSecrets: options.knownSecrets } : {}),
+    ...(knownSecrets.length > 0 ? { knownSecrets } : {}),
   });
 }
 

--- a/test/unit/cli-subprocess-driver.test.ts
+++ b/test/unit/cli-subprocess-driver.test.ts
@@ -136,10 +136,20 @@ describe("createCliSubprocessCodingAgentDriver (#4266)", () => {
     expect(env.HOME).toBe("/tmp/isolated-agent-home");
     expect(env.PATH).toBe("/usr/bin");
     expect(env.AGENT_SESSION_HANDLE).toBe("provided-by-caller");
+    // The actual invariant this case exists to defend, and it is unchanged: an arbitrary runtime var from the
+    // parent env never reaches a prompt-injectable child. Only the allowlist decides, and it is not the full env.
     expect(env.RUNTIME_ONLY_FLAG).toBeUndefined();
-    expect(env.XDG_CONFIG_HOME).toBeUndefined();
-    expect(env.XDG_DATA_HOME).toBeUndefined();
-    expect(env.XDG_STATE_HOME).toBeUndefined();
+    // The XDG paths ARE forwarded now (#6875). This case previously asserted them undefined -- that was a
+    // characterization of the driver's private, drifted allowlist rather than an invariant anyone argued for
+    // (the assertion arrived in #5362, a commit about deriving SDK changed files from git, with no rationale;
+    // the private list itself dates to the #5743 mechanical rename). `claude`/`codex` resolve their persisted
+    // credential under HOME/XDG_CONFIG_HOME, so withholding these is precisely what made every spawned agent
+    // answer "Not logged in · Please run /login". They are config PATHS, not credentials: the name of this case
+    // still holds -- the allowlisted parent copy carries no runtime secret, and a credential still arrives only
+    // via an explicit overlay.
+    expect(env.XDG_CONFIG_HOME).toBe("/home/miner/.config");
+    expect(env.XDG_DATA_HOME).toBe("/home/miner/.local/share");
+    expect(env.XDG_STATE_HOME).toBe("/home/miner/.local/state");
   });
 
   it("redacts known secret values and honors a custom argv builder", async () => {

--- a/test/unit/coding-agent-driver-credentials.test.ts
+++ b/test/unit/coding-agent-driver-credentials.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODING_AGENT_CLI_CREDENTIAL_ENV,
+  CODING_AGENT_DRIVER_CONFIG_ENV,
+  createCodingAgentDriver,
+} from "../../packages/loopover-engine/src/index";
+import type { CodingAgentDriverTask } from "../../packages/loopover-engine/src/index";
+
+// #6875: what the spawned coding-agent subprocess actually receives in its env. The pre-existing CLI-provider
+// cases assert the ARGV shape only, which is why a driver that could never authenticate shipped green -- every
+// case here asserts `opts.env` instead.
+
+const TASK: CodingAgentDriverTask = {
+  attemptId: "attempt-6875",
+  workingDirectory: "/tmp/work",
+  acceptanceCriteriaPath: "/tmp/work/ACCEPTANCE.md",
+  instructions: "fix the flaky test",
+  maxTurns: 4,
+};
+
+/** Run a CLI provider against a fake spawn and hand back the env the child would really have received. */
+async function spawnedEnv(
+  providerName: "claude-cli" | "codex-cli",
+  env: Record<string, string | undefined>,
+): Promise<Record<string, string | undefined>> {
+  let captured: Record<string, string | undefined> = {};
+  const driver = createCodingAgentDriver({
+    providerName,
+    env,
+    spawn: async (_cmd, _args, opts) => {
+      captured = opts.env;
+      return { stdout: "done", code: 0 };
+    },
+  });
+  await driver.run(TASK);
+  return captured;
+}
+
+describe("coding-agent CLI subprocess env (#6875)", () => {
+  it("forwards HOME and the XDG config paths to the child", async () => {
+    // Without these the CLI cannot locate its persisted credential and answers "Not logged in · Please run
+    // /login" behind an is_error:true + subtype:"success" envelope -- i.e. claude_code_error_success, 0 turns.
+    const env = await spawnedEnv("claude-cli", {
+      HOME: "/home/miner",
+      XDG_CONFIG_HOME: "/home/miner/.config",
+      XDG_DATA_HOME: "/home/miner/.local/share",
+      XDG_STATE_HOME: "/home/miner/.local/state",
+      PATH: "/usr/bin",
+    });
+    expect(env.HOME).toBe("/home/miner");
+    expect(env.XDG_CONFIG_HOME).toBe("/home/miner/.config");
+    expect(env.XDG_DATA_HOME).toBe("/home/miner/.local/share");
+    expect(env.XDG_STATE_HOME).toBe("/home/miner/.local/state");
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("forwards only the selected provider's own credential", async () => {
+    // The least-privilege half of the fix: an operator with both keys exported who runs claude-cli must not
+    // hand the unrelated OpenAI key to a prompt-injectable child.
+    const claude = await spawnedEnv("claude-cli", {
+      ANTHROPIC_API_KEY: "anthropic-key-6875",
+      OPENAI_API_KEY: "openai-key-6875",
+    });
+    expect(claude.ANTHROPIC_API_KEY).toBe("anthropic-key-6875");
+    expect(claude.OPENAI_API_KEY).toBeUndefined();
+
+    const codex = await spawnedEnv("codex-cli", {
+      ANTHROPIC_API_KEY: "anthropic-key-6875",
+      OPENAI_API_KEY: "openai-key-6875",
+    });
+    expect(codex.OPENAI_API_KEY).toBe("openai-key-6875");
+    expect(codex.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it("prefers the first configured key of a provider's list", async () => {
+    const both = await spawnedEnv("claude-cli", {
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-tok-6875",
+      ANTHROPIC_API_KEY: "anthropic-key-6875",
+    });
+    expect(both.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-tok-6875");
+    expect(both.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it("treats a blank credential as unconfigured and falls through to the next key", async () => {
+    // firstConfiguredEnvValue's own semantics: an empty/whitespace value is not a token, so forwarding it as if
+    // it were real would authenticate as nobody while masking the key that actually works.
+    const blank = await spawnedEnv("claude-cli", {
+      CLAUDE_CODE_OAUTH_TOKEN: "   ",
+      ANTHROPIC_API_KEY: "anthropic-key-6875",
+    });
+    expect(blank.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(blank.ANTHROPIC_API_KEY).toBe("anthropic-key-6875");
+  });
+
+  it("still spawns when no credential env is set (locally-authenticated)", async () => {
+    // isConfiguredCodingAgentDriver treats CLI providers as always-configured because a credential persisted
+    // under HOME is equally valid -- resolving no key must not throw or fabricate an empty one.
+    const env = await spawnedEnv("claude-cli", { HOME: "/home/miner" });
+    expect(env.HOME).toBe("/home/miner");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it("never forwards an arbitrary runtime var from the parent env", async () => {
+    // The invariant the widened allowlist must not cost us: the child gets the allowlist, never the full env.
+    const env = await spawnedEnv("claude-cli", {
+      HOME: "/home/miner",
+      RUNTIME_ONLY_FLAG: "leak-me",
+      DATABASE_URL: "postgres://leak",
+    });
+    expect(env.RUNTIME_ONLY_FLAG).toBeUndefined();
+    expect(env.DATABASE_URL).toBeUndefined();
+  });
+
+  it("redacts a forwarded credential out of the transcript", async () => {
+    // Anything deliberately handed to a prompt-injectable child must be redactable out of what it says back.
+    // The token is >=8 chars (redactSecrets' length guard) and deliberately matches NO SECRET_PATTERNS shape,
+    // so passing this proves the knownSecrets wiring rather than the pattern fallback.
+    const token = "oauth-tok-6875-not-a-known-shape";
+    const driver = createCodingAgentDriver({
+      providerName: "claude-cli",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: token },
+      spawn: async () => ({ stdout: `authenticated with ${token}`, code: 0 }),
+    });
+    const result = await driver.run(TASK);
+    expect(result.ok).toBe(true);
+    expect(result.transcript).not.toContain(token);
+    expect(result.transcript).toContain("[redacted]");
+  });
+
+  it("keeps a caller's own knownSecrets alongside the forwarded credential", async () => {
+    const token = "oauth-tok-6875-not-a-known-shape";
+    const callerSecret = "caller-secret-6875";
+    const driver = createCodingAgentDriver({
+      providerName: "claude-cli",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: token },
+      knownSecrets: [callerSecret],
+      spawn: async () => ({ stdout: `saw ${token} and ${callerSecret}`, code: 0 }),
+    });
+    const result = await driver.run(TASK);
+    expect(result.transcript).not.toContain(token);
+    expect(result.transcript).not.toContain(callerSecret);
+  });
+
+  it("leaves a codex subprocess without a credential when none is configured", async () => {
+    const env = await spawnedEnv("codex-cli", { HOME: "/home/miner" });
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CODEX_ACCESS_TOKEN).toBeUndefined();
+    expect(env.HOME).toBe("/home/miner");
+  });
+
+  it("declares the credential keys as config-as-code, in preference order", () => {
+    expect(CODING_AGENT_CLI_CREDENTIAL_ENV.claude).toEqual([
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
+    ]);
+    expect(CODING_AGENT_CLI_CREDENTIAL_ENV.codex).toEqual(["OPENAI_API_KEY", "CODEX_ACCESS_TOKEN"]);
+    expect(Object.isFrozen(CODING_AGENT_CLI_CREDENTIAL_ENV)).toBe(true);
+  });
+
+  it("keeps the credential keys OUT of the companion-var registry", () => {
+    // CODING_AGENT_DRIVER_CONFIG_ENV's contract is one `kind -> single env var NAME`, and generic consumers
+    // depend on it: init-wizard.js's promptCompanionVars iterates its entries and prompts once per value, so a
+    // list-valued entry renders as `Optional undefined for claude-cli (env A,B)` and writes a junk .env line if
+    // answered. This pins that contract -- every value stays a plain string.
+    for (const config of Object.values(CODING_AGENT_DRIVER_CONFIG_ENV)) {
+      for (const value of Object.values(config)) {
+        expect(typeof value).toBe("string");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

The `claude-cli`/`codex-cli` coding-agent driver spawned its subprocess with an env that could never authenticate: `CODING_AGENT_ENV_ALLOWLIST` carried no `HOME`/`XDG_*` (so the CLI could not find its persisted credential) and no credential env var either. Both halves are fixed here.

## The allowlist half

`CODING_AGENT_ENV_ALLOWLIST` was a **strict subset** of the shared `SUBPROCESS_CLI_ENV_ALLOWLIST` — byte-identical except that it dropped exactly `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`. This PR deletes the local copy and uses the shared list, which is also what `cli-subprocess-driver.ts`'s own module header already claims it does ("Two safety primitives are reused from subprocess-env.ts (#4284) rather than re-implemented"). The local list was the drift.

## The credential half — least privilege

Credential names are **not** added to the allowlist. They ride in as the driver's `env` **overlay**, resolved per provider, because the allowlist is shared and provider-agnostic — widening it would hand codex's key to a claude subprocess and vice versa.

This is not a new invention: it is exactly what **`createClaudeCodeAi` (`src/selfhost/ai.ts`) already does for the reviewer CLI**, for the reason stated there verbatim — threaded "explicitly here ... rather than widening `SUBSCRIPTION_CLI_ENV_ALLOWLIST` itself (which also gates the codex subprocess and should stay minimal)". The driver was already built for this: `CliSubprocessDriverOptions.env` is documented as *"Extra env overlaid on the allowlisted parent (e.g. an auth value the CLI reads)"* and `knownSecrets` as *"Known secret values (e.g. an injected auth token)"*. **Both seams existed and were simply never wired.** Only the first configured key of the selected provider's own list is forwarded.

**Redaction comes with it.** Anything deliberately handed to a prompt-injectable child must be redactable out of what it says back, and its stdout becomes a stored transcript and an error detail. The forwarded credential is merged into (never replacing) the caller's `knownSecrets`, which the driver already strips from both.

### Why the keys are not in `CODING_AGENT_DRIVER_CONFIG_ENV`

That map looks like the natural home, and a first cut put them there. It is wrong: the map's contract is one `kind -> single env var NAME`, and generic consumers rely on it. `init-wizard.js`'s `promptCompanionVars` iterates its entries and prompts once per value, so a list-valued entry renders as a real user-facing bug:

```
Optional undefined for claude-cli (env CLAUDE_CODE_OAUTH_TOKEN,ANTHROPIC_API_KEY) [Enter to skip]:
```

…and writes a junk `.env` line if answered. **`test/unit/miner-init-wizard.test.ts` passes 22/22 with that regression present**, so CI would not have caught it. The keys therefore live in their own `CODING_AGENT_CLI_CREDENTIAL_ENV`, keyed by the CLI `command` — which also makes the lookup total (`agent-sdk` authenticates in-process, `noop` spawns nothing, so neither can appear), leaving no unreachable fallback branch. A new test pins the registry's string-valued contract so this cannot regress.

## The one behaviour change to an existing test

`test/unit/cli-subprocess-driver.test.ts`'s "strict non-credential env" case asserted `XDG_*` were **undefined**. That assertion arrived in **#5362** — a commit about deriving SDK changed files from git — with no stated rationale, and the private allowlist itself dates to the **#5743** mechanical rename. It was a characterization of the drift, not an invariant anyone argued for; withholding those paths is precisely what made every spawned agent answer `"Not logged in · Please run /login"`. They are config **paths**, not credentials, so the case's name still holds.

**The invariant it exists to defend is unchanged and still asserted**: an arbitrary runtime var from the parent (`RUNTIME_ONLY_FLAG`) never reaches the child. The new suite re-asserts that independently, including `DATABASE_URL`.

## Testing

`test/unit/coding-agent-driver-credentials.test.ts` (new, 10 cases) asserts `opts.env` — **the env the child would really receive** — where the pre-existing CLI-provider cases assert only the argv shape, which is why a driver that could never authenticate shipped green in the first place. Covered: `HOME`/`XDG_*` forwarded; only the selected provider's credential (a claude run with `OPENAI_API_KEY` exported must not see it, and vice versa); preference order; blank/whitespace treated as unconfigured; no-credential still spawns (locally-authenticated); no arbitrary parent var leaks; the credential is redacted from the transcript; a caller's own `knownSecrets` survive the merge.

**Regression proven, not assumed.** Against the un-fixed source these cases fail and the rest of the suite passes; with the fix, all pass. The redaction test's token is ≥8 chars (`redactSecrets`' length guard) and deliberately matches **no** `SECRET_PATTERNS` shape, so it proves the `knownSecrets` wiring rather than the pattern fallback.

**Patch coverage measured, not assumed**: every changed line and branch in both engine files is covered — 0 uncovered statements, 0 uncovered branches. The tests live in the root suite because that is what `vitest.config.ts` measures (`packages/loopover-engine/src/**/*.ts`, imported from source); the engine package's own `node:test` suite runs against `dist/` and would not have counted toward the patch gate.

Green locally at this base: `typecheck`, `build --workspace @loopover/engine`, the full root vitest suite, `npm run test --workspace @loopover/engine` (588), `test:driver-parity`, `test:engine-parity`, `engine-parity:drift-check`, `manifest:drift-check`, `miner:env-reference:check`.

Closes #6875
