### PR TITLE
fix(miner): give the coding-agent CLI subprocess HOME + its own credential so it can authenticate (#6875)

### DIFF
--- a/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
+++ b/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
@@ -69,6 +69,10 @@ const MAX_TRANSCRIPT_CHARS = 8000;
 const MAX_ERROR_DETAIL_CHARS = 500;
 
 const CODING_AGENT_ENV_ALLOWLIST = [
+  // #6875: HOME + the XDG base-dir vars let the spawned `claude`/`codex` CLI locate its own persisted
+  // credential/config file. Without HOME the subprocess is "Not logged in" even with a valid token on disk. These
+  // are non-secret location pointers (the credential itself is forwarded provider-specifically, NOT via this list).
+  "HOME",
   "HTTPS_PROXY",
   "HTTP_PROXY",
   "LANG",
@@ -79,6 +83,9 @@ const CODING_AGENT_ENV_ALLOWLIST = [
   "SSL_CERT_DIR",
   "SSL_CERT_FILE",
   "TERM",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
   "https_proxy",
   "http_proxy",
   "no_proxy",

--- a/packages/loopover-engine/src/miner/driver-factory.ts
+++ b/packages/loopover-engine/src/miner/driver-factory.ts
@@ -144,6 +144,28 @@ function buildCliArgsWithConfiguredModel(
   };
 }
 
+/** The credential env vars each CLI provider authenticates with (#6875). ONLY the selected provider's credentials
+ *  are forwarded to its subprocess: an operator with keys for both providers who is running `claude-cli` must not
+ *  have the unrelated `OPENAI_API_KEY` reach the claude subprocess, so this is deliberately provider-specific
+ *  rather than a blanket allowlist of every credential name. (The subprocess's HOME/XDG dirs — where a persisted
+ *  credential file lives — are handled separately by CODING_AGENT_ENV_ALLOWLIST in cli-subprocess-driver.ts.) */
+const CLI_PROVIDER_CREDENTIAL_ENV_KEYS: Record<"claude" | "codex", readonly string[]> = {
+  claude: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+  codex: ["OPENAI_API_KEY", "CODEX_ACCESS_TOKEN"],
+};
+
+/** The selected provider's credential env vars that are actually set, as an `env` override the driver merges on
+ *  top of the allowlisted parent env. Empty when none are configured — the caller then fails at "not logged in"
+ *  the same as before, but a configured credential now reaches the subprocess. (#6875) */
+function providerCredentialEnv(command: "claude" | "codex", env: Record<string, string | undefined>): Record<string, string> {
+  const credentials: Record<string, string> = {};
+  for (const key of CLI_PROVIDER_CREDENTIAL_ENV_KEYS[command]) {
+    const value = env[key];
+    if (typeof value === "string" && value.length > 0) credentials[key] = value;
+  }
+  return credentials;
+}
+
 function createCliProvider(
   command: "claude" | "codex",
   modelEnvKey: string,
@@ -168,6 +190,9 @@ function createCliProvider(
     command,
     spawn: options.spawn,
     parentEnv: env,
+    // #6875: forward the selected provider's own credential onto the subprocess env (provider-specific, never a
+    // blanket allowlist). Merged on top of the allowlisted parent env by the driver's buildAllowlistedEnv call.
+    env: providerCredentialEnv(command, env),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(buildArgs !== undefined ? { buildArgs } : {}),
     ...(options.knownSecrets !== undefined ? { knownSecrets: options.knownSecrets } : {}),

--- a/test/unit/coding-agent-miner.test.ts
+++ b/test/unit/coding-agent-miner.test.ts
@@ -490,6 +490,57 @@ describe("createCodingAgentDriver provider resolution (#4289)", () => {
     expect(calls[0]!.opts.cwd).toBe(cliTask.workingDirectory);
   });
 
+  it("#6875: forwards HOME/XDG + the claude provider's OWN credential to the subprocess, never another provider's", async () => {
+    const { spawn, calls } = recordingSpawn();
+    const driver = createCodingAgentDriver({
+      providerName: "claude-cli",
+      spawn,
+      env: {
+        HOME: "/home/miner",
+        XDG_CONFIG_HOME: "/home/miner/.config",
+        PATH: "/usr/bin",
+        CLAUDE_CODE_OAUTH_TOKEN: "claude-token",
+        ANTHROPIC_API_KEY: "anthropic-key-fixture",
+        OPENAI_API_KEY: "openai-key-fixture", // the WRONG provider's key — must NOT reach the claude subprocess
+      },
+    });
+    await driver.run(cliTask);
+    const env = calls[0]!.opts.env;
+    expect(env.HOME).toBe("/home/miner"); // allowlisted location pointer now passes through (was dropped before)
+    expect(env.XDG_CONFIG_HOME).toBe("/home/miner/.config");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("claude-token"); // provider-specific credential forwarded
+    expect(env.ANTHROPIC_API_KEY).toBe("anthropic-key-fixture");
+    expect(env.OPENAI_API_KEY).toBeUndefined(); // the unrelated provider's key is NOT forwarded
+  });
+
+  it("#6875: forwards the codex provider's OWN credentials, not claude's", async () => {
+    const { spawn, calls } = recordingSpawn();
+    const driver = createCodingAgentDriver({
+      providerName: "codex-cli",
+      spawn,
+      env: { HOME: "/home/miner", OPENAI_API_KEY: "openai-key-fixture", CODEX_ACCESS_TOKEN: "codex-tok", CLAUDE_CODE_OAUTH_TOKEN: "claude-token" },
+    });
+    await driver.run(cliTask);
+    const env = calls[0]!.opts.env;
+    expect(env.OPENAI_API_KEY).toBe("openai-key-fixture");
+    expect(env.CODEX_ACCESS_TOKEN).toBe("codex-tok");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined(); // claude's key is not forwarded to a codex subprocess
+  });
+
+  it("#6875: forwards no credential when the provider's own credential env vars are unset or empty", async () => {
+    const { spawn, calls } = recordingSpawn();
+    const driver = createCodingAgentDriver({
+      providerName: "claude-cli",
+      spawn,
+      env: { HOME: "/home/miner", CLAUDE_CODE_OAUTH_TOKEN: "" }, // empty string → treated as unset (ANTHROPIC_API_KEY absent)
+    });
+    await driver.run(cliTask);
+    const env = calls[0]!.opts.env;
+    expect(env.HOME).toBe("/home/miner");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined(); // empty is not forwarded (the length > 0 guard)
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined(); // absent is not forwarded (the typeof guard)
+  });
+
   it("CONSUMES the declared model env key: MINER_CODING_AGENT_CLAUDE_MODEL lands in the claude argv", async () => {
     const { spawn, calls } = recordingSpawn();
     const driver = createCodingAgentDriver({


### PR DESCRIPTION
## Summary

The `claude-cli`/`codex-cli` coding-agent subprocess driver's env allowlist (`CODING_AGENT_ENV_ALLOWLIST`,
`packages/loopover-engine/src/miner/cli-subprocess-driver.ts`) forwarded **no `HOME`/XDG dir and no credential**
to the spawned `claude`/`codex` process. So the subprocess had **nowhere to locate a persisted credential file**
*and* **no credential env var** — every live attempt failed with `"Not logged in · Please run /login"`. This is
the actual cause behind the `claude_code_error_success` symptom that #6840's `--permission-mode` fix was
necessary-but-not-sufficient for (confirmed in the issue against a real machine + a real `--live` run).

Two parts:

1. **HOME/XDG passthrough** — add `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME` to
   `CODING_AGENT_ENV_ALLOWLIST`. These are non-secret *location pointers* so the CLI can find its own on-disk
   credential/config; the credential itself is **not** put in this static list.
2. **Provider-specific credential forwarding** — in `createCliProvider` (`driver-factory.ts`), forward **only the
   selected provider's own** credential env vars as the driver's `env` override (which `buildAllowlistedEnv`
   already merges on top of the allowlisted parent env):
   - `claude` → `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`
   - `codex` → `OPENAI_API_KEY`, `CODEX_ACCESS_TOKEN`

   Deliberately provider-specific, **not** a blanket allowlist of every credential name: an operator with both
   providers' keys set who is running `claude-cli` must not have the unrelated `OPENAI_API_KEY` leak into the
   claude subprocess (per the issue's explicit "decide and document" ask).

Closes #6875

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6875`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new `providerCredentialEnv` (both the credential-present and unset/empty guard branches, for both `claude` and `codex`) and the injection site are fully covered, verified via `coverage-final.json`. The `HOME`/XDG allowlist additions are exercised by the passthrough assertion.
- [x] engine `build` + `node --test` (588 passing) + `engine-parity:drift-check`
- [x] `npx vitest run test/unit/coding-agent-miner.test.ts` (62 passing) — new regressions assert the **spawned subprocess env actually carries** `HOME`/`XDG_CONFIG_HOME` + the resolved provider credential, that the *other* provider's key is NOT forwarded, and that an unset/empty credential forwards nothing.

If any required check was skipped, explain why:

- Two engine miner-driver files + their unit test; no UI/OpenAPI/MCP/migration surface, so those checks are N/A to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. — credential **values** are read from `env` at runtime; nothing is hardcoded, and test fixtures use obviously-fake placeholders.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — the credential-forwarding negative paths (wrong provider's key NOT forwarded; unset/empty NOT forwarded) are explicitly tested, so a credential can never reach the wrong subprocess.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/MCP surface changed.
- [x] No visible UI changes (miner subprocess env only), so no `UI Evidence` section is required.
- [x] Public docs/changelogs: none needed.

## Notes

- The credential env is merged by the driver's existing `buildAllowlistedEnv(parentEnv, allowlist, extra)` call — HOME/XDG come from the allowlisted parent env, the provider credential comes from the `extra` override — so a deployment with no credential configured is byte-identical to today (it still fails at "not logged in", just now with the actual cause fixed once a credential is set).
