### PR TITLE
fix(config): update remaining gittensory references across n8n templates, env examples, release.yml, and this repo's own skill files

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contributor-pipeline-gardening
 description: >-
-  Maintenance of the contributor issue pipeline for JSONbored/gittensory (renamed to loopover) —
+  Maintenance of the contributor issue pipeline for JSONbored/loopover —
   closing issues that are already done but not marked so, and keeping the contributor-available
   backlog at its 50-100+ steady-state floor with well-scoped new issues. Runs every ~8h via the
   scheduled task (raised from daily on 2026-07-15 so the floor is maintained continuously, not
@@ -11,7 +11,7 @@ description: >-
   read it before doing real work, not just this file.
 ---
 
-# Contributor pipeline gardening — gittensory / loopover
+# Contributor pipeline gardening — loopover
 
 This repo runs on a **steady stream of well-scoped, correctly-labeled issues** for contributors —
 see `.claude/skills/contributing-to-loopover/`. Contributors can only open a PR that links a real,
@@ -35,7 +35,7 @@ assume it keeps happening, don't assume today's backlog is clean.
 
 **Method — GitHub's cross-reference timeline, not text search:**
 
-1. Pull the full open-issue list: `gh issue list --repo JSONbored/gittensory --state open --limit 1000 --json number,title,labels,milestone,createdAt`.
+1. Pull the full open-issue list: `gh issue list --repo JSONbored/loopover --state open --limit 1000 --json number,title,labels,milestone,createdAt`.
 2. For every open issue, query which merged PRs ever referenced it, via GraphQL `timelineItems(itemTypes: [CROSS_REFERENCED_EVENT])` → `source { ... on PullRequest { number state merged } }` and `willCloseTarget`. Batch in chunks of ~20 issues per query using aliases (`i1234: issue(number: 1234) { ... }`) to stay under complexity limits.
    - **Important CLI gotcha:** `gh api graphql -f query=@file` does NOT read from a file — `-f` treats `@file` as a literal string and the query fails with a cryptic parse error. Use **`-F query=@file`** (capital F) instead; only `-F`/`--field` supports the `@filename` file-read syntax.
 3. Any issue where `willCloseTarget=true` on a merged PR but the issue is still open is worth a first look (should have auto-closed and didn't — check why, e.g. merged to a non-default branch). In practice this repo hasn't produced any of these yet; don't assume it stays that way.

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -1,4 +1,4 @@
-# Contributor pipeline gardening — reference (gittensory / loopover)
+# Contributor pipeline gardening — reference (loopover)
 
 ## Docs architecture is mid-migration (as of 2026-07-15) — don't generate old-pattern docs issues
 

--- a/.env.example
+++ b/.env.example
@@ -586,9 +586,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   never prompts, diffs, tokens, or bodies.
 # SENTRY_RELEASE=                            # custom images only: set this ONLY when you uploaded source maps for
 #                                            #   the exact built bundle under this exact release id. Future official
-#                                            #   images bake LOOPOVER_VERSION=gittensory-selfhost@<version> (yes,
-#                                            #   still that prefix -- see scripts/deploy-selfhost-prebuilt.sh), so do
-#                                            #   not override SENTRY_RELEASE for those images.
+#                                            #   images bake LOOPOVER_VERSION=loopover-selfhost@<version> (see
+#                                            #   scripts/deploy-selfhost-prebuilt.sh), so do not override
+#                                            #   SENTRY_RELEASE for those images.
 # OTEL_METRIC_EXPORT_INTERVAL=10000          # ms between metric exports (default 10s here; CLI default is 60s)
 # OTEL_METRICS_EXPORTER=otlp                 # metrics-side counterpart to OTEL_TRACES_EXPORTER; empty = no app metrics
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318   # override only for an external collector

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -22,7 +22,7 @@
 # both are set. GITHUB_APP_PRIVATE_KEY_FILE below is the one that has always supported this — the
 # rest of the secrets in this section now do too.
 GITHUB_APP_ID=123456
-GITHUB_APP_SLUG=my-gittensory-app
+GITHUB_APP_SLUG=my-loopover-app
 GITHUB_APP_PRIVATE_KEY_FILE=/run/secrets/github-app-private-key.pem   # or GITHUB_APP_PRIVATE_KEY= inline
 GITTENSOR_REGISTRY_URL=https://example.invalid/registry.json
 
@@ -106,7 +106,7 @@ LOOPOVER_REVIEW_ENRICHMENT=false
 # 5. Telemetry — informational only, no action needed
 # =============================================================================
 # Running this image contributes anonymized gate-calibration data (verdict, outcome, cycle time --
-# never repo/PR names, code, or logins) to gittensory's central collector once your App is
+# never repo/PR names, code, or logins) to loopover's central collector once your App is
 # configured -- this starts automatically, it's the self-hosting contract, not a flag you turn on.
 # The one way to disable it is the explicit air-gap flag below; see .env.example's Orb section for
 # full privacy detail.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,7 +12,7 @@
 # PRs are the same operator-facing noise if that ever changes) so none of the three clutter an
 # operator-facing image changelog. Deliberately does NOT exclude `sentry[bot]` (Seer-authored fixes for
 # real production errors, e.g. #3305, get a normal `gittensor:bug` label and are exactly the kind of
-# change this changelog exists to surface) or `gittensory-orb[bot]` (the review engine's own rare, real
+# change this changelog exists to surface) or `loopover-orb[bot]` (the review engine's own rare, real
 # content changes, e.g. #3397).
 changelog:
   exclude:

--- a/n8n/workflows/gate-daily-summary.json
+++ b/n8n/workflows/gate-daily-summary.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gittensory Gate Daily Summary",
+  "name": "LoopOver Gate Daily Summary",
   "nodes": [
     {
       "parameters": {
@@ -21,7 +21,7 @@
     {
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.GITTENSORY_GATE_SUMMARY_URL ?? 'http://loopover:8787/v1/app/selfhost/gate/summary' }}",
+        "url": "={{ $env.LOOPOVER_GATE_SUMMARY_URL ?? 'http://loopover:8787/v1/app/selfhost/gate/summary' }}",
         "options": {}
       },
       "id": "fetch-summary",
@@ -33,7 +33,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.GITTENSORY_SUMMARY_WEBHOOK_URL ?? 'https://example.com/webhook' }}",
+        "url": "={{ $env.LOOPOVER_SUMMARY_WEBHOOK_URL ?? 'https://example.com/webhook' }}",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ $json }}",
@@ -73,6 +73,6 @@
   "pinData": {},
   "meta": {
     "templateCredsSetupCompleted": false,
-    "instanceId": "gittensory-gate-daily-summary"
+    "instanceId": "loopover-gate-daily-summary"
   }
 }

--- a/n8n/workflows/issue-auto-triage.json
+++ b/n8n/workflows/issue-auto-triage.json
@@ -1,10 +1,10 @@
 {
-  "name": "Gittensory Issue Auto-Triage",
+  "name": "LoopOver Issue Auto-Triage",
   "nodes": [
     {
       "parameters": {
         "httpMethod": "POST",
-        "path": "gittensory-pr-closed",
+        "path": "loopover-pr-closed",
         "responseMode": "onReceived",
         "options": {}
       },
@@ -13,7 +13,7 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [0, 0],
-      "webhookId": "gittensory-pr-closed"
+      "webhookId": "loopover-pr-closed"
     },
     {
       "parameters": {
@@ -92,6 +92,6 @@
   "pinData": {},
   "meta": {
     "templateCredsSetupCompleted": false,
-    "instanceId": "gittensory-issue-auto-triage"
+    "instanceId": "loopover-issue-auto-triage"
   }
 }

--- a/n8n/workflows/review-slack-notify.json
+++ b/n8n/workflows/review-slack-notify.json
@@ -1,19 +1,19 @@
 {
-  "name": "Gittensory Review → Slack",
+  "name": "LoopOver Review → Slack",
   "nodes": [
     {
       "parameters": {
         "httpMethod": "POST",
-        "path": "gittensory-review",
+        "path": "loopover-review",
         "responseMode": "onReceived",
         "options": {}
       },
       "id": "webhook-review",
-      "name": "Gittensory review webhook",
+      "name": "LoopOver review webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [0, 0],
-      "webhookId": "gittensory-review"
+      "webhookId": "loopover-review"
     },
     {
       "parameters": {
@@ -35,7 +35,7 @@
     }
   ],
   "connections": {
-    "Gittensory review webhook": {
+    "LoopOver review webhook": {
       "main": [
         [
           {
@@ -50,6 +50,6 @@
   "pinData": {},
   "meta": {
     "templateCredsSetupCompleted": false,
-    "instanceId": "gittensory-review-slack-notify"
+    "instanceId": "loopover-review-slack-notify"
   }
 }


### PR DESCRIPTION
## Summary
- `.github/release.yml`: `gittensory-orb[bot]` doesn't exist anymore (confirmed 404 against the GitHub API) — the real, current bot login is `loopover-orb[bot]`.
- `.env.example`: updated a comment that documented the exact stale `SENTRY_RELEASE`/`LOOPOVER_VERSION` default already fixed in #6876/#6881 — it was telling self-hosters "yes, still that prefix", which is no longer true now that those are fixed.
- `.env.selfhost.example`: example `GITHUB_APP_SLUG` value and a prose line describing the telemetry collector.
- `.claude/skills/contributor-pipeline-gardening/{SKILL,reference}.md`: this repo's own scheduled-task skill had a real, executable `gh issue list --repo JSONbored/gittensory` command. It still resolves today via GitHub's rename redirect, but relying on that indefinitely is fragile and exactly the kind of stale reference that confuses a future AI session working in this repo. Fixed the command and simplified two section titles.
- `n8n/workflows/*.json`: 3 bundled workflow templates (not currently deployed — the `workflows` profile isn't in this fleet's active `COMPOSE_PROFILES`) had `gittensory`-prefixed names, webhook paths/ids, and suggested env var names. Confirmed nothing in `src`/`scripts`/`test` references these specific webhook paths or env vars before renaming, and kept each node-name rename in sync with its `connections` object key (n8n references nodes by display name).

Left untouched: `gittensor:bug`/`feature`/`priority` (the real, current GitHub label convention, unrelated to the old `gittensory` product name) and a `gittensor-deployment-models` cross-reference (points at this session's own memory-file slug, out of scope for a repo-code change).

## Scope
- [x] Narrow, single-purpose change
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `node --check` on all 3 n8n JSON files (valid JSON) — confirmed
- `git diff --check` — clean
- Confirmed via GitHub API that `gittensory-orb[bot]` 404s and `loopover-orb[bot]` is the real, active bot