### PR TITLE
fix(engine): filter maintainer-authored manifest fields out of public findings

### DIFF
--- a/packages/loopover-engine/src/focus-manifest/guidance.ts
+++ b/packages/loopover-engine/src/focus-manifest/guidance.ts
@@ -152,35 +152,63 @@ export function buildFocusManifestGuidance(args: {
   }
 
   if (manifest.wantedPaths.length > 0 && matchedWantedPaths.length === 0 && changedPaths.length > 0) {
+    // Public-safety filter before interpolation (#6770, porting the host's #5945 fix) -- mirrors
+    // safeExpectations below. manifest.wantedPaths is freeform maintainer-authored text that is never
+    // public-safety-checked at parse time; without this, an unsafe pattern leaks verbatim into a
+    // contributor-facing finding.
+    const safeWantedPaths = manifest.wantedPaths.filter(isFocusManifestPublicSafe).slice(0, 5);
+    const wantedPathsDetail = safeWantedPaths.length > 0 ? ` (${safeWantedPaths.join(", ")})` : "";
     findings.push({
       code: "manifest_off_focus",
       severity: "warning",
       title: "Change is outside maintainer-wanted areas",
-      detail: `No changed path matches the maintainer-wanted patterns (${manifest.wantedPaths.slice(0, 5).join(", ")}).`,
+      detail: `No changed path matches the maintainer-wanted patterns${wantedPathsDetail}.`,
       action: "Refocus the change onto a maintainer-wanted area or explain why this out-of-focus work is needed.",
     });
     publicNextSteps.push("Refocus onto the maintainer-wanted areas, or explain why this out-of-focus change is needed.");
   }
 
   if (matchedWantedPaths.length > 0) {
+    // Same filter (#6770): matchedWantedPaths are the manifest's own patterns that matched, so they carry the
+    // same maintainer-authored text into a public finding.
+    const safeMatchedWantedPaths = matchedWantedPaths.filter(isFocusManifestPublicSafe).slice(0, 5);
+    const matchedDetail =
+      safeMatchedWantedPaths.length > 0
+        ? `Changed paths match maintainer-wanted patterns: ${safeMatchedWantedPaths.join(", ")}.`
+        : "Changed paths match the maintainer-wanted patterns.";
     findings.push({
       code: "manifest_preferred_path",
       severity: "info",
       title: "Change aligns with maintainer-wanted areas",
-      detail: `Changed paths match maintainer-wanted patterns: ${matchedWantedPaths.slice(0, 5).join(", ")}.`,
+      detail: matchedDetail,
     });
     publicNextSteps.push("Changed paths align with the maintainer's wanted areas for this repo.");
   }
 
   if (manifest.preferredLabels.length > 0 && preferredLabelHits.length === 0) {
+    // Same filter (#6770). Unlike manifest_off_focus, this finding's ENTIRE detail is built from the label
+    // list, so a zero-safe-entries fallback needs its own sentence rather than a dropped parenthetical -- the
+    // title already says the same thing and is a static, always-public-safe string.
+    const safePreferredLabels = manifest.preferredLabels.filter(isFocusManifestPublicSafe).slice(0, 5);
+    const preferredLabelsDetail =
+      safePreferredLabels.length > 0
+        ? `Maintainer prefers labels: ${safePreferredLabels.join(", ")}.`
+        : "No maintainer-preferred label applied.";
     findings.push({
       code: "manifest_missing_preferred_label",
       severity: "info",
       title: "No maintainer-preferred label applied",
-      detail: `Maintainer prefers labels: ${manifest.preferredLabels.slice(0, 5).join(", ")}.`,
+      detail: preferredLabelsDetail,
       action: "Consider applying a maintainer-preferred label so triage stays aligned.",
     });
-    publicNextSteps.push(`Consider a maintainer-preferred label (${manifest.preferredLabels.slice(0, 3).join(", ")}).`);
+    // The trailing safeNextSteps filter below drops an unsafe entry wholesale; filter the interpolated labels
+    // here too so a safe step isn't lost just because one label was unsafe.
+    const safeStepLabels = manifest.preferredLabels.filter(isFocusManifestPublicSafe).slice(0, 3);
+    if (safeStepLabels.length > 0) {
+      publicNextSteps.push(`Consider a maintainer-preferred label (${safeStepLabels.join(", ")}).`);
+    } else {
+      publicNextSteps.push("Consider applying a maintainer-preferred label so triage stays aligned.");
+    }
   }
 
   if (manifest.linkedIssuePolicy === "required" && linkedIssueCount === 0) {

--- a/test/unit/predicted-gate-engine-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-coverage.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../../packages/loopover-engine/src/signals/change-guardrail";
 import { isDuplicateClusterWinnerByClaim, resolveDuplicateClusterWinnerNumber } from "../../packages/loopover-engine/src/signals/duplicate-winner";
 import { buildCollisionReport, buildPreflightResult, buildPublicReadinessScore, buildQueueHealth, classifyBountyLifecycle, itemSharesPlannedLinkedIssue, predictedGateEngineInternals, termOverlap, unionScopedOverlapClusters } from "../../packages/loopover-engine/src/signals/predicted-gate-engine";
-import type { CollisionItem, FocusManifest, IssueQualityReport, PreMergeCheck, PullRequestRecord, RepositoryRecord } from "../../packages/loopover-engine/src/types/predicted-gate-types";
+import type { CollisionItem, FocusManifest, FocusManifestGuidance, IssueQualityReport, PreMergeCheck, PullRequestRecord, RepositoryRecord } from "../../packages/loopover-engine/src/types/predicted-gate-types";
 
 const REPO: RepositoryRecord = {
   fullName: "acme/widgets",
@@ -299,6 +299,67 @@ describe("predicted-gate engine module coverage (#2283)", () => {
     // Still real, deduped, positive issue numbers — the cap truncates, it doesn't corrupt.
     expect(new Set(preflight.linkedIssues).size).toBe(50);
     expect(preflight.linkedIssues.every((n) => Number.isInteger(n) && n > 0)).toBe(true);
+  });
+
+  it("never leaks public-unsafe wantedPaths/preferredLabels into contributor-facing guidance (#6770)", () => {
+    // wantedPaths and preferredLabels are freeform maintainer-authored text that is never public-safety-checked
+    // at parse time, so buildFocusManifestGuidance must filter them before interpolating them into a finding.
+    const manifest: FocusManifest = {
+      present: true,
+      source: "repo_file",
+      wantedPaths: ["src/reward-payouts/**", "/home/maintainer/secret/**"],
+      preferredLabels: ["trust-score", "hotkey-rotation"],
+      linkedIssuePolicy: "optional",
+      testExpectations: [],
+      issueDiscoveryPolicy: "neutral",
+      maintainerNotes: [],
+      publicNotes: [],
+      gate: { present: true } as FocusManifest["gate"],
+      settings: {},
+      review: { present: true, preMergeChecks: [] },
+      warnings: [],
+    };
+    const forbidden = ["reward-payouts", "/home/maintainer", "trust-score", "hotkey-rotation"];
+    const surfaceOf = (guidance: FocusManifestGuidance): string =>
+      JSON.stringify([guidance.findings, guidance.publicNextSteps, guidance.summary]);
+
+    // Every manifest entry is unsafe here, so each filtered list is empty -> the zero-safe fallback arms fire.
+    const offFocus = buildFocusManifestGuidance({ manifest, changedPaths: ["docs/readme.md"], labels: [], linkedIssueCount: 1, testFileCount: 1 });
+    expect(offFocus.findings.some((f) => f.code === "manifest_off_focus")).toBe(true);
+    expect(offFocus.findings.find((f) => f.code === "manifest_off_focus")?.detail).toBe(
+      "No changed path matches the maintainer-wanted patterns.",
+    );
+    expect(offFocus.findings.find((f) => f.code === "manifest_missing_preferred_label")?.detail).toBe(
+      "No maintainer-preferred label applied.",
+    );
+    expect(offFocus.publicNextSteps).toContain("Consider applying a maintainer-preferred label so triage stays aligned.");
+    for (const term of forbidden) expect(surfaceOf(offFocus)).not.toContain(term);
+
+    // A matched-but-unsafe wanted path must not reach manifest_preferred_path's detail either.
+    const matchedUnsafe = buildFocusManifestGuidance({ manifest, changedPaths: ["src/reward-payouts/a.ts"], labels: [], linkedIssueCount: 1, testFileCount: 1 });
+    expect(matchedUnsafe.matchedWantedPaths.length).toBeGreaterThan(0);
+    expect(matchedUnsafe.findings.find((f) => f.code === "manifest_preferred_path")?.detail).toBe(
+      "Changed paths match the maintainer-wanted patterns.",
+    );
+    for (const term of forbidden) expect(surfaceOf(matchedUnsafe)).not.toContain(term);
+
+    // Safe entries survive: the filter must drop only the unsafe ones, not the whole list.
+    const mixed: FocusManifest = { ...manifest, wantedPaths: ["src/api/**", "src/reward-payouts/**"], preferredLabels: ["bug", "trust-score"] };
+    const mixedOffFocus = buildFocusManifestGuidance({ manifest: mixed, changedPaths: ["docs/readme.md"], labels: [], linkedIssueCount: 1, testFileCount: 1 });
+    expect(mixedOffFocus.findings.find((f) => f.code === "manifest_off_focus")?.detail).toBe(
+      "No changed path matches the maintainer-wanted patterns (src/api/**).",
+    );
+    expect(mixedOffFocus.findings.find((f) => f.code === "manifest_missing_preferred_label")?.detail).toBe(
+      "Maintainer prefers labels: bug.",
+    );
+    expect(mixedOffFocus.publicNextSteps).toContain("Consider a maintainer-preferred label (bug).");
+    for (const term of forbidden) expect(surfaceOf(mixedOffFocus)).not.toContain(term);
+
+    const mixedMatched = buildFocusManifestGuidance({ manifest: mixed, changedPaths: ["src/api/a.ts", "src/reward-payouts/b.ts"], labels: [], linkedIssueCount: 1, testFileCount: 1 });
+    expect(mixedMatched.findings.find((f) => f.code === "manifest_preferred_path")?.detail).toBe(
+      "Changed paths match maintainer-wanted patterns: src/api/**.",
+    );
+    for (const term of forbidden) expect(surfaceOf(mixedMatched)).not.toContain(term);
   });
 
   it("exercises manifest globstar path matching", () => {


### PR DESCRIPTION
## What

`buildFocusManifestGuidance` interpolated three maintainer-authored manifest fields straight into contributor-facing findings without a public-safety check:

| Finding | Leaked field |
|---|---|
| `manifest_off_focus` | `manifest.wantedPaths` |
| `manifest_preferred_path` | `matchedWantedPaths` |
| `manifest_missing_preferred_label` | `manifest.preferredLabels` (+ its `publicNextSteps` entry) |

All three are freeform text the maintainer writes in `.loopover.yml`. They are never public-safety-checked at parse time, so a pattern like `src/reward-payouts/**`, a local path such as `/home/maintainer/secret/**`, or a label like `trust-score` reached a public finding verbatim.

This ports the fix the host module already applies: `src/signals/focus-manifest.ts` filters these same fields through `isFocusManifestPublicSafe` before interpolation. The engine copy exports that predicate (and already uses it for `testExpectations` and `publicNotes`) but skipped it for these three sites.

## How

Filter each list through the module's existing `isFocusManifestPublicSafe` before interpolation, mirroring the neighbouring `safeExpectations` pattern:

- `manifest_off_focus` — drops the parenthetical when no entry is safe (the sentence still reads correctly without it).
- `manifest_preferred_path` / `manifest_missing_preferred_label` — the detail is built *entirely* from the list, so a zero-safe-entries case falls back to its own sentence rather than emitting a dangling `: .`; the static title already conveys the same information.
- The `publicNextSteps` entry filters its labels too. The trailing `safeNextSteps` pass drops an unsafe entry wholesale, so filtering here keeps a safe step from being lost just because one label was unsafe.

Safe entries are unaffected — only the unsafe ones are dropped, not the whole list.

## Validation

- **Regression test** added to `test/unit/predicted-gate-engine-coverage.test.ts` (the existing suite for this module) asserting no forbidden term appears verbatim in any finding, `publicNextSteps`, or `summary` — covering the all-unsafe, mixed, and matched-path cases.
- Confirmed the test **fails against the unfixed module** and passes with the fix.
- `npm run typecheck` clean; `test:engine-parity`, `test:live-gate-parity`, `test:driver-parity`, `engine-parity:drift-check`, `manifest:drift-check` all pass; `@loopover/engine` workspace suite passes.
- 100% line and branch coverage on every changed line.

Closes #6770
