### PR TITLE
fix(rees): fix stale Sentry release prefix, update remaining gittensory references

### DIFF
--- a/review-enrichment/README.md
+++ b/review-enrichment/README.md
@@ -251,7 +251,7 @@ Set these Railway service variables:
 | `REES_SENTRY_UPLOAD_STRICT`    | Optional. Set `true` to fail startup if source-map upload fails.        |
 | `REES_SENTRY_VALIDATE_RELEASE` | Optional. Set `false` only to disable post-upload release validation.   |
 
-By default the release id is `gittensory-rees@<RAILWAY_GIT_COMMIT_SHA>`, using Railway's Git metadata. The Sentry
+By default the release id is `loopover-rees@<RAILWAY_GIT_COMMIT_SHA>`, using Railway's Git metadata. The Sentry
 GitHub code mapping should be:
 
 | Sentry field     | Value               |
@@ -264,7 +264,7 @@ Do **not** pass `SENTRY_AUTH_TOKEN` as a Docker build arg. Railway deploys this 
 can leak through image metadata. Keeping the upload at runtime means Sentry sees the same `dist/` files that the service
 executes, without exposing source maps over HTTP.
 
-After upload, startup validates the exact `gittensory-rees@<RAILWAY_GIT_COMMIT_SHA>` release through the Sentry API:
+After upload, startup validates the exact `loopover-rees@<RAILWAY_GIT_COMMIT_SHA>` release through the Sentry API:
 the release must exist, be finalized, include the deployed commit, and include the Railway deploy id/environment. If
 `REES_SENTRY_UPLOAD_STRICT=true`, a failed upload or failed validation stops the Railway deployment; otherwise it logs a
 `rees_sentry_sourcemap_upload_failed` warning so the problem is visible without blocking startup.
@@ -305,7 +305,7 @@ Useful production queries:
 
 If Sentry still shows frames such as `/app/dist/server.js`, check:
 
-1. The event's `release` is `gittensory-rees@<same Railway commit sha>` or your exact `SENTRY_RELEASE` override.
+1. The event's `release` is `loopover-rees@<same Railway commit sha>` or your exact `SENTRY_RELEASE` override.
 2. The Sentry release has an artifact bundle uploaded for the REES project.
 3. Railway has `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` set on the REES service.
 4. Startup logs include `sentry_release_validation_complete` for the same release id and Railway deployment id.

--- a/review-enrichment/src/sentry.ts
+++ b/review-enrichment/src/sentry.ts
@@ -47,7 +47,7 @@ export function resolveReesSentryRelease(env: NodeJS.ProcessEnv): string | undef
   return (
     nonBlank(env.SENTRY_RELEASE) ??
     (nonBlank(env.RAILWAY_GIT_COMMIT_SHA)
-      ? `gittensory-rees@${nonBlank(env.RAILWAY_GIT_COMMIT_SHA)}`
+      ? `loopover-rees@${nonBlank(env.RAILWAY_GIT_COMMIT_SHA)}`
       : undefined)
   );
 }

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -72,7 +72,7 @@ test("createAnalysisContext parses common PR state once", () => {
   const syntheticGithubToken = ["ghp", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_");
   const context = createAnalysisContext(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1810,
       headSha: "abcdef1234567890",
       files: [
@@ -100,8 +100,8 @@ test("createAnalysisContext parses common PR state once", () => {
 
   assert.deepEqual(context.repo, {
     owner: "JSONbored",
-    repo: "gittensory",
-    fullName: "JSONbored/gittensory",
+    repo: "loopover",
+    fullName: "JSONbored/loopover",
     prNumber: 1810,
     headSha: "abcdef1234567890",
   });
@@ -150,7 +150,7 @@ test("createAnalysisContext parses common PR state once", () => {
 
 test("request cache de-dupes in-flight external lookups and records safe metrics", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1810,
   });
   let loads = 0;
@@ -176,7 +176,7 @@ test("request cache de-dupes in-flight external lookups and records safe metrics
 
 test("request cache preserves category and key boundaries", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1810,
   });
   let loads = 0;
@@ -208,7 +208,7 @@ test("request cache preserves category and key boundaries", async () => {
 
 test("scanDependencyChanges batches and de-dupes OSV package lookups inside one request", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1810,
   });
   let fetchCalls = 0;
@@ -252,7 +252,7 @@ test("scanDependencyChanges batches and de-dupes OSV package lookups inside one 
 
 test("scanDependencyChanges chunks OSV batch lookups before fallback is needed", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1810,
   });
   const batchSizes = [];
@@ -298,7 +298,7 @@ test("scanDependencyChanges chunks OSV batch lookups before fallback is needed",
 
 test("queryOsvBatch honors maxDependencyQueries for direct callers", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1810,
   });
   const batchSizes = [];
@@ -334,7 +334,7 @@ test("queryOsvBatch honors maxDependencyQueries for direct callers", async () =>
 
 test("scanDependencyChanges falls back to direct OSV queries after an oversized batch response", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1810,
   });
   let batchCalls = 0;
@@ -393,7 +393,7 @@ test("scanDependencyChanges falls back to direct OSV queries after an oversized 
 
 test("createAnalysisContext leaves expensive diff surfaces lazy for skipped analyzers", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1817,
     files: [
       {
@@ -416,7 +416,7 @@ test("createAnalysisContext caps materialized diff surfaces", () => {
     ...Array.from({ length: 6000 }, (_, index) => `+const value${index} = ${index};`),
   ].join("\n");
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1817,
     files: [
       {
@@ -435,7 +435,7 @@ test("createAnalysisContext caps materialized diff surfaces", () => {
 
 test("createAnalysisContext keeps uncapped context-only patches as no added lines", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1817,
     files: [
       {
@@ -451,7 +451,7 @@ test("createAnalysisContext keeps uncapped context-only patches as no added line
 
 test("createAnalysisContext treats capped patch scans as added-line presence", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1817,
     files: [
       {
@@ -475,7 +475,7 @@ test("createAnalysisContext treats capped patch scans as added-line presence", (
 
 test("createAnalysisContext classifies workflow paths case-insensitively", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 2516,
     files: [
       {
@@ -500,7 +500,7 @@ test("createAnalysisContext classifies workflow paths case-insensitively", () =>
 
 test("createAnalysisContext classifies Zstandard archives as assets for scheduler gating", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 3128,
     headSha: "abcdef1234567890",
     githubToken: "github_pat_test",
@@ -529,7 +529,7 @@ test("createAnalysisContext classifies Zstandard archives as assets for schedule
 
   const plan = planAnalyzers(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 3128,
       headSha: "abcdef1234567890",
       githubToken: "github_pat_test",
@@ -547,7 +547,7 @@ test("createAnalysisContext classifies Zstandard archives as assets for schedule
 
 test("createAnalysisContext classifies ML model weights as assets for scheduler gating", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 3301,
     headSha: "abcdef1234567890",
     githubToken: "github_pat_test",
@@ -576,7 +576,7 @@ test("createAnalysisContext classifies ML model weights as assets for scheduler 
 
   const plan = planAnalyzers(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 3301,
       headSha: "abcdef1234567890",
       githubToken: "github_pat_test",
@@ -594,7 +594,7 @@ test("createAnalysisContext classifies ML model weights as assets for scheduler 
 
 test("createAnalysisContext classifies long-form doc extensions as docs", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 3264,
     files: [
       { path: "GUIDE.markdown", patch: "@@ -1,0 +1,1 @@\n+# guide" },
@@ -619,7 +619,7 @@ test("createAnalysisContext classifies long-form doc extensions as docs", () => 
 
 test("createAnalysisContext classifies lockfile paths case-insensitively", () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 2611,
     files: [
       {

--- a/review-enrichment/test/analyzer-circuit-breaker.test.ts
+++ b/review-enrichment/test/analyzer-circuit-breaker.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 const baseReq = {
-  repoFullName: "JSONbored/gittensory",
+  repoFullName: "JSONbored/loopover",
   prNumber: 1811,
   analyzers: ["history"],
   githubToken: "token",
@@ -311,8 +311,8 @@ test("REGRESSION: a half-open probe claim is not leaked when the SAME planning p
 test("REGRESSION: repoFullName casing does not split one repository's failures across separate circuit entries", async () => {
   let calls = 0;
   const failing = { history: async () => { calls += 1; throw new Error("boom"); } };
-  const lowerReq = { ...baseReq, repoFullName: "jsonbored/gittensory" };
-  const upperReq = { ...baseReq, repoFullName: "JSONbored/Gittensory" };
+  const lowerReq = { ...baseReq, repoFullName: "jsonbored/loopover" };
+  const upperReq = { ...baseReq, repoFullName: "JSONbored/Loopover" };
   await buildBrief(lowerReq, failing);
   await buildBrief(upperReq, failing);
   await buildBrief(lowerReq, failing);

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -88,7 +88,7 @@ test("analyzer descriptors cover the runtime registry in stable order", () => {
 test("buildBrief uses the descriptor-derived default registry", async () => {
   const syntheticGithubToken = ["ghp", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_");
   const brief = await buildBrief({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1809,
     analyzers: ["secret"],
     files: [
@@ -115,7 +115,7 @@ test("secret analyzer scans added lines beyond shared context cap", async () => 
   ].join("\n");
 
   const brief = await buildBrief({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1809,
     analyzers: ["secret"],
     files: [

--- a/review-enrichment/test/external-fetch.test.ts
+++ b/review-enrichment/test/external-fetch.test.ts
@@ -122,7 +122,7 @@ test("boundedFetchStatus checks status without reading a response body", async (
 
 test("AnalysisContext fetchJson de-dupes identical in-flight calls and caps new category calls", async () => {
   const context = createAnalysisContext({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 1812,
   });
   let calls = 0;

--- a/review-enrichment/test/render-contract.test.ts
+++ b/review-enrichment/test/render-contract.test.ts
@@ -93,7 +93,7 @@ test("buildBrief reports partial analyzer results as degraded", async () => {
 
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 2037,
       analyzers: ["dependency"],
       files: [

--- a/review-enrichment/test/request-guardrails.test.ts
+++ b/review-enrichment/test/request-guardrails.test.ts
@@ -10,7 +10,7 @@ import {
 test("parseEnrichRequestBody accepts a minimal valid enrichment request", () => {
   const result = parseEnrichRequestBody(
     JSON.stringify({
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1814,
       files: [{ path: "src/a.ts", patch: "@@ -1,0 +1,1 @@\n+export const a = 1;" }],
     }),
@@ -18,7 +18,7 @@ test("parseEnrichRequestBody accepts a minimal valid enrichment request", () => 
 
   assert.equal(result.ok, true);
   if (result.ok) {
-    assert.equal(result.payload.repoFullName, "JSONbored/gittensory");
+    assert.equal(result.payload.repoFullName, "JSONbored/loopover");
     assert.equal(result.payload.prNumber, 1814);
     assert.ok(result.bodyBytes > 0);
   }
@@ -51,7 +51,7 @@ test("parseEnrichRequestBody rejects oversized body, file list, diff, and patch 
 
   const tooManyFiles = parseEnrichRequestBody(
     JSON.stringify({
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1814,
       files: Array.from({ length: 301 }, (_, index) => ({ path: `src/${index}.ts` })),
     }),
@@ -61,7 +61,7 @@ test("parseEnrichRequestBody rejects oversized body, file list, diff, and patch 
 
   const hugeDiff = parseEnrichRequestBody(
     JSON.stringify({
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1814,
       diff: "x".repeat(1_000_001),
     }),
@@ -71,7 +71,7 @@ test("parseEnrichRequestBody rejects oversized body, file list, diff, and patch 
 
   const hugePatch = parseEnrichRequestBody(
     JSON.stringify({
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1814,
       files: [{ path: "src/a.ts", patch: "x".repeat(1_500_001) }],
     }),
@@ -137,7 +137,7 @@ test("readEnrichRequestText stops streaming once the request body exceeds the ca
 });
 
 test("readEnrichRequestText returns a small request body", async () => {
-  const raw = JSON.stringify({ repoFullName: "JSONbored/gittensory", prNumber: 1836 });
+  const raw = JSON.stringify({ repoFullName: "JSONbored/loopover", prNumber: 1836 });
   const request = new Request("https://rees.example/v1/enrich", {
     method: "POST",
     body: raw,

--- a/review-enrichment/test/scheduler.test.ts
+++ b/review-enrichment/test/scheduler.test.ts
@@ -7,7 +7,7 @@ test("fast profile skips GitHub-heavy defaults without running them", async () =
   let ran = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       profile: "fast",
       githubToken: "token",
@@ -34,7 +34,7 @@ test("explicit analyzer selection overrides profile membership while retaining b
   let sawTimeoutMs = 0;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       profile: "fast",
       analyzers: ["history"],
@@ -65,7 +65,7 @@ test("slow analyzers time out inside the reserved response budget", async () => 
   const started = Date.now();
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       analyzers: ["history"],
       githubToken: "token",
@@ -96,7 +96,7 @@ test("cost classes run in priority order instead of starting all at once", async
 
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       analyzers: ["secret", "dependency", "history"],
       githubToken: "token",
@@ -158,7 +158,7 @@ test("registry analyzers skip when their relevant inputs are absent", async () =
   let dependencyRan = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       files: [{ path: "src/a.ts", patch: "@@ -1,0 +1,1 @@\n+export const a = 1;" }],
     },
@@ -183,7 +183,7 @@ test("added-line analyzers skip uncapped patches with no additions", async () =>
   let secretRan = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       analyzers: ["secret"],
       files: [
@@ -211,7 +211,7 @@ test("added-line analyzers run when patch scan is capped before additions", asyn
   const ran = new Set();
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 1811,
       analyzers: ["redos", "secret", "secretLog"],
       files: [
@@ -251,7 +251,7 @@ test("actionPin runs for mixed-case workflow paths", async () => {
   let actionPinRan = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 2516,
       analyzers: ["actionPin"],
       files: [
@@ -278,7 +278,7 @@ test("lockfileDrift runs for mixed-case lockfile paths", async () => {
   let lockfileDriftRan = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 2611,
       analyzers: ["lockfileDrift"],
       files: [
@@ -305,7 +305,7 @@ test("eol runs for a *.dockerfile path (gate shares the analyzer's Dockerfile pr
   let eolRan = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 2940,
       analyzers: ["eol"],
       files: [
@@ -332,7 +332,7 @@ test("eol runs for runtime.txt and Gemfile paths (gate shares isRuntimePinPath)"
   let eolRan = false;
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 3253,
       analyzers: ["eol"],
       files: [

--- a/review-enrichment/test/sentry-degradation.test.ts
+++ b/review-enrichment/test/sentry-degradation.test.ts
@@ -36,7 +36,7 @@ function sentryHarness() {
       },
       flush: async () => true,
     },
-    { release: "gittensory-rees@test", environment: "test" },
+    { release: "loopover-rees@test", environment: "test" },
   );
   return { tags, contexts, fingerprints, levels, captured };
 }
@@ -49,7 +49,7 @@ test("captureAnalyzerDegradation is inert when Sentry is disabled", () => {
   assert.doesNotThrow(() =>
     captureAnalyzerDegradation(new Error("boom"), {
       analyzer: "dependency",
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 7,
       headSha: "abc123",
       timeoutMs: 8000,
@@ -64,7 +64,7 @@ test("captureAnalyzerDegradation tags and fingerprints sanitized analyzer failur
 
   captureAnalyzerDegradation(new Error("registry timeout"), {
     analyzer: "dependency",
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 7,
     headSha: "abc123",
     timeoutMs: 8000,
@@ -77,9 +77,9 @@ test("captureAnalyzerDegradation tags and fingerprints sanitized analyzer failur
   assert.deepEqual(sentry.fingerprints, [["rees-analyzer-degraded", "dependency"]]);
   assert.equal(sentry.tags.event, "rees_analyzer_degraded");
   assert.equal(sentry.tags.analyzer, "dependency");
-  assert.equal(sentry.tags.repo, "JSONbored/gittensory");
+  assert.equal(sentry.tags.repo, "JSONbored/loopover");
   assert.equal(sentry.tags.pullNumber, "7");
-  assert.equal(sentry.tags.release, "gittensory-rees@test");
+  assert.equal(sentry.tags.release, "loopover-rees@test");
   assert.equal(sentry.tags.environment, "test");
   assert.equal(sentry.captured[0].message, "registry timeout");
 
@@ -87,11 +87,11 @@ test("captureAnalyzerDegradation tags and fingerprints sanitized analyzer failur
   assert.deepEqual(analyzerContext, {
     event: "rees_analyzer_degraded",
     analyzer: "dependency",
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 7,
     headShaPrefix: "abc123",
     timeoutMs: 8000,
-    release: "gittensory-rees@test",
+    release: "loopover-rees@test",
     environment: "test",
   });
   const serializedContext = JSON.stringify(analyzerContext);
@@ -105,7 +105,7 @@ test("captureAnalyzerDegradation groups by partialReason (WHY), not analyzer nam
 
   captureAnalyzerDegradation(new Error("analyzer_timeout"), {
     analyzer: "installScript",
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 7,
     headSha: "abc123",
     timeoutMs: 1400,
@@ -113,7 +113,7 @@ test("captureAnalyzerDegradation groups by partialReason (WHY), not analyzer nam
   } as never);
   captureAnalyzerDegradation(new Error("analyzer_timeout"), {
     analyzer: "nativeBuild",
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 8,
     headSha: "def456",
     timeoutMs: 1400,
@@ -134,7 +134,7 @@ test("captureAnalyzerDegradation falls back to analyzer name when partialReason 
 
   captureAnalyzerDegradation(new Error("boom"), {
     analyzer: "dependency",
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     prNumber: 7,
     headSha: "abc123",
     timeoutMs: 8000,
@@ -239,7 +239,7 @@ test("captureAnalyzerDegradation attaches safe attribution context for history f
     analysisElapsedMs: 6812,
     requestId: "req-123",
     traceId: "0123456789abcdef0123456789abcdef",
-    release: "gittensory-rees@test",
+    release: "loopover-rees@test",
     environment: "test",
   });
   const serializedContext = JSON.stringify(analyzerContext);
@@ -254,7 +254,7 @@ test("buildBrief stays fail-open and captures a degraded analyzer", async () => 
 
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 42,
       headSha: "head-sha",
       analyzers: ["dependency"],
@@ -271,7 +271,7 @@ test("buildBrief stays fail-open and captures a degraded analyzer", async () => 
   assert.equal(brief.partial, true);
   assert.equal(brief.analyzerStatus.dependency, "degraded");
   assert.deepEqual(brief.findings, {});
-  assert.equal(brief.repoFullName, "JSONbored/gittensory");
+  assert.equal(brief.repoFullName, "JSONbored/loopover");
   assert.equal(brief.prNumber, 42);
   assert.equal(brief.telemetry.analyzers.dependency.partialReason, "analyzer_error");
   assert.equal(JSON.stringify(brief.telemetry).includes(fakeToken), false);
@@ -279,7 +279,7 @@ test("buildBrief stays fail-open and captures a degraded analyzer", async () => 
   assert.equal(sentry.captured.length, 1);
   assert.equal(sentry.captured[0].message, "analyzer_error");
   assert.equal(sentry.tags.analyzer, "dependency");
-  assert.equal(sentry.tags.repo, "JSONbored/gittensory");
+  assert.equal(sentry.tags.repo, "JSONbored/loopover");
   assert.equal(sentry.tags.pullNumber, "42");
   assert.equal(sentry.tags.event, "rees_analyzer_degraded");
   const analyzerContext = sentry.contexts.rees_analyzer as Record<string, unknown>;
@@ -301,13 +301,13 @@ test("captureRouteError applies the route-level fingerprint and allowlisted tags
   assert.equal(sentry.tags.event, "rees_route_error");
   assert.equal(sentry.tags.route, "/v1/enrich");
   assert.equal(sentry.tags.method, "POST");
-  assert.equal(sentry.tags.release, "gittensory-rees@test");
+  assert.equal(sentry.tags.release, "loopover-rees@test");
   assert.equal(sentry.tags.environment, "test");
   assert.deepEqual(sentry.contexts.rees_route, {
     event: "rees_route_error",
     route: "/v1/enrich",
     method: "POST",
-    release: "gittensory-rees@test",
+    release: "loopover-rees@test",
     environment: "test",
   });
 });
@@ -319,11 +319,11 @@ test("captureUnhandledError fingerprints process-level failures by event class",
 
   assert.deepEqual(sentry.fingerprints, [["rees-process-error", "rees_uncaught_exception"]]);
   assert.equal(sentry.tags.event, "rees_uncaught_exception");
-  assert.equal(sentry.tags.release, "gittensory-rees@test");
+  assert.equal(sentry.tags.release, "loopover-rees@test");
   assert.equal(sentry.tags.environment, "test");
   assert.deepEqual(sentry.contexts.rees_process, {
     event: "rees_uncaught_exception",
-    release: "gittensory-rees@test",
+    release: "loopover-rees@test",
     environment: "test",
   });
 });
@@ -332,7 +332,7 @@ test("captureSourcemapUploadFailure applies stable upload grouping and safe tags
   const sentry = sentryHarness();
 
   captureSourcemapUploadFailure(new Error("upload failed"), {
-    release: "gittensory-rees@test",
+    release: "loopover-rees@test",
     railwayDeploymentId: "railway-deploy-123",
     strict: true,
     sha: "abcdef1234567890",
@@ -341,12 +341,12 @@ test("captureSourcemapUploadFailure applies stable upload grouping and safe tags
 
   assert.deepEqual(sentry.fingerprints, [["rees-sourcemap-upload-failed"]]);
   assert.equal(sentry.tags.event, "rees_sourcemap_upload_failed");
-  assert.equal(sentry.tags.release, "gittensory-rees@test");
+  assert.equal(sentry.tags.release, "loopover-rees@test");
   assert.equal(sentry.tags.environment, "test");
   assert.equal(sentry.tags.railwayDeploymentId, "railway-deploy-123");
   assert.deepEqual(sentry.contexts.rees_sourcemap_upload, {
     event: "rees_sourcemap_upload_failed",
-    release: "gittensory-rees@test",
+    release: "loopover-rees@test",
     railwayDeploymentId: "railway-deploy-123",
     strict: true,
     sha: "abcdef1234567890",
@@ -360,7 +360,7 @@ test("buildBrief normalizes unsafe analyzer partial reasons before response tele
 
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 42,
       analyzers: ["history"],
       linkedIssue: { number: 9, title: "add history context" },
@@ -447,7 +447,7 @@ test("buildBrief treats an explicit empty analyzer list as run none", async () =
 
   const brief = await buildBrief(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prNumber: 42,
       headSha: "head-sha",
       analyzers: [],

--- a/review-enrichment/test/sentry-release-validation.test.ts
+++ b/review-enrichment/test/sentry-release-validation.test.ts
@@ -18,8 +18,8 @@ function validationEnv(overrides: Record<string, string | undefined> = {}): Node
   return {
     SENTRY_AUTH_TOKEN: "test-token",
     SENTRY_ORG: "jsonbored",
-    SENTRY_PROJECT: "gittensory",
-    SENTRY_RELEASE: "gittensory-rees@abc123",
+    SENTRY_PROJECT: "loopover",
+    SENTRY_RELEASE: "loopover-rees@abc123",
     SENTRY_COMMIT_SHA: "abc123",
     SENTRY_DEPLOY_NAME: "deploy-1",
     SENTRY_ENVIRONMENT: "production",
@@ -33,8 +33,8 @@ test("loadSentryReleaseValidationConfig resolves exact release validation defaul
     loadSentryReleaseValidationConfig({
       SENTRY_AUTH_TOKEN: "token",
       SENTRY_ORG: "jsonbored",
-      SENTRY_PROJECT: "gittensory",
-      SENTRY_RELEASE: "gittensory-rees@abc123",
+      SENTRY_PROJECT: "loopover",
+      SENTRY_RELEASE: "loopover-rees@abc123",
       RAILWAY_GIT_COMMIT_SHA: "abc123",
       RAILWAY_DEPLOYMENT_ID: "deploy-1",
       RAILWAY_ENVIRONMENT_NAME: "production",
@@ -42,8 +42,8 @@ test("loadSentryReleaseValidationConfig resolves exact release validation defaul
     {
       authToken: "token",
       org: "jsonbored",
-      project: "gittensory",
-      release: "gittensory-rees@abc123",
+      project: "loopover",
+      release: "loopover-rees@abc123",
       baseUrl: "https://sentry.io",
       expectedCommitSha: "abc123",
       expectedDeployName: "deploy-1",
@@ -62,20 +62,20 @@ test("validateSentryRelease verifies finalized release, commits, and deploy", as
     assert.equal((init?.headers as Record<string, string>).authorization, "Bearer test-token");
     const path = new URL(String(input)).pathname;
     calls.push(path);
-    if (path === "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/") {
+    if (path === "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/") {
       return response({
-        version: "gittensory-rees@abc123",
+        version: "loopover-rees@abc123",
         dateReleased: "2026-06-29T00:00:00Z",
         commitCount: 1,
         deployCount: 1,
-        projects: [{ slug: "gittensory" }],
+        projects: [{ slug: "loopover" }],
         lastDeploy: { name: "deploy-1", environment: "production" },
       });
     }
-    if (path === "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/") {
+    if (path === "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/commits/") {
       return response([{ id: "abc123" }]);
     }
-    if (path === "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/deploys/") {
+    if (path === "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/deploys/") {
       return response([{ name: "deploy-1", environment: "production" }]);
     }
     return response({ detail: "not found" }, 404);
@@ -83,14 +83,14 @@ test("validateSentryRelease verifies finalized release, commits, and deploy", as
 
   const result = await validateSentryRelease(validationEnv(), fetchImpl);
 
-  assert.equal(result.release, "gittensory-rees@abc123");
+  assert.equal(result.release, "loopover-rees@abc123");
   assert.equal(result.finalized, true);
   assert.equal(result.commitCount, 1);
   assert.equal(result.deployCount, 1);
   assert.deepEqual(calls, [
-    "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/",
-    "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/",
-    "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/deploys/",
+    "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/",
+    "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/commits/",
+    "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/deploys/",
   ]);
 });
 
@@ -100,11 +100,11 @@ test("validateSentryRelease rejects a release missing the expected commit", asyn
     if (path.endsWith("/commits/")) return response([{ id: "def456" }]);
     if (path.endsWith("/deploys/")) return response([{ name: "deploy-1", environment: "production" }]);
     return response({
-      version: "gittensory-rees@abc123",
+      version: "loopover-rees@abc123",
       dateReleased: "2026-06-29T00:00:00Z",
       commitCount: 1,
       deployCount: 1,
-      projects: [{ slug: "gittensory" }],
+      projects: [{ slug: "loopover" }],
     });
   };
 
@@ -132,20 +132,20 @@ test("REGRESSION: validateSentryRelease does NOT enforce the expected-commit mat
     if (path.endsWith("/commits/")) return response([{ id: "def456" }]);
     if (path.endsWith("/deploys/")) return response([{ name: "deploy-1", environment: "production" }]);
     return response({
-      version: "gittensory-rees@abc123",
+      version: "loopover-rees@abc123",
       dateReleased: "2026-06-29T00:00:00Z",
       commitCount: 1,
       deployCount: 1,
-      projects: [{ slug: "gittensory" }],
+      projects: [{ slug: "loopover" }],
     });
   };
 
   const result = await validateSentryRelease(validationEnv({ SENTRY_REQUIRE_COMMITS: "false" }), fetchImpl);
-  assert.equal(result.release, "gittensory-rees@abc123");
+  assert.equal(result.release, "loopover-rees@abc123");
   // Non-strict mode must not even CALL the commits endpoint -- confirmed below with a second regression pinning
   // this exact call-skip, since a real Sentry API hiccup on /commits/ would otherwise still fail a non-strict
   // deploy (sentryJson throws on any non-OK response) even though no commit check would run on the result.
-  assert.equal(calls.includes("/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/"), false);
+  assert.equal(calls.includes("/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/commits/"), false);
 });
 
 test("REGRESSION: validateSentryRelease never calls the commits endpoint at all when SENTRY_REQUIRE_COMMITS=false, even if that endpoint is unhealthy", async () => {
@@ -158,16 +158,16 @@ test("REGRESSION: validateSentryRelease never calls the commits endpoint at all 
     if (path.endsWith("/commits/")) return response({ detail: "internal error" }, 500);
     if (path.endsWith("/deploys/")) return response([{ name: "deploy-1", environment: "production" }]);
     return response({
-      version: "gittensory-rees@abc123",
+      version: "loopover-rees@abc123",
       dateReleased: "2026-06-29T00:00:00Z",
       commitCount: 1,
       deployCount: 1,
-      projects: [{ slug: "gittensory" }],
+      projects: [{ slug: "loopover" }],
     });
   };
 
   const result = await validateSentryRelease(validationEnv({ SENTRY_REQUIRE_COMMITS: "false" }), fetchImpl);
-  assert.equal(result.release, "gittensory-rees@abc123");
+  assert.equal(result.release, "loopover-rees@abc123");
 });
 
 test("validateSentryRelease rejects a release missing the required deploy", async () => {
@@ -176,11 +176,11 @@ test("validateSentryRelease rejects a release missing the required deploy", asyn
     if (path.endsWith("/commits/")) return response([{ id: "abc123" }]);
     if (path.endsWith("/deploys/")) return response([]);
     return response({
-      version: "gittensory-rees@abc123",
+      version: "loopover-rees@abc123",
       dateReleased: "2026-06-29T00:00:00Z",
       commitCount: 1,
       deployCount: 0,
-      projects: [{ slug: "gittensory" }],
+      projects: [{ slug: "loopover" }],
     });
   };
 

--- a/review-enrichment/test/sentry-upload.test.ts
+++ b/review-enrichment/test/sentry-upload.test.ts
@@ -16,7 +16,7 @@ test("resolveReesSentryRelease prefers explicit releases and falls back to Railw
     }),
     "custom-release",
   );
-  assert.equal(resolveReesSentryRelease({ RAILWAY_GIT_COMMIT_SHA: "abc123" }), "gittensory-rees@abc123");
+  assert.equal(resolveReesSentryRelease({ RAILWAY_GIT_COMMIT_SHA: "abc123" }), "loopover-rees@abc123");
   assert.equal(resolveReesSentryRelease({}), undefined);
 });
 
@@ -34,12 +34,12 @@ async function sentryApiServer(options: { missingCommitOnFirstValidation?: boole
   const server = createServer((req, res) => {
     seen.push(req.url ?? "");
     res.setHeader("content-type", "application/json");
-    if (req.url === "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/") {
+    if (req.url === "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/") {
       releaseReads += 1;
       const missingCommit = options.missingCommitOnFirstValidation && releaseReads === 1;
       res.end(
         JSON.stringify({
-          version: "gittensory-rees@abc123",
+          version: "loopover-rees@abc123",
           dateReleased: "2026-06-29T00:00:00Z",
           commitCount: missingCommit ? 0 : 1,
           deployCount: 1,
@@ -49,7 +49,7 @@ async function sentryApiServer(options: { missingCommitOnFirstValidation?: boole
       );
       return;
     }
-    if (req.url === "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/") {
+    if (req.url === "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/commits/") {
       res.end(
         JSON.stringify(
           options.missingCommitOnFirstValidation && releaseReads === 1 ? [] : [{ id: "abc123" }],
@@ -57,7 +57,7 @@ async function sentryApiServer(options: { missingCommitOnFirstValidation?: boole
       );
       return;
     }
-    if (req.url === "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/deploys/") {
+    if (req.url === "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/deploys/") {
       res.end(JSON.stringify([{ name: "deploy-1", environment: "production" }]));
       return;
     }
@@ -141,7 +141,7 @@ test("upload-sourcemaps calls Sentry CLI with release association on upload", as
       "--project",
       "rees",
       "new",
-      "gittensory-rees@abc123",
+      "loopover-rees@abc123",
     ]);
     assert.deepEqual(calls[1], [
       "releases",
@@ -150,7 +150,7 @@ test("upload-sourcemaps calls Sentry CLI with release association on upload", as
       "--project",
       "rees",
       "set-commits",
-      "gittensory-rees@abc123",
+      "loopover-rees@abc123",
       "--commit",
       "JSONbored/loopover@abc123",
       "--ignore-missing",
@@ -164,15 +164,15 @@ test("upload-sourcemaps calls Sentry CLI with release association on upload", as
       "rees",
       "upload",
       "--release",
-      "gittensory-rees@abc123",
+      "loopover-rees@abc123",
       "--validate",
       "--wait",
       "--strict",
       "dist",
     ]);
-    assert.equal(api.seen.includes("/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/"), true);
-    assert.equal(api.seen.includes("/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/"), true);
-    assert.equal(api.seen.includes("/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/deploys/"), true);
+    assert.equal(api.seen.includes("/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/"), true);
+    assert.equal(api.seen.includes("/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/commits/"), true);
+    assert.equal(api.seen.includes("/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/deploys/"), true);
   } finally {
     await api.close();
   }
@@ -200,7 +200,7 @@ test("upload-sourcemaps retries release validation until Sentry exposes associat
 
     assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
     assert.match(result.stderr, /rees_sentry_release_validation_retry/);
-    const commitPath = "/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/";
+    const commitPath = "/api/0/organizations/jsonbored/releases/loopover-rees%40abc123/commits/";
     assert.equal(
       api.seen.filter((path) => path === commitPath).length,
       2,


### PR DESCRIPTION
## Summary
- `src/sentry.ts`'s `resolveReesSentryRelease()` defaulted every REES release id to `gittensory-rees@<sha>` when `SENTRY_RELEASE` wasn't set — same live bug class as #6876/#6881, this time in REES's own separate Railway deploy rather than the main app. Fixed the default and every test/doc reference describing that exact format (`README.md`'s Sentry setup guide, `sentry-upload`/`sentry-release-validation`/`sentry-degradation` tests).
- The remaining ~70 occurrences across `analysis-context`, `analyzer-registry`, `analyzer-circuit-breaker`, `external-fetch`, `render-contract`, `request-guardrails`, and `scheduler` tests were all an arbitrary `"JSONbored/gittensory"` placeholder `repoFullName` fixture value — any string works equally to test that logic, so this part is consistency-only, not a bug fix. `analyzer-circuit-breaker.test.ts`'s casing REGRESSION test (`"jsonbored/gittensory"` vs `"JSONbored/Gittensory"`) preserves the exact same casing-variation relationship with `"jsonbored/loopover"` / `"JSONbored/Loopover"`.
- Left untouched: `GITTENSORY-15` (a Sentry ticket id — permanent regardless of the project rename) and two historical PR/issue citations in `secret-scan.ts`/`.test.ts` (`"gittensory PR #5346/#5341"`, `"metagraphed/gittensory#4524"`) — PR/issue numbers are stable identifiers independent of a repo rename, and the second one's cross-repo shape wasn't clear enough to edit with confidence.

## Scope
- [x] Focused change (one theme: REES's Sentry-release bug + consistency), 12 files
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `cd review-enrichment && npm run test` — all 1335 tests passing