### PR TITLE
feat(mcp): mirror loopover_get_bounty_advisory over the CLI

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -326,6 +326,12 @@ const skippedPrAuditShape = {
   limit: z.number().int().positive().optional(),
 };
 
+// #6736: mirrors src/mcp/server.ts's bountyShape (same `id: z.string().min(1)` bound) so the local
+// server validates the bounty id identically to the remote surface it proxies.
+const bountyShape = {
+  id: z.string().min(1),
+};
+
 const ownerRepoPullShape = {
   owner: z.string().min(1),
   repo: z.string().min(1),
@@ -965,6 +971,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Derive a structured eligibility plan from local score-preview metadata: whether the branch/PR is eligible now, public-safe blockers, and cleanup paths. Advisory dry-run only — no GitHub writes.",
   },
   {
+    name: "loopover_get_bounty_advisory",
+    category: "discovery",
+    description: "Return lifecycle, funding, and consensus-risk context for a cached Gittensor bounty. Takes id (the bounty id).",
+  },
+  {
     name: "loopover_get_decision_pack",
     category: "discovery",
     description: "Return the private decision pack for a contributor: the ranked repos and issues to work on next, with per-repo go/raise/avoid guidance. Takes login (the contributor's GitHub username).",
@@ -1340,6 +1351,18 @@ registerStdioTool(
     const qs = query.toString();
     return toolResult("LoopOver skipped-PR audit trail.", await apiGet(`/v1/app/skipped-pr-audit${qs ? `?${qs}` : ""}`));
   },
+);
+
+// #6736: CLI mirror of the remote server's loopover_get_bounty_advisory. The fully public route
+// GET /v1/bounties/:id/advisory is the single source of truth (it delegates to the same buildBountyAdvisory
+// the MCP server's getBountyAdvisory calls); this tool only proxies it.
+registerStdioTool(
+  "loopover_get_bounty_advisory",
+  {
+    description: stdioToolDescription("loopover_get_bounty_advisory"),
+    inputSchema: bountyShape,
+  },
+  async ({ id }) => toolResult("LoopOver bounty advisory.", await apiGet(`/v1/bounties/${encodeURIComponent(id)}/advisory`)),
 );
 
 registerStdioTool(

--- a/test/unit/mcp-cli-bounty-advisory.test.ts
+++ b/test/unit/mcp-cli-bounty-advisory.test.ts
@@ -1,0 +1,103 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, run, startFixtureServer } from "./support/mcp-cli-harness";
+
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+const FORBIDDEN_PUBLIC_TERMS = /wallet\s*[:=]\s*\S+|hotkey\s*[:=]\s*\S+|coldkey\s*[:=]\s*\S+|raw trust score is|your trust score|reward estimate is|estimated reward/i;
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+let apiUrl: string;
+let capturedRequests: Array<{ url: string; method: string }>;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-bounty-advisory-"));
+  capturedRequests = [];
+  apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/bounties/")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...process.env,
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_API_TIMEOUT_MS: "5000",
+    },
+  });
+  client = new Client({ name: "bounty-advisory-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+async function disconnect() {
+  await client.close().catch(() => undefined);
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+}
+
+describe("loopover_get_bounty_advisory stdio proxy (#6736)", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("registers the tool in the stdio server tool list", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name)).toContain("loopover_get_bounty_advisory");
+  });
+
+  it("proxies the call to /v1/bounties/{id}/advisory via apiGet and returns the payload verbatim", async () => {
+    const result = await client.callTool({
+      name: "loopover_get_bounty_advisory",
+      arguments: { id: "bounty-42" },
+    });
+    expect(capturedRequests.length).toBe(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.url).toBe("/v1/bounties/bounty-42/advisory");
+    expect(captured.method).toBe("GET");
+    expect(result.isError).toBeFalsy();
+    // Output parity: the tool returns exactly what GET /v1/bounties/{id}/advisory served, unchanged.
+    expect(result.structuredContent).toEqual({
+      id: "bounty-42",
+      repoFullName: "owner/repo",
+      issueNumber: 12,
+      status: "open",
+      isActiveOpportunity: true,
+      fundingStatus: { funded: true },
+      consensusRisk: { level: "low" },
+      linkedPrs: [],
+      findings: [],
+    });
+    const text = JSON.stringify(result);
+    expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+    expect(text).toContain("LoopOver bounty advisory.");
+  });
+
+  it("url-encodes the bounty id in the proxied path", async () => {
+    await client.callTool({
+      name: "loopover_get_bounty_advisory",
+      arguments: { id: "owner/repo#7" },
+    });
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]!.url).toBe("/v1/bounties/owner%2Frepo%237/advisory");
+  });
+
+  it("lists the tool via loopover-mcp tools", () => {
+    const payload = JSON.parse(run(["tools", "--json"])) as {
+      tools: Array<{ name: string; description: string; category: string }>;
+    };
+    const tool = payload.tools.find((entry) => entry.name === "loopover_get_bounty_advisory");
+    expect(tool?.description).toMatch(/lifecycle, funding, and consensus-risk context/i);
+    expect(tool?.category).toBe("discovery");
+    expect(tool?.description.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -539,6 +539,24 @@ export async function startFixtureServer(
       response.end(JSON.stringify({ generatedAt: "2026-05-30T00:00:00.000Z", limit: 20, hasMore: false, items: [{ prNumber: 7, reason: "duplicate", remediation: "link the canonical PR" }] }));
       return;
     }
+    // #6736: the bounty-advisory mirror proxies GET /v1/bounties/:id/advisory; echo a fixed advisory payload.
+    if (request.url?.startsWith("/v1/bounties/") && request.url.endsWith("/advisory") && request.method === "GET") {
+      const id = decodeURIComponent(request.url.slice("/v1/bounties/".length, request.url.length - "/advisory".length));
+      response.end(
+        JSON.stringify({
+          id,
+          repoFullName: "owner/repo",
+          issueNumber: 12,
+          status: "open",
+          isActiveOpportunity: true,
+          fundingStatus: { funded: true },
+          consensusRisk: { level: "low" },
+          linkedPrs: [],
+          findings: [],
+        }),
+      );
+      return;
+    }
     // #6750: the boundary-tests lint mirror proxies here; echo a fired finding + spec.
     if (request.url === "/v1/lint/boundary-tests" && request.method === "POST") {
       response.end(


### PR DESCRIPTION
## Summary

- Add a local stdio CLI mirror of the remote `loopover_get_bounty_advisory` MCP tool. It proxies the fully public `GET /v1/bounties/:id/advisory` route (`src/api/routes.ts`), the same route the remote server's `getBountyAdvisory` serves via `buildBountyAdvisory`, so a bounty's advisory is queryable from the `@loopover/mcp` local wrapper without the hosted MCP server.
- Mirrors the existing precedent (`loopover_get_skipped_pr_audit`): a thin `apiGet` proxy registered with `registerStdioTool`, a `STDIO_TOOL_DESCRIPTORS` entry in the `discovery` category (matching the remote `MCP_TOOL_CATEGORIES` entry for the same name), and a `bountyShape` input schema that reuses the same `id: z.string().min(1)` bound as `src/mcp/server.ts`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The only changed source file is `packages/loopover-mcp/bin/loopover-mcp.js`, which is outside Codecov's collected paths (`src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**`), so `codecov/patch` has no changed measured lines. Coverage of the new tool is still exercised by `test/unit/mcp-cli-bounty-advisory.test.ts` (registration, path/verb proxying, id URL-encoding, verbatim payload parity, and `tools` listing). Ran the affected suites directly: `mcp-cli-bounty-advisory`, `mcp-cli-tools`, `mcp-cli-completion-spec`, `mcp-cli-tools-search`, `mcp-cli-basics`, `mcp-cli-intake-tools`, `mcp-cli-maintain-tools`, plus `command-reference:check`, `docs:drift-check`, and `manifest:drift-check` — all green. UI/openapi/workers checks are not applicable to this MCP-only change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (No visible UI change — MCP CLI only.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Followed the `loopover_get_skipped_pr_audit` precedent for the tool registration and did not add the optional top-level `bounty <id>` command: every other top-level CLI command takes `--flag` options (there is no positional-argument command in this CLI), so a positional `bounty <id>` would invent a new argument convention rather than match the house style. The stdio tool fully satisfies the required deliverables.

Closes #6736
