### PR TITLE
fix(apps): update remaining gittensory references across loopover-miner-ui, loopover-ui, and loopover-miner-extension

### DIFF
--- a/apps/loopover-miner-extension/test/background.test.ts
+++ b/apps/loopover-miner-extension/test/background.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../toolbar-badge.js";
 
 const rankedEntry = {
-  repoFullName: "JSONbored/gittensory",
+  repoFullName: "JSONbored/loopover",
   issueNumber: 145,
   rankScore: 0.82,
   laneFit: 0.9,
@@ -27,14 +27,14 @@ describe("background service worker", () => {
 
   it("returns ready issue context for a watched repo with a cached ranked candidate", async () => {
     const { backgroundInternals } = await loadExtensionModules({
-      watchedRepos: ["JSONbored/gittensory"],
+      watchedRepos: ["JSONbored/loopover"],
       rankedCandidates: [rankedEntry],
       rankedCandidatesSavedAt: Date.parse("2026-07-10T11:00:00.000Z"),
     });
 
     const payload = await backgroundInternals.loadIssueOpportunityContext({
       owner: "JSONbored",
-      repo: "gittensory",
+      repo: "loopover",
       issueNumber: 145,
     });
 
@@ -47,19 +47,19 @@ describe("background service worker", () => {
     const unwatched = await loadExtensionModules({ watchedRepos: ["other/repo"] });
     const notWatched = await unwatched.backgroundInternals.loadIssueOpportunityContext({
       owner: "JSONbored",
-      repo: "gittensory",
+      repo: "loopover",
       issueNumber: 145,
     });
     expect(notWatched.status).toBe("repo-not-watched");
     expect(notWatched.badge).toBeNull();
 
     const empty = await loadExtensionModules({
-      watchedRepos: ["JSONbored/gittensory"],
+      watchedRepos: ["JSONbored/loopover"],
       rankedCandidates: [],
     });
     const noSignal = await empty.backgroundInternals.loadIssueOpportunityContext({
       owner: "JSONbored",
-      repo: "gittensory",
+      repo: "loopover",
       issueNumber: 145,
     });
     expect(noSignal.status).toBe("no-signal");
@@ -68,13 +68,13 @@ describe("background service worker", () => {
 
   it("normalizes watched repos and degrades malformed ranked-candidate storage", async () => {
     const { backgroundInternals } = await loadExtensionModules({
-      watchedRepos: [" JSONbored/gittensory ", "", 42 as unknown as string],
+      watchedRepos: [" JSONbored/loopover ", "", 42 as unknown as string],
       rankedCandidates: "bad" as unknown as unknown[],
       rankedCandidatesSavedAt: "not-a-number" as unknown as number,
     });
 
     expect(await backgroundInternals.loadMinerExtensionSettings()).toEqual({
-      watchedRepos: ["JSONbored/gittensory", "42"],
+      watchedRepos: ["JSONbored/loopover", "42"],
     });
     expect(await backgroundInternals.loadRankedCandidates()).toEqual({
       rankedCandidates: [],
@@ -142,7 +142,7 @@ describe("background service worker", () => {
     expect(syncResult).toMatchObject({ ok: false, error: "offline" });
 
     const mod = await loadExtensionModules({
-      watchedRepos: ["JSONbored/gittensory"],
+      watchedRepos: ["JSONbored/loopover"],
       rankedCandidates: [rankedEntry],
       syncGetThrows: true,
       syncGetRejectsWith: "storage blew up",
@@ -150,7 +150,7 @@ describe("background service worker", () => {
     const response = await mod.dispatchMessage({
       type: mod.backgroundInternals.ISSUE_CONTEXT_MESSAGE,
       owner: "JSONbored",
-      repo: "gittensory",
+      repo: "loopover",
       issueNumber: 145,
     });
     expect((response as { ok: boolean; error: string }).error).toBeTruthy();
@@ -158,12 +158,12 @@ describe("background service worker", () => {
 
   it("matches watched repos case-insensitively", async () => {
     const { backgroundInternals } = await loadExtensionModules({
-      watchedRepos: ["jsonbored/gittensory"],
+      watchedRepos: ["jsonbored/loopover"],
       rankedCandidates: [rankedEntry],
     });
     const payload = await backgroundInternals.loadIssueOpportunityContext({
       owner: "JSONbored",
-      repo: "gittensory",
+      repo: "loopover",
       issueNumber: 145,
     });
     expect(payload.status).toBe("ready");
@@ -171,7 +171,7 @@ describe("background service worker", () => {
 
   it("routes runtime messages for ping, issue context, and sync", async () => {
     const mod = await loadExtensionModules({
-      watchedRepos: ["JSONbored/gittensory"],
+      watchedRepos: ["JSONbored/loopover"],
       rankedCandidates: [rankedEntry],
       fetchImpl: jsonFetch(200, { candidates: [rankedEntry] }),
     });
@@ -182,7 +182,7 @@ describe("background service worker", () => {
     const context = await mod.dispatchMessage({
       type: mod.backgroundInternals.ISSUE_CONTEXT_MESSAGE,
       owner: "JSONbored",
-      repo: "gittensory",
+      repo: "loopover",
       issueNumber: 145,
     });
     expect((context as { payload: { status: string } }).payload.status).toBe("ready");

--- a/apps/loopover-miner-extension/test/opportunity-badge.test.ts
+++ b/apps/loopover-miner-extension/test/opportunity-badge.test.ts
@@ -13,16 +13,16 @@ describe("opportunity-badge exports", () => {
 
   it("builds stable repo#issue lookup keys and finds ranked entries", async () => {
     const { opportunityExports: badge } = await loadExtensionModules();
-    expect(badge.issueLookupKey("JSONbored/gittensory", 145)).toBe("jsonbored/gittensory#145");
+    expect(badge.issueLookupKey("JSONbored/loopover", 145)).toBe("jsonbored/loopover#145");
     expect(badge.issueLookupKey("", 1)).toBeNull();
     expect(badge.issueLookupKey("a/b", 0)).toBeNull();
 
     const ranked = [
-      { repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.8 },
+      { repoFullName: "JSONbored/loopover", issueNumber: 145, rankScore: 0.8 },
       { repoFullName: "owner/repo", issueNumber: 2, rankScore: 0.4 },
     ];
-    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 145)?.rankScore).toBe(0.8);
-    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 404)).toBeNull();
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/loopover", 145)?.rankScore).toBe(0.8);
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/loopover", 404)).toBeNull();
     expect(badge.lookupRankedOpportunity(null, "a/b", 1)).toBeNull();
   });
 
@@ -60,9 +60,9 @@ describe("opportunity-badge exports", () => {
     const ranked = [
       null,
       { repoFullName: "a/b", issueNumber: "nope" },
-      { repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.5 },
+      { repoFullName: "JSONbored/loopover", issueNumber: 145, rankScore: 0.5 },
     ];
-    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 145)?.rankScore).toBe(0.5);
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/loopover", 145)?.rankScore).toBe(0.5);
   });
 
   it("formats relative last-synced labels and escapes badge markup", async () => {

--- a/apps/loopover-miner-ui/src/chat-api.test.ts
+++ b/apps/loopover-miner-ui/src/chat-api.test.ts
@@ -200,7 +200,7 @@ describe("chatApiPlugin middleware (#6517)", () => {
 
   it("registers on both the dev and preview servers", () => {
     const plugin = chatApiPlugin(deps());
-    expect(plugin.name).toBe("gittensory-miner-ui:chat-api");
+    expect(plugin.name).toBe("loopover-miner-ui:chat-api");
     expect(typeof plugin.configureServer).toBe("function");
     expect(typeof plugin.configurePreviewServer).toBe("function");
   });

--- a/apps/loopover-miner-ui/src/governor.test.tsx
+++ b/apps/loopover-miner-ui/src/governor.test.tsx
@@ -199,7 +199,7 @@ describe("handleGovernorRequest (#4857)", () => {
   function deps(overrides: Partial<GovernorApiDeps> = {}): GovernorApiDeps {
     return {
       loadGovernorStateModule: async () => ({
-        resolveGovernorStateDbPath: () => "/home/miner/.config/gittensory-miner/governor-state.sqlite3",
+        resolveGovernorStateDbPath: () => "/home/miner/.config/loopover-miner/governor-state.sqlite3",
         loadPauseState: () => pausedState,
         savePauseState: (input) => ({
           paused: input.paused,
@@ -339,7 +339,7 @@ function captureMiddleware(deps?: Partial<GovernorApiDeps>): CapturedRequestHand
     deps
       ? {
           loadGovernorStateModule: async () => ({
-            resolveGovernorStateDbPath: () => "/home/miner/.config/gittensory-miner/governor-state.sqlite3",
+            resolveGovernorStateDbPath: () => "/home/miner/.config/loopover-miner/governor-state.sqlite3",
             loadPauseState: () => defaultGovernorPauseState(),
             savePauseState: (input) => ({ paused: input.paused, reason: input.reason ?? null, pausedAt: null }),
           }),
@@ -396,7 +396,7 @@ describe("governorApiPlugin (#4857)", () => {
   it("serves GET /api/governor/pause-state from the real (injected) store", async () => {
     const middleware = captureMiddleware({
       loadGovernorStateModule: async () => ({
-        resolveGovernorStateDbPath: () => "/home/miner/.config/gittensory-miner/governor-state.sqlite3",
+        resolveGovernorStateDbPath: () => "/home/miner/.config/loopover-miner/governor-state.sqlite3",
         loadPauseState: () => pausedState,
         savePauseState: () => defaultGovernorPauseState(),
       }),
@@ -411,7 +411,7 @@ describe("governorApiPlugin (#4857)", () => {
   it("reads a POST body and pauses via the real (injected) store", async () => {
     const middleware = captureMiddleware({
       loadGovernorStateModule: async () => ({
-        resolveGovernorStateDbPath: () => "/home/miner/.config/gittensory-miner/governor-state.sqlite3",
+        resolveGovernorStateDbPath: () => "/home/miner/.config/loopover-miner/governor-state.sqlite3",
         loadPauseState: () => defaultGovernorPauseState(),
         savePauseState: (input) => ({
           paused: input.paused,

--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -307,15 +307,15 @@ describe("handleLedgersRequest (#4855)", () => {
   function deps(overrides: Partial<LedgersApiDeps> = {}): LedgersApiDeps {
     return {
       loadClaimLedgerModule: async () => ({
-        resolveClaimLedgerDbPath: () => "/home/miner/.config/gittensory-miner/claim-ledger.sqlite3",
+        resolveClaimLedgerDbPath: () => "/home/miner/.config/loopover-miner/claim-ledger.sqlite3",
         listClaims: () => rawClaimRows,
       }),
       loadEventLedgerModule: async () => ({
-        resolveEventLedgerDbPath: () => "/home/miner/.config/gittensory-miner/event-ledger.sqlite3",
+        resolveEventLedgerDbPath: () => "/home/miner/.config/loopover-miner/event-ledger.sqlite3",
         readEvents: () => rawEventRows,
       }),
       loadGovernorLedgerModule: async () => ({
-        resolveGovernorLedgerDbPath: () => "/home/miner/.config/gittensory-miner/governor-ledger.sqlite3",
+        resolveGovernorLedgerDbPath: () => "/home/miner/.config/loopover-miner/governor-ledger.sqlite3",
         readGovernorEvents: () => rawGovernorRows,
       }),
       fileExists: () => true,

--- a/apps/loopover-miner-ui/src/lib/governor.ts
+++ b/apps/loopover-miner-ui/src/lib/governor.ts
@@ -67,12 +67,12 @@ async function postGovernorAction(
   }
 }
 
-/** Pause the governor, optionally with a reason (mirrors `gittensory-miner governor pause [--reason <text>]`). */
+/** Pause the governor, optionally with a reason (mirrors `loopover-miner governor pause [--reason <text>]`). */
 export function pauseGovernor(reason?: string, fetchImpl: typeof fetch = fetch): Promise<GovernorPauseStateResult> {
   return postGovernorAction(GOVERNOR_PAUSE_API_PATH, reason ? { reason } : {}, fetchImpl);
 }
 
-/** Resume the governor (mirrors `gittensory-miner governor resume`). */
+/** Resume the governor (mirrors `loopover-miner governor resume`). */
 export function resumeGovernor(fetchImpl: typeof fetch = fetch): Promise<GovernorPauseStateResult> {
   return postGovernorAction(GOVERNOR_RESUME_API_PATH, {}, fetchImpl);
 }

--- a/apps/loopover-miner-ui/src/lib/portfolio-queue-actions.ts
+++ b/apps/loopover-miner-ui/src/lib/portfolio-queue-actions.ts
@@ -1,5 +1,5 @@
 // Client for the local portfolio-queue release/requeue write API (#4857, the queue half of "Add real actions to
-// the miner-ui"). Mirrors the CLI's `gittensory-miner queue release` / `queue requeue` commands via the
+// the miner-ui"). Mirrors the CLI's `loopover-miner queue release` / `queue requeue` commands via the
 // authenticated dev-server bridge in vite-portfolio-queue-actions-api.ts.
 
 export const PORTFOLIO_QUEUE_ITEMS_API_PATH = "/api/portfolio-queue/items";
@@ -81,7 +81,7 @@ export async function fetchPortfolioQueueItems(fetchImpl: typeof fetch = fetch):
   }
 }
 
-/** Release a claimed (in_progress) item back to queued — mirrors `gittensory-miner queue release`. */
+/** Release a claimed (in_progress) item back to queued — mirrors `loopover-miner queue release`. */
 export function releasePortfolioQueueItem(
   item: Pick<PortfolioQueueActionItem, "repoFullName" | "identifier" | "apiBaseUrl">,
   fetchImpl: typeof fetch = fetch,
@@ -89,7 +89,7 @@ export function releasePortfolioQueueItem(
   return postPortfolioQueueAction(PORTFOLIO_QUEUE_RELEASE_API_PATH, item, fetchImpl);
 }
 
-/** Requeue a completed (done) item — mirrors `gittensory-miner queue requeue`. */
+/** Requeue a completed (done) item — mirrors `loopover-miner queue requeue`. */
 export function requeuePortfolioQueueItem(
   item: Pick<PortfolioQueueActionItem, "repoFullName" | "identifier" | "apiBaseUrl">,
   fetchImpl: typeof fetch = fetch,

--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -262,7 +262,7 @@ describe("matchPortfolioQueueActionRoute / handlePortfolioQueueActionsRequest (#
     ];
     return {
       loadPortfolioQueueModule: async () => ({
-        resolvePortfolioQueueDbPath: () => "/home/miner/.config/gittensory-miner/portfolio-queue.sqlite3",
+        resolvePortfolioQueueDbPath: () => "/home/miner/.config/loopover-miner/portfolio-queue.sqlite3",
         initPortfolioQueueStore: () => ({
           listQueue: () => entries,
           reclaimStuckItem: (repoFullName, identifier) => {
@@ -401,7 +401,7 @@ describe("portfolioQueueActionsApiPlugin (#4857)", () => {
     let captured: CapturedRequestHandler | undefined;
     const plugin = portfolioQueueActionsApiPlugin({
       loadPortfolioQueueModule: async () => ({
-        resolvePortfolioQueueDbPath: () => "/home/miner/.config/gittensory-miner/portfolio-queue.sqlite3",
+        resolvePortfolioQueueDbPath: () => "/home/miner/.config/loopover-miner/portfolio-queue.sqlite3",
         initPortfolioQueueStore: () => ({
           listQueue: () => [inProgressItem],
           reclaimStuckItem: () => null,

--- a/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
@@ -254,7 +254,7 @@ describe("handlePortfolioQueueRequest (#4306, reunified with the CLI's queue das
   function deps(overrides: Partial<PortfolioQueueApiDeps> = {}): PortfolioQueueApiDeps {
     return {
       loadPortfolioQueueModule: async () => ({
-        resolvePortfolioQueueDbPath: () => "/home/miner/.config/gittensory-miner/portfolio-queue.sqlite3",
+        resolvePortfolioQueueDbPath: () => "/home/miner/.config/loopover-miner/portfolio-queue.sqlite3",
         listQueue: () => rows,
       }),
       loadPortfolioDashboardModule: async () => ({ collectPortfolioDashboard: fakeCollectPortfolioDashboard }),
@@ -336,7 +336,7 @@ describe("handlePortfolioQueueRequest (#4306, reunified with the CLI's queue das
       "/api/portfolio-queue",
       deps({
         loadPortfolioQueueModule: async () => ({
-          resolvePortfolioQueueDbPath: () => "/home/miner/.config/gittensory-miner/portfolio-queue.sqlite3",
+          resolvePortfolioQueueDbPath: () => "/home/miner/.config/loopover-miner/portfolio-queue.sqlite3",
           listQueue: () => [rows[1]!, rows[2]!], // in_progress + done only, no queued row
         }),
       }),

--- a/apps/loopover-miner-ui/src/styles.css
+++ b/apps/loopover-miner-ui/src/styles.css
@@ -5,8 +5,8 @@
 @import "@loopover/ui-kit/theme.css";
 
 /*
- * gittensory-miner-ui renders from the same shared design system as
- * gittensory-ui (imported above from @loopover/ui-kit) — no
+ * loopover-miner-ui renders from the same shared design system as
+ * loopover-ui (imported above from @loopover/ui-kit) — no
  * local tokens, colors, or fonts. Light and dark both ship in the shared
  * theme, switched by the `.dark` class on <html>: the inline no-flash script
  * in index.html restores the persisted choice before first paint, and

--- a/apps/loopover-miner-ui/vite-attempt-api.ts
+++ b/apps/loopover-miner-ui/vite-attempt-api.ts
@@ -172,7 +172,7 @@ export function attemptApiPlugin(deps: AttemptApiDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:attempt-api",
+    name: "loopover-miner-ui:attempt-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-auth.ts
+++ b/apps/loopover-miner-ui/vite-auth.ts
@@ -103,7 +103,7 @@ export function authPlugin(deps: AuthDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:auth",
+    name: "loopover-miner-ui:auth",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-chat-api.ts
+++ b/apps/loopover-miner-ui/vite-chat-api.ts
@@ -136,7 +136,7 @@ export function chatApiPlugin(deps: ChatApiDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:chat-api",
+    name: "loopover-miner-ui:chat-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-discover-api.ts
+++ b/apps/loopover-miner-ui/vite-discover-api.ts
@@ -174,7 +174,7 @@ export function discoverApiPlugin(deps: DiscoverApiDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:discover-api",
+    name: "loopover-miner-ui:discover-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-governor-api.ts
+++ b/apps/loopover-miner-ui/vite-governor-api.ts
@@ -151,7 +151,7 @@ export function governorApiPlugin(deps: GovernorApiDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:governor-api",
+    name: "loopover-miner-ui:governor-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-ledgers-api.ts
+++ b/apps/loopover-miner-ui/vite-ledgers-api.ts
@@ -150,7 +150,7 @@ export function ledgersApiPlugin(deps: LedgersApiDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:ledgers-api",
+    name: "loopover-miner-ui:ledgers-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-portfolio-queue-actions-api.ts
+++ b/apps/loopover-miner-ui/vite-portfolio-queue-actions-api.ts
@@ -205,7 +205,7 @@ export function portfolioQueueActionsApiPlugin(deps: PortfolioQueueActionsApiDep
     });
   };
   return {
-    name: "gittensory-miner-ui:portfolio-queue-actions-api",
+    name: "loopover-miner-ui:portfolio-queue-actions-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-portfolio-queue-api.ts
+++ b/apps/loopover-miner-ui/vite-portfolio-queue-api.ts
@@ -8,7 +8,7 @@ import type { Plugin } from "vite";
 //
 // Reunified with the CLI's own richer dashboard (#4846): the aggregation is now
 // `packages/loopover-miner/lib/portfolio-dashboard.js`'s `collectPortfolioDashboard` -- the SAME pure
-// aggregator `gittensory-miner queue dashboard` and the read-only MCP tool already use -- instead of a
+// aggregator `loopover-miner queue dashboard` and the read-only MCP tool already use -- instead of a
 // narrower global-only re-implementation, so the miner-ui and the CLI share one data path. It still aggregates
 // server-side so the HTTP surface never republishes raw queue identifiers or rank-derived priorities; only
 // status counts, grouped globally and per repo, cross the wire.
@@ -102,7 +102,7 @@ export function portfolioQueueApiPlugin(deps: PortfolioQueueApiDeps = defaultDep
     });
   };
   return {
-    name: "gittensory-miner-ui:portfolio-queue-api",
+    name: "loopover-miner-ui:portfolio-queue-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-ranked-candidates-api.ts
+++ b/apps/loopover-miner-ui/vite-ranked-candidates-api.ts
@@ -89,7 +89,7 @@ export function rankedCandidatesApiPlugin(deps: RankedCandidatesApiDeps = defaul
     });
   };
   return {
-    name: "gittensory-miner-ui:ranked-candidates-api",
+    name: "loopover-miner-ui:ranked-candidates-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite-run-state-api.ts
+++ b/apps/loopover-miner-ui/vite-run-state-api.ts
@@ -84,7 +84,7 @@ export function runStateApiPlugin(deps: RunStateApiDeps = defaultDeps): Plugin {
     });
   };
   return {
-    name: "gittensory-miner-ui:run-state-api",
+    name: "loopover-miner-ui:run-state-api",
     configureServer(server) {
       attach(server.middlewares);
     },

--- a/apps/loopover-miner-ui/vite.config.ts
+++ b/apps/loopover-miner-ui/vite.config.ts
@@ -37,12 +37,12 @@ export default defineConfig({
     attemptApiPlugin(),
   ],
   server: {
-    // Offset from gittensory-ui (5173) so both apps can run side-by-side locally.
+    // Offset from loopover-ui (5173) so both apps can run side-by-side locally.
     port: 5174,
     strictPort: true,
   },
   preview: {
-    // Offset from gittensory-ui preview (4173).
+    // Offset from loopover-ui preview (4173).
     port: 4174,
     strictPort: true,
   },

--- a/apps/loopover-ui/content/docs/self-hosting-operations.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-operations.mdx
@@ -533,7 +533,7 @@ error tracking, point the runtime at a project you control in your own Sentry or
 SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 SENTRY_ENVIRONMENT=production
 SENTRY_SERVER_NAME=loopover-us-east
-SENTRY_RELEASE=gittensory-selfhost@2026.07.05
+SENTRY_RELEASE=loopover-selfhost@2026.07.05
 # Optional: sample review tracing spans (0.05 = 5%)
 # SENTRY_TRACES_SAMPLE_RATE=0.05`}
 />
@@ -1036,7 +1036,7 @@ git merge --ff-only origin/main
 the bundle inside a Dockerized Node container — the host itself never needs Node or npm
 installed — then restarts only the `loopover` service the same way as the image
 path. `SENTRY_RELEASE` defaults to
-`gittensory-selfhost@<short git SHA of the current HEAD>` unless you
+`loopover-selfhost@<short git SHA of the current HEAD>` unless you
 override it, so each deploy from a new commit gets a distinct release id automatically. When
 `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are
 all configured, the script also injects and uploads Sentry source maps for that release

--- a/apps/loopover-ui/src/components/site/proof-of-power-stats.test.tsx
+++ b/apps/loopover-ui/src/components/site/proof-of-power-stats.test.tsx
@@ -51,7 +51,7 @@ const PAYLOAD: PublicStats = {
       closed: 176,
       accuracyPct: 96.8,
     },
-    { project: "JSONbored/gittensory", reviewed: 193, merged: 24, closed: 24, accuracyPct: 93.8 },
+    { project: "JSONbored/loopover", reviewed: 193, merged: 24, closed: 24, accuracyPct: 93.8 },
   ],
   accuracyTrend: [
     { weekStart: "2026-05-04", merged: 40, closed: 10, reversed: 2, accuracyPct: 96 },

--- a/apps/loopover-ui/src/lib/browser-sentry.test.ts
+++ b/apps/loopover-ui/src/lib/browser-sentry.test.ts
@@ -56,13 +56,13 @@ describe("initBrowserSentry", () => {
 
   it("calls Sentry.init with the DSN/release/environment when configured", async () => {
     vi.stubEnv("VITE_SENTRY_DSN", "https://key@o0.ingest.sentry.io/0");
-    vi.stubEnv("VITE_SENTRY_RELEASE", "gittensory-ui@abc123");
+    vi.stubEnv("VITE_SENTRY_RELEASE", "loopover-ui@abc123");
     vi.stubEnv("VITE_SENTRY_ENVIRONMENT", "staging");
     initBrowserSentry();
     await vi.waitFor(() => expect(mocks.init).toHaveBeenCalledTimes(1));
     const options = mocks.init.mock.calls[0]![0] as Record<string, unknown>;
     expect(options.dsn).toBe("https://key@o0.ingest.sentry.io/0");
-    expect(options.release).toBe("gittensory-ui@abc123");
+    expect(options.release).toBe("loopover-ui@abc123");
     expect(options.environment).toBe("staging");
     expect(typeof options.beforeSend).toBe("function");
     expect(typeof options.beforeSendTransaction).toBe("function");

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2335,7 +2335,7 @@ server.registerResource(
 
 // #6620: mirror the two remote static-document MCP resources over the local stdio server, proxying the new
 // unauthenticated REST routes the same way loopover_compatibility proxies /v1/mcp/compatibility. Reuse the exact
-// URIs the remote server registers (enrichment-analyzers keeps its legacy gittensory:// URI on purpose).
+// URIs the remote server registers.
 server.registerResource(
   "loopover_finding_taxonomy",
   "loopover://finding-taxonomy",


### PR DESCRIPTION
## Summary
- CLI command references in comments (`governor.ts`, `portfolio-queue-actions.ts`, `vite-portfolio-queue-api.ts`) still said `gittensory-miner ...`; the real binary is `loopover-miner` (confirmed against `package.json`'s own `bin` field).
- 9 `vite-*-api.ts` dev-server plugins had their `name:` field (and `chat-api.test.ts`'s matching assertion) as `gittensory-miner-ui:...`.
- `vite.config.ts`'s port-offset comments and `styles.css`'s design-system comment referenced the sibling app as `gittensory-ui`; confirmed `loopover-ui`'s own vite config relies on the same default ports (5173/4173) the comments describe.
- `self-hosting-operations.mdx` documented the exact stale `SENTRY_RELEASE`/`LOOPOVER_VERSION` default already fixed in #6876/#6881/#6888 as current behavior ("defaults to gittensory-selfhost@...").
- `packages/loopover-mcp/bin/loopover-mcp.js` had a comment claiming "enrichment-analyzers keeps its legacy gittensory:// URI on purpose" — stale since #6786 actually renamed that URI to `loopover://`.
- Remaining ~50 occurrences (`background.test.ts`, `opportunity-badge.test.ts`, `governor`/`ledgers`/`portfolio-queue-*.test.tsx`'s mock config-dir paths, `proof-of-power-stats.test.tsx`, `browser-sentry.test.ts`) were all arbitrary placeholder fixture values — confirmed each by reading the source under test: `browser-sentry.ts`'s `VITE_SENTRY_RELEASE` has no hardcoded default at all (pure passthrough, not the #6876-class bug), so its test fixture value is genuinely arbitrary, same as the repo-name/path fixtures elsewhere.

Left untouched (verified real, not drift): `try-it.ts`/`.test.ts`'s `LEGACY_STORAGE_KEY = "gittensory.session_token"` and the matching legacy-key arguments in `app.index`/`runs`/`workbench.tsx`'s `useLocalStorage(new, default, legacy)` calls — this is a deliberate migration path so a returning user's existing browser localStorage (session token, onboarding state, saved views, workbench tab) is still recognized after the rebrand. Also left the 3 self-hosting docs' "Renamed from gittensory-selfhost" / "pre-rename name" callouts, which are already correctly historically framed.

## Scope
- [x] Focused change (one theme across 3 related workspaces), 25 files
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `loopover-miner-ui`: 98 tests passing, clean `tsc --noEmit`
- `loopover-ui`: 29 tests passing
- `loopover-miner-extension`: 16 tests passing