### PR TITLE
docs(packages): update remaining gittensory references in loopover-miner/loopover-engine docs

### DIFF
--- a/packages/loopover-engine/README.md
+++ b/packages/loopover-engine/README.md
@@ -221,7 +221,7 @@ import {
 
 const gateVerdicts = ingestGateVerdictCalibrationSignals([
   {
-    repoFullName: "jsonbored/gittensory",
+    repoFullName: "jsonbored/loopover",
     replayRunId: "replay-2026-07-04",
     gateRunId: "gate-123",
     optedIn: true,
@@ -364,7 +364,7 @@ const summary = computeTrackRecordSummary({
   now: "2026-07-04T18:00:00Z",
   outcomes: [
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       authorLogin: "octo-miner",
       state: "merged",
       createdAt: "2026-06-01T00:00:00Z",
@@ -414,7 +414,7 @@ import {
 
 const findingSeverity = ingestFindingSeverityCalibrationSignals([
   {
-    repoFullName: "jsonbored/gittensory",
+    repoFullName: "jsonbored/loopover",
     replayRunId: "replay-2026-07-04",
     reviewRunId: "review-123",
     optedIn: true,
@@ -482,7 +482,7 @@ import {
 
 const reviewerConsensus = ingestReviewerConsensusCalibrationSignals([
   {
-    repoFullName: "jsonbored/gittensory",
+    repoFullName: "jsonbored/loopover",
     replayRunId: "replay-2026-07-05",
     reviewRunId: "review-123",
     optedIn: true,

--- a/packages/loopover-miner/DEPLOYMENT.md
+++ b/packages/loopover-miner/DEPLOYMENT.md
@@ -182,7 +182,7 @@ Want the dashboard too? [`systemd/loopover-miner-ui.service.example`](../../syst
 - Operators own secret injection; images and packages ship without embedded tokens.
 - AMS works against **any** GitHub repository — it does not require ORB installed, gittensor registration, or a `.loopover.yml` file on the target repo to function. Verified end to end (`init`, `doctor`, `discover <owner/repo>`) against real public repositories with no `.loopover.yml` and no gittensor registration, using only a plain `GITHUB_TOKEN`.
 
-See [`docs/operations-runbook.md`](docs/operations-runbook.md) for operational scenarios: ledger corruption, two miners on one state dir, and post-upgrade schema migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
+See [`docs/operations-runbook.md`](docs/operations-runbook.md) for operational scenarios: ledger corruption, two miners on one state dir, and post-upgrade schema migration ([#4875](https://github.com/JSONbored/loopover/issues/4875)).
 
 See [`docs/sizing.md`](docs/sizing.md) for measured CPU/RAM/disk numbers for laptop mode vs. fleet mode at
 different worker counts, with the exact commands used to reproduce them.
@@ -207,4 +207,4 @@ and `LOOPOVER_MINER_CONFIG_DIR` are covered above under the fleet/state notes; t
 
 ## Optional hosted discovery plane (opt-in)
 
-The Phase 6 **hosted discovery-index** is **off by default** — unlike Orb fleet export (`ORB_AIR_GAP` is the only opt-out). Operators who want cross-fleet metadata queries or soft-claim coordination must opt in explicitly. See [`docs/discovery-plane-operator-guide.md`](docs/discovery-plane-operator-guide.md) ([#4309](https://github.com/JSONbored/gittensory/issues/4309), placeholder until [#4300](https://github.com/JSONbored/gittensory/issues/4300) / [#4301](https://github.com/JSONbored/gittensory/issues/4301) / [#4302](https://github.com/JSONbored/gittensory/issues/4302) ship).
+The Phase 6 **hosted discovery-index** is **off by default** — unlike Orb fleet export (`ORB_AIR_GAP` is the only opt-out). Operators who want cross-fleet metadata queries or soft-claim coordination must opt in explicitly. See [`docs/discovery-plane-operator-guide.md`](docs/discovery-plane-operator-guide.md) ([#4309](https://github.com/JSONbored/loopover/issues/4309), placeholder until [#4300](https://github.com/JSONbored/loopover/issues/4300) / [#4301](https://github.com/JSONbored/loopover/issues/4301) / [#4302](https://github.com/JSONbored/loopover/issues/4302) ship).

--- a/packages/loopover-miner/README.md
+++ b/packages/loopover-miner/README.md
@@ -53,7 +53,7 @@ throws, and per its acceptance criteria **fails closed** — a repo with no reco
 `{ detected: false, reason }` and a command that can't be inferred without guessing stays `null`, rather than being
 assumed. The attempt path consumes it: `buildCodingTaskSpec` appends the real stack summary (and any
 confidently-inferred build/test/lint/format commands) to the coding-agent instructions so validation uses
-the target repo's own tooling rather than assuming LoopOver's own CI conventions ([#4786](https://github.com/JSONbored/gittensory/issues/4786)). (#4785)
+the target repo's own tooling rather than assuming LoopOver's own CI conventions ([#4786](https://github.com/JSONbored/loopover/issues/4786)). (#4785)
 
 The package also includes an append-only governor decision ledger: `initGovernorLedger` / `appendGovernorEvent`
 persist structured allow/deny/throttle/kill-switch outcomes in local SQLite for contributor audit. Insert-only —
@@ -159,13 +159,13 @@ enough (e.g. a live-polling dashboard) that the per-read linear event-ledger sca
 
 See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md) for the `.loopover-miner.yml` field reference and [`.loopover-miner.yml.example`](../../.loopover-miner.yml.example) at the repo root.
 
-See [`docs/cross-repo-discovery-phase1.md`](docs/cross-repo-discovery-phase1.md) for the Phase 1 cross-repo discovery scope (re-scoped from [#1060](https://github.com/JSONbored/gittensory/issues/1060), paper trail for [#2299](https://github.com/JSONbored/gittensory/issues/2299)).
+See [`docs/cross-repo-discovery-phase1.md`](docs/cross-repo-discovery-phase1.md) for the Phase 1 cross-repo discovery scope (re-scoped from [#1060](https://github.com/JSONbored/loopover/issues/1060), paper trail for [#2299](https://github.com/JSONbored/loopover/issues/2299)).
 
-See [`docs/discovery-plane-operator-guide.md`](docs/discovery-plane-operator-guide.md) for the optional hosted discovery-index plane (opt-in default OFF; contrasts with Orb's opt-out-only export — [#4309](https://github.com/JSONbored/gittensory/issues/4309)).
+See [`docs/discovery-plane-operator-guide.md`](docs/discovery-plane-operator-guide.md) for the optional hosted discovery-index plane (opt-in default OFF; contrasts with Orb's opt-out-only export — [#4309](https://github.com/JSONbored/loopover/issues/4309)).
 
 See [`DEPLOYMENT.md`](DEPLOYMENT.md) for laptop vs fleet deployment.
 
-See [`docs/operations-runbook.md`](docs/operations-runbook.md) for SQLite concurrency guarantees, corruption recovery, multi-process collision response, and post-upgrade ledger migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
+See [`docs/operations-runbook.md`](docs/operations-runbook.md) for SQLite concurrency guarantees, corruption recovery, multi-process collision response, and post-upgrade ledger migration ([#4875](https://github.com/JSONbored/loopover/issues/4875)).
 
 See [`docs/sizing.md`](docs/sizing.md) for measured CPU/RAM/disk numbers across laptop mode and fleet mode at
 different worker counts.

--- a/packages/loopover-miner/docs/coding-agent-driver.md
+++ b/packages/loopover-miner/docs/coding-agent-driver.md
@@ -118,7 +118,7 @@ real house-rule enforcement for the live `agent-sdk` provider happens via `build
 attached directly in `constructProductionCodingAgentDriver`.
 
 **Metering:** `attempt-metering.ts`'s `accumulateAttemptUsage`/`evaluateAttemptBudget` are wired into
-`iterate-loop.ts` for real ([#5395](https://github.com/JSONbored/gittensory/issues/5395)) -- every iteration
+`iterate-loop.ts` for real ([#5395](https://github.com/JSONbored/loopover/issues/5395)) -- every iteration
 accumulates real `turns`/`costUsd`/`wallClockMs` (`tokens` stays an honest 0; no driver reports a real
 per-iteration token count today) into a running `AttemptMeterTotals`, and `runIterateLoop`'s optional
 `input.budget: AttemptBudget` is evaluated against it each iteration via the SAME `costCeilingReached` signal
@@ -133,7 +133,7 @@ which axis (if any) triggered an abandon, for an operator reading the attempt lo
 
 ## Related docs
 
-- [`operations-runbook.md`](operations-runbook.md) — SQLite `busy_timeout` concurrency, corruption recovery, multi-process collisions, post-upgrade migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
+- [`operations-runbook.md`](operations-runbook.md) — SQLite `busy_timeout` concurrency, corruption recovery, multi-process collisions, post-upgrade migration ([#4875](https://github.com/JSONbored/loopover/issues/4875)).
 - [`env-reference.md`](env-reference.md) — env vars including ledger path overrides.
 - [`../DEPLOYMENT.md`](../DEPLOYMENT.md) — laptop vs fleet deployment and state directory layout.
 - [`miner-goal-spec.md`](miner-goal-spec.md) — per-repo `.loopover-miner.yml` targeting policy.

--- a/packages/loopover-miner/docs/cross-repo-discovery-phase1.md
+++ b/packages/loopover-miner/docs/cross-repo-discovery-phase1.md
@@ -1,8 +1,8 @@
 # Cross-repo discovery — Phase 1 scope (re-scoped from #1060)
 
-This document is the in-repo paper trail for [#2299](https://github.com/JSONbored/gittensory/issues/2299). It records the metadata-only, client-driven discovery model that supersedes the original [#1060](https://github.com/JSONbored/gittensory/issues/1060) wording (registered-repo aggregation and any retired global data layer). Maintainers should reopen #1060 and point its body at this file so the miner backlog has one canonical entry point.
+This document is the in-repo paper trail for [#2299](https://github.com/JSONbored/loopover/issues/2299). It records the metadata-only, client-driven discovery model that supersedes the original [#1060](https://github.com/JSONbored/loopover/issues/1060) wording (registered-repo aggregation and any retired global data layer). Maintainers should reopen #1060 and point its body at this file so the miner backlog has one canonical entry point.
 
-Part of [#1058](https://github.com/JSONbored/gittensory/issues/1058) (close-the-loop epic). Builds on / supersedes the intent of [#816](https://github.com/JSONbored/gittensory/issues/816).
+Part of [#1058](https://github.com/JSONbored/loopover/issues/1058) (close-the-loop epic). Builds on / supersedes the intent of [#816](https://github.com/JSONbored/loopover/issues/816).
 
 ## Re-scoped discovery model
 
@@ -29,23 +29,23 @@ Hosted and stdio MCP surfaces expose the composed shortlist: `loopover_find_oppo
 
 | Issue | Title |
 |-------|-------|
-| [#2299](https://github.com/JSONbored/gittensory/issues/2299) | Scope correction note (this document) |
-| [#2300](https://github.com/JSONbored/gittensory/issues/2300) | `.loopover-miner.yml` MinerGoalSpec schema doc |
-| [#2301](https://github.com/JSONbored/gittensory/issues/2301) | MinerGoalSpec parser with safe-default fallback |
-| [#2302](https://github.com/JSONbored/gittensory/issues/2302) | Pure ranker — `potential × feasibility × laneFit × freshness × (1 − dupRisk)` |
-| [#2303](https://github.com/JSONbored/gittensory/issues/2303) | Ranker invariant test suite |
-| [#2304](https://github.com/JSONbored/gittensory/issues/2304) | Goal model — MinerGoalSpec → ranker weights |
-| [#2305](https://github.com/JSONbored/gittensory/issues/2305) | Per-repo AI-policy map (CONTRIBUTING / AI-USAGE hard-skip) |
-| [#2306](https://github.com/JSONbored/gittensory/issues/2306) | AI-policy fixture corpus + integration test |
-| [#2307](https://github.com/JSONbored/gittensory/issues/2307) | Cross-repo GitHub search/listing fan-out (metadata-only) |
-| [#2308](https://github.com/JSONbored/gittensory/issues/2308) | Hosted `loopover_find_opportunities` MCP tool |
-| [#2309](https://github.com/JSONbored/gittensory/issues/2309) | Stdio `loopover_find_opportunities` in `@loopover/mcp` |
-| [#2310](https://github.com/JSONbored/gittensory/issues/2310) | Miner package `test:miner-pack` / `build:miner` parity checks |
-| [#2311](https://github.com/JSONbored/gittensory/issues/2311) | End-to-end Phase 1 discovery pipeline fixture test |
+| [#2299](https://github.com/JSONbored/loopover/issues/2299) | Scope correction note (this document) |
+| [#2300](https://github.com/JSONbored/loopover/issues/2300) | `.loopover-miner.yml` MinerGoalSpec schema doc |
+| [#2301](https://github.com/JSONbored/loopover/issues/2301) | MinerGoalSpec parser with safe-default fallback |
+| [#2302](https://github.com/JSONbored/loopover/issues/2302) | Pure ranker — `potential × feasibility × laneFit × freshness × (1 − dupRisk)` |
+| [#2303](https://github.com/JSONbored/loopover/issues/2303) | Ranker invariant test suite |
+| [#2304](https://github.com/JSONbored/loopover/issues/2304) | Goal model — MinerGoalSpec → ranker weights |
+| [#2305](https://github.com/JSONbored/loopover/issues/2305) | Per-repo AI-policy map (CONTRIBUTING / AI-USAGE hard-skip) |
+| [#2306](https://github.com/JSONbored/loopover/issues/2306) | AI-policy fixture corpus + integration test |
+| [#2307](https://github.com/JSONbored/loopover/issues/2307) | Cross-repo GitHub search/listing fan-out (metadata-only) |
+| [#2308](https://github.com/JSONbored/loopover/issues/2308) | Hosted `loopover_find_opportunities` MCP tool |
+| [#2309](https://github.com/JSONbored/loopover/issues/2309) | Stdio `loopover_find_opportunities` in `@loopover/mcp` |
+| [#2310](https://github.com/JSONbored/loopover/issues/2310) | Miner package `test:miner-pack` / `build:miner` parity checks |
+| [#2311](https://github.com/JSONbored/loopover/issues/2311) | End-to-end Phase 1 discovery pipeline fixture test |
 
 ## Target feature issue (#1060)
 
-[#1060 — proactive cross-repo opportunity discovery](https://github.com/JSONbored/gittensory/issues/1060) remains the umbrella feature issue. It should be **reopened** with this Phase 1 scope (metadata-only fan-out + deterministic ranker + MCP tool) replacing the older “aggregate across all registered repos” deliverable list. Proactive alerting and notification filters are follow-on work outside this read-only Phase 1 batch.
+[#1060 — proactive cross-repo opportunity discovery](https://github.com/JSONbored/loopover/issues/1060) remains the umbrella feature issue. It should be **reopened** with this Phase 1 scope (metadata-only fan-out + deterministic ranker + MCP tool) replacing the older “aggregate across all registered repos” deliverable list. Proactive alerting and notification filters are follow-on work outside this read-only Phase 1 batch.
 
 ## Acceptance (Phase 1)
 

--- a/packages/loopover-miner/docs/discovery-index-contract.md
+++ b/packages/loopover-miner/docs/discovery-index-contract.md
@@ -3,7 +3,7 @@
 The **discovery-index contract** is the typed request/response shape a miner uses to query the *optional* hosted
 discovery-index service. It is defined in `@loopover/engine`
 (`packages/loopover-engine/src/discovery-index-contract.ts`) so both sides — this repo's future server
-implementation ([#4250](https://github.com/JSONbored/gittensory/issues/4250), maintainer-only, explicitly blocked
+implementation ([#4250](https://github.com/JSONbored/loopover/issues/4250), maintainer-only, explicitly blocked
 on this contract) and any client — build against one shape.
 
 This is **schema/shape only**: no server, no deployed endpoint, no client HTTP implementation (those are #4250 and
@@ -12,7 +12,7 @@ the sibling soft-claim-coordination issue, respectively).
 ## Why
 
 The plane mitigates the rate-limit incident already fixed once for the review stack
-([#1936](https://github.com/JSONbored/gittensory/issues/1936)): *one* shared GitHub-metadata crawler across the
+([#1936](https://github.com/JSONbored/loopover/issues/1936)): *one* shared GitHub-metadata crawler across the
 miner fleet instead of every miner instance independently hammering the same repos' search/listing endpoints. The
 existing single-instance client pipeline (`packages/loopover-miner/lib/opportunity-fanout.js` +
 `opportunity-ranker.js`) is what a hosted version must stay compatible with, so the response candidate shape is

--- a/packages/loopover-miner/docs/discovery-plane-operator-guide.md
+++ b/packages/loopover-miner/docs/discovery-plane-operator-guide.md
@@ -4,7 +4,7 @@
 > (same content, rendered with search and the rest of the maintainer docs nav). This file remains
 > the canonical source and ships inside the published `@loopover/miner` package.
 
-Operator-facing guide for the **optional** Phase 6 hosted discovery-index plane ([#4250](https://github.com/JSONbored/gittensory/issues/4250)). This is the client/miner half of that roadmap item: how a `loopover-miner` instance opts in, what it may send, and what never leaves the operator's machine.
+Operator-facing guide for the **optional** Phase 6 hosted discovery-index plane ([#4250](https://github.com/JSONbored/loopover/issues/4250)). This is the client/miner half of that roadmap item: how a `loopover-miner` instance opts in, what it may send, and what never leaves the operator's machine.
 
 > **Scope:** the request/response **contract shape**, the telemetry event schema, and the client soft-claim
 > request builder have now **shipped** as real, tested modules (see the table). What remains **provisional** is
@@ -13,12 +13,12 @@ Operator-facing guide for the **optional** Phase 6 hosted discovery-index plane 
 >
 > | Defines | Status |
 > |---------|--------|
-> | Public-data-only discovery-index API contract — `DiscoveryIndexQuery` / `DiscoveryIndexResponse` / `DiscoveryIndexCandidate` (request/response shapes) | ✅ **shipped**, stable at `DISCOVERY_INDEX_CONTRACT_VERSION` 1 — [`discovery-index-contract.ts`](../../loopover-engine/src/discovery-index-contract.ts), [`discovery-index-contract.md`](discovery-index-contract.md) ([#4300](https://github.com/JSONbored/gittensory/issues/4300)) |
-> | Anonymized telemetry event schema for the optional hosted plane | ✅ **shipped** — [`miner-telemetry.ts`](../../loopover-engine/src/miner-telemetry.ts) ([#4301](https://github.com/JSONbored/gittensory/issues/4301)) |
-> | Client-side soft-claim coordination request builder | ✅ **shipped** — [`discovery-soft-claim.ts`](../../loopover-engine/src/discovery-soft-claim.ts) ([#4302](https://github.com/JSONbored/gittensory/issues/4302)) |
-> | Hosted discovery-index server + the operator-facing opt-in wiring | ⏳ **still open** — [#4250](https://github.com/JSONbored/gittensory/issues/4250) (the actual blocker for the opt-in mechanism below; the env var names remain TBD until it lands) |
+> | Public-data-only discovery-index API contract — `DiscoveryIndexQuery` / `DiscoveryIndexResponse` / `DiscoveryIndexCandidate` (request/response shapes) | ✅ **shipped**, stable at `DISCOVERY_INDEX_CONTRACT_VERSION` 1 — [`discovery-index-contract.ts`](../../loopover-engine/src/discovery-index-contract.ts), [`discovery-index-contract.md`](discovery-index-contract.md) ([#4300](https://github.com/JSONbored/loopover/issues/4300)) |
+> | Anonymized telemetry event schema for the optional hosted plane | ✅ **shipped** — [`miner-telemetry.ts`](../../loopover-engine/src/miner-telemetry.ts) ([#4301](https://github.com/JSONbored/loopover/issues/4301)) |
+> | Client-side soft-claim coordination request builder | ✅ **shipped** — [`discovery-soft-claim.ts`](../../loopover-engine/src/discovery-soft-claim.ts) ([#4302](https://github.com/JSONbored/loopover/issues/4302)) |
+> | Hosted discovery-index server + the operator-facing opt-in wiring | ⏳ **still open** — [#4250](https://github.com/JSONbored/loopover/issues/4250) (the actual blocker for the opt-in mechanism below; the env var names remain TBD until it lands) |
 
-Part of the Miner Wave 2 discovery plane ([#2353](https://github.com/JSONbored/gittensory/issues/2353) Phase 6). Distinct from Phase 1's **local-only** metadata fan-out documented in [`cross-repo-discovery-phase1.md`](cross-repo-discovery-phase1.md) — that path never phones home today.
+Part of the Miner Wave 2 discovery plane ([#2353](https://github.com/JSONbored/loopover/issues/2353) Phase 6). Distinct from Phase 1's **local-only** metadata fan-out documented in [`cross-repo-discovery-phase1.md`](cross-repo-discovery-phase1.md) — that path never phones home today.
 
 ## Default posture: opt-in (not like Orb)
 
@@ -33,12 +33,12 @@ Do **not** copy Orb's wording for this plane. Orb's header comment is explicit: 
 
 ## What the plane is for
 
-When enabled, a miner may query a **shared, metadata-only** discovery index instead of every fleet member independently fanning out GitHub search/listing calls against the same repos — mitigating cross-fleet rate-limit pressure (the same class of incident addressed for the review stack in [#1936](https://github.com/JSONbored/gittensory/issues/1936)).
+When enabled, a miner may query a **shared, metadata-only** discovery index instead of every fleet member independently fanning out GitHub search/listing calls against the same repos — mitigating cross-fleet rate-limit pressure (the same class of incident addressed for the review stack in [#1936](https://github.com/JSONbored/loopover/issues/1936)).
 
 The plane:
 
 - Serves **public GitHub metadata only** (issue titles, labels, counts, timestamps, URLs — the same class of fields Phase 1 already uses locally).
-- May coordinate **soft claims** across the fleet (server-side dedup is [#4250](https://github.com/JSONbored/gittensory/issues/4250); client request shape is [#4302](https://github.com/JSONbored/gittensory/issues/4302)).
+- May coordinate **soft claims** across the fleet (server-side dedup is [#4250](https://github.com/JSONbored/loopover/issues/4250); client request shape is [#4302](https://github.com/JSONbored/loopover/issues/4302)).
 - Never receives source trees, diffs, tokens, or write credentials.
 
 Local discovery (`opportunity-fanout` + `opportunity-ranker`) continues to work with **zero** hosted configuration.
@@ -53,14 +53,14 @@ should expect once the opt-in wiring (#4250) lands:
 |------------------------|---------|---------|
 | `LOOPOVER_MINER_DISCOVERY_PLANE` | unset / `false` | Master opt-in. When not truthy (`1`, `true`, `yes`, `on`), the miner must not call the hosted index or emit discovery-plane telemetry. |
 | `LOOPOVER_MINER_DISCOVERY_INDEX_URL` | unset | Hosted index base URL. Required when the plane is enabled; ignored when opt-in is off. |
-| `LOOPOVER_MINER_DISCOVERY_TELEMETRY` | unset / `false` | Separate opt-in for anonymized operational telemetry ([#4301](https://github.com/JSONbored/gittensory/issues/4301)). Plane queries can stay on while telemetry stays off. |
+| `LOOPOVER_MINER_DISCOVERY_TELEMETRY` | unset / `false` | Separate opt-in for anonymized operational telemetry ([#4301](https://github.com/JSONbored/loopover/issues/4301)). Plane queries can stay on while telemetry stays off. |
 
 **Truthy-string convention** (when implemented): `/^(1|true|yes|on)$/i`, matching other `LOOPOVER_*` flags in this repo.
 
 **Operator checklist (enabled plane):**
 
-1. Set `LOOPOVER_MINER_DISCOVERY_PLANE=true` (exact name may change — see [#4300](https://github.com/JSONbored/gittensory/issues/4300)).
-2. Set `LOOPOVER_MINER_DISCOVERY_INDEX_URL` to the operator-trusted index endpoint ([#4250](https://github.com/JSONbored/gittensory/issues/4250)).
+1. Set `LOOPOVER_MINER_DISCOVERY_PLANE=true` (exact name may change — see [#4300](https://github.com/JSONbored/loopover/issues/4300)).
+2. Set `LOOPOVER_MINER_DISCOVERY_INDEX_URL` to the operator-trusted index endpoint ([#4250](https://github.com/JSONbored/loopover/issues/4250)).
 3. Optionally set `LOOPOVER_MINER_DISCOVERY_TELEMETRY=true` if you want anonymized operational events for the hosted service — not required for index queries.
 4. Keep `GITHUB_TOKEN` (or equivalent) on the instance only; never configure tokens intended for the hosted plane to receive.
 
@@ -68,7 +68,7 @@ With opt-in off (default), behavior is byte-identical to today: local SQLite led
 
 ## Contrast with local soft-claims today
 
-`packages/loopover-miner/lib/claim-ledger.js` records soft claims **locally only** ("never uploads, syncs, or phones home"). Fleet-wide coordination before work starts is what [#4302](https://github.com/JSONbored/gittensory/issues/4302) + the hosted index ([#4250](https://github.com/JSONbored/gittensory/issues/4250)) add **on top of** that ledger — only after explicit opt-in.
+`packages/loopover-miner/lib/claim-ledger.js` records soft claims **locally only** ("never uploads, syncs, or phones home"). Fleet-wide coordination before work starts is what [#4302](https://github.com/JSONbored/loopover/issues/4302) + the hosted index ([#4250](https://github.com/JSONbored/loopover/issues/4250)) add **on top of** that ledger — only after explicit opt-in.
 
 After-the-fact duplicate adjudication (`isDuplicateClusterWinnerByClaim` in `@loopover/engine`) remains separate; it resolves collisions by observing what publicly landed first, not by preventing overlap up front.
 
@@ -81,14 +81,14 @@ Mirrors [`DEPLOYMENT.md`](../DEPLOYMENT.md) tone — concrete guarantees for ope
 - **Read-only client posture** — the miner uses GET/list/search semantics toward GitHub directly (Phase 1) and toward the hosted index when enabled; the plane does not grant the miner new GitHub write capability.
 - **Credentials stay local** — GitHub tokens, PATs, and actor-capable secrets are injected at runtime on the operator's machine or secret store; they are **never** included in index or telemetry payloads.
 - **No compensation signals in the plane** — raw reward values, wallet addresses, hotkeys, trust scores, or private rankings never cross this boundary (same public boundary as [`cross-repo-discovery-phase1.md`](cross-repo-discovery-phase1.md) Acceptance).
-- **Telemetry is a second opt-in** — even with the plane enabled, anonymized telemetry ([#4301](https://github.com/JSONbored/gittensory/issues/4301)) remains separately gated.
+- **Telemetry is a second opt-in** — even with the plane enabled, anonymized telemetry ([#4301](https://github.com/JSONbored/loopover/issues/4301)) remains separately gated.
 - **Anonymized identifiers only** — when telemetry ships, repo/issue correlation uses HMAC-hashed identifiers keyed by a **per-instance dedicated secret** the collector never holds (same posture as `getOrCreateAnonSecret` / `hmacField` in `src/selfhost/orb-collector.ts` — key separation from GitHub App / webhook secrets).
 - **Low-cardinality reason buckets** — any free-text-adjacent telemetry fields use bucketed categories (Orb's `bucketReasonCode` pattern), not raw maintainer or model prose.
 - **Core miner still works offline** — claims, plans, queues, and local ledgers do not require the hosted plane; `loopover-miner doctor` / `status` remain no-network commands.
 
 ### Never included (client → hosted plane)
 
-Inventory style matches `src/selfhost/orb-collector.ts:15-17` ("No diffs, no code…") adapted for discovery-plane domain ([#4301](https://github.com/JSONbored/gittensory/issues/4301)):
+Inventory style matches `src/selfhost/orb-collector.ts:15-17` ("No diffs, no code…") adapted for discovery-plane domain ([#4301](https://github.com/JSONbored/loopover/issues/4301)):
 
 - Source file contents, patches, or diffs
 - Full issue/PR bodies or review comments
@@ -98,13 +98,13 @@ Inventory style matches `src/selfhost/orb-collector.ts:15-17` ("No diffs, no cod
 - Raw gate reasons, model transcripts, or free-text maintainer notes
 - Reward amounts, wallet addresses, hotkeys, trust scores, or private rankings
 
-### Never retained by the hosted service (server-side — [#4250](https://github.com/JSONbored/gittensory/issues/4250))
+### Never retained by the hosted service (server-side — [#4250](https://github.com/JSONbored/loopover/issues/4250))
 
 The server operating doc (maintainer-only) will restate the same boundary: **never holds source or actor-capable credentials.** This client guide does not define server retention policy; see #4250 deliverables.
 
 ## Related docs
 
 - [`cross-repo-discovery-phase1.md`](cross-repo-discovery-phase1.md) — local, metadata-only Phase 1 discovery (no hosted plane).
-- [`operations-runbook.md`](operations-runbook.md) — SQLite concurrency, corruption recovery, multi-process collisions, post-upgrade migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
+- [`operations-runbook.md`](operations-runbook.md) — SQLite concurrency, corruption recovery, multi-process collisions, post-upgrade migration ([#4875](https://github.com/JSONbored/loopover/issues/4875)).
 - [`miner-goal-spec.md`](miner-goal-spec.md) — per-repo `.loopover-miner.yml` targeting policy.
 - [`../DEPLOYMENT.md`](../DEPLOYMENT.md) — laptop vs fleet deployment and core miner invariants.

--- a/packages/loopover-miner/docs/operations-runbook.md
+++ b/packages/loopover-miner/docs/operations-runbook.md
@@ -6,7 +6,7 @@
 
 Operator-facing runbook for **local SQLite state**: what the concurrency guarantees actually mean, how to recover from corruption, what to do when two miner processes collide on the same files, and how schema upgrades migrate your on-disk ledgers after a package update.
 
-> **Scope:** AMS local stores only. For laptop/fleet deployment layout see [`../DEPLOYMENT.md`](../DEPLOYMENT.md). For Grafana setup see [#5190](https://github.com/JSONbored/gittensory/issues/5190). For the optional hosted discovery plane see [`discovery-plane-operator-guide.md`](discovery-plane-operator-guide.md). This runbook does **not** cover the self-hosted **review stack** (Orb/API/LoopoverDB).
+> **Scope:** AMS local stores only. For laptop/fleet deployment layout see [`../DEPLOYMENT.md`](../DEPLOYMENT.md). For Grafana setup see [#5190](https://github.com/JSONbored/loopover/issues/5190). For the optional hosted discovery plane see [`discovery-plane-operator-guide.md`](discovery-plane-operator-guide.md). This runbook does **not** cover the self-hosted **review stack** (Orb/API/LoopoverDB).
 
 ## Local state at a glance
 
@@ -193,7 +193,7 @@ Append-only stores **do not repair individual bad rows** in place — corrupted 
 
 **How upgrades work**
 
-Stores use the lightweight **`schema-version.js`** convention ([#4832](https://github.com/JSONbored/gittensory/issues/4832)):
+Stores use the lightweight **`schema-version.js`** convention ([#4832](https://github.com/JSONbored/loopover/issues/4832)):
 
 - Bootstrap `CREATE TABLE IF NOT EXISTS …` is schema **version 1** (`BASELINE_SCHEMA_VERSION`).
 - Each store may register post-baseline migrations; `applySchemaMigrations` runs pending steps on **every open**.
@@ -245,5 +245,5 @@ Stores use the lightweight **`schema-version.js`** convention ([#4832](https://g
 - [`../README.md`](../README.md#local-storage) — store inventory
 - [`env-reference.md`](env-reference.md) — per-store path overrides
 - [`coding-agent-driver.md`](coding-agent-driver.md) — attempt log semantics
-- [#5190](https://github.com/JSONbored/gittensory/issues/5190) — Grafana + SQLite ledgers (observability doc)
+- [#5190](https://github.com/JSONbored/loopover/issues/5190) — Grafana + SQLite ledgers (observability doc)
 - [`discovery-plane-operator-guide.md`](discovery-plane-operator-guide.md) — optional hosted plane (distinct from local ledger ops)

--- a/packages/loopover-miner/docs/repo-agnostic-capability-audit.md
+++ b/packages/loopover-miner/docs/repo-agnostic-capability-audit.md
@@ -1,9 +1,9 @@
 # Repo-agnostic capability audit — miner discovery / claim / scoring
 
 Audit of the `packages/loopover-miner` discovery, claim, and scoring code for hardcoded or
-implicitly gittensory-specific assumptions that would need to become per-tenant configuration before
+implicitly loopover-specific assumptions that would need to become per-tenant configuration before
 the loop can run against an arbitrary repo. This is the checklist deliverable for **#4780**; the
-follow-up **#4784** executes it (turning each open item below into config, gittensory's own values
+follow-up **#4784** executes it (turning each open item below into config, loopover's own values
 surviving only as the default). Audit-and-document only — no code changes here.
 
 ## Summary
@@ -18,9 +18,9 @@ caller-supplied, label preferences are generic per-tenant config (`.loopover-min
    search-qualifier syntax. This is the single largest gap for a non-GitHub tenant.
 2. **An existing forge-host override that isn't reachable from the CLI** — `opportunity-fanout` already
    accepts `apiBaseUrl` (GitHub Enterprise), but `discover-cli` never parses or threads it.
-3. **Engine-delegated gittensory *defaults*** — label taxonomy and the miner goal spec default to
-   gittensory's conventions in `@loopover/engine`; they are overridable, but the miner uses
-   the gittensory defaults out of the box unless a per-tenant config is supplied.
+3. **Engine-delegated loopover *defaults*** — label taxonomy and the miner goal spec default to
+   loopover's conventions in `@loopover/engine`; they are overridable, but the miner uses
+   the loopover defaults out of the box unless a per-tenant config is supplied.
 
 Everything else audited is already parameterized (see the last section) and needs no #4784 work.
 
@@ -52,7 +52,7 @@ whatever label strings the forge returns, with no `gittensor:*` filter. No chang
 
 | Line | Assumption | Category | Should become |
 | --- | --- | --- | --- |
-| 1–5 | imports `DEFAULT_MINER_GOAL_SPEC`, `parseMinerGoalSpecContent`, `rankMetadataOpportunities` from `@loopover/engine` | (3) scoring rubric | Ranking is engine-delegated and config-driven via `parseMinerGoalSpecContent`, but falls back to `DEFAULT_MINER_GOAL_SPEC` (gittensory's rubric) when no per-tenant goal spec is provided. #4784 should ensure a tenant goal spec is surfaced/required rather than silently defaulting. |
+| 1–5 | imports `DEFAULT_MINER_GOAL_SPEC`, `parseMinerGoalSpecContent`, `rankMetadataOpportunities` from `@loopover/engine` | (3) scoring rubric | Ranking is engine-delegated and config-driven via `parseMinerGoalSpecContent`, but falls back to `DEFAULT_MINER_GOAL_SPEC` (loopover's rubric) when no per-tenant goal spec is provided. #4784 should ensure a tenant goal spec is surfaced/required rather than silently defaulting. |
 
 ### `lib/feasibility-cli.js` — feasibility verdict (delegated)
 
@@ -64,7 +64,7 @@ whatever label strings the forge returns, with no `gittensor:*` filter. No chang
 
 | Location | Assumption | Category | Should become |
 | --- | --- | --- | --- |
-| `src/settings/pr-type-label.ts:26–28` | `DEFAULT_TYPE_LABELS = { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority" }` | (1) label names | Already overridable per repo (`#label-modularity`), **default gittensory**. The miner inherits these defaults; #4784 should pass the tenant's label names through. |
+| `src/settings/pr-type-label.ts:26–28` | `DEFAULT_TYPE_LABELS = { bug: "gittensor:bug", feature: "gittensor:feature", priority: "gittensor:priority" }` | (1) label names | Already overridable per repo (`#label-modularity`), **default loopover**. The miner inherits these defaults; #4784 should pass the tenant's label names through. |
 
 ## Already parameterized — no #4784 change needed
 
@@ -72,7 +72,7 @@ These were checked and are already tenant-agnostic / config-driven; call them ou
 redo them:
 
 - **Discovery query** — caller-supplied via `discover --search <query>` or explicit `owner/repo`
-  targets; no hardcoded gittensory label query (`discover-cli.js`).
+  targets; no hardcoded loopover label query (`discover-cli.js`).
 - **Label preferences** — `.loopover-miner.yml` `preferredLabels` / `blockedLabels` are generic
   (`bug`, `enhancement`, `wontfix`, `duplicate`), not `gittensor:*`.
 - **Path scope, feasibility gate, self-plagiarism threshold, concurrency** — all per-tenant in
@@ -81,7 +81,7 @@ redo them:
 - **Runtime caps** — `.loopover-ams.yml` (`submissionMode`, `capLimits`, `convergenceThresholds`,
   `maxIterations`) are generic runtime knobs.
 - **Local stores** — `portfolio-queue`, `claim-ledger`, `event-ledger`, etc. are generic SQLite
-  bookkeeping with env-configurable DB paths; no gittensory-specific schema.
+  bookkeeping with env-configurable DB paths; no loopover-specific schema.
 
 ## Prioritized checklist for #4784
 
@@ -95,7 +95,7 @@ redo them:
   configurable (default `GITHUB_TOKEN`).
 - [x] **Medium — pass tenant label taxonomy + goal spec through (`opportunity-ranker.js`, engine
   `DEFAULT_TYPE_LABELS`):** ensure the miner supplies the tenant's labels / goal spec instead of
-  silently falling back to the gittensory defaults.
+  silently falling back to the loopover defaults.
 - [x] **Low — configurable user-agent (`opportunity-fanout.js:70`).**
 
 ## Resolution (#4784)


### PR DESCRIPTION
## Summary
- `github.com/JSONbored/gittensory/issues/NNNN` links across `README.md`, `DEPLOYMENT.md`, and 5 `docs/*.md` files still resolve via GitHub's rename redirect, but relying on that indefinitely is fragile — fixed to point at `JSONbored/loopover` directly.
- `repo-agnostic-capability-audit.md` used "gittensory" adjectivally throughout ("gittensory's conventions", "gittensory defaults") to mean "this product's own opinionated defaults, as opposed to generic per-tenant config" — updated to "loopover" since that's what the product is called now; left the actual `gittensor:bug`/`feature`/`priority` label-name citation (line 67) untouched, the real convention.
- `loopover-engine/README.md`'s example fixtures used `jsonbored/gittensory` as an illustrative `repoFullName`; any string works equally there, updated for consistency.

Left untouched: `global-singleton-tenant-audit.md`'s citation of issue #5218's old package-name terminology (an explicit historical translation note, not drift) and `packages/loopover-miner/terraform/main.tf`, where the only remaining references live inside resource-block attribute values (`name=`, `labels=`, a cloud-init `user_data` string) that I can't confirm are safe to change without checking the Hetzner Terraform provider's `ForceNew` semantics — and, unlike the root `terraform/` module (removed in #6882 after confirming with the repo owner it was never applied), this one is a documented self-host "starter module" an external operator may have already deployed from.

## Scope
- [x] Docs-only change, 9 files
- [x] No secrets/private terms touched
- [x] No changelog edit

## Validation
- `git diff --check` — clean
- Confirmed `gittensor:` label citations unaffected in both edited files (grep count unchanged before/after)