### PR TITLE
fix(miner): cover every local store in doctor's and migrate's sweeps

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.js
+++ b/packages/loopover-miner/lib/migrate-cli.js
@@ -18,6 +18,10 @@ import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./predictio
 import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
 import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
 import { openPlanStore, resolvePlanStoreDbPath } from "./plan-store.js";
+import { openGovernorState, resolveGovernorStateDbPath } from "./governor-state.js";
+import { initAttemptLog, resolveAttemptLogDbPath } from "./attempt-log.js";
+import { openReplaySnapshotStore, resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
+import { openWorktreeAllocator, resolveWorktreeAllocatorDbPath, resolveWorktreeBaseDir } from "./worktree-allocator.js";
 
 const MIGRATE_USAGE = "Usage: loopover-miner migrate [--json]";
 
@@ -29,6 +33,18 @@ const STORES = [
   { name: "claim-ledger", resolveDbPath: resolveClaimLedgerDbPath, open: openClaimLedger },
   { name: "run-state", resolveDbPath: resolveRunStateDbPath, open: initRunStateStore },
   { name: "plan-store", resolveDbPath: resolvePlanStoreDbPath, open: openPlanStore },
+  { name: "governor-state", resolveDbPath: resolveGovernorStateDbPath, open: openGovernorState },
+  { name: "attempt-log", resolveDbPath: resolveAttemptLogDbPath, open: initAttemptLog },
+  { name: "replay-snapshot", resolveDbPath: resolveReplaySnapshotDbPath, open: openReplaySnapshotStore },
+  // openWorktreeAllocator takes an options object rather than a bare dbPath, so it is adapted to this list's
+  // open(dbPath, env) contract. worktreeBaseDir is resolved from the SAME env the sweep was handed -- letting it
+  // fall back to openWorktreeAllocator's own process.env default would be identical in production (runMigrateChecks
+  // defaults env to process.env) but would make a caller-supplied env silently seed slots for the wrong base dir.
+  {
+    name: "worktree-allocator",
+    resolveDbPath: resolveWorktreeAllocatorDbPath,
+    open: (dbPath, env) => openWorktreeAllocator({ dbPath, worktreeBaseDir: resolveWorktreeBaseDir(env) }),
+  },
 ];
 
 /** Read a store file's stamped schema version without ever creating it -- matches checkStoreIntegrity's
@@ -68,7 +84,9 @@ function migrateStore({ name, resolveDbPath, open }, env) {
   let versionBefore = null;
   try {
     versionBefore = peekSchemaVersion(dbPath);
-    const store = open(dbPath);
+    // `env` is forwarded so a store whose open needs more than a path (worktree-allocator's base dir) resolves it
+    // from the same env this sweep was handed; every other store's `open(dbPath)` simply ignores the extra arg.
+    const store = open(dbPath, env);
     store.close();
     const versionAfter = peekSchemaVersion(dbPath);
     return {

--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -19,6 +19,10 @@ import { hasGitHubTokenSource } from "./github-token-resolution.js";
 import { resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
 import { resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
 import { resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import { resolveGovernorStateDbPath } from "./governor-state.js";
+import { resolveAttemptLogDbPath } from "./attempt-log.js";
+import { resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
+import { resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { resolveRunStateDbPath } from "./run-state.js";
 import { resolvePlanStoreDbPath } from "./plan-store.js";
 
@@ -307,6 +311,10 @@ function storeIntegrityChecks(env) {
     ["claim-ledger", resolveClaimLedgerDbPath(env)],
     ["run-state", resolveRunStateDbPath(env)],
     ["plan-store", resolvePlanStoreDbPath(env)],
+    ["governor-state", resolveGovernorStateDbPath(env)],
+    ["attempt-log", resolveAttemptLogDbPath(env)],
+    ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
+    ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
   ];
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -7,6 +7,11 @@ import { runMigrate, runMigrateChecks } from "../../packages/loopover-miner/lib/
 import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "../../packages/loopover-miner/lib/portfolio-queue.js";
 import { resolveEventLedgerDbPath } from "../../packages/loopover-miner/lib/event-ledger.js";
 import { applySchemaMigrations, BASELINE_SCHEMA_VERSION } from "../../packages/loopover-miner/lib/schema-version.js";
+import {
+  openWorktreeAllocator,
+  resolveWorktreeAllocatorDbPath,
+  resolveWorktreeBaseDir,
+} from "../../packages/loopover-miner/lib/worktree-allocator.js";
 
 const roots: string[] = [];
 
@@ -24,6 +29,11 @@ const STORE_NAMES = [
   "claim-ledger",
   "run-state",
   "plan-store",
+  // #6768: the four real stores the sweep previously never touched (migrated/checked only lazily).
+  "governor-state",
+  "attempt-log",
+  "replay-snapshot",
+  "worktree-allocator",
 ];
 
 afterEach(() => {
@@ -193,6 +203,27 @@ describe("loopover-miner migrate (#4871)", () => {
     } finally {
       verifyDb.close();
     }
+  });
+
+  it("#6768: actually OPENS each newly-covered store, bringing an existing worktree-allocator file up to date", () => {
+    const env = tempEnv();
+    // Create the real on-disk file for the store whose `open` needs more than a path, so the sweep takes its
+    // real open/migrate path (not the `existsSync` "skipped" short-circuit that every fresh-env test hits).
+    const allocator = openWorktreeAllocator({
+      dbPath: resolveWorktreeAllocatorDbPath(env),
+      worktreeBaseDir: resolveWorktreeBaseDir(env),
+    });
+    allocator.close();
+
+    const results = runMigrateChecks(env);
+    const worktreeAllocator = results.find((result) => result.name === "worktree-allocator");
+
+    // It exists now, so it must be really opened and reported -- never "skipped".
+    expect(worktreeAllocator?.ok).toBe(true);
+    expect(worktreeAllocator?.status).toBe("up-to-date");
+    expect(worktreeAllocator?.versionAfter).toBe(worktreeAllocator?.versionBefore);
+    // ...and the sweep resolves its base dir from the SAME env it was handed, never the ambient process.env.
+    expect(worktreeAllocator?.dbPath).toBe(resolveWorktreeAllocatorDbPath(env));
   });
 
   it("runMigrate prints human-readable text (exit 0) and machine JSON with --json, and exits 1 when a store fails", () => {

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -125,6 +125,11 @@ describe("loopover-miner status/doctor (#2288)", () => {
       "store-integrity:claim-ledger",
       "store-integrity:run-state",
       "store-integrity:plan-store",
+      // #6768: doctor's sweep now covers every real local store, not just the original seven.
+      "store-integrity:governor-state",
+      "store-integrity:attempt-log",
+      "store-integrity:replay-snapshot",
+      "store-integrity:worktree-allocator",
     ]);
     expect(runDoctor([], env, cwd)).toBe(0);
     expect(log).toHaveBeenCalled();


### PR DESCRIPTION
Closes #6768

_(Supersedes #6873, which was auto-closed on `codecov/patch`: its `worktree-allocator` entry used an inline arrow whose body no test ever executed — every test ran against a fresh env where `migrateStore` short-circuits at `existsSync` and never calls `open`. That line is now driven by a real test; see Validation.)_

## Problem

`status.js`'s `storeIntegrityChecks` and `migrate-cli.js`'s `STORES` both enumerated the same **seven** stores — and `migrate-cli.js`'s own header states its list deliberately mirrors `status.js`'s. Four other real, independent local SQLite stores using the same `resolveLocalStoreDbPath`/`openLocalStoreDb` convention were in **neither** list:

- `governor-state.js`, `attempt-log.js`, `replay-snapshot.js`, `worktree-allocator.js`

So neither `doctor`'s corruption sweep nor an operator's proactive `migrate` — whose stated purpose is to bring *"every known store's EXISTING on-disk file up to date"* — ever touched these four; they were migrated/checked only lazily, whenever some command happened to open them first.

## Fix

Add the same four stores to **both** lists, preserving the mirror invariant (`status.js` → `store-integrity:<name>`; `migrate-cli.js` → `STORES`, same order).

`openWorktreeAllocator` takes an options object rather than a bare `dbPath`, so it's adapted to the list's `open(dbPath, env)` contract. `env` is now forwarded to `open` so the allocator resolves `worktreeBaseDir` from **the same env the sweep was handed** — letting it fall back to its own `process.env` default is identical in production (`runMigrateChecks` defaults `env` to `process.env`) but would make a caller-supplied env silently seed slots for the wrong base dir. Every other store's `open(dbPath)` simply ignores the extra arg.

Disposable/cache-only stores are deliberately left out, consistent with their own documented design.

## Tests

- `miner-migrate-cli.test.ts` — `STORE_NAMES` extended to the eleven-store surface (asserts name + order, and that a fresh env skips all eleven), **plus a new test that creates a real `worktree-allocator` file and runs the sweep**, so the store is genuinely opened (`up-to-date`, not `skipped`) and its `dbPath` is resolved from the supplied env.
- `miner-status.test.ts` — `doctor`'s `--json` check-name list updated to eleven.

## Validation

- `npx vitest run test/unit/miner-migrate-cli.test.ts test/unit/miner-status.test.ts` → **44 passed, 45 total**. The single failure (`resolves the state dir…`) is **pre-existing on Windows only** — the pristine baseline fails it identically — POSIX path-separator semantics; **zero net-new failures**.
- **Patch coverage verified locally** (the #6873 gap): `migrate-cli.js` → **lines 34/34, branches 20/20, functions 8/8 — 100%**, including the `worktree-allocator` `open` adapter. `status.js`'s added lines are executed by `doctor`'s own check-name test.
- `npm run typecheck` → **clean (0 errors)**
- Scope: 2 source files + 2 test files
