### PR TITLE
feat(mcp): add a contributor-profile CLI mirror for loopover_get_contributor_profile (#6737)

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -81,6 +81,7 @@ const CLI_COMMAND_SPEC = {
   "init-client": [],
   "decision-pack": [],
   "repo-decision": [],
+  "contributor-profile": [],
   "monitor-open-prs": [],
   "analyze-branch": [],
   preflight: [],
@@ -2931,6 +2932,7 @@ async function runCli(args) {
   if (command === "issue-slop") return issueSlopCli(args.slice(1));
   if (command === "decision-pack") return decisionPackCli(options);
   if (command === "repo-decision") return repoDecisionCli(options);
+  if (command === "contributor-profile") return contributorProfileCli(options);
   if (command === "monitor-open-prs") return monitorOpenPrsCli(options);
   if (command === "review-pr") return reviewPrCli(options);
   if (command !== "analyze-branch" && command !== "preflight") {
@@ -3327,6 +3329,34 @@ async function monitorOpenPrsCli(options) {
     process.stdout.write(`${sanitizePlainTextTerminalOutput(heading)}\n`);
     for (const step of pr.nextSteps ?? []) process.stdout.write(`  - ${sanitizePlainTextTerminalOutput(step)}\n`);
   }
+}
+
+function printContributorProfileHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp contributor-profile --login <github-login> [--json]",
+      "",
+      "Fetch your own public contributor profile for a GitHub login.",
+      "Mirrors the loopover_get_contributor_profile MCP tool and GET /v1/contributors/{login}/profile. No source upload.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
+async function contributorProfileCli(options) {
+  if (options.help === true) return printContributorProfileHelp();
+  const login = options.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
+  if (!login) throw new Error("Pass --login <github-login> or set LOOPOVER_LOGIN.");
+  const payload = await getContributorProfile(login);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  // #6261: `login` is the user's own --login/env value; the summary is the API's to compose, so it is sanitized
+  // before it reaches the terminal (the same discipline decision-pack / monitor-open-prs apply to API-chosen text).
+  process.stdout.write(`Contributor profile: ${login}\n`);
+  if (payload?.summary) process.stdout.write(`${sanitizePlainTextTerminalOutput(payload.summary)}\n`);
 }
 
 function printRepoDecisionHelp() {
@@ -3807,6 +3837,7 @@ function printHelp() {
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
+  loopover-mcp contributor-profile --login <github-login> [--json]
   loopover-mcp monitor-open-prs --login <github-login> [--json]
   loopover-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--format table] [--json]
   loopover-mcp preflight --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--validation "passed|npm test|summary"] [--format table] [--json]
@@ -3825,7 +3856,7 @@ function printHelp() {
   LOOPOVER_PROFILE
   LOOPOVER_CONFIG_PATH or LOOPOVER_CONFIG_DIR
   LOOPOVER_API_TOKEN, LOOPOVER_MCP_TOKEN, LOOPOVER_TOKEN, or a session from loopover-mcp login
-  LOOPOVER_LOGIN or GITHUB_LOGIN (default --login for analyze-branch, preflight, review-pr, decision-pack, repo-decision, monitor-open-prs, and agent plan/packet)
+  LOOPOVER_LOGIN or GITHUB_LOGIN (default --login for analyze-branch, preflight, review-pr, decision-pack, repo-decision, contributor-profile, monitor-open-prs, and agent plan/packet)
   GITHUB_TOKEN for non-interactive login bootstrap
   GITTENSOR_SCORE_PREVIEW_CMD
   GITTENSOR_ROOT
@@ -4951,6 +4982,12 @@ function repoDecisionToolSummary(login, repoFullName, payload) {
 
 function getOpenPrMonitor(login) {
   return apiGet(`/v1/contributors/${encodeURIComponent(login)}/open-pr-monitor`);
+}
+
+// #6737: CLI mirror for loopover_get_contributor_profile — the same GET /v1/contributors/:login/profile the MCP
+// tool serves, via the same /v1/contributors/:login/... route family + login-resolution decision-pack already uses.
+function getContributorProfile(login) {
+  return apiGet(`/v1/contributors/${encodeURIComponent(login)}/profile`);
 }
 
 // Mirror the API's own `summary` when it sends one, so the CLI and the loopover_monitor_open_prs MCP

--- a/test/unit/mcp-cli-contributor-profile.test.ts
+++ b/test/unit/mcp-cli-contributor-profile.test.ts
@@ -1,0 +1,58 @@
+// #6737: the CLI mirror for loopover_get_contributor_profile. The MCP tool and GET /v1/contributors/:login/profile
+// already served this; only the local CLI surface was missing. These pin the three things that can silently rot:
+// both surfaces hit the same route, `contributor-profile --json` stays byte-identical to the API payload, and the
+// login resolves via --login / LOOPOVER_LOGIN / GITHUB_LOGIN exactly like decision-pack.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// Any CLI command that calls the API must go through runAsync: the fixture server lives in this process, so
+// run()'s execFileSync would block the event loop and the child's fetch would abort before a response.
+import { closeFixtureServer, contributorProfileFixture, run, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
+
+let apiUrl: string;
+let capturedRequests: Array<{ url: string; method: string }>;
+
+beforeEach(async () => {
+  capturedRequests = [];
+  apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/profile")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+});
+afterEach(closeFixtureServer);
+
+describe("loopover-mcp contributor-profile CLI (#6737)", () => {
+  it("--json emits exactly the payload GET /v1/contributors/:login/profile returns (mirror parity)", async () => {
+    const out = await runAsync(["contributor-profile", "--login", "JSONbored", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(JSON.parse(out)).toEqual(contributorProfileFixture());
+    expect(capturedRequests.length).toBe(1);
+    expect(capturedRequests[0]!.url).toContain("/v1/contributors/JSONbored/profile");
+    expect(capturedRequests[0]!.method).toBe("GET");
+  });
+
+  it("prints the login header and the API summary on the plain-text path", async () => {
+    const out = await runAsync(["contributor-profile", "--login", "JSONbored"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(out).toContain("Contributor profile: JSONbored");
+    expect(out).toContain(contributorProfileFixture().summary);
+  });
+
+  it("resolves the login from LOOPOVER_LOGIN, then GITHUB_LOGIN, the way decision-pack does", async () => {
+    const viaLoopover = await runAsync(["contributor-profile", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", LOOPOVER_LOGIN: "JSONbored" });
+    expect(JSON.parse(viaLoopover)).toEqual(contributorProfileFixture());
+    const viaGithub = await runAsync(["contributor-profile", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", GITHUB_LOGIN: "JSONbored" });
+    expect(JSON.parse(viaGithub)).toEqual(contributorProfileFixture());
+  });
+
+  it("fails with the shared login-required message when no login is resolvable", () => {
+    const failure = runExpectingFailure(["contributor-profile"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", LOOPOVER_LOGIN: "", GITHUB_LOGIN: "" });
+    expect(failure.status).toBe(1);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --login <github-login> or set LOOPOVER_LOGIN\./);
+  });
+
+  it("prints help before requiring a login or hitting the network", () => {
+    const out = run(["contributor-profile", "--help"], { LOOPOVER_API_URL: apiUrl });
+    expect(out).toContain("Usage: loopover-mcp contributor-profile");
+    expect(capturedRequests.length).toBe(0);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -275,6 +275,10 @@ export async function startFixtureServer(
       response.end(JSON.stringify({ ...openPrMonitorFixture(), ...(options.openPrMonitor ?? {}) }));
       return;
     }
+    if (request.url === "/v1/contributors/JSONbored/profile" && request.method === "GET") {
+      response.end(JSON.stringify(contributorProfileFixture()));
+      return;
+    }
     if (request.url === "/v1/contributors/JSONbored/repos/JSONbored/gittensory/decision" && request.method === "GET") {
       if (options.repoDecisionStatus && options.repoDecisionStatus >= 400) {
         response.statusCode = options.repoDecisionStatus;
@@ -658,6 +662,18 @@ export function localBranchAnalysisFixture() {
       blockers: [],
       warnings: [],
     },
+  };
+}
+
+/** Mirrors the ContributorProfile shape buildContributorProfile (packages/loopover-engine/src/signals/engine.ts) returns. */
+export function contributorProfileFixture() {
+  return {
+    login: "JSONbored",
+    generatedAt: "2026-06-01T00:00:00.000Z",
+    summary: "Public contributor profile for JSONbored.",
+    github: { topLanguages: ["TypeScript", "Rust"] },
+    outcomes: { mergedPullRequests: 12, resolvedPullRequests: 15 },
+    repoStats: [{ repoFullName: "JSONbored/gittensory", mergedPullRequests: 5 }],
   };
 }
 


### PR DESCRIPTION
## Summary

The `loopover_get_contributor_profile` MCP tool and `GET /v1/contributors/:login/profile` already served a
contributor's own public profile, but no local CLI surface reached it — unlike the sibling `decision-pack` /
`repo-decision` / `monitor-open-prs` commands over the same `/v1/contributors/:login/...` route family and
login-resolution logic.

Adds a `contributor-profile` CLI command that:

- `GET`s `/v1/contributors/{login}/profile` via the shared `apiGet`;
- resolves `login` from `--login` → `LOOPOVER_LOGIN` → `GITHUB_LOGIN`, exactly like `decision-pack`;
- supports `--json` (byte-identical to the API payload) and sanitizes the API-composed summary on the
  plain-text path;
- is documented in `--help` and the login-default list.

`profile` is already taken by local config-profile management (`profile list|create|switch|remove`), so this
uses the issue's suggested `contributor-profile` name.

Closes #6737

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6737`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build:mcp` (node --check)
- [x] `npm run command-reference:check`
- [x] `npx vitest run test/unit/mcp-cli-contributor-profile.test.ts` (5 passing) — mirrors `mcp-cli-monitor-open-prs.test.ts`: `--json` output parity with the API payload for identical input, the plain-text summary path, login resolution via both `LOOPOVER_LOGIN` and `GITHUB_LOGIN`, the shared login-required failure message, and help-before-network.

If any required check was skipped, explain why:

- The CLI-command surface lives in `packages/loopover-mcp/bin/loopover-mcp.js` (not under the `src/**` / `packages/loopover-engine/src/**` Codecov patch scope) plus its test + a harness fixture; no engine/API/OpenAPI/migration change, so those checks are N/A to this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. — the API-composed `summary` is run through `sanitizePlainTextTerminalOutput` before the terminal (same discipline `decision-pack`/`monitor-open-prs` apply); `--json` stays raw on purpose (JSON.stringify escapes control chars).
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — the route is unchanged and stays gated by `requireContributorAccess`; the CLI only adds a login-resolution + login-required negative-path test.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no API/route change; this is a client-side CLI mirror of an existing route.
- [x] No visible UI changes (CLI command only), so no `UI Evidence` section is required.
- [x] Public docs/changelogs: `--help` documents the new command; no changelog edited.

## Notes

- Deliberately a CLI command (the issue allows "command or stdio tool"), reusing the exact structure the `decision-pack`/`repo-decision`/`monitor-open-prs` commands already established for the `/v1/contributors/:login/...` route family — one auditable `apiGet` path, no new route, no new tool surface.
