### PR TITLE
feat(mcp): mirror loopover_get_outcome_calibration over the maintain CLI

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2796,6 +2796,8 @@ function printMaintainHelp() {
       `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
       `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
       "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
+      "  outcome-calibration [--window-days N]",
+      "                               Show slop-band + recommendation outcome calibration (merge rate per slop band).",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -2902,7 +2904,31 @@ async function maintainCli(args) {
     emit(payload, lines.join("\n"));
     return;
   }
-  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision.`);
+  if (subcommand === "outcome-calibration") {
+    // #543 outcome-learning loop: read-only measurement of whether higher-slop bands merge less often and how
+    // agent recommendations are panning out. The API enforces maintainer authorization; the CLI never decides
+    // locally. Optional --window-days bounds the recommendation window the same way the route's ?windowDays
+    // query does (a non-positive value falls through to full history server-side).
+    const windowDays = Number(options.windowDays);
+    const query = windowDays > 0 ? `?windowDays=${encodeURIComponent(windowDays)}` : "";
+    const payload = await apiGet(`${repoBase}/outcome-calibration${query}`);
+    const slop = payload.slop ?? {};
+    const recommendations = payload.recommendations ?? {};
+    const window = payload.windowDays ? `last ${payload.windowDays}d` : "all history";
+    const rate = (value) => (value === null || value === undefined ? "n/a (below sample)" : `${Math.round(value * 100)}%`);
+    const discriminates = slop.discriminates === null || slop.discriminates === undefined ? "" : slop.discriminates ? ", slop bands discriminate" : ", slop bands do not discriminate";
+    const lines = [
+      `Outcome calibration for ${repoFullName} (${window}): ${slop.totalResolved ?? 0} resolved, overall merge rate ${rate(slop.overallMergeRate)}${discriminates}.`,
+      ...(slop.bands ?? []).map(
+        (band) => `- ${band.band}: ${band.sampleSize} resolved, ${band.merged} merged / ${band.closed} closed (${Math.round(band.mergeRate * 100)}% merge)`,
+      ),
+      `Recommendations: ${recommendations.total ?? 0} total, ${recommendations.positive ?? 0} positive, ${recommendations.negative ?? 0} negative, ${recommendations.pending ?? 0} pending, positive rate ${rate(recommendations.positiveRate)}.`,
+      ...(payload.signals ?? []),
+    ];
+    emit(payload, lines.join("\n"));
+    return;
+  }
+  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration.`);
 }
 
 async function runCli(args) {

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -95,6 +95,31 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(scoped).toMatch(/Gate precision for owner\/repo \(last 30d\)/);
   });
 
+  it("outcome-calibration reports slop-band + recommendation calibration (plain + json), passing the window through", async () => {
+    const e = await env();
+    const out = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo"], e);
+    expect(out).toMatch(/Outcome calibration for owner\/repo \(all history\): 12 resolved, overall merge rate 58%, slop bands discriminate\./);
+    expect(out).toMatch(/- clean: 6 resolved, 6 merged \/ 0 closed \(100% merge\)/);
+    expect(out).toMatch(/- high: 4 resolved, 1 merged \/ 3 closed \(25% merge\)/);
+    expect(out).toMatch(/Recommendations: 9 total, 6 positive, 2 negative, 1 pending, positive rate 75%\./);
+    expect(out).toMatch(/Slop bands discriminate/);
+    const json = JSON.parse(await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--json"], e)) as {
+      slop: { totalResolved: number; overallMergeRate: number };
+      recommendations: { positiveRate: number };
+    };
+    expect(json.slop).toMatchObject({ totalResolved: 12, overallMergeRate: 0.583 });
+    expect(json.recommendations).toMatchObject({ positiveRate: 0.75 });
+    // Output parity: the CLI --json surface returns exactly what GET /outcome-calibration yields for identical
+    // input -- the same payload the loopover_get_outcome_calibration MCP tool wraps in its toolResult.
+    const direct = await fetch(`${e.LOOPOVER_API_URL}/v1/repos/owner/repo/outcome-calibration`, {
+      headers: { authorization: `Bearer ${e.LOOPOVER_TOKEN}` },
+    }).then((r) => r.json());
+    expect(json).toEqual(direct);
+    // --window-days bounds the recommendation window; the CLI forwards it as ?windowDays and reflects it.
+    const scoped = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--window-days", "30"], e);
+    expect(scoped).toMatch(/Outcome calibration for owner\/repo \(last 30d\)/);
+  });
+
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {
     const e = await env();
     await expect(runAsync(["maintain", "status"], e)).rejects.toThrow(/Pass --repo/);
@@ -137,5 +162,6 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(out).toMatch(/approve <id>/);
     expect(out).toMatch(/queue/);
     expect(out).toMatch(/pause/);
+    expect(out).toMatch(/outcome-calibration \[--window-days N\]/);
   });
 });

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -464,6 +464,29 @@ export async function startFixtureServer(
       );
       return;
     }
+    // #543 outcome-learning calibration (read-only). Echoes ?windowDays so the CLI window pass-through is testable.
+    if (request.url?.startsWith("/v1/repos/owner/repo/outcome-calibration") && request.method === "GET") {
+      const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          generatedAt: "2026-05-30T00:00:00.000Z",
+          windowDays: windowDays ? Number(windowDays) : null,
+          slop: {
+            totalResolved: 12,
+            bands: [
+              { band: "clean", sampleSize: 6, merged: 6, closed: 0, mergeRate: 1 },
+              { band: "high", sampleSize: 4, merged: 1, closed: 3, mergeRate: 0.25 },
+            ],
+            overallMergeRate: 0.583,
+            discriminates: true,
+          },
+          recommendations: { total: 9, positive: 6, negative: 2, pending: 1, positiveRate: 0.75 },
+          signals: ["Slop bands discriminate: clean PRs merge 100% vs 25% for high — keep the slop signal advisory-plus."],
+        }),
+      );
+      return;
+    }
     if (request.url === "/v1/upstream/drift" && request.method === "GET") {
       response.end(
         JSON.stringify({


### PR DESCRIPTION
## Summary

- Add a `maintain outcome-calibration [--window-days N]` subcommand to the loopover-mcp CLI, mirroring the remote `loopover_get_outcome_calibration` MCP tool (`src/mcp/server.ts`) / `GET /v1/repos/:owner/:repo/outcome-calibration` — the same pattern the sibling `maintain precision` already follows for gate-precision telemetry.
- The subcommand GETs `{repoBase}/outcome-calibration?windowDays=`, renders the slop-band merge rates + recommendation outcome split in plain text, forwards `--json` verbatim, and reflects the bounded window in its summary. `printMaintainHelp` lists the new subcommand.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #6735`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — CLI changes live in `packages/loopover-mcp/bin/**`, which is outside the Codecov-measured paths (`src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**`), so `codecov/patch` has no diff lines to gate; the new subcommand is fully exercised by `test/unit/mcp-cli-maintain.test.ts` (plain, `--json`, window pass-through, and output parity vs the route).
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run command-reference:check`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] New behavior has unit tests covering the plain-text summary, `--json` contract, `--window-days` pass-through, help listing, and output parity with the mirrored route/tool surface.

If any required check was skipped, explain why:

- UI checks (`ui:*`, `ui:openapi:check`) are not applicable — this is a CLI-only change with no API/OpenAPI/schema or UI surface.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence exposed — the CLI is a thin read-only proxy; the API enforces maintainer authorization.
- [x] Public text stays sanitized and low-noise.
- [x] No auth/cookie/CORS/session changes.
- [x] MCP behavior updated and tested where needed (CLI mirror + parity test).

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension changes.

## Notes

- Mirrors `maintain precision` (`packages/loopover-mcp/bin/loopover-mcp.js`) exactly, including the `--window-days` → `?windowDays` handling where a non-positive value falls through to full history server-side.


Closes #6735
