### PR TITLE
fix(test): rename the stale gittensory GITHUB_APP_SLUG default to loopover-orb

### DIFF
--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -82,7 +82,7 @@ export function createTestEnv(overrides: Partial<Env> = {}): Env {
       },
     } as unknown as Queue,
     GITHUB_APP_ID: "3824093",
-    GITHUB_APP_SLUG: "gittensory",
+    GITHUB_APP_SLUG: "loopover-orb",
     GITTENSOR_UPSTREAM_REPO: "entrius/gittensor",
     GITTENSOR_UPSTREAM_REF: "test",
     GITTENSOR_REGISTRY_URL: "https://raw.githubusercontent.com/entrius/gittensor/test/gittensor/validator/weights/master_repositories.json",

--- a/test/unit/backfill-2.test.ts
+++ b/test/unit/backfill-2.test.ts
@@ -673,9 +673,9 @@ describe("GitHub backfill", () => {
               { name: "test", status: "completed", conclusion: "success" },
               // BOTH bot-posted checks, still in_progress (posted but not yet concluded). Counting EITHER would
               // defer the very review that concludes it — the self-deadlock that froze green-CI PRs as "CI pending".
-              { name: "LoopOver Orb Review Agent", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
-              { name: "Gittensory Gate", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
-              { name: "LoopOver Context", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
+              { name: "LoopOver Orb Review Agent", status: "in_progress", conclusion: null, app: { slug: "loopover-orb" } },
+              { name: "Gittensory Gate", status: "in_progress", conclusion: null, app: { slug: "loopover-orb" } },
+              { name: "LoopOver Context", status: "in_progress", conclusion: null, app: { slug: "loopover-orb" } },
             ],
           });
         }
@@ -721,7 +721,7 @@ describe("GitHub backfill", () => {
         const url = input.toString();
         if (url.includes("/check-runs?")) {
           return Response.json({
-            check_runs: [{ name: "LoopOver Orb Review Agent", status: "completed", conclusion: "failure", output: { title: "Real gate failure" }, app: { slug: "gittensory" } }],
+            check_runs: [{ name: "LoopOver Orb Review Agent", status: "completed", conclusion: "failure", output: { title: "Real gate failure" }, app: { slug: "loopover-orb" } }],
           });
         }
         if (url.includes("/status?")) return Response.json({ statuses: [] });
@@ -786,7 +786,7 @@ describe("GitHub backfill", () => {
           return Response.json({
             check_runs: [
               { name: "validate", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
-              { name: "LoopOver Orb Review Agent", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
+              { name: "LoopOver Orb Review Agent", status: "in_progress", conclusion: null, app: { slug: "loopover-orb" } },
             ],
           });
         }
@@ -2005,7 +2005,7 @@ describe("GitHub backfill", () => {
                           {
                             body: "Own bot requested change",
                             url: "https://github.example/thread/own-member",
-                            author: { login: "gittensory-orb[bot]" },
+                            author: { login: "loopover-orb[bot]" },
                             authorAssociation: "MEMBER",
                           },
                         ],
@@ -2157,8 +2157,8 @@ describe("GitHub backfill", () => {
                     nodes: [
                       { isResolved: true, isOutdated: false, path: "a.ts", line: 1, comments: { nodes: [{ body: "resolved", author: { login: "superagent-security[bot]" } }] } },
                       { isResolved: false, isOutdated: true, path: "b.ts", line: 2, comments: { nodes: [{ body: "outdated", author: { login: "superagent-security[bot]" } }] } },
-                      { isResolved: false, isOutdated: false, path: "c.ts", line: 3, comments: { nodes: [{ body: "own bot", author: { login: "gittensory-orb[bot]" }, authorAssociation: "OWNER" }] } },
-                      { isResolved: false, isOutdated: false, path: "own-collaborator.ts", line: 5, comments: { nodes: [{ body: "own bot with collaborator association", author: { login: "gittensory[bot]" }, authorAssociation: "COLLABORATOR" }] } },
+                      { isResolved: false, isOutdated: false, path: "c.ts", line: 3, comments: { nodes: [{ body: "own bot", author: { login: "loopover-orb[bot]" }, authorAssociation: "OWNER" }] } },
+                      { isResolved: false, isOutdated: false, path: "own-collaborator.ts", line: 5, comments: { nodes: [{ body: "own bot with collaborator association", author: { login: "loopover-orb[bot]" }, authorAssociation: "COLLABORATOR" }] } },
                       { isResolved: false, isOutdated: false, path: "no-comments.ts", line: 6, comments: null },
                       { isResolved: false, isOutdated: false, path: "d.ts", line: 4, comments: { nodes: [{ body: "   ", author: { login: "superagent-security[bot]" } }, null] } },
                       null,
@@ -2652,18 +2652,21 @@ describe("GitHub backfill", () => {
 });
 
 describe("isOwnReviewThreadAuthor", () => {
-  const env = createTestEnv(); // GITHUB_APP_SLUG defaults to "gittensory" (test/helpers/d1.ts)
+  // Explicit bare slug -- NOT the shared "loopover-orb" createTestEnv() default (test/helpers/d1.ts) -- so
+  // this prefix-match test can exercise multiple realistic suffix forms below without a double "-orb-orb"
+  // suffix artifact.
+  const env = createTestEnv({ GITHUB_APP_SLUG: "loopover" });
 
-  it("matches our own gittensory app bot logins by prefix", () => {
-    for (const login of ["gittensory[bot]", "gittensory-orb[bot]", "gittensory-review[bot]", "GITTENSORY[bot]", "gittensory", "gittensory-orb"]) {
+  it("matches our own loopover app bot logins by prefix", () => {
+    for (const login of ["loopover[bot]", "loopover-orb[bot]", "loopover-review[bot]", "LOOPOVER[bot]", "loopover", "loopover-orb"]) {
       expect(isOwnReviewThreadAuthor(env, login)).toBe(true);
     }
   });
 
-  it("does not match a third-party bot whose slug only ends in -gittensory[bot] (regression)", () => {
+  it("does not match a third-party bot whose slug only ends in -loopover[bot] (regression)", () => {
     // A `\b` boundary also fires after a hyphen, so the unanchored regex misclassified these external bots as
     // our own author and dropped their review-thread comments as self-authored non-blockers (fail-open).
-    for (const login of ["evil-gittensory[bot]", "x-gittensory[bot]", "not-gittensory", "gittensory-fork"]) {
+    for (const login of ["evil-loopover[bot]", "x-loopover[bot]", "not-loopover", "loopover-fork"]) {
       expect(isOwnReviewThreadAuthor(env, login)).toBe(false);
     }
   });
@@ -2680,7 +2683,7 @@ describe("isOwnReviewThreadAuthor", () => {
     expect(isOwnReviewThreadAuthor(renamed, "acme-review-orb[bot]")).toBe(true);
     expect(isOwnReviewThreadAuthor(renamed, "acme-review")).toBe(true);
     // The OLD slug no longer matches once an operator renames their App -- proves the literal is gone.
-    expect(isOwnReviewThreadAuthor(renamed, "gittensory[bot]")).toBe(false);
+    expect(isOwnReviewThreadAuthor(renamed, "loopover[bot]")).toBe(false);
   });
 
   it("a slug containing regex metacharacters is escaped, not interpreted (defensive)", () => {
@@ -2691,14 +2694,14 @@ describe("isOwnReviewThreadAuthor", () => {
 
   it("fails closed when GITHUB_APP_SLUG is blank (misconfiguration)", () => {
     const blank = createTestEnv({ GITHUB_APP_SLUG: "" });
-    expect(isOwnReviewThreadAuthor(blank, "gittensory[bot]")).toBe(false);
+    expect(isOwnReviewThreadAuthor(blank, "loopover[bot]")).toBe(false);
     expect(isOwnReviewThreadAuthor(blank, "")).toBe(false);
   });
 
   it("fails closed when GITHUB_APP_SLUG is unset (the retired review App was deleted)", () => {
     const unset = createTestEnv();
     delete (unset as Partial<Env>).GITHUB_APP_SLUG;
-    expect(isOwnReviewThreadAuthor(unset, "gittensory[bot]")).toBe(false);
+    expect(isOwnReviewThreadAuthor(unset, "loopover[bot]")).toBe(false);
     expect(isOwnReviewThreadAuthor(unset, "")).toBe(false);
   });
 });

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -768,7 +768,7 @@ describe("resolveLinkedIssueAuthorLogins", () => {
 
   it("falls back to a LIVE fetch for the author when the issue is not cached (#audit-3.11)", async () => {
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey.export({ type: "pkcs1", format: "pem" }).toString(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey.export({ type: "pkcs1", format: "pem" }).toString(), GITHUB_APP_SLUG: "loopover-orb" });
     // Issue #50 is NOT in the local cache; a fresh GitHub fetch must still resolve its author so the
     // self-authored detection isn't silently voided by a cache miss.
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -795,7 +795,7 @@ describe("resolveLinkedIssueAuthorLogins", () => {
 
   it("yields null for a cache-missed issue whose live fetch returns no facts (fail-safe)", async () => {
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey.export({ type: "pkcs1", format: "pem" }).toString(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey.export({ type: "pkcs1", format: "pem" }).toString(), GITHUB_APP_SLUG: "loopover-orb" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
@@ -811,7 +811,7 @@ describe("resolveLinkedIssueAuthorLogins", () => {
 
   it("live-fetches only the cache-missed issues, keeping the cached authors (mixed list)", async () => {
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey.export({ type: "pkcs1", format: "pem" }).toString(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey.export({ type: "pkcs1", format: "pem" }).toString(), GITHUB_APP_SLUG: "loopover-orb" });
     await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 1);
     await upsertIssueFromGitHub(env, "owner/repo", { number: 10, title: "Cached", body: "", state: "open", user: { login: "alice" }, labels: [], html_url: "https://github.com/owner/repo/issues/10", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -85,7 +85,7 @@ describe("GitHub PR intelligence comments", () => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
-        return Response.json([{ id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold body`, user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold body`, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/101") && init?.method === "PATCH") {
         const body = JSON.parse(String(init.body)) as { body: string };
@@ -116,9 +116,9 @@ describe("GitHub PR intelligence comments", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
         return Response.json([
-          { id: 202, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\n\nreviewing placeholder`, user: { login: "gittensory-orb[bot]", type: "Bot" } },
-          { id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold final`, user: { login: "gittensory-orb[bot]", type: "Bot" } },
-          { id: 303, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nsecond duplicate`, user: { login: "gittensory-orb[bot]", type: "Bot" } },
+          { id: 202, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\n\nreviewing placeholder`, user: { login: "loopover-orb[bot]", type: "Bot" } },
+          { id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold final`, user: { login: "loopover-orb[bot]", type: "Bot" } },
+          { id: 303, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nsecond duplicate`, user: { login: "loopover-orb[bot]", type: "Bot" } },
         ]);
       }
       if (url.includes("/issues/comments/202") && init?.method === "DELETE") return new Response(null, { status: 204 });
@@ -132,7 +132,7 @@ describe("GitHub PR intelligence comments", () => {
     });
 
     const result = await createOrUpdatePrIntelligenceComment(
-      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey, GITHUB_APP_SLUG: "gittensory-orb" }),
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey, GITHUB_APP_SLUG: "loopover-orb" }),
       123,
       "JSONbored/gittensory",
       12,
@@ -164,7 +164,7 @@ describe("GitHub PR intelligence comments", () => {
           );
         }
         // Bot comment is on page 2
-        return Response.json([{ id: 999, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold body`, user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 999, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold body`, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/999") && init?.method === "PATCH") {
         return Response.json({ id: 999, html_url: "https://github.com/comment/999" });
@@ -249,7 +249,7 @@ describe("GitHub PR intelligence comments", () => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
-        return Response.json([{ id: 101, body: "<!-- gittensory-pr-intelligence -->\nold body", user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 101, body: "<!-- gittensory-pr-intelligence -->\nold body", user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/101") && init?.method === "PATCH") {
         const body = JSON.parse(String(init.body)) as { body: string };
@@ -281,7 +281,7 @@ describe("GitHub PR intelligence comments", () => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
-        return Response.json([{ id: 202, body: "<!-- gittensory-agent-command -->\nold command body", user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 202, body: "<!-- gittensory-agent-command -->\nold command body", user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/202") && init?.method === "PATCH") {
         const body = JSON.parse(String(init.body)) as { body: string };
@@ -345,7 +345,7 @@ describe("GitHub PR intelligence comments", () => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
-        return Response.json([{ id: 101, body, html_url: "https://github.com/comment/101", user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 101, body, html_url: "https://github.com/comment/101", user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       return new Response("not found", { status: 404 });
     });
@@ -365,7 +365,7 @@ describe("GitHub PR intelligence comments", () => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
-        return Response.json([{ id: 202, body, user: { login: "gittensory[bot]", type: "Bot" } }]); // no html_url field
+        return Response.json([{ id: 202, body, user: { login: "loopover-orb[bot]", type: "Bot" } }]); // no html_url field
       }
       return new Response("not found", { status: 404 });
     });

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -568,9 +568,9 @@ describe("GitHub PR action primitives (#778)", () => {
       if (url.includes("/pulls/7/reviews") && !url.includes("/dismissals") && method === "GET") {
         return Response.json([
           { id: 1, state: "COMMENTED", user: { login: "human-reviewer" } },
-          { id: 2, state: "APPROVED", user: { login: "gittensory[bot]" } }, // an EARLIER bot approve
-          { id: 3, state: "CHANGES_REQUESTED", user: { login: "gittensory[bot]" } },
-          { id: 4, state: "APPROVED", user: { login: "gittensory[bot]" } }, // the LATEST bot approve — this one
+          { id: 2, state: "APPROVED", user: { login: "loopover-orb[bot]" } }, // an EARLIER bot approve
+          { id: 3, state: "CHANGES_REQUESTED", user: { login: "loopover-orb[bot]" } },
+          { id: 4, state: "APPROVED", user: { login: "loopover-orb[bot]" } }, // the LATEST bot approve — this one
         ]);
       }
       if (url.includes("/pulls/7/reviews/4/dismissals") && method === "PUT") {
@@ -586,9 +586,10 @@ describe("GitHub PR action primitives (#778)", () => {
   });
 
   it("dismisses the bot's approve review when GitHub returns a different login casing than GITHUB_APP_SLUG (#6614)", async () => {
-    // The regression: `Gittensory[bot]` vs the default GITHUB_APP_SLUG of `gittensory` matched nothing under
-    // the old case-sensitive ===, so this returned { dismissed: false } — a SILENT no-op, no error, leaving a
-    // stale bot approval standing. The human reviewer whose login differs only in case must still be ignored.
+    // The regression: `Loopover-Orb[bot]` vs the default GITHUB_APP_SLUG of `loopover-orb` matched nothing
+    // under the old case-sensitive ===, so this returned { dismissed: false } — a SILENT no-op, no error,
+    // leaving a stale bot approval standing. The human reviewer whose login differs only in case must still
+    // be ignored.
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -597,9 +598,9 @@ describe("GitHub PR action primitives (#778)", () => {
       if (url.includes("/pulls/11/reviews") && !url.includes("/dismissals") && method === "GET") {
         return Response.json([
           { id: 1, state: "APPROVED", user: { login: "Human-Reviewer" } },
-          { id: 2, state: "APPROVED", user: { login: "Gittensory[bot]" } }, // an EARLIER bot approve, mixed case
-          { id: 3, state: "CHANGES_REQUESTED", user: { login: "GITTENSORY[BOT]" } },
-          { id: 4, state: "APPROVED", user: { login: "GitTensory[Bot]" } }, // the LATEST bot approve — this one
+          { id: 2, state: "APPROVED", user: { login: "Loopover-Orb[bot]" } }, // an EARLIER bot approve, mixed case
+          { id: 3, state: "CHANGES_REQUESTED", user: { login: "LOOPOVER-ORB[BOT]" } },
+          { id: 4, state: "APPROVED", user: { login: "LoopOver-Orb[Bot]" } }, // the LATEST bot approve — this one
         ]);
       }
       if (url.includes("/pulls/11/reviews/4/dismissals") && method === "PUT") {
@@ -646,10 +647,10 @@ describe("GitHub PR action primitives (#778)", () => {
     // approve; the actual latest bot approve is review id 999 on page 2 — a single-page fetch would wrongly
     // dismiss the page-1 review (or miss the real latest one) instead.
     const page1 = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, state: "COMMENTED", user: { login: "human-reviewer" } }));
-    page1[0] = { id: 1, state: "APPROVED", user: { login: "gittensory[bot]" } };
+    page1[0] = { id: 1, state: "APPROVED", user: { login: "loopover-orb[bot]" } };
     const page2 = [
-      { id: 998, state: "CHANGES_REQUESTED", user: { login: "gittensory[bot]" } },
-      { id: 999, state: "APPROVED", user: { login: "gittensory[bot]" } },
+      { id: 998, state: "CHANGES_REQUESTED", user: { login: "loopover-orb[bot]" } },
+      { id: 999, state: "APPROVED", user: { login: "loopover-orb[bot]" } },
     ];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -692,7 +693,7 @@ describe("GitHub PR action primitives (#778)", () => {
       if (url.includes("/pulls/11/reviews") && !url.includes("/dismissals") && method === "GET") {
         getAttempts += 1;
         if (getAttempts === 1) return Response.json({ message: "Bad credentials" }, { status: 401 });
-        return Response.json([{ id: 5, state: "APPROVED", user: { login: "gittensory[bot]" } }]);
+        return Response.json([{ id: 5, state: "APPROVED", user: { login: "loopover-orb[bot]" } }]);
       }
       if (url.includes("/pulls/11/reviews/5/dismissals") && method === "PUT") {
         return Response.json({ id: 5, state: "DISMISSED" });

--- a/test/unit/github-self-authored.test.ts
+++ b/test/unit/github-self-authored.test.ts
@@ -12,11 +12,11 @@ import { createTestEnv } from "../helpers/d1";
 
 describe("self-authored GitHub webhook detection", () => {
   it("recognizes only comments authored by this GitHub App bot", () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
     const payload = {
       action: "edited",
-      sender: { login: "gittensory-orb[bot]", type: "Bot" },
-      comment: { user: { login: "gittensory-orb[bot]", type: "Bot" } },
+      sender: { login: "loopover-orb[bot]", type: "Bot" },
+      comment: { user: { login: "loopover-orb[bot]", type: "Bot" } },
     } as GitHubWebhookPayload;
     const missingSlugEnv = createTestEnv();
     delete (missingSlugEnv as { GITHUB_APP_SLUG?: string }).GITHUB_APP_SLUG;
@@ -36,30 +36,30 @@ describe("self-authored GitHub webhook detection", () => {
   });
 
   it("recognizes self-authored check suites and check runs without matching other CI events", () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
 
     expect(
       isSelfAuthoredCiCompletionWebhook(env, "check_suite", {
         action: "completed",
-        check_suite: { app: { slug: "gittensory-orb" } },
+        check_suite: { app: { slug: "loopover-orb" } },
       } as never),
     ).toBe(true);
     expect(
       isSelfAuthoredCiCompletionWebhook(env, "check_run", {
         action: "completed",
-        check_run: { app: { slug: "gittensory-orb" } },
+        check_run: { app: { slug: "loopover-orb" } },
       } as never),
     ).toBe(true);
     expect(
       isSelfAuthoredCiCompletionWebhook(env, "check_run", {
         action: "completed",
-        check_run: { check_suite: { app: { slug: "gittensory-orb" } } },
+        check_run: { check_suite: { app: { slug: "loopover-orb" } } },
       } as never),
     ).toBe(true);
     expect(
       isSelfAuthoredCiCompletionWebhook(env, "check_run", {
         action: "rerequested",
-        check_run: { app: { slug: "gittensory-orb" } },
+        check_run: { app: { slug: "loopover-orb" } },
       } as never),
     ).toBe(false);
     expect(
@@ -73,7 +73,7 @@ describe("self-authored GitHub webhook detection", () => {
   });
 
   it("classifies non-completed CI lifecycle events as non-actionable noise only until completion", () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
 
     expect(isNonCompletedCiWebhook("check_suite", { action: "requested" })).toBe(true);
     expect(isNonCompletedCiWebhook("check_run", { action: "rerequested" })).toBe(true);
@@ -88,11 +88,11 @@ describe("self-authored GitHub webhook detection", () => {
   });
 
   it("drops bot-sender issue comment edits while preserving human panel edits", () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
     const humanPanelEdit = {
       action: "edited",
       sender: { login: "maintainer", type: "User" },
-      comment: { user: { login: "gittensory-orb[bot]", type: "Bot" } },
+      comment: { user: { login: "loopover-orb[bot]", type: "Bot" } },
     } as GitHubWebhookPayload;
 
     expect(

--- a/test/unit/linear-adapter.test.ts
+++ b/test/unit/linear-adapter.test.ts
@@ -14,7 +14,7 @@ function generateRsaPrivateKeyPem(): string {
 }
 
 function suggestTestEnv() {
-  return createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+  return createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
 }
 
 describe("LinearAdapter (#3186)", () => {

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -103,8 +103,8 @@ describe("operator dashboard payload", () => {
       slug: "custom-app",
       secrets: {},
     });
-    expect(operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "gittensory" }))).toEqual({
-      slug: "gittensory",
+    expect(operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" }))).toEqual({
+      slug: "loopover-orb",
       secrets: {},
     });
     const unset = createTestEnv();

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -161,7 +161,7 @@ describe("recordPrOutcome — realized merge/close ground truth", () => {
         merged_at: null,
         user: { login: "contributor", type: "User" },
       }),
-      sender: { login: "gittensory[bot]", type: "Bot" },
+      sender: { login: "loopover-orb[bot]", type: "Bot" },
     });
     expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({
       target_id: "owner/repo#44",
@@ -188,7 +188,7 @@ describe("recordPrOutcome — realized merge/close ground truth", () => {
         merged_at: null,
         user: { login: "contributor", type: "User" },
       }),
-      sender: { login: "gittensory[bot]", type: "Bot" },
+      sender: { login: "loopover-orb[bot]", type: "Bot" },
     });
     expect(fetchSpy).not.toHaveBeenCalled();
     expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({

--- a/test/unit/project-tracker-adapter.test.ts
+++ b/test/unit/project-tracker-adapter.test.ts
@@ -416,7 +416,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "JSONbored/gittensory" },
       4,
@@ -453,7 +453,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "some-org/gittensory" },
       4,
@@ -488,7 +488,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "some-org/gittensory" },
       4,
@@ -519,7 +519,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "some-org/gittensory" },
       4,
@@ -555,7 +555,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "some-org/gittensory" },
       4,
@@ -586,7 +586,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "JSONbored/gittensory" },
       4,
@@ -616,7 +616,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
         const page = Number(new URL(url).searchParams.get("page") ?? "1");
         requestedPages.push(page);
         if (page === 1) return Response.json(pageOneComments);
-        if (page === 2) return Response.json([{ body: PROJECT_TRACKER_SUGGEST_COMMENT_MARKER, user: { type: "Bot", login: "gittensory[bot]" } }]);
+        if (page === 2) return Response.json([{ body: PROJECT_TRACKER_SUGGEST_COMMENT_MARKER, user: { type: "Bot", login: "loopover-orb[bot]" } }]);
         return Response.json([]);
       }
       if (url.includes("/issues/4/comments") && method === "POST") {
@@ -625,7 +625,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "JSONbored/gittensory" },
       4,
@@ -653,7 +653,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch({ env, installationId: 123, repoFullName: "JSONbored/gittensory" }, 4, "unrelated typo fix", null,
       "github",
       "https://github.com/JSONbored/gittensory/pull/4",
@@ -671,7 +671,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       if (url.includes("/milestones")) return Response.json([{ number: 14, title: "Self-host reliability roadmap" }]);
       if (url.endsWith("/graphql")) return Response.json(noOpenProjectsGraphQlBody());
       if (url.includes("/issues/4/comments") && method === "GET") {
-        return Response.json([{ body: PROJECT_TRACKER_SUGGEST_COMMENT_MARKER, user: { type: "Bot", login: "gittensory[bot]" } }]);
+        return Response.json([{ body: PROJECT_TRACKER_SUGGEST_COMMENT_MARKER, user: { type: "Bot", login: "loopover-orb[bot]" } }]);
       }
       if (url.includes("/comments") && method === "POST") {
         posted = true;
@@ -679,7 +679,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "JSONbored/gittensory" },
       4,
@@ -709,7 +709,7 @@ describe("maybeSuggestProjectOrMilestoneMatch (#3183/#3184)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const result = await maybeSuggestProjectOrMilestoneMatch(
       { env, installationId: 123, repoFullName: "JSONbored/gittensory" },
       4,
@@ -730,7 +730,7 @@ describe("maybeSuggestMilestoneMatchForPr (#3183 webhook-level gating)", () => {
 
   function baseArgs(overrides: Partial<Parameters<typeof maybeSuggestMilestoneMatchForPr>[0]> = {}) {
     return {
-      env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" }),
+      env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" }),
       installationId: 123,
       repoFullName: "JSONbored/gittensory",
       pullNumber: 4,
@@ -897,7 +897,7 @@ describe("maybeAutoApplyProjectOrMilestoneMatch (#3185)", () => {
   const PR_URL = "https://github.com/JSONbored/gittensory/pull/4";
 
   const ctx = () => ({
-    env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" }),
+    env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" }),
     installationId: 123,
     repoFullName: "JSONbored/gittensory",
   });
@@ -1017,7 +1017,7 @@ describe("maybeAutoApplyProjectOrMilestoneMatch (#3185)", () => {
     });
     await expect(
       maybeSuggestMilestoneMatchForPr({
-        env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" }),
+        env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" }),
         installationId: 123,
         repoFullName: "JSONbored/gittensory",
         pullNumber: 4,
@@ -1042,7 +1042,7 @@ describe("maybeAutoApplyProjectOrMilestoneMatch (#3185)", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     await expect(
       maybeSuggestMilestoneMatchForPr({
-        env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" }),
+        env: createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" }),
         installationId: 123,
         repoFullName: "JSONbored/gittensory",
         pullNumber: 4,

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -415,7 +415,7 @@ describe("queue processors", () => {
       if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
       if (url.includes("/issues/7/comments") && method === "GET") {
-        return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+        return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
       }
       if (url.includes("/issues/7/comments") && method === "POST") {
         const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -1011,7 +1011,7 @@ describe("queue processors", () => {
       if (url.includes("/commits/a8/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
       if (url.includes("/issues/8/comments") && method === "GET") {
-        return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+        return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
       }
       if (url.includes("/issues/8/comments") && method === "POST") {
         const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -1741,7 +1741,7 @@ describe("queue processors", () => {
       }
       if (url.includes("/issues/45/comments") && method === "GET") {
         calls.commentGets += 1;
-        return Response.json([{ id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 777, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/777") && method === "PATCH") {
         calls.commentPatches += 1;
@@ -1760,7 +1760,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 45, title: "Refresh panel", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 777, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -1861,7 +1861,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 46, title: "Pending CI rerun", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 778, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 778, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -1922,7 +1922,7 @@ describe("queue processors", () => {
       }
       if (url.includes("/pulls/45/reviews")) return Response.json([]);
       if (url.includes("/commits/panel123/check-runs")) return Response.json({ check_runs: [] });
-      if (url.includes("/issues/45/comments") && method === "GET") return Response.json([{ id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+      if (url.includes("/issues/45/comments") && method === "GET") return Response.json([{ id: 777, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       if (url.includes("/issues/comments/777") && method === "PATCH") return Response.json({ id: 777 });
       return new Response("not found", { status: 404 });
     });
@@ -1936,7 +1936,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 45, title: "Refresh panel", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 777, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -1990,7 +1990,7 @@ describe("queue processors", () => {
         calls.permission += 1;
         return Response.json({ permission: "none" });
       }
-      if (url.includes("/issues/48/comments") && method === "GET") return Response.json([{ id: 778, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+      if (url.includes("/issues/48/comments") && method === "GET") return Response.json([{ id: 778, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       if (url.includes("/issues/comments/778") && method === "PATCH") {
         calls.commentPatches += 1;
         return Response.json({ id: 778 });
@@ -2007,7 +2007,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 48, title: "Miner self-rerun", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 778, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 778, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "contributor", type: "User" },
       },
     });
@@ -2054,7 +2054,7 @@ describe("queue processors", () => {
       }
       if (url.includes("/issues/46/comments")) {
         calls.commentGets += 1;
-        return Response.json([{ id: 778, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 778, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/778")) {
         calls.commentPatches += 1;
@@ -2072,7 +2072,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 46, title: "Unauthorized panel refresh", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 778, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 778, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "drive-by-user", type: "User" },
       },
     });
@@ -2133,7 +2133,7 @@ describe("queue processors", () => {
       }
       if (url.includes("/issues/47/comments") && method === "GET") {
         calls.commentGets += 1;
-        return Response.json([{ id: 779, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+        return Response.json([{ id: 779, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
       }
       if (url.includes("/issues/comments/779") && method === "PATCH") {
         calls.commentPatches += 1;
@@ -2151,7 +2151,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 47, title: "Refresh panel as collaborator", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 779, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 779, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "writer", type: "User" },
       },
     });
@@ -2191,7 +2191,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 48, title: "Unknown panel refresh actor", state: "open", pull_request: {} },
-        comment: { id: 780, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 780, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
       },
     });
 
@@ -2232,7 +2232,7 @@ describe("queue processors", () => {
       payload: {
         action: "created",
         ...basePayload,
-        comment: { id: 800, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 800, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -2243,7 +2243,7 @@ describe("queue processors", () => {
       payload: {
         action: "edited",
         ...basePayload,
-        comment: { id: 801, body: uncheckedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 801, body: uncheckedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -2271,7 +2271,7 @@ describe("queue processors", () => {
       payload: {
         action: "edited",
         ...basePayload,
-        comment: { id: 806, body: "- [x] <!-- gittensory-rerun-review:v1 --> Re-run LoopOver review", user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 806, body: "- [x] <!-- gittensory-rerun-review:v1 --> Re-run LoopOver review", user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -2282,7 +2282,7 @@ describe("queue processors", () => {
       payload: {
         action: "edited",
         ...basePayload,
-        comment: { id: 807, body: "<!-- gittensory-pr-panel:v1 -->\n\n- [x] Re-run LoopOver review", user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 807, body: "<!-- gittensory-pr-panel:v1 -->\n\n- [x] Re-run LoopOver review", user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -2304,8 +2304,8 @@ describe("queue processors", () => {
       payload: {
         action: "edited",
         ...basePayload,
-        comment: { id: 803, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
-        sender: { login: "gittensory[bot]", type: "Bot" },
+        comment: { id: 803, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
+        sender: { login: "loopover-orb[bot]", type: "Bot" },
       },
     });
     await processJob(env, {
@@ -2315,7 +2315,7 @@ describe("queue processors", () => {
       payload: {
         action: "edited",
         ...basePayload,
-        comment: { id: 804, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 804, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -2325,7 +2325,7 @@ describe("queue processors", () => {
       eventName: "issue_comment",
       payload: {
         action: "edited",
-        comment: { id: 805, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 805, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
@@ -6837,7 +6837,7 @@ describe("queue processors", () => {
       eventName: "reaction",
       payload: {
         ...basePayload,
-        comment: { id: 9001, body: commandAnswerBody("answer-maintainer", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-maintainer", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 1, content: "+1", user: { login: "maintainer", type: "User" } },
       },
     });
@@ -6847,7 +6847,7 @@ describe("queue processors", () => {
       eventName: "reaction",
       payload: {
         ...basePayload,
-        comment: { id: 9001, body: commandAnswerBody("answer-maintainer", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-maintainer", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 2, content: "-1", user: { login: "maintainer", type: "User" } },
       },
     });
@@ -6857,7 +6857,7 @@ describe("queue processors", () => {
       eventName: "reaction",
       payload: {
         ...basePayload,
-        comment: { id: 9002, body: commandAnswerBody("answer-author", "next-action"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9002, body: commandAnswerBody("answer-author", "next-action"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 3, content: "+1", user: { login: "oktofeesh1", type: "User" } },
       },
     });
@@ -6867,7 +6867,7 @@ describe("queue processors", () => {
       eventName: "reaction",
       payload: {
         ...basePayload,
-        comment: { id: 9002, body: commandAnswerBody("answer-author", "next-action"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9002, body: commandAnswerBody("answer-author", "next-action"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 4, content: "+1", user: { login: "random", type: "User" } },
       },
     });
@@ -6880,7 +6880,7 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 78, title: "No author", state: "open", pull_request: {}, author_association: "NONE" },
-        comment: { id: 9003, body: commandAnswerBody("answer-no-author", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9003, body: commandAnswerBody("answer-no-author", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 5, content: "+1", user: { login: "random", type: "User" } },
       },
     });
@@ -6921,7 +6921,7 @@ describe("queue processors", () => {
       payload: {
         ...basePayload,
         action: "deleted",
-        comment: { id: 9001, body: commandAnswerBody("answer-skip", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-skip", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 1, content: "+1", user: { login: "maintainer", type: "User" } },
       },
     });
@@ -6931,7 +6931,7 @@ describe("queue processors", () => {
       eventName: "reaction",
       payload: {
         ...basePayload,
-        comment: { id: 9001, body: commandAnswerBody("answer-skip", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-skip", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 11, content: "+1", user: { login: "maintainer", type: "User" } },
       },
     });
@@ -6942,7 +6942,7 @@ describe("queue processors", () => {
       payload: {
         ...basePayload,
         action: "created",
-        comment: { id: 9001, body: commandAnswerBody("answer-skip", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-skip", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 2, content: "+1", user: { login: "helper[bot]", type: "Bot" } },
       },
     });
@@ -6953,7 +6953,7 @@ describe("queue processors", () => {
       payload: {
         ...basePayload,
         action: "created",
-        comment: { id: 9001, body: commandAnswerBody("answer-missing", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-missing", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
         reaction: { id: 3, content: "-1", user: { login: "maintainer", type: "User" } },
       },
     });
@@ -6976,7 +6976,7 @@ describe("queue processors", () => {
       installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
       repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
       issue: { number: 77, title: "Miner command context", state: "open", pull_request: {}, user: { login: "oktofeesh1" }, author_association: "NONE" },
-      comment: { id: 9001, body: commandAnswerBody("answer-owner", "blockers"), user: { login: "gittensory[bot]", type: "Bot" } },
+      comment: { id: 9001, body: commandAnswerBody("answer-owner", "blockers"), user: { login: "loopover-orb[bot]", type: "Bot" } },
     };
 
     await processJob(env, {
@@ -7022,7 +7022,7 @@ describe("queue processors", () => {
       eventName: "reaction",
       payload: {
         ...basePayload,
-        comment: { id: 9002, body: commandAnswerBody("answer-bound", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9002, body: commandAnswerBody("answer-bound", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
       },
     });
     await processJob(env, {
@@ -7032,7 +7032,7 @@ describe("queue processors", () => {
       payload: {
         ...basePayload,
         repository: { name: "other", full_name: "JSONbored/other", private: false, owner: { login: "JSONbored" } },
-        comment: { id: 9001, body: commandAnswerBody("answer-bound", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-bound", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
       },
     });
     await processJob(env, {
@@ -7042,7 +7042,7 @@ describe("queue processors", () => {
       payload: {
         ...basePayload,
         issue: { ...basePayload.issue, number: 78 },
-        comment: { id: 9001, body: commandAnswerBody("answer-bound", "preflight"), user: { login: "gittensory[bot]", type: "Bot" } },
+        comment: { id: 9001, body: commandAnswerBody("answer-bound", "preflight"), user: { login: "loopover-orb[bot]", type: "Bot" } },
       },
     });
 

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -1544,7 +1544,7 @@ describe("queue processors", () => {
         if (url.includes("/issues/321/comments") && method === "GET") {
           // An existing PR-panel review comment: createOrUpdateAgentCommandComment would find + edit this for
           // any OTHER command's answer card, but chat must never reach (or touch) it.
-          return Response.json([{ id: 500, body: "<!-- gittensory-pr-panel:v1 -->\n\nExisting review verdict.", user: { login: "gittensory-orb[bot]", type: "Bot" } }]);
+          return Response.json([{ id: 500, body: "<!-- gittensory-pr-panel:v1 -->\n\nExisting review verdict.", user: { login: "loopover-orb[bot]", type: "Bot" } }]);
         }
         if (url.includes("/issues/comments/500") && method === "PATCH") {
           patchCalls.push(url);
@@ -5268,7 +5268,7 @@ describe("queue processors", () => {
           ...(opts.omitInstallation ? {} : { installation: { id: 123, account: { login: repoFullName.slice(0, slash), id: 1, type: "User" } } }),
           repository: { name: repoFullName.slice(slash + 1), full_name: repoFullName, private: false, owner: { login: repoFullName.slice(0, slash) } },
           issue: { number: prNumber, title: "Add retry to checkout", state: "open", user: { login: "contributor" }, ...(opts.omitPullRequest ? {} : { pull_request: {} }) },
-          comment: { id: commentId, body: opts.body ?? CHECKED_GENERATE_TESTS_PANEL, user: opts.commentUser ?? { login: "gittensory[bot]", type: "Bot" } },
+          comment: { id: commentId, body: opts.body ?? CHECKED_GENERATE_TESTS_PANEL, user: opts.commentUser ?? { login: "loopover-orb[bot]", type: "Bot" } },
           sender: { login: sender.login, type: sender.type ?? "User" },
         },
       } as unknown as Parameters<typeof processJob>[1];
@@ -5415,9 +5415,9 @@ describe("queue processors", () => {
       });
       await seedCheckboxPr(env, repoFullName, 6003, "checkbox-4589-bot-sha");
       const posted = { count: 0, body: "" };
-      stubCheckboxFetch(6003, "gittensory[bot]", "admin", posted);
+      stubCheckboxFetch(6003, "loopover-orb[bot]", "admin", posted);
 
-      await processJob(env, checkboxWebhook(repoFullName, 6003, 902, { login: "gittensory[bot]", type: "Bot" }));
+      await processJob(env, checkboxWebhook(repoFullName, 6003, 902, { login: "loopover-orb[bot]", type: "Bot" }));
 
       expect(posted.count).toBe(0);
       const skipped = await env.DB.prepare("select detail from audit_events where event_type = ?")
@@ -5675,7 +5675,7 @@ describe("queue processors", () => {
         // SAME row -- a stub that always returns [] on GET would make the code re-POST on every update
         // attempt instead of PATCHing, inflating posted.count for reasons unrelated to this test.
         if (url.includes(`/issues/6012/comments`) && method === "GET") {
-          return Response.json(posted.count > 0 ? [{ id: 60120, body: posted.body, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(posted.count > 0 ? [{ id: 60120, body: posted.body, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes(`/issues/6012/comments`) && method === "POST") {
           posted.count += 1;
@@ -5723,7 +5723,7 @@ describe("queue processors", () => {
           eventName: "issue_comment",
           payload: {
             action: "edited",
-            comment: { id: 999, body: CHECKED_GENERATE_TESTS_PANEL, user: { login: "gittensory[bot]", type: "Bot" } },
+            comment: { id: 999, body: CHECKED_GENERATE_TESTS_PANEL, user: { login: "loopover-orb[bot]", type: "Bot" } },
             sender: undefined,
           },
         } as unknown as Parameters<typeof processJob>[1]),

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -348,7 +348,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     // Installed, but WITHOUT pull_requests: write — the distinction that matters. Mirrors the sibling guards'
     // own permission-denied fixtures (e.g. the self-close guard's at :2096).
@@ -390,7 +390,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
     await grantWriteInstallation(env);
 
@@ -425,7 +425,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
     // A maintainer legitimately reopened/re-approved the PR — or a queue retry replayed a stale payload — in
@@ -464,7 +464,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -503,7 +503,7 @@ describe("one-shot reopen prevention", () => {
       }
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -533,7 +533,7 @@ describe("one-shot reopen prevention", () => {
       if (url.endsWith("/pulls/42") && method === "PATCH") return Response.json({ state: "closed" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -569,7 +569,7 @@ describe("one-shot reopen prevention", () => {
       if (url.endsWith("/pulls/42") && method === "PATCH") return Response.json({ state: "closed" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -601,7 +601,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) throw new Error("GitHub events API down");
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -630,7 +630,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -662,7 +662,7 @@ describe("one-shot reopen prevention", () => {
       }
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
     vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
@@ -683,7 +683,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
     vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "head_changed", expectedHeadSha: "abc123", liveHeadSha: "def456", liveState: "open" });
@@ -707,7 +707,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
     vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
@@ -735,7 +735,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await grantWriteInstallation(env);
 
@@ -771,7 +771,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } });
     // Simulates a DIFFERENT concurrent delivery for the same PR already in flight (e.g. the draft-dodge sibling
     // racing this reopen) — the lock key it would hold is pre-claimed here.
@@ -811,7 +811,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     // NO autonomy configured (observe-only / un-opted-in): the agent must take NO destructive action.
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-observe-only", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed
@@ -830,7 +830,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
     await grantWriteInstallation(env);
     await repositoriesModule.setGlobalAgentFrozen(env, true); // emergency brake on
@@ -853,7 +853,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentDryRun: true, autonomy: { merge: "auto", request_changes: "auto", close: "auto" } });
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-dryrun", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed
@@ -870,8 +870,8 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
-    await processJob(env, { type: "github-webhook", deliveryId: "bot-reopen", eventName: "pull_request", payload: reopenedPayload("gittensory[bot]") });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
+    await processJob(env, { type: "github-webhook", deliveryId: "bot-reopen", eventName: "pull_request", payload: reopenedPayload("loopover-orb[bot]") });
     // No collaborator-permission lookup or reclose PATCH -- the bot-login short-circuit fires before either.
     expect(calls.some((c) => c.url.includes("/collaborators/"))).toBe(false);
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
@@ -885,7 +885,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", ADMIN_GITHUB_LOGINS: "admin-user" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb", ADMIN_GITHUB_LOGINS: "admin-user" });
     await processJob(env, { type: "github-webhook", deliveryId: "admin-reopen", eventName: "pull_request", payload: reopenedPayload("admin-user") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
   });
@@ -900,7 +900,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await processJob(env, { type: "github-webhook", deliveryId: "unknown-closer", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
   });
@@ -932,7 +932,7 @@ describe("one-shot reopen prevention", () => {
       if (url.endsWith("/pulls/42") && method === "PATCH") return Response.json({ state: "closed" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
     await grantWriteInstallation(env);
     await processJob(env, { type: "github-webhook", deliveryId: "window-evasion-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
@@ -949,12 +949,12 @@ describe("one-shot reopen prevention", () => {
       calls.push({ url, method });
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
-      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "gittensory[bot]" } }, { event: "reopened", actor: { login: "contributor" } }]);
+      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "loopover-orb[bot]" } }, { event: "reopened", actor: { login: "contributor" } }]);
       if (url.endsWith("/issues/42/comments")) return Response.json({ id: 99 }, { status: 201 });
       if (url.endsWith("/pulls/42") && method === "PATCH") return Response.json({ state: "closed" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto", close: "auto" } }); // opted into acting autonomy
     await grantWriteInstallation(env);
     await processJob(env, { type: "github-webhook", deliveryId: "bot-closer-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
@@ -972,7 +972,7 @@ describe("one-shot reopen prevention", () => {
       if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await processJob(env, { type: "github-webhook", deliveryId: "self-close-reopen", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
   });
@@ -987,7 +987,7 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "contributor" } }]);
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await processJob(env, { type: "github-webhook", deliveryId: "perm-api-error", eventName: "pull_request", payload: reopenedPayload("contributor") });
     // permission API threw → null → non-maintainer reopener + non-maintainer closer → no reclose.
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
@@ -1004,7 +1004,7 @@ describe("one-shot reopen prevention", () => {
       throw new Error("GitHub API unavailable");
     });
     vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await expect(
       processJob(env, { type: "github-webhook", deliveryId: "reopen-api-fail-safe", eventName: "pull_request", payload: reopenedPayload("contributor") }),
     ).resolves.toBeUndefined();
@@ -1028,7 +1028,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } });
 
     await processJob(env, {
@@ -1059,7 +1059,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto_with_approval" } });
 
     await processJob(env, {
@@ -1141,7 +1141,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1163,7 +1163,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     // A maintainer merged/closed the PR — or a fresh commit resolved the gate failure — in the window between
@@ -1192,7 +1192,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "no_longer_draft", expectedHeadSha: "abc123", liveHeadSha: "abc123", liveState: "open" });
@@ -1213,7 +1213,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "closed", expectedHeadSha: "abc123", liveHeadSha: "abc123", liveState: "closed" });
@@ -1236,7 +1236,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     // Installation grant is missing pull_requests: write (revoked or never consented) — issues: write is present,
     // so this isn't a blanket permission failure, just the specific scope this close needs.
@@ -1276,7 +1276,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     // No installations row pre-seeded. processGitHubWebhook auto-upserts one from the payload's bare
     // `installation: { id: 123 }` (no permissions field, as a real pull_request payload carries), so the
@@ -1304,7 +1304,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertInstallation(env, {
       installation: {
@@ -1361,7 +1361,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     await repositoriesModule.setGlobalAgentFrozen(env, true);
@@ -1381,7 +1381,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { agentDryRun: true });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     await processJob(env, { type: "github-webhook", deliveryId: "draft-dryrun", eventName: "pull_request", payload: draftPayload("contributor") });
@@ -1402,7 +1402,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     // Simulates a DIFFERENT concurrent delivery for the same PR already in flight (e.g. a check_suite completion
@@ -1432,7 +1432,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1458,7 +1458,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     // No gate block recorded — gate hasn't run yet.
 
@@ -1476,7 +1476,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     // Block exists but for an OLDER commit — contributor has pushed new code in draft.
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "old-sha-XYZ", blockerCodes: ["missing_linked_issue"] });
@@ -1496,7 +1496,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
     await markGateOutcomeOverridden(env, "JSONbored/gittensory", 42);
@@ -1515,7 +1515,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1534,7 +1534,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", ADMIN_GITHUB_LOGINS: "admin-user" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb", ADMIN_GITHUB_LOGINS: "admin-user" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1553,7 +1553,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { agentPaused: true });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1574,7 +1574,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { autonomy: null });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1595,7 +1595,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     // empty blockerCodes → codes = "" → ternary takes the "" branch
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: [] });
@@ -1620,7 +1620,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       throw new Error("simulated network error"); // all GitHub calls throw
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1642,7 +1642,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1668,7 +1668,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1693,7 +1693,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     // Setup with a slash-free repo name
     await upsertRepositoryFromGitHub(env, { name: "noslash", full_name: "noslash", private: false, owner: { login: "" } }, 200);
     await upsertInstallation(env, {
@@ -1764,7 +1764,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { autonomy: { approve: "auto" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1787,7 +1787,7 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { autonomy: { close: "auto_with_approval" } });
     await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
 
@@ -1914,7 +1914,7 @@ describe("converted_to_draft CI-cancel (#6670, resource-waste)", () => {
   it("cancels in-flight CI runs for the PR's head SHA when it is converted to draft", async () => {
     const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
     vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [401], queued: [402] }));
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
 
     await processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel", eventName: "pull_request", payload: draftConvertPayload() });
@@ -1928,7 +1928,7 @@ describe("converted_to_draft CI-cancel (#6670, resource-waste)", () => {
   it("degrades gracefully when the cancel attempt fails — a genuine error is recorded, nothing throws", async () => {
     const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
     vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [403] }, () => new Response(null, { status: 500 })));
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
 
     await expect(
@@ -1942,7 +1942,7 @@ describe("converted_to_draft CI-cancel (#6670, resource-waste)", () => {
   it("does not attempt to cancel CI while the agent is paused — records a dry-run-shaped skip instead", async () => {
     const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
     vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [404] }));
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { agentPaused: true });
 
     await processJob(env, { type: "github-webhook", deliveryId: "draft-convert-ci-cancel-paused", eventName: "pull_request", payload: draftConvertPayload() });
@@ -1957,7 +1957,7 @@ describe("converted_to_draft CI-cancel (#6670, resource-waste)", () => {
   it("swallows a failing audit write on the paused/dry-run skip path — the handler still completes without throwing", async () => {
     const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
     vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [405] }));
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env, { agentPaused: true });
     const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
     const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockImplementation(async (auditEnv, event) => {
@@ -1975,7 +1975,7 @@ describe("converted_to_draft CI-cancel (#6670, resource-waste)", () => {
   it("swallows a failing audit write on the successful-cancel path — the handler still completes without throwing", async () => {
     const seen = { cancelledIds: [] as number[], listedStatuses: [] as string[] };
     vi.stubGlobal("fetch", stubDraftCiCancelFetch(seen, { in_progress: [406] }));
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     await setupRepo(env);
     const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
     const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockImplementation(async (auditEnv, event) => {
@@ -2058,7 +2058,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       // an actual reopen+re-close, letting a redelivery test assert the second delivery is a true no-op.
       if (url.includes("/issues/42/events")) {
         const priorPatches = calls.filter((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42")).length;
-        const closer = priorPatches >= 2 ? "gittensory[bot]" : "contributor";
+        const closer = priorPatches >= 2 ? "loopover-orb[bot]" : "contributor";
         return Response.json([{ event: "closed", actor: { login: closer } }]);
       }
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
@@ -2077,7 +2077,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("reopens then re-closes as the App, posts the explanation comment, applies the label, and records a review_evasion strike", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2098,7 +2098,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("reopens and re-closes when the live self-closed PR is already closed on the reviewed head", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2124,7 +2124,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("retries (via a thrown lock-contended error) when a concurrent delivery already holds the per-PR actuation lock", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await env.SELFHOST_TRANSIENT_CACHE?.set("pr-actuation-lock:jsonbored/gittensory#42", "1", 60);
@@ -2141,7 +2141,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when reviewEvasionProtection is explicitly off (#4011: the only respected opt-out)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off" });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2155,7 +2155,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when NO active review is tracked for this head (an ordinary close, nothing to evade)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       // No startActiveReviewTracking call at all.
 
@@ -2167,7 +2167,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (#self-close-post-review): re-closes a self-close AFTER the review already published, not just mid-computation -- the active-only window would have missed this, since a human reacting to a now-visible label necessarily acts after the pass already terminalized", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
       // The review pass concludes and publishes -- exactly what happens right before a human could ever SEE
@@ -2185,7 +2185,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (#self-close-post-review): honors settings.autoCloseExemptLogins -- the shared allowlist the draft-conversion/contributor-cap/review-nag guards already use", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autoCloseExemptLogins: ["contributor"] });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
       await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
@@ -2200,7 +2200,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when a THIRD PARTY closed someone else's PR (not the author) — an ordinary maintainer close, not self-close evasion", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2212,7 +2212,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the closer is the repo owner", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2224,7 +2224,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the closer is an ADMIN_GITHUB_LOGINS fleet-operator", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory", ADMIN_GITHUB_LOGINS: "admin-user" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb", ADMIN_GITHUB_LOGINS: "admin-user" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2236,7 +2236,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the closer holds write/maintain/admin collaborator permission", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2248,7 +2248,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing for a protected automation author (e.g. dependabot[bot])", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2260,7 +2260,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("dry-run: audits the would-be enforcement without mutating GitHub or recording a live strike", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { agentDryRun: true });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2278,7 +2278,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the agent is globally frozen", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.setGlobalAgentFrozen(env, true, "test");
@@ -2294,7 +2294,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when close autonomy is not acting (observe)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autonomy: { close: "observe" } });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2309,7 +2309,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION: denies live self-close enforcement when close autonomy requires approval", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autonomy: { close: "auto_with_approval" } });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2324,7 +2324,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when pull_requests: write is not granted", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertInstallation(env, {
         installation: {
@@ -2351,7 +2351,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the closed live PR is not on the reviewed head", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "closed", expectedHeadSha: "abc123", liveHeadSha: "def456", liveState: "closed" });
@@ -2375,7 +2375,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (method === "PATCH" && url.endsWith("/pulls/42")) return new Response("server error", { status: 500 });
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2408,7 +2408,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         }
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2452,7 +2452,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/labels")) return Response.json([{ name: "review-evasion" }]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2473,7 +2473,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("global moderation disabled: the evasion close/label/comment still happen, but no moderation strike/label is recorded", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       // Global moderation config left at its default (disabled).
@@ -2491,7 +2491,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION: no duplicate strike or duplicate enforcement on a webhook redelivery/retry after the first enforcement already succeeded", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2513,7 +2513,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("a subsequent contributor reopen after the App's evasion close is re-closed by the EXISTING one-shot reopen guard", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2528,7 +2528,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         calls.push({ url, method });
         if (url.includes("/access_tokens")) return Response.json({ token: "t" });
         if (url.includes("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
-        if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "gittensory[bot]" } }, { event: "reopened", actor: { login: "contributor" } }]);
+        if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "loopover-orb[bot]" } }, { event: "reopened", actor: { login: "contributor" } }]);
         if (method === "POST" && url.endsWith("/issues/42/comments")) return Response.json({ id: 2 }, { status: 201 });
         if (method === "PATCH" && url.endsWith("/pulls/42")) return Response.json({ state: "closed" });
         return new Response("not found", { status: 404 });
@@ -2548,7 +2548,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       // settings layer directly, confirming neither layer silently reintroduces the old off-by-default gap.
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -2563,7 +2563,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the webhook payload has no sender", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2578,7 +2578,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the PR record has no author (a deleted-account PR)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2593,7 +2593,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the PR record has no headSha", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2608,7 +2608,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the installation record is missing (uninstalled mid-flight)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       vi.spyOn(repositoriesModule, "getInstallation").mockResolvedValue(null);
@@ -2625,7 +2625,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       // Same write-time-coalescing note as the reviewEvasionProtection test above.
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -2656,7 +2656,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/pulls/42/files")) return Response.json([]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       // reviewEvasionLabel is a NOT NULL DB column (upsertRepositorySettings coalesces null -> the default at
@@ -2693,7 +2693,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/pulls/42/files")) return Response.json([]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -2709,7 +2709,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("closes as the App (no reopen needed), posts the explanation comment, applies the label, and records a review_evasion strike", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2729,7 +2729,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("retries (via a thrown lock-contended error) when a concurrent delivery already holds the per-PR actuation lock", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       // Deliberately autonomy: {} (not {close: "auto"}) -- this repo's OUTER dispatch condition for the
       // SIBLING draft-dodge guard requires isAgentConfigured(settings.autonomy), so with no acting autonomy
       // class at all, draft-dodge's OWN lock-claim attempt is skipped entirely and this test genuinely
@@ -2751,7 +2751,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing for a draft conversion BEFORE any active review has started", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       // No startActiveReviewTracking call -- no review has ever run for this PR.
 
@@ -2763,7 +2763,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does NOT require a prior gate failure (unlike the draft-dodge guard) -- an active review alone is enough", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       // Deliberately NO recordGateBlockOutcome call -- the draft-dodge guard's own trigger condition is absent.
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
@@ -2780,7 +2780,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (#draft-evasion-post-review): closes a draft conversion AFTER the review already published, not just mid-computation -- the active-only window would have missed this, since a human reacting to a now-visible label necessarily acts after the pass already terminalized", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       // The review pass concludes and publishes -- exactly what happens right before a human could ever SEE
@@ -2797,7 +2797,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing for a draft conversion once the head has moved past the reviewed commit -- a fresh push earns a fresh shot", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       // The tracked review ran against an OLDER commit -- the payload's current headSha (abc123) has never
       // itself been reviewed.
@@ -2812,7 +2812,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (#draft-evasion-post-review): honors settings.autoCloseExemptLogins -- the shared allowlist the contributor-cap/review-nag guards already use", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autoCloseExemptLogins: ["contributor"] });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
@@ -2827,7 +2827,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the author holds write collaborator permission", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2839,7 +2839,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (gate-flagged): does nothing when a THIRD PARTY converts someone else's PR to draft (not the author) -- an ordinary maintainer action, not self-evasion, must never be enforced against the author who didn't do it", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2856,7 +2856,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("dry-run: audits the would-be enforcement without mutating GitHub or recording a live strike", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { agentDryRun: true });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2874,7 +2874,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the agent is globally frozen", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.setGlobalAgentFrozen(env, true, "test");
@@ -2890,7 +2890,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when close autonomy is not acting (observe)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autonomy: { close: "observe" } });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2905,7 +2905,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION: denies live draft-conversion enforcement when close autonomy requires approval", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autonomy: { close: "auto_with_approval" } });
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -2920,7 +2920,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when pull_requests: write is not granted", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertInstallation(env, {
         installation: {
@@ -2947,7 +2947,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the PR was converted back to ready_for_review before the close fires (requireDraft freshness)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "no_longer_draft", expectedHeadSha: "abc123", liveHeadSha: "abc123", liveState: "open" });
@@ -2971,7 +2971,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (method === "PATCH" && url.endsWith("/pulls/42")) return new Response("server error", { status: 500 });
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
@@ -2987,7 +2987,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("global moderation disabled: the evasion close/label/comment still happen, but no moderation strike is recorded", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -3003,7 +3003,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("STILL protects when reviewEvasionProtection is unset (undefined, not an explicit 'off') (#4011: default-ON)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3017,7 +3017,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the webhook payload has no sender", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -3032,7 +3032,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the PR record has no author (a deleted-account PR)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -3047,7 +3047,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing for a protected automation author (e.g. dependabot[bot])", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -3059,7 +3059,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the PR record has no headSha", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
 
@@ -3074,7 +3074,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the installation record is missing (uninstalled mid-flight)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       vi.spyOn(repositoriesModule, "getInstallation").mockResolvedValue(null);
@@ -3090,7 +3090,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("skips the courtesy comment when reviewEvasionComment is unset (defaults to true, but false is honored too)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3120,7 +3120,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/pulls/42/files")) return Response.json([]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3152,7 +3152,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/pulls/42/files")) return Response.json([]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3168,7 +3168,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing on the FIRST draft conversion, then closes on the SECOND -- independent of active-review/gate-block state", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
       // Deliberately NO startActiveReviewTracking / recordGateBlockOutcome call -- neither sibling guard's own
@@ -3195,7 +3195,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (#6165): honors settings.autoCloseExemptLogins -- the shared allowlist the two sibling review-evasion guards already use, even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autoCloseExemptLogins: ["contributor"] });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
 
@@ -3211,7 +3211,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when reviewEvasionProtection is off, even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off" });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-off-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3223,7 +3223,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("STILL enforces the repeated-cycle close when reviewEvasionProtection is unset (undefined, not an explicit 'off') (#4011: default-ON)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
       vi.spyOn(repositorySettingsModule, "resolveRepositorySettings").mockResolvedValue({ ...baseSettings, reviewEvasionProtection: undefined });
@@ -3240,7 +3240,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (gate-flagged): does not enforce against a THIRD PARTY repeatedly converting someone else's PR to draft", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       const payload = draftEvasionPayload("contributor");
       payload.sender = { login: "a-maintainer", type: "User" };
@@ -3254,7 +3254,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION (gate-flagged, gittensory-orb review): a maintainer's draft conversion must NOT count toward the author's own cycle -- the author's first-ever conversion is never enforced even after a prior third-party one", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       const maintainerConversion = draftEvasionPayload("contributor");
       maintainerConversion.sender = { login: "a-maintainer", type: "User" };
@@ -3280,7 +3280,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing for a protected automation author (e.g. dependabot[bot]), even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-bot-1", eventName: "pull_request", payload: draftEvasionPayload("dependabot[bot]") });
@@ -3292,7 +3292,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the PR record has no headSha, even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       const payload = draftEvasionPayload("contributor");
       payload.pull_request.head = null;
@@ -3306,7 +3306,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the author holds write collaborator permission, even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-maintainer-1", eventName: "pull_request", payload: draftEvasionPayload("write-collaborator") });
@@ -3318,7 +3318,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when close autonomy is not acting (observe)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autonomy: { close: "observe" } });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-observe-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3335,7 +3335,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION: denies live repeated draft-cycling enforcement when close autonomy requires approval", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { autonomy: { close: "auto_with_approval" } });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-approval-required-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3352,7 +3352,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("dry-run: audits the would-be enforcement without mutating GitHub or recording a live strike", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { agentDryRun: true });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
 
@@ -3372,7 +3372,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the agent is paused for this repo", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { agentPaused: true });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-paused-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3389,7 +3389,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when pull_requests: write is not granted", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
       await upsertInstallation(env, {
         installation: {
@@ -3418,7 +3418,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the PR was converted back to ready_for_review before the close fires (requireDraft freshness)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-fresh-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
       vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "no_longer_draft", expectedHeadSha: "abc123", liveHeadSha: "abc123", liveState: "open" });
@@ -3445,7 +3445,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("raw.githubusercontent.com") && url.includes("loopover.y")) return new Response("source: repo_file\n", { status: 200 });
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
 
@@ -3463,7 +3463,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("global moderation disabled: the close/label/comment still happen, but no moderation strike is recorded", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-mod-off-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3497,7 +3497,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("raw.githubusercontent.com") && url.includes("loopover.y")) return new Response("source: repo_file\n", { status: 200 });
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-third-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3514,7 +3514,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("REGRESSION: the first conversion returns before the repeated-cycle lock so a retry cannot double-count it", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       // Deliberately autonomy: {} -- draft-dodge's own outer dispatch condition (isAgentConfigured) is false, so
       // ITS lock claim never fires. The remaining sibling (review-evasion-active-review) has no settings gate at
       // its OWN lock claim, so it claims+releases the lock normally on every converted_to_draft delivery. THIS
@@ -3539,7 +3539,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the webhook payload has no sender, even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       const payload = draftEvasionPayload("contributor");
 
@@ -3552,7 +3552,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the PR record has no author (a deleted-account PR), even after a repeated cycle", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       const payload = draftEvasionPayload("contributor");
       payload.pull_request.user = null;
@@ -3566,7 +3566,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("denies enforcement when the installation record is missing (uninstalled mid-flight)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-no-install-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
       vi.spyOn(repositoriesModule, "getInstallation").mockResolvedValue(null);
@@ -3584,7 +3584,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("skips the courtesy comment when reviewEvasionComment is explicitly false", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionComment: false });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-comment-false-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3597,7 +3597,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("posts the courtesy comment when reviewEvasionComment is unset (undefined, not just a stored default)", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-comment-unset-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3627,7 +3627,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/pulls/42/files")) return Response.json([]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-label-null-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3659,7 +3659,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         if (url.includes("/pulls/42/files")) return Response.json([]);
         return new Response("not found", { status: 404 });
       });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env);
       await processJob(env, { type: "github-webhook", deliveryId: "draft-cycle-label-unset-1", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
       const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
@@ -3776,7 +3776,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when draftPrClosePolicy is off (the default) -- opening directly as a draft is unaffected", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off" }); // draftPrClosePolicy defaults to "off"
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-policy-off-opened", eventName: "pull_request", payload: draftOpenedPayload("contributor") });
@@ -3787,7 +3787,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("closes immediately when a PR is opened directly as a draft -- no prior review needed, unlike reviewEvasionProtection", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off", draftPrClosePolicy: "close" });
       // Deliberately no startActiveReviewTracking / recordGateBlockOutcome call -- unlike every reviewEvasionProtection
       // sibling, this policy fires on the very first draft, before any review has ever run.
@@ -3804,7 +3804,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("closes immediately when the author converts their own PR to draft", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off", draftPrClosePolicy: "close" });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-policy-converted", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
@@ -3817,7 +3817,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does NOT record a moderation strike -- this is a blanket policy against ordinary draft usage, not a detected abuse pattern", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off", draftPrClosePolicy: "close" });
       await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
 
@@ -3831,7 +3831,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("honors settings.autoCloseExemptLogins -- the shared allowlist the review-evasion family already uses", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off", draftPrClosePolicy: "close", autoCloseExemptLogins: ["contributor"] });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-policy-exempt", eventName: "pull_request", payload: draftOpenedPayload("contributor") });
@@ -3842,7 +3842,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when the author holds write collaborator permission", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off", draftPrClosePolicy: "close" });
 
       await processJob(env, { type: "github-webhook", deliveryId: "draft-policy-maintainer", eventName: "pull_request", payload: draftOpenedPayload("write-collaborator") });
@@ -3853,7 +3853,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
     it("does nothing when a THIRD PARTY converts someone else's PR to draft -- an ordinary maintainer action, not the author's own choice", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });
-      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
       await setupEvasionRepo(env, { reviewEvasionProtection: "off", draftPrClosePolicy: "close" });
 
       const payload = draftEvasionPayload("contributor");
@@ -3964,13 +3964,13 @@ describe("recordAgentCommandUsage (signal-snapshot fail-safe)", () => {
       if (input.toString().includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const payload: any = {
       action: "created",
       installation: { id: 123 },
       repository: { id: 1, name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", owner: { login: "JSONbored" } },
-      sender: { login: "gittensory[bot]", type: "Bot" },
-      comment: { id: 999, body: "@loopover help", user: { login: "gittensory[bot]", type: "Bot" } },
+      sender: { login: "loopover-orb[bot]", type: "Bot" },
+      comment: { id: 999, body: "@loopover help", user: { login: "loopover-orb[bot]", type: "Bot" } },
       issue: { id: 1, number: 77, title: "some issue", pull_request: { url: "https://api.github.com/repos/JSONbored/gittensory/pulls/77" } },
     };
     await expect(
@@ -3986,7 +3986,7 @@ describe("recordAgentCommandUsage (signal-snapshot fail-safe)", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       return new Response("not found", { status: 404 });
     });
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
     const payload: any = {
       action: "edited", // an edit re-fires issue_comment with a NEW delivery id — the handler must NOT re-answer
       installation: { id: 123 },

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -3353,7 +3353,7 @@ describe("queue processors", () => {
 
   it("drops already-enqueued self-authored app CI completions without re-reviewing", async () => {
     const env = createTestEnv({
-      GITHUB_APP_SLUG: "gittensory-orb",
+      GITHUB_APP_SLUG: "loopover-orb",
       LOOPOVER_REVIEW_REPOS: "owner/agent-repo",
     });
     let fetchCount = 0;
@@ -3373,7 +3373,7 @@ describe("queue processors", () => {
         check_suite: {
           head_sha: "a7",
           pull_requests: [{ number: 7 }],
-          app: { slug: "gittensory-orb" },
+          app: { slug: "loopover-orb" },
         },
       } as never,
     });
@@ -5960,7 +5960,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a70/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/70/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/70/comments") && method === "POST") {
           commentPosts += 1;
@@ -6044,7 +6044,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a71/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/71/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/71/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6122,7 +6122,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a72/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/72/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/72/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6232,7 +6232,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a90/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/90/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/90/comments") && method === "POST") {
           commentPosts += 1;
@@ -6304,7 +6304,7 @@ describe("queue processors", () => {
         if (url.includes(`/commits/${headSha}/status`)) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/91/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/91/comments") && method === "POST") {
           commentPosts += 1;
@@ -6369,7 +6369,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/d92/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/92/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/92/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6431,7 +6431,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a71/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/71/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/71/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6493,7 +6493,7 @@ describe("queue processors", () => {
         if (url.includes(`/commits/${headSha}/status`)) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/72/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/72/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6559,7 +6559,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a73/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/73/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/73/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6664,7 +6664,7 @@ describe("queue processors", () => {
         if (url.includes("/commits/a75-v2/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/issues/75/comments") && method === "GET") {
-          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+          return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "loopover-orb[bot]", type: "Bot" } }] : []);
         }
         if (url.includes("/issues/75/comments") && method === "POST") {
           const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
@@ -6729,7 +6729,7 @@ describe("queue processors", () => {
         if (url.endsWith("/pulls/90")) return Response.json({ number: 90, title: "Clean PR awaiting retrigger", state: "open", user: { login: "contributor" }, head: { sha: "a90" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
         if (url.includes("/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
         if (url.includes("/status")) return Response.json({ state: "success", statuses: [] });
-        if (url.includes("/issues/90/comments") && method === "GET") return Response.json([{ id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+        if (url.includes("/issues/90/comments") && method === "GET") return Response.json([{ id: 777, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
         if (url.includes("/issues/comments/777") && method === "PATCH") return Response.json({ id: 777 });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
@@ -6756,7 +6756,7 @@ describe("queue processors", () => {
           installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
           repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
           issue: { number: 90, title: "Clean PR awaiting retrigger", state: "open", user: { login: "contributor" }, pull_request: {} },
-          comment: { id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+          comment: { id: 777, body: checkedPanel, user: { login: "loopover-orb[bot]", type: "Bot" } },
           sender: { login: "maintainer", type: "User" },
         },
       });

--- a/test/unit/release-selfhost-notes.test.ts
+++ b/test/unit/release-selfhost-notes.test.ts
@@ -105,7 +105,7 @@ exit 1
           REF_NAME: "orb-v0.2.0",
           RELEASE_VERSION: "0.2.0",
           RELEASE_TAG: "orb-v0.2.0",
-          RELEASE_ID: "gittensory-orb@0.2.0",
+          RELEASE_ID: "loopover-orb@0.2.0",
           REPOSITORY_OWNER: "JSONbored",
           PRERELEASE: "false",
         },

--- a/test/unit/routes-internal-decision-calibration.test.ts
+++ b/test/unit/routes-internal-decision-calibration.test.ts
@@ -31,25 +31,25 @@ describe("GET /v1/internal/decision — operator decision-trail endpoint", () =>
 
   it("200s with the decision trail for a seeded target, scoped to the app slug", async () => {
     const app = createApp();
-    const env = createTestEnv(); // GITHUB_APP_SLUG defaults to "gittensory"
+    const env = createTestEnv(); // GITHUB_APP_SLUG defaults to "loopover-orb"
     // review_targets is raw-SQL-only (migration 0050) — seed the row the endpoint reads back. Its id is the
     // project-namespaced natural key `${slug}:${kind}:${repo}#${number}` (rowId).
     await env.DB.prepare(
       `INSERT INTO review_targets (id, project, kind, repo, number, status, verdict, head_sha, decided_sha, attempt_count, terminal_at, decision_json)
        VALUES (?, ?, 'pull_request', ?, ?, 'merged', 'merge', 'abc123', 'abc123', 1, '2026-07-01T00:00:00Z', ?)`,
     )
-      .bind("gittensory:pull_request:owner/repo#5", "gittensory", "owner/repo", 5, JSON.stringify({ action: "merge", confidence: 0.9 }))
+      .bind("loopover-orb:pull_request:owner/repo#5", "loopover-orb", "owner/repo", 5, JSON.stringify({ action: "merge", confidence: 0.9 }))
       .run();
     await env.DB.prepare(
       `INSERT INTO review_audit (id, project, target_id, event_type, decision, summary, created_at)
-       VALUES ('a1', 'gittensory', ?, 'reviewed', 'merge', 'looks good', '2026-07-01T00:00:00Z')`,
+       VALUES ('a1', 'loopover-orb', ?, 'reviewed', 'merge', 'looks good', '2026-07-01T00:00:00Z')`,
     )
-      .bind("gittensory:pull_request:owner/repo#5")
+      .bind("loopover-orb:pull_request:owner/repo#5")
       .run();
     const res = await app.request("/v1/internal/decision?repo=owner/repo&number=5", { headers: bearer(env) }, env);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { project: string; target: { number: number; status: string }; decision: unknown; audit: Array<{ event: string }> };
-    expect(body.project).toBe("gittensory");
+    expect(body.project).toBe("loopover-orb");
     expect(body.target.number).toBe(5);
     expect(body.target.status).toBe("merged");
     expect(body.decision).toEqual({ action: "merge", confidence: 0.9 });
@@ -72,7 +72,7 @@ describe("GET /v1/internal/calibration — operator calibration endpoint", () =>
     const res = await app.request("/v1/internal/calibration", { headers: bearer(env) }, env);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { project: string; calibration: { currentFloor: number; note: string } };
-    expect(body.project).toBe("gittensory");
+    expect(body.project).toBe("loopover-orb");
     expect(typeof body.calibration.currentFloor).toBe("number");
     expect(typeof body.calibration.note).toBe("string");
   });

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -298,7 +298,7 @@ describe("createPgQueue (durable #977)", () => {
     m.fn.mockResolvedValueOnce({
       rows: [
         { id: "a", payload: JSON.stringify(msg("agent-regate-pr")), priority: 0 },
-        { id: "b", payload: JSON.stringify(webhook({ login: "gittensory-orb[bot]", type: "Bot" })), priority: 10 },
+        { id: "b", payload: JSON.stringify(webhook({ login: "loopover-orb[bot]", type: "Bot" })), priority: 10 },
         { id: "c", payload: JSON.stringify(msg("agent-regate-sweep")), priority: 0 },
       ],
       rowCount: 3,

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -883,7 +883,7 @@ describe("self-host queue common helpers", () => {
         payload: { action: "edited", sender },
       });
     expect(
-      jobPriority(issueCommentEdit({ login: "gittensory-orb[bot]", type: "Bot" })),
+      jobPriority(issueCommentEdit({ login: "loopover-orb[bot]", type: "Bot" })),
     ).toBe(0);
     expect(
       jobPriority(issueCommentEdit({ login: "codecov[bot]", type: "User" })),

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -154,7 +154,7 @@ describe("createSqliteQueue (durable #980)", () => {
     await q.binding.send(msg("agent-regate-pr"), { delaySeconds: 60 });
     await q.binding.send(msg("recapture-preview"), { delaySeconds: 60 });
     await q.binding.send(msg("agent-regate-sweep"), { delaySeconds: 60 });
-    await q.binding.send(webhook({ login: "gittensory-orb[bot]", type: "Bot" }), { delaySeconds: 60 });
+    await q.binding.send(webhook({ login: "loopover-orb[bot]", type: "Bot" }), { delaySeconds: 60 });
     await q.binding.send(webhook({ login: "maintainer", type: "User" }), { delaySeconds: 60 });
     await q.binding.send(msg("rag-index-repo"), { delaySeconds: 60 });
     await q.binding.send({} as unknown as JobMessage, { delaySeconds: 60 }); // no type → priority 0 fallback
@@ -171,7 +171,7 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(prio(JSON.stringify(msg("recapture-preview")))).toBe(9);
     expect(prio(JSON.stringify(msg("agent-regate-sweep")))).toBe(8);
     expect(prio(JSON.stringify(webhook({ login: "maintainer", type: "User" })))).toBe(10);
-    expect(prio(JSON.stringify(webhook({ login: "gittensory-orb[bot]", type: "Bot" })))).toBe(0);
+    expect(prio(JSON.stringify(webhook({ login: "loopover-orb[bot]", type: "Bot" })))).toBe(0);
     expect(prio(JSON.stringify(msg("rag-index-repo")))).toBe(0);
     expect(prio("{}")).toBe(0);
   });
@@ -802,7 +802,7 @@ describe("createSqliteQueue (durable #980)", () => {
     );
     driver.query(
       "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",
-      [JSON.stringify(webhook({ login: "gittensory-orb[bot]", type: "Bot" }))],
+      [JSON.stringify(webhook({ login: "loopover-orb[bot]", type: "Bot" }))],
     );
 
     createSqliteQueue(driver, async () => undefined);
@@ -814,7 +814,7 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(rows.map((row) => row as { payload: string; priority: number })).toEqual([
       { payload: JSON.stringify(msg("agent-regate-pr")), priority: 9 },
       { payload: JSON.stringify(msg("github-webhook")), priority: 10 },
-      { payload: JSON.stringify(webhook({ login: "gittensory-orb[bot]", type: "Bot" })), priority: 0 },
+      { payload: JSON.stringify(webhook({ login: "loopover-orb[bot]", type: "Bot" })), priority: 0 },
     ]);
   });
 
@@ -1445,7 +1445,7 @@ describe("createSqliteQueue (durable #980)", () => {
     );
     driver.query(
       "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 0)",
-      [JSON.stringify(webhook({ login: "gittensory-orb[bot]", type: "Bot" }))],
+      [JSON.stringify(webhook({ login: "loopover-orb[bot]", type: "Bot" }))],
     );
     driver.query(
       "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -409,8 +409,8 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
       repository: { full_name: "JSONbored/gittensory" },
       installation: { id: 1 },
       issue: { number: 1701, pull_request: {} },
-      comment: { id: 123, body: "<!-- gittensory-pr-panel:v1 -->", user: { login: "gittensory[bot]", type: "Bot" } },
-      sender: { login: "gittensory[bot]", type: "Bot" },
+      comment: { id: 123, body: "<!-- gittensory-pr-panel:v1 -->", user: { login: "loopover-orb[bot]", type: "Bot" } },
+      sender: { login: "loopover-orb[bot]", type: "Bot" },
     });
     const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
     const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
@@ -442,7 +442,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
   });
 
   it("drops self-authored app CI completion webhooks before they add queue pressure", async () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
     let webhookSends = 0;
     env.WEBHOOKS = { send: async () => void (webhookSends += 1) } as unknown as Queue;
     const rawBody = JSON.stringify({
@@ -452,7 +452,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
       check_suite: {
         head_sha: "abc123",
         pull_requests: [],
-        app: { slug: "gittensory-orb" },
+        app: { slug: "loopover-orb" },
       },
     });
     const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
@@ -484,7 +484,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
   });
 
   it("drops non-completed CI lifecycle webhooks before they add queue pressure", async () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
     let webhookSends = 0;
     env.WEBHOOKS = { send: async () => void (webhookSends += 1) } as unknown as Queue;
     const rawBody = JSON.stringify({
@@ -526,7 +526,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
   });
 
   it("keeps third-party CI completion webhooks queued for review finalization", async () => {
-    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const env = createTestEnv({ GITHUB_APP_SLUG: "loopover-orb" });
     const sent: unknown[] = [];
     env.WEBHOOKS = { send: async (message: unknown) => void sent.push(message) } as unknown as Queue;
     const rawBody = JSON.stringify({


### PR DESCRIPTION
## Summary

- `test/helpers/d1.ts`'s `createTestEnv()` defaulted `GITHUB_APP_SLUG` to `"gittensory"` -- the pre-rename product name -- even though the real, live canonical GitHub App is `"loopover-orb"` (`src/services/subnet-interface.ts`'s `PUBLIC_GITHUB_APP_SLUG`, described in its own comment as "the same stable, real app across every deployment") and production's own unset-fallback is `"loopover"` (`src/api/routes.ts:936`).
- Surfaced while investigating an unrelated flaky-test report: two tests (`test/unit/github-labels.test.ts`, `test/unit/github-pr-actions.test.ts`, fixed in #6880) constructed a fresh RSA key and D1 database per loop iteration; fixing that revealed the shared `GITHUB_APP_SLUG` default itself was stale.
- Renames the default to `"loopover-orb"` and updates every fixture across ~20 files that depends on it: bot-login strings (`"gittensory[bot]"` -> `"loopover-orb[bot]"`), check-run `app.slug` fixtures, explicit `GITHUB_APP_SLUG` overrides, and one test that asserts on the resulting project-slug value directly.
- **Left deliberately untouched** (confirmed preserved on purpose, not stale -- verified via explicit code comments and other tests that pin these exact values): sticky-comment HTML markers (e.g. `<!-- gittensory-pr-panel:v1 -->`, never renamed in production), the `"gittensory-native"` DB-source literal (written into `review_audit`/`contributor_gate_history` rows, renaming would orphan existing data), Sentry ticket IDs (`GITTENSORY-*`), the `GITTENSORY_LEGACY_*_CHECK_NAME` constants (kept for self-hoster upgrade compatibility), and the `"JSONbored/gittensory"` generic-placeholder-repo-name pattern used across ~144 files (**not** swapped for `"JSONbored/loopover"`, which is a live self-repo sentinel value that would silently change unrelated tests' behavior via `isLoopOverSelfRepo()`).

Two subtleties worth calling out for reviewers:
- **Matching semantics matter.** `isOwnReviewThreadAuthor` does prefix matching, not exact matching, so its own dedicated test (`backfill-2.test.ts`) needed an explicit bare `"loopover"` override to keep testing multiple suffix forms, rather than inheriting the new `"loopover-orb"` default -- a bare `"loopover[bot]"` fixture would not prefix-match a `"loopover-orb"` configured slug (traced through `isAuthorizedReviewThreadAuthor`'s early-return logic to confirm this before assuming).
- **Regenerated the branding-drift baseline.** A one-line comment fix in `packages/loopover-mcp/bin/loopover-mcp.js` (a stale claim that `enrichment-analyzers` "keeps its legacy gittensory:// URI on purpose" -- it was already `loopover://`, confirmed against `src/review/enrichment-analyzers-taxonomy.ts`) dropped that file's tracked "gittensory" mention count from 3 to 2, so `npm run branding-drift:update` was run and the regenerated `scripts/branding-drift-baseline.json` is included.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused on one coherent change (a stale shared test default and its dependents) despite touching many files -- splitting it would leave intermediate states with failing tests, since the default and its dependent fixtures must change together atomically.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- not applicable; this is a maintainer-authored test-reliability fix discovered during unrelated work, not a contributor PR under the linked-issue policy.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- test-only change (plus a regenerated baseline JSON and one comment fix), which Codecov does not measure under `test/**`, so there is no patch-coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- not applicable; no production code changed, and all ~20 affected files' existing tests (1621 total) still pass unchanged in intent.

Additional validation: all ~20 affected files verified individually and together (1621 tests, zero failures). A full local `npm run test:ci` run is green for everything this PR touches. That run also surfaced two unrelated, pre-existing failures, both confirmed via `git blame`/content inspection to be nothing to do with this change: `test/unit/root-terraform-grafana-firewall.test.ts` fails because `terraform/` was deliberately deleted in an earlier, separate commit (`9001197c`, "chore: remove unused terraform/ directory") that didn't clean up this test; `test/unit/selfhost-sentry-release.test.ts` fails because `scripts/deploy-selfhost-prebuilt.sh` has already been renamed to `loopover-selfhost` while the test still pins the old `gittensory-selfhost` value. Both are being fixed in a small separate follow-up PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Not applicable -- test-only change.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable -- no such changes; this only touches how the App's identity is *represented in test fixtures*, not any auth/session logic.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not applicable -- no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (Not applicable -- no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below. (Not applicable -- no visible/UI changes.)
- [x] Public docs/changelogs are updated where needed. (Not applicable.)

## UI Evidence

Not applicable -- test-only change (plus one generated baseline file and one comment fix), no UI/frontend/docs surface touched.

## Notes

- Companion PRs from the same investigation: #6874 (`ai-summaries.test.ts`), #6871 (`agent-sdk-driver.test.ts`), #6869 (miner clone/worktree suite), #6880 (`github-labels`/`github-pr-actions` redundant-setup fix), #6883 (`release-selfhost-prerelease.test.ts` -- a related but independently-discovered `gittensory-orb` -> `loopover-orb` staleness in a different subsystem).
- A follow-up PR will clean up the two unrelated pre-existing failures noted above (`terraform/` test, Sentry release-script test).