### PR TITLE
docs: clarify min_finding_severity is 2-tier for inline findings + lock it in (#6802)

### DIFF
--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -523,9 +523,12 @@ review:
   # blockers -- it can never change the merge/close disposition.
   # memory: false
 
-  # Display-only floor for inline AI findings (`critical` | `major` | `minor` | `nitpick`). Findings below the
-  # configured level are suppressed from inline comments — never from gate blockers. Default: null (show all).
-  # min_finding_severity: major
+  # Display-only floor for inline AI findings. Findings below the configured level are suppressed from inline
+  # comments — never from gate blockers. Default: null (show all). NOTE: inline findings currently occupy only
+  # two of the four severity tiers — `blocker` (ranked `critical`) and `nit` (ranked `nitpick`) — so only two
+  # floors are actually distinguishable: `critical` shows blockers only, and `nitpick` shows everything. `major`
+  # and `minor` behave identically to `critical` (blocker-only) today, NOT an intermediate level.
+  # min_finding_severity: critical
 
   # Display-only caps on how many blocker/nit lines render in the unified comment (#2049).
   # Never removes a blocker from the gate decision — truncation applies to display only.

--- a/test/unit/finding-severity-filter.test.ts
+++ b/test/unit/finding-severity-filter.test.ts
@@ -24,4 +24,25 @@ describe("finding-severity-filter (#2048)", () => {
     expect(shouldShowInlineFinding("nit", "major")).toBe(false);
     expect(shouldShowInlineFinding("nit", null)).toBe(true);
   });
+
+  // #6802: inline findings only ever occupy two of the four severity tiers — blocker→critical (rank 0) and
+  // nit→nitpick (rank 3). So a `nit` fails every floor except `nitpick`, which makes the `critical`, `major`, and
+  // `minor` floors indistinguishable for inline findings (all blocker-only); only `nitpick` shows everything.
+  // This locks in that deliberate behavior so it can't silently drift, and matches the clarified doc in
+  // .loopover.yml.example. (Resolves the 4-tier-doc-vs-2-tier-behavior mismatch in the doc direction.)
+  it("treats critical/major/minor min-severity floors as equivalent for inline findings — only nitpick differs (#6802)", () => {
+    for (const inline of ["blocker", "nit"] as const) {
+      const atCritical = shouldShowInlineFinding(inline, "critical");
+      expect(shouldShowInlineFinding(inline, "major")).toBe(atCritical);
+      expect(shouldShowInlineFinding(inline, "minor")).toBe(atCritical);
+    }
+    // A blocker renders at every floor; a nit is hidden by critical/major/minor alike and shown only by nitpick.
+    for (const floor of ["critical", "major", "minor", "nitpick"] as const) {
+      expect(shouldShowInlineFinding("blocker", floor)).toBe(true);
+    }
+    expect(shouldShowInlineFinding("nit", "critical")).toBe(false);
+    expect(shouldShowInlineFinding("nit", "major")).toBe(false);
+    expect(shouldShowInlineFinding("nit", "minor")).toBe(false);
+    expect(shouldShowInlineFinding("nit", "nitpick")).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #6802.

`.loopover.yml.example` documented `min_finding_severity` as accepting four tiers (`critical|major|minor|nitpick`), but **inline AI findings only ever occupy two of them**: `inlineFindingSeverityTier` maps `blocker → critical` (rank 0) and `nit → nitpick` (rank 3). So the `critical`, `major`, and `minor` floors are indistinguishable for inline findings (all blocker-only) and only `nitpick` differs — a maintainer setting `min_finding_severity: minor` expecting "hide only nitpicks" silently gets blocker-only behavior, with no warning that 3 of the 4 documented values are equivalent.

### Fix (documentation direction — option (b) from the issue)
- **`.loopover.yml.example`**: the `min_finding_severity` note now states that only `critical` (blocker-only) and `nitpick` (show all) are distinguishable for inline findings, and that `major`/`minor` behave identically to `critical` today (not an intermediate level). The example value is changed from the misleading `major` to `critical`.
- **Regression test** (`test/unit/finding-severity-filter.test.ts`): locks in the behavior — `critical`/`major`/`minor` are equivalent for both `blocker` and `nit` inline findings, and only `nitpick` shows a `nit` — so the doc and behavior can't silently drift.

No production behavior change; a doc-accuracy fix + a lock-in test. Only the example file and a test change (no `src/**` lines), so Codecov's patch gate doesn't apply.