### PR TITLE
fix(ui): use shared LoadingState/ErrorState on the changelog page

### DIFF
--- a/apps/loopover-ui/src/routes/changelog.test.tsx
+++ b/apps/loopover-ui/src/routes/changelog.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+// #6822: changelog.tsx hand-rolled its loading/error branches (no role="status"/role="alert", no retry).
+// This mirrors github-stats-chip.test.tsx's QueryClientProvider + mocked apiFetch harness.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+  notifyApiFailure: vi.fn(),
+  notifyApiRecovered: vi.fn(),
+}));
+
+import { Changelog } from "@/routes/changelog";
+
+function renderWithClient(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+// Deliberately NOT the "0.9.0" MCP_PACKAGE_KNOWN_LATEST_VERSION fallback the component renders in its
+// always-present intro paragraph even before data loads -- using a distinct fixture version means a
+// match can only come from the real fetched data, not a loading-state false positive.
+const NPM_METADATA = {
+  "dist-tags": { latest: "1.2.0" },
+  time: { "1.2.0": "2026-07-01T00:00:00.000Z", "1.1.0": "2026-06-01T00:00:00.000Z" },
+  versions: { "1.2.0": {}, "1.1.0": {} },
+};
+
+describe("Changelog (#6822)", () => {
+  afterEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it("renders an accessible loading state (role=status), not the old plain text", async () => {
+    apiFetch.mockReturnValue(new Promise(() => {})); // never resolves -- stays in the loading state
+    renderWithClient(<Changelog />);
+
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByText("Loading from npm…")).toBeTruthy();
+  });
+
+  it("renders an accessible error state (role=alert) with a retry action that refetches, instead of the old dead-end text", async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "http",
+      status: 503,
+      message: "npm_registry_unavailable",
+      durationMs: 20,
+    });
+    renderWithClient(<Changelog />);
+
+    // useMcpPackageMetadata hardcodes retry: 1, which wins over this QueryClient's own retry: false default,
+    // so the first failure isn't final -- isError only settles true after the retried attempt also fails.
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy(), { timeout: 5000 });
+    expect(screen.getByText("Could not reach the npm registry")).toBeTruthy();
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: NPM_METADATA, status: 200, durationMs: 20 });
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    // Each version renders twice (main list card + the sticky sidebar TOC, always in the DOM regardless
+    // of the `hidden lg:` breakpoint class jsdom doesn't apply layout for), hence getAllByText.
+    await waitFor(() => expect(screen.getAllByText("v1.2.0").length).toBeGreaterThan(0));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders the version list once the npm metadata loads", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: NPM_METADATA, status: 200, durationMs: 20 });
+    renderWithClient(<Changelog />);
+
+    await waitFor(() => expect(screen.getAllByText("v1.1.0").length).toBeGreaterThan(0));
+    expect(screen.getAllByText("v1.2.0").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/routes/changelog.tsx
+++ b/apps/loopover-ui/src/routes/changelog.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Rss } from "lucide-react";
 
 import { Section, Eyebrow, Card } from "@/components/site/primitives";
+import { ErrorState, LoadingState } from "@/components/site/state-views";
 import { cn } from "@/lib/utils";
 import {
   MCP_PACKAGE_NAME,
@@ -37,8 +38,8 @@ const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-function Changelog() {
-  const { data, isLoading, isError } = useMcpPackageMetadata();
+export function Changelog() {
+  const { data, isLoading, isError, refetch } = useMcpPackageMetadata();
   const latestVersion = getLatestMcpVersion(data);
 
   const sortedVersions = data
@@ -81,14 +82,14 @@ function Changelog() {
 
       <div className="mt-12 grid gap-10 lg:grid-cols-[1fr_200px]">
         <div className="space-y-4">
-          {isLoading && (
-            <div className="text-token-sm text-muted-foreground">Loading from npm…</div>
-          )}
+          {isLoading && <LoadingState title="Loading from npm…" />}
           {isError && (
             <Card>
-              <div className="text-token-sm text-muted-foreground">
-                Could not reach the npm registry. Try again later.
-              </div>
+              <ErrorState
+                title="Could not reach the npm registry"
+                description="The npm registry didn't respond. This can happen during brief outages."
+                onRetry={() => void refetch()}
+              />
             </Card>
           )}
           {sortedVersions.map((v) => {


### PR DESCRIPTION
## Summary

- `changelog.tsx` hand-rolled its loading (`<div>`, no `role="status"`) and error (`<div>`, no `role="alert"`, no retry) branches, despite `useMcpPackageMetadata()`'s underlying `useQuery` already exposing a `refetch` a retry button could use.
- Swaps both for the shared `@loopover/ui-kit` components already used elsewhere in this app: `LoadingState` for the loading branch, `ErrorState` for the error branch, wiring `ErrorState`'s built-in `onRetry` to `refetch()` so "Try again" actually re-fetches instead of being a dead end.
- Purely presentational — the data-fetch/query logic (`useMcpPackageMetadata`, `fetchMcpPackageMetadata`) and the happy-path version-list rendering are untouched.
- Exported `Changelog` (previously a local, untested function) so it's directly testable, matching the convention already used by `PublicRepoQualityPage`/`RunHistoryPage` elsewhere in this app.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is UI-only work under `apps/**`, outside `coverage.include` per this repo's own convention, so the strict Codecov patch gate doesn't apply — confirmed by checking `vitest.config.ts`. This local Windows environment also can't run `wrangler` (`cf-typegen:check` fails with a pre-existing, change-unrelated `spawnSync wrangler ENOENT`), so `npm run test:ci` was validated step-by-step instead: `git diff --check`, `actionlint`, engine build, `typecheck`, `test:engine-parity`, `test:live-gate-parity`, `test:driver-parity`, `ui:lint`, `ui:typecheck`, `ui:build`, and the full `ui:test` workspace suite all pass clean. New tests: `apps/loopover-ui/src/routes/changelog.test.tsx` (3 tests) cover the accessible loading state (`role="status"`), the accessible error state (`role="alert"`) with a working retry that re-fetches and clears the alert, and the unaffected happy-path version list.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Captured against the local dev server (real component, real rendering) with the npm registry fetch intercepted at the browser network layer to force each state on demand — not a code-level mock in the shipped app.

| State / title | JPG/PNG evidence |
| --- | --- |
| Loading (before: plain text, no role; after: content-shaped `role="status"` with spinner) | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/changelog-loading.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/changelog-loading.png" alt="Loading state" width="480"></a> |
| Error (before: dead-end text, no role; after: `role="alert"` with a working "Try again" retry) | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/changelog-error.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/changelog-error.png" alt="Error state with retry" width="480"></a> |

## Notes

- Closes #6822
