### PR TITLE
refactor(miner-ui): use canonical text-success/warning/danger utilities

### DIFF
--- a/apps/loopover-miner-ui/src/components/chat/governor-action-result.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/governor-action-result.tsx
@@ -26,7 +26,7 @@ export function GovernorChatActionResult({
   if (result === null) return null;
   if (!result.ok) {
     return (
-      <p role="alert" className="text-token-sm text-[var(--danger)]">
+      <p role="alert" className="text-token-sm text-danger">
         {formatGovernorPauseChatMessage(result)}
       </p>
     );

--- a/apps/loopover-miner-ui/src/routes/index.tsx
+++ b/apps/loopover-miner-ui/src/routes/index.tsx
@@ -77,7 +77,7 @@ export function OverviewRunsCard({ runs }: { runs: RunHistoryResult | null }) {
             <Stat
               label="Currently working"
               value={runs.rows.filter((row) => row.state !== "idle").length}
-              tone="text-[var(--success)]"
+              tone="text-success"
             />
           </>
         )}
@@ -100,8 +100,8 @@ export function OverviewPortfolioCard({ portfolio }: { portfolio: PortfolioQueue
           <>
             <Stat label="Total items" value={portfolio.summary.total} />
             <Stat label="Queued" value={portfolio.summary.byStatus.queued} />
-            <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-[var(--warning)]" />
-            <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-[var(--success)]" />
+            <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-warning" />
+            <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-success" />
             {/* Deliver the CLI/web-UI parity the portfolio-queue data path promises (#6185): the CLI's `queue
                 dashboard` renders "oldest-queued: Xm" (portfolio-dashboard.js), and the same minutes-rounded age
                 is shown here. Omitted (like the CLI) when the queue is empty and the age is null. */}
@@ -127,7 +127,7 @@ export function OverviewClaimsCard({ claims }: { claims: LedgersResult | null })
       >
         {claims?.ok && (
           <>
-            <Stat label="Active" value={claims.summary.claims.byStatus.active} tone="text-[var(--success)]" />
+            <Stat label="Active" value={claims.summary.claims.byStatus.active} tone="text-success" />
             <Stat label="Total recorded" value={claims.summary.claims.total} />
           </>
         )}

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -45,9 +45,9 @@ const CLAIM_STATUS_LABELS: Record<ClaimStatus, string> = {
 };
 
 const CLAIM_STATUS_TONE: Record<ClaimStatus, string> = {
-  active: "text-[var(--success)]",
+  active: "text-success",
   released: "text-muted-foreground",
-  expired: "text-[var(--warning)]",
+  expired: "text-warning",
 };
 
 function CountTable({ counts, keyLabel }: { counts: Record<string, number>; keyLabel: string }) {

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -33,8 +33,8 @@ const STATUS_LABELS: Record<QueueStatus, string> = {
 
 const STATUS_TONE: Record<QueueStatus, string> = {
   queued: "text-muted-foreground",
-  in_progress: "text-[var(--warning)]",
-  done: "text-[var(--success)]",
+  in_progress: "text-warning",
+  done: "text-success",
 };
 
 /** Placeholder shaped like the real summary -- three status cards over the repo table -- so the layout doesn't
@@ -152,7 +152,7 @@ export function PortfolioQueueActionsSection({
     <section className="grid gap-3">
       <h3 className="font-display text-token-base font-semibold">Queue actions</h3>
       {actionResult !== null && !actionResult.ok ? (
-        <p role="alert" className="text-token-sm text-[var(--danger)]">
+        <p role="alert" className="text-token-sm text-danger">
           Queue action failed: {actionResult.error}
         </p>
       ) : null}


### PR DESCRIPTION
## What

Replaces the verbose `text-[var(--success)]` / `text-[var(--warning)]` / `text-[var(--danger)]`
arbitrary-value classes in `loopover-miner-ui` with the canonical `text-success` / `text-warning` /
`text-danger` utilities, matching how the rest of the design system (e.g.
`packages/loopover-ui-kit/src/components/state-views.tsx`) already writes status colors.

All 9 sites from the issue are migrated:

- `apps/loopover-miner-ui/src/routes/index.tsx` (4 — lines 80, 103, 104, 130)
- `apps/loopover-miner-ui/src/routes/portfolio.tsx` (3 — lines 36, 37, 155)
- `apps/loopover-miner-ui/src/routes/ledgers.tsx` (2 — lines 48, 50)
- `apps/loopover-miner-ui/src/components/chat/governor-action-result.tsx` (1 — line 29)

## Why no visual change

The utilities resolve to the exact same custom properties. In `packages/loopover-ui-kit/src/theme.css`:

```css
--color-success: var(--success);
--color-warning: var(--warning);
--color-danger:  var(--danger);
```

Tailwind generates `text-success` from `--color-success`, which is literally `var(--success)` — so
`text-success` and `text-[var(--success)]` produce identical rendered color. Before/after renders are
pixel-identical, so a screenshot table would show two identical images; the change is a class-name
normalization only, with no computed-style delta.

## Testing

- `@loopover/ui-miner` typecheck, ESLint (0 errors), Prettier, and full vitest suite (257 tests) pass.
- `vite build` succeeds.

Note: `apps/**` is excluded from the Codecov patch gate (`codecov.yml` `ignore: apps/**`, mirrored in
`vitest.config.ts`), so this class-only change carries no measurable `src/**` patch surface.

Closes #6823
