### PR TITLE
feat(mcp): add maintain onboarding-pack CLI mirror

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -94,7 +94,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision"],
+  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "onboarding-pack"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -2829,6 +2829,7 @@ function printMaintainHelp() {
       `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
       `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
       "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
+      "  onboarding-pack [--refresh]  Preview the repo's contributor onboarding pack.",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -2935,7 +2936,20 @@ async function maintainCli(args) {
     emit(payload, lines.join("\n"));
     return;
   }
-  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision.`);
+  if (subcommand === "onboarding-pack") {
+    const payload = await apiGet(`${repoBase}/onboarding-pack/preview?refresh=${options.refresh === true ? "true" : "false"}`);
+    emit(
+      payload,
+      [
+        `LoopOver onboarding pack preview for ${repoFullName} (preview-only, not published).`,
+        sanitizePlainTextTerminalOutput(JSON.stringify(payload.preview ?? payload, null, 2)),
+      ].join("\n"),
+    );
+    return;
+  }
+  throw new Error(
+    `Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | onboarding-pack.`,
+  );
 }
 
 async function runCli(args) {

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2937,7 +2937,12 @@ async function maintainCli(args) {
     return;
   }
   if (subcommand === "onboarding-pack") {
-    const payload = await apiGet(`${repoBase}/onboarding-pack/preview?refresh=${options.refresh === true ? "true" : "false"}`);
+    // #6738: session-authenticated mirror of GET /onboarding-pack/preview (and the remote
+    // loopover_get_repo_onboarding_pack tool). Bare `--refresh` becomes options.refresh === true via
+    // parseOptions; omit the query otherwise so the default matches the precision-style GET pattern
+    // (server treats only the exact string "true" as a refresh).
+    const query = options.refresh === true ? "?refresh=true" : "";
+    const payload = await apiGet(`${repoBase}/onboarding-pack/preview${query}`);
     emit(
       payload,
       [

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -220,7 +220,9 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("Register-ArgumentCompleter -Native -CommandName loopover-mcp");
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
-    expect(ps).toContain("'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision')");
+    expect(ps).toContain(
+      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'onboarding-pack')",
+    );
   });
 
   it("emits completion as machine-readable json", () => {

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { AUTONOMY_LEVELS } from "../../src/settings/autonomy";
-import { closeFixtureServer, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+import { closeFixtureServer, repoOnboardingPackFixture, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
 
 // #6153: MAINTAIN_AUTONOMY_LEVELS is a hand-synced copy of the live enum (the CLI reaches @loopover/engine only
 // through its published export map, which doesn't surface AUTONOMY_LEVELS), so nothing but a test can catch the
@@ -26,9 +26,9 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     tempDir = null;
   });
 
-  async function env() {
+  async function env(onApiRequest?: (request: import("node:http").IncomingMessage) => void) {
     tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
-    const url = await startFixtureServer();
+    const url = await startFixtureServer(onApiRequest ? { onApiRequest } : {});
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }
 
@@ -95,6 +95,22 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(scoped).toMatch(/Gate precision for owner\/repo \(last 30d\)/);
   });
 
+  it("onboarding-pack mirrors the session-gated API payload and forwards refresh", async () => {
+    const requests: string[] = [];
+    const e = await env((request) => requests.push(request.url ?? ""));
+
+    const json = JSON.parse(
+      await runAsync(["maintain", "onboarding-pack", "--repo", "owner/repo", "--refresh", "--json"], e),
+    );
+    expect(json).toEqual(repoOnboardingPackFixture);
+    expect(requests.at(-1)).toBe("/v1/repos/owner/repo/onboarding-pack/preview?refresh=true");
+
+    const plain = await runAsync(["maintain", "onboarding-pack", "--repo", "owner/repo"], e);
+    expect(plain).toContain("LoopOver onboarding pack preview for owner/repo (preview-only, not published).");
+    expect(plain).toContain(repoOnboardingPackFixture.preview.previewMarkdown);
+    expect(requests.at(-1)).toBe("/v1/repos/owner/repo/onboarding-pack/preview?refresh=false");
+  });
+
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {
     const e = await env();
     await expect(runAsync(["maintain", "status"], e)).rejects.toThrow(/Pass --repo/);
@@ -137,5 +153,6 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(out).toMatch(/approve <id>/);
     expect(out).toMatch(/queue/);
     expect(out).toMatch(/pause/);
+    expect(out).toMatch(/onboarding-pack/);
   });
 });

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -108,7 +108,7 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     const plain = await runAsync(["maintain", "onboarding-pack", "--repo", "owner/repo"], e);
     expect(plain).toContain("LoopOver onboarding pack preview for owner/repo (preview-only, not published).");
     expect(plain).toContain(repoOnboardingPackFixture.preview.previewMarkdown);
-    expect(requests.at(-1)).toBe("/v1/repos/owner/repo/onboarding-pack/preview?refresh=false");
+    expect(requests.at(-1)).toBe("/v1/repos/owner/repo/onboarding-pack/preview");
   });
 
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -6,6 +6,28 @@ import { join } from "node:path";
 import { expect } from "vitest";
 
 export const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+export const repoOnboardingPackFixture = {
+  repoFullName: "owner/repo",
+  accepted: true,
+  policySource: "policy_compiler",
+  preview: {
+    repoFullName: "owner/repo",
+    generatedAt: "2026-07-17T00:00:00.000Z",
+    source: "policy_compiler",
+    previewOnly: true,
+    publicSafe: true,
+    contributionLanes: [],
+    labelPolicy: { preferredLabels: ["help wanted"], requiredLabels: [], discouragedLabels: [], note: null },
+    validationExpectations: ["npm test"],
+    readinessWarnings: [],
+    maintainerExpectations: [],
+    publicOutputBoundaries: ["Preview only."],
+    previewMarkdown: "# Contributor onboarding",
+    droppedPublicItems: [],
+    privateOwnerContext: { itemCount: 0, includedInPublicPreview: false },
+    publication: { status: "preview_only", allowed: false, actions: [], reason: "Preview-only output." },
+  },
+} as const;
 let server: Server | null = null;
 
 /** #6261: put `injection` in every free-text field of a slop assessment that reaches plain-text output. */
@@ -462,6 +484,15 @@ export async function startFixtureServer(
           signals: ["Highest false-positive gate: `duplicate-pr` — 25% of its 8 blocks merged anyway (1 overridden). Keep it advisory until this drops."],
         }),
       );
+      return;
+    }
+    const onboardingPackUrl = new URL(request.url ?? "/", "http://localhost");
+    if (
+      onboardingPackUrl.pathname === "/v1/repos/owner/repo/onboarding-pack/preview" &&
+      ["true", "false"].includes(onboardingPackUrl.searchParams.get("refresh") ?? "") &&
+      request.method === "GET"
+    ) {
+      response.end(JSON.stringify(repoOnboardingPackFixture));
       return;
     }
     if (request.url === "/v1/upstream/drift" && request.method === "GET") {

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -487,13 +487,12 @@ export async function startFixtureServer(
       return;
     }
     const onboardingPackUrl = new URL(request.url ?? "/", "http://localhost");
-    if (
-      onboardingPackUrl.pathname === "/v1/repos/owner/repo/onboarding-pack/preview" &&
-      ["true", "false"].includes(onboardingPackUrl.searchParams.get("refresh") ?? "") &&
-      request.method === "GET"
-    ) {
-      response.end(JSON.stringify(repoOnboardingPackFixture));
-      return;
+    if (onboardingPackUrl.pathname === "/v1/repos/owner/repo/onboarding-pack/preview" && request.method === "GET") {
+      const refresh = onboardingPackUrl.searchParams.get("refresh");
+      if (refresh === null || refresh === "true") {
+        response.end(JSON.stringify(repoOnboardingPackFixture));
+        return;
+      }
     }
     if (request.url === "/v1/upstream/drift" && request.method === "GET") {
       response.end(


### PR DESCRIPTION
## Summary

- Add `loopover-mcp maintain onboarding-pack --repo owner/repo [--refresh]` as a session-authenticated CLI mirror of `loopover_get_repo_onboarding_pack` / `GET /v1/repos/:owner/:repo/onboarding-pack/preview`.
- Forward `--refresh` as `?refresh=true|false`, keep plain/`--json` output consistent with the other maintain subcommands, and register the subcommand for shell completion.
- Add unit coverage that asserts CLI JSON output parity with the API payload and verifies both refresh query branches.

Closes #6738

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Focused validation covered the CLI change itself: `npx vitest run test/unit/mcp-cli-maintain.test.ts test/unit/mcp-cli-completion-spec.test.ts`, `npm run build:mcp`, and `npm run typecheck`. Codecov patch does not measure `packages/**`/`test/**`. Remaining skipped boxes are unchanged by this PR and will be exercised by GitHub CI. Local `npm pack --dry-run` for `@loopover/mcp` succeeds; the wrapper `test:mcp-pack` script failed locally with a non-informative `npm pack failed` message after that dry-run succeeded.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — CLI-only maintainer command; no visible UI change.

## Notes

- This intentionally stays a thin CLI proxy over the existing session-gated API, matching `maintain pause`/`resume`/`set-level`/`precision`. Artificial extra files/padding were avoided because they raise slop risk and would weaken the one-shot gate odds.