### PR TITLE
fix(ui): add arrow-key/Enter navigation to the command palette

### DIFF
--- a/apps/loopover-ui/src/components/site/command-palette.test.tsx
+++ b/apps/loopover-ui/src/components/site/command-palette.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// #6812: the palette had no arrow-key/Enter navigation through results -- selecting a filtered result
+// required the mouse or repeated Tab. This drives the real component's keyboard handling end to end.
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigate }));
+
+import { CommandPalette, type PaletteItem } from "@/components/site/command-palette";
+
+const ITEMS: PaletteItem[] = [
+  { label: "Overview", to: "/app", group: "App" },
+  { label: "Miner command center", to: "/app/miner", group: "App" },
+  { label: "Maintainer console", to: "/app/maintainer", group: "App" },
+];
+
+function openPalette() {
+  render(<CommandPalette items={ITEMS} />);
+  fireEvent.click(screen.getByRole("button", { name: "Open command palette" }));
+  return screen.getByPlaceholderText("Search the app…");
+}
+
+describe("CommandPalette (#6812)", () => {
+  afterEach(() => {
+    navigate.mockClear();
+  });
+
+  it("marks up the results as an accessible listbox with the first result highlighted by default", () => {
+    const input = openPalette();
+    expect(input.getAttribute("role")).toBe("combobox");
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    const listbox = screen.getByRole("listbox", { name: "Command palette results" });
+    expect(listbox.id).toBeTruthy();
+    expect(input.getAttribute("aria-controls")).toBe(listbox.id);
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]!.getAttribute("aria-selected")).toBe("true");
+    expect(options[1]!.getAttribute("aria-selected")).toBe("false");
+    expect(input.getAttribute("aria-activedescendant")).toBe(options[0]!.id);
+  });
+
+  it("moves the highlight with ArrowDown/ArrowUp, wrapping at both ends", () => {
+    const input = openPalette();
+    const options = screen.getAllByRole("option");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(options[1]!.getAttribute("aria-selected")).toBe("true");
+    expect(input.getAttribute("aria-activedescendant")).toBe(options[1]!.id);
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // wraps past the last option back to the first
+    expect(options[0]!.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "ArrowUp" }); // wraps backward past the first option to the last
+    expect(options[2]!.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("navigates to the highlighted result on Enter", () => {
+    const input = openPalette();
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // highlight "Miner command center"
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith({ to: "/app/miner" });
+  });
+
+  it("filters results and resets the highlight to the first match, then Enter navigates to it", () => {
+    const input = openPalette();
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // highlight index 1 before filtering
+    fireEvent.change(input, { target: { value: "maintainer" } });
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]!.textContent).toContain("Maintainer console");
+    expect(options[0]!.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(navigate).toHaveBeenCalledWith({ to: "/app/maintainer" });
+  });
+
+  it("does not navigate on Enter when no result matches the filter", () => {
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: "no such route anywhere" } });
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+    expect(screen.getByText("No matches")).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("syncs the highlight to mouse hover", () => {
+    const input = openPalette();
+    const options = screen.getAllByRole("option");
+    fireEvent.mouseEnter(options[2]!);
+    expect(options[2]!.getAttribute("aria-selected")).toBe("true");
+    expect(input.getAttribute("aria-activedescendant")).toBe(options[2]!.id);
+  });
+});

--- a/apps/loopover-ui/src/components/site/command-palette.tsx
+++ b/apps/loopover-ui/src/components/site/command-palette.tsx
@@ -1,9 +1,13 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Command, ArrowRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+
+/** id prefix for each result's `role="option"` element, referenced by the input's `aria-activedescendant`. */
+const OPTION_ID_PREFIX = "command-palette-option-";
+const LISTBOX_ID = "command-palette-listbox";
 
 export interface PaletteItem {
   label: string;
@@ -68,10 +72,11 @@ const DEFAULT_ITEMS: PaletteItem[] = [
 export function CommandPalette({ items = DEFAULT_ITEMS }: { items?: PaletteItem[] }) {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
+    const onKey = (e: globalThis.KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setOpen((v) => !v);
@@ -87,6 +92,32 @@ export function CommandPalette({ items = DEFAULT_ITEMS }: { items?: PaletteItem[
     if (!term) return items;
     return items.filter((i) => `${i.label} ${i.group ?? ""}`.toLowerCase().includes(term));
   }, [q, items]);
+
+  // The highlighted result resets whenever the filtered set changes or the palette re-opens, so a
+  // stale index from a previous, longer list can never point past the current end.
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [filtered, open]);
+
+  function selectItem(item: PaletteItem | undefined) {
+    if (!item) return;
+    setOpen(false);
+    navigate({ to: item.to });
+  }
+
+  function onInputKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (filtered.length > 0) setHighlightedIndex((i) => (i + 1) % filtered.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (filtered.length > 0)
+        setHighlightedIndex((i) => (i - 1 + filtered.length) % filtered.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      selectItem(filtered[highlightedIndex]);
+    }
+  }
 
   return (
     <>
@@ -123,26 +154,40 @@ export function CommandPalette({ items = DEFAULT_ITEMS }: { items?: PaletteItem[
                 autoFocus
                 value={q}
                 onChange={(e) => setQ(e.target.value)}
+                onKeyDown={onInputKeyDown}
                 placeholder="Search the app…"
+                role="combobox"
+                aria-expanded={open}
+                aria-controls={LISTBOX_ID}
+                aria-activedescendant={
+                  filtered[highlightedIndex] ? `${OPTION_ID_PREFIX}${highlightedIndex}` : undefined
+                }
                 className="w-full border-b border-border bg-transparent px-4 py-3 text-token-sm outline-none placeholder:text-muted-foreground"
               />
-              <ul className="max-h-[60vh] overflow-auto p-2">
+              <ul
+                id={LISTBOX_ID}
+                role="listbox"
+                aria-label="Command palette results"
+                className="max-h-[60vh] overflow-auto p-2"
+              >
                 {filtered.length === 0 && (
                   <li className="px-3 py-6 text-center text-token-sm text-muted-foreground">
                     No matches
                   </li>
                 )}
-                {filtered.map((i) => (
-                  <li key={i.to}>
+                {filtered.map((i, index) => (
+                  <li key={i.to} role="presentation">
                     <button
+                      id={`${OPTION_ID_PREFIX}${index}`}
+                      role="option"
+                      aria-selected={index === highlightedIndex}
                       type="button"
-                      onClick={() => {
-                        setOpen(false);
-                        navigate({ to: i.to });
-                      }}
+                      onClick={() => selectItem(i)}
+                      onMouseEnter={() => setHighlightedIndex(index)}
                       className={cn(
                         "flex w-full items-center justify-between gap-3 rounded-token px-3 py-2 text-left text-token-sm transition-colors",
                         "text-foreground/90 hover:bg-accent hover:text-foreground",
+                        index === highlightedIndex && "bg-accent text-foreground",
                       )}
                     >
                       <span className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- `command-palette.tsx` rendered a search input with no `onKeyDown` followed by a plain `<ul>` of result buttons — no `role="listbox"`/`role="option"`, no `aria-activedescendant`, no ArrowUp/ArrowDown/Enter handling. Selecting a filtered result required the mouse or repeated Tab through every button.
- Adds a `highlightedIndex` state driven by ArrowUp/ArrowDown on the search input (wrapping at both ends), with Enter navigating to the highlighted result. The highlighted index resets to `0` whenever the filtered set changes or the palette re-opens, so a stale index from a longer previous list can never point past the current end.
- Marks the results as an accessible listbox: `role="combobox"` + `aria-expanded` + `aria-controls` on the input, `role="listbox"` on the `<ul>`, `role="option"` + `aria-selected` on each result, and `aria-activedescendant` on the input tracking the highlighted option's id — the standard ARIA APG pattern for a search-with-listbox widget.
- Mouse hover stays in sync with the same `highlightedIndex` state, so keyboard and mouse never disagree about which result is "active".
- Kept the existing hand-rolled structure (framer-motion animation, group badges, styling) rather than migrating to `cmdk`/`@loopover/ui-kit`'s `Command` component — the issue offered both as valid options; this is the smaller, lower-risk diff that doesn't touch the existing visual design.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is UI-only work under `apps/**`, outside `coverage.include` per this repo's own convention (confirmed via `vitest.config.ts`), so the strict Codecov patch gate doesn't apply. This local Windows environment also can't run `wrangler` (`cf-typegen:check` fails with a pre-existing, change-unrelated `spawnSync wrangler ENOENT`), so `npm run test:ci` was validated step-by-step instead: `git diff --check`, `actionlint`, `typecheck`, `test:engine-parity`, `test:live-gate-parity`, `test:driver-parity`, `ui:lint`, `ui:typecheck`, `ui:build`, and the full `ui:test` workspace suite (all files, not just this one) all pass clean. New tests: `apps/loopover-ui/src/components/site/command-palette.test.tsx` (6 tests) cover the listbox/combobox ARIA markup and default highlight, ArrowDown/ArrowUp movement with wraparound at both ends, Enter navigating to the highlighted result, the highlight resetting to the first match on a new filter query, no navigation on Enter when nothing matches, and mouse-hover sync.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Captured against the local dev server with the real component (no mocking) — typed "self-host" into the palette, then pressed ArrowDown twice.

| State / title | JPG/PNG evidence |
| --- | --- |
| First result highlighted by default | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/palette-first-highlighted.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/palette-first-highlighted.png" alt="First result highlighted" width="480"></a> |
| Highlight moved to the 3rd result after 2x ArrowDown | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/palette-third-highlighted.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/palette-third-highlighted.png" alt="Third result highlighted after ArrowDown" width="480"></a> |

## Notes

- Closes #6812
