### PR TITLE
refactor(queue): consolidate bounded-concurrency helpers onto mapWithConcurrency

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -194,8 +194,6 @@ import {
 } from "../services/control-panel-roles";
 import { runFindOpportunities, validateFindOpportunitiesInput, type FindOpportunitiesInput } from "../mcp/find-opportunities";
 import { runIssueRagRetrieval, validateIssueRagInput, type IssueRagInput } from "../mcp/issue-rag";
-import { buildFindingTaxonomyDocument } from "../review/finding-taxonomy";
-import { buildEnrichmentAnalyzersTaxonomyDocument } from "../review/enrichment-analyzers-taxonomy";
 import { loadPrAiReviewFindings } from "../mcp/pr-ai-review-findings";
 import {
   buildMcpCompatibilityMetadata,

--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -1,5 +1,6 @@
 import type { FileFetcher } from "../review/review-grounding";
 import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
+import { mapWithConcurrency } from "./map-with-concurrency";
 
 /** Per-file cap when synthesizing a patch for GitHub's patch-less (binary/large) PR files. */
 export const SECRET_SCAN_PATCH_FALLBACK_MAX_CHARS = 512_000;
@@ -159,17 +160,7 @@ async function mapPatchLessSecretScanFilesWithConcurrency<T, R>(
   limit: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /** When GitHub omits inline `patch` (binary/large files), fetch post-change content and synthesize `+` lines so

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -3,6 +3,7 @@ import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { contentLaneConfigToJson, experimentalConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, maintainerRecapConfigToJson, opsConfigToJson, publicStatsConfigToJson, draftFlowConfigToJson, upstreamDriftIssuesConfigToJson, sweepWatchdogConfigToJson, prReconciliationConfigToJson, federatedIntelligenceConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
 import { LOOPOVER_REPO_FOCUS_MANIFEST_YAML, resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 import type { LocalManifestLoadResult } from "../selfhost/private-config";
 
 export const REPO_FOCUS_MANIFEST_SIGNAL = "repo-focus-manifest";
@@ -237,17 +238,7 @@ async function readBoundedResponseText(response: Response): Promise<string | nul
 
 /** Bounded-concurrency fan-out: runs `mapper` over `items` with at most `limit` in flight at once (#3899). */
 export async function mapWithConcurrencyLimit<T, U>(items: T[], limit: number, mapper: (item: T) => Promise<U>): Promise<U[]> {
-  const results: U[] = new Array(items.length);
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(items[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
+  return mapWithConcurrency(items, limit, mapper);
 }
 
 /**


### PR DESCRIPTION
## What

**Primary (Fixes #6602):** consolidate the two hand-duplicated bounded-concurrency worker-pool loops onto the canonical `mapWithConcurrency` in `src/queue/map-with-concurrency.ts`:

- `src/signals/focus-manifest-loader.ts` — `mapWithConcurrencyLimit` now delegates
- `src/queue/patchless-secret-scan.ts` — `mapPatchLessSecretScanFilesWithConcurrency` now delegates

Both keep their exported names and `(items, limit, mapper)` signatures, so every call site is unchanged. Pure internal consolidation, already exercised transitively by existing suites.

**Prerequisite build fix:** `src/api/routes.ts` imported `buildFindingTaxonomyDocument` and `buildEnrichmentAnalyzersTaxonomyDocument` twice (lines 10-11 and again ~197-198), which `tsc` rejects as duplicate identifiers (TS2300). That break is on `main` today and turns `typecheck` — and every `validate` / `validate-tests` job — red, so *no* PR can go green until it is removed. This PR drops the second copy (the top-of-file declarations already provide both symbols); the concurrency consolidation and the checks that gate it then pass.

## Scope note

The `routes.ts` change is a one-line-pair deletion required for CI to be green at all — it introduces no behavior, only removes a duplicate import that is already breaking the build on `main`.

Fixes #6602
