### PR TITLE
feat(miner-ui): adopt chart and pagination on the ledgers route (#6832)

### DIFF
--- a/apps/loopover-miner-ui/package.json
+++ b/apps/loopover-miner-ui/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-router": "^1.170.17",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "recharts": "^2.15.4",
     "tailwindcss": "^4.3.2",
     "tw-animate-css": "^1.4.0",
     "vite-tsconfig-paths": "^6.1.1"

--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -87,6 +87,18 @@ describe("emptyLedgersSummary (#4855)", () => {
   });
 });
 
+function manyEventTypes(count: number): Record<string, number> {
+  return Object.fromEntries(Array.from({ length: count }, (_, index) => [`event_type_${index}`, count - index]));
+}
+
+function manyRecentEvents(count: number): LedgersSummary["events"]["recent"] {
+  return Array.from({ length: count }, (_, index) => ({
+    eventType: `event_type_${index}`,
+    repoFullName: index % 2 === 0 ? `acme/repo-${index}` : null,
+    createdAt: index % 3 === 0 ? null : `2026-07-10T06:${String(index).padStart(2, "0")}:00.000Z`,
+  }));
+}
+
 describe("LedgersView (#4855)", () => {
   it("renders claim status counts, the governor type table, the events-by-type table, and the recent-events feed", () => {
     render(<LedgersView result={{ ok: true, summary: fixtureSummary }} />);
@@ -99,6 +111,11 @@ describe("LedgersView (#4855)", () => {
     expect(screen.getAllByText("attempt_succeeded").length).toBe(2);
     expect(screen.getAllByText("attempt_started").length).toBe(2);
     expect(screen.getAllByText("acme/widgets").length).toBeGreaterThan(0);
+  });
+
+  it("renders a claims-by-status chart via the ui-kit ChartContainer (#6832)", () => {
+    render(<LedgersView result={{ ok: true, summary: fixtureSummary }} />);
+    expect(screen.getByLabelText("Claims by status chart")).toBeTruthy();
   });
 
   it("renders the fresh-install empty state when every ledger is empty", () => {
@@ -116,6 +133,86 @@ describe("LedgersView (#4855)", () => {
     render(<LedgersView result={null} />);
     expect(screen.getByRole("status", { name: /loading local ledgers/i })).toBeTruthy();
     expect(screen.queryByText("Loading local ledgers…")).toBeNull(); // the pre-#6512 sentence is gone
+  });
+
+  it("does not paginate count/feed tables at or below 20 rows (#6832)", () => {
+    // Only events-by-type + recent feed are populated (20 each) so type labels stay unique across tables.
+    const summary: LedgersSummary = {
+      claims: { total: 1, byStatus: { active: 1, released: 0, expired: 0 } },
+      events: {
+        total: 20,
+        byType: manyEventTypes(20),
+        recent: manyRecentEvents(20),
+      },
+      governor: { total: 0, byEventType: {} },
+    };
+    render(<LedgersView result={{ ok: true, summary }} />);
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).toBeNull();
+    // Each type appears twice (count table + recent feed); both ends of the range must be visible.
+    expect(screen.getAllByText("event_type_0").length).toBe(2);
+    expect(screen.getAllByText("event_type_19").length).toBe(2);
+  });
+
+  it("paginates the events-by-type CountTable client-side above 20 rows (#6832)", () => {
+    const summary: LedgersSummary = {
+      claims: { total: 1, byStatus: { active: 1, released: 0, expired: 0 } },
+      events: {
+        total: 45,
+        byType: manyEventTypes(45),
+        recent: [],
+      },
+      governor: { total: 0, byEventType: {} },
+    };
+    render(<LedgersView result={{ ok: true, summary }} />);
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeTruthy();
+    // Sorted descending by count: event_type_0 has the highest count and appears first.
+    expect(screen.getByText("event_type_0")).toBeTruthy();
+    expect(screen.queryByText("event_type_20")).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: "2" }));
+    expect(screen.getByText("event_type_20")).toBeTruthy();
+    expect(screen.queryByText("event_type_0")).toBeNull();
+  });
+
+  it("paginates the recent-events feed client-side above 20 rows, with null column fallbacks (#6832)", () => {
+    const summary: LedgersSummary = {
+      claims: { total: 1, byStatus: { active: 1, released: 0, expired: 0 } },
+      events: {
+        total: 45,
+        byType: { attempt_started: 45 },
+        recent: manyRecentEvents(45),
+      },
+      governor: { total: 0, byEventType: {} },
+    };
+    render(<LedgersView result={{ ok: true, summary }} />);
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeTruthy();
+    expect(screen.getByText("event_type_0")).toBeTruthy();
+    expect(screen.queryByText("event_type_20")).toBeNull();
+    // Null repo/createdAt render as em-dashes (odd indices / multiples of 3 on page 1).
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("link", { name: "2" }));
+    expect(screen.getByText("event_type_20")).toBeTruthy();
+    expect(screen.queryByText("event_type_0")).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: "3" }));
+    expect(screen.getByText("event_type_40")).toBeTruthy();
+  });
+
+  it("paginates the governor-events CountTable independently of the events tables (#6832)", () => {
+    const summary: LedgersSummary = {
+      claims: { total: 1, byStatus: { active: 1, released: 0, expired: 0 } },
+      events: { total: 0, byType: {}, recent: [] },
+      governor: { total: 45, byEventType: manyEventTypes(45) },
+    };
+    render(<LedgersView result={{ ok: true, summary }} />);
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeTruthy();
+    expect(screen.getByText("event_type_0")).toBeTruthy();
+    expect(screen.queryByText("event_type_20")).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: "2" }));
+    expect(screen.getByText("event_type_20")).toBeTruthy();
+    // Previous / Next buttons also advance the page (covers both onClick arms).
+    fireEvent.click(screen.getByRole("link", { name: /go to previous page/i }));
+    expect(screen.getByText("event_type_0")).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: /go to next page/i }));
+    expect(screen.getByText("event_type_20")).toBeTruthy();
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -1,9 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@loopover/ui-kit/components/chart";
 import { Input } from "@loopover/ui-kit/components/input";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@loopover/ui-kit/components/pagination";
 import { Skeleton } from "@loopover/ui-kit/components/skeleton";
 import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
@@ -12,6 +27,8 @@ import {
   CLAIM_STATUSES,
   fetchLedgers,
   type ClaimStatus,
+  type ClaimStatusCounts,
+  type EventFeedEntry,
   type LedgersResult,
   type LedgersSummary,
 } from "../lib/ledgers";
@@ -29,9 +46,12 @@ export const Route = createFileRoute("/ledgers")({
 // governor control section) are each replaced by the shared @loopover/ui-kit `StateBoundary`, with a
 // content-shaped `Skeleton` placeholder for the loading state so the layout doesn't jump when the poll resolves.
 // The two flows keep their OWN independent boundary — a governor-state fetch failure must not blank the ledger
-// summary, and vice-versa. Purely presentational: `lib/ledgers.ts`/`lib/governor.ts`, the two fetch loops, and
-// the pause/resume Button wiring are untouched; only the loading/error chrome and the governor-control layout
-// change.
+// summary, and vice-versa.
+//
+// #6832: claims status cards gain a ui-kit `ChartContainer` bar chart (so the bare numbers aren't the only
+// signal), and both event count-tables + the recent-events feed paginate client-side via the kit's `Pagination`
+// once they exceed PAGE_SIZE rows — matching the run-history restyle (#6510). Purely presentational:
+// `lib/ledgers.ts`/`lib/governor.ts`, the two fetch loops, and the pause/resume Button wiring stay untouched.
 //
 // The governor control section below is a SEPARATE fetch/action loop from the read-only ledger summary above
 // (#4857, the governor half): it reads/writes the governor's pause state via vite-governor-api.ts, the
@@ -50,32 +70,167 @@ const CLAIM_STATUS_TONE: Record<ClaimStatus, string> = {
   expired: "text-warning",
 };
 
-function CountTable({ counts, keyLabel }: { counts: Record<string, number>; keyLabel: string }) {
-  const entries = Object.entries(counts).sort(([, a], [, b]) => b - a);
+/** Rows per page once a count/feed table grows past this; below it the full table renders unpaginated. */
+const PAGE_SIZE = 20;
+
+const CLAIMS_CHART_CONFIG = {
+  count: { label: "Claims" },
+  active: { label: "Active", color: "var(--success)" },
+  released: { label: "Released", color: "var(--muted-foreground)" },
+  expired: { label: "Expired", color: "var(--warning)" },
+} satisfies ChartConfig;
+
+function TablePagination({
+  page,
+  pageCount,
+  onPageChange,
+}: {
+  page: number;
+  pageCount: number;
+  onPageChange: (next: number) => void;
+}) {
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>{keyLabel}</TableHead>
-          <TableHead>Count</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {entries.map(([type, count]) => (
-          <TableRow key={type}>
-            <TableCell className="font-mono text-foreground">{type}</TableCell>
-            <TableCell>{count}</TableCell>
-          </TableRow>
+    <Pagination className="mt-4">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            href="#"
+            aria-disabled={page === 0}
+            onClick={(event) => {
+              event.preventDefault();
+              onPageChange(Math.max(0, page - 1));
+            }}
+          />
+        </PaginationItem>
+        {Array.from({ length: pageCount }).map((_, index) => (
+          <PaginationItem key={index}>
+            <PaginationLink
+              href="#"
+              isActive={index === page}
+              onClick={(event) => {
+                event.preventDefault();
+                onPageChange(index);
+              }}
+            >
+              {index + 1}
+            </PaginationLink>
+          </PaginationItem>
         ))}
-      </TableBody>
-    </Table>
+        <PaginationItem>
+          <PaginationNext
+            href="#"
+            aria-disabled={page >= pageCount - 1}
+            onClick={(event) => {
+              event.preventDefault();
+              onPageChange(Math.min(pageCount - 1, page + 1));
+            }}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
   );
 }
 
-/** Card+table-shaped loading placeholder for the ledger summary: mirrors the 3 status cards and the stacked
- *  count/feed tables below them, so the summary keeps its shape while the first fetch resolves. `role="status"`
- *  keeps the loading state announced to assistive tech (as the flat "Loading local ledgers…" text it replaces
- *  was). */
+function CountTable({ counts, keyLabel }: { counts: Record<string, number>; keyLabel: string }) {
+  const [page, setPage] = useState(0);
+  const entries = Object.entries(counts).sort(([, a], [, b]) => b - a);
+  const pageCount = Math.max(1, Math.ceil(entries.length / PAGE_SIZE));
+  const isPaginated = entries.length > PAGE_SIZE;
+  const safePage = Math.min(page, pageCount - 1);
+  const visible = isPaginated ? entries.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE) : entries;
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{keyLabel}</TableHead>
+            <TableHead>Count</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visible.map(([type, count]) => (
+            <TableRow key={type}>
+              <TableCell className="font-mono text-foreground">{type}</TableCell>
+              <TableCell>{count}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {isPaginated && <TablePagination page={safePage} pageCount={pageCount} onPageChange={setPage} />}
+    </div>
+  );
+}
+
+function RecentEventsTable({ entries }: { entries: EventFeedEntry[] }) {
+  const [page, setPage] = useState(0);
+  const pageCount = Math.max(1, Math.ceil(entries.length / PAGE_SIZE));
+  const isPaginated = entries.length > PAGE_SIZE;
+  const safePage = Math.min(page, pageCount - 1);
+  const visible = isPaginated ? entries.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE) : entries;
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Event type</TableHead>
+            <TableHead>Repository</TableHead>
+            <TableHead>Recorded</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visible.map((entry, index) => (
+            <TableRow key={`${entry.eventType}-${entry.createdAt ?? index}`}>
+              <TableCell className="font-mono text-foreground">{entry.eventType}</TableCell>
+              <TableCell className="font-mono">{entry.repoFullName ?? "—"}</TableCell>
+              <TableCell>{entry.createdAt ?? "—"}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {isPaginated && <TablePagination page={safePage} pageCount={pageCount} onPageChange={setPage} />}
+    </div>
+  );
+}
+
+/** Horizontal bar chart of claim status counts — the chart.tsx adoption for the claims cards section (#6832).
+ *  Cards still show the exact numbers; the chart is the glanceable breakdown the bare `<dd>`s alone weren't. */
+function ClaimsStatusChart({ byStatus }: { byStatus: ClaimStatusCounts }) {
+  const data = CLAIM_STATUSES.map((status) => ({
+    status,
+    label: CLAIM_STATUS_LABELS[status],
+    count: byStatus[status],
+  }));
+  return (
+    <ChartContainer
+      config={CLAIMS_CHART_CONFIG}
+      className="aspect-auto h-40 w-full"
+      aria-label="Claims by status chart"
+    >
+      <BarChart data={data} layout="vertical" margin={{ left: 4, right: 12, top: 4, bottom: 4 }}>
+        <XAxis type="number" hide />
+        <YAxis
+          type="category"
+          dataKey="label"
+          width={72}
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+        />
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+        <Bar dataKey="count" radius={4}>
+          {data.map((entry) => (
+            <Cell key={entry.status} fill={`var(--color-${entry.status})`} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+/** Card+chart+table-shaped loading placeholder for the ledger summary: mirrors the 3 status cards, the claims
+ *  chart, and the stacked count/feed tables below them, so the summary keeps its shape while the first fetch
+ *  resolves. `role="status"` keeps the loading state announced to assistive tech (as the flat "Loading local
+ *  ledgers…" text it replaces was). */
 function LedgerSummarySkeleton() {
   return (
     <div className="grid gap-6" role="status" aria-label="Loading local ledgers">
@@ -91,6 +246,7 @@ function LedgerSummarySkeleton() {
             </Card>
           ))}
         </div>
+        <Skeleton className="h-40 w-full" />
       </section>
       {Array.from({ length: 2 }).map((_, index) => (
         <section key={index} className="grid gap-3">
@@ -138,6 +294,7 @@ function LedgersSummaryContent({ summary }: { summary: LedgersSummary }) {
             </Card>
           ))}
         </dl>
+        <ClaimsStatusChart byStatus={claims.byStatus} />
       </section>
 
       <section className="grid gap-3">
@@ -163,24 +320,7 @@ function LedgersSummaryContent({ summary }: { summary: LedgersSummary }) {
         {events.recent.length === 0 ? (
           <p className="text-token-sm text-muted-foreground">No event-ledger entries recorded.</p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Event type</TableHead>
-                <TableHead>Repository</TableHead>
-                <TableHead>Recorded</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {events.recent.map((entry, index) => (
-                <TableRow key={`${entry.eventType}-${entry.createdAt ?? index}`}>
-                  <TableCell className="font-mono text-foreground">{entry.eventType}</TableCell>
-                  <TableCell className="font-mono">{entry.repoFullName ?? "—"}</TableCell>
-                  <TableCell>{entry.createdAt ?? "—"}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <RecentEventsTable entries={events.recent} />
         )}
       </section>
     </div>

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -4,12 +4,7 @@ import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  type ChartConfig,
-} from "@loopover/ui-kit/components/chart";
+import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@loopover/ui-kit/components/chart";
 import { Input } from "@loopover/ui-kit/components/input";
 import {
   Pagination,

--- a/apps/loopover-miner-ui/vitest.config.ts
+++ b/apps/loopover-miner-ui/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",

--- a/apps/loopover-miner-ui/vitest.setup.ts
+++ b/apps/loopover-miner-ui/vitest.setup.ts
@@ -1,0 +1,17 @@
+﻿import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Unmount React trees between tests so jsdom state never leaks across cases.
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom has no ResizeObserver -- recharts' ResponsiveContainer (used by ChartContainer on the ledgers
+// claims chart, #6832) needs one to mount at all. A no-op stub is the standard fix: it never actually
+// resizes in a test DOM, and no test here asserts on a resize-driven re-render, only on the rendered markup.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "@tanstack/react-router": "^1.170.17",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "recharts": "^2.15.4",
         "tailwindcss": "^4.3.2",
         "tw-animate-css": "^1.4.0",
         "vite-tsconfig-paths": "^6.1.1"


### PR DESCRIPTION
## Summary

Restyles the miner-ui **Ledgers** route (#6832) to finish the visual/ui-kit track on top of the #6512 StateBoundary/Skeleton work: claims cards get a ui-kit `ChartContainer` bar chart, and both event count-tables plus the recent-events feed paginate client-side via `Pagination` once they exceed 20 rows — matching the run-history restyle (#6510).

## Behavior

- **Claims** → status cards unchanged for exact counts; a horizontal bar chart (`ChartContainer` + recharts) shows the Active / Released / Expired breakdown. Loading skeleton includes a chart-shaped block.
- **Event tables** → governor-events CountTable, events-by-type CountTable, and recent-events feed each paginate client-side above 20 rows; full table below that. No new API route/param.
- **Async chrome** → shared `StateBoundary` (already from #6512) kept for both independent ledger-summary and governor-control flows.
- **Untouched:** `lib/ledgers.ts`, `lib/governor.ts`, both fetch loops, and pause/resume Button wiring — presentation-only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`
- [x] I linked a currently open issue this PR resolves — Closes #6832

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow changes)
- [ ] `npm run typecheck` (root; miner-ui typecheck has a pre-existing `vite-chat-api.ts` cast issue unrelated to this diff)
- [ ] `npm run test:coverage` (N/A — `apps/**` is outside Codecov `coverage.include`)
- [ ] `npm run test:workers` / MCP / ui:* (N/A — miner-ui-only change)
- [x] New or changed behavior has unit tests for chart mount, pagination absent ≤20 / present >20, Previous/Next, and null column fallbacks
- [x] `npm --workspace @loopover/ui-miner run test` green (coverage floors met)

If any required check was skipped, explain why:
Miner-ui-only restyle under `apps/loopover-miner-ui/**` (outside Codecov `src/**`). Local verification is the workspace vitest suite + UI screenshots below.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed
- [x] Public GitHub text stays sanitized
- [x] Auth/CORS unchanged
- [x] API/OpenAPI/MCP unchanged
- [x] UI uses live local API data / real empty/error/loading states
- [ ] Visible UI changes include a `UI Evidence` section — **fill with hosted JPG/PNG before opening**
- [x] No changelog / `site/` / `CNAME` edits

## UI Evidence

<img width="1920" height="3395" alt="image" src="https://github.com/user-attachments/assets/011d6c12-62e6-42ae-a27b-9d3c31f440ea" />


## Notes

Closes #6832. Epic #6504.