### PR TITLE
feat(mcp): add a loopover_get_repo_outcome_patterns CLI mirror

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -895,6 +895,13 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Return the reviewability report for an open PR: how ready it is to review/merge, the blocking or advisory signals against it, and its lane/duplicate/linked-issue context. Metadata-only, no GitHub writes.",
   },
   {
+    // #6734: mirrors the remote server's own loopover_get_repo_outcome_patterns descriptor verbatim, so the two
+    // surfaces describe the same tool identically rather than drifting into two wordings of one thing.
+    name: "loopover_get_repo_outcome_patterns",
+    category: "maintainer",
+    description: "Return cached or freshly-computed per-repo accepted/rejected PR outcome patterns: what maintainers actually merge or close, separated from maintainer-lane activity, with a freshness marker and explicit evidence-completeness.",
+  },
+  {
     name: "loopover_get_pr_ai_review_findings",
     category: "review",
     description:
@@ -1345,6 +1352,22 @@ registerStdioTool(
   async ({ owner, repo, number }) => {
     const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
     return toolResult("LoopOver PR reviewability.", await apiGet(`${prefix}/pulls/${number}/reviewability`));
+  },
+);
+
+// #6734: CLI mirror of the remote server's loopover_get_repo_outcome_patterns. The route is the single source
+// of truth (GET /v1/repos/:owner/:repo/outcome-patterns delegates to the same getRepoOutcomePatterns the MCP
+// server uses); this tool only proxies it, so the two surfaces cannot compute different answers. The route is
+// public/unauthenticated, so — unlike the maintainer tools above — there is nothing to scope here.
+registerStdioTool(
+  "loopover_get_repo_outcome_patterns",
+  {
+    description: stdioToolDescription("loopover_get_repo_outcome_patterns"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }) => {
+    const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    return toolResult("LoopOver repo outcome patterns.", await apiGet(`${prefix}/outcome-patterns`));
   },
 );
 

--- a/test/unit/mcp-cli-outcome-patterns.test.ts
+++ b/test/unit/mcp-cli-outcome-patterns.test.ts
@@ -1,0 +1,100 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// Mirrors mcp-cli-pr-reviewability.test.ts's shape: drive the REAL stdio server over the MCP client and assert
+// what reached the fixture API, so the proxy is pinned end-to-end rather than by unit-testing a closure.
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+const FORBIDDEN_PUBLIC_TERMS = /wallet\s*[:=]\s*\S+|hotkey\s*[:=]\s*\S+|coldkey\s*[:=]\s*\S+|raw trust score is|your trust score|reward estimate is|estimated reward/i;
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+let capturedRequests: Array<{ url: string; method: string }>;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-outcome-patterns-"));
+  capturedRequests = [];
+  const apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/outcome-patterns")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...process.env,
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_API_TIMEOUT_MS: "5000",
+    },
+  });
+  client = new Client({ name: "outcome-patterns-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+async function disconnect() {
+  await client.close().catch(() => undefined);
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+}
+
+describe("loopover_get_repo_outcome_patterns stdio proxy (#6734)", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("registers the tool in the stdio server tool list", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("loopover_get_repo_outcome_patterns");
+  });
+
+  it("proxies owner/repo to GET /v1/repos/:owner/:repo/outcome-patterns via apiGet", async () => {
+    const result = await client.callTool({
+      name: "loopover_get_repo_outcome_patterns",
+      arguments: { owner: "owner", repo: "repo" },
+    });
+    expect(capturedRequests.length).toBe(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.url).toContain("/v1/repos/owner/repo/outcome-patterns");
+    expect(captured.method).toBe("GET");
+    expect(result.isError).toBeFalsy();
+    const text = JSON.stringify(result);
+    expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("returns the route's payload unchanged — output parity with the REST/MCP surfaces", async () => {
+    // The issue's parity requirement: the CLI must not reshape, filter or summarize what the route returns, so
+    // the same input yields the same answer on every surface. Asserted field-by-field rather than by a
+    // substring, since a proxy that dropped `freshness` or `evidenceComplete` would still "contain" the rest.
+    const result = await client.callTool({
+      name: "loopover_get_repo_outcome_patterns",
+      arguments: { owner: "owner", repo: "repo" },
+    });
+    // structuredContent is the route's payload verbatim (toolResult copies `data` onto it), so this pins the
+    // real contract rather than re-parsing the human-readable summary+JSON text block.
+    expect(result.structuredContent).toMatchObject({
+      repoFullName: "owner/repo",
+      freshness: { computedAt: "2026-05-30T00:00:00.000Z", stale: false },
+      evidenceComplete: true,
+      accepted: [{ pattern: "small, single-purpose diffs with a linked issue", support: 12 }],
+      rejected: [{ pattern: "unlinked drive-by refactors", support: 4 }],
+    });
+  });
+
+  it("percent-encodes owner/repo into the path", async () => {
+    // encodeURIComponent is what stops a crafted owner/repo from escaping its path segment.
+    await client.callTool({
+      name: "loopover_get_repo_outcome_patterns",
+      arguments: { owner: "own er", repo: "re/po" },
+    });
+    expect(capturedRequests[0]?.url).toContain("/v1/repos/own%20er/re%2Fpo/outcome-patterns");
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -12,6 +12,10 @@
 // (#6732 registered the loopover_monitor_open_prs CLI mirror, taking the count from 63 to 64.)
 // (#6752 registered the loopover_build_results_payload CLI mirror, taking the count from 67 to 68.)
 // (#6755 registered the loopover_intake_idea CLI mirror, taking the count from 68 to 69.)
+// (A tool then landed WITHOUT its own note here, so the live server already registered 70 while this file
+//  still pinned 69 -- this suite was failing on `main` because of that gap, not because of any one PR. #6734
+//  re-pins it to the number the server actually registers.)
+// (#6734 registered the repo-outcome-patterns CLI mirror, taking the count from 70 to 71.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -55,14 +59,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 69 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 71 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(69);
+    expect(primary.length).toBe(71);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(69);
+    expect(names.length).toBe(71);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -72,11 +76,11 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 69-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 71-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(69);
+    expect(payload.count).toBe(71);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual([...tools.map((t) => t.name)].sort());
   });
 });

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -468,6 +468,20 @@ export async function startFixtureServer(
       response.end(JSON.stringify({ repoFullName: "owner/repo", agentPaused: body.agentPaused === true, ...(body.autonomy ? { autonomy: body.autonomy } : {}) }));
       return;
     }
+    // #6734 repo outcome patterns (public/unauthenticated, read-only). Mirrors the route's real payload shape:
+    // accepted/rejected pattern buckets plus the freshness + evidence-completeness markers.
+    if (request.url?.startsWith("/v1/repos/owner/repo/outcome-patterns") && request.method === "GET") {
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          freshness: { computedAt: "2026-05-30T00:00:00.000Z", stale: false },
+          evidenceComplete: true,
+          accepted: [{ pattern: "small, single-purpose diffs with a linked issue", support: 12 }],
+          rejected: [{ pattern: "unlinked drive-by refactors", support: 4 }],
+        }),
+      );
+      return;
+    }
     // #554 gate precision telemetry (read-only). Echoes ?windowDays so the CLI window pass-through is testable.
     if (request.url?.startsWith("/v1/repos/owner/repo/gate-precision") && request.method === "GET") {
       const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");


### PR DESCRIPTION
## Summary

`loopover_get_repo_outcome_patterns` existed over MCP (`src/mcp/server.ts:1916`) and REST (`GET /v1/repos/:owner/:repo/outcome-patterns`) but had no CLI stdio tool. This registers it, mirroring `loopover_get_repo_context`'s `ownerRepoShape` + `apiGet` shape exactly.

The route stays the **single source of truth** — it delegates to the same `getRepoOutcomePatterns` the MCP server calls — so the CLI proxies rather than recomputes and the two surfaces cannot drift into different answers. The descriptor reuses the remote server's own wording **verbatim**, so the tool is described identically wherever it's listed rather than becoming two phrasings of one thing.

The route is public/unauthenticated, so unlike the maintainer tools beside it there is nothing to scope here.

## It also un-breaks this suite on `main` — please read this bit

`mcp-tool-rename-aliases.test.ts` pins the registered tool count. **It is currently failing on `main`, independently of this PR**: the file asserts `69`, but the live server already registers `70` — a tool landed without bumping the pin, and the file's own per-bump comment ladder stops at `68 → 69`.

I verified this on a clean `upstream/main` checkout with none of my code present:

```
AssertionError: expected 70 to be 69
```

Because this PR must touch that pin anyway, it re-pins to **71** — the number the server actually registers with this tool added — which incidentally makes the suite green again. I added a comment recording *why* the ladder has a gap, so the next person doesn't read `68 → 69 → 71` as an arithmetic mistake.

I'm flagging this rather than quietly changing `69` to `71` and letting it look like my tool added two.

## Tests

A dedicated suite mirroring `mcp-cli-pr-reviewability.test.ts`: it drives the **real** stdio server over an MCP client against the fixture API, so the proxy is pinned end-to-end rather than by unit-testing a closure.

- **Registration** — the tool appears in `listTools()`.
- **Proxying** — asserts what actually *reached* the API: `GET /v1/repos/owner/repo/outcome-patterns`, exactly one request, and no forbidden public terms in the result.
- **Output parity** (the issue's explicit requirement) — asserts `structuredContent` field-by-field against the route's payload. That's the real contract (`toolResult` copies `data` onto it verbatim), and field-by-field matters: a proxy that silently dropped `freshness` or `evidenceComplete` would still pass a substring check.
- **Percent-encoding** — `own er` / `re/po` land as `own%20er/re%2Fpo`, since `encodeURIComponent` is what stops a crafted owner/repo escaping its path segment.

The fixture gained an `/outcome-patterns` handler shaped like the real route (accepted/rejected buckets + freshness + evidence-completeness markers), which is what makes the parity assertion meaningful rather than self-referential.

## Validation

- [x] **63/63 pass** across every affected suite: `mcp-tool-rename-aliases`, the new `mcp-cli-outcome-patterns`, plus `mcp-cli-maintain` and `mcp-cli-basics` (both share the fixture harness I extended).
- [x] `node --check` on the CLI entrypoint passes · `npm run typecheck` — **0 errors** · `eslint` — 0 errors/0 warnings · `git diff --check` clean · rebased on latest `main`, no base conflict.

**Codecov scope, checked rather than assumed:** the root `vitest.config.ts` `coverage.include` is `src/**`, `packages/loopover-engine/src/**`, and `packages/loopover-miner/lib/**` — **`packages/loopover-mcp/**` is not listed**, so the 99% patch gate does not reach this file. Flagging it so a reviewer isn't puzzled by the absent signal; the tool is fully covered by the four tests above regardless.

## Scope

- [x] Four files: the descriptor + registration, its test suite, the fixture route, and the count pin. Wanted paths (`packages/`, `test/`).
- [x] No new route, no new capability, no auth change — this mirrors a surface that already exists and is already public.
- [x] No UI, so no screenshot table applies.
- [x] No secrets; no changelog, `site/`, `CNAME`, or `lovable` changes.

## Safety

- [x] Read-only: a `GET` proxy with no write path.
- [x] Purely additive — every existing tool is untouched; the only edit to shared state is the count pin, corrected to the true value.
- [x] `stdioToolDescription` throws on an unknown name, so the descriptor and the registration cannot drift apart silently.

Closes #6734
