### PR TITLE
fix(ui): use the danger/warning tokens for the extension page's demo dots

### DIFF
--- a/apps/loopover-ui/src/routes/extension.tsx
+++ b/apps/loopover-ui/src/routes/extension.tsx
@@ -198,8 +198,8 @@ function OverlayDemo() {
       {/* faux github header */}
       <div className="rounded-token border border-border bg-[oklch(0.18_0.005_260)]">
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-token-xs text-muted-foreground">
-          <span className="size-2 rounded-full bg-[oklch(0.7_0.18_25)]/60" />
-          <span className="size-2 rounded-full bg-[oklch(0.8_0.15_85)]/60" />
+          <span className="size-2 rounded-full bg-danger/60" />
+          <span className="size-2 rounded-full bg-warning/60" />
           <span className="size-2 rounded-full bg-success/60" />
           <span className="ml-2 truncate font-mono text-token-2xs">
             github.com/jsonbored/loopover/pull/1218


### PR DESCRIPTION
## Summary

The extension page's demo "traffic light" dots (a faux GitHub PR header, `apps/loopover-ui/src/routes/extension.tsx:201-202`) hand-typed `bg-[oklch(0.7_0.18_25)]/60` and `bg-[oklch(0.8_0.15_85)]/60` — close approximations of the real `--danger`/`--warning` theme tokens — instead of referencing them, unlike the sibling dot in the same block which already correctly used `bg-success/60`.

Replaced both with `bg-danger/60` and `bg-warning/60`, matching the existing `bg-success/60` pattern. No visual change: the tokens are the same color family the hardcoded values were approximating.

## UI Evidence

Before (hardcoded oklch approximation) vs. after (real `--danger`/`--warning` tokens) — visually identical, as expected:

| Before | After |
|---|---|
| <a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/extension-dots-before.png"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/extension-dots-before.png" alt="Before: hardcoded oklch dots" width="320"></a> | <a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/extension-dots-after.png"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/extension-dots-after.png" alt="After: danger/warning token dots" width="320"></a> |

Captured via the local dev server (`npm --prefix apps/loopover-ui run dev`, port 8080) against the `/extension` route's `OverlayDemo` component, using a scripted Playwright screenshot (before = `git stash` reverting to the hardcoded values, after = the fix applied).

## Test plan

- [x] Confirmed `--color-danger`/`--color-warning` are real, registered Tailwind theme colors in `packages/loopover-ui-kit/src/theme.css`, already used elsewhere in this codebase (e.g. the sibling `bg-success` dot in the same block)
- [x] Visually verified before/after screenshots are indistinguishable (see UI Evidence above), matching the issue's own "no visual change" expected outcome
- [x] `grep`-confirmed no other reference to the old hardcoded oklch literals remains anywhere in `apps/loopover-ui/`
- [x] `npm run ui:lint`, `npm run ui:typecheck` — clean (0 errors)
- [x] `git diff --check`, `npm run actionlint` — clean
- [x] `apps/**` is outside Codecov's `coverage.include` (confirmed via `codecov.yml`'s ignore list) — no patch-coverage obligation for this UI-only change, per the issue's own Test Coverage Requirements note

Closes #6819