### PR TITLE
test(mcp): pin the stdio tool-count invariant at 70 after two mirrors landed

### DIFF
--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -11,7 +11,8 @@
 // (#6615 registered the loopover_close_pr write-tool — 9th of the 9 buildXSpec builders — taking the count from 62 to 63.)
 // (#6732 registered the loopover_monitor_open_prs CLI mirror, taking the count from 63 to 64.)
 // (#6752 registered the loopover_build_results_payload CLI mirror, taking the count from 67 to 68.)
-// (#6755 registered the loopover_intake_idea CLI mirror, taking the count from 68 to 69.)
+// (#6755 registered the loopover_intake_idea CLI mirror and #6751 the loopover_simulate_open_pr_pressure
+// mirror. Both landed from a 68-tool base, so together they take the count from 68 to 70.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -55,14 +56,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 69 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 70 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(69);
+    expect(primary.length).toBe(70);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(69);
+    expect(names.length).toBe(70);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -72,11 +73,11 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 69-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 70-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(69);
+    expect(payload.count).toBe(70);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual([...tools.map((t) => t.name)].sort());
   });
 });


### PR DESCRIPTION
`main` is currently red on `validate-tests (3)`: `AssertionError: expected 70 to be 69`.

## Cause

The stdio tool-count invariant is asserted as an **absolute count**, so two tool-registering PRs that are each correct against the same base race each other:

- #6751's `loopover_simulate_open_pr_pressure` mirror (#6915) bumped 68 → 69
- #6755's `loopover_intake_idea` mirror (#6916) bumped 68 → 69

Both were correct when written, and both tools registered — leaving **70 live tools against a 69 assertion**. Neither diff is individually wrong; the invariant simply can't express two concurrent bumps.

## Fix

Pin the count at **70**, matching what is actually on `main` right now:

- `70` `registerStdioTool(...)` registrations in `packages/loopover-mcp/bin/loopover-mcp.js`
- `70` `STDIO_TOOL_DESCRIPTORS` entries
- the failing CI run itself reports the live server registering `70`

Both mirrors are recorded in the header comment so the next bump starts from the real base rather than re-deriving it from a stale line.

## Why this matters beyond the invariant

The gate closes contributor PRs on a red required CI, so while `main` is red **unrelated PRs are being auto-closed on inherited failure** — the AI review on those correctly notes that nothing in their diffs explains it. This unblocks them.

Test-only change; no source or behaviour touched.
