### PR TITLE
feat(miner-ui): adopt chart and pagination on the portfolio route (#6831)

### DIFF
--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -41,8 +41,18 @@ const doneItem: PortfolioQueueActionItem = {
   status: "done",
 };
 
+function manyActionItems(count: number): PortfolioQueueActionItem[] {
+  return Array.from({ length: count }, (_, index) => ({
+    apiBaseUrl: "https://api.github.com",
+    repoFullName: `acme/repo-${String(index).padStart(2, "0")}`,
+    identifier: `issue:${index}`,
+    // Alternating status so the default sort (in_progress first) still leaves enough rows for page 2.
+    status: index % 2 === 0 ? ("in_progress" as const) : ("done" as const),
+  }));
+}
+
 describe("PortfolioQueueActionsSection (#4857)", () => {
-  it("renders a content-shaped skeleton before the first result arrives", () => {
+  it("renders a content-shaped loading skeleton (role=status), not the old flat loading text (#6511, #6831)", () => {
     // #6511: StateBoundary renders the skeleton INSTEAD of a loading title, so the old
     // "Loading actionable queue items…" text is intentionally gone; assert the placeholder instead.
     render(
@@ -54,7 +64,9 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
         onRequeue={() => undefined}
       />,
     );
+    expect(screen.getByRole("status", { name: /loading actionable queue items/i })).toBeTruthy();
     expect(screen.getByTestId("queue-actions-skeleton")).toBeTruthy();
+    expect(screen.queryByText("Loading actionable queue items…")).toBeNull();
     // Shaped like the real content, not one generic bar: the real table is not rendered yet.
     expect(screen.queryByRole("table")).toBeNull();
   });
@@ -108,6 +120,65 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
     expect(onRequeue).toHaveBeenCalledWith(doneItem);
   });
 
+  it("does not paginate the queue-actions table at or below 20 rows (#6831)", () => {
+    const items = manyActionItems(20);
+    render(
+      <PortfolioQueueActionsSection
+        result={{ ok: true, items }}
+        actionResult={null}
+        pending={false}
+        onRelease={() => undefined}
+        onRequeue={() => undefined}
+      />,
+    );
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).toBeNull();
+    expect(screen.getByText("acme/repo-00")).toBeTruthy();
+    expect(screen.getByText("acme/repo-19")).toBeTruthy();
+  });
+
+  it("paginates the queue-actions table client-side above 20 rows (#6831)", () => {
+    const items = manyActionItems(45);
+    render(
+      <PortfolioQueueActionsSection
+        result={{ ok: true, items }}
+        actionResult={null}
+        pending={false}
+        onRelease={() => undefined}
+        onRequeue={() => undefined}
+      />,
+    );
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeTruthy();
+    // Sorted in_progress first (even indices by name): page 1 ends at repo-38; repo-40 is the 21st.
+    expect(screen.getByText("acme/repo-00")).toBeTruthy();
+    expect(screen.queryByText("acme/repo-40")).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: "2" }));
+    expect(screen.getByText("acme/repo-40")).toBeTruthy();
+    expect(screen.queryByText("acme/repo-00")).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: /go to previous page/i }));
+    expect(screen.getByText("acme/repo-00")).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: /go to next page/i }));
+    expect(screen.getByText("acme/repo-40")).toBeTruthy();
+  });
+
+  it("breaks same-status/same-repo ties by identifier ascending (#6831)", () => {
+    const sameRepoDone: PortfolioQueueActionItem[] = [
+      { ...doneItem, identifier: "issue:20" },
+      { ...doneItem, identifier: "issue:7" },
+    ];
+    render(
+      <PortfolioQueueActionsSection
+        result={{ ok: true, items: sameRepoDone }}
+        actionResult={null}
+        pending={false}
+        onRelease={() => undefined}
+        onRequeue={() => undefined}
+      />,
+    );
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]?.textContent).toContain("issue:20");
+    expect(rows[2]?.textContent).toContain("issue:7");
+  });
+
   it("disables action buttons while an action is pending", () => {
     render(
       <PortfolioQueueActionsSection
@@ -157,6 +228,24 @@ describe("PortfolioPage queue actions (#4857)", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Release" })).toBeTruthy());
     fireEvent.click(screen.getByRole("button", { name: "Release" }));
     await waitFor(() => expect(releaseItem).toHaveBeenCalledWith(inProgressItem));
+  });
+
+  it("wires requeue through the injected action for done rows (#6831)", async () => {
+    const requeueItem = vi.fn(async () => ({
+      ok: true as const,
+      entry: { repoFullName: "acme/widgets", identifier: "issue:7", status: "queued" },
+    }));
+    render(
+      <PortfolioPage
+        loadPortfolioQueue={loadPortfolioQueue}
+        loadPortfolioQueueItems={async () => ({ ok: true as const, items: [doneItem] })}
+        requeueItem={requeueItem}
+        pollIntervalMs={60_000}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Requeue" })).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Requeue" }));
+    await waitFor(() => expect(requeueItem).toHaveBeenCalledWith(doneItem));
   });
 
   it("REGRESSION (#6090): a failing release action renders the error and does not re-fetch items as if it succeeded", async () => {

--- a/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,6 +6,7 @@ import {
   PORTFOLIO_QUEUE_API_PATH,
   type PortfolioQueueResult,
   type PortfolioQueueSummary,
+  type PortfolioRepoSummary,
 } from "./lib/portfolio-queue";
 import { PortfolioPage, PortfolioQueueView } from "./routes/portfolio";
 import { handlePortfolioQueueRequest, type PortfolioQueueApiDeps } from "../vite-portfolio-queue-api";
@@ -70,6 +71,15 @@ describe("emptyPortfolioQueueSummary (#4306)", () => {
   });
 });
 
+function manyRepos(count: number): PortfolioRepoSummary[] {
+  // Descending totals so the default sort (total desc) puts repo-00 first — mirrors ledgers' manyEventTypes.
+  return Array.from({ length: count }, (_, index) => ({
+    repoFullName: `acme/repo-${String(index).padStart(2, "0")}`,
+    byStatus: { queued: count - index, in_progress: 0, done: 0 },
+    total: count - index,
+  }));
+}
+
 describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
   it("renders one card per status with the aggregated global counts", () => {
     render(<PortfolioQueueView result={{ ok: true, summary: fixtureSummary }} />);
@@ -86,6 +96,65 @@ describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
     expect(screen.getByText("acme/secret-repo")).toBeTruthy();
     // header + 2 repo rows
     expect(screen.getAllByRole("row")).toHaveLength(3);
+  });
+
+  it("renders a queue-by-status chart via the ui-kit ChartContainer (#6831)", () => {
+    render(<PortfolioQueueView result={{ ok: true, summary: fixtureSummary }} />);
+    expect(screen.getByLabelText("Queue by status chart")).toBeTruthy();
+  });
+
+  it("does not paginate the per-repo table at or below 20 rows (#6831)", () => {
+    const repos = manyRepos(20);
+    const summary: PortfolioQueueSummary = {
+      total: 20,
+      byStatus: { queued: 20, in_progress: 0, done: 0 },
+      repos,
+      oldestQueuedAgeMs: null,
+    };
+    render(<PortfolioQueueView result={{ ok: true, summary }} />);
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).toBeNull();
+    expect(screen.getByText("acme/repo-00")).toBeTruthy();
+    expect(screen.getByText("acme/repo-19")).toBeTruthy();
+  });
+
+  it("paginates the per-repo table client-side above 20 rows, sorted by total desc (#6831)", () => {
+    const repos = manyRepos(45);
+    const summary: PortfolioQueueSummary = {
+      total: 45,
+      byStatus: { queued: 45, in_progress: 0, done: 0 },
+      repos,
+      oldestQueuedAgeMs: null,
+    };
+    render(<PortfolioQueueView result={{ ok: true, summary }} />);
+    expect(screen.getByRole("navigation", { name: /pagination/i })).toBeTruthy();
+    // Highest total first: repo-00 has total 45, repo-20 has total 25 — only the first page is visible.
+    expect(screen.getByText("acme/repo-00")).toBeTruthy();
+    expect(screen.queryByText("acme/repo-20")).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: "2" }));
+    expect(screen.getByText("acme/repo-20")).toBeTruthy();
+    expect(screen.queryByText("acme/repo-00")).toBeNull();
+    // Previous / Next buttons also advance the page (covers both onClick arms).
+    fireEvent.click(screen.getByRole("link", { name: /go to previous page/i }));
+    expect(screen.getByText("acme/repo-00")).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: /go to next page/i }));
+    expect(screen.getByText("acme/repo-20")).toBeTruthy();
+  });
+
+  it("breaks equal-total ties by repo name ascending (#6831)", () => {
+    const summary: PortfolioQueueSummary = {
+      total: 4,
+      byStatus: { queued: 4, in_progress: 0, done: 0 },
+      repos: [
+        { repoFullName: "acme/zeta", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 },
+        { repoFullName: "acme/alpha", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 },
+      ],
+      oldestQueuedAgeMs: null,
+    };
+    render(<PortfolioQueueView result={{ ok: true, summary }} />);
+    const rows = screen.getAllByRole("row");
+    // header + alpha then zeta
+    expect(rows[1]?.textContent).toContain("acme/alpha");
+    expect(rows[2]?.textContent).toContain("acme/zeta");
   });
 
   it("renders the fresh-install empty state without erroring", () => {
@@ -105,11 +174,14 @@ describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
     expect(screen.getByRole("alert").textContent).toContain("connection refused");
   });
 
-  it("renders a content-shaped skeleton before the first result arrives", () => {
+  it("renders a content-shaped loading skeleton (role=status), not the old flat loading text (#6511, #6831)", () => {
     // #6511: StateBoundary renders the skeleton INSTEAD of a loading title, so the old
     // "Loading local portfolio queue…" text is intentionally gone; assert the placeholder instead.
+    // #6831: skeleton also announces via role=status (matching ledgers/run-history) and includes a chart-shaped bar.
     render(<PortfolioQueueView result={null} />);
+    expect(screen.getByRole("status", { name: /loading local portfolio queue/i })).toBeTruthy();
     expect(screen.getByTestId("portfolio-queue-skeleton")).toBeTruthy();
+    expect(screen.queryByText("Loading local portfolio queue…")).toBeNull();
     // Shaped like the real content, not one generic bar: the real table is not rendered yet.
     expect(screen.queryByRole("table")).toBeNull();
   });

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
 import { Card, CardContent, CardHeader } from "@loopover/ui-kit/components/card";
+import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@loopover/ui-kit/components/chart";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@loopover/ui-kit/components/pagination";
 import { Skeleton } from "@loopover/ui-kit/components/skeleton";
 import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
@@ -16,7 +26,14 @@ import {
   type PortfolioQueueItemsResult,
 } from "../lib/portfolio-queue-actions";
 import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
-import { fetchPortfolioQueue, type PortfolioQueueResult, type QueueStatus } from "../lib/portfolio-queue";
+import {
+  fetchPortfolioQueue,
+  QUEUE_STATUSES,
+  type PortfolioQueueResult,
+  type PortfolioRepoSummary,
+  type QueueStatus,
+  type QueueStatusCounts,
+} from "../lib/portfolio-queue";
 
 export const Route = createFileRoute("/portfolio")({
   component: PortfolioPage,
@@ -24,6 +41,17 @@ export const Route = createFileRoute("/portfolio")({
 
 // Portfolio/queue summary cards + per-repo table (#4306, reunified with the CLI's own richer `queue dashboard`
 // by #4846), plus release/requeue controls (#4857) backed by the same store methods the CLI uses.
+//
+// #6511: the hand-rolled loading/error/empty `<p>` branches are replaced by the shared @loopover/ui-kit
+// `StateBoundary`, with content-shaped `Skeleton` placeholders so the layout doesn't jump when the poll lands.
+// The summary and the queue-actions section each keep their OWN independent boundary — a failure in one must
+// not blank the other.
+//
+// #6831: status cards gain a ui-kit `ChartContainer` bar chart (so the bare numbers aren't the only signal),
+// and both the per-repo table + the queue-actions table paginate client-side via the kit's `Pagination` once
+// they exceed PAGE_SIZE rows — matching the ledgers restyle (#6832) and run-history (#6510). Purely
+// presentational: `lib/portfolio-queue.ts` / `lib/portfolio-queue-actions.ts`, the poll/fetch loops, and the
+// release/requeue Button wiring stay untouched.
 
 const STATUS_LABELS: Record<QueueStatus, string> = {
   queued: "Queued",
@@ -37,13 +65,210 @@ const STATUS_TONE: Record<QueueStatus, string> = {
   done: "text-success",
 };
 
-/** Placeholder shaped like the real summary -- three status cards over the repo table -- so the layout doesn't
- *  jump when the 10s poll lands. A single generic bar would just move the jump later. */
+/** Rows per page once a repos/actions table grows past this; below it the full table renders unpaginated. */
+const PAGE_SIZE = 20;
+
+const QUEUE_CHART_CONFIG = {
+  count: { label: "Queue items" },
+  queued: { label: "Queued", color: "var(--muted-foreground)" },
+  in_progress: { label: "In progress", color: "var(--warning)" },
+  done: { label: "Done", color: "var(--success)" },
+} satisfies ChartConfig;
+
+function TablePagination({
+  page,
+  pageCount,
+  onPageChange,
+}: {
+  page: number;
+  pageCount: number;
+  onPageChange: (next: number) => void;
+}) {
+  return (
+    <Pagination className="mt-4">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            href="#"
+            aria-disabled={page === 0}
+            onClick={(event) => {
+              event.preventDefault();
+              onPageChange(Math.max(0, page - 1));
+            }}
+          />
+        </PaginationItem>
+        {Array.from({ length: pageCount }).map((_, index) => (
+          <PaginationItem key={index}>
+            <PaginationLink
+              href="#"
+              isActive={index === page}
+              onClick={(event) => {
+                event.preventDefault();
+                onPageChange(index);
+              }}
+            >
+              {index + 1}
+            </PaginationLink>
+          </PaginationItem>
+        ))}
+        <PaginationItem>
+          <PaginationNext
+            href="#"
+            aria-disabled={page >= pageCount - 1}
+            onClick={(event) => {
+              event.preventDefault();
+              onPageChange(Math.min(pageCount - 1, page + 1));
+            }}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+/** Horizontal bar chart of queue status counts — the chart.tsx adoption for the status cards section (#6831).
+ *  Cards still show the exact numbers; the chart is the glanceable breakdown the bare `<dd>`s alone weren't. */
+function QueueStatusChart({ byStatus }: { byStatus: QueueStatusCounts }) {
+  const data = QUEUE_STATUSES.map((status) => ({
+    status,
+    label: STATUS_LABELS[status],
+    count: byStatus[status],
+  }));
+  return (
+    <ChartContainer config={QUEUE_CHART_CONFIG} className="aspect-auto h-40 w-full" aria-label="Queue by status chart">
+      <BarChart data={data} layout="vertical" margin={{ left: 4, right: 12, top: 4, bottom: 4 }}>
+        <XAxis type="number" hide />
+        <YAxis
+          type="category"
+          dataKey="label"
+          width={88}
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+        />
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+        <Bar dataKey="count" radius={4}>
+          {data.map((entry) => (
+            <Cell key={entry.status} fill={`var(--color-${entry.status})`} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+function ReposTable({ repos }: { repos: PortfolioRepoSummary[] }) {
+  const [page, setPage] = useState(0);
+  // Sorted by total desc (then name) so the busiest repos surface first — same "sort then page" shape as the
+  // ledgers CountTable (#6832), without inventing interactive column headers.
+  const sorted = [...repos].sort((a, b) => b.total - a.total || a.repoFullName.localeCompare(b.repoFullName));
+  const pageCount = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const isPaginated = sorted.length > PAGE_SIZE;
+  const safePage = Math.min(page, pageCount - 1);
+  const visible = isPaginated ? sorted.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE) : sorted;
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Repository</TableHead>
+            <TableHead>Queued</TableHead>
+            <TableHead>In progress</TableHead>
+            <TableHead>Done</TableHead>
+            <TableHead>Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visible.map((repo) => (
+            <TableRow key={repo.repoFullName}>
+              <TableCell className="font-mono text-foreground">{repo.repoFullName}</TableCell>
+              <TableCell>{repo.byStatus.queued}</TableCell>
+              <TableCell>{repo.byStatus.in_progress}</TableCell>
+              <TableCell>{repo.byStatus.done}</TableCell>
+              <TableCell>{repo.total}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {isPaginated && <TablePagination page={safePage} pageCount={pageCount} onPageChange={setPage} />}
+    </div>
+  );
+}
+
+function QueueActionsTable({
+  items,
+  pending,
+  onRelease,
+  onRequeue,
+}: {
+  items: PortfolioQueueActionItem[];
+  pending: boolean;
+  onRelease: (item: PortfolioQueueActionItem) => void;
+  onRequeue: (item: PortfolioQueueActionItem) => void;
+}) {
+  const [page, setPage] = useState(0);
+  // in_progress before done, then repo/identifier — actionable release rows float to the top of page 1.
+  const sorted = [...items].sort((a, b) => {
+    const statusOrder = (status: PortfolioQueueActionItem["status"]) => (status === "in_progress" ? 0 : 1);
+    return (
+      statusOrder(a.status) - statusOrder(b.status) ||
+      a.repoFullName.localeCompare(b.repoFullName) ||
+      a.identifier.localeCompare(b.identifier)
+    );
+  });
+  const pageCount = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const isPaginated = sorted.length > PAGE_SIZE;
+  const safePage = Math.min(page, pageCount - 1);
+  const visible = isPaginated ? sorted.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE) : sorted;
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Repository</TableHead>
+            <TableHead>Identifier</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Action</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visible.map((item) => (
+            <TableRow key={`${item.apiBaseUrl}:${item.repoFullName}:${item.identifier}`}>
+              <TableCell className="font-mono text-foreground">{item.repoFullName}</TableCell>
+              <TableCell className="font-mono">{item.identifier}</TableCell>
+              <TableCell>{STATUS_LABELS[item.status]}</TableCell>
+              <TableCell>
+                {item.status === "in_progress" ? (
+                  <Button size="sm" variant="outline" disabled={pending} onClick={() => onRelease(item)}>
+                    Release
+                  </Button>
+                ) : (
+                  <Button size="sm" variant="outline" disabled={pending} onClick={() => onRequeue(item)}>
+                    Requeue
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {isPaginated && <TablePagination page={safePage} pageCount={pageCount} onPageChange={setPage} />}
+    </div>
+  );
+}
+
+/** Placeholder shaped like the real summary -- three status cards, the status chart, and the repo table -- so
+ *  the layout doesn't jump when the 10s poll lands. A single generic bar would just move the jump later. */
 function PortfolioQueueSkeleton() {
   return (
-    <div className="grid gap-6" data-testid="portfolio-queue-skeleton">
+    <div
+      className="grid gap-6"
+      data-testid="portfolio-queue-skeleton"
+      role="status"
+      aria-label="Loading local portfolio queue"
+    >
       <dl className="grid gap-4 sm:grid-cols-3">
-        {(Object.keys(STATUS_LABELS) as QueueStatus[]).map((status) => (
+        {QUEUE_STATUSES.map((status) => (
           <Card key={status}>
             <CardContent className="p-4">
               <Skeleton className="h-3 w-24" />
@@ -52,6 +277,7 @@ function PortfolioQueueSkeleton() {
           </Card>
         ))}
       </dl>
+      <Skeleton className="h-40 w-full" />
       <div className="grid gap-2">
         {[0, 1, 2].map((row) => (
           <Skeleton key={`repo-row-${row}`} className="h-8 w-full" />
@@ -83,7 +309,7 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
       {summary === null ? null : (
         <div className="grid gap-6">
           <dl className="grid gap-4 sm:grid-cols-3">
-            {(Object.keys(STATUS_LABELS) as QueueStatus[]).map((status) => (
+            {QUEUE_STATUSES.map((status) => (
               <Card key={status}>
                 <CardContent className="p-4">
                   <dt className="text-token-2xs uppercase tracking-wider text-muted-foreground">
@@ -96,28 +322,8 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
               </Card>
             ))}
           </dl>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Repository</TableHead>
-                <TableHead>Queued</TableHead>
-                <TableHead>In progress</TableHead>
-                <TableHead>Done</TableHead>
-                <TableHead>Total</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {summary.repos.map((repo) => (
-                <TableRow key={repo.repoFullName}>
-                  <TableCell className="font-mono text-foreground">{repo.repoFullName}</TableCell>
-                  <TableCell>{repo.byStatus.queued}</TableCell>
-                  <TableCell>{repo.byStatus.in_progress}</TableCell>
-                  <TableCell>{repo.byStatus.done}</TableCell>
-                  <TableCell>{repo.total}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <QueueStatusChart byStatus={summary.byStatus} />
+          <ReposTable repos={summary.repos} />
         </div>
       )}
     </StateBoundary>
@@ -127,7 +333,12 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
 /** Placeholder shaped like the queue-actions table's rows, for the same reason as the summary's. */
 function QueueActionsSkeleton() {
   return (
-    <div className="grid gap-2" data-testid="queue-actions-skeleton">
+    <div
+      className="grid gap-2"
+      data-testid="queue-actions-skeleton"
+      role="status"
+      aria-label="Loading actionable queue items"
+    >
       {[0, 1, 2].map((row) => (
         <Skeleton key={`action-row-${row}`} className="h-8 w-full" />
       ))}
@@ -172,36 +383,7 @@ export function PortfolioQueueActionsSection({
         emptyDescription={null}
       >
         {result === null || !result.ok || result.items.length === 0 ? null : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Repository</TableHead>
-                <TableHead>Identifier</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Action</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {result.items.map((item) => (
-                <TableRow key={`${item.apiBaseUrl}:${item.repoFullName}:${item.identifier}`}>
-                  <TableCell className="font-mono text-foreground">{item.repoFullName}</TableCell>
-                  <TableCell className="font-mono">{item.identifier}</TableCell>
-                  <TableCell>{STATUS_LABELS[item.status]}</TableCell>
-                  <TableCell>
-                    {item.status === "in_progress" ? (
-                      <Button size="sm" variant="outline" disabled={pending} onClick={() => onRelease(item)}>
-                        Release
-                      </Button>
-                    ) : (
-                      <Button size="sm" variant="outline" disabled={pending} onClick={() => onRequeue(item)}>
-                        Requeue
-                      </Button>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <QueueActionsTable items={result.items} pending={pending} onRelease={onRelease} onRequeue={onRequeue} />
         )}
       </StateBoundary>
     </section>


### PR DESCRIPTION
## Summary

- Restyle the miner-ui portfolio route to match the ledgers/run-history ui-kit adoption: content-shaped skeletons, a queue-by-status `ChartContainer`, and client-side `Pagination` on the per-repo and queue-actions tables (#6831).
- Keep `StateBoundary` async-state primitives; leave `portfolio-queue` / `portfolio-queue-actions` fetchers and release/requeue wiring untouched (restyle-only).
- Add regression coverage for chart render, ≤20 / >20 pagination, sort tie-breakers, and the requeue action path.

Closes #6831

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint` — eslint on changed miner-ui files: 0 errors (Prettier-formatted)
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Miner-ui-only restyle under `apps/loopover-miner-ui` (outside Codecov `src/**` patch gate). Ran `npm --workspace @loopover/ui-miner run test` (full suite green) and scoped eslint/prettier on the three changed files. Broader `test:ci` / `ui:typecheck` / `ui:build` still to run before push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

<img width="1920" height="3161" alt="image" src="https://github.com/user-attachments/assets/41412353-ca27-4e1a-a0fc-5cba275f5987" />

## Notes

- Mirrors #6832 (ledgers) / #6510 (run-history): `PAGE_SIZE = 20`, default sort then page, no interactive column headers.
- Epic #6504 visual/ui-kit track.