### PR TITLE
fix(ui): add keyboard navigation to the homepage install tabs

### DIFF
--- a/apps/loopover-ui/src/routes/index.test.tsx
+++ b/apps/loopover-ui/src/routes/index.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ClientSetupTabs } from "./index";
+
+// #6813: ClientSetupTabs (the homepage install-snippet tabs) rendered a hand-rolled role="tablist" with
+// no onKeyDown -- every other tabbed UI in this codebase gets arrow-key/Home/End navigation for free from
+// the shared Radix-backed Tabs primitive. This is the regression test for that gap.
+
+describe("ClientSetupTabs keyboard navigation (#6813)", () => {
+  // ClientSetupTabs persists the active tab to localStorage ("gt:install-tab") and reads it back as the
+  // initial state on mount -- without clearing it, a later test's initial "miners" tab assumption breaks
+  // because an earlier test in this file left a different tab persisted.
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("ArrowRight moves to and activates the next tab, wrapping past the last", () => {
+    render(<ClientSetupTabs />);
+    const minerTab = screen.getByRole("tab", { name: /Miner CLI/i });
+    const codexTab = screen.getByRole("tab", { name: /Codex/i });
+    minerTab.focus();
+
+    fireEvent.keyDown(minerTab, { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(codexTab);
+    expect(codexTab.getAttribute("aria-selected")).toBe("true");
+    expect(minerTab.getAttribute("aria-selected")).toBe("false");
+
+    // Arrow through the remaining tabs (claude, cursor, remote) and wrap back to the first (miners).
+    fireEvent.keyDown(codexTab, { key: "ArrowRight" });
+    fireEvent.keyDown(screen.getByRole("tab", { name: /Claude Desktop/i }), { key: "ArrowRight" });
+    fireEvent.keyDown(screen.getByRole("tab", { name: /Cursor/i }), { key: "ArrowRight" });
+    const remoteTab = screen.getByRole("tab", { name: /Remote MCP/i });
+    fireEvent.keyDown(remoteTab, { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(minerTab);
+    expect(minerTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("ArrowLeft moves to the previous tab, wrapping before the first", () => {
+    render(<ClientSetupTabs />);
+    const minerTab = screen.getByRole("tab", { name: /Miner CLI/i });
+    minerTab.focus();
+
+    fireEvent.keyDown(minerTab, { key: "ArrowLeft" });
+
+    const remoteTab = screen.getByRole("tab", { name: /Remote MCP/i });
+    expect(document.activeElement).toBe(remoteTab);
+    expect(remoteTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("Home jumps to the first tab and End jumps to the last", () => {
+    render(<ClientSetupTabs />);
+    const cursorTab = screen.getByRole("tab", { name: /Cursor/i });
+    cursorTab.focus();
+
+    fireEvent.keyDown(cursorTab, { key: "End" });
+    const remoteTab = screen.getByRole("tab", { name: /Remote MCP/i });
+    expect(document.activeElement).toBe(remoteTab);
+    expect(remoteTab.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(remoteTab, { key: "Home" });
+    const minerTab = screen.getByRole("tab", { name: /Miner CLI/i });
+    expect(document.activeElement).toBe(minerTab);
+    expect(minerTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("keeps only the active tab in the page tab order (roving tabindex)", () => {
+    render(<ClientSetupTabs />);
+    const minerTab = screen.getByRole("tab", { name: /Miner CLI/i });
+    const codexTab = screen.getByRole("tab", { name: /Codex/i });
+
+    expect(minerTab.getAttribute("tabIndex")).toBe("0");
+    expect(codexTab.getAttribute("tabIndex")).toBe("-1");
+
+    fireEvent.keyDown(minerTab, { key: "ArrowRight" });
+
+    expect(minerTab.getAttribute("tabIndex")).toBe("-1");
+    expect(codexTab.getAttribute("tabIndex")).toBe("0");
+  });
+
+  it("a non-navigation key is left untouched (no tab change)", () => {
+    render(<ClientSetupTabs />);
+    const minerTab = screen.getByRole("tab", { name: /Miner CLI/i });
+    minerTab.focus();
+
+    fireEvent.keyDown(minerTab, { key: "a" });
+
+    expect(minerTab.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(minerTab);
+  });
+
+  it("clicking a tab still activates it (native button behavior, unaffected by the keyboard handler)", () => {
+    render(<ClientSetupTabs />);
+    const codexTab = screen.getByRole("tab", { name: /Codex/i });
+
+    fireEvent.click(codexTab);
+
+    expect(codexTab.getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/apps/loopover-ui/src/routes/index.tsx
+++ b/apps/loopover-ui/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
 
@@ -510,13 +510,38 @@ args = ["-y", "@loopover/mcp@latest", "--stdio"]`,
   },
 ];
 
-function ClientSetupTabs() {
+export function ClientSetupTabs() {
   const [active, setActive] = useState<ClientTabId>(() => {
     if (typeof window === "undefined") return "miners";
     return (window.localStorage.getItem("gt:install-tab") as ClientTabId) ?? "miners";
   });
   const [copied, setCopied] = useState(false);
   const current = CLIENT_TABS.find((t) => t.id === active) ?? CLIENT_TABS[0];
+  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  // ARIA APG tabs pattern (#6813): ArrowLeft/ArrowRight move (wrapping) and automatically activate the
+  // adjacent tab, Home/End jump to the first/last tab -- matching every other tabbed UI in this codebase
+  // (packages/loopover-ui-kit/src/components/tabs.tsx's Radix-backed Tabs). Roving tabindex below keeps
+  // only the active tab in the page's normal Tab order.
+  const focusTab = (id: ClientTabId) => {
+    setActive(id);
+    tabRefs.current.get(id)?.focus();
+  };
+  const onTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusTab(CLIENT_TABS[(index + 1) % CLIENT_TABS.length]!.id);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusTab(CLIENT_TABS[(index - 1 + CLIENT_TABS.length) % CLIENT_TABS.length]!.id);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      focusTab(CLIENT_TABS[0]!.id);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      focusTab(CLIENT_TABS[CLIENT_TABS.length - 1]!.id);
+    }
+  };
 
   useEffect(() => {
     try {
@@ -546,13 +571,19 @@ function ClientSetupTabs() {
         aria-label="Install snippets"
         className="flex flex-wrap gap-1 border-b border-border p-1.5"
       >
-        {CLIENT_TABS.map((t) => (
+        {CLIENT_TABS.map((t, index) => (
           <button
             key={t.id}
+            ref={(el) => {
+              if (el) tabRefs.current.set(t.id, el);
+              else tabRefs.current.delete(t.id);
+            }}
             type="button"
             role="tab"
             aria-selected={active === t.id}
+            tabIndex={active === t.id ? 0 : -1}
             onClick={() => setActive(t.id)}
+            onKeyDown={(event) => onTabKeyDown(event, index)}
             className={cn(
               "inline-flex items-center gap-1.5 whitespace-nowrap rounded-token px-2.5 py-1 text-token-xs font-medium transition-colors duration-150 focus-ring motion-reduce:transition-none",
               active === t.id


### PR DESCRIPTION
## Summary

`ClientSetupTabs` (`apps/loopover-ui/src/routes/index.tsx:513-`) — the homepage's install-snippet tab bar — rendered a hand-rolled `role="tablist"`/`role="tab"` with no `onKeyDown`. Every other tabbed UI in this codebase (`app.workbench.tsx`, `app.repos.tsx`) uses the shared Radix-backed `Tabs`/`TabsList`/`TabsTrigger` from `packages/loopover-ui-kit/src/components/tabs.tsx`, which provides full arrow-key/Home/End behavior for free — this one hand-rolled instance on the highest-traffic marketing page bypassed it.

**Approach:** I considered migrating to the shared `Tabs` primitive first, but its `TabsTrigger` ships its own styling (`bg-muted`, `data-[state=active]:bg-background`, different padding) that doesn't match this component's existing custom look (the `audience` sub-label, the specific `bg-foreground/[0.06]` active state). Migrating would mean restyling the tab triggers to match — a real visual-risk change on the site's highest-traffic page. So I added the ARIA APG tabs pattern by hand instead, matching the issue's second offered option:

- **ArrowRight/ArrowLeft** move to and automatically activate the adjacent tab, wrapping past the last/first.
- **Home/End** jump to the first/last tab.
- **Roving tabindex** (`tabIndex={active === t.id ? 0 : -1}`) keeps only the active tab in the page's normal Tab order, matching the ARIA APG pattern.
- **Enter/Space** activation is untouched — still native `<button>` behavior, unaffected by the new `onKeyDown`.
- `aria-selected` stays in sync with keyboard-driven selection (verified in tests below).

No visual change — same exact markup/classes, just the new keyboard handler and `tabIndex` attribute.

## UI Evidence

The tab bar's appearance is unchanged (no visual diff — this is a pure keyboard-behavior addition):

<a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/homepage-install-tabs.png"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/homepage-install-tabs.png" alt="Homepage install tabs, unchanged appearance" width="480"></a>

For a keyboard-interaction fix specifically, a static screenshot can't demonstrate the actual behavior (focus movement, `aria-selected` sync) — the automated tests below simulate the real `keydown` events and assert on focus/ARIA state directly, which is stronger evidence than a screenshot could be here.

## Test plan

- [x] New `apps/loopover-ui/src/routes/index.test.tsx` (6 tests, `ClientSetupTabs` exported for direct testing, matching this repo's existing `changelog.tsx`/`Changelog` pattern):
  - ArrowRight moves focus to and activates the next tab, wrapping past the last back to the first
  - ArrowLeft moves to the previous tab, wrapping before the first to the last
  - Home jumps to the first tab, End jumps to the last
  - Roving tabindex: only the active tab has `tabIndex="0"`, every other tab is `"-1"`, and this updates as the active tab changes
  - A non-navigation key (e.g. `"a"`) is a no-op — no tab change, focus stays put
  - Click still activates a tab via native button behavior, unaffected by the new keyboard handler
  - All 6 passing
- [x] `npm run ui:lint`, `npm run ui:typecheck` — clean (0 errors)
- [x] `git diff --check`, `npm run actionlint` — clean
- [x] `apps/**` is outside Codecov's `coverage.include` (confirmed via `codecov.yml`'s ignore list) — no patch-coverage obligation for this UI-only change, per the issue's own Test Coverage Requirements note; added the regression test regardless per that same note

Closes #6813