### PR TITLE
feat(miner-ui): restyle header nav with mint active cues and compact theme toggle

### DIFF
--- a/apps/loopover-miner-ui/src/components/theme-toggle.tsx
+++ b/apps/loopover-miner-ui/src/components/theme-toggle.tsx
@@ -1,17 +1,34 @@
 import { useState } from "react";
 import { Button } from "@loopover/ui-kit/components/button";
 
-// Light/dark theme toggle for miner-ui (#6508). The shared @loopover/ui-kit theme.css already ships BOTH
+// Light/dark theme toggle for miner-ui (#6508 / #6828). The shared @loopover/ui-kit theme.css already ships BOTH
 // palettes (light tokens under :root, dark overrides under .dark), switched purely by whether a `.dark` class
 // is present on <html> — so this control only flips that class, mirrors it into colorScheme (so native form
 // controls follow the theme), and persists the choice. index.html's inline no-flash script reads the same
-// persisted value to restore the theme before first paint.
+// persisted value to restore the theme before first paint. Compact ghost icon so the header row stays usable
+// beside the four nav links on narrow widths.
 const STORAGE_KEY = "loopover.miner_theme";
 
-export function ThemeToggle() {
-  const [isDark, setIsDark] = useState(() =>
-    typeof document === "undefined" ? true : document.documentElement.classList.contains("dark"),
+function SunIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="size-4">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
   );
+}
+
+function MoonIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="size-4">
+      <path d="M21 14.5A8.5 8.5 0 1 1 9.5 3 7 7 0 0 0 21 14.5z" />
+    </svg>
+  );
+}
+
+export function ThemeToggle() {
+  // Client-only Vite SPA — document is always present when this runs.
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains("dark"));
 
   function toggle() {
     const nextIsDark = !isDark;
@@ -27,8 +44,13 @@ export function ThemeToggle() {
   }
 
   return (
-    <Button variant="outline" size="sm" onClick={toggle}>
-      {isDark ? "Switch to light mode" : "Switch to dark mode"}
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
     </Button>
   );
 }

--- a/apps/loopover-miner-ui/src/root-shell-nav.test.tsx
+++ b/apps/loopover-miner-ui/src/root-shell-nav.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Nav active-route regression (#6828). Stub Link like chat-rail.test.tsx, but honor activeProps /
+ * inactiveProps from a controllable mock path so we can assert aria-current + mint-underline classes
+ * without standing up a full RouterProvider.
+ */
+let mockPath = "/";
+
+vi.mock("@tanstack/react-router", async () => {
+  const react = await import("react");
+  return {
+    createRootRoute: (options: unknown) => ({ options }),
+    Outlet: () => null,
+    Link: ({
+      children,
+      to,
+      className,
+      activeProps,
+      inactiveProps,
+      activeOptions: _activeOptions,
+      ...rest
+    }: {
+      children?: React.ReactNode;
+      to?: unknown;
+      className?: string;
+      activeProps?: Record<string, unknown>;
+      inactiveProps?: Record<string, unknown>;
+      activeOptions?: { exact?: boolean };
+    }) => {
+      const href = typeof to === "string" ? to : "#";
+      const exact = _activeOptions?.exact === true;
+      const isActive = exact ? mockPath === href : mockPath === href || mockPath.startsWith(`${href}/`);
+      const stateProps = (isActive ? activeProps : inactiveProps) ?? {};
+      const { className: stateClass, ...stateRest } = stateProps as {
+        className?: string;
+        [key: string]: unknown;
+      };
+      const mergedClass = [className, stateClass].filter(Boolean).join(" ");
+      return react.createElement("a", { href, className: mergedClass || undefined, ...stateRest, ...rest }, children);
+    },
+  };
+});
+
+import { RootShell } from "./routes/__root";
+
+const originalInnerWidth = window.innerWidth;
+
+function setViewport(width: number) {
+  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: width });
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: width < 768,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+beforeEach(() => {
+  mockPath = "/";
+  setViewport(1200);
+  document.documentElement.classList.add("dark");
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: originalInnerWidth });
+  vi.unstubAllGlobals();
+  document.documentElement.classList.remove("dark");
+});
+
+describe("RootShell header nav (#6828)", () => {
+  it("marks exactly the Overview link as current on `/` (exact match)", () => {
+    mockPath = "/";
+    render(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+
+    const current = screen.getAllByRole("link").filter((el) => el.getAttribute("aria-current") === "page");
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent).toBe("Overview");
+    expect(current[0].className).toMatch(/after:bg-mint/);
+    expect(screen.getByRole("link", { name: "Portfolio" }).getAttribute("aria-current")).toBeNull();
+  });
+
+  it("does not keep Overview current on a nested path (exact activeOptions)", () => {
+    mockPath = "/portfolio";
+    render(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+
+    expect(screen.getByRole("link", { name: "Overview" }).getAttribute("aria-current")).toBeNull();
+    const portfolio = screen.getByRole("link", { name: "Portfolio" });
+    expect(portfolio.getAttribute("aria-current")).toBe("page");
+    expect(portfolio.className).toMatch(/after:bg-mint/);
+  });
+
+  it("highlights Run history and Ledgers on their own routes", () => {
+    mockPath = "/run-history";
+    const { rerender } = render(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+    expect(screen.getByRole("link", { name: "Run history" }).getAttribute("aria-current")).toBe("page");
+
+    mockPath = "/ledgers";
+    rerender(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+    expect(screen.getByRole("link", { name: "Ledgers" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("link", { name: "Run history" }).getAttribute("aria-current")).toBeNull();
+  });
+
+  it("exposes a Primary nav landmark and sticky header chrome classes", () => {
+    render(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "Primary" })).toBeTruthy();
+    const header = document.querySelector("header");
+    expect(header?.className).toMatch(/sticky/);
+    expect(header?.className).toMatch(/backdrop-blur/);
+  });
+
+  it("renders the compact theme toggle with the dark→light accessible name", () => {
+    render(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+    expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
+  });
+});

--- a/apps/loopover-miner-ui/src/routes/__root.tsx
+++ b/apps/loopover-miner-ui/src/routes/__root.tsx
@@ -16,55 +16,62 @@ function RootComponent() {
   );
 }
 
+const NAV_ITEMS = [
+  { to: "/", label: "Overview", exact: true },
+  { to: "/run-history", label: "Run history" },
+  { to: "/portfolio", label: "Portfolio" },
+  { to: "/ledgers", label: "Ledgers" },
+] as const;
+
+/** Shared nav-link chrome (#6828) — mint underline active cue mirrors loopover-ui's site-header. */
+const NAV_LINK_CLASS =
+  "relative shrink-0 px-1 py-1 text-token-sm transition-colors duration-150 motion-reduce:transition-none hover:text-foreground after:content-[''] after:absolute after:left-0 after:right-0 after:-bottom-1 after:h-[2px] after:rounded-full after:bg-transparent after:scale-x-0 after:origin-left after:transition-transform after:duration-200 motion-reduce:after:transition-none focus-ring rounded-token-sm";
+
 /**
  * The persistent app shell (#6513). Exported for unit testing. It owns the chat-rail open/collapsed state, and
  * because it's rendered by the root route, TanStack Router keeps it — and that state — mounted across
  * client-side navigation between the four routes, so the rail never resets on a route change. The routed page
  * is `children` (the `<Outlet/>` content), which is what swaps on navigation while this shell stays mounted.
+ *
+ * Header chrome (#6828): sticky translucent bar + mint-underline active routes (site-header language), without
+ * adopting sidebar.tsx as primary nav (reserved for the chat rail's mobile sheet).
  */
 export function RootShell({ children }: { children: React.ReactNode }) {
   const [railOpen, setRailOpen] = React.useState(false);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <header className="border-b-hairline px-6 py-4">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
-          <div>
+      <header className="sticky top-0 z-40 border-b-hairline bg-background/85 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 gap-y-3 px-4 py-3 sm:px-6">
+          <div className="min-w-0 flex-1">
             <p className="text-token-xs uppercase tracking-[0.2em] text-primary font-mono">LoopOver Miner</p>
             <h1 className="text-token-lg font-display font-semibold">Local dashboard</h1>
           </div>
-          <nav className="flex gap-4 text-token-sm text-muted-foreground">
-            <Link
-              to="/"
-              activeOptions={{ exact: true }}
-              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
-              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
-            >
-              Overview
-            </Link>
-            <Link
-              to="/run-history"
-              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
-              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
-            >
-              Run history
-            </Link>
-            <Link
-              to="/portfolio"
-              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
-              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
-            >
-              Portfolio
-            </Link>
-            <Link
-              to="/ledgers"
-              className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
-              activeProps={{ className: "text-primary font-medium", "aria-current": "page" }}
-            >
-              Ledgers
-            </Link>
+          <nav
+            aria-label="Primary"
+            className="flex max-w-full flex-1 basis-full items-center gap-3 overflow-x-auto text-muted-foreground sm:basis-auto sm:justify-center md:gap-4"
+          >
+            {NAV_ITEMS.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                {...("exact" in item && item.exact ? { activeOptions: { exact: true } } : {})}
+                className={NAV_LINK_CLASS}
+                activeProps={{
+                  className: "text-foreground font-medium after:scale-x-100 after:bg-mint",
+                  "aria-current": "page",
+                }}
+                inactiveProps={{
+                  className: "text-muted-foreground hover:after:scale-x-100 hover:after:bg-foreground/40",
+                }}
+              >
+                {item.label}
+              </Link>
+            ))}
           </nav>
-          <ThemeToggle />
+          <div className="ml-auto shrink-0 sm:ml-0">
+            <ThemeToggle />
+          </div>
         </div>
       </header>
       {/* Row: routed content + the persistent rail docked beside it (never overlapping) on wide viewports. */}

--- a/apps/loopover-miner-ui/src/theme-toggle.test.tsx
+++ b/apps/loopover-miner-ui/src/theme-toggle.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeToggle } from "./components/theme-toggle";
 
 describe("ThemeToggle (#6508)", () => {
@@ -15,7 +15,7 @@ describe("ThemeToggle (#6508)", () => {
     localStorage.clear();
   });
 
-  it("labels the button to switch AWAY from the current theme (dark shows 'Switch to light mode')", () => {
+  it("labels the compact icon button to switch AWAY from the current theme (dark → light)", () => {
     render(<ThemeToggle />);
     expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
   });
@@ -40,5 +40,17 @@ describe("ThemeToggle (#6508)", () => {
     expect(document.documentElement.style.colorScheme).toBe("dark");
     expect(localStorage.getItem("loopover.miner_theme")).toBe("dark");
     expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
+  });
+
+  it("survives a localStorage.setItem throw (private mode) and still flips the in-page theme", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole("button", { name: "Switch to light mode" }));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(screen.getByRole("button", { name: "Switch to dark mode" })).toBeTruthy();
+    setItem.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Restyle the miner-ui shell header to match loopover-ui site-header chrome: sticky translucent bar, mint-underline active routes, focus rings, and a wrap-friendly nav row — without adopting `sidebar.tsx` as primary nav.
- Compact the existing theme toggle to a ghost icon button so the header stays usable beside the four nav links on narrow widths (same `.dark` + `loopover.miner_theme` persistence / no-flash script).
- Add RootShell nav active-route regression tests (`aria-current`, exact Overview matching, sticky chrome) and cover the theme toggle's localStorage failure path.

Closes #6828

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint` — scoped eslint on changed miner-ui files (0 errors)
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Miner-ui-only change under `apps/loopover-miner-ui`. Ran `npm --workspace @loopover/ui-miner run test` (276 passing, coverage thresholds met). Full root `npm run test:ci` not run yet — run before push. `apps/**` is outside the Codecov patch include for `src/**`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

<img width="1920" height="2840" alt="image" src="https://github.com/user-attachments/assets/f1426bea-cd88-458a-8df6-8d82af501152" />

