### PR TITLE
fix(ui): add a copy button to the maintainer-panel comment preview

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -2,14 +2,17 @@ import { useEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
   Bot,
+  Check,
   CheckCircle2,
   CircleSlash,
+  Copy,
   ListChecks,
   Play,
   RefreshCw,
   ShieldCheck,
   UserCheck,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import {
   DiffBlock,
@@ -715,6 +718,19 @@ export function PreviewResult({
   error: string | null;
   busy: boolean;
 }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopyComment = async (previewComment: string) => {
+    try {
+      await navigator.clipboard.writeText(previewComment);
+      setCopied(true);
+      toast.success("Comment preview copied", { description: "Paste it wherever you need it." });
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      toast.error("Copy failed", { description: "Select the preview and copy manually." });
+    }
+  };
+
   if (error) {
     return (
       <div className="rounded-token border border-danger/30 bg-danger/[0.04] p-4 text-token-sm text-danger">
@@ -824,7 +840,20 @@ export function PreviewResult({
           <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
             Public comment preview
           </div>
-          <StatusPill status="info">sanitized</StatusPill>
+          <div className="flex items-center gap-2">
+            {preview.previewComment ? (
+              <button
+                type="button"
+                onClick={() => onCopyComment(preview.previewComment!)}
+                aria-label={copied ? "Comment preview copied" : "Copy comment preview"}
+                className="inline-flex h-6 items-center gap-1.5 rounded-token border border-border bg-transparent px-2 text-token-2xs text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground focus-ring motion-reduce:transition-none"
+              >
+                {copied ? <Check className="size-3 text-mint" /> : <Copy className="size-3" />}
+                {copied ? "Copied" : "Copy"}
+              </button>
+            ) : null}
+            <StatusPill status="info">sanitized</StatusPill>
+          </div>
         </div>
         <pre className="max-h-[360px] overflow-auto whitespace-pre-wrap rounded-token border border-border bg-[oklch(0.13_0.005_260)] p-3 font-mono text-token-xs leading-token-relaxed text-foreground/90">
           {preview.previewComment ?? "No public comment would be posted for this scenario."}

--- a/apps/loopover-ui/src/components/site/app-panels/preview-result.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/preview-result.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// #6825: PreviewResult's "Public comment preview" block had no copy affordance, unlike the conceptually
+// identical surface in playground-panel.tsx.
+const { success, error } = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success, error } }));
+
+import {
+  PreviewResult,
+  type SettingsPreviewResponse,
+} from "@/components/site/app-panels/maintainer-panel";
+
+const INSTALL_PREVIEW = {
+  status: "ready" as const,
+  summary: "All checks pass.",
+  readScope: [],
+  computedContext: [],
+  previewBehavior: [],
+  permissions: {
+    status: "ready" as const,
+    required: [],
+    missing: [],
+    missingEvents: [],
+    summary: "ok",
+  },
+  publicOutputs: [],
+  privateOnlyContext: [],
+  commandAuthorization: [],
+  auditBehavior: [],
+  sanitizerBoundaries: [],
+  manualControls: [],
+  checklist: [],
+};
+
+function preview(overrides: Partial<SettingsPreviewResponse> = {}): SettingsPreviewResponse {
+  return {
+    repoFullName: "acme/widgets",
+    generatedAt: "2026-07-10T00:00:00.000Z",
+    installation: null,
+    sample: {
+      authorLogin: "octocat",
+      authorType: "User",
+      authorAssociation: "NONE",
+      minerStatus: "confirmed",
+      title: "Add cursor pagination",
+      labels: [],
+      linkedIssues: [],
+    },
+    decision: {
+      willComment: true,
+      willLabel: true,
+      willCheckRun: true,
+      skipped: false,
+      skipReason: null,
+      actions: ["comment", "label", "check_run"],
+      summary: "Would comment and label this PR.",
+    },
+    previewComment: "Thanks for the PR! A couple of notes...",
+    appliedLabel: "gittensor:reviewed",
+    checkRun: { willCreate: true, title: "LoopOver review", detailLevel: "full" },
+    checkRunReadiness: null,
+    installPreview: INSTALL_PREVIEW,
+    warnings: [],
+    summary: "Would comment and label this PR.",
+    ...overrides,
+  };
+}
+
+describe("PreviewResult public comment preview copy button (#6825)", () => {
+  beforeEach(() => {
+    success.mockReset();
+    error.mockReset();
+  });
+
+  it("copies the preview comment and shows a success toast on a genuine clipboard success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+
+    render(<PreviewResult preview={preview()} error={null} busy={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy comment preview/i }));
+
+    await waitFor(() => expect(success).toHaveBeenCalledTimes(1));
+    expect(writeText).toHaveBeenCalledWith("Thanks for the PR! A couple of notes...");
+    expect(error).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("REGRESSION: shows an error toast (not a false success) when the clipboard write fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+
+    render(<PreviewResult preview={preview()} error={null} busy={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy comment preview/i }));
+
+    await waitFor(() => expect(error).toHaveBeenCalledTimes(1));
+    expect(success).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not render a copy button when there is no comment to copy", () => {
+    render(<PreviewResult preview={preview({ previewComment: null })} error={null} busy={false} />);
+    expect(screen.queryByRole("button", { name: /copy comment preview/i })).toBeNull();
+    expect(screen.getByText(/No public comment would be posted for this scenario\./i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

`PreviewResult`'s "Public comment preview" block (`apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx:822-832`) showed the exact sanitized public GitHub comment text a maintainer would want to copy, with no copy affordance anywhere in the block. The conceptually identical surface in `playground-panel.tsx` (the `public-safe-comment` branch) already has a working "Copy output" button.

Added a copy button next to the "Public comment preview" label, mirroring `playground-panel.tsx`'s existing `onCopyOutput` pattern exactly:
- Success/error toasts driven by the ACTUAL clipboard-write outcome (`toast.success("Comment preview copied", ...)` only on genuine success, `toast.error("Copy failed", ...)` — matching the file's own established copy-fail wording — otherwise).
- The button only renders when `preview.previewComment` is a real string — copying the "No public comment would be posted for this scenario." placeholder wouldn't make sense.
- Same icon-swap-on-copy UX (`Copy` → `Check` for ~1.4s) as every other copy button in this app.

## Test plan

- [x] New `apps/loopover-ui/src/components/site/app-panels/preview-result.test.tsx` (3 tests, `PreviewResult` tested directly since it's already exported):
  - A genuine clipboard success copies the exact comment text and fires the success toast only
  - **REGRESSION**: a clipboard failure fires the error toast, never a false-positive success toast
  - No copy button renders when `previewComment` is `null` (the "no comment" placeholder case)
  - All 3 passing
- [x] Regression sweep: `maintainer-panel.test.tsx` (9 tests) + `onboarding-preview-card.test.tsx` (3 tests, reused its exact `SettingsPreviewResponse` fixture builder) — 12/12 passing
- [x] `npm run ui:lint`, `npm run ui:typecheck` — clean (0 errors)
- [x] `git diff --check`, `npm run actionlint` — clean
- [x] `apps/**` is outside Codecov's `coverage.include` — no patch-coverage obligation for this UI-only change, per the issue's own Test Coverage Requirements note; added the regression tests regardless per that same note
- [x] No live screenshot: this page is behind a maintainer-session auth gate this sandbox can't easily establish without deeper session-mocking than the automated tests already provide. The button's markup/classNames are copied verbatim from `playground-panel.tsx`'s already-shipped, visually-verified `onCopyOutput` button (`inline-flex h-7 items-center gap-1.5 rounded-token border border-border ...`, scaled to `h-6`/`text-token-2xs` to fit this block's smaller header row), so there's no new visual design to verify — the automated tests directly exercise the actual copy behavior, which is the change's real surface area.

Closes #6825