### PR TITLE
feat(mcp): add a loopover_get_maintainer_lane CLI mirror

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -1035,6 +1035,12 @@ const STDIO_TOOL_DESCRIPTORS = [
       "Return the repo's label-policy audit (configured-vs-live labels, missing configured labels, suspicious status/source-style labels, and trusted-label-pipeline readiness) from the private LoopOver API.",
   },
   {
+    name: "loopover_get_maintainer_lane",
+    category: "maintainer",
+    description:
+      "Return the repo's maintainer-lane triage report (the lane recommendation alongside the configured maintainer cut, queue health, config quality, and contributor-intake health) from the private LoopOver API. Advisory only.",
+  },
+  {
     name: "loopover_get_burden_forecast",
     category: "maintainer",
     description:
@@ -1760,6 +1766,26 @@ registerStdioTool(
       repoFullName: intelligence?.repoFullName ?? `${owner}/${repo}`,
       generatedAt: intelligence?.generatedAt,
       labelAudit: intelligence?.labelAudit ?? null,
+    });
+  },
+);
+
+// #6739: CLI mirror of the remote server's loopover_get_maintainer_lane. maintainerLane ships in the same
+// buildRepoIntelligenceResponse payload the sibling loopover_get_label_audit already GETs, so this is a thin
+// extraction over that identical route rather than a new fetch shape.
+registerStdioTool(
+  "loopover_get_maintainer_lane",
+  {
+    description: stdioToolDescription("loopover_get_maintainer_lane"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }) => {
+    const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    const intelligence = await apiGet(`${prefix}/intelligence`);
+    return toolResult("LoopOver maintainer lane.", {
+      repoFullName: intelligence?.repoFullName ?? `${owner}/${repo}`,
+      generatedAt: intelligence?.generatedAt,
+      maintainerLane: intelligence?.maintainerLane ?? null,
     });
   },
 );

--- a/test/unit/mcp-cli-maintainer-lane.test.ts
+++ b/test/unit/mcp-cli-maintainer-lane.test.ts
@@ -1,0 +1,91 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+const FORBIDDEN_PUBLIC_TERMS = /wallet\s*[:=]\s*\S+|hotkey\s*[:=]\s*\S+|coldkey\s*[:=]\s*\S+|raw trust score is|your trust score|reward estimate is|estimated reward/i;
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+let apiUrl: string;
+let capturedRequests: Array<{ url: string; method: string }>;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "gittensory-maintainer-lane-"));
+  capturedRequests = [];
+  apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/intelligence")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...process.env,
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_API_TIMEOUT_MS: "5000",
+    },
+  });
+  client = new Client({ name: "maintainer-lane-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+async function disconnect() {
+  await client.close().catch(() => undefined);
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+}
+
+describe("loopover_get_maintainer_lane stdio proxy", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("registers the tool in the stdio server tool list", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("loopover_get_maintainer_lane");
+  });
+
+  it("proxies owner/repo to /v1/repos/:owner/:repo/intelligence via apiGet and returns the maintainer lane", async () => {
+    const result = await client.callTool({ name: "loopover_get_maintainer_lane", arguments: { owner: "owner", repo: "repo" } });
+    expect(capturedRequests.length).toBe(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.url).toContain("/v1/repos/owner/repo/intelligence");
+    expect(captured.method).toBe("GET");
+    expect(result.isError).toBeFalsy();
+    const text = JSON.stringify(result);
+    expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+    expect(text).toContain("maintainerLane");
+    expect(text).toContain("owner/repo");
+  });
+
+  it("hits the SAME /intelligence route its sibling loopover_get_label_audit uses, extracting only its own field", async () => {
+    // maintainerLane sits beside labelAudit in one buildRepoIntelligenceResponse payload; both tools are thin
+    // extractions over the identical GET, so the mirrored surfaces must agree on the route and repo identity.
+    const lane = await client.callTool({ name: "loopover_get_maintainer_lane", arguments: { owner: "owner", repo: "repo" } });
+    const audit = await client.callTool({ name: "loopover_get_label_audit", arguments: { owner: "owner", repo: "repo" } });
+
+    expect(capturedRequests.map((request) => request.url)).toEqual([
+      expect.stringContaining("/v1/repos/owner/repo/intelligence"),
+      expect.stringContaining("/v1/repos/owner/repo/intelligence"),
+    ]);
+    const laneContent = lane.structuredContent as Record<string, unknown> | undefined;
+    const auditContent = audit.structuredContent as Record<string, unknown> | undefined;
+    expect(laneContent?.repoFullName).toEqual(auditContent?.repoFullName);
+    expect(laneContent?.generatedAt).toEqual(auditContent?.generatedAt);
+    // Each tool surfaces only its own slice of the shared response.
+    expect(laneContent).toHaveProperty("maintainerLane");
+    expect(laneContent).not.toHaveProperty("labelAudit");
+    expect(auditContent).toHaveProperty("labelAudit");
+    expect(auditContent).not.toHaveProperty("maintainerLane");
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -56,14 +56,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 70 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 71 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(70);
+    expect(primary.length).toBe(71);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(70);
+    expect(names.length).toBe(71);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -73,11 +73,11 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 70-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 71-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(70);
+    expect(payload.count).toBe(71);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual([...tools.map((t) => t.name)].sort());
   });
 });


### PR DESCRIPTION
Closes #6739

## Problem

The MCP tool `loopover_get_maintainer_lane` (`src/mcp/server.ts:1863`) returns data that already ships as the `.maintainerLane` field of `GET /v1/repos/:owner/:repo/intelligence`. The CLI already proxies that **exact same endpoint** for its sibling fields — `loopover_get_label_audit` picks out `.labelAudit`, `loopover_get_burden_forecast` picks out its own — but `maintainerLane`, which sits right beside them in the same `buildRepoIntelligenceResponse` payload, had no CLI extraction.

## Fix

Add `registerStdioTool("loopover_get_maintainer_lane", { inputSchema: ownerRepoShape }, ...)`, copying `loopover_get_label_audit`'s implementation exactly and returning `{ repoFullName, generatedAt, maintainerLane: intelligence?.maintainerLane ?? null }`, plus its registry entry (`category: "maintainer"`) so `stdioToolDescription` resolves. No new route and no new fetch shape — it reuses the GET the sibling tools already make.

## Tests

New `test/unit/mcp-cli-maintainer-lane.test.ts` (mirrors `mcp-cli-label-audit.test.ts`):
1. the tool is registered in the stdio server's tool list;
2. it proxies `owner`/`repo` to `/v1/repos/:owner/:repo/intelligence` via `apiGet` and returns the maintainer lane (public-safety regex asserted, as the sibling does);
3. **parity with the mirrored surface** — it hits the *same* `/intelligence` route `loopover_get_label_audit` uses, agrees with it on `repoFullName`/`generatedAt` for identical input, and each tool surfaces only its own slice (`maintainerLane` vs `labelAudit`).

`mcp-tool-rename-aliases.test.ts`'s two exact tool-count assertions are updated 70 → 71 (the count is asserted against both the live server and `loopover-mcp tools --json`).

## Validation

- `npx vitest run test/unit/mcp-cli-maintainer-lane.test.ts test/unit/mcp-tool-rename-aliases.test.ts test/unit/mcp-cli-label-audit.test.ts` → **15/15 pass**
- Full MCP net (`test/unit/mcp-*.test.ts`) → **zero net-new failures** vs the pristine baseline (the failing set is byte-identical; those are Windows-only npm-registry/telemetry/file-mode cases).
- `npm run typecheck` → **clean (0 errors)**; `npm run build:mcp` passes; `npm run command-reference:check` passes.
- Rebased on current `main` (`363a8b5`) so the new tool sits alongside the freshly-merged `loopover_intake_idea` / `loopover_simulate_open_pr_pressure` / `loopover_build_results_payload` mirrors.
- Scope: 1 source file + 1 new test + 1 count update.
