### PR TITLE
fix(ui): shared StateBoundary on public repo-quality page

### DIFF
--- a/apps/loopover-ui/src/components/site/public-repo-quality-page.test.tsx
+++ b/apps/loopover-ui/src/components/site/public-repo-quality-page.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+// #6821: public-repo-quality-page hand-rolled loading/error (plain <p>, no role="status"/alert, no retry).
+// Mirror changelog.test.tsx's QueryClientProvider + mocked apiFetch harness.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+  notifyApiFailure: vi.fn(),
+  notifyApiRecovered: vi.fn(),
+}));
+vi.mock("@/lib/api/origin", () => ({
+  getApiOrigin: () => "https://api.example.test",
+}));
+
+import { PublicRepoQualityPage } from "./public-repo-quality-page";
+
+function renderWithClient(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const FIXTURE = {
+  repoFullName: "JSONbored/loopover",
+  generatedAt: "2026-07-17T00:00:00.000Z",
+  gate: {
+    blocked: 10,
+    blockedThenMerged: 2,
+    falsePositiveRate: 0.2,
+    precisionPct: 80,
+    topGateTypes: [
+      {
+        gateType: "linked_issue",
+        blocked: 4,
+        blockedThenMerged: 1,
+        falsePositiveRate: 0.25,
+        precisionPct: 75,
+      },
+    ],
+  },
+  outcomes: { merged: 20, closed: 5, mergeRatioPct: 80 },
+  slop: { totalResolved: 12, overallMergeRate: 50, discriminates: true },
+  trend: [
+    {
+      weekStart: "2026-07-07",
+      gateBlocked: 3,
+      gateBlockedThenMerged: 1,
+      gateFalsePositiveRate: 0.3,
+      outcomesMerged: 4,
+      outcomesClosed: 1,
+      mergeRatioPct: 80,
+    },
+  ],
+};
+
+describe("PublicRepoQualityPage (#6821)", () => {
+  afterEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it("renders a content-shaped loading skeleton instead of the old plain loading text", () => {
+    apiFetch.mockReturnValue(new Promise(() => {}));
+    const { container } = renderWithClient(
+      <PublicRepoQualityPage owner="JSONbored" repo="loopover" />,
+    );
+
+    // REGRESSION: the old branch was a bare <p>Loading review-quality metrics…</p> with no skeleton.
+    expect(screen.queryByText("Loading review-quality metrics…")).toBeNull();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(1);
+  });
+
+  it("renders an accessible error state (role=alert) with a retry that refetches", async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "http",
+      status: 503,
+      message: "unavailable",
+      durationMs: 10,
+    });
+    renderWithClient(<PublicRepoQualityPage owner="JSONbored" repo="loopover" />);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+    expect(screen.getByText("Review quality unavailable")).toBeTruthy();
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: FIXTURE, status: 200, durationMs: 10 });
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => expect(screen.getByText("JSONbored/loopover")).toBeTruthy());
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders the empty-state copy when the repo has not opted in (null payload)", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: null, status: 200, durationMs: 10 });
+    renderWithClient(<PublicRepoQualityPage owner="JSONbored" repo="loopover" />);
+
+    await waitFor(() => expect(screen.getByText("Review quality unavailable")).toBeTruthy());
+    // Empty (opt-out) is not an alert — that role is reserved for fetch failures with retry.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders the 3-stat cards once metrics load", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: FIXTURE, status: 200, durationMs: 10 });
+    renderWithClient(<PublicRepoQualityPage owner="JSONbored" repo="loopover" />);
+
+    await waitFor(() => expect(screen.getByText("Gate precision")).toBeTruthy());
+    expect(screen.getByText("Merge ratio")).toBeTruthy();
+    expect(screen.getByText("Slop calibration")).toBeTruthy();
+    expect(screen.getByText("Weekly trend")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/components/site/public-repo-quality-page.tsx
+++ b/apps/loopover-ui/src/components/site/public-repo-quality-page.tsx
@@ -3,7 +3,9 @@ import { useQuery } from "@tanstack/react-query";
 import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch } from "@/lib/api/request";
 import { TableScroll } from "@/components/site/data-table";
-import { Card, Section, SectionTitle } from "@/components/site/primitives";
+import { Card, Section } from "@/components/site/primitives";
+import { StateBoundary } from "@/components/site/state-views";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export type PublicQualityMetrics = {
   repoFullName: string;
@@ -48,8 +50,12 @@ async function fetchPublicQualityMetrics(
       silentStatus: true,
     },
   );
-  if (!result.ok || !result.data) return null;
-  return result.data;
+  // Distinguish transport/HTTP failure (ErrorState + retry) from a successful opt-out/null payload
+  // (EmptyState) so StateBoundary can assign the right ARIA role (#6821).
+  if (!result.ok) {
+    throw new Error(result.message || "Public quality metrics unavailable");
+  }
+  return result.data ?? null;
 }
 
 function slopCalibrationHint(discriminates: boolean | null): string {
@@ -58,142 +64,177 @@ function slopCalibrationHint(discriminates: boolean | null): string {
   return "";
 }
 
+/** Content-shaped placeholder matching the 3-stat-card + trend-table layout so the page does not
+ *  jump once metrics arrive (#6821). */
+function PublicRepoQualitySkeleton() {
+  return (
+    <div className="max-w-4xl space-y-10" aria-hidden>
+      <div className="space-y-3">
+        <Skeleton className="h-3 w-36" />
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-full max-w-xl" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }, (_, index) => (
+          <Card key={index} className="space-y-3 p-5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-7 w-16" />
+            <Skeleton className="h-4 w-40" />
+          </Card>
+        ))}
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-32" />
+        <div className="overflow-x-auto rounded-token border border-border">
+          <div className="border-b border-border px-4 py-3">
+            <Skeleton className="h-3 w-48" />
+          </div>
+          <div className="divide-y divide-border/60">
+            {Array.from({ length: 4 }, (_, index) => (
+              <div key={index} className="px-4 py-3">
+                <Skeleton className="h-4 w-full" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function PublicRepoQualityPage({ owner, repo }: { owner: string; repo: string }) {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ["public-quality", owner, repo],
     queryFn: () => fetchPublicQualityMetrics(owner, repo),
     staleTime: 60_000,
   });
 
-  if (isLoading) {
-    return (
-      <Section className="pt-16 pb-16">
-        <p className="text-muted-foreground">Loading review-quality metrics…</p>
-      </Section>
-    );
-  }
-
-  if (!data || isError) {
-    return (
-      <Section className="pt-16 pb-16">
-        <SectionTitle title="Review quality unavailable" />
-        <p className="mt-4 max-w-2xl text-token-sm text-muted-foreground">
-          This repository has not opted in to public review-quality metrics, or the metrics are
-          temporarily unavailable.
-        </p>
-      </Section>
-    );
-  }
-
   return (
     <Section className="pt-16 pb-16">
-      <div className="max-w-4xl">
-        <div className="text-token-xs text-muted-foreground">Public review quality</div>
-        <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
-          {data.repoFullName}
-        </h1>
-        <p className="mt-3 text-token-sm text-muted-foreground">
-          Aggregate counts only — no raw trust scores, rewards, or contributor rankings. Updated{" "}
-          {new Date(data.generatedAt).toLocaleString()}.
-        </p>
+      <StateBoundary
+        isLoading={isLoading}
+        isError={isError}
+        isEmpty={!isLoading && !isError && !data}
+        onRetry={() => void refetch()}
+        loadingSkeleton={<PublicRepoQualitySkeleton />}
+        emptyTitle="Review quality unavailable"
+        emptyDescription="This repository has not opted in to public review-quality metrics, or the metrics are temporarily unavailable."
+        errorTitle="Review quality unavailable"
+        errorDescription="This repository has not opted in to public review-quality metrics, or the metrics are temporarily unavailable."
+      >
+        {data ? (
+          <div className="max-w-4xl">
+            <div className="text-token-xs text-muted-foreground">Public review quality</div>
+            <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
+              {data.repoFullName}
+            </h1>
+            <p className="mt-3 text-token-sm text-muted-foreground">
+              Aggregate counts only — no raw trust scores, rewards, or contributor rankings. Updated{" "}
+              {new Date(data.generatedAt).toLocaleString()}.
+            </p>
 
-        <div className="mt-10 grid gap-4 sm:grid-cols-3">
-          <Card className="p-5">
-            <div className="text-token-xs text-muted-foreground">Gate precision</div>
-            <div className="mt-2 text-token-xl font-medium">
-              {data.gate.precisionPct != null ? `${pctFmt.format(data.gate.precisionPct)}%` : "—"}
+            <div className="mt-10 grid gap-4 sm:grid-cols-3">
+              <Card className="p-5">
+                <div className="text-token-xs text-muted-foreground">Gate precision</div>
+                <div className="mt-2 text-token-xl font-medium">
+                  {data.gate.precisionPct != null
+                    ? `${pctFmt.format(data.gate.precisionPct)}%`
+                    : "—"}
+                </div>
+                <p className="mt-2 text-token-sm text-muted-foreground">
+                  {data.gate.blocked} blocks, {data.gate.blockedThenMerged} later merged
+                </p>
+              </Card>
+              <Card className="p-5">
+                <div className="text-token-xs text-muted-foreground">Merge ratio</div>
+                <div className="mt-2 text-token-xl font-medium">
+                  {data.outcomes.mergeRatioPct != null
+                    ? `${pctFmt.format(data.outcomes.mergeRatioPct)}%`
+                    : "—"}
+                </div>
+                <p className="mt-2 text-token-sm text-muted-foreground">
+                  {data.outcomes.merged} merged / {data.outcomes.closed} closed
+                </p>
+              </Card>
+              <Card className="p-5">
+                <div className="text-token-xs text-muted-foreground">Slop calibration</div>
+                <div className="mt-2 text-token-xl font-medium">
+                  {data.slop.overallMergeRate != null
+                    ? `${pctFmt.format(data.slop.overallMergeRate)}% merge`
+                    : "—"}
+                </div>
+                <p className="mt-2 text-token-sm text-muted-foreground">
+                  {data.slop.totalResolved} resolved PRs
+                  {slopCalibrationHint(data.slop.discriminates)}
+                </p>
+              </Card>
             </div>
-            <p className="mt-2 text-token-sm text-muted-foreground">
-              {data.gate.blocked} blocks, {data.gate.blockedThenMerged} later merged
-            </p>
-          </Card>
-          <Card className="p-5">
-            <div className="text-token-xs text-muted-foreground">Merge ratio</div>
-            <div className="mt-2 text-token-xl font-medium">
-              {data.outcomes.mergeRatioPct != null
-                ? `${pctFmt.format(data.outcomes.mergeRatioPct)}%`
-                : "—"}
-            </div>
-            <p className="mt-2 text-token-sm text-muted-foreground">
-              {data.outcomes.merged} merged / {data.outcomes.closed} closed
-            </p>
-          </Card>
-          <Card className="p-5">
-            <div className="text-token-xs text-muted-foreground">Slop calibration</div>
-            <div className="mt-2 text-token-xl font-medium">
-              {data.slop.overallMergeRate != null
-                ? `${pctFmt.format(data.slop.overallMergeRate)}% merge`
-                : "—"}
-            </div>
-            <p className="mt-2 text-token-sm text-muted-foreground">
-              {data.slop.totalResolved} resolved PRs{slopCalibrationHint(data.slop.discriminates)}
-            </p>
-          </Card>
-        </div>
 
-        {data.gate.topGateTypes.length > 0 ? (
-          <div className="mt-10">
-            <h2 className="text-token-lg font-medium">Top gate types</h2>
-            <ul className="mt-4 space-y-2 text-token-sm">
-              {data.gate.topGateTypes.map((row) => (
-                <li key={row.gateType} className="rounded-token border-hairline px-4 py-3">
-                  <span className="font-mono text-foreground">{row.gateType}</span>
-                  <span className="text-muted-foreground">
-                    {" "}
-                    — {row.blocked} blocks, {row.blockedThenMerged} merged anyway
-                    {row.precisionPct != null
-                      ? ` (${pctFmt.format(row.precisionPct)}% precision)`
-                      : ""}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            {data.gate.topGateTypes.length > 0 ? (
+              <div className="mt-10">
+                <h2 className="text-token-lg font-medium">Top gate types</h2>
+                <ul className="mt-4 space-y-2 text-token-sm">
+                  {data.gate.topGateTypes.map((row) => (
+                    <li key={row.gateType} className="rounded-token border-hairline px-4 py-3">
+                      <span className="font-mono text-foreground">{row.gateType}</span>
+                      <span className="text-muted-foreground">
+                        {" "}
+                        — {row.blocked} blocks, {row.blockedThenMerged} merged anyway
+                        {row.precisionPct != null
+                          ? ` (${pctFmt.format(row.precisionPct)}% precision)`
+                          : ""}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            <div className="mt-10">
+              <h2 className="text-token-lg font-medium">Weekly trend</h2>
+              <TableScroll className="mt-4" label="Weekly trend">
+                <table className="w-full min-w-[36rem] text-left text-token-sm">
+                  <caption className="sr-only">
+                    Weekly gate false-positive rate, merge ratio, and blocked count.
+                  </caption>
+                  <thead className="text-token-xs text-muted-foreground">
+                    <tr>
+                      <th scope="col" className="pb-2 pr-4 font-medium">
+                        Week
+                      </th>
+                      <th scope="col" className="pb-2 pr-4 font-medium">
+                        Gate FP rate
+                      </th>
+                      <th scope="col" className="pb-2 pr-4 font-medium">
+                        Merge ratio
+                      </th>
+                      <th scope="col" className="pb-2 font-medium">
+                        Blocks
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.trend.map((row) => (
+                      <tr key={row.weekStart} className="border-t border-hairline">
+                        <td className="py-2 pr-4 font-mono text-token-xs">{row.weekStart}</td>
+                        <td className="py-2 pr-4">
+                          {row.gateFalsePositiveRate != null
+                            ? `${pctFmt.format(row.gateFalsePositiveRate * 100)}%`
+                            : "—"}
+                        </td>
+                        <td className="py-2 pr-4">
+                          {row.mergeRatioPct != null ? `${pctFmt.format(row.mergeRatioPct)}%` : "—"}
+                        </td>
+                        <td className="py-2">{row.gateBlocked}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </TableScroll>
+            </div>
           </div>
         ) : null}
-
-        <div className="mt-10">
-          <h2 className="text-token-lg font-medium">Weekly trend</h2>
-          <TableScroll className="mt-4" label="Weekly trend">
-            <table className="w-full min-w-[36rem] text-left text-token-sm">
-              <caption className="sr-only">
-                Weekly gate false-positive rate, merge ratio, and blocked count.
-              </caption>
-              <thead className="text-token-xs text-muted-foreground">
-                <tr>
-                  <th scope="col" className="pb-2 pr-4 font-medium">
-                    Week
-                  </th>
-                  <th scope="col" className="pb-2 pr-4 font-medium">
-                    Gate FP rate
-                  </th>
-                  <th scope="col" className="pb-2 pr-4 font-medium">
-                    Merge ratio
-                  </th>
-                  <th scope="col" className="pb-2 font-medium">
-                    Blocks
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.trend.map((row) => (
-                  <tr key={row.weekStart} className="border-t border-hairline">
-                    <td className="py-2 pr-4 font-mono text-token-xs">{row.weekStart}</td>
-                    <td className="py-2 pr-4">
-                      {row.gateFalsePositiveRate != null
-                        ? `${pctFmt.format(row.gateFalsePositiveRate * 100)}%`
-                        : "—"}
-                    </td>
-                    <td className="py-2 pr-4">
-                      {row.mergeRatioPct != null ? `${pctFmt.format(row.mergeRatioPct)}%` : "—"}
-                    </td>
-                    <td className="py-2">{row.gateBlocked}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </TableScroll>
-        </div>
-      </div>
+      </StateBoundary>
     </Section>
   );
 }


### PR DESCRIPTION
## Summary
- Replace hand-rolled loading/error `<p>` branches with `StateBoundary` + content-shaped skeleton (3 cards + trend table).
- Wire `onRetry` to `useQuery` `refetch`; HTTP failures throw so `isError` gets `role="alert"`; successful null payload uses EmptyState.

Closes #6821

## UI Evidence
| Before | After |
| --- | --- |
| [![Before — plain loading text](https://raw.githubusercontent.com/RealDiligent/gittensory/review-evidence-6821/before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/review-evidence-6821/before.png) | [![After — content-shaped loading skeleton](https://raw.githubusercontent.com/RealDiligent/gittensory/review-evidence-6821/after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/review-evidence-6821/after.png) |

## Test plan
- [x] Loading shows skeleton, not plain `Loading review-quality metrics…`
- [x] Error has `role=alert` + Try again refetches
- [x] Null/opt-out uses empty copy without alert
- [ ] CI green

Made with [Cursor](https://cursor.com)