### PR TITLE
fix(ui): add a content-shaped loading skeleton to the operator dashboard

### DIFF
--- a/apps/loopover-ui/src/routes/app.operator.test.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// #6816: app.operator.tsx's StateBoundary had no loadingSkeleton, falling through to the generic spinner.
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: (...args: unknown[]) => useApiResource(...args),
+}));
+
+import { OperatorDashboard } from "@/routes/app.operator";
+
+describe("OperatorDashboard loading skeleton (#6816)", () => {
+  it("shows a content-shaped skeleton (not the generic spinner) while the dashboard loads", () => {
+    useApiResource.mockReturnValue({
+      status: "loading",
+      data: null,
+      error: null,
+      loadedAt: null,
+      reload: () => {},
+    });
+
+    const { container } = render(<OperatorDashboard />);
+    // The custom skeleton replaces the generic LoadingState — neither its title nor its spinner shows.
+    expect(screen.queryByText("Loading operator dashboard…")).toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    // The placeholder renders animate-pulse blocks approximating the dashboard's stat + section grid.
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(1);
+  });
+
+  it("does not show the skeleton once the dashboard has real data", () => {
+    // OperatorDashboard also renders NotificationReadinessCard and DeadLetterQueuePanel, both of which call
+    // this SAME hook for their own resources -- key the mock by path so their unrelated states (including
+    // DeadLetterQueuePanel's own loadingSkeleton) don't leak into the dashboard's own animate-pulse count.
+    useApiResource.mockImplementation((path: string) => {
+      if (path === "/v1/app/operator-dashboard") {
+        return {
+          status: "ready",
+          data: {
+            metrics: [{ label: "Installs", value: "12", delta: "+2" }],
+            noiseReduction: [],
+            weeklyReport: [],
+          },
+          error: null,
+          loadedAt: "2026-07-17T00:00:00.000Z",
+          reload: () => {},
+        };
+      }
+      return {
+        status: "error",
+        data: null,
+        error: "unavailable in this test",
+        errorKind: "unknown",
+        loadedAt: null,
+        reload: () => {},
+      };
+    });
+
+    const { container } = render(<OperatorDashboard />);
+    expect(screen.getByText("Usage & value")).toBeTruthy();
+    expect(container.querySelectorAll(".animate-pulse").length).toBe(0);
+  });
+});

--- a/apps/loopover-ui/src/routes/app.operator.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.tsx
@@ -12,6 +12,7 @@ import {
 import { DeadLetterQueuePanel } from "@/components/site/dead-letter-queue-panel";
 import { NotificationReadinessCard } from "@/components/site/notification-readiness-card";
 import { StateActionButton, StateBoundary } from "@/components/site/state-views";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch } from "@/lib/api/request";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -96,7 +97,29 @@ type RecommendationQualityTotals = {
 
 type ReportExportFormat = "markdown" | "json";
 
-function OperatorDashboard() {
+function OperatorDashboardSkeleton() {
+  return (
+    <div className="space-y-8" aria-hidden>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-16 rounded-token" />
+          <Skeleton className="h-7 w-56 rounded-token" />
+          <Skeleton className="h-4 w-80 rounded-token" />
+        </div>
+        <Skeleton className="h-8 w-28 rounded-token" />
+      </div>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }, (_, index) => (
+          <Skeleton key={index} className="h-24 w-full rounded-token" />
+        ))}
+      </section>
+      <Skeleton className="h-56 w-full rounded-token" />
+      <Skeleton className="h-72 w-full rounded-token" />
+    </div>
+  );
+}
+
+export function OperatorDashboard() {
   const dashboard = useApiResource<OperatorDashboardResponse>(
     "/v1/app/operator-dashboard",
     "Operator dashboard",
@@ -140,6 +163,7 @@ function OperatorDashboard() {
       onRetry={dashboard.reload}
       onRefresh={dashboard.reload}
       loadingTitle="Loading operator dashboard…"
+      loadingSkeleton={<OperatorDashboardSkeleton />}
       emptyTitle="No operator metrics yet"
       emptyDescription="Deployment health and value metrics appear once backend data is available."
       errorDescription={dashboard.status === "error" ? dashboard.error : undefined}


### PR DESCRIPTION
## Summary

`app.operator.tsx`'s `StateBoundary` (lines ~134-146) had no `loadingSkeleton` prop, falling through to the generic centered spinner — unlike every structurally-identical sibling dashboard in this app (`app.runs.tsx`, `miner-panel.tsx`, `maintainer-panel.tsx`, `dead-letter-queue-panel.tsx`), each of which provides a content-shaped skeleton.

Added `OperatorDashboardSkeleton`, mirroring the real dashboard's actual layout:
- Header block (eyebrow + title + description + export button)
- Stat grid (the `data.metrics` section, 2-3 columns)
- A block approximating the "Fleet health" section
- A block approximating the "Recommendation quality" section

Wired via `loadingSkeleton={<OperatorDashboardSkeleton />}` on the existing `StateBoundary`, following the exact same pattern as its siblings.

## Test plan

- [x] New `apps/loopover-ui/src/routes/app.operator.test.tsx` (2 tests, `OperatorDashboard` exported for direct testing, matching this repo's established `changelog.tsx`/`index.tsx`/`extension.tsx` pattern):
  - The custom skeleton (`.animate-pulse` blocks) renders during `status: "loading"`, and neither the generic `LoadingState` title nor its spinner (`.animate-spin`) appears
  - No skeleton remains once the dashboard has real (`status: "ready"`) data — carefully keying the shared `useApiResource` mock by resource path, since `OperatorDashboard` also renders `NotificationReadinessCard` and `DeadLetterQueuePanel`, which call the same hook for their own unrelated resources
  - Both passing
- [x] `npm run ui:lint`, `npm run ui:typecheck` — clean (0 errors)
- [x] `git diff --check`, `npm run actionlint` — clean
- [x] `apps/**` is outside Codecov's `coverage.include` — no patch-coverage obligation for this UI-only change; added the regression tests regardless per the issue's own Test Coverage Requirements note
- [x] No live screenshot: `/app/operator` sits behind this app's session-restoration app-shell gate (a "Loading app shell…" step ahead of the route's own component), which this sandbox can't get past without a real session. The skeleton's markup is copied from the exact same `Skeleton` primitive and `space-y-*`/`grid` shape already shipped in `MaintainerDashboardSkeleton`/`DeadLetterQueueSkeleton` (both visually verified when they themselves shipped), so there's no new visual design to verify — the automated tests directly assert the actual DOM swap (skeleton class present during loading, absent once ready), which is the change's real surface area.

Closes #6816