### PR TITLE
feat(mcp): add a maintain outcome-calibration CLI mirror for loopover_get_outcome_calibration

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -98,7 +98,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "onboarding-pack", "audit-feed"],
+  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "onboarding-pack", "audit-feed", "outcome-calibration"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -2996,6 +2996,8 @@ function printMaintainHelp() {
       "  audit-feed [--since ISO]     Show the agent audit feed (who did what, when).",
       "             [--limit N]       Cap the events returned (1-200).",
       "             [--pull N]        Scope the feed to one pull request.",
+      "  outcome-calibration [--window-days N]",
+      "                               Show recommendation/slop outcome calibration for the repo.",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -3145,8 +3147,28 @@ async function maintainCli(args) {
     );
     return;
   }
+  if (subcommand === "outcome-calibration") {
+    // #6735: read-only mirror of GET {repoBase}/outcome-calibration (the remote loopover_get_outcome_calibration
+    // tool). Identical --window-days handling to `precision` above: a positive value opts into a bounded window
+    // via ?windowDays, anything else is omitted so the route falls through to full history (it clamps/floors
+    // server-side). The CLI never decides locally; the API enforces maintainer authorization.
+    const windowDays = Number(options.windowDays);
+    const query = windowDays > 0 ? `?windowDays=${encodeURIComponent(windowDays)}` : "";
+    const payload = await apiGet(`${repoBase}/outcome-calibration${query}`);
+    const window = payload.windowDays ? `last ${payload.windowDays}d` : "all history";
+    emit(
+      payload,
+      [
+        // The calibration payload is a structured slop/recommendations bundle rather than a flat telemetry row,
+        // so the plain-text path dumps it like onboarding-pack does; --json re-serializes `payload` untouched.
+        `Outcome calibration for ${repoFullName} (${window}):`,
+        sanitizePlainTextTerminalOutput(JSON.stringify({ slop: payload.slop, recommendations: payload.recommendations, signals: payload.signals }, null, 2)),
+      ].join("\n"),
+    );
+    return;
+  }
   throw new Error(
-    `Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | onboarding-pack | audit-feed.`,
+    `Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | onboarding-pack | audit-feed | outcome-calibration.`,
   );
 }
 

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -221,7 +221,7 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
     expect(ps).toContain(
-      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'onboarding-pack', 'audit-feed')",
+      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'onboarding-pack', 'audit-feed', 'outcome-calibration')",
     );
   });
 

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -152,6 +152,40 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(payload.echoedQuery).toEqual({ since: null, limit: null, pull: null });
   });
 
+  it("outcome-calibration shows the calibration bundle (plain + json), with output parity (#6735)", async () => {
+    const e = await env();
+    const out = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo"], e);
+    expect(out).toMatch(/Outcome calibration for owner\/repo \(all history\):/);
+    // The structured slop/recommendations bundle is dumped on the plain-text path.
+    expect(out).toMatch(/"bandAccuracy": 0\.82/);
+    expect(out).toMatch(/"merged": 12/);
+    // Parity: --json re-serializes the API payload untouched, so the same fields reach both surfaces.
+    const json = JSON.parse(await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--json"], e)) as {
+      repoFullName: string;
+      slop: { bandAccuracy: number };
+      recommendations: { merged: number };
+    };
+    expect(json.repoFullName).toBe("owner/repo");
+    expect(json.slop.bandAccuracy).toBe(0.82);
+    expect(json.recommendations.merged).toBe(12);
+  });
+
+  it("outcome-calibration forwards --window-days as ?windowDays and reflects it in the header (#6735)", async () => {
+    const e = await env();
+    // Identical --window-days handling to `precision`: a positive value bounds the window, absent = full history.
+    const scoped = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--window-days", "30"], e);
+    expect(scoped).toMatch(/Outcome calibration for owner\/repo \(last 30d\):/);
+    const scopedJson = JSON.parse(await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--window-days", "30", "--json"], e)) as {
+      windowDays: number;
+    };
+    expect(scopedJson.windowDays).toBe(30);
+    // A non-positive window is omitted from the query, so the route falls through to full history.
+    const zero = JSON.parse(await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--window-days", "0", "--json"], e)) as {
+      windowDays: number | null;
+    };
+    expect(zero.windowDays).toBeNull();
+  });
+
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {
     const e = await env();
     await expect(runAsync(["maintain", "status"], e)).rejects.toThrow(/Pass --repo/);

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -488,6 +488,22 @@ export async function startFixtureServer(
       );
       return;
     }
+    // #6735 outcome calibration (read-only). Echoes ?windowDays so the CLI window pass-through is testable, and
+    // returns the route's structured slop/recommendations/signals bundle so the plain-text dump is exercised.
+    if (request.url?.startsWith("/v1/repos/owner/repo/outcome-calibration") && request.method === "GET") {
+      const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          generatedAt: "2026-05-30T00:00:00.000Z",
+          windowDays: windowDays ? Number(windowDays) : null,
+          slop: { bandAccuracy: 0.82, sampled: 40 },
+          recommendations: { merged: 12, closed: 4, reverted: 1 },
+          signals: ["Recommendation acceptance is tracking above the slop band; keep the current threshold."],
+        }),
+      );
+      return;
+    }
     // #554 gate precision telemetry (read-only). Echoes ?windowDays so the CLI window pass-through is testable.
     if (request.url?.startsWith("/v1/repos/owner/repo/gate-precision") && request.method === "GET") {
       const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");


### PR DESCRIPTION
## Summary

The outcome-calibration report was reachable over MCP (`loopover_get_outcome_calibration`) and REST (`GET /v1/repos/:owner/:repo/outcome-calibration`) but not from the CLI. This adds:

```
loopover-mcp maintain outcome-calibration --repo owner/repo [--window-days N]
```

a thin proxy over that route, following the `maintain precision` subcommand's shape (the precedent the issue names for identical `--window-days` handling).

## Design

- **The CLI never decides locally.** The route enforces maintainer authorization and clamps/floors the window server-side, so the CLI just forwards: a positive `--window-days` becomes `?windowDays=N`, and anything else (absent / 0 / NaN) is omitted so the route falls through to full history — exactly how `precision` already handles it.
- **Output parity is structural.** `--json` re-serializes the API payload untouched via the shared `emit`, so the CLI and REST/MCP surfaces return the same bytes for the same input.
- The calibration payload is a structured `slop` / `recommendations` / `signals` bundle rather than a flat telemetry row, so the plain-text path dumps it with `sanitizePlainTextTerminalOutput` like `onboarding-pack` does, under a windowed header (`(all history)` / `(last 30d)`).

## Tests

Two cases in `mcp-cli-maintain.test.ts`, mirroring `precision`'s pattern, driven through the real CLI against the fixture:

- **Plain + JSON with parity** — the structured bundle renders on the plain path, and `--json` returns the same fields.
- **`--window-days` pass-through** — a positive value bounds the window and is reflected in the header; **`--window-days 0` is asserted to fall through to full history** (`windowDays: null`), which is the branch a naive forward-everything proxy would get wrong.

The fixture gained an `/outcome-calibration` handler shaped like the real route (echoes `windowDays`, returns the slop/recommendations/signals bundle), so the pass-through assertions are meaningful rather than self-referential.

## Validation

- [x] **50/50 pass** across `mcp-cli-maintain`, `mcp-cli-basics`, `mcp-cli-completion-spec` (the last two because the completion list + PowerShell completer assertion changed).
- [x] `node --check` on the CLI entrypoint passes · `npm run typecheck` — **0 errors** · `eslint` — 0 errors/0 warnings · `git diff --check` clean · rebased on latest `main`, no base conflict.

**Codecov scope, checked rather than assumed:** the root `vitest.config.ts` `coverage.include` is `src/**`, `packages/loopover-engine/src/**`, `packages/loopover-miner/lib/**` — **`packages/loopover-mcp/**` is not listed**, so the 99% patch gate does not reach this file. Flagging it so the absent signal isn't mistaken for a miss; the subcommand is fully covered by the two tests above regardless.

**Deliberately does not touch `mcp-tool-rename-aliases.test.ts`:** that pins the registered *stdio tool* count, which a `maintain` subcommand does not change (it is not a `registerStdioTool`). Leaving it untouched avoids the count-pin that has been a contention hotspot.

## Scope & safety

- [x] Four files: the subcommand + help + completion list, its tests, the fixture route, and the pinned completer assertion. Wanted paths (`packages/`, `test/`).
- [x] Read-only `GET` proxy — no write path, no new route, no new capability, no auth change.
- [x] Purely additive — every existing subcommand is untouched; the unknown-subcommand error message is extended to list `outcome-calibration` so it stays accurate.
- [x] No UI, so no screenshot table applies. No secrets; no changelog/`site/`/`CNAME`/`lovable` changes.

Closes #6735
