### PR TITLE
fix(ui): stop the site-wide g-shortcut handler from racing app-shell nav

### DIFF
--- a/apps/loopover-ui/src/components/site/keyboard-shortcuts.test.tsx
+++ b/apps/loopover-ui/src/components/site/keyboard-shortcuts.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #6811: app-shell.tsx registers its own "g <key>" handler for /app/* SPA navigation. This site-wide
+// handler used to fire alongside it unconditionally, racing a hard `window.location.assign` against the
+// SPA navigation on the same "g r" / "g a" keystrokes. Control the reported route via a mocked useLocation.
+const { useLocation } = vi.hoisted(() => ({ useLocation: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: () => useLocation(),
+}));
+
+import { KeyboardShortcutsDialog } from "./keyboard-shortcuts";
+
+function pressKeys(...keys: string[]) {
+  for (const key of keys) {
+    fireEvent.keyDown(window, { key });
+  }
+}
+
+describe("KeyboardShortcutsDialog g-prefix navigation (#6811)", () => {
+  let assign: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    assign = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not hard-navigate on 'g r' while an /app/* route is mounted", () => {
+    useLocation.mockReturnValue({ pathname: "/app/runs" });
+    render(<KeyboardShortcutsDialog />);
+
+    pressKeys("g", "r");
+
+    // AppShell's own handler owns this keystroke on /app/* routes; the site-wide handler must stay inert.
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("does not hard-navigate on 'g a' while an /app/* route is mounted", () => {
+    useLocation.mockReturnValue({ pathname: "/app/analytics" });
+    render(<KeyboardShortcutsDialog />);
+
+    pressKeys("g", "a");
+
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("still hard-navigates on 'g r' outside /app/*", () => {
+    useLocation.mockReturnValue({ pathname: "/docs" });
+    render(<KeyboardShortcutsDialog />);
+
+    pressKeys("g", "r");
+
+    expect(assign).toHaveBeenCalledWith("/api");
+  });
+
+  it("advertises the in-app destinations instead of the site-wide ones while on /app/*", () => {
+    useLocation.mockReturnValue({ pathname: "/app/runs" });
+    render(<KeyboardShortcutsDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open keyboard shortcuts" }));
+
+    expect(screen.getByText("Go to runs")).toBeTruthy();
+    expect(screen.queryByText("Go to API reference")).toBeNull();
+  });
+
+  it("advertises the site-wide destinations outside /app/*", () => {
+    useLocation.mockReturnValue({ pathname: "/docs" });
+    render(<KeyboardShortcutsDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open keyboard shortcuts" }));
+
+    expect(screen.getByText("Go to API reference")).toBeTruthy();
+    expect(screen.queryByText("Go to runs")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/components/site/keyboard-shortcuts.tsx
+++ b/apps/loopover-ui/src/components/site/keyboard-shortcuts.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from "@tanstack/react-router";
 import { Keyboard } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -16,44 +17,61 @@ interface ShortcutGroup {
   items: Shortcut[];
 }
 
-const GROUPS: ShortcutGroup[] = [
-  {
-    group: "Navigation",
-    items: [
-      { keys: ["⌘", "K"], label: "Open command palette" },
-      { keys: ["g", "h"], label: "Go home" },
-      { keys: ["g", "d"], label: "Go to docs" },
-      { keys: ["g", "a"], label: "Go to app" },
-      { keys: ["g", "r"], label: "Go to API reference" },
-    ],
-  },
-  {
-    group: "API reference",
-    items: [
-      { keys: ["←"], label: "Previous endpoint" },
-      { keys: ["→"], label: "Next endpoint" },
-      { keys: ["["], label: "Previous tag section" },
-      { keys: ["]"], label: "Next tag section" },
-    ],
-  },
-  {
-    group: "Reading",
-    items: [
-      { keys: ["j"], label: "Scroll down" },
-      { keys: ["k"], label: "Scroll up" },
-      { keys: ["t"], label: "Back to top" },
-    ],
-  },
-  {
-    group: "General",
-    items: [
-      { keys: ["?"], label: "Open this cheat sheet" },
-      { keys: ["Esc"], label: "Close dialogs / menus" },
-    ],
-  },
+// AppShell (app-shell.tsx) owns "g <key>" navigation while an /app/* route is mounted, using its own
+// destination map (o/w/r/p/a). The site-wide map below only applies outside /app/*, so the advertised
+// list here must match whichever map is actually live (#6811).
+const SITE_NAV_SHORTCUTS: Shortcut[] = [
+  { keys: ["g", "h"], label: "Go home" },
+  { keys: ["g", "d"], label: "Go to docs" },
+  { keys: ["g", "a"], label: "Go to app" },
+  { keys: ["g", "r"], label: "Go to API reference" },
+];
+const APP_NAV_SHORTCUTS: Shortcut[] = [
+  { keys: ["g", "o"], label: "Go to overview" },
+  { keys: ["g", "w"], label: "Go to workbench" },
+  { keys: ["g", "r"], label: "Go to runs" },
+  { keys: ["g", "p"], label: "Go to repositories" },
+  { keys: ["g", "a"], label: "Go to analytics" },
 ];
 
+function buildGroups(isAppRoute: boolean): ShortcutGroup[] {
+  const navShortcuts = isAppRoute ? APP_NAV_SHORTCUTS : SITE_NAV_SHORTCUTS;
+  return [
+    {
+      group: "Navigation",
+      items: [{ keys: ["⌘", "K"], label: "Open command palette" }, ...navShortcuts],
+    },
+    {
+      group: "API reference",
+      items: [
+        { keys: ["←"], label: "Previous endpoint" },
+        { keys: ["→"], label: "Next endpoint" },
+        { keys: ["["], label: "Previous tag section" },
+        { keys: ["]"], label: "Next tag section" },
+      ],
+    },
+    {
+      group: "Reading",
+      items: [
+        { keys: ["j"], label: "Scroll down" },
+        { keys: ["k"], label: "Scroll up" },
+        { keys: ["t"], label: "Back to top" },
+      ],
+    },
+    {
+      group: "General",
+      items: [
+        { keys: ["?"], label: "Open this cheat sheet" },
+        { keys: ["Esc"], label: "Close dialogs / menus" },
+      ],
+    },
+  ];
+}
+
 export function KeyboardShortcutsDialog() {
+  const location = useLocation();
+  const isAppRoute = location.pathname.startsWith("/app");
+  const groups = buildGroups(isAppRoute);
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState<string | null>(null);
 
@@ -103,7 +121,10 @@ export function KeyboardShortcutsDialog() {
         return;
       }
 
-      // Two-key "g <x>" sequences
+      // Two-key "g <x>" sequences — AppShell owns these while an /app/* route is mounted (its own
+      // "g <key>" handler uses a different destination map), so defer entirely rather than racing
+      // it with a second, colliding hard navigation (#6811).
+      if (isAppRoute) return;
       if (e.key === "g") {
         setPending("g");
         if (timer) clearTimeout(timer);
@@ -130,7 +151,7 @@ export function KeyboardShortcutsDialog() {
       window.removeEventListener("keydown", onKey);
       if (timer) clearTimeout(timer);
     };
-  }, [pending]);
+  }, [pending, isAppRoute]);
 
   return (
     <>
@@ -156,13 +177,13 @@ export function KeyboardShortcutsDialog() {
             </DialogTitle>
           </DialogHeader>
           <div className="mt-2 grid gap-5">
-            {GROUPS.length === 0 ? (
+            {groups.length === 0 ? (
               <EmptyState
                 title="No shortcuts available"
                 description="Shortcut metadata did not load. Close this sheet and try opening it again."
               />
             ) : (
-              GROUPS.map((g) => (
+              groups.map((g) => (
                 <section key={g.group}>
                   <div className="mb-2 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
                     {g.group}


### PR DESCRIPTION
## Summary

- `app-shell.tsx`'s document-level "g <key>" handler (o/w/r/p/a -> SPA `navigate()`) and `keyboard-shortcuts.tsx`'s window-level "g <key>" handler (h/d/a/r -> `window.location.assign()`) are both always mounted on every `/app/*` page. Pressing `g` then `r` or `g` then `a` fired both: the SPA navigation from `app-shell.tsx` and a hard, full-page navigation from `keyboard-shortcuts.tsx`, aborting the SPA transition and taking the user out of the app entirely.
- Fixed by making the site-wide handler defer entirely to `app-shell.tsx` while an `/app/*` route is mounted (checked via `useLocation().pathname`), so only one handler ever resolves a given "g <key>" sequence.
- `KeyboardShortcutsDialog`'s advertised shortcut list now also swaps to the in-app destinations (`g o`/`g w`/`g r`/`g p`/`g a`) while on `/app/*`, so the cheat sheet stays accurate instead of advertising bindings that no longer apply.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6811

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (backend-only check; this PR only touches `apps/loopover-ui`)
- [x] `npm run typecheck` (via `npm run ui:typecheck`, the UI-scoped equivalent)
- [ ] `npm run test:coverage` (backend-only; this PR only touches `apps/loopover-ui`, which is outside the Codecov patch gate per `codecov.yml`'s `ignore: apps/**`)
- [ ] `npm run test:workers` (backend-only; not applicable to this UI-only change)
- [ ] `npm run build:mcp` (not applicable to this UI-only change)
- [ ] `npm run test:mcp-pack` (not applicable to this UI-only change)
- [ ] `npm run ui:openapi:check` (no API/schema changes in this PR)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `apps/loopover-ui/src/components/site/keyboard-shortcuts.tsx` (plus its test file). The backend-only checks above (`actionlint`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`) and dependency/API checks (`npm audit`, `ui:openapi:check`) have no surface to exercise for a change scoped entirely to one UI event handler, so they were not run standalone; `npm run ui:lint`, `npm run ui:typecheck`, and `npm run ui:build` all pass locally, and the new `keyboard-shortcuts.test.tsx` suite (5 tests) covers both collision keystrokes plus the advertised-shortcut-list swap.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API/OpenAPI/MCP changes in this PR.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A -- this change is a client-side keyboard event handler, not API-data-driven.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A -- this fix changes keyboard event-handling logic and the shortcut cheat-sheet's text list only; there is no static visual difference to screenshot, and the interaction difference -- one navigation instead of two racing navigations -- is exercised by the new automated tests instead.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI Evidence table: this is a behavioral fix to keyboard event handling (which handler wins a given keystroke) and to the shortcut cheat-sheet's advertised text, not a static visual change -- there is no at-rest pixel difference to capture. The regression is instead pinned by `keyboard-shortcuts.test.tsx`, asserting `window.location.assign` is no longer called for `g r` / `g a` while an `/app/*` route is mounted, and that the cheat sheet's advertised list matches whichever handler is actually live.
