### PR TITLE
feat(api): add POST /v1/repos/:owner/:repo/repo-docs/refresh + CLI mirror

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14299,6 +14299,54 @@
           "actingActionClasses",
           "pendingActionCount"
         ]
+      },
+      "RepoDocRefreshResult": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "opened": {
+                "type": "boolean",
+                "enum": [
+                  true
+                ]
+              },
+              "reused": {
+                "type": "boolean"
+              },
+              "pullNumber": {
+                "type": "integer"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "opened",
+              "reused",
+              "pullNumber",
+              "url"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "opened": {
+                "type": "boolean",
+                "enum": [
+                  false
+                ]
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "opened",
+              "reason"
+            ]
+          }
+        ]
       }
     },
     "parameters": {},
@@ -18485,6 +18533,49 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutomationState"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/repo-docs/refresh": {
+      "post": {
+        "summary": "Open (or find the already-open) AGENTS.md/CLAUDE.md generation pull request",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The repo-doc pull request result -- opened (new or reused) or a reason it was not opened",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepoDocRefreshResult"
                 }
               }
             }

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -100,7 +100,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state"],
+  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -3107,6 +3107,7 @@ function printMaintainHelp() {
       "             [--limit N]       Cap the events returned (1-200).",
       "             [--pull N]        Scope the feed to one pull request.",
       "  automation-state             Show the derived agent automation state (mode, readiness, pending).",
+      "  refresh-docs                 Open (or find the already-open) the AGENTS.md/CLAUDE.md generation PR.",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -3293,8 +3294,18 @@ async function maintainCli(args) {
     );
     return;
   }
+  if (subcommand === "refresh-docs") {
+    // #6743: REST mirror of the loopover_refresh_repo_docs MCP tool -- only ever opens a PR (never merges,
+    // closes, or commits directly), so a single synchronous POST with no body is the whole contract.
+    const payload = await apiPost(`${repoBase}/repo-docs/refresh`, {});
+    const line = payload.opened
+      ? `${payload.reused ? "Found the already-open" : "Opened a new"} repo-doc pull request for ${repoFullName}: ${sanitizePlainTextTerminalOutput(payload.url)}`
+      : `No repo-doc pull request opened for ${repoFullName}: ${sanitizePlainTextTerminalOutput(payload.reason)}`;
+    emit(payload, line);
+    return;
+  }
   throw new Error(
-    `Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state.`,
+    `Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs.`,
   );
 }
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -128,6 +128,7 @@ import {
   refreshInstallationHealthForInstallation,
 } from "../github/backfill";
 import { getRepositoryCollaboratorPermission } from "../github/app";
+import { performRepoDocRefresh } from "../github/repo-doc-refresh-runner";
 import type { LoopOverFooterEnv } from "../github/footer";
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } from "../gittensor/api";
 import { fetchPublicContributorProfile, fetchPublicRepoStats } from "../github/public";
@@ -2737,6 +2738,21 @@ export function createApp() {
     const result = await decidePendingAgentAction(c.env, { id: pending.id, decision, decidedBy });
     if (result.status === "already_decided") return c.json({ error: "already_decided", action: result.action }, 409);
     return c.json(result);
+  });
+
+  // #6743 — REST mirror of the loopover_refresh_repo_docs MCP tool (src/mcp/server.ts's refreshRepoDocs):
+  // opens (or finds the already-open) AGENTS.md/CLAUDE.md generation PR. Only ever opens a PR (never merges,
+  // closes, or commits directly), so — like the decision route above — it's safe to run synchronously in one
+  // call rather than needing the propose/decide staging pattern. Trims the runner's internal `claudeMode`
+  // field the same way the MCP tool's own response does, so both mirrors expose the identical public shape.
+  app.post("/v1/repos/:owner/:repo/repo-docs/refresh", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const gate = await requireRepoWriteAccess(c, fullName);
+    /* v8 ignore next -- unauthorized requests are rejected by the auth middleware before reaching the handler. */
+    if (gate instanceof Response) return gate;
+    const result = await performRepoDocRefresh(c.env, fullName);
+    if (!result.opened) return c.json(result);
+    return c.json({ opened: true, reused: result.reused, pullNumber: result.pullNumber, url: result.url });
   });
 
   // #784 audit feed: the agent's executed actions + approval-queue decisions for this repo. Maintainer-scoped,
@@ -6045,6 +6061,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoValidateLinkedIssuePath(path)) return true;
   if (isRepoAgentAuditFeedPath(path)) return true; // route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
+  if (isRepoDocRefreshPath(path)) return true; // route's requireRepoWriteAccess enforces real per-repo write authority
   if (isRepoAgentPendingActionsPath(path)) return true; // list-only: requireRepoMaintainer; decision POSTs require server tokens
   if (isRepoIncidentReportsPath(path)) return true; // #5672: route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
@@ -6107,6 +6124,12 @@ function isRepoValidateLinkedIssuePath(path: string): boolean {
 
 function isRepoAgentAuditFeedPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/audit-feed$/.test(path);
+}
+
+// #6743: coarse path admission only -- the route's own requireRepoWriteAccess enforces real per-repo write
+// authority (a session with mere read/maintainer-data access still 403s there).
+function isRepoDocRefreshPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/repo-docs\/refresh$/.test(path);
 }
 
 function isRepoIncidentReportsPath(path: string): boolean {

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -910,6 +910,17 @@ export const AutomationStateSchema = z
   })
   .openapi("AutomationState");
 
+// #6743 — the public result shape of the loopover_refresh_repo_docs MCP tool and its REST
+// (`POST /v1/repos/:owner/:repo/repo-docs/refresh`) mirror. Both trim RepoDocPullRequestResult's internal
+// `claudeMode` field (src/github/repo-doc-pr.ts) the same way, so this schema matches what each surface
+// actually returns, not the runner's raw result.
+export const RepoDocRefreshResultSchema = z
+  .discriminatedUnion("opened", [
+    z.object({ opened: z.literal(true), reused: z.boolean(), pullNumber: z.number().int(), url: z.string() }),
+    z.object({ opened: z.literal(false), reason: z.string() }),
+  ])
+  .openapi("RepoDocRefreshResult");
+
 export const RepoSettingsPreviewSchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -72,6 +72,7 @@ import {
   RepositorySchema,
   AutomationStateSchema,
   RepositorySettingsSchema,
+  RepoDocRefreshResultSchema,
   RoleContextSchema,
   RewardRiskActionSchema,
   ScorePreviewSchema,
@@ -131,6 +132,7 @@ export function buildOpenApiSpec() {
   registry.register("BountyLifecycleEvents", BountyLifecycleEventsSchema);
   registry.register("RepositorySettings", RepositorySettingsSchema);
   registry.register("AutomationState", AutomationStateSchema);
+  registry.register("RepoDocRefreshResult", RepoDocRefreshResultSchema);
   registry.register("InstallationRepair", InstallationRepairSchema);
   registry.register("RepoSettingsPreview", RepoSettingsPreviewSchema);
   registry.register("SkippedPrAuditExport", SkippedPrAuditExportSchema);
@@ -701,6 +703,15 @@ export function buildOpenApiSpec() {
           "Maintainer-only derived automation view (mode, permission readiness, acting action classes, pending-approval count) that the raw /settings row does not include",
         content: { "application/json": { schema: AutomationStateSchema } },
       },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/repos/{owner}/{repo}/repo-docs/refresh",
+    summary: "Open (or find the already-open) AGENTS.md/CLAUDE.md generation pull request",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: { description: "The repo-doc pull request result -- opened (new or reused) or a reason it was not opened", content: { "application/json": { schema: RepoDocRefreshResultSchema } } },
     },
   });
   registry.registerPath({

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -221,7 +221,7 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
     expect(ps).toContain(
-      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state')",
+      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state', 'refresh-docs')",
     );
   });
 

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -26,9 +26,9 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     tempDir = null;
   });
 
-  async function env(onApiRequest?: (request: import("node:http").IncomingMessage) => void) {
+  async function env(options: Parameters<typeof startFixtureServer>[0] = {}) {
     tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
-    const url = await startFixtureServer(onApiRequest ? { onApiRequest } : {});
+    const url = await startFixtureServer(options);
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }
 
@@ -115,7 +115,7 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
 
   it("onboarding-pack mirrors the session-gated API payload and forwards refresh", async () => {
     const requests: string[] = [];
-    const e = await env((request) => requests.push(request.url ?? ""));
+    const e = await env({ onApiRequest: (request) => requests.push(request.url ?? "") });
 
     const json = JSON.parse(
       await runAsync(["maintain", "onboarding-pack", "--repo", "owner/repo", "--refresh", "--json"], e),
@@ -184,6 +184,33 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
       pendingActionCount: number;
     };
     expect(json).toMatchObject({ repoFullName: "owner/repo", mode: "live", permissionReadiness: "ready", pendingActionCount: 3 });
+  });
+
+  it("refresh-docs reports a newly opened repo-doc PR (plain + json), with output parity between the surfaces (#6743)", async () => {
+    const e = await env({
+      repoDocRefresh: { opened: true, reused: false, pullNumber: 42, url: "https://github.com/owner/repo/pull/42", claudeMode: "symlink" },
+    });
+    const out = await runAsync(["maintain", "refresh-docs", "--repo", "owner/repo"], e);
+    expect(out).toBe("Opened a new repo-doc pull request for owner/repo: https://github.com/owner/repo/pull/42\n");
+    const json = JSON.parse(await runAsync(["maintain", "refresh-docs", "--repo", "owner/repo", "--json"], e)) as {
+      opened: boolean;
+      pullNumber: number;
+    };
+    expect(json).toMatchObject({ opened: true, pullNumber: 42 });
+  });
+
+  it("refresh-docs reports the already-open PR when the route reuses one (#6743)", async () => {
+    const e = await env({
+      repoDocRefresh: { opened: true, reused: true, pullNumber: 42, url: "https://github.com/owner/repo/pull/42", claudeMode: "copy" },
+    });
+    const out = await runAsync(["maintain", "refresh-docs", "--repo", "owner/repo"], e);
+    expect(out).toBe("Found the already-open repo-doc pull request for owner/repo: https://github.com/owner/repo/pull/42\n");
+  });
+
+  it("refresh-docs reports why no PR was opened, sanitizing the reason (#6743)", async () => {
+    const e = await env({ repoDocRefresh: { opened: false, reason: "no changes needed" } });
+    const out = await runAsync(["maintain", "refresh-docs", "--repo", "owner/repo"], e);
+    expect(out).toBe("No repo-doc pull request opened for owner/repo: no changes needed\n");
   });
 
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {

--- a/test/unit/routes-repo-doc-refresh.test.ts
+++ b/test/unit/routes-repo-doc-refresh.test.ts
@@ -1,0 +1,105 @@
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
+import { createTestEnv } from "../helpers/d1";
+
+// #6743: POST /v1/repos/:owner/:repo/repo-docs/refresh — the REST mirror of the loopover_refresh_repo_docs
+// MCP tool, write-access gated like the pending-actions decision route. performRepoDocRefresh's own
+// opened/reused/not-enabled behavior is already exhaustively covered by test/unit/mcp-refresh-repo-docs.test.ts;
+// these pin the ROUTE contract only: the gate, and that the runner's result reaches the response unmodified.
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+}));
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
+
+const REPO = "owner/widgets";
+const PATH = "/v1/repos/owner/widgets/repo-docs/refresh";
+const TOKEN_URL = /\/access_tokens$/;
+
+function generateRsaPrivateKeyPem(): string {
+  return generateKeyPairSync("rsa", { modulusLength: 2048, privateKeyEncoding: { type: "pkcs1", format: "pem" }, publicKeyEncoding: { type: "pkcs1", format: "pem" } }).privateKey;
+}
+
+async function seedChunk(env: Env, path: string, text: string): Promise<void> {
+  await env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)").bind(`${path}::0`, "owner", "widgets", path, 0, "code", text).run();
+}
+
+describe("POST /v1/repos/:owner/:repo/repo-docs/refresh (#6743)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  beforeEach(() => mockedPermission.mockReset());
+
+  it("opens a repo-doc pull request and returns the runner's result unmodified", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), ADMIN_GITHUB_LOGINS: "operator-admin" });
+    await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: REPO, private: false, owner: { login: "owner" }, default_branch: "main" }, 555);
+    await upsertRepoFocusManifest(env, REPO, { repoDocGeneration: { enabled: true } });
+    await seedChunk(env, "src/widget.ts", "export function widget() {}");
+    await seedChunk(env, "package.json", JSON.stringify({ scripts: { build: "tsc" } }));
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (TOKEN_URL.test(url)) return Response.json({ token: "t" });
+      if (url.includes("/pulls?") && method === "GET") return Response.json([]);
+      if (url.includes("/contents/") && method === "GET") return new Response("not found", { status: 404 });
+      if (url.endsWith("/branches/main")) return Response.json({ commit: { sha: "base-commit-sha", commit: { tree: { sha: "base-tree-sha" } } } });
+      if (url.endsWith("/git/trees") && method === "POST") return Response.json({ sha: "tree-sha" });
+      if (url.endsWith("/git/commits") && method === "POST") return Response.json({ sha: "commit-sha" });
+      if (url.endsWith("/git/refs") && method === "POST") return Response.json({});
+      if (url.endsWith("/repos/owner/widgets/pulls") && method === "POST") return Response.json({ number: 101, html_url: "https://github.com/owner/widgets/pull/101" });
+      return new Response("unexpected", { status: 500 });
+    });
+    const { token } = await createSessionForGitHubUser(env, { login: "operator-admin", id: 1 });
+
+    const response = await app.request(PATH, { method: "POST", headers: { authorization: `Bearer ${token}` } }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ opened: true, reused: false, pullNumber: 101, url: "https://github.com/owner/widgets/pull/101" });
+  });
+
+  it("reports opened: false without touching GitHub when repo-doc generation is not enabled", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator-admin" });
+    await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: REPO, private: false, owner: { login: "owner" } }, 555);
+    const { token } = await createSessionForGitHubUser(env, { login: "operator-admin", id: 1 });
+
+    const response = await app.request(PATH, { method: "POST", headers: { authorization: `Bearer ${token}` } }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      opened: false,
+      reason: "repo-doc generation is not enabled for this repository (.loopover.yml repoDocGeneration.enabled)",
+    });
+  });
+
+  it("forbids a session without real write access to the repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    // The repo must be INSTALLED (not just registered) for a collaborator PR to earn "reader" the maintainer
+    // app-role requireRepoWriteAccess checks first -- otherwise it 403s at that earlier gate instead of the
+    // per-repo write-permission check this test targets (mirrors maintainer-activation.test.ts's seedRepo).
+    await upsertInstallation(env, {
+      installation: { id: 555, account: { login: "owner", id: 555, type: "User" }, repository_selection: "selected", permissions: { metadata: "read" }, events: ["repository"] },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: REPO, private: false, owner: { login: "owner" } }, 555);
+    await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?").bind(REPO).run();
+    await upsertPullRequestFromGitHub(env, REPO, {
+      number: 8,
+      title: "docs tweak",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "def456", ref: "docs-2" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+
+    const response = await app.request(PATH, { method: "POST", headers: { cookie: `loopover_session=${token}` } }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_repo_permission" });
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -178,6 +178,9 @@ export async function startFixtureServer(
     openPrMonitor?: Record<string, unknown>;
     intakeStatus?: number;
     localBranchAnalysisStatus?: number;
+    /** #6743: overrides the repo-doc refresh route's default "opened a new PR" response, e.g. to exercise
+     *  the reused-PR or not-opened branches. */
+    repoDocRefresh?: unknown;
     /** #6792: queued /v1/auth/github/device/poll responses, consumed one per request -- the last entry
      *  repeats once exhausted. Lets a test simulate a transient 429 (or GitHub's own slow_down/pending
      *  statuses) before the device flow eventually resolves. Requires deviceFlowStart to be set too. */
@@ -507,6 +510,22 @@ export async function startFixtureServer(
     if (request.url === "/v1/repos/owner/repo/settings" && request.method === "PUT") {
       const body = (await readJsonRequest(request)) as { agentPaused?: boolean; autonomy?: Record<string, string> };
       response.end(JSON.stringify({ repoFullName: "owner/repo", agentPaused: body.agentPaused === true, ...(body.autonomy ? { autonomy: body.autonomy } : {}) }));
+      return;
+    }
+    // #6743 repo-doc refresh (write). Defaults to the "opened a new PR" shape; a test can override via
+    // options.repoDocRefresh to exercise the reused / not-opened branches.
+    if (request.url === "/v1/repos/owner/repo/repo-docs/refresh" && request.method === "POST") {
+      response.end(
+        JSON.stringify(
+          options.repoDocRefresh ?? {
+            opened: true,
+            reused: false,
+            pullNumber: 42,
+            url: "https://github.com/owner/repo/pull/42",
+            claudeMode: "symlink",
+          },
+        ),
+      );
       return;
     }
     // #6733 agent audit feed (read-only). Echoes the forwarded query so the CLI's pass-through is testable, and


### PR DESCRIPTION
## Summary
- The MCP tool `loopover_refresh_repo_docs` (opens or finds the already-open AGENTS.md/CLAUDE.md generation PR via `performRepoDocRefresh`) had no REST or CLI counterpart.
- Adds `POST /v1/repos/:owner/:repo/repo-docs/refresh` in `src/api/routes.ts`, gated the same way as the pending-actions decision route (`requireRepoWriteAccess` — real per-repo write access, not just maintainer-data visibility).
- Adds the path to the session coarse-path allowlist (`canSessionAccessPath`/`isRepoDocRefreshPath`) — without this, a browser maintainer session would 403 with `insufficient_role` at the global gate before ever reaching the route's own write-access check.
- Adds a `maintain refresh-docs` CLI subcommand (`packages/loopover-mcp/bin/loopover-mcp.js`), proxying the new route.
- Both the REST route and the MCP tool trim the runner's internal `claudeMode` field from the response, so all three surfaces (MCP/REST/CLI) expose the identical public shape.
- Registers `RepoDocRefreshResultSchema` and the route in the OpenAPI spec; regenerated `apps/loopover-ui/public/openapi.json`.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6743

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of what changed (confirmed via a clean-checkout rerun); relied on `npm run build --workspace @loopover/engine` (passed) plus the full targeted vitest run below as the local proxy, and CI's isolated runner for the authoritative `tsc --noEmit`.
- [x] `npm run test:coverage` — full targeted vitest run: `test/unit/routes-repo-doc-refresh.test.ts` (new, 3 tests), `test/unit/mcp-refresh-repo-docs.test.ts` (5, unmodified), `test/unit/mcp-cli-maintain.test.ts` (19, incl. 3 new `refresh-docs` cases), `test/unit/mcp-cli-basics.test.ts` (21, incl. the fixed PowerShell completion snapshot), `test/unit/access-boundary.test.ts` (9) — 94/94 passing.
- [ ] `npm run test:workers` (not applicable — no Cloudflare Worker binding/queue changes)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not applicable — no MCP server packaging changes)
- [x] `npm run ui:openapi` — regenerated (no drift this revision)
- [x] `npm run ui:openapi:settings-parity` — passed
- [x] `npm run command-reference` — ran; no drift
- [x] `npm run ui:lint` — 0 errors (only pre-existing unrelated warnings; this PR touches no `apps/loopover-ui/**` files)
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure (independently reproduced on a clean `main` checkout with no diff at all), so it was not run standalone; `npm run build --workspace @loopover/engine` plus the full targeted test run above stand in as the local proxy, and CI's isolated runner performs the real `tsc --noEmit`. `npm run test:workers` and the MCP packaging checks have no surface to exercise for a change scoped to one REST route + one CLI subcommand.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. This PR adds a new session-reachable maintainer route; `test/unit/routes-repo-doc-refresh.test.ts` covers the write-access-denied (403) path, and `test/unit/access-boundary.test.ts` continues to pass unmodified.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. New route registered in the OpenAPI spec; `RepoDocRefreshResultSchema` matches the trimmed response shape both mirrors actually return.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes in this PR.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — this is a backend REST route + CLI subcommand with no UI surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- A prior attempt at this same change (superseded by this PR) was auto-closed by CI: it missed updating a hand-maintained PowerShell-completion snapshot test (`test/unit/mcp-cli-basics.test.ts`) that hardcodes the full `maintain` subcommand list, so the new `refresh-docs` entry broke that assertion. Fixed here.
- Also caught and fixed during testing: the new route wasn't initially reachable by a session-authenticated maintainer at all (`insufficient_role` from the global coarse-path allowlist, independent of the route's own per-repo write check), discovered only because the negative-path test exercised the real `app.request(...)` flow end-to-end rather than mocking the gate. Fixed by adding `isRepoDocRefreshPath` to `canSessionAccessPath`, mirroring the existing `isRepoAgentAuditFeedPath`/`isRepoAgentPendingActionsPath` precedent.