### PR TITLE
feat(api): REST + CLI mirror to stage a pending agent action

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -100,7 +100,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state"],
+  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "propose"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -3099,6 +3099,8 @@ function printMaintainHelp() {
       "  set-level <action> <level>   Set the autonomy level for one action class.",
       `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
       `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
+      "  propose <class> <pull#>      Stage a new pending action for approval (never auto-executes).",
+      "             [--reason ...]    Optional reason recorded with the staged action.",
       "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
       "  outcome-calibration          Show slop-band merge rates and recommendation-outcome calibration.",
       "             [--window-days N]  Bound the recommendation window (default: full history).",
@@ -3231,6 +3233,25 @@ async function maintainCli(args) {
       ...(payload.signals ?? []),
     ];
     emit(payload, lines.join("\n"));
+    return;
+  }
+  if (subcommand === "propose") {
+    // #6744 create side of the approval-queue trio: stage a new pending action for maintainer approval (it
+    // never auto-executes). Mirrors POST .../agent/pending-actions and the loopover_propose_action tool. The
+    // action class is validated server-side (the route's 400 surfaces a bad class), so no client-side list to
+    // drift against.
+    const actionClass = args[1] && !args[1].startsWith("--") ? args[1] : undefined;
+    const pullNumber = Number(args[2]);
+    if (!actionClass) throw new Error("Usage: loopover-mcp maintain propose <action-class> <pull-number> --repo owner/repo.");
+    if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+      throw new Error("Pass a positive <pull-number>: loopover-mcp maintain propose <action-class> <pull-number> --repo owner/repo.");
+    }
+    const payload = await apiPost(`${repoBase}/agent/pending-actions`, {
+      actionClass,
+      pullNumber,
+      ...(options.reason ? { reason: options.reason } : {}),
+    });
+    emit(payload, `${payload.created ? "Staged" : "Already staged"} a ${sanitizePlainTextTerminalOutput(actionClass)} on ${repoFullName}#${pullNumber} for maintainer approval.`);
     return;
   }
   if (subcommand === "onboarding-pack") {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -52,6 +52,7 @@ import {
   getRepository,
   getRepoQueueTrendSnapshot,
   getRepositorySettings,
+  createPendingAgentActionIfAbsent,
   getPendingAgentAction,
   listAgentAuditEvents,
   listAuditEventsForTarget,
@@ -1023,6 +1024,19 @@ function internalOpsAgentConfig(env: Env): OpsAgentConfig {
   const slug = env.GITHUB_APP_SLUG?.trim() || "loopover";
   return { slug, secrets: { internalSecret: "INTERNAL_JOB_TOKEN" } };
 }
+
+// #6744 body for the create side of the approval-queue trio (POST /v1/repos/:owner/:repo/agent/pending-actions).
+// Mirrors the loopover_propose_action MCP tool's proposeActionShape (same bounds), minus owner/repo which are
+// path params here.
+const proposePendingActionBodySchema = z.object({
+  pullNumber: z.number().int().positive(),
+  actionClass: z.enum(["review", "request_changes", "approve", "merge", "close", "label", "review_state_label"]),
+  reason: z.string().max(500).optional(),
+  label: z.string().min(1).max(100).optional(),
+  reviewBody: z.string().max(60000).optional(),
+  mergeMethod: z.enum(["merge", "squash", "rebase"]).optional(),
+  closeComment: z.string().max(60000).optional(),
+});
 
 export function createApp() {
   const app = new Hono<AppBindings>();
@@ -2737,6 +2751,42 @@ export function createApp() {
     const result = await decidePendingAgentAction(c.env, { id: pending.id, decision, decidedBy });
     if (result.status === "already_decided") return c.json({ error: "already_decided", action: result.action }, 409);
     return c.json(result);
+  });
+
+  // #6744 create side of the approval-queue trio (list/decide already existed): stage a NEW pending action for
+  // maintainer approval. Mirrors the loopover_propose_action MCP tool -- write-gated, head-SHA-pinned (so the
+  // accept path's force-push freshness guard is armed rather than a silent no-op, #2255), idempotent per
+  // (repo, pull, actionClass).
+  app.post("/v1/repos/:owner/:repo/agent/pending-actions", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const gate = await requireRepoWriteAccess(c, fullName);
+    /* v8 ignore next -- unauthorized requests are rejected by the auth middleware before reaching the handler. */
+    if (gate instanceof Response) return gate;
+    const parsed = proposePendingActionBodySchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) return c.json({ error: "invalid_pending_action", issues: parsed.error.issues }, 400);
+    const repo = await getRepository(c.env, fullName);
+    if (!repo?.installationId) return c.json({ error: "app_not_installed", detail: "The LoopOver App is not installed on this repository." }, 409);
+    const pr = await getPullRequest(c.env, fullName, parsed.data.pullNumber);
+    const params = {
+      ...(parsed.data.label !== undefined ? { label: parsed.data.label } : {}),
+      ...(parsed.data.reviewBody !== undefined ? { reviewBody: parsed.data.reviewBody } : {}),
+      ...(parsed.data.mergeMethod !== undefined ? { mergeMethod: parsed.data.mergeMethod } : {}),
+      ...(parsed.data.closeComment !== undefined ? { closeComment: parsed.data.closeComment } : {}),
+      ...(pr?.headSha ? { expectedHeadSha: pr.headSha } : {}),
+    };
+    const { action, created } = await createPendingAgentActionIfAbsent(c.env, {
+      repoFullName: fullName,
+      pullNumber: parsed.data.pullNumber,
+      installationId: repo.installationId,
+      actionClass: parsed.data.actionClass,
+      autonomyLevel: "auto_with_approval",
+      params,
+      reason: parsed.data.reason ?? null,
+    });
+    return c.json(
+      { created, action: { id: action.id, actionClass: action.actionClass, pullNumber: action.pullNumber, status: action.status, reason: action.reason } },
+      created ? 201 : 200,
+    );
   });
 
   // #784 audit feed: the agent's executed actions + approval-queue decisions for this repo. Maintainer-scoped,

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -221,7 +221,7 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
     expect(ps).toContain(
-      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state')",
+      "'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state', 'propose')",
     );
   });
 

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { AUTONOMY_LEVELS } from "../../src/settings/autonomy";
-import { closeFixtureServer, repoOnboardingPackFixture, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+import { closeFixtureServer, repoOnboardingPackFixture, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
 
 // #6153: MAINTAIN_AUTONOMY_LEVELS is a hand-synced copy of the live enum (the CLI reaches @loopover/engine only
 // through its published export map, which doesn't surface AUTONOMY_LEVELS), so nothing but a test can catch the
@@ -111,6 +111,31 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     // --window-days bounds the recommendation window; the CLI forwards it as ?windowDays and reflects it.
     const scoped = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo", "--window-days", "30"], e);
     expect(scoped).toMatch(/Outcome calibration for owner\/repo \(last 30d\)/);
+  });
+
+  it("propose stages a new pending action (plain + json), forwarding class/pull/reason to the create route (#6744)", async () => {
+    const requests: string[] = [];
+    const e = await env((request) => requests.push(`${request.method} ${request.url}`));
+
+    const plain = await runAsync(["maintain", "propose", "review", "7", "--repo", "owner/repo", "--reason", "looks clean"], e);
+    expect(plain).toMatch(/Staged a review on owner\/repo#7 for maintainer approval\./);
+    expect(requests.at(-1)).toBe("POST /v1/repos/owner/repo/agent/pending-actions");
+
+    const json = JSON.parse(await runAsync(["maintain", "propose", "merge", "8", "--repo", "owner/repo", "--json"], e)) as {
+      created: boolean;
+      action: { actionClass: string; pullNumber: number; status: string };
+    };
+    expect(json).toMatchObject({ created: true, action: { actionClass: "merge", pullNumber: 8, status: "pending" } });
+  });
+
+  it("propose validates the pull number and required class locally, before any request (#6744)", async () => {
+    const e = await env();
+    const noNumber = runExpectingFailure(["maintain", "propose", "review", "--repo", "owner/repo"], e);
+    expect(`${noNumber.stdout}${noNumber.stderr}`).toMatch(/positive <pull-number>/);
+    const badNumber = runExpectingFailure(["maintain", "propose", "review", "0", "--repo", "owner/repo"], e);
+    expect(`${badNumber.stdout}${badNumber.stderr}`).toMatch(/positive <pull-number>/);
+    const noClass = runExpectingFailure(["maintain", "propose", "--repo", "owner/repo"], e);
+    expect(`${noClass.stdout}${noClass.stderr}`).toMatch(/Usage: loopover-mcp maintain propose/);
   });
 
   it("onboarding-pack mirrors the session-gated API payload and forwards refresh", async () => {

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -38,7 +38,7 @@ vi.mock("../../src/github/backfill", async (importOriginal) => {
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { createSessionForGitHubUser } from "../../src/auth/security";
 import { createApp } from "../../src/api/routes";
-import { createPendingAgentActionIfAbsent, getPendingAgentAction, recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { createPendingAgentActionIfAbsent, getPendingAgentAction, listPendingAgentActions, recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 const app = createApp();
@@ -358,6 +358,76 @@ describe("agent audit-feed route (#784)", () => {
       const res = await app.request("/v1/repos/owner/repo/agent/audit-feed?pull=7", { headers: headers(env) }, env);
       const body = (await res.json()) as { events: Array<{ detail: string | null }> };
       expect(body.events[0]?.detail).toBeNull();
+    });
+  });
+
+  describe("propose a new pending action (POST .../agent/pending-actions) — #6744", () => {
+    async function seedInstalledRepo(env: Env, opts: { pull?: { number: number; headSha: string } } = {}) {
+      // The 3rd arg pins the repo's installationId (the column getRepository reads), matching how the sibling
+      // tests below seed an installed repo.
+      await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+      if (opts.pull) {
+        await upsertPullRequestFromGitHub(env, "owner/repo", { number: opts.pull.number, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: opts.pull.headSha }, labels: [], body: "x" });
+      }
+    }
+    const propose = (env: Env, body: unknown) =>
+      app.request("/v1/repos/owner/repo/agent/pending-actions", { method: "POST", headers: headers(env), body: JSON.stringify(body) }, env);
+
+    it("stages a new action (201, created) pinned to the PR head, with every optional param passed through", async () => {
+      const env = createTestEnv();
+      await seedInstalledRepo(env, { pull: { number: 7, headSha: "h7" } });
+      const res = await propose(env, { actionClass: "review", pullNumber: 7, reason: "looks clean", label: "ready", reviewBody: "LGTM", mergeMethod: "squash", closeComment: "n/a" });
+      expect(res.status).toBe(201);
+      await expect(res.json()).resolves.toMatchObject({ created: true, action: { actionClass: "review", pullNumber: 7, status: "pending", reason: "looks clean" } });
+      // Head-SHA pinning (#2255) + every optional param reached the stored action's params.
+      const [staged] = await listPendingAgentActions(env, { repoFullName: "owner/repo", status: "pending" });
+      expect(staged?.params).toMatchObject({ expectedHeadSha: "h7", label: "ready", reviewBody: "LGTM", mergeMethod: "squash", closeComment: "n/a" });
+    });
+
+    it("stages an action for a PR with no cached head, omitting every absent optional param AND the head pin", async () => {
+      const env = createTestEnv();
+      await seedInstalledRepo(env); // no cached PR row for #8 → no head SHA to pin
+      const res = await propose(env, { actionClass: "merge", pullNumber: 8 });
+      expect(res.status).toBe(201);
+      await expect(res.json()).resolves.toMatchObject({ created: true, action: { actionClass: "merge", pullNumber: 8, status: "pending", reason: null } });
+      const [staged] = await listPendingAgentActions(env, { repoFullName: "owner/repo", status: "pending" });
+      expect(staged?.params).toEqual({});
+    });
+
+    it("is idempotent per (repo, pull, actionClass): a second identical propose returns 200 created:false", async () => {
+      const env = createTestEnv();
+      await seedInstalledRepo(env, { pull: { number: 7, headSha: "h7" } });
+      expect((await propose(env, { actionClass: "review", pullNumber: 7 })).status).toBe(201);
+      const second = await propose(env, { actionClass: "review", pullNumber: 7 });
+      expect(second.status).toBe(200);
+      await expect(second.json()).resolves.toMatchObject({ created: false, action: { actionClass: "review", pullNumber: 7 } });
+    });
+
+    it("rejects a malformed body and an invalid action class with 400, staging nothing", async () => {
+      const env = createTestEnv();
+      await seedInstalledRepo(env, { pull: { number: 7, headSha: "h7" } });
+      // Unparseable JSON → the .catch(() => null) fallback → schema rejects null.
+      const malformed = await app.request("/v1/repos/owner/repo/agent/pending-actions", { method: "POST", headers: headers(env), body: "not json" }, env);
+      expect(malformed.status).toBe(400);
+      await expect(malformed.json()).resolves.toMatchObject({ error: "invalid_pending_action" });
+      const badClass = await propose(env, { actionClass: "explode", pullNumber: 7 });
+      expect(badClass.status).toBe(400);
+      expect(await listPendingAgentActions(env, { repoFullName: "owner/repo", status: "pending" })).toHaveLength(0);
+    });
+
+    it("returns 409 when the LoopOver App is not installed on the repo", async () => {
+      const env = createTestEnv();
+      // Repo exists but carries no installation id → cannot open the App-authenticated action.
+      await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } });
+      const res = await propose(env, { actionClass: "review", pullNumber: 7 });
+      expect(res.status).toBe(409);
+      await expect(res.json()).resolves.toMatchObject({ error: "app_not_installed" });
+    });
+
+    it("requires authentication", async () => {
+      const env = createTestEnv();
+      const res = await app.request("/v1/repos/owner/repo/agent/pending-actions", { method: "POST", body: JSON.stringify({ actionClass: "review", pullNumber: 7 }) }, env);
+      expect([401, 403]).toContain(res.status);
     });
   });
 });

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -548,6 +548,17 @@ export async function startFixtureServer(
       return;
     }
     // #554 gate precision telemetry (read-only). Echoes ?windowDays so the CLI window pass-through is testable.
+    if (request.url === "/v1/repos/owner/repo/agent/pending-actions" && request.method === "POST") {
+      const body = (await readJsonRequest(request)) as { actionClass?: string; pullNumber?: number; reason?: string };
+      response.statusCode = 201;
+      response.end(
+        JSON.stringify({
+          created: true,
+          action: { id: "pa-new", actionClass: body.actionClass, pullNumber: body.pullNumber, status: "pending", reason: body.reason ?? null },
+        }),
+      );
+      return;
+    }
     if (request.url?.startsWith("/v1/repos/owner/repo/gate-precision") && request.method === "GET") {
       const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");
       response.end(


### PR DESCRIPTION
Closes #6744

## Problem

The MCP tool `loopover_propose_action` stages a new pending agent action for maintainer approval (it never auto-executes). REST already had the **list** side (`GET .../agent/pending-actions`) and the **decide** side (`POST .../agent/pending-actions/:id/:decision`), both CLI-mirrored — but no route to **create** a staged action, and no `maintain propose` CLI subcommand. The trio was list/decide only.

## Fix

**Route** — `POST /v1/repos/:owner/:repo/agent/pending-actions` in `src/api/routes.ts`, mirroring the tool's `proposeAction` handler:
- `requireRepoWriteAccess`-gated (same gate as the sibling decide route);
- body validated by a zod schema mirroring the tool's `proposeActionShape` (minus owner/repo, which are path params);
- pins the action to the PR's current head SHA (so the accept path's force-push freshness guard is armed rather than a silent no-op for a REST-staged action, #2255);
- idempotent per `(repo, pull, actionClass)` via `createPendingAgentActionIfAbsent` → `201 { created: true }` on first stage, `200 { created: false }` on a repeat;
- `409 app_not_installed` when the repo has no installation, `400 invalid_pending_action` on a malformed/invalid body.

These internal agent routes are not part of the public OpenAPI spec (`src/openapi/spec.ts`), matching the sibling list/decide routes, so no spec change is needed.

**CLI** — `maintain propose <action-class> <pull-number> [--reason ...]` in `loopover-mcp.js`, POSTing to the new route (registered in the subcommand table + PowerShell completer + help). The action class is validated server-side (the route's 400 surfaces a bad class), so no client-side enum to drift against.

## Tests

- `test/unit/routes-agent-approval.test.ts` (**6 new**): stages with every optional param + head-SHA pinning; stages with no cached PR head (omitting the pin + all absent params); idempotent repeat; malformed body + invalid class → 400 staging nothing; `409` when not installed; requires auth. **100% line + branch coverage on the new route + schema** (18/18 branches).
- `test/unit/mcp-cli-maintain.test.ts` (**2 new**): the CLI stages (plain + json) forwarding class/pull/reason to the route; local validation of a missing class / non-positive pull number before any request.
- Harness gains a `POST .../agent/pending-actions` fixture; the completer assertion adds `propose`.

## Validation

- `npx vitest run` on the 5 affected suites → **161/161 pass**; new route branch coverage **100%** (verified locally via lcov — the `codecov/patch` gate).
- `npm run typecheck` → **clean (0 errors)**; `node --check` on the CLI passes.
- Scope: 1 route file + 1 CLI file + 4 test/fixture files.
