### PR TITLE
fix(ui): SSR-safe homepage install-tab via useLocalStorage

### DIFF
--- a/apps/loopover-ui/src/routes/index.test.tsx
+++ b/apps/loopover-ui/src/routes/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { ClientSetupTabs } from "./index";
@@ -8,9 +8,9 @@ import { ClientSetupTabs } from "./index";
 // the shared Radix-backed Tabs primitive. This is the regression test for that gap.
 
 describe("ClientSetupTabs keyboard navigation (#6813)", () => {
-  // ClientSetupTabs persists the active tab to localStorage ("gt:install-tab") and reads it back as the
-  // initial state on mount -- without clearing it, a later test's initial "miners" tab assumption breaks
-  // because an earlier test in this file left a different tab persisted.
+  // ClientSetupTabs persists the active tab to localStorage ("gt:install-tab") and reads it back post-
+  // hydrate -- without clearing it, a later test's initial "miners" tab assumption breaks because an
+  // earlier test in this file left a different tab persisted.
   beforeEach(() => {
     window.localStorage.clear();
   });
@@ -98,5 +98,52 @@ describe("ClientSetupTabs keyboard navigation (#6813)", () => {
     fireEvent.click(codexTab);
 
     expect(codexTab.getAttribute("aria-selected")).toBe("true");
+  });
+});
+
+describe("ClientSetupTabs SSR-safe install-tab persistence (#6814)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("initial render is always miners even when localStorage already holds another tab", async () => {
+    window.localStorage.setItem("gt:install-tab", JSON.stringify("cursor"));
+    render(<ClientSetupTabs />);
+    // First paint must match the SSR default — not the stored value.
+    expect(screen.getByRole("tab", { name: /Miner CLI/i }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /Cursor/i }).getAttribute("aria-selected")).toBe(
+      "false",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Cursor/i }).getAttribute("aria-selected")).toBe(
+        "true",
+      );
+    });
+  });
+
+  it("migrates a pre-#6814 bare tab id and selects it after hydrate", async () => {
+    window.localStorage.setItem("gt:install-tab", "codex");
+    render(<ClientSetupTabs />);
+    expect(screen.getByRole("tab", { name: /Miner CLI/i }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Codex/i }).getAttribute("aria-selected")).toBe(
+        "true",
+      );
+    });
+    expect(JSON.parse(window.localStorage.getItem("gt:install-tab")!)).toBe("codex");
+  });
+
+  it("persists the selected tab as JSON after a click", async () => {
+    render(<ClientSetupTabs />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: /Remote MCP/i }));
+    });
+    expect(JSON.parse(window.localStorage.getItem("gt:install-tab")!)).toBe("remote");
   });
 });

--- a/apps/loopover-ui/src/routes/index.tsx
+++ b/apps/loopover-ui/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
+import { useLocalStorage } from "@/lib/use-local-storage";
 
 import { AnimatedTerminal } from "@/components/site/animated-terminal";
 import { ScoreabilityStory } from "@/components/site/home/scoreability-story";
@@ -511,13 +512,36 @@ args = ["-y", "@loopover/mcp@latest", "--stdio"]`,
 ];
 
 export function ClientSetupTabs() {
-  const [active, setActive] = useState<ClientTabId>(() => {
-    if (typeof window === "undefined") return "miners";
-    return (window.localStorage.getItem("gt:install-tab") as ClientTabId) ?? "miners";
-  });
+  // #6814: SSR-safe persistence — never read localStorage in the useState initializer (server has no
+  // window; a client-only read there mismatches hydration). useLocalStorage starts at "miners" and
+  // hydrates post-mount, matching app.workbench.tsx.
+  const [stored, setStored, hydrated] = useLocalStorage<ClientTabId>("gt:install-tab", "miners");
   const [copied, setCopied] = useState(false);
-  const current = CLIENT_TABS.find((t) => t.id === active) ?? CLIENT_TABS[0];
   const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  // Pre-#6814 wrote a bare tab id (not JSON). Migrate once so useLocalStorage can parse it.
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      const raw = window.localStorage.getItem("gt:install-tab");
+      if (raw == null) return;
+      try {
+        JSON.parse(raw);
+      } catch {
+        if (CLIENT_TABS.some((tab) => tab.id === raw)) {
+          setStored(raw as ClientTabId);
+        }
+      }
+    } catch {
+      /* noop */
+    }
+  }, [hydrated, setStored]);
+
+  // Until hydrated, always render the SSR default so markup matches the server.
+  const active: ClientTabId =
+    !hydrated || !CLIENT_TABS.some((tab) => tab.id === stored) ? "miners" : stored;
+  const setActive = (id: ClientTabId) => setStored(id);
+  const current = CLIENT_TABS.find((t) => t.id === active) ?? CLIENT_TABS[0];
 
   // ARIA APG tabs pattern (#6813): ArrowLeft/ArrowRight move (wrapping) and automatically activate the
   // adjacent tab, Home/End jump to the first/last tab -- matching every other tabbed UI in this codebase
@@ -542,14 +566,6 @@ export function ClientSetupTabs() {
       focusTab(CLIENT_TABS[CLIENT_TABS.length - 1]!.id);
     }
   };
-
-  useEffect(() => {
-    try {
-      window.localStorage.setItem("gt:install-tab", active);
-    } catch {
-      /* noop */
-    }
-  }, [active]);
 
   const onCopy = async () => {
     try {


### PR DESCRIPTION
## Summary
- Migrate homepage `ClientSetupTabs` install-tab state to `useLocalStorage`, gating the active tab on `hydrated` so the first paint always matches the SSR default (`miners`).
- Migrate pre-#6814 bare tab ids in `localStorage` to JSON so returning visitors keep their preference.
- Add regression tests for initial SSR-safe render, bare-id migration, and JSON persistence.

Closes #6814.

## Test plan
- [ ] UI unit tests green (`index.test.tsx`)
- [ ] `validate-code` / prettier green
- [ ] Manual: with `gt:install-tab` set, first paint is Miner CLI then hydrates to the stored tab