### PR TITLE
fix(mcp): correct stale gittensory repoFullName in draft-pr-body test

### DIFF
--- a/test/unit/mcp-cli-draft-pr-body.test.ts
+++ b/test/unit/mcp-cli-draft-pr-body.test.ts
@@ -82,7 +82,7 @@ describe("loopover_draft_pr_body stdio mirror (#6741)", () => {
       arguments: {
         login: "JSONbored",
         cwd: repoDir,
-        repoFullName: "JSONbored/gittensory",
+        repoFullName: "JSONbored/loopover",
         baseRef: "HEAD",
       },
     });
@@ -98,7 +98,7 @@ describe("loopover_draft_pr_body stdio mirror (#6741)", () => {
     expect(data.title).toBe("Local branch preflight");
     // Parity: same engine export over the fixture analysis shape yields the same markdown.
     const expected = buildPublicPrBodyDraft({
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       prPacket: {
         titleSuggestion: "Local branch preflight",
         bodySections: [
@@ -133,7 +133,7 @@ describe("loopover_draft_pr_body stdio mirror (#6741)", () => {
       arguments: {
         login: "JSONbored",
         cwd: repoDir,
-        repoFullName: "JSONbored/gittensory",
+        repoFullName: "JSONbored/loopover",
         baseRef: "HEAD",
         format: "markdown",
       },


### PR DESCRIPTION
## Summary
- `test/unit/mcp-cli-draft-pr-body.test.ts`'s "honors format=markdown" case passed `repoFullName: "JSONbored/gittensory"` as an explicit tool argument but asserted the response echoed back `"JSONbored/loopover"`. Since `loopover_draft_pr_body` returns whatever `repoFullName` it was given verbatim (`input.repoFullName ?? parseGitRemote(remoteUrl)`), the two must match.
- Left over from an earlier gittensory -> loopover rebrand pass that missed these test fixtures; the fixture harness's real git remote (`createPacketRepo`) already uses `JSONbored/loopover`.
- Discovered while unblocking CI on the automated release-please branches (which build from a fresh checkout and hit this pre-existing flake).

## Test plan
- [x] `npx vitest run test/unit/mcp-cli-draft-pr-body.test.ts` -- 4/4 pass
- [x] `npx vitest run test/unit/mcp-cli-profiles.test.ts` -- 8/8 pass (adjacent MCP CLI coverage)
- [x] `npm run typecheck`
- Test-only change under `test/**`, not measured by Codecov patch coverage.