### PR TITLE
feat(selfhost): expose a staleness signal for the clock-skew gauge (#7000)

### DIFF
--- a/src/selfhost/clock-skew.ts
+++ b/src/selfhost/clock-skew.ts
@@ -8,6 +8,11 @@
 // outbound request, sampled at exactly the cadence the vulnerable code path itself runs.
 
 let lastSkewSeconds = 0;
+// Wall-clock time (ms) of the last SUCCESSFUL skew sample, or null until the first one (#7000). Because a
+// sample is only taken when a JWT token mint call observes a `Date` header, a long-lived cached/broker-provided
+// token can mean no mint (and thus no fresh sample) for a while — during which `lastSkewSeconds` keeps reporting
+// an old reading as if it were current. Tracking the sample time lets the metric expose that staleness.
+let lastSampleAtMs: number | null = null;
 
 /**
  * Update the last-observed clock-skew sample from a GitHub response's `Date` header. Positive means
@@ -21,6 +26,7 @@ export function recordClockSkewFromResponse(response: Response): void {
   const remoteMs = Date.parse(dateHeader);
   if (!Number.isFinite(remoteMs)) return;
   lastSkewSeconds = (Date.now() - remoteMs) / 1000;
+  lastSampleAtMs = Date.now();
 }
 
 /** The most recently observed clock-skew sample in seconds (0 until the first successful sample). */
@@ -28,7 +34,19 @@ export function clockSkewSecondsSample(): number {
   return lastSkewSeconds;
 }
 
-/** Test-only: reset the module-level sample between tests. */
+/**
+ * Age in seconds since the last successful clock-skew sample, or `-1` when no sample has been taken yet (#7000).
+ * The `-1` sentinel follows the same "no reading available" convention `d1-size-probe.ts` and
+ * `loopover_host_load_avg1_per_core` use, so an operator can distinguish a fresh reading from a stale one
+ * instead of an old sample silently looking current.
+ */
+export function clockSkewSampleAgeSeconds(): number {
+  if (lastSampleAtMs === null) return -1;
+  return (Date.now() - lastSampleAtMs) / 1000;
+}
+
+/** Test-only: reset the module-level sample state between tests. */
 export function resetClockSkewForTest(): void {
   lastSkewSeconds = 0;
+  lastSampleAtMs = null;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ import {
   sqliteBackupAdvisory,
   type ReadinessProbe,
 } from "./selfhost/health";
-import { clockSkewSecondsSample } from "./selfhost/clock-skew";
+import { clockSkewSampleAgeSeconds, clockSkewSecondsSample } from "./selfhost/clock-skew";
 import { d1DatabaseSizeBytesSample, d1SignalSnapshotsRowsPerKeySample, d1TableRowCountSamples, isD1SizeProbeEnabled, runD1SizeProbe } from "./selfhost/d1-size-probe";
 import { gauge, gaugeVector, incr, observe, renderMetrics, setSelfHostedMetricsMode } from "./selfhost/metrics";
 import { runSelfHostMigrations } from "./selfhost/migrate";
@@ -828,6 +828,9 @@ async function main(): Promise<void> {
   // from "no signal on this platform" (see host-pressure.ts).
   gauge("loopover_host_load_avg1_per_core", async () => (await maintenancePressure()).hostLoadAvg1PerCore ?? -1);
   gauge("loopover_clock_skew_seconds", () => clockSkewSecondsSample());
+  // Companion staleness signal (#7000): age of the clock-skew sample, or -1 when never sampled — so a stale
+  // reading (no recent token mint) is distinguishable from a fresh one instead of silently looking current.
+  gauge("loopover_clock_skew_sample_age_seconds", () => clockSkewSampleAgeSeconds());
   // D1 size/row-count observability probe (#3810): opt-in Cloudflare Management API poll for the shared
   // cloud D1's file size and monitored-table row counts. Always registered (byte-identical -1/empty samples
   // when the probe is disabled or has never completed) so the metric names/HELP/TYPE lines are present on

--- a/test/unit/clock-skew.test.ts
+++ b/test/unit/clock-skew.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clockSkewSecondsSample, recordClockSkewFromResponse, resetClockSkewForTest } from "../../src/selfhost/clock-skew";
+import {
+  clockSkewSampleAgeSeconds,
+  clockSkewSecondsSample,
+  recordClockSkewFromResponse,
+  resetClockSkewForTest,
+} from "../../src/selfhost/clock-skew";
 
 beforeEach(() => resetClockSkewForTest());
 afterEach(() => vi.useRealTimers());
@@ -50,5 +55,38 @@ describe("clock-skew", () => {
     expect(clockSkewSecondsSample()).not.toBe(0);
     resetClockSkewForTest();
     expect(clockSkewSecondsSample()).toBe(0);
+  });
+
+  // #7000: the staleness/freshness signal alongside the skew value.
+  it("reports the -1 'never sampled' sentinel before any sample is recorded", () => {
+    expect(clockSkewSampleAgeSeconds()).toBe(-1);
+  });
+
+  it("reports the seconds elapsed since the last successful sample", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T12:00:00.000Z"));
+    recordClockSkewFromResponse(new Response(null, { headers: { date: "Mon, 06 Jul 2026 12:00:00 GMT" } }));
+    expect(clockSkewSampleAgeSeconds()).toBe(0); // just sampled
+
+    vi.setSystemTime(new Date("2026-07-06T12:00:45.000Z"));
+    expect(clockSkewSampleAgeSeconds()).toBe(45); // 45s since the sample, even though the skew value is unchanged
+  });
+
+  it("keeps aging (does not refresh) when a later response is ignored for lack of a usable Date header", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T12:00:00.000Z"));
+    recordClockSkewFromResponse(new Response(null, { headers: { date: "Mon, 06 Jul 2026 12:00:00 GMT" } }));
+
+    vi.setSystemTime(new Date("2026-07-06T12:00:30.000Z"));
+    recordClockSkewFromResponse(new Response(null)); // no Date header → ignored, sample time NOT refreshed
+    recordClockSkewFromResponse(new Response(null, { headers: { date: "not-a-date" } })); // unparseable → ignored too
+    expect(clockSkewSampleAgeSeconds()).toBe(30); // still measured from the original sample
+  });
+
+  it("resetClockSkewForTest restores the age to the -1 sentinel", () => {
+    recordClockSkewFromResponse(new Response(null, { headers: { date: new Date().toUTCString() } }));
+    expect(clockSkewSampleAgeSeconds()).not.toBe(-1);
+    resetClockSkewForTest();
+    expect(clockSkewSampleAgeSeconds()).toBe(-1);
   });
 });


### PR DESCRIPTION
Closes #7000.

`loopover_clock_skew_seconds` is fed from `lastSkewSeconds`, which only updates when a JWT token-mint call observes a GitHub `Date` header (per `clock-skew.ts`'s own #3811 note). If minting stalls — e.g. a long-lived cached/broker-provided token means no fresh mint for a while — the gauge keeps reporting an old sample **as if it were current**, and an operator watching it can't distinguish "clock fine, just sampled a while ago" from "sampled right now".

### Change
- **`src/selfhost/clock-skew.ts`**: track `lastSampleAtMs` in the same place `lastSkewSeconds` is updated, and add `clockSkewSampleAgeSeconds()` — the age in seconds since the last successful sample, or **`-1` when never sampled**. That `-1` sentinel follows the established "no reading available" convention from `d1-size-probe.ts` / `loopover_host_load_avg1_per_core`. `resetClockSkewForTest` clears the new state too; `recordClockSkewFromResponse`'s skew calculation is untouched.
- **`src/server.ts`**: register the companion gauge `loopover_clock_skew_sample_age_seconds` right next to `loopover_clock_skew_seconds`.

### Tests
Extends `test/unit/clock-skew.test.ts`: the age starts at the `-1` sentinel, reports elapsed seconds after a sample (independent of the unchanged skew value), keeps aging when a later response is ignored (missing/unparseable `Date` header), and resets to `-1`. The module is at **100% coverage** (statements/branches/functions/lines).