### PR TITLE
fix(ui-kit): respect prefers-reduced-motion on Skeleton's pulse animation

### DIFF
--- a/apps/loopover-ui/src/components/site/skeleton-reduced-motion.test.tsx
+++ b/apps/loopover-ui/src/components/site/skeleton-reduced-motion.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Skeleton } from "@loopover/ui-kit/components/skeleton";
+
+// #7016: every other animated ui-kit primitive (Spinner, button.tsx, tabs.tsx) disables/reduces its
+// animation under prefers-reduced-motion via motion-reduce:animate-none; Skeleton was the one loading-state
+// primitive that didn't, despite state-views.tsx's own doc comment claiming the whole family respects it.
+describe("Skeleton respects prefers-reduced-motion (#7016)", () => {
+  it("pairs animate-pulse with motion-reduce:animate-none", () => {
+    const { container } = render(<Skeleton data-testid="skeleton" />);
+    const el = container.firstElementChild;
+    expect(el?.className).toContain("animate-pulse");
+    expect(el?.className).toContain("motion-reduce:animate-none");
+  });
+
+  it("still merges a caller-supplied className", () => {
+    const { container } = render(<Skeleton className="h-4 w-full" />);
+    const el = container.firstElementChild;
+    expect(el?.className).toContain("h-4");
+    expect(el?.className).toContain("w-full");
+    expect(el?.className).toContain("motion-reduce:animate-none");
+  });
+});

--- a/packages/loopover-ui-kit/src/components/skeleton.tsx
+++ b/packages/loopover-ui-kit/src/components/skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from "../utils";
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("animate-pulse rounded-md bg-primary/10", className)} {...props} />;
+  return <div className={cn("animate-pulse rounded-md bg-primary/10 motion-reduce:animate-none", className)} {...props} />;
 }
 
 export { Skeleton };


### PR DESCRIPTION
## Summary
- `packages/loopover-ui-kit/src/components/skeleton.tsx`'s `Skeleton` used `animate-pulse` with no `motion-reduce:animate-none` companion class, unlike every other animated primitive in the kit (`Spinner`, `button.tsx`, `tabs.tsx`).
- `state-views.tsx`'s own doc comment claims "All animations respect prefers-reduced-motion" for the loading-state family, and directs callers to `Skeleton` for content-shaped placeholders — making `Skeleton` the one component that didn't actually honor that claim.
- Adds `motion-reduce:animate-none` to `Skeleton`'s className, matching the existing convention exactly. No change to base styling or prop passthrough.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7016

## Validation
- [x] `git diff --check`
- [ ] `npm run actionlint` (backend-only check; this PR only touches `packages/loopover-ui-kit` + a test in `apps/loopover-ui`)
- [x] `npm run typecheck` (via `npm run ui:typecheck`, the UI-scoped equivalent — includes the `ui:kit:build` step)
- [ ] `npm run test:coverage` (backend-only; `packages/loopover-ui-kit` has no standalone test runner — see Notes)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` (not applicable to this UI-kit-only change)
- [ ] `npm run ui:openapi:check` (no API/schema changes)
- [x] `npm run ui:lint` — 0 errors
- [x] `npm run ui:typecheck` — clean
- [x] `npm --workspace @loopover/ui run test src/components/site/skeleton-reduced-motion.test.tsx` — 2/2 passing
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `packages/loopover-ui-kit` has no `test` script or vitest config of its own (confirmed via its `package.json`), so ui-kit components are exercised through `apps/loopover-ui`'s test runner, importing directly from `@loopover/ui-kit/components/...` — the new regression test follows that same pattern (mirrors how `state-views.tsx`'s ported components are consumed/tested). `npm run test:workers`, the MCP packaging checks, and `actionlint` have no surface to exercise for a one-class CSS change to a shared UI primitive.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — this is a CSS-only accessibility fix to a shared primitive, not API-data-driven.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — `prefers-reduced-motion` only changes animation behavior under a media-query condition a static screenshot can't show; the new test asserts the actual class is present, which is the relevant, verifiable evidence for this kind of change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- `packages/loopover-ui-kit/dist/` is gitignored and rebuilt locally via `npm run build --workspace @loopover/ui-kit` (also the `ui:kit:build` step inside `ui:typecheck`) — no generated artifact needs committing for this change.