### PR TITLE
fix: respect prefers-reduced-motion in Skeleton animate-pulse

### DIFF
--- a/packages/loopover-ui-kit/src/components/skeleton.tsx
+++ b/packages/loopover-ui-kit/src/components/skeleton.tsx
@@ -1,7 +1,13 @@
 import { cn } from "../utils";
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("animate-pulse rounded-md bg-primary/10", className)} {...props} />;
+  return (
+    <div
+      className={cn("motion-safe:animate-pulse rounded-md bg-primary/10", className)}
+      aria-hidden="true"
+      {...props}
+    />
+  );
 }
 
 export { Skeleton };


### PR DESCRIPTION
## What

The Skeleton component now respects `prefers-reduced-motion` by using Tailwind's `motion-safe:animate-pulse` instead of bare `animate-pulse`.

## Why

The skeleton pulse animation played regardless of the user's system accessibility preference. Every other animated element in the app (e.g., proof-of-power-stats animate-pulse) uses `motion-safe:` to honor reduced motion — the Skeleton was the odd one out.

## Testing

- With `prefers-reduced-motion: no-preference`: skeleton animates as before
- With `prefers-reduced-motion: reduce`: skeleton is static, no animation
- Existing styles (rounded-md, bg-primary/10) preserved
- Added `aria-hidden="true"` since skeleton is decorative