### PR TITLE
fix(selfhost): fail open on a Redis write failure in the installation-token cache

### DIFF
--- a/src/selfhost/redis-token-cache.ts
+++ b/src/selfhost/redis-token-cache.ts
@@ -64,12 +64,21 @@ export function createRedisTokenCache(redis: Redis): InstallationTokenStore {
         1,
         Math.floor((value.expiresAtMs - Date.now()) / 1000),
       );
-      await redis.set(
-        keyFor(installationId),
-        JSON.stringify(value),
-        "EX",
-        ttlSeconds,
-      );
+      // Fail open on a connection error, same contract as get() above: the caller (github/app.ts's
+      // createInstallationToken, right after successfully minting a fresh token) has no try/catch of its own,
+      // so an uncaught error here would turn an otherwise-successful mint into a hard failure over a transient
+      // cache-write hiccup. The token was already obtained from GitHub before this call, so a write failure
+      // just costs one extra real mint next time -- never the caller's job to fail.
+      try {
+        await redis.set(
+          keyFor(installationId),
+          JSON.stringify(value),
+          "EX",
+          ttlSeconds,
+        );
+      } catch {
+        recordTokenCacheMetric("error");
+      }
     },
   };
 }

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -28,6 +28,8 @@ import type { Advisory } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 import { getInstallation, listLatestGitHubRateLimitObservations, upsertInstallation } from "../../src/db/repositories";
 import { clockSkewSecondsSample, resetClockSkewForTest } from "../../src/selfhost/clock-skew";
+import { createRedisTokenCache } from "../../src/selfhost/redis-token-cache";
+import type { Redis } from "ioredis";
 
 beforeEach(() => {
   clearInstallationTokenCacheForTest();
@@ -2712,6 +2714,32 @@ describe("self-host Redis token store + GitHub GET response cache", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
     await expect(getAppInstallation(env, 99)).rejects.toThrow();
     expect(store.size).toBe(0); // non-200 not cached
+  });
+
+  it("REGRESSION (#6999): a Redis write failure never fails an otherwise-successful token mint", async () => {
+    // The real createRedisTokenCache implementation (not a hand-rolled store), wired to a Redis stand-in whose
+    // set() always throws -- pins that the fail-open fix actually reaches createInstallationToken's uncaught
+    // writeCachedToken call, not just the unit-level contract on redis-token-cache.ts's own set().
+    const throwingRedis = {
+      get: async () => null,
+      set: async () => {
+        throw new Error("connection refused");
+      },
+    } as unknown as Redis;
+    setInstallationTokenStore(createRedisTokenCache(throwingRedis));
+    const privateKey = await generatePrivateKeyPem();
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (input.toString().includes("/access_tokens")) {
+        return Response.json({
+          token: "minted-despite-cache-failure",
+          expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    await expect(createInstallationToken(env, 888)).resolves.toBe("minted-despite-cache-failure");
   });
 });
 

--- a/test/unit/selfhost-redis-token-cache.test.ts
+++ b/test/unit/selfhost-redis-token-cache.test.ts
@@ -4,7 +4,7 @@ import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createRedisTokenCache } from "../../src/selfhost/redis-token-cache";
 
 /** Minimal ioredis stand-in that records the TTL passed to set(). */
-function fakeRedis(options: { getThrows?: boolean } = {}): {
+function fakeRedis(options: { getThrows?: boolean; setThrows?: boolean } = {}): {
   redis: Redis;
   store: Map<string, string>;
   ttl: () => number;
@@ -17,6 +17,7 @@ function fakeRedis(options: { getThrows?: boolean } = {}): {
       return store.get(k) ?? null;
     },
     async set(k: string, v: string, _ex: "EX", ttl: number) {
+      if (options.setThrows) throw new Error("connection refused");
       store.set(k, v);
       lastTtl = ttl;
       return "OK";
@@ -109,5 +110,20 @@ describe("createRedisTokenCache (#perf installation-token persistence)", () => {
     expect(await renderMetrics()).toContain(
       'loopover_redis_token_cache_total{result="error"} 1',
     );
+  });
+
+  it("regression: set() fails open (does not throw) and records an error metric on a Redis connection failure (#6999)", async () => {
+    // The token was already successfully minted from GitHub before set() is called (github/app.ts's
+    // createInstallationToken has no try/catch around this write), so a transient cache-write failure must
+    // never surface as a token-mint failure -- same fail-open contract as get()'s own regression test above.
+    const { redis, store } = fakeRedis({ setThrows: true });
+    await expect(
+      createRedisTokenCache(redis).set(9, { token: "sensitive-value", expiresAtMs: Date.now() + 60_000 }),
+    ).resolves.toBeUndefined();
+
+    expect(store.has("gh:insttoken:9")).toBe(false); // the write never actually landed
+    const metrics = await renderMetrics();
+    expect(metrics).toContain('loopover_redis_token_cache_total{result="error"} 1');
+    expect(metrics).not.toContain("sensitive-value");
   });
 });


### PR DESCRIPTION
## Summary
- `src/selfhost/redis-token-cache.ts`'s `get()` wraps its `redis.get` call in try/catch with an explicit fail-open contract (the caller, `github/app.ts`'s `createInstallationToken`, has no try/catch of its own, so an uncaught error would hard-fail GitHub App token minting on every Redis hiccup). `set()` — the sibling write call — had no try/catch at all.
- Confirmed the caller genuinely has no surrounding try/catch: `writeCachedToken` (`src/github/app.ts`) calls `externalTokenStore.set(...)` directly with no guard, right after `createInstallationToken` successfully obtains a fresh token from GitHub. A transient Redis write failure at that point threw uncaught and turned an otherwise-successful mint into a hard failure.
- Wraps `set()`'s `redis.set(...)` call in try/catch, matching `get()`'s exact fail-open contract: on error, record a metric via the existing `recordTokenCacheMetric("error")` and return without rethrowing. No change to `get()` or the TTL-flooring logic.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6999

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of what changed (reconfirmed this revision, including a fresh attempt after freeing up memory); relied on `npm run build --workspace @loopover/engine` (passed) plus the full targeted vitest run below as the local proxy, and CI's isolated runner for the authoritative `tsc --noEmit`.
- [x] `npm run test:coverage` — full targeted run of both affected test files: `test/unit/selfhost-redis-token-cache.test.ts` (7 tests, incl. the new `set()` fail-open regression) and `test/unit/github-app.test.ts` (93 tests, incl. a new end-to-end regression through the real `createRedisTokenCache` + `createInstallationToken`) — 100/100 passing.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` (not applicable — no Worker binding/queue or MCP packaging changes)
- [ ] `npm run ui:openapi:check` (no API/schema changes)
- [x] `npm run ui:lint` — 0 errors (ran as a sanity check; this PR touches no `apps/loopover-ui/**` files)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure (reproduced multiple times across sessions, including on a clean `main` checkout with no diff), so it was not run standalone; `npm run build --workspace @loopover/engine` plus the full targeted test run above stand in as the local proxy, and CI's isolated runner performs the real `tsc --noEmit`. `npm run test:workers` and the MCP packaging checks have no surface to exercise for a change scoped to one try/catch in one self-host module.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The new regression tests assert the cached token value (`"sensitive-value"`) never reaches the Prometheus metrics text.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. This directly touches GitHub App installation-token caching; both the unit-level fail-open path and the end-to-end `createInstallationToken` success-despite-cache-failure path are tested.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal self-host caching behavior, no external-facing API/MCP surface change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — backend-only change, no UI surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.