### PR TITLE
fix(ui-kit): add a focus-visible indicator to AccordionTrigger

### DIFF
--- a/apps/loopover-ui/src/components/site/accordion-trigger-focus-visible.test.tsx
+++ b/apps/loopover-ui/src/components/site/accordion-trigger-focus-visible.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@loopover/ui-kit/components/accordion";
+
+// #7015: every other styled interactive trigger in ui-kit (button, tabs, toggle, switch, checkbox, slider)
+// applies a focus-visible:ring-* class; AccordionTrigger was the one that didn't, leaving keyboard users with
+// no visible indication of focus when tabbing to an accordion header.
+describe("AccordionTrigger focus-visible indicator (#7015)", () => {
+  it("pairs the trigger with the kit's standard focus-visible ring classes", () => {
+    render(
+      <Accordion type="single" collapsible>
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Section</AccordionTrigger>
+          <AccordionContent>Details</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+    const trigger = screen.getByRole("button", { name: "Section" });
+    expect(trigger.className).toContain("focus-visible:outline-none");
+    expect(trigger.className).toContain("focus-visible:ring-2");
+    expect(trigger.className).toContain("focus-visible:ring-ring");
+    expect(trigger.className).toContain("focus-visible:ring-offset-2");
+  });
+});

--- a/packages/loopover-ui-kit/src/components/accordion.tsx
+++ b/packages/loopover-ui-kit/src/components/accordion.tsx
@@ -22,7 +22,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 text-sm font-medium cursor-pointer transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between py-4 text-sm font-medium cursor-pointer transition-all hover:underline text-left ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 [&[data-state=open]>svg]:rotate-180",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- `packages/loopover-ui-kit/src/components/accordion.tsx`'s `AccordionTrigger` had no focus indicator at all — its className only included `hover:underline` for the hover state, nothing for `:focus-visible`. Every other styled interactive trigger/control in the kit (`button.tsx`, `tabs.tsx`, `toggle.tsx`, `switch.tsx`, `checkbox.tsx`, `slider.tsx`) applies a `focus-visible:ring-*` class.
- Adds `ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` to `AccordionTrigger`'s className, matching the exact convention already used by `button.tsx` and `tabs.tsx`. No change to hover/open-state styling or the chevron rotation behavior.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7015

## Validation
- [x] `git diff --check`
- [ ] `npm run actionlint` (backend-only check; this PR only touches `packages/loopover-ui-kit` + a test in `apps/loopover-ui`)
- [x] `npm run typecheck` (via `npm run ui:typecheck`, the UI-scoped equivalent — includes the `ui:kit:build` step)
- [ ] `npm run test:coverage` (backend-only; `packages/loopover-ui-kit` has no standalone test runner — see Notes)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` (not applicable to this UI-kit-only change)
- [ ] `npm run ui:openapi:check` (no API/schema changes)
- [x] `npm run ui:lint` — 0 errors
- [x] `npm run ui:typecheck` — clean
- [x] `npm --workspace @loopover/ui run test src/components/site/accordion-trigger-focus-visible.test.tsx` — 1/1 passing
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `packages/loopover-ui-kit` has no `test` script or vitest config of its own, so ui-kit components are exercised through `apps/loopover-ui`'s test runner, importing directly from `@loopover/ui-kit/components/...` — the new regression test follows that same pattern established by prior ui-kit fixes in this repo. `npm run test:workers`, the MCP packaging checks, and `actionlint` have no surface to exercise for a one-class CSS change to a shared UI primitive.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — this is a CSS-only accessibility fix to a shared primitive, not API-data-driven.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — `:focus-visible` only renders under real keyboard-focus interaction, which a static screenshot can't demonstrate meaningfully; the new test asserts the actual ring classes are present on the trigger, which is the relevant, verifiable evidence for this kind of change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- `packages/loopover-ui-kit/dist/` is gitignored and rebuilt locally via `npm run build --workspace @loopover/ui-kit` — no generated artifact needs committing for this change.