### PR TITLE
feat(rees): parse pnpm-lock.yaml for lockfile drift analysis

### DIFF
--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -342,11 +342,50 @@ function parsePoetryLock(path: string, patch: string, maxLines: number): Lockfil
   return [...byKey.values()].filter((change) => change.to && change.to !== change.from);
 }
 
+// pnpm encodes the resolved version directly in each `packages:`/`snapshots:` map KEY (`name@version`, with an
+// optional leading `/` on v6 and an optional `(peerA@x)` peer-scope suffix on snapshot keys) rather than on a
+// separate `version:` line the way yarn/npm do. So a bump is just a `-name@old:` / `+name@new:` key-line pair,
+// and dedup-by-package folds the same change appearing in both `packages:` and `snapshots:`. A peer-only churn
+// (`foo@1(react@17)` -> `foo@1(react@18)`) strips to `foo@1` on both sides and is dropped by the to!==from
+// filter. The legacy pnpm v5 `/name/version` key form (slash-separated, no `@`) is intentionally NOT parsed —
+// the issue scopes this to "at minimum the current version", and v5 is out of active use.
+function parsePnpmLock(path: string, patch: string, maxLines: number): LockfileChange[] {
+  const byKey = new Map<string, LockfileChange>();
+  const KEY = /^\s+['"]?\/?(@?[^@'"\s()/]+(?:\/[^@'"\s()]+)?)@([^'"\s():]+)(?:\([^)]*\))?['"]?:\s*$/;
+  for (const line of patchLines(patch, maxLines)) {
+    if (line.sign === " ") continue;
+    const match = KEY.exec(line.content);
+    if (!match) continue;
+    const pkg = match[1]!;
+    const version = match[2]!;
+    const key = `npm::${pkg}`;
+    const entry =
+      byKey.get(key) ??
+      {
+        file: path,
+        line: line.newLine,
+        ecosystem: "npm" as const,
+        package: pkg,
+        from: null,
+        to: "",
+      };
+    if (line.sign === "+") {
+      entry.to = version;
+      entry.line = line.newLine;
+    } else if (line.sign === "-") {
+      entry.from = version;
+    }
+    byKey.set(key, entry);
+  }
+  return [...byKey.values()].filter((change) => change.to && change.to !== change.from);
+}
+
 function parseLockfile(path: string, patch: string, maxLines: number): LockfileChange[] {
   const name = lockfileBasename(path).toLowerCase();
   if (name === "package-lock.json") return parsePackageLock(path, patch, maxLines);
   if (name === "yarn.lock") return parseYarnLock(path, patch, maxLines);
   if (name === "poetry.lock") return parsePoetryLock(path, patch, maxLines);
+  if (name === "pnpm-lock.yaml") return parsePnpmLock(path, patch, maxLines);
   return [];
 }
 

--- a/review-enrichment/src/lockfile-path.ts
+++ b/review-enrichment/src/lockfile-path.ts
@@ -13,7 +13,7 @@ const LOCKFILE_NAMES = new Set([
 ]);
 
 /** Lockfiles the drift analyzer can actually parse today — narrower than categorization. */
-const PARSEABLE_LOCKFILE_NAMES = new Set(["package-lock.json", "yarn.lock", "poetry.lock"]);
+const PARSEABLE_LOCKFILE_NAMES = new Set(["package-lock.json", "yarn.lock", "poetry.lock", "pnpm-lock.yaml"]);
 
 /** Lockfile basenames are case-insensitive on common filesystems — normalize separators first. */
 export function lockfileBasename(path: string): string {

--- a/review-enrichment/test/lockfile-drift.test.ts
+++ b/review-enrichment/test/lockfile-drift.test.ts
@@ -70,9 +70,12 @@ test("extractLockfileChanges does not let unparsed lockfiles consume the scan bu
     "+lodash@^4.17.21:",
     '+  version "4.17.21"',
   ].join("\n");
+  // Cargo.lock is classification-only (not in PARSEABLE_LOCKFILE_NAMES), so it is skipped BEFORE consuming a
+  // scan-budget slot. (This filler used pnpm-lock.yaml until #7010 made pnpm parseable; a currently-unparsed
+  // format is now required to still exercise the "unparsed lockfiles don't consume budget" path.)
   const filler = Array.from({ length: 12 }, (_, index) => ({
-    path: `pkg-${index}/pnpm-lock.yaml`,
-    patch: "@@ -1,0 +1,1 @@\n+lockfileVersion: 6.0",
+    path: `pkg-${index}/Cargo.lock`,
+    patch: '@@ -1,0 +1,2 @@\n+[[package]]\n+name = "serde"',
   }));
 
   const changes = extractLockfileChanges([
@@ -375,4 +378,111 @@ test("queryOsvBatch's per-item fallback stops issuing direct queries once the si
   assert.deepEqual(cvesByKey.get("npm::lodash@4.17.21"), []);
   assert.equal(cvesByKey.has("npm::axios@1.6.1"), true);
   assert.deepEqual(cvesByKey.get("npm::axios@1.6.1"), []);
+});
+
+test("extractLockfileChanges parses a pnpm-lock.yaml v9 version bump (unscoped + scoped) (#7010)", () => {
+  // pnpm encodes name@version in the map key itself, so a bump is a `-name@old:` / `+name@new:` key pair with
+  // no separate version line — unlike yarn/npm.
+  const changes = extractLockfileChanges([
+    {
+      path: "pnpm-lock.yaml",
+      patch: [
+        "@@ -2,4 +2,4 @@ packages:",
+        " packages:",
+        "-  lodash@4.17.20:",
+        "+  lodash@4.17.21:",
+        "-  '@babel/code-frame@7.24.6':",
+        "+  '@babel/code-frame@7.24.7':",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, [
+    { file: "pnpm-lock.yaml", line: 3, ecosystem: "npm", package: "lodash", from: "4.17.20", to: "4.17.21" },
+    { file: "pnpm-lock.yaml", line: 4, ecosystem: "npm", package: "@babel/code-frame", from: "7.24.6", to: "7.24.7" },
+  ]);
+});
+
+test("extractLockfileChanges reports a newly-added pnpm dependency with from:null (#7010)", () => {
+  const changes = extractLockfileChanges([
+    {
+      path: "pnpm-lock.yaml",
+      patch: ["@@ -5,0 +6,1 @@", "+  is-odd@3.0.1:"].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, [
+    { file: "pnpm-lock.yaml", line: 6, ecosystem: "npm", package: "is-odd", from: null, to: "3.0.1" },
+  ]);
+});
+
+test("extractLockfileChanges strips pnpm peer-scope suffixes, so a peer-only churn is NOT a change (#7010)", () => {
+  // A snapshot key carries a `(peerA@x)` suffix; when only the peer version moves, the package's OWN version is
+  // unchanged and must not be reported. Stripping the suffix makes both sides resolve to `foo@1.2.3` -> dropped.
+  const changes = extractLockfileChanges([
+    {
+      path: "pnpm-lock.yaml",
+      patch: [
+        "@@ -10,2 +10,2 @@ snapshots:",
+        "-  foo@1.2.3(react@17.0.2):",
+        "+  foo@1.2.3(react@18.2.0):",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, []);
+});
+
+test("extractLockfileChanges parses a peer-scoped pnpm key when the package's OWN version bumps (#7010)", () => {
+  const changes = extractLockfileChanges([
+    {
+      path: "pnpm-lock.yaml",
+      patch: [
+        "@@ -10,2 +10,2 @@ snapshots:",
+        "-  foo@1.2.3(react@18.2.0):",
+        "+  foo@1.3.0(react@18.2.0):",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, [
+    { file: "pnpm-lock.yaml", line: 10, ecosystem: "npm", package: "foo", from: "1.2.3", to: "1.3.0" },
+  ]);
+});
+
+test("extractLockfileChanges parses the pnpm v6 leading-slash key form (#7010)", () => {
+  const changes = extractLockfileChanges([
+    {
+      path: "pnpm-lock.yaml",
+      patch: [
+        "@@ -2,2 +2,2 @@ packages:",
+        "-  /lodash@4.17.20:",
+        "+  /lodash@4.17.21:",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, [
+    { file: "pnpm-lock.yaml", line: 2, ecosystem: "npm", package: "lodash", from: "4.17.20", to: "4.17.21" },
+  ]);
+});
+
+test("extractLockfileChanges ignores pnpm importer specifier/version lines (only packages/snapshots keys count) (#7010)", () => {
+  // The importers section has `lodash:` / `specifier:` / `version:` lines — none of which is a `name@version`
+  // key — so the parser must extract nothing from them (the real resolved change lives in packages:).
+  const changes = extractLockfileChanges([
+    {
+      path: "pnpm-lock.yaml",
+      patch: [
+        "@@ -1,5 +1,5 @@ importers:",
+        "     lodash:",
+        "-      specifier: ^4.17.20",
+        "+      specifier: ^4.17.21",
+        "-      version: 4.17.20",
+        "+      version: 4.17.21",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, []);
 });

--- a/review-enrichment/test/lockfile-path.test.ts
+++ b/review-enrichment/test/lockfile-path.test.ts
@@ -3,7 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { isSupportedLockfile, lockfileBasename } from "../dist/lockfile-path.js";
+import { isParseableLockfile, isSupportedLockfile, lockfileBasename } from "../dist/lockfile-path.js";
 
 test("isSupportedLockfile classifies the recognized ecosystem lockfiles", () => {
   // Established set (npm / yarn / pnpm / poetry / go).
@@ -39,4 +39,16 @@ test("lockfileBasename returns the final path segment across separators", () => 
   assert.equal(lockfileBasename("a/b/Cargo.lock"), "Cargo.lock");
   assert.equal(lockfileBasename("a\\b\\bun.lockb"), "bun.lockb");
   assert.equal(lockfileBasename("composer.lock"), "composer.lock");
+});
+
+test("isParseableLockfile now includes pnpm-lock.yaml, staying aligned with parseLockfile (#7010)", () => {
+  // pnpm gained a real parser in #7010, so it moves from classification-only into the parseable set. The
+  // invariant is that this set must match parseLockfile()'s dispatch exactly.
+  for (const p of ["pnpm-lock.yaml", "web/pnpm-lock.yaml", "PNPM-LOCK.YAML", "package-lock.json", "yarn.lock", "poetry.lock"]) {
+    assert.equal(isParseableLockfile(p), true, p);
+  }
+  // Classification-only lockfiles are still NOT parseable (no parseLockfile branch exists for them).
+  for (const p of ["go.sum", "Cargo.lock", "composer.lock", "bun.lockb", "package.json"]) {
+    assert.equal(isParseableLockfile(p), false, p);
+  }
 });


### PR DESCRIPTION
## What

`pnpm-lock.yaml` was classified as a lockfile (so a pnpm bump isn't mistaken for a source change) but the drift analyzer couldn't extract dependency changes from it — unlike `package-lock.json`/`yarn.lock`/`poetry.lock`. This adds pnpm parsing.

## How

- **`parsePnpmLock`** in `review-enrichment/src/analyzers/lockfile-drift.ts` + its dispatch case in `parseLockfile`.
- **`"pnpm-lock.yaml"` added to `PARSEABLE_LOCKFILE_NAMES`** in `lockfile-path.ts` — landed *together* with the parser, per `isParseableLockfile`'s own "must stay aligned with `parseLockfile()`" invariant.

pnpm embeds `name@version` directly in each `packages:`/`snapshots:` **map key** (with an optional leading `/` on v6 and an optional `(peerA@x)` peer-scope suffix on snapshot keys), so a version bump is just a `-name@old:` / `+name@new:` key-line pair — there's no separate `version:` line to track the way yarn/npm have. Consequences handled and tested:

- **Dedup by package** folds the same change appearing in both `packages:` and `snapshots:`.
- **Peer-only churn** (`foo@1.2.3(react@17)` → `foo@1.2.3(react@18)`) strips to `foo@1.2.3` on both sides and is dropped by the existing `to !== from` filter — not reported as a change.
- **Importer `specifier:`/`version:` lines are ignored** — none is a `name@version` key, so only the resolved `packages:`/`snapshots:` keys count.
- The legacy pnpm **v5 `/name/version`** key form (slash-separated, no `@`) is intentionally out of scope, matching the issue's "at minimum the current version" and this file's existing classification-only philosophy for formats not worth parsing.

## Testing

`review-enrichment/test/lockfile-drift.test.ts` (+6 cases): v9 bump (unscoped + scoped), newly-added dep (`from: null`), peer-only churn is *not* a change, peer-scoped key when the package's *own* version bumps, the v6 leading-slash form, and importer lines ignored. `lockfile-path.test.ts` (+1): `isParseableLockfile` now includes pnpm and still excludes the classification-only formats (`go.sum`/`Cargo.lock`/`composer.lock`/`bun.lockb`).

**Regression proven, not assumed**: all 5 pnpm assertions fail on the un-fixed source and pass with the fix. One existing test needed updating — "unparsed lockfiles don't consume the scan budget" used `pnpm-lock.yaml` as its *unparsed* filler, which this PR makes parseable; it's repointed to `Cargo.lock` (still classification-only), preserving the test's intent.

Green locally at this base: `npm run rees:test` (**1346/0** — build + `validate:sourcemaps` + `metadata:check` + node tests). Patch coverage measured via the `rees` flag: the changed lines in both files are **0 uncovered lines, 0 uncovered branches**.

Closes #7010
