### PR TITLE
fix(mcp): list maintain and contributor-profile in --help

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -4535,8 +4535,10 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
+  loopover-mcp contributor-profile [--login <github-login>] [--json]
   loopover-mcp monitor-open-prs --login <github-login> [--json]
   loopover-mcp pr-outcomes --login <github-login> [--limit N] [--json]
   loopover-mcp explain-review-risk --repo owner/repo --title <text> [--login <github-login>] [--body <text>] [--json]

--- a/test/unit/mcp-cli-help.test.ts
+++ b/test/unit/mcp-cli-help.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { run } from "./support/mcp-cli-harness";
+
+// #6991: printHelp() listed ~30 real top-level commands but omitted two dispatched ones: `maintain`
+// (packages/loopover-mcp/bin/loopover-mcp.js's maintainCli) and `contributor-profile`
+// (contributorProfileCli, added by #6737). A user running `loopover-mcp --help` had no way to
+// discover either command exists.
+describe("loopover-mcp --help lists every real top-level command (#6991)", () => {
+  it("lists maintain, pointing to its own --help for the full subcommand list", () => {
+    const output = run(["--help"]);
+    expect(output).toMatch(/loopover-mcp maintain .*--repo owner\/repo/);
+    expect(output).toMatch(/loopover-mcp maintain --help/);
+  });
+
+  it("lists contributor-profile", () => {
+    const output = run(["--help"]);
+    expect(output).toMatch(/loopover-mcp contributor-profile/);
+  });
+
+  it("also responds to the bare `help` command with the same usage banner", () => {
+    const output = run(["help"]);
+    expect(output).toMatch(/loopover-mcp maintain/);
+    expect(output).toMatch(/loopover-mcp contributor-profile/);
+  });
+});


### PR DESCRIPTION
## Summary

- `loopover-mcp --help` (`printHelp()`) listed ~30 real, dispatched top-level commands but omitted two: `maintain` (dispatched with its own `printMaintainHelp()` covering 14 subcommands) and `contributor-profile` (`contributorProfileCli`, added by #6737). A user running `--help` had no way to discover either command exists.
- Added a `maintain` usage line following the existing entries' format, listing its subcommands and pointing to `loopover-mcp maintain --help` for the full detail (matching the issue's request not to duplicate `printMaintainHelp()`'s own listing).
- Added a `contributor-profile` usage line in the same style as the neighboring `decision-pack`/`repo-decision` entries.
- Added a regression test (`test/unit/mcp-cli-help.test.ts`) asserting both commands appear in `--help` output, and that the bare `help` command (an alias) shows the same banner.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6991

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes in this PR)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (not applicable: `packages/loopover-mcp/**` is outside the vitest coverage collection scope per `codecov.yml`'s documented src/**-scoped collection, same as every other CLI-only change in this file; the new `mcp-cli-help.test.ts` (3 tests) and the existing `mcp-cli-completion-spec.test.ts`/`mcp-cli-basics.test.ts` (34 tests) all pass locally)
- [ ] `npm run test:workers` (not applicable to this change)
- [ ] `npm run build:mcp` (not applicable to this change)
- [ ] `npm run test:mcp-pack` (not applicable to this change)
- [ ] `npm run ui:openapi:check` (no API/schema changes in this PR)
- [ ] `npm run ui:lint` (no UI changes in this PR)
- [ ] `npm run ui:typecheck` (no UI changes in this PR)
- [ ] `npm run ui:build` (no UI changes in this PR)
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `packages/loopover-mcp/bin/loopover-mcp.js`'s static `--help` usage text plus a new test file -- a plain-text banner change with no branches, API surface, or dependency impact, so the checks above have no surface to exercise. `npm run docs:drift-check` and `npm run command-reference:check` were also run locally and pass.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session changes; this is a static help-text change.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no behavior change, only discoverability of existing commands.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A -- no UI changes in this PR.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A -- this PR has no UI/visual surface; it's a CLI `--help` text change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI Evidence table: this PR changes a terminal `--help` usage banner, not a UI surface -- the new automated test (`mcp-cli-help.test.ts`) is the evidence that both commands are now listed.
