### PR TITLE
feat(selfhost): add a staleness/age signal for the clock-skew gauge

### DIFF
--- a/src/selfhost/clock-skew.ts
+++ b/src/selfhost/clock-skew.ts
@@ -8,6 +8,10 @@
 // outbound request, sampled at exactly the cadence the vulnerable code path itself runs.
 
 let lastSkewSeconds = 0;
+// Epoch ms of the last successful sample; -1 until one is observed (#7000). The skew gauge alone can't
+// distinguish a fresh reading from one that stopped updating (e.g. a long-lived cached/broker token means
+// no fresh JWT-mint call happens, so `Date` headers stop arriving), so an operator needs the sample's age.
+let lastSkewObservedAtMs = -1;
 
 /**
  * Update the last-observed clock-skew sample from a GitHub response's `Date` header. Positive means
@@ -21,6 +25,7 @@ export function recordClockSkewFromResponse(response: Response): void {
   const remoteMs = Date.parse(dateHeader);
   if (!Number.isFinite(remoteMs)) return;
   lastSkewSeconds = (Date.now() - remoteMs) / 1000;
+  lastSkewObservedAtMs = Date.now();
 }
 
 /** The most recently observed clock-skew sample in seconds (0 until the first successful sample). */
@@ -28,7 +33,18 @@ export function clockSkewSecondsSample(): number {
   return lastSkewSeconds;
 }
 
+/**
+ * Age in seconds of the most recent clock-skew sample, or `-1` when none has been observed yet (#7000).
+ * The `-1` sentinel matches `d1-size-probe.ts`/`loopover_host_load_avg1_per_core`'s convention: it separates
+ * "never sampled" from a genuine fresh 0-second age, so a dashboard can flag a stale/stalled reading.
+ */
+export function clockSkewSampleAgeSeconds(): number {
+  if (lastSkewObservedAtMs < 0) return -1;
+  return (Date.now() - lastSkewObservedAtMs) / 1000;
+}
+
 /** Test-only: reset the module-level sample between tests. */
 export function resetClockSkewForTest(): void {
   lastSkewSeconds = 0;
+  lastSkewObservedAtMs = -1;
 }

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -52,6 +52,7 @@ export const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["loopover_github_rest_rate_limit_remaining", { help: "Newest observed GitHub REST rate-limit remaining count, by key scope.", type: "gauge" }],
   ["loopover_host_load_avg1_per_core", { help: "One-minute host load average normalized by CPU core count.", type: "gauge" }],
   ["loopover_clock_skew_seconds", { help: "Clock skew in seconds between this process and GitHub's server time (positive = ahead), sampled from GitHub App JWT-mint response Date headers.", type: "gauge" }],
+  ["loopover_clock_skew_sample_age_seconds", { help: "Age in seconds of the most recent clock-skew sample; -1 until the first sample. A rising value means fresh samples have stopped arriving, so the skew reading may be stale.", type: "gauge" }],
   ["loopover_uptime_seconds", { help: "Self-host process uptime in seconds.", type: "gauge" }],
   ["loopover_backup_acknowledged", { help: "1 when SQLite backup is acknowledged or Postgres is in use; 0 when the boot backup advisory would fire.", type: "gauge" }],
   ["loopover_config_dir_empty_acknowledged", { help: "1 when LOOPOVER_REPO_CONFIG_DIR is unset, has entries, or is acknowledged; 0 when it's configured but the mounted directory is empty.", type: "gauge" }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ import {
   sqliteBackupAdvisory,
   type ReadinessProbe,
 } from "./selfhost/health";
-import { clockSkewSecondsSample } from "./selfhost/clock-skew";
+import { clockSkewSecondsSample, clockSkewSampleAgeSeconds } from "./selfhost/clock-skew";
 import { d1DatabaseSizeBytesSample, d1SignalSnapshotsRowsPerKeySample, d1TableRowCountSamples, isD1SizeProbeEnabled, runD1SizeProbe } from "./selfhost/d1-size-probe";
 import { gauge, gaugeVector, incr, observe, renderMetrics, setSelfHostedMetricsMode } from "./selfhost/metrics";
 import { runSelfHostMigrations } from "./selfhost/migrate";
@@ -828,6 +828,7 @@ async function main(): Promise<void> {
   // from "no signal on this platform" (see host-pressure.ts).
   gauge("loopover_host_load_avg1_per_core", async () => (await maintenancePressure()).hostLoadAvg1PerCore ?? -1);
   gauge("loopover_clock_skew_seconds", () => clockSkewSecondsSample());
+  gauge("loopover_clock_skew_sample_age_seconds", () => clockSkewSampleAgeSeconds());
   // D1 size/row-count observability probe (#3810): opt-in Cloudflare Management API poll for the shared
   // cloud D1's file size and monitored-table row counts. Always registered (byte-identical -1/empty samples
   // when the probe is disabled or has never completed) so the metric names/HELP/TYPE lines are present on

--- a/test/unit/clock-skew.test.ts
+++ b/test/unit/clock-skew.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clockSkewSecondsSample, recordClockSkewFromResponse, resetClockSkewForTest } from "../../src/selfhost/clock-skew";
+import { clockSkewSampleAgeSeconds, clockSkewSecondsSample, recordClockSkewFromResponse, resetClockSkewForTest } from "../../src/selfhost/clock-skew";
 
 beforeEach(() => resetClockSkewForTest());
 afterEach(() => vi.useRealTimers());
@@ -50,5 +50,28 @@ describe("clock-skew", () => {
     expect(clockSkewSecondsSample()).not.toBe(0);
     resetClockSkewForTest();
     expect(clockSkewSecondsSample()).toBe(0);
+  });
+});
+
+describe("clock-skew sample age (#7000)", () => {
+  it("reports the -1 never-sampled sentinel before any sample is recorded", () => {
+    expect(clockSkewSampleAgeSeconds()).toBe(-1);
+  });
+
+  it("reports the most recent sample's age and grows as time passes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T12:05:00.000Z"));
+    recordClockSkewFromResponse(new Response(null, { headers: { date: "Mon, 06 Jul 2026 12:00:00 GMT" } }));
+    expect(clockSkewSampleAgeSeconds()).toBe(0); // observed just now
+
+    vi.setSystemTime(new Date("2026-07-06T12:05:45.000Z"));
+    expect(clockSkewSampleAgeSeconds()).toBe(45); // 45s since the last sample
+  });
+
+  it("resetClockSkewForTest restores the age to the -1 never-sampled sentinel", () => {
+    recordClockSkewFromResponse(new Response(null, { headers: { date: new Date(Date.now() - 60_000).toUTCString() } }));
+    expect(clockSkewSampleAgeSeconds()).not.toBe(-1);
+    resetClockSkewForTest();
+    expect(clockSkewSampleAgeSeconds()).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #7000

`loopover_clock_skew_seconds` is fed from `clock-skew.ts`'s `lastSkewSeconds`, which only updates when a GitHub response `Date` header is observed (piggybacking on JWT-authenticated installation-token mint calls — the #3811 mechanism). If token-minting stalls for any reason (a long-lived cached or broker-provided token means no fresh mint call happens), the gauge keeps reporting an old sample as if it were current, so an operator can't distinguish a fresh reading from a stalled one.

- `clock-skew.ts` now tracks the observation time of the last successful sample and exposes **`clockSkewSampleAgeSeconds()`**, mirroring `clockSkewSecondsSample()`'s shape and using the **`-1` "never sampled" sentinel** (the same convention `d1-size-probe.ts` / `loopover_host_load_avg1_per_core` use — separating "no signal yet" from a genuine fresh 0-second age).
- A companion gauge **`loopover_clock_skew_sample_age_seconds`** is registered in `server.ts` alongside the existing one, with matching HELP/TYPE metadata in `selfhost/metrics.ts`.
- `resetClockSkewForTest` now also resets the new staleness state. `recordClockSkewFromResponse`'s skew-calculation logic is unchanged.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7000`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` *(isolate-typecheck of the changed `clock-skew.ts` is clean; root typecheck OOMs locally, CI runs it in full)*
- [x] `npm run test:coverage` *(the codecov-measured changes are fully covered — see below)*
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- **Coverage.** `test/unit/clock-skew.test.ts` adds three cases for the new signal: the `-1` never-sampled sentinel (before any sample), the age reported and growing after a sample (via fake timers, asserting 0s then 45s), and `resetClockSkewForTest` restoring `-1`. Measured `src/selfhost/clock-skew.ts` at **100% statements / branches / functions / lines** (both branches of `clockSkewSampleAgeSeconds`'s sentinel check are exercised). The one-line `selfhost/metrics.ts` metadata entry is covered on module import. The `server.ts` gauge registration is in a file `codecov.yml` explicitly `ignore`s (self-host process entry, covered by the Docker boot smoke test, not unit-coverable) — so it adds no measured-but-uncovered line.
- Ran `clock-skew` + `selfhost-metrics` suites green (**47 tests**) — the new `DEFAULT_METRIC_META` entry doesn't regress the metrics renderer.
- No API/DB/wrangler/selfhost-env changes, so no generated-artifact regen (OpenAPI / cf-typegen / env-reference / migrations) applies.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section.
- [ ] Public docs/changelogs are updated where needed.

Purely additive observability: a new derived gauge over an existing in-process sample. No new outbound request (the age is computed from the already-recorded observation timestamp), no config/env/DB surface, and the existing skew value + reset semantics are unchanged.

## Notes

The metric name `loopover_clock_skew_sample_age_seconds` follows the existing gauge's naming convention. It is a gauge (not a `_total`), so the `self-hosting-troubleshooting` metric-name doc test (which pins `loopover_*_total` names) is unaffected.

Closes #7000
