### PR TITLE
fix(mcp): honor --help on the contributor-profile CLI command

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -3865,12 +3865,27 @@ function printDecisionPackHelp() {
   );
 }
 
+function printContributorProfileHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp contributor-profile --login <github-login> [--json]",
+      "",
+      "Fetch the contributor profile for a GitHub login.",
+      "Mirrors the loopover_get_contributor_profile MCP tool and GET /v1/contributors/{login}/profile. No source upload.",
+      "",
+      "Login resolves from --login, the active session, LOOPOVER_LOGIN, then GITHUB_LOGIN.",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
 // #6737: CLI mirror of the loopover_get_contributor_profile MCP tool and GET /v1/contributors/{login}/profile
 // (requireContributorAccess-gated -- the same gate decision-pack/repo-decision already satisfy). Login resolves
 // from --login / the active session / LOOPOVER_LOGIN / GITHUB_LOGIN, exactly like the sibling contributor
 // commands, so an already-logged-in contributor never retypes their own login. Named `contributor-profile`
 // because the top-level `profile` command already manages MCP client profiles.
 async function contributorProfileCli(options) {
+  if (options.help === true) return printContributorProfileHelp();
   const login = options.login ?? activeProfile.session?.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
   if (!login) throw new Error("Pass --login <github-login>, log in with `loopover-mcp login`, or set LOOPOVER_LOGIN.");
   const payload = await apiGet(`/v1/contributors/${encodeURIComponent(login)}/profile`);

--- a/test/unit/mcp-cli-contributor-profile.test.ts
+++ b/test/unit/mcp-cli-contributor-profile.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { closeFixtureServer, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
+import { closeFixtureServer, run, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
 
 describe("loopover-mcp CLI — contributor-profile (#6737)", () => {
   let tempDir: string | null = null;
@@ -48,5 +48,14 @@ describe("loopover-mcp CLI — contributor-profile (#6737)", () => {
     const failure = runExpectingFailure(["contributor-profile"], { ...e, LOOPOVER_LOGIN: "", GITHUB_LOGIN: "" });
     expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --login/);
     expect(requests.filter((url) => url.includes("/profile"))).toHaveLength(0);
+  });
+
+  it("prints usage for --help without resolving a login or hitting the network (#6992)", () => {
+    // --help must short-circuit BEFORE login resolution, so this succeeds with no --login and no server --
+    // previously it fell through and threw the "Pass --login" error instead of printing usage.
+    const help = run(["contributor-profile", "--help"], { LOOPOVER_LOGIN: "", GITHUB_LOGIN: "" });
+    expect(help).toContain("Usage: loopover-mcp contributor-profile --login <github-login> [--json]");
+    expect(help).toContain("Mirrors the loopover_get_contributor_profile MCP tool");
+    expect(help).not.toMatch(/Pass --login/);
   });
 });


### PR DESCRIPTION
## What

`contributorProfileCli` (`packages/loopover-mcp/bin/loopover-mcp.js`), the CLI mirror of `loopover_get_contributor_profile`, had no `--help` handling. Every sibling command around it does — `decisionPackCli`, `monitorOpenPrsCli`, `repoDecisionCli`. Running `loopover-mcp contributor-profile --help` fell through to login resolution and threw `"Pass --login <github-login>, log in with \`loopover-mcp login\`, or set LOOPOVER_LOGIN."` instead of printing usage.

## How

Add `printContributorProfileHelp()` and an `if (options.help === true) return printContributorProfileHelp();` guard at the top of the command, mirroring `decisionPackCli` exactly. The help text documents the usage, the `--login`/`--json` flags, and the login-resolution precedence.

## Validation

Test added to the existing `test/unit/mcp-cli-contributor-profile.test.ts` (rather than a parallel file): `contributor-profile --help` prints usage with no `--login` and no fixture server, and never emits the `Pass --login` error. Confirmed it **fails against the unfixed command** and passes with the fix. `build:mcp` and `test:mcp-pack` pass; sibling CLI tests remain green.

Closes #6992
