### PR TITLE
docs(review): correct lockfile-tamper.ts's module header to state its npm-only scope

### DIFF
--- a/src/review/lockfile-tamper.ts
+++ b/src/review/lockfile-tamper.ts
@@ -1,5 +1,6 @@
-// Lockfile-tamper-risk gate check (#2563). Deterministic scan of a changed `package-lock.json` (or another
-// `*.lock` file) diff for the classic supply-chain tell: a `resolved`/`integrity` value changed WITHOUT that
+// Lockfile-tamper-risk gate check (#2563). Deterministic scan of a changed `package-lock.json` diff (npm
+// only — see isNpmLockfilePath below; yarn.lock/pnpm-lock.yaml are not parsed) for the classic supply-chain
+// tell: a `resolved`/`integrity` value changed WITHOUT that
 // SAME package-lock entry's own `"version"` field genuinely changing, or a `resolved` URL that points outside
 // the public npm registry. Distinct from the OSV.dev CVE analyzer (review-enrichment/src/analyzers/lockfile-drift.ts)
 // — that flags KNOWN-CVE versions; this flags tamper/integrity-substitution regardless of whether the substituted


### PR DESCRIPTION
## Summary
- `src/review/lockfile-tamper.ts`'s module-level doc comment claimed the check scans "a changed `package-lock.json` (or another `*.lock` file) diff" — but `isNpmLockfilePath`, the function that actually decides what gets scanned, matches only `basename === "package-lock.json"`; `yarn.lock`, `pnpm-lock.yaml`, and any other `*.lock` file are never scanned, exactly as `isNpmLockfilePath`'s own accurate doc comment already states.
- Corrects the module header to state the npm-only scope, aligning it with `isNpmLockfilePath`'s own correct comment. Doc-only change — no behavioral diff. Does not extend lockfile parsing to yarn/pnpm (explicitly out of scope per the issue).

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6997

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of what changed; this is a comment-only change with zero behavioral surface, so `npx vitest run test/unit/lockfile-tamper.test.ts` (below) is sufficient local confidence, and CI's isolated runner performs the authoritative `tsc --noEmit`.
- [x] `npm run test:coverage` — `test/unit/lockfile-tamper.test.ts` (28 tests, including the existing `isNpmLockfilePath` coverage of `yarn.lock`/`pnpm-lock.yaml` rejection the issue calls out as the acceptable no-op assertion) — 28/28 passing, unmodified.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — this is a single comment change in one backend module)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries. (N/A — doc-only change; the issue itself states no new test is required, and the existing `isNpmLockfilePath` test suite already exercises the exact behavior the corrected comment now accurately describes.)

If any required check was skipped, explain why:

- This is a single-comment doc-accuracy fix with no code/behavior change. The whole-repo `npm run typecheck` OOMs on this sandbox under current memory pressure regardless of diff size, so it was not run standalone for a change with no type-surface at all; the existing, unmodified test suite plus CI's isolated runner cover the rest.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.