### PR TITLE
fix(miner): fail closed when a chat-action handler throws

### DIFF
--- a/packages/loopover-miner/lib/chat-action-dispatch.js
+++ b/packages/loopover-miner/lib/chat-action-dispatch.js
@@ -71,7 +71,15 @@ export async function dispatchChatAction(request, options = {}) {
     return { ok: false, status: "invalid_params", action };
   }
 
-  const result = await registered.handler(request);
+  let result;
+  try {
+    result = await registered.handler(request);
+  } catch (error) {
+    // A handler that throws fails closed with the module's typed result shape (#6989), consistent with the
+    // paramsValidator catch above -- a distinct "handler_error" status lets a caller tell an execution
+    // failure apart from a params-validation failure.
+    return { ok: false, status: "handler_error", action, error: error instanceof Error ? error.message : String(error) };
+  }
   return { ok: true, status: "dispatched", action, result };
 }
 

--- a/test/unit/miner-chat-action-dispatch.test.ts
+++ b/test/unit/miner-chat-action-dispatch.test.ts
@@ -147,4 +147,21 @@ describe("dispatchChatAction (#6519)", () => {
     const result = await dispatchChatAction({ action: "demo", params: {} }, { env: enabledEnv, registry });
     expect(result).toEqual({ ok: false, status: "invalid_params", action: "demo", error: "boom" });
   });
+
+  it("fails closed with handler_error when the handler throws, not an unhandled rejection (#6989)", async () => {
+    const registry = registryWith("demo", () => true, () => {
+      throw new Error("network down");
+    });
+    const result = await dispatchChatAction({ action: "demo", params: {} }, { env: enabledEnv, registry });
+    // Distinct from invalid_params so a caller can tell an execution failure from a validation failure.
+    expect(result).toEqual({ ok: false, status: "handler_error", action: "demo", error: "network down" });
+  });
+
+  it("stringifies a non-Error thrown by the handler (#6989)", async () => {
+    const registry = registryWith("demo", () => true, () => {
+      throw "kaboom";
+    });
+    const result = await dispatchChatAction({ action: "demo", params: {} }, { env: enabledEnv, registry });
+    expect(result).toEqual({ ok: false, status: "handler_error", action: "demo", error: "kaboom" });
+  });
 });


### PR DESCRIPTION
## What

`dispatchChatAction` (`packages/loopover-miner/lib/chat-action-dispatch.js`) wraps its `paramsValidator` call in a try/catch — explicitly "fail closed" — but the next line, `await registered.handler(request)`, was unguarded. A handler that throws (e.g. a network error from a governor action) would surface as an unhandled rejection instead of the module's own typed `{ ok, status }` contract that every other failure path already returns.

This is latent today (the dashboard-chat REST endpoint that invokes it is still an open epic, #6839), but wiring it live would turn any handler throw into an unhandled rejection.

## How

Wrap `registered.handler(request)` in try/catch, returning `{ ok: false, status: "handler_error", action, error }` on throw — mirroring the `paramsValidator` catch immediately above. The distinct `"handler_error"` status (vs `"invalid_params"`) lets a caller tell an execution failure apart from a validation failure. This matches the fail-closed catch pattern used by the package's other must-never-crash paths (`pretooluse-hook.js:32`, `sentry.js:37,47`).

## Validation

Tests added to the existing `test/unit/miner-chat-action-dispatch.test.ts`: a handler throwing an `Error` yields `handler_error` with the message, and a non-`Error` throw is stringified — covering both sides of the `instanceof Error` ternary. Confirmed both **fail against the unfixed code** (unhandled rejection) and pass with the fix; 100% branch coverage on the file.

Closes #6989
