### PR TITLE
test(scripts): guard miner package README against stale public-package wording

### DIFF
--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -27,6 +27,10 @@ const REQUIRED = [
   "schema/miner-goal-spec.schema.json",
 ];
 const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
+// Stale public-package wording the published README must never ship with (#7013). The sibling
+// check-mcp-package.mjs has always guarded its README against this; the miner-package check did not, so a
+// pre-release "private beta"/"preview URL" phrasing could ship in the public `@loopover/miner` README unnoticed.
+const STALE_PACKAGE_TEXT = /(private beta|zeronode\.workers\.dev|preview URL)/i;
 
 export function validateMinerPackFileList(files, readContent) {
   const paths = files.map((file) => (typeof file === "string" ? file : file.path)).sort();
@@ -35,6 +39,8 @@ export function validateMinerPackFileList(files, readContent) {
     if (!ALLOWED.some((pattern) => pattern.test(file))) throw new Error(`Unexpected file in miner package: ${file}`);
     const content = readContent(file);
     if (FORBIDDEN_CONTENT.test(content)) throw new Error(`Secret-like content found in miner package file: ${file}`);
+    if (file === "README.md" && STALE_PACKAGE_TEXT.test(content))
+      throw new Error(`Stale public-package wording found in miner package file: ${file}`);
   }
   for (const required of REQUIRED) {
     if (!paths.includes(required)) throw new Error(`Miner package is missing required file: ${required}`);

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -29,6 +29,24 @@ describe("check-miner-package script", () => {
     expect(result.out).toContain("Forbidden file in miner package: .env");
   });
 
+  it("rejects a README carrying stale public-package wording (#7013)", () => {
+    const result = runChecker({
+      CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
+        "package.json",
+        "bin/loopover-miner.js",
+        "README.md",
+        "DEPLOYMENT.md",
+        "Dockerfile",
+        "lib/cli.js",
+        "docs/quickstart.md",
+        "schema/miner-goal-spec.schema.json",
+      ]),
+      CHECK_MINER_PACK_TEST_CONTENT: "Join the private beta today!",
+    });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Stale public-package wording found in miner package file: README.md");
+  });
+
   it("rejects an unexpected file", () => {
     const result = runChecker({ CHECK_MINER_PACK_TEST_FILES: JSON.stringify(["scripts/extra.mjs"]) });
     expect(result.status).toBe(1);


### PR DESCRIPTION
Closes #7013

The publish-time \`check-miner-package\` check validated the miner package's file list and scanned for secret-like content, but — unlike its sibling \`check-mcp-package\` — never guarded \`README.md\` against stale pre-release wording (\`private beta\`, a preview \`zeronode.workers.dev\` URL, \`preview URL\`). That let placeholder marketing copy ship in the public \`@loopover/miner\` README unnoticed.

## Change
- Mirror the mcp-package guard: reject a \`README.md\` whose content matches \`STALE_PACKAGE_TEXT\` in \`validateMinerPackFileList\`.
- Add a regression test injecting stale README content through the existing \`CHECK_MINER_PACK_TEST_CONTENT\` hook.

## Verification
- \`npx vitest run test/unit/check-miner-package.test.ts\` → 14 passed (incl. the real-workspace pass-through and the new stale-README case).
- The live miner README is already clean, so \`node scripts/check-miner-package.mjs\` still exits 0.

scripts/test-only; no \`src/**\` touched.