### PR TITLE
fix(config): recognize federatedIntelligence manifest block in lint and preview

### DIFF
--- a/packages/loopover-engine/src/config-lint.ts
+++ b/packages/loopover-engine/src/config-lint.ts
@@ -25,6 +25,7 @@ const TOP_LEVEL_FIELDS = [
   "upstreamDriftIssues",
   "sweepWatchdog",
   "prReconciliation",
+  "federatedIntelligence",
 ] as const;
 
 const TOP_LEVEL_FIELD_SET = new Set<string>(TOP_LEVEL_FIELDS);

--- a/packages/loopover-engine/src/focus-manifest-validation.ts
+++ b/packages/loopover-engine/src/focus-manifest-validation.ts
@@ -13,6 +13,7 @@ import {
   upstreamDriftIssuesConfigToJson,
   sweepWatchdogConfigToJson,
   prReconciliationConfigToJson,
+  federatedIntelligenceConfigToJson,
   settingsOverrideToJson,
   type FocusManifest,
   type FocusManifestSource,
@@ -94,6 +95,8 @@ function focusManifestToNormalizedJson(manifest: FocusManifest): Record<string, 
   if (sweepWatchdog !== null) normalized.sweepWatchdog = sweepWatchdog;
   const prReconciliation = prReconciliationConfigToJson(manifest.prReconciliation);
   if (prReconciliation !== null) normalized.prReconciliation = prReconciliation;
+  const federatedIntelligence = federatedIntelligenceConfigToJson(manifest.federatedIntelligence);
+  if (federatedIntelligence !== null) normalized.federatedIntelligence = federatedIntelligence;
 
   return normalized;
 }

--- a/test/unit/focus-manifest-validation.test.ts
+++ b/test/unit/focus-manifest-validation.test.ts
@@ -137,7 +137,7 @@ prReconciliation:
     });
   });
 
-  it("omits maintainerRecap/ops/publicStats/draftFlow/upstreamDriftIssues/sweepWatchdog/prReconciliation from the normalized output when none are configured", () => {
+  it("omits maintainerRecap/ops/publicStats/draftFlow/upstreamDriftIssues/sweepWatchdog/prReconciliation/federatedIntelligence from the normalized output when none are configured", () => {
     const result = buildFocusManifestValidation({ content: "wantedPaths: [src/]\n" });
     expect(result.normalized).not.toHaveProperty("maintainerRecap");
     expect(result.normalized).not.toHaveProperty("ops");
@@ -146,6 +146,13 @@ prReconciliation:
     expect(result.normalized).not.toHaveProperty("upstreamDriftIssues");
     expect(result.normalized).not.toHaveProperty("sweepWatchdog");
     expect(result.normalized).not.toHaveProperty("prReconciliation");
+    expect(result.normalized).not.toHaveProperty("federatedIntelligence");
+  });
+
+  it("includes a configured federatedIntelligence block in the normalized settings-preview output (#6998)", () => {
+    const result = buildFocusManifestValidation({ content: "federatedIntelligence:\n  enabled: true\n" });
+    expect(result.warnings).toEqual([]);
+    expect(result.normalized).toMatchObject({ federatedIntelligence: { enabled: true } });
   });
 
   it("returns error when manifest content is not a mapping", () => {

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -150,6 +150,14 @@ reviewRecap:
     expect(result.recognizedFields).toEqual(["prReconciliation"]);
   });
 
+  it("recognizes a standalone top-level federatedIntelligence: block instead of flagging it as unknown (#6998)", () => {
+    const result = lintManifestText("federatedIntelligence:\n  enabled: true\n");
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.recognizedFields).toEqual(["federatedIntelligence"]);
+  });
+
   it("flags legacy blockedPaths with a migration-specific warning, not the generic unknown-field message", () => {
     const result = lintManifestText("wantedPaths: [src/]\nblockedPaths: [dist/]\n");
 


### PR DESCRIPTION
## Summary

Fixes #6998.

`parseFocusManifest` fully parses a top-level `federatedIntelligence:` block (`packages/loopover-engine/src/focus-manifest.ts`, per #1970/#6479/#6480), and `src/signals/focus-manifest-loader.ts` already includes it in its normalized-JSON output. But two sibling wiring points that enumerate the same top-level manifest fields both omitted it:

1. **`packages/loopover-engine/src/config-lint.ts`** — `TOP_LEVEL_FIELDS` listed every top-level manifest field except `federatedIntelligence`, so a valid `federatedIntelligence:` block in `.loopover.yml` triggered a false "Manifest contains unknown top-level field" warning from `unknownTopLevelWarnings` (and was excluded from `recognizedFields`).
2. **`packages/loopover-engine/src/focus-manifest-validation.ts`** — `focusManifestToNormalizedJson` built the settings-preview normalized JSON field-by-field through `prReconciliation`, with no line for `federatedIntelligence`, so the settings-preview silently dropped the entire block for any repo that configured one.

This wires `federatedIntelligence` into both sites, matching how every other top-level field is already handled:

- Adds `"federatedIntelligence"` to `TOP_LEVEL_FIELDS` (same array-literal style as the ~22 existing entries).
- Adds the `federatedIntelligenceConfigToJson(manifest.federatedIntelligence)` line to `focusManifestToNormalizedJson`, mirroring the `prReconciliation` handling immediately above it. The serializer `federatedIntelligenceConfigToJson` already exists and is reused (not reimplemented) — it returns `null` for an absent block, so the field is emitted only when present.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. The full `npm run test:ci` gate (incl. `test:coverage`, the `@loopover/engine` workspace tests, `ui:openapi:settings-parity`, and `manifest:drift-check`) plus `npm audit --audit-level=moderate` were run locally and are green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This is a backend change to the engine's manifest-field enumeration; there is no auth/CORS/session surface and no UI file change (the settings-preview UI renders this normalized JSON at runtime, so it now reflects a configured `federatedIntelligence` block with no UI edit needed). The normalized JSON is an untyped `Record<string, unknown>` payload, so no OpenAPI schema regeneration is required — `ui:openapi:check` and `ui:openapi:settings-parity` pass unchanged.

## Notes

- Regression tests added to both sibling suites:
  - `test/unit/selfhost-config-lint.test.ts` — a standalone `federatedIntelligence:` block is recognized (`ok`, no warnings, `recognizedFields: ["federatedIntelligence"]`) instead of flagged unknown.
  - `test/unit/focus-manifest-validation.test.ts` — a configured `federatedIntelligence` block appears in the normalized settings-preview output (the `!== null` true branch), and the "omits … when none configured" invariant now also asserts its absence (the false branch).
  - Both new tests were confirmed to fail on the pre-fix code and pass with the fix.
