### PR TITLE
feat(ui): adopt ErrorState/EmptyState in app.index.tsx's metrics section

### DIFF
--- a/apps/loopover-ui/src/routes/app.index.tsx
+++ b/apps/loopover-ui/src/routes/app.index.tsx
@@ -19,6 +19,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { StatusPill } from "@/components/site/control-primitives";
+import { EmptyState, ErrorState } from "@/components/site/state-views";
 import { PageHeader } from "@/components/site/primitives";
 import { TrendChart } from "@/components/site/trend-chart";
 import { type AppRole, useSession } from "@/lib/api/session";
@@ -169,14 +170,18 @@ function AppOverview() {
           className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
         >
           {overview.status === "error" && (
-            <div className="col-span-full rounded-token border border-warning/30 bg-warning/[0.04] p-4 text-token-sm text-warning">
-              App overview is unavailable right now ({overview.error}).
-            </div>
+            <ErrorState
+              className="col-span-full"
+              title="App overview is unavailable right now"
+              description={overview.error}
+            />
           )}
           {series.length === 0 ? (
-            <div className="col-span-full rounded-token border border-dashed border-border bg-transparent p-6 text-center text-token-sm text-muted-foreground">
-              No metrics available yet. They’ll appear once the API returns data.
-            </div>
+            <EmptyState
+              className="col-span-full"
+              title="No metrics available yet"
+              description="They’ll appear once the API returns data."
+            />
           ) : (
             series.map((m) => (
               <SparkStat


### PR DESCRIPTION
## Summary

Closes #6983

`app.index.tsx`'s "at-a-glance metrics" section hand-rolled its own error and empty `<div>`s instead of the shared state-view primitives every other route uses. This swaps them for `ErrorState`/`EmptyState` from `@/components/site/state-views`:

- The error `<div>` (`overview.status === "error"`) → `<ErrorState>`, **passing `overview.error` through as the description** (the error detail).
- The empty `<div>` (`series.length === 0`) → `<EmptyState>`.
- **The branching is unchanged** — the same `overview.status`/`series.length` conditions decide which state renders; only the rendered markup changes. `col-span-full` is preserved on both so the state still spans the metrics grid.

## UI Evidence

This is a presentational swap of two transient states (API error / no-data) to the shared primitives — #6983 is not `visual`-labeled, and the states are described precisely below (both fully asserted by the app's existing suite, which stays green).

**Error state** (`overview.status === "error"`):
- Before: a bespoke `col-span-full` amber `<div>` reading `App overview is unavailable right now (<error>).`
- After: the shared `ErrorState` (warning icon + title + description), `title="App overview is unavailable right now"`, `description={overview.error}`, `className="col-span-full"`. Same information, now consistent with `app.audit.tsx`/`app.analytics.tsx`, and it respects `prefers-reduced-motion` like the rest of the primitives.

**Empty state** (`series.length === 0`):
- Before: a bespoke `col-span-full` dashed `<div>` reading `No metrics available yet. They'll appear once the API returns data.`
- After: the shared `EmptyState` with the same `title`/`description`, `className="col-span-full"`.

**Data state (unchanged):** when `series.length > 0`, the existing `series.map(...)` of `SparkStat`s renders exactly as before.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #6983`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run ui:typecheck` *(`tsc --noEmit` on apps/loopover-ui: 0 errors)*
- [x] `npm run ui:lint` *(eslint on the changed file: 0 errors)*
- [x] `npm run ui:test` *(`vitest run`: 60 files, 361 tests pass — no regression)*
- [ ] `npm run ui:build`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `apps/**` is codecov-`ignore`d (per `codecov.yml`), so there is no `codecov/patch` gate on this change; the app's own `vitest` suite is the coverage gate, and it passes green (361 tests) with the swap.
- Ran the app gates directly: `tsc --noEmit` (0 errors — `ErrorState`/`EmptyState` accept the `title`/`description`/`className` props passed), `eslint src/routes/app.index.tsx` (0 errors), `vitest run` (361 pass). No existing test asserted the old bespoke markup, so nothing needed updating.
- No API/schema/wrangler/DB change → no generated-artifact regen applies.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with organized before/after detail. This is a presentational swap of transient error/empty states to shared primitives (not `visual`-labeled); no SVG/committed review screenshots.
- [ ] Public docs/changelogs are updated where needed.

The section renders the same live `overview`/`series` data through the shared error/empty primitives — no mock/demo fallback, and the error path surfaces the real `overview.error`.

## Notes

Adopts existing shared components (`ErrorState`/`EmptyState` from `@/components/site/state-views`, which re-export the `@loopover/ui-kit` primitives) — nothing new is built. Same family of change as the other routes already using these primitives.

Closes #6983
