### PR TITLE
fix(ui): use LoadingState/ErrorState in NotificationReadinessCard

### DIFF
--- a/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// #6985: a real fetch failure used to render the same generic text as "still loading" — these tests
+// pin the three render paths (loading / error / success) now that LoadingState/ErrorState replace it.
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: (...args: unknown[]) => useApiResource(...args),
+}));
+
+import { NotificationReadinessCard } from "./notification-readiness-card";
+
+const notificationModelFixture = {
+  notificationModel: {
+    mode: "opt_in",
+    defaultState: "disabled",
+    channels: [
+      {
+        id: "browser_push",
+        transport: "web_push",
+        defaultEnabled: false,
+        purpose: "PR review updates",
+      },
+    ],
+    privacyGuards: ["No content leaves the browser without consent."],
+    fallbackWhenUnavailable: "email digest",
+  },
+  pwa: { nativeDependency: false, manifestPath: "/manifest.json", serviceWorkerPath: "/sw.js" },
+  mobileReadyRoutes: [],
+  nativeMobileFuture: [],
+};
+
+describe("NotificationReadinessCard loading/error states (#6985)", () => {
+  it("shows a LoadingState (not the generic spinner-free text) while the model loads", () => {
+    useApiResource.mockReturnValue({
+      status: "loading",
+      data: null,
+      error: null,
+      loadedAt: null,
+      reload: () => {},
+    });
+
+    render(<NotificationReadinessCard />);
+
+    expect(screen.getByText("Loading notification model…")).toBeTruthy();
+    expect(screen.queryByText("Notification model unavailable.")).toBeNull();
+  });
+
+  it("shows an ErrorState with the real error message and a working retry, distinguishing it from loading", () => {
+    const reload = vi.fn();
+    useApiResource.mockReturnValue({
+      status: "error",
+      data: null,
+      error: "The server returned a 500.",
+      errorKind: "http",
+      loadedAt: null,
+      reload,
+    });
+
+    render(<NotificationReadinessCard />);
+
+    expect(screen.getByText("The server returned a 500.")).toBeTruthy();
+    expect(screen.queryByText("Loading notification model…")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the network-specific ErrorState copy when errorKind indicates an unreachable server", () => {
+    useApiResource.mockReturnValue({
+      status: "error",
+      data: null,
+      error: "Failed to fetch",
+      errorKind: "network",
+      loadedAt: null,
+      reload: () => {},
+    });
+
+    render(<NotificationReadinessCard />);
+
+    expect(screen.getByText("Can't reach the server")).toBeTruthy();
+  });
+
+  it("still renders the privacy guards list unchanged on success", () => {
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: notificationModelFixture,
+      error: null,
+      loadedAt: Date.now(),
+      reload: () => {},
+    });
+
+    const { container } = render(<NotificationReadinessCard />);
+
+    expect(container.textContent).toContain("No content leaves the browser without consent.");
+    expect(screen.queryByText("Loading notification model…")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
@@ -2,6 +2,7 @@ import { Bell, BellOff } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { StatusPill } from "./control-primitives";
+import { ErrorState, LoadingState } from "./state-views";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { useLocalStorage } from "@/lib/use-local-storage";
 
@@ -112,12 +113,15 @@ export function NotificationReadinessCard() {
             ))}
           </ul>
         </div>
+      ) : model.status === "loading" ? (
+        <LoadingState className="mt-3" title="Loading notification model…" />
       ) : (
-        <p className="mt-3 text-token-sm text-muted-foreground">
-          {model.status === "loading"
-            ? "Loading notification model…"
-            : "Notification model unavailable."}
-        </p>
+        <ErrorState
+          className="mt-3"
+          description={model.error}
+          errorKind={model.errorKind}
+          onRetry={model.reload}
+        />
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

- `NotificationReadinessCard` (`apps/loopover-ui/src/components/site/notification-readiness-card.tsx`) collapsed its loading and error states into one plain-text branch (`"Loading notification model..."` vs `"Notification model unavailable."`), discarding the `error`/`errorKind` fields `useApiResource` already exposes and giving no retry action -- a real fetch failure and "still loading" rendered identical generic copy, unlike every other `useApiResource` consumer in this app.
- Replaced the collapsed branch with the shared `LoadingState`/`ErrorState` from `state-views.tsx`, wiring through the real error message, `errorKind`, and a retry action (`onRetry={model.reload}`). The success-path rendering (the `privacyGuards` list, opt-in controls) is unchanged.
- Added `notification-readiness-card.test.tsx` covering all three render paths: loading, error (with the real message + working retry), the network-specific error copy, and success.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6985

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes in this PR)
- [x] `npm run typecheck` (via `npm run ui:typecheck`, the UI-scoped equivalent)
- [ ] `npm run test:coverage` (backend-only; this PR only touches `apps/loopover-ui`, which is outside the Codecov patch gate per `codecov.yml`'s `ignore: apps/**`)
- [ ] `npm run test:workers` (not applicable to this UI-only change)
- [ ] `npm run build:mcp` (not applicable to this UI-only change)
- [ ] `npm run test:mcp-pack` (not applicable to this UI-only change)
- [ ] `npm run ui:openapi:check` (no API/schema changes in this PR)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `apps/loopover-ui/src/components/site/notification-readiness-card.tsx` (plus its new test file). The backend-only checks above have no surface to exercise for a change scoped entirely to one UI component's loading/error branches; `npm run ui:lint`, `npm run ui:typecheck`, and `npm run ui:build` all pass locally, and the new test suite (4 tests) covers the loading, error (both generic and network-specific copy), and success render paths, including the retry action.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API/OpenAPI/MCP changes in this PR.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Before (collapsed loading/error) | <a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/notification-readiness-card-before.png"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/notification-readiness-card-before.png" alt="Before: collapsed generic text" width="320"></a> |
| After: Loading state | <a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/notification-readiness-card-loading.png"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/notification-readiness-card-loading.png" alt="After: loading state" width="320"></a> |
| After: Error state (real message + retry) | <a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/notification-readiness-card-error.png"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/notification-readiness-card-error.png" alt="After: error state with retry" width="320"></a> |

## Notes

-
