### PR TITLE
fix(miner): bound oauth-device-flow.js's GitHub fetches with a request timeout

### DIFF
--- a/packages/loopover-miner/lib/oauth-device-flow.js
+++ b/packages/loopover-miner/lib/oauth-device-flow.js
@@ -15,6 +15,9 @@ const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const DEFAULT_SCOPE = "repo";
 const DEFAULT_EXPIRES_IN_SECONDS = 900;
 const DEFAULT_INTERVAL_SECONDS = 5;
+// #miner-github-read-timeouts: matches github-token-resolution.js's GITHUB_TOKEN_FETCH_TIMEOUT_MS -- a stalled
+// connection can't hang forever, here or anywhere else this package talks to GitHub.
+const DEVICE_FLOW_FETCH_TIMEOUT_MS = 10_000;
 
 /** The centrally-held loopover-ams App's OAuth client id -- public (not secret), so it's safe to read from a
  *  plain env var. Empty/unset means device-flow authorization isn't available in this build/deployment. */
@@ -40,6 +43,7 @@ export async function requestDeviceCode({ clientId, scope = DEFAULT_SCOPE, fetch
     method: "POST",
     headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({ client_id: clientId, scope }).toString(),
+    signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
   });
   if (!res.ok) throw new DeviceFlowError("device_code_request_failed", `GitHub returned HTTP ${res.status} requesting a device code`);
   const data = await res.json();
@@ -75,15 +79,23 @@ export async function pollForAccessToken({
   for (;;) {
     if (now() >= deadline) throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
     await sleepFn(interval * 1000);
-    const res = await fetchFn(ACCESS_TOKEN_URL, {
-      method: "POST",
-      headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        client_id: clientId,
-        device_code: deviceCode,
-        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-      }).toString(),
-    });
+    let res;
+    try {
+      res = await fetchFn(ACCESS_TOKEN_URL, {
+        method: "POST",
+        headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: clientId,
+          device_code: deviceCode,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }).toString(),
+        signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      // A stalled/timed-out attempt is a per-attempt failure, not a fatal one -- the existing deadline check
+      // at the top of the loop still bounds total polling time, so this just costs one wasted interval.
+      continue;
+    }
     const data = await res.json().catch(() => ({}));
     if (data && typeof data.access_token === "string" && data.access_token) {
       return { accessToken: data.access_token, scope: typeof data.scope === "string" ? data.scope : "" };

--- a/test/unit/miner-oauth-device-flow.test.ts
+++ b/test/unit/miner-oauth-device-flow.test.ts
@@ -69,6 +69,13 @@ describe("requestDeviceCode (#5682)", () => {
     await expect(requestDeviceCode({ clientId: "c", fetchFn })).rejects.toMatchObject({ code: "device_code_request_failed" });
   });
 
+  it("REGRESSION (#6988): bounds the fetch with a request timeout so a stalled connection can't hang forever", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ device_code: "dc1", user_code: "u", verification_uri: "v" }));
+    await requestDeviceCode({ clientId: "c", fetchFn });
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it("throws device_code_response_invalid when a required field is missing", async () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ device_code: "dc1" }));
     await expect(requestDeviceCode({ clientId: "c", fetchFn })).rejects.toMatchObject({ code: "device_code_response_invalid" });
@@ -110,6 +117,35 @@ describe("pollForAccessToken (#5682)", () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ access_token: "gho_xyz" }));
     const result = await pollForAccessToken({ clientId: "c", deviceCode: "dc1", fetchFn, sleepFn: noSleep });
     expect(result.scope).toBe("");
+  });
+
+  it("REGRESSION (#6988): bounds each poll's fetch with a request timeout so a stalled connection can't hang forever", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ access_token: "gho_xyz" }));
+    await pollForAccessToken({ clientId: "c", deviceCode: "dc1", fetchFn, sleepFn: noSleep });
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("REGRESSION (#6988): a timed-out/rejected fetch is a per-attempt failure that still retries, not an unhandled crash", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new DOMException("The operation was aborted", "TimeoutError"))
+      .mockResolvedValueOnce(jsonResponse({ access_token: "gho_after_timeout" }));
+    const result = await pollForAccessToken({ clientId: "c", deviceCode: "dc1", fetchFn, sleepFn: noSleep });
+    expect(result.accessToken).toBe("gho_after_timeout");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("REGRESSION (#6988): a permanently stalled connection still respects the deadline instead of hanging forever", async () => {
+    let clock = 0;
+    const now = () => clock;
+    const sleepFn = vi.fn().mockImplementation(async (ms: number) => {
+      clock += ms;
+    });
+    const fetchFn = vi.fn().mockRejectedValue(new DOMException("The operation was aborted", "TimeoutError"));
+    await expect(
+      pollForAccessToken({ clientId: "c", deviceCode: "dc1", intervalSeconds: 5, expiresInSeconds: 12, fetchFn, sleepFn, now }),
+    ).rejects.toMatchObject({ code: "expired_token" });
   });
 
   it("keeps polling on authorization_pending until a token is granted", async () => {


### PR DESCRIPTION
## Summary
- `packages/loopover-miner/lib/oauth-device-flow.js`'s two GitHub-facing fetches — `requestDeviceCode` and `pollForAccessToken`'s per-attempt fetch — had no `AbortSignal.timeout`, unlike every other GitHub-facing fetch in this package (`github-token-resolution.js`'s `GITHUB_TOKEN_FETCH_TIMEOUT_MS` precedent, and everything routed through `http-retry.js`).
- `pollForAccessToken`'s own `deadline` check only fires *between* polling attempts, so a single stalled connection mid-fetch could hang indefinitely rather than being caught by the deadline — undermining `init-wizard.js`'s documented "never a hard dependency ... automatic fallback on any device-flow failure", since a hang never reaches the `catch` meant to trigger the pasted-token fallback.
- Adds a local `DEVICE_FLOW_FETCH_TIMEOUT_MS = 10_000` constant (matching the package's existing per-file constant convention) and wires `signal: AbortSignal.timeout(...)` into both fetches.
- Wraps `pollForAccessToken`'s per-attempt fetch in try/catch: a timeout/abort is now a per-attempt failure that `continue`s the polling loop (still bounded by the existing `deadline` check), not an unhandled rejection that crashes the flow.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6988

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of what changed; `node --check` on the modified file (passed) plus the full targeted vitest run below stand in as the local proxy, and CI's isolated runner performs the authoritative `tsc --noEmit`. This module's public function signatures are unchanged (verified against its hand-maintained `oauth-device-flow.d.ts` companion — only internal fetch-call bodies changed), so no `.d.ts` update was needed.
- [x] `npm run test:coverage` — `test/unit/miner-oauth-device-flow.test.ts` (27 tests, incl. 4 new: the `AbortSignal` timeout on both fetches, a rejected/timed-out attempt still retrying to a successful poll, and a permanently-stalled connection still respecting the deadline) — 27/27 passing.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — this is a CLI-package module with no Worker/MCP-packaging/API-schema surface)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure regardless of diff size; `node --check` (syntax) plus the full targeted test run above are the local proxy for this JS module, and CI's isolated runner performs the real `tsc --noEmit` (which type-checks the unchanged, hand-maintained `.d.ts` companion against this file's actual exports). `npm run test:workers` and the MCP/OpenAPI checks have no surface to exercise for a change scoped to two fetch calls in one miner CLI module.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. This touches the OAuth device-flow authorization path; the new tests cover the timeout/abort failure path explicitly.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal CLI module, no API/OpenAPI/MCP surface.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — backend CLI-only change, no UI surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.