### PR TITLE
fix(miner): fail closed when a chat-action handler throws

### DIFF
--- a/packages/loopover-miner/lib/chat-action-dispatch.js
+++ b/packages/loopover-miner/lib/chat-action-dispatch.js
@@ -71,7 +71,17 @@ export async function dispatchChatAction(request, options = {}) {
     return { ok: false, status: "invalid_params", action };
   }
 
-  const result = await registered.handler(request);
+  let result;
+  try {
+    result = await registered.handler(request);
+  } catch {
+    // A handler that throws fails closed with the module's typed result shape (#6989), consistent with the
+    // paramsValidator catch above. The thrown value is deliberately NOT echoed back: a handler wraps
+    // arbitrary action work (e.g. a network call), so its error could carry external detail -- the sibling
+    // fail-closed paths (sentry.js, pretooluse-hook.js) likewise swallow rather than surface it. A distinct
+    // "handler_error" status still lets a caller tell an execution failure from a params-validation failure.
+    return { ok: false, status: "handler_error", action };
+  }
   return { ok: true, status: "dispatched", action, result };
 }
 

--- a/test/unit/miner-chat-action-dispatch.test.ts
+++ b/test/unit/miner-chat-action-dispatch.test.ts
@@ -147,4 +147,22 @@ describe("dispatchChatAction (#6519)", () => {
     const result = await dispatchChatAction({ action: "demo", params: {} }, { env: enabledEnv, registry });
     expect(result).toEqual({ ok: false, status: "invalid_params", action: "demo", error: "boom" });
   });
+
+  it("fails closed with handler_error when the handler throws, not an unhandled rejection (#6989)", async () => {
+    const registry = registryWith("demo", () => true, () => {
+      throw new Error("network down");
+    });
+    const result = await dispatchChatAction({ action: "demo", params: {} }, { env: enabledEnv, registry });
+    // Typed result, distinct from invalid_params so a caller can tell an execution failure from a validation
+    // failure. The thrown value is deliberately not surfaced (it may carry external detail).
+    expect(result).toEqual({ ok: false, status: "handler_error", action: "demo" });
+  });
+
+  it("fails closed the same way regardless of what the handler throws (#6989)", async () => {
+    const registry = registryWith("demo", () => true, () => {
+      throw "kaboom";
+    });
+    const result = await dispatchChatAction({ action: "demo", params: {} }, { env: enabledEnv, registry });
+    expect(result).toEqual({ ok: false, status: "handler_error", action: "demo" });
+  });
 });


### PR DESCRIPTION
## What

`dispatchChatAction` (`packages/loopover-miner/lib/chat-action-dispatch.js`) wraps its `paramsValidator` call in a try/catch — explicitly "fail closed" — but the next line, `await registered.handler(request)`, was unguarded. A handler that throws (e.g. a network error from a governor action) would surface as an unhandled rejection instead of the module's own typed `{ ok, status }` contract that every other failure path returns.

This is latent today (the dashboard-chat REST endpoint that invokes it is still an open epic, #6839), but wiring it live would turn any handler throw into an unhandled rejection.

## How

Wrap `registered.handler(request)` in try/catch, returning `{ ok: false, status: "handler_error", action }` on throw. The distinct `"handler_error"` status (vs `"invalid_params"`) lets a caller tell an execution failure apart from a validation failure.

The thrown value is deliberately **not** echoed back in the result. A handler wraps arbitrary action work (e.g. a network call), so its error could carry external detail — the sibling fail-closed paths named in the issue (`sentry.js`, `pretooluse-hook.js`) likewise swallow rather than surface the thrown value. Fail-closed with a typed status, no raw error string.

## Validation

Tests added to the existing `test/unit/miner-chat-action-dispatch.test.ts`: a handler throwing an `Error` and a handler throwing a non-`Error` both fail closed with the same `{ ok: false, status: "handler_error", action }` shape. Confirmed both **fail against the unfixed code** (unhandled rejection) and pass with the fix; 100% statement and branch coverage on the file.

Closes #6989
