### PR TITLE
fix(ui): adopt Skeleton for SparkStat's loading placeholders

### DIFF
--- a/apps/loopover-ui/src/routes/app.index.test.tsx
+++ b/apps/loopover-ui/src/routes/app.index.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { SparkStat } from "./app.index";
+
+// #6984: SparkStat's loading branch hand-rolled its own animate-pulse divs instead of the shared
+// Skeleton primitive every other loading placeholder in this app already uses.
+describe("SparkStat loading state (#6984)", () => {
+  it("renders Skeleton placeholders (not the raw hand-rolled divs) while loading", () => {
+    const { container } = render(
+      <SparkStat
+        label="Open PRs"
+        value="4"
+        values={[1, 2, 3, 4]}
+        live
+        statusLabel="live"
+        loading
+      />,
+    );
+
+    expect(screen.getByRole("status", { name: "Loading Open PRs" })).toBeTruthy();
+    // Skeleton renders animate-pulse blocks; the label/value/sparkline placeholders are 3 in total.
+    expect(container.querySelectorAll(".animate-pulse").length).toBe(3);
+    // The real label/value text never renders while loading.
+    expect(screen.queryByText("Open PRs")).toBeNull();
+    expect(screen.queryByText("4")).toBeNull();
+  });
+
+  it("renders the real label and value once data is available (not loading)", () => {
+    render(
+      <TooltipProvider>
+        <SparkStat label="Open PRs" value="4" values={[1, 2, 3, 4]} live statusLabel="live" />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("Open PRs")).toBeTruthy();
+    expect(screen.getByText("4")).toBeTruthy();
+    expect(screen.queryByRole("status", { name: "Loading Open PRs" })).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/routes/app.index.tsx
+++ b/apps/loopover-ui/src/routes/app.index.tsx
@@ -16,6 +16,7 @@ import {
   X,
 } from "lucide-react";
 
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { StatusPill } from "@/components/site/control-primitives";
@@ -494,7 +495,7 @@ function OnboardingChecklist() {
   );
 }
 
-function SparkStat({
+export function SparkStat({
   label,
   value,
   hint,
@@ -518,10 +519,10 @@ function SparkStat({
         aria-label={`Loading ${label}`}
         className="rounded-token border-hairline bg-card p-4"
       >
-        <div className="h-3 w-24 animate-pulse rounded bg-muted/40 motion-reduce:animate-none" />
+        <Skeleton className="h-3 w-24" />
         <div className="mt-3 flex items-end justify-between gap-3">
-          <div className="h-7 w-16 animate-pulse rounded bg-muted/40 motion-reduce:animate-none" />
-          <div className="h-10 w-24 animate-pulse rounded bg-muted/30 motion-reduce:animate-none" />
+          <Skeleton className="h-7 w-16" />
+          <Skeleton className="h-10 w-24" />
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

- `SparkStat` (`apps/loopover-ui/src/routes/app.index.tsx`) hand-rolled its own three `animate-pulse` placeholder `<div>`s for its loading state instead of the shared `Skeleton` primitive every other loading placeholder in this app already uses (e.g. `app.analytics.tsx:8`, `app.operator.tsx`). `app.index.tsx` never imported `Skeleton` at all, despite this being the app's highest-traffic authenticated route.
- Replaced the three hand-rolled divs with `Skeleton` (imported from `@/components/ui/skeleton`), preserving the existing sizing (`h-3 w-24`, `h-7 w-16`, `h-10 w-24`) so the loading layout doesn't visually shift once real data arrives.
- Exported `SparkStat` for direct testing, matching the precedent set by other route-local components tested this way (e.g. `DrawerSurface` in `app.runs.tsx`, `OperatorDashboard` in `app.operator.tsx`).
- Added `app.index.test.tsx` covering both the loading render path (asserts 3 `Skeleton`/`animate-pulse` blocks, the `role="status"` accessible name, and that the real label/value never leak through) and the ready render path (real label/value render, no skeleton).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6984

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes in this PR)
- [x] `npm run typecheck` (via `npm run ui:typecheck`, the UI-scoped equivalent)
- [ ] `npm run test:coverage` (backend-only; this PR only touches `apps/loopover-ui`, which is outside the Codecov patch gate per `codecov.yml`'s `ignore: apps/**`)
- [ ] `npm run test:workers` (not applicable to this UI-only change)
- [ ] `npm run build:mcp` (not applicable to this UI-only change)
- [ ] `npm run test:mcp-pack` (not applicable to this UI-only change)
- [ ] `npm run ui:openapi:check` (no API/schema changes in this PR)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build` (ran individually via `npm --workspace @loopover/ui run typecheck`; the full `ui:build` pipeline invokes an unrelated content-collection step for `.mdx` docs that mutates files outside this diff in this sandbox, so I validated via lint + typecheck + the full local test suite instead of committing that noise)
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `apps/loopover-ui/src/routes/app.index.tsx` (plus its new test file) -- a single component's loading-branch markup, no API/backend/dependency surface. `npm run ui:lint` and `npm run ui:typecheck` both pass locally, and the new 2-test suite covers the loading and ready render paths directly, including an assertion on the exact skeleton-block count.
- **UI Evidence (screenshot) honestly could not be captured**: I attempted to screenshot the live loading state via a scripted Playwright run against the local dev server, mocking the route's backing API to hold the response open. The dev server's session-hydration + separate global `useApiStatus` health-poll combination did not reach a stable loading render within a reasonable capture window in this sandboxed environment (no reliable outbound network for the app's own live health check), so the screenshot attempts repeatedly produced either a blank viewport or an unrelated pre-existing crash in `McpVersionBadge` (a different component, not touched by this PR, that throws when `registry.npmjs.org` is unreachable). Rather than fabricate or force a misleading capture, I'm flagging this honestly: the change is small, mechanical, and directly verified by the new automated test's `.animate-pulse` assertion, which is the same assertion pattern used to verify the identical `Skeleton` adoption in the already-merged `app.operator.tsx`/`app.analytics.tsx`/`notification-readiness-card.tsx` PRs.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API/OpenAPI/MCP changes in this PR.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. See the honest explanation above -- capture was attempted and did not succeed in this sandboxed environment.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- See the Validation section above for why UI Evidence screenshots are missing despite a genuine attempt.
