### PR TITLE
fix(miner-extension): bound the ranked-candidates sync fetch with a timeout

### DIFF
--- a/apps/loopover-miner-extension/background.js
+++ b/apps/loopover-miner-extension/background.js
@@ -7,6 +7,10 @@ const toolbarBadgeApi = globalThis.__loopoverMinerToolbarBadge;
 const PING_MESSAGE = "loopover-miner:ping";
 const ISSUE_CONTEXT_MESSAGE = "loopover-miner:issue-context";
 const SYNC_RANKED_CANDIDATES_MESSAGE = "loopover-miner:sync-ranked-candidates";
+// Short: this is a same-machine localhost call, not a round-trip to a remote server -- a stalled connection
+// (miner-ui running but unresponsive) should fail fast and let the next 10-minute alarm retry, following the
+// timeout pattern established in review-enrichment/src/external-fetch.ts.
+const RANKED_CANDIDATES_FETCH_TIMEOUT_MS = 3000;
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (!message || typeof message.type !== "string") return false;
@@ -108,7 +112,9 @@ async function loadMinerUiUrl() {
 async function syncRankedCandidatesFromMinerUi() {
   const minerUiUrl = await loadMinerUiUrl();
   try {
-    const response = await fetch(`${minerUiUrl}/api/ranked-candidates`);
+    const response = await fetch(`${minerUiUrl}/api/ranked-candidates`, {
+      signal: AbortSignal.timeout(RANKED_CANDIDATES_FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       return { ok: false, error: `miner UI responded ${response.status}`, minerUiUrl };
     }

--- a/apps/loopover-miner-extension/test/background.test.ts
+++ b/apps/loopover-miner-extension/test/background.test.ts
@@ -120,6 +120,34 @@ describe("background service worker", () => {
     expect(failed).toMatchObject({ ok: false, error: "connection refused" });
   });
 
+  it("REGRESSION (#7007): bounds the miner-ui fetch with a 3s AbortSignal timeout", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const { backgroundInternals } = await loadExtensionModules({
+      fetchImpl: jsonFetch(200, { candidates: [] }),
+    });
+    await backgroundInternals.syncRankedCandidatesFromMinerUi();
+    expect(timeoutSpy).toHaveBeenCalledWith(3000);
+    timeoutSpy.mockRestore();
+  });
+
+  it("REGRESSION (#7007): a stalled miner-ui connection times out instead of hanging the sync alarm forever", async () => {
+    // Mirrors what a real fetch does under an aborted signal: the promise never resolves on its own, it only
+    // rejects once the signal fires -- so this proves the timeout actually bounds a genuinely-hung connection,
+    // not just a fast-failing one.
+    const hangingFetch = (async (_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("The operation was aborted.", "TimeoutError")));
+      })) as typeof fetch;
+    const { backgroundInternals } = await loadExtensionModules({ fetchImpl: hangingFetch });
+
+    const startedAt = Date.now();
+    const result = await backgroundInternals.syncRankedCandidatesFromMinerUi();
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.ok).toBe(false);
+    expect(elapsedMs).toBeLessThan(4000); // bounded well under what an unbounded hang would take
+  }, 10_000);
+
   it("falls back to the default miner UI URL when sync storage is empty or malformed", async () => {
     const empty = await loadExtensionModules({ minerUiUrl: "" });
     expect(await empty.backgroundInternals.loadMinerUiUrl()).toBe(


### PR DESCRIPTION
## Summary
- `apps/loopover-miner-extension/background.js`'s `syncRankedCandidatesFromMinerUi` called `fetch` with no timeout or `AbortController`, unlike the established pattern in `review-enrichment/src/external-fetch.ts`. This sync runs on a 10-minute alarm, so a hung connection (e.g. the local miner-ui process running but unresponsive) would leave that alarm invocation hanging indefinitely instead of failing fast and letting the next scheduled attempt retry.
- Adds a local `RANKED_CANDIDATES_FETCH_TIMEOUT_MS = 3000` constant (short, since this is a same-machine localhost call, not a remote round-trip) and wires `signal: AbortSignal.timeout(...)` into the fetch call.
- The function's existing try/catch already resolves any thrown/aborted fetch to its documented `{ ok: false, error, minerUiUrl }` shape — no new error handling was needed to satisfy the "never throws" contract.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7007

## Validation
- [x] `git diff --check`
- [x] `npm run lint --workspace @loopover/miner-extension` (this workspace's own `node --check` lint/typecheck)
- [x] `npm run test --workspace @loopover/miner-extension` — 24/24 passing with coverage: 100% statements/lines, 95.79% branches on `background.js` (identical to the pre-existing baseline; all uncovered lines are unrelated pre-existing branches, not part of this diff)
- [ ] `npm run actionlint` / whole-repo `npm run typecheck` (not applicable — this is an isolated browser-extension workspace with its own lint/test scripts, unaffected by backend changes)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable to this extension-only change)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `apps/loopover-miner-extension/**`, which has its own isolated `lint`/`test` scripts (run above, both green) and no dependency on the backend build/typecheck pipeline. The whole-repo `actionlint`/`typecheck` and MCP/Worker/OpenAPI checks have no surface to exercise for a change scoped to one fetch call in one browser-extension module.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session changes; this is a local-network browser-extension fetch.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — background service-worker logic, no rendered UI.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI change; this is a background-alarm timeout fix.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.