### PR TITLE
fix(ui): migrate 3 hand-rolled tables to the shared Table component

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/contributor-quality-table.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/contributor-quality-table.tsx
@@ -2,6 +2,15 @@ import { BoundaryBadge, StatusPill } from "@/components/site/control-primitives"
 import { TableScroll } from "@/components/site/data-table";
 import { EmptyState } from "@/components/site/state-views";
 import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
   QUALITY_BAND_TONE,
   type MaintainerTopContributor,
 } from "@/components/site/app-panels/contributor-quality-table-model";
@@ -32,42 +41,44 @@ export function ContributorQualityTable({
         />
       ) : (
         <TableScroll className="mt-4" label="Top contributors by quality band">
-          <table className="w-full min-w-[420px] whitespace-nowrap text-left text-token-sm">
-            <caption className="sr-only">
+          <Table className="min-w-[420px] whitespace-nowrap text-left text-token-sm">
+            <TableCaption className="sr-only">
               Contributors with their quality band and open pull request count.
-            </caption>
-            <thead>
-              <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                <th scope="col" className="py-2 pr-3 font-normal">
+            </TableCaption>
+            <TableHeader>
+              <TableRow className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                <TableHead scope="col" className="py-2 pr-3 font-normal">
                   Contributor
-                </th>
-                <th scope="col" className="py-2 pr-3 font-normal">
+                </TableHead>
+                <TableHead scope="col" className="py-2 pr-3 font-normal">
                   Band
-                </th>
-                <th scope="col" className="py-2 font-normal">
+                </TableHead>
+                <TableHead scope="col" className="py-2 font-normal">
                   Open PRs
-                </th>
-              </tr>
-            </thead>
-            <tbody>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {topContributors.map((contributor) => (
-                <tr
+                <TableRow
                   key={contributor.login}
                   className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
                 >
-                  <td className="py-2 pr-3 font-medium text-foreground">{contributor.login}</td>
-                  <td className="py-2 pr-3">
+                  <TableCell className="py-2 pr-3 font-medium text-foreground">
+                    {contributor.login}
+                  </TableCell>
+                  <TableCell className="py-2 pr-3">
                     <StatusPill status={QUALITY_BAND_TONE[contributor.band] ?? "info"}>
                       {contributor.band}
                     </StatusPill>
-                  </td>
-                  <td className="py-2 font-mono text-token-xs text-muted-foreground">
+                  </TableCell>
+                  <TableCell className="py-2 font-mono text-token-xs text-muted-foreground">
                     {contributor.openPrCount}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </TableScroll>
       )}
     </section>

--- a/apps/loopover-ui/src/components/site/check-run-readiness-table.tsx
+++ b/apps/loopover-ui/src/components/site/check-run-readiness-table.tsx
@@ -1,6 +1,15 @@
 import { StatusPill, type Status } from "@/components/site/control-primitives";
 import { TableScroll } from "@/components/site/data-table";
 import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
   COMPONENT_BAND_LABEL,
   READINESS_BAND_LABEL,
   resolveCheckRunReadinessView,
@@ -62,43 +71,43 @@ export function CheckRunReadinessTable({
         className="rounded-token border-hairline"
         label="Context check readiness signals"
       >
-        <table className="w-full text-left text-token-xs">
-          <caption className="sr-only">
+        <Table className="text-left text-token-xs">
+          <TableCaption className="sr-only">
             Readiness signals with their band, evidence, and recommended action.
-          </caption>
-          <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
-            <tr>
-              <th scope="col" className="px-3 py-2 font-normal">
+          </TableCaption>
+          <TableHeader className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
+            <TableRow>
+              <TableHead scope="col" className="px-3 py-2 font-normal">
                 Signal
-              </th>
-              <th scope="col" className="px-3 py-2 font-normal">
+              </TableHead>
+              <TableHead scope="col" className="px-3 py-2 font-normal">
                 Band
-              </th>
-              <th scope="col" className="px-3 py-2 font-normal">
+              </TableHead>
+              <TableHead scope="col" className="px-3 py-2 font-normal">
                 Evidence
-              </th>
-              <th scope="col" className="hidden px-3 py-2 font-normal lg:table-cell">
+              </TableHead>
+              <TableHead scope="col" className="hidden px-3 py-2 font-normal lg:table-cell">
                 Action
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {view.components.map((row) => (
-              <tr key={row.key} className="border-b-hairline last:border-b-0 align-top">
-                <td className="px-3 py-2 font-medium text-foreground">{row.label}</td>
-                <td className="px-3 py-2">
+              <TableRow key={row.key} className="border-b-hairline last:border-b-0 align-top">
+                <TableCell className="px-3 py-2 font-medium text-foreground">{row.label}</TableCell>
+                <TableCell className="px-3 py-2">
                   <StatusPill status={COMPONENT_BAND_TONE[row.band]}>
                     {COMPONENT_BAND_LABEL[row.band]}
                   </StatusPill>
-                </td>
-                <td className="px-3 py-2 text-muted-foreground">{row.evidence}</td>
-                <td className="hidden px-3 py-2 text-muted-foreground lg:table-cell">
+                </TableCell>
+                <TableCell className="px-3 py-2 text-muted-foreground">{row.evidence}</TableCell>
+                <TableCell className="hidden px-3 py-2 text-muted-foreground lg:table-cell">
                   {row.action}
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </TableScroll>
     </section>
   );

--- a/apps/loopover-ui/src/components/site/command-table.test.tsx
+++ b/apps/loopover-ui/src/components/site/command-table.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CommandTable } from "@/components/site/command-table";
+
+// #6986: pinned after migrating the hand-rolled <table> markup onto the shared Table primitive --
+// confirms the real table structure, columns, and default-role lookup still render correctly.
+describe("CommandTable", () => {
+  it("renders a real <table> with the syntax/effect/default-roles columns and one row per entry", () => {
+    render(
+      <CommandTable
+        title="Commands"
+        entries={[
+          { id: "review", title: "Review", description: "Runs a review pass." },
+          {
+            id: "unlisted-command",
+            title: "Unlisted",
+            description: "Not in the role summary map.",
+          },
+        ]}
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    const headers = within(table)
+      .getAllByRole("columnheader")
+      .map((cell) => cell.textContent);
+    expect(headers).toEqual(["Syntax", "Effect", "Default roles"]);
+
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(3); // header row + 2 entries
+
+    expect(within(rows[1]!).getByText("@loopover review")).toBeTruthy();
+    expect(within(rows[1]!).getByText("Runs a review pass.")).toBeTruthy();
+    expect(within(rows[1]!).getByText("maintainer, collaborator, confirmed_miner")).toBeTruthy();
+
+    // Falls back to "see policy" when the entry id has no DEFAULT_ROLE_SUMMARY mapping.
+    expect(within(rows[2]!).getByText("@loopover unlisted-command")).toBeTruthy();
+    expect(within(rows[2]!).getByText("see policy")).toBeTruthy();
+  });
+
+  it("renders the title heading", () => {
+    render(<CommandTable title="Commands reference" entries={[]} />);
+    expect(screen.getByRole("heading", { name: "Commands reference" })).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/command-table.tsx
+++ b/apps/loopover-ui/src/components/site/command-table.tsx
@@ -1,3 +1,12 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
 const DEFAULT_ROLE_SUMMARY: Record<string, string> = {
   help: "maintainer, collaborator, confirmed_miner (default policy)",
   ask: "maintainer, collaborator, confirmed_miner",
@@ -38,28 +47,30 @@ export function CommandTable({
     <>
       <h2>{title}</h2>
       <div className="not-prose overflow-x-auto">
-        <table className="w-full border-collapse text-token-sm">
-          <thead>
-            <tr className="border-hairline text-left text-token-xs text-muted-foreground">
-              <th className="py-2 pr-4 font-medium">Syntax</th>
-              <th className="py-2 pr-4 font-medium">Effect</th>
-              <th className="py-2 font-medium">Default roles</th>
-            </tr>
-          </thead>
-          <tbody className="divide-hairline">
+        <Table className="border-collapse text-token-sm">
+          <TableHeader>
+            <TableRow className="border-hairline text-left text-token-xs text-muted-foreground">
+              <TableHead className="py-2 pr-4 font-medium">Syntax</TableHead>
+              <TableHead className="py-2 pr-4 font-medium">Effect</TableHead>
+              <TableHead className="py-2 font-medium">Default roles</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody className="divide-hairline">
             {entries.map((entry) => (
-              <tr key={entry.id} className="align-top">
-                <td className="py-2 pr-4 font-mono text-token-xs whitespace-nowrap">
+              <TableRow key={entry.id} className="align-top">
+                <TableCell className="py-2 pr-4 font-mono text-token-xs whitespace-nowrap">
                   @loopover {entry.id}
-                </td>
-                <td className="py-2 pr-4 text-muted-foreground">{entry.description}</td>
-                <td className="py-2 text-muted-foreground">
+                </TableCell>
+                <TableCell className="py-2 pr-4 text-muted-foreground">
+                  {entry.description}
+                </TableCell>
+                <TableCell className="py-2 text-muted-foreground">
                   {DEFAULT_ROLE_SUMMARY[entry.id] ?? "see policy"}
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

- `check-run-readiness-table.tsx`, `command-table.tsx`, and `contributor-quality-table.tsx` each hand-rolled raw `<table>`/`<thead>`/`<tbody>` markup instead of the shared `Table`/`TableHeader`/`TableBody`/`TableRow`/`TableCell`/`TableCaption` primitives from `@/components/ui/table` (a ui-kit-backed component), unlike the rest of the app's adopted convention (epic #6504, already applied to `apps/loopover-miner-ui`'s tables).
- Migrated all three, preserving each table's existing columns, formatting logic, and per-cell styling exactly (e.g. `contributor-quality-table.tsx`'s `whitespace-nowrap`, `check-run-readiness-table.tsx`'s `scope="col"` + `sr-only` caption a11y pattern, `command-table.tsx`'s `DEFAULT_ROLE_SUMMARY` fallback). No new wrapper component was invented; `TableScroll` (a separate, orthogonal scroll-container wrapper already used by two of the three) is left in place around the migrated `Table`.
- `command-table.tsx` had no existing test; added one covering its columns, per-entry rendering, and the `DEFAULT_ROLE_SUMMARY` fallback (`see policy` for an unmapped command id).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6986

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes in this PR)
- [x] `npm run typecheck` (via `npm run ui:typecheck`, the UI-scoped equivalent)
- [ ] `npm run test:coverage` (backend-only; this PR only touches `apps/loopover-ui`, which is outside the Codecov patch gate per `codecov.yml`'s `ignore: apps/**`)
- [ ] `npm run test:workers` (not applicable to this UI-only change)
- [ ] `npm run build:mcp` (not applicable to this UI-only change)
- [ ] `npm run test:mcp-pack` (not applicable to this UI-only change)
- [ ] `npm run ui:openapi:check` (no API/schema changes in this PR)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build` (validated via lint + typecheck + the full local test suite instead; the full `ui:build` pipeline invokes an unrelated content-collection step for `.mdx` docs that mutates files outside this diff in this sandbox)
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches three presentational components' table markup (plus one new test file) -- no API/backend/dependency surface. `npm run ui:lint` and `npm run ui:typecheck` both pass locally, and all 16 tests across the three components' test suites pass (14 pre-existing + 2 new), confirming the migrated markup still renders the same real `<table>` structure, columns, and content.
- **UI Evidence (screenshots) honestly could not be captured**: I made repeated genuine attempts to screenshot all three tables via a scripted Playwright run against the local dev server. Each attempt hit a *different*, pre-existing, unrelated issue in this sandboxed environment -- e.g. the docs route hosting `command-table.tsx` throws `Error: CodeBlock is not defined` in its compiled MDX content (a bug in the docs renderer, not in this PR's diff), and other routes in this app have separately hit an unrelated `McpVersionBadge` crash against an unreachable `registry.npmjs.org` in earlier attempts this session. None of these are caused by or related to the table-markup migration itself. Rather than force a misleading capture, I'm flagging this honestly, same as the already-merged Skeleton-adoption PR for `app.index.tsx` (#6984) hit and disclosed the same limitation. The three components' test suites (which assert on real DOM roles: `getByRole("table")`, `getAllByRole("columnheader")`, `getAllByRole("row")`) are the verification that the migrated markup renders correctly.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API/OpenAPI/MCP changes in this PR.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. See the honest explanation above -- capture was attempted multiple times and did not succeed due to pre-existing, unrelated sandbox issues.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- See the Validation section above for why UI Evidence screenshots are missing despite genuine, repeated attempts.
