### PR TITLE
docs(scripts): fix stale --db gittensory example in export-d1-data.mjs

### DIFF
--- a/scripts/export-d1-data.mjs
+++ b/scripts/export-d1-data.mjs
@@ -4,7 +4,7 @@
 // a manifest the self-host importer validates against. The data transformation lives in export-d1-core.mjs (pure,
 // unit-tested); this file is the thin IO wrapper.
 //
-//   node scripts/export-d1-data.mjs --db gittensory --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
+//   node scripts/export-d1-data.mjs --db loopover --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
 //
 // --remote reads the deployed D1 (default is the local miniflare DB). --since-date does an INCREMENTAL export
 // (rows whose --since-column is >= the date); omit it for a full export. NEVER pass a write command.


### PR DESCRIPTION
## Summary

- `scripts/export-d1-data.mjs`'s usage comment told a maintainer to run `node scripts/export-d1-data.mjs --db gittensory --output ./export [...]`. The real D1 database name (per `wrangler.jsonc`'s `"database_name": "loopover"`) was renamed from `gittensory` to `loopover` during the 2026-07-15 repo rename. Copy-pasting the example as written would target a database name that no longer exists.
- Updated the usage comment to `--db loopover`.
- Grepped the rest of the file for other stale `gittensory`-named examples — this was the only one.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7012

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes in this PR)
- [x] `npm run typecheck` (no type-level surface in a comment-only change; ran anyway, no errors)
- [ ] `npm run test:coverage` (not applicable; `scripts/**` is outside the Codecov patch gate per `codecov.yml`'s `ignore: scripts/**`, and per the issue this is a doc-comment-only change with no behavioral diff)
- [ ] `npm run test:workers` (not applicable to this change)
- [ ] `npm run build:mcp` (not applicable to this change)
- [ ] `npm run test:mcp-pack` (not applicable to this change)
- [ ] `npm run ui:openapi:check` (not applicable to this change)
- [ ] `npm run ui:lint` (not applicable to this change)
- [ ] `npm run ui:typecheck` (not applicable to this change)
- [ ] `npm run ui:build` (not applicable to this change)
- [ ] `npm audit --audit-level=moderate` (no dependency changes in this PR)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a single-line usage-comment correction in `scripts/export-d1-data.mjs`, explicitly called out in the linked issue as "no behavioral diff, no new test required." `npm run typecheck` and `npm run docs:drift-check` both pass locally; the existing `test/unit/check-branding-drift-script.test.ts` (which scans the repo for stale branding references) also passes with this change applied.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API/OpenAPI/MCP changes in this PR.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A -- no UI changes in this PR.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A -- this PR has no UI/visual surface; it corrects a code comment in a maintenance script.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

-
