### PR TITLE
fix(release): scope MCP publish validation to its own package

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Unprivileged: resolves the version, runs the full test gate, and packs the tarball -- all with
+  # Unprivileged: resolves the version, runs the MCP package's own build/test/pack, all with
   # contents: read only. npm ci here executes dependency lifecycle scripts; keeping that in a job
   # with no write/id-token permission means a compromised build dependency has nothing to abuse
   # (Superagent P2 / mirrors metagraphed's publish-client.yml "validate" job, codex #251).
@@ -39,6 +39,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify release commit is on main
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main; then
+            echo "::error::MCP package releases must be cut from a commit reachable from main."
+            exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -77,16 +88,30 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # packages/loopover-mcp's own test suite pulls in src/mcp/find-opportunities.ts transitively
-      # (via packages/loopover-miner/lib/opportunity-fanout.js), which imports @loopover/engine.
-      # That package's dist/ is gitignored (see ci.yml's own build --workspace @loopover/engine
-      # step for the same reason) -- without building it first, the MCP release validation gate below
-      # fails with "Failed to resolve entry for package @loopover/engine" on every run.
+      # packages/loopover-mcp's CLI test suite (test/unit/mcp-cli-*.test.ts) spawns the real binary,
+      # which imports @loopover/engine. That package's dist/ is gitignored (see ci.yml's own
+      # build --workspace @loopover/engine step for the same reason) -- without building it first,
+      # the CLI test suite below fails with "Failed to resolve entry for package @loopover/engine".
       - name: Build loopover-engine
         run: npm run build --workspace @loopover/engine
 
-      - name: MCP release validation gate
-        run: npm run test:release:mcp
+      # engine/miner/ui-kit's own publish workflows only validate their OWN package (a workspace
+      # test run + pack/smoke-test) -- mcp previously ran the full npm run test:ci (every workspace,
+      # every drift-check, ui:lint/build, migrations, etc.), coupling an MCP release to the health of
+      # the entire monorepo. Confirmed harmful live: an unrelated packages/loopover-miner env-reference
+      # doc going stale blocked MCP's publish outright, even though MCP's own package code was
+      # completely unaffected -- and main's required CI already re-verifies whole-repo health on
+      # every PR, including release-please's own, so re-running all of it here is redundant with what
+      # already gated the merge. Scoped down to match its siblings instead: MCP's own syntax check
+      # (node --check, same as build:mcp) plus its own CLI test suite -- test/unit/mcp-cli-*.test.ts
+      # specifically (imports packages/loopover-mcp and spawns the built binary), NOT the sibling
+      # test/unit/mcp-*.test.ts files that exercise the Worker's separate remote MCP server
+      # (src/mcp/server.ts, a different deployable entirely).
+      - name: MCP package syntax validation
+        run: npm run build:mcp
+
+      - name: MCP CLI test suite
+        run: npx vitest run mcp-cli-
 
       # Build + pack happen in THIS unprivileged job (no id-token). The privileged publish job below
       # never runs npm install/build, so a compromised build dependency can't reach the OIDC token.
@@ -137,6 +162,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify release commit is on main
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main; then
+            echo "::error::MCP package releases must be cut from a commit reachable from main."
+            exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -20749,7 +20749,7 @@
     },
     "packages/loopover-mcp": {
       "name": "@loopover/mcp",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@loopover/engine": "^3.2.0",
@@ -20766,7 +20766,7 @@
     },
     "packages/loopover-miner": {
       "name": "@loopover/miner",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@loopover/engine": "^3.2.0",

--- a/packages/loopover-mcp/CHANGELOG.md
+++ b/packages/loopover-mcp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## mcp-v3.1.1 - 2026-07-17
+
+### Fixes
+- Blunt slop-risk / issue-slop REST + CLI to match the MCP tools (#6990) (#7052)
+
 ## [3.1.0](https://github.com/JSONbored/loopover/compare/mcp-v3.0.0...mcp-v3.1.0) (2026-07-17)
 
 

--- a/packages/loopover-mcp/package.json
+++ b/packages/loopover-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopover/mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "AGPL-3.0-only",
   "type": "module",
   "description": "Local stdio MCP wrapper for the LoopOver Gittensor base-agent.",

--- a/packages/loopover-miner/CHANGELOG.md
+++ b/packages/loopover-miner/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.1.1](https://github.com/JSONbored/loopover/compare/miner-v3.1.0...miner-v3.1.1) (2026-07-17)
+
+
+### Fixes
+
+* **miner:** bound oauth-device-flow.js's GitHub fetches with a request timeout ([77ca20f](https://github.com/JSONbored/loopover/commit/77ca20fdcc30d05137b41a5848bce156110c238a))
+* **miner:** fail closed when a chat-action handler throws ([bdb11d9](https://github.com/JSONbored/loopover/commit/bdb11d974d961594b4555582bd2b7c811b8cde16))
+
+### Chores
+
+- Re-cut release: miner-v3.1.0's release PR merged but the tag/publish never completed (release-please's own trigger only ran on a 2-day cron, and npm's Trusted Publisher config pointed at the pre-rebrand repo identity).
+
 ## [3.1.0](https://github.com/JSONbored/loopover/compare/miner-v3.0.0...miner-v3.1.0) (2026-07-17)
 
 

--- a/packages/loopover-miner/package.json
+++ b/packages/loopover-miner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopover/miner",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "AGPL-3.0-only",
   "type": "module",
   "description": "Foundation CLI for the local LoopOver miner runtime.",


### PR DESCRIPTION
## Summary

**1. Scope MCP's publish validation to its own package** (`.github/workflows/publish-mcp.yml`)

- `publish-engine.yml`/`publish-miner.yml`/`publish-ui-kit.yml` already validate only their own package before publishing (a workspace test run + pack/smoke-test). `publish-mcp.yml` was the outlier: its `validate` job ran `npm run test:release:mcp`, which is literally `npm run test:ci` -- the entire monorepo gate (every workspace, every drift-check, `ui:lint`/`ui:build`, migrations, the works).
- This coupled an MCP release to the health of the *entire* repo. Confirmed harmful live: an unrelated `packages/loopover-miner` env-reference doc going stale blocked `publish-mcp.yml` outright, even though MCP's own package code was completely unaffected. Main's required CI (including release-please's own release PRs) already re-verifies whole-repo health on every merge, so re-running all of it here was redundant with what already gated the merge -- it just meant MCP uniquely re-litigated that whole-repo health at publish time while its 3 siblings didn't.
- Scoped down to match its siblings: MCP's own syntax check (`build:mcp`, `node --check`) plus its own CLI test suite specifically -- `npx vitest run mcp-cli-`, i.e. `test/unit/mcp-cli-*.test.ts`. Confirmed via import analysis these are the right ~50 files: they import `packages/loopover-mcp/package.json` and spawn the built binary via a shared `mcp-cli-harness`, unlike the sibling `test/unit/mcp-*.test.ts` files (no `-cli-`) which import `../../src/mcp/server` -- the Worker's separate remote MCP server, a different deployable entirely.
- Also added the "verify release commit is on main" safety check every other publish workflow already has in both its `validate` and `publish` jobs, which `publish-mcp.yml` was missing entirely.

**2. Cut mcp v3.1.1 and miner v3.1.1**

- `mcp-v3.1.0` and `miner-v3.1.0` are tagged, merged, and GitHub-Released, but never reached npm -- and both tags are now stuck: GitHub's tag-protection ruleset rejects force-moving them to include the fixes above, and `workflow_dispatch` resolves a run's YAML from the ref it's dispatched against, so re-running those exact tags would still execute the pre-fix workflow definition.
- Bumping to fresh, never-tagged versions is the documented human-override path (`publish-mcp.yml`'s own header comment: "A bare manual dispatch ... self-tags HEAD from packages/loopover-mcp/package.json's version").
- mcp v3.1.1 picks up one real fix that landed after v3.1.0's cut (#6990/#7052, via `npm run changelog:mcp`). miner v3.1.1 picks up two (`bdb11d9`, `77ca20f`, hand-verified against `git log` since neither has an associated PR).
- `package-lock.json` synced via the existing `scripts/sync-release-lockfile-versions.mjs`.

## Test plan

- [x] `npm run actionlint` -- clean
- [x] `npm run build --workspace @loopover/engine`, `npm run build:mcp`, `npm run build:miner` -- all pass
- [x] `npx vitest run mcp-cli-` -- 50 files, 341 tests, all passing (~25s)
- [x] `npm run test:mcp-pack`, `npm run test:miner-pack` -- both pass
- [x] `npm run changelog:check:mcp` -- clean (regenerated via `npm run changelog:mcp`)
- [x] `npm run miner:env-reference:check`, `npm run db:migrations:check`, `npm run typecheck` -- all clean