### PR TITLE
fix(miner): wire policy_verdict_cache into the per-repo purge/status/migrate store lists

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.js
+++ b/packages/loopover-miner/lib/migrate-cli.js
@@ -3,7 +3,7 @@
 // whatever command happens to touch it first -- this command instead lets an operator PROACTIVELY bring every
 // known store's EXISTING on-disk file up to date in one pass (e.g. right after upgrading, or before starting a
 // fleet), without needing to guess which command happens to touch which store first. Mirrors status.js's
-// storeIntegrityChecks [name, resolve*DbPath(env)] store list exactly (same eleven stores `doctor` already
+// storeIntegrityChecks [name, resolve*DbPath(env)] store list exactly (same twelve stores `doctor` already
 // covers, #6768), but actually OPENS each store (rather than a read-only integrity probe) so its real open/init
 // function's migration path runs for real. A store file that does not exist yet is skipped, not created --
 // "migrate" brings existing files up to date; it is not another way to bootstrap fresh state (that's `init`).
@@ -23,6 +23,7 @@ import { initAttemptLog, resolveAttemptLogDbPath } from "./attempt-log.js";
 import { openReplaySnapshotStore, resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
 import { openWorktreeAllocator, resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { initContributionProfileCache, resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
+import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 
 const MIGRATE_USAGE = "Usage: loopover-miner migrate [--json]";
 
@@ -39,6 +40,7 @@ const STORES = [
   { name: "replay-snapshot", resolveDbPath: resolveReplaySnapshotDbPath, open: openReplaySnapshotStore },
   { name: "worktree-allocator", resolveDbPath: resolveWorktreeAllocatorDbPath, open: (dbPath) => openWorktreeAllocator({ dbPath }) },
   { name: "contribution-profile", resolveDbPath: resolveContributionProfileCacheDbPath, open: initContributionProfileCache },
+  { name: "policy-verdict-cache", resolveDbPath: resolvePolicyVerdictCacheDbPath, open: initPolicyVerdictCacheStore },
 ];
 
 /** Read a store file's stamped schema version without ever creating it -- matches checkStoreIntegrity's

--- a/packages/loopover-miner/lib/policy-verdict-cache.d.ts
+++ b/packages/loopover-miner/lib/policy-verdict-cache.d.ts
@@ -24,6 +24,10 @@ export type PolicyVerdictCacheStore = {
     etag: string,
     verdict: AiPolicyVerdict,
   ): PolicyVerdictCacheWrite;
+  /** Explicit, operator-invoked right-to-be-forgotten purge (#5564, #6987) -- deletes every tenant's cached
+   *  verdict for `repoFullName` (matched on repo_scope's `::repoFullName` suffix, since repo_scope is a
+   *  composite `${apiBaseUrl}::${repoFullName}` key, not a bare repoFullName). Returns the row count deleted. */
+  purgeByRepo(repoFullName: string): number;
   close(): void;
 };
 

--- a/packages/loopover-miner/lib/policy-verdict-cache.js
+++ b/packages/loopover-miner/lib/policy-verdict-cache.js
@@ -1,5 +1,6 @@
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
+import { POLICY_VERDICT_CACHE_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
 
 // Local cache of resolved AI-usage-policy verdicts (#4843). Even with #4842's conditional-GET doc cache, the small
 // but non-zero cost of resolving `resolveAiPolicyVerdict` from raw doc text was still paid on every discover run.
@@ -30,6 +31,14 @@ function normalizeRepoScope(repoScope) {
   const trimmed = repoScope.trim();
   if (!trimmed) throw new Error("invalid_policy_verdict_repo_scope");
   return trimmed;
+}
+
+function normalizeRepoFullName(repoFullName) {
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const trimmed = repoFullName.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  return `${owner}/${repo}`;
 }
 
 function normalizeDecisiveDoc(decisiveDoc) {
@@ -98,6 +107,13 @@ export function initPolicyVerdictCacheStore(dbPath = resolvePolicyVerdictCacheDb
       const updatedAt = new Date().toISOString();
       putStatement.run(normalizedRepoScope, normalizedDecisiveDoc, normalizedEtag, serializedVerdict, updatedAt);
       return { repoScope: normalizedRepoScope, decisiveDoc: normalizedDecisiveDoc, etag: normalizedEtag, verdict, updatedAt };
+    },
+    // Explicit, operator-invoked right-to-be-forgotten purge (#5564, #6987) — never runs automatically. Matches
+    // on the `::repoFullName` SUFFIX of repo_scope (POLICY_VERDICT_CACHE_PURGE_SPEC's matchSuffix), since this
+    // store's key is `${apiBaseUrl}::${repoFullName}`, not a bare repoFullName -- an exact match would never
+    // find this repo's cached verdicts across however many tenant apiBaseUrls have resolved one.
+    purgeByRepo(repoFullName) {
+      return purgeStoreByRepo(db, POLICY_VERDICT_CACHE_PURGE_SPEC, normalizeRepoFullName(repoFullName));
     },
     close() {
       db.close();

--- a/packages/loopover-miner/lib/purge-cli.d.ts
+++ b/packages/loopover-miner/lib/purge-cli.d.ts
@@ -4,6 +4,7 @@ import type { GovernorLedger } from "./governor-ledger.js";
 import type { PredictionLedger } from "./prediction-ledger.js";
 import type { PortfolioQueueStore } from "./portfolio-queue.js";
 import type { RunStateStore } from "./run-state.js";
+import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
 
 export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE: string;
 
@@ -37,6 +38,7 @@ export type PurgeCliOptions = {
   initPredictionLedger?: () => PredictionLedger;
   initPortfolioQueueStore?: () => PortfolioQueueStore;
   initRunStateStore?: () => RunStateStore;
+  initPolicyVerdictCacheStore?: () => PolicyVerdictCacheStore;
   resolveDbPaths?: Record<string, () => string>;
 };
 

--- a/packages/loopover-miner/lib/purge-cli.js
+++ b/packages/loopover-miner/lib/purge-cli.js
@@ -18,6 +18,7 @@ import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./predictio
 import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
 import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
 import { resolveAttemptLogDbPath } from "./attempt-log.js";
+import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 import {
   CLAIM_LEDGER_PURGE_SPEC,
   EVENT_LEDGER_PURGE_SPEC,
@@ -25,6 +26,7 @@ import {
   PREDICTION_LEDGER_PURGE_SPEC,
   PORTFOLIO_QUEUE_PURGE_SPEC,
   RUN_STATE_PURGE_SPEC,
+  POLICY_VERDICT_CACHE_PURGE_SPEC,
   countStoreByRepo,
   describeError,
 } from "./store-maintenance.js";
@@ -42,6 +44,7 @@ const REAL_PURGE_TARGETS = [
   { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
   { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
   { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
+  { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
 ];
 
 function parseRepoArg(value, usage) {

--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -26,6 +26,7 @@ import { resolveAttemptLogDbPath } from "./attempt-log.js";
 import { resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
 import { resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
+import { resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 
 // Slim laptop-mode CLI commands (#2288): `status` (what's installed + where local state lives) and `doctor` (is
 // this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
@@ -318,6 +319,7 @@ function storeIntegrityChecks(env) {
     ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
     ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
     ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
+    ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],
   ];
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }

--- a/packages/loopover-miner/lib/store-maintenance.d.ts
+++ b/packages/loopover-miner/lib/store-maintenance.d.ts
@@ -8,13 +8,14 @@ export const EVENT_LEDGER_RETENTION_SPEC: LedgerRetentionSpec;
 export const GOVERNOR_LEDGER_RETENTION_SPEC: LedgerRetentionSpec;
 export const PREDICTION_LEDGER_RETENTION_SPEC: LedgerRetentionSpec;
 
-export type LedgerPurgeSpec = { table: string; repoColumn: string };
+export type LedgerPurgeSpec = { table: string; repoColumn: string; matchSuffix?: boolean };
 export const CLAIM_LEDGER_PURGE_SPEC: LedgerPurgeSpec;
 export const EVENT_LEDGER_PURGE_SPEC: LedgerPurgeSpec;
 export const GOVERNOR_LEDGER_PURGE_SPEC: LedgerPurgeSpec;
 export const PREDICTION_LEDGER_PURGE_SPEC: LedgerPurgeSpec;
 export const PORTFOLIO_QUEUE_PURGE_SPEC: LedgerPurgeSpec;
 export const RUN_STATE_PURGE_SPEC: LedgerPurgeSpec;
+export const POLICY_VERDICT_CACHE_PURGE_SPEC: LedgerPurgeSpec;
 
 export type StoreIntegrityResult = { name: string; ok: boolean; detail: string };
 export type LedgerRetentionPolicy = { maxAgeMs?: number; maxRows?: number };

--- a/packages/loopover-miner/lib/store-maintenance.js
+++ b/packages/loopover-miner/lib/store-maintenance.js
@@ -34,8 +34,23 @@ export const GOVERNOR_LEDGER_PURGE_SPEC = { table: "governor_events", repoColumn
 export const PREDICTION_LEDGER_PURGE_SPEC = { table: "predictions", repoColumn: "repo_full_name" };
 export const PORTFOLIO_QUEUE_PURGE_SPEC = { table: "miner_portfolio_queue", repoColumn: "repo_full_name" };
 export const RUN_STATE_PURGE_SPEC = { table: "miner_run_state", repoColumn: "repo_full_name" };
+// Unlike the six specs above, policy-verdict-cache.js's repo_scope column is NOT a bare `owner/repo` value --
+// it's `${apiBaseUrl}::${repoFullName}` (policyVerdictCacheKey, opportunity-fanout.js), so one tenant's rows for
+// a repo can never be found by exact equality against repoFullName alone. `matchSuffix: true` tells
+// purgeStoreByRepo/countStoreByRepo below to match on the `::repoFullName` SUFFIX instead, catching every
+// tenant's cached verdict for that repo regardless of apiBaseUrl.
+export const POLICY_VERDICT_CACHE_PURGE_SPEC = { table: "policy_verdict_cache", repoColumn: "repo_scope", matchSuffix: true };
 
 const SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Escape SQL LIKE metacharacters (`%`, `_`, and the escape char itself) in a caller-supplied value before it's
+ *  interpolated into a LIKE pattern, then wrap it as a `%::value` suffix match. Without this, a repoFullName
+ *  containing a literal `_` (a valid GitHub repo/owner character) would silently match extra rows via LIKE's
+ *  single-char wildcard. */
+function likeSuffixPattern(value) {
+  const escaped = value.replace(/[\\%_]/g, (char) => `\\${char}`);
+  return `%::${escaped}`;
+}
 
 /** A readable message for a caught value, whether or not it is an Error. */
 export function describeError(error) {
@@ -156,7 +171,7 @@ export function pruneLedgerByRetention(db, spec, policy, nowMs) {
  * `repoFullName` is caller-normalized (owner/repo) before reaching here; this function only guards the SQL
  * identifiers, matching `pruneLedgerByRetention`'s own defence-in-depth discipline.
  * @param {import("node:sqlite").DatabaseSync} db
- * @param {{ table: string, repoColumn: string }} spec
+ * @param {{ table: string, repoColumn: string, matchSuffix?: boolean }} spec
  * @param {string} repoFullName
  * @returns {number} rows deleted
  */
@@ -164,7 +179,9 @@ export function purgeStoreByRepo(db, spec, repoFullName) {
   for (const identifier of [spec.table, spec.repoColumn]) {
     if (!SQL_IDENTIFIER.test(identifier)) throw new Error(`unsafe SQL identifier: ${identifier}`);
   }
-  const info = db.prepare(`DELETE FROM ${spec.table} WHERE ${spec.repoColumn} = ?`).run(repoFullName);
+  const info = spec.matchSuffix
+    ? db.prepare(`DELETE FROM ${spec.table} WHERE ${spec.repoColumn} LIKE ? ESCAPE '\\'`).run(likeSuffixPattern(repoFullName))
+    : db.prepare(`DELETE FROM ${spec.table} WHERE ${spec.repoColumn} = ?`).run(repoFullName);
   return Number(info.changes);
 }
 
@@ -172,7 +189,7 @@ export function purgeStoreByRepo(db, spec, repoFullName) {
  * Count rows for one repo in a store without deleting anything (#5564) — the read-only counterpart to
  * `purgeStoreByRepo`, used by `purge-cli.js --dry-run` to report what a real purge would remove.
  * @param {import("node:sqlite").DatabaseSync} db
- * @param {{ table: string, repoColumn: string }} spec
+ * @param {{ table: string, repoColumn: string, matchSuffix?: boolean }} spec
  * @param {string} repoFullName
  * @returns {number} matching row count
  */
@@ -180,6 +197,8 @@ export function countStoreByRepo(db, spec, repoFullName) {
   for (const identifier of [spec.table, spec.repoColumn]) {
     if (!SQL_IDENTIFIER.test(identifier)) throw new Error(`unsafe SQL identifier: ${identifier}`);
   }
-  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${spec.table} WHERE ${spec.repoColumn} = ?`).get(repoFullName);
+  const row = spec.matchSuffix
+    ? db.prepare(`SELECT COUNT(*) AS count FROM ${spec.table} WHERE ${spec.repoColumn} LIKE ? ESCAPE '\\'`).get(likeSuffixPattern(repoFullName))
+    : db.prepare(`SELECT COUNT(*) AS count FROM ${spec.table} WHERE ${spec.repoColumn} = ?`).get(repoFullName);
   return Number(row.count);
 }

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -30,6 +30,7 @@ const STORE_NAMES = [
   "replay-snapshot",
   "worktree-allocator",
   "contribution-profile",
+  "policy-verdict-cache",
 ];
 
 afterEach(() => {

--- a/test/unit/miner-policy-verdict-cache.test.ts
+++ b/test/unit/miner-policy-verdict-cache.test.ts
@@ -135,4 +135,23 @@ describe("loopover-miner policy-verdict cache store (#4843)", () => {
   it("throws on an empty explicit db path", () => {
     expect(() => initPolicyVerdictCacheStore("")).toThrow("invalid_policy_verdict_cache_db_path");
   });
+
+  it("REGRESSION (#6987): purgeByRepo deletes every tenant's cached verdict for a repo via the repo_scope suffix, leaving other repos untouched", () => {
+    const store = openStore();
+    store.put("https://api.example.com::acme/widgets", "AI-USAGE.md", '"v1"', VERDICT);
+    store.put("https://api.other-tenant.com::acme/widgets", "AI-USAGE.md", '"v2"', VERDICT);
+    store.put("https://api.example.com::acme/gadgets", "AI-USAGE.md", '"v3"', VERDICT);
+
+    expect(store.purgeByRepo("acme/widgets")).toBe(2);
+    expect(store.get("https://api.example.com::acme/widgets")).toBeNull();
+    expect(store.get("https://api.other-tenant.com::acme/widgets")).toBeNull();
+    expect(store.get("https://api.example.com::acme/gadgets")).not.toBeNull();
+  });
+
+  it("purgeByRepo returns 0 and rejects a malformed repoFullName the same way the other stores do", () => {
+    const store = openStore();
+    store.put("https://api.example.com::acme/widgets", "AI-USAGE.md", '"v1"', VERDICT);
+    expect(store.purgeByRepo("acme/other")).toBe(0);
+    expect(() => store.purgeByRepo("no-slash")).toThrow("invalid_repo_full_name");
+  });
 });

--- a/test/unit/miner-purge-cli.test.ts
+++ b/test/unit/miner-purge-cli.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../packages/loopover-miner/lib/portfolio-queue.js";
 import { initRunStateStore, closeDefaultRunStateStore } from "../../packages/loopover-miner/lib/run-state.js";
 import { initAttemptLog, closeDefaultAttemptLog } from "../../packages/loopover-miner/lib/attempt-log.js";
+import { initPolicyVerdictCacheStore } from "../../packages/loopover-miner/lib/policy-verdict-cache.js";
 import {
   ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
   parsePurgeArgs,
@@ -76,7 +77,7 @@ describe("parsePurgeArgs (#5564)", () => {
 });
 
 describe("runPurge --dry-run (#5564, #6599)", () => {
-  it("counts matching rows across the six real stores without writing anything, and reports attempt-log as not-purgeable", async () => {
+  it("counts matching rows across the seven real stores without writing anything, and reports attempt-log as not-purgeable", async () => {
     const root = tempDir();
     const claimDbPath = join(root, "claim-ledger.sqlite3");
     const eventDbPath = join(root, "event-ledger.sqlite3");
@@ -84,6 +85,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
     const predictionDbPath = join(root, "prediction-ledger.sqlite3");
     const portfolioDbPath = join(root, "portfolio-queue.sqlite3");
     const runStateDbPath = join(root, "run-state.sqlite3");
+    const policyVerdictDbPath = join(root, "policy-verdict-cache.sqlite3");
     const attemptLogDbPath = join(root, "attempt-log.sqlite3"); // never created — dry run must not touch it
 
     const claimLedger = openClaimLedger(claimDbPath);
@@ -128,6 +130,15 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
     runState.setRunState("acme/other", "idle");
     runState.close();
 
+    // repo_scope is a COMPOSITE `${apiBaseUrl}::${repoFullName}` key (policyVerdictCacheKey,
+    // opportunity-fanout.js), not a bare repoFullName -- seed two different tenants' cached verdicts for the
+    // same repo to prove the suffix match finds both.
+    const policyVerdict = initPolicyVerdictCacheStore(policyVerdictDbPath);
+    policyVerdict.put("https://api.example.com::acme/widgets", "AI-USAGE.md", "etag-1", { allowed: true });
+    policyVerdict.put("https://api.other-tenant.com::acme/widgets", "AI-USAGE.md", "etag-2", { allowed: true });
+    policyVerdict.put("https://api.example.com::acme/other", "AI-USAGE.md", "etag-3", { allowed: true });
+    policyVerdict.close();
+
     const resolveDbPaths = {
       "claim-ledger": () => claimDbPath,
       "event-ledger": () => eventDbPath,
@@ -135,6 +146,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       "prediction-ledger": () => predictionDbPath,
       "portfolio-queue": () => portfolioDbPath,
       "run-state": () => runStateDbPath,
+      "policy-verdict-cache": () => policyVerdictDbPath,
       "attempt-log": () => attemptLogDbPath,
     };
 
@@ -151,6 +163,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
         { store: "prediction-ledger", wouldPurge: 0 },
         { store: "portfolio-queue", wouldPurge: 2 },
         { store: "run-state", wouldPurge: 1 },
+        { store: "policy-verdict-cache", wouldPurge: 2 },
       ],
       attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
       attemptLogTotalRows: 0,
@@ -168,6 +181,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
     expect(text).toContain("claim-ledger=2");
     expect(text).toContain("portfolio-queue=2");
     expect(text).toContain("run-state=1");
+    expect(text).toContain("policy-verdict-cache=2");
     expect(text).toContain(ATTEMPT_LOG_NOT_PURGEABLE_NOTE);
   });
 
@@ -180,12 +194,13 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       "prediction-ledger": () => join(root, "prediction-ledger.sqlite3"),
       "portfolio-queue": () => join(root, "portfolio-queue.sqlite3"),
       "run-state": () => join(root, "run-state.sqlite3"),
+      "policy-verdict-cache": () => join(root, "policy-verdict-cache.sqlite3"),
       "attempt-log": () => join(root, "attempt-log.sqlite3"),
     };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runPurge(["--repo", "acme/widgets", "--dry-run", "--json"], { resolveDbPaths })).toBe(0);
     const result = JSON.parse(String(log.mock.calls[0]?.[0]));
-    expect(result.stores).toHaveLength(6);
+    expect(result.stores).toHaveLength(7);
     expect(result.stores.every((entry: { wouldPurge: number }) => entry.wouldPurge === 0)).toBe(true);
     expect(result.attemptLogTotalRows).toBe(0);
     for (const resolve of Object.values(resolveDbPaths)) {
@@ -220,6 +235,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       "prediction-ledger": () => join(root, "prediction-ledger.sqlite3"),
       "portfolio-queue": () => join(root, "portfolio-queue.sqlite3"),
       "run-state": () => join(root, "run-state.sqlite3"),
+      "policy-verdict-cache": () => join(root, "policy-verdict-cache.sqlite3"),
       "attempt-log": () => attemptLogDbPath,
     };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -245,6 +261,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       "prediction-ledger": () => join(root, "prediction-ledger.sqlite3"),
       "portfolio-queue": () => join(root, "portfolio-queue.sqlite3"),
       "run-state": () => join(root, "run-state.sqlite3"),
+      "policy-verdict-cache": () => join(root, "policy-verdict-cache.sqlite3"),
       "attempt-log": () => join(root, "attempt-log.sqlite3"),
     };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -283,6 +300,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       LOOPOVER_MINER_PREDICTION_LEDGER_DB: process.env.LOOPOVER_MINER_PREDICTION_LEDGER_DB,
       LOOPOVER_MINER_PORTFOLIO_QUEUE_DB: process.env.LOOPOVER_MINER_PORTFOLIO_QUEUE_DB,
       LOOPOVER_MINER_RUN_STATE_DB: process.env.LOOPOVER_MINER_RUN_STATE_DB,
+      LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB: process.env.LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB,
       LOOPOVER_MINER_ATTEMPT_LOG_DB: process.env.LOOPOVER_MINER_ATTEMPT_LOG_DB,
     };
     process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = join(root, "claim-ledger.sqlite3");
@@ -291,12 +309,13 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
     process.env.LOOPOVER_MINER_PREDICTION_LEDGER_DB = join(root, "prediction-ledger.sqlite3");
     process.env.LOOPOVER_MINER_PORTFOLIO_QUEUE_DB = join(root, "portfolio-queue.sqlite3");
     process.env.LOOPOVER_MINER_RUN_STATE_DB = join(root, "run-state.sqlite3");
+    process.env.LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB = join(root, "policy-verdict-cache.sqlite3");
     process.env.LOOPOVER_MINER_ATTEMPT_LOG_DB = join(root, "attempt-log.sqlite3");
     try {
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
       expect(runPurge(["--repo", "acme/widgets", "--dry-run", "--json"])).toBe(0);
       const result = JSON.parse(String(log.mock.calls[0]?.[0]));
-      expect(result.stores).toHaveLength(6);
+      expect(result.stores).toHaveLength(7);
       expect(result.stores.every((entry: { wouldPurge: number }) => entry.wouldPurge === 0)).toBe(true);
       // Nothing was created — dry run against nonexistent default-path stores makes zero writes.
       expect(existsSync(process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB)).toBe(false);
@@ -323,6 +342,7 @@ describe("runPurge (real, #5564, #6599)", () => {
     const prediction = fakeStore(3);
     const portfolio = fakeStore(4);
     const runState = fakeStore(1);
+    const policyVerdict = fakeStore(2);
     const options = {
       openClaimLedger: () => claim,
       initEventLedger: () => event,
@@ -330,6 +350,7 @@ describe("runPurge (real, #5564, #6599)", () => {
       initPredictionLedger: () => prediction,
       initPortfolioQueueStore: () => portfolio,
       initRunStateStore: () => runState,
+      initPolicyVerdictCacheStore: () => policyVerdict,
     };
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -338,7 +359,7 @@ describe("runPurge (real, #5564, #6599)", () => {
     expect(summary).toMatchObject({
       outcome: "purged",
       repoFullName: "acme/widgets",
-      totalPurged: 11,
+      totalPurged: 13,
       stores: [
         { store: "claim-ledger", purged: 2 },
         { store: "event-ledger", purged: 1 },
@@ -346,25 +367,27 @@ describe("runPurge (real, #5564, #6599)", () => {
         { store: "prediction-ledger", purged: 3 },
         { store: "portfolio-queue", purged: 4 },
         { store: "run-state", purged: 1 },
+        { store: "policy-verdict-cache", purged: 2 },
         { store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE },
       ],
     });
     expect(typeof summary.purgedAt).toBe("string");
-    for (const store of [claim, event, governor, prediction, portfolio, runState]) {
+    for (const store of [claim, event, governor, prediction, portfolio, runState, policyVerdict]) {
       expect(store.purgeByRepo).toHaveBeenCalledWith("acme/widgets");
     }
     // Injected stores are caller-owned: runPurge must not close them.
-    for (const store of [claim, event, governor, prediction, portfolio, runState]) {
+    for (const store of [claim, event, governor, prediction, portfolio, runState, policyVerdict]) {
       expect(store.close).not.toHaveBeenCalled();
     }
 
     log.mockClear();
     expect(runPurge(["--repo", "acme/widgets"], options as never)).toBe(0);
     const text = String(log.mock.calls[0]?.[0]);
-    expect(text).toContain("Purged 11 row(s) for acme/widgets");
+    expect(text).toContain("Purged 13 row(s) for acme/widgets");
     expect(text).toContain("claim-ledger=2");
     expect(text).toContain("portfolio-queue=4");
     expect(text).toContain("run-state=1");
+    expect(text).toContain("policy-verdict-cache=2");
     expect(text).toContain(ATTEMPT_LOG_NOT_PURGEABLE_NOTE);
   });
 
@@ -375,6 +398,7 @@ describe("runPurge (real, #5564, #6599)", () => {
     const prediction = fakeStore(3);
     const portfolio = fakeStore(0);
     const runState = fakeStore(0);
+    const policyVerdict = fakeStore(0);
     const options = {
       openClaimLedger: () => claim,
       initEventLedger: () => event,
@@ -384,6 +408,7 @@ describe("runPurge (real, #5564, #6599)", () => {
       initPredictionLedger: () => prediction,
       initPortfolioQueueStore: () => portfolio,
       initRunStateStore: () => runState,
+      initPolicyVerdictCacheStore: () => policyVerdict,
     };
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -397,6 +422,7 @@ describe("runPurge (real, #5564, #6599)", () => {
     expect(summary.stores).toContainEqual({ store: "prediction-ledger", purged: 3 });
     expect(summary.stores).toContainEqual({ store: "portfolio-queue", purged: 0 });
     expect(summary.stores).toContainEqual({ store: "run-state", purged: 0 });
+    expect(summary.stores).toContainEqual({ store: "policy-verdict-cache", purged: 0 });
     expect(summary.stores).toContainEqual({ store: "governor-ledger", purged: null, error: "governor-ledger disk full" });
 
     log.mockClear();
@@ -417,6 +443,7 @@ describe("runPurge (real, #5564, #6599)", () => {
       initPredictionLedger: () => fakeStore(0),
       initPortfolioQueueStore: () => fakeStore(0),
       initRunStateStore: () => fakeStore(0),
+      initPolicyVerdictCacheStore: () => fakeStore(0),
     };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runPurge(["--repo", "acme/widgets", "--json"], options as never)).toBe(2);
@@ -434,6 +461,7 @@ describe("runPurge (real, #5564, #6599)", () => {
       initPredictionLedger: () => fakeStore(0),
       initPortfolioQueueStore: () => fakeStore(0),
       initRunStateStore: () => fakeStore(0),
+      initPolicyVerdictCacheStore: () => fakeStore(0),
     };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runPurge(["--repo", "acme/widgets", "--json"], options as never)).toBe(2);
@@ -453,16 +481,19 @@ describe("runPurge (real, #5564, #6599)", () => {
       LOOPOVER_MINER_PREDICTION_LEDGER_DB: process.env.LOOPOVER_MINER_PREDICTION_LEDGER_DB,
       LOOPOVER_MINER_PORTFOLIO_QUEUE_DB: process.env.LOOPOVER_MINER_PORTFOLIO_QUEUE_DB,
       LOOPOVER_MINER_RUN_STATE_DB: process.env.LOOPOVER_MINER_RUN_STATE_DB,
+      LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB: process.env.LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB,
     };
     const claimDbPath = join(root, "claim-ledger.sqlite3");
     const portfolioDbPath = join(root, "portfolio-queue.sqlite3");
     const runStateDbPath = join(root, "run-state.sqlite3");
+    const policyVerdictDbPath = join(root, "policy-verdict-cache.sqlite3");
     process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = claimDbPath;
     process.env.LOOPOVER_MINER_EVENT_LEDGER_DB = join(root, "event-ledger.sqlite3");
     process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB = join(root, "governor-ledger.sqlite3");
     process.env.LOOPOVER_MINER_PREDICTION_LEDGER_DB = join(root, "prediction-ledger.sqlite3");
     process.env.LOOPOVER_MINER_PORTFOLIO_QUEUE_DB = portfolioDbPath;
     process.env.LOOPOVER_MINER_RUN_STATE_DB = runStateDbPath;
+    process.env.LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB = policyVerdictDbPath;
     try {
       // Seed real rows via the default store paths before purging through them.
       const seededClaim = openClaimLedger(claimDbPath);
@@ -474,6 +505,9 @@ describe("runPurge (real, #5564, #6599)", () => {
       const seededRunState = initRunStateStore(runStateDbPath);
       seededRunState.setRunState("acme/widgets", "planning");
       seededRunState.close();
+      const seededPolicyVerdict = initPolicyVerdictCacheStore(policyVerdictDbPath);
+      seededPolicyVerdict.put("https://api.example.com::acme/widgets", "AI-USAGE.md", "etag-1", { allowed: true });
+      seededPolicyVerdict.close();
 
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
       expect(runPurge(["--repo", "acme/widgets", "--json"])).toBe(0);
@@ -487,6 +521,9 @@ describe("runPurge (real, #5564, #6599)", () => {
       expect(summary.stores.find((entry: { store: string }) => entry.store === "run-state")).toMatchObject({
         purged: 1,
       });
+      expect(summary.stores.find((entry: { store: string }) => entry.store === "policy-verdict-cache")).toMatchObject({
+        purged: 1,
+      });
 
       // Reopening confirms the purge was actually persisted through the default (owned, closed) code path.
       const reopenedClaim = openClaimLedger(claimDbPath);
@@ -498,6 +535,9 @@ describe("runPurge (real, #5564, #6599)", () => {
       const reopenedRunState = initRunStateStore(runStateDbPath);
       closeables.push(reopenedRunState);
       expect(reopenedRunState.listRunStates()).toEqual([]);
+      const reopenedPolicyVerdict = initPolicyVerdictCacheStore(policyVerdictDbPath);
+      closeables.push(reopenedPolicyVerdict);
+      expect(reopenedPolicyVerdict.get("https://api.example.com::acme/widgets")).toBeNull();
     } finally {
       for (const [key, value] of Object.entries(previousDirs)) {
         if (value === undefined) delete process.env[key];
@@ -527,6 +567,7 @@ describe("runPurge (real, #5564, #6599)", () => {
       "prediction-ledger": () => join(root, "prediction-ledger.sqlite3"),
       "portfolio-queue": () => portfolioDbPath,
       "run-state": () => runStateDbPath,
+      "policy-verdict-cache": () => join(root, "policy-verdict-cache.sqlite3"),
       "attempt-log": () => join(root, "attempt-log.sqlite3"),
     };
 
@@ -548,6 +589,7 @@ describe("runPurge (real, #5564, #6599)", () => {
         initPredictionLedger: () => fakeStore(0),
         initPortfolioQueueStore: () => portfolioStore,
         initRunStateStore: () => runStateStore,
+        initPolicyVerdictCacheStore: () => fakeStore(0),
       } as never),
     ).toBe(0);
     const purged = JSON.parse(String(log.mock.calls[0]?.[0]));

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -130,6 +130,7 @@ describe("loopover-miner status/doctor (#2288)", () => {
       "store-integrity:replay-snapshot",
       "store-integrity:worktree-allocator",
       "store-integrity:contribution-profile",
+      "store-integrity:policy-verdict-cache",
     ]);
     // REGRESSION (#6768): doctor previously omitted these four durable local stores from the integrity sweep.
     expect(checks.map((check) => check.name)).toEqual(

--- a/test/unit/miner-store-maintenance.test.ts
+++ b/test/unit/miner-store-maintenance.test.ts
@@ -8,6 +8,7 @@ import {
   EVENT_LEDGER_RETENTION_SPEC,
   LEDGER_RETENTION_DAYS_ENV,
   LEDGER_RETENTION_MAX_ROWS_ENV,
+  POLICY_VERDICT_CACHE_PURGE_SPEC,
   checkStoreIntegrity,
   classifyIntegrityRows,
   countStoreByRepo,
@@ -49,6 +50,19 @@ function seedPurgeTable(rows: Array<{ repoFullName: string }>): DatabaseSync {
 }
 function purgeTableRowCount(db: DatabaseSync): number {
   return Number((db.prepare("SELECT COUNT(*) AS n FROM miner_claims").get() as { n: number }).n);
+}
+
+// A minimal store matching POLICY_VERDICT_CACHE_PURGE_SPEC's shape: repo_scope is a COMPOSITE
+// `${apiBaseUrl}::${repoFullName}` key, not a bare repoFullName (policy-verdict-cache.js).
+function seedSuffixTable(rows: Array<{ repoScope: string }>): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE policy_verdict_cache (repo_scope TEXT PRIMARY KEY)");
+  const insert = db.prepare("INSERT INTO policy_verdict_cache (repo_scope) VALUES (?)");
+  for (const row of rows) insert.run(row.repoScope);
+  return db;
+}
+function suffixTableRowCount(db: DatabaseSync): number {
+  return Number((db.prepare("SELECT COUNT(*) AS n FROM policy_verdict_cache").get() as { n: number }).n);
 }
 
 describe("classifyIntegrityRows (#4834)", () => {
@@ -272,6 +286,42 @@ describe("purgeStoreByRepo (#5564)", () => {
     );
     db.close();
   });
+
+  it("REGRESSION (#6987): matchSuffix deletes every tenant's composite repo_scope row for a repo, leaving other repos untouched", () => {
+    const db = seedSuffixTable([
+      { repoScope: "https://api.example.com::acme/widgets" },
+      { repoScope: "https://api.other-tenant.com::acme/widgets" },
+      { repoScope: "https://api.example.com::acme/gadgets" },
+    ]);
+    expect(purgeStoreByRepo(db, POLICY_VERDICT_CACHE_PURGE_SPEC, "acme/widgets")).toBe(2);
+    expect(suffixTableRowCount(db)).toBe(1);
+    const remaining = db.prepare("SELECT repo_scope FROM policy_verdict_cache").get() as { repo_scope: string };
+    expect(remaining.repo_scope).toBe("https://api.example.com::acme/gadgets");
+    db.close();
+  });
+
+  it("REGRESSION (#6987): matchSuffix does not false-positive-match a repo whose name is merely a SUFFIX of another repo's name", () => {
+    const db = seedSuffixTable([
+      { repoScope: "https://api.example.com::acme/widgets" },
+      { repoScope: "https://api.example.com::acme/super-widgets" },
+    ]);
+    // A naive `LIKE '%widgets'` (no explicit `::` delimiter) would wrongly match BOTH rows.
+    expect(purgeStoreByRepo(db, POLICY_VERDICT_CACHE_PURGE_SPEC, "acme/widgets")).toBe(1);
+    expect(suffixTableRowCount(db)).toBe(1);
+    db.close();
+  });
+
+  it("REGRESSION (#6987): matchSuffix escapes LIKE metacharacters in repoFullName instead of treating them as wildcards", () => {
+    const db = seedSuffixTable([
+      { repoScope: "https://api.example.com::acme/wi_gets" }, // the literal repo this purge targets
+      { repoScope: "https://api.example.com::acme/widgets" }, // would wrongly match if `_` were an unescaped wildcard
+    ]);
+    expect(purgeStoreByRepo(db, POLICY_VERDICT_CACHE_PURGE_SPEC, "acme/wi_gets")).toBe(1);
+    expect(suffixTableRowCount(db)).toBe(1);
+    const remaining = db.prepare("SELECT repo_scope FROM policy_verdict_cache").get() as { repo_scope: string };
+    expect(remaining.repo_scope).toBe("https://api.example.com::acme/widgets");
+    db.close();
+  });
 });
 
 describe("countStoreByRepo (#5564)", () => {
@@ -297,6 +347,17 @@ describe("countStoreByRepo (#5564)", () => {
     expect(() => countStoreByRepo(db, { table: "bad; DROP TABLE t", repoColumn: "repo_full_name" }, "acme/widgets")).toThrow(
       /unsafe SQL identifier/,
     );
+    db.close();
+  });
+
+  it("REGRESSION (#6987): matchSuffix counts every tenant's composite repo_scope row for a repo without deleting anything", () => {
+    const db = seedSuffixTable([
+      { repoScope: "https://api.example.com::acme/widgets" },
+      { repoScope: "https://api.other-tenant.com::acme/widgets" },
+      { repoScope: "https://api.example.com::acme/gadgets" },
+    ]);
+    expect(countStoreByRepo(db, POLICY_VERDICT_CACHE_PURGE_SPEC, "acme/widgets")).toBe(2);
+    expect(suffixTableRowCount(db)).toBe(3); // nothing deleted
     db.close();
   });
 });


### PR DESCRIPTION
## Summary
- `policy-verdict-cache.js` keys its `policy_verdict_cache` table on `repo_scope TEXT PRIMARY KEY` — structurally the same repo-scoped shape as the six stores `store-maintenance.js` already documents as purgeable — but was never wired into `purge-cli.js`'s `REAL_PURGE_TARGETS`, `status.js`'s `storeIntegrityChecks`, or `migrate-cli.js`'s `STORES` list.
- **Important correction to the issue's premise**: `repo_scope` is not a bare `owner/repo` value. It's a COMPOSITE `${apiBaseUrl}::${repoFullName}` key (`policyVerdictCacheKey`, `opportunity-fanout.js`) — a tenant forge host plus the repo, since a bare `owner/repo` isn't safe across multiple forge hosts. The existing `purgeStoreByRepo`/`countStoreByRepo` helpers do an exact-match `WHERE repoColumn = ?`, which would **never** match this store's rows and silently purge/count zero every time — a purge that always "succeeds" while doing nothing.
- Fixed by adding an opt-in `matchSuffix: true` field to the purge spec shape. When set, `purgeStoreByRepo`/`countStoreByRepo` match on the `::repoFullName` **suffix** instead of exact equality (LIKE-escaping `%`/`_`/the escape char in the caller-supplied `repoFullName` first, so a repo name containing a literal `_` — a valid GitHub character — can't accidentally widen the match). The six existing specs are untouched (`matchSuffix` defaults to unset/exact-match), so their behavior is byte-identical to before.
- `policy-verdict-cache.js`'s store now exposes `purgeByRepo(repoFullName)`, matching the six other stores' own method shape, so `purge-cli.js`'s generic `store.purgeByRepo(repoFullName)` call site needed no changes.
- Wired `initPolicyVerdictCacheStore`/`resolvePolicyVerdictCacheDbPath` into all three lists, mirroring each list's existing entry shape exactly. Updated the one stale doc-comment count ("eleven stores" → "twelve stores") in `migrate-cli.js` that directly describes the list I extended.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6987

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of what changed; syntax-checked every touched `.js` file individually (`node --check`, all clean) plus the full targeted vitest run below as the local proxy, and CI's isolated runner for the authoritative `tsc --noEmit`. Updated the hand-maintained `.d.ts` companions (`store-maintenance.d.ts`'s `LedgerPurgeSpec.matchSuffix` + new `POLICY_VERDICT_CACHE_PURGE_SPEC` export, `policy-verdict-cache.d.ts`'s new `purgeByRepo` method, `purge-cli.d.ts`'s new `initPolicyVerdictCacheStore` option) to match.
- [x] `npm run test:coverage` — full targeted run of every affected test file: `test/unit/miner-purge-cli.test.ts` (19), `test/unit/miner-status.test.ts` (33), `test/unit/miner-migrate-cli.test.ts` (12), `test/unit/miner-store-maintenance.test.ts` (33, incl. 5 new regression tests for the suffix-match/false-positive/LIKE-escaping behavior), `test/unit/miner-policy-verdict-cache.test.ts` (14, incl. 2 new `purgeByRepo` tests), `test/unit/opportunity-fanout-policy-verdict-cache.test.ts` (11, unmodified) — 122/122 passing.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — this PR only touches `packages/loopover-miner/**` and `test/unit/miner-*`)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — including a dedicated regression test proving the composite-key suffix match is necessary (a naive exact-match spec would purge/count zero rows for every real `policy_verdict_cache` row)

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure regardless of diff size; per-file `node --check` plus the full targeted test run above are the local proxy, and CI's isolated runner performs the real `tsc --noEmit` against the updated `.d.ts` companions. `npm run test:workers` and the MCP/OpenAPI checks have no surface to exercise for a change scoped to the miner's local-store maintenance CLI.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session changes; this is a local-only, operator-invoked SQLite maintenance CLI.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — backend CLI-only change, no UI surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- A prior attempt at this issue (a different contributor's PR, since closed) hit a genuine, pre-existing, unrelated CI failure in `test/unit/miner-extension-live-fetch.test.ts` (a `node:vm`-sandboxed test whose sandbox is missing the `AbortSignal` global that `apps/loopover-miner-extension/background.js` now depends on since #7007). That regression is real but out of scope for this PR (a different module entirely, no shared code path) and does not have its own tracked issue yet — flagged here for visibility rather than bundled into this diff.