### PR TITLE
ci(workflows): enforce 4 drift checks in CI that only ran locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
               - '.github/workflows/**'
               - 'wrangler.jsonc'
               - 'worker-configuration.d.ts'
+              - '.loopover.yml'
             observability:
               - 'grafana/dashboards/**'
               - 'prometheus/rules/**'
@@ -269,6 +270,16 @@ jobs:
       - name: Selfhost env-reference drift check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run selfhost:env-reference:check
+      # Miner/AMS twin of the selfhost check above -- same generated-artifact-drift class, same
+      # local-only-until-now gap (an `env.SOMETHING` read added under packages/loopover-miner/**
+      # with no CI signal that packages/loopover-miner/docs/env-reference.md and
+      # apps/loopover-ui/src/lib/ams-env-reference.ts had gone stale). Confirmed harmful live: this
+      # exact gap let a stale env-reference block an unrelated MCP npm release, since the release
+      # workflow was the only place this check ever ran. Gated on `ui` too, same reason as its sibling:
+      # the generated UI-side file lives under apps/loopover-ui/**.
+      - name: Miner env-reference drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' }}
+        run: npm run miner:env-reference:check
       # Same generated-artifact-drift class, extracted from src/github/commands.ts's command catalogs (#3046).
       # Also local-only until now; same backend-or-ui gating rationale as the step above.
       - name: Command reference drift check
@@ -282,6 +293,27 @@ jobs:
       - name: Docs drift check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run docs:drift-check
+      # Cross-checks the bundled fallback YAML in src/config/loopover-repo-focus-manifest.ts against the
+      # real root .loopover.yml -- see the script's own header comment. Same local-only-until-now gap as
+      # the drift checks above: nothing in this workflow previously ran it, so the two could silently
+      # diverge with zero CI signal. .loopover.yml itself is now part of the `backend` path filter above
+      # specifically so an edit to ONLY that file still re-triggers this job.
+      - name: Manifest drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        run: npm run manifest:drift-check
+      # Mechanical drift tripwire for the hand-duplicated src/{review,settings,signals} <-> loopover-engine
+      # twin files, plus a version-skew check on the installed @loopover/engine (#4260). Same
+      # local-only-until-now gap as the drift checks above.
+      - name: Engine-parity drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' }}
+        run: npm run engine-parity:drift-check
+      # Guards against the "gittensory" branding creeping back into runtime source after the LoopOver
+      # rebrand -- see the script's own header comment (#6786 is the concrete incident this was written
+      # for). Scoped broadly (src/** plus every workspace package's bin/lib/src/scripts dirs), so it's
+      # gated broadly to match; same local-only-until-now gap as the drift checks above.
+      - name: Branding drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' }}
+        run: npm run branding-drift:check
       - name: Validate observability configs
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}
         env:


### PR DESCRIPTION
## Summary

Root cause of today's release-pipeline pain: `miner:env-reference:check` was never wired into `.github/workflows/ci.yml` -- it only ever ran as part of the local `npm run test:ci` aggregate. A PR could add a new `env.SOMETHING` read under `packages/loopover-miner/**` without regenerating `packages/loopover-miner/docs/env-reference.md` / `apps/loopover-ui/src/lib/ams-env-reference.ts`, merge to main with fully green CI, and the drift would sit invisible until something else happened to catch it -- in this case, `publish-mcp.yml`'s validation gate (before #7064 correctly scoped it down to just the MCP package), which meant an unrelated MCP release started failing days after the actual drift-introducing PR merged.

This is the exact same gap class the existing "Selfhost env-reference drift check" step's own comment documents: *"Was previously enforced ONLY by the local `npm run test:ci` aggregate script, never by this workflow -- went stale twice in one day (2026-07-04) with zero CI signal until someone happened to run the full local script."* That one got fixed. Its miner-side twin didn't.

Auditing the rest of `test:ci`'s ~30 commands against what `ci.yml` actually runs turned up 3 more of the same gap, all drift-tripwire scripts whose own header comments describe them as CI gates but were never actually added as a step:

- `manifest:drift-check` -- cross-checks the bundled fallback YAML in `src/config/loopover-repo-focus-manifest.ts` against the real root `.loopover.yml`. Also adds `.loopover.yml` to the `backend` path filter so an edit to just that file still triggers the check that reads it.
- `engine-parity:drift-check` -- the hand-duplicated `src/{review,settings,signals}` <-> `loopover-engine` twin-file tripwire + engine version-skew check (#4260).
- `branding-drift:check` -- guards against "gittensory" branding creeping back into runtime source (#6786 was the concrete incident this was written for).

(`selfhost:validate-observability`, `test:engine-parity`, `test:live-gate-parity`, `test:driver-parity`, and `rees:test` were also checked -- all four are already enforced, just under a different literal invocation than their npm script name, so no gap there.)

## Test plan

- [x] `npm run actionlint` -- clean
- [x] All 4 newly-wired checks pass on current main in a fresh worktree: `miner:env-reference:check`, `manifest:drift-check`, `engine-parity:drift-check`, `branding-drift:check`
- [x] `npm run typecheck` -- clean (after `npm run build --workspace @loopover/engine`)
- Workflow-YAML-only change; not measured by Codecov.