### PR TITLE
fix(review-enrichment): lockfile-drift OSV batch failure falls back to per-item queries

### DIFF
--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -384,6 +384,44 @@ export function extractLockfileChanges(
   return changes;
 }
 
+/** Per-item OSV.dev query — the fallback the batch path degrades to when `/v1/querybatch` fails, mirroring
+ *  dependency-scan.ts's fetchOsvDirect so a transient batch-API failure yields slower-but-complete results
+ *  instead of silently dropping the whole chunk's findings. */
+async function fetchOsvDirect(
+  ecosystem: string,
+  name: string,
+  version: string,
+  fetchImpl: typeof fetch,
+  signal?: AbortSignal,
+  options: Pick<ScanOptions, "analysis" | "diagnostics" | "limits"> = {},
+): Promise<Cve[]> {
+  if (signal?.aborted) return [];
+  const fetchOptions = {
+    endpointCategory: "osv-query",
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ package: { name, ecosystem }, version }),
+    signal,
+    fetchImpl,
+    diagnostics: options.diagnostics,
+    phase: "lockfile-drift",
+    subcall: "osv-query",
+    maxBytes: 1024 * 1024,
+    maxCallsPerCategory: options.limits?.maxOsvQueries ?? MAX_OSV_QUERIES,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<{ vulns?: OsvVuln[] }>(
+        "https://api.osv.dev/v1/query",
+        fetchOptions,
+      )
+    : await boundedFetchJson<{ vulns?: OsvVuln[] }>(
+        "https://api.osv.dev/v1/query",
+        fetchOptions,
+      );
+  if (!response.ok) return [];
+  return toCves(response.data.vulns);
+}
+
 /** Batch-query OSV.dev for lockfile resolutions. Best-effort: returns empty CVE arrays on any failure. */
 export async function queryOsvBatch(
   changes: LockfileChange[],
@@ -422,7 +460,22 @@ export async function queryOsvBatch(
       : await boundedFetchJson<{
         results?: Array<{ vulns?: OsvVuln[] }>;
       }>("https://api.osv.dev/v1/querybatch", fetchOptions);
-    if (!response.ok) continue;
+    if (!response.ok) {
+      for (const change of chunk) {
+        results.set(
+          `${change.ecosystem}::${change.package}@${change.to}`,
+          await fetchOsvDirect(
+            change.ecosystem,
+            change.package,
+            change.to,
+            fetchImpl,
+            signal,
+            options,
+          ),
+        );
+      }
+      continue;
+    }
     chunk.forEach((change, index) => {
       results.set(
         `${change.ecosystem}::${change.package}@${change.to}`,

--- a/review-enrichment/test/lockfile-drift.test.ts
+++ b/review-enrichment/test/lockfile-drift.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { extractLockfileChanges } from "../dist/analyzers/lockfile-drift.js";
+import { extractLockfileChanges, queryOsvBatch, scanLockfileDrift } from "../dist/analyzers/lockfile-drift.js";
 
 test("extractLockfileChanges matches lockfile basenames case-insensitively", () => {
   const changes = extractLockfileChanges([
@@ -251,4 +251,111 @@ test("extractLockfileChanges skips malformed/partial lockfile hunks rather than 
   ]);
 
   assert.deepEqual(changes, []);
+});
+
+// #7009: queryOsvBatch used to `if (!response.ok) continue;` on a batch-endpoint failure, silently dropping
+// every change in that chunk — unlike dependency-scan.ts, which degrades to per-item /v1/query calls. These
+// pin the added fallback: a batch hiccup must produce slower-but-complete per-item results, never a lost chunk.
+
+/** A minimal OSV `Response` the bounded fetch reader accepts: no content-length, no stream body, so it reads
+ *  via `text()`. Mirrors how api.osv.dev replies to a single or batch query. */
+function osvResponse(payload: unknown) {
+  return { ok: true, status: 200, headers: { get: () => null }, body: null, text: async () => JSON.stringify(payload) };
+}
+function osvFailure(status = 503) {
+  return { ok: false, status, headers: { get: () => null } };
+}
+const lockChange = (pkg: string, to: string) =>
+  ({ file: "package-lock.json", line: 1, ecosystem: "npm" as const, package: pkg, from: null, to });
+
+test("queryOsvBatch: a successful batch maps each change's vulns and never falls back to per-item queries", async () => {
+  let perItemCalls = 0;
+  const fetchImpl = (async (url: string) => {
+    if (url.endsWith("/v1/query")) perItemCalls += 1;
+    return osvResponse({ results: [{ vulns: [{ id: "OSV-batch" }] }, { vulns: [] }] });
+  }) as unknown as typeof fetch;
+  const result = await queryOsvBatch([lockChange("lodash", "4.17.21"), lockChange("leftpad", "1.0.1")], fetchImpl);
+  assert.deepEqual(result.get("npm::lodash@4.17.21")?.map((c) => c.id), ["OSV-batch"]);
+  assert.deepEqual(result.get("npm::leftpad@1.0.1"), []);
+  assert.equal(perItemCalls, 0);
+});
+
+test("queryOsvBatch: on a batch-endpoint failure, falls back to per-item OSV queries instead of dropping the chunk", async () => {
+  const urls: string[] = [];
+  const fetchImpl = (async (url: string, init: { body: string }) => {
+    urls.push(url);
+    if (url.endsWith("/v1/querybatch")) return osvFailure(503);
+    const name = (JSON.parse(init.body) as { package: { name: string } }).package.name;
+    return osvResponse({ vulns: name === "lodash" ? [{ id: "OSV-lodash", summary: "prototype pollution" }] : [] });
+  }) as unknown as typeof fetch;
+  const result = await queryOsvBatch([lockChange("lodash", "4.17.21"), lockChange("leftpad", "1.0.1")], fetchImpl);
+  // the failed batch degraded to per-item queries — the vulnerable package's CVE survives...
+  assert.deepEqual(result.get("npm::lodash@4.17.21")?.map((c) => c.id), ["OSV-lodash"]);
+  // ...and the clean package is still recorded (empty, not silently missing)
+  assert.deepEqual(result.get("npm::leftpad@1.0.1"), []);
+  assert.ok(urls.some((u) => u.endsWith("/v1/querybatch")));
+  assert.equal(urls.filter((u) => u.endsWith("/v1/query")).length, 2);
+});
+
+test("queryOsvBatch: a per-item fallback that also fails records an empty result rather than omitting the change", async () => {
+  const fetchImpl = (async (url: string) => (url.endsWith("/v1/querybatch") ? osvFailure(503) : osvFailure(500))) as unknown as typeof fetch;
+  const result = await queryOsvBatch([lockChange("lodash", "4.17.21")], fetchImpl);
+  assert.ok(result.has("npm::lodash@4.17.21"));
+  assert.deepEqual(result.get("npm::lodash@4.17.21"), []);
+});
+
+test("queryOsvBatch: the per-item fallback routes through an injected AnalysisContext when one is supplied", async () => {
+  const seen: string[] = [];
+  const analysis = {
+    fetchJson: async (url: string, init: { body: string }) => {
+      seen.push(url);
+      if (url.endsWith("/v1/querybatch")) return { ok: false, status: 503 };
+      const name = (JSON.parse(init.body) as { package: { name: string } }).package.name;
+      return { ok: true, status: 200, data: { vulns: name === "lodash" ? [{ id: "OSV-ctx" }] : [] } };
+    },
+  };
+  const noDirectFetch = (async () => {
+    throw new Error("analysis context supplied — the raw fetchImpl must not be used");
+  }) as unknown as typeof fetch;
+  const result = await queryOsvBatch([lockChange("lodash", "4.17.21")], noDirectFetch, undefined, {
+    analysis: analysis as never,
+  });
+  assert.deepEqual(result.get("npm::lodash@4.17.21")?.map((c) => c.id), ["OSV-ctx"]);
+  assert.ok(seen.some((u) => u.endsWith("/v1/query")));
+});
+
+test("queryOsvBatch: a mid-batch abort short-circuits the per-item fallback to empty results", async () => {
+  const controller = new AbortController();
+  const fetchImpl = (async (url: string) => {
+    if (url.endsWith("/v1/querybatch")) {
+      controller.abort();
+      return osvFailure(503);
+    }
+    throw new Error("per-item query must not run once the signal is aborted");
+  }) as unknown as typeof fetch;
+  const result = await queryOsvBatch([lockChange("lodash", "4.17.21")], fetchImpl, controller.signal);
+  assert.deepEqual(result.get("npm::lodash@4.17.21"), []);
+});
+
+test("scanLockfileDrift: a batch-API failure still surfaces a per-item CVE finding for a vulnerable lockfile bump", async () => {
+  const fetchImpl = (async (url: string, init: { body: string }) => {
+    if (url.endsWith("/v1/querybatch")) return osvFailure(503);
+    const name = (JSON.parse(init.body) as { package: { name: string } }).package.name;
+    return osvResponse({ vulns: name === "lodash" ? [{ id: "OSV-lodash", summary: "prototype pollution" }] : [] });
+  }) as unknown as typeof fetch;
+  const findings = await scanLockfileDrift(
+    {
+      files: [
+        {
+          path: "package-lock.json",
+          patch: ['@@ -9,0 +10,2 @@', '+    "node_modules/lodash": {', '+      "version": "4.17.21"'].join("\n"),
+        },
+      ],
+    } as Parameters<typeof scanLockfileDrift>[0],
+    fetchImpl,
+  );
+  // end-to-end: the transient batch failure degraded to a per-item query, so the vulnerable bump is still reported.
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.package, "lodash");
+  assert.deepEqual(findings[0]?.cves.map((c) => c.id), ["OSV-lodash"]);
 });


### PR DESCRIPTION
Closes #7009

## What

`review-enrichment/src/analyzers/lockfile-drift.ts`'s `queryOsvBatch` did
`if (!response.ok) continue;` when the OSV `/v1/querybatch` call failed — silently
dropping every CVE finding for that entire chunk. Its near-identical sibling
`dependency-scan.ts` handles the same failure by falling back to per-item `/v1/query`
calls, so a transient batch-API hiccup degrades to slower-but-complete results instead
of lost data.

This adds the same resilience to `lockfile-drift.ts`:

- On a non-ok batch response, iterate the failed chunk and query each change
  individually via a new `fetchOsvDirect` helper (mirroring `dependency-scan.ts`'s,
  using the lockfile `toCves` mapping and the OSV single-query endpoint).
- Existing chunking, `AbortSignal`, and per-category rate-limit (`maxCallsPerCategory`)
  behavior are preserved — the change is scoped to the failure-fallback path only.

## Tests

- A successful batch still maps each change's vulns and never issues a per-item call.
- A failed batch falls back to per-item queries, keeping the vulnerable package's CVE
  and recording the clean package as empty (not silently dropped).
- A per-item fallback that also fails records an empty result rather than omitting the
  change.
- The fallback routes through an injected `AnalysisContext` when one is supplied.
- A mid-batch abort short-circuits the per-item fallback to empty results.
- End-to-end: `scanLockfileDrift` still surfaces a per-item CVE finding for a
  vulnerable lockfile bump when the batch endpoint fails.
