### PR TITLE
docs(scripts): correct the stale D1 database name in export-d1-data usage

### DIFF
--- a/scripts/export-d1-data.mjs
+++ b/scripts/export-d1-data.mjs
@@ -4,7 +4,7 @@
 // a manifest the self-host importer validates against. The data transformation lives in export-d1-core.mjs (pure,
 // unit-tested); this file is the thin IO wrapper.
 //
-//   node scripts/export-d1-data.mjs --db gittensory --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
+//   node scripts/export-d1-data.mjs --db loopover --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
 //
 // --remote reads the deployed D1 (default is the local miniflare DB). --since-date does an INCREMENTAL export
 // (rows whose --since-column is >= the date); omit it for a full export. NEVER pass a write command.


### PR DESCRIPTION
## Summary

`scripts/export-d1-data.mjs`'s usage comment told a maintainer to run `--db gittensory`, but the D1 database
was renamed from `gittensory` to `loopover` (`wrangler.jsonc`'s `"database_name": "loopover"`) in the
2026-07-15 repo rename — so copy-pasting the example targeted a database name that no longer exists. This points
the usage example at the real current name. `gittensory` appears exactly once in the file (the usage line); the
rest of the file's docs were checked and carry no other stale name.

Closes #7012

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7012`).

## Validation

- [x] `node --check scripts/export-d1-data.mjs`
- [x] `git diff --check`
- Doc-comment-only change (no behavioral diff); per the issue, no new test is required, and `scripts/**` is outside the Codecov patch scope.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — none; a usage-comment correction only.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no behavior change.
- [x] No visible UI changes, so no `UI Evidence` section is required.
- [x] Public docs/changelogs: this IS the doc correction; no changelog edit needed.
