### PR TITLE
fix(test): inject AbortSignal/TextEncoder into miner-extension-live-fetch vm sandbox

### DIFF
--- a/test/unit/miner-extension-live-fetch.test.ts
+++ b/test/unit/miner-extension-live-fetch.test.ts
@@ -75,6 +75,13 @@ function loadBackgroundWithFakeChrome({
     __LOOPOVER_MINER_EXTENSION_TEST__: true,
     chrome,
     fetch: fetchImpl,
+    // node:vm's createContext() is a fresh, isolated realm with none of the outer process's globals --
+    // background.js's live-fetch path bounds its fetch with AbortSignal.timeout(...) (#4c0b19f4) and
+    // measures the real serialized byte size via TextEncoder for the quota guard (#7062), so the sandbox
+    // needs both real globals injected or those calls throw "<Global> is not defined" on any payload that
+    // reaches the success path.
+    AbortSignal,
+    TextEncoder,
   };
   context.globalThis = context;
   const vmContext = createContext(context);


### PR DESCRIPTION
## Summary

- \`main\`'s CI is currently broken: any PR touching \`test/unit/miner-extension-live-fetch.test.ts\` (which is most PRs, since it's part of the required test suite) fails on 4-7 tests depending on which code path they exercise. Confirmed live blocking a real, unrelated release-please PR (#7058, engine v3.2.1).
- Root cause: \`node:vm\`'s \`createContext()\` is a fresh, isolated realm with none of the outer process's globals. Two recent, legitimate fixes to \`background.js\` added real global usage the sandbox never got:
  - \`AbortSignal.timeout(...)\` bounding the live-fetch call (#4c0b19f4)
  - \`new TextEncoder()\` measuring the real serialized byte size for the storage-quota guard (#7062)
- Every call on the success path threw \`"<Global> is not defined"\`, caught by the function's own \`try/catch\` and silently misreported as a typed \`{ ok: false }\` failure result instead of a real one -- which is exactly why this wasn't caught by any assertion on the *error message* itself, only by the tests expecting the *actual* success/failure shape.
- Fix: inject both real globals into the sandboxed \`context\` object, mirroring how \`chrome\`/\`fetch\` are already provided.

## Test plan

- [x] Reproduced deterministically outside CI (not a flake -- same failure every run, for any candidates payload reaching the success path)
- [x] \`npx vitest run miner-extension-live-fetch\` -- 15/15 passing after the fix (was 4-7 failing depending on run)
- [x] \`npm run test:changed\` against \`origin/main\` -- only this one file affected
- [x] \`npm run typecheck\` -- clean