### PR TITLE
fix(review): bound fetchShotContentBlock's screenshot fetch with a timeout

### DIFF
--- a/src/review/visual/capture.ts
+++ b/src/review/visual/capture.ts
@@ -127,7 +127,9 @@ export function hasSuccessfulBotCapture(routes: readonly CaptureRoute[]): boolea
  */
 export async function fetchShotContentBlock(url: string): Promise<AiContentBlock | undefined> {
   try {
-    const response = await fetch(url);
+    // Bound the fetch like every other external screenshot call in this file (#7070) -- resolveShotUrl below
+    // already uses this same timeout; a TimeoutError rejection is caught by the surrounding catch.
+    const response = await fetch(url, { signal: AbortSignal.timeout(EXTERNAL_SCREENSHOT_FETCH_TIMEOUT_MS) });
     if (!response.ok) return undefined;
     const bytes = new Uint8Array(await response.arrayBuffer());
     return { type: "image", data: base64Encode(await downscaleForVision(bytes)), mimeType: "image/png" };

--- a/test/unit/visual-capture.test.ts
+++ b/test/unit/visual-capture.test.ts
@@ -2171,6 +2171,17 @@ describe("fetchShotContentBlock (#4111)", () => {
     vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("network down"); }));
     await expect(fetchShotContentBlock("https://x/loopover/shot?key=broken")).resolves.toBeUndefined();
   });
+
+  it("bounds the fetch with an AbortSignal timeout (#7070)", async () => {
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) => new Response(new Uint8Array([137, 80, 78, 71]), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchShotContentBlock("https://x/loopover/shot?key=timed");
+    // Mirrors resolveShotUrl's own bounded fetch in this file -- an unresponsive shot host can't hang the call.
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 


### PR DESCRIPTION
## What

`fetchShotContentBlock` (`src/review/visual/capture.ts`) fetched a screenshot URL with a bare `fetch(url)` and no time bound. Every other external fetch in this file and its siblings is timeout-bounded — including `resolveShotUrl` in this **same file**, which already uses `AbortSignal.timeout(EXTERNAL_SCREENSHOT_FETCH_TIMEOUT_MS)` (8s). A slow or hanging shot host (a self-host operator's storage backend, an R2/S3 proxy) could stall the review pipeline for that PR indefinitely.

## How

Pass the same `AbortSignal.timeout(EXTERNAL_SCREENSHOT_FETCH_TIMEOUT_MS)` to the fetch, reusing the constant already declared in this file. The function's existing `catch` already returns `undefined` on any rejection, so a `TimeoutError` is handled with no other change.

## Validation

Test added to the existing `fetchShotContentBlock` describe block in `test/unit/visual-capture.test.ts`: the fetch is called with an `AbortSignal`. Confirmed it **fails against the unfixed code** (`signal` is `undefined`) and passes with the fix. `typecheck` clean; the full `visual-capture` suite (118 tests) passes.

Closes #7070
