### PR TITLE
fix(miner-ui): clear governor pause reason after a successful pause

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { fetchLedgers, LEDGERS_API_PATH, type LedgersResult, type LedgersSummary } from "./lib/ledgers";
 import { type GovernorPauseState, type GovernorPauseStateResult } from "./lib/governor";
-import { LedgersPage, LedgersView } from "./routes/ledgers";
+import { GovernorControlSection, LedgersPage, LedgersView } from "./routes/ledgers";
 import { handleLedgersRequest, type LedgersApiDeps } from "../vite-ledgers-api";
 
 // Test-local fixture factories (were lib exports reachable only from tests; moved here per #6187).
@@ -355,6 +355,52 @@ describe("LedgersPage (#4855)", () => {
       await waitFor(() =>
         expect((screen.getByRole("button", { name: "Resume governor" }) as HTMLButtonElement).disabled).toBe(false),
       );
+    });
+
+    it("clears the typed pause reason once a pause succeeds, so it isn't left over for the next pause after a resume (#7079)", () => {
+      const unpaused: GovernorPauseStateResult = { ok: true, pauseState: defaultGovernorPauseState() };
+      const onPause = vi.fn();
+      const onResume = vi.fn();
+      const { rerender } = render(
+        <GovernorControlSection result={unpaused} pending={false} onPause={onPause} onResume={onResume} />,
+      );
+      fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "flaky CI" } });
+      expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("flaky CI");
+
+      // The pause goes in flight, then resolves paused.
+      rerender(<GovernorControlSection result={unpaused} pending onPause={onPause} onResume={onResume} />);
+      const paused: GovernorPauseStateResult = {
+        ok: true,
+        pauseState: { paused: true, reason: "flaky CI", pausedAt: "2026-07-13T12:30:00.000Z" },
+      };
+      rerender(<GovernorControlSection result={paused} pending={false} onPause={onPause} onResume={onResume} />);
+
+      // Resume goes in flight, then resolves unpaused -- the pause form reappears for the next pause attempt.
+      rerender(<GovernorControlSection result={paused} pending onPause={onPause} onResume={onResume} />);
+      rerender(<GovernorControlSection result={unpaused} pending={false} onPause={onPause} onResume={onResume} />);
+      expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("");
+    });
+
+    it("preserves the typed pause reason after a failed pause attempt, so the user can retry without retyping (#7079)", () => {
+      const unpaused: GovernorPauseStateResult = { ok: true, pauseState: defaultGovernorPauseState() };
+      const onPause = vi.fn();
+      const onResume = vi.fn();
+      const { rerender } = render(
+        <GovernorControlSection result={unpaused} pending={false} onPause={onPause} onResume={onResume} />,
+      );
+      fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "flaky CI" } });
+
+      // The pause goes in flight, then fails -- the form is replaced by the error state, but the reason typed
+      // before the failed attempt must survive underneath it.
+      rerender(<GovernorControlSection result={unpaused} pending onPause={onPause} onResume={onResume} />);
+      const failed: GovernorPauseStateResult = { ok: false, error: "local governor action API responded 500" };
+      rerender(<GovernorControlSection result={failed} pending={false} onPause={onPause} onResume={onResume} />);
+      expect(screen.queryByLabelText("Pause reason")).toBeNull();
+
+      // Once the pause form is visible again (e.g. the pause state re-resolves), the reason is still there for
+      // the user to retry without retyping it.
+      rerender(<GovernorControlSection result={unpaused} pending={false} onPause={onPause} onResume={onResume} />);
+      expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("flaky CI");
     });
 
     it("renders an error message when the pause-state load fails, without breaking the ledgers section", async () => {

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
@@ -337,6 +337,17 @@ export function GovernorControlSection({
   // is passed through as `undefined` so it matches the CLI's own optional-flag behavior.
   const [reason, setReason] = useState("");
   const errorText = result !== null && !result.ok ? result.error : undefined;
+  // #7079: clear the typed reason once a pause actually succeeds, so it doesn't survive into the next pause
+  // form after a resume. Tracked via the pending->settled transition (rather than a `result` effect alone)
+  // so a failed pause -- which also updates `result`, just with `ok: false` -- leaves the reason untouched
+  // for the user to retry.
+  const wasPending = useRef(false);
+  useEffect(() => {
+    if (wasPending.current && !pending && result?.ok && result.pauseState.paused) {
+      setReason("");
+    }
+    wasPending.current = pending;
+  }, [pending, result]);
   return (
     <section className="grid gap-3">
       <h3 className="font-display text-token-base font-semibold">Governor control</h3>


### PR DESCRIPTION
## What

The Governor control section's pause-reason input (`GovernorControlSection` in `apps/loopover-miner-ui/src/routes/ledgers.tsx`) never reset the typed reason after a successful pause. After a resume, reopening the pause form showed the previous attempt's stale text instead of a blank field.

## Why

Fixes #7079.

## How

Added a `useEffect` that watches the `pending` -> settled transition: once a pause action resolves with `{ ok: true, pauseState: { paused: true, ... } }`, the reason is cleared. A failed pause (`ok: false`) leaves the typed reason untouched so the user can retry without retyping it. `onPause`/`onResume`'s signatures are unchanged.

## Validation

- `npx vitest run src/ledgers.test.tsx` (workspace `apps/loopover-miner-ui`) -- 28/28 passing, including two new regression tests: one exercising pause (with reason) -> resume -> reopened pause form -> asserts the input is empty, and one asserting a failed pause preserves the typed reason.
- `npm --workspace @loopover/ui-miner run typecheck` and `npm --workspace @loopover/ui-miner run lint` -- clean (only pre-existing warnings unrelated to this change).
- Full workspace `npx vitest run --coverage` (apps/loopover-miner-ui) -- 278/278 passing, coverage above the workspace's configured thresholds.
- No screenshot included -- the linked issue explicitly does not require one (behavioral/state fix, not a visual one).