### PR TITLE
fix(release): sync release-please manifest with actually-published versions

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  "packages/loopover-mcp": "3.1.0",
+  "packages/loopover-mcp": "3.1.1",
   "packages/loopover-engine": "3.2.0",
-  "packages/loopover-miner": "3.1.0",
+  "packages/loopover-miner": "3.1.1",
   "packages/loopover-ui-kit": "1.1.0"
 }


### PR DESCRIPTION
## Summary

`@loopover/mcp@3.1.1` and `@loopover/miner@3.1.1` are both live on npm (published via an out-of-band manual release cut, #7064's hand-authored release PR), but `.release-please-manifest.json` was never updated to reflect it -- it still recorded `3.1.0` as each package's last-released version.

release-please used that stale baseline on its next run and re-proposed "cut v3.1.1" as a brand-new release for both packages (#7086, #7087). Those would fail on publish -- npm rejects republishing an already-published version -- and are superseded by this fix; closing both.

## Test plan

- Compared `.release-please-manifest.json` against the real, currently-published state: `npm view @loopover/mcp version` / `npm view @loopover/miner version` both return `3.1.1`, matching `packages/loopover-mcp/package.json` and `packages/loopover-miner/package.json` on main.
- JSON validated.
- Not measured by Codecov (no `src/**` change).