### PR TITLE
fix(miner-ui): announce completed chat turns via aria-live message list

### DIFF
--- a/apps/loopover-miner-ui/src/chat-conversation.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-conversation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { ChatConversation } from "./components/chat/conversation";
@@ -62,6 +62,32 @@ describe("ChatConversation (#6518)", () => {
     // On completion the streamed answer is committed into the list and the composer re-enables.
     await waitFor(() => expect(sendButton().disabled).toBe(false));
     expect(screen.getByText("Hello")).toBeTruthy();
+  });
+
+  it("streams the in-flight answer outside the live region, then commits it inside it (#7081)", async () => {
+    const gate = deferred();
+    const streamChatImpl = async function* (_messages: ChatWireMessage[]) {
+      yield "Hel";
+      await gate.promise;
+      yield "lo";
+    };
+    render(<ChatConversation streamChatImpl={streamChatImpl} />);
+    ask("hi");
+
+    // While streaming, the live token text renders in the standalone streaming node, NOT inside the
+    // aria-live <ol> — so per-chunk re-renders can never trigger an announcement.
+    const streaming = await screen.findByTestId("chat-streaming-response");
+    expect(streaming.textContent).toContain("Hel");
+    const liveRegion = screen.getByRole("list");
+    expect(liveRegion.contains(streaming)).toBe(false);
+    expect(within(liveRegion).queryByText(/Hel/)).toBeNull();
+
+    gate.resolve();
+
+    // Once the turn completes the finished answer is committed as a bubble inside the live region — the
+    // single point at which assistive tech announces it.
+    await waitFor(() => expect(within(screen.getByRole("list")).getByText("Hello")).toBeTruthy());
+    expect(screen.queryByTestId("chat-streaming-response")).toBeNull();
   });
 
   it("surfaces a backend failure through the message-list error state and re-enables the composer", async () => {

--- a/apps/loopover-miner-ui/src/chat-message-components.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-message-components.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MessageList } from "./components/chat/message-list";
 import { MessageBubble } from "./components/chat/message-bubble";
@@ -39,6 +39,39 @@ describe("MessageList (#6515) — StateBoundary branches", () => {
   it("does not render the typing indicator when not composing", () => {
     render(<MessageList messages={singleMessage} />);
     expect(screen.queryByRole("status", { name: /is typing/i })).toBeNull();
+  });
+
+  it("marks the committed-message list as a polite live region (#7081)", () => {
+    render(<MessageList messages={singleMessage} />);
+    const list = screen.getByRole("list");
+    expect(list.getAttribute("aria-live")).toBe("polite");
+    // `additions` (not the default `additions text`) so a completed turn announces the new bubble once,
+    // not on every mutation of already-present nodes.
+    expect(list.getAttribute("aria-relevant")).toBe("additions");
+  });
+
+  it("appends the completed turn into the same live region so it is announced once (#7081)", () => {
+    const { rerender } = render(<MessageList messages={singleMessage} />);
+    const before = screen.getByRole("list");
+    expect(before.getAttribute("aria-live")).toBe("polite");
+    expect(within(before).getAllByRole("listitem")).toHaveLength(singleMessage.length);
+
+    const completedTurn: ChatMessage[] = [
+      ...singleMessage,
+      {
+        id: "turn-done",
+        role: "assistant",
+        content: "the finished answer",
+        timestamp: "2026-07-16T08:05:00.000Z",
+        authorName: "LoopOver",
+      },
+    ];
+    rerender(<MessageList messages={completedTurn} />);
+    // Same live region, now carrying the newly-appended bubble — a single announce-able addition.
+    const after = screen.getByRole("list");
+    expect(after.getAttribute("aria-live")).toBe("polite");
+    expect(within(after).getAllByRole("listitem")).toHaveLength(completedTurn.length);
+    expect(within(after).getByText("the finished answer")).toBeTruthy();
   });
 });
 

--- a/apps/loopover-miner-ui/src/components/chat/message-list.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/message-list.tsx
@@ -31,7 +31,13 @@ export function MessageList({
         errorTitle="Couldn't load the conversation"
         errorDescription="The conversation source did not respond. Retry, or check back once it has recovered."
       >
-        <ol className="flex flex-col gap-4 p-3">
+        {/* The committed-message list is the live region (#7081): a completed turn appends one <li>, so
+            screen readers announce the finished answer once. `polite` (not `assertive`) — chat answers
+            aren't interrupting content. The live-streaming StreamingText renders OUTSIDE this <ol> (in
+            ChatConversation), so its per-chunk token updates never fire an announcement; only the single
+            committed bubble does. StateBoundary's own role="status"/"alert" branches are unaffected — they
+            replace this subtree entirely when loading/empty/error. */}
+        <ol className="flex flex-col gap-4 p-3" aria-live="polite" aria-relevant="additions">
           {messages.map((message) => (
             <li key={message.id}>
               <MessageBubble message={message} />


### PR DESCRIPTION
fix(miner-ui): announce completed chat turns via aria-live message list

The chat message list rendered committed messages into plain DOM, so a
screen-reader user who moved focus out of the list got no announcement
when an assistant answer finished streaming in.

Mark the committed-message <ol> as an aria-live="polite" region with
aria-relevant="additions". A completed turn appends exactly one <li>, so
the finished answer is announced once. The live StreamingText renders
outside this <ol> (in ChatConversation), so its per-chunk token updates
never trigger an announcement, avoiding a too-chatty live region. The
StateBoundary loading/empty/error branches replace the subtree entirely,
so their existing role=status/alert announcements are unaffected.

Closes #7081

