### PR TITLE
fix(advisory): redact the check-run leak terms sanitizePublicComment already caught

### DIFF
--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -26,8 +26,12 @@ import { CLA_CHECK_UNRESOLVED_CODE, CLA_CONSENT_MISSING_CODE } from "../review/c
 import { REVIEW_THREAD_BLOCKER_CODE } from "../review/review-thread-findings.js";
 import { labelMatchesPattern } from "../scoring/label-match.js";
 
+// Kept byte-identical with the GATE_DECISION_TWIN_PAIR copy in src/rules/advisory.ts
+// (checkGateDecisionVersionBump enforces this). The mnemonics/seed-phrases/cohort/miner-|human-originated/
+// bare-raw-trust/bare-rankings terms were ported from sanitizePublicComment's own fix for the same leak class
+// (#7074) -- `raw\s+trust\s+scores?` stays ahead of bare `raw\s+trust` so the compound still matches first.
 const CHECK_RUN_FORBIDDEN_TERMS =
-  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|reviewability|scoreability|private\s+signals?)\b/gi;
+  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|raw\s+trust|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|mnemonics?|seed\s?phrases?|cohorts?|miner[-_\s]?originated|human[-_\s]?originated|rankings?|reviewability|scoreability|private\s+signals?)\b/gi;
 
 function sanitizeForCheckRun(text: string): string {
   return text.replace(CHECK_RUN_FORBIDDEN_TERMS, "[context]").replace(/\s+/g, " ").trim();

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -322,8 +322,13 @@ export function buildIssueAdvisory(repo: RepositoryRecord | null, issue: IssueRe
   return advisory("issue", targetKey, repoFullName, findings, "Issue advisory generated.", undefined, issue?.number);
 }
 
+// Kept byte-identical with the GATE_DECISION_TWIN_PAIR copy in packages/loopover-engine/src/advisory/
+// gate-advisory.ts (checkGateDecisionVersionBump enforces this). The mnemonics/seed-phrases/cohort/
+// miner-|human-originated/bare-raw-trust/bare-rankings terms were ported from sanitizePublicComment's own fix
+// for the same leak class (#7074) -- `raw\s+trust\s+scores?` stays ahead of bare `raw\s+trust` so the compound
+// still matches first.
 const CHECK_RUN_FORBIDDEN_TERMS =
-  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|reviewability|scoreability|private\s+signals?)\b/gi;
+  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|raw\s+trust|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|mnemonics?|seed\s?phrases?|cohorts?|miner[-_\s]?originated|human[-_\s]?originated|rankings?|reviewability|scoreability|private\s+signals?)\b/gi;
 
 function sanitizeForCheckRun(text: string): string {
   return text.replace(CHECK_RUN_FORBIDDEN_TERMS, "[context]").replace(/\s+/g, " ").trim();

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -378,6 +378,31 @@ describe("advisory rules", () => {
     expect(output.text).not.toMatch(/reward|wallet|trust score|score estimate/i);
   });
 
+  it("redacts the terms sanitizePublicComment already caught but CHECK_RUN_FORBIDDEN_TERMS missed (#7074)", () => {
+    const advisory = buildPullRequestAdvisory(repo, null);
+    const gate = evaluateGateCheck(
+      {
+        ...advisory,
+        findings: [
+          {
+            code: "missing_linked_issue",
+            title: "Check for mnemonic and seed phrase leaks across the cohort",
+            severity: "warning" as const,
+            detail: "This is miner-originated, not human-originated, and touches raw trust plus the rankings.",
+          },
+        ],
+      },
+      { linkedIssueGateMode: "block" },
+    );
+    const output = formatGateCheckOutput(gate);
+
+    expect(gate.conclusion).toBe("failure");
+    // None of the newly-added forbidden terms may survive to the public check-run surface.
+    expect(output.text).not.toMatch(/mnemonic|seed\s?phrase|cohort|originated|raw\s+trust|ranking/i);
+    // The static finding scaffolding still renders, so the finding isn't silently dropped.
+    expect(output.text).toContain("[context]");
+  });
+
   it("keeps missing-issue advisory by default, blocks duplicates by default, honoring explicit modes", () => {
     const pr: PullRequestRecord = {
       repoFullName: repo.fullName,


### PR DESCRIPTION
## What

The GitHub **check-run** output surface is redacted by `CHECK_RUN_FORBIDDEN_TERMS` / `sanitizeForCheckRun`, duplicated byte-for-byte in `src/rules/advisory.ts` and its engine twin `packages/loopover-engine/src/advisory/gate-advisory.ts`. That vocabulary was missing several terms the sibling PR-comment sanitizer `sanitizePublicComment` already fixed for the **same leak class** (its comment documents catching `cohort`, standalone `miner-`/`human-originated`, and bare `raw trust` — not just the `raw trust score` compound). Concretely, `mnemonic(s)`, `seed phrase(s)`, `cohort(s)`, `miner-originated`/`human-originated`, bare `ranking(s)`, and bare `raw trust` could all leak through `sanitizeForCheckRun` into check-run titles/summaries/annotations (which include maintainer- or contributor-influenced text like a configured pre-merge check `name` or a PR title).

## How

Add the missing terms to `CHECK_RUN_FORBIDDEN_TERMS` in **both** files with the **identical** updated regex (the `GATE_DECISION_TWIN_PAIR` enforced by `checkGateDecisionVersionBump`): `mnemonics?`, `seed\s?phrases?`, `cohorts?`, `miner[-_\s]?originated`, `human[-_\s]?originated`, bare `raw\s+trust`, and bare `rankings?`. `raw\s+trust\s+scores?` stays ahead of bare `raw\s+trust` in the alternation so the compound still matches first.

Both files are edited identically and the engine version is **not** bumped — `engine-parity:drift-check` passes ("5 hand-duplicated file pairs agree; version equal"), which is the correct resolution per the twin-pair rule. `CHECK_RUN_FORBIDDEN_TERMS` is kept as its own regex (not converged onto `signals/**`'s `PUBLIC_UNSAFE_TERMS`), matching the file's intentional-divergence contract.

## Validation

Test added to `rules.test.ts`: a finding whose title/detail carries every newly-added term is fed through `formatGateCheckOutput`, and none of `mnemonic`/`seed phrase`/`cohort`/`originated`/`raw trust`/`ranking` survives to the public check-run text. Confirmed it **fails against the unfixed regex** and passes with the fix. `engine-parity:drift-check` and `typecheck` clean.

Closes #7074
