### PR TITLE
fix(release): merge engine's release with its dependents (mcp, miner)

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -16,6 +16,23 @@ name: Package Release Please
 # default, these four packages have genuinely independent release cadences and separate publish
 # targets/workflows, and bundling them would work against this repo's small-focused-PR convention.
 #
+# node-workspace plugin merge: true (release-please-config.json) -- the exception to the above:
+# packages/loopover-mcp and packages/loopover-miner both carry a REAL runtime `dependencies` entry
+# on packages/loopover-engine, so they are not actually independent of it. With merge left at its
+# prior override (false), the plugin still bumps a dependent's `@loopover/engine` version range the
+# moment engine's own version changes, but does so on that dependent's OWN separate branch/PR --
+# meaning the dependent's package.json now requires an engine version that exists NOWHERE (not
+# locally on that branch, since engine's bump lives on a different unmerged branch; not on npm
+# either, since it hasn't published yet). `npm ci` then fails with ETARGET until a human notices and
+# manually walks engine's release through to publish before updating the dependent's branch --
+# confirmed live across several mcp/miner release cycles (#7086/#7087/#7107/#7108). merge: true is
+# the plugin's own purpose-built mechanism for exactly this: it combines a package with the
+# dependents its OWN dependency-bump logic pulled in as candidates into ONE PR/commit, so engine's
+# new version and its dependents' bumped ranges land together atomically -- npm workspaces then
+# resolves the dependency from the LOCAL checkout, which always satisfies the range regardless of
+# npm registry publish timing or ordering. packages/loopover-ui-kit has no dependency edge to any
+# other package here, so it is never pulled into this merge and keeps its fully independent cadence.
+#
 # Runs on every push to main, not just a schedule: release-please is idempotent (it recomputes
 # purely from conventional-commit history since each component's last release tag), so the extra
 # runs cost nothing when there's no new commit or merged Release PR to act on. The push trigger is

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,7 +29,7 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "merge": false
+      "merge": true
     }
   ],
   "changelog-sections": [


### PR DESCRIPTION
## Summary

The actual root cause of the mcp/miner v3.1.x release churn this session (#7086, #7087, #7107, #7108): engine's release and its dependents' (`packages/loopover-mcp` and `packages/loopover-miner` both carry a real runtime `dependencies` entry on `@loopover/engine`) release each landed as **separate** PRs/commits.

release-please's `node-workspace` plugin still bumps a dependent's `@loopover/engine` version range the moment engine's own version changes -- that part is correct and desired. But with `merge: false` (this repo's prior override of the plugin's own default), it does that bump on the dependent's **own separate branch**, not engine's. So the dependent's `package.json` ends up requiring an engine version that exists **nowhere**: not locally (engine's bump lives on a different, unmerged branch), and not on npm (it hasn't published yet). `npm ci` then fails with `ETARGET` until a human notices, manually walks engine's release through to publish, then updates the dependent's branch. That's exactly what ate hours across this session.

`merge: true` is the plugin's own purpose-built mechanism for this exact scenario: it combines a package with the dependents its own dependency-bump logic pulled in as candidates into **one** PR/commit. Engine's new version and its dependents' bumped ranges land together atomically -- npm workspaces then resolves `@loopover/engine` from the local checkout, which always satisfies the range regardless of npm registry publish timing or ordering. This eliminates the failure mode structurally instead of reacting to it after the fact.

`packages/loopover-ui-kit` has no dependency edge to any other package in this repo, so it's never pulled into the merge and keeps its fully independent release cadence -- confirmed via `grep '@loopover' packages/loopover-ui-kit/package.json` returning nothing.

## Test plan

- [x] `npm run actionlint` -- clean
- [x] `npm run typecheck` -- clean (after `npm run build --workspace @loopover/engine`)
- [x] JSON-validated `release-please-config.json`
- [x] Confirmed via `googleapis/release-please`'s own source (`src/plugins/workspace.ts`) that `merge` defaults to `true` and controls exactly this: "If multiple in-scope packages are being updated, it will merge them into a single package [PR]" -- this repo had explicitly overridden that default to `false`
- Config/workflow-comment-only change; not measured by Codecov. The real verification is empirical: the next time engine has an unreleased change alongside mcp/miner, release-please should open ONE combined PR instead of three separately-failing ones.