### PR TITLE
fix(ui): sync MCP_PACKAGE_KNOWN_LATEST_VERSION with npm dist-tags.latest

### DIFF
--- a/apps/loopover-ui/src/lib/mcp-package.ts
+++ b/apps/loopover-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.9.0";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.1.1";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
## Summary

`apps/loopover-ui/src/lib/mcp-package.ts`'s `MCP_PACKAGE_KNOWN_LATEST_VERSION` was still `"0.9.0"`, stale since `@loopover/mcp` published `3.1.1`. `ui:version-audit` (already CI-enforced, not a new check) caught it: `known latest 0.9.0 does not match npm dist-tags.latest 3.1.1`. Mechanical fix via the existing `npm run ui:version-audit:sync`.

## Test plan

- [x] `npm run ui:version-audit` -- clean after the fix
- [x] `npm run ui:test` -- 261/261 tests pass (one unrelated fresh-worktree failure from a not-yet-built `@loopover/engine` dist, resolved by `npm run build --workspace @loopover/engine`, not a real regression)