### PR TITLE
feat(api): REST + CLI mirror for loopover_watch_issues

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14527,6 +14527,38 @@
           "recommendation",
           "summary"
         ]
+      },
+      "IssueWatchList": {
+        "type": "object",
+        "properties": {
+          "watching": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "repoFullName": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "repoFullName",
+                "labels"
+              ]
+            }
+          },
+          "changed": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "watching"
+        ]
       }
     },
     "parameters": {},
@@ -18926,6 +18958,165 @@
           },
           "403": {
             "description": "Forbidden when contributorLogin does not match the authenticated session"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/contributors/{login}/watches": {
+      "get": {
+        "summary": "Contributor issue-watch subscriptions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The contributor's own issue-watch subscriptions (self-scoped): the repos and label filters they watch for new grabbable issues.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueWatchList"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Watch a repository for new grabbable issues",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repoFullName": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "repoFullName"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Subscribes the contributor to a repo (optional label filter) and returns their updated watch list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueWatchList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid watch body"
+          },
+          "403": {
+            "description": "Session cannot watch this repository"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Unwatch a repository",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repoFullName": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "repoFullName"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Removes the contributor's watch on a repo and returns their updated watch list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueWatchList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid watch body"
+          },
+          "403": {
+            "description": "Session cannot watch this repository"
           }
         },
         "security": [

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -93,6 +93,8 @@ const CLI_COMMAND_SPEC = {
   "explain-review-risk": [],
   notifications: [],
   "notifications-read": [],
+  watch: [],
+  unwatch: [],
   "analyze-branch": [],
   preflight: [],
   "review-pr": [],
@@ -3474,6 +3476,8 @@ async function runCli(args) {
   if (command === "explain-review-risk") return explainReviewRiskCli(options);
   if (command === "notifications") return notificationsCli(options);
   if (command === "notifications-read") return notificationsReadCli(options);
+  if (command === "watch") return watchCli(options);
+  if (command === "unwatch") return unwatchCli(options);
   if (command === "review-pr") return reviewPrCli(options);
   if (command !== "analyze-branch" && command !== "preflight") {
     const suggestion = suggestCommand(command);
@@ -4100,6 +4104,73 @@ async function notificationsReadCli(options) {
   process.stdout.write(`Marked ${payload.marked} LoopOver notification(s) read for ${login}.\n`);
 }
 
+function printWatchHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp watch --login <github-login> [--repo owner/repo] [--label <label>]... [--json]",
+      "",
+      "Watch repos for NEW grabbable, high-multiplier issues. With --repo, subscribes that repo (optional",
+      "--label filters, repeatable); without --repo, lists your current watches (the default action).",
+      "Mirrors the loopover_watch_issues MCP tool and GET/POST /v1/contributors/{login}/watches.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
+// #6746: CLI mirror of loopover_watch_issues (watch + list). Login resolves like the sibling contributor
+// commands. With --repo it POSTs a subscription (repeated --label flags collect into a filter); without --repo
+// it GETs the current watch list (the tool's default `list` action).
+async function watchCli(options) {
+  if (options.help === true) return printWatchHelp();
+  const login = options.login ?? activeProfile.session?.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
+  if (!login) throw new Error("Pass --login <github-login>, log in with `loopover-mcp login`, or set LOOPOVER_LOGIN.");
+  if (options.repo !== undefined && !String(options.repo).includes("/")) throw new Error("Pass --repo owner/repo.");
+  const labels = Array.isArray(options.label) ? options.label : options.label ? [options.label] : undefined;
+  const payload = options.repo ? await postWatch(login, options.repo, labels) : await getWatches(login);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `Watching ${payload.watching?.length ?? 0} repo(s) for new grabbable issues${payload.changed ? ` (${payload.changed})` : ""}.\n`,
+  );
+  for (const item of payload.watching ?? []) {
+    // The repo/label strings come from the API; sanitize before writing them to the terminal.
+    const suffix = item.labels && item.labels.length > 0 ? ` [labels: ${item.labels.join(", ")}]` : "";
+    process.stdout.write(`${sanitizePlainTextTerminalOutput(`- ${item.repoFullName}${suffix}`)}\n`);
+  }
+}
+
+function printUnwatchHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp unwatch --login <github-login> --repo owner/repo [--json]",
+      "",
+      "Stop watching a repo for new grabbable issues.",
+      "Mirrors the loopover_watch_issues MCP tool (action=unwatch) and DELETE /v1/contributors/{login}/watches.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
+// #6746: CLI mirror of loopover_watch_issues (unwatch). DELETEs the subscription and reports the updated count.
+async function unwatchCli(options) {
+  if (options.help === true) return printUnwatchHelp();
+  const login = options.login ?? activeProfile.session?.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
+  if (!login) throw new Error("Pass --login <github-login>, log in with `loopover-mcp login`, or set LOOPOVER_LOGIN.");
+  if (!options.repo || !String(options.repo).includes("/")) throw new Error("Pass --repo owner/repo.");
+  const payload = await deleteWatch(login, options.repo);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `${sanitizePlainTextTerminalOutput(payload.changed ?? `unwatched ${options.repo}`)} — now watching ${payload.watching?.length ?? 0} repo(s).\n`,
+  );
+}
+
 function printRepoDecisionHelp() {
   process.stdout.write(
     [
@@ -4585,6 +4656,8 @@ function printHelp() {
   loopover-mcp explain-review-risk --repo owner/repo --title <text> [--login <github-login>] [--body <text>] [--json]
   loopover-mcp notifications --login <github-login> [--json]
   loopover-mcp notifications-read --login <github-login> [--id <delivery-id>]... [--json]
+  loopover-mcp watch --login <github-login> [--repo owner/repo] [--label <label>]... [--json]
+  loopover-mcp unwatch --login <github-login> --repo owner/repo [--json]
   loopover-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--format table] [--json]
   loopover-mcp preflight --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--validation "passed|npm test|summary"] [--format table] [--json]
   loopover-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
@@ -4603,7 +4676,7 @@ function printHelp() {
   LOOPOVER_PROFILE
   LOOPOVER_CONFIG_PATH or LOOPOVER_CONFIG_DIR
   LOOPOVER_API_TOKEN, LOOPOVER_MCP_TOKEN, LOOPOVER_TOKEN, or a session from loopover-mcp login
-  LOOPOVER_LOGIN or GITHUB_LOGIN (default --login for analyze-branch, preflight, review-pr, decision-pack, repo-decision, monitor-open-prs, pr-outcomes, notifications, notifications-read, and agent plan/packet)
+  LOOPOVER_LOGIN or GITHUB_LOGIN (default --login for analyze-branch, preflight, review-pr, decision-pack, repo-decision, monitor-open-prs, pr-outcomes, notifications, notifications-read, watch, unwatch, and agent plan/packet)
   GITHUB_TOKEN for non-interactive login bootstrap
   GITTENSOR_SCORE_PREVIEW_CMD
   GITTENSOR_ROOT
@@ -5745,6 +5818,21 @@ function getNotifications(login) {
 }
 function postMarkNotificationsRead(login, ids) {
   return apiPost(`/v1/contributors/${encodeURIComponent(login)}/notifications/read`, ids ? { ids } : {});
+}
+function getWatches(login) {
+  return apiGet(`/v1/contributors/${encodeURIComponent(login)}/watches`);
+}
+function postWatch(login, repoFullName, labels) {
+  return apiPost(
+    `/v1/contributors/${encodeURIComponent(login)}/watches`,
+    labels && labels.length > 0 ? { repoFullName, labels } : { repoFullName },
+  );
+}
+function deleteWatch(login, repoFullName) {
+  return apiFetch(`/v1/contributors/${encodeURIComponent(login)}/watches`, {
+    method: "DELETE",
+    body: JSON.stringify({ repoFullName }),
+  });
 }
 
 // Mirror the API's own `summary` when it sends one, so the CLI and the loopover_monitor_open_prs MCP

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -57,6 +57,9 @@ import {
   listAgentAuditEvents,
   listAuditEventsForTarget,
   listNotificationDeliveriesForRecipient,
+  listIssueWatchSubscriptionsForLogin,
+  upsertIssueWatchSubscription,
+  deleteIssueWatchSubscription,
   markNotificationDeliveriesRead,
   MAX_NOTIFICATION_DELIVERY_ID_LENGTH,
   MAX_NOTIFICATION_MARK_READ_IDS,
@@ -200,6 +203,7 @@ import {
 import {
   buildStaticControlPanelRoleSummary,
   canLoginAccessRepo,
+  canWatchRepo,
   loadControlPanelAccessScope,
   loadControlPanelRoleSummary,
 } from "../services/control-panel-roles";
@@ -453,6 +457,13 @@ const MAX_LOCAL_BRANCH_TEXT_CHARS = 4000;
 // (src/mcp/server.ts) minus `login` (which is the path param): `ids` is optional (absent = mark all delivered).
 const markNotificationsReadBodySchema = z.object({
   ids: z.array(z.string().min(1).max(MAX_NOTIFICATION_DELIVERY_ID_LENGTH)).max(MAX_NOTIFICATION_MARK_READ_IDS).optional(),
+});
+
+// #6746: body of POST/DELETE /v1/contributors/:login/watches. Mirrors watchIssuesShape (src/mcp/server.ts) minus
+// `login` (the path param) and `action` (the HTTP verb): repoFullName is required, labels is an optional filter.
+const watchIssuesBodySchema = z.object({
+  repoFullName: z.string().min(3).max(200),
+  labels: z.array(z.string().min(1).max(100)).max(50).optional(),
 });
 
 const preflightSchema = z.object({
@@ -3427,6 +3438,43 @@ export function createApp() {
     return c.json({ login: login.toLowerCase(), marked });
   });
 
+  // REST mirror of the `loopover_watch_issues` MCP tool (LoopoverMcp.watchIssues) — a contributor's own
+  // issue-watch subscriptions, self-scoped via requireContributorAccess. GET lists them; POST watches a repo
+  // (optional label filter); DELETE unwatches. watch/unwatch additionally gate the repo via canWatchRepo,
+  // mirroring the tool's requireWatchableRepo. Response bodies match the tool's structuredContent. (#6746)
+  app.get("/v1/contributors/:login/watches", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    return c.json({ watching: await buildContributorWatchList(c.env, login) });
+  });
+
+  app.post("/v1/contributors/:login/watches", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    const parsed = watchIssuesBodySchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) return c.json({ error: "invalid_watch", issues: parsed.error.issues }, 400);
+    const forbidden = await requireWatchableRepo(c, login, parsed.data.repoFullName);
+    if (forbidden) return forbidden;
+    await upsertIssueWatchSubscription(c.env, { login, repoFullName: parsed.data.repoFullName, labels: parsed.data.labels });
+    const changed = `watching ${parsed.data.repoFullName}${parsed.data.labels && parsed.data.labels.length > 0 ? ` (labels: ${parsed.data.labels.join(", ")})` : ""}`;
+    return c.json({ watching: await buildContributorWatchList(c.env, login), changed });
+  });
+
+  app.delete("/v1/contributors/:login/watches", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    const parsed = watchIssuesBodySchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) return c.json({ error: "invalid_watch", issues: parsed.error.issues }, 400);
+    const forbidden = await requireWatchableRepo(c, login, parsed.data.repoFullName);
+    if (forbidden) return forbidden;
+    const removed = await deleteIssueWatchSubscription(c.env, login, parsed.data.repoFullName);
+    const changed = removed ? `unwatched ${parsed.data.repoFullName}` : `was not watching ${parsed.data.repoFullName}`;
+    return c.json({ watching: await buildContributorWatchList(c.env, login), changed });
+  });
+
   app.get("/v1/contributors/:login/repos/:owner/:repo/decision", async (c) => {
     const login = c.req.param("login");
     const unauthorized = await requireContributorAccess(c, login);
@@ -6328,6 +6376,25 @@ async function requireContributorAccess(c: ProtectedRouteContext, login: string)
     return c.json({ error: "forbidden_contributor" }, 403);
   }
   return null;
+}
+
+// #6746: the contributor's issue-watch list, shaped identically to the loopover_watch_issues MCP tool's
+// `watching` structuredContent so the REST↔MCP parity test holds.
+async function buildContributorWatchList(env: Env, login: string): Promise<Array<{ repoFullName: string; labels: string[] }>> {
+  const subscriptions = await listIssueWatchSubscriptionsForLogin(env, login);
+  return subscriptions.map((sub) => ({ repoFullName: sub.repoFullName, labels: sub.labels }));
+}
+
+// #6746: REST mirror of LoopoverMcp.requireWatchableRepo. Only session identities are repo-gated; a session may
+// watch/unwatch a repo only when canWatchRepo allows it (public loopover-tracked repos are watchable; private ones
+// require access). Static/operator tokens are already scoped by requireContributorAccess.
+async function requireWatchableRepo(c: ProtectedRouteContext, login: string, repoFullName: string): Promise<Response | null> {
+  const identity = await authenticateRequestIdentity(c);
+  /* v8 ignore next -- contributor route guard authenticates before the watchable-repo check runs. */
+  if (!identity) return c.json({ error: "unauthorized" }, 401);
+  if (identity.kind !== "session") return null;
+  if (await canWatchRepo(c.env, login, repoFullName)) return null;
+  return c.json({ error: "forbidden_watch_repo" }, 403);
 }
 
 async function requireContributorRepoAccess(c: ProtectedRouteContext, repoFullName: string, repo: RepositoryRecord): Promise<Response | null> {

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -510,6 +510,13 @@ export const NotificationsMarkedSchema = z
   })
   .openapi("NotificationsMarked");
 
+export const IssueWatchListSchema = z
+  .object({
+    watching: z.array(z.object({ repoFullName: z.string(), labels: z.array(z.string()) })),
+    changed: z.string().optional(),
+  })
+  .openapi("IssueWatchList");
+
 export const ContributorOpportunitySchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -25,6 +25,7 @@ import {
   ContributorDecisionPackSchema,
   ContributorOpenPrMonitorSchema,
   ContributorPrOutcomesSchema,
+  IssueWatchListSchema,
   NotificationFeedSchema,
   NotificationsMarkedSchema,
   ContributorRewardRiskStrategySchema,
@@ -828,6 +829,64 @@ export function buildOpenApiSpec() {
         content: { "application/json": { schema: NotificationsMarkedSchema } },
       },
       400: { description: "Invalid mark-read body" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/contributors/{login}/watches",
+    summary: "Contributor issue-watch subscriptions",
+    request: { params: z.object({ login: z.string() }) },
+    responses: {
+      200: {
+        description: "The contributor's own issue-watch subscriptions (self-scoped): the repos and label filters they watch for new grabbable issues.",
+        content: { "application/json": { schema: IssueWatchListSchema } },
+      },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/contributors/{login}/watches",
+    summary: "Watch a repository for new grabbable issues",
+    request: {
+      params: z.object({ login: z.string() }),
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({ repoFullName: z.string(), labels: z.array(z.string()).optional() }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Subscribes the contributor to a repo (optional label filter) and returns their updated watch list.",
+        content: { "application/json": { schema: IssueWatchListSchema } },
+      },
+      400: { description: "Invalid watch body" },
+      403: { description: "Session cannot watch this repository" },
+    },
+  });
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/contributors/{login}/watches",
+    summary: "Unwatch a repository",
+    request: {
+      params: z.object({ login: z.string() }),
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({ repoFullName: z.string(), labels: z.array(z.string()).optional() }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Removes the contributor's watch on a repo and returns their updated watch list.",
+        content: { "application/json": { schema: IssueWatchListSchema } },
+      },
+      400: { description: "Invalid watch body" },
+      403: { description: "Session cannot watch this repository" },
     },
   });
   registry.registerPath({

--- a/test/unit/mcp-cli-watches.test.ts
+++ b/test/unit/mcp-cli-watches.test.ts
@@ -1,0 +1,116 @@
+// #6746: the CLI mirror for loopover_watch_issues. The MCP tool and the new GET/POST/DELETE /watches routes manage
+// a contributor's issue-watch subscriptions; only the stdio/CLI surface was missing. These pin: `watch --json`
+// (list) stays byte-identical to the route, the plain-text path lists the watches, `watch --repo` forwards the
+// subscription body (with repeated --label flags), `unwatch --repo` forwards the delete, the repo-format guard,
+// and login resolution matching the sibling contributor commands.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// Any CLI command that calls the API must go through runAsync: the fixture server lives in this process, so
+// run()'s execFileSync would block the event loop and the child's fetch would abort before a response.
+import { closeFixtureServer, run, runAsync, runExpectingFailure, startFixtureServer, watchesFixture } from "./support/mcp-cli-harness";
+
+let apiUrl: string;
+let watchBodies: unknown[];
+let unwatchBodies: unknown[];
+
+async function connect() {
+  watchBodies = [];
+  unwatchBodies = [];
+  apiUrl = await startFixtureServer({ onWatch: (body) => watchBodies.push(body), onUnwatch: (body) => unwatchBodies.push(body) });
+}
+
+async function disconnect() {
+  await closeFixtureServer();
+}
+
+describe("loopover-mcp watch CLI", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("with no --repo, --json emits exactly the watch list the route returns", async () => {
+    const out = await runAsync(["watch", "--login", "JSONbored", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(JSON.parse(out)).toEqual(watchesFixture());
+  });
+
+  it("prints a count line and a line per watched repo on the plain-text path", async () => {
+    const out = await runAsync(["watch", "--login", "JSONbored"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(out).toContain("Watching 2 repo(s) for new grabbable issues.");
+    expect(out).toContain("- acme/widgets [labels: bug]");
+    expect(out).toContain("- acme/gadgets");
+  });
+
+  it("with --repo, POSTs the subscription and forwards repeated --label flags as a labels array", async () => {
+    await runAsync(["watch", "--login", "JSONbored", "--repo", "acme/widgets", "--label", "bug", "--label", "docs", "--json"], {
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+    });
+    expect(watchBodies).toEqual([{ repoFullName: "acme/widgets", labels: ["bug", "docs"] }]);
+  });
+
+  it("with --repo and no --label, POSTs just the repoFullName", async () => {
+    await runAsync(["watch", "--login", "JSONbored", "--repo", "acme/widgets", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(watchBodies).toEqual([{ repoFullName: "acme/widgets" }]);
+  });
+
+  it("rejects a --repo without an owner/name slash", () => {
+    const failure = runExpectingFailure(["watch", "--login", "JSONbored", "--repo", "widgets"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(failure.status).toBe(1);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --repo owner\/repo/);
+  });
+
+  it("resolves the login from LOOPOVER_LOGIN, then GITHUB_LOGIN, like the sibling contributor commands", async () => {
+    const viaLoopoverLogin = await runAsync(["watch", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", LOOPOVER_LOGIN: "JSONbored" });
+    expect(JSON.parse(viaLoopoverLogin)).toEqual(watchesFixture());
+    const viaGithubLogin = await runAsync(["watch", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", GITHUB_LOGIN: "JSONbored" });
+    expect(JSON.parse(viaGithubLogin)).toEqual(watchesFixture());
+  });
+
+  it("fails with the shared login-required message when no login is resolvable", () => {
+    const failure = runExpectingFailure(["watch"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", LOOPOVER_LOGIN: "", GITHUB_LOGIN: "" });
+    expect(failure.status).toBe(1);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --login <github-login>/);
+  });
+
+  it("documents itself in --help, in its own --help, and in the shell-completion command list", () => {
+    expect(run(["--help"])).toContain("loopover-mcp watch --login <github-login> [--repo owner/repo] [--label <label>]... [--json]");
+    expect(run(["watch", "--help"])).toContain("Mirrors the loopover_watch_issues MCP tool");
+    expect(run(["completion", "bash"])).toContain("watch");
+  });
+});
+
+describe("loopover-mcp unwatch CLI", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("--json emits exactly what the DELETE route returns", async () => {
+    const out = await runAsync(["unwatch", "--login", "JSONbored", "--repo", "acme/widgets", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(JSON.parse(out)).toEqual({ watching: [], changed: "unwatched acme/widgets" });
+  });
+
+  it("DELETEs the subscription, forwarding the repoFullName body", async () => {
+    await runAsync(["unwatch", "--login", "JSONbored", "--repo", "acme/widgets", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(unwatchBodies).toEqual([{ repoFullName: "acme/widgets" }]);
+  });
+
+  it("prints the change and the updated count on the plain-text path", async () => {
+    const out = await runAsync(["unwatch", "--login", "JSONbored", "--repo", "acme/widgets"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(out).toContain("unwatched acme/widgets — now watching 0 repo(s).");
+  });
+
+  it("requires --repo owner/repo", () => {
+    const failure = runExpectingFailure(["unwatch", "--login", "JSONbored"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" });
+    expect(failure.status).toBe(1);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --repo owner\/repo/);
+  });
+
+  it("fails with the shared login-required message when no login is resolvable", () => {
+    const failure = runExpectingFailure(["unwatch", "--repo", "acme/widgets"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token", LOOPOVER_LOGIN: "", GITHUB_LOGIN: "" });
+    expect(failure.status).toBe(1);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --login <github-login>/);
+  });
+
+  it("documents itself in --help, in its own --help, and in the shell-completion command list", () => {
+    expect(run(["--help"])).toContain("loopover-mcp unwatch --login <github-login> --repo owner/repo [--json]");
+    expect(run(["unwatch", "--help"])).toContain("Mirrors the loopover_watch_issues MCP tool");
+    expect(run(["completion", "bash"])).toContain("unwatch");
+  });
+});

--- a/test/unit/routes-watches.test.ts
+++ b/test/unit/routes-watches.test.ts
@@ -1,0 +1,259 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { listIssueWatchSubscriptionsForLogin, upsertIssueWatchSubscription, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+// #6746: GET/POST/DELETE /v1/contributors/:login/watches — the REST mirror of the loopover_watch_issues MCP tool.
+// All three gate on requireContributorAccess; POST/DELETE additionally gate the repo via requireWatchableRepo
+// (session-only, canWatchRepo) mirroring the tool. These tests pin the route contract: the watch-list shape, the
+// watch/unwatch `changed` messages, the guards, and REST↔MCP parity for the list surface.
+const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}` });
+const apiJsonHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" });
+
+async function connectMcp(env: Env) {
+  const server = new LoopoverMcp(env).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "watches-parity-test", version: "0.0.1" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedPublicRepo(env: Env, owner: string, name: string) {
+  await upsertRepositoryFromGitHub(env, { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } });
+}
+
+async function sessionCookie(env: Env, login: string, id: number) {
+  const { token } = await createSessionForGitHubUser(env, { login, id });
+  return `loopover_session=${token}`;
+}
+
+describe("GET /v1/contributors/:login/watches (#6746)", () => {
+  it("returns the contributor's watch list, shaped { watching: [{ repoFullName, labels }] }", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: ["Bug", "good first issue"] });
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/gadgets", labels: [] });
+
+    const response = await app.request("/v1/contributors/Miner1/watches", { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { watching: Array<{ repoFullName: string; labels: string[] }> };
+    expect(body).not.toHaveProperty("changed");
+    expect(body.watching).toContainEqual({ repoFullName: "acme/widgets", labels: ["bug", "good first issue"] });
+    expect(body.watching).toContainEqual({ repoFullName: "acme/gadgets", labels: [] });
+    expect(body.watching).toHaveLength(2);
+  });
+
+  it("returns an empty watch list for a contributor with no subscriptions", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [] });
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", {}, env);
+    expect(response.status).toBeGreaterThanOrEqual(401);
+    expect(response.status).toBeLessThan(404);
+  });
+
+  it("403s the shared mcp token unless fully unscoped (#2455 parity with the MCP surface)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    const response = await app.request("/v1/contributors/miner1/watches", { headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}` } }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+
+  it("returns the same watch list the loopover_watch_issues MCP tool returns (mirror parity)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: ["bug"] });
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/gadgets", labels: [] });
+    const restBody = await (await app.request("/v1/contributors/miner1/watches", { headers: apiHeaders(env) }, env)).json();
+    const client = await connectMcp(env);
+    const viaTool = await client.callTool({ name: "loopover_watch_issues", arguments: { login: "miner1", action: "list" } });
+    expect((viaTool as { structuredContent?: unknown }).structuredContent).toEqual(restBody);
+  });
+
+  it("never leaks wallet/hotkey/trust-score terms in its payload", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: ["bug"] });
+    const response = await app.request("/v1/contributors/miner1/watches", { headers: apiHeaders(env) }, env);
+    expect(JSON.stringify(await response.json())).not.toMatch(/wallet|hotkey|coldkey|trust score|reward estimate/i);
+  });
+});
+
+describe("POST /v1/contributors/:login/watches (#6746)", () => {
+  it("subscribes a repo with a label filter and returns the updated list plus a `changed` message", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: apiJsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets", labels: ["Bug", "docs"] }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { watching: Array<{ repoFullName: string; labels: string[] }>; changed: string };
+    expect(body.changed).toBe("watching acme/widgets (labels: Bug, docs)");
+    expect(body.watching).toContainEqual({ repoFullName: "acme/widgets", labels: ["bug", "docs"] });
+    // Persisted.
+    expect(await listIssueWatchSubscriptionsForLogin(env, "miner1")).toHaveLength(1);
+  });
+
+  it("subscribes a repo with no labels and omits the label suffix from `changed`", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: apiJsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [{ repoFullName: "acme/widgets", labels: [] }], changed: "watching acme/widgets" });
+  });
+
+  it("lets a session watch a repo it can see (canWatchRepo), returning 200", async () => {
+    const app = createApp();
+    // ADMIN_GITHUB_LOGINS grants "miner1" a control-panel role so the session clears the broad contributor-route
+    // guard and actually reaches requireWatchableRepo — the branch under test.
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "miner1" });
+    await seedPublicRepo(env, "acme", "widgets");
+    const cookie = await sessionCookie(env, "miner1", 4242);
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ changed: "watching acme/widgets" });
+  });
+
+  it("403s a session that cannot watch the repo (unknown/inaccessible), mirroring requireWatchableRepo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "miner1" });
+    const cookie = await sessionCookie(env, "miner1", 4242);
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/ghost" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_watch_repo" });
+  });
+
+  it("rejects a malformed body (missing repoFullName) with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    for (const body of [{}, { repoFullName: "x" }, { repoFullName: "acme/widgets", labels: [""] }]) {
+      const response = await app.request(
+        "/v1/contributors/miner1/watches",
+        { method: "POST", headers: apiJsonHeaders(env), body: JSON.stringify(body) },
+        env,
+      );
+      expect(response.status, JSON.stringify(body)).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: "invalid_watch" });
+    }
+    // A body that isn't valid JSON at all: c.req.json() throws, the route falls back to {} and 400s.
+    const invalid = await app.request("/v1/contributors/miner1/watches", { method: "POST", headers: apiJsonHeaders(env), body: "{not json" }, env);
+    expect(invalid.status).toBe(400);
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", { method: "POST" }, env);
+    expect(response.status).toBeGreaterThanOrEqual(401);
+    expect(response.status).toBeLessThan(404);
+  });
+
+  it("403s the shared mcp token unless fully unscoped (#2455 parity with the MCP surface)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+});
+
+describe("DELETE /v1/contributors/:login/watches (#6746)", () => {
+  it("unwatches a subscribed repo and reports it", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: [] });
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: apiJsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [], changed: "unwatched acme/widgets" });
+  });
+
+  it("reports `was not watching` when the repo had no subscription", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: apiJsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [], changed: "was not watching acme/widgets" });
+  });
+
+  it("403s a session that cannot watch the repo, mirroring requireWatchableRepo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "miner1" });
+    const cookie = await sessionCookie(env, "miner1", 4242);
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/ghost" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_watch_repo" });
+  });
+
+  it("rejects a malformed body with 400 (invalid JSON falls back to {} then fails validation)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    for (const body of [JSON.stringify({}), "{not json"]) {
+      const response = await app.request("/v1/contributors/miner1/watches", { method: "DELETE", headers: apiJsonHeaders(env), body }, env);
+      expect(response.status, body).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: "invalid_watch" });
+    }
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", { method: "DELETE" }, env);
+    expect(response.status).toBeGreaterThanOrEqual(401);
+    expect(response.status).toBeLessThan(404);
+  });
+
+  it("403s the shared mcp token unless fully unscoped (#2455 parity with the MCP surface)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -185,6 +185,10 @@ export async function startFixtureServer(
     notifications?: Record<string, unknown>;
     notificationsRead?: Record<string, unknown>;
     onMarkNotificationsRead?: (body: unknown) => void;
+    /** #6746: overrides the watch list, and captures the watch (POST) / unwatch (DELETE) request bodies. */
+    watches?: Record<string, unknown>;
+    onWatch?: (body: unknown) => void;
+    onUnwatch?: (body: unknown) => void;
     intakeStatus?: number;
     localBranchAnalysisStatus?: number;
     /** #6743: overrides the repo-doc refresh route's default "opened a new PR" response, e.g. to exercise
@@ -333,6 +337,20 @@ export async function startFixtureServer(
     if (request.url === "/v1/contributors/JSONbored/notifications/read" && request.method === "POST") {
       options.onMarkNotificationsRead?.(await readJsonRequest(request));
       response.end(JSON.stringify({ login: "jsonbored", marked: 2, ...(options.notificationsRead ?? {}) }));
+      return;
+    }
+    if (request.url === "/v1/contributors/JSONbored/watches" && request.method === "GET") {
+      response.end(JSON.stringify({ ...watchesFixture(), ...(options.watches ?? {}) }));
+      return;
+    }
+    if (request.url === "/v1/contributors/JSONbored/watches" && request.method === "POST") {
+      options.onWatch?.(await readJsonRequest(request));
+      response.end(JSON.stringify({ ...watchesFixture(), changed: "watching acme/widgets", ...(options.watches ?? {}) }));
+      return;
+    }
+    if (request.url === "/v1/contributors/JSONbored/watches" && request.method === "DELETE") {
+      options.onUnwatch?.(await readJsonRequest(request));
+      response.end(JSON.stringify({ watching: [], changed: "unwatched acme/widgets", ...(options.watches ?? {}) }));
       return;
     }
     if (request.url === "/v1/contributors/JSONbored/repos/JSONbored/loopover/decision" && request.method === "GET") {
@@ -1032,6 +1050,16 @@ export function notificationsFixture() {
 /** #6745: mirrors the { login, marked } shape POST /notifications/read returns. */
 export function notificationsReadFixture() {
   return { login: "jsonbored", marked: 2 };
+}
+
+/** #6746: mirrors the { watching: [{ repoFullName, labels }] } shape GET /watches (and the list tool) returns. */
+export function watchesFixture() {
+  return {
+    watching: [
+      { repoFullName: "acme/widgets", labels: ["bug"] },
+      { repoFullName: "acme/gadgets", labels: [] },
+    ],
+  };
 }
 
 export function decisionPackFixture() {


### PR DESCRIPTION
Closes #6746

The `loopover_watch_issues` MCP tool manages a contributor's self-scoped issue-watch subscriptions (watch/unwatch/list), but there was no REST route and no CLI mirror — unlike the sibling notifications surface (#6745). This adds the mirror.

## REST — `src/api/routes.ts`
- `GET /v1/contributors/:login/watches` — list; `POST` — watch a repo (optional `labels` filter); `DELETE` — unwatch.
- All three self-scope via the existing `requireContributorAccess`. `POST`/`DELETE` additionally gate the repo via `canWatchRepo`, mirroring the tool's `requireWatchableRepo` (session-only).
- Response bodies match the tool's `structuredContent` (`{ watching, changed? }`) so the surfaces cannot drift.

## OpenAPI
- The three paths + `IssueWatchListSchema` registered; committed `openapi.json` regenerated (`ui:openapi:check` passes).

## CLI — `packages/loopover-mcp/bin/loopover-mcp.js`
- `loopover-mcp watch --login <l> [--repo owner/repo] [--label <l>]... [--json]` — subscribes with `--repo` (repeated `--label` collects into a filter), or lists when `--repo` is omitted (the tool's default `list` action).
- `loopover-mcp unwatch --login <l> --repo owner/repo [--json]` — unsubscribes.
- Both go through the shared `apiGet`/`apiPost`/`apiFetch` helpers; registered in the command spec, dispatch, help, and login-env note.

## Tests
- `test/unit/routes-watches.test.ts` (19) — route contract, watch/unwatch messages, the guards (401 / mcp-token 403 / session `canWatchRepo` 403), malformed-body 400, and **REST↔MCP list parity**.
- `test/unit/mcp-cli-watches.test.ts` (14) — `--json` route parity, plain-text output, repeated-`--label` forwarding, the repo-format guard, login resolution, and self-documentation; harness stubs added.
- **100% patch coverage** on the changed backend lines. `apps/**` untouched (no UI/screenshot surface).

## Validation
- `npm run typecheck` — clean; full local drift/audit battery (env-reference, openapi, version-audit, docs/branding/manifest/engine-parity drift, actionlint, schema-drift, cf-typegen, command-reference) — all pass.
- `npx vitest run` on the two new files + notifications / completion-spec / openapi regression set — 110+ green.