### PR TITLE
test(miner-extension): cover options.js pure helpers without a jsdom harness

### DIFF
--- a/apps/loopover-miner-extension/README.md
+++ b/apps/loopover-miner-extension/README.md
@@ -36,8 +36,13 @@ quota, instead of silently failing to save or leaving storage partially written.
 `__LOOPOVER_MINER_EXTENSION_TEST__` hook) so v8 can attribute coverage; the root `test/unit/miner-*.test.ts`
 files remain as broader behavior tests through the `node:vm` harness.
 
-`content.js` and `options.js` are deliberately deferred — they need a jsdom mount harness before
-coverage attribution is meaningful. Raise thresholds per-PR as those scripts get covered.
+`content.js`'s import-time logic (`test/content.test.ts`, #6189) and `options.js`'s pure helpers
+(`test/options.test.ts`, #7008) are now behavior-tested through the same `__LOOPOVER_MINER_EXTENSION_TEST__`
+hook: each imports the module on a non-mounted path (a non-issue `location`, a null-returning `document`), so
+its DOM-independent logic runs without any jsdom mount harness. What genuinely still needs a real DOM harness —
+and stays deferred — is the full options-page/content-script UI: the form-submit and live-sync event handlers
+that only run once the page is actually mounted. Those files are not yet in `coverage.include` (their mounted
+paths would report uncovered without the harness); add them and raise thresholds per-PR as that UI gets covered.
 
 ## Host permissions
 

--- a/apps/loopover-miner-extension/test/options.test.ts
+++ b/apps/loopover-miner-extension/test/options.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type OptionsInternals = {
+  parseWatchedRepos: (text: unknown) => string[];
+  parseRankedCandidatesJson: (text: unknown) => unknown[];
+  removeLegacyDiscoveryIndexUrl: () => Promise<void>;
+  normalizeMinerUiUrl: (text: unknown) => string;
+  MAX_RANKED_CANDIDATES_JSON_BYTES: number;
+  SYNC_RANKED_CANDIDATES_MESSAGE: string;
+  DEFAULT_MINER_UI_URL: string;
+};
+
+// options.js reads `document.querySelector` for its form fields at import time; stubbing it to return null makes
+// the module take its "options.html is not mounted" branch, so it never attaches an event listener or touches
+// chrome. Importing it that way exposes the pure helpers through the __LOOPOVER_MINER_EXTENSION_TEST__ hook with
+// no DOM side effects -- the same no-jsdom-harness technique content.test.ts (#6189) already established.
+async function loadOptionsInternals(chromeStub: unknown = {}): Promise<OptionsInternals> {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  vi.stubGlobal("document", { querySelector: () => null });
+  vi.stubGlobal("chrome", chromeStub);
+  vi.stubGlobal("__LOOPOVER_MINER_EXTENSION_TEST__", true);
+  await import("../options.js");
+  return globalThis.__loopoverMinerOptionsInternals as OptionsInternals;
+}
+
+describe("options.js pure helpers (#7008)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("parseWatchedRepos splits on newlines and commas, trims, and drops blanks", async () => {
+    const { parseWatchedRepos } = await loadOptionsInternals();
+    expect(parseWatchedRepos("JSONbored/loopover,  owner/repo \n\n  other/repo ")).toEqual([
+      "JSONbored/loopover",
+      "owner/repo",
+      "other/repo",
+    ]);
+    // Nullish/empty input degrades to an empty list rather than [""] -- exercises both sides of the `?? ""`.
+    expect(parseWatchedRepos("")).toEqual([]);
+    expect(parseWatchedRepos(undefined)).toEqual([]);
+    expect(parseWatchedRepos(null)).toEqual([]);
+  });
+
+  it("parseRankedCandidatesJson returns [] for empty/whitespace input without parsing", async () => {
+    const { parseRankedCandidatesJson } = await loadOptionsInternals();
+    expect(parseRankedCandidatesJson("")).toEqual([]);
+    expect(parseRankedCandidatesJson("   \n  ")).toEqual([]);
+    expect(parseRankedCandidatesJson(undefined)).toEqual([]);
+  });
+
+  it("parseRankedCandidatesJson parses a JSON array of candidates", async () => {
+    const { parseRankedCandidatesJson } = await loadOptionsInternals();
+    expect(parseRankedCandidatesJson('[{"repo":"a/b"},{"repo":"c/d"}]')).toEqual([{ repo: "a/b" }, { repo: "c/d" }]);
+  });
+
+  it("parseRankedCandidatesJson rejects JSON that isn't an array", async () => {
+    const { parseRankedCandidatesJson } = await loadOptionsInternals();
+    expect(() => parseRankedCandidatesJson('{"repo":"a/b"}')).toThrow(/must be an array/);
+  });
+
+  it("parseRankedCandidatesJson rejects a payload past the quota, measured as UTF-8 bytes not char length", async () => {
+    const { parseRankedCandidatesJson, MAX_RANKED_CANDIDATES_JSON_BYTES } = await loadOptionsInternals();
+    // One byte over the limit -- the guard throws on TextEncoder byte length before it ever reaches JSON.parse,
+    // so the payload doesn't need to be valid JSON to trip it.
+    const oversized = "a".repeat(MAX_RANKED_CANDIDATES_JSON_BYTES + 1);
+    expect(() => parseRankedCandidatesJson(oversized)).toThrow(/too large/);
+  });
+
+  it("normalizeMinerUiUrl trims a real URL and falls back to the default when blank/nullish", async () => {
+    const { normalizeMinerUiUrl, DEFAULT_MINER_UI_URL } = await loadOptionsInternals();
+    expect(normalizeMinerUiUrl("  http://localhost:9999  ")).toBe("http://localhost:9999");
+    expect(normalizeMinerUiUrl("")).toBe(DEFAULT_MINER_UI_URL);
+    expect(normalizeMinerUiUrl("   ")).toBe(DEFAULT_MINER_UI_URL);
+    expect(normalizeMinerUiUrl(undefined)).toBe(DEFAULT_MINER_UI_URL);
+  });
+
+  it("removeLegacyDiscoveryIndexUrl purges the pre-#5343 discoveryIndexUrl key from chrome.storage.sync", async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const { removeLegacyDiscoveryIndexUrl } = await loadOptionsInternals({ storage: { sync: { remove } } });
+    await removeLegacyDiscoveryIndexUrl();
+    expect(remove).toHaveBeenCalledWith("discoveryIndexUrl");
+  });
+});


### PR DESCRIPTION
Closes #7008

## Summary

- `apps/loopover-miner-extension/options.js`'s pure, DOM-independent helpers had no test file, while its sibling `content.js` already proved out a lightweight, jsdom-free testing technique (`test/content.test.ts`, #6189).
- Adds `test/options.test.ts` using the same `__LOOPOVER_MINER_EXTENSION_TEST__` import hook: importing `options.js` on a non-mounted path (a null-returning `document`) makes it take its "options.html is not mounted" branch, exposing the internals with no DOM side effects and no jsdom mount harness.
- Covers `parseWatchedRepos`, `parseRankedCandidatesJson` (empty short-circuit, array parse, non-array rejection, and the UTF-8 byte-size quota that guards `chrome.storage.local` against the silent over-quota failure of #4863), `normalizeMinerUiUrl` (trim + default fallback), and the legacy `discoveryIndexUrl` purge (#5343).
- Updates the README's now-stale deferred-coverage note: `content.js` and `options.js` pure logic are now tested this way; only the mounted options-page/content-script UI event handlers still genuinely need a real DOM harness.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes — it is a test-only + README-note change scoped to `apps/loopover-miner-extension/`.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #7008`.

## Validation

- [x] `git diff --check` — clean.
- [x] `npm run typecheck` — 0 errors (the root `tsc` config type-checks the new `test/options.test.ts`).
- [x] Extension suite: `npm --workspace @loopover/miner-extension test` — 31 tests pass (24 prior + 7 new) with `vitest.config.ts` coverage thresholds still met (`options.js` is not in `coverage.include`, so the new test adds behavior coverage without moving the gated numbers, mirroring `content.js`).
- [x] `npm run miner-extension:lint` (`node --check` on all scripts) and `npm run miner-extension:typecheck` pass; ESLint on the new test file is clean.

If any required check was skipped, explain why:

- `test:coverage`, `test:workers`, `build:mcp`/`test:mcp-pack`, `ui:openapi:check`, `ui:lint`/`ui:typecheck`/`ui:build`, and `npm audit` are not applicable: this PR touches only `apps/loopover-miner-extension/**` (a test file plus a README note) — no `src/**`, no MCP/API/OpenAPI surface, no `@loopover/ui` files, and no dependency changes. `apps/**` is outside the Codecov `codecov/patch` scope, so there is no changed backend line/branch to cover; the extension's own vitest thresholds (verified above) are the relevant coverage signal.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A (none in this PR).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (none in this PR).
- [x] UI changes use live API data or real empty/error/loading states — N/A (no UI behavior change).
- [x] Visible UI changes include a `UI Evidence` section — N/A: this is a test-only + README-note change; `options.js`'s runtime behavior and the extension UI are unchanged, so there is nothing visual to screenshot.
- [x] Public docs are updated where needed (the README deferred-coverage note); no changelog edited.

## UI Evidence

Not applicable — no visible UI, frontend, or behavioral change. This PR adds a unit-test file and updates a README note only; `options.js` itself is unchanged, so there is no rendered state to capture.

## Notes

- The extension's `vitest` suite is not currently a CI-gated step (CI runs `miner-extension:lint`/`:typecheck`/`:build`); the new test file is nonetheless type-checked by the root `typecheck` job and passes locally with thresholds met, matching how `content.test.ts` already lives in this package.
