### PR TITLE
fix(scripts): scan the fumadocs-mdx docs content for stale @loopover/mcp versions

### DIFF
--- a/scripts/check-ui-mcp-version-copy.mjs
+++ b/scripts/check-ui-mcp-version-copy.mjs
@@ -16,6 +16,10 @@ export const SCAN_TARGETS = [
   "README.md",
   "packages/loopover-mcp/README.md",
   "apps/loopover-ui/src",
+  // The fumadocs-mdx docs content (5003fabe) lives in a sibling directory OUTSIDE src/; check-docs-drift.mjs was
+  // updated for the move but this scanner was not, leaving 10 real .mdx files with @loopover/mcp install snippets
+  // unscanned for stale-version drift (#7093).
+  "apps/loopover-ui/content",
 ];
 
 async function main() {
@@ -142,7 +146,7 @@ export function collectSourceFiles(path) {
 }
 
 export function isTextSource(path) {
-  return /\.(md|ts|tsx|js|jsx|json)$/.test(path);
+  return /\.(md|mdx|ts|tsx|js|jsx|json)$/.test(path);
 }
 
 export function isMinimumSupportedContext(line) {

--- a/test/unit/check-ui-mcp-version-copy-script.test.ts
+++ b/test/unit/check-ui-mcp-version-copy-script.test.ts
@@ -5,9 +5,12 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildStaleVersionMatchers,
+  collectSourceFiles,
   collectVersionCopyFailures,
   isMinimumSupportedContext,
+  isTextSource,
   readMinimumSupportedVersion,
+  SCAN_TARGETS,
   SOURCE_LATEST_PATH,
   writeKnownLatestVersion,
 } from "../../scripts/check-ui-mcp-version-copy.mjs";
@@ -102,6 +105,48 @@ describe("check-ui-mcp-version-copy script (#6292)", () => {
     });
   });
 
+  describe("scanning the fumadocs-mdx content directory (#7093)", () => {
+    let tempDir: string | undefined;
+
+    afterEach(() => {
+      if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    });
+
+    it("includes the docs content directory and recognizes .mdx as a text source", () => {
+      // Before #7093, SCAN_TARGETS only reached apps/loopover-ui/src and isTextSource didn't match .mdx, so the
+      // fumadocs content pipeline (5003fabe) was entirely invisible to this drift check.
+      expect(SCAN_TARGETS).toContain("apps/loopover-ui/content");
+      expect(isTextSource("apps/loopover-ui/content/docs/quickstart.mdx")).toBe(true);
+    });
+
+    it("collectSourceFiles now picks up real .mdx files under apps/loopover-ui/content/docs", () => {
+      const files = collectSourceFiles(join(root, "apps/loopover-ui/content"));
+      expect(files.some((file) => file.endsWith(join("docs", "quickstart.mdx")))).toBe(true);
+    });
+
+    it("flags a stale @loopover/mcp floor version hardcoded in an .mdx file (the regression this scan now catches)", () => {
+      tempDir = mkdtempSync(join(tmpdir(), "mcp-mdx-"));
+      mkdirSync(join(tempDir, "docs"), { recursive: true });
+      const mdxPath = join(tempDir, "docs", "quickstart.mdx");
+      writeFileSync(mdxPath, "Install with `npx -y @loopover/mcp/0.5.0 --help`\n");
+
+      // Discovery: the .mdx file is collected (it would have been skipped before the isTextSource change).
+      expect(collectSourceFiles(tempDir)).toContain(mdxPath);
+
+      // Flagging: its stale floor version is caught by the same matcher the src/ scan already uses.
+      const matchers = buildStaleVersionMatchers("0.5.0");
+      const failures = collectVersionCopyFailures({
+        label: "docs/quickstart.mdx",
+        text: readFileSync(mdxPath, "utf8"),
+        matchers,
+      });
+      expect(failures).toContain(
+        "docs/quickstart.mdx:1: 0.5.0 is only allowed as an explicit minimum-supported compatibility floor",
+      );
+    });
+  });
+
   it("recognizes minimum-supported context markers", () => {
     expect(
       isMinimumSupportedContext("the minimum supported version is X"),
@@ -170,6 +215,9 @@ describe("check-ui-mcp-version-copy script (#6292)", () => {
     function seedTempRepo(knownLatest: string): string {
       const dir = mkdtempSync(join(tmpdir(), "mcp-write-cli-"));
       mkdirSync(join(dir, "apps/loopover-ui/src/lib"), { recursive: true });
+      // #7093: SCAN_TARGETS now includes apps/loopover-ui/content, so the seeded repo must have it too or the
+      // scan's statSync would ENOENT. Empty is fine — collectSourceFiles returns [] for it.
+      mkdirSync(join(dir, "apps/loopover-ui/content"), { recursive: true });
       mkdirSync(join(dir, "packages/loopover-mcp"), { recursive: true });
       writeFileSync(join(dir, "README.md"), "# repo\n");
       writeFileSync(join(dir, "packages/loopover-mcp/README.md"), "# mcp\n");


### PR DESCRIPTION
Closes #7093

`scripts/check-ui-mcp-version-copy.mjs` guards UI copy against stale `@loopover/mcp` version strings, but its `SCAN_TARGETS` only reached `apps/loopover-ui/src` and `isTextSource` did not match `.mdx`. Since the fumadocs-mdx migration (`5003fabe`) the docs prose moved to `apps/loopover-ui/content/docs/*.mdx` — a sibling of `src/` — leaving ~10 files with `@loopover/mcp` install snippets unscanned. The sibling `check-docs-drift.mjs` was updated for the move; this scanner was not.

## Change (scoped to source-file discovery, per the issue)
- Add `apps/loopover-ui/content` to `SCAN_TARGETS`.
- Extend `isTextSource` from `/\.(md|ts|tsx|js|jsx|json)$/` to also match `.mdx`.
- `collectVersionCopyFailures` matching logic is untouched.

## Tests (`test/unit/check-ui-mcp-version-copy-script.test.ts`)
- Asserts `SCAN_TARGETS` includes the content dir and `isTextSource` matches `.mdx`.
- Asserts `collectSourceFiles` now picks up a real file under `apps/loopover-ui/content/docs/*.mdx` (`quickstart.mdx`).
- Asserts a deliberately-stale `@loopover/mcp` version in a fixture `.mdx` is flagged.
- Updated `seedTempRepo` to create the new content target dir.

## Validation
- `npx vitest run test/unit/check-ui-mcp-version-copy-script.test.ts` — 17 passed; 100% patch coverage on the changed lines.
- `npm run ui:version-audit` — passes, now scanning 4 targets (the content docs currently use the correct `@latest` form).