### PR TITLE
fix(ui): sync MCP_PACKAGE_KNOWN_LATEST_VERSION with npm dist-tags.latest

### DIFF
--- a/apps/loopover-ui/src/lib/mcp-package.ts
+++ b/apps/loopover-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.1.1";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.2.1";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
## Summary

Stale again since \`@loopover/mcp\` published 3.2.1 -- this exact class of drift already hit and got fixed once this session (#7115), and blocked an unrelated auto-generated release PR's (#7133) CI. Mechanical fix via \`npm run ui:version-audit:sync\`.

The durable fix (auto-sync this after every mcp publish instead of relying on a human noticing red CI on an unrelated PR) is a separate follow-up.

## Test plan

- [x] \`npm run ui:version-audit\` -- clean after the fix
- [x] \`npm run typecheck\` -- clean