### PR TITLE
docs(scripts): fix export-d1-data usage example to the current D1 database name

### DIFF
--- a/scripts/export-d1-data.mjs
+++ b/scripts/export-d1-data.mjs
@@ -4,7 +4,7 @@
 // a manifest the self-host importer validates against. The data transformation lives in export-d1-core.mjs (pure,
 // unit-tested); this file is the thin IO wrapper.
 //
-//   node scripts/export-d1-data.mjs --db gittensory --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
+//   node scripts/export-d1-data.mjs --db loopover --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
 //
 // --remote reads the deployed D1 (default is the local miniflare DB). --since-date does an INCREMENTAL export
 // (rows whose --since-column is >= the date); omit it for a full export. NEVER pass a write command.


### PR DESCRIPTION
Closes #7012

`scripts/export-d1-data.mjs`'s usage comment told maintainers to run `--db gittensory`, but the D1 database was renamed `gittensory` → `loopover` in the 2026-07-15 repo rename (`wrangler.jsonc:263` `"database_name": "loopover"`). Copy-pasting the example as-is targeted a database that no longer exists.

Changed the single stale reference (line 7) to `--db loopover`; grepped the rest of the file — no other `gittensory` references remain. Doc-comment-only, no behavioral change.