### PR TITLE
fix(miner-ui): join ledgers and portfolio queue-actions to the shared live-refresh poll

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchLedgers, LEDGERS_API_PATH, type LedgersResult, type LedgersSummary } from "./lib/ledgers";
 import { type GovernorPauseState, type GovernorPauseStateResult } from "./lib/governor";
@@ -366,6 +366,42 @@ describe("LedgersPage (#4855)", () => {
       );
       await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("connection refused"));
       expect(screen.getByText(/No ledger activity yet/i)).toBeTruthy();
+    });
+  });
+
+  describe("live refresh (#7082)", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("re-polls the ledger summary on the shared cadence, without any user action", async () => {
+      vi.useFakeTimers();
+      const loadLedgers = vi.fn(async (): Promise<LedgersResult> => ({ ok: true, summary: fixtureSummary }));
+      render(
+        <LedgersPage
+          loadLedgers={loadLedgers}
+          loadGovernorPauseState={loadGovernorPauseStateDefault}
+          pollIntervalMs={1000}
+        />,
+      );
+      await vi.waitFor(() => expect(loadLedgers).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.waitFor(() => expect(loadLedgers).toHaveBeenCalledTimes(2));
+    });
+
+    it("re-polls the governor pause-state on the shared cadence, without any user action", async () => {
+      vi.useFakeTimers();
+      const loadGovernorPauseState = vi.fn(loadGovernorPauseStateDefault);
+      render(
+        <LedgersPage
+          loadLedgers={async () => ({ ok: true, summary: fixtureSummary })}
+          loadGovernorPauseState={loadGovernorPauseState}
+          pollIntervalMs={1000}
+        />,
+      );
+      await vi.waitFor(() => expect(loadGovernorPauseState).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.waitFor(() => expect(loadGovernorPauseState).toHaveBeenCalledTimes(2));
     });
   });
 });

--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   fetchPortfolioQueueItems,
@@ -268,6 +268,27 @@ describe("PortfolioPage queue actions (#4857)", () => {
     await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("queue_entry_not_in_progress"));
     expect(releaseItem).toHaveBeenCalledWith(inProgressItem);
     expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(1);
+  });
+
+  describe("live refresh (#7082)", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("re-polls the queue-actions items on the shared cadence, without any user action", async () => {
+      vi.useFakeTimers();
+      const loadPortfolioQueueItems = vi.fn(async () => ({ ok: true as const, items: [inProgressItem] }));
+      render(
+        <PortfolioPage
+          loadPortfolioQueue={loadPortfolioQueue}
+          loadPortfolioQueueItems={loadPortfolioQueueItems}
+          pollIntervalMs={1000}
+        />,
+      );
+      await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(2));
+    });
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
@@ -28,6 +28,7 @@ import {
   type LedgersSummary,
 } from "../lib/ledgers";
 import { fetchGovernorPauseState, pauseGovernor, resumeGovernor, type GovernorPauseStateResult } from "../lib/governor";
+import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
 
 export const Route = createFileRoute("/ledgers")({
   component: LedgersPage,
@@ -407,35 +408,30 @@ export function LedgersPage({
   loadGovernorPauseState = fetchGovernorPauseState,
   pauseGovernorAction = pauseGovernor,
   resumeGovernorAction = resumeGovernor,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
 }: {
   loadLedgers?: () => Promise<LedgersResult>;
   loadGovernorPauseState?: () => Promise<GovernorPauseStateResult>;
   pauseGovernorAction?: (reason?: string) => Promise<GovernorPauseStateResult>;
   resumeGovernorAction?: () => Promise<GovernorPauseStateResult>;
+  pollIntervalMs?: number;
 }) {
-  const [result, setResult] = useState<LedgersResult | null>(null);
   const [pauseState, setPauseState] = useState<GovernorPauseStateResult | null>(null);
+  const [lastPolledPauseState, setLastPolledPauseState] = useState<GovernorPauseStateResult | null>(null);
   const [actionPending, setActionPending] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    void loadLedgers().then((loaded) => {
-      if (!cancelled) setResult(loaded);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [loadLedgers]);
+  // Join the app's shared live-refresh cadence so newly-recorded claims/events appear without a manual reload,
+  // matching the Overview page's claims card that reads the same data source (#7082).
+  const result = usePolledFetch(loadLedgers, pollIntervalMs);
 
-  useEffect(() => {
-    let cancelled = false;
-    void loadGovernorPauseState().then((loaded) => {
-      if (!cancelled) setPauseState(loaded);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [loadGovernorPauseState]);
+  // Poll the governor pause-state on the same cadence. Each fresh poll result is synced into `pauseState` during
+  // render, while the operator's own pause/resume action writes `pauseState` directly so it reflects immediately,
+  // not only on the next tick (#7082).
+  const polledPauseState = usePolledFetch(loadGovernorPauseState, pollIntervalMs);
+  if (polledPauseState !== lastPolledPauseState) {
+    setLastPolledPauseState(polledPauseState);
+    setPauseState(polledPauseState);
+  }
 
   const runGovernorAction = (action: () => Promise<GovernorPauseStateResult>) => {
     setActionPending(true);

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
@@ -405,19 +405,16 @@ export function PortfolioPage({
 }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [actionPending, setActionPending] = useState(false);
-  const [itemsResult, setItemsResult] = useState<PortfolioQueueItemsResult | null>(null);
   const [actionResult, setActionResult] = useState<PortfolioQueueActionResult | null>(null);
 
   const loadSummary = useCallback(() => loadPortfolioQueue(), [loadPortfolioQueue, refreshKey]);
   const summaryResult = usePolledFetch(loadSummary, pollIntervalMs);
 
-  const refreshItems = useCallback(() => {
-    void loadPortfolioQueueItems().then(setItemsResult);
-  }, [loadPortfolioQueueItems, refreshKey]);
-
-  useEffect(() => {
-    refreshItems();
-  }, [refreshItems]);
+  // Poll the queue-actions items on the shared cadence too, independently of the summary card's own poll — a slow
+  // or failed fetch in one section must not block the other. Bumping refreshKey after the operator's own action
+  // re-fetches immediately, additive to the timer rather than replacing it (#7082).
+  const loadItems = useCallback(() => loadPortfolioQueueItems(), [loadPortfolioQueueItems, refreshKey]);
+  const itemsResult = usePolledFetch(loadItems, pollIntervalMs);
 
   const runQueueAction = (action: () => Promise<PortfolioQueueActionResult>) => {
     setActionPending(true);
@@ -425,7 +422,6 @@ export function PortfolioPage({
       setActionResult(next);
       if (next.ok) {
         setRefreshKey((key) => key + 1);
-        refreshItems();
       }
       setActionPending(false);
     });


### PR DESCRIPTION
## What & why

The Ledgers page (`routes/ledgers.tsx`) and the Portfolio page's queue-actions
table (`routes/portfolio.tsx`) fetched their data only once on mount, never
joining the miner-ui dashboard's shared `usePolledFetch` cadence
(`DEFAULT_POLL_INTERVAL_MS`) that every other data view uses. As a result the
ledger summary, the governor pause-state, and the portfolio queue-actions table
showed stale local activity until a manual page reload (or, for the governor and
the actions table, the operator's own action).

Closes #7082.

## Changes

- `LedgersPage`: ledger summary now reads through `usePolledFetch`; the governor
  pause-state is polled on the same cadence and synced into local state during
  render so an operator's own pause/resume still reflects immediately from the
  action's result, not only on the next tick.
- `PortfolioPage`: the queue-actions items now poll through `usePolledFetch`
  independently of the summary card's own poll (a slow/failed fetch in one
  section can't block the other), keyed on the existing `refreshKey` so a
  successful release/requeue still re-fetches immediately.
- No change to the fetch clients or their API routes.

## Tests

Regression test per section (fake timers, advance one interval, assert a second
fetch with no user action):
- `ledgers.test.tsx`: summary re-polls; governor pause-state re-polls.
- `portfolio-queue-actions.test.tsx`: queue-actions items re-poll.

`apps/**` is under `ignore:` in `codecov.yml`. Local gate: full `apps/loopover-miner-ui`
suite green (279 tests), the two changed route files at 100% line/branch coverage,
`tsc --noEmit` clean, `eslint` clean (0 errors, warning count unchanged from main),
Prettier clean. No layout change, so no before/after screenshot required.
