### PR TITLE
fix(ui): document chat and generate-tests default roles in the command table

### DIFF
--- a/apps/loopover-ui/src/components/site/command-table.test.tsx
+++ b/apps/loopover-ui/src/components/site/command-table.test.tsx
@@ -2,6 +2,11 @@ import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { CommandTable } from "@/components/site/command-table";
+import {
+  ACTION_COMMAND_ENTRIES,
+  MAINTAINER_COMMAND_ENTRIES,
+  PUBLIC_COMMAND_ENTRIES,
+} from "@/lib/command-reference";
 
 // #6986: pinned after migrating the hand-rolled <table> markup onto the shared Table primitive --
 // confirms the real table structure, columns, and default-role lookup still render correctly.
@@ -42,5 +47,25 @@ describe("CommandTable", () => {
   it("renders the title heading", () => {
     render(<CommandTable title="Commands reference" entries={[]} />);
     expect(screen.getByRole("heading", { name: "Commands reference" })).toBeTruthy();
+  });
+
+  it("has a DEFAULT_ROLE_SUMMARY entry for every generated command id, never the generic fallback (#7096)", () => {
+    // Drift guard: a new command added to any of the three src/github/commands.ts catalogs without a matching
+    // DEFAULT_ROLE_SUMMARY entry must fail here rather than silently render "see policy" on the live docs page.
+    const allEntries = [
+      ...PUBLIC_COMMAND_ENTRIES,
+      ...MAINTAINER_COMMAND_ENTRIES,
+      ...ACTION_COMMAND_ENTRIES,
+    ];
+    expect(allEntries.length).toBeGreaterThan(0);
+    const { container } = render(<CommandTable title="All commands" entries={allEntries} />);
+    const missing = allEntries
+      .filter((entry) => within(container).queryByText(`@loopover ${entry.id}`))
+      .filter((entry) => {
+        const row = within(container).getByText(`@loopover ${entry.id}`).closest("tr");
+        return row?.textContent?.includes("see policy");
+      })
+      .map((entry) => entry.id);
+    expect(missing).toEqual([]);
   });
 });

--- a/apps/loopover-ui/src/components/site/command-table.tsx
+++ b/apps/loopover-ui/src/components/site/command-table.tsx
@@ -10,6 +10,7 @@ import {
 const DEFAULT_ROLE_SUMMARY: Record<string, string> = {
   help: "maintainer, collaborator, confirmed_miner (default policy)",
   ask: "maintainer, collaborator, confirmed_miner",
+  chat: "maintainer, collaborator, pr_author (rate-limited; opt-in per repo)",
   preflight: "maintainer, collaborator, confirmed_miner",
   blockers: "maintainer, collaborator, confirmed_miner",
   "duplicate-check": "maintainer, collaborator, confirmed_miner",
@@ -34,6 +35,7 @@ const DEFAULT_ROLE_SUMMARY: Record<string, string> = {
   resolve: "maintainer, collaborator",
   configuration: "maintainer, collaborator",
   explain: "maintainer, collaborator",
+  "generate-tests": "maintainer",
 };
 
 export function CommandTable({


### PR DESCRIPTION
## What

`command-table.tsx`'s `DEFAULT_ROLE_SUMMARY` — the hand-maintained `Record<string, string>` the docs page uses for each command's "Default roles" column — was missing two real, currently-shipped command ids, so the live docs page rendered the generic `"see policy"` fallback for both:

- `chat` (a public Q&A command; real default `["maintainer", "collaborator", "pr_author"]` per `command-authorization.ts`, PR author added under rate limiting by #5084).
- `generate-tests` (a PR action command; real default `["maintainer"]` — deliberately maintainer-only, the one command whose restrictiveness is most worth surfacing accurately).

The map is untyped against the command-id union, so TypeScript couldn't catch the omission.

## How

Add both entries with their real role lists:
- `chat: "maintainer, collaborator, pr_author (rate-limited; opt-in per repo)"`
- `"generate-tests": "maintainer"`

Add a drift-guard test that renders every id from the generated `PUBLIC_COMMAND_ENTRIES`/`MAINTAINER_COMMAND_ENTRIES`/`ACTION_COMMAND_ENTRIES` and asserts none falls back to `"see policy"` — so a future command added to any `src/github/commands.ts` catalog without a matching role-summary entry fails this test instead of silently rendering the generic fallback on the docs page. The existing `"unlisted-command"` fallback fixture test is unchanged (it stays correct for a genuinely-future, not-yet-catalogued id).

## Validation

New test passes; confirmed it **fails against the unfixed map** (both `chat` and `generate-tests` render "see policy"). `ui:lint`/`ui:typecheck` clean; `command-reference:check` clean (this edits the hand-maintained map, not the generated reference).

Closes #7096
