### PR TITLE
fix(miner-ui): reset governor pause-reason input after a successful pause (#7079)

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { fetchLedgers, LEDGERS_API_PATH, type LedgersResult, type LedgersSummary } from "./lib/ledgers";
 import { type GovernorPauseState, type GovernorPauseStateResult } from "./lib/governor";
-import { LedgersPage, LedgersView } from "./routes/ledgers";
+import { GovernorControlSection, LedgersPage, LedgersView } from "./routes/ledgers";
 import { handleLedgersRequest, type LedgersApiDeps } from "../vite-ledgers-api";
 
 // Test-local fixture factories (were lib exports reachable only from tests; moved here per #6187).
@@ -355,6 +355,55 @@ describe("LedgersPage (#4855)", () => {
       await waitFor(() =>
         expect((screen.getByRole("button", { name: "Resume governor" }) as HTMLButtonElement).disabled).toBe(false),
       );
+    });
+
+    it("clears the pause reason after a successful pause so a later resume -> pause starts blank (#7079)", async () => {
+      const pauseGovernorAction = vi.fn(async (): Promise<GovernorPauseStateResult> => ({
+        ok: true,
+        pauseState: { paused: true, reason: "investigating flaky test", pausedAt: "2026-07-13T12:30:00.000Z" },
+      }));
+      const resumeGovernorAction = vi.fn(async (): Promise<GovernorPauseStateResult> => ({
+        ok: true,
+        pauseState: defaultGovernorPauseState(),
+      }));
+      render(
+        <LedgersPage
+          loadLedgers={loadLedgersEmpty}
+          loadGovernorPauseState={loadGovernorPauseStateDefault}
+          pauseGovernorAction={pauseGovernorAction}
+          resumeGovernorAction={resumeGovernorAction}
+        />,
+      );
+      await waitFor(() => expect(screen.getByText("Not paused")).toBeTruthy());
+      fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "investigating flaky test" } });
+      fireEvent.click(screen.getByRole("button", { name: "Pause governor" }));
+      await waitFor(() => expect(screen.getByRole("button", { name: "Resume governor" })).toBeTruthy());
+
+      fireEvent.click(screen.getByRole("button", { name: "Resume governor" }));
+      await waitFor(() => expect(screen.getByText("Not paused")).toBeTruthy());
+      // The reason input reappears blank, not pre-filled with the previous pause's text.
+      expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("");
+    });
+
+    it("keeps the typed reason after a FAILED pause so it can be retried without retyping (#7079)", () => {
+      const notPaused: GovernorPauseStateResult = { ok: true, pauseState: defaultGovernorPauseState() };
+      const { rerender } = render(
+        <GovernorControlSection result={notPaused} pending={false} onPause={vi.fn()} onResume={vi.fn()} />,
+      );
+      fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "retry me" } });
+
+      // A failed pause surfaces the error branch (result.ok false, never a paused transition) — no reset.
+      rerender(
+        <GovernorControlSection
+          result={{ ok: false, error: "connection refused" }}
+          pending={false}
+          onPause={vi.fn()}
+          onResume={vi.fn()}
+        />,
+      );
+      // Once a not-paused state is readable again, the operator's typed reason is still there to retry.
+      rerender(<GovernorControlSection result={notPaused} pending={false} onPause={vi.fn()} onResume={vi.fn()} />);
+      expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("retry me");
     });
 
     it("renders an error message when the pause-state load fails, without breaking the ledgers section", async () => {

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -336,6 +336,18 @@ export function GovernorControlSection({
   // Optional pause reason, mirroring the CLI's `governor pause [--reason <text>]`; an empty field
   // is passed through as `undefined` so it matches the CLI's own optional-flag behavior.
   const [reason, setReason] = useState("");
+  // #7079: clear the typed reason once a pause actually succeeds, so a later resume -> pause starts from a blank
+  // input instead of pre-filled with the previous pause's text. onPause is fire-and-forget (void), so the success
+  // signal is the shared `result` prop flipping to a paused state; a FAILED pause leaves `result.ok` false (never
+  // paused), so the reason is retained for a retry without retyping. This is React's sanctioned "reset state when a
+  // prop changes" transition guard — a setState during render, NOT a useEffect, so it avoids the
+  // react-hooks/set-state-in-effect the streaming path already documents avoiding, and settles in one extra render.
+  const paused = Boolean(result?.ok && result.pauseState.paused);
+  const [prevPaused, setPrevPaused] = useState(paused);
+  if (paused !== prevPaused) {
+    setPrevPaused(paused);
+    if (paused) setReason("");
+  }
   const errorText = result !== null && !result.ok ? result.error : undefined;
   return (
     <section className="grid gap-3">


### PR DESCRIPTION
## Summary

`GovernorControlSection` (`apps/loopover-miner-ui/src/routes/ledgers.tsx`) keeps the typed pause reason
in a single `useState("")` for the section's whole lifetime. While paused it renders the "Resume
governor" button and the reason `Input` is unmounted, but the component instance — and so the `reason`
state — persists across the paused/not-paused toggle (there is no `key`/remount between branches).
After a successful pause the reason was never cleared, so on a later resume the `Input` reappeared
pre-filled with the *previous* pause's text: an operator who paused for "investigating flaky test",
resumed, then went to pause again for an unrelated reason would see the stale text still in the box —
a real risk of recording a stale/wrong pause reason.

This clears `reason` once a pause actually succeeds. `onPause` is fire-and-forget (`=> void`), so the
success signal is the shared `result` prop flipping to a paused state; the reset uses React's sanctioned
"reset state when a prop changes" transition guard (a setState during render, **not** a `useEffect`, so
it avoids the `react-hooks/set-state-in-effect` the streaming path already documents avoiding). A
**failed** pause leaves `result.ok` false (never a paused transition), so the reason is deliberately
retained for a retry without retyping. No change to the `onPause`/`onResume` signatures, the governor API
routes, or `lib/governor.ts`.

Closes #7079

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7079`).

## Validation

- [x] `git diff --check`
- [x] `npm run ui:typecheck` (`@loopover/ui-miner` — clean)
- [x] `npm run ui:lint` (`@loopover/ui-miner` — 0 errors)
- [x] `npm run ui:build` (`@loopover/ui-miner` — succeeds)
- [x] `@loopover/ui-miner` test suite: 278 passing, coverage above the app's local thresholds. Two new
      regression tests: a pause → resume → pause sequence asserts the reason input reappears blank, and a
      failed-pause case asserts the typed reason is retained for retry.
- [x] New or changed behavior has tests (added two `governor control (#7079)` cases in `ledgers.test.tsx`).

If any required check was skipped, explain why:

- UI-only change confined to `apps/loopover-miner-ui/**` (two files: the component's local-state reset plus
  its tests). `apps/**` is under `ignore:` in `codecov.yml`, so there is no `codecov/patch` obligation.
  Backend-only checks (`actionlint`, root `typecheck`, `test:workers`, `build:mcp`/`test:mcp-pack`,
  `ui:openapi:check`) touch no file changed here and were not run locally; CI runs the full suite regardless.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes in this PR.
- [x] No API/OpenAPI/MCP behavior changes — the fix is purely local component state; callback signatures and governor routes are untouched.
- [x] UI change adds no mock/demo data — real empty/error/loading states via the existing `StateBoundary` are unaffected.
- [x] No visual-layout change — see UI Evidence below.

## UI Evidence

This is a local form-state behavior fix, not a visual redesign: no layout, style, spacing, color, or
copy changes. The only observable difference is that the "Pause reason" input is empty (rather than
pre-filled with the prior pause's text) after a resume → pause sequence — a state transition, not a
static visual, and the issue carries no `visual` label. The behavior is pinned by the two regression
tests listed under Validation.

## Notes

- The reset is intentionally gated on a *successful* pause (`result.ok && paused`): a failed pause keeps
  the operator's text so a retry needs no retyping.
