### PR TITLE
fix(miner-ui): reset the governor pause reason after a successful pause

### DIFF
--- a/apps/loopover-miner-ui/src/ledgers.test.tsx
+++ b/apps/loopover-miner-ui/src/ledgers.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { fetchLedgers, LEDGERS_API_PATH, type LedgersResult, type LedgersSummary } from "./lib/ledgers";
 import { type GovernorPauseState, type GovernorPauseStateResult } from "./lib/governor";
-import { LedgersPage, LedgersView } from "./routes/ledgers";
+import { GovernorControlSection, LedgersPage, LedgersView } from "./routes/ledgers";
 import { handleLedgersRequest, type LedgersApiDeps } from "../vite-ledgers-api";
 
 // Test-local fixture factories (were lib exports reachable only from tests; moved here per #6187).
@@ -491,5 +491,41 @@ describe("handleLedgersRequest (#4855)", () => {
       }),
     );
     expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "sqlite locked" }) });
+  });
+});
+
+describe("GovernorControlSection pause-reason reset (#7079)", () => {
+  const notPaused: GovernorPauseStateResult = { ok: true, pauseState: { paused: false, reason: null, pausedAt: null } };
+  const pausedResult: GovernorPauseStateResult = {
+    ok: true,
+    pauseState: { paused: true, reason: "investigating flaky test", pausedAt: "2026-07-18T00:00:00.000Z" },
+  };
+  const control = (result: GovernorPauseStateResult, onPause = vi.fn()) => (
+    <GovernorControlSection result={result} pending={false} onPause={onPause} onResume={vi.fn()} />
+  );
+
+  it("clears the reason after a successful pause, so a later resume→pause starts from a blank input", () => {
+    const onPause = vi.fn();
+    const { rerender } = render(control(notPaused, onPause));
+    fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "investigating flaky test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Pause governor" }));
+    expect(onPause).toHaveBeenCalledWith("investigating flaky test");
+
+    // The poll reflects the successful pause (paused: true), then the operator resumes back to the pause form.
+    rerender(control(pausedResult, onPause));
+    rerender(control(notPaused, onPause));
+    expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("");
+  });
+
+  it("preserves the typed reason after a FAILED pause, so it can be retried without retyping", () => {
+    const onPause = vi.fn();
+    const { rerender } = render(control(notPaused, onPause));
+    fireEvent.change(screen.getByLabelText("Pause reason"), { target: { value: "investigating flaky test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Pause governor" }));
+
+    // The pause fails (ok: false): the reset must NOT fire. Re-render back to the form (a retry) and the reason stays.
+    rerender(control({ ok: false, error: "governor state write failed" }, onPause));
+    rerender(control(notPaused, onPause));
+    expect((screen.getByLabelText("Pause reason") as HTMLInputElement).value).toBe("investigating flaky test");
   });
 });

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -336,6 +336,16 @@ export function GovernorControlSection({
   // Optional pause reason, mirroring the CLI's `governor pause [--reason <text>]`; an empty field
   // is passed through as `undefined` so it matches the CLI's own optional-flag behavior.
   const [reason, setReason] = useState("");
+  // #7079: once a pause succeeds the polled `result` flips to paused; clear the reason so a later
+  // resume→pause starts from a blank input. Done with React's "info from previous renders" pattern (a
+  // render-phase reset when `paused` turns true) rather than an effect. A FAILED pause leaves `result.ok`
+  // false and never sets `paused`, so the reason is preserved for a retry.
+  const paused = result?.ok === true && result.pauseState.paused;
+  const [wasPaused, setWasPaused] = useState(paused);
+  if (paused !== wasPaused) {
+    setWasPaused(paused);
+    if (paused) setReason("");
+  }
   const errorText = result !== null && !result.ok ? result.error : undefined;
   return (
     <section className="grid gap-3">


### PR DESCRIPTION
Closes #7079

`GovernorControlSection` (`apps/loopover-miner-ui/src/routes/ledgers.tsx`) keeps the pause-reason `Input`'s text in a single `reason` state for the section's lifetime. The `Input` is unmounted while paused, but the component instance persists, so after a pause→resume the field reappeared **pre-filled with the previous pause's reason** — an operator pausing again could submit a stale reason into the persisted governor pause-state.

## Fix (local-state only, scoped to `GovernorControlSection`)
- Reset `reason` to `""` the moment a pause succeeds (the polled `result` flips to `paused: true`), via React's render-phase "info from previous renders" pattern (a `wasPaused` tracker) rather than a `setState`-in-effect (which `react-hooks/set-state-in-effect` rightly flags).
- A **failed** pause leaves `result.ok` false and never sets `paused`, so the effect never runs and the typed reason is preserved for a retry.
- No change to `onPause`/`onResume` signatures, the governor routes, or `lib/governor.ts`.

## Tests (`apps/loopover-miner-ui/src/ledgers.test.tsx`)
- pause with a reason → resume → reopen the pause form → assert the input is empty.
- Negative: a failed pause keeps the typed reason.

## Validation
- `@loopover/ui-miner` suite: 278 passed; coverage bar met (Statements 90.5% / Branches 89% / Functions 85.4% / Lines 93%).
- `tsc --noEmit` clean; `eslint` clean. `apps/**` is under `ignore:` in `codecov.yml`; per the issue this behavioral fix has no layout change, so no screenshot.