### PR TITLE
feat(api): REST + CLI mirror for loopover_watch_issues

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -93,6 +93,7 @@ const CLI_COMMAND_SPEC = {
   "explain-review-risk": [],
   notifications: [],
   "notifications-read": [],
+  watch: ["list", "add", "remove"],
   "analyze-branch": [],
   preflight: [],
   "review-pr": [],
@@ -3474,6 +3475,7 @@ async function runCli(args) {
   if (command === "explain-review-risk") return explainReviewRiskCli(options);
   if (command === "notifications") return notificationsCli(options);
   if (command === "notifications-read") return notificationsReadCli(options);
+  if (command === "watch") return watchCli(args.slice(1));
   if (command === "review-pr") return reviewPrCli(options);
   if (command !== "analyze-branch" && command !== "preflight") {
     const suggestion = suggestCommand(command);
@@ -4072,6 +4074,68 @@ async function notificationsCli(options) {
   }
 }
 
+// #6746: contributor-scoped mirror of the loopover_watch_issues MCP tool and the /v1/contributors/{login}/watches
+// route family. The MCP tool's action enum maps to subcommands here: list=GET, add=POST, remove=DELETE.
+async function watchCli(args) {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "help") return printWatchHelp();
+  const positional = args[1] && !args[1].startsWith("--") ? args[1] : undefined;
+  const options = parseOptions(args.slice(1));
+  const login = options.login ?? activeProfile.session?.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
+  if (!login) throw new Error("Pass --login <github-login>, log in with `loopover-mcp login`, or set LOOPOVER_LOGIN.");
+  const base = `/v1/contributors/${encodeURIComponent(login)}/watches`;
+  // The API chooses `changed` / repo / label text, so the plain-text path is sanitized (#6261); `login` is the
+  // user's own value.
+  const render = (payload) =>
+    [
+      `Watching ${(payload.watching ?? []).length} repo(s) for ${login}${payload.changed ? ` (${sanitizePlainTextTerminalOutput(payload.changed)})` : ""}.`,
+      ...(payload.watching ?? []).map((watch) => {
+        const labels = (watch.labels ?? []).length > 0 ? ` [${watch.labels.map(sanitizePlainTextTerminalOutput).join(", ")}]` : "";
+        return `- ${sanitizePlainTextTerminalOutput(watch.repoFullName)}${labels}`;
+      }),
+    ].join("\n");
+  const emit = (payload) => {
+    if (options.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    else process.stdout.write(`${render(payload)}\n`);
+  };
+
+  if (subcommand === "list") {
+    emit(await apiGet(base));
+    return;
+  }
+  if (subcommand === "add" || subcommand === "remove") {
+    if (!positional || !positional.includes("/")) {
+      throw new Error(`Pass the repo: loopover-mcp watch ${subcommand} <owner/repo>.`);
+    }
+    if (subcommand === "add") {
+      const labels =
+        typeof options.labels === "string" ? options.labels.split(",").map((label) => label.trim()).filter(Boolean) : [];
+      emit(await apiPost(base, { repoFullName: positional, ...(labels.length > 0 ? { labels } : {}) }));
+    } else {
+      emit(await apiDelete(base, { repoFullName: positional }));
+    }
+    return;
+  }
+  throw new Error(`Unknown watch subcommand: ${subcommand}. Use list | add <owner/repo> [--labels a,b] | remove <owner/repo>.`);
+}
+
+function printWatchHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp watch <list|add|remove> [owner/repo] [--labels a,b] [--login <github-login>] [--json]",
+      "",
+      "Manage your issue-watch subscriptions (mirrors the loopover_watch_issues MCP tool and the",
+      "/v1/contributors/{login}/watches routes):",
+      "  list                         Show the repos you are watching.",
+      "  add <owner/repo> [--labels]  Watch a repo for new grabbable issues (optional comma-separated label filter).",
+      "  remove <owner/repo>          Stop watching a repo.",
+      "",
+      "Login resolves from --login, the active session, LOOPOVER_LOGIN, then GITHUB_LOGIN.",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
 function printNotificationsReadHelp() {
   process.stdout.write(
     [
@@ -4585,6 +4649,7 @@ function printHelp() {
   loopover-mcp explain-review-risk --repo owner/repo --title <text> [--login <github-login>] [--body <text>] [--json]
   loopover-mcp notifications --login <github-login> [--json]
   loopover-mcp notifications-read --login <github-login> [--id <delivery-id>]... [--json]
+  loopover-mcp watch <list|add|remove> [owner/repo] [--labels a,b] [--login <github-login>] [--json]
   loopover-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--format table] [--json]
   loopover-mcp preflight --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--validation "passed|npm test|summary"] [--format table] [--json]
   loopover-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
@@ -6101,6 +6166,10 @@ async function apiGet(path) {
 
 async function apiPost(path, body) {
   return apiFetch(path, { method: "POST", body: JSON.stringify(body) });
+}
+
+async function apiDelete(path, body) {
+  return apiFetch(path, { method: "DELETE", body: JSON.stringify(body) });
 }
 
 async function apiFetch(path, init, options = {}) {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -120,6 +120,9 @@ import {
   deleteRepositoryLinearKey,
   getGlobalAgentFrozenState,
   setGlobalAgentFrozen,
+  upsertIssueWatchSubscription,
+  listIssueWatchSubscriptionsForLogin,
+  deleteIssueWatchSubscription,
 } from "../db/repositories";
 import { dedupeSignalSnapshots, pruneExpiredRecords, RETENTION_POLICY } from "../db/retention";
 import {
@@ -200,6 +203,7 @@ import {
 import {
   buildStaticControlPanelRoleSummary,
   canLoginAccessRepo,
+  canWatchRepo,
   loadControlPanelAccessScope,
   loadControlPanelRoleSummary,
 } from "../services/control-panel-roles";
@@ -453,6 +457,13 @@ const MAX_LOCAL_BRANCH_TEXT_CHARS = 4000;
 // (src/mcp/server.ts) minus `login` (which is the path param): `ids` is optional (absent = mark all delivered).
 const markNotificationsReadBodySchema = z.object({
   ids: z.array(z.string().min(1).max(MAX_NOTIFICATION_DELIVERY_ID_LENGTH)).max(MAX_NOTIFICATION_MARK_READ_IDS).optional(),
+});
+
+// #6746: body of POST/DELETE /v1/contributors/:login/watches. Mirrors watchIssuesShape (src/mcp/server.ts) minus
+// `login` (path param) and `action` (the HTTP verb). `labels` is POST-only (a DELETE ignores it).
+const watchSubscriptionBodySchema = z.object({
+  repoFullName: z.string().min(3).max(200),
+  labels: z.array(z.string().min(1).max(100)).max(50).optional(),
 });
 
 const preflightSchema = z.object({
@@ -3425,6 +3436,44 @@ export function createApp() {
     if (!parsed.success) return c.json({ error: "invalid_mark_read", issues: parsed.error.issues }, 400);
     const marked = await markNotificationDeliveriesRead(c.env, login, parsed.data.ids);
     return c.json({ login: login.toLowerCase(), marked });
+  });
+
+  // #6746: REST mirror of the `loopover_watch_issues` MCP tool (LoopoverMcp.watchIssues) — manage a contributor's
+  // own issue-watch subscriptions. The MCP tool's `action` enum splits across the HTTP verbs: GET=list, POST=watch,
+  // DELETE=unwatch. Every verb is self-scoped via requireContributorAccess (a session may only touch its own
+  // login), and the mutating verbs reuse canWatchRepo — the same gate requireWatchableRepo applies in the MCP tool.
+  const listWatches = async (env: Env, login: string) =>
+    (await listIssueWatchSubscriptionsForLogin(env, login)).map((sub) => ({ repoFullName: sub.repoFullName, labels: sub.labels }));
+
+  app.get("/v1/contributors/:login/watches", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    return c.json({ watching: await listWatches(c.env, login) });
+  });
+
+  app.post("/v1/contributors/:login/watches", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    const parsed = watchSubscriptionBodySchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) return c.json({ error: "invalid_watch_request", issues: parsed.error.issues }, 400);
+    if (!(await canWatchRepo(c.env, login, parsed.data.repoFullName))) return c.json({ error: "forbidden_repo" }, 403);
+    await upsertIssueWatchSubscription(c.env, { login, repoFullName: parsed.data.repoFullName, labels: parsed.data.labels });
+    const labelSuffix = parsed.data.labels && parsed.data.labels.length > 0 ? ` (labels: ${parsed.data.labels.join(", ")})` : "";
+    return c.json({ watching: await listWatches(c.env, login), changed: `watching ${parsed.data.repoFullName}${labelSuffix}` });
+  });
+
+  app.delete("/v1/contributors/:login/watches", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    const parsed = watchSubscriptionBodySchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) return c.json({ error: "invalid_watch_request", issues: parsed.error.issues }, 400);
+    if (!(await canWatchRepo(c.env, login, parsed.data.repoFullName))) return c.json({ error: "forbidden_repo" }, 403);
+    const removed = await deleteIssueWatchSubscription(c.env, login, parsed.data.repoFullName);
+    const changed = removed ? `unwatched ${parsed.data.repoFullName}` : `was not watching ${parsed.data.repoFullName}`;
+    return c.json({ watching: await listWatches(c.env, login), changed });
   });
 
   app.get("/v1/contributors/:login/repos/:owner/:repo/decision", async (c) => {

--- a/test/unit/mcp-cli-watch.test.ts
+++ b/test/unit/mcp-cli-watch.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #6746: the `loopover-mcp watch <list|add|remove>` CLI, mirroring the loopover_watch_issues MCP tool and the
+// /v1/contributors/:login/watches routes. list=GET, add=POST, remove=DELETE.
+describe("loopover-mcp CLI — watch (#6746)", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    await closeFixtureServer();
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  async function env(options: Parameters<typeof startFixtureServer>[0] = {}) {
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
+    const url = await startFixtureServer(options);
+    return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
+  }
+
+  it("list shows the watched repos (plain + json), hitting GET", async () => {
+    const requests: string[] = [];
+    const e = await env({ onApiRequest: (r) => requests.push(`${r.method} ${r.url}`) });
+    const plain = await runAsync(["watch", "list", "--login", "octocat"], e);
+    expect(plain).toMatch(/Watching 2 repo\(s\) for octocat\./);
+    expect(plain).toMatch(/- acme\/widgets \[bug\]/);
+    expect(plain).toMatch(/- acme\/gadgets/);
+    expect(requests.at(-1)).toBe("GET /v1/contributors/octocat/watches");
+    const json = JSON.parse(await runAsync(["watch", "list", "--login", "octocat", "--json"], e)) as { watching: unknown[] };
+    expect(json.watching).toHaveLength(2);
+  });
+
+  it("add POSTs {repoFullName,labels} and reports the change", async () => {
+    const seen: Array<{ method: string; body: { repoFullName?: string; labels?: string[] } }> = [];
+    const e = await env({ onWatchRequest: (req) => seen.push(req) });
+    const out = await runAsync(["watch", "add", "acme/widgets", "--labels", "bug,feature", "--login", "octocat"], e);
+    expect(seen[0]).toEqual({ method: "POST", body: { repoFullName: "acme/widgets", labels: ["bug", "feature"] } });
+    expect(out).toMatch(/watching acme\/widgets \(labels: bug, feature\)/);
+  });
+
+  it("add without --labels sends no labels field", async () => {
+    const seen: Array<{ method: string; body: { repoFullName?: string; labels?: string[] } }> = [];
+    const e = await env({ onWatchRequest: (req) => seen.push(req) });
+    await runAsync(["watch", "add", "acme/widgets", "--login", "octocat"], e);
+    expect(seen[0]!.body).toEqual({ repoFullName: "acme/widgets" });
+  });
+
+  it("remove DELETEs and reports it was unwatched", async () => {
+    const seen: Array<{ method: string; body: { repoFullName?: string; labels?: string[] } }> = [];
+    const e = await env({ onWatchRequest: (req) => seen.push(req) });
+    const out = await runAsync(["watch", "remove", "acme/widgets", "--login", "octocat"], e);
+    expect(seen[0]).toEqual({ method: "DELETE", body: { repoFullName: "acme/widgets" } });
+    expect(out).toMatch(/unwatched acme\/widgets/);
+  });
+
+  it("resolves the login from LOOPOVER_LOGIN and url-encodes it", async () => {
+    const requests: string[] = [];
+    const e = await env({ onApiRequest: (r) => requests.push(r.url ?? "") });
+    await runAsync(["watch", "list"], { ...e, LOOPOVER_LOGIN: "a b/c" });
+    expect(requests.at(-1)).toBe("/v1/contributors/a%20b%2Fc/watches");
+  });
+
+  it("errors when add/remove is missing the owner/repo positional", async () => {
+    const e = await env();
+    const failure = runExpectingFailure(["watch", "add", "--login", "octocat"], e);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass the repo: loopover-mcp watch add <owner\/repo>/);
+  });
+
+  it("errors when no login can be resolved", async () => {
+    const e = await env();
+    const failure = runExpectingFailure(["watch", "list"], { ...e, LOOPOVER_LOGIN: "", GITHUB_LOGIN: "" });
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Pass --login/);
+  });
+
+  it("errors on an unknown subcommand", async () => {
+    const e = await env();
+    const failure = runExpectingFailure(["watch", "bogus", "--login", "octocat"], e);
+    expect(`${failure.stdout}${failure.stderr}`).toMatch(/Unknown watch subcommand: bogus/);
+  });
+});

--- a/test/unit/routes-watches.test.ts
+++ b/test/unit/routes-watches.test.ts
@@ -1,0 +1,242 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { upsertIssueWatchSubscription, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+// #6746: GET/POST/DELETE /v1/contributors/:login/watches — the REST mirror of the loopover_watch_issues MCP tool.
+// The tool's action enum splits across the verbs (GET=list, POST=watch, DELETE=unwatch); every verb self-scopes
+// via requireContributorAccess and the mutating verbs reuse canWatchRepo. These pin the ROUTE contract + parity.
+const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}` });
+const jsonHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" });
+
+async function connectMcp(env: Env) {
+  const server = new LoopoverMcp(env).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "watches-parity-test", version: "0.0.1" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedPublicRepo(env: ReturnType<typeof createTestEnv>, fullName: string): Promise<void> {
+  const [owner, name] = fullName.split("/");
+  await upsertRepositoryFromGitHub(env, { name: name!, full_name: fullName, private: false, owner: { login: owner! } }, 555);
+}
+
+describe("GET /v1/contributors/:login/watches (#6746)", () => {
+  it("returns the contributor's watch subscriptions", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: ["bug", "feature"] });
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/gadgets" });
+
+    const response = await app.request("/v1/contributors/Miner1/watches", { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { watching: Array<{ repoFullName: string; labels: string[] }> };
+    expect(body.watching).toContainEqual({ repoFullName: "acme/widgets", labels: ["bug", "feature"] });
+    expect(body.watching).toContainEqual({ repoFullName: "acme/gadgets", labels: [] });
+  });
+
+  it("returns an empty list for a contributor watching nothing", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [] });
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", {}, env);
+    expect(response.status).toBeGreaterThanOrEqual(401);
+    expect(response.status).toBeLessThan(404);
+  });
+
+  it("403s the shared mcp token unless fully unscoped (#2455 parity with the MCP surface)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    const response = await app.request("/v1/contributors/miner1/watches", { headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}` } }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+});
+
+describe("POST /v1/contributors/:login/watches (#6746)", () => {
+  it("watches a public tracked repo and returns the updated list + changed line", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedPublicRepo(env, "acme/widgets");
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: jsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets", labels: ["bug"] }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { watching: Array<{ repoFullName: string; labels: string[] }>; changed: string };
+    expect(body.watching).toEqual([{ repoFullName: "acme/widgets", labels: ["bug"] }]);
+    expect(body.changed).toBe("watching acme/widgets (labels: bug)");
+  });
+
+  it("omits the label suffix when no labels are given", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedPublicRepo(env, "acme/widgets");
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: jsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ changed: "watching acme/widgets" });
+  });
+
+  it("403s a repo the contributor cannot watch (untracked → fail-closed)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: jsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/unknown" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_repo" });
+  });
+
+  it("rejects a malformed or non-JSON body with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    // The trailing raw string is not valid JSON, so `c.req.json()` rejects and the `.catch(() => null)` arm
+    // yields a null the schema then rejects — the same 400, exercised through the parse-failure path.
+    for (const body of [JSON.stringify({}), JSON.stringify({ repoFullName: "x" }), JSON.stringify({ repoFullName: "acme/widgets", labels: [""] }), "not json{"]) {
+      const response = await app.request(
+        "/v1/contributors/miner1/watches",
+        { method: "POST", headers: jsonHeaders(env), body },
+        env,
+      );
+      expect(response.status, body).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: "invalid_watch_request" });
+    }
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request("/v1/contributors/miner1/watches", { method: "POST" }, env);
+    expect(response.status).toBeGreaterThanOrEqual(401);
+    expect(response.status).toBeLessThan(404);
+  });
+
+  it("403s the shared mcp token unless fully unscoped (#2455 parity with the MCP surface)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "POST", headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+});
+
+describe("DELETE /v1/contributors/:login/watches (#6746)", () => {
+  it("unwatches a repo and reports it was removed", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedPublicRepo(env, "acme/widgets");
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: ["bug"] });
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: jsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [], changed: "unwatched acme/widgets" });
+  });
+
+  it("reports 'was not watching' when there was no subscription", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await seedPublicRepo(env, "acme/widgets");
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: jsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ watching: [], changed: "was not watching acme/widgets" });
+  });
+
+  it("403s a repo the contributor cannot watch (untracked → fail-closed)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: jsonHeaders(env), body: JSON.stringify({ repoFullName: "acme/unknown" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_repo" });
+  });
+
+  it("rejects a malformed or non-JSON body with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    for (const body of [JSON.stringify({}), "not json{"]) {
+      const response = await app.request(
+        "/v1/contributors/miner1/watches",
+        { method: "DELETE", headers: jsonHeaders(env), body },
+        env,
+      );
+      expect(response.status, body).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: "invalid_watch_request" });
+    }
+  });
+
+  it("403s the shared mcp token unless fully unscoped (#2455 parity with the MCP surface)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" });
+    const response = await app.request(
+      "/v1/contributors/miner1/watches",
+      { method: "DELETE", headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ repoFullName: "acme/widgets" }) },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden_contributor" });
+  });
+});
+
+describe("watches REST/MCP surface parity (#6746)", () => {
+  it("GET returns the same {watching} the loopover_watch_issues list action returns", async () => {
+    const env = createTestEnv();
+    await upsertIssueWatchSubscription(env, { login: "miner1", repoFullName: "acme/widgets", labels: ["bug"] });
+    const app = createApp();
+    const restBody = await (await app.request("/v1/contributors/miner1/watches", { headers: apiHeaders(env) }, env)).json();
+    const client = await connectMcp(env);
+    const viaTool = await client.callTool({ name: "loopover_watch_issues", arguments: { login: "miner1", action: "list" } });
+    expect((viaTool as { structuredContent?: unknown }).structuredContent).toEqual(restBody);
+  });
+
+  it("POST returns the same {watching,changed} the watch action returns", async () => {
+    const restEnv = createTestEnv();
+    await seedPublicRepo(restEnv, "acme/widgets");
+    const app = createApp();
+    const restBody = await (
+      await app.request(
+        "/v1/contributors/miner1/watches",
+        { method: "POST", headers: jsonHeaders(restEnv), body: JSON.stringify({ repoFullName: "acme/widgets", labels: ["bug"] }) },
+        restEnv,
+      )
+    ).json();
+
+    const toolEnv = createTestEnv();
+    await seedPublicRepo(toolEnv, "acme/widgets");
+    const client = await connectMcp(toolEnv);
+    const viaTool = await client.callTool({ name: "loopover_watch_issues", arguments: { login: "miner1", action: "watch", repoFullName: "acme/widgets", labels: ["bug"] } });
+    expect((viaTool as { structuredContent?: unknown }).structuredContent).toEqual(restBody);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -174,6 +174,7 @@ export async function startFixtureServer(
     prTextLintStatus?: number;
     onPacketRequest?: (body: unknown) => void;
     onIssueDraftRequest?: (body: { dryRun?: boolean; create?: boolean; limit?: number }) => void;
+    onWatchRequest?: (req: { method: string; body: { repoFullName?: string; labels?: string[] } }) => void;
     onApiRequest?: (request: IncomingMessage) => void;
     validateConfigWarnings?: string[];
     openPrMonitor?: Record<string, unknown>;
@@ -314,6 +315,24 @@ export async function startFixtureServer(
           summary: "3 registered repos; 12 merged PRs; strongest in review-tooling.",
         }),
       );
+      return;
+    }
+    // #6746: GET/POST/DELETE /v1/contributors/:login/watches. GET returns a fixed list; POST/DELETE reflect the
+    // forwarded {repoFullName, labels} so the CLI test can assert the exact body + verb it sent.
+    const watchesMatch = /^\/v1\/contributors\/([^/]+)\/watches$/.exec(new URL(request.url ?? "/", "http://localhost").pathname);
+    if (watchesMatch && (request.method === "GET" || request.method === "POST" || request.method === "DELETE")) {
+      if (request.method === "GET") {
+        response.end(JSON.stringify({ watching: [{ repoFullName: "acme/widgets", labels: ["bug"] }, { repoFullName: "acme/gadgets", labels: [] }] }));
+        return;
+      }
+      const requestBody = (await readJsonRequest(request)) as { repoFullName?: string; labels?: string[] };
+      options.onWatchRequest?.({ method: request.method, body: requestBody });
+      if (request.method === "POST") {
+        const labelSuffix = requestBody.labels && requestBody.labels.length > 0 ? ` (labels: ${requestBody.labels.join(", ")})` : "";
+        response.end(JSON.stringify({ watching: [{ repoFullName: requestBody.repoFullName, labels: requestBody.labels ?? [] }], changed: `watching ${requestBody.repoFullName}${labelSuffix}` }));
+      } else {
+        response.end(JSON.stringify({ watching: [], changed: `unwatched ${requestBody.repoFullName}` }));
+      }
       return;
     }
     if (request.url === "/v1/contributors/JSONbored/open-pr-monitor" && request.method === "GET") {


### PR DESCRIPTION
## What

The `loopover_watch_issues` MCP tool managed issue-watch subscriptions, but there was no REST route and no CLI mirror. This adds both.

## How

- **`GET/POST/DELETE /v1/contributors/:login/watches`** in `src/api/routes.ts`. The MCP tool's `action` enum splits across the HTTP verbs: **GET = list, POST = watch, DELETE = unwatch**. Every verb self-scopes via `requireContributorAccess`, and the two mutating verbs reuse **`canWatchRepo`** — the exact gate `requireWatchableRepo` applies inside the MCP tool. All three reuse the existing `upsert`/`delete`/`listIssueWatchSubscriptionsForLogin` functions.
- **`loopover-mcp watch <list|add|remove> [owner/repo] [--labels a,b]`** in `packages/loopover-mcp/bin/loopover-mcp.js`, hitting the REST routes (a new `apiDelete` helper covers the unwatch verb). Login resolves from `--login`, the active session, `LOOPOVER_LOGIN`, then `GITHUB_LOGIN`, like the other contributor-scoped commands. API-chosen text is sanitized on the plain-text path (#6261).

The `POST`/`DELETE` bodies mirror `watchIssuesShape` minus `login` (the path param) and `action` (the verb).

## Testing

- **`test/unit/routes-watches.test.ts`** (new, 17 cases): list / empty / watch / no-label-suffix / unwatch / "was not watching" / `canWatchRepo` 403 (untracked → fail-closed) / malformed + non-JSON body 400 / unauthenticated / shared-mcp-token 403 for each verb, and **surface parity** — GET equals the tool's `list` action and POST equals its `watch` action (`structuredContent === restBody`).
- **`test/unit/mcp-cli-watch.test.ts`** (new, 8 cases): list (plain + json, asserting `GET`), add forwarding `{repoFullName, labels}` via `POST`, add-without-labels omitting the field, remove via `DELETE`, login resolution + URL-encoding, and the three error paths (missing repo, no login, unknown subcommand).

**Regression proven, not assumed**: against un-fixed `routes.ts`, 15 of the 17 route cases fail (the 2 survivors are auth-middleware checks independent of the route). **Patch coverage measured**: every changed line and branch in `src/api/routes.ts` is covered — 0 uncovered statements, 0 uncovered branches (`packages/loopover-mcp/bin/**` is outside `vitest.config.ts`'s coverage scope, so the CLI is exercised for correctness rather than the gate).

Green locally at this base (`1bd3d5f`): `typecheck`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `command-reference:check`, `docs:drift-check`, `manifest:drift-check`, `ui:openapi:settings-parity`, plus the full blast radius of 44 test files (349 tests) touching the changed symbols.

Resubmit of #7151 (auto-closed on `ui:version-audit`, a main-wide external-registry drift — the @loopover/mcp npm package published 3.2.3 while main's MCP_PACKAGE_KNOWN_LATEST_VERSION still said 3.2.2; unrelated to this diff, which never touches mcp-package.ts). Main's constant has since caught up to 3.2.3, so the audit now passes.

Closes #6746
