### PR TITLE
fix(miner-ui): show typing indicator until the first chat SSE chunk (#7078)

### DIFF
--- a/apps/loopover-miner-ui/docs/7078-typing-indicator-before-after.svg
+++ b/apps/loopover-miner-ui/docs/7078-typing-indicator-before-after.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-label="Before and after typing indicator">
+  <rect width="960" height="420" fill="#1a1d21"/>
+  <text x="240" y="36" text-anchor="middle" fill="#9aa3ad" font-family="ui-monospace, monospace" font-size="14">BEFORE (#7078)</text>
+  <text x="720" y="36" text-anchor="middle" fill="#9aa3ad" font-family="ui-monospace, monospace" font-size="14">AFTER</text>
+  <rect x="40" y="56" width="400" height="300" rx="8" fill="#23272c" stroke="#3a4149"/>
+  <rect x="520" y="56" width="400" height="300" rx="8" fill="#23272c" stroke="#3a4149"/>
+  <rect x="64" y="88" width="220" height="44" rx="6" fill="#2f6fed"/>
+  <text x="76" y="115" fill="#fff" font-family="system-ui, sans-serif" font-size="14">what is stuck?</text>
+  <text x="64" y="180" fill="#6b7280" font-family="system-ui, sans-serif" font-size="13">no activity signal</text>
+  <rect x="64" y="300" width="352" height="36" rx="6" fill="#2a2f35" stroke="#3a4149"/>
+  <text x="76" y="323" fill="#6b7280" font-family="system-ui, sans-serif" font-size="12">composer disabled&</text>
+  <rect x="544" y="88" width="220" height="44" rx="6" fill="#2f6fed"/>
+  <text x="556" y="115" fill="#fff" font-family="system-ui, sans-serif" font-size="14">what is stuck?</text>
+  <rect x="544" y="160" width="200" height="36" rx="6" fill="#2a2f35"/>
+  <text x="556" y="183" fill="#c5cdd6" font-family="system-ui, sans-serif" font-size="13">Assistant is typing&</text>
+  <circle cx="760" cy="178" r="3" fill="#8b949e"/>
+  <circle cx="770" cy="178" r="3" fill="#8b949e"/>
+  <circle cx="780" cy="178" r="3" fill="#8b949e"/>
+  <rect x="544" y="300" width="352" height="36" rx="6" fill="#2a2f35" stroke="#3a4149"/>
+  <text x="556" y="323" fill="#6b7280" font-family="system-ui, sans-serif" font-size="12">composer disabled&</text>
+</svg>

--- a/apps/loopover-miner-ui/src/chat-conversation.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-conversation.test.tsx
@@ -75,4 +75,24 @@ describe("ChatConversation (#6518)", () => {
     await waitFor(() => expect(screen.getByText(/Couldn't load the conversation/i)).toBeTruthy());
     expect(sendButton().disabled).toBe(false);
   });
+
+  it("REGRESSION (#7078): shows the typing indicator after submit until the first streamed chunk, then clears it", async () => {
+    const gate = deferred();
+    const streamChatImpl = async function* (_messages: ChatWireMessage[]) {
+      // Hold the stream open with no text so the pre-first-chunk composing window is observable.
+      await gate.promise;
+      yield "Hello";
+    };
+    render(<ChatConversation streamChatImpl={streamChatImpl} />);
+    ask("what is stuck?");
+
+    await waitFor(() => expect(screen.getByRole("status", { name: /is typing/i })).toBeTruthy());
+    expect(screen.getByText("what is stuck?")).toBeTruthy();
+    expect(sendButton().disabled).toBe(true);
+
+    gate.resolve();
+
+    await waitFor(() => expect(screen.getByText("Hello")).toBeTruthy());
+    expect(screen.queryByRole("status", { name: /is typing/i })).toBeNull();
+  });
 });

--- a/apps/loopover-miner-ui/src/components/chat/conversation.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/conversation.tsx
@@ -25,6 +25,9 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [activeSource, setActiveSource] = useState<ChunkSource | null>(null);
   const [streaming, setStreaming] = useState(false);
+  // #7078: true from submit until the first SSE text chunk — drives MessageList's TypingIndicator so the
+  // pre-first-token round-trip isn't a silent gap. Cleared on first chunk, stream completion, or error.
+  const [awaitingFirstChunk, setAwaitingFirstChunk] = useState(false);
   const [errored, setErrored] = useState(false);
   const idCounter = useRef(0);
   const nextId = () => `m${(idCounter.current += 1)}`;
@@ -44,6 +47,7 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
 
       setMessages((prev) => [...prev, userMessage]);
       setErrored(false);
+      setAwaitingFirstChunk(true);
       setStreaming(true);
 
       // This source both feeds the live StreamingText render AND, on natural completion, commits the finished
@@ -54,8 +58,14 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
       const source: ChunkSource = () =>
         (async function* () {
           let answer = "";
+          let sawFirstChunk = false;
           try {
             for await (const delta of streamChatImpl(history)) {
+              if (!sawFirstChunk) {
+                sawFirstChunk = true;
+                // Drop the typing indicator before StreamingText paints real content — they must not overlap.
+                setAwaitingFirstChunk(false);
+              }
               answer += delta;
               yield delta;
             }
@@ -72,6 +82,7 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
           } catch {
             setErrored(true);
           } finally {
+            setAwaitingFirstChunk(false);
             setStreaming(false);
             setActiveSource(null);
           }
@@ -88,7 +99,7 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
     <div className="flex h-full flex-col gap-2 p-4">
       <p className="font-mono text-token-xs uppercase tracking-[0.2em] text-primary">Chat</p>
       <div className="min-h-0 flex-1 overflow-hidden">
-        <MessageList messages={messages} isError={errored} />
+        <MessageList messages={messages} isError={errored} composing={streaming && awaitingFirstChunk} />
         {streaming && activeSource ? (
           <div className="flex gap-3 px-3 pt-4" data-testid="chat-streaming-response">
             <Avatar className="size-8 shrink-0">


### PR DESCRIPTION
## Summary
- Wire `ChatConversation` to pass `composing` into `MessageList` for the window between submit and the first SSE text chunk.
- Clear the indicator on first chunk, stream completion, or error so it never overlaps real `StreamingText` content.
- Add a gated-stream regression test for the pre-first-chunk typing window.
- Replaces closed #7155 (that PR bundled a binary PNG that blocked secret scanning).

Closes #7078

## UI before / after
![Typing indicator before/after](../apps/loopover-miner-ui/docs/7078-typing-indicator-before-after.svg)

Direct: https://raw.githubusercontent.com/RealDiligent/gittensory/feat/chat-typing-indicator-7078-v2/apps/loopover-miner-ui/docs/7078-typing-indicator-before-after.svg

## Test plan
- [ ] miner-ui `ChatConversation` regression (#7078) passes
- [ ] Submit a chat message: typing indicator appears immediately, then clears on first streamed token
- [ ] Indicator also clears on stream error
