### PR TITLE
fix(miner-ui): key run-history rows by forge host and repo (#7080)

### DIFF
--- a/apps/loopover-miner-ui/docs/7080-run-history-forge-before-after.svg
+++ b/apps/loopover-miner-ui/docs/7080-run-history-forge-before-after.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="360" viewBox="0 0 980 360" role="img" aria-label="Run history before and after forge column">
+  <rect width="980" height="360" fill="#1a1d21"/>
+  <text x="230" y="32" text-anchor="middle" fill="#9aa3ad" font-family="ui-monospace, monospace" font-size="13">BEFORE  duplicate keys</text>
+  <text x="750" y="32" text-anchor="middle" fill="#9aa3ad" font-family="ui-monospace, monospace" font-size="13">AFTER (#7080)</text>
+  <rect x="30" y="50" width="400" height="280" rx="8" fill="#23272c" stroke="#3a4149"/>
+  <rect x="550" y="50" width="400" height="280" rx="8" fill="#23272c" stroke="#3a4149"/>
+  <text x="48" y="78" fill="#8b949e" font-family="ui-monospace, monospace" font-size="12">Repository · State · Updated</text>
+  <text x="48" y="118" fill="#e6edf3" font-family="ui-monospace, monospace" font-size="13">acme/widgets   preparing</text>
+  <text x="48" y="150" fill="#6b7280" font-family="system-ui, sans-serif" font-size="12">second forge row dropped / conflated</text>
+  <text x="568" y="78" fill="#8b949e" font-family="ui-monospace, monospace" font-size="12">Repository · Forge · State · Updated</text>
+  <text x="568" y="118" fill="#e6edf3" font-family="ui-monospace, monospace" font-size="13">acme/widgets</text>
+  <text x="700" y="118" fill="#79c0ff" font-family="ui-monospace, monospace" font-size="12">api.github.com</text>
+  <text x="568" y="148" fill="#e6edf3" font-family="ui-monospace, monospace" font-size="13">acme/widgets</text>
+  <text x="700" y="148" fill="#79c0ff" font-family="ui-monospace, monospace" font-size="12">github.example.corp</text>
+  <text x="568" y="190" fill="#8b949e" font-family="system-ui, sans-serif" font-size="12">both forge hosts visible and keyed</text>
+</svg>

--- a/apps/loopover-miner-ui/src/app.test.tsx
+++ b/apps/loopover-miner-ui/src/app.test.tsx
@@ -9,8 +9,18 @@ import { IndexPage, OverviewView } from "./routes/index";
 const runsOk: RunHistoryResult = {
   ok: true,
   rows: [
-    { repoFullName: "acme/widgets", state: "discovering", updatedAt: "2026-07-10T06:00:00.000Z" },
-    { repoFullName: "acme/gadgets", state: "idle", updatedAt: "2026-07-10T05:00:00.000Z" },
+    {
+      apiBaseUrl: "https://api.github.com",
+      repoFullName: "acme/widgets",
+      state: "discovering",
+      updatedAt: "2026-07-10T06:00:00.000Z",
+    },
+    {
+      apiBaseUrl: "https://api.github.com",
+      repoFullName: "acme/gadgets",
+      state: "idle",
+      updatedAt: "2026-07-10T05:00:00.000Z",
+    },
   ],
 };
 const portfolioOk: PortfolioQueueResult = {

--- a/apps/loopover-miner-ui/src/lib/run-history.ts
+++ b/apps/loopover-miner-ui/src/lib/run-history.ts
@@ -7,6 +7,8 @@ export const RUN_STATE_API_PATH = "/api/run-state";
 
 /** One `miner_run_state` row as served by the local API — mirrors `run-state.js`'s row shape. */
 export type RunStateRow = {
+  /** Forge API origin; part of the store's primary key alongside `repoFullName` (#7080). */
+  apiBaseUrl: string;
   repoFullName: string;
   state: "idle" | "discovering" | "planning" | "preparing";
   updatedAt: string;
@@ -18,10 +20,26 @@ function isRunStateRow(value: unknown): value is RunStateRow {
   if (typeof value !== "object" || value === null) return false;
   const row = value as Record<string, unknown>;
   return (
+    typeof row.apiBaseUrl === "string" &&
     typeof row.repoFullName === "string" &&
     typeof row.updatedAt === "string" &&
     (row.state === "idle" || row.state === "discovering" || row.state === "planning" || row.state === "preparing")
   );
+}
+
+/** Host label for the Forge column — prefers URL hostname, falls back to the raw apiBaseUrl. (#7080) */
+export function forgeHostLabel(apiBaseUrl: string): string {
+  try {
+    const host = new URL(apiBaseUrl).host;
+    return host || apiBaseUrl;
+  } catch {
+    return apiBaseUrl;
+  }
+}
+
+/** Stable React key / identity for a run-state row across forge hosts. (#7080) */
+export function runStateRowKey(row: Pick<RunStateRow, "apiBaseUrl" | "repoFullName">): string {
+  return `${row.apiBaseUrl}\0${row.repoFullName}`;
 }
 
 /** Fetch the local run-state rows. Failures (server down, malformed payload) surface as a typed error result —

--- a/apps/loopover-miner-ui/src/routes/run-history.tsx
+++ b/apps/loopover-miner-ui/src/routes/run-history.tsx
@@ -16,7 +16,13 @@ import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
 
 import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
-import { fetchRunStates, forgeHostLabel, runStateRowKey, type RunHistoryResult, type RunStateRow } from "../lib/run-history";
+import {
+  fetchRunStates,
+  forgeHostLabel,
+  runStateRowKey,
+  type RunHistoryResult,
+  type RunStateRow,
+} from "../lib/run-history";
 
 export const Route = createFileRoute("/run-history")({
   component: RunHistoryPage,

--- a/apps/loopover-miner-ui/src/routes/run-history.tsx
+++ b/apps/loopover-miner-ui/src/routes/run-history.tsx
@@ -16,20 +16,22 @@ import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@loopover/ui-kit/components/table";
 
 import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
-import { fetchRunStates, type RunHistoryResult, type RunStateRow } from "../lib/run-history";
+import { fetchRunStates, forgeHostLabel, runStateRowKey, type RunHistoryResult, type RunStateRow } from "../lib/run-history";
 
 export const Route = createFileRoute("/run-history")({
   component: RunHistoryPage,
 });
 
-// Read-only run-history table (#4305): one row per repo from the local `miner_run_state` store (repo, state,
-// last-updated), served by the dev server's local API. No writes, no new state.
+// Read-only run-history table (#4305): one row per (forge, repo) from the local `miner_run_state` store,
+// served by the dev server's local API. No writes, no new state.
 //
 // #6510: the hand-rolled loading/error/empty `<p>` branches are replaced by the shared @loopover/ui-kit
 // `StateBoundary`, with a content-shaped `Skeleton` table for the loading state (so the layout doesn't jump when
 // the poll resolves), and the table paginates client-side once it exceeds PAGE_SIZE rows via the kit's
-// `Pagination`. Purely presentational — `lib/run-history.ts`'s fetch/poll is untouched, and the
-// Repository/State/Last-updated columns + data shown are unchanged.
+// `Pagination`. Purely presentational — `lib/run-history.ts`'s fetch/poll is untouched.
+//
+// #7080: rows are keyed and labeled by (apiBaseUrl, repoFullName) so the same owner/repo on two forge hosts
+// never collides or looks identical.
 
 const STATE_BADGE_VARIANT: Record<RunStateRow["state"], "secondary" | "outline"> = {
   idle: "secondary",
@@ -41,7 +43,7 @@ const STATE_BADGE_VARIANT: Record<RunStateRow["state"], "secondary" | "outline">
 /** Rows per page once the run-state table grows past this; below it the full table renders unpaginated. */
 const PAGE_SIZE = 20;
 
-const TABLE_COLUMNS = ["Repository", "State", "Last updated"] as const;
+const TABLE_COLUMNS = ["Repository", "Forge", "State", "Last updated"] as const;
 
 function RunHistoryTableHeader() {
   return (
@@ -70,6 +72,9 @@ function RunHistorySkeleton({ rows = 5 }: { rows?: number }) {
                 <Skeleton className="h-4 w-48" />
               </TableCell>
               <TableCell>
+                <Skeleton className="h-4 w-36" />
+              </TableCell>
+              <TableCell>
                 <Skeleton className="h-5 w-20" />
               </TableCell>
               <TableCell>
@@ -89,8 +94,9 @@ function RunStateTable({ rows }: { rows: RunStateRow[] }) {
       <RunHistoryTableHeader />
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.repoFullName}>
+          <TableRow key={runStateRowKey(row)}>
             <TableCell className="font-mono text-foreground">{row.repoFullName}</TableCell>
+            <TableCell className="font-mono text-muted-foreground">{forgeHostLabel(row.apiBaseUrl)}</TableCell>
             <TableCell>
               <Badge variant={STATE_BADGE_VARIANT[row.state]}>{row.state}</Badge>
             </TableCell>

--- a/apps/loopover-miner-ui/src/run-history.test.tsx
+++ b/apps/loopover-miner-ui/src/run-history.test.tsx
@@ -1,16 +1,34 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fetchRunStates, RUN_STATE_API_PATH, type RunHistoryResult, type RunStateRow } from "./lib/run-history";
+import {
+  fetchRunStates,
+  forgeHostLabel,
+  RUN_STATE_API_PATH,
+  runStateRowKey,
+  type RunHistoryResult,
+  type RunStateRow,
+} from "./lib/run-history";
 import { RunHistoryPage, RunHistoryView } from "./routes/run-history";
 
 const fixtureRows: RunStateRow[] = [
-  { repoFullName: "acme/widgets", state: "preparing", updatedAt: "2026-07-10T06:00:00.000Z" },
-  { repoFullName: "acme/gadgets", state: "idle", updatedAt: "2026-07-10T05:00:00.000Z" },
+  {
+    apiBaseUrl: "https://api.github.com",
+    repoFullName: "acme/widgets",
+    state: "preparing",
+    updatedAt: "2026-07-10T06:00:00.000Z",
+  },
+  {
+    apiBaseUrl: "https://api.github.com",
+    repoFullName: "acme/gadgets",
+    state: "idle",
+    updatedAt: "2026-07-10T05:00:00.000Z",
+  },
 ];
 
 function manyRows(count: number): RunStateRow[] {
   return Array.from({ length: count }, (_, index) => ({
+    apiBaseUrl: "https://api.github.com",
     repoFullName: `acme/repo-${index}`,
     state: "idle" as const,
     updatedAt: "2026-07-10T05:00:00.000Z",
@@ -18,14 +36,38 @@ function manyRows(count: number): RunStateRow[] {
 }
 
 describe("RunHistoryView (#4305, redesigned #6510)", () => {
-  it("renders one table row per run-state fixture row with repo, state badge, and last-updated", () => {
+  it("renders one table row per run-state fixture row with repo, forge, state badge, and last-updated", () => {
     render(<RunHistoryView result={{ ok: true, rows: fixtureRows }} />);
     expect(screen.getByRole("columnheader", { name: "Repository" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Forge" })).toBeTruthy();
     expect(screen.getByText("acme/widgets")).toBeTruthy();
+    expect(screen.getAllByText("api.github.com")).toHaveLength(2);
     expect(screen.getByText("preparing")).toBeTruthy();
     expect(screen.getByText("acme/gadgets")).toBeTruthy();
     expect(screen.getByText("2026-07-10T05:00:00.000Z")).toBeTruthy();
     expect(screen.getAllByRole("row")).toHaveLength(3); // header + 2 fixture rows
+  });
+
+  it("REGRESSION (#7080): same repoFullName on two forge hosts renders as two distinct, labeled rows", () => {
+    const colliding: RunStateRow[] = [
+      {
+        apiBaseUrl: "https://api.github.com",
+        repoFullName: "acme/widgets",
+        state: "preparing",
+        updatedAt: "2026-07-10T06:00:00.000Z",
+      },
+      {
+        apiBaseUrl: "https://github.example.corp/api/v3",
+        repoFullName: "acme/widgets",
+        state: "idle",
+        updatedAt: "2026-07-10T05:00:00.000Z",
+      },
+    ];
+    render(<RunHistoryView result={{ ok: true, rows: colliding }} />);
+    expect(screen.getAllByText("acme/widgets")).toHaveLength(2);
+    expect(screen.getByText("api.github.com")).toBeTruthy();
+    expect(screen.getByText("github.example.corp")).toBeTruthy();
+    expect(screen.getAllByRole("row")).toHaveLength(3); // header + both forge rows
   });
 
   it("renders a content-shaped loading skeleton (role=status), not the old flat loading text (#6510)", () => {
@@ -122,7 +164,15 @@ describe("fetchRunStates (#4305)", () => {
     ).toMatchObject({ ok: false });
     expect(
       await fetchRunStates(async () =>
-        jsonResponse(200, { rows: [{ repoFullName: "a/b", state: "warp", updatedAt: "t" }] }),
+        jsonResponse(200, {
+          rows: [{ apiBaseUrl: "https://api.github.com", repoFullName: "a/b", state: "warp", updatedAt: "t" }],
+        }),
+      ),
+    ).toMatchObject({ ok: false });
+    // #7080: rows missing apiBaseUrl are rejected so the UI never silently drops forge identity.
+    expect(
+      await fetchRunStates(async () =>
+        jsonResponse(200, { rows: [{ repoFullName: "a/b", state: "idle", updatedAt: "t" }] }),
       ),
     ).toMatchObject({ ok: false });
   });
@@ -132,5 +182,16 @@ describe("fetchRunStates (#4305)", () => {
       throw new Error("connection refused");
     });
     expect(result).toEqual({ ok: false, error: "connection refused" });
+  });
+});
+
+describe("forgeHostLabel / runStateRowKey (#7080)", () => {
+  it("extracts the URL host and builds a composite row key", () => {
+    expect(forgeHostLabel("https://api.github.com")).toBe("api.github.com");
+    expect(forgeHostLabel("https://github.example.corp/api/v3")).toBe("github.example.corp");
+    expect(forgeHostLabel("not-a-url")).toBe("not-a-url");
+    expect(
+      runStateRowKey({ apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets" }),
+    ).toBe("https://api.github.com\0acme/widgets");
   });
 });

--- a/apps/loopover-miner-ui/src/run-history.test.tsx
+++ b/apps/loopover-miner-ui/src/run-history.test.tsx
@@ -190,8 +190,8 @@ describe("forgeHostLabel / runStateRowKey (#7080)", () => {
     expect(forgeHostLabel("https://api.github.com")).toBe("api.github.com");
     expect(forgeHostLabel("https://github.example.corp/api/v3")).toBe("github.example.corp");
     expect(forgeHostLabel("not-a-url")).toBe("not-a-url");
-    expect(
-      runStateRowKey({ apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets" }),
-    ).toBe("https://api.github.com\0acme/widgets");
+    expect(runStateRowKey({ apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets" })).toBe(
+      "https://api.github.com\0acme/widgets",
+    );
   });
 });

--- a/apps/loopover-miner-ui/src/run-state-api.test.ts
+++ b/apps/loopover-miner-ui/src/run-state-api.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { handleRunStateRequest, type RunStateApiDeps } from "../vite-run-state-api";
 
-const rows = [{ repoFullName: "acme/widgets", state: "idle", updatedAt: "2026-07-10T06:00:00.000Z" }];
+const rows = [
+  { apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets", state: "idle", updatedAt: "2026-07-10T06:00:00.000Z" },
+];
 
 function deps(overrides: Partial<RunStateApiDeps> = {}): RunStateApiDeps {
   return {

--- a/apps/loopover-miner-ui/src/run-state-api.test.ts
+++ b/apps/loopover-miner-ui/src/run-state-api.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import { handleRunStateRequest, type RunStateApiDeps } from "../vite-run-state-api";
 
 const rows = [
-  { apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets", state: "idle", updatedAt: "2026-07-10T06:00:00.000Z" },
+  {
+    apiBaseUrl: "https://api.github.com",
+    repoFullName: "acme/widgets",
+    state: "idle",
+    updatedAt: "2026-07-10T06:00:00.000Z",
+  },
 ];
 
 function deps(overrides: Partial<RunStateApiDeps> = {}): RunStateApiDeps {

--- a/apps/loopover-miner-ui/vite-run-state-api.ts
+++ b/apps/loopover-miner-ui/vite-run-state-api.ts
@@ -12,7 +12,9 @@ import type { Plugin } from "vite";
 
 type RunStateModule = {
   resolveRunStateDbPath: () => string;
-  listRunStates: () => Array<{ repoFullName: string; state: string; updatedAt: string }>;
+  // #7080: include apiBaseUrl — listRunStates already returns it so same owner/repo on different forge hosts
+  // stay distinct end-to-end (the UI used to drop the field at this type boundary).
+  listRunStates: () => Array<{ apiBaseUrl: string; repoFullName: string; state: string; updatedAt: string }>;
 };
 
 export type RunStateApiDeps = {


### PR DESCRIPTION
## Summary
- Plumb `apiBaseUrl` through the Vite run-state module type, client `RunStateRow`, and `isRunStateRow` validator.
- Key run-history table rows on `(apiBaseUrl, repoFullName)` and add a Forge column so same-named repos on different hosts stay distinct.
- Add regression coverage for colliding `repoFullName`s across forges.

Closes #7080

## UI before / after
https://raw.githubusercontent.com/RealDiligent/gittensory/feat/run-history-forge-host-7080/apps/loopover-miner-ui/docs/7080-run-history-forge-before-after.svg

## Test plan
- [ ] miner-ui run-history / run-state-api / app tests pass
- [ ] Two `acme/widgets` rows on github.com vs GHE both render with distinct Forge labels
- [ ] Rows missing `apiBaseUrl` are rejected by `fetchRunStates`
