### PR TITLE
fix(miner-ui): preserve chat history and partial answers on stream errors (#7077)

### DIFF
--- a/apps/loopover-miner-ui/docs/7077-chat-error-preserve-before-after.svg
+++ b/apps/loopover-miner-ui/docs/7077-chat-error-preserve-before-after.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="360" viewBox="0 0 980 360" role="img" aria-label="Chat error before and after preserving history">
+  <rect width="980" height="360" fill="#1a1d21"/>
+  <text x="230" y="32" text-anchor="middle" fill="#9aa3ad" font-family="ui-monospace, monospace" font-size="13">BEFORE  full wipe</text>
+  <text x="750" y="32" text-anchor="middle" fill="#9aa3ad" font-family="ui-monospace, monospace" font-size="13">AFTER (#7077)</text>
+  <rect x="30" y="50" width="400" height="280" rx="8" fill="#23272c" stroke="#3a4149"/>
+  <rect x="550" y="50" width="400" height="280" rx="8" fill="#23272c" stroke="#3a4149"/>
+  <text x="50" y="120" fill="#f85149" font-family="system-ui, sans-serif" font-size="14">Couldn't load the conversation</text>
+  <text x="50" y="150" fill="#6b7280" font-family="system-ui, sans-serif" font-size="12">prior turns replaced by ErrorState</text>
+  <text x="570" y="100" fill="#e6edf3" font-family="system-ui, sans-serif" font-size="13">first question</text>
+  <text x="570" y="130" fill="#c9d1d9" font-family="system-ui, sans-serif" font-size="13">first answer</text>
+  <text x="570" y="170" fill="#e6edf3" font-family="system-ui, sans-serif" font-size="13">second question</text>
+  <text x="570" y="200" fill="#c9d1d9" font-family="system-ui, sans-serif" font-size="13">Hel</text>
+  <text x="570" y="240" fill="#d2a8ff" font-family="system-ui, sans-serif" font-size="12">The latest response failed&</text>
+  <text x="570" y="280" fill="#8b949e" font-family="system-ui, sans-serif" font-size="12">history + partial answer kept</text>
+</svg>

--- a/apps/loopover-miner-ui/src/chat-conversation.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-conversation.test.tsx
@@ -64,7 +64,7 @@ describe("ChatConversation (#6518)", () => {
     expect(screen.getByText("Hello")).toBeTruthy();
   });
 
-  it("surfaces a backend failure through the message-list error state and re-enables the composer", async () => {
+  it("surfaces a backend failure as an inline system note and re-enables the composer (#7077)", async () => {
     const streamChatImpl = async function* (_messages: ChatWireMessage[]): AsyncGenerator<string> {
       yield* []; // yields nothing, then fails — models a backend/stream error mid-request
       throw new Error("connection refused");
@@ -72,7 +72,9 @@ describe("ChatConversation (#6518)", () => {
     render(<ChatConversation streamChatImpl={streamChatImpl} />);
     ask("hi");
 
-    await waitFor(() => expect(screen.getByText(/Couldn't load the conversation/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/latest response failed to complete/i)).toBeTruthy());
+    expect(screen.getByText("hi")).toBeTruthy();
+    expect(screen.queryByText(/Couldn't load the conversation/i)).toBeNull();
     expect(sendButton().disabled).toBe(false);
   });
 
@@ -94,5 +96,42 @@ describe("ChatConversation (#6518)", () => {
 
     await waitFor(() => expect(screen.getByText("Hello")).toBeTruthy());
     expect(screen.queryByRole("status", { name: /is typing/i })).toBeNull();
+  });
+
+  it("REGRESSION (#7077): a second-turn failure leaves the first successful turn visible", async () => {
+    let calls = 0;
+    const streamChatImpl = async function* (_messages: ChatWireMessage[]): AsyncGenerator<string> {
+      calls += 1;
+      if (calls === 1) {
+        yield "first answer";
+        return;
+      }
+      throw new Error("connection refused");
+    };
+    render(<ChatConversation streamChatImpl={streamChatImpl} />);
+    ask("first question");
+    await waitFor(() => expect(screen.getByText("first answer")).toBeTruthy());
+
+    ask("second question");
+    await waitFor(() => expect(screen.getByText(/latest response failed to complete/i)).toBeTruthy());
+    expect(screen.getByText("first question")).toBeTruthy();
+    expect(screen.getByText("first answer")).toBeTruthy();
+    expect(screen.getByText("second question")).toBeTruthy();
+    expect(screen.queryByText(/Couldn't load the conversation/i)).toBeNull();
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("REGRESSION (#7077): partial streamed text is preserved after a mid-stream failure", async () => {
+    const streamChatImpl = async function* (_messages: ChatWireMessage[]): AsyncGenerator<string> {
+      yield "Hel";
+      throw new Error("connection reset");
+    };
+    render(<ChatConversation streamChatImpl={streamChatImpl} />);
+    ask("hi");
+
+    await waitFor(() => expect(sendButton().disabled).toBe(false));
+    expect(screen.getByText("Hel")).toBeTruthy();
+    expect(screen.getByText(/latest response failed to complete/i)).toBeTruthy();
+    expect(screen.queryByText(/Couldn't load the conversation/i)).toBeNull();
   });
 });

--- a/apps/loopover-miner-ui/src/components/chat/conversation.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/conversation.tsx
@@ -17,6 +17,9 @@ import { streamChat, type ChatWireMessage } from "@/lib/chat-stream";
 // separate, later, flag-gated issue.
 
 const ASSISTANT_NAME = "LoopOver";
+/** Inline failure note appended after a failed turn — keeps history visible instead of StateBoundary wipe (#7077). */
+const TURN_FAILED_MESSAGE =
+  "The latest response failed to complete. Any partial answer above is incomplete — you can try again.";
 
 /** Injectable so tests can drive the stream deterministically; defaults to the real `POST /api/chat` bridge. */
 export type StreamChatFn = (messages: ChatWireMessage[]) => AsyncIterable<string>;
@@ -28,7 +31,6 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
   // #7078: true from submit until the first SSE text chunk — drives MessageList's TypingIndicator so the
   // pre-first-token round-trip isn't a silent gap. Cleared on first chunk, stream completion, or error.
   const [awaitingFirstChunk, setAwaitingFirstChunk] = useState(false);
-  const [errored, setErrored] = useState(false);
   const idCounter = useRef(0);
   const nextId = () => `m${(idCounter.current += 1)}`;
 
@@ -46,7 +48,6 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
         .map((message) => ({ role: message.role, content: message.content }));
 
       setMessages((prev) => [...prev, userMessage]);
-      setErrored(false);
       setAwaitingFirstChunk(true);
       setStreaming(true);
 
@@ -80,7 +81,28 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
               },
             ]);
           } catch {
-            setErrored(true);
+            // #7077: never gate MessageList on isError (that replaces the whole history via StateBoundary).
+            // Commit any partial streamed text, then append an inline system failure note so prior turns stay.
+            const failedAt = new Date().toISOString();
+            setMessages((prev) => {
+              const next = [...prev];
+              if (answer.length > 0) {
+                next.push({
+                  id: nextId(),
+                  role: "assistant",
+                  content: answer,
+                  timestamp: failedAt,
+                  authorName: ASSISTANT_NAME,
+                });
+              }
+              next.push({
+                id: nextId(),
+                role: "system",
+                content: TURN_FAILED_MESSAGE,
+                timestamp: failedAt,
+              });
+              return next;
+            });
           } finally {
             setAwaitingFirstChunk(false);
             setStreaming(false);
@@ -99,7 +121,7 @@ export function ChatConversation({ streamChatImpl = streamChat }: { streamChatIm
     <div className="flex h-full flex-col gap-2 p-4">
       <p className="font-mono text-token-xs uppercase tracking-[0.2em] text-primary">Chat</p>
       <div className="min-h-0 flex-1 overflow-hidden">
-        <MessageList messages={messages} isError={errored} composing={streaming && awaitingFirstChunk} />
+        <MessageList messages={messages} composing={streaming && awaitingFirstChunk} />
         {streaming && activeSource ? (
           <div className="flex gap-3 px-3 pt-4" data-testid="chat-streaming-response">
             <Avatar className="size-8 shrink-0">


### PR DESCRIPTION
## Summary
- Stop gating `MessageList` on a conversation-wide `isError` flag (StateBoundary was wiping the entire thread).
- On stream failure, commit any partial assistant text and append an inline system failure note so prior turns stay visible.
- Add regressions for second-turn failure and mid-stream partial-text preservation.

Closes #7077

## UI before / after
https://raw.githubusercontent.com/RealDiligent/gittensory/feat/chat-error-preserve-history-7077/apps/loopover-miner-ui/docs/7077-chat-error-preserve-before-after.svg

## Test plan
- [ ] First-turn failure shows user message + inline system note (not StateBoundary wipe)
- [ ] After a successful turn, a failing second submit keeps the first turn in the DOM
- [ ] Mid-stream failure keeps yielded partial text after the composer re-enables
