### PR TITLE
fix(miner): serialize repo clones across processes with a lockfile (#7084)

### DIFF
--- a/packages/loopover-miner/lib/repo-clone.d.ts
+++ b/packages/loopover-miner/lib/repo-clone.d.ts
@@ -12,6 +12,26 @@ export type EnsureRepoClonedResult = { ok: boolean; repoPath: string; error?: st
 
 export type RunGitFn = (args: string[], cwd: string, timeoutMs: number) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
 
+export type RepoCloneLockOptions = {
+  lockTimeoutMs?: number;
+  lockStaleMs?: number;
+  lockPollMs?: number;
+  nowMs?: () => number;
+  lockSleep?: (ms: number) => Promise<unknown>;
+  isProcessAlive?: (pid: number) => boolean;
+  openLock?: (lockPath: string) => number;
+  writeLock?: (fd: number, data: string) => void;
+};
+
+export function isRepoCloneLockStale(
+  lockPath: string,
+  nowMs: number,
+  staleMs: number,
+  isAlive?: (pid: number) => boolean,
+): boolean;
+
+export function acquireRepoCloneLock(repoPath: string, options?: RepoCloneLockOptions): Promise<() => void>;
+
 export function ensureRepoCloned(
   repoFullName: string,
   options?: {
@@ -21,5 +41,5 @@ export function ensureRepoCloned(
     timeoutMs?: number;
     remoteUrl?: string;
     runGit?: RunGitFn;
-  },
+  } & RepoCloneLockOptions,
 ): Promise<EnsureRepoClonedResult>;

--- a/packages/loopover-miner/lib/repo-clone.js
+++ b/packages/loopover-miner/lib/repo-clone.js
@@ -1,8 +1,11 @@
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
+import { registerCleanupResource } from "./process-lifecycle.js";
+import { isProcessAlive } from "./worktree-allocator.js";
 
 // Per-repo base-clone cache (#5132, Wave 3.5 follow-up). packages/loopover-engine/src/miner/
 // worktree-allocator.ts's real `addWorktree` primitive (git worktree add -b <branch> <path> <baseBranch>)
@@ -103,6 +106,150 @@ async function withRepoCloneLock(repoPath, fn) {
   }
 }
 
+// Cross-process serialization for ensureRepoCloned (#7084). The in-process `repoCloneLocks` Map above only
+// serializes callers sharing one Node event loop; fleet mode (DEPLOYMENT.md) runs multiple SEPARATE processes --
+// distinct containers, no shared memory -- against one bind-mounted clone volume, so two of them can still
+// interleave git subprocesses on the same .git dir and corrupt the index/HEAD/refs. An OS-level exclusive lockfile
+// (open(.., 'wx')) on a deterministic path derived from repoPath closes that gap: create-and-hold is atomic across
+// processes, so exactly one holder mutates the clone while a loser waits (bounded) or fails closed. The lock
+// records owner pid+host+timestamp so a holder that CRASHES mid-clone doesn't wedge the repo forever -- a same-host
+// dead-owner or an over-age lock is reclaimed (mirroring worktree-allocator.js's stale reclaim), and
+// registerCleanupResource unlinks it on SIGINT/SIGTERM like this package's other crash-safe resources (#4826).
+
+const DEFAULT_LOCK_TIMEOUT_MS = 10 * 60 * 1000; // comfortably past a slow clone/fetch sequence
+const DEFAULT_LOCK_STALE_MS = 15 * 60 * 1000; // a lock older than this is presumed crashed
+const DEFAULT_LOCK_POLL_MS = 100;
+const defaultLockSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function repoCloneLockPath(repoPath) {
+  return `${repoPath}.clone.lock`;
+}
+
+/**
+ * Decide whether an existing clone lockfile is stale (reclaimable): true when the file is missing or its JSON is
+ * unreadable/partial (a crash mid-write), when its owner pid is confirmed dead within the SAME host's namespace,
+ * or -- ONLY for an owner this host cannot probe (a different host/container, or a malformed record with no
+ * usable pid) -- when it is older than `staleMs`. A same-host owner whose pid IS probeable is judged purely by
+ * liveness: a live one is never stale no matter how long its clone legitimately runs (age reclaim there would
+ * yank the lock out from under an in-progress clone -- a double-holder bug), and a dead one is stale at once.
+ *
+ * @param {string} lockPath
+ * @param {number} nowMs
+ * @param {number} staleMs
+ * @param {(pid: number) => boolean} [isAlive]
+ */
+export function isRepoCloneLockStale(lockPath, nowMs, staleMs, isAlive = isProcessAlive) {
+  let meta;
+  try {
+    meta = JSON.parse(readFileSync(lockPath, "utf8"));
+  } catch {
+    return true;
+  }
+  if (!meta || typeof meta !== "object") return true;
+  // Owner we can directly probe (same host, usable pid): trust liveness exclusively -- alive => held (never
+  // age-reclaim a still-running local clone), dead => reclaim now. The age backstop below is reserved for an
+  // owner whose liveness is genuinely unknowable from here.
+  if (meta.host === hostname() && Number.isInteger(meta.pid)) {
+    return !isAlive(meta.pid);
+  }
+  const atMs = Date.parse(meta.at);
+  if (!Number.isFinite(atMs)) return true;
+  return nowMs - atMs > staleMs;
+}
+
+/**
+ * Take the cross-process clone lock for `repoPath`, returning an idempotent `release()`. Atomically create-and-holds
+ * `${repoPath}.clone.lock` (open .., 'wx'); on contention it reclaims a stale lock (see {@link isRepoCloneLockStale})
+ * or waits `lockPollMs` between retries until `lockTimeoutMs` elapses, then throws `repo_clone_lock_timeout` (fail
+ * closed). Registered for crash-safe cleanup so a SIGINT/SIGTERM releases it. `nowMs`/`lockSleep`/`isProcessAlive`/
+ * `openLock`/`writeLock` are injectable for tests; every real caller relies on the defaults.
+ *
+ * @param {string} repoPath
+ * @param {{ lockTimeoutMs?: number, lockStaleMs?: number, lockPollMs?: number, nowMs?: () => number,
+ *   lockSleep?: (ms: number) => Promise<unknown>, isProcessAlive?: (pid: number) => boolean,
+ *   openLock?: (lockPath: string) => number, writeLock?: (fd: number, data: string) => void }} [options]
+ * @returns {Promise<() => void>}
+ */
+export async function acquireRepoCloneLock(repoPath, options = {}) {
+  const lockPath = repoCloneLockPath(repoPath);
+  const timeoutMs = Number.isFinite(options.lockTimeoutMs) ? options.lockTimeoutMs : DEFAULT_LOCK_TIMEOUT_MS;
+  const staleMs = Number.isFinite(options.lockStaleMs) ? options.lockStaleMs : DEFAULT_LOCK_STALE_MS;
+  const pollMs = Number.isFinite(options.lockPollMs) ? options.lockPollMs : DEFAULT_LOCK_POLL_MS;
+  const now = typeof options.nowMs === "function" ? options.nowMs : Date.now;
+  const sleep = typeof options.lockSleep === "function" ? options.lockSleep : defaultLockSleep;
+  const isAlive = typeof options.isProcessAlive === "function" ? options.isProcessAlive : isProcessAlive;
+  const openLock = typeof options.openLock === "function" ? options.openLock : (path) => openSync(path, "wx", 0o600);
+  const writeLock = typeof options.writeLock === "function" ? options.writeLock : (fd, data) => writeSync(fd, data);
+
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  const deadline = now() + timeoutMs;
+  for (;;) {
+    let fd;
+    try {
+      fd = openLock(lockPath);
+    } catch (error) {
+      if (!error || error.code !== "EEXIST") throw error;
+      if (isRepoCloneLockStale(lockPath, now(), staleMs, isAlive)) {
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Another waiter reclaimed it first -- just retry the open.
+        }
+        continue;
+      }
+      if (now() >= deadline) throw new Error("repo_clone_lock_timeout");
+      await sleep(pollMs);
+      continue;
+    }
+    // A per-acquire token stamps THIS holder's ownership so release() can prove the on-disk lock is still ours
+    // before removing it -- if a peer reclaimed us as stale and re-acquired, the file now carries their token and
+    // we must not delete their lock (that would let a third caller double-hold).
+    const token = randomUUID();
+    try {
+      writeLock(fd, JSON.stringify({ pid: process.pid, host: hostname(), at: new Date(now()).toISOString(), token }));
+    } catch (error) {
+      closeSync(fd);
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // best-effort cleanup of our own just-created lock
+      }
+      throw error;
+    }
+    let released = false;
+    let unregister = () => {};
+    const release = () => {
+      if (released) return;
+      released = true;
+      unregister();
+      try {
+        closeSync(fd);
+      } catch {
+        // fd already closed
+      }
+      try {
+        // Only remove the lockfile while it still carries OUR token; if a peer reclaimed + re-acquired it, leave
+        // their lock intact. A missing/unreadable file just means our lock is already gone -- nothing to do.
+        const current = JSON.parse(readFileSync(lockPath, "utf8"));
+        if (current && current.token === token) unlinkSync(lockPath);
+      } catch {
+        // lock already removed or unreadable -- nothing of ours to clean up
+      }
+    };
+    unregister = registerCleanupResource(release);
+    return release;
+  }
+}
+
+async function withRepoCloneCrossProcessLock(repoPath, options, fn) {
+  const release = await acquireRepoCloneLock(repoPath, options);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
 /**
  * Serialize the git mutations of {@link ensureRepoClonedUnlocked} per resolved repo path so concurrent
  * same-repo attempts never race the shared base clone (#6762), while different repos still run in parallel.
@@ -120,7 +267,11 @@ export async function ensureRepoCloned(repoFullName, options = {}) {
   const target = normalizeRepoFullName(repoFullName);
   const cloneBaseDir = typeof options.cloneBaseDir === "string" && options.cloneBaseDir.trim() ? options.cloneBaseDir.trim() : resolveRepoCloneBaseDir(options.env);
   const repoPath = join(cloneBaseDir, target.owner, target.repo);
-  return withRepoCloneLock(repoPath, () => ensureRepoClonedUnlocked(repoFullName, options));
+  // Two nested locks: the in-process Map (#6762) keeps same-process callers cheap and ordered, and the
+  // cross-process lockfile (#7084) additionally serializes separate OS processes sharing the clone volume.
+  return withRepoCloneLock(repoPath, () =>
+    withRepoCloneCrossProcessLock(repoPath, options, () => ensureRepoClonedUnlocked(repoFullName, options)),
+  );
 }
 
 /**

--- a/test/unit/miner-repo-clone-lock.test.ts
+++ b/test/unit/miner-repo-clone-lock.test.ts
@@ -1,0 +1,262 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireRepoCloneLock, ensureRepoCloned, isRepoCloneLockStale } from "../../packages/loopover-miner/lib/repo-clone.js";
+import {
+  cleanupResourceCount,
+  closeAllCleanupResources,
+  resetProcessLifecycleForTesting,
+} from "../../packages/loopover-miner/lib/process-lifecycle.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  resetProcessLifecycleForTesting();
+});
+
+function tempRepoPath() {
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-repo-clone-lock-"));
+  roots.push(root);
+  const repoPath = join(root, "acme", "widgets");
+  return { root, repoPath, lockPath: `${repoPath}.clone.lock` };
+}
+
+function writeLockFile(lockPath: string, meta: unknown) {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  writeFileSync(lockPath, typeof meta === "string" ? meta : JSON.stringify(meta));
+}
+
+const at1000 = new Date(1000).toISOString();
+
+describe("isRepoCloneLockStale (#7084)", () => {
+  it("treats a missing or unreadable lockfile as stale", () => {
+    const { lockPath } = tempRepoPath();
+    expect(isRepoCloneLockStale(lockPath, 1000, 5000)).toBe(true); // never created
+    writeLockFile(lockPath, "{ not valid json");
+    expect(isRepoCloneLockStale(lockPath, 1000, 5000)).toBe(true);
+  });
+
+  it("treats a non-object payload as stale", () => {
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, "null");
+    expect(isRepoCloneLockStale(lockPath, 1000, 5000)).toBe(true);
+    writeLockFile(lockPath, "123");
+    expect(isRepoCloneLockStale(lockPath, 1000, 5000)).toBe(true);
+  });
+
+  it("reclaims a same-host lock whose owner PID is dead", () => {
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: hostname(), pid: 4242, at: at1000 });
+    expect(isRepoCloneLockStale(lockPath, 1500, 5000, () => false)).toBe(true);
+  });
+
+  it("does not consult the PID probe when the owner PID isn't a usable integer", () => {
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: hostname(), pid: "x", at: at1000 });
+    // Non-integer pid -> skip liveness, fall through to the age check (fresh -> not stale).
+    expect(isRepoCloneLockStale(lockPath, 1500, 5000, () => false)).toBe(false);
+  });
+
+  it("NEVER age-reclaims a live same-host owner, no matter how long its clone runs", () => {
+    // The #7161 close's key blocker: a legitimately-slow local clone must not have its lock stolen by a waiter.
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: hostname(), pid: 4242, at: at1000 });
+    expect(isRepoCloneLockStale(lockPath, 1000 + 5000, 5000, () => true)).toBe(false); // at the age bound
+    expect(isRepoCloneLockStale(lockPath, 1000 + 500_000, 5000, () => true)).toBe(false); // far past it — still held
+    // A dead same-host owner is still reclaimed immediately, regardless of age.
+    expect(isRepoCloneLockStale(lockPath, 1000 + 500_000, 5000, () => false)).toBe(true);
+  });
+
+  it("applies the age backstop only to an un-probeable owner (non-integer pid), fresh vs over-age", () => {
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: hostname(), pid: "x", at: at1000 });
+    expect(isRepoCloneLockStale(lockPath, 1500, 5000, () => false)).toBe(false); // fresh -> held
+    expect(isRepoCloneLockStale(lockPath, 1000 + 5001, 5000, () => false)).toBe(true); // over-age -> reclaim
+    // An un-probeable owner with an unparseable timestamp is stale (can't establish liveness or age).
+    writeLockFile(lockPath, { host: hostname(), pid: "x", at: "not-a-time" });
+    expect(isRepoCloneLockStale(lockPath, 1500, 5000, () => false)).toBe(true);
+  });
+
+  it("judges a cross-host lock by age alone, never by this host's PID namespace", () => {
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: "some-other-container", pid: 4242, at: at1000 });
+    // Even with a 'dead' probe, a different host's pid is irrelevant — fresh age keeps it held.
+    expect(isRepoCloneLockStale(lockPath, 1500, 5000, () => false)).toBe(false);
+    expect(isRepoCloneLockStale(lockPath, 1000 + 6000, 5000, () => false)).toBe(true);
+  });
+
+  it("uses the real same-namespace liveness probe when no isAlive is injected", () => {
+    const { lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: hostname(), pid: process.pid, at: at1000 });
+    expect(isRepoCloneLockStale(lockPath, 1000, 5_000_000)).toBe(false); // this process is alive + fresh
+    writeLockFile(lockPath, { host: hostname(), pid: 9_999_999, at: at1000 });
+    expect(isRepoCloneLockStale(lockPath, 1000, 5_000_000)).toBe(true); // dead pid
+  });
+});
+
+describe("acquireRepoCloneLock (#7084)", () => {
+  it("acquires a free lock, records owner metadata, and releases it", async () => {
+    resetProcessLifecycleForTesting();
+    const { repoPath, lockPath } = tempRepoPath();
+    const release = await acquireRepoCloneLock(repoPath);
+    expect(existsSync(lockPath)).toBe(true);
+    const meta = JSON.parse(readFileSync(lockPath, "utf8"));
+    expect(meta.pid).toBe(process.pid);
+    expect(meta.host).toBe(hostname());
+    expect(cleanupResourceCount()).toBe(1); // registered for crash-safe release
+    release();
+    expect(existsSync(lockPath)).toBe(false);
+    expect(cleanupResourceCount()).toBe(0); // unregistered on release
+  });
+
+  it("release is idempotent", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    const release = await acquireRepoCloneLock(repoPath);
+    release();
+    expect(() => release()).not.toThrow();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("release leaves a lock intact once a peer has reclaimed and re-acquired it", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    const release = await acquireRepoCloneLock(repoPath);
+    // Simulate a peer reclaiming us as stale and taking the lock: the file now carries a DIFFERENT token.
+    writeFileSync(lockPath, JSON.stringify({ host: hostname(), pid: process.pid, at: at1000, token: "peer-token" }));
+    release();
+    expect(existsSync(lockPath)).toBe(true); // must not delete the peer's live lock
+    expect(JSON.parse(readFileSync(lockPath, "utf8")).token).toBe("peer-token");
+  });
+
+  it("release is a no-op when its lockfile is already gone or unrecognizable", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    const releaseGone = await acquireRepoCloneLock(repoPath);
+    rmSync(lockPath, { force: true }); // vanished under us
+    expect(() => releaseGone()).not.toThrow();
+
+    const releaseForeign = await acquireRepoCloneLock(repoPath); // re-acquire cleanly
+    writeFileSync(lockPath, "null"); // valid JSON but not an owner record
+    releaseForeign();
+    expect(existsSync(lockPath)).toBe(true); // untouched (not ours)
+  });
+
+  it("serializes a second acquirer against the same repo until the first releases", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    // A uses the real clock so its lock reads as fresh (not age-stale) to B, forcing B to wait rather than reclaim.
+    const releaseA = await acquireRepoCloneLock(repoPath);
+
+    let bAcquired = false;
+    const pendingB = acquireRepoCloneLock(repoPath, { lockSleep: async () => {}, lockPollMs: 1, isProcessAlive: () => true }).then(
+      (release) => {
+        bAcquired = true;
+        return release;
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bAcquired).toBe(false); // blocked while A holds
+
+    releaseA();
+    const releaseB = await pendingB;
+    expect(bAcquired).toBe(true);
+    expect(existsSync(lockPath)).toBe(true); // B now holds it
+    releaseB();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("waits out a live holder using the default sleep, then acquires", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    const releaseA = await acquireRepoCloneLock(repoPath);
+    // No injected sleep here: exercises the real defaultLockSleep timer on the contended path.
+    const pendingB = acquireRepoCloneLock(repoPath, { lockPollMs: 5, isProcessAlive: () => true });
+    setTimeout(() => releaseA(), 30);
+    const releaseB = await pendingB;
+    expect(existsSync(lockPath)).toBe(true);
+    releaseB();
+  });
+
+  it("fails closed with repo_clone_lock_timeout when a live holder never releases", async () => {
+    const { repoPath } = tempRepoPath();
+    const releaseA = await acquireRepoCloneLock(repoPath, { nowMs: () => 1000 });
+    const clock = [1000, 1300, 1300];
+    let i = 0;
+    await expect(
+      acquireRepoCloneLock(repoPath, {
+        nowMs: () => clock[Math.min(i++, clock.length - 1)]!,
+        lockTimeoutMs: 100,
+        lockStaleMs: 900_000,
+        lockSleep: async () => {},
+        isProcessAlive: () => true,
+      }),
+    ).rejects.toThrow("repo_clone_lock_timeout");
+    releaseA();
+  });
+
+  it("reclaims a stale (dead-owner) lock left by a crashed process and acquires", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    writeLockFile(lockPath, { host: hostname(), pid: 4242, at: at1000 });
+    const release = await acquireRepoCloneLock(repoPath, { isProcessAlive: () => false, lockStaleMs: 5000, nowMs: () => 1500 });
+    const meta = JSON.parse(readFileSync(lockPath, "utf8"));
+    expect(meta.pid).toBe(process.pid); // reclaimed and re-owned
+    release();
+  });
+
+  it("rethrows a non-EEXIST open error and a non-Error thrown value", async () => {
+    const { repoPath } = tempRepoPath();
+    await expect(
+      acquireRepoCloneLock(repoPath, {
+        openLock: () => {
+          const error = new Error("permission denied") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        },
+      }),
+    ).rejects.toThrow("permission denied");
+    await expect(
+      acquireRepoCloneLock(repoPath, {
+        openLock: () => {
+          throw null; // a thrown non-object must not crash the guard
+        },
+      }),
+    ).rejects.toBeNull();
+  });
+
+  it("cleans up its own just-created lock if writing the metadata fails", async () => {
+    const { repoPath, lockPath } = tempRepoPath();
+    await expect(
+      acquireRepoCloneLock(repoPath, {
+        writeLock: () => {
+          throw new Error("disk full");
+        },
+      }),
+    ).rejects.toThrow("disk full");
+    expect(existsSync(lockPath)).toBe(false); // not left wedged
+  });
+
+  it("ensureRepoCloned takes and releases the cross-process lock around its git mutations", async () => {
+    const { root, repoPath, lockPath } = tempRepoPath();
+    const calls: string[][] = [];
+    const runGit = async (args: string[]) => {
+      // The lock must be held while git runs: assert its lockfile exists during the mutation.
+      expect(existsSync(lockPath)).toBe(true);
+      calls.push(args);
+      return { ok: true, stdout: "", stderr: "" };
+    };
+    const result = await ensureRepoCloned("acme/widgets", { cloneBaseDir: root, runGit });
+    expect(result.ok).toBe(true);
+    expect(result.repoPath).toBe(repoPath);
+    expect(calls[0]?.[0]).toBe("clone"); // first-use clone ran under the lock
+    expect(existsSync(lockPath)).toBe(false); // released once the sequence completes
+  });
+
+  it("is released by closeAllCleanupResources when the process dies mid-clone", async () => {
+    resetProcessLifecycleForTesting();
+    const { repoPath, lockPath } = tempRepoPath();
+    await acquireRepoCloneLock(repoPath);
+    expect(cleanupResourceCount()).toBe(1);
+    closeAllCleanupResources(); // what installCliSignalHandlers invokes on SIGINT/SIGTERM
+    expect(cleanupResourceCount()).toBe(0);
+    expect(existsSync(lockPath)).toBe(false); // crash-released, not wedged for the next process
+  });
+});


### PR DESCRIPTION
## Summary

`ensureRepoCloned` keeps a per-repo base clone current by mutating it in place (`git clone`, then
`fetch` + `checkout` + `reset --hard`). Its existing serialization — the in-process `repoCloneLocks`
Map (#6762) — only orders callers that share **one** Node event loop. Fleet mode (per `DEPLOYMENT.md`)
runs multiple **separate** OS processes (distinct containers, no shared memory) against one
bind-mounted clone volume, so two of them can still interleave git subprocesses on the same `.git`
directory and corrupt the index/HEAD/refs (or trip `.git/index.lock`).

This adds an OS-level exclusive **lockfile** around the git mutations, in addition to (not replacing)
the in-process Map:

- `acquireRepoCloneLock(repoPath)` atomically create-and-holds `${repoPath}.clone.lock` via
  `open(.., 'wx')` (`O_EXCL`), so exactly one process across the whole host mutates a given clone at a
  time; different repos still run fully in parallel.
- A losing caller **waits** (bounded poll) and **fails closed** with `repo_clone_lock_timeout` rather
  than racing ahead or hanging forever.
- The lock records `pid` + `host` + `at` + a per-acquire `token`, so a holder that crashes mid-clone
  can't wedge the repo. Staleness is judged **liveness-first**: a same-host owner whose PID is
  probeable is reclaimed **only** when that PID is dead — a live local clone is *never* age-reclaimed
  no matter how long it legitimately runs (that would steal the lock mid-operation). The age backstop
  applies **only** to an owner this host cannot probe (a different host/container, or a record with no
  usable PID). Reuses `worktree-allocator.js`'s `isProcessAlive` and mirrors its stale reclaim.
- `release()` removes the lockfile **only while it still carries this holder's `token`** — if a peer
  had reclaimed us as stale and re-acquired, the file now holds their token and we leave it untouched,
  so `release()` can never delete another holder's live lock. It's also registered with
  `process-lifecycle.js`'s `registerCleanupResource`, so `SIGINT`/`SIGTERM` releases it like this
  package's other crash-safe resources (#4826).

`ensureRepoCloned` now nests the cross-process lock inside the retained in-process lock. Callback
signatures and the git sequence are unchanged.

Closes #7084

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one module + its types + tests) and mixes no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes; no new dependency (native `node:fs` only).
- [x] I linked a currently open issue this PR resolves (`Closes #7084`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` on the changed module — **100% of the changed lines AND branches are covered**
      (verified against `coverage-final.json`: the staleness matrix, acquire success/contention/timeout/
      stale-reclaim/open-error/write-error paths, crash-safe cleanup, idempotent release, and the
      `ensureRepoCloned` wiring). New suite: `test/unit/miner-repo-clone-lock.test.ts` (18 tests).
- [x] `npm run build:miner` (`node --check` on every miner file, incl. `repo-clone.js`)
- [x] New/changed behavior has tests for every branch, the fail-closed timeout path, and the crash-recovery path.

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**` (one module + its `.d.ts` + one test). Frontend
  checks (`ui:*`) and unrelated backend jobs touch nothing changed here and were not run locally; CI runs the
  full suite. The regression test simulates two independent "processes" by driving the exported lock helper
  twice against one real temp lockfile (bypassing the in-memory Map), asserting the second only proceeds after
  the first releases — plus a dead-owner crash-recovery reclaim.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] No API/OpenAPI/MCP surface change — the lock is internal to `ensureRepoCloned`; the two new exports are lock helpers used only by tests.
- [x] The lockfile path derives from the already path-validated `repoPath` (owner/repo segments are pattern-checked and reject `.`/`..`), so no traversal is introduced.
- [x] No UI change — no UI Evidence needed.

## Notes

- Defaults: a 10-minute acquire timeout (comfortably past a slow clone) and a 15-minute stale bound; both
  overridable. The in-process Map lock is deliberately retained so same-process callers stay cheap and #6762's
  guarantee never regresses.
