### PR TITLE
fix(miner-ui): wire discover/attempt chat actions into the shared registry

### DIFF
--- a/apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.test.tsx
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+
+// chat-action-registry → governor-chokepoint → governor-ledger → node:sqlite. jsdom/Vite cannot bundle that
+// builtin (#6837); keep a client-safe registry twin so the real registration module loads. Same pattern as
+// chat-governor-actions.test.tsx.
+vi.mock("../../../../packages/loopover-miner/lib/chat-action-registry.js", () => {
+  const GOVERNOR_GATED = Symbol("loopover.chat-action.governor-gated");
+
+  function isGovernorGatedHandler(handler: unknown): boolean {
+    return typeof handler === "function" && (handler as unknown as { [k: symbol]: unknown })[GOVERNOR_GATED] === true;
+  }
+
+  function governorGatedHandler(
+    run: (request: unknown, gate: unknown) => unknown,
+    options: { evaluateGate?: (input?: unknown) => { decision: { stage: string } } } = {},
+  ) {
+    const evaluateGate = options.evaluateGate ?? (() => ({ decision: { stage: "allow" } }));
+    const handler = async (request: { governorInput?: unknown }) => {
+      const gate = evaluateGate(request?.governorInput);
+      if (gate?.decision?.stage !== "allow") {
+        return { ok: false, status: "gated", decision: gate?.decision ?? null };
+      }
+      const result = await run(request, gate);
+      return { ok: true, status: "executed", decision: gate.decision, result };
+    };
+    Object.defineProperty(handler, GOVERNOR_GATED, { value: true });
+    return handler;
+  }
+
+  function createChatActionRegistry() {
+    const actions = new Map<
+      string,
+      { paramsValidator: (params: unknown) => boolean; handler: (request: unknown) => Promise<unknown> }
+    >();
+    return {
+      register(
+        name: string,
+        definition: {
+          paramsValidator: (params: unknown) => boolean;
+          handler: (request: unknown) => Promise<unknown>;
+        },
+      ) {
+        if (!isGovernorGatedHandler(definition.handler)) {
+          throw new Error(`registerChatAction("${name}"): handler must be produced by governorGatedHandler()`);
+        }
+        actions.set(name, definition);
+        return definition;
+      },
+      get: (name: string) => actions.get(name),
+      has: (name: string) => actions.has(name),
+      names: () => [...actions.keys()],
+      get size() {
+        return actions.size;
+      },
+    };
+  }
+
+  return {
+    createChatActionRegistry,
+    governorGatedHandler,
+    isGovernorGatedHandler,
+    chatActionRegistry: createChatActionRegistry(),
+    registerChatAction: () => {
+      throw new Error("tests use an injected isolated registry");
+    },
+  };
+});
+
+import {
+  CHAT_ACTION_DISPATCH_ENABLE_VALUE,
+  CHAT_ACTION_DISPATCH_FLAG,
+  dispatchChatAction,
+} from "../../../../packages/loopover-miner/lib/chat-action-dispatch.js";
+import { createChatActionRegistry } from "../../../../packages/loopover-miner/lib/chat-action-registry.js";
+import {
+  ATTEMPT_CHAT_ACTION,
+  DISCOVER_CHAT_ACTION,
+  registerDiscoverAttemptChatActions,
+} from "./chat-discover-attempt-actions";
+import { requestAttempt } from "./attempt";
+import { requestDiscover } from "./discover";
+
+const enabledEnv = { [CHAT_ACTION_DISPATCH_FLAG]: CHAT_ACTION_DISPATCH_ENABLE_VALUE };
+
+const discoverOk = { ok: true as const, result: { enqueued: 2 }, exitCode: 0 };
+const attemptOk = { ok: true as const, result: { outcome: "submitted" }, exitCode: 0 };
+
+const validAttemptParams = { repoFullName: "acme/widgets", issueNumber: 12, minerLogin: "octocat" };
+
+describe("registerDiscoverAttemptChatActions (#6837)", () => {
+  it("registers discover and attempt into the supplied registry", () => {
+    const registry = createChatActionRegistry();
+    registerDiscoverAttemptChatActions({ registry });
+    expect(registry.has(DISCOVER_CHAT_ACTION)).toBe(true);
+    expect(registry.has(ATTEMPT_CHAT_ACTION)).toBe(true);
+  });
+
+  it("routes a dispatched discover only through requestDiscover, never attempt", async () => {
+    const registry = createChatActionRegistry();
+    const requestDiscoverFn = vi.fn(async () => discoverOk);
+    const requestAttemptFn = vi.fn(async () => attemptOk);
+    registerDiscoverAttemptChatActions({ registry, requestDiscoverFn, requestAttemptFn });
+
+    const dispatch = await dispatchChatAction(
+      { action: DISCOVER_CHAT_ACTION, params: { search: "typescript", dryRun: true } },
+      { env: enabledEnv, registry },
+    );
+
+    expect(dispatch).toMatchObject({ ok: true, status: "dispatched" });
+    expect(dispatch.result).toMatchObject({ status: "executed", result: discoverOk });
+    expect(requestDiscoverFn).toHaveBeenCalledWith({ search: "typescript", dryRun: true });
+    expect(requestAttemptFn).not.toHaveBeenCalled();
+  });
+
+  it("forwards nullish discover params to requestDiscover as an empty object", async () => {
+    const registry = createChatActionRegistry();
+    const requestDiscoverFn = vi.fn(async () => discoverOk);
+    registerDiscoverAttemptChatActions({ registry, requestDiscoverFn, requestAttemptFn: vi.fn(async () => attemptOk) });
+
+    await dispatchChatAction({ action: DISCOVER_CHAT_ACTION }, { env: enabledEnv, registry });
+
+    expect(requestDiscoverFn).toHaveBeenCalledWith({});
+  });
+
+  it("routes a dispatched attempt only through requestAttempt, never discover", async () => {
+    const registry = createChatActionRegistry();
+    const requestDiscoverFn = vi.fn(async () => discoverOk);
+    const requestAttemptFn = vi.fn(async () => attemptOk);
+    registerDiscoverAttemptChatActions({ registry, requestDiscoverFn, requestAttemptFn });
+
+    const dispatch = await dispatchChatAction(
+      { action: ATTEMPT_CHAT_ACTION, params: validAttemptParams },
+      { env: enabledEnv, registry },
+    );
+
+    expect(dispatch).toMatchObject({ ok: true, status: "dispatched" });
+    expect(dispatch.result).toMatchObject({ status: "executed", result: attemptOk });
+    expect(requestAttemptFn).toHaveBeenCalledWith(validAttemptParams);
+    expect(requestDiscoverFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects an attempt with missing required params before reaching the client", async () => {
+    const registry = createChatActionRegistry();
+    const requestAttemptFn = vi.fn(async () => attemptOk);
+    registerDiscoverAttemptChatActions({
+      registry,
+      requestDiscoverFn: vi.fn(async () => discoverOk),
+      requestAttemptFn,
+    });
+
+    const dispatch = await dispatchChatAction(
+      { action: ATTEMPT_CHAT_ACTION, params: { repoFullName: "acme/widgets" } },
+      { env: enabledEnv, registry },
+    );
+
+    expect(dispatch).toMatchObject({ ok: false, status: "invalid_params" });
+    expect(requestAttemptFn).not.toHaveBeenCalled();
+  });
+
+  it("does not run the client when the injected gate denies the write", async () => {
+    const registry = createChatActionRegistry();
+    const requestAttemptFn = vi.fn(async () => attemptOk);
+    registerDiscoverAttemptChatActions({
+      registry,
+      requestDiscoverFn: vi.fn(async () => discoverOk),
+      requestAttemptFn,
+      evaluateGate: () => ({ decision: { stage: "block" } }),
+    });
+
+    const dispatch = await dispatchChatAction(
+      { action: ATTEMPT_CHAT_ACTION, params: validAttemptParams },
+      { env: enabledEnv, registry },
+    );
+
+    expect(dispatch).toMatchObject({ ok: true, status: "dispatched" });
+    expect(dispatch.result).toMatchObject({ status: "gated" });
+    expect(requestAttemptFn).not.toHaveBeenCalled();
+  });
+
+  it("regression: default wiring binds the exported requestDiscover/requestAttempt clients", async () => {
+    const discoverModule = await import("./discover");
+    const attemptModule = await import("./attempt");
+    const discoverSpy = vi.spyOn(discoverModule, "requestDiscover").mockResolvedValue(discoverOk);
+    const attemptSpy = vi.spyOn(attemptModule, "requestAttempt").mockResolvedValue(attemptOk);
+
+    const registry = createChatActionRegistry();
+    registerDiscoverAttemptChatActions({ registry });
+
+    await dispatchChatAction(
+      { action: DISCOVER_CHAT_ACTION, params: { search: "rust" } },
+      { env: enabledEnv, registry },
+    );
+    expect(discoverSpy).toHaveBeenCalledWith({ search: "rust" });
+
+    await dispatchChatAction(
+      { action: ATTEMPT_CHAT_ACTION, params: validAttemptParams },
+      { env: enabledEnv, registry },
+    );
+    expect(attemptSpy).toHaveBeenCalledWith(validAttemptParams);
+
+    discoverSpy.mockRestore();
+    attemptSpy.mockRestore();
+  });
+
+  it("defaults registration to the real ./discover and ./attempt module exports", () => {
+    // Structural pin: the wire module's default path is `requestDiscover` / `requestAttempt`.
+    expect(typeof requestDiscover).toBe("function");
+    expect(typeof requestAttempt).toBe("function");
+  });
+});
+
+describe("chatDiscoverAttemptActionsPlugin (#6837)", () => {
+  it("registers discover/attempt into the shared registry on configureServer", async () => {
+    const { chatDiscoverAttemptActionsPlugin } = await import("../../vite-chat-discover-attempt-actions");
+    const { chatActionRegistry } = await import("../../../../packages/loopover-miner/lib/chat-action-registry.js");
+
+    const plugin = chatDiscoverAttemptActionsPlugin();
+    expect(plugin.name).toBe("loopover-miner-chat-discover-attempt-actions");
+
+    (plugin.configureServer as () => void)();
+
+    // configureServer fires import().then(register); wait for the shared registration to settle.
+    await vi.waitFor(() => {
+      expect(chatActionRegistry.has(DISCOVER_CHAT_ACTION)).toBe(true);
+      expect(chatActionRegistry.has(ATTEMPT_CHAT_ACTION)).toBe(true);
+    });
+  });
+});

--- a/apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.ts
@@ -1,0 +1,47 @@
+// Miner-ui wire for discover/attempt chat actions (#6837 — completing the miner-ui half that #7076 found
+// missing).
+//
+// Binds the shared registry registrations (packages/loopover-miner/lib/chat-discover-attempt-actions.js) to the
+// existing `requestDiscover` / `requestAttempt` HTTP clients — the same functions that POST `/api/discover` and
+// `/api/attempt`. Like chat-governor-actions.ts, this module only supplies those clients in; it adds no new
+// route and no hand-rolled fetch. UI text-to-action resolution for discover/attempt is intentionally left to a
+// follow-up, so there is no runner/unwrap surface here yet — registering the handlers is the whole scope.
+
+import { type ChatActionRegistry } from "../../../../packages/loopover-miner/lib/chat-action-registry.js";
+import {
+  ATTEMPT_CHAT_ACTION,
+  DISCOVER_CHAT_ACTION,
+  registerDiscoverAttemptChatActions as registerDiscoverAttemptChatActionsCore,
+} from "../../../../packages/loopover-miner/lib/chat-discover-attempt-actions.js";
+import { requestAttempt, type AttemptActionInput } from "./attempt";
+import { requestDiscover, type DiscoverActionInput } from "./discover";
+
+export {
+  ATTEMPT_CHAT_ACTION,
+  DISCOVER_CHAT_ACTION,
+  isAttemptChatParams,
+  isDiscoverChatParams,
+} from "../../../../packages/loopover-miner/lib/chat-discover-attempt-actions.js";
+
+export type DiscoverAttemptChatActionName = typeof DISCOVER_CHAT_ACTION | typeof ATTEMPT_CHAT_ACTION;
+
+export type RegisterDiscoverAttemptChatActionsOptions = {
+  registry?: ChatActionRegistry;
+  requestDiscoverFn?: typeof requestDiscover;
+  requestAttemptFn?: typeof requestAttempt;
+  evaluateGate?: () => { decision: { stage: string } };
+};
+
+/** Idempotently register both actions, defaulting to the real `./discover` / `./attempt` clients. */
+export function registerDiscoverAttemptChatActions(options: RegisterDiscoverAttemptChatActionsOptions = {}): void {
+  const discover = options.requestDiscoverFn ?? requestDiscover;
+  const attempt = options.requestAttemptFn ?? requestAttempt;
+  registerDiscoverAttemptChatActionsCore({
+    // The registry passes an already-validated params record (isDiscoverChatParams / isAttemptChatParams ran
+    // in dispatch first), so narrowing to each client's input type here is safe.
+    requestDiscover: (input) => discover(input as DiscoverActionInput),
+    requestAttempt: (input) => attempt(input as AttemptActionInput),
+    registry: options.registry,
+    evaluateGate: options.evaluateGate,
+  });
+}

--- a/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from "vite";
+
+// Registers discover/attempt chat actions into the shared registry on dev-server start (#6837). Handlers call
+// the existing miner-ui `requestDiscover` / `requestAttempt` clients — the same POST `/api/discover` and
+// `/api/attempt` path the routes already serve. No new /api/* route is added here (mirrors
+// vite-chat-governor-actions.ts).
+
+export function chatDiscoverAttemptActionsPlugin(): Plugin {
+  return {
+    name: "loopover-miner-chat-discover-attempt-actions",
+    configureServer() {
+      void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
+        mod.registerDiscoverAttemptChatActions();
+      });
+    },
+  };
+}

--- a/apps/loopover-miner-ui/vite.config.ts
+++ b/apps/loopover-miner-ui/vite.config.ts
@@ -7,6 +7,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { attemptApiPlugin } from "./vite-attempt-api";
 import { authPlugin } from "./vite-auth";
 import { chatApiPlugin } from "./vite-chat-api";
+import { chatDiscoverAttemptActionsPlugin } from "./vite-chat-discover-attempt-actions";
 import { chatGovernorActionsPlugin } from "./vite-chat-governor-actions";
 import { discoverApiPlugin } from "./vite-discover-api";
 import { governorApiPlugin } from "./vite-governor-api";
@@ -27,6 +28,7 @@ export default defineConfig({
     authPlugin(),
     chatApiPlugin(),
     chatGovernorActionsPlugin(),
+    chatDiscoverAttemptActionsPlugin(),
     runStateApiPlugin(),
     portfolioQueueApiPlugin(),
     portfolioQueueActionsApiPlugin(),


### PR DESCRIPTION
## What

Adds the miner-ui wire module and dev-server plugin that finish #6837's chat discover/attempt
action-dispatch — the half #7076 found missing.

`packages/loopover-miner/lib/chat-discover-attempt-actions.js` (`registerDiscoverAttemptChatActions`)
already shipped, but nothing supplied it the `requestDiscover` / `requestAttempt` clients or registered
the actions, so chat could not dispatch `discover` or `attempt`. This mirrors the governor family exactly:

- `apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.ts` — binds the shared registrations to the
  existing `./discover` / `./attempt` HTTP clients, defaulting to the real ones with test-injectable overrides.
- `apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts` — a `configureServer` plugin registering the
  actions on dev-server start, added to `vite.config.ts` next to `chatGovernorActionsPlugin()`.

No new `/api/*` route, no hand-rolled fetch, and no change to `vite-discover-api.ts` / `vite-attempt-api.ts` —
the handlers still call only the existing `/api/discover` and `/api/attempt` clients. UI text-to-action
resolution for chat is intentionally left to a follow-up, keeping this a small wiring PR.

## Tests

`apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.test.tsx` (mirrors `chat-governor-actions.test.tsx`):

- both actions register into the supplied registry;
- a dispatched `discover` / `attempt` routes only through its own client (never the other, never a CLI/store);
- nullish discover params forward as `{}`;
- an attempt missing required params is rejected before reaching the client;
- an injected deny gate blocks the write;
- default wiring binds the real `requestDiscover` / `requestAttempt` exports;
- the plugin's `configureServer` registers both actions into the shared registry.

Non-visual wiring change — no screenshot required (per the issue). `apps/**` is under `ignore:` in
`codecov.yml`; the local coverage suite passes (both new files 100% lines/branches/functions).

Closes #7076
