### PR TITLE
feat(miner-ui): wire discover/attempt chat actions into the shared registry

### DIFF
--- a/apps/loopover-miner-ui/src/chat-discover-attempt-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-discover-attempt-actions.test.tsx
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+
+// chat-action-registry → governor-chokepoint → governor-ledger → node:sqlite, which jsdom/Vite cannot bundle
+// (#6521); keep a client-safe registry twin so the real dispatch + registration modules load. Mirrors the twin
+// in chat-governor-actions.test.tsx.
+vi.mock("../../../packages/loopover-miner/lib/chat-action-registry.js", () => {
+  const GOVERNOR_GATED = Symbol("loopover.chat-action.governor-gated");
+
+  function isGovernorGatedHandler(handler: unknown): boolean {
+    return typeof handler === "function" && (handler as unknown as { [k: symbol]: unknown })[GOVERNOR_GATED] === true;
+  }
+
+  function governorGatedHandler(
+    run: (request: unknown, gate: unknown) => unknown,
+    options: { evaluateGate?: (input?: unknown) => { decision: { stage: string } } } = {},
+  ) {
+    const evaluateGate = options.evaluateGate ?? (() => ({ decision: { stage: "allow" } }));
+    const handler = async (request: { governorInput?: unknown }) => {
+      const gate = evaluateGate(request?.governorInput);
+      if (gate?.decision?.stage !== "allow") {
+        return { ok: false, status: "gated", decision: gate?.decision ?? null };
+      }
+      const result = await run(request, gate);
+      return { ok: true, status: "executed", decision: gate.decision, result };
+    };
+    Object.defineProperty(handler, GOVERNOR_GATED, { value: true });
+    return handler;
+  }
+
+  function createChatActionRegistry() {
+    const actions = new Map<
+      string,
+      { paramsValidator: (params: unknown) => boolean; handler: (request: unknown) => Promise<unknown> }
+    >();
+    return {
+      register(
+        name: string,
+        definition: {
+          paramsValidator: (params: unknown) => boolean;
+          handler: (request: unknown) => Promise<unknown>;
+        },
+      ) {
+        if (!isGovernorGatedHandler(definition.handler)) {
+          throw new Error(`registerChatAction("${name}"): handler must be produced by governorGatedHandler()`);
+        }
+        actions.set(name, definition);
+        return definition;
+      },
+      get: (name: string) => actions.get(name),
+      has: (name: string) => actions.has(name),
+      names: () => [...actions.keys()],
+      get size() {
+        return actions.size;
+      },
+    };
+  }
+
+  return {
+    createChatActionRegistry,
+    governorGatedHandler,
+    isGovernorGatedHandler,
+    chatActionRegistry: createChatActionRegistry(),
+    registerChatAction: () => {
+      throw new Error("tests use an injected isolated registry");
+    },
+  };
+});
+
+import { createChatActionRegistry } from "../../../packages/loopover-miner/lib/chat-action-registry.js";
+import { requestAttempt, type AttemptActionResult } from "./lib/attempt";
+import {
+  ATTEMPT_CHAT_ACTION,
+  DISCOVER_CHAT_ACTION,
+  enabledChatActionsEnv,
+  registerDiscoverAttemptChatActions,
+  runDiscoverAttemptChatAction,
+  unwrapDiscoverAttemptChatResult,
+} from "./lib/chat-discover-attempt-actions";
+import { requestDiscover, type DiscoverActionResult } from "./lib/discover";
+
+const discoverOk: DiscoverActionResult = { ok: true, result: { opportunities: [] }, exitCode: 0 };
+const attemptOk: AttemptActionResult = { ok: true, result: { pullNumber: 123 }, exitCode: 0 };
+const attemptParams = { repoFullName: "acme/widgets", issueNumber: 42, minerLogin: "miner1" };
+
+describe("chat-discover-attempt-actions wire (#7076)", () => {
+  it("registers both discover and attempt into the shared registry", () => {
+    const registry = createChatActionRegistry();
+    registerDiscoverAttemptChatActions({ registry });
+    expect(registry.has(DISCOVER_CHAT_ACTION)).toBe(true);
+    expect(registry.has(ATTEMPT_CHAT_ACTION)).toBe(true);
+  });
+
+  it("dispatches discover through the injected requestDiscover client with the forwarded params", async () => {
+    const registry = createChatActionRegistry();
+    const requestDiscoverFn = vi.fn(async () => discoverOk);
+    registerDiscoverAttemptChatActions({ registry, requestDiscoverFn, requestAttemptFn: vi.fn(async () => attemptOk) });
+
+    const dispatched = await runDiscoverAttemptChatAction(
+      { action: DISCOVER_CHAT_ACTION, params: { search: "flaky", dryRun: true } },
+      { env: enabledChatActionsEnv(), registry },
+    );
+    expect(requestDiscoverFn).toHaveBeenCalledWith({ search: "flaky", dryRun: true });
+    expect(unwrapDiscoverAttemptChatResult(dispatched)).toEqual(discoverOk);
+  });
+
+  it("forwards {} to requestDiscover when the params are nullish (discover with defaults)", async () => {
+    const registry = createChatActionRegistry();
+    const requestDiscoverFn = vi.fn(async () => discoverOk);
+    registerDiscoverAttemptChatActions({ registry, requestDiscoverFn, requestAttemptFn: vi.fn(async () => attemptOk) });
+    await runDiscoverAttemptChatAction({ action: DISCOVER_CHAT_ACTION }, { env: enabledChatActionsEnv(), registry });
+    expect(requestDiscoverFn).toHaveBeenCalledWith({});
+  });
+
+  it("dispatches attempt through the injected requestAttempt client with the validated params", async () => {
+    const registry = createChatActionRegistry();
+    const requestAttemptFn = vi.fn(async () => attemptOk);
+    registerDiscoverAttemptChatActions({
+      registry,
+      requestDiscoverFn: vi.fn(async () => discoverOk),
+      requestAttemptFn,
+    });
+
+    const dispatched = await runDiscoverAttemptChatAction(
+      { action: ATTEMPT_CHAT_ACTION, params: attemptParams },
+      { env: enabledChatActionsEnv(), registry },
+    );
+    expect(requestAttemptFn).toHaveBeenCalledWith(attemptParams);
+    expect(unwrapDiscoverAttemptChatResult(dispatched)).toEqual(attemptOk);
+  });
+
+  it("regression: default wiring binds the real ./discover and ./attempt clients", async () => {
+    const discoverSpy = vi.spyOn(await import("./lib/discover"), "requestDiscover").mockResolvedValue(discoverOk);
+    const attemptSpy = vi.spyOn(await import("./lib/attempt"), "requestAttempt").mockResolvedValue(attemptOk);
+
+    const registry = createChatActionRegistry();
+    registerDiscoverAttemptChatActions({ registry });
+
+    await runDiscoverAttemptChatAction(
+      { action: DISCOVER_CHAT_ACTION, params: { search: "x" } },
+      { env: enabledChatActionsEnv(), registry },
+    );
+    expect(discoverSpy).toHaveBeenCalledWith({ search: "x" });
+
+    await runDiscoverAttemptChatAction(
+      { action: ATTEMPT_CHAT_ACTION, params: attemptParams },
+      { env: enabledChatActionsEnv(), registry },
+    );
+    expect(attemptSpy).toHaveBeenCalledWith(attemptParams);
+
+    discoverSpy.mockRestore();
+    attemptSpy.mockRestore();
+  });
+
+  it("is idempotent: a second registration keeps the first handlers (registry.has guard)", () => {
+    const registry = createChatActionRegistry();
+    registerDiscoverAttemptChatActions({
+      registry,
+      requestDiscoverFn: vi.fn(async () => discoverOk),
+      requestAttemptFn: vi.fn(async () => attemptOk),
+    });
+    const firstEntry = registry.get(DISCOVER_CHAT_ACTION);
+    registerDiscoverAttemptChatActions({
+      registry,
+      requestDiscoverFn: vi.fn(async () => discoverOk),
+      requestAttemptFn: vi.fn(async () => attemptOk),
+    });
+    expect(registry.get(DISCOVER_CHAT_ACTION)).toBe(firstEntry); // second register is a no-op
+  });
+
+  it("unwrapDiscoverAttemptChatResult returns null for non-executed dispatch envelopes", () => {
+    expect(unwrapDiscoverAttemptChatResult({ ok: false, status: "disabled", action: DISCOVER_CHAT_ACTION })).toBeNull();
+    expect(
+      unwrapDiscoverAttemptChatResult({
+        ok: true,
+        status: "dispatched",
+        action: DISCOVER_CHAT_ACTION,
+        result: { status: "gated", decision: null },
+      }),
+    ).toBeNull();
+  });
+
+  it("defaults to the real discover/attempt module exports", () => {
+    expect(typeof requestDiscover).toBe("function");
+    expect(typeof requestAttempt).toBe("function");
+  });
+});

--- a/apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-discover-attempt-actions.ts
@@ -1,0 +1,93 @@
+// Miner-ui wire for discover/attempt chat actions (#7076).
+//
+// Binds the shared registry registrations (packages/loopover-miner/lib/chat-discover-attempt-actions.js) to the
+// existing `requestDiscover` / `requestAttempt` clients — the same POST /api/discover and POST /api/attempt path
+// the miner-ui already uses. Also owns the pending-aware dispatch helper and result unwrap for the chat surface.
+// Wiring ChatConversation to actually invoke these from a resolved chat message is a deliberate follow-up.
+
+import {
+  CHAT_ACTION_DISPATCH_ENABLE_VALUE,
+  CHAT_ACTION_DISPATCH_FLAG,
+  dispatchChatAction,
+  type ChatActionDispatchResult,
+} from "../../../../packages/loopover-miner/lib/chat-action-dispatch.js";
+import { type ChatActionRegistry } from "../../../../packages/loopover-miner/lib/chat-action-registry.js";
+import {
+  ATTEMPT_CHAT_ACTION,
+  DISCOVER_CHAT_ACTION,
+  registerDiscoverAttemptChatActions as registerDiscoverAttemptChatActionsCore,
+} from "../../../../packages/loopover-miner/lib/chat-discover-attempt-actions.js";
+import { requestAttempt, type AttemptActionResult } from "./attempt";
+import { requestDiscover, type DiscoverActionResult } from "./discover";
+
+export {
+  ATTEMPT_CHAT_ACTION,
+  DISCOVER_CHAT_ACTION,
+  isAttemptChatParams,
+  isDiscoverChatParams,
+} from "../../../../packages/loopover-miner/lib/chat-discover-attempt-actions.js";
+
+export type DiscoverAttemptChatActionName = typeof DISCOVER_CHAT_ACTION | typeof ATTEMPT_CHAT_ACTION;
+
+export type RegisterDiscoverAttemptChatActionsOptions = {
+  registry?: ChatActionRegistry;
+  requestDiscoverFn?: typeof requestDiscover;
+  requestAttemptFn?: typeof requestAttempt;
+  evaluateGate?: () => { decision: { stage: string } };
+};
+
+/** Idempotently register both actions, defaulting to the real `./discover` / `./attempt` clients. */
+export function registerDiscoverAttemptChatActions(options: RegisterDiscoverAttemptChatActionsOptions = {}): void {
+  registerDiscoverAttemptChatActionsCore({
+    requestDiscover: options.requestDiscoverFn ?? requestDiscover,
+    requestAttempt: options.requestAttemptFn ?? requestAttempt,
+    registry: options.registry,
+    evaluateGate: options.evaluateGate,
+  });
+}
+
+export type RunDiscoverAttemptChatActionOptions = {
+  env?: Record<string, string | undefined>;
+  registry?: ChatActionRegistry;
+  /** Flipped true for the duration of the dispatch (mirrors the Ledgers pending pattern). */
+  onPending?: (pending: boolean) => void;
+};
+
+/**
+ * Dispatch a discover/attempt chat action through the shared flag-gated entry point. Always goes through
+ * `dispatchChatAction` — never calls the registered handler directly.
+ */
+export async function runDiscoverAttemptChatAction(
+  request: { action: DiscoverAttemptChatActionName; params?: unknown },
+  options: RunDiscoverAttemptChatActionOptions = {},
+): Promise<ChatActionDispatchResult> {
+  options.onPending?.(true);
+  try {
+    return await dispatchChatAction(request, { env: options.env, registry: options.registry });
+  } finally {
+    options.onPending?.(false);
+  }
+}
+
+/** Env map that enables chat-action dispatch (the only truthy value the shared flag accepts). */
+export function enabledChatActionsEnv(): Record<string, string> {
+  return { [CHAT_ACTION_DISPATCH_FLAG]: CHAT_ACTION_DISPATCH_ENABLE_VALUE };
+}
+
+/**
+ * Unwrap a successful dispatch envelope to the inner `requestDiscover` / `requestAttempt` result. Returns null
+ * when dispatch did not execute (disabled / unknown / invalid / gated).
+ */
+export function unwrapDiscoverAttemptChatResult(
+  dispatchResult: ChatActionDispatchResult,
+): DiscoverActionResult | AttemptActionResult | null {
+  if (dispatchResult.status !== "dispatched") return null;
+  const gated = dispatchResult.result as
+    { status?: string; result?: DiscoverActionResult | AttemptActionResult } | undefined;
+  if (gated?.status !== "executed") return null;
+  const inner = gated.result;
+  if (inner == null || typeof inner !== "object" || !("ok" in inner)) return null;
+  return inner;
+}
+
+export { CHAT_ACTION_DISPATCH_FLAG, CHAT_ACTION_DISPATCH_ENABLE_VALUE };

--- a/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
@@ -1,0 +1,16 @@
+import type { Plugin } from "vite";
+
+// Registers discover/attempt chat actions into the shared registry on dev-server start (#7076).
+// Handlers call the existing miner-ui `requestDiscover` / `requestAttempt` clients (POST /api/discover,
+// /api/attempt) — no new route is added here.
+
+export function chatDiscoverAttemptActionsPlugin(): Plugin {
+  return {
+    name: "loopover-miner-chat-discover-attempt-actions",
+    configureServer() {
+      void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
+        mod.registerDiscoverAttemptChatActions();
+      });
+    },
+  };
+}

--- a/apps/loopover-miner-ui/vite.config.ts
+++ b/apps/loopover-miner-ui/vite.config.ts
@@ -7,6 +7,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { attemptApiPlugin } from "./vite-attempt-api";
 import { authPlugin } from "./vite-auth";
 import { chatApiPlugin } from "./vite-chat-api";
+import { chatDiscoverAttemptActionsPlugin } from "./vite-chat-discover-attempt-actions";
 import { chatGovernorActionsPlugin } from "./vite-chat-governor-actions";
 import { discoverApiPlugin } from "./vite-discover-api";
 import { governorApiPlugin } from "./vite-governor-api";
@@ -27,6 +28,7 @@ export default defineConfig({
     authPlugin(),
     chatApiPlugin(),
     chatGovernorActionsPlugin(),
+    chatDiscoverAttemptActionsPlugin(),
     runStateApiPlugin(),
     portfolioQueueApiPlugin(),
     portfolioQueueActionsApiPlugin(),


### PR DESCRIPTION
Closes #7076

The chat-action registry `packages/loopover-miner/lib/chat-discover-attempt-actions.js` and the `requestDiscover`/`requestAttempt` HTTP clients were both built, but the miner-ui **wire module** that binds them was missing — so #6837 shipped only the registry-contract half and discover/attempt could never dispatch. This mirrors the existing governor wire (#6521).

## Change
- **`src/lib/chat-discover-attempt-actions.ts`** — calls `registerDiscoverAttemptChatActions` from the package registry, supplying `requestDiscover`/`requestAttempt` (from `./discover`/`./attempt`) as the handler backends. Also owns the pending-aware `runDiscoverAttemptChatAction` dispatch helper (always via the shared `dispatchChatAction`), `enabledChatActionsEnv`, and `unwrapDiscoverAttemptChatResult` — exactly `chat-governor-actions.ts`'s shape.
- **`vite-chat-discover-attempt-actions.ts`** — a `configureServer` plugin registering the actions on dev-server start, registered in `vite.config.ts` next to `chatGovernorActionsPlugin()`. No new HTTP route; the existing `/api/discover` + `/api/attempt` clients are the only path the handlers call.
- Out of scope (per the issue, left to a follow-up to keep this small): wiring `ChatConversation` to invoke these from a resolved chat message, and text-to-action resolution.

## Tests (`src/chat-discover-attempt-actions.test.tsx`, mirroring `chat-governor-actions.test.tsx`)
- Both actions register into the shared registry.
- Dispatching `discover`/`attempt` routes **only** through the injected `requestDiscover`/`requestAttempt` clients (with `{}` forwarded for nullish discover params), and a regression test pins that default wiring binds the real `./discover`/`./attempt` exports.
- Idempotency (`registry.has` guard) + `unwrap` null cases.

## Validation
- `@loopover/ui-miner` suite: **299 passed**; coverage bar met (Statements 90.2% / Branches 89.4% / Functions 83.9% / Lines 92.7%).
- `tsc --noEmit`, `eslint`, and `vite build` all clean. `apps/**` is under `ignore:` in `codecov.yml`; non-visual wiring, so no screenshot.