### PR TITLE
fix(observability): stop LoopoverHighHttp5xxRatio paging on low-volume noise

### DIFF
--- a/prometheus/rules/alerts.yml
+++ b/prometheus/rules/alerts.yml
@@ -427,12 +427,25 @@ groups:
         # Share of responses that are 5xx. status="5xx" selects only server errors;
         # the denominator sums all statuses. If the status label is missing entirely
         # (old build), the numerator selector matches nothing → no firing. 0.05 = 5%.
+        #
+        # Real-incident finding (2026-07-18): a quiet self-host install can see well
+        # under 1 req/5m. At that volume a single stray 5xx alone swings the ratio to
+        # 100% and pages on noise, not a real incident -- confirmed live (loopover
+        # logs showed no errors at all while this fired repeatedly). The `and` clause
+        # below requires at least 20 total requests in the same 5m window before the
+        # ratio is trusted -- derived directly from the 5% threshold itself: with
+        # fewer than 20 requests, one single 5xx response ALREADY exceeds 5% on
+        # sample-size noise alone, before the failure rate means anything.
         expr: |
           (
-            sum(rate(loopover_http_requests_total{status="5xx"}[5m]))
-            /
-            sum(rate(loopover_http_requests_total[5m])) > 0
-          ) > 0.05
+            (
+              sum(rate(loopover_http_requests_total{status="5xx"}[5m]))
+              /
+              sum(rate(loopover_http_requests_total[5m])) > 0
+            ) > 0.05
+          )
+          and
+          sum(increase(loopover_http_requests_total[5m])) >= 20
         for: 10m
         labels:
           severity: critical


### PR DESCRIPTION
## Summary
- This self-host install sees well under 1 req/5m, so a single stray 5xx response alone swings the ratio to 100% and pages on sample-size noise, not a real incident -- confirmed live: application logs showed no errors at all while this alert fired repeatedly over several hours, generating multiple PagerDuty pages.
- Adds a minimum-volume guard (`sum(increase(loopover_http_requests_total[5m])) >= 20`) before the ratio is trusted, derived directly from the existing 5% threshold: below 20 requests, one single 5xx response already exceeds 5% regardless of whether there's an actual elevated failure rate.

## Test plan
- [x] `npm run selfhost:validate-observability` passes
- [x] YAML parses correctly (41 rules total, unchanged count)
- [x] Applied live on edge-nl-01 first to confirm the fix actually resolves the paging: rule now reports `state: inactive`, `health: ok`, `alerts: []` instead of repeatedly firing
- [x] Query confirmed to have reloaded correctly via `/api/v1/rules` inspection post-restart