### PR TITLE
fix(ui): adopt LoadingState in docs route Suspense fallbacks

### DIFF
--- a/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
+++ b/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
@@ -1,0 +1,64 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { Suspense, use } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LoadingState } from "@/components/site/state-views";
+
+// #6982: all 46 docs.*.tsx routes hand-rolled an identical plain-text `<p>Loading…</p>` Suspense
+// fallback instead of the shared LoadingState primitive every other consumer in this app already uses
+// (see changelog.tsx). Fixed by importing LoadingState and using `<Suspense fallback={<LoadingState />}>`
+// everywhere, matching LoadingState's own accessible role="status" markup.
+
+function NeverResolves(): never {
+  // Mirrors fumadocs-mdx's real Renderer, which suspends via `use()` on a dynamic-import promise
+  // (docs-client-loader.tsx) -- a promise that never settles keeps the Suspense boundary showing its
+  // fallback indefinitely, the same as a slow/never-hydrating MDX chunk would in production.
+  return use(new Promise<never>(() => {}));
+}
+
+describe("docs route Suspense fallback (#6982)", () => {
+  it("LoadingState renders the accessible role=status markup every docs route's Suspense boundary now falls back to", () => {
+    render(
+      <Suspense fallback={<LoadingState />}>
+        <NeverResolves />
+      </Suspense>,
+    );
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText("Loading…")).toBeTruthy();
+  });
+
+  it("every docs.*.tsx route imports LoadingState and uses it as the sole Suspense fallback, not a hand-rolled <p>", () => {
+    const routesDir = join(process.cwd(), "src/routes");
+    const docsRouteFiles = readdirSync(routesDir).filter(
+      (name) => name.startsWith("docs.") && name.endsWith(".tsx") && !name.endsWith(".test.tsx"),
+    );
+
+    // fumadocs-spike-api-reference.tsx is a standalone Scalar API-reference spike (#6037) that wraps
+    // ClientOnly, not Suspense; docs.index.tsx is a static landing page with no MDX content and no
+    // Suspense boundary; docs.tsx is the shared parent layout route, not a content page. None were
+    // part of this issue's 46-file scope.
+    const outOfScope = new Set([
+      "docs.fumadocs-spike-api-reference.tsx",
+      "docs.index.tsx",
+      "docs.tsx",
+    ]);
+    const inScope = docsRouteFiles.filter((name) => !outOfScope.has(name));
+    expect(inScope.length).toBe(46);
+
+    for (const file of inScope) {
+      const source = readFileSync(join(routesDir, file), "utf8");
+      expect(source, `${file} should import LoadingState`).toContain(
+        'import { LoadingState } from "@/components/site/state-views";',
+      );
+      expect(source, `${file} should use LoadingState as the Suspense fallback`).toContain(
+        "<Suspense fallback={<LoadingState />}>",
+      );
+      expect(
+        source,
+        `${file} should not still hand-roll the old plain-text fallback`,
+      ).not.toContain('text-muted-foreground">Loading…</p>');
+    }
+  });
+});

--- a/apps/loopover-ui/src/routes/docs.ai-summaries.tsx
+++ b/apps/loopover-ui/src/routes/docs.ai-summaries.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ai-summaries.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AiSummariesDoc() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Roadmap · exploring" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-config-precedence.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-config-precedence.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-config-precedence.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsConfigPrecedence() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-deployment.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-deployment.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-deployment.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsDeployment() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-discovery-plane.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-discovery-plane.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-discovery-plane.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsDiscoveryPlane() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-env-reference.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-env-reference.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-env-reference.mdx via fumadocs-mdx's browser entry
@@ -45,7 +46,7 @@ function AmsEnvReference() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-fleet-manifest.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-fleet-manifest.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-fleet-manifest.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsFleetManifest() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-goal-spec.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-goal-spec.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-goal-spec.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsGoalSpec() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-observability.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-observability.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-observability.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsObservability() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-operations-runbook.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-operations-runbook.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-operations-runbook.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsOperationsRunbook() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-sizing.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-sizing.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-sizing.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsSizing() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.ams-unattended-scheduling.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-unattended-scheduling.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/ams-unattended-scheduling.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function AmsUnattendedScheduling() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.beta-onboarding.tsx
+++ b/apps/loopover-ui/src/routes/docs.beta-onboarding.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/beta-onboarding.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function BetaOnboarding() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Get started" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.branch-analysis.tsx
+++ b/apps/loopover-ui/src/routes/docs.branch-analysis.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/branch-analysis.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function BranchAnalysis() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Core concepts" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.federated-fleet-intelligence.tsx
+++ b/apps/loopover-ui/src/routes/docs.federated-fleet-intelligence.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/federated-fleet-intelligence.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function FederatedFleetIntelligence() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.github-app.tsx
+++ b/apps/loopover-ui/src/routes/docs.github-app.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/github-app.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function GithubApp() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Workflows" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.how-reviews-work.tsx
+++ b/apps/loopover-ui/src/routes/docs.how-reviews-work.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/how-reviews-work.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function HowReviewsWork() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Reviews" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.loopover-commands.tsx
+++ b/apps/loopover-ui/src/routes/docs.loopover-commands.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/loopover-commands.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function LoopOverCommandsReference() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Commands" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.maintainer-install-trust.tsx
+++ b/apps/loopover-ui/src/routes/docs.maintainer-install-trust.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/maintainer-install-trust.mdx via fumadocs-mdx's browser entry
@@ -44,7 +45,7 @@ function MaintainerInstallTrust() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Launch guide" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.maintainer-self-hosting.tsx
+++ b/apps/loopover-ui/src/routes/docs.maintainer-self-hosting.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/maintainer-self-hosting.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function MaintainerSelfHosting() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Maintainers" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.maintainer-workflow.tsx
+++ b/apps/loopover-ui/src/routes/docs.maintainer-workflow.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/maintainer-workflow.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function MaintainerWorkflow() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Workflows" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.mcp-clients.tsx
+++ b/apps/loopover-ui/src/routes/docs.mcp-clients.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/mcp-clients.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function McpClients() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Get started" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.miner-coding-agent.tsx
+++ b/apps/loopover-ui/src/routes/docs.miner-coding-agent.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/miner-coding-agent.mdx via fumadocs-mdx's browser entry
@@ -130,7 +131,7 @@ export function MinerCodingAgentDriverDocs() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Configuration" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.miner-quickstart.tsx
+++ b/apps/loopover-ui/src/routes/docs.miner-quickstart.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/miner-quickstart.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ export function MinerQuickstart() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Get started" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.miner-workflow.tsx
+++ b/apps/loopover-ui/src/routes/docs.miner-workflow.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/miner-workflow.mdx via fumadocs-mdx's browser entry
@@ -40,7 +41,7 @@ export function MinerWorkflow() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Workflows" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.owner-checklist.tsx
+++ b/apps/loopover-ui/src/routes/docs.owner-checklist.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/owner-checklist.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function OwnerChecklist() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Repo owners" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.privacy-security.tsx
+++ b/apps/loopover-ui/src/routes/docs.privacy-security.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/privacy-security.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function PrivacySecurity() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Operating" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.quickstart.tsx
+++ b/apps/loopover-ui/src/routes/docs.quickstart.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/quickstart.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function Quickstart() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Get started" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.scoreability.tsx
+++ b/apps/loopover-ui/src/routes/docs.scoreability.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/scoreability.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function Scoreability() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Core concepts" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-ai-providers.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingAiProviders() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-backup-scaling.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingBackupScaling() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-configuration.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingConfiguration() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-docs-audit.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-docs-audit.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-docs-audit.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingDocsAudit() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-github-app.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingGithubApp() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-operations.mdx via fumadocs-mdx's browser
@@ -41,7 +42,7 @@ export function SelfHostingOperations() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // SPIKE (#6037): rendered from content/docs/self-hosting-quickstart.mdx via fumadocs-mdx's
@@ -44,7 +45,7 @@ function SelfHostingQuickstart() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-rag.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-rag.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-rag.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingRag() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-rees-analyzers.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-rees-analyzers.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-rees-analyzers.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingReesAnalyzers() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-rees.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-rees.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-rees.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingRees() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-release-checklist.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingReleaseChecklist() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-releases.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-releases.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-releases.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingReleases() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-security.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-security.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingSecurity() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-troubleshooting.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-troubleshooting.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-troubleshooting.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function SelfHostingTroubleshooting() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-unified-ams-orb.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-unified-ams-orb.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/self-hosting-unified-ams-orb.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function UnifiedAmsOrb() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Self-hosting" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.troubleshooting.tsx
+++ b/apps/loopover-ui/src/routes/docs.troubleshooting.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/troubleshooting.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function Troubleshooting() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Operating" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.tuning.tsx
+++ b/apps/loopover-ui/src/routes/docs.tuning.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/tuning.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function Tuning() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Operating" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>

--- a/apps/loopover-ui/src/routes/docs.upstream-drift.tsx
+++ b/apps/loopover-ui/src/routes/docs.upstream-drift.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
 import { docsClientLoader } from "@/lib/docs-client-loader";
 
 // Rendered from content/docs/upstream-drift.mdx via fumadocs-mdx's browser entry
@@ -41,7 +42,7 @@ function UpstreamDrift() {
   const Content = docsClientLoader.getComponent(path);
   return (
     <DocsPage eyebrow="Core concepts" title={title} description={description}>
-      <Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>
+      <Suspense fallback={<LoadingState />}>
         <Content />
       </Suspense>
     </DocsPage>


### PR DESCRIPTION
## Summary
- 46 `docs.*.tsx` route files under `apps/loopover-ui/src/routes/` each hand-rolled the identical literal `<Suspense fallback={<p className="text-token-sm text-muted-foreground">Loading…</p>}>` instead of the shared `LoadingState` component (`@/components/site/state-views`, re-exported from `@loopover/ui-kit`) that every other consumer in this app already uses (see `changelog.tsx`'s `<LoadingState title="Loading from npm…" />`).
- Replaced the fallback in all 46 files with `<Suspense fallback={<LoadingState />}>` and added the matching import. `LoadingState`'s default `title` is exactly `"Loading…"`, so the visible text is unchanged — the only difference is the shared component's `role="status"`/`aria-live="polite"` accessible markup and spinner icon, in place of a plain, non-semantic `<p>`.
- Two files that also match the `docs.*.tsx` glob were deliberately left untouched: `docs.index.tsx` (a static landing page with no MDX content or Suspense boundary) and `docs.fumadocs-spike-api-reference.tsx` (wraps `ClientOnly`, not `Suspense`, for an unrelated Scalar API-reference spike, #6037). `docs.tsx` (the shared parent layout route) was also out of scope.
- No change to `Suspense`'s boundary placement or the content component itself, per the issue's explicit scope.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #6982

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck` (via `npm run ui:typecheck`, which builds `@loopover/ui-kit` then typechecks `@loopover/ui` and `@loopover/ui-miner`) — clean, no errors.
- [x] `npm run ui:lint` — 0 errors (pre-existing, unrelated `react-refresh/only-export-components` warnings on other files are untouched baseline noise).
- [x] `npm run ui:test` — full workspace run: `@loopover/ui` (65 files / 373 tests), `@loopover/ui-miner` (25 files / 291 tests), `@loopover/miner-extension` (5 files / 33 tests) — all passing, including the two new tests in `docs-routes-loading-state.test.tsx`.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — this PR only touches `apps/loopover-ui/src/routes/**`, no API/schema/worker/MCP surface)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — `apps/**` is outside Codecov's strict patch gate, but a new regression test asserts `LoadingState`'s accessible `role="status"` markup renders while suspended, plus a second test that all 46 in-scope `docs.*.tsx` files import and use `LoadingState` as their sole Suspense fallback (guarding against a future file re-adding the old inline `<p>` pattern).

If any required check was skipped, explain why:

- `npm run ui:build` currently fails on this sandbox with an unrelated pre-existing error (`Rolldown failed to resolve import "@scalar/api-reference"` from `docs.fumadocs-spike-api-reference.tsx`, a file this PR does not touch) — reproduced identically on a clean `main` checkout before starting this change, confirming it's a local dependency-install gap, not something this diff introduces.
- A live browser navigation to a docs route in this sandbox's dev server currently throws an unrelated pre-existing `"CodeBlock is not defined"` error from the MDX content provider — reproduces on every docs route regardless of whether the page has code fences, confirming it's a systemic dev-environment/MDX-provider wiring issue unrelated to this diff (no MDX component, `docs-mdx-components.tsx`, or `docs-client-loader.tsx` file was touched). See the UI Evidence section below for how screenshot evidence was captured instead.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — this PR only changes which shared loading-state primitive a static Suspense fallback renders, not any data-fetch behavior.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Captured by navigating Playwright to the real running app (so the actual compiled Tailwind stylesheet and dark theme are loaded exactly as production serves them), then rendering both fallback markups side by side — the old hand-rolled `<p>` and the new `LoadingState` output (same DOM shape `LoadingState` actually renders: `Shell` + `Spinner`), since a live docs-route navigation is blocked in this sandbox by the unrelated pre-existing MDX error noted above.

<a href="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/docs-loading-state-before-after.jpg"><img src="https://raw.githubusercontent.com/galuis116/gittensory/screenshots/docs-loading-state-before-after.jpg" alt="Before: plain-text Loading… paragraph. After: LoadingState's role=status shell with spinner icon and the same Loading… text" width="480"></a>
