### PR TITLE
feat(scripts): add load-testing tooling for the Worker's key endpoints

### DIFF
--- a/docs/load-test-worker.md
+++ b/docs/load-test-worker.md
@@ -1,0 +1,85 @@
+# worker load test
+
+A committed load-testing harness for the root Cloudflare Worker's HTTP endpoints (`src/api/routes.ts`).
+Every existing test under `test/workers/` and `test/integration/` is correctness-oriented and drives the
+Worker in-process (`worker.fetch(request, env, ctx)` directly, per `test/workers/worker-runtime.test.ts`)
+— no real HTTP layer, no real concurrency semantics. This harness issues real `fetch()` requests against
+a separately-running Worker instance and reports wall-clock throughput/latency per concurrency level. See
+issue #4913; `packages/loopover-engine/docs/iterate-loop-load-test.md` (#5224) is the AMS-side counterpart
+this mirrors.
+
+## Running it
+
+Start the Worker in one terminal:
+
+```sh
+npm run dev
+# Ready on http://127.0.0.1:8787
+```
+
+Then, in another terminal:
+
+```sh
+npm run loadtest:worker
+# or with explicit flags:
+node scripts/load-test-worker.mjs --origin http://127.0.0.1:8787 --path /health --levels 1,8,32,128 --requests-per-level 64
+```
+
+This prints a short text report to stdout and exits `0`. It does not fail the build or a CI job on its
+own — it is a signal to read, not a hard gate (there is no fixed pass/fail threshold, since wall-clock
+timing on a shared machine is too noisy to gate on reliably). Run it locally before/after a change to
+`src/api/routes.ts` or its middleware (`src/auth/rate-limit.ts`, CORS/auth gating) to see whether the
+change moved the needle under concurrency.
+
+## What it measures
+
+Each concurrency level issues a configured number of real HTTP `GET` requests against `${origin}${path}`,
+`concurrency` requests in flight at a time (batched via `Promise.all`, batches run sequentially so one
+level's connection contention never bleeds into the next), and reports wall-clock throughput plus p50/p95
+latency across the successful requests. Non-2xx responses and connection errors/timeouts are counted
+separately (`errorCount`) rather than aborting the batch — how a route degrades under load is itself part
+of what this tool measures.
+
+- **Concurrency levels:** 1, 8, 32, 128 concurrent requests.
+- **Requests per level:** 64.
+- **Default target:** `GET /health` — the one route explicitly exempt from both the `RATE_LIMITER`
+  Durable Object and the CORS-credential gate (`src/api/routes.ts`'s rate-limit middleware short-circuits
+  `c.req.path === "/health"` before `enforceRateLimit` runs), so it can be hammered at any concurrency
+  without every request collapsing into `429`s from the shared per-IP rate-limit bucket a single-machine
+  local run would otherwise produce against any other route. Point `--path` at another public,
+  unauthenticated route (e.g. `/openapi.json`, `/v1/mcp/compatibility`) to measure a CPU-bound handler
+  instead — expect `errorCount` to climb well before `/health`'s does, since those routes are rate-limited
+  at 120 requests/60s per IP.
+
+## Baseline (informational only, machine-dependent)
+
+Captured on a Linux x86_64 dev container, Node.js 22.21.0, against a local `npm run dev` instance
+(`GET /health`, 64 requests per level). Absolute numbers vary by hardware and by what else is running on
+the machine — use this as a rough sense of scale, not a target:
+
+```
+worker load test
+
+concurrency=1 path=/health: 354.69ms wall for 64 requests, 180 req/sec, 64/64 ok (p50 4.13ms, p95 7.60ms)
+concurrency=8 path=/health: 419.84ms wall for 64 requests, 152 req/sec, 64/64 ok (p50 16.45ms, p95 131.20ms)
+concurrency=32 path=/health: 139.87ms wall for 64 requests, 458 req/sec, 64/64 ok (p50 47.71ms, p95 72.89ms)
+concurrency=128 path=/health: 248.75ms wall for 64 requests, 257 req/sec, 64/64 ok (p50 212.24ms, p95 238.08ms)
+```
+
+A second run against the same local instance immediately after produced comparable numbers (same order of
+magnitude, 64/64 ok at every level, latency growing with concurrency as expected):
+
+```
+worker load test
+
+concurrency=1 path=/health: 517.57ms wall for 64 requests, 124 req/sec, 64/64 ok (p50 4.92ms, p95 21.45ms)
+concurrency=8 path=/health: 212.28ms wall for 64 requests, 301 req/sec, 64/64 ok (p50 16.46ms, p95 45.48ms)
+concurrency=32 path=/health: 212.10ms wall for 64 requests, 302 req/sec, 64/64 ok (p50 73.91ms, p95 121.00ms)
+concurrency=128 path=/health: 144.74ms wall for 64 requests, 442 req/sec, 64/64 ok (p50 82.06ms, p95 132.22ms)
+```
+
+`/health` never returned a non-2xx or errored response at any concurrency level in either run, confirming
+the rate-limit exemption holds under load. Latency grows with concurrency (local single-process `wrangler
+dev` has one event loop and one Durable Object namespace serving every request; a real deployed edge
+Worker distributes concurrent requests across many isolates and points of presence, so production latency
+under equivalent concurrency is expected to scale differently than this single-instance local measurement).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "benchmark:miner": "node packages/loopover-miner/scripts/benchmark.mjs",
     "cross-repo-eval:miner": "node packages/loopover-miner/scripts/cross-repo-evaluation.mjs",
     "loadtest:iterate-loop": "npm run build --workspace @loopover/engine && node packages/loopover-engine/scripts/load-test-iterate-loop.mjs",
+    "loadtest:worker": "node scripts/load-test-worker.mjs",
     "command-reference": "node scripts/gen-command-reference.mjs",
     "command-reference:check": "node scripts/gen-command-reference.mjs --check",
     "selfhost:validate-observability": "node scripts/validate-observability-configs.mjs",

--- a/scripts/load-test-worker.d.mts
+++ b/scripts/load-test-worker.d.mts
@@ -1,0 +1,51 @@
+export type RequestOnceOptions = {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+};
+
+export type RequestOnceResult = {
+  ok: boolean;
+  status: number | null;
+  elapsedMs: number;
+  error?: string;
+};
+
+export type LoadTestOptions = {
+  origin?: string;
+  path?: string;
+  levels?: number[];
+  requestCount?: number;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+};
+
+export type LoadTestLevelResult = {
+  concurrency: number;
+  requestCount: number;
+  path: string;
+  wallMs: number;
+  successCount: number;
+  errorCount: number;
+  requestsPerSecond: number;
+  p50Ms: number;
+  p95Ms: number;
+};
+
+export declare const DEFAULT_ORIGIN: string;
+export declare const DEFAULT_PATH: string;
+export declare const DEFAULT_CONCURRENCY_LEVELS: number[];
+export declare const DEFAULT_REQUESTS_PER_LEVEL: number;
+export declare const DEFAULT_TIMEOUT_MS: number;
+
+export declare function requestOnce(url: string, options?: RequestOnceOptions): Promise<RequestOnceResult>;
+
+export declare function percentile(values: readonly number[], p: number): number;
+
+export declare function runConcurrencyLevel(
+  concurrency: number,
+  options?: LoadTestOptions,
+): Promise<LoadTestLevelResult>;
+
+export declare function runLoadTest(options?: LoadTestOptions): Promise<LoadTestLevelResult[]>;
+
+export declare function formatLoadTestReport(results: readonly LoadTestLevelResult[]): string;

--- a/scripts/load-test-worker.mjs
+++ b/scripts/load-test-worker.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { performance } from "node:perf_hooks";
+
+// Load-testing harness for the Worker's key HTTP endpoints (#4913): every existing test under test/workers and
+// test/integration is correctness-oriented and drives the Worker in-process (worker.fetch(request, env, ctx)
+// directly, per test/workers/worker-runtime.test.ts) -- no real HTTP layer, no real concurrency semantics. This
+// harness issues real fetch() requests against a separately-running Worker instance (start one first with
+// `npm run dev`, which serves http://127.0.0.1:8787 by default) and reports wall-clock throughput/latency per
+// concurrency level. See docs/load-test-worker.md for how to run this and read the numbers, and
+// packages/loopover-engine/docs/iterate-loop-load-test.md (#5224) for the AMS-side counterpart this mirrors.
+//
+// Defaults to GET /health: the one route explicitly exempt from both the RATE_LIMITER Durable Object and the
+// CORS-credential gate (src/api/routes.ts's rate-limit middleware short-circuits `c.req.path === "/health"`
+// before enforceRateLimit runs), so it can be hammered at any concurrency without every request collapsing into
+// 429s from the shared per-IP rate-limit bucket a single-machine local run would otherwise produce against any
+// other route. --path can target another public route; non-2xx and errored responses are counted and reported
+// per level rather than treated as a hard script failure, since how a route degrades under load is itself part
+// of what this tool measures.
+
+export const DEFAULT_ORIGIN = "http://127.0.0.1:8787";
+export const DEFAULT_PATH = "/health";
+export const DEFAULT_CONCURRENCY_LEVELS = [1, 8, 32, 128];
+export const DEFAULT_REQUESTS_PER_LEVEL = 64;
+export const DEFAULT_TIMEOUT_MS = 20_000;
+
+/** One GET request against `url`, using an injectable `fetchImpl` (defaults to global fetch) so tests can stub
+ *  the network entirely. Never throws: a connection error or an aborted timeout is reported in the same shape a
+ *  real HTTP response would be (`ok: false`, `status: null`), so one bad request never aborts its batch. */
+export async function requestOnce(url, options = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const start = performance.now();
+  try {
+    const response = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: { "user-agent": "loopover-load-test" },
+    });
+    return { ok: response.ok, status: response.status, elapsedMs: performance.now() - start };
+  } catch (error) {
+    return {
+      ok: false,
+      status: null,
+      elapsedMs: performance.now() - start,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** The p-th percentile (0-100) of `values` via nearest-rank on a sorted copy. Returns 0 for an empty input so a
+ *  level with zero successful requests reports a well-defined (not NaN) latency. */
+export function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, rank)];
+}
+
+/**
+ * Run `requestCount` GET requests against `${origin}${path}` in batches of `concurrency` in flight at a time
+ * (`Promise.all` per batch, batches run sequentially), and report aggregate wall time, throughput, error count,
+ * and latency percentiles. Batching (rather than firing all `requestCount` requests in one `Promise.all`) keeps
+ * each level's in-flight connection count bounded to `concurrency`, matching what "N concurrent users" means.
+ */
+export async function runConcurrencyLevel(concurrency, options = {}) {
+  const origin = options.origin ?? DEFAULT_ORIGIN;
+  const path = options.path ?? DEFAULT_PATH;
+  const requestCount = options.requestCount ?? DEFAULT_REQUESTS_PER_LEVEL;
+  const url = `${origin}${path}`;
+
+  const start = performance.now();
+  const outcomes = [];
+  for (let batchStart = 0; batchStart < requestCount; batchStart += concurrency) {
+    const batchSize = Math.min(concurrency, requestCount - batchStart);
+    const batch = await Promise.all(
+      Array.from({ length: batchSize }, () => requestOnce(url, options)),
+    );
+    outcomes.push(...batch);
+  }
+  const wallMs = performance.now() - start;
+  const successes = outcomes.filter((o) => o.ok);
+  const latencies = successes.map((o) => o.elapsedMs);
+
+  return {
+    concurrency,
+    requestCount,
+    path,
+    wallMs,
+    successCount: successes.length,
+    errorCount: outcomes.length - successes.length,
+    requestsPerSecond: requestCount / (wallMs / 1000),
+    p50Ms: percentile(latencies, 50),
+    p95Ms: percentile(latencies, 95),
+  };
+}
+
+/** Run every concurrency level in `levels` in sequence (never overlapping each other), so one level's connection
+ *  contention never bleeds into the next level's measurement. */
+export async function runLoadTest(options = {}) {
+  const levels = options.levels ?? DEFAULT_CONCURRENCY_LEVELS;
+  const results = [];
+  for (const concurrency of levels) {
+    results.push(await runConcurrencyLevel(concurrency, options));
+  }
+  return results;
+}
+
+/** Render load-test results as a stable, greppable text report (no locale-dependent number formatting). */
+export function formatLoadTestReport(results) {
+  const lines = ["worker load test", ""];
+  for (const r of results) {
+    lines.push(
+      `concurrency=${r.concurrency} path=${r.path}: ${r.wallMs.toFixed(2)}ms wall for ${r.requestCount} requests, ` +
+        `${Math.round(r.requestsPerSecond)} req/sec, ${r.successCount}/${r.requestCount} ok ` +
+        `(p50 ${r.p50Ms.toFixed(2)}ms, p95 ${r.p95Ms.toFixed(2)}ms)`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function parseArgs(argv) {
+  const args = {
+    origin: DEFAULT_ORIGIN,
+    path: DEFAULT_PATH,
+    levels: DEFAULT_CONCURRENCY_LEVELS,
+    requestCount: DEFAULT_REQUESTS_PER_LEVEL,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--origin") args.origin = argv[++i];
+    else if (flag === "--path") args.path = argv[++i];
+    else if (flag === "--requests-per-level") args.requestCount = Number(argv[++i]);
+    else if (flag === "--levels") args.levels = argv[++i].split(",").map(Number);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const results = await runLoadTest({
+    origin: args.origin,
+    path: args.path,
+    levels: args.levels,
+    requestCount: args.requestCount,
+  });
+  console.log(formatLoadTestReport(results));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/test/unit/load-test-worker-script.test.ts
+++ b/test/unit/load-test-worker-script.test.ts
@@ -1,0 +1,196 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CONCURRENCY_LEVELS,
+  DEFAULT_ORIGIN,
+  DEFAULT_PATH,
+  DEFAULT_REQUESTS_PER_LEVEL,
+  DEFAULT_TIMEOUT_MS,
+  formatLoadTestReport,
+  percentile,
+  requestOnce,
+  runConcurrencyLevel,
+  runLoadTest,
+} from "../../scripts/load-test-worker.mjs";
+
+describe("worker load-test script (#4913)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requestOnce reports a successful response's status and a non-negative elapsed time", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    const result = await requestOnce("http://127.0.0.1:8787/health", { fetchImpl });
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.error).toBeUndefined();
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:8787/health",
+      expect.objectContaining({ headers: { "user-agent": "loopover-load-test" } }),
+    );
+  });
+
+  it("requestOnce reports a non-2xx response as not ok without throwing", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 429 }));
+    const result = await requestOnce("http://127.0.0.1:8787/v1/mcp/compatibility", { fetchImpl });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(429);
+  });
+
+  it("requestOnce reports a thrown fetch error (e.g. connection refused) as ok:false with status:null, not a rejection", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const result = await requestOnce("http://127.0.0.1:8787/health", { fetchImpl });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.error).toBe("ECONNREFUSED");
+  });
+
+  it("requestOnce aborts and reports failure once the timeout elapses", async () => {
+    const fetchImpl = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    );
+    const result = await requestOnce("http://127.0.0.1:8787/health", { fetchImpl, timeoutMs: 5 });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("aborted");
+  });
+
+  it("percentile returns 0 for an empty array without dividing by zero", () => {
+    expect(percentile([], 50)).toBe(0);
+    expect(percentile([], 95)).toBe(0);
+  });
+
+  it("percentile picks the nearest-rank value from a sorted copy without mutating the input", () => {
+    const values = [50, 10, 40, 20, 30];
+    expect(percentile(values, 50)).toBe(30);
+    expect(percentile(values, 95)).toBe(50);
+    expect(values).toEqual([50, 10, 40, 20, 30]);
+  });
+
+  it("runConcurrencyLevel batches requests, aggregates successes/errors, and computes latency percentiles", async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      // Every third request fails, so successCount/errorCount are both exercised on a single level.
+      return new Response(null, { status: call % 3 === 0 ? 500 : 200 });
+    });
+    const level = await runConcurrencyLevel(4, {
+      requestCount: 9,
+      path: "/health",
+      fetchImpl,
+    });
+    expect(level.concurrency).toBe(4);
+    expect(level.requestCount).toBe(9);
+    expect(level.path).toBe("/health");
+    expect(level.successCount).toBe(6);
+    expect(level.errorCount).toBe(3);
+    expect(Number.isFinite(level.wallMs)).toBe(true);
+    expect(level.wallMs).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(level.requestsPerSecond)).toBe(true);
+    expect(level.p50Ms).toBeGreaterThanOrEqual(0);
+    expect(level.p95Ms).toBeGreaterThanOrEqual(level.p50Ms);
+    expect(fetchImpl).toHaveBeenCalledTimes(9);
+  });
+
+  it("runConcurrencyLevel handles a batch size that exceeds the request count in a single batch", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    const level = await runConcurrencyLevel(128, { requestCount: 3, fetchImpl });
+    expect(level.requestCount).toBe(3);
+    expect(level.successCount).toBe(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("runConcurrencyLevel reports 0/0 p50/p95 when every request errors", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    const level = await runConcurrencyLevel(2, { requestCount: 2, fetchImpl });
+    expect(level.successCount).toBe(0);
+    expect(level.errorCount).toBe(2);
+    expect(level.p50Ms).toBe(0);
+    expect(level.p95Ms).toBe(0);
+  });
+
+  it("runLoadTest runs every concurrency level supplied via options.levels, in order, against the given origin/path", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    const results = await runLoadTest({
+      levels: [1, 2],
+      requestCount: 2,
+      origin: "http://example.test",
+      path: "/health",
+      fetchImpl,
+    });
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.concurrency)).toEqual([1, 2]);
+    for (const r of results) {
+      expect(r.successCount).toBe(2);
+      expect(r.path).toBe("/health");
+    }
+    expect(fetchImpl).toHaveBeenCalledWith("http://example.test/health", expect.anything());
+  });
+
+  it("exposes the documented defaults", () => {
+    expect(DEFAULT_ORIGIN).toBe("http://127.0.0.1:8787");
+    expect(DEFAULT_PATH).toBe("/health");
+    expect(DEFAULT_CONCURRENCY_LEVELS).toEqual([1, 8, 32, 128]);
+    expect(DEFAULT_REQUESTS_PER_LEVEL).toBe(64);
+    expect(DEFAULT_TIMEOUT_MS).toBe(20_000);
+  });
+
+  it("renders a deterministic report with no locale-dependent number formatting", () => {
+    expect(
+      formatLoadTestReport([
+        {
+          concurrency: 1,
+          requestCount: 10,
+          path: "/health",
+          wallMs: 160.4,
+          successCount: 10,
+          errorCount: 0,
+          requestsPerSecond: 62.34,
+          p50Ms: 12.345,
+          p95Ms: 20.5,
+        },
+        {
+          concurrency: 8,
+          requestCount: 10,
+          path: "/health",
+          wallMs: 20.1,
+          successCount: 9,
+          errorCount: 1,
+          requestsPerSecond: 497.5,
+          p50Ms: 3.1,
+          p95Ms: 6,
+        },
+      ]),
+    ).toBe(
+      [
+        "worker load test",
+        "",
+        "concurrency=1 path=/health: 160.40ms wall for 10 requests, 62 req/sec, 10/10 ok (p50 12.35ms, p95 20.50ms)",
+        "concurrency=8 path=/health: 20.10ms wall for 10 requests, 498 req/sec, 9/10 ok (p50 3.10ms, p95 6.00ms)",
+      ].join("\n"),
+    );
+  });
+
+  it("runs end-to-end as a CLI script against an unreachable origin, reporting connection failures instead of crashing", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/load-test-worker.mjs",
+        "--origin",
+        "http://127.0.0.1:1",
+        "--levels",
+        "1",
+        "--requests-per-level",
+        "1",
+      ],
+      { cwd: process.cwd(), encoding: "utf8", timeout: 15_000 },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("worker load test");
+    expect(result.stdout).toContain("concurrency=1 path=/health:");
+    expect(result.stdout).toContain("0/1 ok");
+  });
+});


### PR DESCRIPTION
## Summary
- No load-testing tooling existed anywhere in the repository — every existing test is correctness-oriented, and the only "real Worker" test harness (`test/workers/worker-runtime.test.ts`) drives `worker.fetch(request, env, ctx)` in-process, with no real HTTP layer or concurrency semantics.
- Added `scripts/load-test-worker.mjs`: a scriptable, real-HTTP load-generation tool that issues concurrent `fetch()` requests against a separately-running Worker instance (`npm run dev`) and reports wall-clock throughput plus p50/p95 latency per concurrency level (1, 8, 32, 128 by default). No new dependency — a hand-rolled batched-`Promise.all` generator, matching the repo's existing convention (confirmed no `autocannon`/`k6`/similar tool is already installed).
- Defaults to `GET /health`, the one route explicitly exempt from both the `RATE_LIMITER` Durable Object and the CORS-credential gate (`src/api/routes.ts`'s rate-limit middleware short-circuits `c.req.path === "/health"`), so a local single-machine run can be hammered at any concurrency without every request collapsing into `429`s from the shared per-IP rate-limit bucket every other route would hit. `--path` can target another public route; non-2xx/errored responses are counted (`errorCount`) rather than treated as a hard script failure, since how a route degrades under load is itself part of what this tool measures.
- Mirrors the structure of `packages/loopover-engine/scripts/load-test-iterate-loop.mjs` (#5224, the AMS-side counterpart this issue's own header comment names as "the parallel Worker-endpoint load-testing precedent") — named exported functions (`requestOnce`, `percentile`, `runConcurrencyLevel`, `runLoadTest`, `formatLoadTestReport`) for direct unit testing, a thin `main()`/CLI wrapper, hand-parsed flags (no arg-parsing dependency), a deterministic report string, and a companion `.d.mts`.
- Added `docs/load-test-worker.md` (new root `docs/` — no root docs directory existed before), mirroring `packages/loopover-engine/docs/iterate-loop-load-test.md`'s structure exactly (intro/cross-reference, running instructions, what-it-measures, an explicitly informational/non-gating baseline section), with **two real, live-captured runs** against a local `npm run dev` instance committed as the baseline — confirming the tool is repeatable (both runs: 64/64 `ok` at every concurrency level, comparable order-of-magnitude throughput, latency growing with concurrency as expected).
- Registered `"loadtest:worker": "node scripts/load-test-worker.mjs"` in `package.json`, alongside the existing `"loadtest:iterate-loop"` entry.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #4913

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run command-reference:check` (unaffected, confirmed no drift)
- [x] `npm run docs:drift-check` / `npm run branding-drift:check` (unaffected by the new `docs/load-test-worker.md`, confirmed no drift)
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of diff size (reproduced on a clean checkout too); `node --check scripts/load-test-worker.mjs` is clean, and the new `.d.mts` companion follows `load-test-iterate-loop.d.mts`'s exact existing shape.
- [x] `npx vitest run test/unit/load-test-worker-script.test.ts` — 13/13 passing (arg parsing is exercised via the CLI smoke test; `requestOnce`/`percentile`/`runConcurrencyLevel`/`runLoadTest`/`formatLoadTestReport` are each directly unit-tested with an injectable `fetchImpl`, including a success case, a non-2xx case, a thrown-connection-error case, and a timeout/abort case).
- [x] `scripts/**` is in `codecov.yml`'s `ignore` list (confirmed), so this PR carries no Codecov patch-coverage obligation — the new script has its own dedicated 13-test regression suite regardless.
- [x] **Live baseline captured**: started the Worker locally (`npm run dev`, ready on `http://127.0.0.1:8787`), ran `node scripts/load-test-worker.mjs` twice against it, confirmed `/health` never returned a non-2xx/errored response at any of the four concurrency levels in either run, and committed both runs' output verbatim in `docs/load-test-worker.md`'s baseline section.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — this PR only adds a standalone script + doc + one npm-script registration; no Worker route, MCP, or OpenAPI surface changed)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure regardless of diff size; `node --check` plus the new `.d.mts` companion (mirroring the existing precedent's shape exactly) are the local proxy, and CI's isolated runner performs the real `tsc --noEmit`.
- `npm run test:coverage` (full unsharded run) did not finish within this session's tool timeout on this shared sandbox; `scripts/**` is Codecov-ignored regardless (confirmed in `codecov.yml`), and the new file's dedicated 13-test suite (including edge cases: non-2xx, thrown fetch error, abort/timeout, empty-percentile, batch-size-exceeds-request-count) is the local coverage proxy for this specific diff.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — this tool only issues unauthenticated `GET` requests against already-public routes; it makes no auth/cookie/CORS/session changes itself.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no route, schema, or MCP behavior changed; this is a standalone diagnostic script.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no UI changes; this is a CLI tool + doc.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
