### PR TITLE
feat(db): add a tenant column to ai_usage_events for centralized hosted billing

### DIFF
--- a/migrations/0163_add_ai_usage_events_installation_id.sql
+++ b/migrations/0163_add_ai_usage_events_installation_id.sql
@@ -1,0 +1,10 @@
+-- Centralized hosted billing (#7176, part of the #7173 shared control-plane): ai_usage_events records AI
+-- usage/cost per event but had no tenant column -- identity was only recoverable indirectly via
+-- actor/route/metadata_json. A central aggregator (shared by ORB + AMS) needs a real column to attribute usage
+-- without parsing free-form metadata. Nullable + backfilled-null: self-host has no installation concept and
+-- keeps working unchanged; hosted containers populate it at insert time. Applies to BOTH this table's purposes
+-- (AI usage AND the BYOK `byok:...` key-lifecycle audit log double-purpose).
+ALTER TABLE ai_usage_events ADD COLUMN installation_id TEXT;
+
+-- Covers the per-tenant billing aggregate (sumAiCostForTenantSince): WHERE installation_id = ? AND created_at >= ?.
+CREATE INDEX IF NOT EXISTS ai_usage_events_installation_created_idx ON ai_usage_events (installation_id, created_at);

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3570,6 +3570,9 @@ export async function recordAiUsageEvent(
     costUsd?: number | null | undefined;
     detail?: string | null | undefined;
     metadata?: Record<string, unknown> | undefined;
+    // #7176: tenant attribution for centralized hosted billing. Optional -- self-host callers omit it and the
+    // column stays null, byte-identical to today; hosted containers pass their installation id.
+    installationId?: string | null | undefined;
   },
 ): Promise<void> {
   const db = getDb(env.DB);
@@ -3589,6 +3592,7 @@ export async function recordAiUsageEvent(
     costUsd: Math.max(0, finiteNumber(event.costUsd)),
     detail: event.detail ?? null,
     metadataJson: jsonString(event.metadata ?? {}),
+    installationId: event.installationId ?? null,
     createdAt: nowIso(),
   });
 }
@@ -3599,6 +3603,20 @@ export async function sumAiEstimatedNeuronsSince(env: Env, sinceIso: string): Pr
     .select({ total: sql<number>`coalesce(sum(${aiUsageEvents.estimatedNeurons}), 0)` })
     .from(aiUsageEvents)
     .where(and(gte(aiUsageEvents.createdAt, sinceIso), eq(aiUsageEvents.status, "ok")));
+  /* v8 ignore next -- SQL aggregate sum always returns one row; fallback protects D1 driver anomalies. */
+  return Number(row?.total ?? 0);
+}
+
+/** #7176: total AI cost (USD) attributed to one tenant (installation) since a timestamp, for centralized hosted
+ *  billing. Mirrors sumAiEstimatedNeuronsSince's shape; scoped by installation_id instead of a global window, and
+ *  covered by the ai_usage_events_installation_created_idx index. Self-host rows (null installation_id) are never
+ *  matched by an equality filter, so this is inherently hosted-only. */
+export async function sumAiCostForTenantSince(env: Env, installationId: string, sinceIso: string): Promise<number> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({ total: sql<number>`coalesce(sum(${aiUsageEvents.costUsd}), 0)` })
+    .from(aiUsageEvents)
+    .where(and(eq(aiUsageEvents.installationId, installationId), gte(aiUsageEvents.createdAt, sinceIso)));
   /* v8 ignore next -- SQL aggregate sum always returns one row; fallback protects D1 driver anomalies. */
   return Number(row?.total ?? 0);
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1304,10 +1304,15 @@ export const aiUsageEvents = sqliteTable(
     costUsd: real("cost_usd").notNull().default(0),
     detail: text("detail"),
     metadataJson: text("metadata_json").notNull().default("{}"),
+    // #7176: tenant attribution for centralized hosted billing (ORB + AMS). Nullable -- self-host rows have no
+    // installation concept; hosted containers populate it at insert time. Applies to the BYOK audit rows too.
+    installationId: text("installation_id"),
     createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
   },
   (table) => ({
     featureCreated: index("ai_usage_events_feature_created_idx").on(table.feature, table.createdAt),
+    // Covers the per-tenant billing aggregate (sumAiCostForTenantSince).
+    installationCreated: index("ai_usage_events_installation_created_idx").on(table.installationId, table.createdAt),
     actorCreated: index("ai_usage_events_actor_created_idx").on(table.actor, table.createdAt),
     providerCreated: index("ai_usage_events_provider_created_idx").on(table.provider, table.createdAt),
     // Covers the daily-budget query (sumAiEstimatedNeuronsSince): WHERE status='ok' AND created_at >= ?.

--- a/test/unit/ai-usage-tenant.test.ts
+++ b/test/unit/ai-usage-tenant.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { recordAiUsageEvent, sumAiCostForTenantSince } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+// #7176: ai_usage_events gained a nullable installation_id tenant column for centralized hosted billing, plus a
+// sumAiCostForTenantSince aggregate. These pin: the column is written when supplied and stays null otherwise
+// (self-host unaffected), and the aggregate is correctly scoped by tenant + time window.
+const base = {
+  feature: "ai_review",
+  model: "claude-sonnet-5",
+  status: "ok",
+  estimatedNeurons: 10,
+  costUsd: 0.5,
+};
+
+async function installationOf(env: Env, id: string): Promise<string | null> {
+  const row = await env.DB.prepare("SELECT installation_id FROM ai_usage_events WHERE id = ?").bind(id).first<{ installation_id: string | null }>();
+  return row?.installation_id ?? null;
+}
+
+describe("ai_usage_events tenant column + billing aggregate (#7176)", () => {
+  it("writes installation_id when a hosted caller supplies it", async () => {
+    const env = createTestEnv();
+    await recordAiUsageEvent(env, { ...base, installationId: "inst-42", metadata: {}, detail: "x" });
+    const { results } = await env.DB.prepare("SELECT id, installation_id FROM ai_usage_events").all<{ id: string; installation_id: string | null }>();
+    expect(results).toHaveLength(1);
+    expect(results[0]!.installation_id).toBe("inst-42");
+  });
+
+  it("leaves installation_id null for a self-host caller that omits it (byte-identical to today)", async () => {
+    const env = createTestEnv();
+    await recordAiUsageEvent(env, { ...base });
+    const { results } = await env.DB.prepare("SELECT id FROM ai_usage_events").all<{ id: string }>();
+    expect(await installationOf(env, results[0]!.id)).toBeNull();
+    // Explicit null is also accepted and stays null.
+    await recordAiUsageEvent(env, { ...base, installationId: null });
+    const rows = await env.DB.prepare("SELECT installation_id FROM ai_usage_events").all<{ installation_id: string | null }>().then((r) => r.results);
+    expect(rows.every((r) => r.installation_id === null)).toBe(true);
+  });
+
+  it("sums cost per tenant since a timestamp, ignoring other tenants, older rows, and null-tenant self-host rows", async () => {
+    const env = createTestEnv();
+    // Two events for inst-1 after the window, one before it, one for inst-2, one self-host (null tenant).
+    const since = "2026-07-10T00:00:00.000Z";
+    const seed = async (installationId: string | null, costUsd: number, createdAt: string) => {
+      await recordAiUsageEvent(env, { ...base, costUsd, installationId });
+      // Backdate the just-inserted row (recordAiUsageEvent stamps nowIso()), so the window filter is exercised.
+      await env.DB.prepare("UPDATE ai_usage_events SET created_at = ? WHERE created_at = (SELECT max(created_at) FROM ai_usage_events)").bind(createdAt).run();
+    };
+    await seed("inst-1", 1.25, "2026-07-11T00:00:00.000Z");
+    await seed("inst-1", 0.75, "2026-07-12T00:00:00.000Z");
+    await seed("inst-1", 9.0, "2026-07-01T00:00:00.000Z"); // before the window
+    await seed("inst-2", 4.0, "2026-07-13T00:00:00.000Z"); // different tenant
+    await seed(null, 3.0, "2026-07-14T00:00:00.000Z"); // self-host, null tenant
+
+    expect(await sumAiCostForTenantSince(env, "inst-1", since)).toBeCloseTo(2.0, 5);
+    expect(await sumAiCostForTenantSince(env, "inst-2", since)).toBeCloseTo(4.0, 5);
+    // A tenant with no rows sums to 0, not an error.
+    expect(await sumAiCostForTenantSince(env, "inst-none", since)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What & why

`ai_usage_events` records AI usage/cost per event but had no tenant column — identity was only recoverable indirectly via `actor`/`route`/`metadata_json`. A central hosted-billing aggregator (shared by ORB + AMS once AMS's storage migration lands, #7173) needs a real column to attribute usage without parsing free-form metadata.

## Changes

- **Migration `0163`** adds a nullable `installation_id` column + a `(installation_id, created_at)` index, with the matching Drizzle declaration in `schema.ts`. `db:schema-drift` and `db:migrations` both pass (0163 contiguous; schema matches migrations).
- **`recordAiUsageEvent`** gains an optional `installationId` field. It's optional and defaults to null, so **every existing self-host call site is byte-identical to today** — only hosted containers populate it. Applies to both this table's purposes (AI usage *and* the double-purposed BYOK `byok:...` audit rows), with no special-casing, per the issue.
- **`sumAiCostForTenantSince(env, installationId, sinceIso)`** — the per-tenant billing aggregate, mirroring `sumAiEstimatedNeuronsSince`'s shape but scoped by `installation_id` (covered by the new index). Because it filters by equality, self-host rows (null tenant) are never matched — it's inherently hosted-only.

## Tests

`installation_id` is written when supplied and stays null when omitted (self-host unaffected), and the aggregate is correctly scoped by tenant + time window — excluding other tenants, rows before the window, and null-tenant self-host rows, and summing to 0 (not erroring) for a tenant with no rows.

**100% patch coverage on the changed lines**; `tsc --noEmit` clean.

Closes #7176
