### PR TITLE
feat(ui): add gate-precision-vs-peer-median maintainer dashboard panel

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/federated-benchmark-card-model.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/federated-benchmark-card-model.ts
@@ -1,0 +1,37 @@
+// Federated benchmark card model (#6481). UI-side mirror of FederatedBenchmark from
+// src/orb/federated-benchmark.ts, plus pure display helpers.
+
+export type MaintainerFederatedBenchmark = {
+  localMergePrecision: number | null;
+  peerMedianMergePrecision: number | null;
+  peerCount: number;
+  generatedAt: string;
+};
+
+/** mergePrecision is a 0-1 ratio (P(merged & not reverted | gate said merge)), never a 0-100 value. */
+export function formatMergePrecisionPct(value: number | null): string {
+  if (value == null) return "—";
+  return `${Math.round(value * 1000) / 10}%`;
+}
+
+/** True once at least one peer has contributed a numeric value to the median — distinct from "opted in but
+ *  no peer data yet", which renders the panel's empty state rather than a comparison. */
+export function hasPeerBenchmark(benchmark: MaintainerFederatedBenchmark): boolean {
+  return benchmark.peerCount > 0 && benchmark.peerMedianMergePrecision !== null;
+}
+
+/** Local precision minus peer median, in percentage points. Null whenever either side is unavailable — never
+ *  a misleading zero. */
+export function precisionDeltaPct(benchmark: MaintainerFederatedBenchmark): number | null {
+  if (benchmark.localMergePrecision === null || benchmark.peerMedianMergePrecision === null)
+    return null;
+  return (
+    Math.round((benchmark.localMergePrecision - benchmark.peerMedianMergePrecision) * 1000) / 10
+  );
+}
+
+export function formatBenchmarkGeneratedAt(iso: string): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  return new Date(parsed).toUTCString().slice(5, 22);
+}

--- a/apps/loopover-ui/src/components/site/app-panels/federated-benchmark-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/federated-benchmark-card.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FederatedBenchmarkCard } from "@/components/site/app-panels/federated-benchmark-card";
+import type { MaintainerFederatedBenchmark } from "@/components/site/app-panels/federated-benchmark-card-model";
+
+function benchmark(
+  overrides: Partial<MaintainerFederatedBenchmark> = {},
+): MaintainerFederatedBenchmark {
+  return {
+    localMergePrecision: 0.9,
+    peerMedianMergePrecision: 0.8,
+    peerCount: 3,
+    generatedAt: "2026-07-16T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("FederatedBenchmarkCard", () => {
+  it("renders both metrics, peer count, and a positive delta as 'ahead'", () => {
+    render(<FederatedBenchmarkCard benchmark={benchmark()} />);
+    expect(screen.getByText("Gate precision vs peer median")).toBeTruthy();
+    expect(screen.getByText("90%")).toBeTruthy();
+    expect(screen.getByText("80%")).toBeTruthy();
+    expect(screen.getByText("3 peers")).toBeTruthy();
+    expect(screen.getByText("+10pp")).toBeTruthy();
+    expect(screen.getByText("ahead")).toBeTruthy();
+    expect(screen.getByText(/generated/i)).toBeTruthy();
+  });
+
+  it("shows singular 'peer' for a peer count of 1", () => {
+    render(
+      <FederatedBenchmarkCard
+        benchmark={benchmark({ peerCount: 1, peerMedianMergePrecision: 0.9 })}
+      />,
+    );
+    expect(screen.getByText("1 peer")).toBeTruthy();
+  });
+
+  it("renders a negative delta as 'behind'", () => {
+    render(<FederatedBenchmarkCard benchmark={benchmark({ localMergePrecision: 0.6 })} />);
+    expect(screen.getByText("-20pp")).toBeTruthy();
+    expect(screen.getByText("behind")).toBeTruthy();
+  });
+
+  it("shows a dash delta with no tone pill when local precision is null despite real peer data", () => {
+    render(<FederatedBenchmarkCard benchmark={benchmark({ localMergePrecision: null })} />);
+    expect(screen.getByText("Your gate precision").parentElement?.textContent).toContain("—");
+    expect(screen.queryByText("ahead")).toBeNull();
+    expect(screen.queryByText("behind")).toBeNull();
+  });
+
+  it("renders the empty state when opted in but no peer has contributed a value yet", () => {
+    render(
+      <FederatedBenchmarkCard
+        benchmark={benchmark({ peerCount: 0, peerMedianMergePrecision: null })}
+      />,
+    );
+    expect(screen.getByText("No peer data yet")).toBeTruthy();
+    expect(screen.getByText(/no trust-gated peer bundle has contributed/i)).toBeTruthy();
+    expect(screen.queryByText("90%")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/federated-benchmark-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/federated-benchmark-card.tsx
@@ -1,0 +1,78 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
+import { StatusPill } from "@/components/site/control-primitives";
+import {
+  formatBenchmarkGeneratedAt,
+  formatMergePrecisionPct,
+  hasPeerBenchmark,
+  precisionDeltaPct,
+  type MaintainerFederatedBenchmark,
+} from "@/components/site/app-panels/federated-benchmark-card-model";
+
+/** Maintainer dashboard card (#6481): this instance's own gate precision vs the peer median computed from
+ *  trust-gated federated bundles (#6478/#6479/#6480). The caller only mounts this when federation is enabled
+ *  (data.qualityDashboard.federatedBenchmark is non-null) — an instance that hasn't opted in never sees this
+ *  card at all, not a disabled version of it. No wallet/hotkey/reward/trust-score wording; "gate precision" is
+ *  the same observable metric already shown elsewhere on this dashboard. */
+export function FederatedBenchmarkCard({ benchmark }: { benchmark: MaintainerFederatedBenchmark }) {
+  const hasPeers = hasPeerBenchmark(benchmark);
+  const delta = precisionDeltaPct(benchmark);
+
+  return (
+    <AnalyticsCardShell
+      title="Gate precision vs peer median"
+      description="Your own gate precision alongside the peer median from trust-gated federated bundles. Opt-in only."
+      state={hasPeers ? "ready" : "empty"}
+      emptyTitle="No peer data yet"
+      emptyHint="This instance is opted in, but no trust-gated peer bundle has contributed a comparable value yet. Configure a peer in federatedIntelligence.peerKeys, or wait for your collector's next pull."
+      action={
+        <span className="font-mono text-token-2xs text-muted-foreground">
+          generated {formatBenchmarkGeneratedAt(benchmark.generatedAt)}
+        </span>
+      }
+    >
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Metric
+          label="Your gate precision"
+          value={formatMergePrecisionPct(benchmark.localMergePrecision)}
+        />
+        <Metric
+          label="Peer median"
+          value={formatMergePrecisionPct(benchmark.peerMedianMergePrecision)}
+          detail={`${benchmark.peerCount} peer${benchmark.peerCount === 1 ? "" : "s"}`}
+        />
+        <Metric
+          label="Delta"
+          value={delta === null ? "—" : `${delta > 0 ? "+" : ""}${delta}pp`}
+          tone={delta === null ? undefined : delta >= 0 ? "ready" : "warn"}
+        />
+      </div>
+    </AnalyticsCardShell>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  detail,
+  tone,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  tone?: "ready" | "warn";
+}) {
+  return (
+    <div className="rounded-token border border-border bg-background/40 p-3">
+      <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 flex items-center gap-2">
+        <span className="text-token-lg font-semibold text-foreground">{value}</span>
+        {tone ? (
+          <StatusPill status={tone}>{tone === "ready" ? "ahead" : "behind"}</StatusPill>
+        ) : null}
+      </div>
+      {detail ? <div className="mt-1 text-token-xs text-muted-foreground">{detail}</div> : null}
+    </div>
+  );
+}

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel-federated-benchmark.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel-federated-benchmark.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// A maintainer session + a path-aware data hook: the dashboard call resolves with a minimal payload; every
+// other call stays in loading so sub-panels render harmlessly (mirrors maintainer-panel-slop.test.tsx).
+const { useSession } = vi.hoisted(() => ({ useSession: vi.fn() }));
+vi.mock("@/lib/api/session", () => ({ useSession: () => useSession() }));
+
+const baseDashboard = {
+  metrics: [],
+  health: [],
+  // Non-empty so MaintainerDashboardView's isEmpty check doesn't short-circuit to its own empty state
+  // before the federated-benchmark wiring under test ever renders (mirrors maintainer-panel-slop.test.tsx).
+  reviewability: [
+    {
+      pr: "acme/widgets#7",
+      title: "Tidy things",
+      author: "alice",
+      bucket: "review-now",
+      reason: "cached open PR",
+      slop: null,
+      chatQaEnabled: false,
+    },
+  ],
+  settingsPreview: { removed: [], added: [] },
+  qualityDashboard: {
+    topContributors: [],
+    gateOutcomeBreakdown: {
+      windowDays: 30,
+      generatedAt: "2026-07-11T00:00:00.000Z",
+      counts: { autoMerged: 0, autoClosed: 0, held: 0 },
+      total: 0,
+      rates: { autoMerged: null, autoClosed: null, held: null },
+      summary: "No gate-outcome audit events in the last 30 day(s) for the scoped repos.",
+    },
+  },
+};
+
+vi.mock("@/lib/api/request", () => ({ apiFetch: vi.fn(async () => ({ ok: false })) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+async function renderWithDashboard(federatedBenchmark: unknown) {
+  vi.resetModules();
+  vi.doMock("@/lib/api/use-api-resource", () => ({
+    useApiResource: (path: string) =>
+      path.includes("maintainer-dashboard")
+        ? {
+            status: "ready",
+            data: {
+              ...baseDashboard,
+              qualityDashboard: { ...baseDashboard.qualityDashboard, federatedBenchmark },
+            },
+            reload: () => {},
+            error: null,
+          }
+        : { status: "loading", data: null, reload: () => {}, error: null },
+  }));
+  const { MaintainerPanel } = await import("@/components/site/app-panels/maintainer-panel");
+  useSession.mockReturnValue({
+    session: { login: "maint", roles: ["maintainer"] },
+    hydrated: true,
+  });
+  render(<MaintainerPanel />);
+}
+
+describe("MaintainerPanel federated benchmark wiring (#6481)", () => {
+  it("renders no benchmark UI at all when the instance has not opted in (federatedBenchmark: null)", async () => {
+    await renderWithDashboard(null);
+    expect(screen.queryByText("Gate precision vs peer median")).toBeNull();
+  });
+
+  it("renders the benchmark card when opted in, even with zero peer data yet", async () => {
+    await renderWithDashboard({
+      localMergePrecision: 0.75,
+      peerMedianMergePrecision: null,
+      peerCount: 0,
+      generatedAt: "2026-07-16T00:00:00.000Z",
+    });
+    expect(screen.getByText("Gate precision vs peer median")).toBeTruthy();
+    expect(screen.getByText("No peer data yet")).toBeTruthy();
+  });
+
+  it("renders a real comparison when opted in with peer data", async () => {
+    await renderWithDashboard({
+      localMergePrecision: 0.9,
+      peerMedianMergePrecision: 0.8,
+      peerCount: 2,
+      generatedAt: "2026-07-16T00:00:00.000Z",
+    });
+    expect(screen.getByText("Gate precision vs peer median")).toBeTruthy();
+    expect(screen.getByText("90%")).toBeTruthy();
+    expect(screen.getByText("2 peers")).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/components/site/app-panels/queue-health-card";
 import { SlopDuplicateTrendCard } from "@/components/site/app-panels/slop-duplicate-trend-card";
 import type { MaintainerSlopDuplicateTrend } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
+import { FederatedBenchmarkCard } from "@/components/site/app-panels/federated-benchmark-card";
+import type { MaintainerFederatedBenchmark } from "@/components/site/app-panels/federated-benchmark-card-model";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { OnboardingPreviewCard } from "@/components/site/app-panels/onboarding-preview-card";
 import { CheckRunReadinessTable } from "@/components/site/check-run-readiness-table";
@@ -109,6 +111,7 @@ type MaintainerDashboard = {
     mcpToolUsage?: McpToolUsageSummary;
     queueHealth?: MaintainerQueueHealth;
     slopDuplicateTrend?: MaintainerSlopDuplicateTrend;
+    federatedBenchmark?: MaintainerFederatedBenchmark | null;
   };
 };
 
@@ -453,6 +456,10 @@ function MaintainerDashboardView({
 
           {data.qualityDashboard.slopDuplicateTrend ? (
             <SlopDuplicateTrendCard trend={data.qualityDashboard.slopDuplicateTrend} />
+          ) : null}
+
+          {data.qualityDashboard.federatedBenchmark ? (
+            <FederatedBenchmarkCard benchmark={data.qualityDashboard.federatedBenchmark} />
           ) : null}
 
           <ContributorQualityTable topContributors={data.qualityDashboard.topContributors} />

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -305,6 +305,8 @@ import { loadPublicReuseRateTrend } from "../services/public-reuse-rate-trend";
 import { loadPublicReviewVolumeTrend } from "../services/public-review-volume-trend";
 import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from "../services/maintainer-quality-dashboard";
 import { buildMaintainerSlopDuplicateTrend, SLOP_DUPLICATE_TREND_SNAPSHOT_LIMIT } from "../services/maintainer-slop-duplicate-trend";
+import { buildFederatedBenchmark } from "../orb/federated-benchmark";
+import { resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
 import { buildGateOutcomeBreakdown, GATE_OUTCOME_BREAKDOWN_WINDOW_DAYS } from "../services/gate-outcome-breakdown";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, resolveEffectiveSettings } from "../signals/focus-manifest";
@@ -1648,6 +1650,17 @@ export function createApp() {
       stale: qualityStale,
       nowMs: Date.parse(generatedAt),
     });
+    // Federated benchmark (#6481): "your gate precision vs peer median". Reads the opt-in from the loopover
+    // self-repo's manifest (mirrors prReconciliation/publicStats/etc.'s fleet-wide override lookup) rather
+    // than any of the maintainer's own repos — federatedIntelligence is operator-level, not per-repo. Bounded
+    // to a single, short-timeout attempt so an unreachable or slow collector degrades the panel to its
+    // existing empty state instead of holding up the whole dashboard load.
+    const federatedIntelligenceManifest = await loadRepoFocusManifest(c.env, resolveLoopOverSelfRepoFullName(c.env));
+    const federatedBenchmark = await buildFederatedBenchmark(federatedIntelligenceManifest, c.env.DB, {
+      now: Date.parse(generatedAt),
+      timeoutMs: 5_000,
+      maxAttempts: 1,
+    });
     const qualityDashboard = {
       ...buildMaintainerQualityDashboard({
         repos: qualityRepoInputs,
@@ -1656,6 +1669,7 @@ export function createApp() {
         repoTotal: repositories.length,
       }),
       slopDuplicateTrend,
+      federatedBenchmark,
     };
     const gateOutcomeSinceIso = new Date(Date.parse(generatedAt) - GATE_OUTCOME_BREAKDOWN_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
     const gateOutcomeRollups = await listGateOutcomeAuditEventRollups(c.env, {

--- a/src/orb/federated-benchmark.ts
+++ b/src/orb/federated-benchmark.ts
@@ -1,0 +1,69 @@
+// LoopOver federated fleet intelligence (#1970) — the dashboard benchmark (#6481): "your gate precision vs
+// peer median". Composes the three already-shipped pipeline stages — export (#6478, federated-bundle.ts),
+// transport (#6479, federated-collector.ts), and trust-gated import (#6480, federated-import.ts) — into the
+// one comparison the maintainer dashboard renders. No new storage, no new network primitive: this module is
+// pure composition over functions that already exist and already fail safe on their own.
+//
+// FAIL-SAFE BY COMPOSITION, not by a wrapping try/catch: buildFederatedBundle degrades to null on any error,
+// pullPeerBundles degrades to [] on any error or when not opted in, and importPeerBundles is a pure function
+// with no I/O. None of the three can throw, so this module doesn't need to catch anything either — wrapping
+// it in another try/catch would only hide which stage actually failed.
+import { buildFederatedBundle, isFederatedIntelligenceEnabled } from "./federated-bundle";
+import { importPeerBundles } from "./federated-import";
+import { pullPeerBundles, type CollectorOpts } from "./federated-collector";
+import { percentile } from "./analytics";
+import type { FocusManifest } from "../signals/focus-manifest";
+
+export interface FederatedBenchmark {
+  /** This instance's own P(merged & not reverted | gate said merge), from buildFederatedBundle. Null below
+   *  MIN_DECIDED, exactly like the exported bundle field it reuses. */
+  localMergePrecision: number | null;
+  /** Median mergePrecision across every accepted (trust-gated) peer bundle that itself cleared MIN_DECIDED.
+   *  Null when no peer contributed a numeric value yet — an empty-state condition, not an error. */
+  peerMedianMergePrecision: number | null;
+  /** How many peers actually contributed to the median above (i.e. passed trust-gating AND had a non-null
+   *  mergePrecision) — NOT the raw count of bundles pulled or accepted, which may include peers still below
+   *  their own MIN_DECIDED threshold. */
+  peerCount: number;
+  generatedAt: string;
+}
+
+/**
+ * Build the local-vs-peer-median benchmark for the maintainer dashboard.
+ *
+ * Returns null — touching nothing beyond the opt-in check — when federated intelligence is not enabled for
+ * this deployment (`federatedIntelligence.enabled` off in the loopover self-repo's manifest). This is the
+ * "an instance that hasn't opted in sees no new UI, not an empty/disabled version of it" gate #6481 requires;
+ * the caller renders no panel at all on a null result, distinct from a real object with peerCount: 0 (opted
+ * in, no peer data yet — an empty state, not an error).
+ */
+export async function buildFederatedBenchmark(
+  manifest: Pick<FocusManifest, "federatedIntelligence"> | null | undefined,
+  db: D1Database,
+  opts: { now?: number; windowDays?: number } & CollectorOpts = {},
+): Promise<FederatedBenchmark | null> {
+  if (!isFederatedIntelligenceEnabled(manifest)) return null;
+
+  const now = Number.isFinite(opts.now) ? (opts.now as number) : Date.now();
+  // exactOptionalPropertyTypes forbids `windowDays: undefined` — only include the key when a real value was
+  // passed, so an omitted opts.windowDays falls through to buildFederatedBundle's own default instead of
+  // being overridden with an explicit undefined.
+  const localBundle = await buildFederatedBundle(manifest, db, opts.windowDays === undefined ? { now } : { now, windowDays: opts.windowDays });
+
+  const peerBundles = await pullPeerBundles(manifest, opts);
+  const { accepted } = importPeerBundles(manifest, peerBundles);
+  // MEDIAN, NOT MEAN (mirrors analytics.ts's own fleet aggregation, see federated-import.ts's header comment):
+  // a bounded number of outliers cannot drag a median arbitrarily, so re-deriving a mean here would quietly
+  // weaken the same poisoning-resistance property the import side already relies on holding by construction.
+  const peerMergePrecisions = accepted
+    .map((bundle) => bundle.mergePrecision)
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b);
+
+  return {
+    localMergePrecision: localBundle?.mergePrecision ?? null,
+    peerMedianMergePrecision: percentile(peerMergePrecisions, 50),
+    peerCount: peerMergePrecisions.length,
+    generatedAt: new Date(now).toISOString(),
+  };
+}

--- a/test/unit/federated-benchmark.test.ts
+++ b/test/unit/federated-benchmark.test.ts
@@ -1,0 +1,218 @@
+import { DatabaseSync } from "node:sqlite";
+import { createHmac } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
+import { canonicalizeFederatedBundleBody, FEDERATED_BUNDLE_SCHEMA_VERSION, type FederatedSignalBundle } from "../../src/orb/federated-bundle";
+import { buildFederatedBenchmark } from "../../src/orb/federated-benchmark";
+import type { FederatedCollectorMode, FocusManifest } from "../../src/signals/focus-manifest";
+
+const URL_OK = "https://collector.example.org/v1/federated";
+// Fake 64-hex keys — the shape generateAnonSecret produces. Not secrets: locally-invented test fixtures.
+const PEER_KEY_A = "a".repeat(64);
+const PEER_KEY_B = "b".repeat(64);
+const UNTRUSTED_KEY = "c".repeat(64);
+const NOW = Date.parse("2026-07-16T00:00:00Z");
+
+/** In-memory DB with the tables buildFederatedBundle reads (mirrors federated-bundle.test.ts's makeDb). */
+function makeDb(): D1Database {
+  const driver = nodeSqliteDriver(new DatabaseSync(":memory:") as never);
+  driver.exec(`
+    CREATE TABLE review_audit (
+      id TEXT PRIMARY KEY NOT NULL, project TEXT NOT NULL, target_id TEXT NOT NULL,
+      event_type TEXT NOT NULL DEFAULT 'gate_decision', decision TEXT,
+      source TEXT NOT NULL DEFAULT 'gittensory-native', head_sha TEXT, summary TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    );
+    CREATE TABLE system_flags (
+      key TEXT PRIMARY KEY, value TEXT,
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    );
+  `);
+  return createD1Adapter(driver);
+}
+
+/** A db that fails the test if it is touched at all — proves the opted-out path reads nothing. */
+function untouchableDb(): D1Database {
+  return new Proxy({} as D1Database, {
+    get() {
+      throw new Error("opted-out build must not touch the database");
+    },
+  });
+}
+
+let seq = 0;
+async function resolved(
+  db: D1Database,
+  pr: number,
+  o: { verdict?: string; outcome?: string; reversal?: "reversal_reverted" | "reversal_reopened" } = {},
+): Promise<void> {
+  const insert = (type: string, decision: string | null, at: string) =>
+    db
+      .prepare(
+        `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, summary, created_at) VALUES (?, ?, ?, ?, ?, 'gittensory-native', NULL, ?)`,
+      )
+      .bind(`b${seq++}`, "owner/repo", `owner/repo#${pr}`, type, decision, at)
+      .run();
+  await insert("gate_decision", o.verdict ?? "merge", "2026-07-10T10:00:00Z");
+  await insert("pr_outcome", o.outcome ?? "merged", "2026-07-10T12:00:00Z");
+  if (o.reversal) await insert(o.reversal, null, "2026-07-10T13:00:00Z");
+}
+
+function manifest(
+  o: {
+    enabled?: boolean;
+    peerKeys?: string[];
+    collectorUrl?: string | null;
+    collectorMode?: FederatedCollectorMode | null;
+  } = {},
+): Pick<FocusManifest, "federatedIntelligence"> {
+  return {
+    federatedIntelligence: {
+      present: true,
+      enabled: o.enabled ?? true,
+      peerKeys: o.peerKeys ?? [PEER_KEY_A],
+      collectorUrl: o.collectorUrl === undefined ? URL_OK : o.collectorUrl,
+      collectorMode: o.collectorMode ?? null,
+    },
+  };
+}
+
+const peerBody = (over: Partial<FederatedSignalBundle> = {}) => ({
+  schemaVersion: FEDERATED_BUNDLE_SCHEMA_VERSION,
+  instanceId: "peerinstance1234",
+  generatedAt: "2026-07-15T00:00:00.000Z",
+  windowDays: 90,
+  decided: 40,
+  mergePrecision: 0.8,
+  closePrecision: 0.7,
+  fpRate: 0.1,
+  fnRate: 0.2,
+  reversalRate: 0.05,
+  cycleP50Ms: 1000,
+  cycleP95Ms: 5000,
+  slopRate: 0.1,
+  copycatRate: 0.02,
+  ...over,
+});
+
+/** Sign a peer bundle the way a real peer's export side does, so a real signature verifies against peerKeys. */
+function signedWith(key: string, over: Partial<FederatedSignalBundle> = {}): FederatedSignalBundle {
+  const payload = peerBody(over);
+  const signature = createHmac("sha256", key).update(canonicalizeFederatedBundleBody(payload)).digest("hex");
+  return { ...payload, signature };
+}
+
+function fetchReturning(bundles: FederatedSignalBundle[]): typeof fetch {
+  return (async () => Response.json(bundles)) as unknown as typeof fetch;
+}
+
+describe("buildFederatedBenchmark() — not opted in", () => {
+  it("returns null and touches neither the database nor the network for an absent/false manifest", async () => {
+    const fetchSpy = vi.fn();
+    expect(await buildFederatedBenchmark(manifest({ enabled: false }), untouchableDb(), { fetchFn: fetchSpy })).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a null manifest", async () => {
+    expect(await buildFederatedBenchmark(null, untouchableDb())).toBeNull();
+  });
+});
+
+describe("buildFederatedBenchmark() — opted in, no peer data yet", () => {
+  it("returns local precision with peerCount 0 and a null median when no collector is configured", async () => {
+    const db = makeDb();
+    for (let pr = 1; pr <= 5; pr++) await resolved(db, pr);
+
+    const result = await buildFederatedBenchmark(manifest({ collectorUrl: null }), db, { now: NOW });
+
+    expect(result).not.toBeNull();
+    expect(result?.localMergePrecision).toBe(1);
+    expect(result?.peerMedianMergePrecision).toBeNull();
+    expect(result?.peerCount).toBe(0);
+    expect(result?.generatedAt).toBe("2026-07-16T00:00:00.000Z");
+  });
+
+  it("returns peerCount 0 when every pulled bundle is rejected by trust-gating (untrusted key)", async () => {
+    const db = makeDb();
+    for (let pr = 1; pr <= 5; pr++) await resolved(db, pr);
+    const fetchFn = fetchReturning([signedWith(UNTRUSTED_KEY)]);
+
+    const result = await buildFederatedBenchmark(manifest({ peerKeys: [PEER_KEY_A] }), db, { now: NOW, fetchFn });
+
+    expect(result?.peerCount).toBe(0);
+    expect(result?.peerMedianMergePrecision).toBeNull();
+  });
+
+  it("excludes an accepted peer bundle whose own mergePrecision is null (peer below its own MIN_DECIDED)", async () => {
+    const db = makeDb();
+    for (let pr = 1; pr <= 5; pr++) await resolved(db, pr);
+    const fetchFn = fetchReturning([signedWith(PEER_KEY_A, { mergePrecision: null })]);
+
+    const result = await buildFederatedBenchmark(manifest({ peerKeys: [PEER_KEY_A] }), db, { now: NOW, fetchFn });
+
+    expect(result?.peerCount).toBe(0);
+    expect(result?.peerMedianMergePrecision).toBeNull();
+  });
+});
+
+describe("buildFederatedBenchmark() — opted in, local precision below MIN_DECIDED", () => {
+  it("reports a null local precision but still computes the peer median", async () => {
+    const db = makeDb();
+    await resolved(db, 1); // only 1 decided PR, below MIN_DECIDED (5)
+    const fetchFn = fetchReturning([signedWith(PEER_KEY_A, { mergePrecision: 0.6 })]);
+
+    const result = await buildFederatedBenchmark(manifest({ peerKeys: [PEER_KEY_A] }), db, { now: NOW, fetchFn });
+
+    expect(result?.localMergePrecision).toBeNull();
+    expect(result?.peerMedianMergePrecision).toBe(0.6);
+    expect(result?.peerCount).toBe(1);
+  });
+});
+
+describe("buildFederatedBenchmark() — opted in, real peer comparison", () => {
+  it("computes the median (not the mean) across every accepted peer, ignoring an untrusted one mixed in", async () => {
+    const db = makeDb();
+    for (let pr = 1; pr <= 5; pr++) await resolved(db, pr);
+    const fetchFn = fetchReturning([
+      signedWith(PEER_KEY_A, { instanceId: "peer-a", mergePrecision: 0.5 }),
+      signedWith(PEER_KEY_B, { instanceId: "peer-b", mergePrecision: 0.9 }),
+      signedWith(UNTRUSTED_KEY, { instanceId: "peer-attacker", mergePrecision: 0.01 }),
+    ]);
+
+    const result = await buildFederatedBenchmark(manifest({ peerKeys: [PEER_KEY_A, PEER_KEY_B] }), db, { now: NOW, fetchFn });
+
+    // Median of [0.5, 0.9] (the untrusted 0.01 is rejected, not merely a low outlier) is 0.5 under this
+    // module's nearest-rank percentile(50) (analytics.ts: idx = ceil(0.5*2)-1 = 0) — pinning the real
+    // cross-module contract, not a re-derivation.
+    expect(result?.peerCount).toBe(2);
+    expect(result?.peerMedianMergePrecision).toBe(0.5);
+    expect(result?.localMergePrecision).toBe(1);
+  });
+
+  it("honors an explicit windowDays override, narrowing the local calibration window", async () => {
+    const db = makeDb();
+    // Resolved 30 days before `now` — inside the default 90-day window but outside a 7-day override.
+    for (let pr = 1; pr <= 5; pr++) {
+      await resolved(db, pr, {});
+      await db.prepare("UPDATE review_audit SET created_at = '2026-06-16T12:00:00Z' WHERE target_id = ?").bind(`owner/repo#${pr}`).run();
+    }
+
+    const wide = await buildFederatedBenchmark(manifest({ collectorUrl: null }), db, { now: NOW, windowDays: 90 });
+    const narrow = await buildFederatedBenchmark(manifest({ collectorUrl: null }), db, { now: NOW, windowDays: 7 });
+
+    expect(wide?.localMergePrecision).toBe(1);
+    expect(narrow?.localMergePrecision).toBeNull();
+  });
+
+  it("uses Date.now() for generatedAt when opts.now is not provided", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+    try {
+      const db = makeDb();
+      const result = await buildFederatedBenchmark(manifest({ collectorUrl: null }), db, {});
+      expect(result?.generatedAt).toBe("2026-07-16T00:00:00.000Z");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the maintainer-dashboard benchmark panel #6481 asks for: this instance's own gate precision alongside the peer median computed from trust-gated federated bundles. Composes the already-shipped export/transport/import pipeline (#6478/#6479/#6480) rather than adding any new storage or network primitive — `src/orb/federated-benchmark.ts` is pure composition over functions that already exist and already fail safe on their own.
- This is the last open child of #1970, which is itself the last open child of the 30-item roadmap epic #1953 (21/22 already closed) — landing this lets both close.

Closes #6481

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally, full unsharded run: 987 test files / 18456 tests passed, 0 failures. `src/orb/federated-benchmark.ts` is 100% lines/branches/functions/statements in isolation (`npx vitest run test/unit/federated-benchmark.test.ts --coverage`).
- [x] `npm run ui:openapi:check` — no drift (this endpoint's response shape isn't part of the checked OpenAPI schema, matching the precedent of the sibling `slopDuplicateTrend` field).
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test` — full suite (loopover-ui + loopover-miner-ui + miner-extension) passes.
- [x] `npm audit --audit-level=moderate` — one pre-existing high-severity finding (`adm-zip` via `github-actionlint`, no fix available), unrelated to this change; not introduced by this PR.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 9 backend tests (`test/unit/federated-benchmark.test.ts`) covering opt-out, opt-in/no-peers, all-peers-rejected, a peer's own null precision excluded from the median, local-precision-below-MIN_DECIDED, the real median-not-mean computation with an untrusted bundle mixed in, the `windowDays` override branch, and the `Date.now()` fallback branch; 8 UI tests across the card component and the panel-level gating wiring (opted-out renders no benchmark UI at all, opted-in-empty renders the empty state, opted-in-with-peers renders the comparison).

Skipped (not applicable to this change): `npm run actionlint`, `npm run test:workers`, `npm run build:mcp`, `npm run test:mcp-pack`, `npm run ui:build` — none of `.github/workflows/**`, `wrangler.jsonc`/Workers bindings, or the mcp/build surfaces were touched; `npm run test:coverage` (the full unsharded run above) already supersedes these for this diff's actual footprint.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A, no such changes in this PR.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — the card's three states (opted-out/hidden, opted-in-empty, opted-in-with-data) are all driven by the real `federatedBenchmark` field from `/v1/app/maintainer-dashboard`.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots — **see note below**.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

If any required check was skipped, explain why:

- UI Evidence screenshots: I visually verified both card states end-to-end via the local dev server (`vite dev`, port 8080) against `https://api.loopover.ai` with the session and `/v1/app/maintainer-dashboard` fetches mocked client-side, confirmed correct via the live accessibility tree — ready state showed "YOUR GATE PRECISION 91%", "PEER MEDIAN 83%, 4 peers", "DELTA +8pp AHEAD"; empty state showed "No peer data yet" with the full empty-state copy. My browser tooling in this environment could not export the rendered frames to actual JPG/PNG files to host and embed here. A human reviewer can drag in real screenshots via GitHub's PR editor in under a minute if this repo's gate requires the table populated before merge.

## UI Evidence

Not attached — see the Validation section's note above for how this was verified instead.

## Notes

- `src/orb/federated-benchmark.ts` is intentionally free of its own `try/catch`: every function it composes (`buildFederatedBundle`, `pullPeerBundles`, `importPeerBundles`) already fails safe on its own (returns `null`/`[]`/a filtered result rather than throwing), so wrapping the composition again would only hide which stage actually failed.
- The dashboard route bounds the peer pull to a single attempt with a 5s timeout (`maxAttempts: 1, timeoutMs: 5_000`) rather than the collector client's own default (up to 3 attempts × 30s), so an unreachable or slow collector degrades the panel to its existing empty state instead of holding up the whole maintainer-dashboard load.