### PR TITLE
feat(orb): add a secret_type discriminator to the enrollment broker

### DIFF
--- a/migrations/0164_orb_enrollment_secret_type.sql
+++ b/migrations/0164_orb_enrollment_secret_type.sql
@@ -1,0 +1,6 @@
+-- Loopover Orb token-broker (#7174) — a discriminator so an enrollment row can eventually carry more than a
+-- GitHub installation token (AI-provider keys, DB credentials for the hosted control-plane's provisioning core,
+-- #7173). Every existing and default-issued row is 'github_token', so brokerOrbToken's behavior is unchanged for
+-- every current caller; the column exists purely so a future mint strategy can be selected per row instead of
+-- assumed.
+ALTER TABLE orb_enrollments ADD COLUMN secret_type TEXT NOT NULL DEFAULT 'github_token';

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4174,7 +4174,8 @@ export function createApp() {
       console.error(JSON.stringify({ level: "error", event: "orb_broker_mint_failed", message: message.slice(0, 200) }));
       return c.json({ error: "broker_error" }, 503);
     }
-    if ("error" in result) return c.json(result, result.error === "invalid_enrollment" ? 401 : result.error === "broker_misconfigured" ? 503 : 403);
+    if ("error" in result)
+      return c.json(result, result.error === "invalid_enrollment" ? 401 : result.error === "broker_misconfigured" ? 503 : result.error === "unsupported_secret_type" ? 500 : 403);
     return c.json(result);
   });
 

--- a/src/orb/broker.ts
+++ b/src/orb/broker.ts
@@ -19,6 +19,13 @@ import { createOrbInstallationToken } from "./app-auth";
 // entry is never handed out (covers clock skew + the engine's own ~5m cache margin).
 const ORB_TOKEN_CACHE_MIN_REMAINING_MS = 10 * 60_000;
 
+// The only secret type this broker actually knows how to mint today (#7174). The `secret_type` column exists
+// so a future AI-provider-key / DB-credential mint strategy (the hosted control-plane's provisioning core,
+// #7180) can record what an enrollment row is FOR without inventing a second table — but until that strategy
+// exists, any row carrying a different value is a config/data error brokerOrbToken must refuse, not silently
+// GitHub-mint against.
+export const ORB_SECRET_TYPE_GITHUB_TOKEN = "github_token";
+
 export function isOrbBrokerEnabled(env: Env): boolean {
   return /^(1|true|yes|on)$/i.test(String(env.ORB_BROKER_ENABLED ?? "").trim());
 }
@@ -28,11 +35,13 @@ export type IssueResult = { enrollId: string; secret: string } | { error: "insta
 /** Mint a one-time enrollment secret for a REGISTERED install. Returns the plaintext secret ONCE (stored only
  *  hashed). Issued by the operator (internal endpoint) OR by a maintainer who proved install-admin via OAuth —
  *  in the latter case the maintainer's GitHub identity is recorded for audit. installation_id is bound here and
- *  read back (never from the request) at token-exchange time, so a secret can never mint a token for another install. */
+ *  read back (never from the request) at token-exchange time, so a secret can never mint a token for another
+ *  install. `secretType` defaults to the only mintable type today; every existing caller is unaffected. */
 export async function issueOrbEnrollment(
   env: Env,
   installationId: number,
   maintainer?: { login: string; githubId?: number | null | undefined },
+  secretType: string = ORB_SECRET_TYPE_GITHUB_TOKEN,
 ): Promise<IssueResult> {
   const install = await env.DB.prepare("SELECT registered FROM orb_github_installations WHERE installation_id = ?").bind(installationId).first<{ registered: number }>();
   if (!install) return { error: "installation_not_found" };
@@ -40,17 +49,17 @@ export async function issueOrbEnrollment(
   const enrollId = createOpaqueToken("orbenr");
   const secret = createOpaqueToken("orbsec");
   await env.DB.prepare(
-    `INSERT INTO orb_enrollments (enroll_id, installation_id, maintainer_login, maintainer_github_id, secret_hash, state, authorized_at, enrolled_at)
-     VALUES (?, ?, ?, ?, ?, 'enrolled', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+    `INSERT INTO orb_enrollments (enroll_id, installation_id, maintainer_login, maintainer_github_id, secret_hash, secret_type, state, authorized_at, enrolled_at)
+     VALUES (?, ?, ?, ?, ?, ?, 'enrolled', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
   )
-    .bind(enrollId, installationId, maintainer?.login ?? null, maintainer?.githubId ?? null, await hashToken(secret))
+    .bind(enrollId, installationId, maintainer?.login ?? null, maintainer?.githubId ?? null, await hashToken(secret), secretType)
     .run();
   return { enrollId, secret };
 }
 
 export type BrokerResult =
   | { token: string; installationId: number; expiresAt: string; permissions: Record<string, string> }
-  | { error: "invalid_enrollment" | "installation_not_eligible" | "broker_misconfigured" };
+  | { error: "invalid_enrollment" | "installation_not_eligible" | "broker_misconfigured" | "unsupported_secret_type" };
 
 /** The container's token-exchange: a valid enrollment secret → a short-lived installation token for the BOUND
  *  install. installation_id is read from the enrollment row, never the caller; the install must still be
@@ -62,10 +71,14 @@ export async function brokerOrbToken(env: Env, secret: string, options: { forceR
     console.warn(JSON.stringify({ level: "warn", event: "orb_broker_no_encryption_key", message: "TOKEN_ENCRYPTION_SECRET is not set; broker token cache is disabled. Set this variable to enable caching and reduce GitHub throttle risk." }));
   }
   const row = await env.DB
-    .prepare("SELECT enroll_id, installation_id, state, revoked_at, cached_token_json FROM orb_enrollments WHERE secret_hash = ?")
+    .prepare("SELECT enroll_id, installation_id, state, revoked_at, cached_token_json, secret_type FROM orb_enrollments WHERE secret_hash = ?")
     .bind(await hashToken(secret))
-    .first<{ enroll_id: string; installation_id: number; state: string; revoked_at: string | null; cached_token_json: string | null }>();
+    .first<{ enroll_id: string; installation_id: number; state: string; revoked_at: string | null; cached_token_json: string | null; secret_type: string }>();
   if (!row || row.state !== "enrolled" || row.revoked_at !== null) return { error: "invalid_enrollment" };
+  // Checked once the caller is already proven to hold a valid enrollment (same ordering rationale as the App-
+  // credential check below, #2710) — this endpoint only ever mints GitHub installation tokens; a row recorded
+  // for a different secret type belongs to a different mint strategy that doesn't exist yet.
+  if (row.secret_type !== ORB_SECRET_TYPE_GITHUB_TOKEN) return { error: "unsupported_secret_type" };
   const install = await env.DB
     .prepare("SELECT registered, suspended_at, removed_at FROM orb_github_installations WHERE installation_id = ?")
     .bind(row.installation_id)

--- a/test/integration/orb-broker.test.ts
+++ b/test/integration/orb-broker.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
-import { brokerOrbToken, isOrbBrokerEnabled, issueOrbEnrollment } from "../../src/orb/broker";
+import { brokerOrbToken, isOrbBrokerEnabled, issueOrbEnrollment, ORB_SECRET_TYPE_GITHUB_TOKEN } from "../../src/orb/broker";
 import { MAX_ORB_RELAY_REGISTER_BODY_BYTES } from "../../src/orb/relay";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
 
@@ -57,9 +57,18 @@ describe("issueOrbEnrollment", () => {
     await seedInstall(e, 201, { registered: 1 });
     const issued = await issueOrbEnrollment(e, 201);
     expect(issued).toMatchObject({ enrollId: expect.stringMatching(/^orbenr_/), secret: expect.stringMatching(/^orbsec_/) });
-    const row = await db(e).prepare("SELECT state, installation_id, secret_hash FROM orb_enrollments WHERE installation_id=201").first<{ state: string; installation_id: number; secret_hash: string }>();
+    const row = await db(e).prepare("SELECT state, installation_id, secret_hash, secret_type FROM orb_enrollments WHERE installation_id=201").first<{ state: string; installation_id: number; secret_hash: string; secret_type: string }>();
     expect(row).toMatchObject({ state: "enrolled", installation_id: 201 });
     expect(row?.secret_hash).not.toContain("orbsec"); // stored hashed, never plaintext
+    expect(row?.secret_type).toBe(ORB_SECRET_TYPE_GITHUB_TOKEN); // #7174: defaults to the only mintable type today
+  });
+
+  it("#7174: records a caller-supplied secretType instead of the default", async () => {
+    const e = await brokerEnv();
+    await seedInstall(e, 202, { registered: 1 });
+    await issueOrbEnrollment(e, 202, undefined, "ai_provider_key");
+    const row = await db(e).prepare("SELECT secret_type FROM orb_enrollments WHERE installation_id=202").first<{ secret_type: string }>();
+    expect(row?.secret_type).toBe("ai_provider_key");
   });
 });
 
@@ -71,6 +80,13 @@ describe("brokerOrbToken", () => {
     tokenFetch("ghs_minted", "2026-06-25T08:00:00Z", { contents: "write" });
     expect(await brokerOrbToken(e, secret)).toEqual({ token: "ghs_minted", installationId: 300, expiresAt: "2026-06-25T08:00:00Z", permissions: { contents: "write" } });
     expect((await db(e).prepare("SELECT last_token_at FROM orb_enrollments WHERE installation_id=300").first<{ last_token_at: string | null }>())?.last_token_at).not.toBeNull();
+  });
+
+  it("#7174: refuses to GitHub-mint a row recorded for a different secret type, before checking install eligibility or App credentials", async () => {
+    const e = await brokerEnvMissingAppCreds("both");
+    await seedInstall(e, 314, { registered: 1 });
+    const { secret } = (await issueOrbEnrollment(e, 314, undefined, "ai_provider_key")) as { secret: string };
+    expect(await brokerOrbToken(e, secret)).toEqual({ error: "unsupported_secret_type" });
   });
 
   it("caches a freshly minted token and serves repeated exchanges without reminting", async () => {
@@ -265,6 +281,15 @@ describe("broker endpoints", () => {
     const { secret } = (await issueOrbEnrollment(e, 401)) as { secret: string };
     await db(e).prepare("UPDATE orb_github_installations SET registered=0 WHERE installation_id=401").run();
     expect((await app.request("/v1/orb/token", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e)).status).toBe(403);
+  });
+
+  it("#7174: /v1/orb/token: 500 for an enrollment recorded under an unsupported secret type", async () => {
+    const e = await brokerEnv();
+    await seedInstall(e, 403, { registered: 1 });
+    const { secret } = (await issueOrbEnrollment(e, 403, undefined, "ai_provider_key")) as { secret: string };
+    const res = await app.request("/v1/orb/token", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "unsupported_secret_type" });
   });
 
   it("/v1/orb/token rejects oversized force-refresh bodies before parsing or validating the bearer", async () => {


### PR DESCRIPTION
## Summary

- First slice of #7174 (generalize `src/orb/broker.ts` into a multi-secret-type broker, shared by ORB + AMS hosted per #7173): adds the `secret_type` schema/safety groundwork only. `orb_enrollments` gains a `secret_type` column (`NOT NULL DEFAULT 'github_token'`), `issueOrbEnrollment` accepts an optional `secretType` param defaulting to the only mintable type today, and `brokerOrbToken` refuses to GitHub-mint a row recorded under a different type (`unsupported_secret_type`, mapped to HTTP 500) instead of silently assuming one.
- Deliberately scoped narrow: no AI-provider-key mint strategy is implemented here — that's real follow-up work once there's an actual caller for it (#7180's provisioning core). This PR only makes the schema and the broker's own safety checks ready for it.
- Every existing GitHub-token caller (`src/orb/oauth.ts`'s self-enrollment, the internal enrollment endpoint) is unaffected — the new parameter is optional and defaults to today's only behavior.

Closes #7174

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run db:migrations:check` — 168 migrations OK, contiguous through 0164.
- [x] `npm run db:schema-drift:check` — `orb_enrollments` already allowlisted as raw-SQL-only, no drift.
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally, full unsharded run: 990 test files / 18484 tests passed, 0 failures. `src/orb/broker.ts` patch is 100% lines/branches/functions/statements — the file's one remaining branch gap (line 126, `entry.permissions ?? {}`) is pre-existing and untouched by this diff.
- [x] `npm run ui:openapi:check` — no drift (this endpoint's response shape isn't part of the checked OpenAPI schema).
- [x] `npm audit --audit-level=moderate` — one pre-existing high-severity finding (`adm-zip` via `github-actionlint`, no fix available), unrelated to this change.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 4 new tests in `test/integration/orb-broker.test.ts`: `issueOrbEnrollment` defaults to `github_token` and records a caller-supplied type, `brokerOrbToken` refuses an unsupported-type row before touching install eligibility or App credentials, and the `/v1/orb/token` route maps that refusal to a 500.

Skipped (not applicable): `npm run actionlint`, `npm run test:workers`, `npm run build:mcp`, `npm run test:mcp-pack`, `npm run ui:lint`, `npm run ui:typecheck`, `npm run ui:build` — no `.github/workflows/**`, Workers-binding, mcp-package, or `apps/loopover-ui/**` changes in this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — the new `unsupported_secret_type` refusal is itself a negative-path addition, tested at both the function and HTTP-route level.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A, this endpoint isn't in the checked OpenAPI schema (matches existing `/v1/orb/token` precedent).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — N/A, no UI in this PR.
- [x] Visible UI changes include a `UI Evidence` section — N/A, backend-only change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change, no visible UI.

## Notes

- The `unsupported_secret_type` check is ordered right after the enrollment-validity check and before the install-eligibility lookup — same "prove a valid enrollment before revealing anything else" ordering rationale as the existing `broker_misconfigured` check below it (#2710): a row's secret type isn't caller-sensitive info, but there's no reason to spend a second DB query checking GitHub install state for a row this endpoint is about to refuse anyway.
- Mapped to HTTP 500 rather than 403/400: this is a data/config condition (a row recorded for a mint strategy that doesn't exist yet), not something the caller did wrong.