### PR TITLE
feat(miner-ui): demo-mode Cloudflare Worker prototype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,22 +512,22 @@ jobs:
       # steps directly instead of the aggregate script, skipping that redundant regen.
       - name: UI build
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build
-      # Bundle-size regression tracking for the deployed marketing/product site (loopover-ui only --
-      # loopover-miner-ui is a self-hosted operator dashboard with no build step in this job at all, see
-      # "UI build" above). Fork-excluded (no secrets.CODECOV_TOKEN on a fork PR, same boundary as the
-      # coverage-upload steps below) and non-blocking (continue-on-error): unlike coverage, nothing gates
-      # merges on bundle size, so an upload hiccup must never fail CI. Uses @codecov/bundle-analyzer's
-      # standalone CLI against the built dist/client directly rather than a bundler-plugin hook --
-      # @codecov/vite-plugin's latest release doesn't support this repo's Vite 8 yet (peer range caps at
-      # 6.x; this repo's Vite 8 runs on rolldown, not classic rollup, so @codecov/rollup-plugin doesn't fit
-      # either) -- revisit wiring the plugin in once upstream catches up.
+        run: npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build && npm --workspace @loopover/ui-miner run build
+      # Bundle-size regression tracking for the deployed marketing/product site (loopover-ui) and the
+      # miner-ui demo/self-host SPA (loopover-miner-ui, #5963). Fork-excluded (no secrets.CODECOV_TOKEN
+      # on a fork PR, same boundary as the coverage-upload steps below) and non-blocking
+      # (continue-on-error): unlike coverage, nothing gates merges on bundle size, so an upload hiccup
+      # must never fail CI. Uses @codecov/bundle-analyzer's standalone CLI against the built dist
+      # directly rather than a bundler-plugin hook -- @codecov/vite-plugin's latest release doesn't
+      # support this repo's Vite 8 yet (peer range caps at 6.x; this repo's Vite 8 runs on rolldown,
+      # not classic rollup, so @codecov/rollup-plugin doesn't fit either) -- revisit wiring the plugin
+      # in once upstream catches up.
       - name: Upload UI bundle stats to Codecov
         if: ${{ (github.event_name == 'push' || needs.changes.outputs.ui == 'true') && github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: npm run bundle-analysis --workspace @loopover/ui
+        run: npm run bundle-analysis --workspace @loopover/ui && npm run bundle-analysis --workspace @loopover/ui-miner
 
   # The full-suite coverage run, sharded (#ci-shard-coverage). This alone was ~9-10 of the ~11 minutes a
   # typical backend PR spent in validate-code, because vitest schedules whole test FILES atomically to

--- a/.github/workflows/miner-ui-demo-deploy.yml
+++ b/.github/workflows/miner-ui-demo-deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy miner-ui demo Worker
+
+# Manual deploy of the apps/loopover-miner-ui public demo (#5963). Mirrors ui-deploy.yml's
+# workflow_dispatch-only trigger so a stale or broken demo never redeploys on every commit.
+# Builds with Vite `--mode demo` (VITE_DEMO_MODE baked in vite.config.ts) so the static SPA needs no
+# SQLite / Vite middleware backend on Cloudflare.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: miner-ui-demo-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy demo
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Check Cloudflare secrets
+        id: cfg
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set — building demo only, skipping deploy."
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build miner-ui demo
+        run: npm --workspace @loopover/ui-kit run build && npm --workspace @loopover/ui-miner run build:demo
+
+      - name: Deploy demo Worker
+        if: steps.cfg.outputs.ready == 'true'
+        working-directory: apps/loopover-miner-ui
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy

--- a/apps/loopover-miner-ui/README.md
+++ b/apps/loopover-miner-ui/README.md
@@ -2,20 +2,37 @@
 
 Local, read-only dashboard for a laptop or fleet miner instance. It mirrors the main
 `apps/loopover-ui/` tooling versions (React 19, TanStack Router, Vite, Tailwind v4) but intentionally
-does **not** adopt that app's Cloudflare Worker deploy model or `@lovable.dev/*` scaffold dependency.
+does **not** adopt that app's Nitro SSR / production Cloudflare deploy model or `@lovable.dev/*`
+scaffold dependency.
 
 The miner package invariant is client-side only with no required phone-home to boot
-(`packages/loopover-miner/DEPLOYMENT.md`). This app is a plain Vite dev server / static build that a
-local miner CLI can serve later — not a Wrangler deploy target.
+(`packages/loopover-miner/DEPLOYMENT.md`). Self-host operators run a plain Vite dev server / static
+build with local SQLite-backed `/api/*` plugins. Separately, a **demo-mode** static build
+(`VITE_DEMO_MODE`, #5963) deploys as Workers Static Assets for a public prototype that informs
+#5229 — synthetic data only, no operator credentials.
 
 The Phase 6 data views have shipped: an overview summary (`routes/index.tsx`, #4853) alongside dedicated
-run-history, portfolio, and ledgers views, each fed by the local read-only `/api/*` endpoints below.
+run-history, portfolio, and ledgers views, each fed by the local read-only `/api/*` endpoints below
+(or by in-bundle demo fixtures when `VITE_DEMO_MODE=true`).
 
 ## Configuration
 
 | Env var                     | Required | Description                                                                                                                                                                                                                                            |
 | --------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `VITE_MINER_UI_GRAFANA_URL` | No       | If set (and non-empty), renders a footer link to your ORB/Grafana dashboard at this URL. Unset ⇒ no link. Must be `VITE_`-prefixed so Vite exposes it to the client bundle. It is a plain navigational link — no token or credential is ever appended. |
+| `VITE_DEMO_MODE`            | No       | When `"true"` (baked by `npm run build:demo` / `vite build --mode demo` via `vite.config.ts`), client fetchers serve synthetic sample data and skip `/api/*`. Used for the public Cloudflare Worker demo only — never for a real miner.                |
+
+## Public demo Worker (#5963)
+
+```bash
+npm --workspace @loopover/ui-kit run build
+npm --workspace @loopover/ui-miner run build:demo   # vite build --mode demo
+npm --workspace @loopover/ui-miner run deploy:demo  # wrangler deploy → loopover-miner-ui-demo
+```
+
+Or trigger `.github/workflows/miner-ui-demo-deploy.yml` (`workflow_dispatch`). Custom domain routes are
+omitted until DNS is provisioned; the Worker publishes on `*.workers.dev`. This demo is **not** a
+decision that hosted AMS ships a web dashboard — that remains #5229.
 
 ## Local API authentication
 

--- a/apps/loopover-miner-ui/docs/5963-miner-ui-demo-worker-before-after.svg
+++ b/apps/loopover-miner-ui/docs/5963-miner-ui-demo-worker-before-after.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-label="Before and after for miner-ui demo mode (#5963)">
+  <rect width="960" height="420" fill="#0f1419"/>
+  <text x="24" y="36" fill="#8b9bab" font-family="ui-monospace,monospace" font-size="14">#5963 miner-ui public demo Worker</text>
+
+  <rect x="24" y="56" width="440" height="340" rx="8" fill="#161b22" stroke="#30363d"/>
+  <text x="40" y="88" fill="#f85149" font-family="ui-sans-serif,system-ui" font-size="16" font-weight="600">Before</text>
+  <text x="40" y="120" fill="#c9d1d9" font-family="ui-sans-serif,system-ui" font-size="14">Self-host only (Vite + SQLite APIs)</text>
+  <text x="40" y="148" fill="#8b9bab" font-family="ui-sans-serif,system-ui" font-size="13">No CI build / no CF Worker / no public URL</text>
+  <text x="40" y="176" fill="#8b9bab" font-family="ui-sans-serif,system-ui" font-size="13">#5229 evaluated without a working prototype</text>
+  <rect x="40" y="210" width="400" height="150" rx="6" fill="#0d1117" stroke="#30363d"/>
+  <text x="56" y="240" fill="#8b9bab" font-family="ui-monospace,monospace" font-size="12">Local dashboard</text>
+  <text x="56" y="270" fill="#484f58" font-family="ui-sans-serif,system-ui" font-size="12">[ empty / needs operator host ]</text>
+  <text x="56" y="300" fill="#484f58" font-family="ui-sans-serif,system-ui" font-size="12">/api/* ’ node:sqlite (not on CF)</text>
+
+  <rect x="496" y="56" width="440" height="340" rx="8" fill="#161b22" stroke="#238636"/>
+  <text x="512" y="88" fill="#3fb950" font-family="ui-sans-serif,system-ui" font-size="16" font-weight="600">After</text>
+  <text x="512" y="120" fill="#c9d1d9" font-family="ui-sans-serif,system-ui" font-size="14">VITE_DEMO_MODE static SPA on Workers</text>
+  <text x="512" y="148" fill="#8b9bab" font-family="ui-sans-serif,system-ui" font-size="13">CI build + Codecov bundle + workflow_dispatch deploy</text>
+  <text x="512" y="176" fill="#8b9bab" font-family="ui-sans-serif,system-ui" font-size="13">Synthetic fixtures  no credentials / live ledgers</text>
+  <rect x="512" y="210" width="400" height="150" rx="6" fill="#0d1117" stroke="#238636"/>
+  <text x="528" y="240" fill="#3fb950" font-family="ui-monospace,monospace" font-size="12">Demo dashboard</text>
+  <text x="528" y="268" fill="#c9d1d9" font-family="ui-sans-serif,system-ui" font-size="12">Public demo  synthetic sample data only</text>
+  <text x="528" y="296" fill="#8b9bab" font-family="ui-sans-serif,system-ui" font-size="12">run-history / portfolio / ledgers / chat canned</text>
+  <text x="528" y="324" fill="#8b9bab" font-family="ui-sans-serif,system-ui" font-size="12">Worker: loopover-miner-ui-demo</text>
+</svg>

--- a/apps/loopover-miner-ui/package.json
+++ b/apps/loopover-miner-ui/package.json
@@ -8,7 +8,11 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
+    "build:demo": "vite build --mode demo",
     "preview": "vite preview",
+    "preview:demo": "vite preview --mode demo",
+    "bundle-analysis": "bundle-analyzer ./dist --bundle-name=loopover-miner-ui --upload-token=$CODECOV_TOKEN",
+    "deploy:demo": "npm run build:demo && wrangler deploy",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run --coverage",
@@ -26,6 +30,7 @@
     "vite-tsconfig-paths": "^6.1.1"
   },
   "devDependencies": {
+    "@codecov/bundle-analyzer": "^2.0.1",
     "@eslint/js": "^9.39.4",
     "@tanstack/router-plugin": "^1.168.19",
     "@testing-library/dom": "^10.4.1",

--- a/apps/loopover-miner-ui/src/components/demo-mode-banner.tsx
+++ b/apps/loopover-miner-ui/src/components/demo-mode-banner.tsx
@@ -1,0 +1,14 @@
+import { isDemoMode } from "@/lib/demo-mode";
+
+/** Persistent notice when the public demo Worker is serving synthetic data (#5963). */
+export function DemoModeBanner() {
+  if (!isDemoMode()) return null;
+  return (
+    <div
+      role="status"
+      className="border-b-hairline bg-muted/60 px-4 py-2 text-center text-token-sm text-muted-foreground"
+    >
+      Public demo — synthetic sample data only. Not a live miner and not a commitment to hosted AMS (#5229).
+    </div>
+  );
+}

--- a/apps/loopover-miner-ui/src/demo-mode-banner.test.tsx
+++ b/apps/loopover-miner-ui/src/demo-mode-banner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DemoModeBanner } from "./components/demo-mode-banner";
+
+describe("DemoModeBanner (#5963)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("renders nothing outside demo mode", () => {
+    vi.stubEnv("VITE_DEMO_MODE", "");
+    const { container } = render(<DemoModeBanner />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows the synthetic-data notice in demo mode", () => {
+    vi.stubEnv("VITE_DEMO_MODE", "true");
+    render(<DemoModeBanner />);
+    expect(screen.getByRole("status").textContent).toMatch(/synthetic sample data/i);
+  });
+});

--- a/apps/loopover-miner-ui/src/lib/attempt.ts
+++ b/apps/loopover-miner-ui/src/lib/attempt.ts
@@ -4,6 +4,9 @@
 // request. `/api/attempt` can run for minutes (a real worktree + coding-agent iteration), so a caller that needs
 // a deadline applies it here at the fetch layer — the route imposes none.
 
+import { demoRequestAttempt } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const ATTEMPT_API_PATH = "/api/attempt";
 
 /** Non-secret attempt inputs — never a credential; `runAttempt` resolves its own token server-side. */
@@ -44,6 +47,7 @@ export async function requestAttempt(
   input: AttemptActionInput,
   fetchImpl: typeof fetch = fetch,
 ): Promise<AttemptActionResult> {
+  if (isDemoMode()) return demoRequestAttempt(input);
   try {
     const response = await fetchImpl(ATTEMPT_API_PATH, {
       method: "POST",

--- a/apps/loopover-miner-ui/src/lib/chat-stream.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-stream.ts
@@ -7,6 +7,9 @@
 // stream. A validation failure comes back as a plain non-streamed 4xx JSON body, surfaced here as a thrown error
 // before any token is yielded.
 
+import { demoStreamChat } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 /** The wire event union the endpoint emits (mirrored from vite-chat-api.ts's `ChatSseEvent`; the app
  *  deliberately doesn't import the server plugin module just for its type). */
 export type ChatStreamEvent =
@@ -41,6 +44,10 @@ export async function* streamChat(
   messages: ChatWireMessage[],
   fetchImpl: FetchImpl = (input, init) => fetch(input, init),
 ): AsyncGenerator<string> {
+  if (isDemoMode()) {
+    yield* demoStreamChat();
+    return;
+  }
   const response = await fetchImpl(CHAT_API_PATH, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/loopover-miner-ui/src/lib/demo-data.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-data.ts
@@ -1,0 +1,248 @@
+// Synthetic fixtures for the public miner-ui demo Worker (#5963). Values are deliberately fake —
+// no real trust scores, reward amounts, operator credentials, or private scoring detail. Mutable
+// module state lets pause / release / requeue feel interactive without a backend.
+
+import type { AttemptActionInput, AttemptActionResult } from "./attempt";
+import type { DiscoverActionInput, DiscoverActionResult } from "./discover";
+import type { GovernorPauseState, GovernorPauseStateResult } from "./governor";
+import type { LedgersResult, LedgersSummary } from "./ledgers";
+import type { PortfolioQueueResult, PortfolioQueueSummary } from "./portfolio-queue";
+import type {
+  PortfolioQueueActionItem,
+  PortfolioQueueActionResult,
+  PortfolioQueueItemsResult,
+} from "./portfolio-queue-actions";
+import type { RunHistoryResult, RunStateRow } from "./run-history";
+
+const DEMO_API_BASE = "https://api.github.com";
+const DEMO_REPO_A = "demo-org/sample-widgets";
+const DEMO_REPO_B = "demo-org/sample-gadgets";
+
+const DEMO_RUN_ROWS: RunStateRow[] = [
+  {
+    apiBaseUrl: DEMO_API_BASE,
+    repoFullName: DEMO_REPO_A,
+    state: "discovering",
+    updatedAt: "2026-07-16T12:00:00.000Z",
+  },
+  {
+    apiBaseUrl: DEMO_API_BASE,
+    repoFullName: DEMO_REPO_B,
+    state: "idle",
+    updatedAt: "2026-07-16T11:45:00.000Z",
+  },
+  {
+    apiBaseUrl: "https://gitlab.example.test/api/v4",
+    repoFullName: DEMO_REPO_A,
+    state: "planning",
+    updatedAt: "2026-07-16T11:30:00.000Z",
+  },
+];
+
+const DEMO_LEDGERS: LedgersSummary = {
+  claims: { total: 5, byStatus: { active: 2, released: 2, expired: 1 } },
+  events: {
+    total: 4,
+    byType: { attempt_started: 2, attempt_succeeded: 1, attempt_deferred: 1 },
+    recent: [
+      {
+        eventType: "attempt_succeeded",
+        repoFullName: DEMO_REPO_A,
+        createdAt: "2026-07-16T10:05:00.000Z",
+      },
+      {
+        eventType: "attempt_started",
+        repoFullName: DEMO_REPO_B,
+        createdAt: "2026-07-16T10:00:00.000Z",
+      },
+      {
+        eventType: "attempt_deferred",
+        repoFullName: DEMO_REPO_A,
+        createdAt: "2026-07-16T09:55:00.000Z",
+      },
+    ],
+  },
+  governor: {
+    total: 3,
+    byEventType: { rate_limit_deferred: 2, budget_deferred: 1 },
+  },
+};
+
+function buildQueueSummary(items: PortfolioQueueActionItem[]): PortfolioQueueSummary {
+  const queuedExtra = 2; // synthetic queued-only rows that aren't actionable
+  const byStatus = { queued: queuedExtra, in_progress: 0, done: 0 };
+  for (const item of items) {
+    byStatus[item.status] += 1;
+  }
+  const repos = [DEMO_REPO_A, DEMO_REPO_B].map((repoFullName) => {
+    const repoItems = items.filter((item) => item.repoFullName === repoFullName);
+    const repoByStatus = {
+      queued: repoFullName === DEMO_REPO_A ? 1 : 1,
+      in_progress: repoItems.filter((i) => i.status === "in_progress").length,
+      done: repoItems.filter((i) => i.status === "done").length,
+    };
+    return {
+      repoFullName,
+      byStatus: repoByStatus,
+      total: repoByStatus.queued + repoByStatus.in_progress + repoByStatus.done,
+    };
+  });
+  return {
+    total: byStatus.queued + byStatus.in_progress + byStatus.done,
+    byStatus,
+    repos,
+    oldestQueuedAgeMs: 3_600_000,
+  };
+}
+
+let pauseState: GovernorPauseState = {
+  paused: false,
+  reason: null,
+  pausedAt: null,
+};
+
+let actionItems: PortfolioQueueActionItem[] = [
+  {
+    apiBaseUrl: DEMO_API_BASE,
+    repoFullName: DEMO_REPO_A,
+    identifier: "issue:42",
+    status: "in_progress",
+  },
+  {
+    apiBaseUrl: DEMO_API_BASE,
+    repoFullName: DEMO_REPO_B,
+    identifier: "issue:7",
+    status: "done",
+  },
+];
+
+/** Reset mutable demo state — used by unit tests. */
+export function resetDemoData(): void {
+  pauseState = { paused: false, reason: null, pausedAt: null };
+  actionItems = [
+    {
+      apiBaseUrl: DEMO_API_BASE,
+      repoFullName: DEMO_REPO_A,
+      identifier: "issue:42",
+      status: "in_progress",
+    },
+    {
+      apiBaseUrl: DEMO_API_BASE,
+      repoFullName: DEMO_REPO_B,
+      identifier: "issue:7",
+      status: "done",
+    },
+  ];
+}
+
+export function demoFetchRunStates(): RunHistoryResult {
+  return { ok: true, rows: DEMO_RUN_ROWS };
+}
+
+export function demoFetchLedgers(): LedgersResult {
+  return { ok: true, summary: DEMO_LEDGERS };
+}
+
+export function demoFetchPortfolioQueue(): PortfolioQueueResult {
+  return { ok: true, summary: buildQueueSummary(actionItems) };
+}
+
+export function demoFetchPortfolioQueueItems(): PortfolioQueueItemsResult {
+  return { ok: true, items: [...actionItems] };
+}
+
+export function demoFetchGovernorPauseState(): GovernorPauseStateResult {
+  return { ok: true, pauseState: { ...pauseState } };
+}
+
+export function demoPauseGovernor(reason?: string): GovernorPauseStateResult {
+  pauseState = {
+    paused: true,
+    reason: reason?.trim() ? reason.trim() : "demo pause",
+    pausedAt: "2026-07-16T12:30:00.000Z",
+  };
+  return { ok: true, pauseState: { ...pauseState } };
+}
+
+export function demoResumeGovernor(): GovernorPauseStateResult {
+  pauseState = { paused: false, reason: null, pausedAt: null };
+  return { ok: true, pauseState: { ...pauseState } };
+}
+
+export function demoReleasePortfolioQueueItem(
+  item: Pick<PortfolioQueueActionItem, "repoFullName" | "identifier" | "apiBaseUrl">,
+): PortfolioQueueActionResult {
+  const index = actionItems.findIndex(
+    (entry) =>
+      entry.repoFullName === item.repoFullName &&
+      entry.identifier === item.identifier &&
+      entry.apiBaseUrl === item.apiBaseUrl &&
+      entry.status === "in_progress",
+  );
+  if (index === -1) {
+    return { ok: false, error: "demo queue: no matching in_progress item to release" };
+  }
+  actionItems = actionItems.filter((_, i) => i !== index);
+  return {
+    ok: true,
+    entry: { repoFullName: item.repoFullName, identifier: item.identifier, status: "queued" },
+  };
+}
+
+export function demoRequeuePortfolioQueueItem(
+  item: Pick<PortfolioQueueActionItem, "repoFullName" | "identifier" | "apiBaseUrl">,
+): PortfolioQueueActionResult {
+  const index = actionItems.findIndex(
+    (entry) =>
+      entry.repoFullName === item.repoFullName &&
+      entry.identifier === item.identifier &&
+      entry.apiBaseUrl === item.apiBaseUrl &&
+      entry.status === "done",
+  );
+  if (index === -1) {
+    return { ok: false, error: "demo queue: no matching done item to requeue" };
+  }
+  const next = [...actionItems];
+  next[index] = { ...next[index]!, status: "in_progress" };
+  actionItems = next;
+  return {
+    ok: true,
+    entry: { repoFullName: item.repoFullName, identifier: item.identifier, status: "queued" },
+  };
+}
+
+export function demoRequestDiscover(_input: DiscoverActionInput): DiscoverActionResult {
+  return {
+    ok: true,
+    exitCode: 0,
+    result: {
+      dryRun: true,
+      targets: [DEMO_REPO_A],
+      note: "Synthetic discover result for the public demo — no real forge calls were made.",
+    },
+  };
+}
+
+export function demoRequestAttempt(input: AttemptActionInput): AttemptActionResult {
+  return {
+    ok: true,
+    exitCode: 0,
+    result: {
+      dryRun: true,
+      repoFullName: input.repoFullName,
+      issueNumber: input.issueNumber,
+      outcome: "demo_skipped",
+      note: "Synthetic attempt result for the public demo — no worktree or agent was started.",
+    },
+  };
+}
+
+/** Yield a short canned assistant reply without contacting `/api/chat`. */
+export async function* demoStreamChat(): AsyncGenerator<string> {
+  const reply =
+    "This is the public LoopOver miner-ui demo. Queue, run-history, and ledger panels show synthetic sample data only — no operator credentials or live miner state.";
+  // Chunk like a real SSE stream so the typing indicator / StreamingText path still exercises.
+  const mid = Math.ceil(reply.length / 2);
+  yield reply.slice(0, mid);
+  yield reply.slice(mid);
+}

--- a/apps/loopover-miner-ui/src/lib/demo-data.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-data.ts
@@ -77,7 +77,7 @@ function buildQueueSummary(items: PortfolioQueueActionItem[]): PortfolioQueueSum
   const repos = [DEMO_REPO_A, DEMO_REPO_B].map((repoFullName) => {
     const repoItems = items.filter((item) => item.repoFullName === repoFullName);
     const repoByStatus = {
-      queued: repoFullName === DEMO_REPO_A ? 1 : 1,
+      queued: 1,
       in_progress: repoItems.filter((i) => i.status === "in_progress").length,
       done: repoItems.filter((i) => i.status === "done").length,
     };

--- a/apps/loopover-miner-ui/src/lib/demo-mode.test.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-mode.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  demoFetchPortfolioQueueItems,
+  demoRequestAttempt,
+  demoRequestDiscover,
+  demoStreamChat,
+  resetDemoData,
+} from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+import { fetchRunStates } from "./run-history";
+import { fetchLedgers } from "./ledgers";
+import { fetchPortfolioQueue } from "./portfolio-queue";
+import {
+  fetchPortfolioQueueItems,
+  releasePortfolioQueueItem,
+  requeuePortfolioQueueItem,
+} from "./portfolio-queue-actions";
+import { fetchGovernorPauseState, pauseGovernor, resumeGovernor } from "./governor";
+import { requestDiscover } from "./discover";
+import { requestAttempt } from "./attempt";
+import { streamChat } from "./chat-stream";
+
+describe("demo mode fixtures (#5963)", () => {
+  afterEach(() => {
+    resetDemoData();
+    vi.unstubAllEnvs();
+  });
+
+  it("isDemoMode reads VITE_DEMO_MODE", () => {
+    vi.stubEnv("VITE_DEMO_MODE", "true");
+    expect(isDemoMode()).toBe(true);
+    vi.stubEnv("VITE_DEMO_MODE", "");
+    expect(isDemoMode()).toBe(false);
+  });
+
+  it("serves synthetic run-state / ledger / queue payloads without fetch", async () => {
+    vi.stubEnv("VITE_DEMO_MODE", "true");
+    const fetchImpl = vi.fn();
+    const runs = await fetchRunStates(fetchImpl);
+    const ledgers = await fetchLedgers(fetchImpl);
+    const queue = await fetchPortfolioQueue(fetchImpl);
+    expect(runs.ok && runs.rows.length).toBeGreaterThan(0);
+    expect(ledgers.ok && ledgers.summary.claims.total).toBeGreaterThan(0);
+    expect(queue.ok && queue.summary.total).toBeGreaterThan(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("mutates governor pause state in memory", async () => {
+    vi.stubEnv("VITE_DEMO_MODE", "true");
+    expect((await pauseGovernor("demo reason")).ok).toBe(true);
+    const paused = await fetchGovernorPauseState();
+    expect(paused.ok && paused.pauseState.paused).toBe(true);
+    expect(paused.ok && paused.pauseState.reason).toBe("demo reason");
+    expect((await resumeGovernor()).ok).toBe(true);
+    const resumed = await fetchGovernorPauseState();
+    expect(resumed.ok && resumed.pauseState.paused).toBe(false);
+  });
+
+  it("release / requeue mutate actionable demo queue items", async () => {
+    vi.stubEnv("VITE_DEMO_MODE", "true");
+    const before = await fetchPortfolioQueueItems();
+    expect(before.ok).toBe(true);
+    if (!before.ok) return;
+    const inProgress = before.items.find((i) => i.status === "in_progress");
+    const done = before.items.find((i) => i.status === "done");
+    expect(inProgress).toBeTruthy();
+    expect(done).toBeTruthy();
+
+    await expect(releasePortfolioQueueItem(inProgress!)).resolves.toMatchObject({
+      ok: true,
+      entry: { status: "queued" },
+    });
+    const afterRelease = await fetchPortfolioQueueItems();
+    expect(afterRelease.ok && afterRelease.items.every((i) => i.status !== "in_progress")).toBe(true);
+    await expect(releasePortfolioQueueItem(inProgress!)).resolves.toMatchObject({ ok: false });
+
+    resetDemoData();
+    const seeded = demoFetchPortfolioQueueItems();
+    expect(seeded.ok).toBe(true);
+    if (!seeded.ok) return;
+    const doneAgain = seeded.items.find((i) => i.status === "done")!;
+    await expect(requeuePortfolioQueueItem(doneAgain)).resolves.toMatchObject({ ok: true });
+    await expect(requeuePortfolioQueueItem(doneAgain)).resolves.toMatchObject({ ok: false });
+  });
+
+  it("discover / attempt / chat return canned demo results", async () => {
+    vi.stubEnv("VITE_DEMO_MODE", "true");
+    await expect(requestDiscover({ dryRun: true })).resolves.toMatchObject({ ok: true, exitCode: 0 });
+    await expect(
+      requestAttempt({ repoFullName: "demo-org/sample-widgets", issueNumber: 1, minerLogin: "demo" }),
+    ).resolves.toMatchObject({ ok: true, exitCode: 0 });
+    expect(demoRequestDiscover({}).ok).toBe(true);
+    expect(demoRequestAttempt({ repoFullName: "a/b", issueNumber: 1, minerLogin: "x" }).ok).toBe(true);
+
+    const chunks: string[] = [];
+    for await (const chunk of streamChat([{ role: "user", content: "hi" }], vi.fn())) {
+      chunks.push(chunk);
+    }
+    expect(chunks.join("")).toContain("synthetic sample data");
+    const demoChunks: string[] = [];
+    for await (const chunk of demoStreamChat()) demoChunks.push(chunk);
+    expect(demoChunks.join("")).toEqual(chunks.join(""));
+  });
+});

--- a/apps/loopover-miner-ui/src/lib/demo-mode.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-mode.ts
@@ -1,0 +1,4 @@
+/** True when the client was built with `VITE_DEMO_MODE=true` (vite `--mode demo`, #5963). */
+export function isDemoMode(): boolean {
+  return import.meta.env.VITE_DEMO_MODE === "true";
+}

--- a/apps/loopover-miner-ui/src/lib/discover.ts
+++ b/apps/loopover-miner-ui/src/lib/discover.ts
@@ -2,6 +2,9 @@
 // Mirrors governor.ts's shape: a typed discriminated result, never a thrown exception for an HTTP-level failure,
 // and a guard narrowing the parsed payload. Safe only because vite-auth.ts authenticates every /api/* request.
 
+import { demoRequestDiscover } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const DISCOVER_API_PATH = "/api/discover";
 
 /** Non-secret discover inputs — never a credential; the server resolves its own token, exactly as the CLI does. */
@@ -39,6 +42,7 @@ export async function requestDiscover(
   input: DiscoverActionInput,
   fetchImpl: typeof fetch = fetch,
 ): Promise<DiscoverActionResult> {
+  if (isDemoMode()) return demoRequestDiscover(input);
   try {
     const response = await fetchImpl(DISCOVER_API_PATH, {
       method: "POST",

--- a/apps/loopover-miner-ui/src/lib/governor.ts
+++ b/apps/loopover-miner-ui/src/lib/governor.ts
@@ -3,6 +3,9 @@
 // response, a guard narrowing the parsed JSON payload) but adds two WRITE actions, the miner-ui's first — safe
 // only because vite-auth.ts (#4858) now authenticates every /api/* request, including these.
 
+import { demoFetchGovernorPauseState, demoPauseGovernor, demoResumeGovernor } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const GOVERNOR_PAUSE_STATE_API_PATH = "/api/governor/pause-state";
 export const GOVERNOR_PAUSE_API_PATH = "/api/governor/pause";
 export const GOVERNOR_RESUME_API_PATH = "/api/governor/resume";
@@ -36,6 +39,7 @@ async function parseGovernorPauseStateResponse(
 
 /** Fetch the governor's current pause state; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchGovernorPauseState(fetchImpl: typeof fetch = fetch): Promise<GovernorPauseStateResult> {
+  if (isDemoMode()) return demoFetchGovernorPauseState();
   try {
     const response = await fetchImpl(GOVERNOR_PAUSE_STATE_API_PATH);
     return await parseGovernorPauseStateResponse(response, "local governor pause-state API");
@@ -69,10 +73,12 @@ async function postGovernorAction(
 
 /** Pause the governor, optionally with a reason (mirrors `loopover-miner governor pause [--reason <text>]`). */
 export function pauseGovernor(reason?: string, fetchImpl: typeof fetch = fetch): Promise<GovernorPauseStateResult> {
+  if (isDemoMode()) return Promise.resolve(demoPauseGovernor(reason));
   return postGovernorAction(GOVERNOR_PAUSE_API_PATH, reason ? { reason } : {}, fetchImpl);
 }
 
 /** Resume the governor (mirrors `loopover-miner governor resume`). */
 export function resumeGovernor(fetchImpl: typeof fetch = fetch): Promise<GovernorPauseStateResult> {
+  if (isDemoMode()) return Promise.resolve(demoResumeGovernor());
   return postGovernorAction(GOVERNOR_RESUME_API_PATH, {}, fetchImpl);
 }

--- a/apps/loopover-miner-ui/src/lib/ledgers.ts
+++ b/apps/loopover-miner-ui/src/lib/ledgers.ts
@@ -4,6 +4,9 @@
 // enforce). This client just fetches that summary and validates its shape; a failure surfaces as a typed error
 // result the view renders, never a crash.
 
+import { demoFetchLedgers } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const LEDGERS_API_PATH = "/api/ledgers";
 
 export const CLAIM_STATUSES = ["active", "released", "expired"] as const;
@@ -56,6 +59,7 @@ function isLedgersSummary(value: unknown): value is LedgersSummary {
 
 /** Fetch the local ledgers summary; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchLedgers(fetchImpl: typeof fetch = fetch): Promise<LedgersResult> {
+  if (isDemoMode()) return demoFetchLedgers();
   try {
     const response = await fetchImpl(LEDGERS_API_PATH);
     if (!response.ok) return { ok: false, error: `local ledgers API responded ${response.status}` };

--- a/apps/loopover-miner-ui/src/lib/portfolio-queue-actions.ts
+++ b/apps/loopover-miner-ui/src/lib/portfolio-queue-actions.ts
@@ -2,6 +2,13 @@
 // the miner-ui"). Mirrors the CLI's `loopover-miner queue release` / `queue requeue` commands via the
 // authenticated dev-server bridge in vite-portfolio-queue-actions-api.ts.
 
+import {
+  demoFetchPortfolioQueueItems,
+  demoReleasePortfolioQueueItem,
+  demoRequeuePortfolioQueueItem,
+} from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const PORTFOLIO_QUEUE_ITEMS_API_PATH = "/api/portfolio-queue/items";
 export const PORTFOLIO_QUEUE_RELEASE_API_PATH = "/api/portfolio-queue/release";
 export const PORTFOLIO_QUEUE_REQUEUE_API_PATH = "/api/portfolio-queue/requeue";
@@ -70,6 +77,7 @@ function parseActionResponse(response: Response, label: string): Promise<Portfol
 
 /** Fetch actionable queue rows (in_progress + done) for release/requeue controls. */
 export async function fetchPortfolioQueueItems(fetchImpl: typeof fetch = fetch): Promise<PortfolioQueueItemsResult> {
+  if (isDemoMode()) return demoFetchPortfolioQueueItems();
   try {
     const response = await fetchImpl(PORTFOLIO_QUEUE_ITEMS_API_PATH);
     return await parseItemsResponse(response, "local portfolio-queue items API");
@@ -86,6 +94,7 @@ export function releasePortfolioQueueItem(
   item: Pick<PortfolioQueueActionItem, "repoFullName" | "identifier" | "apiBaseUrl">,
   fetchImpl: typeof fetch = fetch,
 ): Promise<PortfolioQueueActionResult> {
+  if (isDemoMode()) return Promise.resolve(demoReleasePortfolioQueueItem(item));
   return postPortfolioQueueAction(PORTFOLIO_QUEUE_RELEASE_API_PATH, item, fetchImpl);
 }
 
@@ -94,6 +103,7 @@ export function requeuePortfolioQueueItem(
   item: Pick<PortfolioQueueActionItem, "repoFullName" | "identifier" | "apiBaseUrl">,
   fetchImpl: typeof fetch = fetch,
 ): Promise<PortfolioQueueActionResult> {
+  if (isDemoMode()) return Promise.resolve(demoRequeuePortfolioQueueItem(item));
   return postPortfolioQueueAction(PORTFOLIO_QUEUE_REQUEUE_API_PATH, item, fetchImpl);
 }
 

--- a/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
+++ b/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
@@ -4,6 +4,9 @@
 // global-only aggregate, so the miner-ui and the CLI share one data path rather than maintaining two. It still
 // never republishes raw queue identifiers or rank-derived priorities — only status counts, grouped by repo.
 
+import { demoFetchPortfolioQueue } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const PORTFOLIO_QUEUE_API_PATH = "/api/portfolio-queue";
 
 export const QUEUE_STATUSES = ["queued", "in_progress", "done"] as const;
@@ -53,6 +56,7 @@ function isPortfolioQueueSummary(value: unknown): value is PortfolioQueueSummary
 
 /** Fetch the local queue summary; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchPortfolioQueue(fetchImpl: typeof fetch = fetch): Promise<PortfolioQueueResult> {
+  if (isDemoMode()) return demoFetchPortfolioQueue();
   try {
     const response = await fetchImpl(PORTFOLIO_QUEUE_API_PATH);
     if (!response.ok) return { ok: false, error: `local portfolio-queue API responded ${response.status}` };

--- a/apps/loopover-miner-ui/src/lib/run-history.ts
+++ b/apps/loopover-miner-ui/src/lib/run-history.ts
@@ -3,6 +3,9 @@
 // endpoint (see `vite-run-state-api.ts`), which itself calls into `packages/loopover-miner/lib/run-state.js`'s
 // existing exports.
 
+import { demoFetchRunStates } from "./demo-data";
+import { isDemoMode } from "./demo-mode";
+
 export const RUN_STATE_API_PATH = "/api/run-state";
 
 /** One `miner_run_state` row as served by the local API — mirrors `run-state.js`'s row shape. */
@@ -45,6 +48,7 @@ export function runStateRowKey(row: Pick<RunStateRow, "apiBaseUrl" | "repoFullNa
 /** Fetch the local run-state rows. Failures (server down, malformed payload) surface as a typed error result —
  *  the view renders them as a message, never a crash. `fetchImpl` is injectable for tests. */
 export async function fetchRunStates(fetchImpl: typeof fetch = fetch): Promise<RunHistoryResult> {
+  if (isDemoMode()) return demoFetchRunStates();
   try {
     const response = await fetchImpl(RUN_STATE_API_PATH);
     if (!response.ok) return { ok: false, error: `local run-state API responded ${response.status}` };

--- a/apps/loopover-miner-ui/src/routes/__root.tsx
+++ b/apps/loopover-miner-ui/src/routes/__root.tsx
@@ -1,8 +1,10 @@
 import { Outlet, createRootRoute, Link } from "@tanstack/react-router";
 import * as React from "react";
+import { DemoModeBanner } from "@/components/demo-mode-banner";
 import { GrafanaFooterLink } from "@/components/grafana-footer-link";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ChatRail } from "@/components/chat-rail";
+import { isDemoMode } from "@/lib/demo-mode";
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -41,11 +43,14 @@ export function RootShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <DemoModeBanner />
       <header className="sticky top-0 z-40 border-b-hairline bg-background/85 backdrop-blur">
         <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 gap-y-3 px-4 py-3 sm:px-6">
           <div className="min-w-0 flex-1">
             <p className="text-token-xs uppercase tracking-[0.2em] text-primary font-mono">LoopOver Miner</p>
-            <h1 className="text-token-lg font-display font-semibold">Local dashboard</h1>
+            <h1 className="text-token-lg font-display font-semibold">
+              {isDemoMode() ? "Demo dashboard" : "Local dashboard"}
+            </h1>
           </div>
           <nav
             aria-label="Primary"

--- a/apps/loopover-miner-ui/src/vite-env.d.ts
+++ b/apps/loopover-miner-ui/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** When `"true"`, client fetchers serve synthetic data and skip `/api/*` (#5963). */
+  readonly VITE_DEMO_MODE?: string;
+  /** Optional footer link to an operator Grafana dashboard. */
+  readonly VITE_MINER_UI_GRAFANA_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/loopover-miner-ui/vite.config.ts
+++ b/apps/loopover-miner-ui/vite.config.ts
@@ -17,7 +17,15 @@ import { portfolioQueueApiPlugin } from "./vite-portfolio-queue-api";
 import { rankedCandidatesApiPlugin } from "./vite-ranked-candidates-api";
 import { runStateApiPlugin } from "./vite-run-state-api";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  // `--mode demo` (#5963) — bake VITE_DEMO_MODE so the static CF Worker build needs no .env file
+  // (`.env.*` is gitignored). Self-host `vite build` / `vite dev` leave demo mode off.
+  define:
+    mode === "demo"
+      ? {
+          "import.meta.env.VITE_DEMO_MODE": JSON.stringify("true"),
+        }
+      : undefined,
   plugins: [
     TanStackRouterVite({ target: "react", autoCodeSplitting: true }),
     react(),
@@ -48,4 +56,4 @@ export default defineConfig({
     port: 4174,
     strictPort: true,
   },
-});
+}));

--- a/apps/loopover-miner-ui/wrangler.jsonc
+++ b/apps/loopover-miner-ui/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  // Public prototype/demo Worker for apps/loopover-miner-ui (#5963). Static SPA assets only —
+  // client fetchers serve synthetic data when built with `vite build --mode demo`. Custom domain
+  // routes are intentionally omitted until DNS is provisioned; workers.dev preview is enough for
+  // the prototype. Distinct Worker name so it never collides with `loopover-ui` / `loopover-api`.
+  "name": "loopover-miner-ui-demo",
+  "compatibility_date": "2026-05-28",
+  "workers_dev": true,
+  "preview_urls": true,
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "vite-tsconfig-paths": "^6.1.1"
       },
       "devDependencies": {
+        "@codecov/bundle-analyzer": "^2.0.1",
         "@eslint/js": "^9.39.4",
         "@tanstack/router-plugin": "^1.168.19",
         "@testing-library/dom": "^10.4.1",

--- a/test/unit/ci-ui-build-openapi.test.ts
+++ b/test/unit/ci-ui-build-openapi.test.ts
@@ -16,7 +16,7 @@ describe("UI build steps skip the redundant OpenAPI regen", () => {
     const step = workflow.slice(stepStart, stepEnd === -1 ? undefined : stepEnd);
 
     expect(step).toContain(
-      "run: npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build",
+      "run: npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build && npm --workspace @loopover/ui-miner run build",
     );
     expect(step).not.toContain("npm run ui:build");
   });
@@ -28,5 +28,12 @@ describe("UI build steps skip the redundant OpenAPI regen", () => {
       "run: npm run ui:openapi:check && npm run ui:lint && npm run ui:typecheck && npm run extension:lint && npm run miner-extension:lint && npm run extension:typecheck && npm run miner-extension:typecheck && npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build",
     );
     expect(workflow).not.toContain("&& npm run ui:build");
+  });
+
+  it("miner-ui-demo-deploy.yml builds the demo mode SPA on workflow_dispatch (#5963)", () => {
+    const workflow = read(".github/workflows/miner-ui-demo-deploy.yml");
+    expect(workflow).toContain("workflow_dispatch");
+    expect(workflow).toContain("npm --workspace @loopover/ui-miner run build:demo");
+    expect(workflow).toContain("npx wrangler deploy");
   });
 });

--- a/test/unit/codecov-policy.test.ts
+++ b/test/unit/codecov-policy.test.ts
@@ -165,10 +165,8 @@ describe("Codecov policy", () => {
     expect(trustedWith.token).toBe("${{ secrets.CODECOV_TOKEN }}");
   });
 
-  it("uploads loopover-ui's bundle stats without letting an upload hiccup fail CI", () => {
-    // loopover-miner-ui deliberately has no build step in this job at all (self-hosted operator
-    // dashboard, not something we deploy -- see "UI build"'s own comment), so there is nothing to
-    // upload bundle stats for on that app here.
+  it("uploads loopover-ui and loopover-miner-ui bundle stats without letting an upload hiccup fail CI", () => {
+    // Both SPAs now have a CI build step (#5963 added miner-ui); bundle uploads stay non-blocking.
     const workflow = readYaml(".github/workflows/ci.yml");
     const validateCode = nestedRecord(workflow, ["jobs", "validate-code"]);
     const steps = recordArray(validateCode.steps, "jobs.validate-code.steps");
@@ -178,6 +176,9 @@ describe("Codecov policy", () => {
     expect(buildIndex).toBeGreaterThan(-1);
     expect(bundleIndex).toBeGreaterThan(buildIndex);
 
+    const buildStep = steps[buildIndex]!;
+    expect(String(buildStep.run)).toContain("npm --workspace @loopover/ui-miner run build");
+
     const bundleStep = steps[bundleIndex]!;
     // Unlike the coverage uploads above, nothing gates a merge on bundle size -- a Codecov outage or a
     // missing token must never fail CI for an otherwise-honest PR.
@@ -185,7 +186,9 @@ describe("Codecov policy", () => {
     expect(String(bundleStep.if)).toContain("github.event.pull_request.head.repo.fork != true");
     const bundleEnv = record(bundleStep.env, "bundle step env");
     expect(bundleEnv.CODECOV_TOKEN).toBe("${{ secrets.CODECOV_TOKEN }}");
-    expect(bundleStep.run).toBe("npm run bundle-analysis --workspace @loopover/ui");
+    expect(bundleStep.run).toBe(
+      "npm run bundle-analysis --workspace @loopover/ui && npm run bundle-analysis --workspace @loopover/ui-miner",
+    );
 
     const uiPkg = JSON.parse(readFileSync("apps/loopover-ui/package.json", "utf8")) as {
       scripts: Record<string, string>;
@@ -195,6 +198,16 @@ describe("Codecov policy", () => {
       "bundle-analyzer ./dist/client --bundle-name=loopover-ui --upload-token=$CODECOV_TOKEN",
     );
     expect(uiPkg.devDependencies["@codecov/bundle-analyzer"]).toBeDefined();
+
+    const minerUiPkg = JSON.parse(readFileSync("apps/loopover-miner-ui/package.json", "utf8")) as {
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(minerUiPkg.scripts["bundle-analysis"]).toBe(
+      "bundle-analyzer ./dist --bundle-name=loopover-miner-ui --upload-token=$CODECOV_TOKEN",
+    );
+    expect(minerUiPkg.scripts["build:demo"]).toBe("vite build --mode demo");
+    expect(minerUiPkg.devDependencies["@codecov/bundle-analyzer"]).toBeDefined();
   });
 
   it("captures review-enrichment node:test coverage for Codecov (#6250)", () => {


### PR DESCRIPTION
## Summary
- Adds `VITE_DEMO_MODE` (`vite build --mode demo`) so client fetchers serve synthetic sample data with no `/api/*` / SQLite backend — safe for a public static Worker.
- Ships `wrangler.jsonc` (`loopover-miner-ui-demo`) + `.github/workflows/miner-ui-demo-deploy.yml` (`workflow_dispatch` only).
- Extends CI UI build + Codecov bundle analysis to `@loopover/ui-miner`.

Prototype for the AMS miner-ui demo Worker (issue 5963). Prior attempt #7189 was CI-green but auto-closed because that issue is maintainer-assigned — this PR does not auto-close the issue so it can sit for manual review (also touches guardrailed workflow paths).

## Before / after
![before-after](https://raw.githubusercontent.com/RealDiligent/gittensory/feat/miner-ui-demo-worker-5963-v2/apps/loopover-miner-ui/docs/5963-miner-ui-demo-worker-before-after.svg)

## Test plan
- [x] `npm --workspace @loopover/ui-miner run test`
- [x] `npm --workspace @loopover/ui-miner run typecheck`
- [x] `npm --workspace @loopover/ui-miner run build:demo`
- [ ] CI green
- [ ] Maintainer manual review (workflows + optional issue 5963 link)