### PR TITLE
feat(api): add an optional cost dimension to product-usage events

### DIFF
--- a/migrations/0165_product_usage_events_cost_usd.sql
+++ b/migrations/0165_product_usage_events_cost_usd.sql
@@ -1,0 +1,7 @@
+-- #4918: a cost dimension on product_usage_events. Nullable and unset by default -- the vast majority of
+-- product actions (viewed a page, ran a preview) have no direct cost; callers that DO know a per-event cost
+-- (e.g. an AI-backed action already priced via ai_usage_events.costUsd) can now attach it to the SAME usage
+-- row instead of requiring a join. Distinct from ai_usage_events.costUsd, which stays the authoritative,
+-- detailed AI-spend ledger (tokens/model/provider) -- this is a lightweight, optional summary figure on the
+-- broader, cross-surface usage stream.
+ALTER TABLE product_usage_events ADD COLUMN cost_usd REAL;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2212,6 +2212,7 @@ export async function recordProductUsageEvent(
     latencyMs?: number | null | undefined;
     clientName?: string | null | undefined;
     clientVersion?: string | null | undefined;
+    costUsd?: number | null | undefined;
     metadata?: Record<string, unknown> | null | undefined;
     occurredAt?: string | null | undefined;
   },
@@ -2238,6 +2239,7 @@ export async function recordProductUsageEvent(
     latencyMs: normalizeProductUsageLatency(event.latencyMs),
     clientName: redactProductUsageActor(boundedProductUsageField(event.clientName, 80), actorRedactor),
     clientVersion: redactProductUsageActor(boundedProductUsageField(event.clientVersion, 80), actorRedactor),
+    costUsd: normalizeProductUsageCostUsd(event.costUsd),
     metadata: sanitizedMetadata,
     occurredAt: event.occurredAt ?? nowIso(),
   };
@@ -2255,6 +2257,7 @@ export async function recordProductUsageEvent(
     latencyMs: record.latencyMs ?? null,
     clientName: record.clientName ?? null,
     clientVersion: record.clientVersion ?? null,
+    costUsd: record.costUsd ?? null,
     metadataJson: jsonString(record.metadata),
     occurredAt: record.occurredAt,
   });
@@ -6936,6 +6939,7 @@ function toProductUsageEventRecord(row: typeof productUsageEvents.$inferSelect):
     latencyMs: row.latencyMs,
     clientName: row.clientName,
     clientVersion: row.clientVersion,
+    costUsd: row.costUsd,
     metadata: parseJson<Record<string, JsonValue>>(row.metadataJson, {}),
     occurredAt: row.occurredAt,
   };
@@ -6987,6 +6991,13 @@ function normalizeProductUsageDailyRollupStatus(status: unknown): ProductUsageDa
 
 function normalizeProductUsageLatency(latencyMs: unknown): number | null {
   return typeof latencyMs === "number" && Number.isFinite(latencyMs) ? Math.max(0, Math.round(latencyMs)) : null;
+}
+
+/** #4918: same defensive shape as normalizeProductUsageLatency -- a non-number/non-finite value (caller error,
+ *  not a real amount) degrades to null (no cost recorded), while a negative number floors to 0 rather than
+ *  persisting a nonsense negative cost. */
+function normalizeProductUsageCostUsd(costUsd: unknown): number | null {
+  return typeof costUsd === "number" && Number.isFinite(costUsd) ? Math.max(0, costUsd) : null;
 }
 
 async function hashProductUsageIdentifier(env: Env, kind: "actor" | "session", value: unknown): Promise<string | null> {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1241,6 +1241,10 @@ export const productUsageEvents = sqliteTable(
     latencyMs: integer("latency_ms"),
     clientName: text("client_name"),
     clientVersion: text("client_version"),
+    // #4918: optional per-event cost, nullable -- most product actions have no direct cost. Distinct from
+    // ai_usage_events.costUsd (the detailed, authoritative AI-spend ledger); this is a lightweight summary
+    // figure for the broader, cross-surface usage stream.
+    costUsd: real("cost_usd"),
     metadataJson: text("metadata_json").notNull().default("{}"),
     occurredAt: text("occurred_at").notNull().$defaultFn(() => nowIso()),
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -2449,6 +2449,8 @@ export type ProductUsageEventRecord = {
   latencyMs?: number | null | undefined;
   clientName?: string | null | undefined;
   clientVersion?: string | null | undefined;
+  // #4918: optional per-event cost (USD). Null for the vast majority of non-billable product actions.
+  costUsd?: number | null | undefined;
   metadata: Record<string, JsonValue>;
   occurredAt: string;
 };

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -1189,4 +1189,55 @@ describe("product usage events", () => {
       retention: expect.arrayContaining([expect.objectContaining({ window: "previous_30_days", capped: true, activeActors: 1, retainedActors: 0 })]),
     });
   });
+
+  // #4918: an optional per-event cost dimension, distinct from ai_usage_events.costUsd's detailed AI-spend
+  // ledger -- a lightweight summary figure any surface can attach when it knows one.
+  it("records an optional per-event cost", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+
+    const recorded = await recordProductUsageEvent(env, {
+      surface: "api",
+      eventName: "billable_action",
+      outcome: "success",
+      costUsd: 1.5,
+    });
+
+    expect(recorded.costUsd).toBe(1.5);
+    const [row] = await listProductUsageEvents(env);
+    expect(row).toMatchObject({ costUsd: 1.5 });
+  });
+
+  it("defaults cost to null when not supplied (byte-identical to before #4918)", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+
+    const recorded = await recordProductUsageEvent(env, {
+      surface: "api",
+      eventName: "free_action",
+      outcome: "success",
+    });
+
+    expect(recorded.costUsd).toBeNull();
+    const [row] = await listProductUsageEvents(env);
+    expect(row).toMatchObject({ costUsd: null });
+  });
+
+  it("clamps a negative cost to 0 (mirrors normalizeProductUsageLatency's own floor) and nulls a non-finite one", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+
+    const negative = await recordProductUsageEvent(env, {
+      surface: "api",
+      eventName: "bad_cost_negative",
+      outcome: "success",
+      costUsd: -3,
+    });
+    const nonFinite = await recordProductUsageEvent(env, {
+      surface: "api",
+      eventName: "bad_cost_non_finite",
+      outcome: "success",
+      costUsd: Number.NaN,
+    });
+
+    expect(negative.costUsd).toBe(0);
+    expect(nonFinite.costUsd).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- Closes #4918: adds a nullable \`cost_usd\` column to \`product_usage_events\`, threaded through \`recordProductUsageEvent\`. Distinct from \`ai_usage_events.costUsd\` (the detailed, authoritative AI-spend ledger with tokens/model/provider) — this is a lightweight, optional summary figure any surface can attach to its own usage row when it knows a per-event cost, without requiring a join.
- Normalization mirrors the existing \`normalizeProductUsageLatency\` helper exactly: a non-number/non-finite value degrades to \`null\` (no cost recorded), a negative number floors to \`0\` — same defensive shape as the sibling field already in this file.
- Null/unset by default — the vast majority of product actions (viewed a page, ran a preview) have no direct cost, and every existing caller of \`recordProductUsageEvent\` is unaffected.

Closes #4918

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run db:migrations:check` — 169 migrations OK, contiguous through 0165.
- [x] `npm run db:schema-drift:check` — no drift.
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally, full unsharded run: 990 test files / 18487 tests passed, 0 failures.
- [x] `npm run ui:openapi:check` — no drift.
- [x] `npm audit --audit-level=moderate` — one pre-existing high-severity finding (`adm-zip` via `github-actionlint`, no fix available), unrelated to this change.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 3 new tests: recording a real cost, defaulting to null when omitted (regression-pins byte-identical behavior for every existing caller), and normalizing a negative (floors to 0) vs. non-finite (nulls) value — both branches of the new helper covered.

Skipped (not applicable): `npm run actionlint`, `npm run test:workers`, `npm run build:mcp`, `npm run test:mcp-pack`, `npm run ui:lint`, `npm run ui:typecheck`, `npm run ui:build` — no `.github/workflows/**`, Workers-binding, mcp-package, or `apps/loopover-ui/**` changes in this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A, internal telemetry-recording function, not a public API surface.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — N/A, backend-only.
- [x] Visible UI changes include a `UI Evidence` section — N/A, no UI in this PR.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change, no visible UI.

## Notes

- No new aggregation/reporting function added here — that's a natural follow-up (mirroring how #7176 added the \`ai_usage_events\` tenant column first, and #4916/#7191 added its fleet-wide aggregate separately). This PR is scoped to the field existing and being recordable.