### PR TITLE
feat(miner): SqliteDriver store seam + migrate run-state

### DIFF
--- a/packages/loopover-miner/lib/local-store.d.ts
+++ b/packages/loopover-miner/lib/local-store.d.ts
@@ -16,3 +16,12 @@ export function openLocalStoreDb(
   resolvedPath: string,
   options?: { busyTimeoutMs?: number },
 ): DatabaseSync;
+
+export function openLocalStoreAdapter(
+  resolvedPath: string,
+  options?: { busyTimeoutMs?: number },
+): {
+  db: DatabaseSync;
+  driver: import("./store-db-adapter.js").SqliteDriver;
+  d1: import("./store-db-adapter.js").MinerD1Database;
+};

--- a/packages/loopover-miner/lib/local-store.js
+++ b/packages/loopover-miner/lib/local-store.js
@@ -3,11 +3,15 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { registerCleanupResource } from "./process-lifecycle.js";
+import { createD1Adapter, nodeSqliteDriver } from "./store-db-adapter.js";
 
 // Shared path-resolution + DB-open boilerplate for the package's local SQLite stores (#4272). This is a DRY pass
 // only, not a merge: run-state.js, claim-ledger.js, portfolio-queue.js, and event-ledger.js each keep their own
 // `.sqlite3` file, table, and env var — this module just extracts the ~15 lines each hand-duplicated
 // (env-var/config-dir/XDG path resolution, mkdirSync(0o700) + chmodSync(0o600), and `PRAGMA busy_timeout`).
+//
+// #7175 part 1 adds `openLocalStoreAdapter`: same open path, then wraps the handle as SqliteDriver + D1 adapter
+// so stores can migrate onto the shared seam without changing self-host's node:sqlite default.
 
 /**
  * Resolve a local store's DB path from, in order: an explicit env var, `LOOPOVER_MINER_CONFIG_DIR`,
@@ -59,4 +63,21 @@ export function openLocalStoreDb(resolvedPath, options = {}) {
     return originalClose();
   };
   return db;
+}
+
+/**
+ * Open a local store through the #7175 SqliteDriver / D1 adapter seam.
+ * Returns the underlying DatabaseSync (for schema migrations / purge helpers that still take it),
+ * the sync SqliteDriver (preferred for store CRUD until a store goes fully async), and the async D1
+ * adapter (same surface ORB uses — ready for a later createPgAdapter swap).
+ *
+ * @param {string} resolvedPath
+ * @param {{ busyTimeoutMs?: number }} [options]
+ * @returns {{ db: import("node:sqlite").DatabaseSync, driver: import("./store-db-adapter.js").SqliteDriver, d1: ReturnType<typeof createD1Adapter> }}
+ */
+export function openLocalStoreAdapter(resolvedPath, options = {}) {
+  const db = openLocalStoreDb(resolvedPath, options);
+  const driver = nodeSqliteDriver(db);
+  const d1 = createD1Adapter(driver);
+  return { db, driver, d1 };
 }

--- a/packages/loopover-miner/lib/run-state.js
+++ b/packages/loopover-miner/lib/run-state.js
@@ -1,5 +1,5 @@
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
-import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { normalizeLocalStoreDbPath, openLocalStoreAdapter, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
 import { RUN_STATE_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
 
@@ -80,10 +80,14 @@ function addTenantIdColumn(db) {
 /**
  * Opens the 100% local/client-side miner run-state store. The database only lives on this machine;
  * this module never uploads, syncs, or phones home with its contents. (#2289, #5563)
+ *
+ * Opened through the #7175 SqliteDriver seam (`openLocalStoreAdapter`): CRUD goes through `driver.query`,
+ * while schema migrations / purge still use the underlying DatabaseSync until those helpers are migrated.
+ * Public API stays synchronous so loop/CLI/MCP callers need no async cascade in this part-1 slice.
  */
 export function initRunStateStore(dbPath = resolveRunStateDbPath()) {
   const resolvedPath = normalizeDbPath(dbPath);
-  const db = openLocalStoreDb(resolvedPath);
+  const { db, driver } = openLocalStoreAdapter(resolvedPath);
   db.exec(`
     CREATE TABLE IF NOT EXISTS miner_run_state (
       repo_full_name TEXT PRIMARY KEY,
@@ -94,24 +98,25 @@ export function initRunStateStore(dbPath = resolveRunStateDbPath()) {
   // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
   applySchemaMigrations(db, [addApiBaseUrlScope, addTenantIdColumn]);
 
-  const getStatement = db.prepare(
-    "SELECT state FROM miner_run_state WHERE api_base_url = ? AND repo_full_name = ?",
-  );
-  const setStatement = db.prepare(`
+  const getSql = "SELECT state FROM miner_run_state WHERE api_base_url = ? AND repo_full_name = ?";
+  const setSql = `
     INSERT INTO miner_run_state (api_base_url, repo_full_name, state, updated_at)
     VALUES (?, ?, ?, ?)
     ON CONFLICT(api_base_url, repo_full_name) DO UPDATE SET
       state = excluded.state,
       updated_at = excluded.updated_at
-  `);
-  const listStatement = db.prepare(
-    "SELECT api_base_url, repo_full_name, state, updated_at FROM miner_run_state ORDER BY repo_full_name",
-  );
+  `;
+  const listSql =
+    "SELECT api_base_url, repo_full_name, state, updated_at FROM miner_run_state ORDER BY repo_full_name";
 
   return {
     dbPath: resolvedPath,
     getRunState(repoFullName, apiBaseUrl) {
-      const row = getStatement.get(normalizeApiBaseUrl(apiBaseUrl), normalizeRepoFullName(repoFullName));
+      const { rows } = driver.query(getSql, [
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+      ]);
+      const row = rows[0];
       return runStateSet.has(row?.state) ? row.state : null;
     },
     setRunState(repoFullName, state, apiBaseUrl) {
@@ -119,13 +124,14 @@ export function initRunStateStore(dbPath = resolveRunStateDbPath()) {
       const normalizedRepo = normalizeRepoFullName(repoFullName);
       const normalizedState = normalizeRunState(state);
       const updatedAt = new Date().toISOString();
-      setStatement.run(normalizedForge, normalizedRepo, normalizedState, updatedAt);
+      driver.query(setSql, [normalizedForge, normalizedRepo, normalizedState, updatedAt]);
       return { apiBaseUrl: normalizedForge, repoFullName: normalizedRepo, state: normalizedState, updatedAt };
     },
     /** Every repo with a recorded run state, across the whole store — the per-repo discover/plan/prepare
      *  signal a "run portfolio" view folds alongside managed PR rows (#4279). */
     listRunStates() {
-      return listStatement.all()
+      const { rows } = driver.query(listSql, []);
+      return rows
         .filter((row) => runStateSet.has(row.state))
         .map((row) => ({
           apiBaseUrl: row.api_base_url,

--- a/packages/loopover-miner/lib/store-db-adapter.d.ts
+++ b/packages/loopover-miner/lib/store-db-adapter.d.ts
@@ -1,0 +1,30 @@
+import type { DatabaseSync } from "node:sqlite";
+
+/** Sync SQLite primitive both node:sqlite and (later) Postgres-backed drivers satisfy (#7175). */
+export interface SqliteDriver {
+  query(
+    sql: string,
+    params: unknown[],
+  ): { rows: Record<string, unknown>[]; changes: number; lastInsertRowid: number };
+  exec(sql: string): void;
+}
+
+/** Minimal D1-shaped surface returned by `createD1Adapter` (async wrappers over SqliteDriver). */
+export interface MinerD1Database {
+  prepare(sql: string): MinerD1PreparedStatement;
+  batch(statements: MinerD1PreparedStatement[]): Promise<unknown[]>;
+  exec(sql: string): Promise<{ count: number; duration: number }>;
+  dump(): Promise<ArrayBuffer>;
+}
+
+export interface MinerD1PreparedStatement {
+  bind(...values: unknown[]): MinerD1PreparedStatement;
+  all<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }>;
+  run<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }>;
+  first<T = unknown>(colName?: string): Promise<T | null>;
+  raw<T = unknown>(): Promise<T[]>;
+}
+
+export function createD1Adapter(driver: SqliteDriver): MinerD1Database;
+
+export function nodeSqliteDriver(db: DatabaseSync): SqliteDriver;

--- a/packages/loopover-miner/lib/store-db-adapter.js
+++ b/packages/loopover-miner/lib/store-db-adapter.js
@@ -1,0 +1,124 @@
+// Shared SqliteDriver / D1 adapter seam for AMS local stores (#7175 part 1).
+//
+// Mirrors ORB's `src/selfhost/d1-adapter.ts` so hosted AMS can later swap in `createPgAdapter` without
+// inventing a second abstraction. Self-host default remains node:sqlite via `nodeSqliteDriver`.
+// Keep this surface in sync with the ORB module when either side grows (Postgres interactive txn /
+// `runOn` arrives in a later #7175 slice — not this file yet).
+
+/**
+ * @typedef {{
+ *   query: (sql: string, params: unknown[]) => { rows: Record<string, unknown>[]; changes: number; lastInsertRowid: number };
+ *   exec: (sql: string) => void;
+ * }} SqliteDriver
+ */
+
+function meta(changes = 0, lastRowId = 0) {
+  return {
+    duration: 0,
+    size_after: 0,
+    rows_read: 0,
+    rows_written: changes,
+    last_row_id: lastRowId,
+    changed_db: changes > 0,
+    changes,
+  };
+}
+
+/** One prepared (and optionally bound) statement — D1 statements are immutable after bind. */
+class Statement {
+  /**
+   * @param {SqliteDriver} driver
+   * @param {string} sql
+   * @param {unknown[]} [values]
+   */
+  constructor(driver, sql, values = []) {
+    this.driver = driver;
+    this.sql = sql;
+    this.values = values;
+  }
+
+  /** @param {...unknown} values */
+  bind(...values) {
+    return new Statement(this.driver, this.sql, values);
+  }
+
+  execSync() {
+    const r = this.driver.query(this.sql, this.values);
+    return { results: r.rows, success: true, meta: meta(r.changes, r.lastInsertRowid) };
+  }
+
+  async all() {
+    return this.execSync();
+  }
+
+  async run() {
+    return this.execSync();
+  }
+
+  /** @param {string} [colName] */
+  async first(colName) {
+    const row = this.driver.query(this.sql, this.values).rows[0];
+    if (row == null) return null;
+    return (colName != null ? row[colName] : row) ?? null;
+  }
+
+  async raw() {
+    return this.driver.query(this.sql, this.values).rows.map((row) => Object.values(row));
+  }
+}
+
+/**
+ * Wrap a synchronous SqliteDriver as a D1-shaped database (async prepare/batch/exec).
+ * @param {SqliteDriver} driver
+ */
+export function createD1Adapter(driver) {
+  return {
+    prepare(sql) {
+      return new Statement(driver, sql);
+    },
+    async batch(statements) {
+      driver.exec("BEGIN");
+      try {
+        const out = statements.map((s) => s.execSync());
+        driver.exec("COMMIT");
+        return out;
+      } catch (error) {
+        try {
+          driver.exec("ROLLBACK");
+        } catch {
+          /* ignore */
+        }
+        throw error;
+      }
+    },
+    async exec(sql) {
+      driver.exec(sql);
+      return { count: (sql.match(/;/g) ?? []).length || 1, duration: 0 };
+    },
+    async dump() {
+      return new ArrayBuffer(0);
+    },
+  };
+}
+
+/**
+ * Build a SqliteDriver from a node:sqlite DatabaseSync.
+ * A statement with zero result columns is a WRITE; otherwise a READ.
+ * @param {{ prepare: (sql: string) => { columns: () => unknown[]; all: (...p: unknown[]) => unknown[]; run: (...p: unknown[]) => { changes: number | bigint; lastInsertRowid: number | bigint } }; exec: (sql: string) => void }} db
+ * @returns {SqliteDriver}
+ */
+export function nodeSqliteDriver(db) {
+  return {
+    query(sql, params) {
+      const stmt = db.prepare(sql);
+      if (stmt.columns().length > 0) {
+        return { rows: /** @type {Record<string, unknown>[]} */ (stmt.all(...params)), changes: 0, lastInsertRowid: 0 };
+      }
+      const info = stmt.run(...params);
+      return { rows: [], changes: Number(info.changes), lastInsertRowid: Number(info.lastInsertRowid) };
+    },
+    exec(sql) {
+      db.exec(sql);
+    },
+  };
+}

--- a/packages/loopover-miner/lib/store-db-adapter.js
+++ b/packages/loopover-miner/lib/store-db-adapter.js
@@ -104,6 +104,11 @@ export function createD1Adapter(driver) {
 /**
  * Build a SqliteDriver from a node:sqlite DatabaseSync.
  * A statement with zero result columns is a WRITE; otherwise a READ.
+ *
+ * LIMITATION (#7175 follow-up): `INSERT/UPDATE/DELETE … RETURNING` statements report result columns, so
+ * this heuristic would treat them as reads and drop `changes`/`lastInsertRowid`. claim-ledger and other
+ * RETURNING callers must not migrate onto `driver.query` until the heuristic is sharpened (e.g. statement
+ * class detection) or those stores use `createD1Adapter`/`run` exclusively.
  * @param {{ prepare: (sql: string) => { columns: () => unknown[]; all: (...p: unknown[]) => unknown[]; run: (...p: unknown[]) => { changes: number | bigint; lastInsertRowid: number | bigint } }; exec: (sql: string) => void }} db
  * @returns {SqliteDriver}
  */

--- a/test/unit/miner-store-db-adapter.test.ts
+++ b/test/unit/miner-store-db-adapter.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { openLocalStoreAdapter } from "../../packages/loopover-miner/lib/local-store.js";
+import { createD1Adapter, nodeSqliteDriver } from "../../packages/loopover-miner/lib/store-db-adapter.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-store-db-adapter-"));
+  roots.push(root);
+  return root;
+}
+
+describe("miner store-db-adapter seam (#7175 part 1)", () => {
+  it("nodeSqliteDriver + createD1Adapter implement prepare/bind/all/first/run", async () => {
+    const db = new DatabaseSync(":memory:");
+    const d1 = createD1Adapter(nodeSqliteDriver(db));
+    await d1.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+    await d1.prepare("INSERT INTO t (name) VALUES (?)").bind("a").run();
+    expect((await d1.prepare("SELECT count(*) AS n FROM t").first<{ n: number }>())?.n).toBe(1);
+    expect((await d1.prepare("SELECT name FROM t WHERE id = ?").bind(1).first<{ name: string }>())?.name).toBe(
+      "a",
+    );
+    expect(await d1.prepare("SELECT * FROM t WHERE id = 99").first()).toBeNull();
+    const all = await d1.prepare("SELECT id, name FROM t ORDER BY id").all<{ id: number; name: string }>();
+    expect(all.results).toEqual([{ id: 1, name: "a" }]);
+    expect(await d1.prepare("SELECT id, name FROM t").raw()).toEqual([[1, "a"]]);
+  });
+
+  it("batch is atomic and rolls back on error", async () => {
+    const db = new DatabaseSync(":memory:");
+    const d1 = createD1Adapter(nodeSqliteDriver(db));
+    await d1.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT UNIQUE)");
+    await d1.prepare("INSERT INTO t (name) VALUES (?)").bind("dup").run();
+    await expect(
+      d1.batch([
+        d1.prepare("INSERT INTO t (name) VALUES (?)").bind("ok"),
+        d1.prepare("INSERT INTO t (name) VALUES (?)").bind("dup"),
+      ]),
+    ).rejects.toThrow();
+    expect((await d1.prepare("SELECT count(*) AS n FROM t").first<{ n: number }>())?.n).toBe(1);
+  });
+
+  it("openLocalStoreAdapter returns db + driver + d1 over the same file", async () => {
+    const dbPath = join(tempRoot(), "seam.sqlite3");
+    const { db, driver, d1 } = openLocalStoreAdapter(dbPath);
+    try {
+      driver.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+      driver.query("INSERT INTO t (name) VALUES (?)", ["via-driver"]);
+      expect(driver.query("SELECT name FROM t", []).rows).toEqual([{ name: "via-driver" }]);
+      expect((await d1.prepare("SELECT count(*) AS n FROM t").first<{ n: number }>())?.n).toBe(1);
+      expect(db.prepare("SELECT name FROM t").get()).toEqual({ name: "via-driver" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("dump() returns an ArrayBuffer for D1 surface completeness", async () => {
+    const db = new DatabaseSync(":memory:");
+    expect(await createD1Adapter(nodeSqliteDriver(db)).dump()).toBeInstanceOf(ArrayBuffer);
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `packages/loopover-miner/lib/store-db-adapter.js` (mirrors ORB `src/selfhost/d1-adapter.ts`: `SqliteDriver`, `nodeSqliteDriver`, `createD1Adapter`).
- Adds `openLocalStoreAdapter` beside `openLocalStoreDb`.
- Migrates `run-state` CRUD onto `driver.query` while keeping the sync public API and node:sqlite self-host default.
- Documents the `RETURNING` read/write heuristic limit before claim-ledger migrates.

Closes #7175

This is the first vertical slice of the AMS storage migration (seam + run-state). Follow-ups for the remaining stores, Postgres/`createPgAdapter`, interactive `batchClaim`/`runOn`, and lease-expiry can be filed as child issues after merge if needed — prior PR #7192 was CI-green but auto-closed for lacking a `Closes` keyword (Advances was not detected as a linked issue).

## Test plan
- [x] `npx vitest run test/unit/miner-store-db-adapter.test.ts`
- [x] run-state functional tests
- [ ] CI green