### PR TITLE
fix(selfhost): auto-generate self-host secrets instead of empty placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,9 +175,11 @@ LOOPOVER_REVIEW_DRAFT=false
 # mounts (secrets/README.md) cover the Core secrets above plus TOKEN_ENCRYPTION_SECRET,
 # DRAFT_TOKEN_ENCRYPTION_SECRET, SELFHOST_SETUP_TOKEN, ORB_ENROLLMENT_SECRET, PAGERDUTY_ROUTING_KEY,
 # and CLAUDE_CODE_OAUTH_TOKEN.
-# Run `./scripts/selfhost-init-secrets.sh` once, then write each real value into its file under secrets/
-# instead of uncommenting the var here — an inline .env value always takes priority if you set both, so
-# migrating is safe to do one secret at a time.
+# Run `./scripts/selfhost-init-secrets.sh` once (#4928) — it generates a real random value for every
+# one of those EXCEPT ORB_ENROLLMENT_SECRET and PAGERDUTY_ROUTING_KEY and CLAUDE_CODE_OAUTH_TOKEN and
+# the GitHub App private key (those come from an external party; write the real issued value into its
+# file yourself) — instead of uncommenting the var here. An inline .env value always takes priority
+# if you set both, so migrating is safe to do one secret at a time.
 
 # PUBLIC_API_ORIGIN=https://reviews.example.com  # REQUIRED before the first-run setup wizards (GET /setup and
 #                                            #   GET /orb/setup). The wizard embeds this origin in the GitHub App

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -15,12 +15,12 @@
 # =============================================================================
 #
 # RECOMMENDED: use native Docker Compose secret files instead of pasting values below. Run
-# `./scripts/selfhost-init-secrets.sh` once, then write each real secret into its file under
-# secrets/ (see secrets/README.md) — docker-compose.yml already wires the matching <NAME>_FILE
-# var for every secret in this section, so if you go that route you can leave the plain vars below
-# commented out entirely. Either path works; an inline value here always wins over a secret file if
-# both are set. GITHUB_APP_PRIVATE_KEY_FILE below is the one that has always supported this — the
-# rest of the secrets in this section now do too.
+# `./scripts/selfhost-init-secrets.sh` once (#4928) — it generates a real random value for every
+# secret below EXCEPT the GitHub App private key (that one is issued by GitHub, not something this
+# host can generate; write it into secrets/github_app_private_key.pem yourself, see
+# secrets/README.md) — docker-compose.yml already wires the matching <NAME>_FILE var for every
+# secret in this section, so if you go that route you can leave the plain vars below commented out
+# entirely. Either path works; an inline value here always wins over a secret file if both are set.
 GITHUB_APP_ID=123456
 GITHUB_APP_SLUG=my-loopover-app
 GITHUB_APP_PRIVATE_KEY_FILE=/run/secrets/github-app-private-key.pem   # or GITHUB_APP_PRIVATE_KEY= inline
@@ -45,7 +45,7 @@ GITTENSOR_REGISTRY_URL=https://example.invalid/registry.json
 # Funnel) makes every screenshot render as a broken image with no other warning besides this instance's
 # own boot log (see PUBLIC_ORIGIN_ACKNOWLEDGED below).
 PUBLIC_API_ORIGIN=https://reviews.example.com
-# SELFHOST_SETUP_TOKEN=           # generate a real random value the same way as above before setting this
+# SELFHOST_SETUP_TOKEN=           # generate a real random value the same way as above before setting this (or use secrets/selfhost_setup_token.txt, see above)
 
 # REQUIRED for control-panel access. Comma/whitespace-separated GitHub logins. FAIL-CLOSED: unset
 # means nobody (not even you) can sign into the dashboard.

--- a/apps/loopover-ui/content/docs/self-hosting-quickstart.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-quickstart.mdx
@@ -21,7 +21,9 @@ for multiline values like the GitHub App private key.
   `LOOPOVER_MCP_TOKEN`, `INTERNAL_JOB_TOKEN`, `SELFHOST_SETUP_TOKEN`) ship commented out on purpose.
   Generate a distinct random value for each one (e.g. `openssl rand -hex 32`) — never reuse the same
   string across more than one of them. The app refuses to boot if any of these is left at a
-  known-placeholder or too-short value.
+  known-placeholder or too-short value. Prefer skipping this by hand entirely: run
+  `./scripts/selfhost-init-secrets.sh` instead, which generates and writes each of these for you
+  under `secrets/` (see `secrets/README.md`) — no `openssl` command required.
 </Callout>
 
 <Callout variant="note">

--- a/apps/loopover-ui/content/docs/self-hosting-security.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-security.mdx
@@ -29,8 +29,8 @@ description: The self-host stack holds maintainer credentials and policy. Keep t
 
 <CodeBlock
   filename="shell"
-  code={`./scripts/selfhost-init-secrets.sh   # creates empty placeholder files (idempotent)
-printf '%s' 'your-real-secret-value' > secrets/github_webhook_secret.txt
+  code={`./scripts/selfhost-init-secrets.sh   # generates the self-generatable secrets, idempotent
+cp /path/to/your-downloaded-key.pem secrets/github_app_private_key.pem   # the one it can't generate for you
 docker compose up -d --no-deps loopover`}
 />
 

--- a/scripts/selfhost-init-secrets.sh
+++ b/scripts/selfhost-init-secrets.sh
@@ -15,11 +15,14 @@
 # bar: requires an actual shell on this machine) for what the original hardening was actually about:
 # no longer visible via `docker inspect`/`docker compose config`/full env-var dumps.
 #
-# IDEMPOTENT AND NON-DESTRUCTIVE: creates any MISSING file empty at 644. For a file that already exists,
-# self-heals the mode to 644 ONLY while it is still empty (a placeholder, never populated, so nothing to
-# protect via 600 in the first place) -- the instant an operator writes a real secret into it, its size is
-# no longer zero, so this leaves both its content AND whatever permissions they set entirely alone. Safe
-# to run on every deploy, unconditionally.
+# IDEMPOTENT AND NON-DESTRUCTIVE: for a RANDOM_SECRET_FILE (below), generates a real `openssl rand -hex
+# 32` value the first time the file is missing or still empty (#4928 -- this is what lets an operator
+# boot without ever running that command by hand). For an EXTERNAL_SECRET_FILE (issued by GitHub /
+# PagerDuty / Claude / the broker operator -- nothing this host can generate a USABLE value for), it
+# still only creates an empty placeholder, unchanged from before. Either way, a file that already has
+# real content is left completely alone: the instant a value is written into it (by an operator or by
+# this script), its size is no longer zero, so nothing here regenerates or re-heals it again. Safe to
+# run on every deploy, unconditionally.
 #
 # Usage:
 #   ./scripts/selfhost-init-secrets.sh
@@ -31,8 +34,13 @@ cd "$SCRIPT_DIR/.."
 SECRETS_DIR="secrets"
 
 # Keep in sync with the `secrets:` table in docker-compose.yml and secrets/README.md.
-SECRET_FILES=(
-  "github_app_private_key.pem"
+#
+# Self-generatable: no external party has to have already agreed on the value, so a random one is exactly
+# as valid as an operator-typed one. github_webhook_secret is included here too -- an operator creating
+# the GitHub App by hand (rather than through the /setup wizard's manifest flow, which gets this value
+# for free from GitHub) picks this value themselves and pastes the SAME string into the App's webhook
+# settings; generating it here just gives them something to copy instead of typing the command themselves.
+RANDOM_SECRET_FILES=(
   "github_webhook_secret.txt"
   "loopover_api_token.txt"
   "loopover_mcp_token.txt"
@@ -40,6 +48,13 @@ SECRET_FILES=(
   "selfhost_setup_token.txt"
   "token_encryption_secret.txt"
   "draft_token_encryption_secret.txt"
+)
+
+# Externally issued: a randomly generated value here would never match a real GitHub App keypair, broker
+# enrollment, PagerDuty routing key, or Claude Code OAuth token -- stays an empty placeholder for the
+# operator to fill in from that external source, exactly as before this change.
+EXTERNAL_SECRET_FILES=(
+  "github_app_private_key.pem"
   "orb_enrollment_secret.txt"
   "pagerduty_routing_key.txt"
   "claude_code_oauth_token.txt"
@@ -47,9 +62,20 @@ SECRET_FILES=(
 
 mkdir -p "$SECRETS_DIR"
 
+generated=0
 created=0
 healed=0
-for name in "${SECRET_FILES[@]}"; do
+
+for name in "${RANDOM_SECRET_FILES[@]}"; do
+  path="$SECRETS_DIR/$name"
+  if [ ! -e "$path" ] || [ ! -s "$path" ]; then
+    openssl rand -hex 32 >"$path"
+    chmod 644 "$path"
+    generated=$((generated + 1))
+  fi
+done
+
+for name in "${EXTERNAL_SECRET_FILES[@]}"; do
   path="$SECRETS_DIR/$name"
   if [ ! -e "$path" ]; then
     : >"$path"
@@ -61,8 +87,8 @@ for name in "${SECRET_FILES[@]}"; do
   fi
 done
 
-if [ "$created" -gt 0 ] || [ "$healed" -gt 0 ]; then
-  echo "selfhost init-secrets: created $created, mode-healed $healed empty placeholder file(s) in $SECRETS_DIR/"
+if [ "$generated" -gt 0 ] || [ "$created" -gt 0 ] || [ "$healed" -gt 0 ]; then
+  echo "selfhost init-secrets: generated $generated random secret(s), created $created and mode-healed $healed empty placeholder file(s) in $SECRETS_DIR/"
 else
   echo "selfhost init-secrets: all secret files already present, nothing to do"
 fi

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -37,10 +37,13 @@ migrate one secret at a time, or never migrate at all.
 To use a secret file instead of an inline `.env` value:
 
 1. Remove (or leave commented) the plain `<NAME>=...` line in `.env`.
-2. Write the raw secret value into the matching file below, with no surrounding quotes and no
-   trailing newline requirement (the loader trims whitespace):
+2. Get a real value into the matching file below. For most of them, running
+   `./scripts/selfhost-init-secrets.sh` (#4928) already did this step for you — it generates a
+   random value for every file EXCEPT `github_app_private_key.pem`, `orb_enrollment_secret.txt`,
+   `pagerduty_routing_key.txt`, and `claude_code_oauth_token.txt` (those four come from an external
+   party, so there's no "generate" step — write the real issued value in yourself):
    ```sh
-   printf '%s' 'your-real-secret-value' > secrets/github_webhook_secret.txt
+   printf '%s' 'your-real-secret-value' > secrets/orb_enrollment_secret.txt
    ```
    For the GitHub App private key specifically, write the full PEM file as-is:
    ```sh
@@ -77,7 +80,9 @@ of those too; add a matching `secrets:` entry in `docker-compose.yml` (or a
 ## Never commit real files here
 
 Everything in this directory except this README is gitignored. `scripts/selfhost-init-secrets.sh`
-only ever creates **empty** placeholder files (so `docker compose build`/`up` never fails on a
-missing file) and only ever touches the *permissions* of a file that is still empty, never its
-content — the moment you write a real value into one, both the content and whatever mode you set
-are left alone on every future run. Always safe to re-run.
+generates a real random value for the seven self-generatable files (so `docker compose build`/`up`
+never fails on a missing file, and boots without any manual `openssl` step) and creates only an
+**empty** placeholder for the four externally-issued ones it can't generate a usable value for. Either
+way, it only ever touches the *permissions* of a file that is still empty, never its content — the
+moment a real value lands in one (written by the script or by you), both the content and whatever
+mode you set are left alone on every future run. Always safe to re-run.


### PR DESCRIPTION
## Summary
- `scripts/selfhost-init-secrets.sh` used to create **empty** placeholder files for every Docker Compose secret — the operator still had to manually run `openssl rand -hex 32` and paste a value into each one before the app would boot.
- For the seven secrets no external party has to agree on beforehand (`github_webhook_secret`, `loopover_api_token`, `loopover_mcp_token`, `internal_job_token`, `selfhost_setup_token`, `token_encryption_secret`, `draft_token_encryption_secret`), the script now generates a real random value the first time the file is missing or still empty — same idempotent/non-destructive guard as before (`[ ! -e "$path" ] || [ ! -s "$path" ]`), so a file that already has real content is never touched again.
- The four externally-issued secrets (GitHub App private key, Orb enrollment secret, PagerDuty routing key, Claude Code OAuth token) are unaffected — there's no value this host could generate that would actually work against those external services, so they still get an empty placeholder exactly as before.
- Updates the docs/env-var comments (`.env.example`, `.env.selfhost.example`, `secrets/README.md`, `self-hosting-quickstart.mdx`, `self-hosting-security.mdx`) that described the old manual step.

Closes #4928

## Test plan
- [x] Manually ran the updated script end-to-end in a scratch directory: first run generates 7 distinct 64-char-hex secrets + creates 4 empty external placeholders; second run is a true no-op on the generated files (byte-identical content, confirmed via diff) and only re-heals the mode on the still-empty external placeholders, matching the pre-existing idempotency contract
- [x] `npm run typecheck` — clean (this change touches no TypeScript)
- [x] `npm run docs:drift-check` — passes
- [x] `npm run test:ci` (full local gate, unsharded) — green
- [ ] UI Evidence — not applicable, no frontend/UI change (shell script + docs only)

`scripts/**` and `*.mdx`/`*.example`/`*.md` are outside Codecov's `src/**` patch-coverage scope, so this PR carries no coverage obligation.