### PR TITLE
docs(privacy): review what future orb fleet-telemetry data would be safe

### DIFF
--- a/apps/loopover-ui/content/docs/privacy-security.mdx
+++ b/apps/loopover-ui/content/docs/privacy-security.mdx
@@ -98,3 +98,40 @@ anti-abuse defaults that reveal no review direction and are not per-repo tunable
   Website copy may discuss private scoreability and risk reasoning, but it's always framed as
   **private MCP/API context**. The public web never carries score numbers.
 </Callout>
+
+## Orb fleet telemetry (#4893)
+
+The always-on fleet-calibration pipeline (`POST /v1/orb/ingest`) aggregates anonymized signals
+from every registered *and unregistered* self-host instance into one shared table
+(`orb_signals`) — see [self-hosting: GitHub App](/docs/self-hosting-github-app#telemetry-is-separate-from-token-brokerage)
+for what's exported today and how to opt out. That table is intentional and not a leak: repo/PR
+identifiers are HMAC-anonymized with a per-instance secret LoopOver's own collector never holds,
+and nothing beyond verdict/outcome/reversal/cycle-time is even read out of an instance's local
+data before export.
+
+This section is the forward-looking half the code doesn't yet need to answer: **as the product
+grows a hosted, per-customer model, what would be safe to add to this pipeline, and what
+wouldn't?** A clear yes/no per category, so a future PR that touches this table has a rule to
+check itself against instead of relitigating anonymization from scratch.
+
+| Potential future data | Safe to add? | Why |
+| --- | --- | --- |
+| Raw repo/org names or logins, even opt-in | **No** | The anonymization promise is fleet-wide, not per-tenant-configurable — one customer opting into raw identifiers doesn't change what every *other* instance was told about this shared table. A hosted customer who wants their own data identifiable should read it back from their own instance/dashboard, never from the shared fleet table. |
+| PR/commit content, diffs, or comments | **No** | Never queried into the export today (the collector's own DB query selects only verdict/outcome/reversal/timestamps) — there is no path for this to leave an instance short of a deliberate, separate feature. Adding it to fleet telemetry would be a new capability, not an extension of this one. |
+| Full-text gate reasons | **No** | Already bucketed to a fixed, low-cardinality category before export specifically so free text (which can quote file paths, identifiers, or reviewer commentary) never leaves the instance. A hosted model doesn't change the fact that this text wasn't written for cross-tenant eyes. |
+| A raw `installation_id` column on `orb_signals` itself | **No** | `orb_signals`/`orb_instances` were built with only an opaque, HMAC-derived `instance_id` — retrofitting a raw installation id onto that table would retroactively de-anonymize every row collected under the existing anonymity promise. If hosted billing/support ever needs to map a fleet instance to a paying installation, that mapping belongs in a **separate** table (mirroring how `orb_github_installations` already keeps raw account identity in its own table, entirely apart from `orb_signals`), not a new column here. |
+| Per-instance metrics surfaced back to *that instance's own* operator | **Yes, with new authz** | `GET /v1/internal/fleet/analytics` already computes per-instance breakdowns keyed by the same opaque `instanceId` — the data already exists. A hosted per-customer dashboard could show a customer their own row. What doesn't exist yet is anything that maps "this session belongs to instance X" and enforces that a customer can only ever see their own opaque id, never another tenant's — that authz layer is new work, not a data-model change. |
+| Cross-tenant fleet-median/percentile comparisons (e.g. gate precision vs. the peer median) | **Yes, unchanged** | Already shipped, in aggregate form only — a single percentile/median across the whole fleet, with no way to reverse-engineer any other specific tenant's raw value from it. This category is the one place "more data" is already safe, because it was designed to stay aggregate-only from the start. |
+
+<Callout variant="warn" title="A real gap, not a future one">
+  Anonymization is enforced entirely on the **sender**, not the receiver: `ORB_ANONYMIZE=false`
+  makes a self-host instance export raw repo/PR names, and `POST /v1/orb/ingest` has no
+  server-side check that a submitted `repo_hash`/`pr_hash` actually looks like a hash before
+  storing it in the shared table — it validates only type and length. Today this only affects an
+  operator who deliberately opted out for their own private collector. It becomes a sharper
+  problem the moment `/v1/orb/ingest` is fronted by anything resembling a hosted, multi-tenant
+  path: a misconfigured or malicious sender could land raw identifiers in a table every other
+  instance was told stays anonymized. Closing this (reject a submission whose `repo_hash`/`pr_hash`
+  doesn't match the expected HMAC-output shape) is real follow-up work, tracked separately from
+  this review.
+</Callout>


### PR DESCRIPTION
## Summary
- Fleet-wide telemetry (`POST /v1/orb/ingest`) already aggregates anonymized signals from every self-host instance into one shared table (`orb_signals`) — intentional, and the current behavior is already documented (`self-hosting-github-app.mdx`'s "Telemetry is separate from token brokerage" section).
- What wasn't documented anywhere was the forward-looking question this issue asks: as the product grows a hosted, per-customer model, what would and wouldn't be safe to add to that pipeline.
- Adds a new "Orb fleet telemetry" section to `privacy-security.mdx` (the doc actually titled "Privacy & security," which previously had zero telemetry content) with a yes/no-per-category table, grounded in a read of the actual ingest/collector/analytics code (what's queried, what's hashed, what tables exist, what's already exposed internally vs. publicly).
- Flags one concrete, real (not hypothetical) gap found along the way: anonymization is enforced entirely on the **sender** today — `ORB_ANONYMIZE=false` lets a self-host instance export raw repo/PR names, and the ingest handler never checks that a submitted `repo_hash`/`pr_hash` actually looks like a hash before storing it. Called out as follow-up work, not fixed in this PR (this issue is documentation-only, matching its own "Deliverables: a written privacy review").

Closes #4893

## Test plan
- [x] `npm run test:ci` (full local gate, unsharded, includes the UI build that compiles this MDX) — green
- [x] Verified the new anchor link (`/docs/self-hosting-github-app#telemetry-is-separate-from-token-brokerage`) matches that page's existing heading-slug convention (same pattern already used elsewhere in the docs, e.g. `self-hosting-ai-providers#recognizing-a-stale-or-missing-credential`)
- [ ] UI Evidence — not applicable, docs-content-only change (no component/layout change)

`apps/loopover-ui/content/**` is outside Codecov's `src/**` patch-coverage scope, so this PR carries no coverage obligation.