### PR TITLE
feat(selfhost): make collision-prone compose ports and the tailscale hostname overridable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -244,7 +244,22 @@ LOOPOVER_REVIEW_DRAFT=false
 #                                            #   confirmed this is intentional, e.g. a fresh install with no
 #                                            #   .loopover.yml written yet. Default false (warning shown).
 # COMPOSE_PROJECT_NAME=loopover              # Docker Compose's own project name; also labels the log stream
-#                                            #   Promtail ships to Loki. Change it to run two stacks on one host.
+#                                            #   Promtail ships to Loki. Change it to run two stacks on one host
+#                                            #   (#4896) -- Compose namespaces container names, named volumes, and
+#                                            #   the default network by this automatically, so changing it alone
+#                                            #   already gets you that far. It does NOT free up host ports or the
+#                                            #   Tailscale hostname (a global namespace on your tailnet, not
+#                                            #   per-project) -- run each instance from its OWN checkout directory
+#                                            #   (secrets/ and .env are plain host paths, not Compose-namespaced)
+#                                            #   and, for any profile you enable on more than one instance, give
+#                                            #   each instance distinct values for: QDRANT_HTTP_PORT/QDRANT_GRPC_PORT
+#                                            #   (--profile qdrant), N8N_PORT (--profile workflows),
+#                                            #   MINIO_API_PORT/MINIO_CONSOLE_PORT (--profile storage), GRAFANA_PORT
+#                                            #   (--profile observability), and TAILSCALE_HOSTNAME (--profile
+#                                            #   tailscale). The `caddy` profile is the one exception: it binds the
+#                                            #   real TLS ports (80/443), which only one process on a host can hold
+#                                            #   regardless of Compose project -- run it on at most one instance, or
+#                                            #   front both instances with a single shared Caddy by domain/subdomain.
 # TZ=UTC                                     # timezone passed to n8n (--profile workflows) for cron schedules
 # POSTGRES_PASSWORD=change-this-long-random-value  # used by the --profile postgres / --profile pgbouncer services
 # DATABASE_URL=                              # set to postgres://user:pw@host:5432/db to use Postgres instead of
@@ -281,6 +296,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   most installs never need to touch this.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
+# QDRANT_HTTP_PORT=6333                      # host-side REST/Web-UI port (--profile qdrant); change on a second
+#                                            #   instance sharing this host (#4896).
+# QDRANT_GRPC_PORT=6334                      # host-side gRPC port (--profile qdrant); same as above.
 # BROWSER_WS_ENDPOINT=                       # ws:// URL of a browserless/chrome-compatible instance for
 #                                            #   visual-review screenshot capture. Unset = visual review is
 #                                            #   fully inert (no screenshots, no error) — entirely optional.
@@ -399,12 +417,15 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # N8N_WEBHOOK_URL=https://n8n.example.com   # set to public URL if receiving external webhooks
 # N8N_ENCRYPTION_KEY=                       # 32-char random string; persists credentials across restarts
 # N8N_MEM_LIMIT=512m
+# N8N_PORT=5678                             # host-side port; change on a second instance sharing this host (#4896)
 
 # --- MinIO S3-compatible object storage (--profile storage) ---
 # MINIO_ROOT_USER=minio                     # REQUIRED when using --profile storage
 # MINIO_ROOT_PASSWORD=changeme              # REQUIRED when using --profile storage
 # MINIO_BUCKET=loopover                     # default bucket name (create via console at http://localhost:9001)
 # MINIO_MEM_LIMIT=1g
+# MINIO_API_PORT=9000                       # host-side S3 API port; change on a second instance sharing this host (#4896)
+# MINIO_CONSOLE_PORT=9001                   # host-side console port; same as above
 # Console at http://localhost:9001
 # S3 API at http://minio:9000 (from other containers) or http://localhost:9000 (from host)
 
@@ -499,6 +520,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # Blank is valid until --profile tailscale is enabled.
 # TS_AUTHKEY=                                # Tailscale auth key (generate at tailscale.com/admin/settings/keys)
 # TS_EXTRA_ARGS=                             # extra tailscale up flags, e.g. --advertise-tags=tag:self-host
+# TAILSCALE_HOSTNAME=loopover                # advertised tailnet hostname; this container uses network_mode: host,
+#                                            #   so it never gets COMPOSE_PROJECT_NAME's usual isolation -- give a
+#                                            #   second instance on the same tailnet a distinct value (#4896).
 
 # --- Self-hosted GitHub Actions runner (#1205; requires --profile runners) ---
 # NOT part of the default recommended stack -- it is an OPTIONAL profile. Pick a deployment mode:
@@ -535,6 +559,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # prometheus/rules/, routing in alertmanager/alertmanager.yml — silent until you fill in a receiver) +
 # Loki + Promtail (ship every container's logs to Loki) + Grafana (dashboards for metrics AND logs).
 # GRAFANA_ADMIN_PASSWORD=                    # REQUIRED at runtime when using --profile observability; generate a strong value
+# GRAFANA_PORT=3000                          # host-side port; change on a second instance sharing this host (#4896)
 # PROMETHEUS_RETENTION_TIME=90d              # metrics history window (a full quarter for trend/capacity review).
 #                                            #   Deliberately longer than Loki's 14d / Tempo's 7d: the TSDB
 #                                            #   compresses samples to ~1-2 bytes each, so metrics cost far less

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,8 +375,8 @@ services:
     # qdrant-vectorize.ts) plus a firewall rule. SSH-forward the port for remote dashboard access. This
     # matches the in-network-only posture of Prometheus/Loki/Alertmanager above.
     ports:
-      - "127.0.0.1:6333:6333" # REST API + Web UI (localhost only)
-      - "127.0.0.1:6334:6334" # gRPC (localhost only)
+      - "127.0.0.1:${QDRANT_HTTP_PORT:-6333}:6333" # REST API + Web UI (localhost only)
+      - "127.0.0.1:${QDRANT_GRPC_PORT:-6334}:6334" # gRPC (localhost only)
     volumes:
       - qdrant-data:/qdrant/storage
     deploy:
@@ -702,7 +702,7 @@ services:
     <<: *default-logging
     profiles: ["workflows"]
     ports:
-      - "5678:5678"
+      - "${N8N_PORT:-5678}:5678"
     volumes:
       - n8n-data:/home/node/.n8n
     environment:
@@ -740,8 +740,8 @@ services:
     <<: *default-logging
     profiles: ["storage"]
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
     volumes:
       - minio-data:/data
     environment:
@@ -848,7 +848,7 @@ services:
       reporting-exporter:
         condition: service_healthy
     ports:
-      - "3000:3000"
+      - "${GRAFANA_PORT:-3000}:3000"
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
@@ -1118,7 +1118,10 @@ services:
     restart: unless-stopped
     <<: *default-logging
     profiles: ["tailscale"]
-    hostname: loopover
+    # Set TAILSCALE_HOSTNAME in .env when running a second named instance on the same tailnet --
+    # network_mode: host below means this collides on the tailnet's OWN hostname namespace regardless
+    # of COMPOSE_PROJECT_NAME, since the container never joins the Compose-managed default network.
+    hostname: ${TAILSCALE_HOSTNAME:-loopover}
     cap_add:
       - NET_ADMIN
       - SYS_MODULE

--- a/test/unit/selfhost-compose-workflows-storage.test.ts
+++ b/test/unit/selfhost-compose-workflows-storage.test.ts
@@ -59,7 +59,7 @@ describe("docker-compose.yml — workflows + storage profiles (#1219)", () => {
   it("gates n8n behind --profile workflows with basic-auth env and a runtime password check", () => {
     expect(n8n.image).toBe("n8nio/n8n:2.31.0");
     expect(n8n.profiles).toEqual(["workflows"]);
-    expect(n8n.ports).toEqual(["5678:5678"]);
+    expect(n8n.ports).toEqual(["${N8N_PORT:-5678}:5678"]);
     expect(n8n.volumes).toEqual(["n8n-data:/home/node/.n8n"]);
 
     const env = record(n8n.environment);
@@ -103,7 +103,7 @@ describe("docker-compose.yml — workflows + storage profiles (#1219)", () => {
   it("gates MinIO behind --profile storage on the S3 API and console ports", () => {
     expect(minio.image).toBe("minio/minio:RELEASE.2025-09-07T16-13-09Z");
     expect(minio.profiles).toEqual(["storage"]);
-    expect(minio.ports).toEqual(["9000:9000", "9001:9001"]);
+    expect(minio.ports).toEqual(["${MINIO_API_PORT:-9000}:9000", "${MINIO_CONSOLE_PORT:-9001}:9001"]);
     expect(minio.volumes).toEqual(["minio-data:/data"]);
     expect(minio.command).toContain("server");
     expect(minio.command).toContain("--console-address");


### PR DESCRIPTION
## Summary
- The self-host docker-compose stack had zero concept of instance identity beyond `COMPOSE_PROJECT_NAME` — which already namespaces container names, named volumes, and the default network for free (verified: no service sets `container_name:`, so Compose's own `<project>-<service>-<N>` default naming already applies) — but several services still bind literal, non-overridable host ports, or a hardcoded Tailscale hostname, so a second named instance on the same host would still collide on those even with a distinct project name.
- Parameterizes each with an env var defaulting to today's exact literal value: `QDRANT_HTTP_PORT`/`QDRANT_GRPC_PORT`, `N8N_PORT`, `MINIO_API_PORT`/`MINIO_CONSOLE_PORT`, `GRAFANA_PORT`, `TAILSCALE_HOSTNAME` — mirroring the existing `${PORT:-8787}` pattern the `loopover` service already uses.
- **Caddy's 80/443 stay fixed on purpose**: those are real ACME/browser-default TLS ports — a port override wouldn't actually let two instances both serve real TLS on one host, so making them "configurable" would be misleading. Documented as the one profile that's still effectively single-instance-per-host.
- Documents the full multi-instance recipe in `.env.example`'s existing `COMPOSE_PROJECT_NAME` comment: what Compose's own project-name mechanism already isolates, what still needs a distinct value per instance, and the one genuine remaining constraint (Caddy).
- Fixes 2 existing structural tests (`test/unit/selfhost-compose-workflows-storage.test.ts`) that asserted on the now-templated port strings.

Closes #4896

## Test plan
- [x] `docker compose config` with every relevant profile active — confirmed every changed port/hostname's **default** value (var unset) is byte-for-byte identical to today's literal (no-op for existing single-instance self-hosters)
- [x] Same command with each new var explicitly set — confirmed the override actually takes effect end-to-end
- [x] `npm run test:ci` (full local gate, unsharded) — green, including the two structural compose tests updated to match
- [ ] UI Evidence — not applicable, no frontend change

## Safety
No behavior change for any self-hoster who doesn't set the new vars — every default reproduces today's exact `docker compose config` output, verified directly rather than assumed.