### PR TITLE
feat(api): surface per-tenant storage row-counts on the operator dashboard

### DIFF
--- a/apps/loopover-ui/src/routes/app.operator.test.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.test.tsx
@@ -114,3 +114,59 @@ describe("OperatorDashboard AI cost by tenant (#4916)", () => {
     expect(screen.getByText("$2.00")).toBeTruthy();
   });
 });
+
+describe("OperatorDashboard storage by tenant (#4890)", () => {
+  function mockDashboard(
+    storageRowCountByTenant?: Array<{ installationId: string; rowCount: number }>,
+  ) {
+    useApiResource.mockImplementation((path: string) => {
+      if (path === "/v1/app/operator-dashboard") {
+        return {
+          status: "ready",
+          data: {
+            metrics: [{ label: "Installs", value: "12", delta: "+2" }],
+            noiseReduction: [],
+            weeklyReport: [],
+            storageRowCountByTenant,
+          },
+          error: null,
+          loadedAt: "2026-07-17T00:00:00.000Z",
+          reload: () => {},
+        };
+      }
+      return {
+        status: "error",
+        data: null,
+        error: "unavailable in this test",
+        errorKind: "unknown",
+        loadedAt: null,
+        reload: () => {},
+      };
+    });
+  }
+
+  it("renders no section at all when storageRowCountByTenant is absent (self-host, the common case)", () => {
+    mockDashboard(undefined);
+    render(<OperatorDashboard />);
+    expect(screen.queryByText("Storage by tenant")).toBeNull();
+  });
+
+  it("renders no section when storageRowCountByTenant is an empty list", () => {
+    mockDashboard([]);
+    render(<OperatorDashboard />);
+    expect(screen.queryByText("Storage by tenant")).toBeNull();
+  });
+
+  it("renders each tenant's formatted row count, highest-count-first as the backend already ordered them", () => {
+    mockDashboard([
+      { installationId: "inst-2", rowCount: 3000 },
+      { installationId: "inst-1", rowCount: 2 },
+    ]);
+    render(<OperatorDashboard />);
+    expect(screen.getByText("Storage by tenant")).toBeTruthy();
+    expect(screen.getByText("inst-2")).toBeTruthy();
+    expect(screen.getByText("3,000 rows")).toBeTruthy();
+    expect(screen.getByText("inst-1")).toBeTruthy();
+    expect(screen.getByText("2 rows")).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/routes/app.operator.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.tsx
@@ -35,6 +35,7 @@ type OperatorDashboardResponse = {
   };
   upstreamDrift?: { status?: string } | null;
   aiCostByTenant?: Array<{ installationId: string; totalCostUsd: number }>;
+  storageRowCountByTenant?: Array<{ installationId: string; rowCount: number }>;
 };
 
 type FleetMetrics = {
@@ -53,6 +54,7 @@ type FleetMetrics = {
 
 const formatPct = (v: number | null): string => (v === null ? "—" : `${Math.round(v * 100)}%`);
 const usdFmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+const countFmt = new Intl.NumberFormat("en-US");
 const formatMs = (v: number | null): string =>
   v === null
     ? "—"
@@ -502,6 +504,31 @@ export function OperatorDashboard() {
                     </span>
                     <span className="font-mono text-token-sm text-foreground">
                       {usdFmt.format(tenant.totalCostUsd)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+          {data.storageRowCountByTenant && data.storageRowCountByTenant.length > 0 ? (
+            <section className="rounded-token border border-border bg-transparent p-5">
+              <h2 className="font-display text-token-lg font-semibold">Storage by tenant</h2>
+              <p className="mt-1 text-token-xs text-muted-foreground">
+                AI-usage row count per tenant, highest first — the account-wide D1 storage cap has
+                its own alert; this is the per-tenant dimension that alert doesn't have. Empty for
+                self-host.
+              </p>
+              <ul className="mt-4 space-y-2">
+                {data.storageRowCountByTenant.map((tenant) => (
+                  <li
+                    key={tenant.installationId}
+                    className="flex items-center justify-between gap-4 border-b-hairline pb-2 last:border-b-0 last:pb-0"
+                  >
+                    <span className="font-mono text-token-xs text-foreground/90">
+                      {tenant.installationId}
+                    </span>
+                    <span className="font-mono text-token-sm text-foreground">
+                      {countFmt.format(tenant.rowCount)} rows
                     </span>
                   </li>
                 ))}

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3645,6 +3645,29 @@ export async function listAiCostByTenantSince(env: Env, sinceIso: string): Promi
   return rows.map((row) => ({ installationId: row.installationId ?? "", totalCostUsd: Number(row.total) }));
 }
 
+export type RowCountByTenant = { installationId: string; rowCount: number };
+
+/** #4890 (re-scoped): per-installation row-count breakdown of `ai_usage_events` for the operator dashboard --
+ *  the account-wide D1 storage cap already has alerting (src/selfhost/d1-size-probe.ts,
+ *  LoopoverD1DatabaseSizeWarning/Critical), but that's table-level only, with no way to attribute usage to a
+ *  specific tenant. `ai_usage_events` is the one high-growth table with a clean installationId column today
+ *  (see the sibling per-tenant AI-cost breakdown above); row count is a plain, honest proxy for a tenant's
+ *  storage footprint here since D1 has no per-row-group byte-size query surface. Same GROUP BY shape as
+ *  listAiCostByTenantSince -- one query rather than N per-tenant calls, ordered highest-count-first so the
+ *  dashboard never needs its own client-side sort. */
+export async function listRowCountByTenantSince(env: Env, sinceIso: string): Promise<RowCountByTenant[]> {
+  const db = getDb(env.DB);
+  const rows = await db
+    .select({ installationId: aiUsageEvents.installationId, rowCount: sql<number>`count(*)` })
+    .from(aiUsageEvents)
+    .where(and(isNotNull(aiUsageEvents.installationId), gte(aiUsageEvents.createdAt, sinceIso)))
+    .groupBy(aiUsageEvents.installationId)
+    .orderBy(desc(sql`count(*)`));
+  /* v8 ignore next -- installationId is the GROUP BY key under an isNotNull filter; D1 cannot return a null
+   *  group here, so the fallback only guards the driver's own typing, not a real runtime path. */
+  return rows.map((row) => ({ installationId: row.installationId ?? "", rowCount: Number(row.rowCount) }));
+}
+
 /** Spend-attempt statuses `countByokAiEventsForRepoSince`/`sumByokAiUsageForRepoSince` count: a real request
  *  reached the provider, whether or not it returned something usable ("ok") or genuinely failed ("error" --
  *  timeout/http_error/exception, see e.g. queue/processors.ts's recordVisualVisionUsage). Deliberately an

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -11,9 +11,11 @@ import {
   listLatestGitHubRateLimitObservations,
   listProductUsageDailyRollups,
   listRepositories,
+  listRowCountByTenantSince,
   summarizeMcpCompatibilityAdoption,
   summarizeProductUsageEvents,
   type AiCostByTenant,
+  type RowCountByTenant,
 } from "../db/repositories";
 import { getLatestRegistrySnapshot } from "../registry/sync";
 import type {
@@ -96,6 +98,10 @@ export type OperatorDashboardPayload = {
   // operator (no installation-scoped ai_usage_events rows exist there) -- this surfaces the #7176/#7183 ledger
   // data that had no dashboard consumer until now.
   aiCostByTenant: AiCostByTenant[];
+  // #4890 (re-scoped): per-tenant row-count breakdown of ai_usage_events, highest-count-first. The account-wide
+  // D1 storage cap already has alerting (src/selfhost/d1-size-probe.ts); this is the per-installation dimension
+  // that alerting doesn't have. Same self-host-always-empty caveat as aiCostByTenant above.
+  storageRowCountByTenant: RowCountByTenant[];
 };
 
 const USAGE_WINDOW_DAYS = 7;
@@ -133,6 +139,7 @@ export async function buildOperatorDashboardPayload(
     slopCalibration,
     findingAcceptance,
     aiCostByTenant,
+    storageRowCountByTenant,
   ] = await Promise.all([
     listRepositories(env),
     listInstallations(env),
@@ -162,6 +169,8 @@ export async function buildOperatorDashboardPayload(
     computeFindingAcceptance(env, { days: GATE_ANALYTICS_WINDOW_DAYS, nowMs: Date.now() }),
     // #4916: per-tenant AI cost breakdown, same window as the rest of the usage metrics above.
     listAiCostByTenantSince(env, usageSince),
+    // #4890 (re-scoped): per-tenant row-count breakdown, same window as the rest of the usage metrics above.
+    listRowCountByTenantSince(env, usageSince),
   ]);
   const weeklyValueReport = buildWeeklyValueReport({
     generatedAt: nowIso(),
@@ -281,6 +290,7 @@ export async function buildOperatorDashboardPayload(
     slopCalibration,
     acceptance,
     aiCostByTenant,
+    storageRowCountByTenant,
   };
 }
 

--- a/test/unit/ai-usage-tenant.test.ts
+++ b/test/unit/ai-usage-tenant.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { listAiCostByTenantSince, recordAiUsageEvent, sumAiCostForTenantSince } from "../../src/db/repositories";
+import { listAiCostByTenantSince, listRowCountByTenantSince, recordAiUsageEvent, sumAiCostForTenantSince } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 // #7176: ai_usage_events gained a nullable installation_id tenant column for centralized hosted billing, plus a
@@ -96,5 +96,43 @@ describe("listAiCostByTenantSince (#4916): fleet-wide per-tenant breakdown for t
   it("returns an empty list, not an error, when there are no hosted rows at all (the self-host default)", async () => {
     const env = createTestEnv();
     expect(await listAiCostByTenantSince(env, "2026-07-10T00:00:00.000Z")).toEqual([]);
+  });
+});
+
+describe("listRowCountByTenantSince (#4890): per-tenant storage breakdown for the operator dashboard", () => {
+  it("groups by tenant, counts correctly, and orders highest-count-first", async () => {
+    const env = createTestEnv();
+    const since = "2026-07-10T00:00:00.000Z";
+    await seedCostEvent(env, "inst-1", 1.25, "2026-07-11T00:00:00.000Z");
+    await seedCostEvent(env, "inst-1", 0.75, "2026-07-12T00:00:00.000Z"); // inst-1: 2 rows
+    await seedCostEvent(env, "inst-2", 4.0, "2026-07-13T00:00:00.000Z");
+    await seedCostEvent(env, "inst-2", 4.0, "2026-07-13T00:00:00.000Z");
+    await seedCostEvent(env, "inst-2", 4.0, "2026-07-13T00:00:00.000Z"); // inst-2: 3 rows (highest)
+    await seedCostEvent(env, "inst-3", 0.5, "2026-07-13T00:00:00.000Z"); // inst-3: 1 row (lowest)
+
+    const rows = await listRowCountByTenantSince(env, since);
+
+    expect(rows).toEqual([
+      { installationId: "inst-2", rowCount: 3 },
+      { installationId: "inst-1", rowCount: 2 },
+      { installationId: "inst-3", rowCount: 1 },
+    ]);
+  });
+
+  it("excludes self-host rows (null installation_id) and rows outside the time window", async () => {
+    const env = createTestEnv();
+    const since = "2026-07-10T00:00:00.000Z";
+    await seedCostEvent(env, "inst-1", 2.0, "2026-07-11T00:00:00.000Z"); // in window
+    await seedCostEvent(env, "inst-1", 9.0, "2026-07-01T00:00:00.000Z"); // before the window
+    await seedCostEvent(env, null, 5.0, "2026-07-11T00:00:00.000Z"); // self-host, must never appear
+
+    const rows = await listRowCountByTenantSince(env, since);
+
+    expect(rows).toEqual([{ installationId: "inst-1", rowCount: 1 }]);
+  });
+
+  it("returns an empty list, not an error, when there are no hosted rows at all (the self-host default)", async () => {
+    const env = createTestEnv();
+    expect(await listRowCountByTenantSince(env, "2026-07-10T00:00:00.000Z")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- The account-wide D1 storage cap already has alerting (`src/selfhost/d1-size-probe.ts`, 70%/90% Prometheus alerts shipped as a direct follow-up to the #3810 incident) — but it's table-level only, with no way to attribute usage to a specific tenant. This issue was already re-scoped to that specific gap by an earlier narrowing comment on the issue itself.
- Adds `listRowCountByTenantSince` (`src/db/repositories.ts`) — a per-installation row-count breakdown of `ai_usage_events`, the one high-growth table with a clean `installationId` column today. Same `GROUP BY` shape as the existing `listAiCostByTenantSince` (added in #7191) — row count is a plain, honest proxy for storage footprint here, since D1 has no per-row-group byte-size query surface.
- Wires it into the operator dashboard payload and a new "Storage by tenant" UI section, following the exact same pattern #7191 established for AI cost by tenant. Empty for self-host, as with its sibling.

Closes #4890

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:ci` (full local gate, unsharded) — green
- [x] New unit tests in `test/unit/ai-usage-tenant.test.ts`: groups/orders by tenant correctly, excludes self-host (null-tenant) rows and rows outside the time window, returns `[]` (not an error) with no hosted rows
- [x] New UI tests in `apps/loopover-ui/src/routes/app.operator.test.tsx`: no section when the field is absent/empty, renders each tenant's formatted row count highest-first
- [x] 100% branch coverage on every line touched in `src/db/repositories.ts` (mirrors the already-covered `listAiCostByTenantSince` shape 1:1)
- [ ] UI Evidence — dashboard-only addition following an already-shipped sibling panel's exact visual pattern (`AI cost by tenant`); no new visual pattern introduced