### PR TITLE
feat(ui): add the self-serve install-entry surface

### DIFF
--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as RoadmapRouteImport } from './routes/roadmap'
 import { Route as MinersRouteImport } from './routes/miners'
 import { Route as MaintainersRouteImport } from './routes/maintainers'
+import { Route as InstallRouteImport } from './routes/install'
 import { Route as ExtensionRouteImport } from './routes/extension'
 import { Route as DocsRouteImport } from './routes/docs'
 import { Route as ChangelogRouteImport } from './routes/changelog'
@@ -98,6 +99,11 @@ const MinersRoute = MinersRouteImport.update({
 const MaintainersRoute = MaintainersRouteImport.update({
   id: '/maintainers',
   path: '/maintainers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InstallRoute = InstallRouteImport.update({
+  id: '/install',
+  path: '/install',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ExtensionRoute = ExtensionRouteImport.update({
@@ -486,6 +492,7 @@ export interface FileRoutesByFullPath {
   '/changelog': typeof ChangelogRoute
   '/docs': typeof DocsRouteWithChildren
   '/extension': typeof ExtensionRoute
+  '/install': typeof InstallRoute
   '/maintainers': typeof MaintainersRoute
   '/miners': typeof MinersRoute
   '/roadmap': typeof RoadmapRoute
@@ -560,6 +567,7 @@ export interface FileRoutesByTo {
   '/agents': typeof AgentsRoute
   '/changelog': typeof ChangelogRoute
   '/extension': typeof ExtensionRoute
+  '/install': typeof InstallRoute
   '/maintainers': typeof MaintainersRoute
   '/miners': typeof MinersRoute
   '/roadmap': typeof RoadmapRoute
@@ -638,6 +646,7 @@ export interface FileRoutesById {
   '/changelog': typeof ChangelogRoute
   '/docs': typeof DocsRouteWithChildren
   '/extension': typeof ExtensionRoute
+  '/install': typeof InstallRoute
   '/maintainers': typeof MaintainersRoute
   '/miners': typeof MinersRoute
   '/roadmap': typeof RoadmapRoute
@@ -717,6 +726,7 @@ export interface FileRouteTypes {
     | '/changelog'
     | '/docs'
     | '/extension'
+    | '/install'
     | '/maintainers'
     | '/miners'
     | '/roadmap'
@@ -791,6 +801,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/changelog'
     | '/extension'
+    | '/install'
     | '/maintainers'
     | '/miners'
     | '/roadmap'
@@ -868,6 +879,7 @@ export interface FileRouteTypes {
     | '/changelog'
     | '/docs'
     | '/extension'
+    | '/install'
     | '/maintainers'
     | '/miners'
     | '/roadmap'
@@ -946,6 +958,7 @@ export interface RootRouteChildren {
   ChangelogRoute: typeof ChangelogRoute
   DocsRoute: typeof DocsRouteWithChildren
   ExtensionRoute: typeof ExtensionRoute
+  InstallRoute: typeof InstallRoute
   MaintainersRoute: typeof MaintainersRoute
   MinersRoute: typeof MinersRoute
   RoadmapRoute: typeof RoadmapRoute
@@ -973,6 +986,13 @@ declare module '@tanstack/react-router' {
       path: '/maintainers'
       fullPath: '/maintainers'
       preLoaderRoute: typeof MaintainersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/install': {
+      id: '/install'
+      path: '/install'
+      fullPath: '/install'
+      preLoaderRoute: typeof InstallRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/extension': {
@@ -1642,6 +1662,7 @@ const rootRouteChildren: RootRouteChildren = {
   ChangelogRoute: ChangelogRoute,
   DocsRoute: DocsRouteWithChildren,
   ExtensionRoute: ExtensionRoute,
+  InstallRoute: InstallRoute,
   MaintainersRoute: MaintainersRoute,
   MinersRoute: MinersRoute,
   RoadmapRoute: RoadmapRoute,

--- a/apps/loopover-ui/src/routes/install.test.tsx
+++ b/apps/loopover-ui/src/routes/install.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => ({}),
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+import { InstallPage } from "./install";
+
+// Self-serve signup & App-install entry surface (part of #4802).
+describe("InstallPage (#4802 self-serve install entry)", () => {
+  it("presents the three self-serve steps: sign up, install, confirm permissions", () => {
+    render(<InstallPage />);
+    expect(
+      screen.getByRole("heading", { name: /Connect your repository in three steps/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Sign up" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Install the App" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Confirm scoped permissions" })).toBeTruthy();
+    // The steps are numbered 1..3 in order.
+    ["Step 1", "Step 2", "Step 3"].forEach((label) => expect(screen.getByText(label)).toBeTruthy());
+  });
+
+  it("routes the install CTA to the real GitHub App configuration guide, not a fabricated live install", () => {
+    render(<InstallPage />);
+    const cta = screen.getByRole("link", { name: /Install on GitHub/i });
+    // Deliberately the documented setup route -- hosted self-serve install is a follow-up, so this slice
+    // must not pretend a one-click live install exists.
+    expect(cta.getAttribute("href")).toBe("/docs/github-app");
+  });
+
+  it("surfaces the scoped-permissions guarantee with a link to privacy & security", () => {
+    render(<InstallPage />);
+    const callout = screen.getByText(/only the permissions review needs/i).closest("div");
+    expect(callout).toBeTruthy();
+    const privacyLink = screen.getByRole("link", { name: /privacy & security/i });
+    expect(privacyLink.getAttribute("href")).toBe("/docs/privacy-security");
+  });
+
+  it("offers the onboarding guide as a secondary path", () => {
+    render(<InstallPage />);
+    const guide = screen.getByRole("link", { name: /Read the onboarding guide/i });
+    expect(guide.getAttribute("href")).toBe("/docs/beta-onboarding");
+  });
+});

--- a/apps/loopover-ui/src/routes/install.tsx
+++ b/apps/loopover-ui/src/routes/install.tsx
@@ -1,0 +1,129 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRight, UserPlus, Github, ShieldCheck } from "lucide-react";
+
+import { Section, SectionTitle, Card, Callout, Eyebrow } from "@/components/site/primitives";
+
+// Self-serve signup & App-install entry surface (part of #4802). This is the front door of the
+// signup -> install -> confirm-scoped-permissions flow: it explains the three steps and routes a new
+// customer to the existing GitHub App configuration guide. It reads no secrets and changes no auth
+// backend -- the install itself is completed on GitHub, and post-install permission confirmation is a
+// deliberate follow-up so this slice stays a small, reviewable UI surface.
+
+export const Route = createFileRoute("/install")({
+  head: () => ({
+    meta: [
+      { title: "Install LoopOver — self-serve setup" },
+      {
+        name: "description",
+        content:
+          "Sign up, install the LoopOver App on your own repository, and confirm the scoped permissions being granted — self-serve, no engineering step required.",
+      },
+      { property: "og:title", content: "Install LoopOver — self-serve setup" },
+      {
+        property: "og:description",
+        content:
+          "A self-serve signup-through-install flow: connect your repository and grant scoped permissions.",
+      },
+      { property: "og:url", content: "/install" },
+    ],
+    links: [{ rel: "canonical", href: "/install" }],
+  }),
+  component: InstallPage,
+});
+
+const STEPS = [
+  {
+    icon: UserPlus,
+    title: "Sign up",
+    description:
+      "Create your account. No engineering involvement — you own the connection to your repository from the start.",
+  },
+  {
+    icon: Github,
+    title: "Install the App",
+    description:
+      "Add the LoopOver GitHub App to the repositories you want reviewed. You choose which repos it can see.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Confirm scoped permissions",
+    description:
+      "Review exactly which permissions you're granting before you finish — scoped to what review needs, nothing more.",
+  },
+];
+
+export function InstallPage() {
+  return (
+    <>
+      <Section className="pt-16 pb-12 sm:pt-24">
+        <div className="max-w-3xl">
+          <Eyebrow accent>Self-serve setup</Eyebrow>
+          <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
+            Connect your repository in three steps.
+          </h1>
+          <p className="mt-4 max-w-2xl text-token-md text-muted-foreground">
+            Sign up, install the LoopOver App on your own repository, and confirm the scoped
+            permissions being granted — without a manual or engineering step.
+          </p>
+          <div className="mt-7 flex flex-wrap items-center gap-2">
+            <Link
+              to="/docs/github-app"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
+            >
+              Install on GitHub
+              <ArrowRight className="size-3.5" />
+            </Link>
+            <Link
+              to="/docs/beta-onboarding"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token border border-border bg-transparent px-4 text-token-sm font-medium text-foreground transition-colors duration-150 hover:bg-accent focus-ring motion-reduce:transition-none"
+            >
+              Read the onboarding guide
+            </Link>
+          </div>
+        </div>
+      </Section>
+
+      <Section className="py-0">
+        <SectionTitle
+          eyebrow="How it works"
+          title="From signup to a connected repo"
+          description="Each step is self-serve. You stay in control of which repositories the App can access and what it's allowed to do."
+        />
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {STEPS.map((step, index) => {
+            const Icon = step.icon;
+            return (
+              <Card key={step.title}>
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Icon aria-hidden className="size-4" />
+                  <span className="font-mono text-token-2xs uppercase tracking-wider">
+                    Step {index + 1}
+                  </span>
+                </div>
+                <h3 className="mt-3 text-token-md font-medium text-foreground">{step.title}</h3>
+                <p className="mt-1.5 text-token-sm text-muted-foreground">{step.description}</p>
+              </Card>
+            );
+          })}
+        </div>
+      </Section>
+
+      <Section className="pt-12 pb-24">
+        <div className="max-w-3xl">
+          <Callout variant="safety" title="Scoped by design">
+            LoopOver requests only the permissions review needs, on only the repositories you
+            choose. You confirm the exact scopes on GitHub before the install completes, and you can
+            review or revoke them at any time from your repository's installed-Apps settings. See{" "}
+            <Link
+              to="/docs/privacy-security"
+              className="text-foreground underline underline-offset-2"
+            >
+              privacy &amp; security
+            </Link>{" "}
+            for what is and isn't stored.
+          </Callout>
+        </div>
+      </Section>
+    </>
+  );
+}


### PR DESCRIPTION
## What

Adds the **self-serve install-entry surface** — a new `/install` route that is the front door of the signup → install → confirm-scoped-permissions flow described in #4802. A prospective customer lands here, sees the three self-serve steps, and is routed to the existing GitHub App configuration guide to complete the install on their own repository.

This is a **scoped slice of #4802**, not the whole epic. It deliberately covers only the entry surface:
- **In scope:** the `/install` route, the three-step explainer, the "Install on GitHub" CTA, and the scoped-permissions guarantee, all built on the shared design-system primitives (`@/components/site/primitives`, the same tokens/components the rest of the site uses, per #4966/#4967).
- **Out of scope (deliberate follow-ups):** the post-install permission-confirmation screen that reads the install callback, and any change to the auth/install backend. This keeps the PR small, reviewable, and free of guarded-surface (`src/orb/**`) changes.

## Design/accuracy notes

- The install CTA points to `/docs/github-app` (the real, documented setup path), **not** a fabricated one-click live install — hosted self-serve install is still being built, and this surface must not misrepresent product state. A test pins that.
- No secrets or backend reads: the page is a static marketing/onboarding surface; the install itself is completed on GitHub.
- Scoped-permissions messaging links to `/docs/privacy-security` for what is and isn't stored.

## Validation

New `install.test.tsx`: asserts the three ordered steps render, the CTA routes to the documented setup guide (not a fabricated live install), the scoped-permissions callout + privacy link are present, and the onboarding guide is offered as a secondary path. `ui:typecheck` (which type-checks every `<Link to>` against the real route tree), `ui:lint`, and `ui:build` pass.

## UI Evidence

| Desktop (1280×800) | Mobile (375×812) |
|---|---|
| <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/install-desktop.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/install-desktop.png" alt="Install route — desktop" width="380"></a> | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/install-mobile.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/install-mobile.png" alt="Install route — mobile" width="200"></a> |

New `/install` route (dark-mode-only build). No "before" — this is a new surface.

Part of #4802.
