### PR TITLE
feat(orb): add fleet-wide instance health aggregation

### DIFF
--- a/apps/loopover-ui/src/routes/app.operator.test.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.test.tsx
@@ -170,3 +170,61 @@ describe("OperatorDashboard storage by tenant (#4890)", () => {
     expect(screen.getByText("2 rows")).toBeTruthy();
   });
 });
+
+describe("OperatorDashboard instance status (#4933)", () => {
+  function mockDashboard(fleetHealth?: {
+    healthyCount: number;
+    unhealthyCount: number;
+    unknownCount: number;
+    totalCount: number;
+  }) {
+    useApiResource.mockImplementation((path: string) => {
+      if (path === "/v1/app/operator-dashboard") {
+        return {
+          status: "ready",
+          data: {
+            metrics: [{ label: "Installs", value: "12", delta: "+2" }],
+            noiseReduction: [],
+            weeklyReport: [],
+            fleetHealth,
+          },
+          error: null,
+          loadedAt: "2026-07-17T00:00:00.000Z",
+          reload: () => {},
+        };
+      }
+      return {
+        status: "error",
+        data: null,
+        error: "unavailable in this test",
+        errorKind: "unknown",
+        loadedAt: null,
+        reload: () => {},
+      };
+    });
+  }
+
+  it("renders no section at all when fleetHealth is absent (self-host, the common case)", () => {
+    mockDashboard(undefined);
+    render(<OperatorDashboard />);
+    expect(screen.queryByText("Instance status")).toBeNull();
+  });
+
+  it("renders no section when fleetHealth.totalCount is 0", () => {
+    mockDashboard({ healthyCount: 0, unhealthyCount: 0, unknownCount: 0, totalCount: 0 });
+    render(<OperatorDashboard />);
+    expect(screen.queryByText("Instance status")).toBeNull();
+  });
+
+  it("renders the healthy/unhealthy/unknown counts, distinct from the gate-calibration Fleet health card", () => {
+    mockDashboard({ healthyCount: 3, unhealthyCount: 1, unknownCount: 2, totalCount: 6 });
+    render(<OperatorDashboard />);
+    expect(screen.getByText("Instance status")).toBeTruthy();
+    expect(screen.getByText("Healthy")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("Unhealthy")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("Unknown")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/routes/app.operator.tsx
+++ b/apps/loopover-ui/src/routes/app.operator.tsx
@@ -36,6 +36,12 @@ type OperatorDashboardResponse = {
   upstreamDrift?: { status?: string } | null;
   aiCostByTenant?: Array<{ installationId: string; totalCostUsd: number }>;
   storageRowCountByTenant?: Array<{ installationId: string; rowCount: number }>;
+  fleetHealth?: {
+    healthyCount: number;
+    unhealthyCount: number;
+    unknownCount: number;
+    totalCount: number;
+  };
 };
 
 type FleetMetrics = {
@@ -249,6 +255,36 @@ export function OperatorDashboard() {
                   label="Instance outliers"
                   value={String(data.fleetMetrics.outliers.length)}
                   hint="off the fleet median"
+                />
+              </div>
+            </section>
+          ) : null}
+
+          {data.fleetHealth && data.fleetHealth.totalCount > 0 ? (
+            <section className="rounded-token border border-border bg-transparent p-5">
+              <div className="flex items-center gap-2">
+                <BarChart3 className="size-4 text-mint" />
+                <h2 className="font-display text-token-lg font-semibold">Instance status</h2>
+              </div>
+              <p className="mt-1 max-w-2xl text-token-xs text-muted-foreground">
+                Fleet instance readiness across {data.fleetHealth.totalCount} registered self-hosted
+                instance(s) — separate from the gate-calibration numbers above.
+              </p>
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                <Stat
+                  label="Healthy"
+                  value={String(data.fleetHealth.healthyCount)}
+                  hint="reported ready"
+                />
+                <Stat
+                  label="Unhealthy"
+                  value={String(data.fleetHealth.unhealthyCount)}
+                  hint="reported not ready"
+                />
+                <Stat
+                  label="Unknown"
+                  value={String(data.fleetHealth.unknownCount)}
+                  hint="no recent report"
                 />
               </div>
             </section>

--- a/migrations/0166_orb_instances_health.sql
+++ b/migrations/0166_orb_instances_health.sql
@@ -1,0 +1,6 @@
+-- #4933: fleet-wide instance health aggregation. Distinct from orb_instances.last_seen_at (bumped on EVERY
+-- ingest call, including outcome-only exports from an older self-host build that doesn't send a health
+-- signal at all): healthy/health_reported_at are only set when a payload actually carries one, so an
+-- instance that hasn't upgraded yet stays NULL (unknown) rather than silently reading as healthy.
+ALTER TABLE orb_instances ADD COLUMN healthy INTEGER;
+ALTER TABLE orb_instances ADD COLUMN health_reported_at TEXT;

--- a/src/orb/analytics.ts
+++ b/src/orb/analytics.ts
@@ -248,3 +248,41 @@ export async function computeFleetAnalytics(env: Env, opts: { windowDays?: numbe
     gamingPatternFlags,
   };
 }
+
+/** #4933: fleet-wide instance READINESS, not gate-calibration quality -- deliberately separate from (and
+ *  named differently on the dashboard than) the "Fleet health" gate-precision card above, which this is
+ *  often confused with despite measuring something unrelated. */
+export interface FleetHealthSummary {
+  healthyCount: number;
+  unhealthyCount: number;
+  // Never reported a health status, or its last report is older than HEALTH_STALE_HOURS -- an
+  // unresponsive instance must read as "don't know," not silently keep counting as its last-known state.
+  unknownCount: number;
+  totalCount: number; // registered instances only, matching computeFleetAnalytics's own trust gate
+}
+
+// A bit over 2x the hourly export cron (server.ts's runOrbExport), so one missed tick doesn't immediately
+// flip an instance to "unknown."
+export const HEALTH_STALE_HOURS = 3;
+
+export async function getFleetHealthSummary(env: Env, now: Date = new Date()): Promise<FleetHealthSummary> {
+  const staleBefore = new Date(now.getTime() - HEALTH_STALE_HOURS * 60 * 60 * 1000).toISOString();
+  try {
+    const row = await env.DB.prepare(
+      `SELECT
+         SUM(CASE WHEN healthy = 1 AND health_reported_at IS NOT NULL AND health_reported_at > ? THEN 1 ELSE 0 END) AS healthy_count,
+         SUM(CASE WHEN healthy = 0 AND health_reported_at IS NOT NULL AND health_reported_at > ? THEN 1 ELSE 0 END) AS unhealthy_count,
+         COUNT(*) AS total_count
+       FROM orb_instances
+       WHERE registered = 1`,
+    )
+      .bind(staleBefore, staleBefore)
+      .first<{ healthy_count: number | null; unhealthy_count: number | null; total_count: number }>();
+    const healthyCount = Number(row?.healthy_count ?? 0);
+    const unhealthyCount = Number(row?.unhealthy_count ?? 0);
+    const totalCount = Number(row?.total_count ?? 0);
+    return { healthyCount, unhealthyCount, unknownCount: totalCount - healthyCount - unhealthyCount, totalCount };
+  } catch {
+    return { healthyCount: 0, unhealthyCount: 0, unknownCount: 0, totalCount: 0 };
+  }
+}

--- a/src/orb/analytics.ts
+++ b/src/orb/analytics.ts
@@ -280,6 +280,9 @@ export async function getFleetHealthSummary(env: Env, now: Date = new Date()): P
       .first<{ healthy_count: number | null; unhealthy_count: number | null; total_count: number }>();
     const healthyCount = Number(row?.healthy_count ?? 0);
     const unhealthyCount = Number(row?.unhealthy_count ?? 0);
+    /* v8 ignore next -- COUNT(*) always returns a non-null number for a matched row (unlike the SUM(CASE...)
+     *  cells above, which legitimately return NULL over zero matching rows); the ?? 0 only guards `row` being
+     *  absent entirely, which a scalar aggregate query never produces. */
     const totalCount = Number(row?.total_count ?? 0);
     return { healthyCount, unhealthyCount, unknownCount: totalCount - healthyCount - unhealthyCount, totalCount };
   } catch {

--- a/src/orb/ingest.ts
+++ b/src/orb/ingest.ts
@@ -63,6 +63,9 @@ interface OrbIngestEvent {
 interface OrbIngestPayload {
   instance_id: string;
   events: OrbIngestEvent[];
+  // #4933: optional -- an older self-host build that hasn't upgraded yet simply omits this, and the
+  // instance's stored health stays whatever it last was (or NULL/unknown on first contact).
+  health?: { ok: boolean };
 }
 
 export type OrbIngestResult = { accepted: number } | { error: string };
@@ -89,19 +92,35 @@ export async function handleOrbIngest(body: string, db: D1Database): Promise<Orb
     return { error: "invalid_payload" };
   }
 
-  const { instance_id, events } = payload as OrbIngestPayload;
-  if (!instance_id || instance_id.length > MAX_INSTANCE_ID_CHARS || events.length === 0) {
+  const { instance_id, events, health } = payload as OrbIngestPayload;
+  // #4933: an empty batch is only valid when it's carrying a health-only ping (the hourly export still
+  // has to report health even in a tick with nothing new to export) -- a truly empty, health-less payload
+  // stays rejected exactly as before.
+  const healthy = typeof health === "object" && health !== null && typeof health.ok === "boolean" ? (health.ok ? 1 : 0) : null;
+  if (!instance_id || instance_id.length > MAX_INSTANCE_ID_CHARS || (events.length === 0 && healthy === null)) {
     return { error: "invalid_payload" };
   }
+  const healthReportedAt = healthy === null ? null : new Date().toISOString();
 
   // Record the instance on first contact (registered=0 by default) and bump last_seen. The registration
   // gate lives in computeFleetAnalytics: signals are stored for everyone, but only registered instances
   // count toward the fleet median — so open ingest can't be used to skew calibration (the das-github-mirror
   // model: every source is seen, trusted only once an operator opts it in).
+  //
+  // healthy/health_reported_at only move when THIS payload actually reported a health status (COALESCE
+  // falls back to whatever was already stored) -- an outcome-only ingest from a self-host build that
+  // hasn't upgraded to send health yet must never silently overwrite a real prior health reading with
+  // NULL, and must never look "healthy" just because the instance is otherwise active.
   try {
     await db
-      .prepare(`INSERT INTO orb_instances (instance_id) VALUES (?) ON CONFLICT(instance_id) DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP`)
-      .bind(instance_id)
+      .prepare(
+        `INSERT INTO orb_instances (instance_id, healthy, health_reported_at) VALUES (?, ?, ?)
+         ON CONFLICT(instance_id) DO UPDATE SET
+           last_seen_at = CURRENT_TIMESTAMP,
+           healthy = COALESCE(excluded.healthy, orb_instances.healthy),
+           health_reported_at = COALESCE(excluded.health_reported_at, orb_instances.health_reported_at)`,
+      )
+      .bind(instance_id, healthy, healthReportedAt)
       .run();
   } catch {
     // best-effort: never fail ingest because the instance bookkeeping hiccupped

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -51,6 +51,7 @@ interface FleetEvent {
 interface OrbExportPayload {
   instance_id: string;
   events: FleetEvent[];
+  health?: { ok: boolean };
 }
 
 /** Stable instance identifier (hash of the Orb/App ID — no PII). A brokered instance holds no App id, so its
@@ -154,11 +155,14 @@ export function cycleTimeMs(decidedAt: string, outcomeAt: string): number | null
 }
 
 /**
- * Export newly-resolved PR outcomes (since this instance's watermark) to the central collector. Reads from
- * review_audit (de-noised, reversal-aware), anonymizes, signs, POSTs, then advances the cursor.
- * Returns the number of events exported (0 if air-gapped, the App isn't configured, or nothing new).
+ * Export newly-resolved PR outcomes (since this instance's watermark) to the central collector, and --
+ * when `healthOk` is supplied (#4933, threaded from server.ts's own readiness() result) -- a health ping
+ * riding the same request, even in a tick with nothing new to export. Reads from review_audit (de-noised,
+ * reversal-aware), anonymizes, signs, POSTs, then advances the cursor.
+ * Returns the number of events exported (0 if air-gapped, the App isn't configured, or nothing new to
+ * export -- a health-only ping with zero events still returns 0, matching "nothing new" today).
  */
-export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: typeof fetch = fetch): Promise<number> {
+export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: typeof fetch = fetch, healthOk?: boolean): Promise<number> {
   // Air-gapped/offline deployments explicitly suppress every outbound telemetry call, including brokered mode.
   if ((process.env.ORB_AIR_GAP ?? "").toLowerCase() === "true") return 0;
 
@@ -185,11 +189,13 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
   const cursorTargetId = cursorRow?.last_exported_target_id ?? "";
 
   const { results } = await db.prepare(FLEET_QUERY).bind(cursorAt, cursorAt, cursorTargetId, batchSize).all<FleetRow>();
-  if (!results || results.length === 0) return 0;
+  // A health-only ping (healthOk !== undefined) still has something to send even with zero new events;
+  // otherwise, exactly as before, nothing new means nothing to do.
+  if ((!results || results.length === 0) && healthOk === undefined) return 0;
 
   const payload: OrbExportPayload = {
     instance_id: instance,
-    events: results.map((r) => ({
+    events: (results ?? []).map((r) => ({
       repo_hash: anonymize ? hmacAnonymize(r.project, secret) : r.project,
       pr_hash: anonymize ? hmacAnonymize(r.target_id, secret) : r.target_id,
       gate_verdict: r.verdict,
@@ -200,6 +206,7 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
       decision_timestamp: r.decided_at,
       outcome_timestamp: r.outcome_at,
     })),
+    ...(healthOk !== undefined ? { health: { ok: healthOk } } : {}),
   };
 
   const body = JSON.stringify(payload);
@@ -235,14 +242,18 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
   }
 
   // Advance the watermark to the newest event in this batch (rows are ordered by event_at, target_id).
-  const lastRow = results[results.length - 1]!;
-  await db
-    .prepare(
-      `INSERT OR REPLACE INTO orb_export_cursor (instance_hash, last_exported_at, last_exported_target_id, updated_at) VALUES (?, ?, ?, ?)`,
-    )
-    .bind(instance, lastRow.event_at, lastRow.target_id, new Date().toISOString())
-    .run();
+  // A health-only ping (no results) has no watermark to advance -- nothing new was read or sent as events.
+  if (results && results.length > 0) {
+    const lastRow = results[results.length - 1]!;
+    await db
+      .prepare(
+        `INSERT OR REPLACE INTO orb_export_cursor (instance_hash, last_exported_at, last_exported_target_id, updated_at) VALUES (?, ?, ?, ?)`,
+      )
+      .bind(instance, lastRow.event_at, lastRow.target_id, new Date().toISOString())
+      .run();
+  }
 
-  incr("loopover_orb_events_exported_total", {}, results.length);
-  return results.length;
+  const exportedCount = results?.length ?? 0;
+  if (exportedCount > 0) incr("loopover_orb_events_exported_total", {}, exportedCount);
+  return exportedCount;
 }

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -195,6 +195,8 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
 
   const payload: OrbExportPayload = {
     instance_id: instance,
+    /* v8 ignore next -- D1's .all() always returns a `results` array (possibly empty), never omits the field;
+     *  the ?? [] only guards the driver's own optional typing, not a real runtime path. */
     events: (results ?? []).map((r) => ({
       repo_hash: anonymize ? hmacAnonymize(r.project, secret) : r.project,
       pr_hash: anonymize ? hmacAnonymize(r.target_id, secret) : r.target_id,
@@ -253,6 +255,7 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
       .run();
   }
 
+  /* v8 ignore next -- same D1 .all() guarantee as above: `results` is always at least an empty array here. */
   const exportedCount = results?.length ?? 0;
   if (exportedCount > 0) incr("loopover_orb_events_exported_total", {}, exportedCount);
   return exportedCount;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1115,9 +1115,17 @@ async function main(): Promise<void> {
 
   // Orb fleet-telemetry export — ALWAYS ON (the fleet-calibration contract of self-hosting). Self-gates
   // inside exportOrbBatch: a no-op until the GitHub App is configured, or when ORB_AIR_GAP=true.
+  //
+  // #4933: rides the SAME readiness() this instance's own /ready endpoint uses (readinessProbes, built
+  // above) rather than inventing a second, parallel health check -- so "healthy" reported to the fleet
+  // always means exactly what /ready already means locally. A readiness() failure here degrades to "no
+  // health signal this tick" (healthOk stays undefined) rather than reporting a wrong status.
   /* v8 ignore start -- self-host entrypoint timers start a live server; monitor semantics are covered in selfhost tests. */
   const runOrbExport = () =>
-    runOrbExportWithMonitor(() => exportOrbBatch(backend.db)).catch((error) =>
+    runOrbExportWithMonitor(async () => {
+      const health = await readiness(backend.db, readinessProbes).catch(() => null);
+      return exportOrbBatch(backend.db, undefined, undefined, health?.ok);
+    }).catch((error) =>
       console.error(
         JSON.stringify({
           level: "error",

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -30,7 +30,7 @@ import type {
   ScoringModelSnapshotRecord,
   WeeklyValueReport,
 } from "../types";
-import { computeFleetAnalytics, type FleetAnalytics } from "../orb/analytics";
+import { computeFleetAnalytics, getFleetHealthSummary, type FleetAnalytics, type FleetHealthSummary } from "../orb/analytics";
 import { computeAgentHealth, computeCalibration, type AgentHealth, type Calibration } from "../review/ops";
 import { computeGateEval, type GateEvalReport } from "../review/parity";
 import { computeCycleTimeAggregate, computeFindingAcceptance, type CycleTimeAggregate } from "../review/stats";
@@ -102,6 +102,9 @@ export type OperatorDashboardPayload = {
   // D1 storage cap already has alerting (src/selfhost/d1-size-probe.ts); this is the per-installation dimension
   // that alerting doesn't have. Same self-host-always-empty caveat as aiCostByTenant above.
   storageRowCountByTenant: RowCountByTenant[];
+  // #4933: fleet-wide instance READINESS (up/down/unknown), distinct from fleetMetrics above (gate-calibration
+  // quality). Always all-zero for a self-host operator (no registered peer instances).
+  fleetHealth: FleetHealthSummary;
 };
 
 const USAGE_WINDOW_DAYS = 7;
@@ -140,6 +143,7 @@ export async function buildOperatorDashboardPayload(
     findingAcceptance,
     aiCostByTenant,
     storageRowCountByTenant,
+    fleetHealth,
   ] = await Promise.all([
     listRepositories(env),
     listInstallations(env),
@@ -171,6 +175,8 @@ export async function buildOperatorDashboardPayload(
     listAiCostByTenantSince(env, usageSince),
     // #4890 (re-scoped): per-tenant row-count breakdown, same window as the rest of the usage metrics above.
     listRowCountByTenantSince(env, usageSince),
+    // #4933: fleet-wide instance readiness -- a point-in-time summary, no window needed.
+    getFleetHealthSummary(env),
   ]);
   const weeklyValueReport = buildWeeklyValueReport({
     generatedAt: nowIso(),
@@ -291,6 +297,7 @@ export async function buildOperatorDashboardPayload(
     acceptance,
     aiCostByTenant,
     storageRowCountByTenant,
+    fleetHealth,
   };
 }
 

--- a/test/integration/orb-ingest.test.ts
+++ b/test/integration/orb-ingest.test.ts
@@ -160,6 +160,60 @@ describe("handleOrbIngest()", () => {
   });
 });
 
+describe("handleOrbIngest() health ping (#4933)", () => {
+  function makeDb(): D1Database {
+    return new TestD1Database() as unknown as D1Database;
+  }
+  const ev = (o: Record<string, unknown> = {}) => ({ repo_hash: "rh", pr_hash: "ph", outcome: "merged", ...o });
+  const instanceRow = async (db: D1Database, instanceId: string) =>
+    (await (db as unknown as TestD1Database).prepare("SELECT healthy, health_reported_at FROM orb_instances WHERE instance_id=?").bind(instanceId).first<{ healthy: number | null; health_reported_at: string | null }>()) ?? null;
+
+  it("accepts a health-only payload with zero events (rejected on its own without a health field)", async () => {
+    const db = makeDb();
+    const result = await handleOrbIngest(JSON.stringify({ instance_id: "h1", events: [], health: { ok: true } }), db);
+    expect(result).toEqual({ accepted: 0 });
+    expect(await instanceRow(db, "h1")).toEqual({ healthy: 1, health_reported_at: expect.any(String) });
+  });
+
+  it("persists healthy=0 for health.ok === false", async () => {
+    const db = makeDb();
+    await handleOrbIngest(JSON.stringify({ instance_id: "h2", events: [], health: { ok: false } }), db);
+    expect((await instanceRow(db, "h2"))?.healthy).toBe(0);
+  });
+
+  it("a malformed health object (not an object / ok not boolean) is treated as absent", async () => {
+    const db = makeDb();
+    expect(await handleOrbIngest(JSON.stringify({ instance_id: "h3", events: [], health: "bad" }), db)).toEqual({ error: "invalid_payload" });
+    expect(await handleOrbIngest(JSON.stringify({ instance_id: "h4", events: [], health: { ok: "yes" } }), db)).toEqual({ error: "invalid_payload" });
+    expect(await handleOrbIngest(JSON.stringify({ instance_id: "h5", events: [], health: null }), db)).toEqual({ error: "invalid_payload" });
+  });
+
+  it("an outcome-only ingest (no health field) never overwrites a previously-reported health status", async () => {
+    const db = makeDb();
+    await handleOrbIngest(JSON.stringify({ instance_id: "h6", events: [], health: { ok: true } }), db);
+    const first = await instanceRow(db, "h6");
+    expect(first?.healthy).toBe(1);
+    // Same instance, later, exports real outcome events but (e.g. an older build) sends no health field.
+    await handleOrbIngest(JSON.stringify({ instance_id: "h6", events: [ev({ pr_hash: "h6-p" })] }), db);
+    const second = await instanceRow(db, "h6");
+    expect(second?.healthy).toBe(1); // unchanged, not wiped to null
+    expect(second?.health_reported_at).toBe(first?.health_reported_at); // unchanged timestamp too
+  });
+
+  it("a fresh health report on a later ingest overwrites the prior stored value", async () => {
+    const db = makeDb();
+    await handleOrbIngest(JSON.stringify({ instance_id: "h7", events: [], health: { ok: true } }), db);
+    await handleOrbIngest(JSON.stringify({ instance_id: "h7", events: [], health: { ok: false } }), db);
+    expect((await instanceRow(db, "h7"))?.healthy).toBe(0);
+  });
+
+  it("an instance that has never reported health stays NULL (unknown), not defaulted to any status", async () => {
+    const db = makeDb();
+    await handleOrbIngest(JSON.stringify({ instance_id: "h8", events: [ev({ pr_hash: "h8-p" })] }), db);
+    expect(await instanceRow(db, "h8")).toEqual({ healthy: null, health_reported_at: null });
+  });
+});
+
 describe("readOrbIngestBody()", () => {
   const reqWithBody = (body: BodyInit, headers?: Record<string, string>) =>
     new Request("http://collector/v1/orb/ingest", { method: "POST", body, ...(headers ? { headers } : {}) });

--- a/test/unit/orb-analytics.test.ts
+++ b/test/unit/orb-analytics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeFleetAnalytics } from "../../src/orb/analytics";
+import { computeFleetAnalytics, getFleetHealthSummary, HEALTH_STALE_HOURS } from "../../src/orb/analytics";
 import { createTestEnv, TestD1Database } from "../helpers/d1";
 
 let seq = 0;
@@ -308,5 +308,58 @@ describe("gamingPatternFlags — anti-farming detection (#2350)", () => {
     const broken = { DB: { prepare: () => ({ bind: () => ({ all: () => Promise.reject(new Error("boom")) }) }) } } as unknown as Env;
     const result = await computeFleetAnalytics(broken);
     expect(result.gamingPatternFlags).toEqual([]);
+  });
+});
+
+describe("getFleetHealthSummary() (#4933)", () => {
+  const NOW = new Date("2026-07-18T12:00:00.000Z");
+  const FRESH = "2026-07-18T11:30:00.000Z"; // 30m ago -- within the staleness window
+  const STALE = "2026-07-18T08:00:00.000Z"; // 4h ago -- older than HEALTH_STALE_HOURS
+
+  async function seedInstance(env: Env, id: string, opts: { registered?: boolean; healthy?: number | null; healthReportedAt?: string | null } = {}): Promise<void> {
+    await env.DB
+      .prepare(`INSERT INTO orb_instances (instance_id, registered, healthy, health_reported_at) VALUES (?, ?, ?, ?)`)
+      .bind(id, opts.registered === false ? 0 : 1, opts.healthy ?? null, opts.healthReportedAt ?? null)
+      .run();
+  }
+
+  it("empty store → all zero", async () => {
+    const env = createTestEnv();
+    expect(await getFleetHealthSummary(env, NOW)).toEqual({ healthyCount: 0, unhealthyCount: 0, unknownCount: 0, totalCount: 0 });
+  });
+
+  it("counts fresh healthy/unhealthy separately, and a never-reported instance as unknown", async () => {
+    const env = createTestEnv();
+    await seedInstance(env, "h1", { healthy: 1, healthReportedAt: FRESH });
+    await seedInstance(env, "h2", { healthy: 1, healthReportedAt: FRESH });
+    await seedInstance(env, "u1", { healthy: 0, healthReportedAt: FRESH });
+    await seedInstance(env, "n1"); // never reported -- healthy/health_reported_at both NULL
+    expect(await getFleetHealthSummary(env, NOW)).toEqual({ healthyCount: 2, unhealthyCount: 1, unknownCount: 1, totalCount: 4 });
+  });
+
+  it("a stale health report (older than HEALTH_STALE_HOURS) counts as unknown, not its last-known status", async () => {
+    const env = createTestEnv();
+    expect(HEALTH_STALE_HOURS).toBeGreaterThan(0);
+    await seedInstance(env, "stale-healthy", { healthy: 1, healthReportedAt: STALE });
+    await seedInstance(env, "stale-unhealthy", { healthy: 0, healthReportedAt: STALE });
+    expect(await getFleetHealthSummary(env, NOW)).toEqual({ healthyCount: 0, unhealthyCount: 0, unknownCount: 2, totalCount: 2 });
+  });
+
+  it("excludes unregistered instances entirely, matching computeFleetAnalytics's own trust gate", async () => {
+    const env = createTestEnv();
+    await seedInstance(env, "reg", { registered: true, healthy: 1, healthReportedAt: FRESH });
+    await seedInstance(env, "unreg", { registered: false, healthy: 1, healthReportedAt: FRESH });
+    expect(await getFleetHealthSummary(env, NOW)).toEqual({ healthyCount: 1, unhealthyCount: 0, unknownCount: 0, totalCount: 1 });
+  });
+
+  it("fails safe to an all-zero summary on a DB read error", async () => {
+    const broken = { DB: { prepare: () => ({ bind: () => ({ first: () => Promise.reject(new Error("boom")) }) }) } } as unknown as Env;
+    expect(await getFleetHealthSummary(broken, NOW)).toEqual({ healthyCount: 0, unhealthyCount: 0, unknownCount: 0, totalCount: 0 });
+  });
+
+  it("defaults `now` to the current time when omitted", async () => {
+    const env = createTestEnv();
+    await seedInstance(env, "h1", { healthy: 1, healthReportedAt: new Date().toISOString() });
+    expect(await getFleetHealthSummary(env)).toEqual({ healthyCount: 1, unhealthyCount: 0, unknownCount: 0, totalCount: 1 });
   });
 });

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -272,4 +272,55 @@ describe("exportOrbBatch() — always-on; reads review_audit, ships anonymized r
     await exportOrbBatch(db, 200, async (_u, init) => { header = (init!.headers as Record<string, string>)["x-orb-instance"]; return new Response(null, { status: 200 }); });
     expect(header).toMatch(/^[a-f0-9]{16}$/);
   });
+
+  describe("health ping (#4933)", () => {
+    it("does NOT call the collector when healthOk is undefined and there's nothing new (unchanged pre-#4933 behavior)", async () => {
+      const db = makeDb();
+      let called = false;
+      const n = await exportOrbBatch(db, 200, async () => { called = true; return new Response(null, { status: 200 }); });
+      expect(n).toBe(0);
+      expect(called).toBe(false);
+    });
+
+    it("sends a health-only ping (events: []) when healthOk is provided and there's nothing new to export", async () => {
+      const db = makeDb();
+      let captured: { events: unknown[]; health?: { ok: boolean } } | undefined;
+      const n = await exportOrbBatch(db, 200, async (_u, init) => { captured = JSON.parse(init!.body as string); return new Response(null, { status: 200 }); }, true);
+      expect(n).toBe(0); // no outcome events exported
+      expect(captured).toEqual({ instance_id: expect.any(String), events: [], health: { ok: true } });
+    });
+
+    it("reports healthOk === false", async () => {
+      const db = makeDb();
+      let captured: { health?: { ok: boolean } } | undefined;
+      await exportOrbBatch(db, 200, async (_u, init) => { captured = JSON.parse(init!.body as string); return new Response(null, { status: 200 }); }, false);
+      expect(captured!.health).toEqual({ ok: false });
+    });
+
+    it("includes the health field ALONGSIDE real outcome events in the same tick", async () => {
+      const db = makeDb();
+      await audit(db, "owner/repo", 3, "gate_decision", "merge", "2026-01-01T00:00:00Z");
+      await audit(db, "owner/repo", 3, "pr_outcome", "merged", "2026-01-01T01:00:00Z");
+      let captured: { events: unknown[]; health?: { ok: boolean } } | undefined;
+      const n = await exportOrbBatch(db, 200, async (_u, init) => { captured = JSON.parse(init!.body as string); return new Response(null, { status: 200 }); }, true);
+      expect(n).toBe(1);
+      expect(captured!.events).toHaveLength(1);
+      expect(captured!.health).toEqual({ ok: true });
+    });
+
+    it("still gates on air-gap/App-configured BEFORE ever considering healthOk", async () => {
+      process.env.ORB_AIR_GAP = "true";
+      let called = false;
+      const n = await exportOrbBatch(makeDb(), 200, async () => { called = true; return new Response(null, { status: 200 }); }, true);
+      expect(n).toBe(0);
+      expect(called).toBe(false);
+    });
+
+    it("a health-only ping does not advance the export cursor (nothing new was actually exported)", async () => {
+      const db = makeDb();
+      await exportOrbBatch(db, 200, async () => new Response(null, { status: 200 }), true);
+      const cursor = await db.prepare("SELECT COUNT(*) AS n FROM orb_export_cursor").first<{ n: number }>();
+      expect(cursor?.n).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- The existing readiness check (`/health`, `/ready`) is per-instance only and never leaves the instance — no way for an operator centrally managing many self-hosted instances to see which ones are actually up.
- Threads `readiness()` (the exact same check `/ready` already answers with) into the hourly Orb telemetry export, riding the same request even in a tick with nothing new to export — no second, parallel health-check mechanism.
- The central ingest handler (`POST /v1/orb/ingest`) accepts this as an optional `health: { ok: boolean }` field, relaxing the "empty events" rejection only when a health signal accompanies it, and persists it to two new `orb_instances` columns (`healthy`, `health_reported_at`) via a `COALESCE`-based upsert: an outcome-only export from a build that hasn't upgraded yet never overwrites a previously-reported status with null, and never looks healthy just because the instance is otherwise active.
- A new `getFleetHealthSummary()` (`src/orb/analytics.ts`) aggregates healthy/unhealthy/unknown counts across registered instances, with a staleness window (`HEALTH_STALE_HOURS = 3`, a bit over 2× the hourly export cron) — an unresponsive instance reads as "unknown," not stuck on its last-known status.
- Surfaced on the operator dashboard as **"Instance status"**, named distinctly from the existing **"Fleet health"** card — that card measures gate-calibration quality (median merge precision, etc.), an unrelated concept that happens to share the word "health"; conflating the two would be a real confusion risk on the same page.

Closes #4933

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run db:migrations:check` / `npm run db:schema-drift:check` — clean
- [x] `npm run test:ci` (full local gate, unsharded) — green
- [x] New tests: `test/integration/orb-ingest.test.ts` (health-only payload accepted, both `ok` values, malformed `health` still rejected, an outcome-only re-ingest never overwrites a prior health status, a never-reported instance stays `NULL`), `test/unit/selfhost-orb-collector.test.ts` (health ping sent even with zero new events, included alongside real events, gated correctly behind air-gap/App-configured, doesn't advance the export cursor on its own), `test/unit/orb-analytics.test.ts` (`getFleetHealthSummary`: healthy/unhealthy/unknown counts, staleness window, registered-only filter, fail-safe on DB error), plus new UI tests for the dashboard section (absent/empty/populated states)
- [x] 100% branch coverage on every line touched in `src/**` (verified via scoped test runs before the full unsharded run)
- [ ] UI Evidence — dashboard-only addition following the already-shipped sibling panels' exact visual pattern (`Stat` grid, same as the existing "Fleet health" section); no new visual pattern introduced

## Safety
No behavior change for a self-host operator who never registers a peer instance — `fleetHealth`/`Instance status` render nothing when `totalCount` is 0. The `readiness()` call added to the hourly export tick reuses the exact same probes `/ready` already runs (no new checks, no new failure modes) and degrades to "no health signal this tick" rather than reporting a wrong status if it errors.