### PR TITLE
fix(orb): reject a present-but-malformed health field even alongside real events

### DIFF
--- a/src/orb/ingest.ts
+++ b/src/orb/ingest.ts
@@ -93,10 +93,19 @@ export async function handleOrbIngest(body: string, db: D1Database): Promise<Orb
   }
 
   const { instance_id, events, health } = payload as OrbIngestPayload;
+  // #7210: a `health` key that IS present must always be well-formed ({ ok: boolean }), whether or not
+  // real outcome events also ride along in the same payload. A malformed health field is a sender-side
+  // bug we surface (reject the whole payload) rather than silently coerce to "absent" -- consistent with
+  // how every other field in this handler validates. An ABSENT health key (an older self-host build that
+  // doesn't send this field yet) stays fine and falls through as healthy = null, exactly as before.
+  const healthValid = typeof health === "object" && health !== null && typeof health.ok === "boolean";
+  if (health !== undefined && !healthValid) {
+    return { error: "invalid_payload" };
+  }
   // #4933: an empty batch is only valid when it's carrying a health-only ping (the hourly export still
   // has to report health even in a tick with nothing new to export) -- a truly empty, health-less payload
   // stays rejected exactly as before.
-  const healthy = typeof health === "object" && health !== null && typeof health.ok === "boolean" ? (health.ok ? 1 : 0) : null;
+  const healthy = health === undefined ? null : health.ok ? 1 : 0;
   if (!instance_id || instance_id.length > MAX_INSTANCE_ID_CHARS || (events.length === 0 && healthy === null)) {
     return { error: "invalid_payload" };
   }

--- a/test/integration/orb-ingest.test.ts
+++ b/test/integration/orb-ingest.test.ts
@@ -181,11 +181,21 @@ describe("handleOrbIngest() health ping (#4933)", () => {
     expect((await instanceRow(db, "h2"))?.healthy).toBe(0);
   });
 
-  it("a malformed health object (not an object / ok not boolean) is treated as absent", async () => {
+  it("a present-but-malformed health field (not an object / ok not boolean / null) is rejected", async () => {
     const db = makeDb();
     expect(await handleOrbIngest(JSON.stringify({ instance_id: "h3", events: [], health: "bad" }), db)).toEqual({ error: "invalid_payload" });
     expect(await handleOrbIngest(JSON.stringify({ instance_id: "h4", events: [], health: { ok: "yes" } }), db)).toEqual({ error: "invalid_payload" });
     expect(await handleOrbIngest(JSON.stringify({ instance_id: "h5", events: [], health: null }), db)).toEqual({ error: "invalid_payload" });
+  });
+
+  it("#7210: a malformed health field is rejected even when real outcome events also ride along, persisting neither", async () => {
+    const db = makeDb();
+    const result = await handleOrbIngest(JSON.stringify({ instance_id: "h9", events: [ev({ pr_hash: "h9-p" })], health: { ok: "nope" } }), db);
+    expect(result).toEqual({ error: "invalid_payload" });
+    // The whole payload is rejected: neither the event row nor the instance row is written.
+    const signal = await (db as unknown as TestD1Database).prepare("SELECT COUNT(*) AS n FROM orb_signals WHERE pr_hash=?").bind("h9-p").first<{ n: number }>();
+    expect(signal?.n).toBe(0);
+    expect(await instanceRow(db, "h9")).toBeNull();
   });
 
   it("an outcome-only ingest (no health field) never overwrites a previously-reported health status", async () => {


### PR DESCRIPTION
fix(orb): reject a present-but-malformed health field even alongside real events

handleOrbIngest only rejected a malformed health object when events was
also empty; a payload carrying BOTH a malformed health field AND real
outcome events silently coerced health to absent (healthy = null) and
accepted the batch, masking a sender-side bug instead of surfacing it.

A health key that IS present in the payload must always be well-formed
({ ok: boolean }), whether or not events also ride along. An absent
health key (an older self-host build that omits the field) still falls
through as healthy = null, exactly as before.

Closes #7210

