### PR TITLE
fix(orb): reject a malformed health field even when real events are present

### DIFF
--- a/src/orb/ingest.ts
+++ b/src/orb/ingest.ts
@@ -93,10 +93,21 @@ export async function handleOrbIngest(body: string, db: D1Database): Promise<Orb
   }
 
   const { instance_id, events, health } = payload as OrbIngestPayload;
-  // #4933: an empty batch is only valid when it's carrying a health-only ping (the hourly export still
-  // has to report health even in a tick with nothing new to export) -- a truly empty, health-less payload
-  // stays rejected exactly as before.
-  const healthy = typeof health === "object" && health !== null && typeof health.ok === "boolean" ? (health.ok ? 1 : 0) : null;
+  // #4933: a `health` key that IS present must be well-formed, whether or not `events` also carries real
+  // outcome rows -- rejecting only when events is also empty would silently drop a malformed health report
+  // from a sender that also has real events to export, instead of surfacing the sender's bug. An ABSENT
+  // health key (an older self-host build that doesn't send this field yet) is fine and falls through as
+  // healthy = null, exactly as before this field existed.
+  let healthy: number | null = null;
+  if (health !== undefined) {
+    if (typeof health !== "object" || health === null || typeof health.ok !== "boolean") {
+      return { error: "invalid_payload" };
+    }
+    healthy = health.ok ? 1 : 0;
+  }
+  // An empty batch is only valid when it's carrying a (well-formed) health-only ping (the hourly export
+  // still has to report health even in a tick with nothing new to export) -- a truly empty, health-less
+  // payload stays rejected exactly as before #4933.
   if (!instance_id || instance_id.length > MAX_INSTANCE_ID_CHARS || (events.length === 0 && healthy === null)) {
     return { error: "invalid_payload" };
   }

--- a/test/integration/orb-ingest.test.ts
+++ b/test/integration/orb-ingest.test.ts
@@ -181,11 +181,21 @@ describe("handleOrbIngest() health ping (#4933)", () => {
     expect((await instanceRow(db, "h2"))?.healthy).toBe(0);
   });
 
-  it("a malformed health object (not an object / ok not boolean) is treated as absent", async () => {
+  it("a malformed health object (not an object / ok not boolean) is rejected", async () => {
     const db = makeDb();
     expect(await handleOrbIngest(JSON.stringify({ instance_id: "h3", events: [], health: "bad" }), db)).toEqual({ error: "invalid_payload" });
     expect(await handleOrbIngest(JSON.stringify({ instance_id: "h4", events: [], health: { ok: "yes" } }), db)).toEqual({ error: "invalid_payload" });
     expect(await handleOrbIngest(JSON.stringify({ instance_id: "h5", events: [], health: null }), db)).toEqual({ error: "invalid_payload" });
+  });
+
+  it("REGRESSION: a malformed health object is rejected even when real outcome events are ALSO present -- a present-but-invalid health key must never be silently dropped just because there's other work to do", async () => {
+    const db = makeDb();
+    const malformed = { instance_id: "h3b", events: [ev({ pr_hash: "h3b-p" })], health: { ok: "yes" } };
+    expect(await handleOrbIngest(JSON.stringify(malformed), db)).toEqual({ error: "invalid_payload" });
+    // Confirms the whole payload was rejected -- neither the event nor any instance row was persisted.
+    expect(await instanceRow(db, "h3b")).toBeNull();
+    const signalCount = await (db as unknown as TestD1Database).prepare("SELECT COUNT(*) AS n FROM orb_signals WHERE pr_hash='h3b-p'").first<{ n: number }>();
+    expect(signalCount?.n).toBe(0);
   });
 
   it("an outcome-only ingest (no health field) never overwrites a previously-reported health status", async () => {


### PR DESCRIPTION
## Summary
- `handleOrbIngest` (added by #4933/PR #7208) only rejected a malformed `health` object when `events` was also empty — a payload carrying both real outcome events AND a malformed health field had the malformed health silently treated as absent instead of the whole payload being rejected. Masks a sender-side bug instead of surfacing it, and inconsistent with how every other field in this handler is validated (reject on malformed, never silently coerce).
- Caught in review of #4933/PR #7208, after it had already merged.
- A `health` key that IS present in the payload must now always be well-formed (`{ ok: boolean }`), regardless of whether `events` is also non-empty. An ABSENT `health` key (an older self-host build that doesn't send this field yet) is unaffected — still falls through as `healthy = null`, exactly as before.

Closes #7210

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:ci` (full local gate, unsharded) — green
- [x] New regression test: malformed `health` + non-empty `events` → `invalid_payload`, with neither the event nor the instance row persisted (confirms the whole payload was rejected, not partially processed)
- [x] 100% branch coverage on every line touched in `src/orb/ingest.ts` (verified via scoped `--coverage` run)
- [ ] UI Evidence — not applicable, no frontend change