### PR TITLE
docs(ui): publish a capacity & throughput operator doc

### DIFF
--- a/apps/loopover-ui/content/docs/capacity.mdx
+++ b/apps/loopover-ui/content/docs/capacity.mdx
@@ -1,0 +1,103 @@
+---
+title: Capacity & throughput
+description: Real, measured throughput/concurrency numbers and the configured PR-processing caps, so an operator can reason about capacity from data instead of guessing.
+---
+
+Real, measured throughput/concurrency numbers and the configured PR-processing caps, so an
+operator can reason about capacity from data instead of guessing. This is the throughput/concurrency
+counterpart to [Resource sizing](/docs/ams-sizing) (which covers CPU/RAM/disk) — it is scoped
+strictly to the numbers, the fixed caps that bound them, and where each comes from.
+
+<Callout variant="note">
+  The throughput numbers below are host-dependent — treat them as a rough sense of scale and of how
+  throughput scales with concurrency, not a hard target. Re-run the exact command below on your own
+  hardware for numbers specific to it. The configured caps, by contrast, are fixed constants in the
+  code and are the same on every deployment.
+</Callout>
+
+## Iterate-loop orchestration throughput
+
+`runIterateLoop` (`packages/loopover-engine/src/miner/iterate-loop.ts`) is the
+create → score → self-review → decide orchestrator AMS runs once per attempt. The committed
+load-test harness measures its own per-attempt orchestration/scheduling overhead under concurrent,
+multi-tenant-like load — a distinct `repoFullName`/`contributorLogin` per attempt, `concurrency`
+attempts in flight at a time — with the coding-agent driver stubbed (no real subprocess, no API
+budget) behind a fixed artificial per-iteration delay, so the numbers isolate the loop's own work
+from network latency.
+
+### Baseline (informational only, machine-dependent)
+
+Captured on a Linux x86_64 dev container, Node.js 22.23.1, 64 attempts per level, 15 ms simulated
+driver latency per iteration:
+
+<CodeBlock
+  lang="text"
+  code={`concurrency=1:    63 attempts/sec   (1023.87 ms wall, 64 attempts)
+concurrency=8:   422 attempts/sec   ( 151.74 ms wall, 64 attempts)
+concurrency=32:  982 attempts/sec   (  65.20 ms wall, 64 attempts)
+concurrency=128: 1577 attempts/sec  (  40.59 ms wall, 64 attempts)`}
+/>
+
+Throughput scales roughly linearly with concurrency up to the point where the batch size matches (or
+exceeds) the attempt count per level — at that point every attempt starts in the same tick and the
+per-attempt overhead is fully parallelized, bounded only by the simulated driver latency plus the
+loop's own synchronous work per attempt. These numbers do not change `runIterateLoop`'s own
+concurrency model; they measure the existing, already-injectable driver seam.
+
+**Reproduce it:**
+
+<CodeBlock
+  lang="bash"
+  code={`npm run loadtest:iterate-loop
+# or, from a workspace checkout, after building the engine:
+npm --workspace @loopover/engine run build
+node packages/loopover-engine/scripts/load-test-iterate-loop.mjs`}
+/>
+
+The harness prints a text report and exits `0`; it is a signal to read, not a hard CI gate (wall-clock
+timing on shared runners is too noisy to threshold on). Full methodology lives in
+`packages/loopover-engine/docs/iterate-loop-load-test.md`.
+
+## PR-processing concurrency caps
+
+Unlike the throughput baseline above, these are **fixed constants** in
+`src/settings/agent-sweep.ts` — identical on every deployment — that bound how many pull requests a
+single trigger processes, sized to stay within GitHub's REST rate-limit budget (a single GitHub App
+installation shares one ~5,000-request/hour bucket across all its repos).
+
+<FeatureRow
+  items={[
+    {
+      title: "Recurring sweep",
+      description:
+        "SWEEP_MAX_PRS = 3 PRs per sweep, re-arming every ~2 minutes (≈30 ticks/hour). Each per-PR re-review costs ~9 REST GETs, so the worst-case HOURLY cost is SWEEP_MAX_PRS × repos × 9 × 30 — a cap of 3 over 3 repos bounds that to ≈2,400/hour, well inside the shared bucket (the old cap of 25 cost ~200k/hour).",
+    },
+    {
+      title: "Issue-triggered wake",
+      description:
+        "ISSUE_WAKE_MAX_PRS = 25 PRs as a one-shot budget per issue label/assignment event (a rare trigger) — worst case ~25 × 9 ≈ 225 REST calls, staggered by the caller's delay window.",
+    },
+    {
+      title: "Merge-triggered wake",
+      description:
+        "MERGE_WAKE_MAX_PRS = 15 PRs as a one-shot budget per merge — worst case ~15 × 9 ≈ 135 REST calls. Lower than the issue budget because merges are far more common, so repeated merges inside one rate-limit window can't compound the way a 25-PR burst would.",
+    },
+  ]}
+/>
+
+**Takeaways:**
+
+- Iterate-loop orchestration is cheap relative to the coding-agent work it schedules: even at
+  concurrency 1 the loop sustains ~63 attempts/sec of its own overhead, and scales past 1,500/sec
+  as concurrency rises — real per-attempt throughput is dominated by the operator's chosen
+  coding-agent CLI, not by this orchestrator.
+- The PR-processing caps, not orchestration throughput, are the practical ceiling in production:
+  they exist to keep a single installation inside its shared ~5,000-request/hour GitHub REST bucket,
+  which is why the recurring sweep cap (3) is far below the one-shot wake budgets (15/25).
+- Adding repositories to one installation multiplies the sweep's worst-case hourly request cost
+  linearly (`× repos` in the formula above) against that fixed shared bucket — the constraint that
+  sizes the caps in the first place.
+
+See [Resource sizing](/docs/ams-sizing) for CPU/RAM/disk numbers, and the
+[AMS operations runbook](/docs/ams-operations-runbook) for operational scenarios beyond capacity
+planning.

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -81,6 +81,7 @@ export const docsNav: DocsGroup[] = [
           { to: "/docs/ams-observability", label: "Observing your miner" },
           { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
           { to: "/docs/ams-sizing", label: "Resource sizing" },
+          { to: "/docs/capacity", label: "Capacity & throughput" },
           { to: "/docs/ams-config-precedence", label: "Config precedence" },
           { to: "/docs/ams-env-reference", label: "Env var reference" },
           { to: "/docs/ams-discovery-plane", label: "Discovery plane (opt-in)" },

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -57,6 +57,7 @@ import { Route as DocsHowReviewsWorkRouteImport } from './routes/docs.how-review
 import { Route as DocsGithubAppRouteImport } from './routes/docs.github-app'
 import { Route as DocsFumadocsSpikeApiReferenceRouteImport } from './routes/docs.fumadocs-spike-api-reference'
 import { Route as DocsFederatedFleetIntelligenceRouteImport } from './routes/docs.federated-fleet-intelligence'
+import { Route as DocsCapacityRouteImport } from './routes/docs.capacity'
 import { Route as DocsBranchAnalysisRouteImport } from './routes/docs.branch-analysis'
 import { Route as DocsBetaOnboardingRouteImport } from './routes/docs.beta-onboarding'
 import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.ams-unattended-scheduling'
@@ -341,6 +342,11 @@ const DocsFederatedFleetIntelligenceRoute =
     path: '/federated-fleet-intelligence',
     getParentRoute: () => DocsRoute,
   } as any)
+const DocsCapacityRoute = DocsCapacityRouteImport.update({
+  id: '/capacity',
+  path: '/capacity',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsBranchAnalysisRoute = DocsBranchAnalysisRouteImport.update({
   id: '/branch-analysis',
   path: '/branch-analysis',
@@ -523,6 +529,7 @@ export interface FileRoutesByFullPath {
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
+  '/docs/capacity': typeof DocsCapacityRoute
   '/docs/federated-fleet-intelligence': typeof DocsFederatedFleetIntelligenceRoute
   '/docs/fumadocs-spike-api-reference': typeof DocsFumadocsSpikeApiReferenceRoute
   '/docs/github-app': typeof DocsGithubAppRoute
@@ -598,6 +605,7 @@ export interface FileRoutesByTo {
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
+  '/docs/capacity': typeof DocsCapacityRoute
   '/docs/federated-fleet-intelligence': typeof DocsFederatedFleetIntelligenceRoute
   '/docs/fumadocs-spike-api-reference': typeof DocsFumadocsSpikeApiReferenceRoute
   '/docs/github-app': typeof DocsGithubAppRoute
@@ -677,6 +685,7 @@ export interface FileRoutesById {
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
+  '/docs/capacity': typeof DocsCapacityRoute
   '/docs/federated-fleet-intelligence': typeof DocsFederatedFleetIntelligenceRoute
   '/docs/fumadocs-spike-api-reference': typeof DocsFumadocsSpikeApiReferenceRoute
   '/docs/github-app': typeof DocsGithubAppRoute
@@ -757,6 +766,7 @@ export interface FileRouteTypes {
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
+    | '/docs/capacity'
     | '/docs/federated-fleet-intelligence'
     | '/docs/fumadocs-spike-api-reference'
     | '/docs/github-app'
@@ -832,6 +842,7 @@ export interface FileRouteTypes {
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
+    | '/docs/capacity'
     | '/docs/federated-fleet-intelligence'
     | '/docs/fumadocs-spike-api-reference'
     | '/docs/github-app'
@@ -910,6 +921,7 @@ export interface FileRouteTypes {
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
+    | '/docs/capacity'
     | '/docs/federated-fleet-intelligence'
     | '/docs/fumadocs-spike-api-reference'
     | '/docs/github-app'
@@ -1303,6 +1315,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsFederatedFleetIntelligenceRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/capacity': {
+      id: '/docs/capacity'
+      path: '/capacity'
+      fullPath: '/docs/capacity'
+      preLoaderRoute: typeof DocsCapacityRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/branch-analysis': {
       id: '/docs/branch-analysis'
       path: '/branch-analysis'
@@ -1564,6 +1583,7 @@ interface DocsRouteChildren {
   DocsAmsUnattendedSchedulingRoute: typeof DocsAmsUnattendedSchedulingRoute
   DocsBetaOnboardingRoute: typeof DocsBetaOnboardingRoute
   DocsBranchAnalysisRoute: typeof DocsBranchAnalysisRoute
+  DocsCapacityRoute: typeof DocsCapacityRoute
   DocsFederatedFleetIntelligenceRoute: typeof DocsFederatedFleetIntelligenceRoute
   DocsFumadocsSpikeApiReferenceRoute: typeof DocsFumadocsSpikeApiReferenceRoute
   DocsGithubAppRoute: typeof DocsGithubAppRoute
@@ -1615,6 +1635,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAmsUnattendedSchedulingRoute: DocsAmsUnattendedSchedulingRoute,
   DocsBetaOnboardingRoute: DocsBetaOnboardingRoute,
   DocsBranchAnalysisRoute: DocsBranchAnalysisRoute,
+  DocsCapacityRoute: DocsCapacityRoute,
   DocsFederatedFleetIntelligenceRoute: DocsFederatedFleetIntelligenceRoute,
   DocsFumadocsSpikeApiReferenceRoute: DocsFumadocsSpikeApiReferenceRoute,
   DocsGithubAppRoute: DocsGithubAppRoute,

--- a/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
+++ b/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
@@ -38,14 +38,15 @@ describe("docs route Suspense fallback (#6982)", () => {
     // fumadocs-spike-api-reference.tsx is a standalone Scalar API-reference spike (#6037) that wraps
     // ClientOnly, not Suspense; docs.index.tsx is a static landing page with no MDX content and no
     // Suspense boundary; docs.tsx is the shared parent layout route, not a content page. None were
-    // part of this issue's 46-file scope.
+    // part of this issue's 46-file scope. (docs.capacity.tsx, added by #4914, follows the same
+    // LoadingState-fallback convention and is in scope, bringing the count to 47.)
     const outOfScope = new Set([
       "docs.fumadocs-spike-api-reference.tsx",
       "docs.index.tsx",
       "docs.tsx",
     ]);
     const inScope = docsRouteFiles.filter((name) => !outOfScope.has(name));
-    expect(inScope.length).toBe(46);
+    expect(inScope.length).toBe(47);
 
     for (const file of inScope) {
       const source = readFileSync(join(routesDir, file), "utf8");

--- a/apps/loopover-ui/src/routes/docs.capacity.tsx
+++ b/apps/loopover-ui/src/routes/docs.capacity.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
+import { docsClientLoader } from "@/lib/docs-client-loader";
+
+// Rendered from content/docs/capacity.mdx via fumadocs-mdx's browser entry
+// (docsClientLoader), through the existing DocsPage/Callout/CodeBlock/FeatureRow
+// primitives -- not fumadocs-ui's bundled components. Mirrors docs.ams-sizing.tsx.
+export const Route = createFileRoute("/docs/capacity")({
+  loader: async () => {
+    const { docsSource } = await import("@/lib/docs-source");
+    const page = docsSource.getPage(["capacity"]);
+    if (!page) throw notFound();
+    return { path: page.path, title: page.data.title, description: page.data.description };
+  },
+  head: () => ({
+    meta: [
+      { title: "Capacity & throughput — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "Real, measured throughput/concurrency numbers and the configured PR-processing caps, so an operator can reason about capacity from data instead of guessing.",
+      },
+      { property: "og:title", content: "Capacity & throughput — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "Real, measured throughput/concurrency numbers and the configured PR-processing caps, so an operator can reason about capacity from data instead of guessing.",
+      },
+      { property: "og:url", content: "/docs/capacity" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/capacity" }],
+  }),
+  component: Capacity,
+});
+
+function Capacity() {
+  const { path, title, description } = Route.useLoaderData();
+  const Content = docsClientLoader.getComponent(path);
+  return (
+    <DocsPage eyebrow="Maintainers" title={title} description={description}>
+      <Suspense fallback={<LoadingState />}>
+        <Content />
+      </Suspense>
+    </DocsPage>
+  );
+}

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -79,6 +79,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/ams-observability", label: "Observing your miner" },
       { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
       { to: "/docs/ams-sizing", label: "Resource sizing" },
+      { to: "/docs/capacity", label: "Capacity & throughput" },
       { to: "/docs/ams-config-precedence", label: "Config precedence" },
       { to: "/docs/ams-env-reference", label: "Env var reference" },
       { to: "/docs/ams-discovery-plane", label: "Discovery plane (opt-in)" },


### PR DESCRIPTION
Closes #4914

No user-facing doc surfaced capacity/throughput/concurrency numbers — they existed only in scattered code comments and the iterate-loop load-test harness output. This adds `/docs/capacity` as the throughput/concurrency counterpart to the existing `/docs/ams-sizing` (CPU/RAM/disk), scoped strictly to the numbers and where each comes from.

## Content (`content/docs/capacity.mdx`)
- **Iterate-loop orchestration throughput** — from the committed load-test harness (`packages/loopover-engine/docs/iterate-loop-load-test.md`, the #4913 tooling): 63 / 422 / 982 / 1577 attempts/sec at concurrency 1 / 8 / 32 / 128, with the **same host-dependent `<Callout>` caveat** `ams-sizing.mdx` uses ("rough sense of scale, not a hard target") and the exact `npm run loadtest:iterate-loop` reproduce command.
- **Fixed PR-processing concurrency caps** — from `src/settings/agent-sweep.ts`: `SWEEP_MAX_PRS=3`, `ISSUE_WAKE_MAX_PRS=25`, `MERGE_WAKE_MAX_PRS=15`, with the ~9-REST-GET-per-PR cost and shared ~5,000-req/hr installation bucket rationale that sizes them (all numbers verified against the source comments).

## Wiring (mirrors `docs.ams-sizing`)
- `src/routes/docs.capacity.tsx` route (same DocsPage + LoadingState-fallback pattern), registered in `docs-nav.tsx` and `docs.index.tsx`, routeTree regenerated.
- Bumped the `docs-routes-loading-state.test.tsx` count guard 46 → 47 (the new route follows the LoadingState convention).

## Validation
- `vite build`, `tsc --noEmit`, `eslint` (0 errors), `docs:drift-check`, `ui:version-audit` — all clean.
- Full `@loopover/ui` suite: **394 passed**. Content-only docs page (no new visual design, mirrors ams-sizing); `apps/**` is Codecov-ignored.