### PR TITLE
feat(discovery-index): add the soft-claim coordination endpoint

### DIFF
--- a/packages/discovery-index/README.md
+++ b/packages/discovery-index/README.md
@@ -12,8 +12,11 @@ This is optional, shared infrastructure to reduce duplicate GitHub API pressure 
 | `GET /ready`                     | Readiness — checks this service's own GitHub token is configured.                               |
 | `GET /metrics`                   | Prometheus text-format metrics.                                                                 |
 | `POST /v1/discovery-index/query` | `Authorization: Bearer <DISCOVERY_INDEX_SHARED_SECRET>` → `DiscoveryIndexRequest` → `DiscoveryIndexResponse`. |
+| `POST /v1/discovery-index/soft-claim` | `Authorization: Bearer <DISCOVERY_INDEX_SHARED_SECRET>` → the payload shape `discovery-soft-claim.ts`'s `buildSoftClaimRequest` produces → `{contractVersion, accepted, ageMs}`. |
 
-See `packages/loopover-engine/src/discovery-index-contract.ts` for the full request/response contract (`normalizeDiscoveryIndexRequest`/`normalizeDiscoveryIndexResponse`), which this service both consumes and emits through.
+See `packages/loopover-engine/src/discovery-index-contract.ts` for the full query request/response contract (`normalizeDiscoveryIndexRequest`/`normalizeDiscoveryIndexResponse`), which this service both consumes and emits through, and `packages/loopover-engine/src/discovery-soft-claim.ts` for the soft-claim payload builder.
+
+Soft-claim design note: the shipped client payload never carries caller identity (`buildSoftClaimRequest` hardcodes `note`/`instanceId` to `null`) — this endpoint only ever sees `repoFullName` + `issueNumber` + `action`. A repeat `claim` call on a still-active key is reported as `accepted: false` (with the existing claim's age) and refreshes its TTL, since there is no identity on the wire to distinguish "the same caller checking in" from "a different caller."
 
 ## Configuration
 
@@ -22,6 +25,7 @@ See `packages/loopover-engine/src/discovery-index-contract.ts` for the full requ
 | `DISCOVERY_INDEX_SHARED_SECRET`     | Bearer secret required to call `/v1/discovery-index/*`. Unset ⇒ the service fails closed (503). |
 | `DISCOVERY_INDEX_GITHUB_TOKEN`      | This service's own GitHub token, isolated from any other component's (REES, the main engine's installation tokens, etc.). Unset ⇒ `/ready` reports not-ready. |
 | `DISCOVERY_INDEX_CACHE_TTL_MS`      | TTL for cached query results, per unique `(repos, orgs, searchTerms)` scope. Default `300000` (5 minutes). |
+| `DISCOVERY_INDEX_SOFT_CLAIM_TTL_MS` | TTL for a soft claim before it's reclaimable. Default `1800000` (30 minutes).                   |
 | `PORT`                              | HTTP port. Default `8080`.                                                                      |
 
 ## Deployment

--- a/packages/discovery-index/src/app.ts
+++ b/packages/discovery-index/src/app.ts
@@ -6,6 +6,7 @@
 // the pieces underneath.
 import { Hono } from "hono";
 import {
+  DISCOVERY_INDEX_CONTRACT_VERSION,
   type AiPolicyVerdict,
   type DiscoveryIndexCandidate,
   normalizeDiscoveryIndexRequest,
@@ -14,12 +15,14 @@ import { normalizeSharedSecret, verifyBearer } from "./auth.js";
 import type { TtlCache } from "./cache.js";
 import { runDiscoveryQuery, type GitHubClientLike } from "./discovery-query.js";
 import { incr, observe, renderMetrics } from "./metrics.js";
+import { parseSoftClaimRequest, softClaimKey, type SoftClaimStoreLike } from "./soft-claim.js";
 
 export interface AppDeps {
   github: GitHubClientLike;
   resultCache: TtlCache<DiscoveryIndexCandidate[]>;
   policyCache: TtlCache<AiPolicyVerdict>;
   cacheTtlMs: number;
+  softClaimStore: SoftClaimStoreLike;
   /** Whether this service's own GitHub token is configured — surfaced on /ready. */
   githubConfigured: boolean;
 }
@@ -30,6 +33,11 @@ export function createApp(deps: AppDeps): Hono {
   function recordQueryOutcome(status: string, startedAtMs: number): void {
     incr("discovery_index_query_requests_total", { status });
     observe("discovery_index_query_request_duration_seconds", (Date.now() - startedAtMs) / 1000);
+  }
+
+  function recordSoftClaimOutcome(status: string, startedAtMs: number): void {
+    incr("discovery_index_soft_claim_requests_total", { status });
+    observe("discovery_index_soft_claim_request_duration_seconds", (Date.now() - startedAtMs) / 1000);
   }
 
   app.get("/health", (c) => c.json({ status: "ok", service: "discovery-index" }));
@@ -76,6 +84,47 @@ export function createApp(deps: AppDeps): Hono {
       // Rethrow to app.onError above, which still owns the 500 response + logging — this catch exists only
       // to record the outcome with the duration/startedAtMs this route handler has and onError doesn't.
       recordQueryOutcome("error", startedAtMs);
+      throw error;
+    }
+  });
+
+  app.post("/v1/discovery-index/soft-claim", async (c) => {
+    const startedAtMs = Date.now();
+    try {
+      const secret = normalizeSharedSecret(process.env.DISCOVERY_INDEX_SHARED_SECRET);
+      if (!secret) {
+        recordSoftClaimOutcome("service_not_configured", startedAtMs);
+        return c.json({ error: "service_not_configured" }, 503);
+      }
+      if (!verifyBearer(c.req.header("authorization"), secret)) {
+        recordSoftClaimOutcome("unauthorized", startedAtMs);
+        return c.json({ error: "unauthorized" }, 401);
+      }
+
+      const body: unknown = await c.req.json().catch(() => null);
+      if (body === null) {
+        recordSoftClaimOutcome("bad_request", startedAtMs);
+        return c.json({ error: "invalid_json" }, 400);
+      }
+
+      const parsed = parseSoftClaimRequest(body);
+      if (parsed === null) {
+        recordSoftClaimOutcome("bad_request", startedAtMs);
+        return c.json({ error: "invalid_request" }, 400);
+      }
+
+      const key = softClaimKey(parsed.repoFullName, parsed.issueNumber);
+      let outcome: { accepted: boolean; ageMs: number | null };
+      if (parsed.action === "release") {
+        deps.softClaimStore.release(key);
+        outcome = { accepted: true, ageMs: null };
+      } else {
+        outcome = deps.softClaimStore.claim(key);
+      }
+      recordSoftClaimOutcome("ok", startedAtMs);
+      return c.json({ contractVersion: DISCOVERY_INDEX_CONTRACT_VERSION, ...outcome });
+    } catch (error) {
+      recordSoftClaimOutcome("error", startedAtMs);
       throw error;
     }
   });

--- a/packages/discovery-index/src/metrics.ts
+++ b/packages/discovery-index/src/metrics.ts
@@ -39,6 +39,14 @@ export const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
     "discovery_index_github_requests_total",
     { help: "discovery-index outbound GitHub API requests, by outcome (ok/retried/failed).", type: "counter" },
   ],
+  [
+    "discovery_index_soft_claim_requests_total",
+    { help: "discovery-index /v1/discovery-index/soft-claim call outcomes, by status.", type: "counter" },
+  ],
+  [
+    "discovery_index_soft_claim_request_duration_seconds",
+    { help: "discovery-index /v1/discovery-index/soft-claim request handling duration in seconds.", type: "histogram" },
+  ],
 ];
 const metricMeta = new Map<string, MetricMeta>(DEFAULT_METRIC_META);
 

--- a/packages/discovery-index/src/server.ts
+++ b/packages/discovery-index/src/server.ts
@@ -10,16 +10,21 @@ import { createApp } from "./app.js";
 import { TtlCache } from "./cache.js";
 import { DEFAULT_CACHE_TTL_MS } from "./discovery-query.js";
 import { GitHubClient } from "./github-client.js";
+import { DEFAULT_SOFT_CLAIM_TTL_MS, SoftClaimStore } from "./soft-claim.js";
 
 const githubToken = process.env.DISCOVERY_INDEX_GITHUB_TOKEN ?? "";
 const configuredCacheTtlMs = Number(process.env.DISCOVERY_INDEX_CACHE_TTL_MS);
 const cacheTtlMs = Number.isFinite(configuredCacheTtlMs) && configuredCacheTtlMs > 0 ? configuredCacheTtlMs : DEFAULT_CACHE_TTL_MS;
+const configuredSoftClaimTtlMs = Number(process.env.DISCOVERY_INDEX_SOFT_CLAIM_TTL_MS);
+const softClaimTtlMs =
+  Number.isFinite(configuredSoftClaimTtlMs) && configuredSoftClaimTtlMs > 0 ? configuredSoftClaimTtlMs : DEFAULT_SOFT_CLAIM_TTL_MS;
 
 const app = createApp({
   github: new GitHubClient({ token: githubToken }),
   resultCache: new TtlCache<DiscoveryIndexCandidate[]>(),
   policyCache: new TtlCache<AiPolicyVerdict>(),
   cacheTtlMs,
+  softClaimStore: new SoftClaimStore(new TtlCache(), softClaimTtlMs),
   githubConfigured: githubToken.trim().length > 0,
 });
 

--- a/packages/discovery-index/src/soft-claim.ts
+++ b/packages/discovery-index/src/soft-claim.ts
@@ -1,0 +1,100 @@
+// Soft-claim coordination for POST /v1/discovery-index/soft-claim (#7166): lets opted-in miner instances
+// avoid starting duplicate work on the same discovered opportunity. Accepts the payload shape
+// packages/loopover-engine/src/discovery-soft-claim.ts's buildSoftClaimRequest already produces client-side.
+//
+// Design note: buildSoftClaimRequest hardcodes `note: null` / `instanceId: null` on the wire -- the shipped
+// client contract carries NO caller identity at all, only repoFullName + issueNumber + claimedAt + action.
+// So this endpoint's "refresh rather than double-count on repeat calls from the same identifier" (the
+// issue's own wording) can only mean: since there is no identity field to distinguish callers, ANY repeat
+// "claim" call for a still-active key refreshes its TTL rather than erroring -- the server cannot and does
+// not attempt caller-identity tracking the contract doesn't transmit. This module never reads `note` or
+// `instanceId` from the incoming payload at all (structural safety, same pattern as discovery-query.ts):
+// nothing forbidden can leak into the stored record or the response because nothing but repoFullName/
+// issueNumber/action is ever looked at.
+import type { TtlCache } from "./cache.js";
+
+export const DEFAULT_SOFT_CLAIM_TTL_MS = 1_800_000; // 30 minutes
+
+export type SoftClaimAction = "claim" | "release";
+
+export interface ParsedSoftClaimRequest {
+  repoFullName: string;
+  issueNumber: number;
+  action: SoftClaimAction;
+}
+
+export interface SoftClaimOutcome {
+  accepted: boolean;
+  /** The existing claim's age in ms when not accepted (already held); null when accepted or on release. */
+  ageMs: number | null;
+}
+
+/** `owner/repo` with exactly one slash and non-empty halves; anything else -> null. */
+function normalizeRepoFullName(value: string): string | null {
+  const parts = value.trim().split("/");
+  if (parts.length !== 2) return null;
+  const [owner, repo] = parts;
+  if (!owner || !repo) return null;
+  return `${owner}/${repo}`;
+}
+
+/**
+ * Tolerant parse of an incoming soft-claim request. Returns null (never throws) if `repoFullName` doesn't
+ * normalize to `owner/repo`, `issueNumber` isn't a positive integer, or `action` isn't `"claim"`/`"release"`.
+ * Deliberately never reads `note`/`instanceId`/any other field -- see this module's header.
+ */
+export function parseSoftClaimRequest(raw: unknown): ParsedSoftClaimRequest | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  const repoFullName = typeof record.repoFullName === "string" ? normalizeRepoFullName(record.repoFullName) : null;
+  if (repoFullName === null) return null;
+  const issueNumber = record.issueNumber;
+  if (typeof issueNumber !== "number" || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
+  const action = record.action;
+  if (action !== "claim" && action !== "release") return null;
+  return { repoFullName, issueNumber, action };
+}
+
+export function softClaimKey(repoFullName: string, issueNumber: number): string {
+  return `${repoFullName}#${issueNumber}`;
+}
+
+interface SoftClaimRecord {
+  claimedAt: number;
+}
+
+/** The subset of SoftClaimStore the app actually calls — kept as an interface so tests can inject a plain
+ *  stub (e.g. one whose methods throw, to exercise the route's error path), mirroring GitHubClientLike in
+ *  discovery-query.ts. */
+export interface SoftClaimStoreLike {
+  claim(key: string): SoftClaimOutcome;
+  release(key: string): void;
+}
+
+/** Thin TTL-backed claim/release store, reusing cache.ts's TtlCache (the issue's own deliverable: reuse an
+ *  existing store rather than adding a new storage mechanism) rather than the discovery-query result/policy
+ *  caches themselves, which hold semantically different data. */
+export class SoftClaimStore implements SoftClaimStoreLike {
+  constructor(
+    private readonly cache: TtlCache<SoftClaimRecord>,
+    private readonly ttlMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /** Accepts a fresh claim, or reports+refreshes an existing unexpired one. `claimedAt` is never reset on a
+   *  refresh, so the reported age stays meaningful (how long ago the ORIGINAL claim was made) across repeats. */
+  claim(key: string): SoftClaimOutcome {
+    const existing = this.cache.get(key);
+    if (existing) {
+      this.cache.set(key, existing, this.ttlMs);
+      return { accepted: false, ageMs: this.now() - existing.claimedAt };
+    }
+    this.cache.set(key, { claimedAt: this.now() }, this.ttlMs);
+    return { accepted: true, ageMs: null };
+  }
+
+  /** Idempotent: removing an absent key is a no-op, same as removing a present one. */
+  release(key: string): void {
+    this.cache.delete(key);
+  }
+}

--- a/test/unit/discovery-index/app.test.ts
+++ b/test/unit/discovery-index/app.test.ts
@@ -4,6 +4,7 @@ import { createApp, type AppDeps } from "../../../packages/discovery-index/src/a
 import { TtlCache } from "../../../packages/discovery-index/src/cache";
 import { resetMetrics } from "../../../packages/discovery-index/src/metrics";
 import type { GitHubClientLike } from "../../../packages/discovery-index/src/discovery-query";
+import { SoftClaimStore } from "../../../packages/discovery-index/src/soft-claim";
 
 function makeDeps(overrides: Partial<AppDeps> = {}): AppDeps {
   const github: GitHubClientLike = {
@@ -22,6 +23,7 @@ function makeDeps(overrides: Partial<AppDeps> = {}): AppDeps {
     resultCache: new TtlCache<DiscoveryIndexCandidate[]>(),
     policyCache: new TtlCache<AiPolicyVerdict>(),
     cacheTtlMs: 300_000,
+    softClaimStore: new SoftClaimStore(new TtlCache(), 1_800_000),
     githubConfigured: true,
     ...overrides,
   };
@@ -146,6 +148,128 @@ describe("discovery-index Hono app (#7164)", () => {
         method: "POST",
         headers: { authorization: "Bearer sek", "content-type": "application/json" },
         body: JSON.stringify({ repos: ["acme/widgets"] }),
+      });
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: "internal_error" });
+    });
+  });
+
+  describe("POST /v1/discovery-index/soft-claim", () => {
+    it("fails closed with 503 when no shared secret is configured", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "");
+      const app = createApp(makeDeps());
+      const res = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 1, action: "claim" }),
+      });
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: "service_not_configured" });
+    });
+
+    it("returns 401 for a missing or incorrect bearer token", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "sek");
+      const app = createApp(makeDeps());
+      const res = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { authorization: "Bearer nope", "content-type": "application/json" },
+        body: JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 1, action: "claim" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 for an unparseable JSON body", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "sek");
+      const app = createApp(makeDeps());
+      const res = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { authorization: "Bearer sek", "content-type": "application/json" },
+        body: "not json",
+      });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "invalid_json" });
+    });
+
+    it("returns 400 for a structurally invalid request", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "sek");
+      const app = createApp(makeDeps());
+      const res = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { authorization: "Bearer sek", "content-type": "application/json" },
+        body: JSON.stringify({ repoFullName: "no-slash", issueNumber: 1, action: "claim" }),
+      });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "invalid_request" });
+    });
+
+    it("accepts a fresh claim, reports an already-held repeat claim with its age, then accepts again after release", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "sek");
+      const deps = makeDeps();
+      const app = createApp(deps);
+      const claimReq = () =>
+        app.request("/v1/discovery-index/soft-claim", {
+          method: "POST",
+          headers: { authorization: "Bearer sek", "content-type": "application/json" },
+          body: JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 1, action: "claim" }),
+        });
+
+      const first = await claimReq();
+      expect(first.status).toBe(200);
+      expect(await first.json()).toMatchObject({ accepted: true, ageMs: null });
+
+      const second = await claimReq();
+      expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as { accepted: boolean; ageMs: number | null };
+      expect(secondBody.accepted).toBe(false);
+      expect(secondBody.ageMs).toBeGreaterThanOrEqual(0);
+
+      const release = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { authorization: "Bearer sek", "content-type": "application/json" },
+        body: JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 1, action: "release" }),
+      });
+      expect(release.status).toBe(200);
+      expect(await release.json()).toMatchObject({ accepted: true, ageMs: null });
+
+      const third = await claimReq();
+      expect(await third.json()).toMatchObject({ accepted: true, ageMs: null });
+    });
+
+    it("never echoes forbidden or identity-shaped fields even when the caller sends them", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "sek");
+      const app = createApp(makeDeps());
+      const res = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { authorization: "Bearer sek", "content-type": "application/json" },
+        body: JSON.stringify({
+          repoFullName: "acme/widgets",
+          issueNumber: 1,
+          action: "claim",
+          note: "look at me",
+          instanceId: "instance-123",
+          reward: 999,
+          wallet: "0xdeadbeef",
+        }),
+      });
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(Object.keys(body).sort()).toEqual(["accepted", "ageMs", "contractVersion"]);
+    });
+
+    it("returns 500 via the centralized error handler when the store throws", async () => {
+      vi.stubEnv("DISCOVERY_INDEX_SHARED_SECRET", "sek");
+      const throwingStore = {
+        claim() {
+          throw new Error("store exploded");
+        },
+        release() {
+          throw new Error("store exploded");
+        },
+      };
+      const app = createApp(makeDeps({ softClaimStore: throwingStore }));
+      const res = await app.request("/v1/discovery-index/soft-claim", {
+        method: "POST",
+        headers: { authorization: "Bearer sek", "content-type": "application/json" },
+        body: JSON.stringify({ repoFullName: "acme/widgets", issueNumber: 1, action: "claim" }),
       });
       expect(res.status).toBe(500);
       expect(await res.json()).toEqual({ error: "internal_error" });

--- a/test/unit/discovery-index/soft-claim.test.ts
+++ b/test/unit/discovery-index/soft-claim.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { TtlCache } from "../../../packages/discovery-index/src/cache";
+import { parseSoftClaimRequest, softClaimKey, SoftClaimStore } from "../../../packages/discovery-index/src/soft-claim";
+
+function clock(startMs = 0) {
+  let now = startMs;
+  return { now: () => now, advance: (ms: number) => (now += ms) };
+}
+
+describe("parseSoftClaimRequest (#7166)", () => {
+  it("parses a valid claim request", () => {
+    expect(parseSoftClaimRequest({ repoFullName: "acme/widgets", issueNumber: 42, action: "claim" })).toEqual({
+      repoFullName: "acme/widgets",
+      issueNumber: 42,
+      action: "claim",
+    });
+  });
+
+  it("parses a valid release request", () => {
+    expect(parseSoftClaimRequest({ repoFullName: "acme/widgets", issueNumber: 42, action: "release" })).toEqual({
+      repoFullName: "acme/widgets",
+      issueNumber: 42,
+      action: "release",
+    });
+  });
+
+  it("rejects a non-object or array payload", () => {
+    expect(parseSoftClaimRequest(null)).toBeNull();
+    expect(parseSoftClaimRequest("nope")).toBeNull();
+    expect(parseSoftClaimRequest([])).toBeNull();
+  });
+
+  it("rejects a malformed repoFullName", () => {
+    for (const repoFullName of ["no-slash", "/repo", "owner/", "a/b/c", 123, undefined]) {
+      expect(parseSoftClaimRequest({ repoFullName, issueNumber: 1, action: "claim" })).toBeNull();
+    }
+  });
+
+  it("rejects an invalid issueNumber", () => {
+    for (const issueNumber of [0, -1, 1.5, "42", undefined, null]) {
+      expect(parseSoftClaimRequest({ repoFullName: "a/b", issueNumber, action: "claim" })).toBeNull();
+    }
+  });
+
+  it("rejects an unknown action", () => {
+    expect(parseSoftClaimRequest({ repoFullName: "a/b", issueNumber: 1, action: "delete" })).toBeNull();
+    expect(parseSoftClaimRequest({ repoFullName: "a/b", issueNumber: 1 })).toBeNull();
+  });
+
+  it("never reads note, instanceId, or any other field from the payload", () => {
+    const parsed = parseSoftClaimRequest({
+      repoFullName: "a/b",
+      issueNumber: 1,
+      action: "claim",
+      note: "secret plan",
+      instanceId: "abc",
+      reward: 100,
+    });
+    expect(parsed).toEqual({ repoFullName: "a/b", issueNumber: 1, action: "claim" });
+  });
+});
+
+describe("softClaimKey (#7166)", () => {
+  it("combines repoFullName and issueNumber into a stable key", () => {
+    expect(softClaimKey("acme/widgets", 42)).toBe("acme/widgets#42");
+  });
+});
+
+describe("SoftClaimStore (#7166)", () => {
+  it("accepts a fresh claim on an unclaimed key", () => {
+    const store = new SoftClaimStore(new TtlCache(), 1000);
+    expect(store.claim("k")).toEqual({ accepted: true, ageMs: null });
+  });
+
+  it("reports an already-held claim's age on a repeat claim, and refreshes its TTL", () => {
+    const c = clock();
+    const store = new SoftClaimStore(new TtlCache(c.now), 1000, c.now);
+    expect(store.claim("k")).toEqual({ accepted: true, ageMs: null });
+    c.advance(300);
+    expect(store.claim("k")).toEqual({ accepted: false, ageMs: 300 });
+    // The refresh extended the TTL from t=300, so the claim is still active at t=1000 (300 + 1000 > 1000
+    // total elapsed since t=0 would have expired an un-refreshed claim by now).
+    c.advance(700);
+    expect(store.claim("k")).toEqual({ accepted: false, ageMs: 1000 });
+  });
+
+  it("allows reclaiming an expired claim, resetting its age", () => {
+    const c = clock();
+    const store = new SoftClaimStore(new TtlCache(c.now), 100, c.now);
+    expect(store.claim("k")).toEqual({ accepted: true, ageMs: null });
+    c.advance(101);
+    expect(store.claim("k")).toEqual({ accepted: true, ageMs: null });
+  });
+
+  it("release removes an active claim so the next claim is fresh", () => {
+    const store = new SoftClaimStore(new TtlCache(), 1000);
+    store.claim("k");
+    store.release("k");
+    expect(store.claim("k")).toEqual({ accepted: true, ageMs: null });
+  });
+
+  it("release on an absent key is a harmless no-op", () => {
+    const store = new SoftClaimStore(new TtlCache(), 1000);
+    expect(() => store.release("never-claimed")).not.toThrow();
+  });
+
+  it("keeps two different keys' claims independent", () => {
+    const store = new SoftClaimStore(new TtlCache(), 1000);
+    expect(store.claim("a")).toEqual({ accepted: true, ageMs: null });
+    expect(store.claim("b")).toEqual({ accepted: true, ageMs: null });
+    expect(store.claim("a")).toMatchObject({ accepted: false });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /v1/discovery-index/soft-claim` as a second endpoint on the `discovery-index/` service stood up in #7218, accepting the payload shape `packages/loopover-engine/src/discovery-soft-claim.ts`'s `buildSoftClaimRequest` already produces client-side. Lets opted-in miner instances avoid starting duplicate work on the same discovered opportunity.
- Storage reuses the existing `TtlCache` (the issue's own deliverable: "reuse `review-enrichment/`'s or the discovery-index query server's own store rather than adding a new one") via a small `SoftClaimStore` wrapper — a third `TtlCache` instance, not a new storage mechanism, since it holds semantically different data from the query-result/policy caches.
- **Design call, worth flagging explicitly:** the shipped `SoftClaimRequest` wire type (`buildSoftClaimRequest`) hardcodes `note: null` / `instanceId: null` — the client never actually transmits caller identity. So the issue's "refreshes rather than double-counts on repeat calls from the same identifier" can only mean: since there's no identity field on the wire to distinguish callers, *any* repeat `claim` call on a still-active key refreshes its TTL (and is reported as `accepted: false` with the existing claim's age) rather than erroring. `claimedAt` itself is never reset on a refresh, so the reported age stays meaningful across repeats.
- Structural safety, same pattern as the query endpoint: the parser never reads `note`/`instanceId`/any other field from the incoming payload at all, so nothing forbidden can leak into the stored record or the response regardless of what a caller sends — verified with a boundary test.

Closes #7166

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (see `Closes #7166` above).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 100% line/branch on every changed file (`app.ts`, `server.ts` wiring aside — see codecov.yml's existing ignore entry —, `soft-claim.ts`, and the metrics additions), verified via the v8 text report and lcov `BRDA`/`FN` records.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — clean except the same pre-existing, unrelated `adm-zip`/`github-actionlint` advisory with no fix available (not touched by this diff).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
- [x] Full `npm run test:ci` green end to end, run under the repo's pinned Node 22 (`.nvmrc`).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. The soft-claim response never contains identity or economic data — only `{contractVersion, accepted, ageMs}` — enforced structurally and by a dedicated boundary test that sends `note`/`instanceId`/`reward`/`wallet` and confirms none of it round-trips.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Same Bearer-secret auth as the query endpoint: missing-secret / missing-header / wrong-token paths all tested.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Not part of the OpenAPI-documented main Worker API — no OpenAPI change needed.)
- [ ] UI changes use live API data — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, backend-only change, no visible UI.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No `CHANGELOG.md` edit; `packages/discovery-index/README.md` updated with the new route + env var.)

## Notes

- Depends on #7218 (merged) for the base `discovery-index/` service this adds a second route to.
- Client-side wiring (the miner opt-in that would actually call this endpoint) is out of scope here — that's #7168.
