### PR TITLE
fix(portfolio): key the queue dashboard per-repo map by (apiBaseUrl, repoFullName)

### DIFF
--- a/packages/loopover-miner/lib/portfolio-dashboard.d.ts
+++ b/packages/loopover-miner/lib/portfolio-dashboard.d.ts
@@ -1,4 +1,5 @@
 export interface PortfolioRepoSummary {
+  apiBaseUrl: string;
   repoFullName: string;
   byStatus: { queued: number; in_progress: number; done: number };
   total: number;

--- a/packages/loopover-miner/lib/portfolio-dashboard.js
+++ b/packages/loopover-miner/lib/portfolio-dashboard.js
@@ -36,12 +36,17 @@ export function collectPortfolioDashboard(sources, options = {}) {
     const status = entry?.status;
     if (!QUEUE_STATUS_KEYS.includes(status)) continue;
     const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName : "";
+    // #7225: key per-repo backlogs by (apiBaseUrl, repoFullName) so two forge hosts sharing a repo name keep
+    // independent counts instead of silently merging. The composite map key uses "\n" — never valid in either
+    // component — so distinct (host, repo) pairs can never collide.
+    const apiBaseUrl = typeof entry.apiBaseUrl === "string" ? entry.apiBaseUrl : "";
     total += 1;
     byStatus[status] += 1;
-    let repo = perRepo.get(repoFullName);
+    const key = `${apiBaseUrl}\n${repoFullName}`;
+    let repo = perRepo.get(key);
     if (!repo) {
-      repo = { repoFullName, byStatus: emptyCounts(), total: 0 };
-      perRepo.set(repoFullName, repo);
+      repo = { apiBaseUrl, repoFullName, byStatus: emptyCounts(), total: 0 };
+      perRepo.set(key, repo);
     }
     repo.byStatus[status] += 1;
     repo.total += 1;
@@ -51,7 +56,9 @@ export function collectPortfolioDashboard(sources, options = {}) {
     }
   }
 
-  const repos = [...perRepo.values()].sort((left, right) => left.repoFullName.localeCompare(right.repoFullName));
+  const repos = [...perRepo.values()].sort(
+    (left, right) => left.repoFullName.localeCompare(right.repoFullName) || left.apiBaseUrl.localeCompare(right.apiBaseUrl),
+  );
   const oldestQueuedAgeMs = nowMs !== null && oldestQueuedMs !== null ? Math.max(0, nowMs - oldestQueuedMs) : null;
   return { total, byStatus, repos, oldestQueuedAgeMs };
 }
@@ -60,10 +67,11 @@ export function collectPortfolioDashboard(sources, options = {}) {
 export function renderPortfolioDashboardTable(summary) {
   if (!summary || summary.total === 0) return "portfolio queue is empty";
   const age = summary.oldestQueuedAgeMs !== null ? `  oldest-queued: ${Math.round(summary.oldestQueuedAgeMs / 60000)}m` : "";
-  const header = ["repo".padEnd(28), "queued".padStart(7), "in_prog".padStart(8), "done".padStart(6), "total".padStart(6)].join(" ");
+  const header = ["repo".padEnd(28), "host".padEnd(30), "queued".padStart(7), "in_prog".padStart(8), "done".padStart(6), "total".padStart(6)].join(" ");
   const lines = summary.repos.map((repo) =>
     [
       repo.repoFullName.padEnd(28),
+      String(repo.apiBaseUrl).padEnd(30),
       String(repo.byStatus.queued).padStart(7),
       String(repo.byStatus.in_progress).padStart(8),
       String(repo.byStatus.done).padStart(6),

--- a/packages/loopover-miner/lib/portfolio-queue-cli.js
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.js
@@ -202,6 +202,9 @@ export function renderQueueTable(entries) {
   const header = [
     "repo".padEnd(24),
     "identifier".padEnd(16),
+    // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
+    // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
+    "host".padEnd(30),
     "status".padEnd(12),
     "pri".padStart(4),
     "enqueued-at".padEnd(24),
@@ -210,6 +213,7 @@ export function renderQueueTable(entries) {
     [
       entry.repoFullName.padEnd(24),
       entry.identifier.padEnd(16),
+      display(entry.apiBaseUrl).padEnd(30),
       entry.status.padEnd(12),
       display(entry.priority).padStart(4),
       display(entry.enqueuedAt).padEnd(24),

--- a/test/unit/miner-portfolio-dashboard.test.ts
+++ b/test/unit/miner-portfolio-dashboard.test.ts
@@ -35,9 +35,29 @@ describe("collectPortfolioDashboard (#4287)", () => {
     expect(summary.total).toBe(7);
     expect(summary.byStatus).toEqual({ queued: 5, in_progress: 1, done: 1 });
     expect(summary.repos.map((r) => r.repoFullName)).toEqual(["", "acme/a", "acme/b"]); // sorted
-    expect(summary.repos.find((r) => r.repoFullName === "acme/a")).toEqual({ repoFullName: "acme/a", byStatus: { queued: 2, in_progress: 0, done: 1 }, total: 3 });
+    expect(summary.repos.find((r) => r.repoFullName === "acme/a")).toEqual({ apiBaseUrl: "", repoFullName: "acme/a", byStatus: { queued: 2, in_progress: 0, done: 1 }, total: 3 });
     // oldest queued is acme/a's 2026-07-01 → 9 days before NOW
     expect(summary.oldestQueuedAgeMs).toBe(9 * 24 * 60 * 60 * 1000);
+  });
+
+  it("keeps two forge hosts sharing a repo name as distinct, non-merged per-repo entries (#7225)", () => {
+    const summary = collectPortfolioDashboard(
+      {
+        portfolioQueue: mockQueue([
+          { apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets", status: "queued", enqueuedAt: "2026-07-01T00:00:00.000Z" },
+          { apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets", status: "queued", enqueuedAt: "2026-07-02T00:00:00.000Z" },
+          { apiBaseUrl: "https://ghe.example.com/api/v3", repoFullName: "acme/widgets", status: "done", enqueuedAt: "2026-07-03T00:00:00.000Z" },
+        ]),
+      },
+      { nowMs: NOW },
+    );
+    // Same repoFullName across two hosts → two entries, tie-broken by apiBaseUrl (github.com before ghe.example.com).
+    expect(summary.repos).toEqual([
+      { apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 },
+      { apiBaseUrl: "https://ghe.example.com/api/v3", repoFullName: "acme/widgets", byStatus: { queued: 0, in_progress: 0, done: 1 }, total: 1 },
+    ]);
+    // The two hosts' backlogs stay independent instead of collapsing into one { queued: 2, done: 1, total: 3 } entry.
+    expect(summary.total).toBe(3);
   });
 
   it("reports a null oldest-queued age when no clock is supplied, and when nothing is queued", () => {
@@ -56,12 +76,27 @@ describe("renderPortfolioDashboardTable (#4287)", () => {
   });
 
   it("renders totals, per-repo rows, and the oldest-queued age when present", () => {
-    const withAge = renderPortfolioDashboardTable({ total: 2, byStatus: { queued: 2, in_progress: 0, done: 0 }, repos: [{ repoFullName: "acme/a", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 }], oldestQueuedAgeMs: 3_600_000 });
+    const withAge = renderPortfolioDashboardTable({ total: 2, byStatus: { queued: 2, in_progress: 0, done: 0 }, repos: [{ apiBaseUrl: "https://api.github.com", repoFullName: "acme/a", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 }], oldestQueuedAgeMs: 3_600_000 });
     expect(withAge).toContain("total: 2");
     expect(withAge).toContain("oldest-queued: 60m");
     expect(withAge).toContain("acme/a");
-    const noAge = renderPortfolioDashboardTable({ total: 1, byStatus: { queued: 0, in_progress: 1, done: 0 }, repos: [{ repoFullName: "acme/a", byStatus: { queued: 0, in_progress: 1, done: 0 }, total: 1 }], oldestQueuedAgeMs: null });
+    const noAge = renderPortfolioDashboardTable({ total: 1, byStatus: { queued: 0, in_progress: 1, done: 0 }, repos: [{ apiBaseUrl: "https://api.github.com", repoFullName: "acme/a", byStatus: { queued: 0, in_progress: 1, done: 0 }, total: 1 }], oldestQueuedAgeMs: null });
     expect(noAge).not.toContain("oldest-queued");
+  });
+
+  it("shows a host column so two same-named repos on different forge hosts are distinguishable (#7225)", () => {
+    const table = renderPortfolioDashboardTable({
+      total: 2,
+      byStatus: { queued: 2, in_progress: 0, done: 0 },
+      repos: [
+        { apiBaseUrl: "https://api.github.com", repoFullName: "acme/widgets", byStatus: { queued: 1, in_progress: 0, done: 0 }, total: 1 },
+        { apiBaseUrl: "https://ghe.example.com/api/v3", repoFullName: "acme/widgets", byStatus: { queued: 1, in_progress: 0, done: 0 }, total: 1 },
+      ],
+      oldestQueuedAgeMs: null,
+    });
+    expect(table).toContain("host");
+    expect(table).toContain("https://api.github.com");
+    expect(table).toContain("https://ghe.example.com/api/v3");
   });
 });
 

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -78,6 +78,32 @@ describe("loopover-miner portfolio queue CLI (#2292)", () => {
     expect(renderQueueTable(entries)).toContain("issue:7");
   });
 
+  it("renderQueueTable distinguishes two same-repo/identifier rows on different forge hosts (#7225)", () => {
+    const entries: QueueEntry[] = [
+      {
+        apiBaseUrl: "https://api.github.com",
+        repoFullName: "acme/widgets",
+        identifier: "issue:1",
+        status: "queued",
+        priority: 10,
+        enqueuedAt: "2026-07-04T12:00:00.000Z",
+      },
+      {
+        apiBaseUrl: "https://ghe.example.com/api/v3",
+        repoFullName: "acme/widgets",
+        identifier: "issue:1",
+        status: "in_progress",
+        priority: 10,
+        enqueuedAt: "2026-07-04T12:00:00.000Z",
+      },
+    ];
+    const table = renderQueueTable(entries);
+    // Both rows share repo+identifier, so only the host column tells them apart for a `--api-base-url` follow-up.
+    expect(table).toContain("host");
+    expect(table).toContain("https://api.github.com");
+    expect(table).toContain("https://ghe.example.com/api/v3");
+  });
+
   it("runQueueList prints table and JSON output", () => {
     const portfolioQueue = tempQueueStore();
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });


### PR DESCRIPTION
fix(portfolio): key the queue dashboard per-repo map by (apiBaseUrl, repoFullName)

collectPortfolioDashboard grouped queue rows into perRepo keyed purely by
repoFullName, so two forge hosts sharing a repo name (e.g. the same repo on
api.github.com and a self-hosted GHE) had their independent backlogs silently
merged into one entry with summed counts — a data-loss bug the --json output
couldn't recover either, since the host was discarded before either output
format saw it.

Key perRepo by the composite (apiBaseUrl, repoFullName) and carry apiBaseUrl
on each repo entry so the two hosts stay separate with correct, non-merged
counts. renderPortfolioDashboardTable gains a host column, and renderQueueTable
gains one too so a reader of `queue list`'s plain-text output can supply the
--api-base-url a follow-up done/release/requeue needs to disambiguate two rows
sharing a repo+identifier across hosts. Single-host installs render identically
modulo the new column/field.

Closes #7225

