### PR TITLE
fix(miner): size-guard cross-repo manifest by UTF-8 bytes, not UTF-16 length (#7223)

### DIFF
--- a/packages/loopover-miner/lib/cross-repo-evaluation.js
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.js
@@ -33,6 +33,23 @@ export const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH = "benchmarks/cross-repo/
 export const MAX_CROSS_REPO_MANIFEST_BYTES = 65_536;
 export const MAX_CROSS_REPO_MANIFEST_REPOS = 100;
 
+// True UTF-8 byte count for the size guard (#7223): JS string `.length` is UTF-16 code units, which under-counts
+// any multi-byte character (up to 4x for astral-plane code points), so `MAX_CROSS_REPO_MANIFEST_BYTES` -- named
+// and warned about in BYTES -- was actually being compared against a code-unit count. Mirrors the identical helper
+// in the three siblings this parser's own comment claims to follow: fleet-run-manifest.ts, miner-goal-spec.ts,
+// and ams-policy-spec.ts.
+function utf8ByteLength(value) {
+  let bytes = 0;
+  for (const char of value) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint <= 0x7f) bytes += 1;
+    else if (codePoint <= 0x7ff) bytes += 2;
+    else if (codePoint <= 0xffff) bytes += 3;
+    else bytes += 4;
+  }
+  return bytes;
+}
+
 function cloneEmptyManifest(warnings = []) {
   return { present: false, manifest: { repos: [] }, warnings };
 }
@@ -125,7 +142,7 @@ export function parseCrossRepoEvaluationManifest(content) {
   }
   const trimmed = content.trim();
   if (!trimmed) return cloneEmptyManifest();
-  if (trimmed.length > MAX_CROSS_REPO_MANIFEST_BYTES) {
+  if (utf8ByteLength(trimmed) > MAX_CROSS_REPO_MANIFEST_BYTES) {
     return cloneEmptyManifest([
       `CrossRepoEvaluationManifest exceeded ${MAX_CROSS_REPO_MANIFEST_BYTES} bytes; ignoring the file.`,
     ]);

--- a/test/unit/miner-cross-repo-evaluation.test.ts
+++ b/test/unit/miner-cross-repo-evaluation.test.ts
@@ -86,6 +86,22 @@ describe("cross-repo evaluation harness (#4788)", () => {
       expect(parsed.warnings[0]).toContain("exceeded");
     });
 
+    it("measures the size guard in true UTF-8 bytes, not UTF-16 code units (#7223)", () => {
+      // A small manifest carrying all four code-point widths — 1-byte 'a', 2-byte 'é', 3-byte '中', 4-byte '😀' —
+      // stays well under the cap and parses normally (exercises every branch of the byte counter).
+      const mixed = parseCrossRepoEvaluationManifest('{"repos":[],"note":"aé中😀"}');
+      expect(mixed.warnings.some((warning) => warning.includes("exceeded"))).toBe(false);
+      expect(mixed.present).toBe(true);
+
+      // 25,000 three-byte characters: UTF-16 `.length` is 25,000 (under the cap) but the real UTF-8 size is
+      // 75,000 bytes (over it). The old code-unit guard wrongly admitted this; the byte guard rejects it up front.
+      const oversizeByBytes = "中".repeat(25_000);
+      expect(oversizeByBytes.length).toBeLessThanOrEqual(MAX_CROSS_REPO_MANIFEST_BYTES);
+      const parsed = parseCrossRepoEvaluationManifest(oversizeByBytes);
+      expect(parsed.present).toBe(false);
+      expect(parsed.warnings[0]).toContain("exceeded");
+    });
+
     it("normalizes string and object repo entries and skips invalid duplicates", () => {
       const parsed = parseCrossRepoEvaluationManifest(
         JSON.stringify({


### PR DESCRIPTION
## Summary

`parseCrossRepoEvaluationManifest`'s size guard compared `trimmed.length` — JS `String.prototype.length`,
which counts **UTF-16 code units** — against `MAX_CROSS_REPO_MANIFEST_BYTES`, a constant named (and whose
warning message reads) in **bytes**. Because `.length` under-counts the true UTF-8 size of any multi-byte
character (up to 4× for astral-plane code points), a manifest whose real byte size is well over the cap could
slip past the guard (then fail later as invalid JSON), and the guard's byte accounting was simply wrong.

This adds a local `utf8ByteLength` helper and measures the guard against it — mirroring the identical helper
in the three siblings this parser's own doc comment says it follows: `fleet-run-manifest.ts`,
`miner-goal-spec.ts`, and `ams-policy-spec.ts`. No other behavior changes; an all-ASCII manifest (every
existing case) is counted identically.

Closes #7223

## Scope

- [x] Conventional Commit title; focused (one module + its test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7223`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` on the changed module — **100% of the changed lines AND branches covered**: the
      new byte counter is exercised across all four code-point widths (1/2/3/4-byte), plus a regression asserting
      a manifest whose UTF-16 length is under the cap but whose UTF-8 size (25,000 × 3-byte chars = 75,000 bytes)
      is over it is now rejected up front. Existing all-ASCII oversize test still passes unchanged.
- [x] `npm run build:miner` (`node --check` passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**` (one module + its test); frontend/unrelated jobs
  touch nothing changed here. CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — a pure internal size-accounting fix.
- [x] No UI change — no UI Evidence needed.
