### PR TITLE
fix(miner): order pr-outcome map by event recency so disengagement streaks are correct (#7222)

### DIFF
--- a/packages/loopover-miner/lib/pr-outcome.js
+++ b/packages/loopover-miner/lib/pr-outcome.js
@@ -84,7 +84,14 @@ export function readPrOutcomes(eventLedger, filter = {}) {
     if (typeof event.repoFullName !== "string" || !event.repoFullName.trim()) continue;
     const normalized = normalizePrOutcomePayload(event.payload);
     if (!normalized) continue;
-    latest.set(`${event.repoFullName}:${normalized.prNumber}`, { ...normalized, repoFullName: event.repoFullName });
+    // Re-key on every event so Map iteration order tracks most-recently-UPDATED last, not first-seen (#7222). A
+    // bare Map.set() on an existing key updates the value but leaves the key frozen at its original position, so a
+    // later outcome for the same PR (e.g. closed-without-merge, then reopened + merged) stayed at its old slot --
+    // breaking recency-ordered consumers like loop-reentry.js's countConsecutiveDisengagements. Deleting first
+    // moves the freshly-updated entry to the end, matching this reducer's own "a later event supersedes" contract.
+    const key = `${event.repoFullName}:${normalized.prNumber}`;
+    latest.delete(key);
+    latest.set(key, { ...normalized, repoFullName: event.repoFullName });
   }
   return latest;
 }

--- a/test/unit/miner-loop-reentry.test.ts
+++ b/test/unit/miner-loop-reentry.test.ts
@@ -112,6 +112,18 @@ describe("attemptLoopReentry (#2338)", () => {
     expect(countConsecutiveDisengagements(eventLedger, "acme/widgets")).toBe(0);
   });
 
+  it("orders by true event recency: a later merged outcome for an EARLIER PR number resets the streak (#7222)", () => {
+    const eventLedger = tempEventLedger();
+    // PR 1 closed, PR 2 closed, then PR 1 is reopened and MERGED — a second, later outcome for the same PR number.
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 1, decision: "closed", closedAt: new Date().toISOString(), reason: "stale" }, { eventLedger });
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 2, decision: "closed", closedAt: new Date().toISOString(), reason: "stale" }, { eventLedger });
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 1, decision: "merged", closedAt: new Date().toISOString() }, { eventLedger });
+
+    // The most recent event is PR 1's merge, so the consecutive-disengagement streak is 0. Before #7222, the
+    // superseded PR 1 stayed frozen at its first-seen Map slot, so the backward walk mis-counted it as 1.
+    expect(countConsecutiveDisengagements(eventLedger, "acme/widgets")).toBe(0);
+  });
+
   it("the hourly rate cap suppresses re-entry independent of the per-repo circuit breaker, and does not move the run-state or dequeue", () => {
     const eventLedger = tempEventLedger();
     const portfolioQueue = tempPortfolioQueue();


### PR DESCRIPTION
## Summary

`loop-reentry.js`'s `countConsecutiveDisengagements` walks backward from the end of
`readPrOutcomes(...).values()`, treating array order as event recency. But `pr-outcome.js`'s
`readPrOutcomes` builds a `Map` keyed by `repoFullName:prNumber`, and a bare `Map.set()` on an
already-present key updates its *value* while leaving the key frozen at its first-seen iteration
position. So once the same PR gets a second, later outcome — a real case: a PR closed-without-merge,
then reopened and merged, which `pr-disposition-poller.js` re-polls and re-records — that entry stayed
at its *old* slot even though its value was now the *newest*. The backward walk then mis-counted a
resolved streak (e.g. reported 1 consecutive disengagement when the most recent event was actually a
merge, which should reset the streak to 0), wrongly pausing re-entry for the repo.

This applies the issue's suggested minimal fix: `readPrOutcomes` now `delete`s the key immediately
before `set`ting it, so Map iteration order always reflects **most-recently-updated last** — matching
the reducer's own documented "a later event supersedes an earlier one" contract — without changing its
public `Map` shape. The only other consumer, `orb-export.js`'s `buildAnonymizedOrbBatch`, sorts its own
output by `prHash` independently of input order, so it is unaffected (confirmed by its existing suite).

Closes #7222

## Scope

- [x] Conventional Commit title; focused (one module + one test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7222`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` on the changed module — **100% of the changed lines covered**. New regression in
      `miner-loop-reentry.test.ts`: PR 1 closed, PR 2 closed, then PR 1 reopened+merged (a later event for the
      same PR number) now yields a streak of 0; it returned 1 before the fix. `miner-pr-outcome` and
      `miner-orb-export` suites pass unchanged (the other consumer is order-independent).
- [x] `npm run build:miner` (`node --check` passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**` (one module + one test); CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — a pure internal ordering fix; `readPrOutcomes`'s shape is unchanged.
- [x] No UI change — no UI Evidence needed.
