### PR TITLE
fix(ranker): only flag default-goal-spec use when every ranked repo lacks one (#7226)

### DIFF
--- a/packages/loopover-miner/lib/opportunity-ranker.js
+++ b/packages/loopover-miner/lib/opportunity-ranker.js
@@ -91,7 +91,11 @@ function rankedUsesDefaultGoalSpec(ranked, options = {}) {
   const goalSpecsByRepo = buildGoalSpecsByRepo(options);
   const specRepos = Object.keys(goalSpecsByRepo);
   if (ranked.length === 0) return specRepos.length === 0;
-  return ranked.some((issue) => {
+  // The "ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)" note is only
+  // truthful when the WHOLE batch fell back to the default -- so require EVERY ranked repo to lack a supplied spec,
+  // not just any one of them (#7226). With `.some`, a single spec-less repo made a mixed batch (where other repos
+  // genuinely had a spec supplied and applied) print the blanket note as if none did.
+  return ranked.every((issue) => {
     const target = issue.repoFullName.trim().toLowerCase();
     return !specRepos.some((repo) => repo.trim().toLowerCase() === target);
   });

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -106,6 +106,24 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     expect(summary.usedDefaultGoalSpec).toBe(false);
   });
 
+  it("does not report a blanket default-goal-spec note when only SOME ranked repos lack a spec (#7226)", () => {
+    const summary = rankCandidateIssuesWithSummary(
+      [
+        rawIssue({ repo: "widgets", repoFullName: "acme/widgets", issueNumber: 1 }),
+        rawIssue({ repo: "gadgets", repoFullName: "acme/gadgets", issueNumber: 2 }),
+      ],
+      {
+        nowMs: NOW,
+        // Only acme/widgets has a per-tenant spec supplied+applied; acme/gadgets falls back to the default.
+        goalSpecContentByRepo: { "acme/widgets": "minerEnabled: true\npreferredLabels: [help wanted]\n" },
+      },
+    );
+    // Both repos are ranked and one genuinely used a supplied spec, so the batch is NOT "all default" —
+    // the blanket "no per-tenant .loopover-miner.yml supplied" note must NOT fire. Before #7226 this was `true`.
+    expect(summary.issues).toHaveLength(2);
+    expect(summary.usedDefaultGoalSpec).toBe(false);
+  });
+
   it("raises dupRisk when repo-level contention inputs are provided", () => {
     const calm = rankCandidateIssues([rawIssue()], { nowMs: NOW, highRiskDuplicateClusters: 0, openPullRequests: 4 });
     const busy = rankCandidateIssues([rawIssue()], { nowMs: NOW, highRiskDuplicateClusters: 4, openPullRequests: 4 });


### PR DESCRIPTION
## Summary

`rankedUsesDefaultGoalSpec` (`opportunity-ranker.js`) decided whether a ranked batch fell back to the
built-in default goal spec with `ranked.some(repo lacks a supplied spec)` — so it returned `true` the
moment **any** ranked repo lacked a per-tenant spec, even when other repos in the same batch genuinely
had one supplied and applied. `discover-cli.js` then printed the blanket note *"ranked with the built-in
default goal spec (no per-tenant `.loopover-miner.yml` supplied)"* for the whole run, misreporting a
mixed batch as fully-default.

The note is only truthful when the **entire** batch fell back to the default, so this changes `.some`
to `.every`: `usedDefaultGoalSpec` is now `true` only when every ranked repo lacks a supplied spec. The
existing empty-batch guard (`ranked.length === 0 → specRepos.length === 0`) is unchanged, so `.every`'s
vacuous-true case is never reached. All-default and all-supplied batches behave exactly as before; only
the mixed case is corrected.

Closes #7226

## Scope

- [x] Conventional Commit title; focused (one module + one test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7226`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` on the changed module — **100% of the changed line + branches covered**. New
      regression: a two-repo batch where only `acme/widgets` has a supplied spec (and `acme/gadgets` does not)
      now yields `usedDefaultGoalSpec: false`; it was `true` before the fix. Existing all-default (`true`) and
      all-supplied (`false`) cases still pass unchanged.
- [x] `npm run build:miner` (`node --check` passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**` (one module + one test); CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — a pure reporting-accuracy fix; the return type is unchanged.
- [x] No UI change — no UI Evidence needed.
