### PR TITLE
fix(miner-ui): auto-scroll the chat rail to new and streaming messages

### DIFF
--- a/apps/loopover-miner-ui/src/chat-conversation.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-conversation.test.tsx
@@ -193,4 +193,32 @@ describe("ChatConversation (#6518)", () => {
     expect(handlePortfolioQueueChatCommandImpl).not.toHaveBeenCalled();
     expect(seen[0]).toEqual([{ role: "user", content: "what is stuck?" }]);
   });
+
+  it("REGRESSION (#7229): auto-scrolls the viewport as streamed chunks accumulate, unless scrolled up", async () => {
+    const gate = deferred();
+    const streamChatImpl = async function* (_messages: ChatWireMessage[]) {
+      yield "Hel";
+      await gate.promise;
+      yield "lo";
+    };
+    const { container } = render(<ChatConversation streamChatImpl={streamChatImpl} />);
+    const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]")!;
+    // jsdom does not lay out; fake an overflowing viewport so the scroll side effect is observable.
+    Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: 1000 });
+    Object.defineProperty(viewport, "clientHeight", { configurable: true, value: 200 });
+
+    ask("hi");
+
+    // The first streamed chunk paints StreamingText inside the viewport footer -> the follow pins to bottom.
+    await waitFor(() => expect(screen.getByText("Hel")).toBeTruthy());
+    await waitFor(() => expect(viewport.scrollTop).toBe(1000));
+
+    // The operator scrolls up mid-stream: the remaining chunks (and the committed answer) must not yank down.
+    viewport.scrollTop = 0;
+    viewport.dispatchEvent(new Event("scroll"));
+    gate.resolve();
+
+    await waitFor(() => expect(screen.getByText("Hello")).toBeTruthy());
+    expect(viewport.scrollTop).toBe(0);
+  });
 });

--- a/apps/loopover-miner-ui/src/chat-message-components.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-message-components.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MessageList } from "./components/chat/message-list";
 import { MessageBubble } from "./components/chat/message-bubble";
@@ -83,6 +83,68 @@ describe("MessageList (#7081) — message list is a polite live region for compl
     render(<MessageList messages={emptyConversation} isLoading />);
     expect(screen.getByText(/Loading conversation/i)).toBeTruthy();
     expect(screen.queryByRole("list")).toBeNull();
+  });
+});
+
+describe("MessageList (#7229) — auto-follow the newest content", () => {
+  const line = (id: string, content: string): ChatMessage => ({
+    id,
+    role: "assistant",
+    content,
+    timestamp: "2026-07-16T08:00:00.000Z",
+  });
+
+  // jsdom does not lay out; scrollHeight/clientHeight default to 0. Fake an overflowing viewport so the
+  // scroll-position side effect is observable (scrollTop is a real writable/readable property in jsdom).
+  function fakeOverflow(viewport: HTMLElement, scrollHeight = 1000, clientHeight = 200): void {
+    Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: scrollHeight });
+    Object.defineProperty(viewport, "clientHeight", { configurable: true, value: clientHeight });
+  }
+
+  const viewportOf = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]")!;
+
+  it("scrolls to the bottom when a new message is committed and the reader is at the bottom", async () => {
+    const initial = [line("a1", "one"), line("a2", "two")];
+    const { container, rerender } = render(<MessageList messages={initial} />);
+    const viewport = viewportOf(container);
+    fakeOverflow(viewport);
+
+    rerender(<MessageList messages={[...initial, line("a3", "three")]} />);
+
+    await waitFor(() => expect(viewport.scrollTop).toBe(1000));
+  });
+
+  it("leaves the scroll position alone when the reader has scrolled up (#7229)", async () => {
+    const initial = [line("a1", "one"), line("a2", "two")];
+    const { container, rerender } = render(<MessageList messages={initial} />);
+    const viewport = viewportOf(container);
+    fakeOverflow(viewport);
+
+    // The operator scrolls up to re-read history: a following message must not yank them back down.
+    viewport.scrollTop = 0;
+    viewport.dispatchEvent(new Event("scroll"));
+
+    rerender(<MessageList messages={[...initial, line("a3", "three")]} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  it("follows a growing footer (the live streaming render) while pinned to the bottom", async () => {
+    const initial = [line("a1", "one")];
+    const { container, rerender } = render(<MessageList messages={initial} />);
+    const viewport = viewportOf(container);
+    fakeOverflow(viewport);
+
+    // A streaming footer whose text keeps growing is the second trigger the same follow mechanism covers.
+    rerender(<MessageList messages={initial} footer={<p data-testid="stream">partial</p>} />);
+    await waitFor(() => expect(viewport.scrollTop).toBe(1000));
+
+    viewport.scrollTop = 0;
+    rerender(<MessageList messages={initial} footer={<p data-testid="stream">partial answer</p>} />);
+    await waitFor(() => expect(viewport.scrollTop).toBe(1000));
+    expect(screen.getByTestId("stream").textContent).toBe("partial answer");
   });
 });
 

--- a/apps/loopover-miner-ui/src/components/chat/conversation.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/conversation.tsx
@@ -191,18 +191,29 @@ export function ChatConversation({
     <div className="flex h-full flex-col gap-2 p-4">
       <p className="font-mono text-token-xs uppercase tracking-[0.2em] text-primary">Chat</p>
       <div className="min-h-0 flex-1 overflow-hidden">
-        <MessageList messages={messages} composing={streaming && awaitingFirstChunk} />
-        {streaming && activeSource ? (
-          <div className="flex gap-3 px-3 pt-4" data-testid="chat-streaming-response">
-            <Avatar className="size-8 shrink-0">
-              <AvatarFallback>{ASSISTANT_NAME.slice(0, 2).toUpperCase()}</AvatarFallback>
-            </Avatar>
-            <StreamingText
-              source={activeSource}
-              className="min-w-0 whitespace-pre-wrap break-words rounded-token-sm bg-muted px-3 py-2 text-token-sm text-foreground"
-            />
-          </div>
-        ) : null}
+        {/*
+          #7229: the live streaming render goes through MessageList's `footer` so it sits INSIDE the same
+          scrollable viewport as the committed messages (still outside the #7081 aria-live `<ol>`). That lets
+          MessageList's auto-follow keep the accumulating answer pinned to the bottom as tokens arrive, the
+          same way it follows a newly-committed message.
+        */}
+        <MessageList
+          messages={messages}
+          composing={streaming && awaitingFirstChunk}
+          footer={
+            streaming && activeSource ? (
+              <div className="flex gap-3 px-3 pt-4" data-testid="chat-streaming-response">
+                <Avatar className="size-8 shrink-0">
+                  <AvatarFallback>{ASSISTANT_NAME.slice(0, 2).toUpperCase()}</AvatarFallback>
+                </Avatar>
+                <StreamingText
+                  source={activeSource}
+                  className="min-w-0 whitespace-pre-wrap break-words rounded-token-sm bg-muted px-3 py-2 text-token-sm text-foreground"
+                />
+              </div>
+            ) : null
+          }
+        />
       </div>
       <ChatComposer onSubmit={handleSubmit} disabled={streaming} />
     </div>

--- a/apps/loopover-miner-ui/src/components/chat/message-list.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/message-list.tsx
@@ -1,26 +1,39 @@
+import { useRef, type ReactNode } from "react";
+
 import { ScrollArea } from "@loopover/ui-kit/components/scroll-area";
 import { StateBoundary } from "@loopover/ui-kit/components/state-views";
 import { MessageBubble } from "./message-bubble";
 import { TypingIndicator } from "./typing-indicator";
 import type { ChatMessage } from "./fixtures";
+import { useStickToBottom } from "@/lib/use-stick-to-bottom";
 
 // The scrollable message list for the chat rail (#6515). Backend-agnostic: it renders whatever message
 // array it's given, wrapping the content in ui-kit's StateBoundary for its own loading/empty/error states
 // and using ui-kit's ScrollArea (not a raw overflow div) for the viewport. The composing flag surfaces the
 // TypingIndicator below the list regardless of the message-array state.
+//
+// #7229: the ScrollArea auto-follows its newest content (a committed message, or the live streaming answer
+// passed in via `footer`) via useStickToBottom, so a growing conversation stays in view without a manual
+// scroll — unless the operator has scrolled up, in which case their position is left alone. `footer` renders
+// inside the same scrollable viewport (but outside the #7081 aria-live `<ol>`) so the streaming render grows
+// the viewport the same way a committed message does, and the one follow mechanism covers both.
 export function MessageList({
   messages,
   isLoading = false,
   isError = false,
   composing = false,
+  footer,
 }: {
   messages: ChatMessage[];
   isLoading?: boolean;
   isError?: boolean;
   composing?: boolean;
+  footer?: ReactNode;
 }) {
+  const scrollRootRef = useRef<HTMLDivElement>(null);
+  useStickToBottom(scrollRootRef);
   return (
-    <ScrollArea className="h-full">
+    <ScrollArea ref={scrollRootRef} className="h-full">
       <StateBoundary
         isLoading={isLoading}
         isError={isError}
@@ -35,8 +48,8 @@ export function MessageList({
           #7081: the message list is a polite ARIA live region so assistive tech announces each completed turn
           even when the user has moved focus out of the list. `messages` gains a committed entry exactly once per
           turn — conversation.tsx appends the finished answer only after StreamingText's per-chunk accumulation
-          resolves, never mid-stream, and the live StreamingText render lives OUTSIDE this list — so each new
-          message announces once, never once-per-streaming-chunk. `aria-relevant="additions"` keeps it to newly
+          resolves, never mid-stream, and the live StreamingText render lives OUTSIDE this `<ol>` (it comes in via
+          `footer`, below) — so each new message announces once, never once-per-streaming-chunk. `aria-relevant="additions"` keeps it to newly
           appended messages; StateBoundary's own loading/empty/error status/alert regions are separate and
           untouched (an added message can't reach here in those branches anyway).
         */}
@@ -49,6 +62,7 @@ export function MessageList({
         </ol>
       </StateBoundary>
       {composing ? <TypingIndicator composing authorName="Assistant" /> : null}
+      {footer}
     </ScrollArea>
   );
 }

--- a/apps/loopover-miner-ui/src/lib/use-stick-to-bottom.ts
+++ b/apps/loopover-miner-ui/src/lib/use-stick-to-bottom.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+/** Within this many px of the bottom still counts as "at the bottom" for the auto-follow (#7229). */
+export const STICK_TO_BOTTOM_THRESHOLD_PX = 24;
+
+function isNearBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.clientHeight - el.scrollTop <= STICK_TO_BOTTOM_THRESHOLD_PX;
+}
+
+/**
+ * Keep a ui-kit `ScrollArea` pinned to its newest content as that content grows — but only while the operator
+ * is already at (or within {@link STICK_TO_BOTTOM_THRESHOLD_PX} of) the bottom. If they scroll up to re-read
+ * history, the auto-follow suppresses itself until they return to the bottom, the well-worn chat-rail pattern
+ * (#7229): a new committed message or a live streaming answer must never yank a deliberately-scrolled reader
+ * back down.
+ *
+ * `rootRef` points at the `ScrollArea` *Root* (what its `ref` forwards to). The actual scrollable node is Radix's
+ * viewport, resolved here via the `[data-radix-scroll-area-viewport]` attribute the primitive sets — so this never
+ * depends on the shared ui-kit component exposing a viewport ref of its own.
+ */
+export function useStickToBottom(rootRef: RefObject<HTMLElement | null>): void {
+  // Was the viewport at the bottom just *before* the latest content mutation? Seeded true so an already-
+  // overflowing conversation opens scrolled to the newest turn; recomputed on every scroll so that once the
+  // operator scrolls up the follow stays suppressed until they scroll back down.
+  const pinnedRef = useRef(true);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const viewport = root.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    if (!viewport) return;
+
+    const onScroll = () => {
+      pinnedRef.current = isNearBottom(viewport);
+    };
+    viewport.addEventListener("scroll", onScroll, { passive: true });
+
+    const followIfPinned = () => {
+      if (pinnedRef.current) viewport.scrollTop = viewport.scrollHeight;
+    };
+
+    // One observer covers both triggers: a committed message adds an <li> (childList) and a streaming chunk
+    // rewrites StreamingText's text (characterData) — both are mutations under the viewport, so neither the
+    // new-message case nor the live-streaming case is special-cased.
+    const observer = new MutationObserver(followIfPinned);
+    observer.observe(viewport, { childList: true, subtree: true, characterData: true });
+
+    // Snap to the bottom once on mount so a conversation that is already past the fold opens on its newest turn.
+    followIfPinned();
+
+    return () => {
+      viewport.removeEventListener("scroll", onScroll);
+      observer.disconnect();
+    };
+  }, [rootRef]);
+}

--- a/apps/loopover-miner-ui/src/use-stick-to-bottom.test.ts
+++ b/apps/loopover-miner-ui/src/use-stick-to-bottom.test.ts
@@ -1,0 +1,110 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { STICK_TO_BOTTOM_THRESHOLD_PX, useStickToBottom } from "./lib/use-stick-to-bottom";
+
+// A minimal stand-in for ui-kit's ScrollArea DOM: a Root wrapping the Radix viewport node (the one carrying
+// the `[data-radix-scroll-area-viewport]` attribute the hook resolves against) wrapping a content node.
+function makeScrollArea(): { root: HTMLDivElement; viewport: HTMLDivElement; content: HTMLDivElement } {
+  const root = document.createElement("div");
+  const viewport = document.createElement("div");
+  viewport.setAttribute("data-radix-scroll-area-viewport", "");
+  const content = document.createElement("div");
+  viewport.appendChild(content);
+  root.appendChild(viewport);
+  document.body.appendChild(root);
+  return { root, viewport, content };
+}
+
+// jsdom does not lay out, so scrollHeight/clientHeight are 0 unless overridden; scrollTop is a real
+// writable/readable property (unclamped), which is what the hook writes and the assertions read.
+function setDims(el: HTMLElement, scrollHeight: number, clientHeight: number): void {
+  Object.defineProperty(el, "scrollHeight", { configurable: true, value: scrollHeight });
+  Object.defineProperty(el, "clientHeight", { configurable: true, value: clientHeight });
+}
+
+/** Flush the MutationObserver microtask so its follow callback has run. */
+const flushObserver = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function grow(viewport: HTMLElement): void {
+  viewport.appendChild(document.createElement("p"));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useStickToBottom (#7229)", () => {
+  it("follows content to the bottom when the viewport is already at the bottom", async () => {
+    const { root, viewport } = makeScrollArea();
+    renderHook(() => useStickToBottom({ current: root }));
+    setDims(viewport, 1000, 200);
+
+    grow(viewport);
+    await flushObserver();
+
+    expect(viewport.scrollTop).toBe(1000);
+  });
+
+  it("does NOT follow when the operator has scrolled up to read history", async () => {
+    const { root, viewport } = makeScrollArea();
+    renderHook(() => useStickToBottom({ current: root }));
+    setDims(viewport, 1000, 200);
+
+    // Scroll well away from the bottom (gap 800 > threshold) and announce it — the follow must now stay off.
+    viewport.scrollTop = 0;
+    viewport.dispatchEvent(new Event("scroll"));
+
+    grow(viewport);
+    await flushObserver();
+
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  it("resumes following once the operator returns to within the bottom threshold", async () => {
+    const { root, viewport } = makeScrollArea();
+    renderHook(() => useStickToBottom({ current: root }));
+    setDims(viewport, 1000, 200);
+
+    // First scroll up so the follow is suppressed...
+    viewport.scrollTop = 0;
+    viewport.dispatchEvent(new Event("scroll"));
+    // ...then scroll back to within the threshold of the bottom (gap 10 <= 24) — the follow re-arms.
+    viewport.scrollTop = 1000 - 200 - (STICK_TO_BOTTOM_THRESHOLD_PX - 14);
+    viewport.dispatchEvent(new Event("scroll"));
+
+    grow(viewport);
+    await flushObserver();
+
+    expect(viewport.scrollTop).toBe(1000);
+  });
+
+  it("stops following after unmount (listener + observer are torn down)", async () => {
+    const { root, viewport } = makeScrollArea();
+    const { unmount } = renderHook(() => useStickToBottom({ current: root }));
+    setDims(viewport, 1000, 200);
+
+    unmount();
+
+    viewport.scrollTop = 0;
+    grow(viewport);
+    await flushObserver();
+
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  it("is a no-op when the Root holds no Radix viewport", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    expect(() => renderHook(() => useStickToBottom({ current: root }))).not.toThrow();
+
+    // Nothing to follow: the bare root never gains a viewport, so a mutation on it can't move any scroll.
+    root.appendChild(document.createElement("p"));
+    await flushObserver();
+    expect(root.scrollTop).toBe(0);
+  });
+
+  it("is a no-op when the Root ref is unset", () => {
+    expect(() => renderHook(() => useStickToBottom({ current: null }))).not.toThrow();
+  });
+});


### PR DESCRIPTION
fix(miner-ui): auto-scroll the chat rail to new and streaming messages

The chat rail's MessageList renders inside ui-kit's ScrollArea but never
held a ref to the scrollable viewport or called scrollTo/scrollIntoView, so
once a conversation overflowed the ~380px rail a newly-committed message and
the live streaming answer both appended below the fold with nothing bringing
them into view. An operator had to scroll down by hand to see a reply arrive.

Add a useStickToBottom hook that resolves the Radix viewport (via the
[data-radix-scroll-area-viewport] attribute, so the shared ScrollArea stays
untouched) and, with one MutationObserver, follows the newest content to the
bottom — a committed <li> lands as a childList change, a streaming chunk as a
characterData change, so both cases share the mechanism. The follow is gated
on the reader already being at (or within 24px of) the bottom, tracked via a
scroll listener, so scrolling up to re-read history is never yanked back down
until the reader returns to the bottom themselves.

Route the live StreamingText render through a new MessageList `footer` slot so
it sits inside the same scrollable viewport as the committed messages (still
outside the #7081 aria-live <ol>), letting the accumulating answer grow the
viewport the same way a message does.

Closes #7229

