### PR TITLE
refactor(engine): dedup scoring/preview.ts's label matching onto label-match.ts

### DIFF
--- a/packages/loopover-engine/src/scoring/preview.ts
+++ b/packages/loopover-engine/src/scoring/preview.ts
@@ -1,6 +1,12 @@
 import type { ContributorEvidenceRecord, JsonValue, RepositoryRecord, RepoTimeDecayOverrides, ScoringModelSnapshotRecord, ScorePreviewRecord } from "./types.js";
 import { DEFAULT_SCORING_CONSTANTS } from "./model.js";
 import { hasUnsafeWildcardCount } from "../signals/change-guardrail.js";
+import {
+  clearLabelPatternRegExpCacheForTest,
+  LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES,
+  labelMatchesPattern,
+  labelPatternRegExpCacheKeysForTest,
+} from "./label-match.js";
 
 // Deterministic score-preview builder extracted verbatim from the backend's `src/scoring/preview.ts`
 // (#2282) — this file has no D1/network/env dependency in the original, so it ports unchanged aside from
@@ -941,159 +947,21 @@ function selectLabelMultiplier(labels: string[], multipliers: Record<string, num
   const normalized = labels.map((label) => label.toLowerCase());
   const matched = Object.entries(multipliers).flatMap(([pattern, multiplier]) => {
     if (!isValidLabelMultiplier(multiplier)) return [];
-    const matcher = labelPatternToRegExp(pattern.toLowerCase());
-    return normalized.some((label) => matcher.test(label)) ? [multiplier] : [];
+    return normalized.some((label) => labelMatchesPattern(label, pattern)) ? [multiplier] : [];
   });
   return matched.length > 0 ? Math.max(...matched) : isValidLabelMultiplier(fallback) ? fallback : 1;
 }
 
-/** True when `label` matches the configured multiplier `pattern` under the SAME case-insensitive fnmatch glob
- *  semantics scoring uses to resolve label multipliers (see {@link labelPatternToRegExp}). Exported so the
- *  signals surfaces that audit configured label keys (config-quality, label-audit) match them as the GLOBS they
- *  are: a `type:*` key must count `type:bug-fix` as observed/configured, not silently report it missing because
- *  the literal pattern never appears verbatim on a real issue/PR. A literal key (no glob metacharacter) still
- *  matches only its exact label, so existing configs behave identically. */
-export function labelMatchesPattern(label: string, pattern: string): boolean {
-  return labelPatternToRegExp(pattern.toLowerCase()).test(label.toLowerCase());
-}
-
-// Compiled fnmatch→RegExp matchers are memoized by pattern. The same small,
-// config-derived set of label keys is matched on every scored PR/issue, so the
-// per-call recompile inside the nested label loops in engine.ts is pure waste.
-// Keys come from a repo's registryConfig.labelMultipliers, sourced from the externally-fetched gittensor
-// registry (registry/sync.ts + registry/normalize.ts, not a value this repo's own maintainer directly controls
-// via .loopover.yml) — so the pattern SET is small per repo, but individual pattern CONTENT is untrusted, not
-// literally attacker-supplied-per-request the way GitHub PR content is. The wildcard-count cap below (#2456)
-// bounds a single pattern's compile cost; this cache is additionally bounded to a fixed max entry count and
-// evicted LRU, so a long-running isolate that observes many distinct registry snapshots over its life still
-// can't grow the cache unboundedly. The compiled RegExp carries only the "i" flag (no global/sticky `lastIndex`
-// state), so sharing one instance across calls is safe and byte-identical to recompiling on every call.
-export const LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES = 256;
-const labelPatternRegExpCache = new Map<string, RegExp>();
-
-// A RegExp that never matches any input — mirrors change-guardrail.ts's identical NEVER_MATCHES fallback for an
-// over-complex pattern, so a pathological registry entry degrades to "this label multiplier never applies"
-// instead of hanging the scoring path that evaluates it.
-const LABEL_PATTERN_NEVER_MATCHES = /^(?!)$/;
-
-// Upstream resolves label multipliers by matching each configured key as a Python `fnmatch` GLOB, not a
-// literal string: `fnmatch(label.lower(), pattern.lower())` in
-// gittensor/validator/oss_contributions/label_resolution.py, so a repo can configure `type:*`, `kind/*`, or
-// `priority:?` and have it match `type:bug-fix`, `kind/bug`, `priority:1` (#1244-class scoring parity). The
-// preview previously did exact equality, so it silently scored every wildcard-configured trusted label at the
-// neutral default — under-/over-estimating the score for any repo using glob keys. Translate one fnmatch
-// pattern to an anchored, case-insensitive RegExp. fnmatch semantics differ from the path-glob in
-// change-guardrail.ts (there `*` stops at `/` and `?` is literal): labels are flat strings, so `*` matches any
-// run, `?` any single character, and `[seq]`/`[!seq]` a character class. Literal keys are unaffected — for a
-// pattern with no glob metacharacter the RegExp is an exact match, so existing configs score identically.
-function labelPatternToRegExp(pattern: string): RegExp {
-  const cached = labelPatternRegExpCache.get(pattern);
-  if (cached !== undefined) {
-    // Refresh recency on hit so the cache behaves as an LRU: the most-recently-matched patterns
-    // survive eviction, not just the most-recently-inserted ones.
-    labelPatternRegExpCache.delete(pattern);
-    labelPatternRegExpCache.set(pattern, cached);
-    return cached;
-  }
-  // Reuses change-guardrail.ts's wildcard-GROUP counting (a `*` here matches the same "any run of chars"
-  // semantics as that glob compiler's `*`, so the same catastrophic-backtracking risk and the same empirically-
-  // safe threshold apply) — an over-complex registry-sourced label_multipliers key degrades to a safe never-match
-  // instead of hanging RegExp.test() on an adversarial near-miss label (#2456). Reachable via the public
-  // score-preview API, the MCP tool, and the per-PR label-audit signal, so one bad registry entry could otherwise
-  // hang scoring for every PR on that repo.
-  if (hasUnsafeWildcardCount(pattern)) {
-    setLabelPatternRegExpCacheEntry(pattern, LABEL_PATTERN_NEVER_MATCHES);
-    return LABEL_PATTERN_NEVER_MATCHES;
-  }
-  let regex = "";
-  let i = 0;
-  while (i < pattern.length) {
-    const char = pattern.charAt(i);
-    i += 1;
-    if (char === "*") {
-      regex += ".*";
-    } else if (char === "?") {
-      regex += ".";
-    } else if (char === "[") {
-      const close = pattern.indexOf("]", i);
-      if (close === -1) {
-        // No closing bracket: fnmatch treats the `[` as a literal character.
-        regex += "\\[";
-      } else {
-        const rawBody = pattern.slice(i, close);
-        if (rawBody === "" || rawBody === "!") {
-          // Empty classes and bare `[!]` stay literal in Python fnmatch instead of compiling as classes.
-          regex += `\\[${escapeRegExpLiteral(rawBody)}\\]`;
-        } else if (hasDescendingCharacterRange(rawBody)) {
-          // Python fnmatch treats invalid ranges like `[z-a]` as a never-match pattern; RegExp throws.
-          regex += "(?!)";
-        } else {
-          let body = rawBody.replace(/\\/g, "\\\\");
-          // `[!seq]` is fnmatch's negated class; RegExp spells negation as `[^seq]`.
-          if (body.startsWith("!")) body = `^${body.slice(1)}`;
-          else if (body.startsWith("^")) body = `\\${body}`;
-          regex += `[${body}]`;
-        }
-        i = close + 1;
-      }
-    } else if (/[.+^${}()|\]\\]/.test(char)) {
-      regex += `\\${char}`;
-    } else {
-      regex += char;
-    }
-  }
-  const compiled = new RegExp(`^${regex}$`, "i");
-  setLabelPatternRegExpCacheEntry(pattern, compiled);
-  return compiled;
-}
-
-// Inserts a new (never-before-cached) entry, evicting the least-recently-used entry first if the
-// cache is already at its bound. Callers must only use this for keys not already present — refreshing
-// an existing key's recency on a cache hit is handled inline above via delete+set.
-function setLabelPatternRegExpCacheEntry(pattern: string, compiled: RegExp): void {
-  if (labelPatternRegExpCache.size >= LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES) {
-    // Map iteration order is insertion order, so the first key is always the least-recently-used
-    // one (recency is refreshed via delete+set on every hit/insert). The map is non-empty here
-    // because size >= LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES (a positive constant), so the loop body
-    // always runs exactly once.
-    for (const oldestPattern of labelPatternRegExpCache.keys()) {
-      labelPatternRegExpCache.delete(oldestPattern);
-      break;
-    }
-  }
-  labelPatternRegExpCache.set(pattern, compiled);
-}
-
-export function clearLabelPatternRegExpCacheForTest(): void {
-  labelPatternRegExpCache.clear();
-}
-
-export function labelPatternRegExpCacheKeysForTest(): string[] {
-  return [...labelPatternRegExpCache.keys()];
-}
-
-function escapeRegExpLiteral(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function hasDescendingCharacterRange(body: string): boolean {
-  const start = body.startsWith("!") ? 1 : 0;
-  // Walk the class left-to-right, consuming each `X-Y` range as a unit so a range endpoint can't be
-  // misread as the start of a spurious second range. Only a genuinely inverted range like `[z-a]` — the
-  // case JS `RegExp` actually throws on — must degrade the class to never-match; a literal `-` that
-  // follows a completed range (as in `[a-z-9]`, a valid class) must NOT be suppressed. The prior scan
-  // flagged any `-` whose left neighbor outranked its right neighbor, so it wrongly killed `[a-z-9]`.
-  let i = start;
-  while (i < body.length) {
-    if (i + 2 < body.length && body.charAt(i + 1) === "-") {
-      if (body.charCodeAt(i) > body.charCodeAt(i + 2)) return true;
-      i += 3;
-    } else {
-      i += 1;
-    }
-  }
-  return false;
-}
+// Label-pattern matching (fnmatch glob semantics + a bounded compiled-regex cache) lives in the canonical
+// ./label-match.ts, extracted specifically to hold this logic for reuse (#7254). preview.ts previously kept a
+// byte-identical private copy; it now imports from that module and re-exports the same public names so the
+// external consumers (signals/engine.ts, src/rules/advisory.ts) and the test helpers are unchanged.
+export {
+  clearLabelPatternRegExpCacheForTest,
+  LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES,
+  labelMatchesPattern,
+  labelPatternRegExpCacheKeysForTest,
+};
 
 function decideLinkedIssueMultiplier(
   mode: "none" | "standard" | "maintainer",


### PR DESCRIPTION
## What

`scoring/preview.ts` kept a **byte-identical private copy** of the label-pattern matching logic that `scoring/label-match.ts` was extracted specifically to hold for reuse: `labelMatchesPattern`, `labelPatternToRegExp`, an LRU-bounded compiled-regex cache (`LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES`), and `hasDescendingCharacterRange`. `preview.ts` never imported the shared module — it duplicated the implementation.

Two costs: a **silent drift risk** (a future ReDoS-hardening, cache-tuning, or fnmatch-semantics fix to one copy has no mechanism forcing it into the other — exactly the divergence that already produced a confirmed bug in `reward-risk.ts`'s `bestFitLabels`), and a **doubled compiled-regex cache** over the identical keyspace doing duplicate work.

## How

- `preview.ts` now imports the shared implementation from `label-match.ts`.
- The four public names (`labelMatchesPattern`, `LABEL_PATTERN_REGEXP_CACHE_MAX_ENTRIES`, and the two `*ForTest` cache helpers) are **re-exported** so the external consumers — `signals/engine.ts` and `src/rules/advisory.ts` both import `labelMatchesPattern` from `preview.ts` — and the tests are unchanged.
- The entire duplicated block (local `labelMatchesPattern`/`labelPatternToRegExp`/`hasDescendingCharacterRange`/`escapeRegExpLiteral`/the second cache + accessors) is deleted.
- `selectLabelMultiplier` now calls the shared `labelMatchesPattern` directly (behavior-identical: it lower-cases inputs the same way).

Net −132 lines, one implementation instead of two, one shared cache.

## Validation

Pure deduplication, no intended behavior change — the two copies were byte-identical. The engine build/typecheck passes, and the label-matching test suites (`scoring.test.ts`, `predicted-gate-engine-coverage.test.ts`, `label-audit.test.ts` — 134 tests) pass **unmodified**, exercising the shared path through the re-export. Coverage on the changed lines is intact (the one uncovered range in the file is pre-existing code far outside this diff).

Closes #7254
