### PR TITLE
fix(miner): correct Map ordering so a superseding pr-outcome event moves to the end of iteration

### DIFF
--- a/packages/loopover-miner/lib/pr-outcome.js
+++ b/packages/loopover-miner/lib/pr-outcome.js
@@ -74,7 +74,14 @@ export function recordPrOutcomeSnapshot(input, options = {}) {
  * Reconstruct the latest outcome per repo/PR from the ledger's ascending append-only event stream (mirrors
  * manage-status.js's `indexLatestManageUpdates`). Reads via the injected ledger's `readEvents(filter)` and reduces
  * the pure result — a later event for the same repo/PR supersedes an earlier one. Returns a `Map` keyed by
- * `repoFullName:prNumber`.
+ * `repoFullName:prNumber`, in TRUE latest-event order (not first-insertion order): a repo/PR that receives a
+ * second, correcting event later in the stream (e.g. closed-without-merge, then reopened and merged — a real,
+ * reachable case: pr-disposition-poller.js can legitimately re-observe and re-record a reopened PR's new terminal
+ * state) is deleted and re-set on each occurrence, so its position in `.values()`/`.keys()` iteration always
+ * reflects when it was MOST recently updated, matching the "a later event supersedes an earlier one" doc claim
+ * above literally rather than only in the stored VALUE (#7222 — `Map.set` on an already-present key updates the
+ * value in place but does not move it, so consumers relying on iteration-order-as-recency, e.g. loop-reentry.js's
+ * `countConsecutiveDisengagements`, would otherwise miscount after a correction like this).
  */
 export function readPrOutcomes(eventLedger, filter = {}) {
   const events = eventLedger && typeof eventLedger.readEvents === "function" ? eventLedger.readEvents(filter) : [];
@@ -84,7 +91,9 @@ export function readPrOutcomes(eventLedger, filter = {}) {
     if (typeof event.repoFullName !== "string" || !event.repoFullName.trim()) continue;
     const normalized = normalizePrOutcomePayload(event.payload);
     if (!normalized) continue;
-    latest.set(`${event.repoFullName}:${normalized.prNumber}`, { ...normalized, repoFullName: event.repoFullName });
+    const key = `${event.repoFullName}:${normalized.prNumber}`;
+    latest.delete(key);
+    latest.set(key, { ...normalized, repoFullName: event.repoFullName });
   }
   return latest;
 }

--- a/test/unit/miner-loop-reentry.test.ts
+++ b/test/unit/miner-loop-reentry.test.ts
@@ -112,6 +112,22 @@ describe("attemptLoopReentry (#2338)", () => {
     expect(countConsecutiveDisengagements(eventLedger, "acme/widgets")).toBe(0);
   });
 
+  it("REGRESSION (#7222): a corrected outcome (reopened-then-merged after later PRs resolved) resets the streak, not just its own value", () => {
+    const eventLedger = tempEventLedger();
+    // PR #1 closed-without-merge first, then #2 and #3 close after it -- a real streak of 3.
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 1, decision: "closed", closedAt: new Date().toISOString(), reason: "stale" }, { eventLedger });
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 2, decision: "closed", closedAt: new Date().toISOString(), reason: "stale" }, { eventLedger });
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 3, decision: "closed", closedAt: new Date().toISOString(), reason: "stale" }, { eventLedger });
+    expect(countConsecutiveDisengagements(eventLedger, "acme/widgets")).toBe(3);
+
+    // PR #1 -- the earliest-inserted key -- is reopened and merged AFTER #2 and #3. Before #7222's fix, Map
+    // insertion order left #1's entry frozen at its original (oldest) position, so the backward walk still saw
+    // #3, #2 as the "most recent" and miscounted the streak at 2 instead of the correct 0.
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 1, decision: "merged", closedAt: new Date().toISOString() }, { eventLedger });
+
+    expect(countConsecutiveDisengagements(eventLedger, "acme/widgets")).toBe(0);
+  });
+
   it("the hourly rate cap suppresses re-entry independent of the per-repo circuit breaker, and does not move the run-state or dequeue", () => {
     const eventLedger = tempEventLedger();
     const portfolioQueue = tempPortfolioQueue();

--- a/test/unit/miner-pr-outcome.test.ts
+++ b/test/unit/miner-pr-outcome.test.ts
@@ -105,4 +105,17 @@ describe("readPrOutcomes (#4274)", () => {
     expect(readPrOutcomes({} as never).size).toBe(0);
     expect(readPrOutcomes({ readEvents: () => null } as never).size).toBe(0);
   });
+
+  it("REGRESSION (#7222): a same-key correction moves the key to the end of iteration order, not just its value", () => {
+    const ledger = mockLedger();
+    // insertion order: acme/widgets:1, acme/widgets:2 — then a correcting event for the FIRST key.
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 1, decision: "closed", reason: "gate_close" }, { eventLedger: ledger });
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 2, decision: "closed", reason: "gate_close" }, { eventLedger: ledger });
+    recordPrOutcomeSnapshot({ repoFullName: "acme/widgets", prNumber: 1, decision: "merged" }, { eventLedger: ledger }); // corrects key 1, recorded LAST
+    const latest = readPrOutcomes(ledger);
+    // a plain Map.set on an already-present key would leave key 1 in its original (first) position; the fix
+    // deletes-then-sets so the corrected key reflects when it was MOST recently updated, matching the doc claim.
+    expect([...latest.keys()]).toEqual(["acme/widgets:2", "acme/widgets:1"]);
+    expect(latest.get("acme/widgets:1")?.decision).toBe("merged");
+  });
 });


### PR DESCRIPTION
## Summary

- `readPrOutcomes` (`packages/loopover-miner/lib/pr-outcome.js`) reduces the miner's append-only event stream into a `Map` keyed by `repoFullName:prNumber`, one entry per PR. It used a plain `Map.set()` on the repeat key when a PR's outcome is later corrected -- which updates the stored value in place but does **not** move that key's iteration position, since `Map.set` on an already-present key is a no-op for ordering.
- A real, reachable case: `pr-disposition-poller.js` can legitimately re-observe a reopened PR and re-record its new terminal state (e.g. `closed` without merge, then later `reopened` and genuinely `merged`). Before this fix, that PR's key stayed pinned at its ORIGINAL insertion position in the Map's iteration order, even though its value was correctly updated to `merged`.
- `loop-reentry.js`'s `countConsecutiveDisengagements` relies on iteration order as a proxy for recency to count a trailing streak of non-merged outcomes. With the stale ordering, a corrected-to-merged PR that was originally inserted before a run of later `closed` PRs would not correctly reset that streak to zero, silently miscounting engagement.

Fixed by adding `latest.delete(key)` immediately before `latest.set(key, ...)` in the reduction loop, so a repeat key is always removed and re-inserted at the end -- the Map's iteration order now always reflects true latest-event order, matching the function's own existing doc comment ("a later event supersedes an earlier one") literally, not just in the stored value.

Closes #7222

## Scope

- [x] Conventional Commit title; focused (one module + two test files); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7222`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root -- clean)
- [x] `npm run test:coverage` scoped to the changed module -- **100% statements/branches/functions/lines** on `pr-outcome.js` (44/44, 52/52, 4/4, 33/33), verified against the raw coverage report, not just the text summary.
- [x] Two new regression tests: a direct unit test in `test/unit/miner-pr-outcome.test.ts` proving `readPrOutcomes`'s own Map now reflects true latest-event order after a same-key correction, and an integration-level test in `test/unit/miner-loop-reentry.test.ts` proving `countConsecutiveDisengagements` correctly resets the streak through the real consumer path.
- [x] Full `npm run test:ci` green end to end, run under the repo's pinned Node 22 (`.nvmrc`), isolated to only this change's files (no unrelated diffs in the tree).
- [x] `npm audit --audit-level=moderate` -- clean except the same pre-existing, unrelated `adm-zip`/`github-actionlint` advisory with no fix available.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- local event-ledger reducer, not an auth surface.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no OpenAPI-documented surface touched.)
- [ ] UI changes use live API data -- N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, backend-only change, no visible UI.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No `CHANGELOG.md` edit; the fix's rationale is documented inline in the function's own doc comment.)

## Notes

- Found via a conservative, empirically-verified round-3 gap-audit of `packages/loopover-miner` (both prior AMS-hardening rounds, Wave 4 and 4.5, are fully closed -- 245 issues total). Verified with a standalone reproduction against the real module before filing #7222.
