### PR TITLE
fix(engine): block the RFC 6598 CGNAT range in safe-url's SSRF guard

### DIFF
--- a/packages/loopover-engine/src/review/safe-url.ts
+++ b/packages/loopover-engine/src/review/safe-url.ts
@@ -51,6 +51,7 @@ function ipv4IsPrivateOrLocal(host: string): boolean {
   if (a === 169 && b === 254) return true; // link-local (incl. cloud metadata 169.254.169.254)
   if (a === 192 && b === 168) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 shared address space (RFC 6598 CGNAT)
   return false;
 }
 

--- a/test/unit/safe-url-engine.test.ts
+++ b/test/unit/safe-url-engine.test.ts
@@ -25,6 +25,17 @@ describe("isSafeHttpUrl", () => {
     expect(isSafeHttpUrl("https://printer.local")).toBe(false);
   });
 
+  it("rejects the RFC 6598 shared-address-space (CGNAT) range 100.64.0.0/10 (#7253)", () => {
+    // A URL resolving to a carrier-grade-NAT / shared-address-space host is internal, not publicly routable,
+    // and must be blocked like the other private ranges. Boundary-tested at the /10's inclusive edges.
+    expect(isSafeHttpUrl("https://100.64.0.0")).toBe(false); // lower inclusive bound
+    expect(isSafeHttpUrl("https://100.100.50.1")).toBe(false); // mid-range
+    expect(isSafeHttpUrl("https://100.127.255.255")).toBe(false); // upper inclusive bound
+    // Just outside the /10 in either direction must remain public/safe.
+    expect(isSafeHttpUrl("https://100.63.255.255")).toBe(true); // one below the range
+    expect(isSafeHttpUrl("https://100.128.0.0")).toBe(true); // one above the range
+  });
+
   it("rejects the RFC 6761 *.localhost loopback namespace (not just bare localhost)", () => {
     // RFC 6761 makes every `*.localhost` name loopback (systemd-resolved, browsers), so the bare
     // `=== "localhost"` check leaked sub-labelled forms; `.endsWith(".localhost")` closes them.


### PR DESCRIPTION
## What

`safe-url.ts`'s `ipv4IsPrivateOrLocal` — the SSRF-safe URL guard's IPv4 check — rejected five private/reserved ranges (0/8, 10/8, 127/8, 169.254/16, 192.168/16, 172.16/12) but **not `100.64.0.0/10`** (RFC 6598 "Shared Address Space" / carrier-grade NAT). That range is non-publicly-routable and is assigned by several major cloud/hosting providers to internal service endpoints — exactly the category this guard exists to block. A URL resolving to a `100.64.x.x`–`100.127.x.x` host currently passes the IPv4 check as if it were a normal public address.

## How

Add one additive check — `if (a === 100 && b >= 64 && b <= 127) return true;` — following the identical inline style and range-comment convention as the five existing checks. No other range, the function signature, or any other part of the SSRF surface (hostname checks, IPv6, encoded-IP decoding) is touched, per the issue's security-scoping requirement.

## Validation

Regression tests added to `safe-url-engine.test.ts` covering the range boundaries: `100.64.0.0` and `100.127.255.255` (inclusive bounds — must be blocked), `100.100.50.1` (mid-range — blocked), and `100.63.255.255` / `100.128.0.0` (just outside — must remain public/safe), matching the file's existing boundary-testing style. Confirmed the tests **fail against the unfixed guard** (the CGNAT addresses pass through) and pass with the fix; the full `safe-url-engine` suite (21 tests) passes.

Closes #7253
