### PR TITLE
fix(portfolio): scope per-repo WIP caps by forge host, not repo name alone (#7224)

### DIFF
--- a/packages/loopover-miner/lib/portfolio-queue-cli.js
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.js
@@ -118,8 +118,14 @@ export function selectNextEligibleTarget(entries, caps) {
   }
   const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
   if (globalActiveCount >= caps.globalWipCap) return [];
+  // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
+  // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
+  // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
   const repoActiveCount = entries.filter(
-    (entry) => entry.status === "in_progress" && entry.repoFullName === topQueued.repoFullName,
+    (entry) =>
+      entry.status === "in_progress" &&
+      entry.repoFullName === topQueued.repoFullName &&
+      entry.apiBaseUrl === topQueued.apiBaseUrl,
   ).length;
   if (repoActiveCount >= caps.perRepoWipCap) return [];
   return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];

--- a/packages/loopover-miner/lib/portfolio-queue-manager.js
+++ b/packages/loopover-miner/lib/portfolio-queue-manager.js
@@ -56,22 +56,32 @@ export function entriesToPortfolioQueue(entries) {
     // Falls back to the github.com default (matching every store's own normalizeApiBaseUrl) so a row from
     // before #5563 threaded apiBaseUrl through this fold still gets a valid, host-scoped id.
     const apiBaseUrl = typeof entry.apiBaseUrl === "string" && entry.apiBaseUrl.trim() ? entry.apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
-    const repoKey = repoFullName.toLowerCase();
+    // Host-qualify the engine's per-repo WIP grouping key (#7224). nextEligibleItems groups its per-repo cap by each
+    // item's `repoFullName`, which it treats as an OPAQUE string -- the engine has no apiBaseUrl concept, the host is
+    // smuggled through the opaque `id` (queueItemId, #5563). The store keys rows by apiBaseUrl too, so two forge
+    // hosts' same-named repos are distinct backlogs; without qualifying the grouping key by host here, a per-repo cap
+    // was shared across them (e.g. perRepoWipCap: 1 let only ONE host's backlog advance). The `id` still carries the
+    // TRUE repoFullName and selectEligibleBatch maps results back via parseQueueItemId(id), so the real repo/host
+    // survive to the caller. Single-host behavior is unchanged: one apiBaseUrl means one grouping key per repo.
+    const repoLower = repoFullName.toLowerCase();
+    const repoKey = `${apiBaseUrl}\n${repoLower}`;
     if (!bucketsByRepo.has(repoKey)) {
-      bucketsByRepo.set(repoKey, []);
+      // The bucket's own repoFullName stays the plain repo (display/diversification), while each ITEM carries the
+      // host-qualified key the engine groups on -- so the returned bucket shape is unchanged for single-host.
+      bucketsByRepo.set(repoKey, { repoFullName: repoLower, items: [] });
       bucketOrder.push(repoKey);
     }
-    bucketsByRepo.get(repoKey).push({
+    bucketsByRepo.get(repoKey).items.push({
       id: queueItemId(apiBaseUrl, repoFullName, identifier),
-      repoFullName,
+      repoFullName: repoKey,
       state: entry.status === "in_progress" ? "in_progress" : "queued",
     });
   }
   return {
-    buckets: bucketOrder.map((repoFullName) => ({
-      repoFullName,
-      items: bucketsByRepo.get(repoFullName),
-    })),
+    buckets: bucketOrder.map((repoKey) => {
+      const bucket = bucketsByRepo.get(repoKey);
+      return { repoFullName: bucket.repoFullName, items: bucket.items };
+    }),
   };
 }
 

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -210,6 +210,18 @@ describe("loopover-miner portfolio queue CLI (#2292)", () => {
         { apiBaseUrl: "https://api.github.com", repoFullName: "acme/other", identifier: "b1" },
       ]);
     });
+
+    it("REGRESSION: an in-progress item on one host does not consume another host's per-repo WIP budget (#7224)", () => {
+      const entries = [
+        entry({ status: "in_progress", identifier: "host-a", apiBaseUrl: "https://api.github.com" }),
+        entry({ status: "queued", identifier: "host-b", apiBaseUrl: "https://ghe.example.com/api/v3" }),
+      ];
+      // Same repo name, cap 1 — but the in-progress item is on a DIFFERENT forge host, so host B's queued row is
+      // eligible. Before #7224 the host-A item was mis-counted against host B's cap and this returned [].
+      expect(selectNextEligibleTarget(entries, { globalWipCap: 5, perRepoWipCap: 1 })).toEqual([
+        { apiBaseUrl: "https://ghe.example.com/api/v3", repoFullName: "acme/widgets", identifier: "host-b" },
+      ]);
+    });
   });
 
   it("runQueueNext with --global-wip/--per-repo-wip claims only within the configured caps (#4850)", () => {

--- a/test/unit/miner-portfolio-queue-manager.test.ts
+++ b/test/unit/miner-portfolio-queue-manager.test.ts
@@ -170,6 +170,21 @@ describe("initPortfolioQueueManager().claimNextBatch() (#4285)", () => {
     expect(rows.every((row) => row.status === "in_progress")).toBe(true);
   });
 
+  it("REGRESSION: a binding per-repo WIP cap of 1 still lets two hosts' same-named repos each advance (#7224)", () => {
+    const manager = memoryManager({ globalWipCap: 4, perRepoWipCap: 1 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 1, apiBaseUrl: "https://api.github.com" });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 1, apiBaseUrl: "https://ghe.example.com/api/v3" });
+
+    // The cap binds PER HOST: each host's independent backlog gets its one claim. Before #7224, the two hosts were
+    // bucketed together under the bare repoFullName, so a cap of 1 let only ONE of them advance.
+    const claimed = manager.claimNextBatch();
+    expect(claimed).toHaveLength(2);
+    expect(claimed.map((entry) => entry.apiBaseUrl).sort()).toEqual([
+      "https://api.github.com",
+      "https://ghe.example.com/api/v3",
+    ]);
+  });
+
   it("does not claim rows another writer already took inside the same transaction window", () => {
     const store = initPortfolioQueueStore(":memory:");
     stores.push(store);


### PR DESCRIPTION
## Summary

The portfolio store's #5563 composite primary key `(api_base_url, repo_full_name, identifier)` keeps two
forge hosts serving a same-named `owner/repo` as distinct rows — but the two WIP-cap/selection paths built on
top of it dropped the host dimension, so a per-repo cap was silently shared across hosts:

- `entriesToPortfolioQueue` (`portfolio-queue-manager.js`) folded active rows for the engine's `nextEligibleItems`,
  which groups its per-repo WIP cap by each item's `repoFullName` — an **opaque** string to the engine (it has no
  `apiBaseUrl` concept; the host is smuggled through the opaque `id` via `queueItemId`, #5563). Two hosts' rows
  therefore merged into one group, so e.g. `perRepoWipCap: 1` let only ONE host's backlog advance.
- `selectNextEligibleTarget` (`portfolio-queue-cli.js`, `queue next --per-repo-wip`) counted `repoActiveCount`
  by `repoFullName` alone, so an in-progress item on host A blocked a queued item for the same repo on host B.

This host-qualifies both:

- Each item's engine-grouping `repoFullName` is now `${apiBaseUrl}\n${repo}` — the same "smuggle the host through
  the string the engine treats opaquely" approach `queueItemId` already uses for the `id`. The item `id` still
  carries the true repo, and `selectEligibleBatch` maps results back via `parseQueueItemId(id)`, so the real
  repo/host reach the caller unchanged. The returned bucket's own `repoFullName` stays the plain repo name.
- `selectNextEligibleTarget`'s `repoActiveCount` filter additionally matches `entry.apiBaseUrl === topQueued.apiBaseUrl`.

Single-host behavior (the overwhelming common case) is unchanged: one `apiBaseUrl` means one grouping key per
repo, and the added filter match is always true — confirmed by the existing suites passing untouched.

Closes #7224

## Scope

- [x] Conventional Commit title; focused (two modules + their tests); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7224`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` on both changed modules — **100% of the changed lines + branches covered**. Two new
      regressions with a cap that actually binds (`perRepoWipCap: 1`, which the existing #5563 test at cap 2 could
      not catch): `claimNextBatch` claims both hosts' same-named rows, and `selectNextEligibleTarget` does not let
      host A's in-progress item block host B's queued one. All existing portfolio-queue tests pass unchanged.
- [x] `npm run build:miner` (`node --check` on both files passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**`; CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — internal WIP-cap accounting only; return shapes are unchanged.
- [x] No UI change — no UI Evidence needed.
