### PR TITLE
fix(miner): add policy-doc-cache to doctor and migrate store lists (#7238)

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.js
+++ b/packages/loopover-miner/lib/migrate-cli.js
@@ -24,6 +24,7 @@ import { openReplaySnapshotStore, resolveReplaySnapshotDbPath } from "./replay-s
 import { openWorktreeAllocator, resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { initContributionProfileCache, resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
 import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
+import { initPolicyDocCacheStore, resolvePolicyDocCacheDbPath } from "./policy-doc-cache.js";
 
 const MIGRATE_USAGE = "Usage: loopover-miner migrate [--json]";
 
@@ -41,6 +42,7 @@ const STORES = [
   { name: "worktree-allocator", resolveDbPath: resolveWorktreeAllocatorDbPath, open: (dbPath) => openWorktreeAllocator({ dbPath }) },
   { name: "contribution-profile", resolveDbPath: resolveContributionProfileCacheDbPath, open: initContributionProfileCache },
   { name: "policy-verdict-cache", resolveDbPath: resolvePolicyVerdictCacheDbPath, open: initPolicyVerdictCacheStore },
+  { name: "policy-doc-cache", resolveDbPath: resolvePolicyDocCacheDbPath, open: initPolicyDocCacheStore },
 ];
 
 /** Read a store file's stamped schema version without ever creating it -- matches checkStoreIntegrity's

--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -27,6 +27,7 @@ import { resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
 import { resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
 import { resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
+import { resolvePolicyDocCacheDbPath } from "./policy-doc-cache.js";
 
 // Slim laptop-mode CLI commands (#2288): `status` (what's installed + where local state lives) and `doctor` (is
 // this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
@@ -320,6 +321,7 @@ function storeIntegrityChecks(env) {
     ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
     ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
     ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],
+    ["policy-doc-cache", resolvePolicyDocCacheDbPath(env)],
   ];
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -31,6 +31,7 @@ const STORE_NAMES = [
   "worktree-allocator",
   "contribution-profile",
   "policy-verdict-cache",
+  "policy-doc-cache",
 ];
 
 afterEach(() => {
@@ -39,7 +40,7 @@ afterEach(() => {
 });
 
 describe("loopover-miner migrate (#4871)", () => {
-  it("covers the exact same thirteen stores doctor's store-integrity sweep covers, in the same order, and skips every one when nothing has been created yet", () => {
+  it("covers the exact same fourteen stores doctor's store-integrity sweep covers, in the same order, and skips every one when nothing has been created yet", () => {
     const env = tempEnv();
     const results = runMigrateChecks(env);
 

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -139,6 +139,7 @@ describe("loopover-miner status/doctor (#2288)", () => {
       "store-integrity:worktree-allocator",
       "store-integrity:contribution-profile",
       "store-integrity:policy-verdict-cache",
+      "store-integrity:policy-doc-cache",
     ]);
     // REGRESSION (#6768): doctor previously omitted these four durable local stores from the integrity sweep.
     expect(checks.map((check) => check.name)).toEqual(


### PR DESCRIPTION
## Summary

`packages/loopover-miner/lib/policy-doc-cache.js` is a durable local SQLite store (opened through
`resolveLocalStoreDbPath`, like every other miner store), but it was missing from the two lists that are
meant to cover *every* such store:

- `status.js`'s `storeIntegrityChecks` — `doctor`'s per-store `PRAGMA integrity_check` sweep, whose own
  comment says to keep it in sync with migrate-cli's `STORES`. A corrupted `policy-doc-cache.sqlite3` went
  unflagged by `doctor`.
- `migrate-cli.js`'s `STORES` — the migrate sweep. The store's schema was never brought up to date by `migrate`.

This adds `policy-doc-cache` to both, strictly appended after `policy-verdict-cache` (its distinct sibling)
without reordering or touching any of the existing 13 entries.

Closes #7238

## Scope

- [x] Conventional Commit title; focused (two modules + their tests); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7238`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` — **100% of the changed lines covered**. The existing doctor/migrate parity tests
      (which assert the exact store list, in order) are updated from 13 to 14 entries and pass; the migrate
      test's `STORE_NAMES` and the doctor integrity-list assertion now include `policy-doc-cache`.
- [x] `npm run build:miner` (`node --check` on both files passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**`; CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — additive store-list entries only.
- [x] No UI change — no UI Evidence needed.
