### PR TITLE
fix(engine): tolerate a malformed repoFullName per-row in deny-hook blocker history

### DIFF
--- a/packages/loopover-engine/src/miner/deny-hook-synthesis.ts
+++ b/packages/loopover-engine/src/miner/deny-hook-synthesis.ts
@@ -60,6 +60,20 @@ function normalizeOptionalStringArray(value: unknown): string[] {
   return value.filter((entry) => typeof entry === "string" && entry.trim()).map((entry) => entry.trim());
 }
 
+// Best-effort per-row repoFullName: a malformed value degrades to null exactly like every other optional
+// field this record normalizes (normalizeOptionalStringArray drops bad entries; pullNumber/recordedAt fall
+// back to null), so one bad row can't throw out of normalizeBlockerHistory's loop and abort the whole batch
+// (#7248). The exported, strict normalizeRepoFullName keeps throwing for the callers that require a valid
+// repo (the miner store's write paths), so only this row-level normalization is made tolerant.
+function normalizeOptionalRepoFullName(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    return normalizeRepoFullName(value);
+  } catch {
+    return null;
+  }
+}
+
 /** Validate one blocker-history row from the review stack (gate block/close audit). */
 export function normalizeBlockerHistoryRecord(record: unknown): BlockerHistoryRecord | null {
   if (!record || typeof record !== "object" || Array.isArray(record)) return null;
@@ -68,9 +82,7 @@ export function normalizeBlockerHistoryRecord(record: unknown): BlockerHistoryRe
   if (blockerCodes.length === 0) return null;
   const changedPaths = normalizeOptionalStringArray(source.changedPaths);
   const guardrailMatches = normalizeOptionalStringArray(source.guardrailMatches);
-  const repoFullName = typeof source.repoFullName === "string" && source.repoFullName.trim()
-    ? normalizeRepoFullName(source.repoFullName)
-    : null;
+  const repoFullName = normalizeOptionalRepoFullName(source.repoFullName);
   return {
     repoFullName,
     blockerCodes,

--- a/test/unit/deny-hook-engine-extraction.test.ts
+++ b/test/unit/deny-hook-engine-extraction.test.ts
@@ -99,6 +99,29 @@ describe("deny-hook engine extraction — synthesizer, via @loopover/engine alon
     expect(() => normalizeRepoFullName("a/b/c")).toThrow("invalid_repo_full_name");
   });
 
+  it("normalizeBlockerHistoryRecord degrades a malformed repoFullName to null per-row instead of throwing (#7248)", () => {
+    // A well-formed owner/repo is still normalized (surrounding whitespace trimmed).
+    expect(normalizeBlockerHistoryRecord({ repoFullName: " owner/repo ", blockerCodes: ["x"] })?.repoFullName).toBe(
+      "owner/repo",
+    );
+    // Every shape the strict normalizeRepoFullName THROWS on degrades to null here rather than aborting the row —
+    // consistent with the record's other fields, which all degrade gracefully instead of throwing.
+    for (const bad of ["no-slash", "owner/repo/extra", "/leading", "trailing/"]) {
+      expect(normalizeBlockerHistoryRecord({ repoFullName: bad, blockerCodes: ["x"] })?.repoFullName).toBeNull();
+    }
+    // Empty/whitespace never reaches the strict normalizer and also degrades to null.
+    expect(normalizeBlockerHistoryRecord({ repoFullName: "   ", blockerCodes: ["x"] })?.repoFullName).toBeNull();
+
+    // The batch normalizer keeps every valid row even when one row carries a malformed repoFullName: pre-#7248
+    // the throw from the "acme/two/three" row aborted normalizeBlockerHistory entirely, dropping the valid rows.
+    const normalized = normalizeBlockerHistory([
+      { repoFullName: "acme/one", blockerCodes: ["guardrail_hold"] },
+      { repoFullName: "acme/two/three", blockerCodes: ["guardrail_hold"] },
+      { repoFullName: "acme/three", blockerCodes: ["guardrail_hold"] },
+    ]);
+    expect(normalized.map((record) => record.repoFullName)).toEqual(["acme/one", null, "acme/three"]);
+  });
+
   it("canonicalizes and globs changed paths, rejecting traversal and non-strings", () => {
     expect(canonicalizeChangedPath("./Src/Foo.ts")).toBe("src/foo.ts");
     expect(canonicalizeChangedPath("a\\b\\C.TS")).toBe("a/b/c.ts");


### PR DESCRIPTION
Closes #7248.

## Problem
`normalizeBlockerHistoryRecord` normalizes each field of a blocker-history row with per-row tolerance — `blockerCodes`/`changedPaths`/`guardrailMatches` drop bad entries via `normalizeOptionalStringArray`, and `pullNumber`/`recordedAt` fall back to `null` on a bad shape. `repoFullName` was the one exception: it ran the value through the exported, **throwing** `normalizeRepoFullName`, which raises `invalid_repo_full_name` for any non-empty string that isn't exactly `owner/repo` (no slash, a leading/trailing slash, or an `owner/repo/extra` shape).

Because `normalizeBlockerHistory` calls `normalizeBlockerHistoryRecord` in a bare loop with no try/catch, a single malformed `repoFullName` **threw out of the whole batch**, discarding every otherwise-valid row.

## Fix (behavior-preserving except for the bug)
Normalize `repoFullName` best-effort per row via a small local helper that catches the throw and degrades to `null`, matching how every other field on the record already behaves:

```ts
function normalizeOptionalRepoFullName(value: unknown): string | null {
  if (typeof value !== "string" || !value.trim()) return null;
  try {
    return normalizeRepoFullName(value);
  } catch {
    return null;
  }
}
```

The exported, strict `normalizeRepoFullName` is **unchanged** and keeps throwing for the callers that require a valid repo — the miner store's write paths (`packages/loopover-miner/lib/deny-hook-synthesis.js`). A well-formed `owner/repo` still normalizes identically (whitespace-trimmed), so valid input is unaffected.

## Tests
Added a regression test in `deny-hook-engine-extraction.test.ts` (which imports the engine via its source barrel, so the changed lines are instrumented): a valid `repoFullName` still normalizes; every shape `normalizeRepoFullName` throws on (`no-slash`, `owner/repo/extra`, `/leading`, `trailing/`) plus empty/whitespace degrade to `null`; and `normalizeBlockerHistory` keeps every valid row when one row carries a malformed `repoFullName` (pre-fix that row's throw aborted the batch).

## Verification
- `tsc --noEmit` (root typecheck) — clean.
- `npm run build --workspace @loopover/engine` — clean.
- Full deny-hook suite (extraction + miner + calibration) — 52 tests green.
- Changed file `deny-hook-synthesis.ts`: 98/98 lines, 22/22 functions, 99/99 branches covered (v8/lcov).
