### PR TITLE
fix(review): block the RFC 6598 CGNAT range in both safe-url twin guards

### DIFF
--- a/packages/loopover-engine/src/review/safe-url.ts
+++ b/packages/loopover-engine/src/review/safe-url.ts
@@ -51,6 +51,7 @@ function ipv4IsPrivateOrLocal(host: string): boolean {
   if (a === 169 && b === 254) return true; // link-local (incl. cloud metadata 169.254.169.254)
   if (a === 192 && b === 168) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 shared address space (RFC 6598 CGNAT)
   return false;
 }
 

--- a/src/review/content-lane/safe-url.ts
+++ b/src/review/content-lane/safe-url.ts
@@ -51,6 +51,7 @@ function ipv4IsPrivateOrLocal(host: string): boolean {
   if (a === 169 && b === 254) return true; // link-local (incl. cloud metadata 169.254.169.254)
   if (a === 192 && b === 168) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 shared address space (RFC 6598 CGNAT)
   return false;
 }
 

--- a/test/unit/content-lane-safe-url.test.ts
+++ b/test/unit/content-lane-safe-url.test.ts
@@ -24,6 +24,17 @@ describe("isSafeHttpUrl", () => {
     expect(isSafeHttpUrl("https://printer.local")).toBe(false);
   });
 
+  it("rejects the RFC 6598 shared-address-space (CGNAT) range 100.64.0.0/10 (#7253)", () => {
+    // A URL resolving to a carrier-grade-NAT / shared-address-space host is internal, not publicly routable,
+    // and must be blocked like the other private ranges. Boundary-tested at the /10's inclusive edges.
+    expect(isSafeHttpUrl("https://100.64.0.0")).toBe(false); // lower inclusive bound
+    expect(isSafeHttpUrl("https://100.100.50.1")).toBe(false); // mid-range
+    expect(isSafeHttpUrl("https://100.127.255.255")).toBe(false); // upper inclusive bound
+    // Just outside the /10 in either direction must remain public/safe.
+    expect(isSafeHttpUrl("https://100.63.255.255")).toBe(true); // one below the range
+    expect(isSafeHttpUrl("https://100.128.0.0")).toBe(true); // one above the range
+  });
+
   it("rejects the RFC 6761 *.localhost loopback namespace (not just bare localhost)", () => {
     // RFC 6761 makes every `*.localhost` name loopback (systemd-resolved, browsers), so the bare
     // `=== "localhost"` check leaked sub-labelled forms; `.endsWith(".localhost")` closes them.

--- a/test/unit/safe-url-engine.test.ts
+++ b/test/unit/safe-url-engine.test.ts
@@ -25,6 +25,17 @@ describe("isSafeHttpUrl", () => {
     expect(isSafeHttpUrl("https://printer.local")).toBe(false);
   });
 
+  it("rejects the RFC 6598 shared-address-space (CGNAT) range 100.64.0.0/10 (#7253)", () => {
+    // A URL resolving to a carrier-grade-NAT / shared-address-space host is internal, not publicly routable,
+    // and must be blocked like the other private ranges. Boundary-tested at the /10's inclusive edges.
+    expect(isSafeHttpUrl("https://100.64.0.0")).toBe(false); // lower inclusive bound
+    expect(isSafeHttpUrl("https://100.100.50.1")).toBe(false); // mid-range
+    expect(isSafeHttpUrl("https://100.127.255.255")).toBe(false); // upper inclusive bound
+    // Just outside the /10 in either direction must remain public/safe.
+    expect(isSafeHttpUrl("https://100.63.255.255")).toBe(true); // one below the range
+    expect(isSafeHttpUrl("https://100.128.0.0")).toBe(true); // one above the range
+  });
+
   it("rejects the RFC 6761 *.localhost loopback namespace (not just bare localhost)", () => {
     // RFC 6761 makes every `*.localhost` name loopback (systemd-resolved, browsers), so the bare
     // `=== "localhost"` check leaked sub-labelled forms; `.endsWith(".localhost")` closes them.


### PR DESCRIPTION
## What

`ipv4IsPrivateOrLocal` — the SSRF-safe URL guard's IPv4 check — rejected five private/reserved ranges but **not `100.64.0.0/10`** (RFC 6598 "Shared Address Space" / carrier-grade NAT), which cloud/hosting providers assign to internal service endpoints. A URL resolving to a `100.64.x.x`–`100.127.x.x` host passed the check as if it were public.

## How

Add one additive check — `if (a === 100 && b >= 64 && b <= 127) return true;` — following the identical inline style as the five existing checks, to **both** copies of the guard:
- `packages/loopover-engine/src/review/safe-url.ts` (engine copy)
- `src/review/content-lane/safe-url.ts` (the **live host twin** — imported by `queue/processors.ts`, `orb/relay.ts`, `orb/federated-collector.ts`, and the visual-capture path)

These two files are a `NAMED_TWIN_PAIR` enforced by `scripts/check-engine-parity.ts`, so patching only one would both leave a live SSRF gap and fail the parity drift-check. `engine-parity:drift-check` passes with both patched identically.

## Validation

Boundary regression tests added to **both** test suites (`safe-url-engine.test.ts` and `content-lane-safe-url.test.ts`): `100.64.0.0`/`100.127.255.255` (inclusive bounds — blocked), `100.100.50.1` (mid-range — blocked), and `100.63.255.255`/`100.128.0.0` (just outside — public/safe). Confirmed both suites **fail against the unfixed guards** and pass with the fix; `engine-parity:drift-check` and `typecheck` pass.

Closes #7253
