### PR TITLE
fix(miner): report a clean CLI failure when manage status collection throws (#7236)

### DIFF
--- a/packages/loopover-miner/lib/manage-status.js
+++ b/packages/loopover-miner/lib/manage-status.js
@@ -1,7 +1,7 @@
 import { initEventLedger } from "./event-ledger.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initRunStateStore } from "./run-state.js";
-import { argsWantJson, reportCliFailure } from "./cli-error.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 /** Event vocabulary for manage-phase PR snapshots written by manage poll. (#2325) */
 export const MANAGE_PR_UPDATE_EVENT = "manage_pr_update";
@@ -233,6 +233,10 @@ export function runManageStatus(args = [], options = {}) {
       console.log(`${renderManageStatusTable(rows)}\n\n${renderRunPortfolioTable(runPortfolio)}`);
     }
     return 0;
+  } catch (error) {
+    // Collecting/rendering manage status touches three SQLite stores; a read/render failure must surface as a
+    // clean CLI error (honoring --json), not an unhandled throw -- matching runOrbExportCli / runQueueList (#7236).
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     if (ownsPortfolioQueue) portfolioQueue.close();
     if (ownsEventLedger) eventLedger.close();

--- a/test/unit/miner-manage-status.test.ts
+++ b/test/unit/miner-manage-status.test.ts
@@ -275,6 +275,32 @@ describe("loopover-miner manage status (#2325)", () => {
     ]);
   });
 
+  it("reports a clean CLI failure (honoring --json) when collecting status throws, instead of an unhandled throw (#7236)", () => {
+    const throwingQueue = {
+      listQueue() {
+        throw new Error("boom: portfolio-queue read failed");
+      },
+      close() {},
+    };
+    const initStores = {
+      initPortfolioQueue: () => throwingQueue,
+      initEventLedger: () => ({ readEvents: () => [], close() {} }),
+      initRunStateStore: () => ({ listRunStates: () => [], close() {} }),
+    } as unknown as Parameters<typeof runManageStatus>[1];
+
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => runManageStatus([], initStores)).not.toThrow();
+    expect(runManageStatus([], initStores)).toBe(2);
+    expect(String(error.mock.calls.at(-1)?.[0])).toContain("boom: portfolio-queue read failed");
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(runManageStatus(["--json"], initStores)).toBe(2);
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toEqual({
+      ok: false,
+      error: "boom: portfolio-queue read failed",
+    });
+  });
+
   it("rejects unknown CLI options", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(runManageStatus(["--verbose"])).toBe(2);


### PR DESCRIPTION
## Summary

`manage-status.js`'s `runManageStatus` opened three local SQLite stores and ran `collectManageStatus` /
`collectRunPortfolio` + the `console.log` inside a `try { ... } finally { ...close... }` with **no `catch`**.
A read/render failure therefore propagated as an unhandled throw out of the CLI command — inconsistent
with every other store-touching command, which fail cleanly through `reportCliFailure` (honoring `--json`).

This adds the missing `catch` between the existing `try` body and `finally`, matching the exact pattern
`runOrbExportCli` (`orb-export.js`) and `runQueueList` (`portfolio-queue-cli.js`) already use:
`catch (error) { return reportCliFailure(parsed.json, describeCliError(error)); }`. The store-opening lines
stay outside the `try`, and the `finally`'s store-closing logic is untouched. `describeCliError` is now
imported alongside the existing `argsWantJson, reportCliFailure`.

Closes #7236

## Scope

- [x] Conventional Commit title; focused (one module + its test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7236`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` — **100% of the changed line covered**. New regression: when `collectManageStatus`
      throws, `runManageStatus` returns a clean exit code (2) and surfaces the message via `console.error` (text)
      or a `{ ok: false, error }` JSON object (`--json`), never an unhandled throw. Existing tests pass unchanged.
- [x] `npm run build:miner` (`node --check` passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**`; CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise — the surfaced error is `describeCliError`'s message string, same as the sibling commands.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — error-handling only; success-path output is byte-identical.
- [x] No UI change — no UI Evidence needed.
