### PR TITLE
fix(miner): bound the AMS export POST with a request timeout (#7237)

### DIFF
--- a/packages/loopover-miner/lib/orb-export.d.ts
+++ b/packages/loopover-miner/lib/orb-export.d.ts
@@ -53,6 +53,8 @@ export function latestClosedAt(batch: OrbExportRow[]): string | null;
 
 export const DEFAULT_AMS_COLLECTOR_URL: string;
 
+export const DEFAULT_ORB_EXPORT_TIMEOUT_MS: number;
+
 export function resolveAmsCollectorUrl(env?: Record<string, string | undefined>): string;
 
 export function sendAmsExportBatch(options: {
@@ -61,6 +63,7 @@ export function sendAmsExportBatch(options: {
   collectorUrl?: string;
   collectorToken?: string | undefined;
   fetchFn?: typeof fetch;
+  timeoutMs?: number;
 }): Promise<AmsExportSendResult>;
 
 export type ParsedOrbExportArgs = { json: boolean; enable: boolean; send: boolean; dryRun: boolean } | { error: string };

--- a/packages/loopover-miner/lib/orb-export.js
+++ b/packages/loopover-miner/lib/orb-export.js
@@ -177,7 +177,18 @@ export function resolveAmsCollectorUrl(env = process.env) {
  * response, `{ sent: 0, error }` otherwise — a network failure or non-2xx never throws, matching this module's
  * fail-open posture (a telemetry hiccup must never break the miner's real work).
  */
-export async function sendAmsExportBatch({ batch, secret, collectorUrl = resolveAmsCollectorUrl(), collectorToken, fetchFn = fetch }) {
+// Bound a single AMS-collector POST so a hung/black-holed collector can't stall the export indefinitely (#7237).
+// 10s matches this package's other default request timeouts (live-issue-snapshot.js / opportunity-fanout.js).
+export const DEFAULT_ORB_EXPORT_TIMEOUT_MS = 10_000;
+
+export async function sendAmsExportBatch({
+  batch,
+  secret,
+  collectorUrl = resolveAmsCollectorUrl(),
+  collectorToken,
+  fetchFn = fetch,
+  timeoutMs = DEFAULT_ORB_EXPORT_TIMEOUT_MS,
+}) {
   if (!Array.isArray(batch) || batch.length === 0) return { sent: 0 };
   const instanceId = amsInstanceId(secret);
   const body = JSON.stringify({ instanceId, events: batch });
@@ -192,6 +203,7 @@ export async function sendAmsExportBatch({ batch, secret, collectorUrl = resolve
         ...(collectorToken ? { authorization: `Bearer ${collectorToken}` } : {}),
       },
       body,
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) return { sent: 0, error: `http_${res.status}` };
   } catch (error) {

--- a/test/unit/miner-orb-export.test.ts
+++ b/test/unit/miner-orb-export.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ORB_EXPORT_ENABLED_BY_DEFAULT,
   DEFAULT_AMS_COLLECTOR_URL,
+  DEFAULT_ORB_EXPORT_TIMEOUT_MS,
   amsInstanceId,
   buildAnonymizedOrbBatch,
   collectOrbExportBatch,
@@ -230,5 +231,26 @@ describe("sendAmsExportBatch (#5681)", () => {
     const result = await sendAmsExportBatch({ batch, secret: "s".repeat(64), fetchFn });
     expect(result.sent).toBe(0);
     expect(result.error).toBeTruthy();
+  });
+
+  it("bounds the request with an AbortSignal.timeout (default 10s), honoring an explicit timeoutMs (#7237)", async () => {
+    expect(DEFAULT_ORB_EXPORT_TIMEOUT_MS).toBe(10_000);
+
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    await sendAmsExportBatch({ batch, secret: "s".repeat(64), fetchFn }); // no timeoutMs -> default applies
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+
+    fetchFn.mockClear();
+    await sendAmsExportBatch({ batch, secret: "s".repeat(64), fetchFn, timeoutMs: 250 }); // explicit override
+    const [, override] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(override.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("catches an aborted (timed-out) request via the existing catch, without throwing (#7237)", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new DOMException("The operation was aborted.", "TimeoutError"));
+    const result = await sendAmsExportBatch({ batch, secret: "s".repeat(64), fetchFn });
+    expect(result.sent).toBe(0);
+    expect(result.error).toContain("aborted");
   });
 });


### PR DESCRIPTION
## Summary

`orb-export.js`'s `sendAmsExportBatch` POSTed the anonymized telemetry batch to the AMS collector with **no
request timeout** — a hung or black-holed collector could stall the export indefinitely (and, since the
export runs inside the miner loop, back-pressure it).

This bounds the single request with `signal: AbortSignal.timeout(timeoutMs)`, added to the existing `fetchFn`
init object without touching `method`/`headers`/`body`. `timeoutMs` is a new option defaulting to a new
exported `DEFAULT_ORB_EXPORT_TIMEOUT_MS` (`10_000` — matching this package's other default request timeouts in
`live-issue-snapshot.js`/`opportunity-fanout.js`), so every real invocation is bounded automatically without
`runOrbExportCli` passing anything. A timeout surfaces as a thrown `AbortError`/`TimeoutError` that the
**existing** `catch` already turns into `{ sent: 0, error }` — no new catch branch, and no retry logic added.

Closes #7237

## Scope

- [x] Conventional Commit title; focused (one module + its `.d.ts` + its test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7237`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean; `.d.ts` updated with the new export + `timeoutMs` option)
- [x] `npm run test:coverage` — **100% of the changed lines + branches covered**. New regressions: the request
      init carries an `AbortSignal` (default and explicit `timeoutMs`), `DEFAULT_ORB_EXPORT_TIMEOUT_MS === 10_000`,
      and an aborted (timed-out) request is caught into `{ sent: 0, error }` without throwing. Existing tests pass unchanged.
- [x] `npm run build:miner` (`node --check` passes).

If any required check was skipped, explain why:

- Backend change confined to `packages/loopover-miner/lib/**`; CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — bounds an existing outbound request only; success-path payload is byte-identical.
- [x] No UI change — no UI Evidence needed.
