### PR TITLE
fix(ui-miner): sync PortfolioRepoSummary's apiBaseUrl into the miner-ui's UI-side type mirror

### DIFF
--- a/apps/loopover-miner-ui/src/lib/demo-data.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-data.ts
@@ -69,10 +69,30 @@ export const DEMO_PORTFOLIO_QUEUE_SUMMARY: PortfolioQueueSummary = {
   total: 27,
   byStatus: { queued: 9, in_progress: 3, done: 15 },
   repos: [
-    { repoFullName: "acme/widgets", byStatus: { queued: 4, in_progress: 1, done: 6 }, total: 11 },
-    { repoFullName: "acme/api-gateway", byStatus: { queued: 2, in_progress: 1, done: 4 }, total: 7 },
-    { repoFullName: "acme/docs-site", byStatus: { queued: 1, in_progress: 0, done: 3 }, total: 4 },
-    { repoFullName: "northwind/inventory", byStatus: { queued: 2, in_progress: 1, done: 2 }, total: 5 },
+    {
+      repoFullName: "acme/widgets",
+      apiBaseUrl: "https://forge.example.com",
+      byStatus: { queued: 4, in_progress: 1, done: 6 },
+      total: 11,
+    },
+    {
+      repoFullName: "acme/api-gateway",
+      apiBaseUrl: "https://forge.example.com",
+      byStatus: { queued: 2, in_progress: 1, done: 4 },
+      total: 7,
+    },
+    {
+      repoFullName: "acme/docs-site",
+      apiBaseUrl: "https://forge.example.com",
+      byStatus: { queued: 1, in_progress: 0, done: 3 },
+      total: 4,
+    },
+    {
+      repoFullName: "northwind/inventory",
+      apiBaseUrl: "https://forge.example.com",
+      byStatus: { queued: 2, in_progress: 1, done: 2 },
+      total: 5,
+    },
   ],
   oldestQueuedAgeMs: 6 * 60 * 60 * 1000, // 6h
 };

--- a/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
+++ b/apps/loopover-miner-ui/src/lib/portfolio-queue.ts
@@ -16,6 +16,7 @@ export type QueueStatusCounts = Record<QueueStatus, number>;
 
 export type PortfolioRepoSummary = {
   repoFullName: string;
+  apiBaseUrl: string;
   byStatus: QueueStatusCounts;
   total: number;
 };
@@ -38,7 +39,12 @@ function isQueueStatusCounts(value: unknown): value is QueueStatusCounts {
 function isPortfolioRepoSummary(value: unknown): value is PortfolioRepoSummary {
   if (typeof value !== "object" || value === null) return false;
   const repo = value as Record<string, unknown>;
-  return typeof repo.repoFullName === "string" && isQueueStatusCounts(repo.byStatus) && typeof repo.total === "number";
+  return (
+    typeof repo.repoFullName === "string" &&
+    typeof repo.apiBaseUrl === "string" &&
+    isQueueStatusCounts(repo.byStatus) &&
+    typeof repo.total === "number"
+  );
 }
 
 function isPortfolioQueueSummary(value: unknown): value is PortfolioQueueSummary {

--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -24,7 +24,14 @@ import {
 const fixtureSummary = {
   total: 2,
   byStatus: { queued: 0, in_progress: 1, done: 1 },
-  repos: [{ repoFullName: "acme/widgets", byStatus: { queued: 0, in_progress: 1, done: 1 }, total: 2 }],
+  repos: [
+    {
+      repoFullName: "acme/widgets",
+      apiBaseUrl: "https://api.github.com",
+      byStatus: { queued: 0, in_progress: 1, done: 1 },
+      total: 2,
+    },
+  ],
   oldestQueuedAgeMs: null,
 };
 

--- a/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue.test.tsx
@@ -23,8 +23,18 @@ const fixtureSummary: PortfolioQueueSummary = {
   total: 4,
   byStatus: { queued: 2, in_progress: 1, done: 1 },
   repos: [
-    { repoFullName: "acme/another-repo", byStatus: { queued: 1, in_progress: 0, done: 1 }, total: 2 },
-    { repoFullName: "acme/secret-repo", byStatus: { queued: 1, in_progress: 1, done: 0 }, total: 2 },
+    {
+      repoFullName: "acme/another-repo",
+      apiBaseUrl: "https://api.github.com",
+      byStatus: { queued: 1, in_progress: 0, done: 1 },
+      total: 2,
+    },
+    {
+      repoFullName: "acme/secret-repo",
+      apiBaseUrl: "https://api.github.com",
+      byStatus: { queued: 1, in_progress: 1, done: 0 },
+      total: 2,
+    },
   ],
   oldestQueuedAgeMs: 5_400_000,
 };
@@ -75,6 +85,7 @@ function manyRepos(count: number): PortfolioRepoSummary[] {
   // Descending totals so the default sort (total desc) puts repo-00 first — mirrors ledgers' manyEventTypes.
   return Array.from({ length: count }, (_, index) => ({
     repoFullName: `acme/repo-${String(index).padStart(2, "0")}`,
+    apiBaseUrl: "https://api.github.com",
     byStatus: { queued: count - index, in_progress: 0, done: 0 },
     total: count - index,
   }));
@@ -145,8 +156,18 @@ describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
       total: 4,
       byStatus: { queued: 4, in_progress: 0, done: 0 },
       repos: [
-        { repoFullName: "acme/zeta", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 },
-        { repoFullName: "acme/alpha", byStatus: { queued: 2, in_progress: 0, done: 0 }, total: 2 },
+        {
+          repoFullName: "acme/zeta",
+          apiBaseUrl: "https://api.github.com",
+          byStatus: { queued: 2, in_progress: 0, done: 0 },
+          total: 2,
+        },
+        {
+          repoFullName: "acme/alpha",
+          apiBaseUrl: "https://api.github.com",
+          byStatus: { queued: 2, in_progress: 0, done: 0 },
+          total: 2,
+        },
       ],
       oldestQueuedAgeMs: null,
     };
@@ -306,7 +327,10 @@ function fakeCollectPortfolioDashboard(
   options: { nowMs: number },
 ): PortfolioQueueSummary {
   const byStatus = { queued: 0, in_progress: 0, done: 0 };
-  const perRepo = new Map<string, { repoFullName: string; byStatus: typeof byStatus; total: number }>();
+  const perRepo = new Map<
+    string,
+    { repoFullName: string; apiBaseUrl: string; byStatus: typeof byStatus; total: number }
+  >();
   let total = 0;
   let oldestQueuedMs: number | null = null;
   for (const entry of sources.portfolioQueue.listQueue()) {
@@ -315,7 +339,15 @@ function fakeCollectPortfolioDashboard(
     byStatus[status] += 1;
     let repo = perRepo.get(entry.repoFullName);
     if (!repo) {
-      repo = { repoFullName: entry.repoFullName, byStatus: { queued: 0, in_progress: 0, done: 0 }, total: 0 };
+      // Fixed default apiBaseUrl: this fixture only exercises single-host WIRING (see the comment above), never
+      // host-scoped grouping -- that is the real portfolio-dashboard.js's own concern, covered by
+      // test/unit/miner-portfolio-dashboard.test.ts.
+      repo = {
+        repoFullName: entry.repoFullName,
+        apiBaseUrl: "https://api.github.com",
+        byStatus: { queued: 0, in_progress: 0, done: 0 },
+        total: 0,
+      };
       perRepo.set(entry.repoFullName, repo);
     }
     repo.byStatus[status] += 1;
@@ -361,11 +393,13 @@ describe("handlePortfolioQueueRequest (#4306, reunified with the CLI's queue das
       repos: [
         {
           repoFullName: "private-org/another-repo",
+          apiBaseUrl: "https://api.github.com",
           byStatus: { queued: 1, in_progress: 0, done: 1 },
           total: 2,
         },
         {
           repoFullName: "private-org/secret-repo",
+          apiBaseUrl: "https://api.github.com",
           byStatus: { queued: 1, in_progress: 1, done: 0 },
           total: 2,
         },


### PR DESCRIPTION
## Summary

- `packages/loopover-miner/lib/portfolio-dashboard.d.ts`'s `PortfolioRepoSummary` recently gained a required `apiBaseUrl: string` field (host-scoped per-repo dashboard grouping, #7225). `apps/loopover-miner-ui` maintains its own hand-written structural mirror of this same shape in `apps/loopover-miner-ui/src/lib/portfolio-queue.ts` -- the miner-ui cannot import the real backend module directly, since `portfolio-dashboard.js` transitively pulls in `node:sqlite` via `portfolio-queue.js`, which the browser/test bundler cannot bundle.
- That local mirror was not updated alongside the backend type change, so `npm run ui:typecheck` currently fails on `main` itself: `apps/loopover-miner-ui/vite-portfolio-queue-api.ts`'s `PortfolioDashboardModule.collectPortfolioDashboard` return type is declared directly against the real `PortfolioDashboardSummary`, and the test doubles constructing the UI's own `PortfolioQueueSummary`/`PortfolioRepoSummary` no longer satisfy it -- verified locally with `npm run ui:typecheck` (a real compile error, not a false positive).
- Fixed by adding `apiBaseUrl: string` to the UI-side `PortfolioRepoSummary` type, updating its `isPortfolioRepoSummary` runtime guard to validate it, and supplying a value in every fixture that constructs one (`demo-data.ts`'s `DEMO_PORTFOLIO_QUEUE_SUMMARY`, and every `PortfolioRepoSummary`-shaped object literal in `portfolio-queue.test.tsx` and `portfolio-queue-actions.test.tsx`). Pure type-completeness fix -- no behavior or display change; the miner-ui's own visible host column (if wanted) is separate, unscoped follow-up work.

Closes #7262

## Scope

- [x] Conventional Commit title; focused (one UI-side type + its fixtures); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7262`).

## Validation

- [x] `git diff --check`
- [x] `npm run ui:typecheck` -- clean (was failing before this fix).
- [x] `npm --workspace @loopover/ui-miner run lint` -- 0 errors (10 pre-existing warnings unrelated to this change).
- [x] `npm --workspace @loopover/ui-miner run test` -- 320/320 tests pass.
- [x] Full `npm run test:ci` green end to end, run twice under the repo's pinned Node 22 (`.nvmrc`) to confirm reproducibility.
- [x] `npm audit --audit-level=moderate` -- clean except the same pre-existing, unrelated `adm-zip`/`github-actionlint` advisory with no fix available.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- a local type-mirror sync, not an auth surface.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no OpenAPI-documented surface touched; this is a client-side TypeScript type, not a wire contract.)
- [ ] UI changes use live API data -- N/A, no visible UI/display change, only an internal type + its fixtures.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No `CHANGELOG.md` edit; internal type-completeness fix needs no doc update.)

## Notes

- Found while running the full local gate for an unrelated fix (#7224) on a freshly-synced `main` -- `apps/**` isn't scored by Codecov's `src/**`-scoped patch gate, so this type drift had gone unnoticed by CI's coverage signal, but `ui:typecheck` is still a required, currently-broken check on `main`. Filed as its own issue/PR rather than folded into #7224's unrelated backend change, per the "one coherent PR" rule.
