### PR TITLE
fix(content-lane): add snake_case source-url aliases to sourceUrlFields (#7250)

### DIFF
--- a/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
+++ b/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
@@ -106,6 +106,17 @@ export const AWESOME_CLAUDE_CONTENT_SPEC: ContentRepoSpec = {
     "repositoryUrl",
     "sourceUrl",
     "websiteUrl",
+    // snake_case aliases, matching urlFields one-for-one (#7250): source-evidence.ts read only the camelCase
+    // names, so an entry using a legitimately-listed snake_case key (e.g. the canonical `source_url`) was visible
+    // to duplicates.ts but invisible to the source-evidence gate.
+    "docs_url",
+    "download_url",
+    "github_url",
+    "package_url",
+    "repo_url",
+    "repository_url",
+    "source_url",
+    "website_url",
   ],
   sourceUrlListFields: new Set(["sourceUrls", "retrievalSources"]),
   distributionSourceFields: new Set(["downloadUrl", "packageUrl"]),

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -51,6 +51,18 @@ describe("extractSubmittedSourceUrls", () => {
     const urls = extractSubmittedSourceUrls(mdx({ downloadUrl: "/downloads/skills/foo.zip" }));
     expect(urls).toHaveLength(0);
   });
+
+  it("reads snake_case source fields (e.g. the canonical source_url), matching urlFields (#7250)", () => {
+    // Before #7250, sourceUrlFields listed only the camelCase names, so a legitimately-aliased snake_case field
+    // was invisible to the source-evidence gate even though duplicates.ts (which reads urlFields) saw it.
+    const pairs = extractSubmittedSourceUrls(mdx({ source_url: "https://github.com/acme/y" })).map((u) => `${u.field}:${u.url}`);
+    expect(pairs).toContain("source_url:https://github.com/acme/y");
+    // Every snake_case alias urlFields carries is now recognized here too.
+    for (const field of ["docs_url", "download_url", "github_url", "package_url", "repo_url", "repository_url", "source_url", "website_url"]) {
+      expect(AWESOME_CLAUDE_CONTENT_SPEC.sourceUrlFields).toContain(field);
+      expect(AWESOME_CLAUDE_CONTENT_SPEC.urlFields.has(field)).toBe(true);
+    }
+  });
 });
 
 describe("checkSubmittedSourceEvidence", () => {


### PR DESCRIPTION
## Summary

`content-repo-spec.ts` defines two lists over the same concept — the manifest-entry keys that hold a
source/provenance URL — but they had diverged:

- `urlFields` (a `Set`, read by `duplicates.ts`) lists both camelCase **and** snake_case aliases
  (`sourceUrl`/`source_url`, `githubUrl`/`github_url`, …).
- `sourceUrlFields` (an array, read by `source-evidence.ts`) listed **only** the camelCase names.

So a manifest entry using a legitimately-listed snake_case key — e.g. `source_url:`, in fact the canonical
field per the repo's contribution conventions — was seen by duplicate-detection but **invisible** to the
source-evidence gate.

This adds the eight snake_case aliases (`docs_url`, `download_url`, `github_url`, `package_url`, `repo_url`,
`repository_url`, `source_url`, `website_url`) to `sourceUrlFields`, matching `urlFields`'s existing pairing
one-for-one. Data-only change to the spec constant; neither consumer's logic is touched. (`src/review/content-lane/content-repo-spec.ts` is a `export *` re-export shim, so the app sees the fix automatically.)

Closes #7250

## Scope

- [x] Conventional Commit title; focused (one spec constant + its test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7250`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` — **100% of the changed lines covered**. New regression: a `source_url:` frontmatter
      field is now extracted by `extractSubmittedSourceUrls` (it was dropped before), and every snake_case alias in
      `sourceUrlFields` is asserted present in both lists. Existing content-lane duplicate/source-evidence suites pass unchanged.
- [x] Change is a pure data addition to a `readonly string[]`; both consumers' logic is untouched.

If any required check was skipped, explain why:

- Change confined to `packages/loopover-engine/src/review/content-lane/**` (one constant + one test); CI runs the full suite incl. engine-parity.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — a spec-constant data fix; it only makes the source-evidence gate recognize the same fields duplicate-detection already did.
- [x] No UI change — no UI Evidence needed.
