### PR TITLE
fix(engine): don't charge per-file-skipped files against repo-map's aggregate budget

### DIFF
--- a/packages/loopover-engine/src/miner/repo-map.ts
+++ b/packages/loopover-engine/src/miner/repo-map.ts
@@ -268,11 +268,22 @@ export async function buildRepoMap(
     }
     const languageName = resolveRepoMapLanguage(file.path);
     const sourceBytes = Buffer.byteLength(file.sourceText, "utf8");
+    // A file exceeding the per-file cap is skipped without being parsed, so it must NOT consume the
+    // aggregate parsed-work budget. Counting it before this check let one oversized file (a vendored/
+    // minified asset or generated bundle) exhaust maxTotalSourceBytes and force every subsequent small,
+    // legitimate file to skip too — a silent, order-dependent near-empty map (#7247). Only files that pass
+    // the per-file cap accrue against the aggregate, exactly as before for in-cap files.
+    if (sourceBytes > maxSourceBytes) {
+      entries.push({
+        path: file.path,
+        language: languageName,
+        symbols: [],
+        skipped: "resource_limit",
+      });
+      continue;
+    }
     totalSourceBytes += sourceBytes;
-    if (
-      sourceBytes > maxSourceBytes ||
-      totalSourceBytes > maxTotalSourceBytes
-    ) {
+    if (totalSourceBytes > maxTotalSourceBytes) {
       entries.push({
         path: file.path,
         language: languageName,

--- a/test/unit/repo-map.test.ts
+++ b/test/unit/repo-map.test.ts
@@ -229,6 +229,28 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
     });
   });
 
+  it("does not charge a file skipped for the per-file cap against the aggregate budget (#7247)", async () => {
+    // "function reallyLongName() {}" (28 bytes) exceeds the per-file cap and is skipped WITHOUT being
+    // parsed; pre-#7247 its bytes were still charged to the aggregate budget, exhausting it and skipping
+    // the small, legitimate file after it. The aggregate must only account for files actually parsed.
+    const entries = await buildRepoMap(
+      [
+        { path: "src/huge.ts", sourceText: "function reallyLongName() {}" },
+        { path: "src/small.ts", sourceText: "function s() {}" },
+      ],
+      { maxSourceBytes: 20, maxTotalSourceBytes: 20 },
+    );
+    expect(entries[0]).toEqual({
+      path: "src/huge.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "resource_limit",
+    });
+    // The small file after the skipped-oversized one is still parsed, not starved of aggregate budget.
+    expect(entries[1]!.skipped).toBeUndefined();
+    expect(entries[1]!.symbols.map((symbol) => symbol.name)).toEqual(["s"]);
+  });
+
   it("keeps one entry per input file but resource-limits files beyond the file-count budget", async () => {
     const entries = await buildRepoMap(
       [


### PR DESCRIPTION
Closes #7247.

## Problem
`buildRepoMap` enforces two byte budgets: a per-file cap (`maxSourceBytes`) and an aggregate cap across all parsed files (`maxTotalSourceBytes`). It added each file's byte count to `totalSourceBytes` **before** the check that skips a file for exceeding the per-file cap:

```ts
const sourceBytes = Buffer.byteLength(file.sourceText, "utf8");
totalSourceBytes += sourceBytes;               // charged unconditionally...
if (sourceBytes > maxSourceBytes || totalSourceBytes > maxTotalSourceBytes) {
  entries.push({ ..., skipped: "resource_limit" });   // ...even for a file skipped here, never parsed
  continue;
}
```

So a single oversized file (a vendored/minified asset or generated bundle that slips into the input list) that is itself skipped for exceeding `maxSourceBytes` still burned its full byte count against `maxTotalSourceBytes` — the aggregate budget meant to bound total *parsed* work. Every subsequent small, legitimate file then also tripped `totalSourceBytes > maxTotalSourceBytes` and was marked `skipped: "resource_limit"`, producing a near-empty, order-dependent repo map with no error surfaced to the driver that consumes it.

## Fix
Accrue to the aggregate **after** the per-file cap check, so only files that pass the per-file cap (and are actually parsed) count against the aggregate. Files under the per-file cap accrue and gate against the aggregate exactly as before — the only behavior change is that a per-file-oversized, unparsed file no longer poisons the aggregate for the files after it.

## Tests
Added a regression test in `repo-map.test.ts` (imports the engine via its source barrel, so the changed lines are instrumented): an oversized first file (28 bytes, over a `maxSourceBytes: 20` / `maxTotalSourceBytes: 20` config) is skipped, and the small legitimate file after it is still parsed (symbols extracted) rather than starved of aggregate budget. The existing per-file-cap and aggregate-cap tests continue to cover both skip branches.

## Verification
- `tsc --noEmit` (root typecheck) — clean.
- `npm run build --workspace @loopover/engine` — clean.
- `repo-map.test.ts` — 35 tests green.
- Changed file `repo-map.ts`: 113/113 lines, 12/12 functions, 84/84 branches covered (v8/lcov).
