### PR TITLE
fix(engine): single-source the suspicious-label matcher so bestFitLabels can't drift

### DIFF
--- a/packages/loopover-engine/src/reward-risk.ts
+++ b/packages/loopover-engine/src/reward-risk.ts
@@ -8,6 +8,7 @@
 // (#4256).
 import type { ScorePreviewResult } from "./scoring/preview.js";
 import { buildScorePreview } from "./scoring/preview.js";
+import { isSuspiciousConfiguredLabel } from "./scoring/label-match.js";
 import { isFailingCheckSummary } from "./signals/check-summary.js";
 import { nowIso } from "./utils/json.js";
 import type {
@@ -832,11 +833,11 @@ function analysisRank(analysis: RepoRewardRisk): number {
 function bestFitLabels(repo: RepositoryRecord | null): string[] {
   const multipliers = repo?.registryConfig?.labelMultipliers ?? {};
   const labels = Object.entries(multipliers)
-    // Exclude meta labels only at a keyword boundary (a real separator or end-of-string after the keyword),
-    // not mid-word — mirroring the anchored `suspiciousConfiguredLabels` matcher in engine.ts. The old
-    // unanchored regex over-matched substrings (e.g. "opensource" via "source", "risky-refactor" via "risk"),
-    // wrongly dropping a legitimate high-multiplier label from the best-fit suggestion.
-    .filter(([label]) => !/^(status|source|contributor|verified|risk|codex)([:/-]|$)/i.test(label))
+    // Exclude meta labels using the SHARED canonical matcher (#7251) so this can't drift from engine.ts's
+    // `suspiciousConfiguredLabels` audit again -- the two had diverged (this copy was missing
+    // state/bot/loopover/reward/score/miner and wrongly excluded `contributor`, which the canonical audit does
+    // not treat as suspicious).
+    .filter(([label]) => !isSuspiciousConfiguredLabel(label))
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
     .map(([label]) => label);
   return labels.slice(0, 1);

--- a/packages/loopover-engine/src/scoring/label-match.ts
+++ b/packages/loopover-engine/src/scoring/label-match.ts
@@ -4,6 +4,15 @@ export function labelMatchesPattern(label: string, pattern: string): boolean {
   return labelPatternToRegExp(pattern.toLowerCase()).test(label.toLowerCase());
 }
 
+/** Canonical "meta / suspicious configured-label" keyword matcher (#7251). A configured label multiplier key
+ *  whose keyword matches at a real boundary (`status:ready`, `reward/x`, or bare `bot`) — but NOT mid-word
+ *  (`bottleneck`, `scoreboard`, `riskier`) — is treated as a meta label rather than a genuine work label. Single
+ *  source of truth so engine.ts's `suspiciousConfiguredLabels` audit and reward-risk.ts's `bestFitLabels`
+ *  exclusion can't drift apart the way they already had. */
+export function isSuspiciousConfiguredLabel(label: string): boolean {
+  return /^(status|state|source|bot|codex|loopover|reward|score|miner|verified|risk)([:/-]|$)/i.test(label);
+}
+
 // Compiled fnmatch→RegExp matchers are memoized by pattern. The same small,
 // config-derived set of label keys is matched on every scored PR/issue, so the
 // per-call recompile inside the nested label loops in engine.ts is pure waste.

--- a/packages/loopover-engine/src/signals/engine.ts
+++ b/packages/loopover-engine/src/signals/engine.ts
@@ -32,6 +32,7 @@ import { nowIso } from "../utils/json.js";
 import { extractLinkedIssueNumbers } from "../../../../src/db/repositories";
 import { sanitizePublicComment } from "../../../../src/queue-intelligence";
 import { labelMatchesPattern, projectLinkedIssueMultiplierForPlannedSolve, type LinkedIssueMultiplierStatus } from "../scoring/preview.js";
+import { isSuspiciousConfiguredLabel } from "../scoring/label-match.js";
 import { hasLocalTestEvidence, hasValidationNote, isTestPath } from "./test-evidence.js";
 import { isCodeFile, isTestFile } from "./path-matchers.js";
 import { isFailingCheckSummary } from "./check-summary.js";
@@ -1179,7 +1180,7 @@ export function buildLabelAudit(repo: RepositoryRecord | null, repoLabels: RepoL
   // Require a real separator (`:`/`/`/`-`) OR end-of-string after the keyword so this flags prefix-style labels
   // (`status:ready`, `reward/x`) and bare keywords (`bot`) — but NOT mid-word matches like `bottleneck` (`bot`),
   // `scoreboard` (`score`), or `riskier` (`risk`). The old optional+unanchored `[:/-]?` over-matched those.
-  const suspiciousConfiguredLabels = configuredLabels.filter((label) => /^(status|state|source|bot|codex|loopover|reward|score|miner|verified|risk)([:/-]|$)/i.test(label));
+  const suspiciousConfiguredLabels = configuredLabels.filter((label) => isSuspiciousConfiguredLabel(label));
   const findings: SignalFinding[] = [];
   if (repo?.registryConfig?.trustedLabelPipeline && missingConfiguredLabels.length > 0) {
     findings.push({

--- a/test/unit/reward-risk-freshness.test.ts
+++ b/test/unit/reward-risk-freshness.test.ts
@@ -196,4 +196,14 @@ describe("bestFitLabels keyword anchoring", () => {
     expect(pick({})).toEqual([]);
     expect(rewardRiskFreshnessInternals.bestFitLabels(null)).toEqual([]);
   });
+
+  it("aligns its meta-label exclusion set to engine.ts's canonical suspicious-label matcher (#7251)", () => {
+    // Keywords the canonical audit excludes that the old divergent copy MISSED are now excluded here too.
+    for (const key of ["state", "bot", "loopover", "reward", "score", "miner"]) {
+      expect(pick({ [`${key}:x`]: 5, bug: 2 })).toEqual(["bug"]);
+    }
+    // `contributor` was wrongly excluded before -- the canonical audit does not treat it as suspicious, so a
+    // high-multiplier contributor:* label must now surface as the best fit instead of being silently dropped.
+    expect(pick({ "contributor:top-tier": 5, bug: 2 })).toEqual(["contributor:top-tier"]);
+  });
 });


### PR DESCRIPTION
## What

`reward-risk.ts`'s `bestFitLabels` filtered configured label-multiplier keys with a regex that **claimed** to "mirror the anchored `suspiciousConfiguredLabels` matcher in engine.ts" but had drifted from it:

- **Missing** from `bestFitLabels`: `state`, `bot`, `loopover`, `reward`, `score`, `miner` (all in the canonical set).
- **Extra** in `bestFitLabels`: `contributor` (not in the canonical set at all).

Since `bestFitLabels` feeds the contributor-facing reward preview (`currentEstimatedScore`/`estimatedScoreIfClean`), the divergence was behavioral: a repo's high-multiplier `contributor:top-tier` label was silently dropped from the preview, while a `bot:*` label the maintainer audit flags as suspicious was folded in.

## How

Extract the canonical keyword matcher into a single shared source and have both consumers use it, so they can't drift again:

- Add `isSuspiciousConfiguredLabel` to `scoring/label-match.ts` — a **neutral leaf module** (imports only `change-guardrail`) that neither `engine.ts` nor `reward-risk.ts` imported before, so this introduces **no circular dependency**.
- `engine.ts`'s `suspiciousConfiguredLabels` audit now calls it (behavior-identical — same regex).
- `bestFitLabels` now calls it, which corrects its exclusion set to the canonical one.

## Behavior change to flag for review

Per the issue's guidance, I **defaulted to matching the canonical set** (dropping `contributor` from the exclusion). If `contributor:*` should genuinely be excluded from the contributor-facing best-fit preview for a reason distinct from the maintainer suspicious-label audit, that would need to be a separate, explicitly-named exclusion — not folded into a "mirrors the canonical matcher" regex. I found no such reason in the code; surfacing it here for maintainer confirmation.

## Validation

Engine build/typecheck clean; the reward-risk and label-audit suites pass (`engine.ts`'s audit is byte-identical). A regression test added to `bestFitLabels`'s existing anchoring block asserts the corrected set: the six previously-missing keywords are now excluded, and `contributor:top-tier` now surfaces as the best fit. Confirmed it **fails against the unfixed `bestFitLabels`**.

Closes #7251
