### PR TITLE
fix(miner): clamp out-of-contract usage from the iterate-loop running totals (#7246)

### DIFF
--- a/packages/loopover-engine/src/miner/iterate-loop.ts
+++ b/packages/loopover-engine/src/miner/iterate-loop.ts
@@ -420,8 +420,8 @@ async function runIterateLoopCore(input: IterateLoopInput, deps: IterateLoopDeps
       maxTurns: input.maxTurnsPerIteration,
     });
     const iterationElapsedMs = Math.max(0, nowMs() - iterationStartMs);
-    totalTurnsUsed += driverResult.turnsUsed ?? 0;
-    totalCostUsd += driverResult.costUsd ?? 0;
+    totalTurnsUsed += finiteNonNegativeUsage(driverResult.turnsUsed);
+    totalCostUsd += finiteNonNegativeUsage(driverResult.costUsd);
     // Real per-iteration tokens (#5653): CodingAgentDriverResult.tokensUsed is now populated by every driver
     // that reports one (Agent SDK's own result-message usage, or CLI JSON/JSONL stdout) -- 0 only when the
     // driver genuinely reports no token signal for this iteration, same honest-absence discipline as costUsd.

--- a/test/unit/iterate-loop-usage-guard.test.ts
+++ b/test/unit/iterate-loop-usage-guard.test.ts
@@ -83,4 +83,16 @@ describe("runIterateLoop usage guard (#5827)", () => {
     expect(result.finalMeterTotals.turns).toBe(0);
     expect(result.finalMeterTotals.costUsd).toBe(0.02);
   });
+
+  it("clamps out-of-contract turnsUsed/costUsd out of the totalTurnsUsed/totalCostUsd accumulators too (#7246)", async () => {
+    for (const bad of [Number.NaN, -5, Number.POSITIVE_INFINITY]) {
+      const { deps } = collectingDeps(driverReturning({ ok: true, changedFiles: ["src/upload.ts"], summary: "x", turnsUsed: bad as number, costUsd: bad as number }));
+      const result = await runIterateLoop(passingInput(), deps);
+      // Before #7246 these used only `?? 0`, so NaN/negative/Infinity flowed straight into the running totals.
+      expect(result.totalTurnsUsed).toBe(0);
+      expect(result.totalCostUsd).toBe(0);
+      expect(Number.isFinite(result.totalTurnsUsed)).toBe(true);
+      expect(Number.isFinite(result.totalCostUsd)).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`iterate-loop.ts`'s `finiteNonNegativeUsage` exists specifically to clamp malformed driver-reported usage
numbers so "no current or future driver can crash the loop instead of being governed." But inside
`runIterateLoopCore`'s per-iteration loop it was applied inconsistently to two adjacent statements reading the
same `driverResult` fields:

- `tracker.totals` (budget-ceiling enforcement) correctly clamps `turnsUsed`/`costUsd` via `finiteNonNegativeUsage`.
- The `totalTurnsUsed`/`totalCostUsd` running accumulators two lines above used only `?? 0` — which catches
  `undefined`/`null` but **not** `NaN`, `Infinity`, or a negative number — before a raw `+=`.

So a driver reporting `NaN`/`Infinity`/a negative `turnsUsed`/`costUsd` poisoned the returned
`totalTurnsUsed`/`totalCostUsd` (`NaN` or a negative running total), even though the same values were correctly
clamped for budget enforcement. This applies the exact same `finiteNonNegativeUsage` guard to both accumulators.

Closes #7246

## Scope

- [x] Conventional Commit title; focused (one module + its test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7246`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` — **100% of the changed lines covered**. New regression: a driver reporting
      `NaN`/`-5`/`Infinity` for `turnsUsed`/`costUsd` now yields `totalTurnsUsed === 0` / `totalCostUsd === 0`
      (finite), instead of a poisoned running total. Existing usage-guard tests pass unchanged.

If any required check was skipped, explain why:

- Change confined to `packages/loopover-engine/src/miner/**` (one module + one test); CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — a defensive clamp on internal usage accounting; a well-behaved driver's totals are byte-identical.
- [x] No UI change — no UI Evidence needed.
