### PR TITLE
fix(signals): single-source predicted-gate-engine isCodeFile so .kts counts as code

### DIFF
--- a/packages/loopover-engine/src/signals/predicted-gate-engine.ts
+++ b/packages/loopover-engine/src/signals/predicted-gate-engine.ts
@@ -20,7 +20,7 @@ import type {
 } from "../types/predicted-gate-types.js";
 import { nowIso } from "../utils/json.js";
 import { PREFLIGHT_LIMITS } from "./preflight-limits.js";
-import { hasValidationNote, isTestPath } from "./test-evidence.js";
+import { hasValidationNote, isCodeFile, isTestPath } from "./test-evidence.js";
 import { diffFilePriority } from "../review/diff-file-priority.js";
 
 export type { IssueQualityReport, CollisionReport, CollisionCluster } from "../types/predicted-gate-types.js";
@@ -991,19 +991,6 @@ function daysSince(value: string | null | undefined): number {
   return Math.floor((Date.now() - parsed) / 86_400_000);
 }
 
-
-function isCodeFile(file: string): boolean {
-  // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php and C/C++/Objective-C added
-  // so native/C#/Swift/Groovy/PHP source counts as code, matching the test conventions
-  // isTestPath already recognizes; vue/svelte/astro match rag.ts, visual paths, and isCodePath;
-  // cc/hpp complete the C++ extension set alongside cpp/c/h; dart matches rag.ts and
-  // test-evidence's *_test.dart test convention).
-  return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(
-      file,
-    ) && !isTestFile(file)
-  );
-}
 
 function isTestFile(file: string): boolean {
   // Single-sourced with the canonical matcher (test-evidence.ts isTestPath), mirroring local-branch.ts's

--- a/test/unit/predicted-gate-engine-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-coverage.test.ts
@@ -447,6 +447,19 @@ describe("predicted-gate engine module coverage (#2283)", () => {
     expect(observed.findings.some((f) => f.code === "missing_linked_issue")).toBe(true);
   });
 
+  it("REGRESSION (#7252): a Kotlin-script-only change counts as code so it trips missing_test_evidence like the canonical matcher", () => {
+    // build.gradle.kts is hand-authored source; the predicted-gate engine's old local isCodeFile copy
+    // lacked the `kts` extension the canonical test-evidence matcher has, so a .kts-only PR skipped the
+    // missing-test-evidence preflight. Single-sourcing on isCodeFile widens the predicted gate to match.
+    const ktsOnly = buildPreflightResult(
+      { repoFullName: REPO.fullName, title: "Bump Gradle plugin", body: "Closes #7", linkedIssues: [7], changedFiles: ["build.gradle.kts"] },
+      REPO,
+      [],
+      [],
+    );
+    expect(ktsOnly.findings.some((f) => f.code === "missing_test_evidence")).toBe(true);
+  });
+
   it("REGRESSION (#6628): predicted preflight honors a clear no-issue rationale like the live gate", () => {
     const docsOnly = buildPreflightResult(
       { repoFullName: REPO.fullName, title: "docs-only: fix typo", body: "", linkedIssues: [] },


### PR DESCRIPTION
fix(signals): single-source predicted-gate-engine isCodeFile so .kts counts as code

The predicted-gate engine kept its own local isCodeFile regex, which had
kt but not kts, so a build.gradle.kts-only PR was classified as non-code
and skipped the missing-test-evidence preflight the canonical matcher
would have flagged. Delete the local copy and delegate to test-evidence's
isCodeFile (the single source of truth), which recognizes kts alongside
the same extended extensions and excludes generated Dart part files.

Closes #7252

