### PR TITLE
fix(scripts): bound gittensor-impact-card's fetches with a request timeout

### DIFF
--- a/scripts/gittensor-impact-card.d.mts
+++ b/scripts/gittensor-impact-card.d.mts
@@ -1,0 +1,14 @@
+// Deliberately not `typeof fetch`: the global fetch type (in a Cloudflare Workers-typed environment) is
+// overloaded to accept URL/RequestInfo/CfProperties, which a plainly-typed vi.fn() mock can't satisfy under
+// strict function-type checking (see scripts/load-test-worker.d.mts's identical note). Both functions here
+// only ever call fetchImpl with a string URL and a plain {headers?, signal} init.
+export type ImpactCardFetch = (
+  url: string,
+  init?: { headers?: Record<string, string>; signal?: AbortSignal },
+) => Promise<{ ok?: boolean; status?: number; json?: () => Promise<unknown>; text?: () => Promise<string> }>;
+
+export declare const GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS: number;
+
+export declare function fetchJson(url: string, fetchImpl?: ImpactCardFetch): Promise<unknown>;
+
+export declare function fetchGtLogoSvg(fetchImpl?: ImpactCardFetch): Promise<string>;

--- a/scripts/gittensor-impact-card.mjs
+++ b/scripts/gittensor-impact-card.mjs
@@ -9,10 +9,15 @@
 // Usage: node scripts/gittensor-impact-card.mjs <owner/repo> <out-file.svg>
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 
 const WEEKS = 12;
+// Bounds every outbound fetch in this script so a hung api.gittensor.io/gittensor.io connection can't block
+// the README-card regeneration job indefinitely -- matches the AbortSignal.timeout discipline every other
+// external-fetch script in this repo already follows (src/github/client.ts's GITHUB_FETCH_TIMEOUT_MS,
+// scripts/check-mcp-release-due.mjs's GITHUB_REQUEST_TIMEOUT_MS, etc.), which this script had been missing.
+export const GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS = 10_000;
 const THEME = {
   cardBg: "#0e100d",
   fg: "#f3f6f3",
@@ -47,12 +52,20 @@ function escapeXml(value) {
     .replace(/'/g, "&#x27;");
 }
 
-async function fetchJson(url) {
-  const res = await fetch(url, {
+export async function fetchJson(url, fetchImpl = fetch) {
+  const res = await fetchImpl(url, {
     headers: { "User-Agent": "gittensor-impact-card/1.0" },
+    signal: AbortSignal.timeout(GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS),
   });
   if (!res.ok) throw new Error(`fetch failed: ${url} (${res.status})`);
   return res.json();
+}
+
+export async function fetchGtLogoSvg(fetchImpl = fetch) {
+  const res = await fetchImpl("https://gittensor.io/gt-logo.svg", {
+    signal: AbortSignal.timeout(GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS),
+  });
+  return res.text();
 }
 
 function bucketWeekly(prs, now) {
@@ -214,7 +227,7 @@ async function main() {
   const [impact, prs, gtLogoSvg] = await Promise.all([
     fetchJson(`https://api.gittensor.io/repos/${encoded}/impact`),
     fetchJson(`https://api.gittensor.io/repos/${encoded}/prs`),
-    fetch("https://gittensor.io/gt-logo.svg").then((r) => r.text()),
+    fetchGtLogoSvg(),
   ]);
   const buckets = bucketWeekly(prs, new Date());
   const gtLogoB64 = Buffer.from(gtLogoSvg).toString("base64");
@@ -227,7 +240,13 @@ async function main() {
   console.log(`Wrote ${outFile} (${svg.length} bytes)`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Run only when invoked directly as a CLI script, not when imported (e.g. by this file's own unit tests
+// for fetchJson/fetchGtLogoSvg) -- matches every other CLI script's entrypoint guard in this repo (e.g.
+// scripts/check-mcp-release-due.mjs).
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (import.meta.url === pathToFileURL(entrypointPath).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/test/unit/gittensor-impact-card-script.test.ts
+++ b/test/unit/gittensor-impact-card-script.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchGtLogoSvg,
+  fetchJson,
+  GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS,
+} from "../../scripts/gittensor-impact-card.mjs";
+
+describe("gittensor-impact-card.mjs (#7231)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetchJson returns the parsed JSON body on a 200 response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ totalPRs: 5 }),
+    });
+    await expect(fetchJson("https://api.gittensor.io/repos/x/impact", fetchImpl)).resolves.toEqual({
+      totalPRs: 5,
+    });
+  });
+
+  it("fetchJson throws on a non-ok response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    await expect(fetchJson("https://api.gittensor.io/repos/x/impact", fetchImpl)).rejects.toThrow(
+      "fetch failed: https://api.gittensor.io/repos/x/impact (500)",
+    );
+  });
+
+  it("fetchJson bounds its request with the configured AbortSignal.timeout", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    await fetchJson("https://api.gittensor.io/repos/x/impact", fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("fetchJson aborts instead of hanging when fetchImpl never resolves, using the configured timeout value", async () => {
+    // Node's AbortSignal.timeout schedules its own internal, unmockable timer -- vi.useFakeTimers() doesn't
+    // intercept it, so asserting the real 10s wait would make this test genuinely slow. Stub
+    // AbortSignal.timeout itself instead: confirms fetchJson requests exactly the configured timeout value,
+    // and lets the test fire the abort immediately rather than waiting it out.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => AbortSignal.abort());
+    const hangingFetch = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<{ ok: boolean }>((_resolve, reject) => {
+          if (init?.signal?.aborted) reject(new DOMException("aborted", "AbortError"));
+          else init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+        }),
+    );
+
+    await expect(fetchJson("https://api.gittensor.io/repos/x/impact", hangingFetch)).rejects.toThrow();
+    expect(timeoutSpy).toHaveBeenCalledWith(GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS);
+  });
+
+  it("fetchGtLogoSvg returns the response body text", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ text: async () => "<svg></svg>" });
+    await expect(fetchGtLogoSvg(fetchImpl)).resolves.toBe("<svg></svg>");
+  });
+
+  it("fetchGtLogoSvg bounds its request with the configured AbortSignal.timeout", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ text: async () => "<svg></svg>" });
+    await fetchGtLogoSvg(fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://gittensor.io/gt-logo.svg",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("exposes the documented default timeout", () => {
+    expect(GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/gittensor-impact-card.mjs`'s `fetchJson` (used for both the `api.gittensor.io/repos/:repo/impact` and `.../prs` calls) and the standalone `gt-logo.svg` fetch had no request timeout at all — unlike every other external-fetch script in this repo (`scripts/check-mcp-release-due.mjs`'s `GITHUB_REQUEST_TIMEOUT_MS`, `scripts/smoke-observability-metrics.mjs`, `src/github/client.ts`'s `GITHUB_FETCH_TIMEOUT_MS`, etc.). A hung `api.gittensor.io`/`gittensor.io` connection would block the README-card regeneration job (`.github/workflows/gittensor-impact.yml`) indefinitely.
- Added a single shared `GITTENSOR_IMPACT_CARD_FETCH_TIMEOUT_MS` constant (`10_000`, exported) and passed `signal: AbortSignal.timeout(...)` on all three call sites (both via `fetchJson`, plus the extracted `fetchGtLogoSvg` helper for the logo fetch, which previously wasn't even wrapped in a named function).
- Both functions now accept an injectable `fetchImpl` parameter (defaulting to global `fetch`) so they're independently unit-testable without a real network call — matching this repo's established pattern for testable fetch adapters (e.g. `scripts/load-test-worker.mjs`).
- Added the CLI entry-point guard (`if (import.meta.url === pathToFileURL(...).href)`) every other script in this repo already has around its `main()` invocation (e.g. `scripts/check-mcp-release-due.mjs`) — this script was missing it, so simply *importing* the module (as the new test file needs to, to reach `fetchJson`/`fetchGtLogoSvg`) previously ran `main()` immediately and crashed via `process.exit(1)`. This is a pure test-enablement fix: CLI usage (`node scripts/gittensor-impact-card.mjs <owner/repo> <out-file.svg>`) and output are byte-identical — confirmed by running the script directly post-change and seeing the same `Usage: ...` message on missing args.
- No change to the generated SVG output shape, the script's non-error-path behavior, or any of the `render`/`bucketWeekly`/`sparkline`/`meter` pure helpers.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7231

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `node --check scripts/gittensor-impact-card.mjs` — clean.
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of diff size (reproduced on a clean checkout too, documented pattern from prior PRs in this repo's history). Verified instead via a standalone scoped `tsc --noEmit --strict --exactOptionalPropertyTypes` invocation against just the new test file (small enough to avoid the OOM) — clean. The new `.d.mts` companion deliberately types `fetchImpl` as a narrow custom `ImpactCardFetch` shape rather than `typeof fetch`, since the latter (in this repo's Cloudflare-Workers-typed environment) is overloaded in a way a plainly-typed `vi.fn()` mock can't satisfy — the same pitfall a previous PR in this repo (#7184) hit and fixed the same way.
- [x] `npx vitest run test/unit/gittensor-impact-card-script.test.ts` — 7/7 passing: success path, non-2xx throw, the `AbortSignal` is passed on every request, a genuinely-hanging `fetchImpl` still resolves via the configured timeout (verified by stubbing `AbortSignal.timeout` itself rather than waiting out a real 10s, since Node's `AbortSignal.timeout` schedules an internal timer `vi.useFakeTimers()` doesn't intercept), the logo fetch's body-text return, and the documented default constant value.
- [x] `scripts/**` is in `codecov.yml`'s `ignore` list (confirmed — matches the issue's own note), so this PR carries no Codecov patch-coverage obligation; the new dedicated test suite is the local coverage proxy.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — this PR only touches one standalone script + its test + its `.d.mts`; no Worker route, MCP, UI, or OpenAPI surface changed)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure regardless of diff size; a scoped `tsc --noEmit` against the new test file (with the same strict flags) is the local proxy, and CI's isolated runner performs the real whole-repo `tsc --noEmit`.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — this script only issues unauthenticated `GET` requests against already-public endpoints; no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no route, schema, or MCP behavior changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes; the generated SVG's content/shape is unchanged.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no UI changes; the generated README card's visual output is byte-for-byte unchanged, only the network layer underneath it gained a timeout.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
