### PR TITLE
fix(miner): grant Read/Bash in the agent-sdk driver's tool allowlist (#7245)

### DIFF
--- a/packages/loopover-engine/src/miner/agent-sdk-driver.ts
+++ b/packages/loopover-engine/src/miner/agent-sdk-driver.ts
@@ -30,6 +30,7 @@ export type AgentSdkQueryOptions = {
   cwd: string;
   maxTurns: number;
   permissionMode: "acceptEdits";
+  allowedTools: readonly string[];
   hooks?: AgentSdkHooks | undefined;
 };
 
@@ -160,9 +161,13 @@ export function createAgentSdkCodingAgentDriver(
           options: {
             cwd: task.workingDirectory,
             maxTurns: task.maxTurns,
-            // Same edit-permission scope as the CLI-subprocess driver (#4266): `--permission-mode acceptEdits`
-            // there, `acceptEdits` here — file edits run unattended inside the scoped worktree, nothing broader.
+            // Match the CLI-subprocess driver's headless permission scope (#4266, #6840): `acceptEdits` auto-
+            // approves file EDIT tool calls inside the scoped worktree, but does NOT grant `Read` or `Bash` — a
+            // real task needs both to explore the repo and run tests, so without an explicit allowlist every such
+            // call was denied and the driver silently produced zero work. Grant exactly `Read` + `Bash` (the CLI's
+            // `--allowedTools Read Bash`), nothing broader; `bypassPermissions` would drop every other safety rail.
             permissionMode: "acceptEdits",
+            allowedTools: ["Read", "Bash"],
             hooks: options.hooks,
           },
         });

--- a/test/unit/agent-sdk-driver.test.ts
+++ b/test/unit/agent-sdk-driver.test.ts
@@ -84,6 +84,9 @@ describe("createAgentSdkCodingAgentDriver", () => {
     expect(captured.input!.options.cwd).toBe(task.workingDirectory);
     expect(captured.input!.options.maxTurns).toBe(6);
     expect(captured.input!.options.permissionMode).toBe("acceptEdits");
+    // Read + Bash are explicitly allowlisted (#7245): acceptEdits alone auto-approves only file EDITs, so a
+    // headless task that must explore the repo and run tests would otherwise have every Read/Bash call denied.
+    expect(captured.input!.options.allowedTools).toEqual(["Read", "Bash"]);
     expect(captured.input!.options.hooks).toBe(hooks);
   });
 


### PR DESCRIPTION
## Summary

`agent-sdk-driver.ts`'s `run()` built its Agent-SDK session with `permissionMode: "acceptEdits"` but **no tool
allowlist** (`AgentSdkQueryOptions` had no `allowedTools` field at all). As documented for its CLI-subprocess
sibling's identical gap (fixed in #6840), `acceptEdits` only auto-approves file **edit** tool calls — it does
NOT grant `Read` or `Bash`. So a real headless task, which needs both to explore the repo and run tests, had
every one of those calls denied and the driver silently produced zero work.

This adds `allowedTools: ["Read", "Bash"]` to the session (matching the CLI driver's `--allowedTools Read Bash`),
adds the field to `AgentSdkQueryOptions`, and updates the stale "same edit-permission scope" comment to describe
both the `acceptEdits` mode and the `Read`/`Bash` grant. Per the CLI driver's own reasoning, this deliberately
does NOT widen to `bypassPermissions`, which would drop every other safety rail rather than closing just the
Read/Bash gap the task hits.

Closes #7245

## Scope

- [x] Conventional Commit title; focused (one module + its test); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7245`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` — **100% of the changed lines covered**. The driver's option-mapping test now asserts
      `options.allowedTools === ["Read", "Bash"]` alongside the existing `permissionMode`/`hooks` assertions; all
      existing agent-sdk-driver tests pass unchanged.
- [x] `npm run build:miner` (engine builds clean).

If any required check was skipped, explain why:

- Change confined to `packages/loopover-engine/src/miner/**` (one module + one test); CI runs the full suite incl. driver-parity.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change. The permission scope is NARROWED-to-explicit, not widened: exactly Read + Bash are allowed, `bypassPermissions` is explicitly avoided, edits stay `acceptEdits`-scoped inside the worktree.
- [x] No UI change — no UI Evidence needed.
