### PR TITLE
fix(github): search up to 10 comment pages for the marker before posting a duplicate (#7232)

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -7,7 +7,12 @@ export const PR_INTELLIGENCE_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
 export const AGENT_COMMAND_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
 const LEGACY_PR_INTELLIGENCE_COMMENT_MARKER = "<!-- gittensory-pr-intelligence -->";
 const LEGACY_AGENT_COMMAND_COMMENT_MARKER = "<!-- gittensory-agent-command -->";
-const COMMENT_SEARCH_PAGE_LIMIT = 3;
+// Bound the marker-comment search at 10 pages (up to 1,000 comments), matching src/github's other pagination
+// caps (app.ts's MAX_WORKFLOW_RUN_LIST_PAGES, pr-actions.ts's REVIEW_PAGE_LIMIT). The old cap of 3 (300 comments)
+// let a PR/issue that accrued >300 comments before LoopOver's own marker comment hide it from this search, so
+// createOrUpdateIssueCommentWithMarker POSTed a DUPLICATE instead of PATCHing the existing one (#7232). The
+// `batch.length < 100` early-exit below still keeps a short comment list to a single request.
+const COMMENT_SEARCH_PAGE_LIMIT = 10;
 
 type IssueComment = {
   id: number;

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -35,6 +35,48 @@ describe("GitHub PR intelligence comments", () => {
     expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(true);
   });
 
+  it("finds a marker comment beyond the first 300 comments (page 4) and PATCHes instead of duplicating (#7232)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const calls: string[] = [];
+    const chatter = (id: number) => ({ id, user: { login: "operator", type: "User" }, body: "unrelated chatter" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push(`${method} ${url}`);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/12/comments") && method === "GET") {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        // Pages 1-3 are full of unrelated chatter (the old cap of 3 stopped here); LoopOver's own marker
+        // comment sits on page 4, only reachable now that the search follows up to 10 pages.
+        if (page < 4) return Response.json(Array.from({ length: 100 }, (_, i) => chatter(page * 1000 + i)));
+        if (page === 4) {
+          return Response.json([
+            { id: 4001, user: { login: "loopover[bot]", type: "Bot" }, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nstale panel` },
+            ...Array.from({ length: 99 }, (_, i) => chatter(4100 + i)),
+          ]);
+        }
+        return Response.json([]); // page 5 short-circuits the loop
+      }
+      if (url.includes("/issues/comments/4001") && method === "PATCH") {
+        return Response.json({ id: 4001, html_url: "https://github.com/comment/4001" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdatePrIntelligenceComment(
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey, GITHUB_APP_SLUG: "loopover" }),
+      123,
+      "JSONbored/gittensory",
+      12,
+      `${PR_INTELLIGENCE_COMMENT_MARKER}\nfresh panel`,
+    );
+
+    expect(result?.id).toBe(4001); // PATCHed the existing marker comment
+    expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/4001"))).toBe(true);
+    // It must NOT have posted a duplicate panel comment.
+    expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(false);
+  });
+
   it("expires a rejected cached installation token and retries PR panel publication once", async () => {
     const privateKey = await generatePrivateKeyPem();
     let mints = 0;
@@ -214,7 +256,8 @@ describe("GitHub PR intelligence comments", () => {
     );
 
     expect(result?.id).toBe(303);
-    expect(commentListCalls).toEqual([1, 2, 3]);
+    // The search is still bounded (no unbounded pagination), now at the 10-page sibling cap (#7232) rather than 3.
+    expect(commentListCalls).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
   it("returns null without creating a late first comment when createIfMissing is false", async () => {


### PR DESCRIPTION
## Summary

`createOrUpdateIssueCommentWithMarker` — the single chokepoint every LoopOver PR-panel / agent-command comment
goes through — searches an issue/PR's existing comments for LoopOver's own marker comment so it can `PATCH` it
instead of posting a duplicate. That search was capped at `COMMENT_SEARCH_PAGE_LIMIT = 3` (the first **300**
comments). On a PR/issue that accrued more than 300 comments before LoopOver's own, the marker fell outside the
search window, so every re-gate cycle POSTed a brand-new panel comment instead of updating the existing one.

This raises the cap to **10 pages** (up to 1,000 comments), matching `src/github`'s other pagination bounds
(`app.ts`'s `MAX_WORKFLOW_RUN_LIST_PAGES`, `pr-actions.ts`'s `REVIEW_PAGE_LIMIT`). The existing
`if (batch.length < 100) break;` early-exit is unchanged, so a short comment list still costs a single request;
`per_page: 100` and the bot/marker filtering are untouched. Common-case behavior (< 300 comments) is identical.

Closes #7232

## Scope

- [x] Conventional Commit title; focused (one constant + its tests); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7232`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root — clean)
- [x] `npm run test:coverage` — **100% of the changed lines covered**. New regression: a marker comment on page 4
      (beyond the old 300-comment cap) is now found and PATCHed rather than duplicated; the existing bound-enforcement
      test is updated to assert the search still stops (now at 10 pages, not unbounded).

If any required check was skipped, explain why:

- Change confined to `src/github/comments.ts` (a non-guarded path) + its test; CI runs the full suite.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise — this REDUCES duplicate public comments.
- [x] The search remains bounded (10 pages), so it cannot spin unboundedly on a pathological comment list.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — one internal pagination bound; the read is idempotent.
- [x] No UI change — no UI Evidence needed.
