### PR TITLE
fix(engine): redact secret-shaped titles from the public-safe results summary

### DIFF
--- a/packages/loopover-engine/src/results-payload.ts
+++ b/packages/loopover-engine/src/results-payload.ts
@@ -3,6 +3,8 @@
 // path #4778). Deterministic and side-effect-free: a plain in/out transform over already-computed iteration
 // metadata (no IO, no GitHub calls), mirroring the intake bridge (#4798) at the other end of the loop.
 
+import { redactSecrets } from "./subprocess-env.js";
+
 // Cap the preview so a large change never floods the customer surface; the totals below still count every file.
 export const MAX_DIFF_PREVIEW_FILES = 10;
 
@@ -58,7 +60,11 @@ export function buildResultsPayload(result: IterationResult): ResultsPayload {
     totals.files === 0
       ? "no file changes"
       : `${totals.files} file${totals.files === 1 ? "" : "s"} changed (+${totals.additions} / -${totals.deletions})`;
-  const summary = `${prPart}: ${result.title}. ${changePart}. Status: ${status}.`;
+  // `result.title` is contributor/miner-authored free text; scrub it with the same secret-redaction primitive this
+  // package already applies to any free text that reaches a public surface (pr-body-draft, gate-advisory, the
+  // agent-sdk driver) so the documented "public-safe" contract actually holds for a title carrying a token shape.
+  const safeTitle = redactSecrets(result.title);
+  const summary = `${prPart}: ${safeTitle}. ${changePart}. Status: ${status}.`;
 
   return { prLink, summary, diffPreview: normalized.slice(0, MAX_DIFF_PREVIEW_FILES), totals };
 }

--- a/test/unit/results-payload.test.ts
+++ b/test/unit/results-payload.test.ts
@@ -55,4 +55,22 @@ describe("buildResultsPayload — packages a completed loop iteration (#4801)", 
     expect(p.totals.files).toBe(MAX_DIFF_PREVIEW_FILES + 3);
     expect(p.summary).toContain(`${MAX_DIFF_PREVIEW_FILES + 3} files changed`); // plural
   });
+
+  it("redacts a secret-shaped title before splicing it into the public-safe summary (#7249)", () => {
+    const p = buildResultsPayload({
+      repoFullName: "acme/widgets",
+      prNumber: 7,
+      title: "Rotate leaked key sk-ABCDEFGHIJKLMNOP123456 in config",
+      changedFiles: [{ path: "src/config.ts", additions: 1, deletions: 1 }],
+      status: "open",
+    });
+    expect(p.summary).not.toContain("sk-ABCDEFGHIJKLMNOP123456");
+    expect(p.summary).toBe("Opened PR #7 in acme/widgets: Rotate leaked key [redacted] in config. 1 file changed (+1 / -1). Status: open.");
+  });
+
+  it("leaves a benign title byte-for-byte unchanged (no regression for the common case, #7249)", () => {
+    const title = "Uploads should retry on 5xx";
+    const p = buildResultsPayload({ repoFullName: "acme/widgets", prNumber: 12, title, changedFiles: [] });
+    expect(p.summary).toBe(`Opened PR #12 in acme/widgets: ${title}. no file changes. Status: open.`);
+  });
 });


### PR DESCRIPTION
fix(engine): redact secret-shaped titles from the public-safe results summary

buildResultsPayload documents ResultsPayload.summary as a public-safe
sentence, but spliced result.title in verbatim. That title is
contributor/miner-authored free text, so a secret-shaped token in it
flowed straight into the customer-facing summary unredacted — violating
the module's own contract, unlike sibling composers (pr-body-draft,
gate-advisory) that scrub free text first.

Run result.title through the package's shared redactSecrets primitive
before embedding it, leaving benign titles byte-for-byte unchanged.

Closes #7249

