### PR TITLE
fix(miner-ui): align demo portfolio-queue items with the summary's status counts

### DIFF
--- a/apps/loopover-miner-ui/src/lib/demo-data.test.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-data.test.ts
@@ -78,6 +78,23 @@ describe("demo portfolio-queue items (#5963)", () => {
     expect(getDemoPortfolioQueueItems().length).toBeGreaterThan(0);
   });
 
+  it("its actionable-item counts match DEMO_PORTFOLIO_QUEUE_SUMMARY's byStatus, so the table can't disagree with the status cards (#7227)", () => {
+    const items = getDemoPortfolioQueueItems();
+    const count = (status: string) => items.filter((i) => i.status === status).length;
+    expect(count("in_progress")).toBe(DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus.in_progress);
+    expect(count("done")).toBe(DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus.done);
+    expect(items).toHaveLength(
+      DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus.in_progress + DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus.done,
+    );
+  });
+
+  it("references only the four synthetic demo repos, never a real repo name (#7227)", () => {
+    const allowed = new Set(["acme/widgets", "acme/api-gateway", "acme/docs-site", "northwind/inventory"]);
+    for (const item of getDemoPortfolioQueueItems()) {
+      expect(allowed.has(item.repoFullName)).toBe(true);
+    }
+  });
+
   it("removeDemoPortfolioQueueItem removes and returns the matching item", () => {
     const beforeCount = getDemoPortfolioQueueItems().length;
     const target = { ...getDemoPortfolioQueueItems()[0]! };

--- a/apps/loopover-miner-ui/src/lib/demo-data.ts
+++ b/apps/loopover-miner-ui/src/lib/demo-data.ts
@@ -97,26 +97,31 @@ export const DEMO_PORTFOLIO_QUEUE_SUMMARY: PortfolioQueueSummary = {
   oldestQueuedAgeMs: 6 * 60 * 60 * 1000, // 6h
 };
 
+// Every actionable (in_progress/done) row the fleet's DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus reports (#7227):
+// exactly 3 in_progress and 15 done, so the demo "Queue actions" table can't visibly disagree with the status
+// cards above it. Entirely synthetic -- only the four demo repos and the existing wgt-/gw-/docs-/inv- id style.
+const FORGE = "https://forge.example.com";
 const DEFAULT_DEMO_PORTFOLIO_QUEUE_ITEMS: PortfolioQueueActionItem[] = [
-  {
-    apiBaseUrl: "https://forge.example.com",
-    repoFullName: "acme/widgets",
-    identifier: "wgt-2451",
-    status: "in_progress",
-  },
-  {
-    apiBaseUrl: "https://forge.example.com",
-    repoFullName: "acme/api-gateway",
-    identifier: "gw-118",
-    status: "in_progress",
-  },
-  { apiBaseUrl: "https://forge.example.com", repoFullName: "acme/widgets", identifier: "wgt-2438", status: "done" },
-  {
-    apiBaseUrl: "https://forge.example.com",
-    repoFullName: "northwind/inventory",
-    identifier: "inv-77",
-    status: "done",
-  },
+  // 3 in_progress
+  { apiBaseUrl: FORGE, repoFullName: "acme/widgets", identifier: "wgt-2451", status: "in_progress" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/api-gateway", identifier: "gw-118", status: "in_progress" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/docs-site", identifier: "docs-64", status: "in_progress" },
+  // 15 done
+  { apiBaseUrl: FORGE, repoFullName: "acme/widgets", identifier: "wgt-2438", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/widgets", identifier: "wgt-2402", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/widgets", identifier: "wgt-2377", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/widgets", identifier: "wgt-2340", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/api-gateway", identifier: "gw-104", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/api-gateway", identifier: "gw-97", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/api-gateway", identifier: "gw-83", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/docs-site", identifier: "docs-58", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/docs-site", identifier: "docs-51", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/docs-site", identifier: "docs-49", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "northwind/inventory", identifier: "inv-77", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "northwind/inventory", identifier: "inv-71", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/widgets", identifier: "wgt-2311", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/api-gateway", identifier: "gw-76", status: "done" },
+  { apiBaseUrl: FORGE, repoFullName: "acme/docs-site", identifier: "docs-42", status: "done" },
 ];
 
 // Mutable, in-memory, browser-session-only copy -- release/requeue removes the item from this actionable list


### PR DESCRIPTION
## What

In `apps/loopover-miner-ui/src/lib/demo-data.ts` (the `VITE_DEMO_MODE=1` fixture layer), two fixtures describing the same portfolio queue disagreed:

- `DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus` reports `in_progress: 3, done: 15` (18 actionable items).
- `DEFAULT_DEMO_PORTFOLIO_QUEUE_ITEMS` listed only **4** actionable items (2 in_progress, 2 done).

In the real system these agree — the queue-actions route returns every `in_progress`/`done` row, the same rows the summary aggregates. So a demo visitor saw status cards claiming "In progress: 3, Done: 15" directly above a table with only 4 rows — a visibly inconsistent demo.

## How

Expand `DEFAULT_DEMO_PORTFOLIO_QUEUE_ITEMS` to exactly **3 in_progress + 15 done = 18** items, matching the summary. Every item uses one of the four existing synthetic demo repos (`acme/widgets`, `acme/api-gateway`, `acme/docs-site`, `northwind/inventory`) with plausible synthetic identifiers in the established `wgt-`/`gw-`/`docs-`/`inv-` style — no new or real repo names.

## Validation

Two tests added to `demo-data.test.ts`'s existing portfolio-queue block: the items' `in_progress`/`done` counts (and total) equal `DEMO_PORTFOLIO_QUEUE_SUMMARY.byStatus`'s declared counts (so the two fixtures can't silently drift again — the drift-guard the issue asked for), and every item references only the four synthetic repos. Confirmed the cross-check **fails against the old 4-item fixture**; `ui:lint`/`ui:typecheck` and the demo-data suite pass.

Closes #7227
