### PR TITLE
fix(engine): correct mergeReadinessGateMode doc comment's sub-gate count

### DIFF
--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -69,9 +69,11 @@ export type GateCheckPolicy = {
   slopGateMode?: GateRuleMode | undefined;
   slopGateMinScore?: number | null | undefined;
   slopRisk?: number | null | undefined;
-  /** Master "merge-readiness" composite (#551). When set (advisory/block) it OVERRIDES all four sub-gates —
-   *  linked-issue, duplicate, quality/readiness, slop — to its mode, so a maintainer flips ONE switch instead
-   *  of four and the review-agent check stays the single required check. `off` = sub-gates use their own modes. */
+  /** Master "merge-readiness" composite (#551). When set (advisory/block) it OVERRIDES three sub-gates —
+   *  linked-issue, duplicate, slop — to its mode, so a maintainer flips ONE switch instead of three and the
+   *  review-agent check stays the single required check. Quality/readiness is deliberately NOT part of this
+   *  composite (`buildQualityGateWarning` can only ever produce an advisory warning, never a blocker) — it
+   *  always stays advisory-only regardless of this field's mode. `off` = sub-gates use their own modes. */
   mergeReadinessGateMode?: GateRuleMode | undefined;
   /** Focus-manifest policy gate (#555). When `block`, linked-issue/test policy findings become hard blockers.
    *  Path-based manual-review holds are configured only with `settings.hardGuardrailGlobs`.

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -558,6 +558,19 @@ describe("merge-readiness composite gate (#551)", () => {
     expect(result.blockers).toEqual([]);
     expect(result.warnings.map((finding) => finding.code)).toEqual(["readiness_score_below_threshold"]);
   });
+
+  it("also escalates slop (the third documented sub-gate) into a hard blocker (#7242)", () => {
+    // Completes this describe block's coverage of the mergeReadinessGateMode doc comment's three escalated
+    // sub-gates: linked-issue (above) and duplicate ("lists each unmet sub-gate condition" below) already
+    // have dedicated tests; slop did not.
+    const eff = resolveEffectiveSettings(settings({ slopGateMode: "advisory", mergeReadinessGateMode: "block" }), parseFocusManifest(null));
+    const result = evaluateGateCheck(
+      { ...missingIssueAdvisory(), findings: [] },
+      { ...gateCheckPolicy(eff, null, true), slopRisk: 90, slopGateMinScore: 60 },
+    );
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.map((finding) => finding.code)).toContain("slop_risk_above_threshold");
+  });
 });
 
 describe("author-history blockers stay unsoftened (#552/#2266/#2411)", () => {


### PR DESCRIPTION
## Summary
- `GateCheckPolicy.mergeReadinessGateMode`'s doc comment (`packages/loopover-engine/src/advisory/gate-advisory.ts`) claimed the merge-readiness composite (#551) overrides **four** sub-gates when set: linked-issue, duplicate, quality/readiness, and slop. `applyMergeReadinessGate` (same file) only ever escalates **three** — linked-issue, duplicate, slop. Quality/readiness findings come from `buildQualityGateWarning`, which can only ever produce an advisory `warnings` entry, never a `blockers` entry, regardless of any gate mode — so it always stays advisory-only.
- Corrected the doc comment to list the three sub-gates that are actually escalated and added a sentence explaining why quality/readiness is deliberately excluded from the composite.
- Checked the twin field in `src/types.ts` (`mergeReadinessGateMode: GateRuleMode`, line 881) — its doc comment is terse ("Merge-readiness gate (#merge-readiness). `off`/`advisory`/`block`. No min-score. Default `off`.") but doesn't make the same incorrect claim, so it needed no change.
- Added a regression test in `test/unit/gate-check-policy.test.ts`'s `describe("merge-readiness composite gate (#551)", ...)` block asserting slop escalates into a hard blocker under `mergeReadinessGateMode: "block"` — the block already had dedicated tests for linked-issue and duplicate escalation (and for quality/readiness staying advisory-only), but not slop.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7242

## Validation
- [x] `git diff --check` — clean.
- [x] `npm run actionlint` — clean.
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of diff size (documented pattern from prior PRs in this repo's history). Verified instead with two targeted checks: (1) `tsc --noEmit -p packages/loopover-engine/tsconfig.json` — the whole `loopover-engine` workspace package (small enough to avoid the OOM), clean; (2) a standalone scoped `tsc --noEmit` against the changed test file using this project's *exact* root `tsconfig.json` compiler options (`--strict --exactOptionalPropertyTypes --noUncheckedIndexedAccess --noImplicitOverride --noFallthroughCasesInSwitch --forceConsistentCasingInFileNames`), clean.
- [x] `npx vitest run test/unit/gate-check-policy.test.ts` — 117/117 passing, including the new slop-escalation regression test.
- [x] Comment-only change to the non-test file; the test file addition is fully covered by the new test itself. `packages/loopover-engine/**` and `test/**` are both outside Codecov's measured `src/**`.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — no Worker route, MCP, UI, or OpenAPI surface changed)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure regardless of diff size; the two scoped `tsc --noEmit` checks above (full package + exact-flags scoped check) are the local proxy, and CI's isolated runner performs the real whole-repo `tsc --noEmit`.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — doc-comment fix + a pure gate-evaluation unit test; no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no route, schema, or MCP behavior changed; this is a comment correction plus test coverage for existing, unchanged runtime behavior.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
