### PR TITLE
fix(engine): cap idea-intake acceptanceHints entry length

### DIFF
--- a/packages/loopover-engine/src/idea-intake.ts
+++ b/packages/loopover-engine/src/idea-intake.ts
@@ -102,8 +102,9 @@ export function validateIdeaSubmission(raw: unknown): IdeaValidationResult {
     else if (constraints.some((c) => c.length > IDEA_CONSTRAINT_MAX_CHARS)) errors.push("constraint_too_long");
   }
   const acceptanceHints = input.acceptanceHints;
-  if (acceptanceHints !== undefined && (!Array.isArray(acceptanceHints) || !acceptanceHints.every((h) => typeof h === "string"))) {
-    errors.push("acceptance_hints_invalid");
+  if (acceptanceHints !== undefined) {
+    if (!Array.isArray(acceptanceHints) || !acceptanceHints.every((h) => typeof h === "string")) errors.push("acceptance_hints_invalid");
+    else if (acceptanceHints.some((h) => h.length > IDEA_CONSTRAINT_MAX_CHARS)) errors.push("acceptance_hint_too_long");
   }
   const priority = input.priority;
   if (priority !== undefined && priority !== "normal" && priority !== "high") errors.push("priority_invalid");

--- a/test/unit/idea-intake-bridge.test.ts
+++ b/test/unit/idea-intake-bridge.test.ts
@@ -73,6 +73,35 @@ describe("validateIdeaSubmission", () => {
     expect(validateIdeaSubmission(validIdea({ priority: "urgent" as unknown as IdeaSubmission["priority"] })).ok).toBe(false);
     expect(validateIdeaSubmission(validIdea({ priority: "normal" })).ok).toBe(true);
   });
+
+  it("caps acceptanceHints entry length at IDEA_CONSTRAINT_MAX_CHARS, same bound as constraints (#7243)", () => {
+    const atCap = validateIdeaSubmission(validIdea({ acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS)] }));
+    expect(atCap.ok).toBe(true);
+
+    const overCap = validateIdeaSubmission(validIdea({ acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1)] }));
+    expect(overCap.ok).toBe(false);
+    if (!overCap.ok) expect(overCap.errors).toContain("acceptance_hint_too_long");
+  });
+
+  it("does not raise acceptance_hint_too_long for a malformed (non-array) acceptanceHints — shape error only", () => {
+    const r = validateIdeaSubmission(validIdea({ acceptanceHints: "x".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1) as unknown as string[] }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors).toContain("acceptance_hints_invalid");
+      expect(r.errors).not.toContain("acceptance_hint_too_long");
+    }
+  });
+
+  it("collects an over-length acceptanceHints entry alongside other unrelated errors in one pass", () => {
+    const r = validateIdeaSubmission({
+      title: "t",
+      body: "b",
+      targetRepo: "o/n",
+      acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1)],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors).toEqual(expect.arrayContaining(["id_required", "acceptance_hint_too_long"]));
+  });
 });
 
 describe("buildTaskGraph — spec §4 Example A (simple idea → one issue → go)", () => {


### PR DESCRIPTION
## Summary
- `packages/loopover-engine/src/idea-intake.ts:12-14` states the module's own invariant: a renter's freeform text is length-capped so one submission can never dominate a public surface. This is enforced for `title`, `body`, and `constraints` (`IDEA_CONSTRAINT_MAX_CHARS`), but `acceptanceHints` — a renter-supplied `string[]` of the identical shape as `constraints` — had no per-entry length check at all, only a shape check (array of strings).
- `acceptanceHints` entries are later folded verbatim into `AcceptanceCriterion.statement`, which becomes part of the public constituent-issue body a contributor reads — an unbounded entry could dominate that surface exactly the way the module's stated invariant says it shouldn't.
- Added the same bound `constraints` already uses (`IDEA_CONSTRAINT_MAX_CHARS`, both are short freeform renter strings of the same shape — no new constant introduced) and a new `acceptance_hint_too_long` error code, mirroring the existing `constraint_too_long` pattern: checked only in the `else if` branch after the shape check passes, so a malformed (non-array/non-string) input still surfaces `acceptance_hints_invalid`, not a length error.
- `validateIdeaSubmission` still returns every failure in one pass (never short-circuits), unchanged.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7243

## Validation
- [x] `git diff --check` — clean.
- [x] `npm run actionlint` — clean.
- [x] `npm run typecheck` — the whole-repo `tsc --noEmit` reliably OOMs on this shared, memory-constrained sandbox regardless of diff size (documented pattern from prior PRs in this repo's history). Verified instead with two targeted checks: (1) `tsc --noEmit -p packages/loopover-engine/tsconfig.json` — the whole `loopover-engine` workspace package (small enough to avoid the OOM), clean; (2) a standalone scoped `tsc --noEmit` against the changed test file using this project's *exact* root `tsconfig.json` compiler options (`--strict --exactOptionalPropertyTypes --noUncheckedIndexedAccess --noImplicitOverride --noFallthroughCasesInSwitch --forceConsistentCasingInFileNames`), clean.
- [x] `npx vitest run test/unit/idea-intake-bridge.test.ts test/unit/routes-intake-idea.test.ts test/unit/mcp-cli-intake-idea-tool.test.ts` — 37/37 passing, including three new regression tests: an entry at exactly the cap passes, one character over returns `acceptance_hint_too_long`, a malformed (non-array) `acceptanceHints` raises only the shape error (not the length error), and an over-length hint combines correctly with other unrelated field errors in one pass.
- [x] `packages/loopover-engine/src/**` is measured by Codecov (per `codecov.yml`). Ran `vitest --coverage` scoped to `idea-intake.ts` across every test file that exercises it: **100% statements, 100% branches, 100% functions, 100% lines**.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — no Worker route, MCP transport, UI, or OpenAPI surface changed; this only affects an existing pure-validation function's behavior)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck` OOMs on this specific sandbox under current memory pressure regardless of diff size; the two scoped `tsc --noEmit` checks above (full package + exact-flags scoped check) are the local proxy, and CI's isolated runner performs the real whole-repo `tsc --noEmit`.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — pure input-validation change; no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — `validateIdeaSubmission`'s existing callers already surface its `errors` array verbatim, so no route/schema/MCP wiring changed; the new error code is additive to an existing, already-passed-through list.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
