### PR TITLE
docs(ui): publish a capacity & throughput operator doc

### DIFF
--- a/apps/loopover-ui/content/docs/capacity.mdx
+++ b/apps/loopover-ui/content/docs/capacity.mdx
@@ -1,0 +1,96 @@
+---
+title: Capacity and throughput
+description: Real throughput and concurrency numbers for AMS's iterate-loop and the review-gate's PR-processing queue, so an operator can plan for load instead of guessing.
+---
+
+Real throughput and concurrency numbers for AMS's iterate-loop and the review-gate's PR-processing
+queue — the counterpart to [Resource sizing](/docs/ams-sizing) (CPU/RAM/disk), scoped strictly to
+throughput/concurrency and where each number comes from.
+
+## AMS: iterate-loop orchestration throughput
+
+From the committed load-test harness (`packages/loopover-engine/docs/iterate-loop-load-test.md`,
+built for #4913/#5224), measuring `runIterateLoop`'s own orchestration overhead under concurrent,
+multi-tenant-like load with a 15ms simulated per-iteration driver latency:
+
+<FeatureRow
+  items={[
+    { title: "Concurrency 1", description: "63 attempts/sec" },
+    { title: "Concurrency 8", description: "422 attempts/sec" },
+    { title: "Concurrency 32", description: "982 attempts/sec" },
+    { title: "Concurrency 128", description: "1,577 attempts/sec" },
+  ]}
+/>
+
+<Callout variant="note">
+  Absolute numbers are host-dependent — treat these as a rough sense of scale and of how throughput
+  scales with concurrency, not a hard target. Reproduce them on your own hardware with:
+</Callout>
+
+<CodeBlock lang="bash" code={`npm run loadtest:iterate-loop`} />
+
+## Review-gate: PR-processing concurrency caps
+
+Fixed, hardcoded caps from `src/settings/agent-sweep.ts`, sized against a single GitHub App
+installation's shared ~5,000-request/hour REST rate-limit bucket (each PR touched costs roughly 9
+REST GETs):
+
+<FeatureRow
+  items={[
+    {
+      title: "SWEEP_MAX_PRS = 3",
+      description: "The recurring sweep's per-tick cap — sized for a sweep that re-runs every ~2 minutes, so a low steady-state budget compounds safely across ticks.",
+    },
+    {
+      title: "ISSUE_WAKE_MAX_PRS = 25",
+      description: "One-shot budget for an issue-linked wake event — a rarer trigger than a merge, so a larger one-time budget doesn't risk compounding across repeated events in one rate-limit window.",
+    },
+    {
+      title: "MERGE_WAKE_MAX_PRS = 15",
+      description: "One-shot budget for a merge-triggered wake — sized lower than the issue-wake budget because merges are a far more common trigger; a repeated-merge burst inside one rate-limit window must not compound the way the rarer issue-wake trigger safely can.",
+    },
+  ]}
+/>
+
+## Review-gate: Cloudflare Queue consumer bounds
+
+From `wrangler.jsonc`'s `loopover-jobs` queue consumer — Cloudflare Queues consumer-binding
+attributes, read at `wrangler deploy` time (not runtime-configurable via `env.SOMETHING`):
+
+<FeatureRow
+  items={[
+    {
+      title: "max_batch_size = 5",
+      description: "The most jobs one batch can bundle at once — bounds how many heavy sweep/backfill jobs land in a single delivery.",
+    },
+    {
+      title: "max_concurrency = 3",
+      description: "Bounded fan-out, sized to drain one heavy installation's worst sweep within the 2-minute cron interval without flooding that installation's own GitHub rate-limit bucket.",
+    },
+  ]}
+/>
+
+<Callout variant="note" title="Re-tuning these for real multi-tenant volume">
+  `max_batch_size × max_concurrency` bounds the most jobs that can be in flight — each making
+  GitHub calls — at any one instant, kept comfortably under an installation's rate-limit headroom.
+  A genuinely multi-tenant volume model needs real production job-volume data (job rate, distinct-
+  installation count, GitHub rate-limit headroom actually observed) to re-derive against — re-tune
+  from a live dashboard/`audit_events` query when that data exists, not by guessing a bigger
+  number.
+</Callout>
+
+**Takeaways:**
+
+- Iterate-loop's own orchestration overhead scales roughly linearly with concurrency — the
+  bottleneck at real scale is each attempt's actual coding-agent driver latency, not the loop's
+  scheduling/bookkeeping around it.
+- The review-gate's PR-processing caps are deliberately asymmetric across trigger type
+  (`SWEEP_MAX_PRS` \< `MERGE_WAKE_MAX_PRS` \< `ISSUE_WAKE_MAX_PRS`) because each trigger recurs at a
+  different rate — a budget sized for a rare trigger would compound dangerously if applied to a
+  frequent one.
+- Every number above was measured or verified directly against the source it's read from (the
+  committed load-test harness, or the literal constant/config value) — none are estimates.
+
+See [Resource sizing](/docs/ams-sizing) for CPU/RAM/disk numbers, and the [AMS Cloud Readiness
+milestone](https://github.com/JSONbored/loopover/milestone/28) for the per-tenant scheduling and
+queue-fairness design work these numbers feed into.

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -53,6 +53,7 @@ export const docsNav: DocsGroup[] = [
         items: [
           { to: "/docs/self-hosting-operations", label: "Operations" },
           { to: "/docs/self-hosting-backup-scaling", label: "Backup & scaling" },
+          { to: "/docs/capacity", label: "Capacity & throughput" },
           { to: "/docs/self-hosting-troubleshooting", label: "Troubleshooting" },
         ],
       },

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -57,6 +57,7 @@ import { Route as DocsHowReviewsWorkRouteImport } from './routes/docs.how-review
 import { Route as DocsGithubAppRouteImport } from './routes/docs.github-app'
 import { Route as DocsFumadocsSpikeApiReferenceRouteImport } from './routes/docs.fumadocs-spike-api-reference'
 import { Route as DocsFederatedFleetIntelligenceRouteImport } from './routes/docs.federated-fleet-intelligence'
+import { Route as DocsCapacityRouteImport } from './routes/docs.capacity'
 import { Route as DocsBranchAnalysisRouteImport } from './routes/docs.branch-analysis'
 import { Route as DocsBetaOnboardingRouteImport } from './routes/docs.beta-onboarding'
 import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.ams-unattended-scheduling'
@@ -341,6 +342,11 @@ const DocsFederatedFleetIntelligenceRoute =
     path: '/federated-fleet-intelligence',
     getParentRoute: () => DocsRoute,
   } as any)
+const DocsCapacityRoute = DocsCapacityRouteImport.update({
+  id: '/capacity',
+  path: '/capacity',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsBranchAnalysisRoute = DocsBranchAnalysisRouteImport.update({
   id: '/branch-analysis',
   path: '/branch-analysis',
@@ -523,6 +529,7 @@ export interface FileRoutesByFullPath {
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
+  '/docs/capacity': typeof DocsCapacityRoute
   '/docs/federated-fleet-intelligence': typeof DocsFederatedFleetIntelligenceRoute
   '/docs/fumadocs-spike-api-reference': typeof DocsFumadocsSpikeApiReferenceRoute
   '/docs/github-app': typeof DocsGithubAppRoute
@@ -598,6 +605,7 @@ export interface FileRoutesByTo {
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
+  '/docs/capacity': typeof DocsCapacityRoute
   '/docs/federated-fleet-intelligence': typeof DocsFederatedFleetIntelligenceRoute
   '/docs/fumadocs-spike-api-reference': typeof DocsFumadocsSpikeApiReferenceRoute
   '/docs/github-app': typeof DocsGithubAppRoute
@@ -677,6 +685,7 @@ export interface FileRoutesById {
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
+  '/docs/capacity': typeof DocsCapacityRoute
   '/docs/federated-fleet-intelligence': typeof DocsFederatedFleetIntelligenceRoute
   '/docs/fumadocs-spike-api-reference': typeof DocsFumadocsSpikeApiReferenceRoute
   '/docs/github-app': typeof DocsGithubAppRoute
@@ -757,6 +766,7 @@ export interface FileRouteTypes {
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
+    | '/docs/capacity'
     | '/docs/federated-fleet-intelligence'
     | '/docs/fumadocs-spike-api-reference'
     | '/docs/github-app'
@@ -832,6 +842,7 @@ export interface FileRouteTypes {
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
+    | '/docs/capacity'
     | '/docs/federated-fleet-intelligence'
     | '/docs/fumadocs-spike-api-reference'
     | '/docs/github-app'
@@ -910,6 +921,7 @@ export interface FileRouteTypes {
     | '/docs/ams-unattended-scheduling'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
+    | '/docs/capacity'
     | '/docs/federated-fleet-intelligence'
     | '/docs/fumadocs-spike-api-reference'
     | '/docs/github-app'
@@ -1303,6 +1315,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsFederatedFleetIntelligenceRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/capacity': {
+      id: '/docs/capacity'
+      path: '/capacity'
+      fullPath: '/docs/capacity'
+      preLoaderRoute: typeof DocsCapacityRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/branch-analysis': {
       id: '/docs/branch-analysis'
       path: '/branch-analysis'
@@ -1564,6 +1583,7 @@ interface DocsRouteChildren {
   DocsAmsUnattendedSchedulingRoute: typeof DocsAmsUnattendedSchedulingRoute
   DocsBetaOnboardingRoute: typeof DocsBetaOnboardingRoute
   DocsBranchAnalysisRoute: typeof DocsBranchAnalysisRoute
+  DocsCapacityRoute: typeof DocsCapacityRoute
   DocsFederatedFleetIntelligenceRoute: typeof DocsFederatedFleetIntelligenceRoute
   DocsFumadocsSpikeApiReferenceRoute: typeof DocsFumadocsSpikeApiReferenceRoute
   DocsGithubAppRoute: typeof DocsGithubAppRoute
@@ -1615,6 +1635,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAmsUnattendedSchedulingRoute: DocsAmsUnattendedSchedulingRoute,
   DocsBetaOnboardingRoute: DocsBetaOnboardingRoute,
   DocsBranchAnalysisRoute: DocsBranchAnalysisRoute,
+  DocsCapacityRoute: DocsCapacityRoute,
   DocsFederatedFleetIntelligenceRoute: DocsFederatedFleetIntelligenceRoute,
   DocsFumadocsSpikeApiReferenceRoute: DocsFumadocsSpikeApiReferenceRoute,
   DocsGithubAppRoute: DocsGithubAppRoute,

--- a/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
+++ b/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
@@ -45,7 +45,7 @@ describe("docs route Suspense fallback (#6982)", () => {
       "docs.tsx",
     ]);
     const inScope = docsRouteFiles.filter((name) => !outOfScope.has(name));
-    expect(inScope.length).toBe(46);
+    expect(inScope.length).toBe(47);
 
     for (const file of inScope) {
       const source = readFileSync(join(routesDir, file), "utf8");

--- a/apps/loopover-ui/src/routes/docs.capacity.tsx
+++ b/apps/loopover-ui/src/routes/docs.capacity.tsx
@@ -1,0 +1,50 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
+import { docsClientLoader } from "@/lib/docs-client-loader";
+
+// Rendered from content/docs/capacity.mdx via fumadocs-mdx's browser entry
+// (docsClientLoader), through the existing DocsPage/Callout/CodeBlock/FeatureRow
+// primitives -- not fumadocs-ui's bundled components. See docs-source.ts's comment
+// for why the loader below resolves only a plain, serializable path string.
+export const Route = createFileRoute("/docs/capacity")({
+  loader: async () => {
+    const { docsSource } = await import("@/lib/docs-source");
+    const page = docsSource.getPage(["capacity"]);
+    if (!page) throw notFound();
+    return { path: page.path, title: page.data.title, description: page.data.description };
+  },
+  head: () => ({
+    meta: [
+      { title: "Capacity and throughput — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "Real throughput and concurrency numbers for AMS's iterate-loop and the review-gate's PR-processing queue, so an operator can plan for load instead of guessing.",
+      },
+      { property: "og:title", content: "Capacity and throughput — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "Real throughput and concurrency numbers for AMS's iterate-loop and the review-gate's PR-processing queue, so an operator can plan for load instead of guessing.",
+      },
+      { property: "og:url", content: "/docs/capacity" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/capacity" }],
+  }),
+  component: Capacity,
+});
+
+function Capacity() {
+  const { path, title, description } = Route.useLoaderData();
+  const Content = docsClientLoader.getComponent(path);
+  return (
+    <DocsPage eyebrow="Maintainers" title={title} description={description}>
+      <Suspense fallback={<LoadingState />}>
+        <Content />
+      </Suspense>
+    </DocsPage>
+  );
+}

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -79,6 +79,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/ams-observability", label: "Observing your miner" },
       { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
       { to: "/docs/ams-sizing", label: "Resource sizing" },
+      { to: "/docs/capacity", label: "Capacity & throughput" },
       { to: "/docs/ams-config-precedence", label: "Config precedence" },
       { to: "/docs/ams-env-reference", label: "Env var reference" },
       { to: "/docs/ams-discovery-plane", label: "Discovery plane (opt-in)" },


### PR DESCRIPTION
## Summary

No user-facing doc surfaced capacity/throughput/concurrency numbers -- they existed only in scattered code comments and the iterate-loop load-test harness output. Adds `/docs/capacity` as the throughput/concurrency counterpart to the existing `/docs/ams-sizing` (CPU/RAM/disk), scoped strictly to the numbers and where each comes from.

## Content (`content/docs/capacity.mdx`)

- **AMS iterate-loop orchestration throughput** -- from the committed load-test harness (`packages/loopover-engine/docs/iterate-loop-load-test.md`, #4913's tooling): 63 / 422 / 982 / 1,577 attempts/sec at concurrency 1 / 8 / 32 / 128, with the same host-dependent `<Callout>` caveat `ams-sizing.mdx` uses and the exact `npm run loadtest:iterate-loop` reproduce command.
- **Review-gate PR-processing concurrency caps** -- from `src/settings/agent-sweep.ts`: `SWEEP_MAX_PRS=3`, `ISSUE_WAKE_MAX_PRS=25`, `MERGE_WAKE_MAX_PRS=15`, with the trigger-frequency rationale that sizes them asymmetrically.
- **Cloudflare Queue consumer bounds** -- from `wrangler.jsonc`'s `loopover-jobs` queue: `max_batch_size=5`, `max_concurrency=3`, plus a note (mirroring the existing inline comment) that re-tuning these for real multi-tenant volume needs live production data, not a guess.

## Wiring (mirrors `docs.ams-sizing`)

- `src/routes/docs.capacity.tsx` route (same `DocsPage` + `LoadingState`-fallback pattern), registered in `docs-nav.tsx` (under "Self-hosting: operations", alongside "Backup & scaling") and `docs.index.tsx`, `routeTree.gen.ts` regenerated.
- Bumped the `docs-routes-loading-state.test.tsx` count guard 46 -> 47 (the new route follows the `LoadingState` convention; the historical "#6982's 46-file scope" prose comments left untouched, since those describe that past issue's own scope, not today's live count).

Closes #4914

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (see `Closes #4914` above).

## Validation

- [x] `git diff --check`
- [x] `npm run docs:drift-check` -- clean, unrelated to this change.
- [x] `npm run ui:kit:build && vite build` (loopover-ui) -- clean, regenerated `routeTree.gen.ts`.
- [x] `npm --workspace @loopover/ui run typecheck` -- clean.
- [x] `npm run ui:lint` -- 0 errors (pre-existing warnings only, unrelated).
- [x] `npm --workspace @loopover/ui run test` -- 394/394 passed.
- [x] Full `npm run test:ci` green end to end, run under the repo's pinned Node 22 (`.nvmrc`).
- [x] `npm audit --audit-level=moderate` -- clean except the same pre-existing, unrelated `adm-zip`/`github-actionlint` advisory with no fix available.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- content-only docs page.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API surface touched.)
- [ ] UI changes use live API data -- N/A, content-only docs page, no new visual design (mirrors `ams-sizing`).
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, same reason; `apps/**` is Codecov-ignored.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (This PR IS the docs update; no `CHANGELOG.md` edit.)

## Notes

- A prior attempt at this exact doc (#7214) had fully green CI but was auto-closed by the gate because #4914 was assigned to the maintainer -- reserved, not eligible for contributor auto-merge. Rebuilt from scratch (the original branch was deleted) under owner authorship this time; content verified against the same real sources.
