### PR TITLE
fix(miner-ui): register chat governor and discover/attempt actions under vite preview too

### DIFF
--- a/apps/loopover-miner-ui/src/vite-chat-discover-attempt-actions.test.ts
+++ b/apps/loopover-miner-ui/src/vite-chat-discover-attempt-actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The plugin dynamically imports this module by the same relative path it resolves to from here
+// (apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts's `./src/lib/chat-discover-attempt-actions`
+// and this test's `./lib/chat-discover-attempt-actions` both resolve to src/lib/chat-discover-attempt-actions.ts)
+// — mocking it here intercepts the plugin's own dynamic import.
+const h = vi.hoisted(() => ({ registerDiscoverAttemptChatActions: vi.fn() }));
+vi.mock("./lib/chat-discover-attempt-actions", () => ({
+  registerDiscoverAttemptChatActions: h.registerDiscoverAttemptChatActions,
+}));
+
+import { chatDiscoverAttemptActionsPlugin } from "../vite-chat-discover-attempt-actions";
+
+// #7228: `vite preview` (the systemd-deployed persistent-service path per the README) only ever invokes
+// configurePreviewServer, never configureServer — proves the registration call also fires from that hook.
+describe("chatDiscoverAttemptActionsPlugin (#6837, #7228)", () => {
+  it("registers a configureServer and a configurePreviewServer hook", () => {
+    const plugin = chatDiscoverAttemptActionsPlugin();
+    expect(typeof plugin.configureServer).toBe("function");
+    expect(typeof plugin.configurePreviewServer).toBe("function");
+  });
+
+  it("invokes registerDiscoverAttemptChatActions when only configurePreviewServer is exercised", async () => {
+    h.registerDiscoverAttemptChatActions.mockClear();
+    const plugin = chatDiscoverAttemptActionsPlugin();
+    // @ts-expect-error -- configurePreviewServer's registration call reads no properties off its server arg.
+    plugin.configurePreviewServer?.();
+    await vi.waitFor(() => expect(h.registerDiscoverAttemptChatActions).toHaveBeenCalledTimes(1));
+  });
+
+  it("invokes registerDiscoverAttemptChatActions when configureServer is exercised (unchanged behavior)", async () => {
+    h.registerDiscoverAttemptChatActions.mockClear();
+    const plugin = chatDiscoverAttemptActionsPlugin();
+    // @ts-expect-error -- configureServer's registration call reads no properties off its server arg.
+    plugin.configureServer?.();
+    await vi.waitFor(() => expect(h.registerDiscoverAttemptChatActions).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/loopover-miner-ui/src/vite-chat-governor-actions.test.ts
+++ b/apps/loopover-miner-ui/src/vite-chat-governor-actions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The plugin dynamically imports this module by the same relative path it resolves to from here
+// (apps/loopover-miner-ui/vite-chat-governor-actions.ts's `./src/lib/chat-governor-actions` and this test's
+// `./lib/chat-governor-actions` both resolve to src/lib/chat-governor-actions.ts) — mocking it here intercepts
+// the plugin's own dynamic import.
+const h = vi.hoisted(() => ({ registerGovernorChatActions: vi.fn() }));
+vi.mock("./lib/chat-governor-actions", () => ({ registerGovernorChatActions: h.registerGovernorChatActions }));
+
+import { chatGovernorActionsPlugin } from "../vite-chat-governor-actions";
+
+// #7228: `vite preview` (the systemd-deployed persistent-service path per the README) only ever invokes
+// configurePreviewServer, never configureServer — proves the registration call also fires from that hook.
+describe("chatGovernorActionsPlugin (#6521, #7228)", () => {
+  it("registers a configureServer and a configurePreviewServer hook", () => {
+    const plugin = chatGovernorActionsPlugin();
+    expect(typeof plugin.configureServer).toBe("function");
+    expect(typeof plugin.configurePreviewServer).toBe("function");
+  });
+
+  it("invokes registerGovernorChatActions when only configurePreviewServer is exercised", async () => {
+    h.registerGovernorChatActions.mockClear();
+    const plugin = chatGovernorActionsPlugin();
+    // @ts-expect-error -- configurePreviewServer's registration call reads no properties off its server arg.
+    plugin.configurePreviewServer?.();
+    await vi.waitFor(() => expect(h.registerGovernorChatActions).toHaveBeenCalledTimes(1));
+  });
+
+  it("invokes registerGovernorChatActions when configureServer is exercised (unchanged behavior)", async () => {
+    h.registerGovernorChatActions.mockClear();
+    const plugin = chatGovernorActionsPlugin();
+    // @ts-expect-error -- configureServer's registration call reads no properties off its server arg.
+    plugin.configureServer?.();
+    await vi.waitFor(() => expect(h.registerGovernorChatActions).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
@@ -3,15 +3,21 @@ import type { Plugin } from "vite";
 // Registers discover/attempt chat actions into the shared registry on dev-server start (#6837). Handlers call
 // the existing miner-ui `requestDiscover` / `requestAttempt` clients — the same POST `/api/discover` and
 // `/api/attempt` path the routes already serve. No new /api/* route is added here (mirrors
-// vite-chat-governor-actions.ts).
+// vite-chat-governor-actions.ts). Also registers under `vite preview` (#7228) — the documented
+// persistent-service deployment path (systemd/loopover-miner-ui.service.example) only ever invokes
+// configurePreviewServer, never configureServer, and registerDiscoverAttemptChatActions is idempotent so
+// calling it from either hook is safe.
+
+function register(): void {
+  void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
+    mod.registerDiscoverAttemptChatActions();
+  });
+}
 
 export function chatDiscoverAttemptActionsPlugin(): Plugin {
   return {
     name: "loopover-miner-chat-discover-attempt-actions",
-    configureServer() {
-      void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
-        mod.registerDiscoverAttemptChatActions();
-      });
-    },
+    configureServer: register,
+    configurePreviewServer: register,
   };
 }

--- a/apps/loopover-miner-ui/vite-chat-governor-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-governor-actions.ts
@@ -2,15 +2,21 @@ import type { Plugin } from "vite";
 
 // Registers governor pause/resume chat actions into the shared registry on dev-server start (#6521).
 // Handlers call the existing miner-ui `pauseGovernor` / `resumeGovernor` clients — same path as the Ledgers
-// buttons. No new /api/governor/* route is added here.
+// buttons. No new /api/governor/* route is added here. Also registers under `vite preview` (#7228) — the
+// documented persistent-service deployment path (systemd/loopover-miner-ui.service.example) only ever
+// invokes configurePreviewServer, never configureServer, and registerGovernorChatActions is idempotent so
+// calling it from either hook is safe.
+
+function register(): void {
+  void import("./src/lib/chat-governor-actions").then((mod) => {
+    mod.registerGovernorChatActions();
+  });
+}
 
 export function chatGovernorActionsPlugin(): Plugin {
   return {
     name: "loopover-miner-chat-governor-actions",
-    configureServer() {
-      void import("./src/lib/chat-governor-actions").then((mod) => {
-        mod.registerGovernorChatActions();
-      });
-    },
+    configureServer: register,
+    configurePreviewServer: register,
   };
 }


### PR DESCRIPTION
## Summary
- `apps/loopover-miner-ui/README.md`'s "Running as a persistent service" section documents that every `vite-*-api.ts` plugin registers for both `configureServer` and `configurePreviewServer`, so `npm run build && npm run preview` alone is sufficient — no extra step needed. Two plugins didn't actually honor that contract: `vite-chat-governor-actions.ts`'s `chatGovernorActionsPlugin()` and `vite-chat-discover-attempt-actions.ts`'s `chatDiscoverAttemptActionsPlugin()` only implemented `configureServer`.
- `vite preview` only ever runs a plugin's `configurePreviewServer` hook, never `configureServer` — which is exactly the deployment mode `systemd/loopover-miner-ui.service.example` (this repo's own recommended persistent-deployment unit) uses. Under that mode, `registerGovernorChatActions()` / `registerDiscoverAttemptChatActions()` never ran, so the shared chat-action registry stayed empty and any chat-issued governor pause/resume or discover/attempt command dispatched against it, surfacing to the operator as a silent-looking `unknown_action` ("Couldn't {pause/release/…}: action is not registered.") — identical wording to a real bug, with the actual cause being the deployment mode, not the command itself.
- Factored each plugin's registration call into a shared `register()` function and wired it to both `configureServer` and `configurePreviewServer`, matching the shape every other plugin in this app already uses (`vite-chat-api.ts`'s `chatApiPlugin`). `registerGovernorChatActions`/`registerDiscoverAttemptChatActions` are already idempotent — confirmed by reading `packages/loopover-miner/lib/chat-governor-actions.js`/`chat-discover-attempt-actions.js`, both guard each registration with a `registry.has(...)` check before calling `register` — so no new idempotency logic was needed; calling the same function from either hook is safe.
- No change to `configureServer`'s existing behavior, the registration modules under `src/lib/`, or any other plugin file.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #7228

## Validation
- [x] `git diff --check` — clean.
- [x] `npm --workspace apps/loopover-miner-ui run typecheck` (`tsc --noEmit`) — clean.
- [x] `npm --workspace apps/loopover-miner-ui run lint` (`eslint .`) — 0 errors; the 7 pre-existing warnings (Fast Refresh / `exhaustive-deps` on unrelated files) are untouched by this change.
- [x] `npx vitest run` in `apps/loopover-miner-ui` — 328/328 passing across all 29 test files (no regressions), including two new test files: `src/vite-chat-governor-actions.test.ts` and `src/vite-chat-discover-attempt-actions.test.ts`, each proving the registration function is invoked when only `configurePreviewServer` is exercised (not just `configureServer`), via a mock of the dynamically-imported registration module.
- [x] `apps/**` is outside this repo's Codecov `coverage.include` scope (confirmed in PR #7082's own body and this issue's own Test Coverage Requirements section), so this PR carries no `codecov/patch` obligation — the new dedicated tests are the local coverage proxy.
- [ ] The repo-root `npm run test:ci`'s `ui:build` step (which builds `@loopover/ui-miner` among other workspaces) was not run locally — it's a heavy, multi-workspace build (engine + both UI apps + both extensions) on this shared, memory-constrained sandbox, and this change is scoped to two plugin files' Vite lifecycle hooks with no build-config or route changes; `ui:typecheck`/`ui:lint`/`ui:test` above are the local proxy for this workspace.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` (not applicable — no Worker route, MCP transport, or OpenAPI surface changed)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- The repo-root whole-workspace `ui:build` step wasn't run locally for the resource reasons above; CI's isolated runner performs the real build. `ui:typecheck`/`ui:lint`/`ui:test` (all clean, scoped to the actual affected workspace) are the local substitute.

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — this only wires an existing, already-tested registration call into a second Vite lifecycle hook; no auth/cookie/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no `/api/*` route added or changed; the governor/discover/attempt HTTP routes this registry ultimately gates dispatch for are unchanged and already tested elsewhere.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no visible UI changes; this is a server-side Vite plugin lifecycle fix.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
