### PR TITLE
fix(miner-ui): register chat-action vite plugins for the preview server too

### DIFF
--- a/apps/loopover-miner-ui/src/vite-chat-action-plugins.test.ts
+++ b/apps/loopover-miner-ui/src/vite-chat-action-plugins.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { chatDiscoverAttemptActionsPlugin } from "../vite-chat-discover-attempt-actions";
+import { chatGovernorActionsPlugin } from "../vite-chat-governor-actions";
+
+// #7228: the app's documented persistent-service path (README + systemd/loopover-miner-ui.service.example) runs
+// `npm run build && npm run preview`, and `vite preview` fires ONLY `configurePreviewServer`, never
+// `configureServer`. These two chat-action plugins used to implement `configureServer` alone, so their governor
+// and discover/attempt actions were silently unregistered in production — unlike every sibling vite-*-api.ts
+// plugin, which registers for both hooks. Lock in that both plugins now wire both hooks.
+describe("chat-action vite plugins register for dev AND preview servers (#7228)", () => {
+  const cases = [
+    ["chatGovernorActionsPlugin", chatGovernorActionsPlugin],
+    ["chatDiscoverAttemptActionsPlugin", chatDiscoverAttemptActionsPlugin],
+  ] as const;
+
+  for (const [label, factory] of cases) {
+    it(`${label} implements both configureServer and configurePreviewServer`, () => {
+      const plugin = factory();
+      expect(plugin.configureServer).toBeTypeOf("function");
+      expect(plugin.configurePreviewServer).toBeTypeOf("function");
+    });
+  }
+});

--- a/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
@@ -6,12 +6,21 @@ import type { Plugin } from "vite";
 // vite-chat-governor-actions.ts).
 
 export function chatDiscoverAttemptActionsPlugin(): Plugin {
+  // Register on BOTH dev (`configureServer`) and preview (`configurePreviewServer`) start — `vite preview` (the
+  // persistent-service path in this app's README and systemd unit) only runs the preview hook, so without it
+  // these actions were silently missing in production, unlike every sibling vite-*-api.ts plugin (#7228).
+  const register = () => {
+    void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
+      mod.registerDiscoverAttemptChatActions();
+    });
+  };
   return {
     name: "loopover-miner-chat-discover-attempt-actions",
     configureServer() {
-      void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
-        mod.registerDiscoverAttemptChatActions();
-      });
+      register();
+    },
+    configurePreviewServer() {
+      register();
     },
   };
 }

--- a/apps/loopover-miner-ui/vite-chat-governor-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-governor-actions.ts
@@ -5,12 +5,22 @@ import type { Plugin } from "vite";
 // buttons. No new /api/governor/* route is added here.
 
 export function chatGovernorActionsPlugin(): Plugin {
+  // Register into the shared registry on BOTH dev (`configureServer`) and preview (`configurePreviewServer`)
+  // start. `vite preview` — the persistent-service path in this app's README and systemd unit — only runs the
+  // preview hook, so without it these actions were silently missing in production, unlike every sibling
+  // vite-*-api.ts plugin (which registers for both) (#7228).
+  const register = () => {
+    void import("./src/lib/chat-governor-actions").then((mod) => {
+      mod.registerGovernorChatActions();
+    });
+  };
   return {
     name: "loopover-miner-chat-governor-actions",
     configureServer() {
-      void import("./src/lib/chat-governor-actions").then((mod) => {
-        mod.registerGovernorChatActions();
-      });
+      register();
+    },
+    configurePreviewServer() {
+      register();
     },
   };
 }


### PR DESCRIPTION
Closes #7228

## Summary

- `apps/loopover-miner-ui/vite-chat-governor-actions.ts` (`chatGovernorActionsPlugin`) and `vite-chat-discover-attempt-actions.ts` (`chatDiscoverAttemptActionsPlugin`) implemented only `configureServer()`.
- The app's documented persistent-service deployment path (`apps/loopover-miner-ui/README.md`'s "Running as a persistent service" + `systemd/loopover-miner-ui.service.example`) runs `npm run build && npm run preview`, and `vite preview` fires **only** `configurePreviewServer`, never `configureServer`. So the governor pause/resume and discover/attempt chat actions were silently unregistered under `vite preview` in production — unlike every sibling `vite-*-api.ts` plugin, all of which register for both hooks.
- Fix: register into the shared registry on **both** `configureServer` and `configurePreviewServer` via a shared `register` helper in each plugin (the exact both-hooks shape the sibling plugins already use). No new `/api/*` route is added; only the existing plugin hook is wired for preview. Adds a parity test asserting both plugins now implement both hooks.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: the two named plugin files plus one test, scoped exactly to the `configurePreviewServer` gap called out in the issue. No other `vite-*-api.ts` file and no new route are touched.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #7228` (bare, above).

## Validation

- [x] `git diff --check` — clean.
- [x] `npm run ui:typecheck` (`@loopover/ui-miner` `tsc --noEmit`) — 0 errors.
- [x] `npm run ui:test` (`@loopover/ui-miner` `vitest run --coverage`) — **322 tests pass**, coverage thresholds met; the new `vite-chat-action-plugins.test.ts` (2 tests) passes.
- [x] `npm --workspace @loopover/ui-miner run build` (`vite build`) — built successfully.
- [x] ESLint clean on all changed files.

If any required check was skipped, explain why:

- Backend checks (`test:coverage`, `test:workers`, `build:mcp`/`test:mcp-pack`, `ui:openapi:check`, engine/miner suites, `npm audit`) are not applicable: this PR touches only `apps/loopover-miner-ui/**` (two Vite plugin config files + one test) — no `src/**`, no MCP/API/OpenAPI surface, no engine, and no dependency changes. `apps/**` is outside the Codecov `codecov/patch` scope; the miner-ui workspace's own vitest coverage thresholds (verified above) are the relevant signal.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A: no auth/route logic changes; the plugins register the same actions on an additional lifecycle hook. The plugins already sit under `/api/*` behind `authPlugin()` in `vite.config.ts`, unchanged.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (no new/changed route or tool).
- [x] UI changes use live API data or real empty/error/loading states — N/A: this is dev/preview-server plugin wiring, not a rendered UI change.
- [x] Visible UI changes include a `UI Evidence` section — N/A: no visible/visual change. The fix only makes existing chat actions register when the app is served via `vite preview`; there is no new or altered rendered surface to screenshot.
- [x] Public docs/changelogs are updated where needed; no changelog edited. The README already documents the both-hooks contract this fix makes true.

## UI Evidence

Not applicable — no visible/visual change. This PR wires two Vite dev/preview-server plugins to register on the preview hook in addition to the dev hook; nothing rendered changes.

## Notes

- The two hooks are mutually exclusive at runtime (`vite dev` fires `configureServer`, `vite preview` fires `configurePreviewServer`), so registering on both is safe — only one runs per process.
