### PR TITLE
feat(miner): migrate policy-doc-cache onto the SqliteDriver store seam

### DIFF
--- a/packages/loopover-miner/lib/policy-doc-cache.js
+++ b/packages/loopover-miner/lib/policy-doc-cache.js
@@ -1,4 +1,4 @@
-import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { normalizeLocalStoreDbPath, openLocalStoreAdapter, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
 
 // Local ETag cache for discovery's small policy-doc fetches (#4842). `discover` refetches each target repo's
@@ -30,10 +30,14 @@ function normalizeUrl(url) {
 /**
  * Opens the 100% local/client-side miner policy-doc ETag cache. The database only lives on this machine; this
  * module never uploads, syncs, or phones home with its contents. (#4842)
+ *
+ * Opened through the #7175 SqliteDriver seam (`openLocalStoreAdapter`): CRUD goes through `driver.query`,
+ * while schema creation/migrations still use the underlying DatabaseSync until those helpers are migrated.
+ * Public API stays synchronous so callers need no async cascade in this part-1 slice.
  */
 export function initPolicyDocCacheStore(dbPath = resolvePolicyDocCacheDbPath()) {
   const resolvedPath = normalizeDbPath(dbPath);
-  const db = openLocalStoreDb(resolvedPath);
+  const { db, driver } = openLocalStoreAdapter(resolvedPath);
   db.exec(`
     CREATE TABLE IF NOT EXISTS policy_doc_cache (
       url TEXT PRIMARY KEY,
@@ -45,22 +49,23 @@ export function initPolicyDocCacheStore(dbPath = resolvePolicyDocCacheDbPath()) 
   // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations (none yet).
   applySchemaMigrations(db, []);
 
-  const getStatement = db.prepare("SELECT etag, content FROM policy_doc_cache WHERE url = ?");
-  const putStatement = db.prepare(`
+  const getSql = "SELECT etag, content FROM policy_doc_cache WHERE url = ?";
+  const putSql = `
     INSERT INTO policy_doc_cache (url, etag, content, updated_at)
     VALUES (?, ?, ?, ?)
     ON CONFLICT(url) DO UPDATE SET
       etag = excluded.etag,
       content = excluded.content,
       updated_at = excluded.updated_at
-  `);
+  `;
 
   return {
     dbPath: resolvedPath,
     /** The last-known `{ etag, content }` for a policy-doc URL, or null when it has never been cached. Both columns
      *  are `TEXT NOT NULL`, so a present row always carries string values. */
     get(url) {
-      const row = getStatement.get(normalizeUrl(url));
+      const { rows } = driver.query(getSql, [normalizeUrl(url)]);
+      const row = rows[0];
       return row ? { etag: row.etag, content: row.content } : null;
     },
     /** Record the fresh ETag + body so the next run can revalidate it with a conditional GET. */
@@ -69,7 +74,7 @@ export function initPolicyDocCacheStore(dbPath = resolvePolicyDocCacheDbPath()) 
       if (typeof etag !== "string" || !etag.trim()) throw new Error("invalid_policy_doc_etag");
       if (typeof content !== "string") throw new Error("invalid_policy_doc_content");
       const updatedAt = new Date().toISOString();
-      putStatement.run(normalizedUrl, etag, content, updatedAt);
+      driver.query(putSql, [normalizedUrl, etag, content, updatedAt]);
       return { url: normalizedUrl, etag, content, updatedAt };
     },
     close() {


### PR DESCRIPTION
## Summary

- Continues #7175/#7194's storage-abstraction pattern -- currently only `run-state.js` had been
  migrated onto the `SqliteDriver` seam (`store-db-adapter.js`), despite #7175 closing with the
  broader migration still ~1/13 done (see #7282, updated to track the accurate remaining scope).
- `policy-doc-cache.js`'s `get`/`put` now route through `openLocalStoreAdapter`'s `driver.query`
  instead of raw `DatabaseSync`-backed prepared statements, matching `run-state.js`'s exact
  pattern.
- Public API stays fully synchronous -- this is a pure seam migration (routing through an
  abstraction that could later back onto a different driver), not a behavior or logic change.
  Proven by every existing test passing completely unmodified.

Advances #7282

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one store migrated, no unrelated changes) and does not mix unrelated
      backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or
      `CNAME`.
- [x] I linked a currently open issue this PR advances (`Advances #7282` above -- deliberately not
      `Closes`, since #7282 tracks migrating the remaining ~11 stores too, not just this one).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root -- clean)
- [x] `npm run test:coverage` on the changed module -- **100% statements/branches/functions/lines**
      (28/28, 14/14, 7/7, 24/24), verified against the raw coverage report.
- [x] Every existing test in `test/unit/miner-policy-doc-cache.test.ts` and
      `test/unit/opportunity-fanout-policy-doc-cache.test.ts` (20 tests total) passes completely
      unmodified -- direct evidence this migration changed no observable behavior.
- [x] Full `npm run test:ci` green end to end, run under the repo's pinned Node 22 (`.nvmrc`), on a
      clean coverage directory (a prior run hit a transient coverage-tmp-file race from overlapping
      local gate invocations; re-run clean to confirm).
- [x] `npm audit --audit-level=moderate` -- clean except the same pre-existing, unrelated
      `adm-zip`/`github-actionlint` advisory with no fix available.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores,
      private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or
      optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
      (N/A -- local SQLite cache store, not an auth surface.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no OpenAPI-documented
      surface touched.)
- [ ] UI changes use live API data -- N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, backend-only change, no visible UI.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for
      release-prep PRs. (No `CHANGELOG.md` edit; internal storage-abstraction detail.)

## Notes

- `policy-doc-cache.js` was chosen as the next store to migrate for being the smallest (79 lines,
  no interactive transactions, no `RETURNING` statements to trip `store-db-adapter.js`'s own
  documented read/write heuristic limitation).
- #7282 has been corrected to describe the real remaining scope of this migration (the seam exists
  and is proven; the actual Postgres driver and interactive-transaction support are separate,
  larger follow-on efforts, not part of this PR or #7282's current scope).
