### PR TITLE
fix(ui): register chat action plugins under vite preview, not just dev

### DIFF
--- a/apps/loopover-miner-ui/src/chat-action-plugins-preview.test.ts
+++ b/apps/loopover-miner-ui/src/chat-action-plugins-preview.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { chatGovernorActionsPlugin } from "../vite-chat-governor-actions";
+import { chatDiscoverAttemptActionsPlugin } from "../vite-chat-discover-attempt-actions";
+
+// The two plugins register their chat actions via a dynamic `import("./src/lib/...")` on server start; mock those
+// lib modules so the registration functions are spies. vi.hoisted keeps the spies referenceable from the hoisted
+// vi.mock factories. The mock paths resolve to the SAME files the plugins import (both resolve to
+// apps/loopover-miner-ui/src/lib/chat-*-actions), so a single mock intercepts the plugin's own dynamic import.
+const { registerGovernorChatActions, registerDiscoverAttemptChatActions } = vi.hoisted(() => ({
+  registerGovernorChatActions: vi.fn(),
+  registerDiscoverAttemptChatActions: vi.fn(),
+}));
+vi.mock("./lib/chat-governor-actions", () => ({ registerGovernorChatActions }));
+vi.mock("./lib/chat-discover-attempt-actions", () => ({ registerDiscoverAttemptChatActions }));
+
+type HookFn = () => void;
+
+beforeEach(() => {
+  registerGovernorChatActions.mockClear();
+  registerDiscoverAttemptChatActions.mockClear();
+});
+
+describe("chatGovernorActionsPlugin (#7228)", () => {
+  it("registers the governor chat actions on configureServer", async () => {
+    const plugin = chatGovernorActionsPlugin();
+    (plugin.configureServer as HookFn)();
+    await vi.waitFor(() => expect(registerGovernorChatActions).toHaveBeenCalledTimes(1));
+  });
+
+  it("REGRESSION (#7228): also registers under configurePreviewServer (the `vite preview` deployment path)", async () => {
+    const plugin = chatGovernorActionsPlugin();
+    expect(plugin.configurePreviewServer).toBeTypeOf("function");
+    (plugin.configurePreviewServer as HookFn)();
+    await vi.waitFor(() => expect(registerGovernorChatActions).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("chatDiscoverAttemptActionsPlugin (#7228)", () => {
+  it("registers the discover/attempt chat actions on configureServer", async () => {
+    const plugin = chatDiscoverAttemptActionsPlugin();
+    (plugin.configureServer as HookFn)();
+    await vi.waitFor(() => expect(registerDiscoverAttemptChatActions).toHaveBeenCalledTimes(1));
+  });
+
+  it("REGRESSION (#7228): also registers under configurePreviewServer (the `vite preview` deployment path)", async () => {
+    const plugin = chatDiscoverAttemptActionsPlugin();
+    expect(plugin.configurePreviewServer).toBeTypeOf("function");
+    (plugin.configurePreviewServer as HookFn)();
+    await vi.waitFor(() => expect(registerDiscoverAttemptChatActions).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-discover-attempt-actions.ts
@@ -1,17 +1,28 @@
 import type { Plugin } from "vite";
 
-// Registers discover/attempt chat actions into the shared registry on dev-server start (#6837). Handlers call
-// the existing miner-ui `requestDiscover` / `requestAttempt` clients — the same POST `/api/discover` and
+// Registers discover/attempt chat actions into the shared registry on server start (#6837). Handlers call the
+// existing miner-ui `requestDiscover` / `requestAttempt` clients — the same POST `/api/discover` and
 // `/api/attempt` path the routes already serve. No new /api/* route is added here (mirrors
 // vite-chat-governor-actions.ts).
-
+//
+// Registered from BOTH configureServer AND configurePreviewServer (#7228): `vite preview` — the mode the
+// README's "persistent service" path and systemd/loopover-miner-ui.service.example actually run — only fires
+// configurePreviewServer, so registering on configureServer alone left the chat-action registry empty under
+// preview and every discover/attempt chat command dispatched as "unknown_action".
+// registerDiscoverAttemptChatActions is already idempotent, so calling it from both hooks is safe.
 export function chatDiscoverAttemptActionsPlugin(): Plugin {
+  const register = () => {
+    void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
+      mod.registerDiscoverAttemptChatActions();
+    });
+  };
   return {
     name: "loopover-miner-chat-discover-attempt-actions",
     configureServer() {
-      void import("./src/lib/chat-discover-attempt-actions").then((mod) => {
-        mod.registerDiscoverAttemptChatActions();
-      });
+      register();
+    },
+    configurePreviewServer() {
+      register();
     },
   };
 }

--- a/apps/loopover-miner-ui/vite-chat-governor-actions.ts
+++ b/apps/loopover-miner-ui/vite-chat-governor-actions.ts
@@ -1,16 +1,27 @@
 import type { Plugin } from "vite";
 
-// Registers governor pause/resume chat actions into the shared registry on dev-server start (#6521).
-// Handlers call the existing miner-ui `pauseGovernor` / `resumeGovernor` clients — same path as the Ledgers
-// buttons. No new /api/governor/* route is added here.
-
+// Registers governor pause/resume chat actions into the shared registry on server start (#6521). Handlers call
+// the existing miner-ui `pauseGovernor` / `resumeGovernor` clients — same path as the Ledgers buttons. No new
+// /api/governor/* route is added here.
+//
+// Registered from BOTH configureServer AND configurePreviewServer (#7228): `vite preview` — the mode the
+// README's "persistent service" path and systemd/loopover-miner-ui.service.example actually run — only fires
+// configurePreviewServer, so registering on configureServer alone left the chat-action registry empty under
+// preview and every governor chat command dispatched as "unknown_action". registerGovernorChatActions is already
+// idempotent, so calling it from both hooks is safe.
 export function chatGovernorActionsPlugin(): Plugin {
+  const register = () => {
+    void import("./src/lib/chat-governor-actions").then((mod) => {
+      mod.registerGovernorChatActions();
+    });
+  };
   return {
     name: "loopover-miner-chat-governor-actions",
     configureServer() {
-      void import("./src/lib/chat-governor-actions").then((mod) => {
-        mod.registerGovernorChatActions();
-      });
+      register();
+    },
+    configurePreviewServer() {
+      register();
     },
   };
 }


### PR DESCRIPTION
## Summary

`chatGovernorActionsPlugin` (`vite-chat-governor-actions.ts`) and `chatDiscoverAttemptActionsPlugin` (`vite-chat-discover-attempt-actions.ts`) implemented only `configureServer`, so their `registerGovernorChatActions` / `registerDiscoverAttemptChatActions` calls never ran under `vite preview` — the exact deployment mode the miner-ui README's "persistent service" section documents and `systemd/loopover-miner-ui.service.example` runs (`npm run build` + `npm run preview`, which fires only `configurePreviewServer`).

The result: under preview, the shared chat-action registry stayed empty, so an operator's chat-issued `pause`/`resume`/`release`/`requeue`/discover/attempt commands dispatched against nothing and surfaced as "action is not registered" — a confusing gap, since the same command works under `npm run dev`.

Every other local `vite-*-api` plugin already registers on both hooks. This makes these two match: each now registers on **both** `configureServer` and `configurePreviewServer`, calling the same (already-idempotent) registration function from each — the exact shape `chatApiPlugin` uses.

## Scope

- [x] Touches only the two named plugin files + a new test; no `configureServer` behavior change, no change to the `src/lib/` registration modules or any other plugin
- [x] No new `/api/*` route added — the existing plugin hook is registered, as the issue requires

## Validation

- [x] `@loopover/ui-miner` typecheck, lint, **test**, and build all green (after `ui:kit:build`)
- [x] New regression test proves both `registerGovernorChatActions` and `registerDiscoverAttemptChatActions` are invoked when only `configurePreviewServer` is exercised (not just `configureServer`), mirroring the app's existing plugin-test convention
- [x] `ui:version-audit` clean; rebased onto latest `main`

## Safety

- [x] No secrets or private terms introduced; registration functions remain idempotent (no new idempotency logic added in the plugin files)

Closes #7228
