### PR TITLE
fix(miner-ui): keep PortfolioPage's polls additive across operator actions (#7230)

### DIFF
--- a/apps/loopover-miner-ui/src/lib/use-polled-fetch.ts
+++ b/apps/loopover-miner-ui/src/lib/use-polled-fetch.ts
@@ -1,16 +1,44 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Shared "live refresh" cadence for the local, offline dev-server API views (#4856) — frequent enough to feel
  *  live for a cheap local SQLite read, without polling so tightly it's wasteful. */
 export const DEFAULT_POLL_INTERVAL_MS = 10_000;
 
+export interface PolledFetch<T> {
+  /** Latest fetched value, or `null` until the first fetch resolves. */
+  result: T | null;
+  /**
+   * Imperatively fetch now, without disturbing the periodic schedule. An operator's own action can reflect
+   * immediately via this trigger, while the `setInterval` keeps ticking on its original cadence — additive to
+   * the timer, not a replacement for it (#7230). Coalesces with an already-in-flight fetch just like a tick does.
+   */
+  refresh: () => void;
+}
+
 /**
  * Fetch once on mount, then re-fetch on a fixed interval so newly-recorded local activity appears without a
  * manual page reload (#4856). Skips overlapping ticks: if a fetch from a previous tick is still in flight when
  * the next interval fires, that tick is a no-op rather than stacking concurrent requests.
+ *
+ * The interval is keyed on `intervalMs` alone: `loadFn` is read through a ref so a caller handing in a fresh
+ * `loadFn` identity (e.g. a `useCallback` whose deps changed) neither tears down nor restarts the timer. Callers
+ * that need an operator action to refresh immediately use the returned `refresh()` instead of forcing a new
+ * `loadFn`, which would otherwise reset the interval's countdown (#7230).
  */
-export function usePolledFetch<T>(loadFn: () => Promise<T>, intervalMs: number): T | null {
+export function usePolledFetch<T>(loadFn: () => Promise<T>, intervalMs: number): PolledFetch<T> {
   const [result, setResult] = useState<T | null>(null);
+
+  // Always read the freshest loadFn without listing it as an effect dependency, so its identity changing never
+  // restarts the interval (that restart is exactly the schedule-reset bug #7230 is about). Synced in an effect
+  // rather than during render, since a ref must not be written while rendering.
+  const loadFnRef = useRef(loadFn);
+  useEffect(() => {
+    loadFnRef.current = loadFn;
+  }, [loadFn]);
+
+  // The active tick runner, published by the mount effect. Held in a ref so `refresh`'s identity stays stable
+  // for every caller and invoking it never re-arms the interval.
+  const runRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     let cancelled = false;
@@ -19,7 +47,8 @@ export function usePolledFetch<T>(loadFn: () => Promise<T>, intervalMs: number):
     const run = () => {
       if (inFlight) return;
       inFlight = true;
-      void loadFn()
+      void loadFnRef
+        .current()
         .then((loaded) => {
           if (!cancelled) setResult(loaded);
         })
@@ -27,14 +56,18 @@ export function usePolledFetch<T>(loadFn: () => Promise<T>, intervalMs: number):
           inFlight = false;
         });
     };
+    runRef.current = run;
 
     run();
     const id = window.setInterval(run, intervalMs);
     return () => {
       cancelled = true;
       window.clearInterval(id);
+      runRef.current = () => {};
     };
-  }, [loadFn, intervalMs]);
+  }, [intervalMs]);
 
-  return result;
+  const refresh = useCallback(() => runRef.current(), []);
+
+  return { result, refresh };
 }

--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -296,6 +296,71 @@ describe("PortfolioPage queue actions (#4857)", () => {
       await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(1));
       await vi.advanceTimersByTimeAsync(1000);
       await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  describe("additive live-refresh schedule (#7230)", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // #7230 REGRESSION: an operator action must fetch immediately AND leave the periodic schedule undisturbed.
+    // Before the fix, bumping refreshKey gave loadSummary/loadItems a new identity, which tore down and restarted
+    // each poll's setInterval -- so the next scheduled tick landed pollIntervalMs after the ACTION (t=1600 below)
+    // instead of on the original cadence (t=1000). Both the summary and queue-actions polls must stay additive.
+    //
+    // Timing here is asserted with EXACT fake-timer advances plus manual microtask flushes -- never vi.waitFor,
+    // which auto-advances the fake clock and would blur the t=600-vs-t=1000 distinction this test turns on.
+    it("keeps both polls on their original interval after a release, rather than resetting to the action time", async () => {
+      vi.useFakeTimers();
+      // Drain the promise/effect microtask queue WITHOUT moving the fake clock, so time only advances where we say.
+      const flush = () =>
+        act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+      const loadSummary = vi.fn(async (): Promise<PortfolioQueueResult> => ({ ok: true, summary: fixtureSummary }));
+      const loadItems = vi.fn(async () => ({ ok: true as const, items: [inProgressItem] }));
+      const releaseItem = vi.fn(async () => ({
+        ok: true as const,
+        entry: { repoFullName: "acme/widgets", identifier: "issue:12", status: "queued" },
+      }));
+      render(
+        <PortfolioPage
+          loadPortfolioQueue={loadSummary}
+          loadPortfolioQueueItems={loadItems}
+          releaseItem={releaseItem}
+          pollIntervalMs={1000}
+        />,
+      );
+      // Mount fetch for both sections (t=0), flushed without advancing the clock.
+      await flush();
+      expect(loadSummary).toHaveBeenCalledTimes(1);
+      expect(loadItems).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("button", { name: "Release" })).toBeTruthy();
+
+      // Advance exactly part-way through the interval, then act (t=600). No scheduled tick has fired yet.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+      expect(loadSummary).toHaveBeenCalledTimes(1);
+      expect(loadItems).toHaveBeenCalledTimes(1);
+
+      // Operator releases at t=600; the async action chain resolves via microtasks, not the clock.
+      fireEvent.click(screen.getByRole("button", { name: "Release" }));
+      await flush();
+      await flush();
+      expect(releaseItem).toHaveBeenCalledWith(inProgressItem);
+      // The action's own immediate extra fetch fires for both sections.
+      expect(loadSummary).toHaveBeenCalledTimes(2);
+      expect(loadItems).toHaveBeenCalledTimes(2);
+
+      // Advance ONLY the remaining 400ms to the ORIGINAL t=1000 tick. With the pre-fix reset, the next tick would
+      // be at t=1600 and both would still read 2; additive scheduling makes the original tick fire here (-> 3).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      expect(loadSummary).toHaveBeenCalledTimes(3);
+      expect(loadItems).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/apps/loopover-miner-ui/src/routes/index.tsx
+++ b/apps/loopover-miner-ui/src/routes/index.tsx
@@ -173,8 +173,8 @@ export function IndexPage({
   loadClaims?: () => Promise<LedgersResult>;
   pollIntervalMs?: number;
 }) {
-  const runs = usePolledFetch(loadRuns, pollIntervalMs);
-  const portfolio = usePolledFetch(loadPortfolio, pollIntervalMs);
-  const claims = usePolledFetch(loadClaims, pollIntervalMs);
+  const { result: runs } = usePolledFetch(loadRuns, pollIntervalMs);
+  const { result: portfolio } = usePolledFetch(loadPortfolio, pollIntervalMs);
+  const { result: claims } = usePolledFetch(loadClaims, pollIntervalMs);
   return <OverviewView runs={runs} portfolio={portfolio} claims={claims} />;
 }

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -432,12 +432,12 @@ export function LedgersPage({
 
   // Join the app's shared live-refresh cadence so newly-recorded claims/events appear without a manual reload,
   // matching the Overview page's claims card that reads the same data source (#7082).
-  const result = usePolledFetch(loadLedgers, pollIntervalMs);
+  const { result } = usePolledFetch(loadLedgers, pollIntervalMs);
 
   // Poll the governor pause-state on the same cadence. Each fresh poll result is synced into `pauseState` during
   // render, while the operator's own pause/resume action writes `pauseState` directly so it reflects immediately,
   // not only on the next tick (#7082).
-  const polledPauseState = usePolledFetch(loadGovernorPauseState, pollIntervalMs);
+  const { result: polledPauseState } = usePolledFetch(loadGovernorPauseState, pollIntervalMs);
   if (polledPauseState !== lastPolledPauseState) {
     setLastPolledPauseState(polledPauseState);
     setPauseState(polledPauseState);

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { Button } from "@loopover/ui-kit/components/button";
@@ -403,25 +403,25 @@ export function PortfolioPage({
   requeueItem?: typeof requeuePortfolioQueueItem;
   pollIntervalMs?: number;
 }) {
-  const [refreshKey, setRefreshKey] = useState(0);
   const [actionPending, setActionPending] = useState(false);
   const [actionResult, setActionResult] = useState<PortfolioQueueActionResult | null>(null);
 
-  const loadSummary = useCallback(() => loadPortfolioQueue(), [loadPortfolioQueue, refreshKey]);
-  const summaryResult = usePolledFetch(loadSummary, pollIntervalMs);
+  const { result: summaryResult, refresh: refreshSummary } = usePolledFetch(loadPortfolioQueue, pollIntervalMs);
 
   // Poll the queue-actions items on the shared cadence too, independently of the summary card's own poll — a slow
-  // or failed fetch in one section must not block the other. Bumping refreshKey after the operator's own action
-  // re-fetches immediately, additive to the timer rather than replacing it (#7082).
-  const loadItems = useCallback(() => loadPortfolioQueueItems(), [loadPortfolioQueueItems, refreshKey]);
-  const itemsResult = usePolledFetch(loadItems, pollIntervalMs);
+  // or failed fetch in one section must not block the other.
+  const { result: itemsResult, refresh: refreshItems } = usePolledFetch(loadPortfolioQueueItems, pollIntervalMs);
 
   const runQueueAction = (action: () => Promise<PortfolioQueueActionResult>) => {
     setActionPending(true);
     void action().then((next) => {
       setActionResult(next);
       if (next.ok) {
-        setRefreshKey((key) => key + 1);
+        // Refresh both sections immediately so the operator's own action reflects at once — additive to each
+        // poll's timer, which keeps running on its original cadence rather than being reset by the action (#7230,
+        // restoring #7082's "additive... not a replacement" intent that the refreshKey-in-deps wiring broke).
+        refreshSummary();
+        refreshItems();
       }
       setActionPending(false);
     });

--- a/apps/loopover-miner-ui/src/routes/run-history.tsx
+++ b/apps/loopover-miner-ui/src/routes/run-history.tsx
@@ -185,7 +185,7 @@ export function RunHistoryPage({
   loadRunStates?: () => Promise<RunHistoryResult>;
   pollIntervalMs?: number;
 }) {
-  const result = usePolledFetch(loadRunStates, pollIntervalMs);
+  const { result } = usePolledFetch(loadRunStates, pollIntervalMs);
 
   return (
     <Card>

--- a/apps/loopover-miner-ui/src/use-polled-fetch.test.ts
+++ b/apps/loopover-miner-ui/src/use-polled-fetch.test.ts
@@ -12,7 +12,7 @@ describe("usePolledFetch (#4856)", () => {
   it("fetches once immediately on mount", async () => {
     const loadFn = vi.fn(async () => "loaded");
     const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
-    await waitFor(() => expect(result.current).toBe("loaded"));
+    await waitFor(() => expect(result.current.result).toBe("loaded"));
     expect(loadFn).toHaveBeenCalledTimes(1);
   });
 
@@ -22,13 +22,13 @@ describe("usePolledFetch (#4856)", () => {
     const loadFn = vi.fn(async () => `loaded-${(call += 1)}`);
     const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
 
-    await vi.waitFor(() => expect(result.current).toBe("loaded-1"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-1"));
 
     await vi.advanceTimersByTimeAsync(1000);
-    await vi.waitFor(() => expect(result.current).toBe("loaded-2"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-2"));
 
     await vi.advanceTimersByTimeAsync(1000);
-    await vi.waitFor(() => expect(result.current).toBe("loaded-3"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-3"));
 
     expect(loadFn).toHaveBeenCalledTimes(3);
   });
@@ -37,7 +37,7 @@ describe("usePolledFetch (#4856)", () => {
     vi.useFakeTimers();
     const loadFn = vi.fn(async () => "loaded");
     const { result, unmount } = renderHook(() => usePolledFetch(loadFn, 1000));
-    await vi.waitFor(() => expect(result.current).toBe("loaded"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded"));
     expect(loadFn).toHaveBeenCalledTimes(1);
 
     unmount();
@@ -85,10 +85,56 @@ describe("usePolledFetch (#4856)", () => {
     unmount();
     resolveLoad?.("too-late");
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(result.current).toBeNull();
+    expect(result.current.result).toBeNull();
   });
 
   it("exports a sensible default poll interval", () => {
     expect(DEFAULT_POLL_INTERVAL_MS).toBeGreaterThan(0);
+  });
+
+  // #7230: a caller handing in a fresh loadFn identity (e.g. a useCallback whose deps changed) must NOT tear down
+  // and restart the interval -- doing so resets the periodic countdown, which is the schedule-reset bug.
+  it("does not restart the interval when the loadFn identity changes between renders (#7230)", async () => {
+    vi.useFakeTimers();
+    // Each render gets a brand-new loadFn closure, but the periodic schedule must stay on its original cadence.
+    let ticks = 0;
+    const makeLoadFn = () => vi.fn(async () => `tick-${(ticks += 1)}`);
+    const { result, rerender } = renderHook(({ loadFn }) => usePolledFetch(loadFn, 1000), {
+      initialProps: { loadFn: makeLoadFn() },
+    });
+    await vi.waitFor(() => expect(result.current.result).toBe("tick-1"));
+
+    // Part-way through the interval, re-render with a new loadFn identity -- the schedule must be undisturbed.
+    await vi.advanceTimersByTimeAsync(600);
+    rerender({ loadFn: makeLoadFn() });
+    // No immediate fetch fired from the identity change, and no restart: still 1 fetch so far.
+    expect(ticks).toBe(1);
+
+    // The ORIGINAL schedule's next tick lands 1000ms after mount (i.e. 400ms more), not 1000ms after the rerender.
+    // The tick fetches once (ticks -> 2) using the freshest loadFn read through the ref.
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => expect(result.current.result).toBe("tick-2"));
+    expect(ticks).toBe(2);
+  });
+
+  // #7230: refresh() imperatively fetches now, additive to the timer -- it neither resets the countdown nor is a
+  // no-op; the very next scheduled tick still lands on the ORIGINAL cadence.
+  it("refresh() fetches immediately without resetting the interval schedule (#7230)", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const loadFn = vi.fn(async () => `load-${(calls += 1)}`);
+    const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
+    await vi.waitFor(() => expect(calls).toBe(1)); // mount fetch
+
+    // Fire an imperative refresh mid-interval (at t=500ms) -- the immediate extra fetch happens right away.
+    await vi.advanceTimersByTimeAsync(500);
+    result.current.refresh();
+    await vi.waitFor(() => expect(result.current.result).toBe("load-2"));
+    expect(calls).toBe(2);
+
+    // The periodic tick still fires at the ORIGINAL t=1000ms (500ms after the refresh), not 1000ms after it.
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.waitFor(() => expect(result.current.result).toBe("load-3"));
+    expect(calls).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

`PortfolioPage`'s summary and queue-actions polls reset their interval schedule on every operator action, contradicting #7082's own "additive... not a replacement" acceptance criterion.

- Both polls were wired through `useCallback`s that depended on `refreshKey` (a counter bumped after each successful release/requeue). That gave `loadSummary`/`loadItems` a new function identity, so `usePolledFetch`'s effect — keyed on `[loadFn, intervalMs]` — tore down its `setInterval` and started a fresh one, restarting the 10s countdown from the moment of the action. If an operator released an item mid-cycle at t=23s, the next scheduled poll landed at t=33s instead of the original t=30s; with rapid back-to-back actions the periodic tick could be deferred indefinitely.
- Fix: decouple the imperative "refresh now" from the interval lifecycle. `usePolledFetch` now keys its interval on `intervalMs` alone, reads `loadFn` through a ref (synced in an effect, never written during render) so a changed identity never restarts the timer, and returns `{ result, refresh }`. `PortfolioPage` calls `refresh()` on a successful action for the immediate extra fetch, while the periodic schedule keeps running undisturbed on its original cadence.
- The other callers (`routes/index.tsx`, `routes/run-history.tsx`, `routes/ledgers.tsx`) destructure `.result`; their `loadFn`s are stable so there is no behavior change, and fetch-on-mount / skip-overlapping-ticks / cancel-on-unmount are all preserved. `LedgersPage`'s separate additive pause/resume write is untouched.

No visible UI change: this only alters *when* background polls fire — the rendered DOM is byte-identical, so there is no screenshot-able at-rest or in-motion difference.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7230`).

## Validation

- [x] `git diff --check`
- [x] miner-ui `vitest run` — 27 files, 325 tests pass (incl. the new #7230 regression + hook tests)
- [x] miner-ui `typecheck` (`tsc --noEmit`)
- [x] miner-ui `lint` (0 errors; only pre-existing `react-refresh/only-export-components` warnings on route files)
- [x] miner-ui `build` (`vite build`)
- [x] `prettier --check` on all changed files
- [x] New behavior has tests: a fake-timer regression asserting the next scheduled tick still lands on the original cadence after a mid-interval action (fails against the old `refreshKey`-in-deps wiring), plus hook-level tests for the ref-read of a changed `loadFn` and for `refresh()`.

`apps/**` is outside this repo's Codecov `coverage.include` scope (confirmed in #7082's body), so this change is not gated by `codecov/patch`; the bar is the miner-ui Vitest suite, which passes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, trust scores, or private rankings exposed.
- [x] Public text stays sanitized and low-noise.
- [x] No auth/cookie/CORS/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] UI uses live API data / real states, not demo fallbacks.
- [x] No visible UI change — behavior-only (poll scheduling), so no `UI Evidence` section applies.
- [x] No changelog/docs edits needed.

## Notes

- The interval effect intentionally depends on `[intervalMs]` only; `loadFn` is read through a ref that is updated in a dedicated effect (a ref must not be written during render). This is the crux of the fix — a changed `loadFn` identity no longer re-arms the timer.


Closes #7230
