### PR TITLE
fix(ui): keep the portfolio poll additive, not a schedule reset, on actions

### DIFF
--- a/apps/loopover-miner-ui/src/lib/use-polled-fetch.ts
+++ b/apps/loopover-miner-ui/src/lib/use-polled-fetch.ts
@@ -1,40 +1,64 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Shared "live refresh" cadence for the local, offline dev-server API views (#4856) — frequent enough to feel
  *  live for a cheap local SQLite read, without polling so tightly it's wasteful. */
 export const DEFAULT_POLL_INTERVAL_MS = 10_000;
 
+/** What {@link usePolledFetch} returns: the latest fetched value, plus an imperative `refresh` (#7230). */
+export type PolledFetch<T> = {
+  /** Latest fetched value, or `null` until the first fetch resolves. */
+  result: T | null;
+  /** Fetch once now, additively — without tearing down or re-arming the periodic timer. Skipped while a fetch
+   *  is already in flight (same overlap guard as a scheduled tick). */
+  refresh: () => void;
+};
+
 /**
  * Fetch once on mount, then re-fetch on a fixed interval so newly-recorded local activity appears without a
  * manual page reload (#4856). Skips overlapping ticks: if a fetch from a previous tick is still in flight when
  * the next interval fires, that tick is a no-op rather than stacking concurrent requests.
+ *
+ * The returned `refresh()` performs an immediate, additive fetch that does NOT reset the interval schedule
+ * (#7230): a caller that wants its own action reflected right away calls `refresh()` instead of perturbing
+ * `loadFn`'s identity, so the periodic cadence stays on its original clock. `loadFn` is read through a ref so a
+ * changed `loadFn` identity likewise never re-arms the timer — the next scheduled tick just uses the latest one.
  */
-export function usePolledFetch<T>(loadFn: () => Promise<T>, intervalMs: number): T | null {
+export function usePolledFetch<T>(loadFn: () => Promise<T>, intervalMs: number): PolledFetch<T> {
   const [result, setResult] = useState<T | null>(null);
+  // Latest loadFn, read by `refresh` without being an effect dependency — so a new loadFn identity never tears
+  // down and re-arms the interval (the #7230 root cause when a caller changed loadFn to force an extra fetch).
+  // Synced in an effect (not during render) so refresh always calls the current loadFn; refresh only ever runs
+  // from an event handler or a scheduled tick, both of which happen after this sync effect has committed.
+  const loadFnRef = useRef(loadFn);
+  const inFlightRef = useRef(false);
+  const cancelledRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
-    let inFlight = false;
+    loadFnRef.current = loadFn;
+  }, [loadFn]);
 
-    const run = () => {
-      if (inFlight) return;
-      inFlight = true;
-      void loadFn()
-        .then((loaded) => {
-          if (!cancelled) setResult(loaded);
-        })
-        .finally(() => {
-          inFlight = false;
-        });
-    };
+  const refresh = useCallback(() => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    void loadFnRef
+      .current()
+      .then((loaded) => {
+        if (!cancelledRef.current) setResult(loaded);
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+      });
+  }, []);
 
-    run();
-    const id = window.setInterval(run, intervalMs);
+  useEffect(() => {
+    cancelledRef.current = false;
+    refresh();
+    const id = window.setInterval(refresh, intervalMs);
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
       window.clearInterval(id);
     };
-  }, [loadFn, intervalMs]);
+  }, [refresh, intervalMs]);
 
-  return result;
+  return { result, refresh };
 }

--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -297,6 +297,37 @@ describe("PortfolioPage queue actions (#4857)", () => {
       await vi.advanceTimersByTimeAsync(1000);
       await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(2));
     });
+
+    it("REGRESSION (#7230): an operator action's immediate refresh is additive and does not reset the poll schedule", async () => {
+      vi.useFakeTimers();
+      const loadPortfolioQueueItems = vi.fn(async () => ({ ok: true as const, items: [inProgressItem] }));
+      const releaseItem = vi.fn(async (): Promise<PortfolioQueueActionResult> => ({
+        ok: true,
+        entry: { repoFullName: "acme/widgets", identifier: "issue:12", status: "queued" },
+      }));
+      render(
+        <PortfolioPage
+          loadPortfolioQueue={loadPortfolioQueue}
+          loadPortfolioQueueItems={loadPortfolioQueueItems}
+          releaseItem={releaseItem}
+          pollIntervalMs={1000}
+        />,
+      );
+      // Mount fetch.
+      await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(1));
+
+      // Part-way through the interval, the operator releases an item — an immediate, additive re-fetch.
+      await vi.advanceTimersByTimeAsync(600);
+      fireEvent.click(screen.getByRole("button", { name: "Release" }));
+      await vi.waitFor(() => expect(releaseItem).toHaveBeenCalled());
+      await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(2));
+
+      // The original 1000ms schedule is undisturbed: the next scheduled tick still lands at t=1000 (400ms later),
+      // NOT 1000ms after the action. Before the fix (refreshKey re-armed the interval) this tick would not have
+      // fired until t=1600.
+      await vi.advanceTimersByTimeAsync(400);
+      await vi.waitFor(() => expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(3));
+    });
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/index.tsx
+++ b/apps/loopover-miner-ui/src/routes/index.tsx
@@ -173,8 +173,8 @@ export function IndexPage({
   loadClaims?: () => Promise<LedgersResult>;
   pollIntervalMs?: number;
 }) {
-  const runs = usePolledFetch(loadRuns, pollIntervalMs);
-  const portfolio = usePolledFetch(loadPortfolio, pollIntervalMs);
-  const claims = usePolledFetch(loadClaims, pollIntervalMs);
+  const { result: runs } = usePolledFetch(loadRuns, pollIntervalMs);
+  const { result: portfolio } = usePolledFetch(loadPortfolio, pollIntervalMs);
+  const { result: claims } = usePolledFetch(loadClaims, pollIntervalMs);
   return <OverviewView runs={runs} portfolio={portfolio} claims={claims} />;
 }

--- a/apps/loopover-miner-ui/src/routes/ledgers.tsx
+++ b/apps/loopover-miner-ui/src/routes/ledgers.tsx
@@ -432,12 +432,12 @@ export function LedgersPage({
 
   // Join the app's shared live-refresh cadence so newly-recorded claims/events appear without a manual reload,
   // matching the Overview page's claims card that reads the same data source (#7082).
-  const result = usePolledFetch(loadLedgers, pollIntervalMs);
+  const { result } = usePolledFetch(loadLedgers, pollIntervalMs);
 
   // Poll the governor pause-state on the same cadence. Each fresh poll result is synced into `pauseState` during
   // render, while the operator's own pause/resume action writes `pauseState` directly so it reflects immediately,
   // not only on the next tick (#7082).
-  const polledPauseState = usePolledFetch(loadGovernorPauseState, pollIntervalMs);
+  const { result: polledPauseState } = usePolledFetch(loadGovernorPauseState, pollIntervalMs);
   if (polledPauseState !== lastPolledPauseState) {
     setLastPolledPauseState(polledPauseState);
     setPauseState(polledPauseState);

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -403,25 +403,29 @@ export function PortfolioPage({
   requeueItem?: typeof requeuePortfolioQueueItem;
   pollIntervalMs?: number;
 }) {
-  const [refreshKey, setRefreshKey] = useState(0);
   const [actionPending, setActionPending] = useState(false);
   const [actionResult, setActionResult] = useState<PortfolioQueueActionResult | null>(null);
 
-  const loadSummary = useCallback(() => loadPortfolioQueue(), [loadPortfolioQueue, refreshKey]);
-  const summaryResult = usePolledFetch(loadSummary, pollIntervalMs);
+  const loadSummary = useCallback(() => loadPortfolioQueue(), [loadPortfolioQueue]);
+  const { result: summaryResult, refresh: refreshSummary } = usePolledFetch(loadSummary, pollIntervalMs);
 
   // Poll the queue-actions items on the shared cadence too, independently of the summary card's own poll — a slow
-  // or failed fetch in one section must not block the other. Bumping refreshKey after the operator's own action
-  // re-fetches immediately, additive to the timer rather than replacing it (#7082).
-  const loadItems = useCallback(() => loadPortfolioQueueItems(), [loadPortfolioQueueItems, refreshKey]);
-  const itemsResult = usePolledFetch(loadItems, pollIntervalMs);
+  // or failed fetch in one section must not block the other.
+  const loadItems = useCallback(() => loadPortfolioQueueItems(), [loadPortfolioQueueItems]);
+  const { result: itemsResult, refresh: refreshItems } = usePolledFetch(loadItems, pollIntervalMs);
 
   const runQueueAction = (action: () => Promise<PortfolioQueueActionResult>) => {
     setActionPending(true);
     void action().then((next) => {
       setActionResult(next);
       if (next.ok) {
-        setRefreshKey((key) => key + 1);
+        // Reflect the operator's own action immediately — additively, via usePolledFetch's imperative refresh so
+        // the periodic cadence stays on its original clock (#7230). The prior refreshKey→loadFn-identity bump
+        // instead tore down and re-armed each poll's interval, deferring the next scheduled tick to `intervalMs`
+        // after the action rather than keeping it at its undisturbed time (contradicting #7082's "additive, not a
+        // replacement" requirement).
+        refreshSummary();
+        refreshItems();
       }
       setActionPending(false);
     });

--- a/apps/loopover-miner-ui/src/routes/run-history.tsx
+++ b/apps/loopover-miner-ui/src/routes/run-history.tsx
@@ -185,7 +185,7 @@ export function RunHistoryPage({
   loadRunStates?: () => Promise<RunHistoryResult>;
   pollIntervalMs?: number;
 }) {
-  const result = usePolledFetch(loadRunStates, pollIntervalMs);
+  const { result } = usePolledFetch(loadRunStates, pollIntervalMs);
 
   return (
     <Card>

--- a/apps/loopover-miner-ui/src/use-polled-fetch.test.ts
+++ b/apps/loopover-miner-ui/src/use-polled-fetch.test.ts
@@ -12,7 +12,7 @@ describe("usePolledFetch (#4856)", () => {
   it("fetches once immediately on mount", async () => {
     const loadFn = vi.fn(async () => "loaded");
     const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
-    await waitFor(() => expect(result.current).toBe("loaded"));
+    await waitFor(() => expect(result.current.result).toBe("loaded"));
     expect(loadFn).toHaveBeenCalledTimes(1);
   });
 
@@ -22,13 +22,13 @@ describe("usePolledFetch (#4856)", () => {
     const loadFn = vi.fn(async () => `loaded-${(call += 1)}`);
     const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
 
-    await vi.waitFor(() => expect(result.current).toBe("loaded-1"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-1"));
 
     await vi.advanceTimersByTimeAsync(1000);
-    await vi.waitFor(() => expect(result.current).toBe("loaded-2"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-2"));
 
     await vi.advanceTimersByTimeAsync(1000);
-    await vi.waitFor(() => expect(result.current).toBe("loaded-3"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-3"));
 
     expect(loadFn).toHaveBeenCalledTimes(3);
   });
@@ -37,12 +37,79 @@ describe("usePolledFetch (#4856)", () => {
     vi.useFakeTimers();
     const loadFn = vi.fn(async () => "loaded");
     const { result, unmount } = renderHook(() => usePolledFetch(loadFn, 1000));
-    await vi.waitFor(() => expect(result.current).toBe("loaded"));
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded"));
     expect(loadFn).toHaveBeenCalledTimes(1);
 
     unmount();
     await vi.advanceTimersByTimeAsync(5000);
     expect(loadFn).toHaveBeenCalledTimes(1); // no further calls after unmount
+  });
+
+  it("REGRESSION (#7230): refresh() fetches immediately but does NOT reset the interval schedule", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const loadFn = vi.fn(async () => `loaded-${(call += 1)}`);
+    const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
+
+    // Mount fetch.
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-1"));
+    expect(loadFn).toHaveBeenCalledTimes(1);
+
+    // Part-way through the first interval, an operator action triggers refresh(): an immediate extra fetch.
+    await vi.advanceTimersByTimeAsync(600);
+    result.current.refresh();
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-2"));
+    expect(loadFn).toHaveBeenCalledTimes(2);
+
+    // The original schedule is undisturbed: the next scheduled tick still lands at t=1000 (400ms later), NOT
+    // 1000ms after the refresh. Advancing the remaining 400ms fires it.
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-3"));
+    expect(loadFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("REGRESSION (#7230): a changed loadFn identity does not tear down and re-arm the interval", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const makeLoadFn = () => vi.fn(async () => `loaded-${(call += 1)}`);
+    const { result, rerender } = renderHook(({ loadFn }) => usePolledFetch(loadFn, 1000), {
+      initialProps: { loadFn: makeLoadFn() },
+    });
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-1"));
+
+    // A new loadFn identity mid-interval must NOT trigger an immediate fetch or restart the timer — the next
+    // scheduled tick simply uses the latest loadFn.
+    await vi.advanceTimersByTimeAsync(600);
+    rerender({ loadFn: makeLoadFn() });
+    expect(call).toBe(1); // no extra fetch fired on the identity change
+
+    await vi.advanceTimersByTimeAsync(400); // original schedule's t=1000 tick
+    await vi.waitFor(() => expect(result.current.result).toBe("loaded-2"));
+  });
+
+  it("refresh() is skipped while a fetch is already in flight", async () => {
+    vi.useFakeTimers();
+    let resolveFirst: ((value: string) => void) | undefined;
+    let callCount = 0;
+    const loadFn = vi.fn(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve(`loaded-${callCount}`);
+    });
+    const { result } = renderHook(() => usePolledFetch(loadFn, 1000));
+    expect(loadFn).toHaveBeenCalledTimes(1); // mount fetch in flight
+
+    result.current.refresh(); // in-flight → no-op
+    expect(loadFn).toHaveBeenCalledTimes(1);
+
+    resolveFirst?.("loaded-1");
+    await vi.advanceTimersByTimeAsync(0);
+    result.current.refresh(); // now free
+    await vi.waitFor(() => expect(loadFn).toHaveBeenCalledTimes(2));
   });
 
   it("skips an overlapping tick when the previous fetch is still in flight, instead of stacking concurrent requests", async () => {
@@ -85,7 +152,7 @@ describe("usePolledFetch (#4856)", () => {
     unmount();
     resolveLoad?.("too-late");
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(result.current).toBeNull();
+    expect(result.current.result).toBeNull();
   });
 
   it("exports a sensible default poll interval", () => {


### PR DESCRIPTION
## Summary

`PortfolioPage`'s summary and queue-actions polls were wired through `useCallback`s that depended on `refreshKey` — a counter bumped after every successful release/requeue. Since `usePolledFetch` keys its effect on the `loadFn` identity, each bump tore down and re-armed the `setInterval`, **resetting** the 10s poll countdown from the moment of the action rather than leaving the periodic schedule undisturbed.

That contradicts #7082's own acceptance criterion (verbatim): the manual refresh after an action "is **additive** to the timer-based refresh, **not a replacement** for it." Concretely, a release at t=23s pushed the next scheduled poll from t=30s to t=33s, and several actions within one interval could keep re-arming a fresh wait so the periodic tick never fired on its own.

**Fix:** `usePolledFetch` now returns `{ result, refresh }`. `refresh()` performs an immediate, overlap-guarded fetch **without** touching the interval, and `loadFn` is read through a ref so a changed identity never re-arms the timer either. `PortfolioPage` drops `refreshKey` entirely and calls `refresh()` after a successful action — the immediate extra fetch still happens, additively, while the cadence stays on its original clock. The other three callers (overview, run-history, ledgers) pass stable loadFns and are unaffected beyond destructuring `{ result }`.

## Scope

- [x] `usePolledFetch` public shape change (`T | null` → `{ result, refresh }`) — explicitly in scope per the issue; existing behavior (mount fetch, skip-overlap, cancel-on-unmount) preserved for every caller
- [x] No behavior change for `LedgersPage` (already-correct additive pattern) or the read-only overview/run-history polls

## Validation

- [x] `@loopover/ui-miner` typecheck, lint, **test** (330 tests), and build all green
- [x] Fake-timer regression at the hook level: `refresh()` fetches immediately but the next scheduled tick still lands at its original time (not `intervalMs` after the refresh); a changed `loadFn` identity no longer re-arms the interval
- [x] Fake-timer regression at the `PortfolioPage` level: after a release action mid-interval, the periodic poll still fires at the original schedule time, not deferred to `intervalMs` after the action
- [x] Existing `#7082` live-refresh and `#6090` failed-action tests still pass unchanged; rebased onto latest `main`

## Safety

- [x] No secrets or private terms; no new network surface — purely the poll-scheduling lifecycle

Closes #7230
