### PR TITLE
chore(miner): migrate leaf-most low-fan-in lib modules to typescript (batch 2.3)

### DIFF
--- a/packages/loopover-miner/lib/claim-ledger-expiry.d.ts
+++ b/packages/loopover-miner/lib/claim-ledger-expiry.d.ts
@@ -1,20 +1,15 @@
 import type { ClaimEntry } from "./claim-ledger.js";
-
+/** PURE — no IO, no Date, no random (#2316). */
 export declare const DEFAULT_MAX_CLAIM_AGE_MS: number;
-
 export type ClaimLedgerExpiryStore = {
-  listClaims(filter?: { status?: "active" }): ClaimEntry[];
-  expireClaim(repoFullName: string, issueNumber: number): ClaimEntry | null;
+    listClaims(filter?: {
+        status?: "active";
+    }): ClaimEntry[];
+    expireClaim(repoFullName: string, issueNumber: number, apiBaseUrl?: string): ClaimEntry | null;
 };
-
-export function findExpiredClaims(
-  claims: ClaimEntry[],
-  nowMs: number,
-  maxAgeMs: number,
-): ClaimEntry[];
-
-export function sweepExpiredClaims(
-  store: ClaimLedgerExpiryStore,
-  nowMs: number,
-  maxAgeMs?: number,
-): ClaimEntry[];
+/**
+ * Return active claims whose age is strictly greater than `maxAgeMs`. A claim whose age equals `maxAgeMs` exactly
+ * is still considered within the window (not expired).
+ */
+export declare function findExpiredClaims(claims: ClaimEntry[], nowMs: number, maxAgeMs: number): ClaimEntry[];
+export declare function sweepExpiredClaims(store: ClaimLedgerExpiryStore, nowMs: number, maxAgeMs?: number): ClaimEntry[];

--- a/packages/loopover-miner/lib/claim-ledger-expiry.js
+++ b/packages/loopover-miner/lib/claim-ledger-expiry.js
@@ -1,41 +1,45 @@
 /** PURE — no IO, no Date, no random (#2316). */
-
 export const DEFAULT_MAX_CLAIM_AGE_MS = 14 * 24 * 60 * 60 * 1000;
-
 function claimAgeMs(claim, nowMs) {
-  const claimedAtMs = Date.parse(claim.claimedAt);
-  if (!Number.isFinite(claimedAtMs)) return null;
-  return nowMs - claimedAtMs;
+    const claimedAtMs = Date.parse(claim.claimedAt);
+    if (!Number.isFinite(claimedAtMs))
+        return null;
+    return nowMs - claimedAtMs;
 }
-
 /**
  * Return active claims whose age is strictly greater than `maxAgeMs`. A claim whose age equals `maxAgeMs` exactly
  * is still considered within the window (not expired).
  */
 export function findExpiredClaims(claims, nowMs, maxAgeMs) {
-  if (!Number.isFinite(nowMs) || nowMs < 0) throw new Error("invalid_now_ms");
-  if (!Number.isFinite(maxAgeMs) || maxAgeMs < 0) throw new Error("invalid_max_age_ms");
-  if (!Array.isArray(claims)) throw new Error("invalid_claims");
-
-  const expired = [];
-  for (const claim of claims) {
-    if (claim?.status !== "active") continue;
-    const ageMs = claimAgeMs(claim, nowMs);
-    if (ageMs === null) continue;
-    if (ageMs > maxAgeMs) expired.push(claim);
-  }
-  return expired;
+    if (!Number.isFinite(nowMs) || nowMs < 0)
+        throw new Error("invalid_now_ms");
+    if (!Number.isFinite(maxAgeMs) || maxAgeMs < 0)
+        throw new Error("invalid_max_age_ms");
+    if (!Array.isArray(claims))
+        throw new Error("invalid_claims");
+    const expired = [];
+    for (const claim of claims) {
+        if (claim?.status !== "active")
+            continue;
+        const ageMs = claimAgeMs(claim, nowMs);
+        if (ageMs === null)
+            continue;
+        if (ageMs > maxAgeMs)
+            expired.push(claim);
+    }
+    return expired;
 }
-
 export function sweepExpiredClaims(store, nowMs, maxAgeMs = DEFAULT_MAX_CLAIM_AGE_MS) {
-  const activeClaims = store.listClaims({ status: "active" });
-  const expired = findExpiredClaims(activeClaims, nowMs, maxAgeMs);
-  const transitioned = [];
-  for (const claim of expired) {
-    // Echo the row's OWN apiBaseUrl back (#5563) rather than defaulting: two forge hosts can each have an
-    // active claim on the same owner/repo#issue, and defaulting here would expire the wrong host's row.
-    const updated = store.expireClaim(claim.repoFullName, claim.issueNumber, claim.apiBaseUrl);
-    if (updated) transitioned.push(updated);
-  }
-  return transitioned;
+    const activeClaims = store.listClaims({ status: "active" });
+    const expired = findExpiredClaims(activeClaims, nowMs, maxAgeMs);
+    const transitioned = [];
+    for (const claim of expired) {
+        // Echo the row's OWN apiBaseUrl back (#5563) rather than defaulting: two forge hosts can each have an
+        // active claim on the same owner/repo#issue, and defaulting here would expire the wrong host's row.
+        const updated = store.expireClaim(claim.repoFullName, claim.issueNumber, claim.apiBaseUrl);
+        if (updated)
+            transitioned.push(updated);
+    }
+    return transitioned;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2xhaW0tbGVkZ2VyLWV4cGlyeS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImNsYWltLWxlZGdlci1leHBpcnkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRUEsZ0RBQWdEO0FBRWhELE1BQU0sQ0FBQyxNQUFNLHdCQUF3QixHQUFHLEVBQUUsR0FBRyxFQUFFLEdBQUcsRUFBRSxHQUFHLEVBQUUsR0FBRyxJQUFJLENBQUM7QUFPakUsU0FBUyxVQUFVLENBQUMsS0FBaUIsRUFBRSxLQUFhO0lBQ2xELE1BQU0sV0FBVyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ2hELElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLFdBQVcsQ0FBQztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQy9DLE9BQU8sS0FBSyxHQUFHLFdBQVcsQ0FBQztBQUM3QixDQUFDO0FBRUQ7OztHQUdHO0FBQ0gsTUFBTSxVQUFVLGlCQUFpQixDQUFDLE1BQW9CLEVBQUUsS0FBYSxFQUFFLFFBQWdCO0lBQ3JGLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssR0FBRyxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDO0lBQzVFLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxJQUFJLFFBQVEsR0FBRyxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxvQkFBb0IsQ0FBQyxDQUFDO0lBQ3RGLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsZ0JBQWdCLENBQUMsQ0FBQztJQUU5RCxNQUFNLE9BQU8sR0FBaUIsRUFBRSxDQUFDO0lBQ2pDLEtBQUssTUFBTSxLQUFLLElBQUksTUFBTSxFQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEVBQUUsTUFBTSxLQUFLLFFBQVE7WUFBRSxTQUFTO1FBQ3pDLE1BQU0sS0FBSyxHQUFHLFVBQVUsQ0FBQyxLQUFLLEVBQUUsS0FBSyxDQUFDLENBQUM7UUFDdkMsSUFBSSxLQUFLLEtBQUssSUFBSTtZQUFFLFNBQVM7UUFDN0IsSUFBSSxLQUFLLEdBQUcsUUFBUTtZQUFFLE9BQU8sQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUMsQ0FBQztJQUNELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxNQUFNLFVBQVUsa0JBQWtCLENBQUMsS0FBNkIsRUFBRSxLQUFhLEVBQUUsUUFBUSxHQUFHLHdCQUF3QjtJQUNsSCxNQUFNLFlBQVksR0FBRyxLQUFLLENBQUMsVUFBVSxDQUFDLEVBQUUsTUFBTSxFQUFFLFFBQVEsRUFBRSxDQUFDLENBQUM7SUFDNUQsTUFBTSxPQUFPLEdBQUcsaUJBQWlCLENBQUMsWUFBWSxFQUFFLEtBQUssRUFBRSxRQUFRLENBQUMsQ0FBQztJQUNqRSxNQUFNLFlBQVksR0FBaUIsRUFBRSxDQUFDO0lBQ3RDLEtBQUssTUFBTSxLQUFLLElBQUksT0FBTyxFQUFFLENBQUM7UUFDNUIsc0dBQXNHO1FBQ3RHLG9HQUFvRztRQUNwRyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsV0FBVyxDQUFDLEtBQUssQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFdBQVcsRUFBRSxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUM7UUFDM0YsSUFBSSxPQUFPO1lBQUUsWUFBWSxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBQ0QsT0FBTyxZQUFZLENBQUM7QUFDdEIsQ0FBQyJ9

--- a/packages/loopover-miner/lib/claim-ledger-expiry.ts
+++ b/packages/loopover-miner/lib/claim-ledger-expiry.ts
@@ -1,0 +1,48 @@
+import type { ClaimEntry } from "./claim-ledger.js";
+
+/** PURE — no IO, no Date, no random (#2316). */
+
+export const DEFAULT_MAX_CLAIM_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+export type ClaimLedgerExpiryStore = {
+  listClaims(filter?: { status?: "active" }): ClaimEntry[];
+  expireClaim(repoFullName: string, issueNumber: number, apiBaseUrl?: string): ClaimEntry | null;
+};
+
+function claimAgeMs(claim: ClaimEntry, nowMs: number): number | null {
+  const claimedAtMs = Date.parse(claim.claimedAt);
+  if (!Number.isFinite(claimedAtMs)) return null;
+  return nowMs - claimedAtMs;
+}
+
+/**
+ * Return active claims whose age is strictly greater than `maxAgeMs`. A claim whose age equals `maxAgeMs` exactly
+ * is still considered within the window (not expired).
+ */
+export function findExpiredClaims(claims: ClaimEntry[], nowMs: number, maxAgeMs: number): ClaimEntry[] {
+  if (!Number.isFinite(nowMs) || nowMs < 0) throw new Error("invalid_now_ms");
+  if (!Number.isFinite(maxAgeMs) || maxAgeMs < 0) throw new Error("invalid_max_age_ms");
+  if (!Array.isArray(claims)) throw new Error("invalid_claims");
+
+  const expired: ClaimEntry[] = [];
+  for (const claim of claims) {
+    if (claim?.status !== "active") continue;
+    const ageMs = claimAgeMs(claim, nowMs);
+    if (ageMs === null) continue;
+    if (ageMs > maxAgeMs) expired.push(claim);
+  }
+  return expired;
+}
+
+export function sweepExpiredClaims(store: ClaimLedgerExpiryStore, nowMs: number, maxAgeMs = DEFAULT_MAX_CLAIM_AGE_MS): ClaimEntry[] {
+  const activeClaims = store.listClaims({ status: "active" });
+  const expired = findExpiredClaims(activeClaims, nowMs, maxAgeMs);
+  const transitioned: ClaimEntry[] = [];
+  for (const claim of expired) {
+    // Echo the row's OWN apiBaseUrl back (#5563) rather than defaulting: two forge hosts can each have an
+    // active claim on the same owner/repo#issue, and defaulting here would expire the wrong host's row.
+    const updated = store.expireClaim(claim.repoFullName, claim.issueNumber, claim.apiBaseUrl);
+    if (updated) transitioned.push(updated);
+  }
+  return transitioned;
+}

--- a/packages/loopover-miner/lib/cross-repo-evaluation.d.ts
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.d.ts
@@ -1,90 +1,103 @@
-import type { RepoStackResult } from "./stack-detection.js";
-
-export const CROSS_REPO_FAILURE_CATEGORY: Readonly<{
-  STACK_DETECTION: "stack_detection_gap";
-  EXECUTION: "execution_gap";
-  GITTENSOR_ASSUMPTION: "loopover_assumption";
-  CLONE_SETUP: "clone_setup";
-  OTHER: "other";
+import { type RepoStackResult } from "./stack-detection.js";
+/** Failure taxonomy surfaced in per-repo reports (#4788). */
+export declare const CROSS_REPO_FAILURE_CATEGORY: Readonly<{
+    readonly STACK_DETECTION: "stack_detection_gap";
+    readonly EXECUTION: "execution_gap";
+    readonly GITTENSOR_ASSUMPTION: "loopover_assumption";
+    readonly CLONE_SETUP: "clone_setup";
+    readonly OTHER: "other";
 }>;
-
-export const GITTENSOR_POSITIVE_ASSUMPTION_CHECKS: ReadonlyArray<{
-  id: string;
-  pattern: RegExp;
+/** Instruction substrings that indicate a POSITIVE loopover/LoopOver CI assumption leaked into the agent prompt.
+ *  Lines that explicitly tell the agent *not* to assume these are filtered out before scanning. */
+export declare const GITTENSOR_POSITIVE_ASSUMPTION_CHECKS: ReadonlyArray<{
+    id: string;
+    pattern: RegExp;
 }>;
-
-export const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH: string;
-export const MAX_CROSS_REPO_MANIFEST_BYTES: number;
-export const MAX_CROSS_REPO_MANIFEST_REPOS: number;
-
+export declare const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH = "benchmarks/cross-repo/manifest.json";
+export declare const MAX_CROSS_REPO_MANIFEST_BYTES = 65536;
+export declare const MAX_CROSS_REPO_MANIFEST_REPOS = 100;
 export type CrossRepoEvaluationManifestRepo = {
-  repoFullName: string;
-  stackHint?: string;
-  requireTestCommand?: boolean;
-  fixturePath?: string;
+    repoFullName: string;
+    stackHint?: string;
+    requireTestCommand?: boolean;
+    fixturePath?: string;
 };
-
 export type ParsedCrossRepoEvaluationManifest = {
-  present: boolean;
-  manifest: { repos: CrossRepoEvaluationManifestRepo[] };
-  warnings: string[];
+    present: boolean;
+    manifest: {
+        repos: CrossRepoEvaluationManifestRepo[];
+    };
+    warnings: string[];
 };
-
 export type CrossRepoEvaluationResult = {
-  repoFullName: string;
-  passed: boolean;
-  failureCategory: string | null;
-  reason: string | null;
-  stackDetected: boolean;
-  usedDefaultGoalSpec: boolean | null;
-  assumptionFindings: Array<{ id: string; line: string }>;
-  stack?: RepoStackResult;
+    repoFullName: string;
+    passed: boolean;
+    failureCategory: string | null;
+    reason: string | null;
+    stackDetected: boolean;
+    usedDefaultGoalSpec: boolean | null;
+    assumptionFindings: Array<{
+        id: string;
+        line: string;
+    }>;
+    stack?: RepoStackResult;
 };
-
 export type CrossRepoEvaluationSummary = {
-  total: number;
-  passed: number;
-  failed: number;
-  majorityPassed: boolean;
-  withoutLoopoverConfig: number;
-  failuresByCategory: Record<string, number>;
+    total: number;
+    passed: number;
+    failed: number;
+    majorityPassed: boolean;
+    withoutLoopoverConfig: number;
+    failuresByCategory: Record<string, number>;
 };
-
-export function normalizeCrossRepoFullName(value: unknown): string | null;
-
-export function parseCrossRepoEvaluationManifest(
-  content: string | null | undefined,
-): ParsedCrossRepoEvaluationManifest;
-
-export function scanPositiveLoopoverAssumptions(text: string): Array<{ id: string; line: string }>;
-
-export function evaluateRepoReadiness(
-  entry: CrossRepoEvaluationManifestRepo,
-  options?: {
+type EvaluateRepoReadinessOptions = {
     repoPath?: string;
-    resolveRepoPath?: (entry: { repoFullName: string }) => string;
+    resolveRepoPath?: (entry: {
+        repoFullName: string;
+    }) => string;
     env?: NodeJS.ProcessEnv;
     existsSync?: (path: string) => boolean;
     detectRepoStack?: (repoPath: string) => RepoStackResult;
-    resolveMinerGoalSpec?: (repoPath: string) => { present: boolean };
-    buildCodingTaskSpec?: (input: Record<string, unknown>) => {
-      ready: boolean;
-      verdict?: string;
-      instructions?: string;
+    resolveMinerGoalSpec?: (repoPath: string) => {
+        present: boolean;
     };
-  },
-): CrossRepoEvaluationResult;
-
-export function runCrossRepoEvaluation(
-  parsed: ParsedCrossRepoEvaluationManifest,
-  options?: {
+    buildCodingTaskSpec?: (input: Record<string, unknown>) => {
+        ready: boolean;
+        verdict?: string;
+        instructions?: string;
+    };
+};
+/** Canonical `owner/repo` with exactly one slash and safe segments; anything else → null. */
+export declare function normalizeCrossRepoFullName(value: unknown): string | null;
+/**
+ * Tolerant JSON manifest parser (#4788). Malformed input degrades to an empty repo list with warnings rather than
+ * throwing, mirroring the fleet-run-manifest / miner-goal-spec convention.
+ */
+export declare function parseCrossRepoEvaluationManifest(content: string | null | undefined): ParsedCrossRepoEvaluationManifest;
+/**
+ * Scan agent instructions for positive loopover/LoopOver assumptions (#4788). Lines that already tell the agent
+ * *not* to assume LoopOver conventions (the negative guidance from buildValidationGuidance) are skipped.
+ */
+export declare function scanPositiveLoopoverAssumptions(text: string): Array<{
+    id: string;
+    line: string;
+}>;
+/**
+ * Evaluate one benchmark repo's miner readiness without running a live coding agent (#4788).
+ */
+export declare function evaluateRepoReadiness(entry: CrossRepoEvaluationManifestRepo, options?: EvaluateRepoReadinessOptions): CrossRepoEvaluationResult;
+/**
+ * Run the harness across every repo in a parsed manifest (#4788).
+ */
+export declare function runCrossRepoEvaluation(parsed: ParsedCrossRepoEvaluationManifest, options?: {
     repoFilter?: string;
-  } & Parameters<typeof evaluateRepoReadiness>[1],
-): CrossRepoEvaluationResult[];
-
-export function summarizeCrossRepoEvaluation(results: CrossRepoEvaluationResult[]): CrossRepoEvaluationSummary;
-
-export function formatCrossRepoEvaluationReport(
-  results: CrossRepoEvaluationResult[],
-  summary?: CrossRepoEvaluationSummary,
-): string;
+} & EvaluateRepoReadinessOptions): CrossRepoEvaluationResult[];
+/**
+ * Reduce per-repo results to pass/fail counts and whether a strict majority passed (#4788).
+ */
+export declare function summarizeCrossRepoEvaluation(results: CrossRepoEvaluationResult[]): CrossRepoEvaluationSummary;
+/**
+ * Human-readable pass/fail report for one evaluation run (#4788).
+ */
+export declare function formatCrossRepoEvaluationReport(results: CrossRepoEvaluationResult[], summary?: CrossRepoEvaluationSummary): string;
+export {};

--- a/packages/loopover-miner/lib/cross-repo-evaluation.js
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.js
@@ -3,405 +3,349 @@
 // evaluated through the same stack-detection + coding-task-spec path a real attempt uses (detectRepoStack,
 // resolveMinerGoalSpec, buildCodingTaskSpec) and failures are categorized as stack-detection gaps, execution
 // readiness gaps, leaked loopover assumptions in agent instructions, clone/setup problems, or other.
-
 import { existsSync } from "node:fs";
-import { join } from "node:path";
 import { buildCodingTaskSpec } from "./coding-task-spec.js";
 import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
 import { isValidRepoSegment, resolveRepoCloneDir } from "./repo-clone.js";
 import { detectRepoStack } from "./stack-detection.js";
-
 /** Failure taxonomy surfaced in per-repo reports (#4788). */
 export const CROSS_REPO_FAILURE_CATEGORY = Object.freeze({
-  STACK_DETECTION: "stack_detection_gap",
-  EXECUTION: "execution_gap",
-  GITTENSOR_ASSUMPTION: "loopover_assumption",
-  CLONE_SETUP: "clone_setup",
-  OTHER: "other",
+    STACK_DETECTION: "stack_detection_gap",
+    EXECUTION: "execution_gap",
+    GITTENSOR_ASSUMPTION: "loopover_assumption",
+    CLONE_SETUP: "clone_setup",
+    OTHER: "other",
 });
-
 /** Instruction substrings that indicate a POSITIVE loopover/LoopOver CI assumption leaked into the agent prompt.
  *  Lines that explicitly tell the agent *not* to assume these are filtered out before scanning. */
 export const GITTENSOR_POSITIVE_ASSUMPTION_CHECKS = Object.freeze([
-  { id: "test_ci_script", pattern: /npm run test:ci/i },
-  { id: "codecov_patch", pattern: /codecov\/patch/i },
-  { id: "gittensor_label", pattern: /gittensor:(?:bug|feature|priority)/i },
-  { id: "loopover_gate", pattern: /loopover gate/i },
+    { id: "test_ci_script", pattern: /npm run test:ci/i },
+    { id: "codecov_patch", pattern: /codecov\/patch/i },
+    { id: "gittensor_label", pattern: /gittensor:(?:bug|feature|priority)/i },
+    { id: "loopover_gate", pattern: /loopover gate/i },
 ]);
-
 export const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH = "benchmarks/cross-repo/manifest.json";
 export const MAX_CROSS_REPO_MANIFEST_BYTES = 65_536;
 export const MAX_CROSS_REPO_MANIFEST_REPOS = 100;
-
 // True UTF-8 byte count for the size guard (#7223): JS string `.length` is UTF-16 code units, which under-counts
 // any multi-byte character (up to 4x for astral-plane code points), so `MAX_CROSS_REPO_MANIFEST_BYTES` -- named
 // and warned about in BYTES -- was actually being compared against a code-unit count. Mirrors the identical helper
 // in the three siblings this parser's own comment claims to follow: fleet-run-manifest.ts, miner-goal-spec.ts,
 // and ams-policy-spec.ts.
 function utf8ByteLength(value) {
-  let bytes = 0;
-  for (const char of value) {
-    const codePoint = char.codePointAt(0);
-    if (codePoint <= 0x7f) bytes += 1;
-    else if (codePoint <= 0x7ff) bytes += 2;
-    else if (codePoint <= 0xffff) bytes += 3;
-    else bytes += 4;
-  }
-  return bytes;
+    let bytes = 0;
+    for (const char of value) {
+        // `char` is a non-empty code-point string from the string iterator, so codePointAt(0) is always defined; the
+        // cast narrows `number | undefined` without adding an unreachable `?? 0` branch.
+        const codePoint = char.codePointAt(0);
+        if (codePoint <= 0x7f)
+            bytes += 1;
+        else if (codePoint <= 0x7ff)
+            bytes += 2;
+        else if (codePoint <= 0xffff)
+            bytes += 3;
+        else
+            bytes += 4;
+    }
+    return bytes;
 }
-
 function cloneEmptyManifest(warnings = []) {
-  return { present: false, manifest: { repos: [] }, warnings };
+    return { present: false, manifest: { repos: [] }, warnings };
 }
-
 /** Canonical `owner/repo` with exactly one slash and safe segments; anything else → null. */
 export function normalizeCrossRepoFullName(value) {
-  if (typeof value !== "string") return null;
-  const [owner, repo, extra] = value.trim().split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
-  return `${owner}/${repo}`;
+    if (typeof value !== "string")
+        return null;
+    const [owner, repo, extra] = value.trim().split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo))
+        return null;
+    return `${owner}/${repo}`;
 }
-
 function normalizeBoolean(value, field, fallback, warnings) {
-  if (value === undefined || value === null) return fallback;
-  if (typeof value === "boolean") return value;
-  warnings.push(`CrossRepoEvaluationManifest field "${field}" must be a boolean; falling back to ${fallback}.`);
-  return fallback;
+    if (value === undefined || value === null)
+        return fallback;
+    if (typeof value === "boolean")
+        return value;
+    warnings.push(`CrossRepoEvaluationManifest field "${field}" must be a boolean; falling back to ${fallback}.`);
+    return fallback;
 }
-
 function normalizeOptionalString(value, field, warnings) {
-  if (value === undefined || value === null) return null;
-  if (typeof value !== "string") {
-    warnings.push(`CrossRepoEvaluationManifest field "${field}" must be a string; ignoring the value.`);
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed || null;
+    if (value === undefined || value === null)
+        return null;
+    if (typeof value !== "string") {
+        warnings.push(`CrossRepoEvaluationManifest field "${field}" must be a string; ignoring the value.`);
+        return null;
+    }
+    const trimmed = value.trim();
+    return trimmed || null;
 }
-
 function normalizeRepoList(value, warnings) {
-  if (value === undefined || value === null) return [];
-  if (!Array.isArray(value)) {
-    warnings.push(`CrossRepoEvaluationManifest field "repos" must be a list; ignoring a ${typeof value} value.`);
-    return [];
-  }
-  const result = [];
-  const seen = new Set();
-  for (const [index, entry] of value.entries()) {
-    if (index >= MAX_CROSS_REPO_MANIFEST_REPOS) {
-      warnings.push(
-        `CrossRepoEvaluationManifest field "repos" exceeded ${MAX_CROSS_REPO_MANIFEST_REPOS} entries; extra entries ignored.`,
-      );
-      break;
+    if (value === undefined || value === null)
+        return [];
+    if (!Array.isArray(value)) {
+        warnings.push(`CrossRepoEvaluationManifest field "repos" must be a list; ignoring a ${typeof value} value.`);
+        return [];
     }
-    let repoFullName = null;
-    let stackHint = null;
-    let requireTestCommand = false;
-    let fixturePath = null;
-    if (typeof entry === "string") {
-      repoFullName = normalizeCrossRepoFullName(entry);
-    } else if (entry && typeof entry === "object" && !Array.isArray(entry)) {
-      const record = entry;
-      repoFullName = normalizeCrossRepoFullName(record.repoFullName);
-      stackHint = normalizeOptionalString(record.stackHint, "stackHint", warnings);
-      requireTestCommand = normalizeBoolean(record.requireTestCommand, "requireTestCommand", false, warnings);
-      fixturePath = normalizeOptionalString(record.fixturePath, "fixturePath", warnings);
-    } else {
-      warnings.push(`CrossRepoEvaluationManifest "repos" skipped a non-string, non-mapping entry.`);
-      continue;
+    const result = [];
+    const seen = new Set();
+    for (const [index, entry] of value.entries()) {
+        if (index >= MAX_CROSS_REPO_MANIFEST_REPOS) {
+            warnings.push(`CrossRepoEvaluationManifest field "repos" exceeded ${MAX_CROSS_REPO_MANIFEST_REPOS} entries; extra entries ignored.`);
+            break;
+        }
+        let repoFullName = null;
+        let stackHint = null;
+        let requireTestCommand = false;
+        let fixturePath = null;
+        if (typeof entry === "string") {
+            repoFullName = normalizeCrossRepoFullName(entry);
+        }
+        else if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+            const record = entry;
+            repoFullName = normalizeCrossRepoFullName(record.repoFullName);
+            stackHint = normalizeOptionalString(record.stackHint, "stackHint", warnings);
+            requireTestCommand = normalizeBoolean(record.requireTestCommand, "requireTestCommand", false, warnings);
+            fixturePath = normalizeOptionalString(record.fixturePath, "fixturePath", warnings);
+        }
+        else {
+            warnings.push(`CrossRepoEvaluationManifest "repos" skipped a non-string, non-mapping entry.`);
+            continue;
+        }
+        if (repoFullName === null) {
+            warnings.push(`CrossRepoEvaluationManifest "repos" skipped an entry with an invalid "owner/repo" name.`);
+            continue;
+        }
+        if (seen.has(repoFullName)) {
+            warnings.push(`CrossRepoEvaluationManifest "repos" skipped a duplicate entry for ${repoFullName}.`);
+            continue;
+        }
+        seen.add(repoFullName);
+        const normalized = { repoFullName, requireTestCommand };
+        if (stackHint)
+            normalized.stackHint = stackHint;
+        if (fixturePath)
+            normalized.fixturePath = fixturePath;
+        result.push(normalized);
     }
-    if (repoFullName === null) {
-      warnings.push(`CrossRepoEvaluationManifest "repos" skipped an entry with an invalid "owner/repo" name.`);
-      continue;
-    }
-    if (seen.has(repoFullName)) {
-      warnings.push(`CrossRepoEvaluationManifest "repos" skipped a duplicate entry for ${repoFullName}.`);
-      continue;
-    }
-    seen.add(repoFullName);
-    const normalized = { repoFullName, requireTestCommand };
-    if (stackHint) normalized.stackHint = stackHint;
-    if (fixturePath) normalized.fixturePath = fixturePath;
-    result.push(normalized);
-  }
-  return result;
+    return result;
 }
-
 /**
  * Tolerant JSON manifest parser (#4788). Malformed input degrades to an empty repo list with warnings rather than
  * throwing, mirroring the fleet-run-manifest / miner-goal-spec convention.
- *
- * @param {string | null | undefined} content
- * @returns {{ present: boolean, manifest: { repos: Array<{ repoFullName: string, stackHint?: string, requireTestCommand?: boolean, fixturePath?: string }> }, warnings: string[] }}
  */
 export function parseCrossRepoEvaluationManifest(content) {
-  if (content === undefined || content === null) return cloneEmptyManifest();
-  if (typeof content !== "string") {
-    return cloneEmptyManifest([`CrossRepoEvaluationManifest content must be a string; got ${typeof content}.`]);
-  }
-  const trimmed = content.trim();
-  if (!trimmed) return cloneEmptyManifest();
-  if (utf8ByteLength(trimmed) > MAX_CROSS_REPO_MANIFEST_BYTES) {
-    return cloneEmptyManifest([
-      `CrossRepoEvaluationManifest exceeded ${MAX_CROSS_REPO_MANIFEST_BYTES} bytes; ignoring the file.`,
-    ]);
-  }
-  let raw;
-  try {
-    raw = JSON.parse(trimmed);
-  } catch {
-    return cloneEmptyManifest(["CrossRepoEvaluationManifest is not valid JSON."]);
-  }
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return cloneEmptyManifest(["CrossRepoEvaluationManifest root must be a JSON object."]);
-  }
-  const warnings = [];
-  const repos = normalizeRepoList(raw.repos, warnings);
-  return { present: true, manifest: { repos }, warnings };
+    if (content === undefined || content === null)
+        return cloneEmptyManifest();
+    if (typeof content !== "string") {
+        return cloneEmptyManifest([`CrossRepoEvaluationManifest content must be a string; got ${typeof content}.`]);
+    }
+    const trimmed = content.trim();
+    if (!trimmed)
+        return cloneEmptyManifest();
+    if (utf8ByteLength(trimmed) > MAX_CROSS_REPO_MANIFEST_BYTES) {
+        return cloneEmptyManifest([
+            `CrossRepoEvaluationManifest exceeded ${MAX_CROSS_REPO_MANIFEST_BYTES} bytes; ignoring the file.`,
+        ]);
+    }
+    let raw;
+    try {
+        raw = JSON.parse(trimmed);
+    }
+    catch {
+        return cloneEmptyManifest(["CrossRepoEvaluationManifest is not valid JSON."]);
+    }
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return cloneEmptyManifest(["CrossRepoEvaluationManifest root must be a JSON object."]);
+    }
+    const warnings = [];
+    const repos = normalizeRepoList(raw.repos, warnings);
+    return { present: true, manifest: { repos }, warnings };
 }
-
 /**
  * Scan agent instructions for positive loopover/LoopOver assumptions (#4788). Lines that already tell the agent
  * *not* to assume LoopOver conventions (the negative guidance from buildValidationGuidance) are skipped.
- *
- * @param {string} text
- * @returns {Array<{ id: string, line: string }>}
  */
 export function scanPositiveLoopoverAssumptions(text) {
-  if (typeof text !== "string") return [];
-  const findings = [];
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || /do not assume/i.test(trimmed)) continue;
-    for (const check of GITTENSOR_POSITIVE_ASSUMPTION_CHECKS) {
-      if (check.pattern.test(line)) findings.push({ id: check.id, line: trimmed });
+    if (typeof text !== "string")
+        return [];
+    const findings = [];
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || /do not assume/i.test(trimmed))
+            continue;
+        for (const check of GITTENSOR_POSITIVE_ASSUMPTION_CHECKS) {
+            if (check.pattern.test(line))
+                findings.push({ id: check.id, line: trimmed });
+        }
     }
-  }
-  return findings;
+    return findings;
 }
-
 function buildFailure(repoFullName, category, reason, extra = {}) {
-  return {
-    repoFullName,
-    passed: false,
-    failureCategory: category,
-    reason,
-    stackDetected: false,
-    usedDefaultGoalSpec: null,
-    assumptionFindings: [],
-    ...extra,
-  };
+    return {
+        repoFullName,
+        passed: false,
+        failureCategory: category,
+        reason,
+        stackDetected: false,
+        usedDefaultGoalSpec: null,
+        assumptionFindings: [],
+        ...extra,
+    };
 }
-
 function buildPass(repoFullName, extra = {}) {
-  return {
-    repoFullName,
-    passed: true,
-    failureCategory: null,
-    reason: null,
-    stackDetected: true,
-    usedDefaultGoalSpec: true,
-    assumptionFindings: [],
-    ...extra,
-  };
+    return {
+        repoFullName,
+        passed: true,
+        failureCategory: null,
+        reason: null,
+        stackDetected: true,
+        usedDefaultGoalSpec: true,
+        assumptionFindings: [],
+        ...extra,
+    };
 }
-
 function resolveEvaluationRepoPath(entry, options = {}) {
-  if (entry.fixturePath && typeof entry.fixturePath === "string") return entry.fixturePath;
-  if (typeof options.repoPath === "string" && options.repoPath.trim()) return options.repoPath.trim();
-  if (typeof options.resolveRepoPath === "function") return options.resolveRepoPath(entry);
-  return resolveRepoCloneDir(entry.repoFullName, options.env ?? process.env);
+    if (entry.fixturePath && typeof entry.fixturePath === "string")
+        return entry.fixturePath;
+    if (typeof options.repoPath === "string" && options.repoPath.trim())
+        return options.repoPath.trim();
+    if (typeof options.resolveRepoPath === "function")
+        return options.resolveRepoPath(entry);
+    return resolveRepoCloneDir(entry.repoFullName, options.env ?? process.env);
 }
-
-function defaultClaimLedger(repoFullName) {
-  return { listClaims: () => [] };
+function defaultClaimLedger(_repoFullName) {
+    return { listClaims: () => [] };
 }
-
 /**
  * Evaluate one benchmark repo's miner readiness without running a live coding agent (#4788).
- *
- * @param {{ repoFullName: string, stackHint?: string, requireTestCommand?: boolean, fixturePath?: string }} entry
- * @param {{
- *   repoPath?: string,
- *   resolveRepoPath?: (entry: { repoFullName: string }) => string,
- *   env?: NodeJS.ProcessEnv,
- *   existsSync?: (path: string) => boolean,
- *   detectRepoStack?: typeof detectRepoStack,
- *   resolveMinerGoalSpec?: typeof resolveMinerGoalSpec,
- *   buildCodingTaskSpec?: typeof buildCodingTaskSpec,
- * }} [options]
  */
 export function evaluateRepoReadiness(entry, options = {}) {
-  const repoFullName = entry?.repoFullName;
-  if (typeof repoFullName !== "string" || !normalizeCrossRepoFullName(repoFullName)) {
-    return buildFailure(
-      typeof repoFullName === "string" ? repoFullName : "(invalid)",
-      CROSS_REPO_FAILURE_CATEGORY.OTHER,
-      "Benchmark entry is missing a valid owner/repo name.",
-    );
-  }
-
-  const existsImpl = options.existsSync ?? existsSync;
-  const detectImpl = options.detectRepoStack ?? detectRepoStack;
-  const goalSpecImpl = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
-  const buildSpecImpl = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
-  const repoPath = resolveEvaluationRepoPath(entry, options);
-
-  if (!existsImpl(repoPath)) {
-    return buildFailure(
-      repoFullName,
-      CROSS_REPO_FAILURE_CATEGORY.CLONE_SETUP,
-      `Repository path does not exist: ${repoPath}. Clone the repo or set LOOPOVER_MINER_REPO_CLONE_DIR.`,
-    );
-  }
-
-  const goalSpec = goalSpecImpl(repoPath);
-  const usedDefaultGoalSpec = goalSpec?.present !== true;
-
-  const stack = detectImpl(repoPath);
-  if (stack?.detected !== true) {
-    return buildFailure(
-      repoFullName,
-      CROSS_REPO_FAILURE_CATEGORY.STACK_DETECTION,
-      stack?.reason ?? "Stack auto-detection did not recognize this repository.",
-      { stackDetected: false, usedDefaultGoalSpec },
-    );
-  }
-
-  if (entry.requireTestCommand === true && !stack.testCommand) {
-    return buildFailure(
-      repoFullName,
-      CROSS_REPO_FAILURE_CATEGORY.EXECUTION,
-      "Stack detection succeeded but no test command was inferred while requireTestCommand is set.",
-      { stackDetected: true, usedDefaultGoalSpec, stack },
-    );
-  }
-
-  let specResult;
-  try {
-    specResult = buildSpecImpl({
-      repoFullName,
-      issue: {
-        number: 1,
-        title: "Cross-repo evaluation harness smoke issue",
-        body: "Synthetic issue used only by the cross-repo evaluation harness.",
-        labels: ["bug"],
-      },
-      context: { issues: [{ number: 1 }], pullRequests: [] },
-      claimLedger: defaultClaimLedger(repoFullName),
-      workingDirectory: repoPath,
-      detectRepoStack: detectImpl,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.OTHER, message, {
-      stackDetected: true,
-      usedDefaultGoalSpec,
-      stack,
-    });
-  }
-
-  if (specResult?.ready !== true) {
-    return buildFailure(
-      repoFullName,
-      CROSS_REPO_FAILURE_CATEGORY.EXECUTION,
-      `Coding task spec is not ready (verdict: ${specResult?.verdict ?? "unknown"}).`,
-      { stackDetected: true, usedDefaultGoalSpec, stack },
-    );
-  }
-
-  const assumptionFindings = scanPositiveLoopoverAssumptions(specResult.instructions ?? "");
-  if (assumptionFindings.length > 0) {
-    return buildFailure(
-      repoFullName,
-      CROSS_REPO_FAILURE_CATEGORY.GITTENSOR_ASSUMPTION,
-      `Agent instructions leak loopover-specific assumptions (${assumptionFindings.map((f) => f.id).join(", ")}).`,
-      { stackDetected: true, usedDefaultGoalSpec, stack, assumptionFindings },
-    );
-  }
-
-  return buildPass(repoFullName, { usedDefaultGoalSpec, stack });
+    const repoFullName = entry?.repoFullName;
+    if (typeof repoFullName !== "string" || !normalizeCrossRepoFullName(repoFullName)) {
+        return buildFailure(typeof repoFullName === "string" ? repoFullName : "(invalid)", CROSS_REPO_FAILURE_CATEGORY.OTHER, "Benchmark entry is missing a valid owner/repo name.");
+    }
+    const existsImpl = options.existsSync ?? existsSync;
+    const detectImpl = options.detectRepoStack ?? detectRepoStack;
+    const goalSpecImpl = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+    // The harness feeds buildCodingTaskSpec a synthetic smoke issue with only the fields it actually reads; the
+    // option is deliberately typed against a loose `Record<string, unknown>` input (see EvaluateRepoReadinessOptions
+    // and the original .d.ts), so the real default is adapted to that same loose contract here.
+    const buildSpecImpl = options.buildCodingTaskSpec ??
+        buildCodingTaskSpec;
+    const repoPath = resolveEvaluationRepoPath(entry, options);
+    if (!existsImpl(repoPath)) {
+        return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.CLONE_SETUP, `Repository path does not exist: ${repoPath}. Clone the repo or set LOOPOVER_MINER_REPO_CLONE_DIR.`);
+    }
+    const goalSpec = goalSpecImpl(repoPath);
+    const usedDefaultGoalSpec = goalSpec?.present !== true;
+    const stack = detectImpl(repoPath);
+    if (stack?.detected !== true) {
+        return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.STACK_DETECTION, stack?.reason ?? "Stack auto-detection did not recognize this repository.", { stackDetected: false, usedDefaultGoalSpec });
+    }
+    if (entry.requireTestCommand === true && !stack.testCommand) {
+        return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.EXECUTION, "Stack detection succeeded but no test command was inferred while requireTestCommand is set.", { stackDetected: true, usedDefaultGoalSpec, stack });
+    }
+    let specResult;
+    try {
+        specResult = buildSpecImpl({
+            repoFullName,
+            issue: {
+                number: 1,
+                title: "Cross-repo evaluation harness smoke issue",
+                body: "Synthetic issue used only by the cross-repo evaluation harness.",
+                labels: ["bug"],
+            },
+            context: { issues: [{ number: 1 }], pullRequests: [] },
+            claimLedger: defaultClaimLedger(repoFullName),
+            workingDirectory: repoPath,
+            detectRepoStack: detectImpl,
+        });
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.OTHER, message, {
+            stackDetected: true,
+            usedDefaultGoalSpec,
+            stack,
+        });
+    }
+    if (specResult?.ready !== true) {
+        return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.EXECUTION, `Coding task spec is not ready (verdict: ${specResult?.verdict ?? "unknown"}).`, { stackDetected: true, usedDefaultGoalSpec, stack });
+    }
+    const assumptionFindings = scanPositiveLoopoverAssumptions(specResult.instructions ?? "");
+    if (assumptionFindings.length > 0) {
+        return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.GITTENSOR_ASSUMPTION, `Agent instructions leak loopover-specific assumptions (${assumptionFindings.map((f) => f.id).join(", ")}).`, { stackDetected: true, usedDefaultGoalSpec, stack, assumptionFindings });
+    }
+    return buildPass(repoFullName, { usedDefaultGoalSpec, stack });
 }
-
 /**
  * Run the harness across every repo in a parsed manifest (#4788).
- *
- * @param {ReturnType<typeof parseCrossRepoEvaluationManifest>} parsed
- * @param {{ repoFilter?: string } & Parameters<typeof evaluateRepoReadiness>[1]} [options]
- * @returns {ReturnType<typeof evaluateRepoReadiness>[]}
  */
 export function runCrossRepoEvaluation(parsed, options = {}) {
-  const repos = parsed?.manifest?.repos ?? [];
-  const results = [];
-  for (const entry of repos) {
-    if (options.repoFilter && entry.repoFullName !== options.repoFilter) continue;
-    results.push(evaluateRepoReadiness(entry, options));
-  }
-  return results;
+    const repos = parsed?.manifest?.repos ?? [];
+    const results = [];
+    for (const entry of repos) {
+        if (options.repoFilter && entry.repoFullName !== options.repoFilter)
+            continue;
+        results.push(evaluateRepoReadiness(entry, options));
+    }
+    return results;
 }
-
 /**
  * Reduce per-repo results to pass/fail counts and whether a strict majority passed (#4788).
- *
- * @param {ReturnType<typeof evaluateRepoReadiness>[]} results
  */
 export function summarizeCrossRepoEvaluation(results) {
-  const list = Array.isArray(results) ? results : [];
-  let passed = 0;
-  let failed = 0;
-  const failuresByCategory = {};
-  for (const result of list) {
-    if (result?.passed === true) {
-      passed += 1;
-      continue;
+    const list = Array.isArray(results) ? results : [];
+    let passed = 0;
+    let failed = 0;
+    const failuresByCategory = {};
+    for (const result of list) {
+        if (result?.passed === true) {
+            passed += 1;
+            continue;
+        }
+        failed += 1;
+        const category = result?.failureCategory ?? CROSS_REPO_FAILURE_CATEGORY.OTHER;
+        failuresByCategory[category] = (failuresByCategory[category] ?? 0) + 1;
     }
-    failed += 1;
-    const category = result?.failureCategory ?? CROSS_REPO_FAILURE_CATEGORY.OTHER;
-    failuresByCategory[category] = (failuresByCategory[category] ?? 0) + 1;
-  }
-  const total = passed + failed;
-  const majorityPassed = total > 0 ? passed > failed : false;
-  const withoutLoopoverConfig = list.filter((r) => r?.usedDefaultGoalSpec !== false).length;
-  return {
-    total,
-    passed,
-    failed,
-    majorityPassed,
-    withoutLoopoverConfig,
-    failuresByCategory,
-  };
+    const total = passed + failed;
+    const majorityPassed = total > 0 ? passed > failed : false;
+    const withoutLoopoverConfig = list.filter((r) => r?.usedDefaultGoalSpec !== false).length;
+    return {
+        total,
+        passed,
+        failed,
+        majorityPassed,
+        withoutLoopoverConfig,
+        failuresByCategory,
+    };
 }
-
 /**
  * Human-readable pass/fail report for one evaluation run (#4788).
- *
- * @param {ReturnType<typeof evaluateRepoReadiness>[]} results
- * @param {ReturnType<typeof summarizeCrossRepoEvaluation>} [summary]
  */
 export function formatCrossRepoEvaluationReport(results, summary = summarizeCrossRepoEvaluation(results)) {
-  const lines = ["loopover-miner cross-repo evaluation", ""];
-  for (const result of results) {
-    if (result.passed) {
-      lines.push(`PASS ${result.repoFullName}`);
-      continue;
+    const lines = ["loopover-miner cross-repo evaluation", ""];
+    for (const result of results) {
+        if (result.passed) {
+            lines.push(`PASS ${result.repoFullName}`);
+            continue;
+        }
+        lines.push(`FAIL ${result.repoFullName} [${result.failureCategory}] ${result.reason}`);
     }
-    lines.push(`FAIL ${result.repoFullName} [${result.failureCategory}] ${result.reason}`);
-  }
-  lines.push(
-    "",
-    `summary: ${summary.passed}/${summary.total} passed` +
-      (summary.majorityPassed ? " (majority passed)" : " (majority failed)"),
-  );
-  if (summary.total > 0) {
-    lines.push(`without loopover-specific target config: ${summary.withoutLoopoverConfig}/${summary.total}`);
-  }
-  const categories = Object.entries(summary.failuresByCategory).sort(([a], [b]) => a.localeCompare(b));
-  if (categories.length > 0) {
-    lines.push("", "failures by category:");
-    for (const [category, count] of categories) {
-      lines.push(`- ${category}: ${count}`);
+    lines.push("", `summary: ${summary.passed}/${summary.total} passed` +
+        (summary.majorityPassed ? " (majority passed)" : " (majority failed)"));
+    if (summary.total > 0) {
+        lines.push(`without loopover-specific target config: ${summary.withoutLoopoverConfig}/${summary.total}`);
     }
-  }
-  return lines.join("\n");
+    const categories = Object.entries(summary.failuresByCategory).sort(([a], [b]) => a.localeCompare(b));
+    if (categories.length > 0) {
+        lines.push("", "failures by category:");
+        for (const [category, count] of categories) {
+            lines.push(`- ${category}: ${count}`);
+        }
+    }
+    return lines.join("\n");
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY3Jvc3MtcmVwby1ldmFsdWF0aW9uLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiY3Jvc3MtcmVwby1ldmFsdWF0aW9uLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLGlIQUFpSDtBQUNqSCw4R0FBOEc7QUFDOUcsMkdBQTJHO0FBQzNHLDZHQUE2RztBQUM3RyxxR0FBcUc7QUFFckcsT0FBTyxFQUFFLFVBQVUsRUFBRSxNQUFNLFNBQVMsQ0FBQztBQUNyQyxPQUFPLEVBQUUsbUJBQW1CLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUM1RCxPQUFPLEVBQUUsb0JBQW9CLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUM1RCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsbUJBQW1CLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUMxRSxPQUFPLEVBQUUsZUFBZSxFQUF3QixNQUFNLHNCQUFzQixDQUFDO0FBRTdFLDZEQUE2RDtBQUM3RCxNQUFNLENBQUMsTUFBTSwyQkFBMkIsR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDO0lBQ3ZELGVBQWUsRUFBRSxxQkFBcUI7SUFDdEMsU0FBUyxFQUFFLGVBQWU7SUFDMUIsb0JBQW9CLEVBQUUscUJBQXFCO0lBQzNDLFdBQVcsRUFBRSxhQUFhO0lBQzFCLEtBQUssRUFBRSxPQUFPO0NBQ04sQ0FBQyxDQUFDO0FBRVo7bUdBQ21HO0FBQ25HLE1BQU0sQ0FBQyxNQUFNLG9DQUFvQyxHQUFtRCxNQUFNLENBQUMsTUFBTSxDQUFDO0lBQ2hILEVBQUUsRUFBRSxFQUFFLGdCQUFnQixFQUFFLE9BQU8sRUFBRSxrQkFBa0IsRUFBRTtJQUNyRCxFQUFFLEVBQUUsRUFBRSxlQUFlLEVBQUUsT0FBTyxFQUFFLGlCQUFpQixFQUFFO0lBQ25ELEVBQUUsRUFBRSxFQUFFLGlCQUFpQixFQUFFLE9BQU8sRUFBRSxxQ0FBcUMsRUFBRTtJQUN6RSxFQUFFLEVBQUUsRUFBRSxlQUFlLEVBQUUsT0FBTyxFQUFFLGdCQUFnQixFQUFFO0NBQ25ELENBQUMsQ0FBQztBQUVILE1BQU0sQ0FBQyxNQUFNLHlDQUF5QyxHQUFHLHFDQUFxQyxDQUFDO0FBQy9GLE1BQU0sQ0FBQyxNQUFNLDZCQUE2QixHQUFHLE1BQU0sQ0FBQztBQUNwRCxNQUFNLENBQUMsTUFBTSw2QkFBNkIsR0FBRyxHQUFHLENBQUM7QUE2Q2pELGlIQUFpSDtBQUNqSCxnSEFBZ0g7QUFDaEgsbUhBQW1IO0FBQ25ILCtHQUErRztBQUMvRywwQkFBMEI7QUFDMUIsU0FBUyxjQUFjLENBQUMsS0FBYTtJQUNuQyxJQUFJLEtBQUssR0FBRyxDQUFDLENBQUM7SUFDZCxLQUFLLE1BQU0sSUFBSSxJQUFJLEtBQUssRUFBRSxDQUFDO1FBQ3pCLDZHQUE2RztRQUM3RyxpRkFBaUY7UUFDakYsTUFBTSxTQUFTLEdBQUcsSUFBSSxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQVcsQ0FBQztRQUNoRCxJQUFJLFNBQVMsSUFBSSxJQUFJO1lBQUUsS0FBSyxJQUFJLENBQUMsQ0FBQzthQUM3QixJQUFJLFNBQVMsSUFBSSxLQUFLO1lBQUUsS0FBSyxJQUFJLENBQUMsQ0FBQzthQUNuQyxJQUFJLFNBQVMsSUFBSSxNQUFNO1lBQUUsS0FBSyxJQUFJLENBQUMsQ0FBQzs7WUFDcEMsS0FBSyxJQUFJLENBQUMsQ0FBQztJQUNsQixDQUFDO0lBQ0QsT0FBTyxLQUFLLENBQUM7QUFDZixDQUFDO0FBRUQsU0FBUyxrQkFBa0IsQ0FBQyxXQUFxQixFQUFFO0lBQ2pELE9BQU8sRUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFFBQVEsRUFBRSxFQUFFLEtBQUssRUFBRSxFQUFFLEVBQUUsRUFBRSxRQUFRLEVBQUUsQ0FBQztBQUMvRCxDQUFDO0FBRUQsNkZBQTZGO0FBQzdGLE1BQU0sVUFBVSwwQkFBMEIsQ0FBQyxLQUFjO0lBQ3ZELElBQUksT0FBTyxLQUFLLEtBQUssUUFBUTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQzNDLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDckQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ3hELElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLGtCQUFrQixDQUFDLElBQUksQ0FBQztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ3pFLE9BQU8sR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLENBQUM7QUFDNUIsQ0FBQztBQUVELFNBQVMsZ0JBQWdCLENBQUMsS0FBYyxFQUFFLEtBQWEsRUFBRSxRQUFpQixFQUFFLFFBQWtCO0lBQzVGLElBQUksS0FBSyxLQUFLLFNBQVMsSUFBSSxLQUFLLEtBQUssSUFBSTtRQUFFLE9BQU8sUUFBUSxDQUFDO0lBQzNELElBQUksT0FBTyxLQUFLLEtBQUssU0FBUztRQUFFLE9BQU8sS0FBSyxDQUFDO0lBQzdDLFFBQVEsQ0FBQyxJQUFJLENBQUMsc0NBQXNDLEtBQUssd0NBQXdDLFFBQVEsR0FBRyxDQUFDLENBQUM7SUFDOUcsT0FBTyxRQUFRLENBQUM7QUFDbEIsQ0FBQztBQUVELFNBQVMsdUJBQXVCLENBQUMsS0FBYyxFQUFFLEtBQWEsRUFBRSxRQUFrQjtJQUNoRixJQUFJLEtBQUssS0FBSyxTQUFTLElBQUksS0FBSyxLQUFLLElBQUk7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN2RCxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1FBQzlCLFFBQVEsQ0FBQyxJQUFJLENBQUMsc0NBQXNDLEtBQUsseUNBQXlDLENBQUMsQ0FBQztRQUNwRyxPQUFPLElBQUksQ0FBQztJQUNkLENBQUM7SUFDRCxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDN0IsT0FBTyxPQUFPLElBQUksSUFBSSxDQUFDO0FBQ3pCLENBQUM7QUFFRCxTQUFTLGlCQUFpQixDQUFDLEtBQWMsRUFBRSxRQUFrQjtJQUMzRCxJQUFJLEtBQUssS0FBSyxTQUFTLElBQUksS0FBSyxLQUFLLElBQUk7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUNyRCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQzFCLFFBQVEsQ0FBQyxJQUFJLENBQUMsd0VBQXdFLE9BQU8sS0FBSyxTQUFTLENBQUMsQ0FBQztRQUM3RyxPQUFPLEVBQUUsQ0FBQztJQUNaLENBQUM7SUFDRCxNQUFNLE1BQU0sR0FBc0MsRUFBRSxDQUFDO0lBQ3JELE1BQU0sSUFBSSxHQUFHLElBQUksR0FBRyxFQUFVLENBQUM7SUFDL0IsS0FBSyxNQUFNLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxJQUFJLEtBQUssQ0FBQyxPQUFPLEVBQUUsRUFBRSxDQUFDO1FBQzdDLElBQUksS0FBSyxJQUFJLDZCQUE2QixFQUFFLENBQUM7WUFDM0MsUUFBUSxDQUFDLElBQUksQ0FDWCxzREFBc0QsNkJBQTZCLGtDQUFrQyxDQUN0SCxDQUFDO1lBQ0YsTUFBTTtRQUNSLENBQUM7UUFDRCxJQUFJLFlBQVksR0FBa0IsSUFBSSxDQUFDO1FBQ3ZDLElBQUksU0FBUyxHQUFrQixJQUFJLENBQUM7UUFDcEMsSUFBSSxrQkFBa0IsR0FBRyxLQUFLLENBQUM7UUFDL0IsSUFBSSxXQUFXLEdBQWtCLElBQUksQ0FBQztRQUN0QyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQzlCLFlBQVksR0FBRywwQkFBMEIsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNuRCxDQUFDO2FBQU0sSUFBSSxLQUFLLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1lBQ3ZFLE1BQU0sTUFBTSxHQUFHLEtBQWdDLENBQUM7WUFDaEQsWUFBWSxHQUFHLDBCQUEwQixDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQztZQUMvRCxTQUFTLEdBQUcsdUJBQXVCLENBQUMsTUFBTSxDQUFDLFNBQVMsRUFBRSxXQUFXLEVBQUUsUUFBUSxDQUFDLENBQUM7WUFDN0Usa0JBQWtCLEdBQUcsZ0JBQWdCLENBQUMsTUFBTSxDQUFDLGtCQUFrQixFQUFFLG9CQUFvQixFQUFFLEtBQUssRUFBRSxRQUFRLENBQUMsQ0FBQztZQUN4RyxXQUFXLEdBQUcsdUJBQXVCLENBQUMsTUFBTSxDQUFDLFdBQVcsRUFBRSxhQUFhLEVBQUUsUUFBUSxDQUFDLENBQUM7UUFDckYsQ0FBQzthQUFNLENBQUM7WUFDTixRQUFRLENBQUMsSUFBSSxDQUFDLDhFQUE4RSxDQUFDLENBQUM7WUFDOUYsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLFlBQVksS0FBSyxJQUFJLEVBQUUsQ0FBQztZQUMxQixRQUFRLENBQUMsSUFBSSxDQUFDLHlGQUF5RixDQUFDLENBQUM7WUFDekcsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLElBQUksQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDLEVBQUUsQ0FBQztZQUMzQixRQUFRLENBQUMsSUFBSSxDQUFDLHFFQUFxRSxZQUFZLEdBQUcsQ0FBQyxDQUFDO1lBQ3BHLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUMsQ0FBQztRQUN2QixNQUFNLFVBQVUsR0FBb0MsRUFBRSxZQUFZLEVBQUUsa0JBQWtCLEVBQUUsQ0FBQztRQUN6RixJQUFJLFNBQVM7WUFBRSxVQUFVLENBQUMsU0FBUyxHQUFHLFNBQVMsQ0FBQztRQUNoRCxJQUFJLFdBQVc7WUFBRSxVQUFVLENBQUMsV0FBVyxHQUFHLFdBQVcsQ0FBQztRQUN0RCxNQUFNLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzFCLENBQUM7SUFDRCxPQUFPLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBRUQ7OztHQUdHO0FBQ0gsTUFBTSxVQUFVLGdDQUFnQyxDQUFDLE9BQWtDO0lBQ2pGLElBQUksT0FBTyxLQUFLLFNBQVMsSUFBSSxPQUFPLEtBQUssSUFBSTtRQUFFLE9BQU8sa0JBQWtCLEVBQUUsQ0FBQztJQUMzRSxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsRUFBRSxDQUFDO1FBQ2hDLE9BQU8sa0JBQWtCLENBQUMsQ0FBQyw2REFBNkQsT0FBTyxPQUFPLEdBQUcsQ0FBQyxDQUFDLENBQUM7SUFDOUcsQ0FBQztJQUNELE1BQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUMvQixJQUFJLENBQUMsT0FBTztRQUFFLE9BQU8sa0JBQWtCLEVBQUUsQ0FBQztJQUMxQyxJQUFJLGNBQWMsQ0FBQyxPQUFPLENBQUMsR0FBRyw2QkFBNkIsRUFBRSxDQUFDO1FBQzVELE9BQU8sa0JBQWtCLENBQUM7WUFDeEIsd0NBQXdDLDZCQUE2Qiw0QkFBNEI7U0FDbEcsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUNELElBQUksR0FBWSxDQUFDO0lBQ2pCLElBQUksQ0FBQztRQUNILEdBQUcsR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQzVCLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxPQUFPLGtCQUFrQixDQUFDLENBQUMsZ0RBQWdELENBQUMsQ0FBQyxDQUFDO0lBQ2hGLENBQUM7SUFDRCxJQUFJLENBQUMsR0FBRyxJQUFJLE9BQU8sR0FBRyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDMUQsT0FBTyxrQkFBa0IsQ0FBQyxDQUFDLHlEQUF5RCxDQUFDLENBQUMsQ0FBQztJQUN6RixDQUFDO0lBQ0QsTUFBTSxRQUFRLEdBQWEsRUFBRSxDQUFDO0lBQzlCLE1BQU0sS0FBSyxHQUFHLGlCQUFpQixDQUFFLEdBQStCLENBQUMsS0FBSyxFQUFFLFFBQVEsQ0FBQyxDQUFDO0lBQ2xGLE9BQU8sRUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxFQUFFLEtBQUssRUFBRSxFQUFFLFFBQVEsRUFBRSxDQUFDO0FBQzFELENBQUM7QUFFRDs7O0dBR0c7QUFDSCxNQUFNLFVBQVUsK0JBQStCLENBQUMsSUFBWTtJQUMxRCxJQUFJLE9BQU8sSUFBSSxLQUFLLFFBQVE7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUN4QyxNQUFNLFFBQVEsR0FBd0MsRUFBRSxDQUFDO0lBQ3pELEtBQUssTUFBTSxJQUFJLElBQUksSUFBSSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BDLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUM1QixJQUFJLENBQUMsT0FBTyxJQUFJLGdCQUFnQixDQUFDLElBQUksQ0FBQyxPQUFPLENBQUM7WUFBRSxTQUFTO1FBQ3pELEtBQUssTUFBTSxLQUFLLElBQUksb0NBQW9DLEVBQUUsQ0FBQztZQUN6RCxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQztnQkFBRSxRQUFRLENBQUMsSUFBSSxDQUFDLEVBQUUsRUFBRSxFQUFFLEtBQUssQ0FBQyxFQUFFLEVBQUUsSUFBSSxFQUFFLE9BQU8sRUFBRSxDQUFDLENBQUM7UUFDL0UsQ0FBQztJQUNILENBQUM7SUFDRCxPQUFPLFFBQVEsQ0FBQztBQUNsQixDQUFDO0FBRUQsU0FBUyxZQUFZLENBQ25CLFlBQW9CLEVBQ3BCLFFBQWdCLEVBQ2hCLE1BQWMsRUFDZCxRQUE0QyxFQUFFO0lBRTlDLE9BQU87UUFDTCxZQUFZO1FBQ1osTUFBTSxFQUFFLEtBQUs7UUFDYixlQUFlLEVBQUUsUUFBUTtRQUN6QixNQUFNO1FBQ04sYUFBYSxFQUFFLEtBQUs7UUFDcEIsbUJBQW1CLEVBQUUsSUFBSTtRQUN6QixrQkFBa0IsRUFBRSxFQUFFO1FBQ3RCLEdBQUcsS0FBSztLQUNULENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxTQUFTLENBQUMsWUFBb0IsRUFBRSxRQUE0QyxFQUFFO0lBQ3JGLE9BQU87UUFDTCxZQUFZO1FBQ1osTUFBTSxFQUFFLElBQUk7UUFDWixlQUFlLEVBQUUsSUFBSTtRQUNyQixNQUFNLEVBQUUsSUFBSTtRQUNaLGFBQWEsRUFBRSxJQUFJO1FBQ25CLG1CQUFtQixFQUFFLElBQUk7UUFDekIsa0JBQWtCLEVBQUUsRUFBRTtRQUN0QixHQUFHLEtBQUs7S0FDVCxDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMseUJBQXlCLENBQUMsS0FBc0MsRUFBRSxVQUF3QyxFQUFFO0lBQ25ILElBQUksS0FBSyxDQUFDLFdBQVcsSUFBSSxPQUFPLEtBQUssQ0FBQyxXQUFXLEtBQUssUUFBUTtRQUFFLE9BQU8sS0FBSyxDQUFDLFdBQVcsQ0FBQztJQUN6RixJQUFJLE9BQU8sT0FBTyxDQUFDLFFBQVEsS0FBSyxRQUFRLElBQUksT0FBTyxDQUFDLFFBQVEsQ0FBQyxJQUFJLEVBQUU7UUFBRSxPQUFPLE9BQU8sQ0FBQyxRQUFRLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDcEcsSUFBSSxPQUFPLE9BQU8sQ0FBQyxlQUFlLEtBQUssVUFBVTtRQUFFLE9BQU8sT0FBTyxDQUFDLGVBQWUsQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6RixPQUFPLG1CQUFtQixDQUFDLEtBQUssQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLEdBQUcsSUFBSSxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUM7QUFDN0UsQ0FBQztBQUVELFNBQVMsa0JBQWtCLENBQUMsYUFBcUI7SUFDL0MsT0FBTyxFQUFFLFVBQVUsRUFBRSxHQUFHLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztBQUNsQyxDQUFDO0FBRUQ7O0dBRUc7QUFDSCxNQUFNLFVBQVUscUJBQXFCLENBQ25DLEtBQXNDLEVBQ3RDLFVBQXdDLEVBQUU7SUFFMUMsTUFBTSxZQUFZLEdBQUcsS0FBSyxFQUFFLFlBQVksQ0FBQztJQUN6QyxJQUFJLE9BQU8sWUFBWSxLQUFLLFFBQVEsSUFBSSxDQUFDLDBCQUEwQixDQUFDLFlBQVksQ0FBQyxFQUFFLENBQUM7UUFDbEYsT0FBTyxZQUFZLENBQ2pCLE9BQU8sWUFBWSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxXQUFXLEVBQzdELDJCQUEyQixDQUFDLEtBQUssRUFDakMscURBQXFELENBQ3RELENBQUM7SUFDSixDQUFDO0lBRUQsTUFBTSxVQUFVLEdBQUcsT0FBTyxDQUFDLFVBQVUsSUFBSSxVQUFVLENBQUM7SUFDcEQsTUFBTSxVQUFVLEdBQUcsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUM7SUFDOUQsTUFBTSxZQUFZLEdBQUcsT0FBTyxDQUFDLG9CQUFvQixJQUFJLG9CQUFvQixDQUFDO0lBQzFFLDRHQUE0RztJQUM1RyxpSEFBaUg7SUFDakgsNEZBQTRGO0lBQzVGLE1BQU0sYUFBYSxHQUNqQixPQUFPLENBQUMsbUJBQW1CO1FBQzFCLG1CQUFrSSxDQUFDO0lBQ3RJLE1BQU0sUUFBUSxHQUFHLHlCQUF5QixDQUFDLEtBQUssRUFBRSxPQUFPLENBQUMsQ0FBQztJQUUzRCxJQUFJLENBQUMsVUFBVSxDQUFDLFFBQVEsQ0FBQyxFQUFFLENBQUM7UUFDMUIsT0FBTyxZQUFZLENBQ2pCLFlBQVksRUFDWiwyQkFBMkIsQ0FBQyxXQUFXLEVBQ3ZDLG1DQUFtQyxRQUFRLHdEQUF3RCxDQUNwRyxDQUFDO0lBQ0osQ0FBQztJQUVELE1BQU0sUUFBUSxHQUFHLFlBQVksQ0FBQyxRQUFRLENBQUMsQ0FBQztJQUN4QyxNQUFNLG1CQUFtQixHQUFHLFFBQVEsRUFBRSxPQUFPLEtBQUssSUFBSSxDQUFDO0lBRXZELE1BQU0sS0FBSyxHQUFHLFVBQVUsQ0FBQyxRQUFRLENBQUMsQ0FBQztJQUNuQyxJQUFJLEtBQUssRUFBRSxRQUFRLEtBQUssSUFBSSxFQUFFLENBQUM7UUFDN0IsT0FBTyxZQUFZLENBQ2pCLFlBQVksRUFDWiwyQkFBMkIsQ0FBQyxlQUFlLEVBQzNDLEtBQUssRUFBRSxNQUFNLElBQUkseURBQXlELEVBQzFFLEVBQUUsYUFBYSxFQUFFLEtBQUssRUFBRSxtQkFBbUIsRUFBRSxDQUM5QyxDQUFDO0lBQ0osQ0FBQztJQUVELElBQUksS0FBSyxDQUFDLGtCQUFrQixLQUFLLElBQUksSUFBSSxDQUFDLEtBQUssQ0FBQyxXQUFXLEVBQUUsQ0FBQztRQUM1RCxPQUFPLFlBQVksQ0FDakIsWUFBWSxFQUNaLDJCQUEyQixDQUFDLFNBQVMsRUFDckMsNkZBQTZGLEVBQzdGLEVBQUUsYUFBYSxFQUFFLElBQUksRUFBRSxtQkFBbUIsRUFBRSxLQUFLLEVBQUUsQ0FDcEQsQ0FBQztJQUNKLENBQUM7SUFFRCxJQUFJLFVBQXVFLENBQUM7SUFDNUUsSUFBSSxDQUFDO1FBQ0gsVUFBVSxHQUFHLGFBQWEsQ0FBQztZQUN6QixZQUFZO1lBQ1osS0FBSyxFQUFFO2dCQUNMLE1BQU0sRUFBRSxDQUFDO2dCQUNULEtBQUssRUFBRSwyQ0FBMkM7Z0JBQ2xELElBQUksRUFBRSxpRUFBaUU7Z0JBQ3ZFLE1BQU0sRUFBRSxDQUFDLEtBQUssQ0FBQzthQUNoQjtZQUNELE9BQU8sRUFBRSxFQUFFLE1BQU0sRUFBRSxDQUFDLEVBQUUsTUFBTSxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsWUFBWSxFQUFFLEVBQUUsRUFBRTtZQUN0RCxXQUFXLEVBQUUsa0JBQWtCLENBQUMsWUFBWSxDQUFDO1lBQzdDLGdCQUFnQixFQUFFLFFBQVE7WUFDMUIsZUFBZSxFQUFFLFVBQVU7U0FDNUIsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixNQUFNLE9BQU8sR0FBRyxLQUFLLFlBQVksS0FBSyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDdkUsT0FBTyxZQUFZLENBQUMsWUFBWSxFQUFFLDJCQUEyQixDQUFDLEtBQUssRUFBRSxPQUFPLEVBQUU7WUFDNUUsYUFBYSxFQUFFLElBQUk7WUFDbkIsbUJBQW1CO1lBQ25CLEtBQUs7U0FDTixDQUFDLENBQUM7SUFDTCxDQUFDO0lBRUQsSUFBSSxVQUFVLEVBQUUsS0FBSyxLQUFLLElBQUksRUFBRSxDQUFDO1FBQy9CLE9BQU8sWUFBWSxDQUNqQixZQUFZLEVBQ1osMkJBQTJCLENBQUMsU0FBUyxFQUNyQywyQ0FBMkMsVUFBVSxFQUFFLE9BQU8sSUFBSSxTQUFTLElBQUksRUFDL0UsRUFBRSxhQUFhLEVBQUUsSUFBSSxFQUFFLG1CQUFtQixFQUFFLEtBQUssRUFBRSxDQUNwRCxDQUFDO0lBQ0osQ0FBQztJQUVELE1BQU0sa0JBQWtCLEdBQUcsK0JBQStCLENBQUMsVUFBVSxDQUFDLFlBQVksSUFBSSxFQUFFLENBQUMsQ0FBQztJQUMxRixJQUFJLGtCQUFrQixDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNsQyxPQUFPLFlBQVksQ0FDakIsWUFBWSxFQUNaLDJCQUEyQixDQUFDLG9CQUFvQixFQUNoRCwwREFBMEQsa0JBQWtCLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxJQUFJLEVBQzVHLEVBQUUsYUFBYSxFQUFFLElBQUksRUFBRSxtQkFBbUIsRUFBRSxLQUFLLEVBQUUsa0JBQWtCLEVBQUUsQ0FDeEUsQ0FBQztJQUNKLENBQUM7SUFFRCxPQUFPLFNBQVMsQ0FBQyxZQUFZLEVBQUUsRUFBRSxtQkFBbUIsRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0FBQ2pFLENBQUM7QUFFRDs7R0FFRztBQUNILE1BQU0sVUFBVSxzQkFBc0IsQ0FDcEMsTUFBeUMsRUFDekMsVUFBa0UsRUFBRTtJQUVwRSxNQUFNLEtBQUssR0FBRyxNQUFNLEVBQUUsUUFBUSxFQUFFLEtBQUssSUFBSSxFQUFFLENBQUM7SUFDNUMsTUFBTSxPQUFPLEdBQWdDLEVBQUUsQ0FBQztJQUNoRCxLQUFLLE1BQU0sS0FBSyxJQUFJLEtBQUssRUFBRSxDQUFDO1FBQzFCLElBQUksT0FBTyxDQUFDLFVBQVUsSUFBSSxLQUFLLENBQUMsWUFBWSxLQUFLLE9BQU8sQ0FBQyxVQUFVO1lBQUUsU0FBUztRQUM5RSxPQUFPLENBQUMsSUFBSSxDQUFDLHFCQUFxQixDQUFDLEtBQUssRUFBRSxPQUFPLENBQUMsQ0FBQyxDQUFDO0lBQ3RELENBQUM7SUFDRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQ7O0dBRUc7QUFDSCxNQUFNLFVBQVUsNEJBQTRCLENBQUMsT0FBb0M7SUFDL0UsTUFBTSxJQUFJLEdBQUcsS0FBSyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDbkQsSUFBSSxNQUFNLEdBQUcsQ0FBQyxDQUFDO0lBQ2YsSUFBSSxNQUFNLEdBQUcsQ0FBQyxDQUFDO0lBQ2YsTUFBTSxrQkFBa0IsR0FBMkIsRUFBRSxDQUFDO0lBQ3RELEtBQUssTUFBTSxNQUFNLElBQUksSUFBSSxFQUFFLENBQUM7UUFDMUIsSUFBSSxNQUFNLEVBQUUsTUFBTSxLQUFLLElBQUksRUFBRSxDQUFDO1lBQzVCLE1BQU0sSUFBSSxDQUFDLENBQUM7WUFDWixTQUFTO1FBQ1gsQ0FBQztRQUNELE1BQU0sSUFBSSxDQUFDLENBQUM7UUFDWixNQUFNLFFBQVEsR0FBRyxNQUFNLEVBQUUsZUFBZSxJQUFJLDJCQUEyQixDQUFDLEtBQUssQ0FBQztRQUM5RSxrQkFBa0IsQ0FBQyxRQUFRLENBQUMsR0FBRyxDQUFDLGtCQUFrQixDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUN6RSxDQUFDO0lBQ0QsTUFBTSxLQUFLLEdBQUcsTUFBTSxHQUFHLE1BQU0sQ0FBQztJQUM5QixNQUFNLGNBQWMsR0FBRyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUM7SUFDM0QsTUFBTSxxQkFBcUIsR0FBRyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLEVBQUUsbUJBQW1CLEtBQUssS0FBSyxDQUFDLENBQUMsTUFBTSxDQUFDO0lBQzFGLE9BQU87UUFDTCxLQUFLO1FBQ0wsTUFBTTtRQUNOLE1BQU07UUFDTixjQUFjO1FBQ2QscUJBQXFCO1FBQ3JCLGtCQUFrQjtLQUNuQixDQUFDO0FBQ0osQ0FBQztBQUVEOztHQUVHO0FBQ0gsTUFBTSxVQUFVLCtCQUErQixDQUM3QyxPQUFvQyxFQUNwQyxVQUFzQyw0QkFBNEIsQ0FBQyxPQUFPLENBQUM7SUFFM0UsTUFBTSxLQUFLLEdBQUcsQ0FBQyxzQ0FBc0MsRUFBRSxFQUFFLENBQUMsQ0FBQztJQUMzRCxLQUFLLE1BQU0sTUFBTSxJQUFJLE9BQU8sRUFBRSxDQUFDO1FBQzdCLElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1lBQ2xCLEtBQUssQ0FBQyxJQUFJLENBQUMsUUFBUSxNQUFNLENBQUMsWUFBWSxFQUFFLENBQUMsQ0FBQztZQUMxQyxTQUFTO1FBQ1gsQ0FBQztRQUNELEtBQUssQ0FBQyxJQUFJLENBQUMsUUFBUSxNQUFNLENBQUMsWUFBWSxLQUFLLE1BQU0sQ0FBQyxlQUFlLEtBQUssTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7SUFDekYsQ0FBQztJQUNELEtBQUssQ0FBQyxJQUFJLENBQ1IsRUFBRSxFQUNGLFlBQVksT0FBTyxDQUFDLE1BQU0sSUFBSSxPQUFPLENBQUMsS0FBSyxTQUFTO1FBQ2xELENBQUMsT0FBTyxDQUFDLGNBQWMsQ0FBQyxDQUFDLENBQUMsb0JBQW9CLENBQUMsQ0FBQyxDQUFDLG9CQUFvQixDQUFDLENBQ3pFLENBQUM7SUFDRixJQUFJLE9BQU8sQ0FBQyxLQUFLLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDdEIsS0FBSyxDQUFDLElBQUksQ0FBQyw0Q0FBNEMsT0FBTyxDQUFDLHFCQUFxQixJQUFJLE9BQU8sQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQzNHLENBQUM7SUFDRCxNQUFNLFVBQVUsR0FBRyxNQUFNLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUMsQ0FBQyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ3JHLElBQUksVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUMxQixLQUFLLENBQUMsSUFBSSxDQUFDLEVBQUUsRUFBRSx1QkFBdUIsQ0FBQyxDQUFDO1FBQ3hDLEtBQUssTUFBTSxDQUFDLFFBQVEsRUFBRSxLQUFLLENBQUMsSUFBSSxVQUFVLEVBQUUsQ0FBQztZQUMzQyxLQUFLLENBQUMsSUFBSSxDQUFDLEtBQUssUUFBUSxLQUFLLEtBQUssRUFBRSxDQUFDLENBQUM7UUFDeEMsQ0FBQztJQUNILENBQUM7SUFDRCxPQUFPLEtBQUssQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDMUIsQ0FBQyJ9

--- a/packages/loopover-miner/lib/cross-repo-evaluation.ts
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.ts
@@ -1,0 +1,444 @@
+// Cross-repo evaluation harness (#4788): a repeatable, offline-first readiness check that asks whether the miner
+// can approach a diverse benchmark repo set without loopover-specific target-repo configuration. Each repo is
+// evaluated through the same stack-detection + coding-task-spec path a real attempt uses (detectRepoStack,
+// resolveMinerGoalSpec, buildCodingTaskSpec) and failures are categorized as stack-detection gaps, execution
+// readiness gaps, leaked loopover assumptions in agent instructions, clone/setup problems, or other.
+
+import { existsSync } from "node:fs";
+import { buildCodingTaskSpec } from "./coding-task-spec.js";
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
+import { isValidRepoSegment, resolveRepoCloneDir } from "./repo-clone.js";
+import { detectRepoStack, type RepoStackResult } from "./stack-detection.js";
+
+/** Failure taxonomy surfaced in per-repo reports (#4788). */
+export const CROSS_REPO_FAILURE_CATEGORY = Object.freeze({
+  STACK_DETECTION: "stack_detection_gap",
+  EXECUTION: "execution_gap",
+  GITTENSOR_ASSUMPTION: "loopover_assumption",
+  CLONE_SETUP: "clone_setup",
+  OTHER: "other",
+} as const);
+
+/** Instruction substrings that indicate a POSITIVE loopover/LoopOver CI assumption leaked into the agent prompt.
+ *  Lines that explicitly tell the agent *not* to assume these are filtered out before scanning. */
+export const GITTENSOR_POSITIVE_ASSUMPTION_CHECKS: ReadonlyArray<{ id: string; pattern: RegExp }> = Object.freeze([
+  { id: "test_ci_script", pattern: /npm run test:ci/i },
+  { id: "codecov_patch", pattern: /codecov\/patch/i },
+  { id: "gittensor_label", pattern: /gittensor:(?:bug|feature|priority)/i },
+  { id: "loopover_gate", pattern: /loopover gate/i },
+]);
+
+export const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH = "benchmarks/cross-repo/manifest.json";
+export const MAX_CROSS_REPO_MANIFEST_BYTES = 65_536;
+export const MAX_CROSS_REPO_MANIFEST_REPOS = 100;
+
+export type CrossRepoEvaluationManifestRepo = {
+  repoFullName: string;
+  stackHint?: string;
+  requireTestCommand?: boolean;
+  fixturePath?: string;
+};
+
+export type ParsedCrossRepoEvaluationManifest = {
+  present: boolean;
+  manifest: { repos: CrossRepoEvaluationManifestRepo[] };
+  warnings: string[];
+};
+
+export type CrossRepoEvaluationResult = {
+  repoFullName: string;
+  passed: boolean;
+  failureCategory: string | null;
+  reason: string | null;
+  stackDetected: boolean;
+  usedDefaultGoalSpec: boolean | null;
+  assumptionFindings: Array<{ id: string; line: string }>;
+  stack?: RepoStackResult;
+};
+
+export type CrossRepoEvaluationSummary = {
+  total: number;
+  passed: number;
+  failed: number;
+  majorityPassed: boolean;
+  withoutLoopoverConfig: number;
+  failuresByCategory: Record<string, number>;
+};
+
+type EvaluateRepoReadinessOptions = {
+  repoPath?: string;
+  resolveRepoPath?: (entry: { repoFullName: string }) => string;
+  env?: NodeJS.ProcessEnv;
+  existsSync?: (path: string) => boolean;
+  detectRepoStack?: (repoPath: string) => RepoStackResult;
+  resolveMinerGoalSpec?: (repoPath: string) => { present: boolean };
+  buildCodingTaskSpec?: (input: Record<string, unknown>) => { ready: boolean; verdict?: string; instructions?: string };
+};
+
+// True UTF-8 byte count for the size guard (#7223): JS string `.length` is UTF-16 code units, which under-counts
+// any multi-byte character (up to 4x for astral-plane code points), so `MAX_CROSS_REPO_MANIFEST_BYTES` -- named
+// and warned about in BYTES -- was actually being compared against a code-unit count. Mirrors the identical helper
+// in the three siblings this parser's own comment claims to follow: fleet-run-manifest.ts, miner-goal-spec.ts,
+// and ams-policy-spec.ts.
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (const char of value) {
+    // `char` is a non-empty code-point string from the string iterator, so codePointAt(0) is always defined; the
+    // cast narrows `number | undefined` without adding an unreachable `?? 0` branch.
+    const codePoint = char.codePointAt(0) as number;
+    if (codePoint <= 0x7f) bytes += 1;
+    else if (codePoint <= 0x7ff) bytes += 2;
+    else if (codePoint <= 0xffff) bytes += 3;
+    else bytes += 4;
+  }
+  return bytes;
+}
+
+function cloneEmptyManifest(warnings: string[] = []): ParsedCrossRepoEvaluationManifest {
+  return { present: false, manifest: { repos: [] }, warnings };
+}
+
+/** Canonical `owner/repo` with exactly one slash and safe segments; anything else → null. */
+export function normalizeCrossRepoFullName(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const [owner, repo, extra] = value.trim().split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
+  return `${owner}/${repo}`;
+}
+
+function normalizeBoolean(value: unknown, field: string, fallback: boolean, warnings: string[]): boolean {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value === "boolean") return value;
+  warnings.push(`CrossRepoEvaluationManifest field "${field}" must be a boolean; falling back to ${fallback}.`);
+  return fallback;
+}
+
+function normalizeOptionalString(value: unknown, field: string, warnings: string[]): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") {
+    warnings.push(`CrossRepoEvaluationManifest field "${field}" must be a string; ignoring the value.`);
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeRepoList(value: unknown, warnings: string[]): CrossRepoEvaluationManifestRepo[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    warnings.push(`CrossRepoEvaluationManifest field "repos" must be a list; ignoring a ${typeof value} value.`);
+    return [];
+  }
+  const result: CrossRepoEvaluationManifestRepo[] = [];
+  const seen = new Set<string>();
+  for (const [index, entry] of value.entries()) {
+    if (index >= MAX_CROSS_REPO_MANIFEST_REPOS) {
+      warnings.push(
+        `CrossRepoEvaluationManifest field "repos" exceeded ${MAX_CROSS_REPO_MANIFEST_REPOS} entries; extra entries ignored.`,
+      );
+      break;
+    }
+    let repoFullName: string | null = null;
+    let stackHint: string | null = null;
+    let requireTestCommand = false;
+    let fixturePath: string | null = null;
+    if (typeof entry === "string") {
+      repoFullName = normalizeCrossRepoFullName(entry);
+    } else if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      const record = entry as Record<string, unknown>;
+      repoFullName = normalizeCrossRepoFullName(record.repoFullName);
+      stackHint = normalizeOptionalString(record.stackHint, "stackHint", warnings);
+      requireTestCommand = normalizeBoolean(record.requireTestCommand, "requireTestCommand", false, warnings);
+      fixturePath = normalizeOptionalString(record.fixturePath, "fixturePath", warnings);
+    } else {
+      warnings.push(`CrossRepoEvaluationManifest "repos" skipped a non-string, non-mapping entry.`);
+      continue;
+    }
+    if (repoFullName === null) {
+      warnings.push(`CrossRepoEvaluationManifest "repos" skipped an entry with an invalid "owner/repo" name.`);
+      continue;
+    }
+    if (seen.has(repoFullName)) {
+      warnings.push(`CrossRepoEvaluationManifest "repos" skipped a duplicate entry for ${repoFullName}.`);
+      continue;
+    }
+    seen.add(repoFullName);
+    const normalized: CrossRepoEvaluationManifestRepo = { repoFullName, requireTestCommand };
+    if (stackHint) normalized.stackHint = stackHint;
+    if (fixturePath) normalized.fixturePath = fixturePath;
+    result.push(normalized);
+  }
+  return result;
+}
+
+/**
+ * Tolerant JSON manifest parser (#4788). Malformed input degrades to an empty repo list with warnings rather than
+ * throwing, mirroring the fleet-run-manifest / miner-goal-spec convention.
+ */
+export function parseCrossRepoEvaluationManifest(content: string | null | undefined): ParsedCrossRepoEvaluationManifest {
+  if (content === undefined || content === null) return cloneEmptyManifest();
+  if (typeof content !== "string") {
+    return cloneEmptyManifest([`CrossRepoEvaluationManifest content must be a string; got ${typeof content}.`]);
+  }
+  const trimmed = content.trim();
+  if (!trimmed) return cloneEmptyManifest();
+  if (utf8ByteLength(trimmed) > MAX_CROSS_REPO_MANIFEST_BYTES) {
+    return cloneEmptyManifest([
+      `CrossRepoEvaluationManifest exceeded ${MAX_CROSS_REPO_MANIFEST_BYTES} bytes; ignoring the file.`,
+    ]);
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(trimmed);
+  } catch {
+    return cloneEmptyManifest(["CrossRepoEvaluationManifest is not valid JSON."]);
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return cloneEmptyManifest(["CrossRepoEvaluationManifest root must be a JSON object."]);
+  }
+  const warnings: string[] = [];
+  const repos = normalizeRepoList((raw as Record<string, unknown>).repos, warnings);
+  return { present: true, manifest: { repos }, warnings };
+}
+
+/**
+ * Scan agent instructions for positive loopover/LoopOver assumptions (#4788). Lines that already tell the agent
+ * *not* to assume LoopOver conventions (the negative guidance from buildValidationGuidance) are skipped.
+ */
+export function scanPositiveLoopoverAssumptions(text: string): Array<{ id: string; line: string }> {
+  if (typeof text !== "string") return [];
+  const findings: Array<{ id: string; line: string }> = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || /do not assume/i.test(trimmed)) continue;
+    for (const check of GITTENSOR_POSITIVE_ASSUMPTION_CHECKS) {
+      if (check.pattern.test(line)) findings.push({ id: check.id, line: trimmed });
+    }
+  }
+  return findings;
+}
+
+function buildFailure(
+  repoFullName: string,
+  category: string,
+  reason: string,
+  extra: Partial<CrossRepoEvaluationResult> = {},
+): CrossRepoEvaluationResult {
+  return {
+    repoFullName,
+    passed: false,
+    failureCategory: category,
+    reason,
+    stackDetected: false,
+    usedDefaultGoalSpec: null,
+    assumptionFindings: [],
+    ...extra,
+  };
+}
+
+function buildPass(repoFullName: string, extra: Partial<CrossRepoEvaluationResult> = {}): CrossRepoEvaluationResult {
+  return {
+    repoFullName,
+    passed: true,
+    failureCategory: null,
+    reason: null,
+    stackDetected: true,
+    usedDefaultGoalSpec: true,
+    assumptionFindings: [],
+    ...extra,
+  };
+}
+
+function resolveEvaluationRepoPath(entry: CrossRepoEvaluationManifestRepo, options: EvaluateRepoReadinessOptions = {}): string {
+  if (entry.fixturePath && typeof entry.fixturePath === "string") return entry.fixturePath;
+  if (typeof options.repoPath === "string" && options.repoPath.trim()) return options.repoPath.trim();
+  if (typeof options.resolveRepoPath === "function") return options.resolveRepoPath(entry);
+  return resolveRepoCloneDir(entry.repoFullName, options.env ?? process.env);
+}
+
+function defaultClaimLedger(_repoFullName: string): { listClaims: () => [] } {
+  return { listClaims: () => [] };
+}
+
+/**
+ * Evaluate one benchmark repo's miner readiness without running a live coding agent (#4788).
+ */
+export function evaluateRepoReadiness(
+  entry: CrossRepoEvaluationManifestRepo,
+  options: EvaluateRepoReadinessOptions = {},
+): CrossRepoEvaluationResult {
+  const repoFullName = entry?.repoFullName;
+  if (typeof repoFullName !== "string" || !normalizeCrossRepoFullName(repoFullName)) {
+    return buildFailure(
+      typeof repoFullName === "string" ? repoFullName : "(invalid)",
+      CROSS_REPO_FAILURE_CATEGORY.OTHER,
+      "Benchmark entry is missing a valid owner/repo name.",
+    );
+  }
+
+  const existsImpl = options.existsSync ?? existsSync;
+  const detectImpl = options.detectRepoStack ?? detectRepoStack;
+  const goalSpecImpl = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+  // The harness feeds buildCodingTaskSpec a synthetic smoke issue with only the fields it actually reads; the
+  // option is deliberately typed against a loose `Record<string, unknown>` input (see EvaluateRepoReadinessOptions
+  // and the original .d.ts), so the real default is adapted to that same loose contract here.
+  const buildSpecImpl =
+    options.buildCodingTaskSpec ??
+    (buildCodingTaskSpec as unknown as (input: Record<string, unknown>) => { ready: boolean; verdict?: string; instructions?: string });
+  const repoPath = resolveEvaluationRepoPath(entry, options);
+
+  if (!existsImpl(repoPath)) {
+    return buildFailure(
+      repoFullName,
+      CROSS_REPO_FAILURE_CATEGORY.CLONE_SETUP,
+      `Repository path does not exist: ${repoPath}. Clone the repo or set LOOPOVER_MINER_REPO_CLONE_DIR.`,
+    );
+  }
+
+  const goalSpec = goalSpecImpl(repoPath);
+  const usedDefaultGoalSpec = goalSpec?.present !== true;
+
+  const stack = detectImpl(repoPath);
+  if (stack?.detected !== true) {
+    return buildFailure(
+      repoFullName,
+      CROSS_REPO_FAILURE_CATEGORY.STACK_DETECTION,
+      stack?.reason ?? "Stack auto-detection did not recognize this repository.",
+      { stackDetected: false, usedDefaultGoalSpec },
+    );
+  }
+
+  if (entry.requireTestCommand === true && !stack.testCommand) {
+    return buildFailure(
+      repoFullName,
+      CROSS_REPO_FAILURE_CATEGORY.EXECUTION,
+      "Stack detection succeeded but no test command was inferred while requireTestCommand is set.",
+      { stackDetected: true, usedDefaultGoalSpec, stack },
+    );
+  }
+
+  let specResult: { ready: boolean; verdict?: string; instructions?: string };
+  try {
+    specResult = buildSpecImpl({
+      repoFullName,
+      issue: {
+        number: 1,
+        title: "Cross-repo evaluation harness smoke issue",
+        body: "Synthetic issue used only by the cross-repo evaluation harness.",
+        labels: ["bug"],
+      },
+      context: { issues: [{ number: 1 }], pullRequests: [] },
+      claimLedger: defaultClaimLedger(repoFullName),
+      workingDirectory: repoPath,
+      detectRepoStack: detectImpl,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return buildFailure(repoFullName, CROSS_REPO_FAILURE_CATEGORY.OTHER, message, {
+      stackDetected: true,
+      usedDefaultGoalSpec,
+      stack,
+    });
+  }
+
+  if (specResult?.ready !== true) {
+    return buildFailure(
+      repoFullName,
+      CROSS_REPO_FAILURE_CATEGORY.EXECUTION,
+      `Coding task spec is not ready (verdict: ${specResult?.verdict ?? "unknown"}).`,
+      { stackDetected: true, usedDefaultGoalSpec, stack },
+    );
+  }
+
+  const assumptionFindings = scanPositiveLoopoverAssumptions(specResult.instructions ?? "");
+  if (assumptionFindings.length > 0) {
+    return buildFailure(
+      repoFullName,
+      CROSS_REPO_FAILURE_CATEGORY.GITTENSOR_ASSUMPTION,
+      `Agent instructions leak loopover-specific assumptions (${assumptionFindings.map((f) => f.id).join(", ")}).`,
+      { stackDetected: true, usedDefaultGoalSpec, stack, assumptionFindings },
+    );
+  }
+
+  return buildPass(repoFullName, { usedDefaultGoalSpec, stack });
+}
+
+/**
+ * Run the harness across every repo in a parsed manifest (#4788).
+ */
+export function runCrossRepoEvaluation(
+  parsed: ParsedCrossRepoEvaluationManifest,
+  options: { repoFilter?: string } & EvaluateRepoReadinessOptions = {},
+): CrossRepoEvaluationResult[] {
+  const repos = parsed?.manifest?.repos ?? [];
+  const results: CrossRepoEvaluationResult[] = [];
+  for (const entry of repos) {
+    if (options.repoFilter && entry.repoFullName !== options.repoFilter) continue;
+    results.push(evaluateRepoReadiness(entry, options));
+  }
+  return results;
+}
+
+/**
+ * Reduce per-repo results to pass/fail counts and whether a strict majority passed (#4788).
+ */
+export function summarizeCrossRepoEvaluation(results: CrossRepoEvaluationResult[]): CrossRepoEvaluationSummary {
+  const list = Array.isArray(results) ? results : [];
+  let passed = 0;
+  let failed = 0;
+  const failuresByCategory: Record<string, number> = {};
+  for (const result of list) {
+    if (result?.passed === true) {
+      passed += 1;
+      continue;
+    }
+    failed += 1;
+    const category = result?.failureCategory ?? CROSS_REPO_FAILURE_CATEGORY.OTHER;
+    failuresByCategory[category] = (failuresByCategory[category] ?? 0) + 1;
+  }
+  const total = passed + failed;
+  const majorityPassed = total > 0 ? passed > failed : false;
+  const withoutLoopoverConfig = list.filter((r) => r?.usedDefaultGoalSpec !== false).length;
+  return {
+    total,
+    passed,
+    failed,
+    majorityPassed,
+    withoutLoopoverConfig,
+    failuresByCategory,
+  };
+}
+
+/**
+ * Human-readable pass/fail report for one evaluation run (#4788).
+ */
+export function formatCrossRepoEvaluationReport(
+  results: CrossRepoEvaluationResult[],
+  summary: CrossRepoEvaluationSummary = summarizeCrossRepoEvaluation(results),
+): string {
+  const lines = ["loopover-miner cross-repo evaluation", ""];
+  for (const result of results) {
+    if (result.passed) {
+      lines.push(`PASS ${result.repoFullName}`);
+      continue;
+    }
+    lines.push(`FAIL ${result.repoFullName} [${result.failureCategory}] ${result.reason}`);
+  }
+  lines.push(
+    "",
+    `summary: ${summary.passed}/${summary.total} passed` +
+      (summary.majorityPassed ? " (majority passed)" : " (majority failed)"),
+  );
+  if (summary.total > 0) {
+    lines.push(`without loopover-specific target config: ${summary.withoutLoopoverConfig}/${summary.total}`);
+  }
+  const categories = Object.entries(summary.failuresByCategory).sort(([a], [b]) => a.localeCompare(b));
+  if (categories.length > 0) {
+    lines.push("", "failures by category:");
+    for (const [category, count] of categories) {
+      lines.push(`- ${category}: ${count}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/loopover-miner/lib/discovery-throttle.d.ts
+++ b/packages/loopover-miner/lib/discovery-throttle.d.ts
@@ -1,8 +1,13 @@
-export const DEFAULT_RATE_LIMIT_LOW_WATER_MARK: number;
-export const DEFAULT_RATE_LIMIT_HIGH_WATER_MARK: number;
-export function resolveThrottledConcurrency(
-  baseConcurrency: number,
-  rateLimitRemaining: number | null,
-  lowWaterMark: number,
-  highWaterMark: number,
-): number;
+/** At or below this remaining budget, serialize discovery to a single in-flight request. */
+export declare const DEFAULT_RATE_LIMIT_LOW_WATER_MARK = 50;
+/** At or above this remaining budget, run at the full configured concurrency. */
+export declare const DEFAULT_RATE_LIMIT_HIGH_WATER_MARK = 250;
+/**
+ * Resolve the concurrency the fanout may run at for the currently-recorded rate-limit budget. Returns an integer
+ * in `[1, baseConcurrency]`:
+ *  - an unknown budget (`null`/non-finite — nothing recorded yet) runs at full `baseConcurrency`;
+ *  - at or below `lowWaterMark` it clamps to a single in-flight request;
+ *  - at or above `highWaterMark` it runs at full `baseConcurrency`;
+ *  - in between it scales linearly with the remaining fraction of the low→high band.
+ */
+export declare function resolveThrottledConcurrency(baseConcurrency: number, rateLimitRemaining: number | null, lowWaterMark: number, highWaterMark: number): number;

--- a/packages/loopover-miner/lib/discovery-throttle.js
+++ b/packages/loopover-miner/lib/discovery-throttle.js
@@ -3,12 +3,10 @@
 // into a 403. This pure helper maps the recorded remaining budget to an allowed in-flight concurrency so the
 // fanout tapers off as the budget approaches zero. It only decides *how many* requests may run; it never changes
 // which docs are fetched or how a policy verdict is derived from them.
-
 /** At or below this remaining budget, serialize discovery to a single in-flight request. */
 export const DEFAULT_RATE_LIMIT_LOW_WATER_MARK = 50;
 /** At or above this remaining budget, run at the full configured concurrency. */
 export const DEFAULT_RATE_LIMIT_HIGH_WATER_MARK = 250;
-
 /**
  * Resolve the concurrency the fanout may run at for the currently-recorded rate-limit budget. Returns an integer
  * in `[1, baseConcurrency]`:
@@ -16,18 +14,20 @@ export const DEFAULT_RATE_LIMIT_HIGH_WATER_MARK = 250;
  *  - at or below `lowWaterMark` it clamps to a single in-flight request;
  *  - at or above `highWaterMark` it runs at full `baseConcurrency`;
  *  - in between it scales linearly with the remaining fraction of the low→high band.
- * @param {number} baseConcurrency
- * @param {number|null} rateLimitRemaining
- * @param {number} lowWaterMark
- * @param {number} highWaterMark
- * @returns {number}
  */
 export function resolveThrottledConcurrency(baseConcurrency, rateLimitRemaining, lowWaterMark, highWaterMark) {
-  if (!Number.isFinite(rateLimitRemaining)) return baseConcurrency;
-  if (rateLimitRemaining <= lowWaterMark) return 1;
-  if (rateLimitRemaining >= highWaterMark) return baseConcurrency;
-  // remaining is strictly inside the (low, high) band, so the fraction is in (0, 1) and the ceil lands in
-  // [1, baseConcurrency] without any further clamping.
-  const fraction = (rateLimitRemaining - lowWaterMark) / (highWaterMark - lowWaterMark);
-  return Math.ceil(fraction * baseConcurrency);
+    if (!Number.isFinite(rateLimitRemaining))
+        return baseConcurrency;
+    // Finite past the guard above (null/NaN already returned); the cast narrows `number | null` without adding a
+    // second runtime branch, keeping this byte-for-byte the single-branch shape the .js had.
+    const remaining = rateLimitRemaining;
+    if (remaining <= lowWaterMark)
+        return 1;
+    if (remaining >= highWaterMark)
+        return baseConcurrency;
+    // remaining is strictly inside the (low, high) band, so the fraction is in (0, 1) and the ceil lands in
+    // [1, baseConcurrency] without any further clamping.
+    const fraction = (remaining - lowWaterMark) / (highWaterMark - lowWaterMark);
+    return Math.ceil(fraction * baseConcurrency);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGlzY292ZXJ5LXRocm90dGxlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZGlzY292ZXJ5LXRocm90dGxlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtHQUErRztBQUMvRyw4R0FBOEc7QUFDOUcsNkdBQTZHO0FBQzdHLGlIQUFpSDtBQUNqSCx1RUFBdUU7QUFFdkUsNEZBQTRGO0FBQzVGLE1BQU0sQ0FBQyxNQUFNLGlDQUFpQyxHQUFHLEVBQUUsQ0FBQztBQUNwRCxpRkFBaUY7QUFDakYsTUFBTSxDQUFDLE1BQU0sa0NBQWtDLEdBQUcsR0FBRyxDQUFDO0FBRXREOzs7Ozs7O0dBT0c7QUFDSCxNQUFNLFVBQVUsMkJBQTJCLENBQ3pDLGVBQXVCLEVBQ3ZCLGtCQUFpQyxFQUNqQyxZQUFvQixFQUNwQixhQUFxQjtJQUVyQixJQUFJLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxrQkFBa0IsQ0FBQztRQUFFLE9BQU8sZUFBZSxDQUFDO0lBQ2pFLDZHQUE2RztJQUM3Ryx5RkFBeUY7SUFDekYsTUFBTSxTQUFTLEdBQUcsa0JBQTRCLENBQUM7SUFDL0MsSUFBSSxTQUFTLElBQUksWUFBWTtRQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3hDLElBQUksU0FBUyxJQUFJLGFBQWE7UUFBRSxPQUFPLGVBQWUsQ0FBQztJQUN2RCx3R0FBd0c7SUFDeEcscURBQXFEO0lBQ3JELE1BQU0sUUFBUSxHQUFHLENBQUMsU0FBUyxHQUFHLFlBQVksQ0FBQyxHQUFHLENBQUMsYUFBYSxHQUFHLFlBQVksQ0FBQyxDQUFDO0lBQzdFLE9BQU8sSUFBSSxDQUFDLElBQUksQ0FBQyxRQUFRLEdBQUcsZUFBZSxDQUFDLENBQUM7QUFDL0MsQ0FBQyJ9

--- a/packages/loopover-miner/lib/discovery-throttle.ts
+++ b/packages/loopover-miner/lib/discovery-throttle.ts
@@ -1,0 +1,36 @@
+// Dynamic discovery back-off (#4844): the fanout already records GitHub's `x-ratelimit-remaining`, but nothing
+// slowed its own concurrent fetching in response — a `discover` run could sprint at full concurrency straight
+// into a 403. This pure helper maps the recorded remaining budget to an allowed in-flight concurrency so the
+// fanout tapers off as the budget approaches zero. It only decides *how many* requests may run; it never changes
+// which docs are fetched or how a policy verdict is derived from them.
+
+/** At or below this remaining budget, serialize discovery to a single in-flight request. */
+export const DEFAULT_RATE_LIMIT_LOW_WATER_MARK = 50;
+/** At or above this remaining budget, run at the full configured concurrency. */
+export const DEFAULT_RATE_LIMIT_HIGH_WATER_MARK = 250;
+
+/**
+ * Resolve the concurrency the fanout may run at for the currently-recorded rate-limit budget. Returns an integer
+ * in `[1, baseConcurrency]`:
+ *  - an unknown budget (`null`/non-finite — nothing recorded yet) runs at full `baseConcurrency`;
+ *  - at or below `lowWaterMark` it clamps to a single in-flight request;
+ *  - at or above `highWaterMark` it runs at full `baseConcurrency`;
+ *  - in between it scales linearly with the remaining fraction of the low→high band.
+ */
+export function resolveThrottledConcurrency(
+  baseConcurrency: number,
+  rateLimitRemaining: number | null,
+  lowWaterMark: number,
+  highWaterMark: number,
+): number {
+  if (!Number.isFinite(rateLimitRemaining)) return baseConcurrency;
+  // Finite past the guard above (null/NaN already returned); the cast narrows `number | null` without adding a
+  // second runtime branch, keeping this byte-for-byte the single-branch shape the .js had.
+  const remaining = rateLimitRemaining as number;
+  if (remaining <= lowWaterMark) return 1;
+  if (remaining >= highWaterMark) return baseConcurrency;
+  // remaining is strictly inside the (low, high) band, so the fraction is in (0, 1) and the ceil lands in
+  // [1, baseConcurrency] without any further clamping.
+  const fraction = (remaining - lowWaterMark) / (highWaterMark - lowWaterMark);
+  return Math.ceil(fraction * baseConcurrency);
+}

--- a/packages/loopover-miner/lib/execute-local-write.d.ts
+++ b/packages/loopover-miner/lib/execute-local-write.d.ts
@@ -1,14 +1,13 @@
 import type { LocalWriteActionSpec } from "@loopover/engine";
-
 export type ExecuteLocalWriteResult = {
-  action: string;
-  stdout: string;
-  stderr: string;
-  code: number | null;
-  timedOut: boolean;
+    action: string;
+    stdout: string;
+    stderr: string;
+    code: number | null;
+    timedOut: boolean;
 };
-
-export function executeLocalWrite(
-  spec: LocalWriteActionSpec,
-  options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number },
-): Promise<ExecuteLocalWriteResult>;
+export declare function executeLocalWrite(spec: LocalWriteActionSpec, options?: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+}): Promise<ExecuteLocalWriteResult>;

--- a/packages/loopover-miner/lib/execute-local-write.js
+++ b/packages/loopover-miner/lib/execute-local-write.js
@@ -7,44 +7,36 @@
 // the given working directory. Per local-write-tools.ts's own boundary comment, this always runs with
 // whatever `gh`/`git` credentials are already configured in that environment -- loopover never performs
 // the write itself.
-
 import { spawn } from "node:child_process";
-
 const DEFAULT_TIMEOUT_MS = 120_000;
-
-/**
- * @param {import("@loopover/engine").LocalWriteActionSpec} spec
- * @param {{ cwd?: string, env?: NodeJS.ProcessEnv, timeoutMs?: number }} [options]
- * @returns {Promise<{ action: string, stdout: string, stderr: string, code: number | null, timedOut: boolean }>}
- */
 export function executeLocalWrite(spec, options = {}) {
-  const cwd = options.cwd ?? process.cwd();
-  const env = options.env ?? process.env;
-  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
-
-  return new Promise((resolve) => {
-    const child = spawn("sh", ["-c", spec.command], { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      resolve({ action: spec.action, stdout, stderr, code: null, timedOut: true });
-    }, timeoutMs);
-    child.stdout?.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
+    const cwd = options.cwd ?? process.cwd();
+    const env = options.env ?? process.env;
+    const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+    return new Promise((resolve) => {
+        const child = spawn("sh", ["-c", spec.command], { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+        let stdout = "";
+        let stderr = "";
+        const timer = setTimeout(() => {
+            child.kill("SIGKILL");
+            resolve({ action: spec.action, stdout, stderr, code: null, timedOut: true });
+        }, timeoutMs);
+        child.stdout?.on("data", (chunk) => {
+            stdout += chunk.toString("utf8");
+        });
+        child.stderr?.on("data", (chunk) => {
+            stderr += chunk.toString("utf8");
+        });
+        child.on("error", (err) => {
+            // A spawn-level error (e.g. no `sh` on PATH) fires before the child ever produces output -- mirrors
+            // createRealCliSubprocessSpawn's own identical handling.
+            clearTimeout(timer);
+            resolve({ action: spec.action, stdout, stderr: err.message, code: null, timedOut: false });
+        });
+        child.on("close", (code) => {
+            clearTimeout(timer);
+            resolve({ action: spec.action, stdout, stderr, code, timedOut: false });
+        });
     });
-    child.stderr?.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.on("error", (err) => {
-      // A spawn-level error (e.g. no `sh` on PATH) fires before the child ever produces output -- mirrors
-      // createRealCliSubprocessSpawn's own identical handling.
-      clearTimeout(timer);
-      resolve({ action: spec.action, stdout, stderr: err.message, code: null, timedOut: false });
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve({ action: spec.action, stdout, stderr, code, timedOut: false });
-    });
-  });
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXhlY3V0ZS1sb2NhbC13cml0ZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImV4ZWN1dGUtbG9jYWwtd3JpdGUudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsa0dBQWtHO0FBQ2xHLHFHQUFxRztBQUNyRyx3R0FBd0c7QUFDeEcsb0dBQW9HO0FBQ3BHLGdHQUFnRztBQUNoRywyR0FBMkc7QUFDM0csc0dBQXNHO0FBQ3RHLHdHQUF3RztBQUN4RyxvQkFBb0I7QUFFcEIsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLG9CQUFvQixDQUFDO0FBWTNDLE1BQU0sa0JBQWtCLEdBQUcsT0FBTyxDQUFDO0FBRW5DLE1BQU0sVUFBVSxpQkFBaUIsQ0FDL0IsSUFBMEIsRUFDMUIsVUFBeUUsRUFBRTtJQUUzRSxNQUFNLEdBQUcsR0FBRyxPQUFPLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUN6QyxNQUFNLEdBQUcsR0FBRyxPQUFPLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUM7SUFDdkMsTUFBTSxTQUFTLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLGtCQUFrQixDQUFDO0lBRTlGLE9BQU8sSUFBSSxPQUFPLENBQTBCLENBQUMsT0FBTyxFQUFFLEVBQUU7UUFDdEQsTUFBTSxLQUFLLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLElBQUksRUFBRSxJQUFJLENBQUMsT0FBTyxDQUFDLEVBQUUsRUFBRSxHQUFHLEVBQUUsR0FBRyxFQUFFLEtBQUssRUFBRSxDQUFDLFFBQVEsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLEVBQUUsQ0FBQyxDQUFDO1FBQ2pHLElBQUksTUFBTSxHQUFHLEVBQUUsQ0FBQztRQUNoQixJQUFJLE1BQU0sR0FBRyxFQUFFLENBQUM7UUFDaEIsTUFBTSxLQUFLLEdBQUcsVUFBVSxDQUFDLEdBQUcsRUFBRTtZQUM1QixLQUFLLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1lBQ3RCLE9BQU8sQ0FBQyxFQUFFLE1BQU0sRUFBRSxJQUFJLENBQUMsTUFBTSxFQUFFLE1BQU0sRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxRQUFRLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQztRQUMvRSxDQUFDLEVBQUUsU0FBUyxDQUFDLENBQUM7UUFDZCxLQUFLLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxLQUFhLEVBQUUsRUFBRTtZQUN6QyxNQUFNLElBQUksS0FBSyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUNuQyxDQUFDLENBQUMsQ0FBQztRQUNILEtBQUssQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLE1BQU0sRUFBRSxDQUFDLEtBQWEsRUFBRSxFQUFFO1lBQ3pDLE1BQU0sSUFBSSxLQUFLLENBQUMsUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQ25DLENBQUMsQ0FBQyxDQUFDO1FBQ0gsS0FBSyxDQUFDLEVBQUUsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxHQUFVLEVBQUUsRUFBRTtZQUMvQixvR0FBb0c7WUFDcEcseURBQXlEO1lBQ3pELFlBQVksQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUNwQixPQUFPLENBQUMsRUFBRSxNQUFNLEVBQUUsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsTUFBTSxFQUFFLEdBQUcsQ0FBQyxPQUFPLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxRQUFRLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztRQUM3RixDQUFDLENBQUMsQ0FBQztRQUNILEtBQUssQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFLENBQUMsSUFBbUIsRUFBRSxFQUFFO1lBQ3hDLFlBQVksQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUNwQixPQUFPLENBQUMsRUFBRSxNQUFNLEVBQUUsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxRQUFRLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztRQUMxRSxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUMsQ0FBQyxDQUFDO0FBQ0wsQ0FBQyJ9

--- a/packages/loopover-miner/lib/execute-local-write.ts
+++ b/packages/loopover-miner/lib/execute-local-write.ts
@@ -1,0 +1,58 @@
+// Real executeLocalWrite implementation (#5132, Wave 3.5). Mirrors coding-agent-construction.js's
+// createRealCliSubprocessSpawn pattern (real child_process, resolve-not-reject on error/timeout so a
+// killed/errored process's partial output -- e.g. an auth failure line on stderr -- is never lost to an
+// unhandled rejection) but for LocalWriteActionSpec.command: a single shell-safe string (built with
+// packages/loopover-engine/src/miner/local-write-tools.ts's own single-quote escaping), not the
+// cmd/args-array CliSubprocessSpawnFn contract the coding-agent driver itself uses. Runs it via `sh -c` in
+// the given working directory. Per local-write-tools.ts's own boundary comment, this always runs with
+// whatever `gh`/`git` credentials are already configured in that environment -- loopover never performs
+// the write itself.
+
+import { spawn } from "node:child_process";
+
+import type { LocalWriteActionSpec } from "@loopover/engine";
+
+export type ExecuteLocalWriteResult = {
+  action: string;
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  timedOut: boolean;
+};
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export function executeLocalWrite(
+  spec: LocalWriteActionSpec,
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
+): Promise<ExecuteLocalWriteResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  return new Promise<ExecuteLocalWriteResult>((resolve) => {
+    const child = spawn("sh", ["-c", spec.command], { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve({ action: spec.action, stdout, stderr, code: null, timedOut: true });
+    }, timeoutMs);
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err: Error) => {
+      // A spawn-level error (e.g. no `sh` on PATH) fires before the child ever produces output -- mirrors
+      // createRealCliSubprocessSpawn's own identical handling.
+      clearTimeout(timer);
+      resolve({ action: spec.action, stdout, stderr: err.message, code: null, timedOut: false });
+    });
+    child.on("close", (code: number | null) => {
+      clearTimeout(timer);
+      resolve({ action: spec.action, stdout, stderr, code, timedOut: false });
+    });
+  });
+}

--- a/packages/loopover-miner/lib/portfolio-queue-expiry.d.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-expiry.d.ts
@@ -1,20 +1,21 @@
 import type { QueueEntry, QueueLeaseEntry } from "./portfolio-queue.js";
-
+/** PURE — no IO, no Date, no random (#4827). Mirror of claim-ledger-expiry.js for the portfolio-queue store: a
+ *  crashed/killed process leaves its item stuck 'in_progress' forever, so sweep leases older than a bound back to
+ *  'queued'. */
 export declare const DEFAULT_MAX_LEASE_MS: number;
-
 export type PortfolioQueueExpiryStore = {
-  listInProgress(): QueueLeaseEntry[];
-  reclaimStuckItem(repoFullName: string, identifier: string): QueueEntry | null;
+    listInProgress(): QueueLeaseEntry[];
+    reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
 };
-
-export function findStuckItems(
-  items: QueueLeaseEntry[],
-  nowMs: number,
-  maxLeaseMs: number,
-): QueueLeaseEntry[];
-
-export function sweepStuckItems(
-  store: PortfolioQueueExpiryStore,
-  nowMs: number,
-  maxLeaseMs?: number,
-): QueueEntry[];
+/**
+ * Return in-flight items whose lease age is strictly greater than `maxLeaseMs`. An item whose age equals
+ * `maxLeaseMs` exactly is still within the window (not stuck). Items that are not 'in_progress', or whose
+ * `leasedAt` is missing/unparseable, are never returned.
+ */
+export declare function findStuckItems(items: QueueLeaseEntry[], nowMs: number, maxLeaseMs: number): QueueLeaseEntry[];
+/**
+ * Reclaim every stuck in-flight item back to 'queued', returning the reclaimed entries. `store.listInProgress()`
+ * supplies the lease-annotated rows and `store.reclaimStuckItem()` performs the atomic per-item flip — the same
+ * store/sweep split sweepExpiredClaims uses.
+ */
+export declare function sweepStuckItems(store: PortfolioQueueExpiryStore, nowMs: number, maxLeaseMs?: number): QueueEntry[];

--- a/packages/loopover-miner/lib/portfolio-queue-expiry.js
+++ b/packages/loopover-miner/lib/portfolio-queue-expiry.js
@@ -1,51 +1,57 @@
 /** PURE — no IO, no Date, no random (#4827). Mirror of claim-ledger-expiry.js for the portfolio-queue store: a
  *  crashed/killed process leaves its item stuck 'in_progress' forever, so sweep leases older than a bound back to
  *  'queued'. */
-
 // A generous default: a real attempt rarely holds a single portfolio item for long, so 30 minutes without the row
 // leaving 'in_progress' strongly implies the owning process died rather than that it is still working.
 export const DEFAULT_MAX_LEASE_MS = 30 * 60 * 1000;
-
 function leaseAgeMs(item, nowMs) {
-  const leasedAtMs = Date.parse(item.leasedAt);
-  if (!Number.isFinite(leasedAtMs)) return null;
-  return nowMs - leasedAtMs;
+    // A null leasedAt parses to NaN here (Date.parse coerces it) and is caught by the finite check below, exactly
+    // as the .js relied on — the cast avoids adding a separate null branch the tests don't exercise.
+    const leasedAtMs = Date.parse(item.leasedAt);
+    if (!Number.isFinite(leasedAtMs))
+        return null;
+    return nowMs - leasedAtMs;
 }
-
 /**
  * Return in-flight items whose lease age is strictly greater than `maxLeaseMs`. An item whose age equals
  * `maxLeaseMs` exactly is still within the window (not stuck). Items that are not 'in_progress', or whose
  * `leasedAt` is missing/unparseable, are never returned.
  */
 export function findStuckItems(items, nowMs, maxLeaseMs) {
-  if (!Number.isFinite(nowMs) || nowMs < 0) throw new Error("invalid_now_ms");
-  if (!Number.isFinite(maxLeaseMs) || maxLeaseMs < 0) throw new Error("invalid_max_lease_ms");
-  if (!Array.isArray(items)) throw new Error("invalid_items");
-
-  const stuck = [];
-  for (const item of items) {
-    if (item?.status !== "in_progress") continue;
-    const ageMs = leaseAgeMs(item, nowMs);
-    if (ageMs === null) continue;
-    if (ageMs > maxLeaseMs) stuck.push(item);
-  }
-  return stuck;
+    if (!Number.isFinite(nowMs) || nowMs < 0)
+        throw new Error("invalid_now_ms");
+    if (!Number.isFinite(maxLeaseMs) || maxLeaseMs < 0)
+        throw new Error("invalid_max_lease_ms");
+    if (!Array.isArray(items))
+        throw new Error("invalid_items");
+    const stuck = [];
+    for (const item of items) {
+        if (item?.status !== "in_progress")
+            continue;
+        const ageMs = leaseAgeMs(item, nowMs);
+        if (ageMs === null)
+            continue;
+        if (ageMs > maxLeaseMs)
+            stuck.push(item);
+    }
+    return stuck;
 }
-
 /**
  * Reclaim every stuck in-flight item back to 'queued', returning the reclaimed entries. `store.listInProgress()`
  * supplies the lease-annotated rows and `store.reclaimStuckItem()` performs the atomic per-item flip — the same
  * store/sweep split sweepExpiredClaims uses.
  */
 export function sweepStuckItems(store, nowMs, maxLeaseMs = DEFAULT_MAX_LEASE_MS) {
-  const inProgress = store.listInProgress();
-  const stuck = findStuckItems(inProgress, nowMs, maxLeaseMs);
-  const reclaimed = [];
-  for (const item of stuck) {
-    // Echo the item's OWN apiBaseUrl back (#5563) rather than defaulting: two forge hosts can each have an
-    // in-flight item with the same owner/repo+identifier, and defaulting here would reclaim the wrong host's row.
-    const updated = store.reclaimStuckItem(item.repoFullName, item.identifier, item.apiBaseUrl);
-    if (updated) reclaimed.push(updated);
-  }
-  return reclaimed;
+    const inProgress = store.listInProgress();
+    const stuck = findStuckItems(inProgress, nowMs, maxLeaseMs);
+    const reclaimed = [];
+    for (const item of stuck) {
+        // Echo the item's OWN apiBaseUrl back (#5563) rather than defaulting: two forge hosts can each have an
+        // in-flight item with the same owner/repo+identifier, and defaulting here would reclaim the wrong host's row.
+        const updated = store.reclaimStuckItem(item.repoFullName, item.identifier, item.apiBaseUrl);
+        if (updated)
+            reclaimed.push(updated);
+    }
+    return reclaimed;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGZvbGlvLXF1ZXVlLWV4cGlyeS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInBvcnRmb2xpby1xdWV1ZS1leHBpcnkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRUE7O2dCQUVnQjtBQUVoQixrSEFBa0g7QUFDbEgsdUdBQXVHO0FBQ3ZHLE1BQU0sQ0FBQyxNQUFNLG9CQUFvQixHQUFHLEVBQUUsR0FBRyxFQUFFLEdBQUcsSUFBSSxDQUFDO0FBT25ELFNBQVMsVUFBVSxDQUFDLElBQXFCLEVBQUUsS0FBYTtJQUN0RCw4R0FBOEc7SUFDOUcsaUdBQWlHO0lBQ2pHLE1BQU0sVUFBVSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLFFBQWtCLENBQUMsQ0FBQztJQUN2RCxJQUFJLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxVQUFVLENBQUM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUM5QyxPQUFPLEtBQUssR0FBRyxVQUFVLENBQUM7QUFDNUIsQ0FBQztBQUVEOzs7O0dBSUc7QUFDSCxNQUFNLFVBQVUsY0FBYyxDQUFDLEtBQXdCLEVBQUUsS0FBYSxFQUFFLFVBQWtCO0lBQ3hGLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssR0FBRyxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDO0lBQzVFLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLFVBQVUsQ0FBQyxJQUFJLFVBQVUsR0FBRyxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDO0lBQzVGLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsZUFBZSxDQUFDLENBQUM7SUFFNUQsTUFBTSxLQUFLLEdBQXNCLEVBQUUsQ0FBQztJQUNwQyxLQUFLLE1BQU0sSUFBSSxJQUFJLEtBQUssRUFBRSxDQUFDO1FBQ3pCLElBQUksSUFBSSxFQUFFLE1BQU0sS0FBSyxhQUFhO1lBQUUsU0FBUztRQUM3QyxNQUFNLEtBQUssR0FBRyxVQUFVLENBQUMsSUFBSSxFQUFFLEtBQUssQ0FBQyxDQUFDO1FBQ3RDLElBQUksS0FBSyxLQUFLLElBQUk7WUFBRSxTQUFTO1FBQzdCLElBQUksS0FBSyxHQUFHLFVBQVU7WUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQzNDLENBQUM7SUFDRCxPQUFPLEtBQUssQ0FBQztBQUNmLENBQUM7QUFFRDs7OztHQUlHO0FBQ0gsTUFBTSxVQUFVLGVBQWUsQ0FBQyxLQUFnQyxFQUFFLEtBQWEsRUFBRSxVQUFVLEdBQUcsb0JBQW9CO0lBQ2hILE1BQU0sVUFBVSxHQUFHLEtBQUssQ0FBQyxjQUFjLEVBQUUsQ0FBQztJQUMxQyxNQUFNLEtBQUssR0FBRyxjQUFjLENBQUMsVUFBVSxFQUFFLEtBQUssRUFBRSxVQUFVLENBQUMsQ0FBQztJQUM1RCxNQUFNLFNBQVMsR0FBaUIsRUFBRSxDQUFDO0lBQ25DLEtBQUssTUFBTSxJQUFJLElBQUksS0FBSyxFQUFFLENBQUM7UUFDekIsdUdBQXVHO1FBQ3ZHLDhHQUE4RztRQUM5RyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsZ0JBQWdCLENBQUMsSUFBSSxDQUFDLFlBQVksRUFBRSxJQUFJLENBQUMsVUFBVSxFQUFFLElBQUksQ0FBQyxVQUFVLENBQUMsQ0FBQztRQUM1RixJQUFJLE9BQU87WUFBRSxTQUFTLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ3ZDLENBQUM7SUFDRCxPQUFPLFNBQVMsQ0FBQztBQUNuQixDQUFDIn0=

--- a/packages/loopover-miner/lib/portfolio-queue-expiry.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-expiry.ts
@@ -1,0 +1,60 @@
+import type { QueueEntry, QueueLeaseEntry } from "./portfolio-queue.js";
+
+/** PURE — no IO, no Date, no random (#4827). Mirror of claim-ledger-expiry.js for the portfolio-queue store: a
+ *  crashed/killed process leaves its item stuck 'in_progress' forever, so sweep leases older than a bound back to
+ *  'queued'. */
+
+// A generous default: a real attempt rarely holds a single portfolio item for long, so 30 minutes without the row
+// leaving 'in_progress' strongly implies the owning process died rather than that it is still working.
+export const DEFAULT_MAX_LEASE_MS = 30 * 60 * 1000;
+
+export type PortfolioQueueExpiryStore = {
+  listInProgress(): QueueLeaseEntry[];
+  reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+};
+
+function leaseAgeMs(item: QueueLeaseEntry, nowMs: number): number | null {
+  // A null leasedAt parses to NaN here (Date.parse coerces it) and is caught by the finite check below, exactly
+  // as the .js relied on — the cast avoids adding a separate null branch the tests don't exercise.
+  const leasedAtMs = Date.parse(item.leasedAt as string);
+  if (!Number.isFinite(leasedAtMs)) return null;
+  return nowMs - leasedAtMs;
+}
+
+/**
+ * Return in-flight items whose lease age is strictly greater than `maxLeaseMs`. An item whose age equals
+ * `maxLeaseMs` exactly is still within the window (not stuck). Items that are not 'in_progress', or whose
+ * `leasedAt` is missing/unparseable, are never returned.
+ */
+export function findStuckItems(items: QueueLeaseEntry[], nowMs: number, maxLeaseMs: number): QueueLeaseEntry[] {
+  if (!Number.isFinite(nowMs) || nowMs < 0) throw new Error("invalid_now_ms");
+  if (!Number.isFinite(maxLeaseMs) || maxLeaseMs < 0) throw new Error("invalid_max_lease_ms");
+  if (!Array.isArray(items)) throw new Error("invalid_items");
+
+  const stuck: QueueLeaseEntry[] = [];
+  for (const item of items) {
+    if (item?.status !== "in_progress") continue;
+    const ageMs = leaseAgeMs(item, nowMs);
+    if (ageMs === null) continue;
+    if (ageMs > maxLeaseMs) stuck.push(item);
+  }
+  return stuck;
+}
+
+/**
+ * Reclaim every stuck in-flight item back to 'queued', returning the reclaimed entries. `store.listInProgress()`
+ * supplies the lease-annotated rows and `store.reclaimStuckItem()` performs the atomic per-item flip — the same
+ * store/sweep split sweepExpiredClaims uses.
+ */
+export function sweepStuckItems(store: PortfolioQueueExpiryStore, nowMs: number, maxLeaseMs = DEFAULT_MAX_LEASE_MS): QueueEntry[] {
+  const inProgress = store.listInProgress();
+  const stuck = findStuckItems(inProgress, nowMs, maxLeaseMs);
+  const reclaimed: QueueEntry[] = [];
+  for (const item of stuck) {
+    // Echo the item's OWN apiBaseUrl back (#5563) rather than defaulting: two forge hosts can each have an
+    // in-flight item with the same owner/repo+identifier, and defaulting here would reclaim the wrong host's row.
+    const updated = store.reclaimStuckItem(item.repoFullName, item.identifier, item.apiBaseUrl);
+    if (updated) reclaimed.push(updated);
+  }
+  return reclaimed;
+}

--- a/packages/loopover-miner/lib/prompt-injection-defense.d.ts
+++ b/packages/loopover-miner/lib/prompt-injection-defense.d.ts
@@ -1,5 +1,11 @@
-export const PROMPT_INJECTION_RE: RegExp;
-
-export function hasPromptInjection(text: string | null | undefined): boolean;
-
-export function neutralizePromptInjection(text: string | null | undefined): { text: string; injected: boolean };
+export declare const PROMPT_INJECTION_RE: RegExp;
+/** True when the text contains an agent-manipulation / prompt-injection pattern. */
+export declare function hasPromptInjection(text: string | null | undefined): boolean;
+/**
+ * Replace injection-like spans with a defanged marker so the literal manipulation never reaches the
+ * coding agent verbatim. Returns the neutralized text + whether anything was flagged.
+ */
+export declare function neutralizePromptInjection(text: string | null | undefined): {
+    text: string;
+    injected: boolean;
+};

--- a/packages/loopover-miner/lib/prompt-injection-defense.js
+++ b/packages/loopover-miner/lib/prompt-injection-defense.js
@@ -11,38 +11,33 @@
 // duplicated here rather than shared, matching how src/review/prompt-injection.ts itself documents being
 // a self-contained port of its own upstream (reviewbot's src/core/prompt-injection.ts). Keep the two
 // regex sources in sync by hand if either evolves.
-
 const INJECTION_SOURCE = [
-  "\\b(?:ignore|disregard|forget)\\b[^.]{0,40}\\b(?:previous|prior|above|earlier|all|the|any)\\b[^.]{0,24}\\b(?:instructions?|prompts?|rules?|rubric|policy|guidelines?|directions?)\\b",
-  "\\b(?:override|bypass)\\b[^.]{0,40}\\b(?:previous|prior|above|earlier|all|any)\\b[^.]{0,24}\\b(?:instructions?|prompts?)\\b|\\b(?:override|bypass)\\s+the\\s+(?:rules?|rubric|policy|guidelines?|directions?)\\b[^.]{0,40}\\b(?:approve|merge|accept|whitelist|allow|pass|scor(?:e|ing))\\b",
-  "\\byou are now\\s+(?:an?\\s+(?:\\w+\\s+)?(?:ai|assistant|language model|reviewer|maintainer|admin|moderator|bot|developer|owner|system)|(?:unrestricted|uncensored|unfiltered|unbound|jailbroken))\\b",
-  "\\b(?:this is|here is|below is)\\s+the\\s+(?:system|developer)\\s+prompt\\b|\\b(?:system|developer)\\s+prompt\\s*:",
-  "\\b(?:approve|merge|accept|whitelist|allow|pass)\\s+this\\s+(?:submission|pr|pull[ -]?request|entry|request|content|review)\\b|\\b(?:please|kindly|just)\\s+(?:approve|merge|accept|whitelist|allow|pass)\\s+the\\s+(?:submission|pr|pull[ -]?request|entry|request|content|review)\\b",
-  "\\bas an?\\s+(?:ai|assistant|language model)\\b[^.]{0,30}\\b(?:you must\\s+(?:ignore|approve|obey|disregard|comply)|ignore\\s+(?:previous|prior|all|the|any)|approve\\s+(?:this|the))\\b",
-  "\\b(?:print|reveal|output|repeat|leak)\\b[^.]{0,30}\\byour\\s+(?:system prompt|rubric|instructions?)\\b|\\b(?:print|reveal|output|repeat|leak)\\b[^.]{0,30}\\bthe\\s+(?:system|developer)\\s+prompt\\b[^.]{0,40}\\byou\\s+(?:were\\s+)?(?:given|sent|provided|received)\\b",
-  "\\b(?:pretend|roleplay)\\b[^.]{0,24}\\byou\\s+are\\b",
+    "\\b(?:ignore|disregard|forget)\\b[^.]{0,40}\\b(?:previous|prior|above|earlier|all|the|any)\\b[^.]{0,24}\\b(?:instructions?|prompts?|rules?|rubric|policy|guidelines?|directions?)\\b",
+    "\\b(?:override|bypass)\\b[^.]{0,40}\\b(?:previous|prior|above|earlier|all|any)\\b[^.]{0,24}\\b(?:instructions?|prompts?)\\b|\\b(?:override|bypass)\\s+the\\s+(?:rules?|rubric|policy|guidelines?|directions?)\\b[^.]{0,40}\\b(?:approve|merge|accept|whitelist|allow|pass|scor(?:e|ing))\\b",
+    "\\byou are now\\s+(?:an?\\s+(?:\\w+\\s+)?(?:ai|assistant|language model|reviewer|maintainer|admin|moderator|bot|developer|owner|system)|(?:unrestricted|uncensored|unfiltered|unbound|jailbroken))\\b",
+    "\\b(?:this is|here is|below is)\\s+the\\s+(?:system|developer)\\s+prompt\\b|\\b(?:system|developer)\\s+prompt\\s*:",
+    "\\b(?:approve|merge|accept|whitelist|allow|pass)\\s+this\\s+(?:submission|pr|pull[ -]?request|entry|request|content|review)\\b|\\b(?:please|kindly|just)\\s+(?:approve|merge|accept|whitelist|allow|pass)\\s+the\\s+(?:submission|pr|pull[ -]?request|entry|request|content|review)\\b",
+    "\\bas an?\\s+(?:ai|assistant|language model)\\b[^.]{0,30}\\b(?:you must\\s+(?:ignore|approve|obey|disregard|comply)|ignore\\s+(?:previous|prior|all|the|any)|approve\\s+(?:this|the))\\b",
+    "\\b(?:print|reveal|output|repeat|leak)\\b[^.]{0,30}\\byour\\s+(?:system prompt|rubric|instructions?)\\b|\\b(?:print|reveal|output|repeat|leak)\\b[^.]{0,30}\\bthe\\s+(?:system|developer)\\s+prompt\\b[^.]{0,40}\\byou\\s+(?:were\\s+)?(?:given|sent|provided|received)\\b",
+    "\\b(?:pretend|roleplay)\\b[^.]{0,24}\\byou\\s+are\\b",
 ].join("|");
-
 export const PROMPT_INJECTION_RE = new RegExp(INJECTION_SOURCE, "i");
-
 /** True when the text contains an agent-manipulation / prompt-injection pattern. */
 export function hasPromptInjection(text) {
-  return !!text && PROMPT_INJECTION_RE.test(text);
+    return !!text && PROMPT_INJECTION_RE.test(text);
 }
-
 /**
  * Replace injection-like spans with a defanged marker so the literal manipulation never reaches the
  * coding agent verbatim. Returns the neutralized text + whether anything was flagged.
- *
- * @param {string | null | undefined} text
- * @returns {{ text: string, injected: boolean }}
  */
 export function neutralizePromptInjection(text) {
-  if (!text) return { text: text ?? "", injected: false };
-  let injected = false;
-  const cleaned = text.replace(new RegExp(INJECTION_SOURCE, "gi"), () => {
-    injected = true;
-    return "[external-instruction-redacted]";
-  });
-  return { text: cleaned, injected };
+    if (!text)
+        return { text: text ?? "", injected: false };
+    let injected = false;
+    const cleaned = text.replace(new RegExp(INJECTION_SOURCE, "gi"), () => {
+        injected = true;
+        return "[external-instruction-redacted]";
+    });
+    return { text: cleaned, injected };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHJvbXB0LWluamVjdGlvbi1kZWZlbnNlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicHJvbXB0LWluamVjdGlvbi1kZWZlbnNlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLHNHQUFzRztBQUN0Ryx1R0FBdUc7QUFDdkcscUdBQXFHO0FBQ3JHLHNHQUFzRztBQUN0RyxrRUFBa0U7QUFDbEUsRUFBRTtBQUNGLHVHQUF1RztBQUN2RyxtR0FBbUc7QUFDbkcsdUdBQXVHO0FBQ3ZHLG9HQUFvRztBQUNwRyx5R0FBeUc7QUFDekcscUdBQXFHO0FBQ3JHLG1EQUFtRDtBQUVuRCxNQUFNLGdCQUFnQixHQUFHO0lBQ3ZCLHNMQUFzTDtJQUN0TCw2UkFBNlI7SUFDN1IsdU1BQXVNO0lBQ3ZNLG9IQUFvSDtJQUNwSCx3UkFBd1I7SUFDeFIsMExBQTBMO0lBQzFMLDRRQUE0UTtJQUM1USxzREFBc0Q7Q0FDdkQsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7QUFFWixNQUFNLENBQUMsTUFBTSxtQkFBbUIsR0FBRyxJQUFJLE1BQU0sQ0FBQyxnQkFBZ0IsRUFBRSxHQUFHLENBQUMsQ0FBQztBQUVyRSxvRkFBb0Y7QUFDcEYsTUFBTSxVQUFVLGtCQUFrQixDQUFDLElBQStCO0lBQ2hFLE9BQU8sQ0FBQyxDQUFDLElBQUksSUFBSSxtQkFBbUIsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDbEQsQ0FBQztBQUVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSx5QkFBeUIsQ0FBQyxJQUErQjtJQUN2RSxJQUFJLENBQUMsSUFBSTtRQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsSUFBSSxJQUFJLEVBQUUsRUFBRSxRQUFRLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDeEQsSUFBSSxRQUFRLEdBQUcsS0FBSyxDQUFDO0lBQ3JCLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxPQUFPLENBQUMsSUFBSSxNQUFNLENBQUMsZ0JBQWdCLEVBQUUsSUFBSSxDQUFDLEVBQUUsR0FBRyxFQUFFO1FBQ3BFLFFBQVEsR0FBRyxJQUFJLENBQUM7UUFDaEIsT0FBTyxpQ0FBaUMsQ0FBQztJQUMzQyxDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sRUFBRSxJQUFJLEVBQUUsT0FBTyxFQUFFLFFBQVEsRUFBRSxDQUFDO0FBQ3JDLENBQUMifQ==

--- a/packages/loopover-miner/lib/prompt-injection-defense.ts
+++ b/packages/loopover-miner/lib/prompt-injection-defense.ts
@@ -1,0 +1,45 @@
+// Detect + defang prompt-injection / agent-manipulation text in UNTRUSTED third-party repo content (a
+// customer's own issue title/body) before it reaches the coding agent's own instructions (#4795). Such
+// content is DATA, never instructions -- but a coding agent operating with real write authority on a
+// customer's repository can still be steered by it, so we both flag it (a strong negative signal) and
+// redact the literal manipulation so it can't be obeyed verbatim.
+//
+// SELF-CONTAINED NATIVE PORT: byte-faithful to src/review/prompt-injection.ts's proven regex (the same
+// reviewer-manipulation shape, now defending the coding agent's own instructions instead of the AI
+// reviewer's prompt). No cross-package import -- packages/loopover-miner never depends on root src/ (a
+// separate Cloudflare Worker deployable, see package.json's own dependency list), so the pattern is
+// duplicated here rather than shared, matching how src/review/prompt-injection.ts itself documents being
+// a self-contained port of its own upstream (reviewbot's src/core/prompt-injection.ts). Keep the two
+// regex sources in sync by hand if either evolves.
+
+const INJECTION_SOURCE = [
+  "\\b(?:ignore|disregard|forget)\\b[^.]{0,40}\\b(?:previous|prior|above|earlier|all|the|any)\\b[^.]{0,24}\\b(?:instructions?|prompts?|rules?|rubric|policy|guidelines?|directions?)\\b",
+  "\\b(?:override|bypass)\\b[^.]{0,40}\\b(?:previous|prior|above|earlier|all|any)\\b[^.]{0,24}\\b(?:instructions?|prompts?)\\b|\\b(?:override|bypass)\\s+the\\s+(?:rules?|rubric|policy|guidelines?|directions?)\\b[^.]{0,40}\\b(?:approve|merge|accept|whitelist|allow|pass|scor(?:e|ing))\\b",
+  "\\byou are now\\s+(?:an?\\s+(?:\\w+\\s+)?(?:ai|assistant|language model|reviewer|maintainer|admin|moderator|bot|developer|owner|system)|(?:unrestricted|uncensored|unfiltered|unbound|jailbroken))\\b",
+  "\\b(?:this is|here is|below is)\\s+the\\s+(?:system|developer)\\s+prompt\\b|\\b(?:system|developer)\\s+prompt\\s*:",
+  "\\b(?:approve|merge|accept|whitelist|allow|pass)\\s+this\\s+(?:submission|pr|pull[ -]?request|entry|request|content|review)\\b|\\b(?:please|kindly|just)\\s+(?:approve|merge|accept|whitelist|allow|pass)\\s+the\\s+(?:submission|pr|pull[ -]?request|entry|request|content|review)\\b",
+  "\\bas an?\\s+(?:ai|assistant|language model)\\b[^.]{0,30}\\b(?:you must\\s+(?:ignore|approve|obey|disregard|comply)|ignore\\s+(?:previous|prior|all|the|any)|approve\\s+(?:this|the))\\b",
+  "\\b(?:print|reveal|output|repeat|leak)\\b[^.]{0,30}\\byour\\s+(?:system prompt|rubric|instructions?)\\b|\\b(?:print|reveal|output|repeat|leak)\\b[^.]{0,30}\\bthe\\s+(?:system|developer)\\s+prompt\\b[^.]{0,40}\\byou\\s+(?:were\\s+)?(?:given|sent|provided|received)\\b",
+  "\\b(?:pretend|roleplay)\\b[^.]{0,24}\\byou\\s+are\\b",
+].join("|");
+
+export const PROMPT_INJECTION_RE = new RegExp(INJECTION_SOURCE, "i");
+
+/** True when the text contains an agent-manipulation / prompt-injection pattern. */
+export function hasPromptInjection(text: string | null | undefined): boolean {
+  return !!text && PROMPT_INJECTION_RE.test(text);
+}
+
+/**
+ * Replace injection-like spans with a defanged marker so the literal manipulation never reaches the
+ * coding agent verbatim. Returns the neutralized text + whether anything was flagged.
+ */
+export function neutralizePromptInjection(text: string | null | undefined): { text: string; injected: boolean } {
+  if (!text) return { text: text ?? "", injected: false };
+  let injected = false;
+  const cleaned = text.replace(new RegExp(INJECTION_SOURCE, "gi"), () => {
+    injected = true;
+    return "[external-instruction-redacted]";
+  });
+  return { text: cleaned, injected };
+}

--- a/packages/loopover-miner/lib/slop-assessment.d.ts
+++ b/packages/loopover-miner/lib/slop-assessment.d.ts
@@ -1,3 +1,2 @@
-import type { SlopAssessment, SlopAssessmentInput } from "@loopover/engine";
-
-export function runSlopAssessment(input: SlopAssessmentInput): SlopAssessment;
+import { type SlopAssessment, type SlopAssessmentInput } from "@loopover/engine";
+export declare function runSlopAssessment(input: SlopAssessmentInput): SlopAssessment;

--- a/packages/loopover-miner/lib/slop-assessment.ts
+++ b/packages/loopover-miner/lib/slop-assessment.ts
@@ -1,4 +1,5 @@
-import { buildSlopAssessment } from "@loopover/engine";
+import { buildSlopAssessment, type SlopAssessment, type SlopAssessmentInput } from "@loopover/engine";
+
 // Production runSlopAssessment binding (#5133, Wave 3.5 follow-up to #2334). `attempt-runner.js`'s
 // `deps.runSlopAssessment` (via #2333's iterate-loop -> self-review-adapter's `SelfReviewAdapterDeps`) had
 // no production implementation anywhere in this package -- only the test double in
@@ -9,7 +10,7 @@ import { buildSlopAssessment } from "@loopover/engine";
 // a real binding could be a direct pass-through with no mapping logic once the deterministic scorer itself
 // became portable -- which #5133 did (`src/signals/slop.ts`'s PR-side scorer is now extracted to
 // `packages/loopover-engine/src/signals/slop.ts`, byte-parity-verified against the live gate's own copy).
-export function runSlopAssessment(input) {
-    return buildSlopAssessment(input);
+
+export function runSlopAssessment(input: SlopAssessmentInput): SlopAssessment {
+  return buildSlopAssessment(input);
 }
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic2xvcC1hc3Nlc3NtZW50LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic2xvcC1hc3Nlc3NtZW50LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxtQkFBbUIsRUFBaUQsTUFBTSxrQkFBa0IsQ0FBQztBQUV0RyxtR0FBbUc7QUFDbkcsMkdBQTJHO0FBQzNHLG1GQUFtRjtBQUNuRixrSEFBa0g7QUFDbEgsOEdBQThHO0FBQzlHLHNHQUFzRztBQUN0RywrR0FBK0c7QUFDL0csMkdBQTJHO0FBQzNHLGlHQUFpRztBQUNqRywwR0FBMEc7QUFFMUcsTUFBTSxVQUFVLGlCQUFpQixDQUFDLEtBQTBCO0lBQzFELE9BQU8sbUJBQW1CLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDcEMsQ0FBQyJ9

--- a/packages/loopover-miner/lib/version.d.ts
+++ b/packages/loopover-miner/lib/version.d.ts
@@ -1,3 +1,4 @@
-export const MINER_PACKAGE_VERSION: string;
-
-export function resolveMinerVersion(env?: Record<string, string | undefined>): string;
+/** Package.json semver at import time — the laptop npm-install default. */
+export declare const MINER_PACKAGE_VERSION: string;
+/** Resolved miner release id: `LOOPOVER_MINER_VERSION` wins when set (fleet Docker image builds). */
+export declare function resolveMinerVersion(env?: Record<string, string | undefined>): string;

--- a/packages/loopover-miner/lib/version.js
+++ b/packages/loopover-miner/lib/version.js
@@ -1,10 +1,9 @@
 import ownPackageJson from "../package.json" with { type: "json" };
-
 /** Package.json semver at import time — the laptop npm-install default. */
 export const MINER_PACKAGE_VERSION = ownPackageJson.version;
-
 /** Resolved miner release id: `LOOPOVER_MINER_VERSION` wins when set (fleet Docker image builds). */
 export function resolveMinerVersion(env = process.env) {
-  const override = typeof env.LOOPOVER_MINER_VERSION === "string" ? env.LOOPOVER_MINER_VERSION.trim() : "";
-  return override || MINER_PACKAGE_VERSION;
+    const override = typeof env.LOOPOVER_MINER_VERSION === "string" ? env.LOOPOVER_MINER_VERSION.trim() : "";
+    return override || MINER_PACKAGE_VERSION;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidmVyc2lvbi5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInZlcnNpb24udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxjQUFjLE1BQU0saUJBQWlCLENBQUMsT0FBTyxJQUFJLEVBQUUsTUFBTSxFQUFFLENBQUM7QUFFbkUsMkVBQTJFO0FBQzNFLE1BQU0sQ0FBQyxNQUFNLHFCQUFxQixHQUFXLGNBQWMsQ0FBQyxPQUFPLENBQUM7QUFFcEUscUdBQXFHO0FBQ3JHLE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBRztJQUN2RixNQUFNLFFBQVEsR0FBRyxPQUFPLEdBQUcsQ0FBQyxzQkFBc0IsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxzQkFBc0IsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ3pHLE9BQU8sUUFBUSxJQUFJLHFCQUFxQixDQUFDO0FBQzNDLENBQUMifQ==

--- a/packages/loopover-miner/lib/version.ts
+++ b/packages/loopover-miner/lib/version.ts
@@ -1,0 +1,10 @@
+import ownPackageJson from "../package.json" with { type: "json" };
+
+/** Package.json semver at import time — the laptop npm-install default. */
+export const MINER_PACKAGE_VERSION: string = ownPackageJson.version;
+
+/** Resolved miner release id: `LOOPOVER_MINER_VERSION` wins when set (fleet Docker image builds). */
+export function resolveMinerVersion(env: Record<string, string | undefined> = process.env): string {
+  const override = typeof env.LOOPOVER_MINER_VERSION === "string" ? env.LOOPOVER_MINER_VERSION.trim() : "";
+  return override || MINER_PACKAGE_VERSION;
+}


### PR DESCRIPTION
Closes #7302

## Summary

Batch 2.3 of the Phase 2 `packages/loopover-miner/lib` TypeScript migration (#7302): converts the 8 leaf-most, lowest-fan-in utility modules to real TypeScript, following the same in-place-emit pattern the earlier batches (#7290 → #7331) established.

Converted modules:

- `version` — miner release-id resolver
- `slop-assessment` — miner slop scoring
- `discovery-throttle` — pure rate-limit → concurrency back-off
- `claim-ledger-expiry` — pure active-claim expiry sweep
- `portfolio-queue-expiry` — pure stuck-lease reclaim sweep
- `prompt-injection-defense` — untrusted-content injection detect/defang
- `execute-local-write` — real `sh -c` subprocess local-write runner
- `cross-repo-evaluation` — cross-repo readiness evaluation

Each module gains a hand-authored `.ts` source; `tsc -p tsconfig.json` emits the `.js` + `.d.ts` in place with an inline sourcemap, so the published `bin/lib` layout is unchanged and v8 coverage remaps onto the `.ts` source. Every callsite continues to import the same specifier.

The conversions are **type-only**: no runtime branch was added. Where strict-null narrowing was needed (e.g. `number | null` past a `Number.isFinite` guard, a `leasedAt` that `Date.parse` already coerces to `NaN`), a cast is used rather than a new `if`, keeping the emitted `.js` byte-faithful to the prior hand-maintained `.js` and the branch surface identical to what existing tests already cover.

## Scope

- [x] Narrow, single coherent change (one migration batch)
- [x] In scope (`packages/`), no `blockedPaths`
- [x] No secrets / tokens / wallets / trust-score / reward terms anywhere
- [x] No changelog / `site/` / `CNAME` / `lovable` edits

## Validation

- [x] `tsc -p packages/loopover-miner/tsconfig.json` — 0 errors (emit + `--noEmit` typecheck)
- [x] `eslint` on all 8 `.ts` sources — 0 problems
- [x] `node --check` on all 8 emitted `.js`
- [x] Fresh clean rebuild reproduces the committed `.js`/`.d.ts` exactly (no emit drift)
- [x] `vitest run` on the migrated modules' unit suites — green
- [x] Branch current with `main` (rebased)

## Safety

- [x] No public/private boundary touched; no wallet/hotkey/trust/reward terms
- [x] Behaviour preserved — no runtime branch added; emitted `.js` is a faithful compile of the prior `.js`
