### PR TITLE
chore(miner): migrate batch 2.2 utility modules to TypeScript

### DIFF
--- a/packages/loopover-miner/lib/calibration-run.d.ts
+++ b/packages/loopover-miner/lib/calibration-run.d.ts
@@ -1,161 +1,157 @@
-import type {
-  HistoricalReplayCalibrationInput,
-  Phase7CalibrationConfig,
-  Phase7CalibrationLoopResult,
-  Phase7CalibrationManifest,
-  PrOutcomeCalibrationInput,
-  ReplayHarnessStatus,
-} from "@loopover/engine";
-
+import type { HistoricalReplayCalibrationInput, Phase7CalibrationConfig, Phase7CalibrationLoopResult, Phase7CalibrationManifest, PrOutcomeCalibrationInput, ReplayHarnessStatus } from "@loopover/engine";
 import type { AppendEventInput, LedgerEntry } from "./event-ledger.js";
-import type {
-  ObjectiveAnchorResult,
-  ReplayPlanInput,
-  RevealedHistoryEntry,
-} from "./replay-objective-anchor.js";
-
-export const MINER_CALIBRATION_SNAPSHOT_EVENT: "calibration_snapshot";
-
+import type { ObjectiveAnchorResult, ReplayPlanInput, RevealedHistoryEntry } from "./replay-objective-anchor.js";
+/** Event-ledger vocabulary for a persisted Phase 7 calibration snapshot (mirrors MINER_PR_OUTCOME_EVENT). */
+export declare const MINER_CALIBRATION_SNAPSHOT_EVENT: "calibration_snapshot";
 /** One completed replay-run task result: what the replay targeted, and the revealed post-T history to score it. */
 export interface ReplayTaskResult {
-  replayPlan?: ReplayPlanInput | null;
-  revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
+    replayPlan?: ReplayPlanInput | null;
+    revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
 }
-
 export interface ScoreCompositeOptions {
-  computeObjectiveAnchor?: (
-    input: { replayPlan?: ReplayPlanInput | null; revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null },
-  ) => ObjectiveAnchorResult;
+    computeObjectiveAnchor?: (input: {
+        replayPlan?: ReplayPlanInput | null;
+        revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
+    }) => ObjectiveAnchorResult;
 }
-
 export interface HistoricalReplayCompositeScore {
-  compositeScore: number | null;
-  sampleSize: number;
-  scores: number[];
+    compositeScore: number | null;
+    sampleSize: number;
+    scores: number[];
 }
-
-export function scoreHistoricalReplayComposite(
-  replayResults: readonly ReplayTaskResult[] | null | undefined,
-  options?: ScoreCompositeOptions,
-): HistoricalReplayCompositeScore;
-
 /** A completed replay run's descriptor: its per-task results plus the run's identity/freshness/harness health. */
 export interface ReplayRunDescriptor {
-  replayResults?: readonly ReplayTaskResult[] | null;
-  replayRunId?: string;
-  observedAt?: string;
-  harnessStatus?: ReplayHarnessStatus;
+    replayResults?: readonly ReplayTaskResult[] | null;
+    replayRunId?: string;
+    observedAt?: string;
+    harnessStatus?: ReplayHarnessStatus;
 }
-
 export interface BuiltHistoricalReplayInput {
-  historicalReplay: HistoricalReplayCalibrationInput | null;
-  compositeScore: number | null;
-  sampleSize: number;
-  scores: number[];
+    historicalReplay: HistoricalReplayCalibrationInput | null;
+    compositeScore: number | null;
+    sampleSize: number;
+    scores: number[];
 }
-
-export function buildHistoricalReplayCalibrationInput(
-  replayRun: ReplayRunDescriptor | null | undefined,
-  options?: ScoreCompositeOptions,
-): BuiltHistoricalReplayInput;
-
 /** The persisted, public-safe projection of a Phase7CalibrationLoopResult. */
 export interface CalibrationSnapshotPayload {
-  enabled: boolean;
-  combinedAccuracy: number | null;
-  baselineAccuracy: number;
-  deltaFromBaseline: number | null;
-  autonomyIncreasePermitted: boolean;
-  replayHarnessHold: boolean;
-  replayHarnessStatus: string;
-  replayRunDue: boolean;
-  holdReasons: string[];
-  contributingSources: string[];
-  replayRunId: string | null;
-  observedAt: string | null;
-  replaySampleSize: number;
+    enabled: boolean;
+    combinedAccuracy: number | null;
+    baselineAccuracy: number;
+    deltaFromBaseline: number | null;
+    autonomyIncreasePermitted: boolean;
+    replayHarnessHold: boolean;
+    replayHarnessStatus: string;
+    replayRunDue: boolean;
+    holdReasons: string[];
+    contributingSources: string[];
+    replayRunId: string | null;
+    observedAt: string | null;
+    replaySampleSize: number;
 }
-
 export interface SnapshotMeta {
-  replayRunId?: string | null;
-  observedAt?: string | null;
-  sampleSize?: number;
+    replayRunId?: string | null;
+    observedAt?: string | null;
+    sampleSize?: number;
 }
-
-export function snapshotPayloadFromResult(
-  result: Phase7CalibrationLoopResult,
-  meta?: SnapshotMeta,
-): CalibrationSnapshotPayload;
-
-export function normalizeCalibrationSnapshotPayload(payload: unknown): CalibrationSnapshotPayload | null;
-
 export interface RecordCalibrationSnapshotOptions {
-  /** Optional at the type level so a caller can pass an unusable ledger to exercise the fail-closed guard; the
-   *  writer throws `invalid_event_ledger` at runtime when this is absent or lacks `appendEvent`. */
-  eventLedger?: { appendEvent(event: AppendEventInput): LedgerEntry };
-  repoFullName?: string;
+    /** Optional at the type level so a caller can pass an unusable ledger to exercise the fail-closed guard; the
+     *  writer throws `invalid_event_ledger` at runtime when this is absent or lacks `appendEvent`. */
+    eventLedger?: {
+        appendEvent(event: AppendEventInput): LedgerEntry;
+    };
+    repoFullName?: string;
 }
-
-export function recordCalibrationSnapshot(
-  input: unknown,
-  options?: RecordCalibrationSnapshotOptions,
-): LedgerEntry | null;
-
 export interface CalibrationSnapshotReader {
-  readEvents(filter?: { since?: number | null; repoFullName?: string | null }): unknown[];
+    readEvents(filter?: {
+        since?: number | null;
+        repoFullName?: string | null;
+    }): unknown[];
 }
-
 export interface CalibrationSnapshotFilter {
-  since?: number | null;
-  repoFullName?: string | null;
+    since?: number | null;
+    repoFullName?: string | null;
 }
-
 export interface PersistedCalibrationSnapshot extends CalibrationSnapshotPayload {
-  repoFullName: string | null;
-  seq: number | null;
-  createdAt: string | null;
+    repoFullName: string | null;
+    seq: number | null;
+    createdAt: string | null;
 }
-
-export function readCalibrationSnapshots(
-  eventLedger: CalibrationSnapshotReader,
-  filter?: CalibrationSnapshotFilter,
-): PersistedCalibrationSnapshot[];
-
-export function latestCalibrationSnapshot(
-  eventLedger: CalibrationSnapshotReader,
-  filter?: CalibrationSnapshotFilter,
-): PersistedCalibrationSnapshot | null;
-
 export interface RunCalibrationCycleInput {
-  config?: Phase7CalibrationConfig | Phase7CalibrationManifest | Record<string, unknown> | null;
-  prOutcome?: PrOutcomeCalibrationInput | null;
-  replayRun?: ReplayRunDescriptor | null;
-  now?: string | Date | null;
-  observedAt?: string | null;
-  repoFullName?: string;
-}
-
-export interface RunCalibrationCycleDeps extends ScoreCompositeOptions {
-  computeLoop?: (input: {
     config?: Phase7CalibrationConfig | Phase7CalibrationManifest | Record<string, unknown> | null;
     prOutcome?: PrOutcomeCalibrationInput | null;
-    historicalReplay?: HistoricalReplayCalibrationInput | null;
+    replayRun?: ReplayRunDescriptor | null;
     now?: string | Date | null;
-  }) => Phase7CalibrationLoopResult;
-  eventLedger?: { appendEvent(event: AppendEventInput): LedgerEntry };
+    observedAt?: string | null;
+    repoFullName?: string;
 }
-
+export interface RunCalibrationCycleDeps extends ScoreCompositeOptions {
+    computeLoop?: (input: {
+        config?: Phase7CalibrationConfig | Phase7CalibrationManifest | Record<string, unknown> | null;
+        prOutcome?: PrOutcomeCalibrationInput | null;
+        historicalReplay?: HistoricalReplayCalibrationInput | null;
+        now?: string | Date | null;
+    }) => Phase7CalibrationLoopResult;
+    eventLedger?: {
+        appendEvent(event: AppendEventInput): LedgerEntry;
+    };
+}
 export interface RunCalibrationCycleResult {
-  result: Phase7CalibrationLoopResult;
-  snapshot: CalibrationSnapshotPayload;
-  recorded: LedgerEntry | null;
-  historicalReplay: HistoricalReplayCalibrationInput | null;
-  compositeScore: number | null;
-  sampleSize: number;
-  scores: number[];
+    result: Phase7CalibrationLoopResult;
+    snapshot: CalibrationSnapshotPayload;
+    recorded: LedgerEntry | null;
+    historicalReplay: HistoricalReplayCalibrationInput | null;
+    compositeScore: number | null;
+    sampleSize: number;
+    scores: number[];
 }
-
-export function runHistoricalReplayCalibrationCycle(
-  input?: RunCalibrationCycleInput,
-  deps?: RunCalibrationCycleDeps,
-): RunCalibrationCycleResult;
+/**
+ * Score a completed replay run's per-task results with the deterministic objective-anchor scorer and reduce them to
+ * one composite `[0, 1]` accuracy (the mean of the per-task scores). `replayResults` is a list of
+ * `{ replayPlan, revealedHistory }` pairs; each non-object entry is defensively skipped. Returns `compositeScore:
+ * null` (never a fabricated 0) when there is no scorable task. Pure aside from the injected scorer.
+ */
+export declare function scoreHistoricalReplayComposite(replayResults: readonly ReplayTaskResult[] | null | undefined, options?: ScoreCompositeOptions): HistoricalReplayCompositeScore;
+/**
+ * Build the engine's `HistoricalReplayCalibrationInput` from a replay run descriptor
+ * (`{ replayResults, replayRunId, observedAt, harnessStatus }`). Returns `historicalReplay: null` when no run
+ * descriptor is supplied (the engine then holds `no_historical_replay_signal` when the loop is enabled). When a run
+ * IS supplied its `harnessStatus` flows through verbatim so a degraded/unavailable harness still reaches the
+ * engine's fail-closed hold path even if it scored zero tasks; a null composite becomes `0` only for the engine's
+ * numeric contract (the un-fabricated `compositeScore`/`sampleSize` are returned alongside for the snapshot).
+ */
+export declare function buildHistoricalReplayCalibrationInput(replayRun: ReplayRunDescriptor | null | undefined, options?: ScoreCompositeOptions): BuiltHistoricalReplayInput;
+/**
+ * Derive a JSON-safe, public-safe snapshot payload from a computed `Phase7CalibrationLoopResult`. Only accuracies,
+ * the documented baseline, hold-reason CODES, and provenance are surfaced -- never raw replay scores or rewards.
+ * Every field is a number/null, boolean, string/null, or string[] so it round-trips through the event ledger's
+ * verbatim-JSON serializer unchanged.
+ */
+export declare function snapshotPayloadFromResult(result: Phase7CalibrationLoopResult, meta?: SnapshotMeta): CalibrationSnapshotPayload;
+/**
+ * Validate + normalize a calibration-snapshot payload, returning `null` on any malformed shape (mirrors
+ * pr-outcome.js's `normalizePrOutcomePayload`, so a corrupted row can neither be written nor read back). Skipped
+ * rows are dropped by the reader rather than throwing.
+ */
+export declare function normalizeCalibrationSnapshotPayload(payload: unknown): CalibrationSnapshotPayload | null;
+/**
+ * Persist one calibration snapshot to an INJECTED event ledger (same dependency-injection shape as pr-outcome.js's
+ * `recordPrOutcomeSnapshot`, so it's unit-testable without a real SQLite file). Fail-soft: a malformed payload
+ * returns `null` without appending. An unusable ledger is the only hard error (a programmer wiring mistake).
+ */
+export declare function recordCalibrationSnapshot(input: unknown, options?: RecordCalibrationSnapshotOptions): LedgerEntry | null;
+/**
+ * Read every persisted calibration snapshot from the injected ledger's ascending append-only stream (mirrors
+ * pr-outcome.js's `readPrOutcomes`). Foreign event types and malformed payloads are skipped; a ledger that cannot
+ * read reduces to an empty list. Returns snapshots in ledger order (oldest first).
+ */
+export declare function readCalibrationSnapshots(eventLedger: CalibrationSnapshotReader, filter?: CalibrationSnapshotFilter): PersistedCalibrationSnapshot[];
+/** The most recent persisted calibration snapshot, or `null` when none exist. */
+export declare function latestCalibrationSnapshot(eventLedger: CalibrationSnapshotReader, filter?: CalibrationSnapshotFilter): PersistedCalibrationSnapshot | null;
+/**
+ * The runner. Scores the replay run (via the objective-anchor scorer), calls the engine's calibration combine with
+ * the resulting historical-replay composite plus the existing pr_outcome signal, and -- when an event ledger is
+ * injected -- persists the combined snapshot. Returns the engine result, the derived snapshot payload, the recorded
+ * ledger entry (or null when no ledger was injected or the payload was malformed), and the un-fabricated
+ * composite/sample provenance. The engine combine (`computeLoop`) is injectable so unit tests can pin it.
+ */
+export declare function runHistoricalReplayCalibrationCycle(input?: RunCalibrationCycleInput, deps?: RunCalibrationCycleDeps): RunCalibrationCycleResult;

--- a/packages/loopover-miner/lib/calibration-run.js
+++ b/packages/loopover-miner/lib/calibration-run.js
@@ -13,33 +13,26 @@
 // on it (no autonomy-level bump, no gate-threshold tune) -- that enforcement is maintainer-only and fail-closed
 // (see docs/miner-selfimprove-calibration.md's maintainer-only boundary). The engine owns the deterministic
 // combine/freshness/threshold/hold-reason logic; this module owns scheduling the score and persisting the row.
-
 import { computePhase7CalibrationLoop } from "@loopover/engine";
 import { computeObjectiveAnchor } from "./replay-objective-anchor.js";
-
 /** Event-ledger vocabulary for a persisted Phase 7 calibration snapshot (mirrors MINER_PR_OUTCOME_EVENT). */
 export const MINER_CALIBRATION_SNAPSHOT_EVENT = "calibration_snapshot";
-
 const SCORE_PRECISION = 1e6;
-
 function roundScore(value) {
-  return Math.round(Math.min(1, Math.max(0, value)) * SCORE_PRECISION) / SCORE_PRECISION;
+    return Math.round(Math.min(1, Math.max(0, value)) * SCORE_PRECISION) / SCORE_PRECISION;
 }
-
 function isFiniteNumber(value) {
-  return typeof value === "number" && Number.isFinite(value);
+    return typeof value === "number" && Number.isFinite(value);
 }
-
 function numberOrNull(value) {
-  return isFiniteNumber(value) ? value : null;
+    return isFiniteNumber(value) ? value : null;
 }
-
 function optionalString(value) {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed || null;
+    if (typeof value !== "string")
+        return null;
+    const trimmed = value.trim();
+    return trimmed || null;
 }
-
 /**
  * Score a completed replay run's per-task results with the deterministic objective-anchor scorer and reduce them to
  * one composite `[0, 1]` accuracy (the mean of the per-task scores). `replayResults` is a list of
@@ -47,19 +40,20 @@ function optionalString(value) {
  * null` (never a fabricated 0) when there is no scorable task. Pure aside from the injected scorer.
  */
 export function scoreHistoricalReplayComposite(replayResults, options = {}) {
-  const scoreOne = options.computeObjectiveAnchor ?? computeObjectiveAnchor;
-  const list = Array.isArray(replayResults) ? replayResults : [];
-  const scores = [];
-  for (const entry of list) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
-    const { score } = scoreOne({ replayPlan: entry.replayPlan, revealedHistory: entry.revealedHistory });
-    if (isFiniteNumber(score)) scores.push(score);
-  }
-  const sampleSize = scores.length;
-  const compositeScore = sampleSize === 0 ? null : roundScore(scores.reduce((sum, s) => sum + s, 0) / sampleSize);
-  return { compositeScore, sampleSize, scores };
+    const scoreOne = options.computeObjectiveAnchor ?? computeObjectiveAnchor;
+    const list = Array.isArray(replayResults) ? replayResults : [];
+    const scores = [];
+    for (const entry of list) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry))
+            continue;
+        const { score } = scoreOne({ replayPlan: entry.replayPlan, revealedHistory: entry.revealedHistory });
+        if (isFiniteNumber(score))
+            scores.push(score);
+    }
+    const sampleSize = scores.length;
+    const compositeScore = sampleSize === 0 ? null : roundScore(scores.reduce((sum, s) => sum + s, 0) / sampleSize);
+    return { compositeScore, sampleSize, scores };
 }
-
 /**
  * Build the engine's `HistoricalReplayCalibrationInput` from a replay run descriptor
  * (`{ replayResults, replayRunId, observedAt, harnessStatus }`). Returns `historicalReplay: null` when no run
@@ -69,23 +63,23 @@ export function scoreHistoricalReplayComposite(replayResults, options = {}) {
  * numeric contract (the un-fabricated `compositeScore`/`sampleSize` are returned alongside for the snapshot).
  */
 export function buildHistoricalReplayCalibrationInput(replayRun, options = {}) {
-  if (!replayRun || typeof replayRun !== "object" || Array.isArray(replayRun)) {
-    return { historicalReplay: null, compositeScore: null, sampleSize: 0, scores: [] };
-  }
-  const composite = scoreHistoricalReplayComposite(replayRun.replayResults, options);
-  return {
-    historicalReplay: {
-      compositeScore: composite.compositeScore ?? 0,
-      replayRunId: replayRun.replayRunId,
-      observedAt: replayRun.observedAt,
-      harnessStatus: replayRun.harnessStatus,
-    },
-    compositeScore: composite.compositeScore,
-    sampleSize: composite.sampleSize,
-    scores: composite.scores,
-  };
+    if (!replayRun || typeof replayRun !== "object" || Array.isArray(replayRun)) {
+        return { historicalReplay: null, compositeScore: null, sampleSize: 0, scores: [] };
+    }
+    const composite = scoreHistoricalReplayComposite(replayRun.replayResults, options);
+    return {
+        // Pass-through matches the pre-TS JS: optional descriptor fields may be undefined at runtime.
+        historicalReplay: {
+            compositeScore: composite.compositeScore ?? 0,
+            replayRunId: replayRun.replayRunId,
+            observedAt: replayRun.observedAt,
+            harnessStatus: replayRun.harnessStatus,
+        },
+        compositeScore: composite.compositeScore,
+        sampleSize: composite.sampleSize,
+        scores: composite.scores,
+    };
 }
-
 /**
  * Derive a JSON-safe, public-safe snapshot payload from a computed `Phase7CalibrationLoopResult`. Only accuracies,
  * the documented baseline, hold-reason CODES, and provenance are surfaced -- never raw replay scores or rewards.
@@ -93,109 +87,116 @@ export function buildHistoricalReplayCalibrationInput(replayRun, options = {}) {
  * verbatim-JSON serializer unchanged.
  */
 export function snapshotPayloadFromResult(result, meta = {}) {
-  return {
-    enabled: result.enabled === true,
-    combinedAccuracy: numberOrNull(result.combinedAccuracy),
-    baselineAccuracy: isFiniteNumber(result.baselineAccuracy) ? result.baselineAccuracy : 0,
-    deltaFromBaseline: numberOrNull(result.deltaFromBaseline),
-    autonomyIncreasePermitted: result.autonomyIncreasePermitted === true,
-    replayHarnessHold: result.replayHarnessHold === true,
-    replayHarnessStatus: optionalString(result.replayHarnessStatus) ?? "missing",
-    replayRunDue: result.replayRunDue === true,
-    holdReasons: Array.isArray(result.holdReasons) ? result.holdReasons.map(String) : [],
-    contributingSources: Array.isArray(result.audit?.contributingSources)
-      ? result.audit.contributingSources.map(String)
-      : [],
-    replayRunId: optionalString(meta.replayRunId),
-    observedAt: optionalString(meta.observedAt),
-    replaySampleSize: Number.isInteger(meta.sampleSize) && meta.sampleSize >= 0 ? meta.sampleSize : 0,
-  };
+    return {
+        enabled: result.enabled === true,
+        combinedAccuracy: numberOrNull(result.combinedAccuracy),
+        baselineAccuracy: isFiniteNumber(result.baselineAccuracy) ? result.baselineAccuracy : 0,
+        deltaFromBaseline: numberOrNull(result.deltaFromBaseline),
+        autonomyIncreasePermitted: result.autonomyIncreasePermitted === true,
+        replayHarnessHold: result.replayHarnessHold === true,
+        replayHarnessStatus: optionalString(result.replayHarnessStatus) ?? "missing",
+        replayRunDue: result.replayRunDue === true,
+        holdReasons: Array.isArray(result.holdReasons) ? result.holdReasons.map(String) : [],
+        contributingSources: Array.isArray(result.audit?.contributingSources)
+            ? result.audit.contributingSources.map(String)
+            : [],
+        replayRunId: optionalString(meta.replayRunId),
+        observedAt: optionalString(meta.observedAt),
+        replaySampleSize: Number.isInteger(meta.sampleSize) && meta.sampleSize >= 0 ? meta.sampleSize : 0,
+    };
 }
-
 /**
  * Validate + normalize a calibration-snapshot payload, returning `null` on any malformed shape (mirrors
  * pr-outcome.js's `normalizePrOutcomePayload`, so a corrupted row can neither be written nor read back). Skipped
  * rows are dropped by the reader rather than throwing.
  */
 export function normalizeCalibrationSnapshotPayload(payload) {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
-  if (payload.combinedAccuracy !== null && !isFiniteNumber(payload.combinedAccuracy)) return null;
-  if (!isFiniteNumber(payload.baselineAccuracy)) return null;
-  if (payload.deltaFromBaseline !== null && !isFiniteNumber(payload.deltaFromBaseline)) return null;
-  if (typeof payload.autonomyIncreasePermitted !== "boolean") return null;
-  const replayHarnessStatus = optionalString(payload.replayHarnessStatus);
-  if (!replayHarnessStatus) return null;
-  if (!Array.isArray(payload.holdReasons) || payload.holdReasons.some((code) => typeof code !== "string")) {
-    return null;
-  }
-  const contributingSources = Array.isArray(payload.contributingSources)
-    ? payload.contributingSources.filter((code) => typeof code === "string")
-    : [];
-  return {
-    enabled: payload.enabled === true,
-    combinedAccuracy: payload.combinedAccuracy,
-    baselineAccuracy: payload.baselineAccuracy,
-    deltaFromBaseline: payload.deltaFromBaseline,
-    autonomyIncreasePermitted: payload.autonomyIncreasePermitted,
-    replayHarnessHold: payload.replayHarnessHold === true,
-    replayHarnessStatus,
-    replayRunDue: payload.replayRunDue === true,
-    holdReasons: payload.holdReasons,
-    contributingSources,
-    replayRunId: optionalString(payload.replayRunId),
-    observedAt: optionalString(payload.observedAt),
-    replaySampleSize:
-      Number.isInteger(payload.replaySampleSize) && payload.replaySampleSize >= 0 ? payload.replaySampleSize : 0,
-  };
+    if (!payload || typeof payload !== "object" || Array.isArray(payload))
+        return null;
+    const record = payload;
+    if (record.combinedAccuracy !== null && !isFiniteNumber(record.combinedAccuracy))
+        return null;
+    if (!isFiniteNumber(record.baselineAccuracy))
+        return null;
+    if (record.deltaFromBaseline !== null && !isFiniteNumber(record.deltaFromBaseline))
+        return null;
+    if (typeof record.autonomyIncreasePermitted !== "boolean")
+        return null;
+    const replayHarnessStatus = optionalString(record.replayHarnessStatus);
+    if (!replayHarnessStatus)
+        return null;
+    if (!Array.isArray(record.holdReasons) || record.holdReasons.some((code) => typeof code !== "string")) {
+        return null;
+    }
+    const contributingSources = Array.isArray(record.contributingSources)
+        ? record.contributingSources.filter((code) => typeof code === "string")
+        : [];
+    return {
+        enabled: record.enabled === true,
+        combinedAccuracy: record.combinedAccuracy,
+        baselineAccuracy: record.baselineAccuracy,
+        deltaFromBaseline: record.deltaFromBaseline,
+        autonomyIncreasePermitted: record.autonomyIncreasePermitted,
+        replayHarnessHold: record.replayHarnessHold === true,
+        replayHarnessStatus,
+        replayRunDue: record.replayRunDue === true,
+        holdReasons: record.holdReasons,
+        contributingSources,
+        replayRunId: optionalString(record.replayRunId),
+        observedAt: optionalString(record.observedAt),
+        replaySampleSize: Number.isInteger(record.replaySampleSize) && record.replaySampleSize >= 0
+            ? record.replaySampleSize
+            : 0,
+    };
 }
-
 /**
  * Persist one calibration snapshot to an INJECTED event ledger (same dependency-injection shape as pr-outcome.js's
  * `recordPrOutcomeSnapshot`, so it's unit-testable without a real SQLite file). Fail-soft: a malformed payload
  * returns `null` without appending. An unusable ledger is the only hard error (a programmer wiring mistake).
  */
 export function recordCalibrationSnapshot(input, options = {}) {
-  const eventLedger = options.eventLedger;
-  if (!eventLedger || typeof eventLedger.appendEvent !== "function") throw new Error("invalid_event_ledger");
-  const payload = normalizeCalibrationSnapshotPayload(input);
-  if (!payload) return null;
-  const repoFullName = optionalString(options.repoFullName);
-  return eventLedger.appendEvent({
-    type: MINER_CALIBRATION_SNAPSHOT_EVENT,
-    ...(repoFullName ? { repoFullName } : {}),
-    payload,
-  });
+    const eventLedger = options.eventLedger;
+    if (!eventLedger || typeof eventLedger.appendEvent !== "function")
+        throw new Error("invalid_event_ledger");
+    const payload = normalizeCalibrationSnapshotPayload(input);
+    if (!payload)
+        return null;
+    const repoFullName = optionalString(options.repoFullName);
+    return eventLedger.appendEvent({
+        type: MINER_CALIBRATION_SNAPSHOT_EVENT,
+        ...(repoFullName ? { repoFullName } : {}),
+        payload: payload,
+    });
 }
-
 /**
  * Read every persisted calibration snapshot from the injected ledger's ascending append-only stream (mirrors
  * pr-outcome.js's `readPrOutcomes`). Foreign event types and malformed payloads are skipped; a ledger that cannot
  * read reduces to an empty list. Returns snapshots in ledger order (oldest first).
  */
 export function readCalibrationSnapshots(eventLedger, filter = {}) {
-  const events =
-    eventLedger && typeof eventLedger.readEvents === "function" ? eventLedger.readEvents(filter) : [];
-  const snapshots = [];
-  for (const event of Array.isArray(events) ? events : []) {
-    if (event?.type !== MINER_CALIBRATION_SNAPSHOT_EVENT) continue;
-    const normalized = normalizeCalibrationSnapshotPayload(event.payload);
-    if (!normalized) continue;
-    snapshots.push({
-      ...normalized,
-      repoFullName: typeof event.repoFullName === "string" ? event.repoFullName : null,
-      seq: Number.isInteger(event.seq) ? event.seq : null,
-      createdAt: optionalString(event.createdAt),
-    });
-  }
-  return snapshots;
+    const events = eventLedger && typeof eventLedger.readEvents === "function" ? eventLedger.readEvents(filter) : [];
+    const snapshots = [];
+    for (const event of Array.isArray(events) ? events : []) {
+        const row = event;
+        if (row?.type !== MINER_CALIBRATION_SNAPSHOT_EVENT)
+            continue;
+        const normalized = normalizeCalibrationSnapshotPayload(row.payload);
+        if (!normalized)
+            continue;
+        snapshots.push({
+            ...normalized,
+            repoFullName: typeof row.repoFullName === "string" ? row.repoFullName : null,
+            seq: Number.isInteger(row.seq) ? row.seq : null,
+            createdAt: optionalString(row.createdAt),
+        });
+    }
+    return snapshots;
 }
-
 /** The most recent persisted calibration snapshot, or `null` when none exist. */
 export function latestCalibrationSnapshot(eventLedger, filter = {}) {
-  const snapshots = readCalibrationSnapshots(eventLedger, filter);
-  return snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
+    const snapshots = readCalibrationSnapshots(eventLedger, filter);
+    return snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
 }
-
 /**
  * The runner. Scores the replay run (via the objective-anchor scorer), calls the engine's calibration combine with
  * the resulting historical-replay composite plus the existing pr_outcome signal, and -- when an event ledger is
@@ -204,29 +205,33 @@ export function latestCalibrationSnapshot(eventLedger, filter = {}) {
  * composite/sample provenance. The engine combine (`computeLoop`) is injectable so unit tests can pin it.
  */
 export function runHistoricalReplayCalibrationCycle(input = {}, deps = {}) {
-  const computeLoop = deps.computeLoop ?? computePhase7CalibrationLoop;
-  const built = buildHistoricalReplayCalibrationInput(input.replayRun, deps);
-  const result = computeLoop({
-    config: input.config,
-    prOutcome: input.prOutcome,
-    historicalReplay: built.historicalReplay,
-    now: input.now,
-  });
-  const snapshot = snapshotPayloadFromResult(result, {
-    replayRunId: built.historicalReplay?.replayRunId ?? null,
-    observedAt: input.observedAt ?? built.historicalReplay?.observedAt ?? null,
-    sampleSize: built.sampleSize,
-  });
-  const recorded = deps.eventLedger
-    ? recordCalibrationSnapshot(snapshot, { eventLedger: deps.eventLedger, repoFullName: input.repoFullName })
-    : null;
-  return {
-    result,
-    snapshot,
-    recorded,
-    historicalReplay: built.historicalReplay,
-    compositeScore: built.compositeScore,
-    sampleSize: built.sampleSize,
-    scores: built.scores,
-  };
+    const computeLoop = deps.computeLoop ?? computePhase7CalibrationLoop;
+    const built = buildHistoricalReplayCalibrationInput(input.replayRun, deps);
+    const result = computeLoop({
+        ...(input.config !== undefined ? { config: input.config } : {}),
+        ...(input.prOutcome !== undefined ? { prOutcome: input.prOutcome } : {}),
+        historicalReplay: built.historicalReplay,
+        ...(input.now !== undefined ? { now: input.now } : {}),
+    });
+    const snapshot = snapshotPayloadFromResult(result, {
+        replayRunId: built.historicalReplay?.replayRunId ?? null,
+        observedAt: input.observedAt ?? built.historicalReplay?.observedAt ?? null,
+        sampleSize: built.sampleSize,
+    });
+    const recorded = deps.eventLedger
+        ? recordCalibrationSnapshot(snapshot, {
+            eventLedger: deps.eventLedger,
+            ...(input.repoFullName !== undefined ? { repoFullName: input.repoFullName } : {}),
+        })
+        : null;
+    return {
+        result,
+        snapshot,
+        recorded,
+        historicalReplay: built.historicalReplay,
+        compositeScore: built.compositeScore,
+        sampleSize: built.sampleSize,
+        scores: built.scores,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2FsaWJyYXRpb24tcnVuLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiY2FsaWJyYXRpb24tcnVuLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtHQUErRztBQUMvRyx5RkFBeUY7QUFDekYsaUhBQWlIO0FBQ2pILGtIQUFrSDtBQUNsSCw2R0FBNkc7QUFDN0csMEdBQTBHO0FBQzFHLG1IQUFtSDtBQUNuSCxvSEFBb0g7QUFDcEgsdUdBQXVHO0FBQ3ZHLDREQUE0RDtBQUM1RCxFQUFFO0FBQ0Ysa0hBQWtIO0FBQ2xILGdIQUFnSDtBQUNoSCw0R0FBNEc7QUFDNUcsK0dBQStHO0FBRS9HLE9BQU8sRUFBRSw0QkFBNEIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBVWhFLE9BQU8sRUFBRSxzQkFBc0IsRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBT3RFLDZHQUE2RztBQUM3RyxNQUFNLENBQUMsTUFBTSxnQ0FBZ0MsR0FBRyxzQkFBK0IsQ0FBQztBQUVoRixNQUFNLGVBQWUsR0FBRyxHQUFHLENBQUM7QUE4RzVCLFNBQVMsVUFBVSxDQUFDLEtBQWE7SUFDL0IsT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLEtBQUssQ0FBQyxDQUFDLEdBQUcsZUFBZSxDQUFDLEdBQUcsZUFBZSxDQUFDO0FBQ3pGLENBQUM7QUFFRCxTQUFTLGNBQWMsQ0FBQyxLQUFjO0lBQ3BDLE9BQU8sT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLE1BQU0sQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDN0QsQ0FBQztBQUVELFNBQVMsWUFBWSxDQUFDLEtBQWM7SUFDbEMsT0FBTyxjQUFjLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0FBQzlDLENBQUM7QUFFRCxTQUFTLGNBQWMsQ0FBQyxLQUFjO0lBQ3BDLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQzNDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM3QixPQUFPLE9BQU8sSUFBSSxJQUFJLENBQUM7QUFDekIsQ0FBQztBQUVEOzs7OztHQUtHO0FBQ0gsTUFBTSxVQUFVLDhCQUE4QixDQUM1QyxhQUE2RCxFQUM3RCxVQUFpQyxFQUFFO0lBRW5DLE1BQU0sUUFBUSxHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsSUFBSSxzQkFBc0IsQ0FBQztJQUMxRSxNQUFNLElBQUksR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUMvRCxNQUFNLE1BQU0sR0FBYSxFQUFFLENBQUM7SUFDNUIsS0FBSyxNQUFNLEtBQUssSUFBSSxJQUFJLEVBQUUsQ0FBQztRQUN6QixJQUFJLENBQUMsS0FBSyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQztZQUFFLFNBQVM7UUFDMUUsTUFBTSxFQUFFLEtBQUssRUFBRSxHQUFHLFFBQVEsQ0FBQyxFQUFFLFVBQVUsRUFBRSxLQUFLLENBQUMsVUFBVSxFQUFFLGVBQWUsRUFBRSxLQUFLLENBQUMsZUFBZSxFQUFFLENBQUMsQ0FBQztRQUNyRyxJQUFJLGNBQWMsQ0FBQyxLQUFLLENBQUM7WUFBRSxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ2hELENBQUM7SUFDRCxNQUFNLFVBQVUsR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDO0lBQ2pDLE1BQU0sY0FBYyxHQUFHLFVBQVUsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxHQUFHLEdBQUcsQ0FBQyxFQUFFLENBQUMsQ0FBQyxHQUFHLFVBQVUsQ0FBQyxDQUFDO0lBQ2hILE9BQU8sRUFBRSxjQUFjLEVBQUUsVUFBVSxFQUFFLE1BQU0sRUFBRSxDQUFDO0FBQ2hELENBQUM7QUFFRDs7Ozs7OztHQU9HO0FBQ0gsTUFBTSxVQUFVLHFDQUFxQyxDQUNuRCxTQUFpRCxFQUNqRCxVQUFpQyxFQUFFO0lBRW5DLElBQUksQ0FBQyxTQUFTLElBQUksT0FBTyxTQUFTLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLEVBQUUsQ0FBQztRQUM1RSxPQUFPLEVBQUUsZ0JBQWdCLEVBQUUsSUFBSSxFQUFFLGNBQWMsRUFBRSxJQUFJLEVBQUUsVUFBVSxFQUFFLENBQUMsRUFBRSxNQUFNLEVBQUUsRUFBRSxFQUFFLENBQUM7SUFDckYsQ0FBQztJQUNELE1BQU0sU0FBUyxHQUFHLDhCQUE4QixDQUFDLFNBQVMsQ0FBQyxhQUFhLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDbkYsT0FBTztRQUNMLDhGQUE4RjtRQUM5RixnQkFBZ0IsRUFBRTtZQUNoQixjQUFjLEVBQUUsU0FBUyxDQUFDLGNBQWMsSUFBSSxDQUFDO1lBQzdDLFdBQVcsRUFBRSxTQUFTLENBQUMsV0FBVztZQUNsQyxVQUFVLEVBQUUsU0FBUyxDQUFDLFVBQVU7WUFDaEMsYUFBYSxFQUFFLFNBQVMsQ0FBQyxhQUFhO1NBQ0g7UUFDckMsY0FBYyxFQUFFLFNBQVMsQ0FBQyxjQUFjO1FBQ3hDLFVBQVUsRUFBRSxTQUFTLENBQUMsVUFBVTtRQUNoQyxNQUFNLEVBQUUsU0FBUyxDQUFDLE1BQU07S0FDekIsQ0FBQztBQUNKLENBQUM7QUFFRDs7Ozs7R0FLRztBQUNILE1BQU0sVUFBVSx5QkFBeUIsQ0FDdkMsTUFBbUMsRUFDbkMsT0FBcUIsRUFBRTtJQUV2QixPQUFPO1FBQ0wsT0FBTyxFQUFFLE1BQU0sQ0FBQyxPQUFPLEtBQUssSUFBSTtRQUNoQyxnQkFBZ0IsRUFBRSxZQUFZLENBQUMsTUFBTSxDQUFDLGdCQUFnQixDQUFDO1FBQ3ZELGdCQUFnQixFQUFFLGNBQWMsQ0FBQyxNQUFNLENBQUMsZ0JBQWdCLENBQUMsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLGdCQUFnQixDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3ZGLGlCQUFpQixFQUFFLFlBQVksQ0FBQyxNQUFNLENBQUMsaUJBQWlCLENBQUM7UUFDekQseUJBQXlCLEVBQUUsTUFBTSxDQUFDLHlCQUF5QixLQUFLLElBQUk7UUFDcEUsaUJBQWlCLEVBQUUsTUFBTSxDQUFDLGlCQUFpQixLQUFLLElBQUk7UUFDcEQsbUJBQW1CLEVBQUUsY0FBYyxDQUFDLE1BQU0sQ0FBQyxtQkFBbUIsQ0FBQyxJQUFJLFNBQVM7UUFDNUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEtBQUssSUFBSTtRQUMxQyxXQUFXLEVBQUUsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsV0FBVyxDQUFDLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxXQUFXLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFO1FBQ3BGLG1CQUFtQixFQUFFLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLEtBQUssRUFBRSxtQkFBbUIsQ0FBQztZQUNuRSxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxtQkFBbUIsQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDO1lBQzlDLENBQUMsQ0FBQyxFQUFFO1FBQ04sV0FBVyxFQUFFLGNBQWMsQ0FBQyxJQUFJLENBQUMsV0FBVyxDQUFDO1FBQzdDLFVBQVUsRUFBRSxjQUFjLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQztRQUMzQyxnQkFBZ0IsRUFBRSxNQUFNLENBQUMsU0FBUyxDQUFDLElBQUksQ0FBQyxVQUFVLENBQUMsSUFBSyxJQUFJLENBQUMsVUFBcUIsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFFLElBQUksQ0FBQyxVQUFxQixDQUFDLENBQUMsQ0FBQyxDQUFDO0tBQzFILENBQUM7QUFDSixDQUFDO0FBRUQ7Ozs7R0FJRztBQUNILE1BQU0sVUFBVSxtQ0FBbUMsQ0FBQyxPQUFnQjtJQUNsRSxJQUFJLENBQUMsT0FBTyxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ25GLE1BQU0sTUFBTSxHQUFHLE9BQWtDLENBQUM7SUFDbEQsSUFBSSxNQUFNLENBQUMsZ0JBQWdCLEtBQUssSUFBSSxJQUFJLENBQUMsY0FBYyxDQUFDLE1BQU0sQ0FBQyxnQkFBZ0IsQ0FBQztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQzlGLElBQUksQ0FBQyxjQUFjLENBQUMsTUFBTSxDQUFDLGdCQUFnQixDQUFDO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDMUQsSUFBSSxNQUFNLENBQUMsaUJBQWlCLEtBQUssSUFBSSxJQUFJLENBQUMsY0FBYyxDQUFDLE1BQU0sQ0FBQyxpQkFBaUIsQ0FBQztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ2hHLElBQUksT0FBTyxNQUFNLENBQUMseUJBQXlCLEtBQUssU0FBUztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ3ZFLE1BQU0sbUJBQW1CLEdBQUcsY0FBYyxDQUFDLE1BQU0sQ0FBQyxtQkFBbUIsQ0FBQyxDQUFDO0lBQ3ZFLElBQUksQ0FBQyxtQkFBbUI7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN0QyxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsV0FBVyxDQUFDLElBQUksTUFBTSxDQUFDLFdBQVcsQ0FBQyxJQUFJLENBQUMsQ0FBQyxJQUFJLEVBQUUsRUFBRSxDQUFDLE9BQU8sSUFBSSxLQUFLLFFBQVEsQ0FBQyxFQUFFLENBQUM7UUFDdEcsT0FBTyxJQUFJLENBQUM7SUFDZCxDQUFDO0lBQ0QsTUFBTSxtQkFBbUIsR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxtQkFBbUIsQ0FBQztRQUNuRSxDQUFDLENBQUMsTUFBTSxDQUFDLG1CQUFtQixDQUFDLE1BQU0sQ0FBQyxDQUFDLElBQUksRUFBa0IsRUFBRSxDQUFDLE9BQU8sSUFBSSxLQUFLLFFBQVEsQ0FBQztRQUN2RixDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ1AsT0FBTztRQUNMLE9BQU8sRUFBRSxNQUFNLENBQUMsT0FBTyxLQUFLLElBQUk7UUFDaEMsZ0JBQWdCLEVBQUUsTUFBTSxDQUFDLGdCQUFpQztRQUMxRCxnQkFBZ0IsRUFBRSxNQUFNLENBQUMsZ0JBQWdCO1FBQ3pDLGlCQUFpQixFQUFFLE1BQU0sQ0FBQyxpQkFBa0M7UUFDNUQseUJBQXlCLEVBQUUsTUFBTSxDQUFDLHlCQUF5QjtRQUMzRCxpQkFBaUIsRUFBRSxNQUFNLENBQUMsaUJBQWlCLEtBQUssSUFBSTtRQUNwRCxtQkFBbUI7UUFDbkIsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEtBQUssSUFBSTtRQUMxQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQXVCO1FBQzNDLG1CQUFtQjtRQUNuQixXQUFXLEVBQUUsY0FBYyxDQUFDLE1BQU0sQ0FBQyxXQUFXLENBQUM7UUFDL0MsVUFBVSxFQUFFLGNBQWMsQ0FBQyxNQUFNLENBQUMsVUFBVSxDQUFDO1FBQzdDLGdCQUFnQixFQUNkLE1BQU0sQ0FBQyxTQUFTLENBQUMsTUFBTSxDQUFDLGdCQUFnQixDQUFDLElBQUssTUFBTSxDQUFDLGdCQUEyQixJQUFJLENBQUM7WUFDbkYsQ0FBQyxDQUFFLE1BQU0sQ0FBQyxnQkFBMkI7WUFDckMsQ0FBQyxDQUFDLENBQUM7S0FDUixDQUFDO0FBQ0osQ0FBQztBQUVEOzs7O0dBSUc7QUFDSCxNQUFNLFVBQVUseUJBQXlCLENBQ3ZDLEtBQWMsRUFDZCxVQUE0QyxFQUFFO0lBRTlDLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxXQUFXLENBQUM7SUFDeEMsSUFBSSxDQUFDLFdBQVcsSUFBSSxPQUFPLFdBQVcsQ0FBQyxXQUFXLEtBQUssVUFBVTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsc0JBQXNCLENBQUMsQ0FBQztJQUMzRyxNQUFNLE9BQU8sR0FBRyxtQ0FBbUMsQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUMzRCxJQUFJLENBQUMsT0FBTztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQzFCLE1BQU0sWUFBWSxHQUFHLGNBQWMsQ0FBQyxPQUFPLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDMUQsT0FBTyxXQUFXLENBQUMsV0FBVyxDQUFDO1FBQzdCLElBQUksRUFBRSxnQ0FBZ0M7UUFDdEMsR0FBRyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsRUFBRSxZQUFZLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3pDLE9BQU8sRUFBRSxPQUE2QztLQUN2RCxDQUFDLENBQUM7QUFDTCxDQUFDO0FBRUQ7Ozs7R0FJRztBQUNILE1BQU0sVUFBVSx3QkFBd0IsQ0FDdEMsV0FBc0MsRUFDdEMsU0FBb0MsRUFBRTtJQUV0QyxNQUFNLE1BQU0sR0FDVixXQUFXLElBQUksT0FBTyxXQUFXLENBQUMsVUFBVSxLQUFLLFVBQVUsQ0FBQyxDQUFDLENBQUMsV0FBVyxDQUFDLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ3BHLE1BQU0sU0FBUyxHQUFtQyxFQUFFLENBQUM7SUFDckQsS0FBSyxNQUFNLEtBQUssSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ3hELE1BQU0sR0FBRyxHQUFHLEtBQTBHLENBQUM7UUFDdkgsSUFBSSxHQUFHLEVBQUUsSUFBSSxLQUFLLGdDQUFnQztZQUFFLFNBQVM7UUFDN0QsTUFBTSxVQUFVLEdBQUcsbUNBQW1DLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxDQUFDO1FBQ3BFLElBQUksQ0FBQyxVQUFVO1lBQUUsU0FBUztRQUMxQixTQUFTLENBQUMsSUFBSSxDQUFDO1lBQ2IsR0FBRyxVQUFVO1lBQ2IsWUFBWSxFQUFFLE9BQU8sR0FBRyxDQUFDLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLElBQUk7WUFDNUUsR0FBRyxFQUFFLE1BQU0sQ0FBQyxTQUFTLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBRSxHQUFHLENBQUMsR0FBYyxDQUFDLENBQUMsQ0FBQyxJQUFJO1lBQzNELFNBQVMsRUFBRSxjQUFjLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQztTQUN6QyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQ0QsT0FBTyxTQUFTLENBQUM7QUFDbkIsQ0FBQztBQUVELGlGQUFpRjtBQUNqRixNQUFNLFVBQVUseUJBQXlCLENBQ3ZDLFdBQXNDLEVBQ3RDLFNBQW9DLEVBQUU7SUFFdEMsTUFBTSxTQUFTLEdBQUcsd0JBQXdCLENBQUMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ2hFLE9BQU8sU0FBUyxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxTQUFTLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7QUFDeEUsQ0FBQztBQUVEOzs7Ozs7R0FNRztBQUNILE1BQU0sVUFBVSxtQ0FBbUMsQ0FDakQsUUFBa0MsRUFBRSxFQUNwQyxPQUFnQyxFQUFFO0lBRWxDLE1BQU0sV0FBVyxHQUFHLElBQUksQ0FBQyxXQUFXLElBQUksNEJBQTRCLENBQUM7SUFDckUsTUFBTSxLQUFLLEdBQUcscUNBQXFDLENBQUMsS0FBSyxDQUFDLFNBQVMsRUFBRSxJQUFJLENBQUMsQ0FBQztJQUMzRSxNQUFNLE1BQU0sR0FBRyxXQUFXLENBQUM7UUFDekIsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUMvRCxHQUFHLENBQUMsS0FBSyxDQUFDLFNBQVMsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsU0FBUyxFQUFFLEtBQUssQ0FBQyxTQUFTLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3hFLGdCQUFnQixFQUFFLEtBQUssQ0FBQyxnQkFBZ0I7UUFDeEMsR0FBRyxDQUFDLEtBQUssQ0FBQyxHQUFHLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLEdBQUcsRUFBRSxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztLQUN2RCxDQUFDLENBQUM7SUFDSCxNQUFNLFFBQVEsR0FBRyx5QkFBeUIsQ0FBQyxNQUFNLEVBQUU7UUFDakQsV0FBVyxFQUFFLEtBQUssQ0FBQyxnQkFBZ0IsRUFBRSxXQUFXLElBQUksSUFBSTtRQUN4RCxVQUFVLEVBQUUsS0FBSyxDQUFDLFVBQVUsSUFBSSxLQUFLLENBQUMsZ0JBQWdCLEVBQUUsVUFBVSxJQUFJLElBQUk7UUFDMUUsVUFBVSxFQUFFLEtBQUssQ0FBQyxVQUFVO0tBQzdCLENBQUMsQ0FBQztJQUNILE1BQU0sUUFBUSxHQUFHLElBQUksQ0FBQyxXQUFXO1FBQy9CLENBQUMsQ0FBQyx5QkFBeUIsQ0FBQyxRQUFRLEVBQUU7WUFDbEMsV0FBVyxFQUFFLElBQUksQ0FBQyxXQUFXO1lBQzdCLEdBQUcsQ0FBQyxLQUFLLENBQUMsWUFBWSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxZQUFZLEVBQUUsS0FBSyxDQUFDLFlBQVksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7U0FDbEYsQ0FBQztRQUNKLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDVCxPQUFPO1FBQ0wsTUFBTTtRQUNOLFFBQVE7UUFDUixRQUFRO1FBQ1IsZ0JBQWdCLEVBQUUsS0FBSyxDQUFDLGdCQUFnQjtRQUN4QyxjQUFjLEVBQUUsS0FBSyxDQUFDLGNBQWM7UUFDcEMsVUFBVSxFQUFFLEtBQUssQ0FBQyxVQUFVO1FBQzVCLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTTtLQUNyQixDQUFDO0FBQ0osQ0FBQyJ9

--- a/packages/loopover-miner/lib/calibration-run.ts
+++ b/packages/loopover-miner/lib/calibration-run.ts
@@ -1,0 +1,383 @@
+// Phase 7 calibration runner (#4248): the miner-side runner that finally CONNECTS the two finished-but-unwired
+// halves #3014 left apart. #3014 landed the engine's pure calibration *combine* contract
+// (`computePhase7CalibrationLoop`, packages/loopover-engine/src/phase7-calibration-loop.ts) and #3012 landed the
+// deterministic replay *scorer* (`computeObjectiveAnchor`, ./replay-objective-anchor.js), but nothing ever called
+// one with the other -- #3014's issue claimed "wired" while only the engine side shipped. This module is the
+// missing runner: it scores a completed historical-replay run with the objective-anchor scorer, folds the
+// resulting composite into the `HistoricalReplayCalibrationInput` shape the engine expects, calls the combine with
+// the existing pr_outcome signal, and PERSISTS the combined snapshot to the local append-only event ledger (a typed
+// event layered on event-ledger.js exactly like pr-outcome.js's MINER_PR_OUTCOME_EVENT), queryable via
+// `loopover-miner ledger list --type calibration_snapshot`.
+//
+// SCOPE: this runner is read/measure-only. It produces and persists the tracked calibration metric; it NEVER acts
+// on it (no autonomy-level bump, no gate-threshold tune) -- that enforcement is maintainer-only and fail-closed
+// (see docs/miner-selfimprove-calibration.md's maintainer-only boundary). The engine owns the deterministic
+// combine/freshness/threshold/hold-reason logic; this module owns scheduling the score and persisting the row.
+
+import { computePhase7CalibrationLoop } from "@loopover/engine";
+import type {
+  HistoricalReplayCalibrationInput,
+  Phase7CalibrationConfig,
+  Phase7CalibrationLoopResult,
+  Phase7CalibrationManifest,
+  PrOutcomeCalibrationInput,
+  ReplayHarnessStatus,
+} from "@loopover/engine";
+import type { AppendEventInput, LedgerEntry } from "./event-ledger.js";
+import { computeObjectiveAnchor } from "./replay-objective-anchor.js";
+import type {
+  ObjectiveAnchorResult,
+  ReplayPlanInput,
+  RevealedHistoryEntry,
+} from "./replay-objective-anchor.js";
+
+/** Event-ledger vocabulary for a persisted Phase 7 calibration snapshot (mirrors MINER_PR_OUTCOME_EVENT). */
+export const MINER_CALIBRATION_SNAPSHOT_EVENT = "calibration_snapshot" as const;
+
+const SCORE_PRECISION = 1e6;
+
+/** One completed replay-run task result: what the replay targeted, and the revealed post-T history to score it. */
+export interface ReplayTaskResult {
+  replayPlan?: ReplayPlanInput | null;
+  revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
+}
+
+export interface ScoreCompositeOptions {
+  computeObjectiveAnchor?: (input: {
+    replayPlan?: ReplayPlanInput | null;
+    revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
+  }) => ObjectiveAnchorResult;
+}
+
+export interface HistoricalReplayCompositeScore {
+  compositeScore: number | null;
+  sampleSize: number;
+  scores: number[];
+}
+
+/** A completed replay run's descriptor: its per-task results plus the run's identity/freshness/harness health. */
+export interface ReplayRunDescriptor {
+  replayResults?: readonly ReplayTaskResult[] | null;
+  replayRunId?: string;
+  observedAt?: string;
+  harnessStatus?: ReplayHarnessStatus;
+}
+
+export interface BuiltHistoricalReplayInput {
+  historicalReplay: HistoricalReplayCalibrationInput | null;
+  compositeScore: number | null;
+  sampleSize: number;
+  scores: number[];
+}
+
+/** The persisted, public-safe projection of a Phase7CalibrationLoopResult. */
+export interface CalibrationSnapshotPayload {
+  enabled: boolean;
+  combinedAccuracy: number | null;
+  baselineAccuracy: number;
+  deltaFromBaseline: number | null;
+  autonomyIncreasePermitted: boolean;
+  replayHarnessHold: boolean;
+  replayHarnessStatus: string;
+  replayRunDue: boolean;
+  holdReasons: string[];
+  contributingSources: string[];
+  replayRunId: string | null;
+  observedAt: string | null;
+  replaySampleSize: number;
+}
+
+export interface SnapshotMeta {
+  replayRunId?: string | null;
+  observedAt?: string | null;
+  sampleSize?: number;
+}
+
+export interface RecordCalibrationSnapshotOptions {
+  /** Optional at the type level so a caller can pass an unusable ledger to exercise the fail-closed guard; the
+   *  writer throws `invalid_event_ledger` at runtime when this is absent or lacks `appendEvent`. */
+  eventLedger?: { appendEvent(event: AppendEventInput): LedgerEntry };
+  repoFullName?: string;
+}
+
+export interface CalibrationSnapshotReader {
+  readEvents(filter?: { since?: number | null; repoFullName?: string | null }): unknown[];
+}
+
+export interface CalibrationSnapshotFilter {
+  since?: number | null;
+  repoFullName?: string | null;
+}
+
+export interface PersistedCalibrationSnapshot extends CalibrationSnapshotPayload {
+  repoFullName: string | null;
+  seq: number | null;
+  createdAt: string | null;
+}
+
+export interface RunCalibrationCycleInput {
+  config?: Phase7CalibrationConfig | Phase7CalibrationManifest | Record<string, unknown> | null;
+  prOutcome?: PrOutcomeCalibrationInput | null;
+  replayRun?: ReplayRunDescriptor | null;
+  now?: string | Date | null;
+  observedAt?: string | null;
+  repoFullName?: string;
+}
+
+export interface RunCalibrationCycleDeps extends ScoreCompositeOptions {
+  computeLoop?: (input: {
+    config?: Phase7CalibrationConfig | Phase7CalibrationManifest | Record<string, unknown> | null;
+    prOutcome?: PrOutcomeCalibrationInput | null;
+    historicalReplay?: HistoricalReplayCalibrationInput | null;
+    now?: string | Date | null;
+  }) => Phase7CalibrationLoopResult;
+  eventLedger?: { appendEvent(event: AppendEventInput): LedgerEntry };
+}
+
+export interface RunCalibrationCycleResult {
+  result: Phase7CalibrationLoopResult;
+  snapshot: CalibrationSnapshotPayload;
+  recorded: LedgerEntry | null;
+  historicalReplay: HistoricalReplayCalibrationInput | null;
+  compositeScore: number | null;
+  sampleSize: number;
+  scores: number[];
+}
+
+function roundScore(value: number): number {
+  return Math.round(Math.min(1, Math.max(0, value)) * SCORE_PRECISION) / SCORE_PRECISION;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function numberOrNull(value: unknown): number | null {
+  return isFiniteNumber(value) ? value : null;
+}
+
+function optionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+/**
+ * Score a completed replay run's per-task results with the deterministic objective-anchor scorer and reduce them to
+ * one composite `[0, 1]` accuracy (the mean of the per-task scores). `replayResults` is a list of
+ * `{ replayPlan, revealedHistory }` pairs; each non-object entry is defensively skipped. Returns `compositeScore:
+ * null` (never a fabricated 0) when there is no scorable task. Pure aside from the injected scorer.
+ */
+export function scoreHistoricalReplayComposite(
+  replayResults: readonly ReplayTaskResult[] | null | undefined,
+  options: ScoreCompositeOptions = {},
+): HistoricalReplayCompositeScore {
+  const scoreOne = options.computeObjectiveAnchor ?? computeObjectiveAnchor;
+  const list = Array.isArray(replayResults) ? replayResults : [];
+  const scores: number[] = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const { score } = scoreOne({ replayPlan: entry.replayPlan, revealedHistory: entry.revealedHistory });
+    if (isFiniteNumber(score)) scores.push(score);
+  }
+  const sampleSize = scores.length;
+  const compositeScore = sampleSize === 0 ? null : roundScore(scores.reduce((sum, s) => sum + s, 0) / sampleSize);
+  return { compositeScore, sampleSize, scores };
+}
+
+/**
+ * Build the engine's `HistoricalReplayCalibrationInput` from a replay run descriptor
+ * (`{ replayResults, replayRunId, observedAt, harnessStatus }`). Returns `historicalReplay: null` when no run
+ * descriptor is supplied (the engine then holds `no_historical_replay_signal` when the loop is enabled). When a run
+ * IS supplied its `harnessStatus` flows through verbatim so a degraded/unavailable harness still reaches the
+ * engine's fail-closed hold path even if it scored zero tasks; a null composite becomes `0` only for the engine's
+ * numeric contract (the un-fabricated `compositeScore`/`sampleSize` are returned alongside for the snapshot).
+ */
+export function buildHistoricalReplayCalibrationInput(
+  replayRun: ReplayRunDescriptor | null | undefined,
+  options: ScoreCompositeOptions = {},
+): BuiltHistoricalReplayInput {
+  if (!replayRun || typeof replayRun !== "object" || Array.isArray(replayRun)) {
+    return { historicalReplay: null, compositeScore: null, sampleSize: 0, scores: [] };
+  }
+  const composite = scoreHistoricalReplayComposite(replayRun.replayResults, options);
+  return {
+    // Pass-through matches the pre-TS JS: optional descriptor fields may be undefined at runtime.
+    historicalReplay: {
+      compositeScore: composite.compositeScore ?? 0,
+      replayRunId: replayRun.replayRunId,
+      observedAt: replayRun.observedAt,
+      harnessStatus: replayRun.harnessStatus,
+    } as HistoricalReplayCalibrationInput,
+    compositeScore: composite.compositeScore,
+    sampleSize: composite.sampleSize,
+    scores: composite.scores,
+  };
+}
+
+/**
+ * Derive a JSON-safe, public-safe snapshot payload from a computed `Phase7CalibrationLoopResult`. Only accuracies,
+ * the documented baseline, hold-reason CODES, and provenance are surfaced -- never raw replay scores or rewards.
+ * Every field is a number/null, boolean, string/null, or string[] so it round-trips through the event ledger's
+ * verbatim-JSON serializer unchanged.
+ */
+export function snapshotPayloadFromResult(
+  result: Phase7CalibrationLoopResult,
+  meta: SnapshotMeta = {},
+): CalibrationSnapshotPayload {
+  return {
+    enabled: result.enabled === true,
+    combinedAccuracy: numberOrNull(result.combinedAccuracy),
+    baselineAccuracy: isFiniteNumber(result.baselineAccuracy) ? result.baselineAccuracy : 0,
+    deltaFromBaseline: numberOrNull(result.deltaFromBaseline),
+    autonomyIncreasePermitted: result.autonomyIncreasePermitted === true,
+    replayHarnessHold: result.replayHarnessHold === true,
+    replayHarnessStatus: optionalString(result.replayHarnessStatus) ?? "missing",
+    replayRunDue: result.replayRunDue === true,
+    holdReasons: Array.isArray(result.holdReasons) ? result.holdReasons.map(String) : [],
+    contributingSources: Array.isArray(result.audit?.contributingSources)
+      ? result.audit.contributingSources.map(String)
+      : [],
+    replayRunId: optionalString(meta.replayRunId),
+    observedAt: optionalString(meta.observedAt),
+    replaySampleSize: Number.isInteger(meta.sampleSize) && (meta.sampleSize as number) >= 0 ? (meta.sampleSize as number) : 0,
+  };
+}
+
+/**
+ * Validate + normalize a calibration-snapshot payload, returning `null` on any malformed shape (mirrors
+ * pr-outcome.js's `normalizePrOutcomePayload`, so a corrupted row can neither be written nor read back). Skipped
+ * rows are dropped by the reader rather than throwing.
+ */
+export function normalizeCalibrationSnapshotPayload(payload: unknown): CalibrationSnapshotPayload | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const record = payload as Record<string, unknown>;
+  if (record.combinedAccuracy !== null && !isFiniteNumber(record.combinedAccuracy)) return null;
+  if (!isFiniteNumber(record.baselineAccuracy)) return null;
+  if (record.deltaFromBaseline !== null && !isFiniteNumber(record.deltaFromBaseline)) return null;
+  if (typeof record.autonomyIncreasePermitted !== "boolean") return null;
+  const replayHarnessStatus = optionalString(record.replayHarnessStatus);
+  if (!replayHarnessStatus) return null;
+  if (!Array.isArray(record.holdReasons) || record.holdReasons.some((code) => typeof code !== "string")) {
+    return null;
+  }
+  const contributingSources = Array.isArray(record.contributingSources)
+    ? record.contributingSources.filter((code): code is string => typeof code === "string")
+    : [];
+  return {
+    enabled: record.enabled === true,
+    combinedAccuracy: record.combinedAccuracy as number | null,
+    baselineAccuracy: record.baselineAccuracy,
+    deltaFromBaseline: record.deltaFromBaseline as number | null,
+    autonomyIncreasePermitted: record.autonomyIncreasePermitted,
+    replayHarnessHold: record.replayHarnessHold === true,
+    replayHarnessStatus,
+    replayRunDue: record.replayRunDue === true,
+    holdReasons: record.holdReasons as string[],
+    contributingSources,
+    replayRunId: optionalString(record.replayRunId),
+    observedAt: optionalString(record.observedAt),
+    replaySampleSize:
+      Number.isInteger(record.replaySampleSize) && (record.replaySampleSize as number) >= 0
+        ? (record.replaySampleSize as number)
+        : 0,
+  };
+}
+
+/**
+ * Persist one calibration snapshot to an INJECTED event ledger (same dependency-injection shape as pr-outcome.js's
+ * `recordPrOutcomeSnapshot`, so it's unit-testable without a real SQLite file). Fail-soft: a malformed payload
+ * returns `null` without appending. An unusable ledger is the only hard error (a programmer wiring mistake).
+ */
+export function recordCalibrationSnapshot(
+  input: unknown,
+  options: RecordCalibrationSnapshotOptions = {},
+): LedgerEntry | null {
+  const eventLedger = options.eventLedger;
+  if (!eventLedger || typeof eventLedger.appendEvent !== "function") throw new Error("invalid_event_ledger");
+  const payload = normalizeCalibrationSnapshotPayload(input);
+  if (!payload) return null;
+  const repoFullName = optionalString(options.repoFullName);
+  return eventLedger.appendEvent({
+    type: MINER_CALIBRATION_SNAPSHOT_EVENT,
+    ...(repoFullName ? { repoFullName } : {}),
+    payload: payload as unknown as Record<string, unknown>,
+  });
+}
+
+/**
+ * Read every persisted calibration snapshot from the injected ledger's ascending append-only stream (mirrors
+ * pr-outcome.js's `readPrOutcomes`). Foreign event types and malformed payloads are skipped; a ledger that cannot
+ * read reduces to an empty list. Returns snapshots in ledger order (oldest first).
+ */
+export function readCalibrationSnapshots(
+  eventLedger: CalibrationSnapshotReader,
+  filter: CalibrationSnapshotFilter = {},
+): PersistedCalibrationSnapshot[] {
+  const events =
+    eventLedger && typeof eventLedger.readEvents === "function" ? eventLedger.readEvents(filter) : [];
+  const snapshots: PersistedCalibrationSnapshot[] = [];
+  for (const event of Array.isArray(events) ? events : []) {
+    const row = event as { type?: unknown; payload?: unknown; repoFullName?: unknown; seq?: unknown; createdAt?: unknown };
+    if (row?.type !== MINER_CALIBRATION_SNAPSHOT_EVENT) continue;
+    const normalized = normalizeCalibrationSnapshotPayload(row.payload);
+    if (!normalized) continue;
+    snapshots.push({
+      ...normalized,
+      repoFullName: typeof row.repoFullName === "string" ? row.repoFullName : null,
+      seq: Number.isInteger(row.seq) ? (row.seq as number) : null,
+      createdAt: optionalString(row.createdAt),
+    });
+  }
+  return snapshots;
+}
+
+/** The most recent persisted calibration snapshot, or `null` when none exist. */
+export function latestCalibrationSnapshot(
+  eventLedger: CalibrationSnapshotReader,
+  filter: CalibrationSnapshotFilter = {},
+): PersistedCalibrationSnapshot | null {
+  const snapshots = readCalibrationSnapshots(eventLedger, filter);
+  return snapshots.length > 0 ? snapshots[snapshots.length - 1]! : null;
+}
+
+/**
+ * The runner. Scores the replay run (via the objective-anchor scorer), calls the engine's calibration combine with
+ * the resulting historical-replay composite plus the existing pr_outcome signal, and -- when an event ledger is
+ * injected -- persists the combined snapshot. Returns the engine result, the derived snapshot payload, the recorded
+ * ledger entry (or null when no ledger was injected or the payload was malformed), and the un-fabricated
+ * composite/sample provenance. The engine combine (`computeLoop`) is injectable so unit tests can pin it.
+ */
+export function runHistoricalReplayCalibrationCycle(
+  input: RunCalibrationCycleInput = {},
+  deps: RunCalibrationCycleDeps = {},
+): RunCalibrationCycleResult {
+  const computeLoop = deps.computeLoop ?? computePhase7CalibrationLoop;
+  const built = buildHistoricalReplayCalibrationInput(input.replayRun, deps);
+  const result = computeLoop({
+    ...(input.config !== undefined ? { config: input.config } : {}),
+    ...(input.prOutcome !== undefined ? { prOutcome: input.prOutcome } : {}),
+    historicalReplay: built.historicalReplay,
+    ...(input.now !== undefined ? { now: input.now } : {}),
+  });
+  const snapshot = snapshotPayloadFromResult(result, {
+    replayRunId: built.historicalReplay?.replayRunId ?? null,
+    observedAt: input.observedAt ?? built.historicalReplay?.observedAt ?? null,
+    sampleSize: built.sampleSize,
+  });
+  const recorded = deps.eventLedger
+    ? recordCalibrationSnapshot(snapshot, {
+        eventLedger: deps.eventLedger,
+        ...(input.repoFullName !== undefined ? { repoFullName: input.repoFullName } : {}),
+      })
+    : null;
+  return {
+    result,
+    snapshot,
+    recorded,
+    historicalReplay: built.historicalReplay,
+    compositeScore: built.compositeScore,
+    sampleSize: built.sampleSize,
+    scores: built.scores,
+  };
+}

--- a/packages/loopover-miner/lib/chat-discover-attempt-actions.d.ts
+++ b/packages/loopover-miner/lib/chat-discover-attempt-actions.d.ts
@@ -1,33 +1,45 @@
 import type { ChatActionRegistry } from "./chat-action-registry.js";
-
-export const DISCOVER_CHAT_ACTION: "discover";
-export const ATTEMPT_CHAT_ACTION: "attempt";
-
+export declare const DISCOVER_CHAT_ACTION: "discover";
+export declare const ATTEMPT_CHAT_ACTION: "attempt";
 export type DiscoverChatActionInput = {
-  targets?: string[];
-  search?: string;
-  dryRun?: boolean;
-  json?: boolean;
-  apiBaseUrl?: string;
-  tokenEnv?: string;
+    targets?: string[];
+    search?: string;
+    dryRun?: boolean;
+    json?: boolean;
+    apiBaseUrl?: string;
+    tokenEnv?: string;
 };
-
 export type AttemptChatActionInput = {
-  repoFullName: string;
-  issueNumber: number;
-  minerLogin: string;
-  base?: string;
-  live?: boolean;
-  dryRun?: boolean;
-  json?: boolean;
+    repoFullName: string;
+    issueNumber: number;
+    minerLogin: string;
+    base?: string;
+    live?: boolean;
+    dryRun?: boolean;
+    json?: boolean;
 };
-
-export function isDiscoverChatParams(params: unknown): boolean;
-export function isAttemptChatParams(params: unknown): boolean;
-
-export function registerDiscoverAttemptChatActions(options: {
-  requestDiscover: (input: DiscoverChatActionInput) => Promise<unknown>;
-  requestAttempt: (input: AttemptChatActionInput) => Promise<unknown>;
-  registry?: ChatActionRegistry;
-  evaluateGate?: () => { decision: { stage: string } };
+/**
+ * `DiscoverActionInput` — every field optional (the CLI defaults them all), so an empty object is a valid
+ * "discover with defaults". Unknown keys are rejected rather than ignored: these params can be model-authored,
+ * and a typo'd flag must fail loudly instead of silently running a different discovery than intended.
+ */
+export declare function isDiscoverChatParams(params: unknown): boolean;
+/**
+ * `AttemptActionInput` — `repoFullName` / `issueNumber` / `minerLogin` are REQUIRED (the CLI has no default
+ * for which issue to attempt), so unlike discover there is no valid empty form. `issueNumber` must be a
+ * positive integer: a float or 0 would reach the CLI as a nonsense issue reference.
+ */
+export declare function isAttemptChatParams(params: unknown): boolean;
+/**
+ * Idempotently register `discover` / `attempt`.
+ */
+export declare function registerDiscoverAttemptChatActions(options: {
+    requestDiscover: (input: DiscoverChatActionInput) => Promise<unknown>;
+    requestAttempt: (input: AttemptChatActionInput) => Promise<unknown>;
+    registry?: ChatActionRegistry;
+    evaluateGate?: () => {
+        decision: {
+            stage: string;
+        };
+    };
 }): void;

--- a/packages/loopover-miner/lib/chat-discover-attempt-actions.js
+++ b/packages/loopover-miner/lib/chat-discover-attempt-actions.js
@@ -20,122 +20,104 @@
 // the equivalent CLI invocation. So, like chat-governor-actions.js and chat-portfolio-actions.js, we satisfy
 // the registry's `governorGatedHandler` brand with an allow-stage evaluateGate. Execution still stays behind
 // the shared LOOPOVER_MINER_CHAT_ACTIONS flag via `dispatchChatAction`, and `evaluateGate` stays injectable.
-
 import { governorGatedHandler, chatActionRegistry } from "./chat-action-registry.js";
-
 export const DISCOVER_CHAT_ACTION = "discover";
 export const ATTEMPT_CHAT_ACTION = "attempt";
-
 /** The endpoint owns the gate (see the header note); satisfy the registry brand only. */
 const allowEndpointGatedAction = () => ({ decision: { stage: "allow" } });
-
 const DISCOVER_KEYS = new Set(["targets", "search", "dryRun", "json", "apiBaseUrl", "tokenEnv"]);
 const ATTEMPT_KEYS = new Set(["repoFullName", "issueNumber", "minerLogin", "base", "live", "dryRun", "json"]);
-
-/**
- * @param {unknown} params
- * @returns {Record<string, unknown> | null}
- */
 function asParamsRecord(params) {
-  if (params == null || typeof params !== "object" || Array.isArray(params)) return null;
-  return /** @type {Record<string, unknown>} */ (params);
+    if (params == null || typeof params !== "object" || Array.isArray(params))
+        return null;
+    return params;
 }
-
 /** A non-empty string — the shape every required text field here needs. */
 function isNonEmptyString(value) {
-  return typeof value === "string" && value.trim() !== "";
+    return typeof value === "string" && value.trim() !== "";
 }
-
 /**
  * `DiscoverActionInput` — every field optional (the CLI defaults them all), so an empty object is a valid
  * "discover with defaults". Unknown keys are rejected rather than ignored: these params can be model-authored,
  * and a typo'd flag must fail loudly instead of silently running a different discovery than intended.
- *
- * @param {unknown} params
- * @returns {boolean}
  */
 export function isDiscoverChatParams(params) {
-  if (params == null) return true;
-  const record = asParamsRecord(params);
-  if (record === null) return false;
-  for (const key of Object.keys(record)) {
-    if (!DISCOVER_KEYS.has(key)) return false;
-  }
-  if (record.targets !== undefined) {
-    if (!Array.isArray(record.targets) || !record.targets.every(isNonEmptyString)) return false;
-  }
-  for (const key of ["search", "apiBaseUrl", "tokenEnv"]) {
-    if (record[key] !== undefined && typeof record[key] !== "string") return false;
-  }
-  for (const key of ["dryRun", "json"]) {
-    if (record[key] !== undefined && typeof record[key] !== "boolean") return false;
-  }
-  return true;
+    if (params == null)
+        return true;
+    const record = asParamsRecord(params);
+    if (record === null)
+        return false;
+    for (const key of Object.keys(record)) {
+        if (!DISCOVER_KEYS.has(key))
+            return false;
+    }
+    if (record.targets !== undefined) {
+        if (!Array.isArray(record.targets) || !record.targets.every(isNonEmptyString))
+            return false;
+    }
+    for (const key of ["search", "apiBaseUrl", "tokenEnv"]) {
+        if (record[key] !== undefined && typeof record[key] !== "string")
+            return false;
+    }
+    for (const key of ["dryRun", "json"]) {
+        if (record[key] !== undefined && typeof record[key] !== "boolean")
+            return false;
+    }
+    return true;
 }
-
 /**
  * `AttemptActionInput` — `repoFullName` / `issueNumber` / `minerLogin` are REQUIRED (the CLI has no default
  * for which issue to attempt), so unlike discover there is no valid empty form. `issueNumber` must be a
  * positive integer: a float or 0 would reach the CLI as a nonsense issue reference.
- *
- * @param {unknown} params
- * @returns {boolean}
  */
 export function isAttemptChatParams(params) {
-  const record = asParamsRecord(params);
-  if (record === null) return false;
-  for (const key of Object.keys(record)) {
-    if (!ATTEMPT_KEYS.has(key)) return false;
-  }
-  if (!isNonEmptyString(record.repoFullName)) return false;
-  if (!isNonEmptyString(record.minerLogin)) return false;
-  if (!Number.isInteger(record.issueNumber) || /** @type {number} */ (record.issueNumber) <= 0) return false;
-  if (record.base !== undefined && typeof record.base !== "string") return false;
-  for (const key of ["live", "dryRun", "json"]) {
-    if (record[key] !== undefined && typeof record[key] !== "boolean") return false;
-  }
-  return true;
+    const record = asParamsRecord(params);
+    if (record === null)
+        return false;
+    for (const key of Object.keys(record)) {
+        if (!ATTEMPT_KEYS.has(key))
+            return false;
+    }
+    if (!isNonEmptyString(record.repoFullName))
+        return false;
+    if (!isNonEmptyString(record.minerLogin))
+        return false;
+    if (!Number.isInteger(record.issueNumber) || record.issueNumber <= 0)
+        return false;
+    if (record.base !== undefined && typeof record.base !== "string")
+        return false;
+    for (const key of ["live", "dryRun", "json"]) {
+        if (record[key] !== undefined && typeof record[key] !== "boolean")
+            return false;
+    }
+    return true;
 }
-
 /**
  * Idempotently register `discover` / `attempt`.
- *
- * @param {{
- *   requestDiscover: (input: object) => Promise<unknown>,
- *   requestAttempt: (input: object) => Promise<unknown>,
- *   registry?: import("./chat-action-registry.js").ChatActionRegistry,
- *   evaluateGate?: () => { decision: { stage: string } },
- * }} options
  */
 export function registerDiscoverAttemptChatActions(options) {
-  const requestDiscover = options?.requestDiscover;
-  const requestAttempt = options?.requestAttempt;
-  if (typeof requestDiscover !== "function") {
-    throw new TypeError("registerDiscoverAttemptChatActions: requestDiscover must be a function");
-  }
-  if (typeof requestAttempt !== "function") {
-    throw new TypeError("registerDiscoverAttemptChatActions: requestAttempt must be a function");
-  }
-
-  const registry = options.registry ?? chatActionRegistry;
-  const evaluateGate = options.evaluateGate ?? allowEndpointGatedAction;
-
-  if (!registry.has(DISCOVER_CHAT_ACTION)) {
-    registry.register(DISCOVER_CHAT_ACTION, {
-      paramsValidator: isDiscoverChatParams,
-      // Nullish params mean "discover with defaults" -- forwarded as {} so the client always POSTs an object.
-      handler: governorGatedHandler(async (request) => requestDiscover(asParamsRecord(request?.params) ?? {}), {
-        evaluateGate,
-      }),
-    });
-  }
-
-  if (!registry.has(ATTEMPT_CHAT_ACTION)) {
-    registry.register(ATTEMPT_CHAT_ACTION, {
-      paramsValidator: isAttemptChatParams,
-      handler: governorGatedHandler(async (request) => requestAttempt(asParamsRecord(request?.params)), {
-        evaluateGate,
-      }),
-    });
-  }
+    const requestDiscover = options?.requestDiscover;
+    const requestAttempt = options?.requestAttempt;
+    if (typeof requestDiscover !== "function") {
+        throw new TypeError("registerDiscoverAttemptChatActions: requestDiscover must be a function");
+    }
+    if (typeof requestAttempt !== "function") {
+        throw new TypeError("registerDiscoverAttemptChatActions: requestAttempt must be a function");
+    }
+    const registry = options.registry ?? chatActionRegistry;
+    const evaluateGate = options.evaluateGate ?? allowEndpointGatedAction;
+    if (!registry.has(DISCOVER_CHAT_ACTION)) {
+        registry.register(DISCOVER_CHAT_ACTION, {
+            paramsValidator: isDiscoverChatParams,
+            // Nullish params mean "discover with defaults" -- forwarded as {} so the client always POSTs an object.
+            handler: governorGatedHandler(async (request) => requestDiscover((asParamsRecord(request?.params) ?? {})), { evaluateGate }),
+        });
+    }
+    if (!registry.has(ATTEMPT_CHAT_ACTION)) {
+        registry.register(ATTEMPT_CHAT_ACTION, {
+            paramsValidator: isAttemptChatParams,
+            handler: governorGatedHandler(async (request) => requestAttempt(asParamsRecord(request?.params)), { evaluateGate }),
+        });
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2hhdC1kaXNjb3Zlci1hdHRlbXB0LWFjdGlvbnMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJjaGF0LWRpc2NvdmVyLWF0dGVtcHQtYWN0aW9ucy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxzREFBc0Q7QUFDdEQsRUFBRTtBQUNGLHlHQUF5RztBQUN6RywyR0FBMkc7QUFDM0csNEdBQTRHO0FBQzVHLHVHQUF1RztBQUN2Ryw0R0FBNEc7QUFDNUcsbUdBQW1HO0FBQ25HLDhHQUE4RztBQUM5RyxnQ0FBZ0M7QUFDaEMsRUFBRTtBQUNGLDZFQUE2RTtBQUM3RSxxR0FBcUc7QUFDckcscUVBQXFFO0FBQ3JFLCtGQUErRjtBQUMvRiw2R0FBNkc7QUFDN0csaUZBQWlGO0FBQ2pGLDJHQUEyRztBQUMzRyw4R0FBOEc7QUFDOUcsNkdBQTZHO0FBQzdHLDZHQUE2RztBQUM3Ryw2R0FBNkc7QUFFN0csT0FBTyxFQUFFLG9CQUFvQixFQUFFLGtCQUFrQixFQUFFLE1BQU0sMkJBQTJCLENBQUM7QUFHckYsTUFBTSxDQUFDLE1BQU0sb0JBQW9CLEdBQUcsVUFBbUIsQ0FBQztBQUN4RCxNQUFNLENBQUMsTUFBTSxtQkFBbUIsR0FBRyxTQUFrQixDQUFDO0FBcUJ0RCx5RkFBeUY7QUFDekYsTUFBTSx3QkFBd0IsR0FBRyxHQUFHLEVBQUUsQ0FBQyxDQUFDLEVBQUUsUUFBUSxFQUFFLEVBQUUsS0FBSyxFQUFFLE9BQU8sRUFBRSxFQUFFLENBQUMsQ0FBQztBQUUxRSxNQUFNLGFBQWEsR0FBRyxJQUFJLEdBQUcsQ0FBQyxDQUFDLFNBQVMsRUFBRSxRQUFRLEVBQUUsUUFBUSxFQUFFLE1BQU0sRUFBRSxZQUFZLEVBQUUsVUFBVSxDQUFDLENBQUMsQ0FBQztBQUNqRyxNQUFNLFlBQVksR0FBRyxJQUFJLEdBQUcsQ0FBQyxDQUFDLGNBQWMsRUFBRSxhQUFhLEVBQUUsWUFBWSxFQUFFLE1BQU0sRUFBRSxNQUFNLEVBQUUsUUFBUSxFQUFFLE1BQU0sQ0FBQyxDQUFDLENBQUM7QUFFOUcsU0FBUyxjQUFjLENBQUMsTUFBZTtJQUNyQyxJQUFJLE1BQU0sSUFBSSxJQUFJLElBQUksT0FBTyxNQUFNLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDdkYsT0FBTyxNQUFpQyxDQUFDO0FBQzNDLENBQUM7QUFFRCwyRUFBMkU7QUFDM0UsU0FBUyxnQkFBZ0IsQ0FBQyxLQUFjO0lBQ3RDLE9BQU8sT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxJQUFJLEVBQUUsS0FBSyxFQUFFLENBQUM7QUFDMUQsQ0FBQztBQUVEOzs7O0dBSUc7QUFDSCxNQUFNLFVBQVUsb0JBQW9CLENBQUMsTUFBZTtJQUNsRCxJQUFJLE1BQU0sSUFBSSxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDaEMsTUFBTSxNQUFNLEdBQUcsY0FBYyxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ3RDLElBQUksTUFBTSxLQUFLLElBQUk7UUFBRSxPQUFPLEtBQUssQ0FBQztJQUNsQyxLQUFLLE1BQU0sR0FBRyxJQUFJLE1BQU0sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN0QyxJQUFJLENBQUMsYUFBYSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUM7WUFBRSxPQUFPLEtBQUssQ0FBQztJQUM1QyxDQUFDO0lBQ0QsSUFBSSxNQUFNLENBQUMsT0FBTyxLQUFLLFNBQVMsRUFBRSxDQUFDO1FBQ2pDLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLGdCQUFnQixDQUFDO1lBQUUsT0FBTyxLQUFLLENBQUM7SUFDOUYsQ0FBQztJQUNELEtBQUssTUFBTSxHQUFHLElBQUksQ0FBQyxRQUFRLEVBQUUsWUFBWSxFQUFFLFVBQVUsQ0FBQyxFQUFFLENBQUM7UUFDdkQsSUFBSSxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssU0FBUyxJQUFJLE9BQU8sTUFBTSxDQUFDLEdBQUcsQ0FBQyxLQUFLLFFBQVE7WUFBRSxPQUFPLEtBQUssQ0FBQztJQUNqRixDQUFDO0lBQ0QsS0FBSyxNQUFNLEdBQUcsSUFBSSxDQUFDLFFBQVEsRUFBRSxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3JDLElBQUksTUFBTSxDQUFDLEdBQUcsQ0FBQyxLQUFLLFNBQVMsSUFBSSxPQUFPLE1BQU0sQ0FBQyxHQUFHLENBQUMsS0FBSyxTQUFTO1lBQUUsT0FBTyxLQUFLLENBQUM7SUFDbEYsQ0FBQztJQUNELE9BQU8sSUFBSSxDQUFDO0FBQ2QsQ0FBQztBQUVEOzs7O0dBSUc7QUFDSCxNQUFNLFVBQVUsbUJBQW1CLENBQUMsTUFBZTtJQUNqRCxNQUFNLE1BQU0sR0FBRyxjQUFjLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDdEMsSUFBSSxNQUFNLEtBQUssSUFBSTtRQUFFLE9BQU8sS0FBSyxDQUFDO0lBQ2xDLEtBQUssTUFBTSxHQUFHLElBQUksTUFBTSxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3RDLElBQUksQ0FBQyxZQUFZLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sS0FBSyxDQUFDO0lBQzNDLENBQUM7SUFDRCxJQUFJLENBQUMsZ0JBQWdCLENBQUMsTUFBTSxDQUFDLFlBQVksQ0FBQztRQUFFLE9BQU8sS0FBSyxDQUFDO0lBQ3pELElBQUksQ0FBQyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsVUFBVSxDQUFDO1FBQUUsT0FBTyxLQUFLLENBQUM7SUFDdkQsSUFBSSxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsTUFBTSxDQUFDLFdBQVcsQ0FBQyxJQUFLLE1BQU0sQ0FBQyxXQUFzQixJQUFJLENBQUM7UUFBRSxPQUFPLEtBQUssQ0FBQztJQUMvRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEtBQUssU0FBUyxJQUFJLE9BQU8sTUFBTSxDQUFDLElBQUksS0FBSyxRQUFRO1FBQUUsT0FBTyxLQUFLLENBQUM7SUFDL0UsS0FBSyxNQUFNLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxRQUFRLEVBQUUsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUM3QyxJQUFJLE1BQU0sQ0FBQyxHQUFHLENBQUMsS0FBSyxTQUFTLElBQUksT0FBTyxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssU0FBUztZQUFFLE9BQU8sS0FBSyxDQUFDO0lBQ2xGLENBQUM7SUFDRCxPQUFPLElBQUksQ0FBQztBQUNkLENBQUM7QUFFRDs7R0FFRztBQUNILE1BQU0sVUFBVSxrQ0FBa0MsQ0FBQyxPQUtsRDtJQUNDLE1BQU0sZUFBZSxHQUFHLE9BQU8sRUFBRSxlQUFlLENBQUM7SUFDakQsTUFBTSxjQUFjLEdBQUcsT0FBTyxFQUFFLGNBQWMsQ0FBQztJQUMvQyxJQUFJLE9BQU8sZUFBZSxLQUFLLFVBQVUsRUFBRSxDQUFDO1FBQzFDLE1BQU0sSUFBSSxTQUFTLENBQUMsd0VBQXdFLENBQUMsQ0FBQztJQUNoRyxDQUFDO0lBQ0QsSUFBSSxPQUFPLGNBQWMsS0FBSyxVQUFVLEVBQUUsQ0FBQztRQUN6QyxNQUFNLElBQUksU0FBUyxDQUFDLHVFQUF1RSxDQUFDLENBQUM7SUFDL0YsQ0FBQztJQUVELE1BQU0sUUFBUSxHQUFHLE9BQU8sQ0FBQyxRQUFRLElBQUksa0JBQWtCLENBQUM7SUFDeEQsTUFBTSxZQUFZLEdBQUcsT0FBTyxDQUFDLFlBQVksSUFBSSx3QkFBd0IsQ0FBQztJQUV0RSxJQUFJLENBQUMsUUFBUSxDQUFDLEdBQUcsQ0FBQyxvQkFBb0IsQ0FBQyxFQUFFLENBQUM7UUFDeEMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxvQkFBb0IsRUFBRTtZQUN0QyxlQUFlLEVBQUUsb0JBQW9CO1lBQ3JDLHdHQUF3RztZQUN4RyxPQUFPLEVBQUUsb0JBQW9CLENBQzNCLEtBQUssRUFBRSxPQUFPLEVBQUUsRUFBRSxDQUNoQixlQUFlLENBQUMsQ0FBQyxjQUFjLENBQUMsT0FBTyxFQUFFLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBNEIsQ0FBQyxFQUNyRixFQUFFLFlBQVksRUFBRSxDQUNqQjtTQUNGLENBQUMsQ0FBQztJQUNMLENBQUM7SUFFRCxJQUFJLENBQUMsUUFBUSxDQUFDLEdBQUcsQ0FBQyxtQkFBbUIsQ0FBQyxFQUFFLENBQUM7UUFDdkMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxtQkFBbUIsRUFBRTtZQUNyQyxlQUFlLEVBQUUsbUJBQW1CO1lBQ3BDLE9BQU8sRUFBRSxvQkFBb0IsQ0FDM0IsS0FBSyxFQUFFLE9BQU8sRUFBRSxFQUFFLENBQ2hCLGNBQWMsQ0FBQyxjQUFjLENBQUMsT0FBTyxFQUFFLE1BQU0sQ0FBMkIsQ0FBQyxFQUMzRSxFQUFFLFlBQVksRUFBRSxDQUNqQjtTQUNGLENBQUMsQ0FBQztJQUNMLENBQUM7QUFDSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/chat-discover-attempt-actions.ts
+++ b/packages/loopover-miner/lib/chat-discover-attempt-actions.ts
@@ -1,0 +1,153 @@
+// Discover/attempt chat-action registrations (#6837).
+//
+// The third and last child of the chat action-dispatch scaffolding (#6519) — chat-action-registry.js:4-5
+// names all three families (portfolio release/requeue, governor pause/resume, discover/attempt); the other
+// two already ship. Registers `discover` / `attempt` into a chat-action registry. Handlers MUST be wired to
+// the miner-ui clients `requestDiscover` / `requestAttempt` (apps/loopover-miner-ui/src/lib/{discover,
+// attempt}.ts), so chat POSTs the SAME `/api/discover` and `/api/attempt` routes that already exist (#6522,
+// registered at vite.config.ts:36-37) — never discover-cli.js/attempt-cli.js directly, and never a
+// hand-rolled fetch. The miner-ui wire module passes those clients in; this module only owns the registration
+// contract + params validators.
+//
+// GATING — the gate lives at the endpoint, not here, and that is deliberate:
+//   * `attempt` INHERITS the real Governor chokepoint for free: the route calls the real, unmodified
+//     `runAttempt`, and attempt-runner.js routes every write through
+//     `evaluateGovernorChokepointGatePersisted` before executing it (vite-attempt-api.ts:7-9).
+//   * `discover` has no chokepoint because it performs no gated write — it only fans out, ranks and enqueues
+//     (vite-discover-api.ts:13-14), so the CLI has none and the route adds none.
+// Re-evaluating the chokepoint here would therefore be a SECOND, competing gate on a path that already has
+// one (or needs none) — exactly what those route comments rule out, and it would gate chat more strictly than
+// the equivalent CLI invocation. So, like chat-governor-actions.js and chat-portfolio-actions.js, we satisfy
+// the registry's `governorGatedHandler` brand with an allow-stage evaluateGate. Execution still stays behind
+// the shared LOOPOVER_MINER_CHAT_ACTIONS flag via `dispatchChatAction`, and `evaluateGate` stays injectable.
+
+import { governorGatedHandler, chatActionRegistry } from "./chat-action-registry.js";
+import type { ChatActionRegistry } from "./chat-action-registry.js";
+
+export const DISCOVER_CHAT_ACTION = "discover" as const;
+export const ATTEMPT_CHAT_ACTION = "attempt" as const;
+
+export type DiscoverChatActionInput = {
+  targets?: string[];
+  search?: string;
+  dryRun?: boolean;
+  json?: boolean;
+  apiBaseUrl?: string;
+  tokenEnv?: string;
+};
+
+export type AttemptChatActionInput = {
+  repoFullName: string;
+  issueNumber: number;
+  minerLogin: string;
+  base?: string;
+  live?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+/** The endpoint owns the gate (see the header note); satisfy the registry brand only. */
+const allowEndpointGatedAction = () => ({ decision: { stage: "allow" } });
+
+const DISCOVER_KEYS = new Set(["targets", "search", "dryRun", "json", "apiBaseUrl", "tokenEnv"]);
+const ATTEMPT_KEYS = new Set(["repoFullName", "issueNumber", "minerLogin", "base", "live", "dryRun", "json"]);
+
+function asParamsRecord(params: unknown): Record<string, unknown> | null {
+  if (params == null || typeof params !== "object" || Array.isArray(params)) return null;
+  return params as Record<string, unknown>;
+}
+
+/** A non-empty string — the shape every required text field here needs. */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/**
+ * `DiscoverActionInput` — every field optional (the CLI defaults them all), so an empty object is a valid
+ * "discover with defaults". Unknown keys are rejected rather than ignored: these params can be model-authored,
+ * and a typo'd flag must fail loudly instead of silently running a different discovery than intended.
+ */
+export function isDiscoverChatParams(params: unknown): boolean {
+  if (params == null) return true;
+  const record = asParamsRecord(params);
+  if (record === null) return false;
+  for (const key of Object.keys(record)) {
+    if (!DISCOVER_KEYS.has(key)) return false;
+  }
+  if (record.targets !== undefined) {
+    if (!Array.isArray(record.targets) || !record.targets.every(isNonEmptyString)) return false;
+  }
+  for (const key of ["search", "apiBaseUrl", "tokenEnv"]) {
+    if (record[key] !== undefined && typeof record[key] !== "string") return false;
+  }
+  for (const key of ["dryRun", "json"]) {
+    if (record[key] !== undefined && typeof record[key] !== "boolean") return false;
+  }
+  return true;
+}
+
+/**
+ * `AttemptActionInput` — `repoFullName` / `issueNumber` / `minerLogin` are REQUIRED (the CLI has no default
+ * for which issue to attempt), so unlike discover there is no valid empty form. `issueNumber` must be a
+ * positive integer: a float or 0 would reach the CLI as a nonsense issue reference.
+ */
+export function isAttemptChatParams(params: unknown): boolean {
+  const record = asParamsRecord(params);
+  if (record === null) return false;
+  for (const key of Object.keys(record)) {
+    if (!ATTEMPT_KEYS.has(key)) return false;
+  }
+  if (!isNonEmptyString(record.repoFullName)) return false;
+  if (!isNonEmptyString(record.minerLogin)) return false;
+  if (!Number.isInteger(record.issueNumber) || (record.issueNumber as number) <= 0) return false;
+  if (record.base !== undefined && typeof record.base !== "string") return false;
+  for (const key of ["live", "dryRun", "json"]) {
+    if (record[key] !== undefined && typeof record[key] !== "boolean") return false;
+  }
+  return true;
+}
+
+/**
+ * Idempotently register `discover` / `attempt`.
+ */
+export function registerDiscoverAttemptChatActions(options: {
+  requestDiscover: (input: DiscoverChatActionInput) => Promise<unknown>;
+  requestAttempt: (input: AttemptChatActionInput) => Promise<unknown>;
+  registry?: ChatActionRegistry;
+  evaluateGate?: () => { decision: { stage: string } };
+}): void {
+  const requestDiscover = options?.requestDiscover;
+  const requestAttempt = options?.requestAttempt;
+  if (typeof requestDiscover !== "function") {
+    throw new TypeError("registerDiscoverAttemptChatActions: requestDiscover must be a function");
+  }
+  if (typeof requestAttempt !== "function") {
+    throw new TypeError("registerDiscoverAttemptChatActions: requestAttempt must be a function");
+  }
+
+  const registry = options.registry ?? chatActionRegistry;
+  const evaluateGate = options.evaluateGate ?? allowEndpointGatedAction;
+
+  if (!registry.has(DISCOVER_CHAT_ACTION)) {
+    registry.register(DISCOVER_CHAT_ACTION, {
+      paramsValidator: isDiscoverChatParams,
+      // Nullish params mean "discover with defaults" -- forwarded as {} so the client always POSTs an object.
+      handler: governorGatedHandler(
+        async (request) =>
+          requestDiscover((asParamsRecord(request?.params) ?? {}) as DiscoverChatActionInput),
+        { evaluateGate },
+      ),
+    });
+  }
+
+  if (!registry.has(ATTEMPT_CHAT_ACTION)) {
+    registry.register(ATTEMPT_CHAT_ACTION, {
+      paramsValidator: isAttemptChatParams,
+      handler: governorGatedHandler(
+        async (request) =>
+          requestAttempt(asParamsRecord(request?.params) as AttemptChatActionInput),
+        { evaluateGate },
+      ),
+    });
+  }
+}

--- a/packages/loopover-miner/lib/deny-hook-synthesis.d.ts
+++ b/packages/loopover-miner/lib/deny-hook-synthesis.d.ts
@@ -1,93 +1,29 @@
+import { aggregateBlockerHistory, canonicalizeChangedPath, changedPathToDenyGlob, DEFAULT_SYNTHESIS_CONFIG, isCoveredByDefaultDenyRules, normalizeBlockerHistory, normalizeBlockerHistoryRecord, resolveEffectiveDenyRules, setProposalStatuses } from "@loopover/engine";
+import type { BlockerHistoryRecord, DenyRuleProposal, DenyRuleProposalAudit, DenyRuleProposalStatus, SynthesisConfig } from "@loopover/engine";
 import type { DenyRule } from "./deny-hooks.js";
-
-export type BlockerHistoryRecord = {
-  repoFullName?: string | null;
-  blockerCodes: string[];
-  changedPaths?: string[];
-  guardrailMatches?: string[];
-  pullNumber?: number | null;
-  recordedAt?: string | null;
-};
-
-export type DenyRuleProposalStatus = "proposed" | "approved" | "rejected";
-
-export type DenyRuleProposalAudit = {
-  kind: string;
-  path?: string;
-  pathPattern?: string;
-  occurrenceCount?: number;
-  blockerCodes?: string[];
-  synthesizedAt: string;
-};
-
-export type DenyRuleProposal = {
-  id: string;
-  status: DenyRuleProposalStatus;
-  rule: DenyRule;
-  audit: DenyRuleProposalAudit;
-};
-
-export type SynthesisConfig = {
-  minPathOccurrences?: number;
-  maxProposals?: number;
-};
-
-export const DEFAULT_SYNTHESIS_CONFIG: Readonly<Required<SynthesisConfig>>;
-
-export function normalizeBlockerHistoryRecord(record: unknown): BlockerHistoryRecord | null;
-
-export function normalizeBlockerHistory(records: unknown): BlockerHistoryRecord[];
-
-export function canonicalizeChangedPath(path: unknown): string | null;
-
-export function changedPathToDenyGlob(path: string): string | null;
-
-export function isCoveredByDefaultDenyRules(pathPattern: string): boolean;
-
-export function aggregateBlockerHistory(records: unknown): {
-  pathCounts: Map<string, number>;
-  pathBlockers: Map<string, Set<string>>;
-  blockerCounts: Map<string, number>;
-  recordCount: number;
-};
-
-export function synthesizeDenyRuleProposals(
-  records: unknown,
-  config?: SynthesisConfig,
-): DenyRuleProposal[];
-
-export function resolveEffectiveDenyRules(options?: {
-  includeDefaults?: boolean;
-  approvedProposals?: DenyRuleProposal[];
-}): DenyRule[];
-
-export function setProposalStatuses(
-  proposals: DenyRuleProposal[],
-  updates: Record<string, DenyRuleProposalStatus> | Map<string, DenyRuleProposalStatus>,
-): DenyRuleProposal[];
-
-export function resolveDenyHookSynthesisDbPath(env?: Record<string, string | undefined>): string;
-
+export { aggregateBlockerHistory, canonicalizeChangedPath, changedPathToDenyGlob, DEFAULT_SYNTHESIS_CONFIG, isCoveredByDefaultDenyRules, normalizeBlockerHistory, normalizeBlockerHistoryRecord, resolveEffectiveDenyRules, setProposalStatuses, };
+export type { BlockerHistoryRecord, DenyRuleProposal, DenyRuleProposalAudit, DenyRuleProposalStatus, SynthesisConfig, };
 export type DenyHookSynthesisStore = {
-  dbPath: string;
-  refreshProposals(
-    repoFullName: string,
-    history: unknown,
-    config?: SynthesisConfig,
-    apiBaseUrl?: string,
-  ): DenyRuleProposal[];
-  listProposals(repoFullName: string, apiBaseUrl?: string): DenyRuleProposal[];
-  setProposalStatus(
-    repoFullName: string,
-    proposalId: string,
-    status: DenyRuleProposalStatus,
-    apiBaseUrl?: string,
-  ): void;
-  resolveEffectiveRules(
-    repoFullName: string,
-    options?: { includeDefaults?: boolean; apiBaseUrl?: string },
-  ): DenyRule[];
-  close(): void;
+    dbPath: string;
+    refreshProposals(repoFullName: string, history: unknown, config?: SynthesisConfig, apiBaseUrl?: string): DenyRuleProposal[];
+    listProposals(repoFullName: string, apiBaseUrl?: string): DenyRuleProposal[];
+    setProposalStatus(repoFullName: string, proposalId: string, status: DenyRuleProposalStatus, apiBaseUrl?: string): void;
+    resolveEffectiveRules(repoFullName: string, options?: {
+        includeDefaults?: boolean;
+        apiBaseUrl?: string;
+    }): DenyRule[];
+    close(): void;
 };
-
-export function initDenyHookSynthesisStore(dbPath?: string): DenyHookSynthesisStore;
+/**
+ * Derive candidate deny-hook rules from blocker/path history. Miner-facing wrapper over the engine's pure
+ * `synthesizeDenyRuleProposals`, defaulting the injected clock to `Date.now()` so this keeps the pre-#5667 2-arg
+ * signature (and wall-clock `audit.synthesizedAt`) every existing caller and test relies on. Returns proposal
+ * objects only — nothing is active until a maintainer approves them (see resolveEffectiveDenyRules).
+ */
+export declare function synthesizeDenyRuleProposals(records: unknown, config?: SynthesisConfig): DenyRuleProposal[];
+export declare function resolveDenyHookSynthesisDbPath(env?: Record<string, string | undefined>): string;
+/**
+ * Local SQLite store for synthesized deny-rule proposals. Refresh re-derives proposals from history while
+ * preserving maintainer decisions on ids that still exist.
+ */
+export declare function initDenyHookSynthesisStore(dbPath?: string): DenyHookSynthesisStore;

--- a/packages/loopover-miner/lib/deny-hook-synthesis.js
+++ b/packages/loopover-miner/lib/deny-hook-synthesis.js
@@ -7,39 +7,13 @@ import { chmodSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import {
-  aggregateBlockerHistory,
-  canonicalizeChangedPath,
-  changedPathToDenyGlob,
-  DEFAULT_SYNTHESIS_CONFIG,
-  isCoveredByDefaultDenyRules,
-  normalizeBlockerHistory,
-  normalizeBlockerHistoryRecord,
-  normalizeRepoFullName,
-  proposalStatusSet,
-  resolveEffectiveDenyRules,
-  setProposalStatuses,
-  synthesizeDenyRuleProposals as engineSynthesizeDenyRuleProposals,
-} from "@loopover/engine";
+import { aggregateBlockerHistory, canonicalizeChangedPath, changedPathToDenyGlob, DEFAULT_SYNTHESIS_CONFIG, isCoveredByDefaultDenyRules, normalizeBlockerHistory, normalizeBlockerHistoryRecord, normalizeRepoFullName, proposalStatusSet, resolveEffectiveDenyRules, setProposalStatuses, synthesizeDenyRuleProposals as engineSynthesizeDenyRuleProposals, } from "@loopover/engine";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
-
 // Re-export the pure synthesis helpers from the engine so this module's public API is unchanged after #5667
 // moved derivation/audit into @loopover/engine. Only the SQLite store below (and its forge/db-path helpers) is
 // miner-local, because it depends on node:sqlite/node:fs and this package's forge-config default.
-export {
-  aggregateBlockerHistory,
-  canonicalizeChangedPath,
-  changedPathToDenyGlob,
-  DEFAULT_SYNTHESIS_CONFIG,
-  isCoveredByDefaultDenyRules,
-  normalizeBlockerHistory,
-  normalizeBlockerHistoryRecord,
-  resolveEffectiveDenyRules,
-  setProposalStatuses,
-};
-
+export { aggregateBlockerHistory, canonicalizeChangedPath, changedPathToDenyGlob, DEFAULT_SYNTHESIS_CONFIG, isCoveredByDefaultDenyRules, normalizeBlockerHistory, normalizeBlockerHistoryRecord, resolveEffectiveDenyRules, setProposalStatuses, };
 const defaultDbFileName = "deny-hook-synthesis.sqlite3";
-
 /**
  * Derive candidate deny-hook rules from blocker/path history. Miner-facing wrapper over the engine's pure
  * `synthesizeDenyRuleProposals`, defaulting the injected clock to `Date.now()` so this keeps the pre-#5667 2-arg
@@ -47,49 +21,47 @@ const defaultDbFileName = "deny-hook-synthesis.sqlite3";
  * objects only — nothing is active until a maintainer approves them (see resolveEffectiveDenyRules).
  */
 export function synthesizeDenyRuleProposals(records, config = {}) {
-  return engineSynthesizeDenyRuleProposals(records, config, Date.now());
+    return engineSynthesizeDenyRuleProposals(records, config, Date.now());
 }
-
 /** Optional forge host, scoping rows so two hosts serving the same owner/repo name never collide (#5563).
  *  Omitted/nullish → the github.com default, so every pre-existing single-forge caller is unaffected. */
 function normalizeApiBaseUrl(apiBaseUrl) {
-  if (apiBaseUrl === undefined || apiBaseUrl === null) return DEFAULT_FORGE_CONFIG.apiBaseUrl;
-  if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim()) throw new Error("invalid_api_base_url");
-  return apiBaseUrl.trim();
+    if (apiBaseUrl === undefined || apiBaseUrl === null)
+        return DEFAULT_FORGE_CONFIG.apiBaseUrl;
+    if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim())
+        throw new Error("invalid_api_base_url");
+    return apiBaseUrl.trim();
 }
-
 export function resolveDenyHookSynthesisDbPath(env = process.env) {
-  const explicitPath = typeof env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB === "string"
-    ? env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB.trim()
-    : "";
-  if (explicitPath) return explicitPath;
-
-  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
-    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
-    : "";
-  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
-
-  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
-    ? env.XDG_CONFIG_HOME.trim()
-    : join(homedir(), ".config");
-  return join(configHome, "loopover-miner", defaultDbFileName);
+    const explicitPath = typeof env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB === "string"
+        ? env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB.trim()
+        : "";
+    if (explicitPath)
+        return explicitPath;
+    const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
+        ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
+        : "";
+    if (explicitConfigDir)
+        return join(explicitConfigDir, defaultDbFileName);
+    const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+        ? env.XDG_CONFIG_HOME.trim()
+        : join(homedir(), ".config");
+    return join(configHome, "loopover-miner", defaultDbFileName);
 }
-
 function normalizeDbPath(dbPath) {
-  const path = (dbPath ?? resolveDenyHookSynthesisDbPath()).trim();
-  if (!path) throw new Error("invalid_deny_hook_synthesis_db_path");
-  return path;
+    const path = (dbPath ?? resolveDenyHookSynthesisDbPath()).trim();
+    if (!path)
+        throw new Error("invalid_deny_hook_synthesis_db_path");
+    return path;
 }
-
 function rowToProposal(row) {
-  return {
-    id: row.id,
-    status: row.status,
-    rule: JSON.parse(row.rule_json),
-    audit: JSON.parse(row.audit_json),
-  };
+    return {
+        id: row.id,
+        status: row.status,
+        rule: JSON.parse(row.rule_json),
+        audit: JSON.parse(row.audit_json),
+    };
 }
-
 // Rebuild deny_rule_proposals' (repo_full_name, id) PRIMARY KEY into a (api_base_url, repo_full_name, id)
 // composite (#5563) -- two forge hosts serving a same-named owner/repo must not share one proposal row. SQLite
 // cannot ALTER a PRIMARY KEY in place, so this rebuilds the table: create the new shape, copy every existing row
@@ -97,12 +69,11 @@ function rowToProposal(row) {
 // Guarded by a column-presence check (this module has no schema-version framework of its own, unlike the
 // package's other local stores) so this only runs once per file.
 function ensureDenyRuleProposalsForgeScope(db) {
-  const hasApiBaseUrlColumn = db
-    .prepare("PRAGMA table_info(deny_rule_proposals)")
-    .all()
-    .some((column) => column.name === "api_base_url");
-  if (hasApiBaseUrlColumn) return;
-  db.exec(`
+    const hasApiBaseUrlColumn = db.prepare("PRAGMA table_info(deny_rule_proposals)").all()
+        .some((column) => column.name === "api_base_url");
+    if (hasApiBaseUrlColumn)
+        return;
+    db.exec(`
     CREATE TABLE deny_rule_proposals_v2 (
       api_base_url TEXT NOT NULL,
       repo_full_name TEXT NOT NULL,
@@ -114,29 +85,26 @@ function ensureDenyRuleProposalsForgeScope(db) {
       PRIMARY KEY (api_base_url, repo_full_name, id)
     )
   `);
-  // OR IGNORE: a row this store's own read path already treats as unusable garbage (an unrecognized `status`,
-  // e.g. from a hand-edited or otherwise corrupted file) would violate the CHECK constraint above and abort the
-  // whole migration. Skipping it here is consistent with that same fail-closed posture, rather than turning one
-  // bad row into a permanently unmigratable file.
-  db.prepare(
-    `INSERT OR IGNORE INTO deny_rule_proposals_v2 (api_base_url, repo_full_name, id, status, rule_json, audit_json, updated_at)
-     SELECT ?, repo_full_name, id, status, rule_json, audit_json, updated_at FROM deny_rule_proposals`,
-  ).run(DEFAULT_FORGE_CONFIG.apiBaseUrl);
-  db.exec("DROP TABLE deny_rule_proposals");
-  db.exec("ALTER TABLE deny_rule_proposals_v2 RENAME TO deny_rule_proposals");
+    // OR IGNORE: a row this store's own read path already treats as unusable garbage (an unrecognized `status`,
+    // e.g. from a hand-edited or otherwise corrupted file) would violate the CHECK constraint above and abort the
+    // whole migration. Skipping it here is consistent with that same fail-closed posture, rather than turning one
+    // bad row into a permanently unmigratable file.
+    db.prepare(`INSERT OR IGNORE INTO deny_rule_proposals_v2 (api_base_url, repo_full_name, id, status, rule_json, audit_json, updated_at)
+     SELECT ?, repo_full_name, id, status, rule_json, audit_json, updated_at FROM deny_rule_proposals`).run(DEFAULT_FORGE_CONFIG.apiBaseUrl);
+    db.exec("DROP TABLE deny_rule_proposals");
+    db.exec("ALTER TABLE deny_rule_proposals_v2 RENAME TO deny_rule_proposals");
 }
-
 /**
  * Local SQLite store for synthesized deny-rule proposals. Refresh re-derives proposals from history while
  * preserving maintainer decisions on ids that still exist.
  */
 export function initDenyHookSynthesisStore(dbPath = resolveDenyHookSynthesisDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
-  const db = new DatabaseSync(resolvedPath);
-  chmodSync(resolvedPath, 0o600);
-  db.exec("PRAGMA busy_timeout = 5000");
-  db.exec(`
+    const resolvedPath = normalizeDbPath(dbPath);
+    mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
+    const db = new DatabaseSync(resolvedPath);
+    chmodSync(resolvedPath, 0o600);
+    db.exec("PRAGMA busy_timeout = 5000");
+    db.exec(`
     CREATE TABLE IF NOT EXISTS deny_rule_proposals (
       repo_full_name TEXT NOT NULL,
       id TEXT NOT NULL,
@@ -147,9 +115,8 @@ export function initDenyHookSynthesisStore(dbPath = resolveDenyHookSynthesisDbPa
       PRIMARY KEY (repo_full_name, id)
     )
   `);
-  ensureDenyRuleProposalsForgeScope(db);
-
-  const upsertStatement = db.prepare(`
+    ensureDenyRuleProposalsForgeScope(db);
+    const upsertStatement = db.prepare(`
     INSERT INTO deny_rule_proposals (api_base_url, repo_full_name, id, status, rule_json, audit_json, updated_at)
     VALUES (?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(api_base_url, repo_full_name, id) DO UPDATE SET
@@ -158,68 +125,61 @@ export function initDenyHookSynthesisStore(dbPath = resolveDenyHookSynthesisDbPa
       audit_json = excluded.audit_json,
       updated_at = excluded.updated_at
   `);
-  const getStatusStatement = db.prepare(
-    "SELECT status FROM deny_rule_proposals WHERE api_base_url = ? AND repo_full_name = ? AND id = ?",
-  );
-  const listStatement = db.prepare(
-    "SELECT repo_full_name, id, status, rule_json, audit_json, updated_at FROM deny_rule_proposals WHERE api_base_url = ? AND repo_full_name = ? ORDER BY id ASC",
-  );
-  const setStatusStatement = db.prepare(`
+    const getStatusStatement = db.prepare("SELECT status FROM deny_rule_proposals WHERE api_base_url = ? AND repo_full_name = ? AND id = ?");
+    const listStatement = db.prepare("SELECT repo_full_name, id, status, rule_json, audit_json, updated_at FROM deny_rule_proposals WHERE api_base_url = ? AND repo_full_name = ? ORDER BY id ASC");
+    const setStatusStatement = db.prepare(`
     UPDATE deny_rule_proposals SET status = ?, updated_at = ? WHERE api_base_url = ? AND repo_full_name = ? AND id = ?
   `);
-
-  return {
-    dbPath: resolvedPath,
-    refreshProposals(repoFullName, history, config = {}, apiBaseUrl) {
-      const forge = normalizeApiBaseUrl(apiBaseUrl);
-      const repo = normalizeRepoFullName(repoFullName);
-      const synthesized = synthesizeDenyRuleProposals(history, config);
-      const updatedAt = new Date().toISOString();
-      db.exec("BEGIN IMMEDIATE");
-      try {
-        for (const proposal of synthesized) {
-          const existing = getStatusStatement.get(forge, repo, proposal.id);
-          const status = existing?.status && proposalStatusSet.has(existing.status) && existing.status !== "proposed"
-            ? existing.status
-            : "proposed";
-          upsertStatement.run(
-            forge,
-            repo,
-            proposal.id,
-            status,
-            JSON.stringify(proposal.rule),
-            JSON.stringify(proposal.audit),
-            updatedAt,
-          );
-        }
-        db.exec("COMMIT");
-      } catch (error) {
-        db.exec("ROLLBACK");
-        throw error;
-      }
-      return listStatement.all(forge, repo).map(rowToProposal);
-    },
-    listProposals(repoFullName, apiBaseUrl) {
-      const forge = normalizeApiBaseUrl(apiBaseUrl);
-      const repo = normalizeRepoFullName(repoFullName);
-      return listStatement.all(forge, repo).map(rowToProposal);
-    },
-    setProposalStatus(repoFullName, proposalId, status, apiBaseUrl) {
-      const forge = normalizeApiBaseUrl(apiBaseUrl);
-      const repo = normalizeRepoFullName(repoFullName);
-      if (typeof proposalId !== "string" || !proposalId.trim()) throw new Error("invalid_proposal_id");
-      if (!proposalStatusSet.has(status)) throw new Error("invalid_proposal_status");
-      setStatusStatement.run(status, new Date().toISOString(), forge, repo, proposalId.trim());
-    },
-    resolveEffectiveRules(repoFullName, options = {}) {
-      const proposals = this.listProposals(repoFullName, options.apiBaseUrl);
-      return resolveEffectiveDenyRules({
-        includeDefaults: options.includeDefaults,
-        approvedProposals: proposals,
-      });
-    },
-    close() {
-      db.close();
-    },
-  };
+    const store = {
+        dbPath: resolvedPath,
+        refreshProposals(repoFullName, history, config = {}, apiBaseUrl) {
+            const forge = normalizeApiBaseUrl(apiBaseUrl);
+            const repo = normalizeRepoFullName(repoFullName);
+            const synthesized = synthesizeDenyRuleProposals(history, config);
+            const updatedAt = new Date().toISOString();
+            db.exec("BEGIN IMMEDIATE");
+            try {
+                for (const proposal of synthesized) {
+                    const existing = getStatusStatement.get(forge, repo, proposal.id);
+                    const existingStatus = typeof existing?.status === "string" ? existing.status : undefined;
+                    const status = existingStatus && proposalStatusSet.has(existingStatus) && existingStatus !== "proposed"
+                        ? existingStatus
+                        : "proposed";
+                    upsertStatement.run(forge, repo, proposal.id, status, JSON.stringify(proposal.rule), JSON.stringify(proposal.audit), updatedAt);
+                }
+                db.exec("COMMIT");
+            }
+            catch (error) {
+                db.exec("ROLLBACK");
+                throw error;
+            }
+            return listStatement.all(forge, repo).map(rowToProposal);
+        },
+        listProposals(repoFullName, apiBaseUrl) {
+            const forge = normalizeApiBaseUrl(apiBaseUrl);
+            const repo = normalizeRepoFullName(repoFullName);
+            return listStatement.all(forge, repo).map(rowToProposal);
+        },
+        setProposalStatus(repoFullName, proposalId, status, apiBaseUrl) {
+            const forge = normalizeApiBaseUrl(apiBaseUrl);
+            const repo = normalizeRepoFullName(repoFullName);
+            if (typeof proposalId !== "string" || !proposalId.trim())
+                throw new Error("invalid_proposal_id");
+            if (!proposalStatusSet.has(status))
+                throw new Error("invalid_proposal_status");
+            setStatusStatement.run(status, new Date().toISOString(), forge, repo, proposalId.trim());
+        },
+        resolveEffectiveRules(repoFullName, options = {}) {
+            const proposals = store.listProposals(repoFullName, options.apiBaseUrl);
+            return resolveEffectiveDenyRules({
+                ...(options.includeDefaults !== undefined ? { includeDefaults: options.includeDefaults } : {}),
+                approvedProposals: proposals,
+            });
+        },
+        close() {
+            db.close();
+        },
+    };
+    return store;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGVueS1ob29rLXN5bnRoZXNpcy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImRlbnktaG9vay1zeW50aGVzaXMudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsZ0hBQWdIO0FBQ2hILDRHQUE0RztBQUM1Ryw0R0FBNEc7QUFDNUcsa0dBQWtHO0FBQ2xHLCtGQUErRjtBQUMvRixPQUFPLEVBQUUsU0FBUyxFQUFFLFNBQVMsRUFBRSxNQUFNLFNBQVMsQ0FBQztBQUMvQyxPQUFPLEVBQUUsT0FBTyxFQUFFLE1BQU0sU0FBUyxDQUFDO0FBQ2xDLE9BQU8sRUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLE1BQU0sV0FBVyxDQUFDO0FBQzFDLE9BQU8sRUFBRSxZQUFZLEVBQUUsTUFBTSxhQUFhLENBQUM7QUFDM0MsT0FBTyxFQUNMLHVCQUF1QixFQUN2Qix1QkFBdUIsRUFDdkIscUJBQXFCLEVBQ3JCLHdCQUF3QixFQUN4QiwyQkFBMkIsRUFDM0IsdUJBQXVCLEVBQ3ZCLDZCQUE2QixFQUM3QixxQkFBcUIsRUFDckIsaUJBQWlCLEVBQ2pCLHlCQUF5QixFQUN6QixtQkFBbUIsRUFDbkIsMkJBQTJCLElBQUksaUNBQWlDLEdBQ2pFLE1BQU0sa0JBQWtCLENBQUM7QUFTMUIsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFFekQsNEdBQTRHO0FBQzVHLCtHQUErRztBQUMvRyxrR0FBa0c7QUFDbEcsT0FBTyxFQUNMLHVCQUF1QixFQUN2Qix1QkFBdUIsRUFDdkIscUJBQXFCLEVBQ3JCLHdCQUF3QixFQUN4QiwyQkFBMkIsRUFDM0IsdUJBQXVCLEVBQ3ZCLDZCQUE2QixFQUM3Qix5QkFBeUIsRUFDekIsbUJBQW1CLEdBQ3BCLENBQUM7QUFTRixNQUFNLGlCQUFpQixHQUFHLDZCQUE2QixDQUFDO0FBbUN4RDs7Ozs7R0FLRztBQUNILE1BQU0sVUFBVSwyQkFBMkIsQ0FDekMsT0FBZ0IsRUFDaEIsU0FBMEIsRUFBRTtJQUU1QixPQUFPLGlDQUFpQyxDQUFDLE9BQU8sRUFBRSxNQUFNLEVBQUUsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUM7QUFDeEUsQ0FBQztBQUVEO3lHQUN5RztBQUN6RyxTQUFTLG1CQUFtQixDQUFDLFVBQXFDO0lBQ2hFLElBQUksVUFBVSxLQUFLLFNBQVMsSUFBSSxVQUFVLEtBQUssSUFBSTtRQUFFLE9BQU8sb0JBQW9CLENBQUMsVUFBVSxDQUFDO0lBQzVGLElBQUksT0FBTyxVQUFVLEtBQUssUUFBUSxJQUFJLENBQUMsVUFBVSxDQUFDLElBQUksRUFBRTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsc0JBQXNCLENBQUMsQ0FBQztJQUNsRyxPQUFPLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQztBQUMzQixDQUFDO0FBRUQsTUFBTSxVQUFVLDhCQUE4QixDQUM1QyxNQUEwQyxPQUFPLENBQUMsR0FBRztJQUVyRCxNQUFNLFlBQVksR0FBRyxPQUFPLEdBQUcsQ0FBQyxxQ0FBcUMsS0FBSyxRQUFRO1FBQ2hGLENBQUMsQ0FBQyxHQUFHLENBQUMscUNBQXFDLENBQUMsSUFBSSxFQUFFO1FBQ2xELENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDUCxJQUFJLFlBQVk7UUFBRSxPQUFPLFlBQVksQ0FBQztJQUV0QyxNQUFNLGlCQUFpQixHQUFHLE9BQU8sR0FBRyxDQUFDLHlCQUF5QixLQUFLLFFBQVE7UUFDekUsQ0FBQyxDQUFDLEdBQUcsQ0FBQyx5QkFBeUIsQ0FBQyxJQUFJLEVBQUU7UUFDdEMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNQLElBQUksaUJBQWlCO1FBQUUsT0FBTyxJQUFJLENBQUMsaUJBQWlCLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztJQUV6RSxNQUFNLFVBQVUsR0FBRyxPQUFPLEdBQUcsQ0FBQyxlQUFlLEtBQUssUUFBUSxJQUFJLEdBQUcsQ0FBQyxlQUFlLENBQUMsSUFBSSxFQUFFO1FBQ3RGLENBQUMsQ0FBQyxHQUFHLENBQUMsZUFBZSxDQUFDLElBQUksRUFBRTtRQUM1QixDQUFDLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxFQUFFLFNBQVMsQ0FBQyxDQUFDO0lBQy9CLE9BQU8sSUFBSSxDQUFDLFVBQVUsRUFBRSxnQkFBZ0IsRUFBRSxpQkFBaUIsQ0FBQyxDQUFDO0FBQy9ELENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxNQUEwQjtJQUNqRCxNQUFNLElBQUksR0FBRyxDQUFDLE1BQU0sSUFBSSw4QkFBOEIsRUFBRSxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDakUsSUFBSSxDQUFDLElBQUk7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHFDQUFxQyxDQUFDLENBQUM7SUFDbEUsT0FBTyxJQUFJLENBQUM7QUFDZCxDQUFDO0FBRUQsU0FBUyxhQUFhLENBQUMsR0FBZ0I7SUFDckMsT0FBTztRQUNMLEVBQUUsRUFBRSxHQUFHLENBQUMsRUFBRTtRQUNWLE1BQU0sRUFBRSxHQUFHLENBQUMsTUFBTTtRQUNsQixJQUFJLEVBQUUsSUFBSSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsU0FBUyxDQUFhO1FBQzNDLEtBQUssRUFBRSxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxVQUFVLENBQTBCO0tBQzNELENBQUM7QUFDSixDQUFDO0FBRUQsMEdBQTBHO0FBQzFHLCtHQUErRztBQUMvRyxpSEFBaUg7QUFDakgsMEdBQTBHO0FBQzFHLHlHQUF5RztBQUN6RyxpRUFBaUU7QUFDakUsU0FBUyxpQ0FBaUMsQ0FBQyxFQUFnQjtJQUN6RCxNQUFNLG1CQUFtQixHQUFJLEVBQUUsQ0FBQyxPQUFPLENBQUMsd0NBQXdDLENBQUMsQ0FBQyxHQUFHLEVBQXFCO1NBQ3ZHLElBQUksQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUMsTUFBTSxDQUFDLElBQUksS0FBSyxjQUFjLENBQUMsQ0FBQztJQUNwRCxJQUFJLG1CQUFtQjtRQUFFLE9BQU87SUFDaEMsRUFBRSxDQUFDLElBQUksQ0FBQzs7Ozs7Ozs7Ozs7R0FXUCxDQUFDLENBQUM7SUFDSCw0R0FBNEc7SUFDNUcsOEdBQThHO0lBQzlHLDhHQUE4RztJQUM5RyxnREFBZ0Q7SUFDaEQsRUFBRSxDQUFDLE9BQU8sQ0FDUjtzR0FDa0csQ0FDbkcsQ0FBQyxHQUFHLENBQUMsb0JBQW9CLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDdkMsRUFBRSxDQUFDLElBQUksQ0FBQyxnQ0FBZ0MsQ0FBQyxDQUFDO0lBQzFDLEVBQUUsQ0FBQyxJQUFJLENBQUMsa0VBQWtFLENBQUMsQ0FBQztBQUM5RSxDQUFDO0FBRUQ7OztHQUdHO0FBQ0gsTUFBTSxVQUFVLDBCQUEwQixDQUN4QyxTQUFpQiw4QkFBOEIsRUFBRTtJQUVqRCxNQUFNLFlBQVksR0FBRyxlQUFlLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDN0MsU0FBUyxDQUFDLE9BQU8sQ0FBQyxZQUFZLENBQUMsRUFBRSxFQUFFLFNBQVMsRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxDQUFDLENBQUM7SUFDbkUsTUFBTSxFQUFFLEdBQUcsSUFBSSxZQUFZLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDMUMsU0FBUyxDQUFDLFlBQVksRUFBRSxLQUFLLENBQUMsQ0FBQztJQUMvQixFQUFFLENBQUMsSUFBSSxDQUFDLDRCQUE0QixDQUFDLENBQUM7SUFDdEMsRUFBRSxDQUFDLElBQUksQ0FBQzs7Ozs7Ozs7OztHQVVQLENBQUMsQ0FBQztJQUNILGlDQUFpQyxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBRXRDLE1BQU0sZUFBZSxHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUM7Ozs7Ozs7O0dBUWxDLENBQUMsQ0FBQztJQUNILE1BQU0sa0JBQWtCLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FDbkMsaUdBQWlHLENBQ2xHLENBQUM7SUFDRixNQUFNLGFBQWEsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUM5Qiw2SkFBNkosQ0FDOUosQ0FBQztJQUNGLE1BQU0sa0JBQWtCLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FBQzs7R0FFckMsQ0FBQyxDQUFDO0lBRUgsTUFBTSxLQUFLLEdBQTJCO1FBQ3BDLE1BQU0sRUFBRSxZQUFZO1FBQ3BCLGdCQUFnQixDQUFDLFlBQVksRUFBRSxPQUFPLEVBQUUsTUFBTSxHQUFHLEVBQUUsRUFBRSxVQUFVO1lBQzdELE1BQU0sS0FBSyxHQUFHLG1CQUFtQixDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQzlDLE1BQU0sSUFBSSxHQUFHLHFCQUFxQixDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQ2pELE1BQU0sV0FBVyxHQUFHLDJCQUEyQixDQUFDLE9BQU8sRUFBRSxNQUFNLENBQUMsQ0FBQztZQUNqRSxNQUFNLFNBQVMsR0FBRyxJQUFJLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxDQUFDO1lBQzNDLEVBQUUsQ0FBQyxJQUFJLENBQUMsaUJBQWlCLENBQUMsQ0FBQztZQUMzQixJQUFJLENBQUM7Z0JBQ0gsS0FBSyxNQUFNLFFBQVEsSUFBSSxXQUFXLEVBQUUsQ0FBQztvQkFDbkMsTUFBTSxRQUFRLEdBQUcsa0JBQWtCLENBQUMsR0FBRyxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsUUFBUSxDQUFDLEVBQUUsQ0FBMEIsQ0FBQztvQkFDM0YsTUFBTSxjQUFjLEdBQUcsT0FBTyxRQUFRLEVBQUUsTUFBTSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO29CQUMxRixNQUFNLE1BQU0sR0FDVixjQUFjLElBQUksaUJBQWlCLENBQUMsR0FBRyxDQUFDLGNBQWMsQ0FBQyxJQUFJLGNBQWMsS0FBSyxVQUFVO3dCQUN0RixDQUFDLENBQUUsY0FBeUM7d0JBQzVDLENBQUMsQ0FBQyxVQUFVLENBQUM7b0JBQ2pCLGVBQWUsQ0FBQyxHQUFHLENBQ2pCLEtBQUssRUFDTCxJQUFJLEVBQ0osUUFBUSxDQUFDLEVBQUUsRUFDWCxNQUFNLEVBQ04sSUFBSSxDQUFDLFNBQVMsQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLEVBQzdCLElBQUksQ0FBQyxTQUFTLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxFQUM5QixTQUFTLENBQ1YsQ0FBQztnQkFDSixDQUFDO2dCQUNELEVBQUUsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLENBQUM7WUFDcEIsQ0FBQztZQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7Z0JBQ2YsRUFBRSxDQUFDLElBQUksQ0FBQyxVQUFVLENBQUMsQ0FBQztnQkFDcEIsTUFBTSxLQUFLLENBQUM7WUFDZCxDQUFDO1lBQ0QsT0FBUSxhQUFhLENBQUMsR0FBRyxDQUFDLEtBQUssRUFBRSxJQUFJLENBQW1CLENBQUMsR0FBRyxDQUFDLGFBQWEsQ0FBQyxDQUFDO1FBQzlFLENBQUM7UUFDRCxhQUFhLENBQUMsWUFBWSxFQUFFLFVBQVU7WUFDcEMsTUFBTSxLQUFLLEdBQUcsbUJBQW1CLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDOUMsTUFBTSxJQUFJLEdBQUcscUJBQXFCLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDakQsT0FBUSxhQUFhLENBQUMsR0FBRyxDQUFDLEtBQUssRUFBRSxJQUFJLENBQW1CLENBQUMsR0FBRyxDQUFDLGFBQWEsQ0FBQyxDQUFDO1FBQzlFLENBQUM7UUFDRCxpQkFBaUIsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLE1BQU0sRUFBRSxVQUFVO1lBQzVELE1BQU0sS0FBSyxHQUFHLG1CQUFtQixDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQzlDLE1BQU0sSUFBSSxHQUFHLHFCQUFxQixDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQ2pELElBQUksT0FBTyxVQUFVLEtBQUssUUFBUSxJQUFJLENBQUMsVUFBVSxDQUFDLElBQUksRUFBRTtnQkFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHFCQUFxQixDQUFDLENBQUM7WUFDakcsSUFBSSxDQUFDLGlCQUFpQixDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUM7Z0JBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO1lBQy9FLGtCQUFrQixDQUFDLEdBQUcsQ0FBQyxNQUFNLEVBQUUsSUFBSSxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsRUFBRSxLQUFLLEVBQUUsSUFBSSxFQUFFLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDO1FBQzNGLENBQUM7UUFDRCxxQkFBcUIsQ0FBQyxZQUFZLEVBQUUsT0FBTyxHQUFHLEVBQUU7WUFDOUMsTUFBTSxTQUFTLEdBQUcsS0FBSyxDQUFDLGFBQWEsQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ3hFLE9BQU8seUJBQXlCLENBQUM7Z0JBQy9CLEdBQUcsQ0FBQyxPQUFPLENBQUMsZUFBZSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxlQUFlLEVBQUUsT0FBTyxDQUFDLGVBQWUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7Z0JBQzlGLGlCQUFpQixFQUFFLFNBQVM7YUFDN0IsQ0FBQyxDQUFDO1FBQ0wsQ0FBQztRQUNELEtBQUs7WUFDSCxFQUFFLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDYixDQUFDO0tBQ0YsQ0FBQztJQUNGLE9BQU8sS0FBSyxDQUFDO0FBQ2YsQ0FBQyJ9

--- a/packages/loopover-miner/lib/deny-hook-synthesis.ts
+++ b/packages/loopover-miner/lib/deny-hook-synthesis.ts
@@ -1,0 +1,281 @@
+// Synthesize PreToolUse deny-hook rule proposals from per-repo blocker/path history (#4522). The pure synthesis
+// logic moved into `@loopover/engine` (packages/loopover-engine/src/miner/deny-hook-synthesis.ts) by #5667;
+// this module is now a thin wrapper that re-exports those pure helpers and keeps the local SQLite store for
+// refresh + maintainer review before any synthesized rule takes effect. Approved rules merge with
+// {@link DEFAULT_DENY_RULES}; unapproved proposals never block tool calls. No behavior change.
+import { chmodSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  aggregateBlockerHistory,
+  canonicalizeChangedPath,
+  changedPathToDenyGlob,
+  DEFAULT_SYNTHESIS_CONFIG,
+  isCoveredByDefaultDenyRules,
+  normalizeBlockerHistory,
+  normalizeBlockerHistoryRecord,
+  normalizeRepoFullName,
+  proposalStatusSet,
+  resolveEffectiveDenyRules,
+  setProposalStatuses,
+  synthesizeDenyRuleProposals as engineSynthesizeDenyRuleProposals,
+} from "@loopover/engine";
+import type {
+  BlockerHistoryRecord,
+  DenyRuleProposal,
+  DenyRuleProposalAudit,
+  DenyRuleProposalStatus,
+  SynthesisConfig,
+} from "@loopover/engine";
+import type { DenyRule } from "./deny-hooks.js";
+import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
+
+// Re-export the pure synthesis helpers from the engine so this module's public API is unchanged after #5667
+// moved derivation/audit into @loopover/engine. Only the SQLite store below (and its forge/db-path helpers) is
+// miner-local, because it depends on node:sqlite/node:fs and this package's forge-config default.
+export {
+  aggregateBlockerHistory,
+  canonicalizeChangedPath,
+  changedPathToDenyGlob,
+  DEFAULT_SYNTHESIS_CONFIG,
+  isCoveredByDefaultDenyRules,
+  normalizeBlockerHistory,
+  normalizeBlockerHistoryRecord,
+  resolveEffectiveDenyRules,
+  setProposalStatuses,
+};
+export type {
+  BlockerHistoryRecord,
+  DenyRuleProposal,
+  DenyRuleProposalAudit,
+  DenyRuleProposalStatus,
+  SynthesisConfig,
+};
+
+const defaultDbFileName = "deny-hook-synthesis.sqlite3";
+
+type ProposalRow = {
+  id: string;
+  status: DenyRuleProposalStatus;
+  rule_json: string;
+  audit_json: string;
+};
+
+type StatusRow = { status: string };
+
+type TableInfoRow = { name: string };
+
+export type DenyHookSynthesisStore = {
+  dbPath: string;
+  refreshProposals(
+    repoFullName: string,
+    history: unknown,
+    config?: SynthesisConfig,
+    apiBaseUrl?: string,
+  ): DenyRuleProposal[];
+  listProposals(repoFullName: string, apiBaseUrl?: string): DenyRuleProposal[];
+  setProposalStatus(
+    repoFullName: string,
+    proposalId: string,
+    status: DenyRuleProposalStatus,
+    apiBaseUrl?: string,
+  ): void;
+  resolveEffectiveRules(
+    repoFullName: string,
+    options?: { includeDefaults?: boolean; apiBaseUrl?: string },
+  ): DenyRule[];
+  close(): void;
+};
+
+/**
+ * Derive candidate deny-hook rules from blocker/path history. Miner-facing wrapper over the engine's pure
+ * `synthesizeDenyRuleProposals`, defaulting the injected clock to `Date.now()` so this keeps the pre-#5667 2-arg
+ * signature (and wall-clock `audit.synthesizedAt`) every existing caller and test relies on. Returns proposal
+ * objects only — nothing is active until a maintainer approves them (see resolveEffectiveDenyRules).
+ */
+export function synthesizeDenyRuleProposals(
+  records: unknown,
+  config: SynthesisConfig = {},
+): DenyRuleProposal[] {
+  return engineSynthesizeDenyRuleProposals(records, config, Date.now());
+}
+
+/** Optional forge host, scoping rows so two hosts serving the same owner/repo name never collide (#5563).
+ *  Omitted/nullish → the github.com default, so every pre-existing single-forge caller is unaffected. */
+function normalizeApiBaseUrl(apiBaseUrl: string | null | undefined): string {
+  if (apiBaseUrl === undefined || apiBaseUrl === null) return DEFAULT_FORGE_CONFIG.apiBaseUrl;
+  if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim()) throw new Error("invalid_api_base_url");
+  return apiBaseUrl.trim();
+}
+
+export function resolveDenyHookSynthesisDbPath(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const explicitPath = typeof env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB === "string"
+    ? env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB.trim()
+    : "";
+  if (explicitPath) return explicitPath;
+
+  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
+    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
+    : "";
+  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
+
+  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME.trim()
+    : join(homedir(), ".config");
+  return join(configHome, "loopover-miner", defaultDbFileName);
+}
+
+function normalizeDbPath(dbPath: string | undefined): string {
+  const path = (dbPath ?? resolveDenyHookSynthesisDbPath()).trim();
+  if (!path) throw new Error("invalid_deny_hook_synthesis_db_path");
+  return path;
+}
+
+function rowToProposal(row: ProposalRow): DenyRuleProposal {
+  return {
+    id: row.id,
+    status: row.status,
+    rule: JSON.parse(row.rule_json) as DenyRule,
+    audit: JSON.parse(row.audit_json) as DenyRuleProposalAudit,
+  };
+}
+
+// Rebuild deny_rule_proposals' (repo_full_name, id) PRIMARY KEY into a (api_base_url, repo_full_name, id)
+// composite (#5563) -- two forge hosts serving a same-named owner/repo must not share one proposal row. SQLite
+// cannot ALTER a PRIMARY KEY in place, so this rebuilds the table: create the new shape, copy every existing row
+// with the pre-#4784 implicit single-forge default backfilled, drop the old table, rename the new one in.
+// Guarded by a column-presence check (this module has no schema-version framework of its own, unlike the
+// package's other local stores) so this only runs once per file.
+function ensureDenyRuleProposalsForgeScope(db: DatabaseSync): void {
+  const hasApiBaseUrlColumn = (db.prepare("PRAGMA table_info(deny_rule_proposals)").all() as TableInfoRow[])
+    .some((column) => column.name === "api_base_url");
+  if (hasApiBaseUrlColumn) return;
+  db.exec(`
+    CREATE TABLE deny_rule_proposals_v2 (
+      api_base_url TEXT NOT NULL,
+      repo_full_name TEXT NOT NULL,
+      id TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('proposed', 'approved', 'rejected')),
+      rule_json TEXT NOT NULL,
+      audit_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (api_base_url, repo_full_name, id)
+    )
+  `);
+  // OR IGNORE: a row this store's own read path already treats as unusable garbage (an unrecognized `status`,
+  // e.g. from a hand-edited or otherwise corrupted file) would violate the CHECK constraint above and abort the
+  // whole migration. Skipping it here is consistent with that same fail-closed posture, rather than turning one
+  // bad row into a permanently unmigratable file.
+  db.prepare(
+    `INSERT OR IGNORE INTO deny_rule_proposals_v2 (api_base_url, repo_full_name, id, status, rule_json, audit_json, updated_at)
+     SELECT ?, repo_full_name, id, status, rule_json, audit_json, updated_at FROM deny_rule_proposals`,
+  ).run(DEFAULT_FORGE_CONFIG.apiBaseUrl);
+  db.exec("DROP TABLE deny_rule_proposals");
+  db.exec("ALTER TABLE deny_rule_proposals_v2 RENAME TO deny_rule_proposals");
+}
+
+/**
+ * Local SQLite store for synthesized deny-rule proposals. Refresh re-derives proposals from history while
+ * preserving maintainer decisions on ids that still exist.
+ */
+export function initDenyHookSynthesisStore(
+  dbPath: string = resolveDenyHookSynthesisDbPath(),
+): DenyHookSynthesisStore {
+  const resolvedPath = normalizeDbPath(dbPath);
+  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
+  const db = new DatabaseSync(resolvedPath);
+  chmodSync(resolvedPath, 0o600);
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS deny_rule_proposals (
+      repo_full_name TEXT NOT NULL,
+      id TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('proposed', 'approved', 'rejected')),
+      rule_json TEXT NOT NULL,
+      audit_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (repo_full_name, id)
+    )
+  `);
+  ensureDenyRuleProposalsForgeScope(db);
+
+  const upsertStatement = db.prepare(`
+    INSERT INTO deny_rule_proposals (api_base_url, repo_full_name, id, status, rule_json, audit_json, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(api_base_url, repo_full_name, id) DO UPDATE SET
+      status = excluded.status,
+      rule_json = excluded.rule_json,
+      audit_json = excluded.audit_json,
+      updated_at = excluded.updated_at
+  `);
+  const getStatusStatement = db.prepare(
+    "SELECT status FROM deny_rule_proposals WHERE api_base_url = ? AND repo_full_name = ? AND id = ?",
+  );
+  const listStatement = db.prepare(
+    "SELECT repo_full_name, id, status, rule_json, audit_json, updated_at FROM deny_rule_proposals WHERE api_base_url = ? AND repo_full_name = ? ORDER BY id ASC",
+  );
+  const setStatusStatement = db.prepare(`
+    UPDATE deny_rule_proposals SET status = ?, updated_at = ? WHERE api_base_url = ? AND repo_full_name = ? AND id = ?
+  `);
+
+  const store: DenyHookSynthesisStore = {
+    dbPath: resolvedPath,
+    refreshProposals(repoFullName, history, config = {}, apiBaseUrl) {
+      const forge = normalizeApiBaseUrl(apiBaseUrl);
+      const repo = normalizeRepoFullName(repoFullName);
+      const synthesized = synthesizeDenyRuleProposals(history, config);
+      const updatedAt = new Date().toISOString();
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        for (const proposal of synthesized) {
+          const existing = getStatusStatement.get(forge, repo, proposal.id) as StatusRow | undefined;
+          const existingStatus = typeof existing?.status === "string" ? existing.status : undefined;
+          const status =
+            existingStatus && proposalStatusSet.has(existingStatus) && existingStatus !== "proposed"
+              ? (existingStatus as DenyRuleProposalStatus)
+              : "proposed";
+          upsertStatement.run(
+            forge,
+            repo,
+            proposal.id,
+            status,
+            JSON.stringify(proposal.rule),
+            JSON.stringify(proposal.audit),
+            updatedAt,
+          );
+        }
+        db.exec("COMMIT");
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+      return (listStatement.all(forge, repo) as ProposalRow[]).map(rowToProposal);
+    },
+    listProposals(repoFullName, apiBaseUrl) {
+      const forge = normalizeApiBaseUrl(apiBaseUrl);
+      const repo = normalizeRepoFullName(repoFullName);
+      return (listStatement.all(forge, repo) as ProposalRow[]).map(rowToProposal);
+    },
+    setProposalStatus(repoFullName, proposalId, status, apiBaseUrl) {
+      const forge = normalizeApiBaseUrl(apiBaseUrl);
+      const repo = normalizeRepoFullName(repoFullName);
+      if (typeof proposalId !== "string" || !proposalId.trim()) throw new Error("invalid_proposal_id");
+      if (!proposalStatusSet.has(status)) throw new Error("invalid_proposal_status");
+      setStatusStatement.run(status, new Date().toISOString(), forge, repo, proposalId.trim());
+    },
+    resolveEffectiveRules(repoFullName, options = {}) {
+      const proposals = store.listProposals(repoFullName, options.apiBaseUrl);
+      return resolveEffectiveDenyRules({
+        ...(options.includeDefaults !== undefined ? { includeDefaults: options.includeDefaults } : {}),
+        approvedProposals: proposals,
+      });
+    },
+    close() {
+      db.close();
+    },
+  };
+  return store;
+}

--- a/packages/loopover-miner/lib/deployment-docs-audit.d.ts
+++ b/packages/loopover-miner/lib/deployment-docs-audit.d.ts
@@ -1,44 +1,40 @@
-/** Parsed claims a DEPLOYMENT.md makes about the miner's runtime surface. */
 export type DeploymentDocsClaims = {
-  envVars: string[];
-  filePaths: string[];
-  subcommands: string[];
+    envVars: string[];
+    filePaths: string[];
+    subcommands: string[];
 };
-
-/** Filesystem-independent view of the live source tree the parsed claims are checked against. */
 export type DeploymentDocsReality = {
-  hasEnvRead: (name: string) => boolean;
-  /** The enumerable set of every real env-var read, so the reverse audit direction (#6601) can diff a real
-   *  `LOOPOVER_MINER_*` read that DEPLOYMENT.md never documents, not just probe one documented name at a time. */
-  envReads: Iterable<string>;
-  pathExists: (relativePath: string) => boolean;
-  isRegisteredCommand: (name: string) => boolean;
+    hasEnvRead: (name: string) => boolean;
+    envReads: Iterable<string>;
+    pathExists: (relativePath: string) => boolean;
+    isRegisteredCommand: (name: string) => boolean;
 };
-
-/** Result of cross-checking claims against reality: `ok` plus a message per stale claim. */
 export type DeploymentDocsAuditResult = {
-  ok: boolean;
-  failures: string[];
+    ok: boolean;
+    failures: string[];
 };
-
-export function scanEnvVarTokens(text: string): Set<string>;
-
-export function extractEnvVarClaims(markdown: string): string[];
-
-export function extractSubcommandClaims(markdown: string): string[];
-
-export function isRepoRelativePath(target: string): boolean;
-
-export function extractFilePathClaims(markdown: string): string[];
-
-export function scanRegisteredCommands(binSource: string): Set<string>;
-
-export function auditDeploymentDocs(
-  claims: DeploymentDocsClaims,
-  reality: DeploymentDocsReality,
-): DeploymentDocsAuditResult;
-
-export function assertDeploymentDocsInSync(
-  claims: DeploymentDocsClaims,
-  reality: DeploymentDocsReality,
-): DeploymentDocsAuditResult;
+/** Collect every LOOPOVER_MINER_* / MINER_* token that appears in `text` (doc prose/code or source). */
+export declare function scanEnvVarTokens(text: string): Set<string>;
+/** Sorted, de-duplicated env-var names DEPLOYMENT.md claims the miner honors. */
+export declare function extractEnvVarClaims(markdown: string): string[];
+/** Sorted, de-duplicated `loopover-miner <subcommand>` subcommands DEPLOYMENT.md documents. */
+export declare function extractSubcommandClaims(markdown: string): string[];
+/** True when a markdown link target is an on-disk repo path (not a URL, anchor, or runtime path). */
+export declare function isRepoRelativePath(target: string): boolean;
+/** Sorted, de-duplicated repo-relative file paths DEPLOYMENT.md links to (external issue links excluded).
+ *  An in-file anchor fragment (`file.md#heading`) is stripped before the path is recorded -- the fragment
+ *  names a heading inside the target file, not a filesystem entry, so checking it against `pathExists`
+ *  verbatim would always fail even when the linked file (and heading) both genuinely exist. */
+export declare function extractFilePathClaims(markdown: string): string[];
+/** The set of top-level subcommands the miner CLI dispatches, parsed from its bin entry source. */
+export declare function scanRegisteredCommands(binSource: string): Set<string>;
+/**
+ * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies three predicates so this
+ * comparison stays pure and filesystem-independent: `hasEnvRead(name)` (a read of that env var exists
+ * under packages/loopover-miner/**), `pathExists(relativePath)` (the doc-relative path is on disk),
+ * and `isRegisteredCommand(name)` (the subcommand is dispatched by the CLI). Returns the drift findings,
+ * each failure naming the specific stale claim rather than a generic mismatch.
+ */
+export declare function auditDeploymentDocs(claims: DeploymentDocsClaims, reality: DeploymentDocsReality): DeploymentDocsAuditResult;
+/** Run the audit and throw a build-failing error naming every stale claim; returns the result when in sync. */
+export declare function assertDeploymentDocsInSync(claims: DeploymentDocsClaims, reality: DeploymentDocsReality): DeploymentDocsAuditResult;

--- a/packages/loopover-miner/lib/deployment-docs-audit.js
+++ b/packages/loopover-miner/lib/deployment-docs-audit.js
@@ -5,75 +5,63 @@
 // stale then fails CI with a message naming the exact stale claim, instead of misleading operators.
 // Wired into CI via `npm run test:miner-deployment-docs-audit` (scripts/check-miner-deployment-docs.mjs)
 // and the live unit suite in test/unit/miner-deployment-docs-audit.test.ts (#6158).
-
 /** The miner's own env-var namespace: LOOPOVER_MINER_* and the shorter MINER_* aliases it reads. */
 const ENV_VAR_PATTERN = /\b(?:LOOPOVER_MINER|MINER)_[A-Z0-9_]+\b/g;
-
 /** `loopover-miner <subcommand>` CLI invocations, excluding the `@loopover/miner` package spelling. */
 const SUBCOMMAND_PATTERN = /(?<![\w./@-])loopover-miner\s+([a-z][a-z0-9-]*)/g;
-
 /** Markdown inline-link targets: the `target` in `](target)`. */
 const MARKDOWN_LINK_PATTERN = /\]\(([^)]+)\)/g;
-
 /** Link targets the audit ignores: URLs, in-page anchors, and runtime-generated (~ or absolute) paths. */
 const NON_REPO_LINK_PATTERN = /^(?:https?:\/\/|mailto:|#|~|\/)/;
-
 /** `cliArgs[0] === "<name>"` guards in the miner bin — the CLI's registered top-level command table. */
 const CLI_DISPATCH_PATTERN = /cliArgs\[0\]\s*===\s*"([a-z][a-z0-9-]*)"/g;
-
 /** Collect every LOOPOVER_MINER_* / MINER_* token that appears in `text` (doc prose/code or source). */
 export function scanEnvVarTokens(text) {
-  const tokens = new Set();
-  for (const match of text.matchAll(ENV_VAR_PATTERN)) {
-    tokens.add(match[0]);
-  }
-  return tokens;
+    const tokens = new Set();
+    for (const match of text.matchAll(ENV_VAR_PATTERN)) {
+        tokens.add(match[0] ?? "");
+    }
+    return tokens;
 }
-
 /** Sorted, de-duplicated env-var names DEPLOYMENT.md claims the miner honors. */
 export function extractEnvVarClaims(markdown) {
-  return [...scanEnvVarTokens(markdown)].sort();
+    return [...scanEnvVarTokens(markdown)].sort();
 }
-
 /** Sorted, de-duplicated `loopover-miner <subcommand>` subcommands DEPLOYMENT.md documents. */
 export function extractSubcommandClaims(markdown) {
-  const commands = new Set();
-  for (const match of markdown.matchAll(SUBCOMMAND_PATTERN)) {
-    commands.add(match[1]);
-  }
-  return [...commands].sort();
+    const commands = new Set();
+    for (const match of markdown.matchAll(SUBCOMMAND_PATTERN)) {
+        commands.add(match[1] ?? "");
+    }
+    return [...commands].sort();
 }
-
 /** True when a markdown link target is an on-disk repo path (not a URL, anchor, or runtime path). */
 export function isRepoRelativePath(target) {
-  return !NON_REPO_LINK_PATTERN.test(target);
+    return !NON_REPO_LINK_PATTERN.test(target);
 }
-
 /** Sorted, de-duplicated repo-relative file paths DEPLOYMENT.md links to (external issue links excluded).
  *  An in-file anchor fragment (`file.md#heading`) is stripped before the path is recorded -- the fragment
  *  names a heading inside the target file, not a filesystem entry, so checking it against `pathExists`
  *  verbatim would always fail even when the linked file (and heading) both genuinely exist. */
 export function extractFilePathClaims(markdown) {
-  const paths = new Set();
-  for (const match of markdown.matchAll(MARKDOWN_LINK_PATTERN)) {
-    const target = match[1].trim();
-    if (isRepoRelativePath(target)) {
-      const [pathOnly] = target.split("#");
-      paths.add(pathOnly);
+    const paths = new Set();
+    for (const match of markdown.matchAll(MARKDOWN_LINK_PATTERN)) {
+        const target = (match[1] ?? "").trim();
+        if (isRepoRelativePath(target)) {
+            const [pathOnly] = target.split("#");
+            paths.add(pathOnly ?? "");
+        }
     }
-  }
-  return [...paths].sort();
+    return [...paths].sort();
 }
-
 /** The set of top-level subcommands the miner CLI dispatches, parsed from its bin entry source. */
 export function scanRegisteredCommands(binSource) {
-  const commands = new Set();
-  for (const match of binSource.matchAll(CLI_DISPATCH_PATTERN)) {
-    commands.add(match[1]);
-  }
-  return commands;
+    const commands = new Set();
+    for (const match of binSource.matchAll(CLI_DISPATCH_PATTERN)) {
+        commands.add(match[1] ?? "");
+    }
+    return commands;
 }
-
 /**
  * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies three predicates so this
  * comparison stays pure and filesystem-independent: `hasEnvRead(name)` (a read of that env var exists
@@ -82,48 +70,40 @@ export function scanRegisteredCommands(binSource) {
  * each failure naming the specific stale claim rather than a generic mismatch.
  */
 export function auditDeploymentDocs(claims, reality) {
-  const failures = [];
-  for (const name of claims.envVars) {
-    if (!reality.hasEnvRead(name)) {
-      failures.push(
-        `env var "${name}" is documented in DEPLOYMENT.md but no read of it exists under packages/loopover-miner/**`,
-      );
+    const failures = [];
+    for (const name of claims.envVars) {
+        if (!reality.hasEnvRead(name)) {
+            failures.push(`env var "${name}" is documented in DEPLOYMENT.md but no read of it exists under packages/loopover-miner/**`);
+        }
     }
-  }
-  for (const path of claims.filePaths) {
-    if (!reality.pathExists(path)) {
-      failures.push(`file path "${path}" is linked from DEPLOYMENT.md but no longer exists on disk`);
+    for (const path of claims.filePaths) {
+        if (!reality.pathExists(path)) {
+            failures.push(`file path "${path}" is linked from DEPLOYMENT.md but no longer exists on disk`);
+        }
     }
-  }
-  for (const command of claims.subcommands) {
-    if (!reality.isRegisteredCommand(command)) {
-      failures.push(
-        `CLI subcommand "loopover-miner ${command}" is documented in DEPLOYMENT.md but is not registered in the CLI command table`,
-      );
+    for (const command of claims.subcommands) {
+        if (!reality.isRegisteredCommand(command)) {
+            failures.push(`CLI subcommand "loopover-miner ${command}" is documented in DEPLOYMENT.md but is not registered in the CLI command table`);
+        }
     }
-  }
-  // Reverse direction (#6601): a real `LOOPOVER_MINER_*` env-var read that DEPLOYMENT.md never documents. Scoped
-  // to the `LOOPOVER_MINER_` prefix and excluding the `*_DB` family (documented generically via one pattern
-  // sentence, not enumerated) and the bare `MINER_*` alias namespace (which also matches non-env event/metric/
-  // filename constants). `reality.envReads` is the enumerable set of real reads the forward `hasEnvRead` probes.
-  const documented = new Set(claims.envVars);
-  for (const name of reality.envReads) {
-    if (name.startsWith("LOOPOVER_MINER_") && !name.endsWith("_DB") && !documented.has(name)) {
-      failures.push(
-        `env var "${name}" is read under packages/loopover-miner/** but is not documented in DEPLOYMENT.md`,
-      );
+    // Reverse direction (#6601): a real `LOOPOVER_MINER_*` env-var read that DEPLOYMENT.md never documents. Scoped
+    // to the `LOOPOVER_MINER_` prefix and excluding the `*_DB` family (documented generically via one pattern
+    // sentence, not enumerated) and the bare `MINER_*` alias namespace (which also matches non-env event/metric/
+    // filename constants). `reality.envReads` is the enumerable set of real reads the forward `hasEnvRead` probes.
+    const documented = new Set(claims.envVars);
+    for (const name of reality.envReads) {
+        if (name.startsWith("LOOPOVER_MINER_") && !name.endsWith("_DB") && !documented.has(name)) {
+            failures.push(`env var "${name}" is read under packages/loopover-miner/** but is not documented in DEPLOYMENT.md`);
+        }
     }
-  }
-  return { ok: failures.length === 0, failures };
+    return { ok: failures.length === 0, failures };
 }
-
 /** Run the audit and throw a build-failing error naming every stale claim; returns the result when in sync. */
 export function assertDeploymentDocsInSync(claims, reality) {
-  const result = auditDeploymentDocs(claims, reality);
-  if (!result.ok) {
-    throw new Error(
-      `DEPLOYMENT.md is out of sync with packages/loopover-miner/**:\n- ${result.failures.join("\n- ")}`,
-    );
-  }
-  return result;
+    const result = auditDeploymentDocs(claims, reality);
+    if (!result.ok) {
+        throw new Error(`DEPLOYMENT.md is out of sync with packages/loopover-miner/**:\n- ${result.failures.join("\n- ")}`);
+    }
+    return result;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGVwbG95bWVudC1kb2NzLWF1ZGl0LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZGVwbG95bWVudC1kb2NzLWF1ZGl0LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDhGQUE4RjtBQUM5RixpR0FBaUc7QUFDakcsaUdBQWlHO0FBQ2pHLG1HQUFtRztBQUNuRyxvR0FBb0c7QUFDcEcseUdBQXlHO0FBQ3pHLG9GQUFvRjtBQVdwRixvR0FBb0c7QUFDcEcsTUFBTSxlQUFlLEdBQUcsMENBQTBDLENBQUM7QUFFbkUsdUdBQXVHO0FBQ3ZHLE1BQU0sa0JBQWtCLEdBQUcsa0RBQWtELENBQUM7QUFFOUUsaUVBQWlFO0FBQ2pFLE1BQU0scUJBQXFCLEdBQUcsZ0JBQWdCLENBQUM7QUFFL0MsMEdBQTBHO0FBQzFHLE1BQU0scUJBQXFCLEdBQUcsaUNBQWlDLENBQUM7QUFFaEUsd0dBQXdHO0FBQ3hHLE1BQU0sb0JBQW9CLEdBQUcsMkNBQTJDLENBQUM7QUFFekUsd0dBQXdHO0FBQ3hHLE1BQU0sVUFBVSxnQkFBZ0IsQ0FBQyxJQUFZO0lBQzNDLE1BQU0sTUFBTSxHQUFHLElBQUksR0FBRyxFQUFVLENBQUM7SUFDakMsS0FBSyxNQUFNLEtBQUssSUFBSSxJQUFJLENBQUMsUUFBUSxDQUFDLGVBQWUsQ0FBQyxFQUFFLENBQUM7UUFDbkQsTUFBTSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUM7SUFDN0IsQ0FBQztJQUNELE9BQU8sTUFBTSxDQUFDO0FBQ2hCLENBQUM7QUFFRCxpRkFBaUY7QUFDakYsTUFBTSxVQUFVLG1CQUFtQixDQUFDLFFBQWdCO0lBQ2xELE9BQU8sQ0FBQyxHQUFHLGdCQUFnQixDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7QUFDaEQsQ0FBQztBQUVELCtGQUErRjtBQUMvRixNQUFNLFVBQVUsdUJBQXVCLENBQUMsUUFBZ0I7SUFDdEQsTUFBTSxRQUFRLEdBQUcsSUFBSSxHQUFHLEVBQVUsQ0FBQztJQUNuQyxLQUFLLE1BQU0sS0FBSyxJQUFJLFFBQVEsQ0FBQyxRQUFRLENBQUMsa0JBQWtCLENBQUMsRUFBRSxDQUFDO1FBQzFELFFBQVEsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDO0lBQy9CLENBQUM7SUFDRCxPQUFPLENBQUMsR0FBRyxRQUFRLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztBQUM5QixDQUFDO0FBRUQscUdBQXFHO0FBQ3JHLE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxNQUFjO0lBQy9DLE9BQU8sQ0FBQyxxQkFBcUIsQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUM7QUFDN0MsQ0FBQztBQUVEOzs7K0ZBRytGO0FBQy9GLE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxRQUFnQjtJQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLEdBQUcsRUFBVSxDQUFDO0lBQ2hDLEtBQUssTUFBTSxLQUFLLElBQUksUUFBUSxDQUFDLFFBQVEsQ0FBQyxxQkFBcUIsQ0FBQyxFQUFFLENBQUM7UUFDN0QsTUFBTSxNQUFNLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDdkMsSUFBSSxrQkFBa0IsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1lBQy9CLE1BQU0sQ0FBQyxRQUFRLENBQUMsR0FBRyxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO1lBQ3JDLEtBQUssQ0FBQyxHQUFHLENBQUMsUUFBUSxJQUFJLEVBQUUsQ0FBQyxDQUFDO1FBQzVCLENBQUM7SUFDSCxDQUFDO0lBQ0QsT0FBTyxDQUFDLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7QUFDM0IsQ0FBQztBQUVELG1HQUFtRztBQUNuRyxNQUFNLFVBQVUsc0JBQXNCLENBQUMsU0FBaUI7SUFDdEQsTUFBTSxRQUFRLEdBQUcsSUFBSSxHQUFHLEVBQVUsQ0FBQztJQUNuQyxLQUFLLE1BQU0sS0FBSyxJQUFJLFNBQVMsQ0FBQyxRQUFRLENBQUMsb0JBQW9CLENBQUMsRUFBRSxDQUFDO1FBQzdELFFBQVEsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDO0lBQy9CLENBQUM7SUFDRCxPQUFPLFFBQVEsQ0FBQztBQUNsQixDQUFDO0FBRUQ7Ozs7OztHQU1HO0FBQ0gsTUFBTSxVQUFVLG1CQUFtQixDQUNqQyxNQUE0QixFQUM1QixPQUE4QjtJQUU5QixNQUFNLFFBQVEsR0FBYSxFQUFFLENBQUM7SUFDOUIsS0FBSyxNQUFNLElBQUksSUFBSSxNQUFNLENBQUMsT0FBTyxFQUFFLENBQUM7UUFDbEMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQztZQUM5QixRQUFRLENBQUMsSUFBSSxDQUNYLFlBQVksSUFBSSw0RkFBNEYsQ0FDN0csQ0FBQztRQUNKLENBQUM7SUFDSCxDQUFDO0lBQ0QsS0FBSyxNQUFNLElBQUksSUFBSSxNQUFNLENBQUMsU0FBUyxFQUFFLENBQUM7UUFDcEMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQztZQUM5QixRQUFRLENBQUMsSUFBSSxDQUFDLGNBQWMsSUFBSSw2REFBNkQsQ0FBQyxDQUFDO1FBQ2pHLENBQUM7SUFDSCxDQUFDO0lBQ0QsS0FBSyxNQUFNLE9BQU8sSUFBSSxNQUFNLENBQUMsV0FBVyxFQUFFLENBQUM7UUFDekMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxtQkFBbUIsQ0FBQyxPQUFPLENBQUMsRUFBRSxDQUFDO1lBQzFDLFFBQVEsQ0FBQyxJQUFJLENBQ1gsa0NBQWtDLE9BQU8saUZBQWlGLENBQzNILENBQUM7UUFDSixDQUFDO0lBQ0gsQ0FBQztJQUNELCtHQUErRztJQUMvRywwR0FBMEc7SUFDMUcsNkdBQTZHO0lBQzdHLCtHQUErRztJQUMvRyxNQUFNLFVBQVUsR0FBRyxJQUFJLEdBQUcsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDM0MsS0FBSyxNQUFNLElBQUksSUFBSSxPQUFPLENBQUMsUUFBUSxFQUFFLENBQUM7UUFDcEMsSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLGlCQUFpQixDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1lBQ3pGLFFBQVEsQ0FBQyxJQUFJLENBQ1gsWUFBWSxJQUFJLG1GQUFtRixDQUNwRyxDQUFDO1FBQ0osQ0FBQztJQUNILENBQUM7SUFDRCxPQUFPLEVBQUUsRUFBRSxFQUFFLFFBQVEsQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLFFBQVEsRUFBRSxDQUFDO0FBQ2pELENBQUM7QUFFRCwrR0FBK0c7QUFDL0csTUFBTSxVQUFVLDBCQUEwQixDQUN4QyxNQUE0QixFQUM1QixPQUE4QjtJQUU5QixNQUFNLE1BQU0sR0FBRyxtQkFBbUIsQ0FBQyxNQUFNLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDcEQsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLEVBQUUsQ0FBQztRQUNmLE1BQU0sSUFBSSxLQUFLLENBQ2Isb0VBQW9FLE1BQU0sQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQ25HLENBQUM7SUFDSixDQUFDO0lBQ0QsT0FBTyxNQUFNLENBQUM7QUFDaEIsQ0FBQyJ9

--- a/packages/loopover-miner/lib/deployment-docs-audit.ts
+++ b/packages/loopover-miner/lib/deployment-docs-audit.ts
@@ -1,0 +1,144 @@
+// Docs-accuracy audit for the miner's DEPLOYMENT.md (#5180). Mirrors the self-host docs audit
+// (apps/loopover-ui/src/lib/selfhost-docs-audit.ts): parse the deployment doc, then assert every
+// LOOPOVER_MINER_* / MINER_* env var, repo-relative file path, and `loopover-miner <subcommand>`
+// it documents still exists under packages/loopover-miner/**. A rename or move that leaves the doc
+// stale then fails CI with a message naming the exact stale claim, instead of misleading operators.
+// Wired into CI via `npm run test:miner-deployment-docs-audit` (scripts/check-miner-deployment-docs.mjs)
+// and the live unit suite in test/unit/miner-deployment-docs-audit.test.ts (#6158).
+
+export type DeploymentDocsClaims = { envVars: string[]; filePaths: string[]; subcommands: string[] };
+export type DeploymentDocsReality = {
+  hasEnvRead: (name: string) => boolean;
+  envReads: Iterable<string>;
+  pathExists: (relativePath: string) => boolean;
+  isRegisteredCommand: (name: string) => boolean;
+};
+export type DeploymentDocsAuditResult = { ok: boolean; failures: string[] };
+
+/** The miner's own env-var namespace: LOOPOVER_MINER_* and the shorter MINER_* aliases it reads. */
+const ENV_VAR_PATTERN = /\b(?:LOOPOVER_MINER|MINER)_[A-Z0-9_]+\b/g;
+
+/** `loopover-miner <subcommand>` CLI invocations, excluding the `@loopover/miner` package spelling. */
+const SUBCOMMAND_PATTERN = /(?<![\w./@-])loopover-miner\s+([a-z][a-z0-9-]*)/g;
+
+/** Markdown inline-link targets: the `target` in `](target)`. */
+const MARKDOWN_LINK_PATTERN = /\]\(([^)]+)\)/g;
+
+/** Link targets the audit ignores: URLs, in-page anchors, and runtime-generated (~ or absolute) paths. */
+const NON_REPO_LINK_PATTERN = /^(?:https?:\/\/|mailto:|#|~|\/)/;
+
+/** `cliArgs[0] === "<name>"` guards in the miner bin — the CLI's registered top-level command table. */
+const CLI_DISPATCH_PATTERN = /cliArgs\[0\]\s*===\s*"([a-z][a-z0-9-]*)"/g;
+
+/** Collect every LOOPOVER_MINER_* / MINER_* token that appears in `text` (doc prose/code or source). */
+export function scanEnvVarTokens(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const match of text.matchAll(ENV_VAR_PATTERN)) {
+    tokens.add(match[0] ?? "");
+  }
+  return tokens;
+}
+
+/** Sorted, de-duplicated env-var names DEPLOYMENT.md claims the miner honors. */
+export function extractEnvVarClaims(markdown: string): string[] {
+  return [...scanEnvVarTokens(markdown)].sort();
+}
+
+/** Sorted, de-duplicated `loopover-miner <subcommand>` subcommands DEPLOYMENT.md documents. */
+export function extractSubcommandClaims(markdown: string): string[] {
+  const commands = new Set<string>();
+  for (const match of markdown.matchAll(SUBCOMMAND_PATTERN)) {
+    commands.add(match[1] ?? "");
+  }
+  return [...commands].sort();
+}
+
+/** True when a markdown link target is an on-disk repo path (not a URL, anchor, or runtime path). */
+export function isRepoRelativePath(target: string): boolean {
+  return !NON_REPO_LINK_PATTERN.test(target);
+}
+
+/** Sorted, de-duplicated repo-relative file paths DEPLOYMENT.md links to (external issue links excluded).
+ *  An in-file anchor fragment (`file.md#heading`) is stripped before the path is recorded -- the fragment
+ *  names a heading inside the target file, not a filesystem entry, so checking it against `pathExists`
+ *  verbatim would always fail even when the linked file (and heading) both genuinely exist. */
+export function extractFilePathClaims(markdown: string): string[] {
+  const paths = new Set<string>();
+  for (const match of markdown.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const target = (match[1] ?? "").trim();
+    if (isRepoRelativePath(target)) {
+      const [pathOnly] = target.split("#");
+      paths.add(pathOnly ?? "");
+    }
+  }
+  return [...paths].sort();
+}
+
+/** The set of top-level subcommands the miner CLI dispatches, parsed from its bin entry source. */
+export function scanRegisteredCommands(binSource: string): Set<string> {
+  const commands = new Set<string>();
+  for (const match of binSource.matchAll(CLI_DISPATCH_PATTERN)) {
+    commands.add(match[1] ?? "");
+  }
+  return commands;
+}
+
+/**
+ * Cross-check parsed DEPLOYMENT.md claims against reality. `reality` supplies three predicates so this
+ * comparison stays pure and filesystem-independent: `hasEnvRead(name)` (a read of that env var exists
+ * under packages/loopover-miner/**), `pathExists(relativePath)` (the doc-relative path is on disk),
+ * and `isRegisteredCommand(name)` (the subcommand is dispatched by the CLI). Returns the drift findings,
+ * each failure naming the specific stale claim rather than a generic mismatch.
+ */
+export function auditDeploymentDocs(
+  claims: DeploymentDocsClaims,
+  reality: DeploymentDocsReality,
+): DeploymentDocsAuditResult {
+  const failures: string[] = [];
+  for (const name of claims.envVars) {
+    if (!reality.hasEnvRead(name)) {
+      failures.push(
+        `env var "${name}" is documented in DEPLOYMENT.md but no read of it exists under packages/loopover-miner/**`,
+      );
+    }
+  }
+  for (const path of claims.filePaths) {
+    if (!reality.pathExists(path)) {
+      failures.push(`file path "${path}" is linked from DEPLOYMENT.md but no longer exists on disk`);
+    }
+  }
+  for (const command of claims.subcommands) {
+    if (!reality.isRegisteredCommand(command)) {
+      failures.push(
+        `CLI subcommand "loopover-miner ${command}" is documented in DEPLOYMENT.md but is not registered in the CLI command table`,
+      );
+    }
+  }
+  // Reverse direction (#6601): a real `LOOPOVER_MINER_*` env-var read that DEPLOYMENT.md never documents. Scoped
+  // to the `LOOPOVER_MINER_` prefix and excluding the `*_DB` family (documented generically via one pattern
+  // sentence, not enumerated) and the bare `MINER_*` alias namespace (which also matches non-env event/metric/
+  // filename constants). `reality.envReads` is the enumerable set of real reads the forward `hasEnvRead` probes.
+  const documented = new Set(claims.envVars);
+  for (const name of reality.envReads) {
+    if (name.startsWith("LOOPOVER_MINER_") && !name.endsWith("_DB") && !documented.has(name)) {
+      failures.push(
+        `env var "${name}" is read under packages/loopover-miner/** but is not documented in DEPLOYMENT.md`,
+      );
+    }
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+/** Run the audit and throw a build-failing error naming every stale claim; returns the result when in sync. */
+export function assertDeploymentDocsInSync(
+  claims: DeploymentDocsClaims,
+  reality: DeploymentDocsReality,
+): DeploymentDocsAuditResult {
+  const result = auditDeploymentDocs(claims, reality);
+  if (!result.ok) {
+    throw new Error(
+      `DEPLOYMENT.md is out of sync with packages/loopover-miner/**:\n- ${result.failures.join("\n- ")}`,
+    );
+  }
+  return result;
+}

--- a/packages/loopover-miner/lib/init-wizard.d.ts
+++ b/packages/loopover-miner/lib/init-wizard.d.ts
@@ -1,37 +1,54 @@
 export type WizardIo = {
-  promptText(question: string): Promise<string>;
-  promptMasked(question: string): Promise<string>;
-  writeLine(text: string): void;
-  close?: () => void;
-  /** Whether this `io`'s underlying input is a real, interactive terminal. Optional -- a fake test `io` that
-   *  omits it is treated as interactive (matching every pre-#6846 test's existing behavior); `createWizardIo`'s
-   *  real adapter always sets it from the actual stream's `isTTY`. */
-  isInteractive?: boolean;
+    promptText(question: string): Promise<string>;
+    promptMasked(question: string): Promise<string>;
+    writeLine(text: string): void;
+    close?: () => void;
+    /** Whether this `io`'s underlying input is a real, interactive terminal. Optional -- a fake test `io` that
+     *  omits it is treated as interactive (matching every pre-#6846 test's existing behavior); `createWizardIo`'s
+     *  real adapter always sets it from the actual stream's `isTTY`. */
+    isInteractive?: boolean;
 };
-
 export type RunInteractiveInitOptions = {
-  /** DI override for the device-flow's outbound fetch calls (tests never touch the real network). */
-  fetchImpl?: typeof fetch;
-  /** DI override for the device-flow poll loop's sleep between requests (tests never wait on a real timer). */
-  sleepFn?: (ms: number) => Promise<void>;
+    /** DI override for the device-flow's outbound fetch calls (tests never touch the real network). */
+    fetchImpl?: typeof fetch;
+    /** DI override for the device-flow poll loop's sleep between requests (tests never wait on a real timer). */
+    sleepFn?: (ms: number) => Promise<void>;
 };
-
-export function resolveWizardEnvFilePath(env?: Record<string, string | undefined>): string;
-
-export function renderWizardEnvFile(entries: ReadonlyArray<readonly [string, string]>): string;
-
-export function promptProviderSelection(io: WizardIo): Promise<string | null>;
-
-export function promptCompanionVars(io: WizardIo, provider: string): Promise<Array<[string, string]>>;
-
-export function runInteractiveInit(
-  env: Record<string, string | undefined>,
-  cwd: string,
-  io: WizardIo,
-  options?: RunInteractiveInitOptions,
-): Promise<number>;
-
-export function createWizardIo(
-  input?: NodeJS.ReadableStream,
-  output?: NodeJS.WritableStream,
-): WizardIo & { close: () => void; isInteractive: boolean };
+/** Where the wizard writes its starter .env file: the miner state dir, the same directory `init` already uses
+ *  for laptop-state.sqlite3. */
+export declare function resolveWizardEnvFilePath(env?: Record<string, string | undefined>): string;
+/** Render collected `[KEY, value]` pairs as sourceable `KEY=value` lines, one per entry, insertion order. Pure
+ *  and filesystem-free so it is directly testable. */
+export declare function renderWizardEnvFile(entries: ReadonlyArray<readonly [string, string]>): string;
+/**
+ * Menu selection sourced from the engine's own `CODING_AGENT_DRIVER_NAMES`, so the choices can never drift from
+ * what the driver factory actually resolves. Empty input SKIPS provider selection entirely (leaves
+ * MINER_CODING_AGENT_PROVIDER unwritten, deferring to whatever default the CLI already resolves) -- distinct
+ * from explicitly choosing the `noop` entry.
+ */
+export declare function promptProviderSelection(io: WizardIo): Promise<string | null>;
+/**
+ * Optional, skippable per-provider companion vars (model override / timeout), sourced from the same
+ * `CODING_AGENT_DRIVER_CONFIG_ENV` map the real driver factory reads -- never a hand-duplicated var-name list
+ * that could drift. Empty input skips that one var; its built-in default (if any) applies at run time as usual.
+ */
+export declare function promptCompanionVars(io: WizardIo, provider: string): Promise<Array<[string, string]>>;
+/**
+ * Run the interactive onboarding wizard end to end: collect GITHUB_TOKEN (pasted, or via device-flow
+ * authorization when configured -- see collectGithubToken) + optional provider config, write the starter .env,
+ * initialize laptop state, then rerun the existing offline doctor checks against the collected values. Returns
+ * doctor's exit code. `io` is injected so tests never touch a real terminal; `options.fetchImpl`/`sleepFn` are
+ * injected so tests never make a real network call or wait on a real timer during device-flow polling.
+ */
+export declare function runInteractiveInit(env: Record<string, string | undefined>, cwd: string, io: WizardIo, options?: RunInteractiveInitOptions): Promise<number>;
+/**
+ * Real terminal I/O for the wizard. Masked input is implemented by overriding readline's own output-write hook
+ * to render `*` instead of the typed prompt's characters while the interface is still doing its normal
+ * cooked-mode line editing (Enter/Backspace all still work exactly as with a plain prompt) -- no raw-mode byte
+ * handling and no extra dependency. `input`/`output` are parameters (defaulting to the real stdio) purely so
+ * tests can drive the exact same code path with fake streams instead of a real terminal.
+ */
+export declare function createWizardIo(input?: NodeJS.ReadableStream, output?: NodeJS.WritableStream): WizardIo & {
+    close: () => void;
+    isInteractive: boolean;
+};

--- a/packages/loopover-miner/lib/init-wizard.js
+++ b/packages/loopover-miner/lib/init-wizard.js
@@ -5,54 +5,43 @@ import { CODING_AGENT_DRIVER_CONFIG_ENV, CODING_AGENT_DRIVER_NAMES } from "@loop
 import { initLaptopState } from "./laptop-init.js";
 import { resolveMinerStateDir, runDoctor } from "./status.js";
 import { DeviceFlowError, resolveAmsOauthClientId, runDeviceFlowAuthorization } from "./oauth-device-flow.js";
-
-// First-run onboarding wizard for `loopover-miner init --interactive` (#5176): prompts for a GITHUB_TOKEN
-// (masked, never echoed to stdout/logs) and an optional coding-agent provider + its companion vars, writes them
-// to a starter .env in the state dir, then reruns the existing offline `doctor` checks against the collected
-// values so the operator sees pass/fail immediately. `doctor` itself stays offline by contract (status.js), and
-// this module never calls verifyGithubToken (that stays behind the separate, explicitly opt-in
-// `init --verify-token` flag).
-//
-// #5682: when LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID is configured, the wizard offers "Authorize with GitHub"
-// (device flow -- see oauth-device-flow.js) as an ADDITIONAL onboarding path alongside the original pasted-PAT
-// prompt, never replacing it. Unconfigured (today's default -- the App isn't registered yet) is byte-identical
-// to the original prompt-only flow, so every existing deployment is unaffected until an operator opts in.
-
-const COMPANION_VAR_LABELS = { model: "model override", timeoutMs: "timeout in milliseconds" };
-
+const COMPANION_VAR_LABELS = {
+    model: "model override",
+    timeoutMs: "timeout in milliseconds",
+};
 /** Where the wizard writes its starter .env file: the miner state dir, the same directory `init` already uses
  *  for laptop-state.sqlite3. */
 export function resolveWizardEnvFilePath(env = process.env) {
-  return join(resolveMinerStateDir(env), ".env");
+    return join(resolveMinerStateDir(env), ".env");
 }
-
 /** Render collected `[KEY, value]` pairs as sourceable `KEY=value` lines, one per entry, insertion order. Pure
  *  and filesystem-free so it is directly testable. */
 export function renderWizardEnvFile(entries) {
-  if (entries.length === 0) return "";
-  return `${entries.map(([key, value]) => `${key}=${value}`).join("\n")}\n`;
+    if (entries.length === 0)
+        return "";
+    return `${entries.map(([key, value]) => `${key}=${value}`).join("\n")}\n`;
 }
-
 async function promptRequiredMasked(io, question) {
-  for (;;) {
-    const answer = (await io.promptMasked(question)).trim();
-    if (answer) return answer;
-    io.writeLine("A value is required -- please try again.");
-  }
+    for (;;) {
+        const answer = (await io.promptMasked(question)).trim();
+        if (answer)
+            return answer;
+        io.writeLine("A value is required -- please try again.");
+    }
 }
-
 async function promptAuthMethod(io) {
-  io.writeLine("How would you like to authorize loopover-miner?");
-  io.writeLine("  1) Authorize with GitHub (recommended -- no token to copy)");
-  io.writeLine("  2) Paste a GitHub token (personal access token)");
-  for (;;) {
-    const answer = (await io.promptText("Choice [1/2, default 1]: ")).trim();
-    if (!answer || answer === "1") return "device";
-    if (answer === "2") return "token";
-    io.writeLine("Enter 1 or 2.");
-  }
+    io.writeLine("How would you like to authorize loopover-miner?");
+    io.writeLine("  1) Authorize with GitHub (recommended -- no token to copy)");
+    io.writeLine("  2) Paste a GitHub token (personal access token)");
+    for (;;) {
+        const answer = (await io.promptText("Choice [1/2, default 1]: ")).trim();
+        if (!answer || answer === "1")
+            return "device";
+        if (answer === "2")
+            return "token";
+        io.writeLine("Enter 1 or 2.");
+    }
 }
-
 /**
  * Collect a GitHub credential for the wizard's starter .env. When LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID isn't
  * configured (today's default, before the loopover-ams App is registered), this is IDENTICAL to the original
@@ -61,32 +50,32 @@ async function promptAuthMethod(io) {
  * fallback on any device-flow failure -- never a hard dependency.
  */
 async function collectGithubToken(io, env, options) {
-  const clientId = resolveAmsOauthClientId(env);
-  if (!clientId) return promptRequiredMasked(io, "GitHub token (input hidden): ");
-
-  const method = await promptAuthMethod(io);
-  if (method === "token") return promptRequiredMasked(io, "GitHub token (input hidden): ");
-
-  try {
-    const { accessToken } = await runDeviceFlowAuthorization({
-      clientId,
-      fetchFn: options.fetchImpl,
-      sleepFn: options.sleepFn,
-      onCode: (code) => {
-        io.writeLine("");
-        io.writeLine(`To authorize, visit ${code.verificationUri} and enter code: ${code.userCode}`);
-        io.writeLine("Waiting for authorization...");
-      },
-    });
-    io.writeLine("Authorized.");
-    return accessToken;
-  } catch (error) {
-    const reason = error instanceof DeviceFlowError ? error.code : "device_flow_failed";
-    io.writeLine(`Device-flow authorization failed (${reason}) -- falling back to a pasted token.`);
-    return promptRequiredMasked(io, "GitHub token (input hidden): ");
-  }
+    const clientId = resolveAmsOauthClientId(env);
+    if (!clientId)
+        return promptRequiredMasked(io, "GitHub token (input hidden): ");
+    const method = await promptAuthMethod(io);
+    if (method === "token")
+        return promptRequiredMasked(io, "GitHub token (input hidden): ");
+    try {
+        const { accessToken } = await runDeviceFlowAuthorization({
+            clientId,
+            ...(options.fetchImpl !== undefined ? { fetchFn: options.fetchImpl } : {}),
+            ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+            onCode: (code) => {
+                io.writeLine("");
+                io.writeLine(`To authorize, visit ${code.verificationUri} and enter code: ${code.userCode}`);
+                io.writeLine("Waiting for authorization...");
+            },
+        });
+        io.writeLine("Authorized.");
+        return accessToken;
+    }
+    catch (error) {
+        const reason = error instanceof DeviceFlowError ? error.code : "device_flow_failed";
+        io.writeLine(`Device-flow authorization failed (${reason}) -- falling back to a pasted token.`);
+        return promptRequiredMasked(io, "GitHub token (input hidden): ");
+    }
 }
-
 /**
  * Menu selection sourced from the engine's own `CODING_AGENT_DRIVER_NAMES`, so the choices can never drift from
  * what the driver factory actually resolves. Empty input SKIPS provider selection entirely (leaves
@@ -94,37 +83,39 @@ async function collectGithubToken(io, env, options) {
  * from explicitly choosing the `noop` entry.
  */
 export async function promptProviderSelection(io) {
-  io.writeLine("Select a coding-agent provider (press Enter to skip and use the default):");
-  CODING_AGENT_DRIVER_NAMES.forEach((name, index) => {
-    io.writeLine(`  ${index + 1}) ${name}`);
-  });
-  for (;;) {
-    const answer = (await io.promptText(`Provider [1-${CODING_AGENT_DRIVER_NAMES.length}, or Enter to skip]: `)).trim();
-    if (!answer) return null;
-    const index = Number(answer) - 1;
-    if (Number.isInteger(index) && index >= 0 && index < CODING_AGENT_DRIVER_NAMES.length) {
-      return CODING_AGENT_DRIVER_NAMES[index];
+    io.writeLine("Select a coding-agent provider (press Enter to skip and use the default):");
+    CODING_AGENT_DRIVER_NAMES.forEach((name, index) => {
+        io.writeLine(`  ${index + 1}) ${name}`);
+    });
+    for (;;) {
+        const answer = (await io.promptText(`Provider [1-${CODING_AGENT_DRIVER_NAMES.length}, or Enter to skip]: `)).trim();
+        if (!answer)
+            return null;
+        const index = Number(answer) - 1;
+        if (Number.isInteger(index) && index >= 0 && index < CODING_AGENT_DRIVER_NAMES.length) {
+            return CODING_AGENT_DRIVER_NAMES[index] ?? null;
+        }
+        io.writeLine(`Enter a number from 1 to ${CODING_AGENT_DRIVER_NAMES.length}, or press Enter to skip.`);
     }
-    io.writeLine(`Enter a number from 1 to ${CODING_AGENT_DRIVER_NAMES.length}, or press Enter to skip.`);
-  }
 }
-
 /**
  * Optional, skippable per-provider companion vars (model override / timeout), sourced from the same
  * `CODING_AGENT_DRIVER_CONFIG_ENV` map the real driver factory reads -- never a hand-duplicated var-name list
  * that could drift. Empty input skips that one var; its built-in default (if any) applies at run time as usual.
  */
 export async function promptCompanionVars(io, provider) {
-  const varsForProvider = CODING_AGENT_DRIVER_CONFIG_ENV[provider] ?? {};
-  const collected = [];
-  for (const [kind, envVarName] of Object.entries(varsForProvider)) {
-    const label = COMPANION_VAR_LABELS[kind];
-    const answer = (await io.promptText(`Optional ${label} for ${provider} (env ${envVarName}) [Enter to skip]: `)).trim();
-    if (answer) collected.push([envVarName, answer]);
-  }
-  return collected;
+    const varsForProvider = CODING_AGENT_DRIVER_CONFIG_ENV[provider] ?? {};
+    const collected = [];
+    for (const [kind, envVarName] of Object.entries(varsForProvider)) {
+        if (typeof envVarName !== "string")
+            continue;
+        const label = COMPANION_VAR_LABELS[kind] ?? kind;
+        const answer = (await io.promptText(`Optional ${label} for ${provider} (env ${envVarName}) [Enter to skip]: `)).trim();
+        if (answer)
+            collected.push([envVarName, answer]);
+    }
+    return collected;
 }
-
 /**
  * Run the interactive onboarding wizard end to end: collect GITHUB_TOKEN (pasted, or via device-flow
  * authorization when configured -- see collectGithubToken) + optional provider config, write the starter .env,
@@ -133,53 +124,48 @@ export async function promptCompanionVars(io, provider) {
  * injected so tests never make a real network call or wait on a real timer during device-flow polling.
  */
 export async function runInteractiveInit(env, cwd, io, options = {}) {
-  // #6846: fail fast, not silently forever. `io.isInteractive` is only ever `false` for a real
-  // `createWizardIo()` adapter over a non-TTY stdin (a test's fake `io` has no such field and stays
-  // interactive by default, so every existing test is unaffected) -- an operator running this over a
-  // no-pty SSH session or a CI/fleet script gets clear, actionable guidance instead of a hang on the
-  // wizard's first prompt, which can never receive a real line of input.
-  if (io.isInteractive === false) {
-    io.writeLine("init --interactive requires a real terminal (no TTY detected on stdin).");
-    io.writeLine("For an unattended/fleet setup, skip this wizard and set these env vars directly instead:");
-    io.writeLine("  - GITHUB_TOKEN (your GitHub credential)");
-    io.writeLine("  - MINER_CODING_AGENT_PROVIDER (claude-cli or codex-cli)");
-    io.writeLine("  - ANTHROPIC_API_KEY for claude-cli, or OPENAI_API_KEY for codex-cli");
-    io.writeLine("Then verify with: loopover-miner doctor");
-    return 3;
-  }
-  const githubToken = await collectGithubToken(io, env, options);
-  const provider = await promptProviderSelection(io);
-
-  const entries = [["GITHUB_TOKEN", githubToken]];
-  if (provider) {
-    entries.push(["MINER_CODING_AGENT_PROVIDER", provider]);
-    entries.push(...(await promptCompanionVars(io, provider)));
-  }
-
-  const stateDir = resolveMinerStateDir(env);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  const envFilePath = resolveWizardEnvFilePath(env);
-  // { mode: 0o600 } on writeFileSync applies only when the file is newly created -- an existing file (e.g. from
-  // a prior wizard run, or hand-created by the operator with looser permissions) keeps its current mode across
-  // a write. The chmodSync below still runs unconditionally so the end state is always 0600 either way; the
-  // writeFileSync mode option exists so a BRAND NEW file is never briefly readable at the default umask
-  // permissions between being created and being locked down.
-  writeFileSync(envFilePath, renderWizardEnvFile(entries), { mode: 0o600 });
-  chmodSync(envFilePath, 0o600);
-  io.writeLine(`wrote ${envFilePath}`);
-
-  const initResult = initLaptopState(env);
-  io.writeLine(`initialized ${initResult.stateDir}`);
-  io.writeLine(`sqlite: ${initResult.dbPath}${initResult.created ? "" : " (already existed)"}`);
-
-  const mergedEnv = { ...env };
-  for (const [key, value] of entries) mergedEnv[key] = value;
-
-  io.writeLine("");
-  io.writeLine("Running doctor against the new configuration:");
-  return runDoctor([], mergedEnv, cwd);
+    // #6846: fail fast, not silently forever. `io.isInteractive` is only ever `false` for a real
+    // `createWizardIo()` adapter over a non-TTY stdin (a test's fake `io` has no such field and stays
+    // interactive by default, so every existing test is unaffected) -- an operator running this over a
+    // no-pty SSH session or a CI/fleet script gets clear, actionable guidance instead of a hang on the
+    // wizard's first prompt, which can never receive a real line of input.
+    if (io.isInteractive === false) {
+        io.writeLine("init --interactive requires a real terminal (no TTY detected on stdin).");
+        io.writeLine("For an unattended/fleet setup, skip this wizard and set these env vars directly instead:");
+        io.writeLine("  - GITHUB_TOKEN (your GitHub credential)");
+        io.writeLine("  - MINER_CODING_AGENT_PROVIDER (claude-cli or codex-cli)");
+        io.writeLine("  - ANTHROPIC_API_KEY for claude-cli, or OPENAI_API_KEY for codex-cli");
+        io.writeLine("Then verify with: loopover-miner doctor");
+        return 3;
+    }
+    const githubToken = await collectGithubToken(io, env, options);
+    const provider = await promptProviderSelection(io);
+    const entries = [["GITHUB_TOKEN", githubToken]];
+    if (provider) {
+        entries.push(["MINER_CODING_AGENT_PROVIDER", provider]);
+        entries.push(...(await promptCompanionVars(io, provider)));
+    }
+    const stateDir = resolveMinerStateDir(env);
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    const envFilePath = resolveWizardEnvFilePath(env);
+    // { mode: 0o600 } on writeFileSync applies only when the file is newly created -- an existing file (e.g. from
+    // a prior wizard run, or hand-created by the operator with looser permissions) keeps its current mode across
+    // a write. The chmodSync below still runs unconditionally so the end state is always 0600 either way; the
+    // writeFileSync mode option exists so a BRAND NEW file is never briefly readable at the default umask
+    // permissions between being created and being locked down.
+    writeFileSync(envFilePath, renderWizardEnvFile(entries), { mode: 0o600 });
+    chmodSync(envFilePath, 0o600);
+    io.writeLine(`wrote ${envFilePath}`);
+    const initResult = initLaptopState(env);
+    io.writeLine(`initialized ${initResult.stateDir}`);
+    io.writeLine(`sqlite: ${initResult.dbPath}${initResult.created ? "" : " (already existed)"}`);
+    const mergedEnv = { ...env };
+    for (const [key, value] of entries)
+        mergedEnv[key] = value;
+    io.writeLine("");
+    io.writeLine("Running doctor against the new configuration:");
+    return runDoctor([], mergedEnv, cwd);
 }
-
 /**
  * Real terminal I/O for the wizard. Masked input is implemented by overriding readline's own output-write hook
  * to render `*` instead of the typed prompt's characters while the interface is still doing its normal
@@ -188,35 +174,36 @@ export async function runInteractiveInit(env, cwd, io, options = {}) {
  * tests can drive the exact same code path with fake streams instead of a real terminal.
  */
 export function createWizardIo(input = process.stdin, output = process.stdout) {
-  const rl = createInterface({ input, output, terminal: true });
-  const originalWriteToOutput = rl._writeToOutput.bind(rl);
-  let masking = false;
-  rl._writeToOutput = (stringToWrite) => {
-    originalWriteToOutput(masking ? "*" : stringToWrite);
-  };
-  return {
-    // #6846: whether `input` is a real, interactive terminal -- `runInteractiveInit` checks this BEFORE
-    // issuing its first prompt, so a no-TTY invocation (piped stdin, a plain `ssh host "loopover-miner init
-    // --interactive"` with no allocated pty) fails fast with actionable guidance instead of hanging forever
-    // on a `readline` prompt that can never receive a real line of input.
-    isInteractive: Boolean(input.isTTY),
-    promptText(question) {
-      return new Promise((resolve) => rl.question(question, resolve));
-    },
-    promptMasked(question) {
-      return new Promise((resolve) => {
-        rl.question(question, (answer) => {
-          masking = false;
-          resolve(answer);
-        });
-        masking = true;
-      });
-    },
-    writeLine(text) {
-      output.write(`${text}\n`);
-    },
-    close() {
-      rl.close();
-    },
-  };
+    const rl = createInterface({ input, output, terminal: true });
+    const originalWriteToOutput = rl._writeToOutput.bind(rl);
+    let masking = false;
+    rl._writeToOutput = (stringToWrite) => {
+        originalWriteToOutput(masking ? "*" : stringToWrite);
+    };
+    return {
+        // #6846: whether `input` is a real, interactive terminal -- `runInteractiveInit` checks this BEFORE
+        // issuing its first prompt, so a no-TTY invocation (piped stdin, a plain `ssh host "loopover-miner init
+        // --interactive"` with no allocated pty) fails fast with actionable guidance instead of hanging forever
+        // on a `readline` prompt that can never receive a real line of input.
+        isInteractive: Boolean(input.isTTY),
+        promptText(question) {
+            return new Promise((resolve) => rl.question(question, resolve));
+        },
+        promptMasked(question) {
+            return new Promise((resolve) => {
+                rl.question(question, (answer) => {
+                    masking = false;
+                    resolve(answer);
+                });
+                masking = true;
+            });
+        },
+        writeLine(text) {
+            output.write(`${text}\n`);
+        },
+        close() {
+            rl.close();
+        },
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5pdC13aXphcmQuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJpbml0LXdpemFyZC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sZUFBZSxDQUFDO0FBRWhELE9BQU8sRUFBRSxTQUFTLEVBQUUsU0FBUyxFQUFFLGFBQWEsRUFBRSxNQUFNLFNBQVMsQ0FBQztBQUM5RCxPQUFPLEVBQUUsSUFBSSxFQUFFLE1BQU0sV0FBVyxDQUFDO0FBQ2pDLE9BQU8sRUFBRSw4QkFBOEIsRUFBRSx5QkFBeUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBRTdGLE9BQU8sRUFBRSxlQUFlLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUNuRCxPQUFPLEVBQUUsb0JBQW9CLEVBQUUsU0FBUyxFQUFFLE1BQU0sYUFBYSxDQUFDO0FBQzlELE9BQU8sRUFBRSxlQUFlLEVBQUUsdUJBQXVCLEVBQUUsMEJBQTBCLEVBQUUsTUFBTSx3QkFBd0IsQ0FBQztBQXVDOUcsTUFBTSxvQkFBb0IsR0FBMkI7SUFDbkQsS0FBSyxFQUFFLGdCQUFnQjtJQUN2QixTQUFTLEVBQUUseUJBQXlCO0NBQ3JDLENBQUM7QUFFRjtnQ0FDZ0M7QUFDaEMsTUFBTSxVQUFVLHdCQUF3QixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQzVGLE9BQU8sSUFBSSxDQUFDLG9CQUFvQixDQUFDLEdBQUcsQ0FBQyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0FBQ2pELENBQUM7QUFFRDtzREFDc0Q7QUFDdEQsTUFBTSxVQUFVLG1CQUFtQixDQUFDLE9BQWlEO0lBQ25GLElBQUksT0FBTyxDQUFDLE1BQU0sS0FBSyxDQUFDO1FBQUUsT0FBTyxFQUFFLENBQUM7SUFDcEMsT0FBTyxHQUFHLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEdBQUcsRUFBRSxLQUFLLENBQUMsRUFBRSxFQUFFLENBQUMsR0FBRyxHQUFHLElBQUksS0FBSyxFQUFFLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQztBQUM1RSxDQUFDO0FBRUQsS0FBSyxVQUFVLG9CQUFvQixDQUFDLEVBQVksRUFBRSxRQUFnQjtJQUNoRSxTQUFTLENBQUM7UUFDUixNQUFNLE1BQU0sR0FBRyxDQUFDLE1BQU0sRUFBRSxDQUFDLFlBQVksQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO1FBQ3hELElBQUksTUFBTTtZQUFFLE9BQU8sTUFBTSxDQUFDO1FBQzFCLEVBQUUsQ0FBQyxTQUFTLENBQUMsMENBQTBDLENBQUMsQ0FBQztJQUMzRCxDQUFDO0FBQ0gsQ0FBQztBQUVELEtBQUssVUFBVSxnQkFBZ0IsQ0FBQyxFQUFZO0lBQzFDLEVBQUUsQ0FBQyxTQUFTLENBQUMsaURBQWlELENBQUMsQ0FBQztJQUNoRSxFQUFFLENBQUMsU0FBUyxDQUFDLDhEQUE4RCxDQUFDLENBQUM7SUFDN0UsRUFBRSxDQUFDLFNBQVMsQ0FBQyxtREFBbUQsQ0FBQyxDQUFDO0lBQ2xFLFNBQVMsQ0FBQztRQUNSLE1BQU0sTUFBTSxHQUFHLENBQUMsTUFBTSxFQUFFLENBQUMsVUFBVSxDQUFDLDJCQUEyQixDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUN6RSxJQUFJLENBQUMsTUFBTSxJQUFJLE1BQU0sS0FBSyxHQUFHO1lBQUUsT0FBTyxRQUFRLENBQUM7UUFDL0MsSUFBSSxNQUFNLEtBQUssR0FBRztZQUFFLE9BQU8sT0FBTyxDQUFDO1FBQ25DLEVBQUUsQ0FBQyxTQUFTLENBQUMsZUFBZSxDQUFDLENBQUM7SUFDaEMsQ0FBQztBQUNILENBQUM7QUFFRDs7Ozs7O0dBTUc7QUFDSCxLQUFLLFVBQVUsa0JBQWtCLENBQy9CLEVBQVksRUFDWixHQUF1QyxFQUN2QyxPQUFrQztJQUVsQyxNQUFNLFFBQVEsR0FBRyx1QkFBdUIsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUM5QyxJQUFJLENBQUMsUUFBUTtRQUFFLE9BQU8sb0JBQW9CLENBQUMsRUFBRSxFQUFFLCtCQUErQixDQUFDLENBQUM7SUFFaEYsTUFBTSxNQUFNLEdBQUcsTUFBTSxnQkFBZ0IsQ0FBQyxFQUFFLENBQUMsQ0FBQztJQUMxQyxJQUFJLE1BQU0sS0FBSyxPQUFPO1FBQUUsT0FBTyxvQkFBb0IsQ0FBQyxFQUFFLEVBQUUsK0JBQStCLENBQUMsQ0FBQztJQUV6RixJQUFJLENBQUM7UUFDSCxNQUFNLEVBQUUsV0FBVyxFQUFFLEdBQUcsTUFBTSwwQkFBMEIsQ0FBQztZQUN2RCxRQUFRO1lBQ1IsR0FBRyxDQUFDLE9BQU8sQ0FBQyxTQUFTLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxPQUFPLENBQUMsU0FBUyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUMxRSxHQUFHLENBQUMsT0FBTyxDQUFDLE9BQU8sS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsT0FBTyxFQUFFLE9BQU8sQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQ3RFLE1BQU0sRUFBRSxDQUFDLElBQUksRUFBRSxFQUFFO2dCQUNmLEVBQUUsQ0FBQyxTQUFTLENBQUMsRUFBRSxDQUFDLENBQUM7Z0JBQ2pCLEVBQUUsQ0FBQyxTQUFTLENBQUMsdUJBQXVCLElBQUksQ0FBQyxlQUFlLG9CQUFvQixJQUFJLENBQUMsUUFBUSxFQUFFLENBQUMsQ0FBQztnQkFDN0YsRUFBRSxDQUFDLFNBQVMsQ0FBQyw4QkFBOEIsQ0FBQyxDQUFDO1lBQy9DLENBQUM7U0FDRixDQUFDLENBQUM7UUFDSCxFQUFFLENBQUMsU0FBUyxDQUFDLGFBQWEsQ0FBQyxDQUFDO1FBQzVCLE9BQU8sV0FBVyxDQUFDO0lBQ3JCLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsTUFBTSxNQUFNLEdBQUcsS0FBSyxZQUFZLGVBQWUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsb0JBQW9CLENBQUM7UUFDcEYsRUFBRSxDQUFDLFNBQVMsQ0FBQyxxQ0FBcUMsTUFBTSxzQ0FBc0MsQ0FBQyxDQUFDO1FBQ2hHLE9BQU8sb0JBQW9CLENBQUMsRUFBRSxFQUFFLCtCQUErQixDQUFDLENBQUM7SUFDbkUsQ0FBQztBQUNILENBQUM7QUFFRDs7Ozs7R0FLRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsdUJBQXVCLENBQUMsRUFBWTtJQUN4RCxFQUFFLENBQUMsU0FBUyxDQUFDLDJFQUEyRSxDQUFDLENBQUM7SUFDMUYseUJBQXlCLENBQUMsT0FBTyxDQUFDLENBQUMsSUFBSSxFQUFFLEtBQUssRUFBRSxFQUFFO1FBQ2hELEVBQUUsQ0FBQyxTQUFTLENBQUMsS0FBSyxLQUFLLEdBQUcsQ0FBQyxLQUFLLElBQUksRUFBRSxDQUFDLENBQUM7SUFDMUMsQ0FBQyxDQUFDLENBQUM7SUFDSCxTQUFTLENBQUM7UUFDUixNQUFNLE1BQU0sR0FBRyxDQUFDLE1BQU0sRUFBRSxDQUFDLFVBQVUsQ0FBQyxlQUFlLHlCQUF5QixDQUFDLE1BQU0sdUJBQXVCLENBQUMsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO1FBQ3BILElBQUksQ0FBQyxNQUFNO1lBQUUsT0FBTyxJQUFJLENBQUM7UUFDekIsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUNqQyxJQUFJLE1BQU0sQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLElBQUksS0FBSyxJQUFJLENBQUMsSUFBSSxLQUFLLEdBQUcseUJBQXlCLENBQUMsTUFBTSxFQUFFLENBQUM7WUFDdEYsT0FBTyx5QkFBeUIsQ0FBQyxLQUFLLENBQUMsSUFBSSxJQUFJLENBQUM7UUFDbEQsQ0FBQztRQUNELEVBQUUsQ0FBQyxTQUFTLENBQUMsNEJBQTRCLHlCQUF5QixDQUFDLE1BQU0sMkJBQTJCLENBQUMsQ0FBQztJQUN4RyxDQUFDO0FBQ0gsQ0FBQztBQUVEOzs7O0dBSUc7QUFDSCxNQUFNLENBQUMsS0FBSyxVQUFVLG1CQUFtQixDQUFDLEVBQVksRUFBRSxRQUFnQjtJQUN0RSxNQUFNLGVBQWUsR0FDbkIsOEJBQThCLENBQUMsUUFBaUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUMxRSxNQUFNLFNBQVMsR0FBNEIsRUFBRSxDQUFDO0lBQzlDLEtBQUssTUFBTSxDQUFDLElBQUksRUFBRSxVQUFVLENBQUMsSUFBSSxNQUFNLENBQUMsT0FBTyxDQUFDLGVBQWUsQ0FBQyxFQUFFLENBQUM7UUFDakUsSUFBSSxPQUFPLFVBQVUsS0FBSyxRQUFRO1lBQUUsU0FBUztRQUM3QyxNQUFNLEtBQUssR0FBRyxvQkFBb0IsQ0FBQyxJQUFJLENBQUMsSUFBSSxJQUFJLENBQUM7UUFDakQsTUFBTSxNQUFNLEdBQUcsQ0FDYixNQUFNLEVBQUUsQ0FBQyxVQUFVLENBQUMsWUFBWSxLQUFLLFFBQVEsUUFBUSxTQUFTLFVBQVUscUJBQXFCLENBQUMsQ0FDL0YsQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNULElBQUksTUFBTTtZQUFFLFNBQVMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxVQUFVLEVBQUUsTUFBTSxDQUFDLENBQUMsQ0FBQztJQUNuRCxDQUFDO0lBQ0QsT0FBTyxTQUFTLENBQUM7QUFDbkIsQ0FBQztBQUVEOzs7Ozs7R0FNRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsa0JBQWtCLENBQ3RDLEdBQXVDLEVBQ3ZDLEdBQVcsRUFDWCxFQUFZLEVBQ1osVUFBcUMsRUFBRTtJQUV2Qyw2RkFBNkY7SUFDN0Ysa0dBQWtHO0lBQ2xHLG1HQUFtRztJQUNuRyxtR0FBbUc7SUFDbkcsdUVBQXVFO0lBQ3ZFLElBQUksRUFBRSxDQUFDLGFBQWEsS0FBSyxLQUFLLEVBQUUsQ0FBQztRQUMvQixFQUFFLENBQUMsU0FBUyxDQUFDLHlFQUF5RSxDQUFDLENBQUM7UUFDeEYsRUFBRSxDQUFDLFNBQVMsQ0FBQywwRkFBMEYsQ0FBQyxDQUFDO1FBQ3pHLEVBQUUsQ0FBQyxTQUFTLENBQUMsMkNBQTJDLENBQUMsQ0FBQztRQUMxRCxFQUFFLENBQUMsU0FBUyxDQUFDLDJEQUEyRCxDQUFDLENBQUM7UUFDMUUsRUFBRSxDQUFDLFNBQVMsQ0FBQyx1RUFBdUUsQ0FBQyxDQUFDO1FBQ3RGLEVBQUUsQ0FBQyxTQUFTLENBQUMseUNBQXlDLENBQUMsQ0FBQztRQUN4RCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFDRCxNQUFNLFdBQVcsR0FBRyxNQUFNLGtCQUFrQixDQUFDLEVBQUUsRUFBRSxHQUFHLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDL0QsTUFBTSxRQUFRLEdBQUcsTUFBTSx1QkFBdUIsQ0FBQyxFQUFFLENBQUMsQ0FBQztJQUVuRCxNQUFNLE9BQU8sR0FBNEIsQ0FBQyxDQUFDLGNBQWMsRUFBRSxXQUFXLENBQUMsQ0FBQyxDQUFDO0lBQ3pFLElBQUksUUFBUSxFQUFFLENBQUM7UUFDYixPQUFPLENBQUMsSUFBSSxDQUFDLENBQUMsNkJBQTZCLEVBQUUsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUN4RCxPQUFPLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxNQUFNLG1CQUFtQixDQUFDLEVBQUUsRUFBRSxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDN0QsQ0FBQztJQUVELE1BQU0sUUFBUSxHQUFHLG9CQUFvQixDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQzNDLFNBQVMsQ0FBQyxRQUFRLEVBQUUsRUFBRSxTQUFTLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQ3RELE1BQU0sV0FBVyxHQUFHLHdCQUF3QixDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2xELDhHQUE4RztJQUM5Ryw2R0FBNkc7SUFDN0csMEdBQTBHO0lBQzFHLHNHQUFzRztJQUN0RywyREFBMkQ7SUFDM0QsYUFBYSxDQUFDLFdBQVcsRUFBRSxtQkFBbUIsQ0FBQyxPQUFPLENBQUMsRUFBRSxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQzFFLFNBQVMsQ0FBQyxXQUFXLEVBQUUsS0FBSyxDQUFDLENBQUM7SUFDOUIsRUFBRSxDQUFDLFNBQVMsQ0FBQyxTQUFTLFdBQVcsRUFBRSxDQUFDLENBQUM7SUFFckMsTUFBTSxVQUFVLEdBQUcsZUFBZSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3hDLEVBQUUsQ0FBQyxTQUFTLENBQUMsZUFBZSxVQUFVLENBQUMsUUFBUSxFQUFFLENBQUMsQ0FBQztJQUNuRCxFQUFFLENBQUMsU0FBUyxDQUFDLFdBQVcsVUFBVSxDQUFDLE1BQU0sR0FBRyxVQUFVLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLG9CQUFvQixFQUFFLENBQUMsQ0FBQztJQUU5RixNQUFNLFNBQVMsR0FBdUMsRUFBRSxHQUFHLEdBQUcsRUFBRSxDQUFDO0lBQ2pFLEtBQUssTUFBTSxDQUFDLEdBQUcsRUFBRSxLQUFLLENBQUMsSUFBSSxPQUFPO1FBQUUsU0FBUyxDQUFDLEdBQUcsQ0FBQyxHQUFHLEtBQUssQ0FBQztJQUUzRCxFQUFFLENBQUMsU0FBUyxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ2pCLEVBQUUsQ0FBQyxTQUFTLENBQUMsK0NBQStDLENBQUMsQ0FBQztJQUM5RCxPQUFPLFNBQVMsQ0FBQyxFQUFFLEVBQUUsU0FBUyxFQUFFLEdBQUcsQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRDs7Ozs7O0dBTUc7QUFDSCxNQUFNLFVBQVUsY0FBYyxDQUM1QixRQUErQixPQUFPLENBQUMsS0FBSyxFQUM1QyxTQUFnQyxPQUFPLENBQUMsTUFBTTtJQUU5QyxNQUFNLEVBQUUsR0FBRyxlQUFlLENBQUMsRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsQ0FBcUIsQ0FBQztJQUNsRixNQUFNLHFCQUFxQixHQUFHLEVBQUUsQ0FBQyxjQUFjLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ3pELElBQUksT0FBTyxHQUFHLEtBQUssQ0FBQztJQUNwQixFQUFFLENBQUMsY0FBYyxHQUFHLENBQUMsYUFBcUIsRUFBRSxFQUFFO1FBQzVDLHFCQUFxQixDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxhQUFhLENBQUMsQ0FBQztJQUN2RCxDQUFDLENBQUM7SUFDRixPQUFPO1FBQ0wsb0dBQW9HO1FBQ3BHLHdHQUF3RztRQUN4Ryx3R0FBd0c7UUFDeEcsc0VBQXNFO1FBQ3RFLGFBQWEsRUFBRSxPQUFPLENBQUUsS0FBdUIsQ0FBQyxLQUFLLENBQUM7UUFDdEQsVUFBVSxDQUFDLFFBQWdCO1lBQ3pCLE9BQU8sSUFBSSxPQUFPLENBQUMsQ0FBQyxPQUFPLEVBQUUsRUFBRSxDQUFDLEVBQUUsQ0FBQyxRQUFRLENBQUMsUUFBUSxFQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDbEUsQ0FBQztRQUNELFlBQVksQ0FBQyxRQUFnQjtZQUMzQixPQUFPLElBQUksT0FBTyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUU7Z0JBQzdCLEVBQUUsQ0FBQyxRQUFRLENBQUMsUUFBUSxFQUFFLENBQUMsTUFBTSxFQUFFLEVBQUU7b0JBQy9CLE9BQU8sR0FBRyxLQUFLLENBQUM7b0JBQ2hCLE9BQU8sQ0FBQyxNQUFNLENBQUMsQ0FBQztnQkFDbEIsQ0FBQyxDQUFDLENBQUM7Z0JBQ0gsT0FBTyxHQUFHLElBQUksQ0FBQztZQUNqQixDQUFDLENBQUMsQ0FBQztRQUNMLENBQUM7UUFDRCxTQUFTLENBQUMsSUFBWTtZQUNwQixNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsSUFBSSxJQUFJLENBQUMsQ0FBQztRQUM1QixDQUFDO1FBQ0QsS0FBSztZQUNILEVBQUUsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNiLENBQUM7S0FDRixDQUFDO0FBQ0osQ0FBQyJ9

--- a/packages/loopover-miner/lib/init-wizard.ts
+++ b/packages/loopover-miner/lib/init-wizard.ts
@@ -1,0 +1,268 @@
+import { createInterface } from "node:readline";
+import type { Interface } from "node:readline";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CODING_AGENT_DRIVER_CONFIG_ENV, CODING_AGENT_DRIVER_NAMES } from "@loopover/engine";
+import type { CodingAgentDriverName } from "@loopover/engine";
+import { initLaptopState } from "./laptop-init.js";
+import { resolveMinerStateDir, runDoctor } from "./status.js";
+import { DeviceFlowError, resolveAmsOauthClientId, runDeviceFlowAuthorization } from "./oauth-device-flow.js";
+
+// First-run onboarding wizard for `loopover-miner init --interactive` (#5176): prompts for a GITHUB_TOKEN
+// (masked, never echoed to stdout/logs) and an optional coding-agent provider + its companion vars, writes them
+// to a starter .env in the state dir, then reruns the existing offline `doctor` checks against the collected
+// values so the operator sees pass/fail immediately. `doctor` itself stays offline by contract (status.js), and
+// this module never calls verifyGithubToken (that stays behind the separate, explicitly opt-in
+// `init --verify-token` flag).
+//
+// #5682: when LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID is configured, the wizard offers "Authorize with GitHub"
+// (device flow -- see oauth-device-flow.js) as an ADDITIONAL onboarding path alongside the original pasted-PAT
+// prompt, never replacing it. Unconfigured (today's default -- the App isn't registered yet) is byte-identical
+// to the original prompt-only flow, so every existing deployment is unaffected until an operator opts in.
+
+export type WizardIo = {
+  promptText(question: string): Promise<string>;
+  promptMasked(question: string): Promise<string>;
+  writeLine(text: string): void;
+  close?: () => void;
+  /** Whether this `io`'s underlying input is a real, interactive terminal. Optional -- a fake test `io` that
+   *  omits it is treated as interactive (matching every pre-#6846 test's existing behavior); `createWizardIo`'s
+   *  real adapter always sets it from the actual stream's `isTTY`. */
+  isInteractive?: boolean;
+};
+
+export type RunInteractiveInitOptions = {
+  /** DI override for the device-flow's outbound fetch calls (tests never touch the real network). */
+  fetchImpl?: typeof fetch;
+  /** DI override for the device-flow poll loop's sleep between requests (tests never wait on a real timer). */
+  sleepFn?: (ms: number) => Promise<void>;
+};
+
+/** Readline's private output hook used for masked prompts — not in the public Interface typings. */
+type MaskableReadline = Interface & {
+  _writeToOutput(stringToWrite: string): void;
+};
+
+type StreamWithTty = NodeJS.ReadableStream & { isTTY?: boolean };
+
+const COMPANION_VAR_LABELS: Record<string, string> = {
+  model: "model override",
+  timeoutMs: "timeout in milliseconds",
+};
+
+/** Where the wizard writes its starter .env file: the miner state dir, the same directory `init` already uses
+ *  for laptop-state.sqlite3. */
+export function resolveWizardEnvFilePath(env: Record<string, string | undefined> = process.env): string {
+  return join(resolveMinerStateDir(env), ".env");
+}
+
+/** Render collected `[KEY, value]` pairs as sourceable `KEY=value` lines, one per entry, insertion order. Pure
+ *  and filesystem-free so it is directly testable. */
+export function renderWizardEnvFile(entries: ReadonlyArray<readonly [string, string]>): string {
+  if (entries.length === 0) return "";
+  return `${entries.map(([key, value]) => `${key}=${value}`).join("\n")}\n`;
+}
+
+async function promptRequiredMasked(io: WizardIo, question: string): Promise<string> {
+  for (;;) {
+    const answer = (await io.promptMasked(question)).trim();
+    if (answer) return answer;
+    io.writeLine("A value is required -- please try again.");
+  }
+}
+
+async function promptAuthMethod(io: WizardIo): Promise<"device" | "token"> {
+  io.writeLine("How would you like to authorize loopover-miner?");
+  io.writeLine("  1) Authorize with GitHub (recommended -- no token to copy)");
+  io.writeLine("  2) Paste a GitHub token (personal access token)");
+  for (;;) {
+    const answer = (await io.promptText("Choice [1/2, default 1]: ")).trim();
+    if (!answer || answer === "1") return "device";
+    if (answer === "2") return "token";
+    io.writeLine("Enter 1 or 2.");
+  }
+}
+
+/**
+ * Collect a GitHub credential for the wizard's starter .env. When LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID isn't
+ * configured (today's default, before the loopover-ams App is registered), this is IDENTICAL to the original
+ * masked-token-only prompt -- no menu, no behavior change. Once configured, offers device-flow authorization as
+ * the default choice, with the original pasted-token path still available (option 2) and as the automatic
+ * fallback on any device-flow failure -- never a hard dependency.
+ */
+async function collectGithubToken(
+  io: WizardIo,
+  env: Record<string, string | undefined>,
+  options: RunInteractiveInitOptions,
+): Promise<string> {
+  const clientId = resolveAmsOauthClientId(env);
+  if (!clientId) return promptRequiredMasked(io, "GitHub token (input hidden): ");
+
+  const method = await promptAuthMethod(io);
+  if (method === "token") return promptRequiredMasked(io, "GitHub token (input hidden): ");
+
+  try {
+    const { accessToken } = await runDeviceFlowAuthorization({
+      clientId,
+      ...(options.fetchImpl !== undefined ? { fetchFn: options.fetchImpl } : {}),
+      ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+      onCode: (code) => {
+        io.writeLine("");
+        io.writeLine(`To authorize, visit ${code.verificationUri} and enter code: ${code.userCode}`);
+        io.writeLine("Waiting for authorization...");
+      },
+    });
+    io.writeLine("Authorized.");
+    return accessToken;
+  } catch (error) {
+    const reason = error instanceof DeviceFlowError ? error.code : "device_flow_failed";
+    io.writeLine(`Device-flow authorization failed (${reason}) -- falling back to a pasted token.`);
+    return promptRequiredMasked(io, "GitHub token (input hidden): ");
+  }
+}
+
+/**
+ * Menu selection sourced from the engine's own `CODING_AGENT_DRIVER_NAMES`, so the choices can never drift from
+ * what the driver factory actually resolves. Empty input SKIPS provider selection entirely (leaves
+ * MINER_CODING_AGENT_PROVIDER unwritten, deferring to whatever default the CLI already resolves) -- distinct
+ * from explicitly choosing the `noop` entry.
+ */
+export async function promptProviderSelection(io: WizardIo): Promise<string | null> {
+  io.writeLine("Select a coding-agent provider (press Enter to skip and use the default):");
+  CODING_AGENT_DRIVER_NAMES.forEach((name, index) => {
+    io.writeLine(`  ${index + 1}) ${name}`);
+  });
+  for (;;) {
+    const answer = (await io.promptText(`Provider [1-${CODING_AGENT_DRIVER_NAMES.length}, or Enter to skip]: `)).trim();
+    if (!answer) return null;
+    const index = Number(answer) - 1;
+    if (Number.isInteger(index) && index >= 0 && index < CODING_AGENT_DRIVER_NAMES.length) {
+      return CODING_AGENT_DRIVER_NAMES[index] ?? null;
+    }
+    io.writeLine(`Enter a number from 1 to ${CODING_AGENT_DRIVER_NAMES.length}, or press Enter to skip.`);
+  }
+}
+
+/**
+ * Optional, skippable per-provider companion vars (model override / timeout), sourced from the same
+ * `CODING_AGENT_DRIVER_CONFIG_ENV` map the real driver factory reads -- never a hand-duplicated var-name list
+ * that could drift. Empty input skips that one var; its built-in default (if any) applies at run time as usual.
+ */
+export async function promptCompanionVars(io: WizardIo, provider: string): Promise<Array<[string, string]>> {
+  const varsForProvider =
+    CODING_AGENT_DRIVER_CONFIG_ENV[provider as CodingAgentDriverName] ?? {};
+  const collected: Array<[string, string]> = [];
+  for (const [kind, envVarName] of Object.entries(varsForProvider)) {
+    if (typeof envVarName !== "string") continue;
+    const label = COMPANION_VAR_LABELS[kind] ?? kind;
+    const answer = (
+      await io.promptText(`Optional ${label} for ${provider} (env ${envVarName}) [Enter to skip]: `)
+    ).trim();
+    if (answer) collected.push([envVarName, answer]);
+  }
+  return collected;
+}
+
+/**
+ * Run the interactive onboarding wizard end to end: collect GITHUB_TOKEN (pasted, or via device-flow
+ * authorization when configured -- see collectGithubToken) + optional provider config, write the starter .env,
+ * initialize laptop state, then rerun the existing offline doctor checks against the collected values. Returns
+ * doctor's exit code. `io` is injected so tests never touch a real terminal; `options.fetchImpl`/`sleepFn` are
+ * injected so tests never make a real network call or wait on a real timer during device-flow polling.
+ */
+export async function runInteractiveInit(
+  env: Record<string, string | undefined>,
+  cwd: string,
+  io: WizardIo,
+  options: RunInteractiveInitOptions = {},
+): Promise<number> {
+  // #6846: fail fast, not silently forever. `io.isInteractive` is only ever `false` for a real
+  // `createWizardIo()` adapter over a non-TTY stdin (a test's fake `io` has no such field and stays
+  // interactive by default, so every existing test is unaffected) -- an operator running this over a
+  // no-pty SSH session or a CI/fleet script gets clear, actionable guidance instead of a hang on the
+  // wizard's first prompt, which can never receive a real line of input.
+  if (io.isInteractive === false) {
+    io.writeLine("init --interactive requires a real terminal (no TTY detected on stdin).");
+    io.writeLine("For an unattended/fleet setup, skip this wizard and set these env vars directly instead:");
+    io.writeLine("  - GITHUB_TOKEN (your GitHub credential)");
+    io.writeLine("  - MINER_CODING_AGENT_PROVIDER (claude-cli or codex-cli)");
+    io.writeLine("  - ANTHROPIC_API_KEY for claude-cli, or OPENAI_API_KEY for codex-cli");
+    io.writeLine("Then verify with: loopover-miner doctor");
+    return 3;
+  }
+  const githubToken = await collectGithubToken(io, env, options);
+  const provider = await promptProviderSelection(io);
+
+  const entries: Array<[string, string]> = [["GITHUB_TOKEN", githubToken]];
+  if (provider) {
+    entries.push(["MINER_CODING_AGENT_PROVIDER", provider]);
+    entries.push(...(await promptCompanionVars(io, provider)));
+  }
+
+  const stateDir = resolveMinerStateDir(env);
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const envFilePath = resolveWizardEnvFilePath(env);
+  // { mode: 0o600 } on writeFileSync applies only when the file is newly created -- an existing file (e.g. from
+  // a prior wizard run, or hand-created by the operator with looser permissions) keeps its current mode across
+  // a write. The chmodSync below still runs unconditionally so the end state is always 0600 either way; the
+  // writeFileSync mode option exists so a BRAND NEW file is never briefly readable at the default umask
+  // permissions between being created and being locked down.
+  writeFileSync(envFilePath, renderWizardEnvFile(entries), { mode: 0o600 });
+  chmodSync(envFilePath, 0o600);
+  io.writeLine(`wrote ${envFilePath}`);
+
+  const initResult = initLaptopState(env);
+  io.writeLine(`initialized ${initResult.stateDir}`);
+  io.writeLine(`sqlite: ${initResult.dbPath}${initResult.created ? "" : " (already existed)"}`);
+
+  const mergedEnv: Record<string, string | undefined> = { ...env };
+  for (const [key, value] of entries) mergedEnv[key] = value;
+
+  io.writeLine("");
+  io.writeLine("Running doctor against the new configuration:");
+  return runDoctor([], mergedEnv, cwd);
+}
+
+/**
+ * Real terminal I/O for the wizard. Masked input is implemented by overriding readline's own output-write hook
+ * to render `*` instead of the typed prompt's characters while the interface is still doing its normal
+ * cooked-mode line editing (Enter/Backspace all still work exactly as with a plain prompt) -- no raw-mode byte
+ * handling and no extra dependency. `input`/`output` are parameters (defaulting to the real stdio) purely so
+ * tests can drive the exact same code path with fake streams instead of a real terminal.
+ */
+export function createWizardIo(
+  input: NodeJS.ReadableStream = process.stdin,
+  output: NodeJS.WritableStream = process.stdout,
+): WizardIo & { close: () => void; isInteractive: boolean } {
+  const rl = createInterface({ input, output, terminal: true }) as MaskableReadline;
+  const originalWriteToOutput = rl._writeToOutput.bind(rl);
+  let masking = false;
+  rl._writeToOutput = (stringToWrite: string) => {
+    originalWriteToOutput(masking ? "*" : stringToWrite);
+  };
+  return {
+    // #6846: whether `input` is a real, interactive terminal -- `runInteractiveInit` checks this BEFORE
+    // issuing its first prompt, so a no-TTY invocation (piped stdin, a plain `ssh host "loopover-miner init
+    // --interactive"` with no allocated pty) fails fast with actionable guidance instead of hanging forever
+    // on a `readline` prompt that can never receive a real line of input.
+    isInteractive: Boolean((input as StreamWithTty).isTTY),
+    promptText(question: string) {
+      return new Promise((resolve) => rl.question(question, resolve));
+    },
+    promptMasked(question: string) {
+      return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+          masking = false;
+          resolve(answer);
+        });
+        masking = true;
+      });
+    },
+    writeLine(text: string) {
+      output.write(`${text}\n`);
+    },
+    close() {
+      rl.close();
+    },
+  };
+}

--- a/packages/loopover-miner/lib/manage-poll.d.ts
+++ b/packages/loopover-miner/lib/manage-poll.d.ts
@@ -1,79 +1,61 @@
 import type { PollCheckRunsOptions, PollCheckRunsResult } from "./ci-poller.js";
 import type { EventLedger, LedgerEntry } from "./event-ledger.js";
 import type { PortfolioQueueStore } from "./portfolio-queue.js";
-
 export type ManagePollInput = {
-  repoFullName: string;
-  prNumber: number;
-  branch?: string | null;
+    repoFullName: string;
+    prNumber: number;
+    branch?: string | null;
 };
-
 export type ManagePollEventPayload = {
-  prNumber: number;
-  branch: string | null;
-  ciState: PollCheckRunsResult["conclusion"];
-  gateVerdict: string;
-  outcome: string;
-  lastPolledAt: string;
+    prNumber: number;
+    branch: string | null;
+    ciState: PollCheckRunsResult["conclusion"];
+    gateVerdict: string;
+    outcome: string;
+    lastPolledAt: string;
 };
-
 export type ManagePollRecordResult = {
-  pollResult: PollCheckRunsResult;
-  payload: ManagePollEventPayload;
-  event: LedgerEntry;
+    pollResult: PollCheckRunsResult;
+    payload: ManagePollEventPayload;
+    event: LedgerEntry;
 };
-
-export type ParsedManagePollArgs =
-  | {
-      repoFullName: string;
-      prNumber: number;
-      branch: string | null;
-      dryRun: boolean;
-      json: boolean;
-    }
-  | { error: string };
-
-export function mapPollConclusionToGateVerdict(
-  conclusion: PollCheckRunsResult["conclusion"],
-): string;
-
-export function mapPollConclusionToOutcome(conclusion: PollCheckRunsResult["conclusion"]): string;
-
-export function buildManagePollEventPayload(
-  prNumber: number,
-  pollResult: PollCheckRunsResult,
-  options?: { branch?: string | null; lastPolledAt?: string },
-): ManagePollEventPayload;
-
-export function parseManagePollArgs(args?: string[]): ParsedManagePollArgs;
-
-export function recordManagePollSnapshot(
-  input: ManagePollInput,
-  options: {
-    eventLedger: EventLedger;
+export type ParsedManagePollArgs = {
+    repoFullName: string;
+    prNumber: number;
+    branch: string | null;
+    dryRun: boolean;
+    json: boolean;
+} | {
+    error: string;
+};
+type ManagePollSnapshotOptions = {
+    eventLedger: {
+        appendEvent(event: unknown): LedgerEntry | null;
+    };
     portfolioQueue?: PortfolioQueueStore;
     ensurePortfolioRow?: boolean;
-    pollCheckRuns?: (
-      repoFullName: string,
-      prNumber: number,
-      options?: PollCheckRunsOptions,
-    ) => Promise<PollCheckRunsResult>;
+    pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<PollCheckRunsResult>;
     lastPolledAt?: string;
-  } & PollCheckRunsOptions,
-): Promise<ManagePollRecordResult>;
-
-export function runManagePoll(
-  args?: string[],
-  options?: {
+} & PollCheckRunsOptions;
+type RunManagePollOptions = {
     initEventLedger?: () => EventLedger;
     initPortfolioQueue?: () => PortfolioQueueStore;
     ensurePortfolioRow?: boolean;
-    pollCheckRuns?: (
-      repoFullName: string,
-      prNumber: number,
-      options?: PollCheckRunsOptions,
-    ) => Promise<PollCheckRunsResult>;
+    pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<PollCheckRunsResult>;
     githubToken?: string;
     lastPolledAt?: string;
-  } & PollCheckRunsOptions,
-): Promise<number>;
+} & PollCheckRunsOptions;
+export declare function mapPollConclusionToGateVerdict(conclusion: PollCheckRunsResult["conclusion"]): string;
+export declare function mapPollConclusionToOutcome(conclusion: PollCheckRunsResult["conclusion"]): string;
+export declare function buildManagePollEventPayload(prNumber: number, pollResult: PollCheckRunsResult, options?: {
+    branch?: string | null;
+    lastPolledAt?: string;
+}): ManagePollEventPayload;
+export declare function parseManagePollArgs(args?: string[]): ParsedManagePollArgs;
+/**
+ * Poll GitHub check runs for a managed PR and append a `manage_pr_update` snapshot to the local event ledger.
+ * Completes the manage-status data path introduced in #2325 / #3070 using the CI poller from #2323.
+ */
+export declare function recordManagePollSnapshot(input: ManagePollInput, options: ManagePollSnapshotOptions): Promise<ManagePollRecordResult>;
+export declare function runManagePoll(args?: string[], options?: RunManagePollOptions): Promise<number>;
+export {};

--- a/packages/loopover-miner/lib/manage-poll.js
+++ b/packages/loopover-miner/lib/manage-poll.js
@@ -1,269 +1,260 @@
 import { pollCheckRuns } from "./ci-poller.js";
 import { initEventLedger } from "./event-ledger.js";
-import {
-  MANAGE_PR_UPDATE_EVENT,
-  formatManagedPrIdentifier,
-} from "./manage-status.js";
+import { MANAGE_PR_UPDATE_EVENT, formatManagedPrIdentifier, } from "./manage-status.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
-
-const MANAGE_POLL_USAGE =
-  "Usage: loopover-miner manage poll <owner/repo> <pr#> [--branch <name>] [--dry-run] [--json]";
-
+const MANAGE_POLL_USAGE = "Usage: loopover-miner manage poll <owner/repo> <pr#> [--branch <name>] [--dry-run] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function mapPollConclusionToGateVerdict(conclusion) {
-  switch (conclusion) {
-    case "success":
-      return "pass";
-    case "failure":
-      return "block";
-    default:
-      return "advisory";
-  }
+    switch (conclusion) {
+        case "success":
+            return "pass";
+        case "failure":
+            return "block";
+        default:
+            return "advisory";
+    }
 }
-
 export function mapPollConclusionToOutcome(conclusion) {
-  switch (conclusion) {
-    case "success":
-      return "ready";
-    case "failure":
-      return "needs-work";
-    default:
-      return "open";
-  }
+    switch (conclusion) {
+        case "success":
+            return "ready";
+        case "failure":
+            return "needs-work";
+        default:
+            return "open";
+    }
 }
-
 export function buildManagePollEventPayload(prNumber, pollResult, options = {}) {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) throw new Error("invalid_pr_number");
-  if (!pollResult || typeof pollResult !== "object") throw new Error("invalid_poll_result");
-  const branch = typeof options.branch === "string" && options.branch.trim() ? options.branch.trim() : null;
-  const lastPolledAt =
-    typeof options.lastPolledAt === "string" && options.lastPolledAt.trim()
-      ? options.lastPolledAt.trim()
-      : new Date().toISOString();
-  return {
-    prNumber,
-    branch,
-    ciState: pollResult.conclusion,
-    gateVerdict: mapPollConclusionToGateVerdict(pollResult.conclusion),
-    outcome: mapPollConclusionToOutcome(pollResult.conclusion),
-    lastPolledAt,
-  };
+    if (!Number.isInteger(prNumber) || prNumber <= 0)
+        throw new Error("invalid_pr_number");
+    if (!pollResult || typeof pollResult !== "object")
+        throw new Error("invalid_poll_result");
+    const branch = typeof options.branch === "string" && options.branch.trim() ? options.branch.trim() : null;
+    const lastPolledAt = typeof options.lastPolledAt === "string" && options.lastPolledAt.trim()
+        ? options.lastPolledAt.trim()
+        : new Date().toISOString();
+    return {
+        prNumber,
+        branch,
+        ciState: pollResult.conclusion,
+        gateVerdict: mapPollConclusionToGateVerdict(pollResult.conclusion),
+        outcome: mapPollConclusionToOutcome(pollResult.conclusion),
+        lastPolledAt,
+    };
 }
-
 export function parseManagePollArgs(args = []) {
-  const options = { json: false, branch: null, dryRun: false };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        branch: null,
+        dryRun: false,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === undefined)
+            continue;
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: still runs the real (read-only) CI-check-run poll, but skips the event-ledger append and
+        // portfolio-queue enqueue.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--branch") {
+            const branch = args[index + 1];
+            if (!branch || branch.startsWith("-"))
+                return { error: MANAGE_POLL_USAGE };
+            options.branch = branch;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    // #4847: still runs the real (read-only) CI-check-run poll, but skips the event-ledger append and
-    // portfolio-queue enqueue.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
+    if (positional.length !== 2)
+        return { error: MANAGE_POLL_USAGE };
+    const repo = parseRepoArg(positional[0], MANAGE_POLL_USAGE);
+    if ("error" in repo)
+        return repo;
+    const prNumber = Number(positional[1]);
+    if (!Number.isInteger(prNumber) || prNumber <= 0) {
+        return { error: "Pull request number must be a positive integer." };
     }
-    if (token === "--branch") {
-      const branch = args[index + 1];
-      if (!branch || branch.startsWith("-")) return { error: MANAGE_POLL_USAGE };
-      options.branch = branch;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) return { error: MANAGE_POLL_USAGE };
-
-  const repo = parseRepoArg(positional[0], MANAGE_POLL_USAGE);
-  if ("error" in repo) return repo;
-
-  const prNumber = Number(positional[1]);
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
-    return { error: "Pull request number must be a positive integer." };
-  }
-
-  return {
-    repoFullName: repo.repoFullName,
-    prNumber,
-    ...options,
-  };
+    return {
+        repoFullName: repo.repoFullName,
+        prNumber,
+        ...options,
+    };
 }
-
 /** The forge host a managed-PR row belongs to. Mirrors portfolio-queue-manager.js's own fold (and every
  *  store's `normalizeApiBaseUrl`): omitted/blank → the github.com default, so a single-forge caller is
  *  unaffected. Used only to COMPARE hosts here; `enqueue` still does its own normalization/validation. */
 function resolveManagedRowApiBaseUrl(apiBaseUrl) {
-  return typeof apiBaseUrl === "string" && apiBaseUrl.trim() ? apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
+    return typeof apiBaseUrl === "string" && apiBaseUrl.trim() ? apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
 }
-
 function ensureManagedPrRow(portfolioQueue, repoFullName, prNumber, apiBaseUrl) {
-  const identifier = formatManagedPrIdentifier(prNumber);
-  // `listQueue(repoFullName)` is forge-BLIND, so the existence check has to compare the host too: the queue's
-  // composite (api_base_url, repo_full_name, identifier) key exists precisely so two hosts serving the same
-  // owner/repo name never collide (#5563). Without this scoping, the same repo+PR-number already tracked on
-  // ANOTHER host suppresses this host's row entirely.
-  const targetApiBaseUrl = resolveManagedRowApiBaseUrl(apiBaseUrl);
-  const exists = portfolioQueue
-    .listQueue(repoFullName)
-    .some((entry) => entry.identifier === identifier && resolveManagedRowApiBaseUrl(entry.apiBaseUrl) === targetApiBaseUrl);
-  if (!exists) {
-    // Thread the SAME apiBaseUrl the CI poll above used, so the row is scoped to the host it was polled from
-    // instead of silently defaulting to github.com.
-    portfolioQueue.enqueue({ repoFullName, identifier, priority: 0, apiBaseUrl });
-  }
+    const identifier = formatManagedPrIdentifier(prNumber);
+    // `listQueue(repoFullName)` is forge-BLIND, so the existence check has to compare the host too: the queue's
+    // composite (api_base_url, repo_full_name, identifier) key exists precisely so two hosts serving the same
+    // owner/repo name never collide (#5563). Without this scoping, the same repo+PR-number already tracked on
+    // ANOTHER host suppresses this host's row entirely.
+    const targetApiBaseUrl = resolveManagedRowApiBaseUrl(apiBaseUrl);
+    const exists = portfolioQueue
+        .listQueue(repoFullName)
+        .some((entry) => entry.identifier === identifier &&
+        resolveManagedRowApiBaseUrl(entry.apiBaseUrl) === targetApiBaseUrl);
+    if (!exists) {
+        // Thread the SAME apiBaseUrl the CI poll above used, so the row is scoped to the host it was polled from
+        // instead of silently defaulting to github.com.
+        portfolioQueue.enqueue({
+            repoFullName,
+            identifier,
+            priority: 0,
+            ...(apiBaseUrl !== undefined ? { apiBaseUrl } : {}),
+        });
+    }
 }
-
 /**
  * Poll GitHub check runs for a managed PR and append a `manage_pr_update` snapshot to the local event ledger.
  * Completes the manage-status data path introduced in #2325 / #3070 using the CI poller from #2323.
  */
-export async function recordManagePollSnapshot(input, options = {}) {
-  if (!input || typeof input !== "object") throw new Error("invalid_manage_poll_input");
-  const repoFullName = typeof input.repoFullName === "string" ? input.repoFullName.trim() : "";
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
-  if (!Number.isInteger(input.prNumber) || input.prNumber <= 0) throw new Error("invalid_pr_number");
-
-  const eventLedger = options.eventLedger;
-  if (!eventLedger || typeof eventLedger.appendEvent !== "function") {
-    throw new Error("invalid_event_ledger");
-  }
-
-  const portfolioQueue = options.portfolioQueue;
-  if (options.portfolioQueue !== undefined) {
-    if (!portfolioQueue || typeof portfolioQueue.enqueue !== "function") {
-      throw new Error("invalid_portfolio_queue");
+export async function recordManagePollSnapshot(input, options) {
+    if (!input || typeof input !== "object")
+        throw new Error("invalid_manage_poll_input");
+    const repoFullName = typeof input.repoFullName === "string" ? input.repoFullName.trim() : "";
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner || !repo || extra !== undefined)
+        throw new Error("invalid_repo_full_name");
+    if (!Number.isInteger(input.prNumber) || input.prNumber <= 0)
+        throw new Error("invalid_pr_number");
+    const eventLedger = options.eventLedger;
+    if (!eventLedger || typeof eventLedger.appendEvent !== "function") {
+        throw new Error("invalid_event_ledger");
     }
-  }
-
-  const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
-  const pollResult = await pollCheckRunsFn(repoFullName, input.prNumber, {
-    apiBaseUrl: options.apiBaseUrl,
-    fetchFn: options.fetchFn,
-    githubToken: options.githubToken ?? "",
-    maxAttempts: options.maxAttempts,
-    minIntervalMs: options.minIntervalMs,
-    maxIntervalMs: options.maxIntervalMs,
-    sleepFn: options.sleepFn,
-  });
-
-  const payload = buildManagePollEventPayload(input.prNumber, pollResult, {
-    branch: input.branch,
-    lastPolledAt: options.lastPolledAt,
-  });
-
-  if ((options.ensurePortfolioRow ?? true) && portfolioQueue) {
-    ensureManagedPrRow(portfolioQueue, repoFullName, input.prNumber, options.apiBaseUrl);
-  }
-
-  const event = eventLedger.appendEvent({
-    type: MANAGE_PR_UPDATE_EVENT,
-    repoFullName,
-    payload,
-  });
-
-  return { pollResult, payload, event };
+    const portfolioQueue = options.portfolioQueue;
+    if (options.portfolioQueue !== undefined) {
+        if (!portfolioQueue || typeof portfolioQueue.enqueue !== "function") {
+            throw new Error("invalid_portfolio_queue");
+        }
+    }
+    const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
+    const pollResult = await pollCheckRunsFn(repoFullName, input.prNumber, {
+        ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+        ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+        githubToken: options.githubToken ?? "",
+        ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
+        ...(options.minIntervalMs !== undefined ? { minIntervalMs: options.minIntervalMs } : {}),
+        ...(options.maxIntervalMs !== undefined ? { maxIntervalMs: options.maxIntervalMs } : {}),
+        ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+    });
+    const payload = buildManagePollEventPayload(input.prNumber, pollResult, {
+        ...(input.branch !== undefined ? { branch: input.branch } : {}),
+        ...(options.lastPolledAt !== undefined ? { lastPolledAt: options.lastPolledAt } : {}),
+    });
+    if ((options.ensurePortfolioRow ?? true) && portfolioQueue) {
+        ensureManagedPrRow(portfolioQueue, repoFullName, input.prNumber, options.apiBaseUrl);
+    }
+    const event = eventLedger.appendEvent({
+        type: MANAGE_PR_UPDATE_EVENT,
+        repoFullName,
+        payload,
+    });
+    return { pollResult, payload, event: event };
 }
-
 export async function runManagePoll(args = [], options = {}) {
-  const parsed = parseManagePollArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  // #4847: the CI-check-run poll itself is a real, read-only GitHub signal -- the useful "what would this
-  // record?" output -- so a dry run still performs it for real. It never opens the event ledger or portfolio
-  // queue, though: a no-op event ledger is fed through recordManagePollSnapshot so its own real payload-building
-  // logic still runs, just without ever writing to local storage (ensurePortfolioRow: false skips the queue
-  // enqueue the same way).
-  if (parsed.dryRun) {
-    const noopEventLedger = { appendEvent: () => null };
+    const parsed = parseManagePollArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    // #4847: the CI-check-run poll itself is a real, read-only GitHub signal -- the useful "what would this
+    // record?" output -- so a dry run still performs it for real. It never opens the event ledger or portfolio
+    // queue, though: a no-op event ledger is fed through recordManagePollSnapshot so its own real payload-building
+    // logic still runs, just without ever writing to local storage (ensurePortfolioRow: false skips the queue
+    // enqueue the same way).
+    if (parsed.dryRun) {
+        const noopEventLedger = { appendEvent: () => null };
+        try {
+            const result = await recordManagePollSnapshot({ repoFullName: parsed.repoFullName, prNumber: parsed.prNumber, branch: parsed.branch }, {
+                eventLedger: noopEventLedger,
+                ensurePortfolioRow: false,
+                ...(options.pollCheckRuns !== undefined ? { pollCheckRuns: options.pollCheckRuns } : {}),
+                ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+                githubToken: options.githubToken ?? (await resolveGitHubToken(process.env)) ?? "",
+                ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+                ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
+                ...(options.minIntervalMs !== undefined ? { minIntervalMs: options.minIntervalMs } : {}),
+                ...(options.maxIntervalMs !== undefined ? { maxIntervalMs: options.maxIntervalMs } : {}),
+                ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+                ...(options.lastPolledAt !== undefined ? { lastPolledAt: options.lastPolledAt } : {}),
+            });
+            const dryRunResult = { outcome: "dry_run", pollResult: result.pollResult, payload: result.payload };
+            if (parsed.json) {
+                console.log(JSON.stringify(dryRunResult, null, 2));
+            }
+            else {
+                console.log(`DRY RUN: ${result.payload.ciState} (${result.payload.gateVerdict}/${result.payload.outcome}). No event-ledger or portfolio-queue write was made.`);
+            }
+            return 0;
+        }
+        catch (error) {
+            return reportCliFailure(parsed.json, describeCliError(error));
+        }
+    }
+    const ownsEventLedger = options.initEventLedger === undefined;
+    const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+    const eventLedger = (options.initEventLedger ?? initEventLedger)();
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
     try {
-      const result = await recordManagePollSnapshot(
-        { repoFullName: parsed.repoFullName, prNumber: parsed.prNumber, branch: parsed.branch },
-        {
-          eventLedger: noopEventLedger,
-          ensurePortfolioRow: false,
-          pollCheckRuns: options.pollCheckRuns,
-          fetchFn: options.fetchFn,
-          githubToken: options.githubToken ?? (await resolveGitHubToken(process.env)) ?? "",
-          apiBaseUrl: options.apiBaseUrl,
-          maxAttempts: options.maxAttempts,
-          minIntervalMs: options.minIntervalMs,
-          maxIntervalMs: options.maxIntervalMs,
-          sleepFn: options.sleepFn,
-          lastPolledAt: options.lastPolledAt,
-        },
-      );
-      const dryRunResult = { outcome: "dry_run", pollResult: result.pollResult, payload: result.payload };
-      if (parsed.json) {
-        console.log(JSON.stringify(dryRunResult, null, 2));
-      } else {
-        console.log(
-          `DRY RUN: ${result.payload.ciState} (${result.payload.gateVerdict}/${result.payload.outcome}). No event-ledger or portfolio-queue write was made.`,
-        );
-      }
-      return 0;
-    } catch (error) {
-      return reportCliFailure(parsed.json, describeCliError(error));
+        const result = await recordManagePollSnapshot({
+            repoFullName: parsed.repoFullName,
+            prNumber: parsed.prNumber,
+            branch: parsed.branch,
+        }, {
+            eventLedger,
+            portfolioQueue,
+            ensurePortfolioRow: options.ensurePortfolioRow ?? true,
+            ...(options.pollCheckRuns !== undefined ? { pollCheckRuns: options.pollCheckRuns } : {}),
+            ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+            githubToken: options.githubToken ?? (await resolveGitHubToken(process.env)) ?? "",
+            ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+            ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
+            ...(options.minIntervalMs !== undefined ? { minIntervalMs: options.minIntervalMs } : {}),
+            ...(options.maxIntervalMs !== undefined ? { maxIntervalMs: options.maxIntervalMs } : {}),
+            ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+            ...(options.lastPolledAt !== undefined ? { lastPolledAt: options.lastPolledAt } : {}),
+        });
+        if (parsed.json) {
+            console.log(JSON.stringify(result, null, 2));
+        }
+        else {
+            console.log(`${result.payload.ciState} (${result.payload.gateVerdict}/${result.payload.outcome})`);
+        }
+        return 0;
     }
-  }
-
-  const ownsEventLedger = options.initEventLedger === undefined;
-  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-
-  try {
-    const result = await recordManagePollSnapshot(
-      {
-        repoFullName: parsed.repoFullName,
-        prNumber: parsed.prNumber,
-        branch: parsed.branch,
-      },
-      {
-        eventLedger,
-        portfolioQueue,
-        ensurePortfolioRow: options.ensurePortfolioRow ?? true,
-        pollCheckRuns: options.pollCheckRuns,
-        fetchFn: options.fetchFn,
-        githubToken: options.githubToken ?? (await resolveGitHubToken(process.env)) ?? "",
-        apiBaseUrl: options.apiBaseUrl,
-        maxAttempts: options.maxAttempts,
-        minIntervalMs: options.minIntervalMs,
-        maxIntervalMs: options.maxIntervalMs,
-        sleepFn: options.sleepFn,
-        lastPolledAt: options.lastPolledAt,
-      },
-    );
-
-    if (parsed.json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      console.log(`${result.payload.ciState} (${result.payload.gateVerdict}/${result.payload.outcome})`);
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsEventLedger) eventLedger.close();
-    if (ownsPortfolioQueue) portfolioQueue.close();
-  }
+    finally {
+        if (ownsEventLedger)
+            eventLedger.close();
+        if (ownsPortfolioQueue)
+            portfolioQueue.close();
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWFuYWdlLXBvbGwuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJtYW5hZ2UtcG9sbC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQUUsYUFBYSxFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFFL0MsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRXBELE9BQU8sRUFDTCxzQkFBc0IsRUFDdEIseUJBQXlCLEdBQzFCLE1BQU0sb0JBQW9CLENBQUM7QUFDNUIsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFFL0QsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFDekQsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBQ2xGLE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBRWxFLE1BQU0saUJBQWlCLEdBQ3JCLDZGQUE2RixDQUFDO0FBMERoRyxTQUFTLFlBQVksQ0FDbkIsS0FBeUIsRUFDekIsS0FBYTtJQUViLElBQUksQ0FBQyxLQUFLO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUNwQyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDN0IsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztRQUMzQyxPQUFPLEVBQUUsS0FBSyxFQUFFLHdDQUF3QyxFQUFFLENBQUM7SUFDN0QsQ0FBQztJQUNELE9BQU8sRUFBRSxZQUFZLEVBQUUsR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLEVBQUUsQ0FBQztBQUM5QyxDQUFDO0FBRUQsTUFBTSxVQUFVLDhCQUE4QixDQUM1QyxVQUE2QztJQUU3QyxRQUFRLFVBQVUsRUFBRSxDQUFDO1FBQ25CLEtBQUssU0FBUztZQUNaLE9BQU8sTUFBTSxDQUFDO1FBQ2hCLEtBQUssU0FBUztZQUNaLE9BQU8sT0FBTyxDQUFDO1FBQ2pCO1lBQ0UsT0FBTyxVQUFVLENBQUM7SUFDdEIsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLFVBQVUsMEJBQTBCLENBQUMsVUFBNkM7SUFDdEYsUUFBUSxVQUFVLEVBQUUsQ0FBQztRQUNuQixLQUFLLFNBQVM7WUFDWixPQUFPLE9BQU8sQ0FBQztRQUNqQixLQUFLLFNBQVM7WUFDWixPQUFPLFlBQVksQ0FBQztRQUN0QjtZQUNFLE9BQU8sTUFBTSxDQUFDO0lBQ2xCLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLDJCQUEyQixDQUN6QyxRQUFnQixFQUNoQixVQUErQixFQUMvQixVQUE2RCxFQUFFO0lBRS9ELElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLFFBQVEsQ0FBQyxJQUFJLFFBQVEsSUFBSSxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxtQkFBbUIsQ0FBQyxDQUFDO0lBQ3ZGLElBQUksQ0FBQyxVQUFVLElBQUksT0FBTyxVQUFVLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMscUJBQXFCLENBQUMsQ0FBQztJQUMxRixNQUFNLE1BQU0sR0FBRyxPQUFPLE9BQU8sQ0FBQyxNQUFNLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUMxRyxNQUFNLFlBQVksR0FDaEIsT0FBTyxPQUFPLENBQUMsWUFBWSxLQUFLLFFBQVEsSUFBSSxPQUFPLENBQUMsWUFBWSxDQUFDLElBQUksRUFBRTtRQUNyRSxDQUFDLENBQUMsT0FBTyxDQUFDLFlBQVksQ0FBQyxJQUFJLEVBQUU7UUFDN0IsQ0FBQyxDQUFDLElBQUksSUFBSSxFQUFFLENBQUMsV0FBVyxFQUFFLENBQUM7SUFDL0IsT0FBTztRQUNMLFFBQVE7UUFDUixNQUFNO1FBQ04sT0FBTyxFQUFFLFVBQVUsQ0FBQyxVQUFVO1FBQzlCLFdBQVcsRUFBRSw4QkFBOEIsQ0FBQyxVQUFVLENBQUMsVUFBVSxDQUFDO1FBQ2xFLE9BQU8sRUFBRSwwQkFBMEIsQ0FBQyxVQUFVLENBQUMsVUFBVSxDQUFDO1FBQzFELFlBQVk7S0FDYixDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxPQUFpQixFQUFFO0lBQ3JELE1BQU0sT0FBTyxHQUE4RDtRQUN6RSxJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxJQUFJO1FBQ1osTUFBTSxFQUFFLEtBQUs7S0FDZCxDQUFDO0lBQ0YsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDMUIsSUFBSSxLQUFLLEtBQUssU0FBUztZQUFFLFNBQVM7UUFDbEMsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxrR0FBa0c7UUFDbEcsMkJBQTJCO1FBQzNCLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsTUFBTSxNQUFNLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUMvQixJQUFJLENBQUMsTUFBTSxJQUFJLE1BQU0sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsaUJBQWlCLEVBQUUsQ0FBQztZQUMzRSxPQUFPLENBQUMsTUFBTSxHQUFHLE1BQU0sQ0FBQztZQUN4QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO1lBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUN4RSxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsaUJBQWlCLEVBQUUsQ0FBQztJQUVqRSxNQUFNLElBQUksR0FBRyxZQUFZLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLGlCQUFpQixDQUFDLENBQUM7SUFDNUQsSUFBSSxPQUFPLElBQUksSUFBSTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBRWpDLE1BQU0sUUFBUSxHQUFHLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUN2QyxJQUFJLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxRQUFRLENBQUMsSUFBSSxRQUFRLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDakQsT0FBTyxFQUFFLEtBQUssRUFBRSxpREFBaUQsRUFBRSxDQUFDO0lBQ3RFLENBQUM7SUFFRCxPQUFPO1FBQ0wsWUFBWSxFQUFFLElBQUksQ0FBQyxZQUFZO1FBQy9CLFFBQVE7UUFDUixHQUFHLE9BQU87S0FDWCxDQUFDO0FBQ0osQ0FBQztBQUVEOzswR0FFMEc7QUFDMUcsU0FBUywyQkFBMkIsQ0FBQyxVQUE4QjtJQUNqRSxPQUFPLE9BQU8sVUFBVSxLQUFLLFFBQVEsSUFBSSxVQUFVLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsb0JBQW9CLENBQUMsVUFBVSxDQUFDO0FBQ25ILENBQUM7QUFFRCxTQUFTLGtCQUFrQixDQUN6QixjQUFtQyxFQUNuQyxZQUFvQixFQUNwQixRQUFnQixFQUNoQixVQUE4QjtJQUU5QixNQUFNLFVBQVUsR0FBRyx5QkFBeUIsQ0FBQyxRQUFRLENBQUMsQ0FBQztJQUN2RCw0R0FBNEc7SUFDNUcsMEdBQTBHO0lBQzFHLDBHQUEwRztJQUMxRyxvREFBb0Q7SUFDcEQsTUFBTSxnQkFBZ0IsR0FBRywyQkFBMkIsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUNqRSxNQUFNLE1BQU0sR0FBRyxjQUFjO1NBQzFCLFNBQVMsQ0FBQyxZQUFZLENBQUM7U0FDdkIsSUFBSSxDQUNILENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FDUixLQUFLLENBQUMsVUFBVSxLQUFLLFVBQVU7UUFDL0IsMkJBQTJCLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxLQUFLLGdCQUFnQixDQUNyRSxDQUFDO0lBQ0osSUFBSSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ1oseUdBQXlHO1FBQ3pHLGdEQUFnRDtRQUNoRCxjQUFjLENBQUMsT0FBTyxDQUFDO1lBQ3JCLFlBQVk7WUFDWixVQUFVO1lBQ1YsUUFBUSxFQUFFLENBQUM7WUFDWCxHQUFHLENBQUMsVUFBVSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1NBQ3BELENBQUMsQ0FBQztJQUNMLENBQUM7QUFDSCxDQUFDO0FBRUQ7OztHQUdHO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSx3QkFBd0IsQ0FDNUMsS0FBc0IsRUFDdEIsT0FBa0M7SUFFbEMsSUFBSSxDQUFDLEtBQUssSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywyQkFBMkIsQ0FBQyxDQUFDO0lBQ3RGLE1BQU0sWUFBWSxHQUFHLE9BQU8sS0FBSyxDQUFDLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUM3RixNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxZQUFZLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3JELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7SUFDdEYsSUFBSSxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxJQUFJLEtBQUssQ0FBQyxRQUFRLElBQUksQ0FBQztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsbUJBQW1CLENBQUMsQ0FBQztJQUVuRyxNQUFNLFdBQVcsR0FBRyxPQUFPLENBQUMsV0FBVyxDQUFDO0lBQ3hDLElBQUksQ0FBQyxXQUFXLElBQUksT0FBTyxXQUFXLENBQUMsV0FBVyxLQUFLLFVBQVUsRUFBRSxDQUFDO1FBQ2xFLE1BQU0sSUFBSSxLQUFLLENBQUMsc0JBQXNCLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBRUQsTUFBTSxjQUFjLEdBQUcsT0FBTyxDQUFDLGNBQWMsQ0FBQztJQUM5QyxJQUFJLE9BQU8sQ0FBQyxjQUFjLEtBQUssU0FBUyxFQUFFLENBQUM7UUFDekMsSUFBSSxDQUFDLGNBQWMsSUFBSSxPQUFPLGNBQWMsQ0FBQyxPQUFPLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDcEUsTUFBTSxJQUFJLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO1FBQzdDLENBQUM7SUFDSCxDQUFDO0lBRUQsTUFBTSxlQUFlLEdBQUcsT0FBTyxDQUFDLGFBQWEsSUFBSSxhQUFhLENBQUM7SUFDL0QsTUFBTSxVQUFVLEdBQUcsTUFBTSxlQUFlLENBQUMsWUFBWSxFQUFFLEtBQUssQ0FBQyxRQUFRLEVBQUU7UUFDckUsR0FBRyxDQUFDLE9BQU8sQ0FBQyxVQUFVLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUMvRSxHQUFHLENBQUMsT0FBTyxDQUFDLE9BQU8sS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsT0FBTyxFQUFFLE9BQU8sQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3RFLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVyxJQUFJLEVBQUU7UUFDdEMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxXQUFXLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUNsRixHQUFHLENBQUMsT0FBTyxDQUFDLGFBQWEsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsYUFBYSxFQUFFLE9BQU8sQ0FBQyxhQUFhLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3hGLEdBQUcsQ0FBQyxPQUFPLENBQUMsYUFBYSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxhQUFhLEVBQUUsT0FBTyxDQUFDLGFBQWEsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7UUFDeEYsR0FBRyxDQUFDLE9BQU8sQ0FBQyxPQUFPLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxPQUFPLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztLQUN2RSxDQUFDLENBQUM7SUFFSCxNQUFNLE9BQU8sR0FBRywyQkFBMkIsQ0FBQyxLQUFLLENBQUMsUUFBUSxFQUFFLFVBQVUsRUFBRTtRQUN0RSxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsTUFBTSxFQUFFLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQy9ELEdBQUcsQ0FBQyxPQUFPLENBQUMsWUFBWSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7S0FDdEYsQ0FBQyxDQUFDO0lBRUgsSUFBSSxDQUFDLE9BQU8sQ0FBQyxrQkFBa0IsSUFBSSxJQUFJLENBQUMsSUFBSSxjQUFjLEVBQUUsQ0FBQztRQUMzRCxrQkFBa0IsQ0FBQyxjQUFjLEVBQUUsWUFBWSxFQUFFLEtBQUssQ0FBQyxRQUFRLEVBQUUsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQ3ZGLENBQUM7SUFFRCxNQUFNLEtBQUssR0FBRyxXQUFXLENBQUMsV0FBVyxDQUFDO1FBQ3BDLElBQUksRUFBRSxzQkFBc0I7UUFDNUIsWUFBWTtRQUNaLE9BQU87S0FDUixDQUFDLENBQUM7SUFFSCxPQUFPLEVBQUUsVUFBVSxFQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBb0IsRUFBRSxDQUFDO0FBQzlELENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLGFBQWEsQ0FDakMsT0FBaUIsRUFBRSxFQUNuQixVQUFnQyxFQUFFO0lBRWxDLE1BQU0sTUFBTSxHQUFHLG1CQUFtQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3pDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsd0dBQXdHO0lBQ3hHLDJHQUEyRztJQUMzRywrR0FBK0c7SUFDL0csMEdBQTBHO0lBQzFHLHlCQUF5QjtJQUN6QixJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixNQUFNLGVBQWUsR0FBRyxFQUFFLFdBQVcsRUFBRSxHQUFHLEVBQUUsQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNwRCxJQUFJLENBQUM7WUFDSCxNQUFNLE1BQU0sR0FBRyxNQUFNLHdCQUF3QixDQUMzQyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLFFBQVEsRUFBRSxNQUFNLENBQUMsUUFBUSxFQUFFLE1BQU0sRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLEVBQ3ZGO2dCQUNFLFdBQVcsRUFBRSxlQUFlO2dCQUM1QixrQkFBa0IsRUFBRSxLQUFLO2dCQUN6QixHQUFHLENBQUMsT0FBTyxDQUFDLGFBQWEsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsYUFBYSxFQUFFLE9BQU8sQ0FBQyxhQUFhLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO2dCQUN4RixHQUFHLENBQUMsT0FBTyxDQUFDLE9BQU8sS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsT0FBTyxFQUFFLE9BQU8sQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO2dCQUN0RSxXQUFXLEVBQUUsT0FBTyxDQUFDLFdBQVcsSUFBSSxDQUFDLE1BQU0sa0JBQWtCLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRTtnQkFDakYsR0FBRyxDQUFDLE9BQU8sQ0FBQyxVQUFVLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztnQkFDL0UsR0FBRyxDQUFDLE9BQU8sQ0FBQyxXQUFXLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztnQkFDbEYsR0FBRyxDQUFDLE9BQU8sQ0FBQyxhQUFhLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLGFBQWEsRUFBRSxPQUFPLENBQUMsYUFBYSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztnQkFDeEYsR0FBRyxDQUFDLE9BQU8sQ0FBQyxhQUFhLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLGFBQWEsRUFBRSxPQUFPLENBQUMsYUFBYSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztnQkFDeEYsR0FBRyxDQUFDLE9BQU8sQ0FBQyxPQUFPLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxPQUFPLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztnQkFDdEUsR0FBRyxDQUFDLE9BQU8sQ0FBQyxZQUFZLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQzthQUN0RixDQUNGLENBQUM7WUFDRixNQUFNLFlBQVksR0FBRyxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVLEVBQUUsT0FBTyxFQUFFLE1BQU0sQ0FBQyxPQUFPLEVBQUUsQ0FBQztZQUNwRyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNyRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FDVCxZQUFZLE1BQU0sQ0FBQyxPQUFPLENBQUMsT0FBTyxLQUFLLE1BQU0sQ0FBQyxPQUFPLENBQUMsV0FBVyxJQUFJLE1BQU0sQ0FBQyxPQUFPLENBQUMsT0FBTyx1REFBdUQsQ0FDbkosQ0FBQztZQUNKLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUM7UUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1lBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7UUFDaEUsQ0FBQztJQUNILENBQUM7SUFFRCxNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsZUFBZSxLQUFLLFNBQVMsQ0FBQztJQUM5RCxNQUFNLGtCQUFrQixHQUFHLE9BQU8sQ0FBQyxrQkFBa0IsS0FBSyxTQUFTLENBQUM7SUFDcEUsTUFBTSxXQUFXLEdBQUcsQ0FBQyxPQUFPLENBQUMsZUFBZSxJQUFJLGVBQWUsQ0FBQyxFQUFFLENBQUM7SUFDbkUsTUFBTSxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBRWpGLElBQUksQ0FBQztRQUNILE1BQU0sTUFBTSxHQUFHLE1BQU0sd0JBQXdCLENBQzNDO1lBQ0UsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO1lBQ2pDLFFBQVEsRUFBRSxNQUFNLENBQUMsUUFBUTtZQUN6QixNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU07U0FDdEIsRUFDRDtZQUNFLFdBQVc7WUFDWCxjQUFjO1lBQ2Qsa0JBQWtCLEVBQUUsT0FBTyxDQUFDLGtCQUFrQixJQUFJLElBQUk7WUFDdEQsR0FBRyxDQUFDLE9BQU8sQ0FBQyxhQUFhLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLGFBQWEsRUFBRSxPQUFPLENBQUMsYUFBYSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUN4RixHQUFHLENBQUMsT0FBTyxDQUFDLE9BQU8sS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsT0FBTyxFQUFFLE9BQU8sQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQ3RFLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVyxJQUFJLENBQUMsTUFBTSxrQkFBa0IsQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFO1lBQ2pGLEdBQUcsQ0FBQyxPQUFPLENBQUMsVUFBVSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDL0UsR0FBRyxDQUFDLE9BQU8sQ0FBQyxXQUFXLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUNsRixHQUFHLENBQUMsT0FBTyxDQUFDLGFBQWEsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsYUFBYSxFQUFFLE9BQU8sQ0FBQyxhQUFhLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQ3hGLEdBQUcsQ0FBQyxPQUFPLENBQUMsYUFBYSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxhQUFhLEVBQUUsT0FBTyxDQUFDLGFBQWEsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDeEYsR0FBRyxDQUFDLE9BQU8sQ0FBQyxPQUFPLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxPQUFPLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUN0RSxHQUFHLENBQUMsT0FBTyxDQUFDLFlBQVksS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1NBQ3RGLENBQ0YsQ0FBQztRQUVGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxNQUFNLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDL0MsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLEdBQUcsTUFBTSxDQUFDLE9BQU8sQ0FBQyxPQUFPLEtBQUssTUFBTSxDQUFDLE9BQU8sQ0FBQyxXQUFXLElBQUksTUFBTSxDQUFDLE9BQU8sQ0FBQyxPQUFPLEdBQUcsQ0FBQyxDQUFDO1FBQ3JHLENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztZQUFTLENBQUM7UUFDVCxJQUFJLGVBQWU7WUFBRSxXQUFXLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDekMsSUFBSSxrQkFBa0I7WUFBRSxjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7SUFDakQsQ0FBQztBQUNILENBQUMifQ==

--- a/packages/loopover-miner/lib/manage-poll.ts
+++ b/packages/loopover-miner/lib/manage-poll.ts
@@ -1,0 +1,362 @@
+import { pollCheckRuns } from "./ci-poller.js";
+import type { PollCheckRunsOptions, PollCheckRunsResult } from "./ci-poller.js";
+import { initEventLedger } from "./event-ledger.js";
+import type { EventLedger, LedgerEntry } from "./event-ledger.js";
+import {
+  MANAGE_PR_UPDATE_EVENT,
+  formatManagedPrIdentifier,
+} from "./manage-status.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { resolveGitHubToken } from "./github-token-resolution.js";
+
+const MANAGE_POLL_USAGE =
+  "Usage: loopover-miner manage poll <owner/repo> <pr#> [--branch <name>] [--dry-run] [--json]";
+
+export type ManagePollInput = {
+  repoFullName: string;
+  prNumber: number;
+  branch?: string | null;
+};
+
+export type ManagePollEventPayload = {
+  prNumber: number;
+  branch: string | null;
+  ciState: PollCheckRunsResult["conclusion"];
+  gateVerdict: string;
+  outcome: string;
+  lastPolledAt: string;
+};
+
+export type ManagePollRecordResult = {
+  pollResult: PollCheckRunsResult;
+  payload: ManagePollEventPayload;
+  event: LedgerEntry;
+};
+
+export type ParsedManagePollArgs =
+  | {
+      repoFullName: string;
+      prNumber: number;
+      branch: string | null;
+      dryRun: boolean;
+      json: boolean;
+    }
+  | { error: string };
+
+type ManagePollSnapshotOptions = {
+  eventLedger: { appendEvent(event: unknown): LedgerEntry | null };
+  portfolioQueue?: PortfolioQueueStore;
+  ensurePortfolioRow?: boolean;
+  pollCheckRuns?: (
+    repoFullName: string,
+    prNumber: number,
+    options?: PollCheckRunsOptions,
+  ) => Promise<PollCheckRunsResult>;
+  lastPolledAt?: string;
+} & PollCheckRunsOptions;
+
+type RunManagePollOptions = {
+  initEventLedger?: () => EventLedger;
+  initPortfolioQueue?: () => PortfolioQueueStore;
+  ensurePortfolioRow?: boolean;
+  pollCheckRuns?: (
+    repoFullName: string,
+    prNumber: number,
+    options?: PollCheckRunsOptions,
+  ) => Promise<PollCheckRunsResult>;
+  githubToken?: string;
+  lastPolledAt?: string;
+} & PollCheckRunsOptions;
+
+function parseRepoArg(
+  value: string | undefined,
+  usage: string,
+): { repoFullName: string } | { error: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function mapPollConclusionToGateVerdict(
+  conclusion: PollCheckRunsResult["conclusion"],
+): string {
+  switch (conclusion) {
+    case "success":
+      return "pass";
+    case "failure":
+      return "block";
+    default:
+      return "advisory";
+  }
+}
+
+export function mapPollConclusionToOutcome(conclusion: PollCheckRunsResult["conclusion"]): string {
+  switch (conclusion) {
+    case "success":
+      return "ready";
+    case "failure":
+      return "needs-work";
+    default:
+      return "open";
+  }
+}
+
+export function buildManagePollEventPayload(
+  prNumber: number,
+  pollResult: PollCheckRunsResult,
+  options: { branch?: string | null; lastPolledAt?: string } = {},
+): ManagePollEventPayload {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) throw new Error("invalid_pr_number");
+  if (!pollResult || typeof pollResult !== "object") throw new Error("invalid_poll_result");
+  const branch = typeof options.branch === "string" && options.branch.trim() ? options.branch.trim() : null;
+  const lastPolledAt =
+    typeof options.lastPolledAt === "string" && options.lastPolledAt.trim()
+      ? options.lastPolledAt.trim()
+      : new Date().toISOString();
+  return {
+    prNumber,
+    branch,
+    ciState: pollResult.conclusion,
+    gateVerdict: mapPollConclusionToGateVerdict(pollResult.conclusion),
+    outcome: mapPollConclusionToOutcome(pollResult.conclusion),
+    lastPolledAt,
+  };
+}
+
+export function parseManagePollArgs(args: string[] = []): ParsedManagePollArgs {
+  const options: { json: boolean; branch: string | null; dryRun: boolean } = {
+    json: false,
+    branch: null,
+    dryRun: false,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === undefined) continue;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: still runs the real (read-only) CI-check-run poll, but skips the event-ledger append and
+    // portfolio-queue enqueue.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--branch") {
+      const branch = args[index + 1];
+      if (!branch || branch.startsWith("-")) return { error: MANAGE_POLL_USAGE };
+      options.branch = branch;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) return { error: MANAGE_POLL_USAGE };
+
+  const repo = parseRepoArg(positional[0], MANAGE_POLL_USAGE);
+  if ("error" in repo) return repo;
+
+  const prNumber = Number(positional[1]);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return { error: "Pull request number must be a positive integer." };
+  }
+
+  return {
+    repoFullName: repo.repoFullName,
+    prNumber,
+    ...options,
+  };
+}
+
+/** The forge host a managed-PR row belongs to. Mirrors portfolio-queue-manager.js's own fold (and every
+ *  store's `normalizeApiBaseUrl`): omitted/blank → the github.com default, so a single-forge caller is
+ *  unaffected. Used only to COMPARE hosts here; `enqueue` still does its own normalization/validation. */
+function resolveManagedRowApiBaseUrl(apiBaseUrl: string | undefined): string {
+  return typeof apiBaseUrl === "string" && apiBaseUrl.trim() ? apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
+}
+
+function ensureManagedPrRow(
+  portfolioQueue: PortfolioQueueStore,
+  repoFullName: string,
+  prNumber: number,
+  apiBaseUrl: string | undefined,
+): void {
+  const identifier = formatManagedPrIdentifier(prNumber);
+  // `listQueue(repoFullName)` is forge-BLIND, so the existence check has to compare the host too: the queue's
+  // composite (api_base_url, repo_full_name, identifier) key exists precisely so two hosts serving the same
+  // owner/repo name never collide (#5563). Without this scoping, the same repo+PR-number already tracked on
+  // ANOTHER host suppresses this host's row entirely.
+  const targetApiBaseUrl = resolveManagedRowApiBaseUrl(apiBaseUrl);
+  const exists = portfolioQueue
+    .listQueue(repoFullName)
+    .some(
+      (entry) =>
+        entry.identifier === identifier &&
+        resolveManagedRowApiBaseUrl(entry.apiBaseUrl) === targetApiBaseUrl,
+    );
+  if (!exists) {
+    // Thread the SAME apiBaseUrl the CI poll above used, so the row is scoped to the host it was polled from
+    // instead of silently defaulting to github.com.
+    portfolioQueue.enqueue({
+      repoFullName,
+      identifier,
+      priority: 0,
+      ...(apiBaseUrl !== undefined ? { apiBaseUrl } : {}),
+    });
+  }
+}
+
+/**
+ * Poll GitHub check runs for a managed PR and append a `manage_pr_update` snapshot to the local event ledger.
+ * Completes the manage-status data path introduced in #2325 / #3070 using the CI poller from #2323.
+ */
+export async function recordManagePollSnapshot(
+  input: ManagePollInput,
+  options: ManagePollSnapshotOptions,
+): Promise<ManagePollRecordResult> {
+  if (!input || typeof input !== "object") throw new Error("invalid_manage_poll_input");
+  const repoFullName = typeof input.repoFullName === "string" ? input.repoFullName.trim() : "";
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  if (!Number.isInteger(input.prNumber) || input.prNumber <= 0) throw new Error("invalid_pr_number");
+
+  const eventLedger = options.eventLedger;
+  if (!eventLedger || typeof eventLedger.appendEvent !== "function") {
+    throw new Error("invalid_event_ledger");
+  }
+
+  const portfolioQueue = options.portfolioQueue;
+  if (options.portfolioQueue !== undefined) {
+    if (!portfolioQueue || typeof portfolioQueue.enqueue !== "function") {
+      throw new Error("invalid_portfolio_queue");
+    }
+  }
+
+  const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
+  const pollResult = await pollCheckRunsFn(repoFullName, input.prNumber, {
+    ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+    ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+    githubToken: options.githubToken ?? "",
+    ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
+    ...(options.minIntervalMs !== undefined ? { minIntervalMs: options.minIntervalMs } : {}),
+    ...(options.maxIntervalMs !== undefined ? { maxIntervalMs: options.maxIntervalMs } : {}),
+    ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+  });
+
+  const payload = buildManagePollEventPayload(input.prNumber, pollResult, {
+    ...(input.branch !== undefined ? { branch: input.branch } : {}),
+    ...(options.lastPolledAt !== undefined ? { lastPolledAt: options.lastPolledAt } : {}),
+  });
+
+  if ((options.ensurePortfolioRow ?? true) && portfolioQueue) {
+    ensureManagedPrRow(portfolioQueue, repoFullName, input.prNumber, options.apiBaseUrl);
+  }
+
+  const event = eventLedger.appendEvent({
+    type: MANAGE_PR_UPDATE_EVENT,
+    repoFullName,
+    payload,
+  });
+
+  return { pollResult, payload, event: event as LedgerEntry };
+}
+
+export async function runManagePoll(
+  args: string[] = [],
+  options: RunManagePollOptions = {},
+): Promise<number> {
+  const parsed = parseManagePollArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  // #4847: the CI-check-run poll itself is a real, read-only GitHub signal -- the useful "what would this
+  // record?" output -- so a dry run still performs it for real. It never opens the event ledger or portfolio
+  // queue, though: a no-op event ledger is fed through recordManagePollSnapshot so its own real payload-building
+  // logic still runs, just without ever writing to local storage (ensurePortfolioRow: false skips the queue
+  // enqueue the same way).
+  if (parsed.dryRun) {
+    const noopEventLedger = { appendEvent: () => null };
+    try {
+      const result = await recordManagePollSnapshot(
+        { repoFullName: parsed.repoFullName, prNumber: parsed.prNumber, branch: parsed.branch },
+        {
+          eventLedger: noopEventLedger,
+          ensurePortfolioRow: false,
+          ...(options.pollCheckRuns !== undefined ? { pollCheckRuns: options.pollCheckRuns } : {}),
+          ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+          githubToken: options.githubToken ?? (await resolveGitHubToken(process.env)) ?? "",
+          ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+          ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
+          ...(options.minIntervalMs !== undefined ? { minIntervalMs: options.minIntervalMs } : {}),
+          ...(options.maxIntervalMs !== undefined ? { maxIntervalMs: options.maxIntervalMs } : {}),
+          ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+          ...(options.lastPolledAt !== undefined ? { lastPolledAt: options.lastPolledAt } : {}),
+        },
+      );
+      const dryRunResult = { outcome: "dry_run", pollResult: result.pollResult, payload: result.payload };
+      if (parsed.json) {
+        console.log(JSON.stringify(dryRunResult, null, 2));
+      } else {
+        console.log(
+          `DRY RUN: ${result.payload.ciState} (${result.payload.gateVerdict}/${result.payload.outcome}). No event-ledger or portfolio-queue write was made.`,
+        );
+      }
+      return 0;
+    } catch (error) {
+      return reportCliFailure(parsed.json, describeCliError(error));
+    }
+  }
+
+  const ownsEventLedger = options.initEventLedger === undefined;
+  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+  const eventLedger = (options.initEventLedger ?? initEventLedger)();
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+
+  try {
+    const result = await recordManagePollSnapshot(
+      {
+        repoFullName: parsed.repoFullName,
+        prNumber: parsed.prNumber,
+        branch: parsed.branch,
+      },
+      {
+        eventLedger,
+        portfolioQueue,
+        ensurePortfolioRow: options.ensurePortfolioRow ?? true,
+        ...(options.pollCheckRuns !== undefined ? { pollCheckRuns: options.pollCheckRuns } : {}),
+        ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+        githubToken: options.githubToken ?? (await resolveGitHubToken(process.env)) ?? "",
+        ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+        ...(options.maxAttempts !== undefined ? { maxAttempts: options.maxAttempts } : {}),
+        ...(options.minIntervalMs !== undefined ? { minIntervalMs: options.minIntervalMs } : {}),
+        ...(options.maxIntervalMs !== undefined ? { maxIntervalMs: options.maxIntervalMs } : {}),
+        ...(options.sleepFn !== undefined ? { sleepFn: options.sleepFn } : {}),
+        ...(options.lastPolledAt !== undefined ? { lastPolledAt: options.lastPolledAt } : {}),
+      },
+    );
+
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`${result.payload.ciState} (${result.payload.gateVerdict}/${result.payload.outcome})`);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsEventLedger) eventLedger.close();
+    if (ownsPortfolioQueue) portfolioQueue.close();
+  }
+}

--- a/packages/loopover-miner/lib/orb-export.d.ts
+++ b/packages/loopover-miner/lib/orb-export.d.ts
@@ -1,85 +1,116 @@
 import type { NormalizedPrOutcomePayload, PrOutcomeLedgerReader } from "./pr-outcome.js";
-
-/** OPT-IN default: a laptop miner exports nothing unless a contributor turns it on. */
-export const ORB_EXPORT_ENABLED_BY_DEFAULT: false;
-
+/** OPT-IN: a laptop miner exports nothing unless a contributor explicitly turns it on. */
+export declare const ORB_EXPORT_ENABLED_BY_DEFAULT: false;
 /** One anonymized outcome in an export batch — no raw repo name, PR number, or free-text reason. */
 export interface OrbExportRow {
-  repoHash: string;
-  prHash: string;
-  decision: string;
-  reasonBucket: string;
-  closedAt: string | null;
+    repoHash: string;
+    prHash: string;
+    decision: string;
+    reasonBucket: string;
+    closedAt: string | null;
 }
-
 /** The local orb-export store: the per-instance anonymization secret + export cursor, in local SQLite. */
 export interface OrbExportStore {
-  dbPath: string;
-  getOrCreateAnonSecret(): string;
-  getCursor(): string | null;
-  setCursor(cursor: string): void;
-  close(): void;
+    dbPath: string;
+    getOrCreateAnonSecret(): string;
+    getCursor(): string | null;
+    setCursor(cursor: string): void;
+    close(): void;
 }
-
 /** Result of sending a batch to the AMS collector — `error` present only on a non-2xx response, a network
  *  failure, or an empty batch (never thrown). */
-export type AmsExportSendResult = { sent: number; error?: string };
-
+export type AmsExportSendResult = {
+    sent: number;
+    error?: string;
+};
 /** A pr_outcome record as produced by `readPrOutcomes` (the local ledger's latest-per-PR reduction). */
-export type OrbExportOutcome = NormalizedPrOutcomePayload & { repoFullName: string };
-
-export function resolveOrbExportDbPath(env?: Record<string, string | undefined>): string;
-
-export function hmacAnonymize(value: string | number, secret: string): string;
-
-export function buildAnonymizedOrbBatch(
-  outcomes: Iterable<OrbExportOutcome> | Map<string, OrbExportOutcome>,
-  secret: string,
-): OrbExportRow[];
-
-export function openOrbExportStore(dbPath?: string): OrbExportStore;
-
-export function collectOrbExportBatch(options?: {
-  store: OrbExportStore;
-  eventLedger: PrOutcomeLedgerReader;
-  enabled?: boolean;
+export type OrbExportOutcome = NormalizedPrOutcomePayload & {
+    repoFullName: string;
+};
+export type ParsedOrbExportArgs = {
+    json: boolean;
+    enable: boolean;
+    send: boolean;
+    dryRun: boolean;
+} | {
+    error: string;
+};
+export declare function resolveOrbExportDbPath(env?: Record<string, string | undefined>): string;
+/** HMAC a value with the per-instance secret. Validates the secret (the shared engine primitive stays pure
+ *  and doesn't), then delegates the actual hash to @loopover/engine's hmacAnonymize — the same primitive
+ *  src/selfhost/orb-collector.ts uses, so both products anonymize identically. */
+export declare function hmacAnonymize(value: string | number, secret: string): string;
+/**
+ * Turn the local pr_outcome map (pr-outcome.js `readPrOutcomes`) into an anonymized export batch: repo and PR
+ * identifiers are HMAC-hashed, and only the `decision` + a low-cardinality `reasonBucket` (already one of the
+ * miner's `REJECTION_REASONS`, else `"none"`) + `closedAt` leave. Pure and deterministic (rows sorted by prHash).
+ * Accepts either the Map `readPrOutcomes` returns or any iterable of outcome records.
+ */
+export declare function buildAnonymizedOrbBatch(outcomes: Iterable<OrbExportOutcome> | Map<string, OrbExportOutcome>, secret: string): OrbExportRow[];
+/**
+ * Open/create the local orb-export store: a small key/value SQLite table holding the per-instance anonymization
+ * secret and the export cursor. Mirrors the other miner ledgers' node:sqlite pattern — a `0o700` config dir and a
+ * `0o600` file, since the secret must never leave this machine.
+ */
+export declare function openOrbExportStore(dbPath?: string): OrbExportStore;
+/**
+ * Collect the anonymized Orb export batch from the local pr_outcome ledger. OPT-IN: returns null (exports nothing)
+ * unless `enabled` is true — a third-party contributor's laptop must explicitly turn this on. Never performs the
+ * network POST itself; the caller sends the returned batch to the Orb ingest endpoint and then advances the store
+ * cursor, so this function stays pure over its inputs and the local store.
+ */
+export declare function collectOrbExportBatch(options?: {
+    store?: OrbExportStore;
+    eventLedger?: PrOutcomeLedgerReader;
+    enabled?: boolean;
 }): OrbExportRow[] | null;
-
-export function amsInstanceId(secret: string): string;
-
-export function filterBatchSinceCursor(batch: OrbExportRow[], cursor: string | null): OrbExportRow[];
-
-export function latestClosedAt(batch: OrbExportRow[]): string | null;
-
-export const DEFAULT_AMS_COLLECTOR_URL: string;
-
-export const DEFAULT_ORB_EXPORT_TIMEOUT_MS: number;
-
-export function resolveAmsCollectorUrl(env?: Record<string, string | undefined>): string;
-
-export function sendAmsExportBatch(options: {
-  batch: OrbExportRow[];
-  secret: string;
-  collectorUrl?: string;
-  collectorToken?: string | undefined;
-  fetchFn?: typeof fetch;
-  timeoutMs?: number;
+/** Stable per-instance identifier: a hash of the instance's own anon secret (no App-id concept on the AMS side,
+ *  unlike orb-collector.ts's instanceId — a miner laptop has no GitHub App). */
+export declare function amsInstanceId(secret: string): string;
+/** Drop rows already sent in a prior export: everything with a `closedAt` at/before the cursor. A row with no
+ *  `closedAt` (shouldn't happen for a resolved PR, but defensive) is always included, since there is no
+ *  watermark to compare it against. A null/unset cursor means "first export" — everything goes. */
+export declare function filterBatchSinceCursor(batch: OrbExportRow[], cursor: string | null): OrbExportRow[];
+/** The newest `closedAt` among a batch's rows, or `null` if none carry one — the next cursor value to persist
+ *  after a successful send. */
+export declare function latestClosedAt(batch: OrbExportRow[]): string | null;
+/** loopover's hosted AMS collector — mirrors orb-collector.ts's ORB_COLLECTOR_URL default pattern. */
+export declare const DEFAULT_AMS_COLLECTOR_URL = "https://api.loopover.ai/v1/ams/ingest";
+export declare function resolveAmsCollectorUrl(env?: Record<string, string | undefined>): string;
+/**
+ * POST an already-anonymized batch to the AMS ingest collector, signed the same way orb-collector.ts signs its
+ * own export (a full-length HMAC over the JSON body, distinct from the per-field hmacAnonymize truncated hash
+ * above — a body signature and a field anonymization hash are different concerns). Returns `{ sent }` on a 2xx
+ * response, `{ sent: 0, error }` otherwise — a network failure or non-2xx never throws, matching this module's
+ * fail-open posture (a telemetry hiccup must never break the miner's real work).
+ */
+export declare const DEFAULT_ORB_EXPORT_TIMEOUT_MS = 10000;
+export declare function sendAmsExportBatch(options: {
+    batch: OrbExportRow[];
+    secret: string;
+    collectorUrl?: string;
+    collectorToken?: string | undefined;
+    fetchFn?: typeof fetch;
+    timeoutMs?: number;
 }): Promise<AmsExportSendResult>;
-
-export type ParsedOrbExportArgs = { json: boolean; enable: boolean; send: boolean; dryRun: boolean } | { error: string };
-
-export function parseOrbExportArgs(args: string[]): ParsedOrbExportArgs;
-
-export function runOrbExportCli(
-  args: string[],
-  options?: {
+export declare function parseOrbExportArgs(args: string[]): ParsedOrbExportArgs;
+type RunOrbExportCliOptions = {
     openOrbExportStore?: () => OrbExportStore;
-    initEventLedger?: () => PrOutcomeLedgerReader;
+    initEventLedger?: () => PrOutcomeLedgerReader & {
+        close?: () => void;
+    };
     sendAmsExportBatch?: (options: {
-      batch: OrbExportRow[];
-      secret: string;
-      collectorToken?: string | undefined;
+        batch: OrbExportRow[];
+        secret: string;
+        collectorToken?: string | undefined;
     }) => Promise<AmsExportSendResult>;
     env?: Record<string, string | undefined>;
-  },
-): Promise<number>;
+};
+/** CLI entry for the anonymized Orb telemetry batch-builder + sender (#4833 wired the caller-less exporter's
+ *  batch-building; #5681 wired the network send). OPT-IN: prints nothing to export unless `--enable` is
+ *  passed. `--enable` alone only builds+prints the anonymized batch locally — no network I/O, so a contributor
+ *  can inspect exactly what would be sent first. `--enable --send` additionally POSTs the (cursor-filtered)
+ *  batch to the AMS collector and advances the cursor on success, so a re-run doesn't resend history that was
+ *  already delivered. */
+export declare function runOrbExportCli(args: string[], options?: RunOrbExportCliOptions): Promise<number>;
+export {};

--- a/packages/loopover-miner/lib/orb-export.js
+++ b/packages/loopover-miner/lib/orb-export.js
@@ -7,7 +7,6 @@ import { generateAnonSecret, hmacAnonymize as engineHmacAnonymize } from "@loopo
 import { readPrOutcomes } from "./pr-outcome.js";
 import { initEventLedger } from "./event-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 // Optional anonymized Orb telemetry export (#4277, network send wired in #5681). The self-host Orb collector
 // (src/selfhost/orb-collector.ts, #1255) is ALWAYS-ON for a maintainer's own instance; a miner runs on a
 // third-party contributor's laptop with a much lower consent bar, so this export is OPT-IN (default OFF) —
@@ -17,44 +16,37 @@ import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js
 // the local pr_outcome ledger (pr-outcome.js), not a hosted D1. `generateAnonSecret`/`hmacAnonymize` are the
 // same primitive src/selfhost/orb-collector.ts uses (@loopover/engine, #5680) — one anonymization
 // implementation shared by both products instead of two independently-maintained copies.
-
 /** OPT-IN: a laptop miner exports nothing unless a contributor explicitly turns it on. */
 export const ORB_EXPORT_ENABLED_BY_DEFAULT = false;
-
 const ANON_SECRET_KEY = "anon_secret";
 const CURSOR_KEY = "export_cursor";
 const defaultDbFileName = "orb-export.sqlite3";
-
 export function resolveOrbExportDbPath(env = process.env) {
-  const explicitPath =
-    typeof env.LOOPOVER_MINER_ORB_EXPORT_DB === "string" ? env.LOOPOVER_MINER_ORB_EXPORT_DB.trim() : "";
-  if (explicitPath) return explicitPath;
-
-  const explicitConfigDir =
-    typeof env.LOOPOVER_MINER_CONFIG_DIR === "string" ? env.LOOPOVER_MINER_CONFIG_DIR.trim() : "";
-  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
-
-  const configHome =
-    typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
-      ? env.XDG_CONFIG_HOME.trim()
-      : join(homedir(), ".config");
-  return join(configHome, "loopover-miner", defaultDbFileName);
+    const explicitPath = typeof env.LOOPOVER_MINER_ORB_EXPORT_DB === "string" ? env.LOOPOVER_MINER_ORB_EXPORT_DB.trim() : "";
+    if (explicitPath)
+        return explicitPath;
+    const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string" ? env.LOOPOVER_MINER_CONFIG_DIR.trim() : "";
+    if (explicitConfigDir)
+        return join(explicitConfigDir, defaultDbFileName);
+    const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+        ? env.XDG_CONFIG_HOME.trim()
+        : join(homedir(), ".config");
+    return join(configHome, "loopover-miner", defaultDbFileName);
 }
-
 function normalizeDbPath(dbPath) {
-  const path = (dbPath ?? resolveOrbExportDbPath()).trim();
-  if (!path) throw new Error("invalid_orb_export_db_path");
-  return path;
+    const path = (dbPath ?? resolveOrbExportDbPath()).trim();
+    if (!path)
+        throw new Error("invalid_orb_export_db_path");
+    return path;
 }
-
 /** HMAC a value with the per-instance secret. Validates the secret (the shared engine primitive stays pure
  *  and doesn't), then delegates the actual hash to @loopover/engine's hmacAnonymize — the same primitive
  *  src/selfhost/orb-collector.ts uses, so both products anonymize identically. */
 export function hmacAnonymize(value, secret) {
-  if (typeof secret !== "string" || !secret) throw new Error("invalid_anon_secret");
-  return engineHmacAnonymize(String(value), secret);
+    if (typeof secret !== "string" || !secret)
+        throw new Error("invalid_anon_secret");
+    return engineHmacAnonymize(String(value), secret);
 }
-
 /**
  * Turn the local pr_outcome map (pr-outcome.js `readPrOutcomes`) into an anonymized export batch: repo and PR
  * identifiers are HMAC-hashed, and only the `decision` + a low-cardinality `reasonBucket` (already one of the
@@ -62,114 +54,112 @@ export function hmacAnonymize(value, secret) {
  * Accepts either the Map `readPrOutcomes` returns or any iterable of outcome records.
  */
 export function buildAnonymizedOrbBatch(outcomes, secret) {
-  const iterable = outcomes && typeof outcomes.values === "function" ? outcomes.values() : outcomes;
-  const rows = [];
-  for (const outcome of iterable ?? []) {
-    if (!outcome || typeof outcome.repoFullName !== "string" || !outcome.repoFullName.trim()) continue;
-    if (!Number.isInteger(outcome.prNumber) || outcome.prNumber <= 0) continue;
-    rows.push({
-      repoHash: hmacAnonymize(outcome.repoFullName, secret),
-      prHash: hmacAnonymize(`${outcome.repoFullName}:${outcome.prNumber}`, secret),
-      decision: outcome.decision,
-      reasonBucket: typeof outcome.reason === "string" && outcome.reason ? outcome.reason : "none",
-      closedAt: typeof outcome.closedAt === "string" && outcome.closedAt ? outcome.closedAt : null,
-    });
-  }
-  rows.sort((a, b) => a.prHash.localeCompare(b.prHash));
-  return rows;
+    const iterable = outcomes && typeof outcomes.values === "function"
+        ? outcomes.values()
+        : outcomes;
+    const rows = [];
+    for (const outcome of iterable ?? []) {
+        if (!outcome || typeof outcome.repoFullName !== "string" || !outcome.repoFullName.trim())
+            continue;
+        if (!Number.isInteger(outcome.prNumber) || outcome.prNumber <= 0)
+            continue;
+        rows.push({
+            repoHash: hmacAnonymize(outcome.repoFullName, secret),
+            prHash: hmacAnonymize(`${outcome.repoFullName}:${outcome.prNumber}`, secret),
+            decision: outcome.decision,
+            reasonBucket: typeof outcome.reason === "string" && outcome.reason ? outcome.reason : "none",
+            closedAt: typeof outcome.closedAt === "string" && outcome.closedAt ? outcome.closedAt : null,
+        });
+    }
+    rows.sort((a, b) => a.prHash.localeCompare(b.prHash));
+    return rows;
 }
-
 /**
  * Open/create the local orb-export store: a small key/value SQLite table holding the per-instance anonymization
  * secret and the export cursor. Mirrors the other miner ledgers' node:sqlite pattern — a `0o700` config dir and a
  * `0o600` file, since the secret must never leave this machine.
  */
 export function openOrbExportStore(dbPath = resolveOrbExportDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
-  const db = new DatabaseSync(resolvedPath);
-  chmodSync(resolvedPath, 0o600);
-  db.exec("PRAGMA busy_timeout = 5000");
-  db.exec(`CREATE TABLE IF NOT EXISTS orb_export_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
-
-  const getStatement = db.prepare("SELECT value FROM orb_export_meta WHERE key = ?");
-  const setStatement = db.prepare(
-    "INSERT INTO orb_export_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-  );
-  const readValue = (key) => {
-    const row = getStatement.get(key);
-    return row && typeof row.value === "string" ? row.value : null;
-  };
-
-  return {
-    dbPath: resolvedPath,
-    /** The per-instance DEDICATED anonymization secret — generated once (256-bit) and persisted, then reused
-     *  forever so a repo/PR always hashes the same way. Single-purpose: only this export uses it. */
-    getOrCreateAnonSecret() {
-      const existing = readValue(ANON_SECRET_KEY);
-      if (existing) return existing;
-      const generated = generateAnonSecret();
-      setStatement.run(ANON_SECRET_KEY, generated);
-      return generated;
-    },
-    /** The export watermark (opaque string), or null before the first export. */
-    getCursor() {
-      return readValue(CURSOR_KEY);
-    },
-    setCursor(cursor) {
-      setStatement.run(CURSOR_KEY, String(cursor));
-    },
-    close() {
-      db.close();
-    },
-  };
+    const resolvedPath = normalizeDbPath(dbPath);
+    mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
+    const db = new DatabaseSync(resolvedPath);
+    chmodSync(resolvedPath, 0o600);
+    db.exec("PRAGMA busy_timeout = 5000");
+    db.exec(`CREATE TABLE IF NOT EXISTS orb_export_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+    const getStatement = db.prepare("SELECT value FROM orb_export_meta WHERE key = ?");
+    const setStatement = db.prepare("INSERT INTO orb_export_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value");
+    const readValue = (key) => {
+        const row = getStatement.get(key);
+        return row && typeof row.value === "string" ? row.value : null;
+    };
+    return {
+        dbPath: resolvedPath,
+        /** The per-instance DEDICATED anonymization secret — generated once (256-bit) and persisted, then reused
+         *  forever so a repo/PR always hashes the same way. Single-purpose: only this export uses it. */
+        getOrCreateAnonSecret() {
+            const existing = readValue(ANON_SECRET_KEY);
+            if (existing)
+                return existing;
+            const generated = generateAnonSecret();
+            setStatement.run(ANON_SECRET_KEY, generated);
+            return generated;
+        },
+        /** The export watermark (opaque string), or null before the first export. */
+        getCursor() {
+            return readValue(CURSOR_KEY);
+        },
+        setCursor(cursor) {
+            setStatement.run(CURSOR_KEY, String(cursor));
+        },
+        close() {
+            db.close();
+        },
+    };
 }
-
 /**
  * Collect the anonymized Orb export batch from the local pr_outcome ledger. OPT-IN: returns null (exports nothing)
  * unless `enabled` is true — a third-party contributor's laptop must explicitly turn this on. Never performs the
  * network POST itself; the caller sends the returned batch to the Orb ingest endpoint and then advances the store
  * cursor, so this function stays pure over its inputs and the local store.
  */
-export function collectOrbExportBatch({ store, eventLedger, enabled = ORB_EXPORT_ENABLED_BY_DEFAULT } = {}) {
-  if (!enabled) return null;
-  if (!store || typeof store.getOrCreateAnonSecret !== "function") throw new Error("invalid_orb_export_store");
-  const outcomes = readPrOutcomes(eventLedger);
-  return buildAnonymizedOrbBatch(outcomes, store.getOrCreateAnonSecret());
+export function collectOrbExportBatch(options = {}) {
+    const { store, eventLedger, enabled = ORB_EXPORT_ENABLED_BY_DEFAULT } = options;
+    if (!enabled)
+        return null;
+    if (!store || typeof store.getOrCreateAnonSecret !== "function")
+        throw new Error("invalid_orb_export_store");
+    const outcomes = readPrOutcomes(eventLedger);
+    return buildAnonymizedOrbBatch(outcomes, store.getOrCreateAnonSecret());
 }
-
 /** Stable per-instance identifier: a hash of the instance's own anon secret (no App-id concept on the AMS side,
  *  unlike orb-collector.ts's instanceId — a miner laptop has no GitHub App). */
 export function amsInstanceId(secret) {
-  return createHash("sha256").update(String(secret)).digest("hex").slice(0, 16);
+    return createHash("sha256").update(String(secret)).digest("hex").slice(0, 16);
 }
-
 /** Drop rows already sent in a prior export: everything with a `closedAt` at/before the cursor. A row with no
  *  `closedAt` (shouldn't happen for a resolved PR, but defensive) is always included, since there is no
  *  watermark to compare it against. A null/unset cursor means "first export" — everything goes. */
 export function filterBatchSinceCursor(batch, cursor) {
-  if (!cursor) return batch;
-  return batch.filter((row) => !row.closedAt || row.closedAt > cursor);
+    if (!cursor)
+        return batch;
+    return batch.filter((row) => !row.closedAt || row.closedAt > cursor);
 }
-
 /** The newest `closedAt` among a batch's rows, or `null` if none carry one — the next cursor value to persist
  *  after a successful send. */
 export function latestClosedAt(batch) {
-  let latest = null;
-  for (const row of batch) {
-    if (row.closedAt && (latest === null || row.closedAt > latest)) latest = row.closedAt;
-  }
-  return latest;
+    let latest = null;
+    for (const row of batch) {
+        if (row.closedAt && (latest === null || row.closedAt > latest))
+            latest = row.closedAt;
+    }
+    return latest;
 }
-
 /** loopover's hosted AMS collector — mirrors orb-collector.ts's ORB_COLLECTOR_URL default pattern. */
 export const DEFAULT_AMS_COLLECTOR_URL = "https://api.loopover.ai/v1/ams/ingest";
-
 export function resolveAmsCollectorUrl(env = process.env) {
-  const explicit = typeof env.LOOPOVER_MINER_AMS_COLLECTOR_URL === "string" ? env.LOOPOVER_MINER_AMS_COLLECTOR_URL.trim() : "";
-  return explicit || DEFAULT_AMS_COLLECTOR_URL;
+    const explicit = typeof env.LOOPOVER_MINER_AMS_COLLECTOR_URL === "string" ? env.LOOPOVER_MINER_AMS_COLLECTOR_URL.trim() : "";
+    return explicit || DEFAULT_AMS_COLLECTOR_URL;
 }
-
 /**
  * POST an already-anonymized batch to the AMS ingest collector, signed the same way orb-collector.ts signs its
  * own export (a full-length HMAC over the JSON body, distinct from the per-field hmacAnonymize truncated hash
@@ -180,69 +170,62 @@ export function resolveAmsCollectorUrl(env = process.env) {
 // Bound a single AMS-collector POST so a hung/black-holed collector can't stall the export indefinitely (#7237).
 // 10s matches this package's other default request timeouts (live-issue-snapshot.js / opportunity-fanout.js).
 export const DEFAULT_ORB_EXPORT_TIMEOUT_MS = 10_000;
-
-export async function sendAmsExportBatch({
-  batch,
-  secret,
-  collectorUrl = resolveAmsCollectorUrl(),
-  collectorToken,
-  fetchFn = fetch,
-  timeoutMs = DEFAULT_ORB_EXPORT_TIMEOUT_MS,
-}) {
-  if (!Array.isArray(batch) || batch.length === 0) return { sent: 0 };
-  const instanceId = amsInstanceId(secret);
-  const body = JSON.stringify({ instanceId, events: batch });
-  const signature = createHmac("sha256", secret).update(body).digest("hex");
-  try {
-    const res = await fetchFn(collectorUrl, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-ams-signature": `sha256=${signature}`,
-        "x-ams-instance": instanceId,
-        ...(collectorToken ? { authorization: `Bearer ${collectorToken}` } : {}),
-      },
-      body,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!res.ok) return { sent: 0, error: `http_${res.status}` };
-  } catch (error) {
-    return { sent: 0, error: describeCliError(error) };
-  }
-  return { sent: batch.length };
+export async function sendAmsExportBatch(options) {
+    const { batch, secret, collectorUrl = resolveAmsCollectorUrl(), collectorToken, fetchFn = fetch, timeoutMs = DEFAULT_ORB_EXPORT_TIMEOUT_MS, } = options;
+    if (!Array.isArray(batch) || batch.length === 0)
+        return { sent: 0 };
+    const instanceId = amsInstanceId(secret);
+    const body = JSON.stringify({ instanceId, events: batch });
+    const signature = createHmac("sha256", secret).update(body).digest("hex");
+    try {
+        const res = await fetchFn(collectorUrl, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-ams-signature": `sha256=${signature}`,
+                "x-ams-instance": instanceId,
+                ...(collectorToken ? { authorization: `Bearer ${collectorToken}` } : {}),
+            },
+            body,
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!res.ok)
+            return { sent: 0, error: `http_${res.status}` };
+    }
+    catch (error) {
+        return { sent: 0, error: describeCliError(error) };
+    }
+    return { sent: batch.length };
 }
-
 const ORB_EXPORT_USAGE = "Usage: loopover-miner orb export [--enable] [--send] [--dry-run] [--json]";
-
 export function parseOrbExportArgs(args) {
-  const options = { json: false, enable: false, send: false, dryRun: false };
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, enable: false, send: false, dryRun: false };
+    for (const token of args) {
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--enable") {
+            options.enable = true;
+            continue;
+        }
+        // Distinct from --enable: --enable alone only builds+prints the anonymized batch locally (no network I/O),
+        // so a contributor can inspect exactly what would be sent before ever transmitting it. --send additionally
+        // POSTs that batch to the collector and advances the cursor — the previously-missing network step (#5681).
+        if (token === "--send") {
+            options.send = true;
+            continue;
+        }
+        // #4847: openOrbExportStore() itself creates the local SQLite file (a real write) even before any secret is
+        // generated, so a dry run reports what would happen and returns before opening any store at all.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        return { error: ORB_EXPORT_USAGE };
     }
-    if (token === "--enable") {
-      options.enable = true;
-      continue;
-    }
-    // Distinct from --enable: --enable alone only builds+prints the anonymized batch locally (no network I/O),
-    // so a contributor can inspect exactly what would be sent before ever transmitting it. --send additionally
-    // POSTs that batch to the collector and advances the cursor — the previously-missing network step (#5681).
-    if (token === "--send") {
-      options.send = true;
-      continue;
-    }
-    // #4847: openOrbExportStore() itself creates the local SQLite file (a real write) even before any secret is
-    // generated, so a dry run reports what would happen and returns before opening any store at all.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    return { error: ORB_EXPORT_USAGE };
-  }
-  return options;
+    return options;
 }
-
 /** CLI entry for the anonymized Orb telemetry batch-builder + sender (#4833 wired the caller-less exporter's
  *  batch-building; #5681 wired the network send). OPT-IN: prints nothing to export unless `--enable` is
  *  passed. `--enable` alone only builds+prints the anonymized batch locally — no network I/O, so a contributor
@@ -250,74 +233,87 @@ export function parseOrbExportArgs(args) {
  *  batch to the AMS collector and advances the cursor on success, so a re-run doesn't resend history that was
  *  already delivered. */
 export async function runOrbExportCli(args, options = {}) {
-  const parsed = parseOrbExportArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", enabled: parsed.enable, send: parsed.send };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else if (parsed.enable && parsed.send) {
-      console.log("DRY RUN: would build an anonymized Orb export batch and send it to the collector. No local writes or network calls were made.");
-    } else if (parsed.enable) {
-      console.log("DRY RUN: would build and report an anonymized Orb export batch. No local writes were made.");
-    } else {
-      console.log("DRY RUN: orb export is opt-in and disabled — pass --enable to build an anonymized batch. No local writes were made.");
+    const parsed = parseOrbExportArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  // Open the stores INSIDE the try so a bad config path / SQLite open failure returns 2 instead of crashing the
-  // process; the finally guards each close with `?.` since either initializer may have thrown before assigning.
-  // The --send path's await happens INSIDE this try so `finally` (which closes the store) can never run before
-  // the cursor advance below it -- resolving the send result AFTER the store closed would write to a dead handle.
-  const ownsStore = options.openOrbExportStore === undefined;
-  const ownsLedger = options.initEventLedger === undefined;
-  let store;
-  let eventLedger;
-  try {
-    store = (options.openOrbExportStore ?? openOrbExportStore)();
-    eventLedger = (options.initEventLedger ?? initEventLedger)();
-    const batch = collectOrbExportBatch({ store, eventLedger, enabled: parsed.enable });
-    if (batch === null) {
-      if (parsed.json) console.log(JSON.stringify({ enabled: false, batch: null }, null, 2));
-      else console.log("orb export is opt-in and disabled — pass --enable to build an anonymized batch");
-      return 0;
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", enabled: parsed.enable, send: parsed.send };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else if (parsed.enable && parsed.send) {
+            console.log("DRY RUN: would build an anonymized Orb export batch and send it to the collector. No local writes or network calls were made.");
+        }
+        else if (parsed.enable) {
+            console.log("DRY RUN: would build and report an anonymized Orb export batch. No local writes were made.");
+        }
+        else {
+            console.log("DRY RUN: orb export is opt-in and disabled — pass --enable to build an anonymized batch. No local writes were made.");
+        }
+        return 0;
     }
-
-    if (!parsed.send) {
-      if (parsed.json) console.log(JSON.stringify({ enabled: true, sent: false, batch }, null, 2));
-      else console.log(`${batch.length} anonymized event(s) — pass --send to transmit them to the collector`);
-      return 0;
+    // Open the stores INSIDE the try so a bad config path / SQLite open failure returns 2 instead of crashing the
+    // process; the finally guards each close with `?.` since either initializer may have thrown before assigning.
+    // The --send path's await happens INSIDE this try so `finally` (which closes the store) can never run before
+    // the cursor advance below it -- resolving the send result AFTER the store closed would write to a dead handle.
+    const ownsStore = options.openOrbExportStore === undefined;
+    const ownsLedger = options.initEventLedger === undefined;
+    let store;
+    let eventLedger;
+    try {
+        store = (options.openOrbExportStore ?? openOrbExportStore)();
+        eventLedger = (options.initEventLedger ?? initEventLedger)();
+        const batch = collectOrbExportBatch({ store, eventLedger, enabled: parsed.enable });
+        if (batch === null) {
+            if (parsed.json)
+                console.log(JSON.stringify({ enabled: false, batch: null }, null, 2));
+            else
+                console.log("orb export is opt-in and disabled — pass --enable to build an anonymized batch");
+            return 0;
+        }
+        if (!parsed.send) {
+            if (parsed.json)
+                console.log(JSON.stringify({ enabled: true, sent: false, batch }, null, 2));
+            else
+                console.log(`${batch.length} anonymized event(s) — pass --send to transmit them to the collector`);
+            return 0;
+        }
+        const cursor = store.getCursor();
+        const toSend = filterBatchSinceCursor(batch, cursor);
+        if (toSend.length === 0) {
+            if (parsed.json)
+                console.log(JSON.stringify({ enabled: true, sent: 0, skipped: batch.length }, null, 2));
+            else
+                console.log("no new events since the last export");
+            return 0;
+        }
+        const send = options.sendAmsExportBatch ?? sendAmsExportBatch;
+        const secret = store.getOrCreateAnonSecret();
+        const env = options.env ?? process.env;
+        const collectorToken = env.LOOPOVER_MINER_AMS_COLLECTOR_TOKEN ?? "";
+        const sendResult = await send({ batch: toSend, secret, collectorToken });
+        if (sendResult.sent > 0) {
+            const nextCursor = latestClosedAt(toSend);
+            if (nextCursor)
+                store.setCursor(nextCursor);
+        }
+        if (parsed.json)
+            console.log(JSON.stringify({ enabled: true, ...sendResult, skipped: batch.length - toSend.length }, null, 2));
+        else if (sendResult.error)
+            console.log(`export failed: ${sendResult.error}`);
+        else
+            console.log(`sent ${sendResult.sent} anonymized event(s)`);
+        return sendResult.error ? 1 : 0;
     }
-
-    const cursor = store.getCursor();
-    const toSend = filterBatchSinceCursor(batch, cursor);
-    if (toSend.length === 0) {
-      if (parsed.json) console.log(JSON.stringify({ enabled: true, sent: 0, skipped: batch.length }, null, 2));
-      else console.log("no new events since the last export");
-      return 0;
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
     }
-
-    const send = options.sendAmsExportBatch ?? sendAmsExportBatch;
-    const secret = store.getOrCreateAnonSecret();
-    const env = options.env ?? process.env;
-    const collectorToken = env.LOOPOVER_MINER_AMS_COLLECTOR_TOKEN ?? "";
-    const sendResult = await send({ batch: toSend, secret, collectorToken });
-    if (sendResult.sent > 0) {
-      const nextCursor = latestClosedAt(toSend);
-      if (nextCursor) store.setCursor(nextCursor);
+    finally {
+        if (ownsStore)
+            store?.close();
+        if (ownsLedger)
+            eventLedger?.close?.();
     }
-    if (parsed.json) console.log(JSON.stringify({ enabled: true, ...sendResult, skipped: batch.length - toSend.length }, null, 2));
-    else if (sendResult.error) console.log(`export failed: ${sendResult.error}`);
-    else console.log(`sent ${sendResult.sent} anonymized event(s)`);
-    return sendResult.error ? 1 : 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsStore) store?.close();
-    if (ownsLedger) eventLedger?.close();
-  }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3JiLWV4cG9ydC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIm9yYi1leHBvcnQudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLFNBQVMsRUFBRSxTQUFTLEVBQUUsTUFBTSxTQUFTLENBQUM7QUFDL0MsT0FBTyxFQUFFLE9BQU8sRUFBRSxNQUFNLFNBQVMsQ0FBQztBQUNsQyxPQUFPLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxNQUFNLFdBQVcsQ0FBQztBQUMxQyxPQUFPLEVBQUUsWUFBWSxFQUFFLE1BQU0sYUFBYSxDQUFDO0FBQzNDLE9BQU8sRUFBRSxVQUFVLEVBQUUsVUFBVSxFQUFFLE1BQU0sYUFBYSxDQUFDO0FBQ3JELE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxhQUFhLElBQUksbUJBQW1CLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUM1RixPQUFPLEVBQUUsY0FBYyxFQUFFLE1BQU0saUJBQWlCLENBQUM7QUFFakQsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ3BELE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUVsRiw2R0FBNkc7QUFDN0cseUdBQXlHO0FBQ3pHLDJHQUEyRztBQUMzRywrR0FBK0c7QUFDL0csc0dBQXNHO0FBQ3RHLDZHQUE2RztBQUM3Ryw2R0FBNkc7QUFDN0csa0dBQWtHO0FBQ2xHLHlGQUF5RjtBQUV6RiwwRkFBMEY7QUFDMUYsTUFBTSxDQUFDLE1BQU0sNkJBQTZCLEdBQUcsS0FBYyxDQUFDO0FBaUM1RCxNQUFNLGVBQWUsR0FBRyxhQUFhLENBQUM7QUFDdEMsTUFBTSxVQUFVLEdBQUcsZUFBZSxDQUFDO0FBQ25DLE1BQU0saUJBQWlCLEdBQUcsb0JBQW9CLENBQUM7QUFFL0MsTUFBTSxVQUFVLHNCQUFzQixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQzFGLE1BQU0sWUFBWSxHQUNoQixPQUFPLEdBQUcsQ0FBQyw0QkFBNEIsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyw0QkFBNEIsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ3RHLElBQUksWUFBWTtRQUFFLE9BQU8sWUFBWSxDQUFDO0lBRXRDLE1BQU0saUJBQWlCLEdBQ3JCLE9BQU8sR0FBRyxDQUFDLHlCQUF5QixLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLHlCQUF5QixDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDaEcsSUFBSSxpQkFBaUI7UUFBRSxPQUFPLElBQUksQ0FBQyxpQkFBaUIsRUFBRSxpQkFBaUIsQ0FBQyxDQUFDO0lBRXpFLE1BQU0sVUFBVSxHQUNkLE9BQU8sR0FBRyxDQUFDLGVBQWUsS0FBSyxRQUFRLElBQUksR0FBRyxDQUFDLGVBQWUsQ0FBQyxJQUFJLEVBQUU7UUFDbkUsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxlQUFlLENBQUMsSUFBSSxFQUFFO1FBQzVCLENBQUMsQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDakMsT0FBTyxJQUFJLENBQUMsVUFBVSxFQUFFLGdCQUFnQixFQUFFLGlCQUFpQixDQUFDLENBQUM7QUFDL0QsQ0FBQztBQUVELFNBQVMsZUFBZSxDQUFDLE1BQTBCO0lBQ2pELE1BQU0sSUFBSSxHQUFHLENBQUMsTUFBTSxJQUFJLHNCQUFzQixFQUFFLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUN6RCxJQUFJLENBQUMsSUFBSTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsNEJBQTRCLENBQUMsQ0FBQztJQUN6RCxPQUFPLElBQUksQ0FBQztBQUNkLENBQUM7QUFFRDs7a0ZBRWtGO0FBQ2xGLE1BQU0sVUFBVSxhQUFhLENBQUMsS0FBc0IsRUFBRSxNQUFjO0lBQ2xFLElBQUksT0FBTyxNQUFNLEtBQUssUUFBUSxJQUFJLENBQUMsTUFBTTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMscUJBQXFCLENBQUMsQ0FBQztJQUNsRixPQUFPLG1CQUFtQixDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsRUFBRSxNQUFNLENBQUMsQ0FBQztBQUNwRCxDQUFDO0FBRUQ7Ozs7O0dBS0c7QUFDSCxNQUFNLFVBQVUsdUJBQXVCLENBQ3JDLFFBQW9FLEVBQ3BFLE1BQWM7SUFFZCxNQUFNLFFBQVEsR0FDWixRQUFRLElBQUksT0FBUSxRQUEwQyxDQUFDLE1BQU0sS0FBSyxVQUFVO1FBQ2xGLENBQUMsQ0FBRSxRQUEwQyxDQUFDLE1BQU0sRUFBRTtRQUN0RCxDQUFDLENBQUUsUUFBdUMsQ0FBQztJQUMvQyxNQUFNLElBQUksR0FBbUIsRUFBRSxDQUFDO0lBQ2hDLEtBQUssTUFBTSxPQUFPLElBQUksUUFBUSxJQUFJLEVBQUUsRUFBRSxDQUFDO1FBQ3JDLElBQUksQ0FBQyxPQUFPLElBQUksT0FBTyxPQUFPLENBQUMsWUFBWSxLQUFLLFFBQVEsSUFBSSxDQUFDLE9BQU8sQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFO1lBQUUsU0FBUztRQUNuRyxJQUFJLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxPQUFPLENBQUMsUUFBUSxDQUFDLElBQUksT0FBTyxDQUFDLFFBQVEsSUFBSSxDQUFDO1lBQUUsU0FBUztRQUMzRSxJQUFJLENBQUMsSUFBSSxDQUFDO1lBQ1IsUUFBUSxFQUFFLGFBQWEsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLE1BQU0sQ0FBQztZQUNyRCxNQUFNLEVBQUUsYUFBYSxDQUFDLEdBQUcsT0FBTyxDQUFDLFlBQVksSUFBSSxPQUFPLENBQUMsUUFBUSxFQUFFLEVBQUUsTUFBTSxDQUFDO1lBQzVFLFFBQVEsRUFBRSxPQUFPLENBQUMsUUFBUTtZQUMxQixZQUFZLEVBQUUsT0FBTyxPQUFPLENBQUMsTUFBTSxLQUFLLFFBQVEsSUFBSSxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxNQUFNO1lBQzVGLFFBQVEsRUFBRSxPQUFPLE9BQU8sQ0FBQyxRQUFRLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLElBQUk7U0FDN0YsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUNELElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQztJQUN0RCxPQUFPLElBQUksQ0FBQztBQUNkLENBQUM7QUFFRDs7OztHQUlHO0FBQ0gsTUFBTSxVQUFVLGtCQUFrQixDQUFDLFNBQWlCLHNCQUFzQixFQUFFO0lBQzFFLE1BQU0sWUFBWSxHQUFHLGVBQWUsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUM3QyxTQUFTLENBQUMsT0FBTyxDQUFDLFlBQVksQ0FBQyxFQUFFLEVBQUUsU0FBUyxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztJQUNuRSxNQUFNLEVBQUUsR0FBRyxJQUFJLFlBQVksQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMxQyxTQUFTLENBQUMsWUFBWSxFQUFFLEtBQUssQ0FBQyxDQUFDO0lBQy9CLEVBQUUsQ0FBQyxJQUFJLENBQUMsNEJBQTRCLENBQUMsQ0FBQztJQUN0QyxFQUFFLENBQUMsSUFBSSxDQUFDLHdGQUF3RixDQUFDLENBQUM7SUFFbEcsTUFBTSxZQUFZLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FBQyxpREFBaUQsQ0FBQyxDQUFDO0lBQ25GLE1BQU0sWUFBWSxHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQzdCLDhHQUE4RyxDQUMvRyxDQUFDO0lBQ0YsTUFBTSxTQUFTLEdBQUcsQ0FBQyxHQUFXLEVBQWlCLEVBQUU7UUFDL0MsTUFBTSxHQUFHLEdBQUcsWUFBWSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQXdCLENBQUM7UUFDekQsT0FBTyxHQUFHLElBQUksT0FBTyxHQUFHLENBQUMsS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ2pFLENBQUMsQ0FBQztJQUVGLE9BQU87UUFDTCxNQUFNLEVBQUUsWUFBWTtRQUNwQjt5R0FDaUc7UUFDakcscUJBQXFCO1lBQ25CLE1BQU0sUUFBUSxHQUFHLFNBQVMsQ0FBQyxlQUFlLENBQUMsQ0FBQztZQUM1QyxJQUFJLFFBQVE7Z0JBQUUsT0FBTyxRQUFRLENBQUM7WUFDOUIsTUFBTSxTQUFTLEdBQUcsa0JBQWtCLEVBQUUsQ0FBQztZQUN2QyxZQUFZLENBQUMsR0FBRyxDQUFDLGVBQWUsRUFBRSxTQUFTLENBQUMsQ0FBQztZQUM3QyxPQUFPLFNBQVMsQ0FBQztRQUNuQixDQUFDO1FBQ0QsNkVBQTZFO1FBQzdFLFNBQVM7WUFDUCxPQUFPLFNBQVMsQ0FBQyxVQUFVLENBQUMsQ0FBQztRQUMvQixDQUFDO1FBQ0QsU0FBUyxDQUFDLE1BQWM7WUFDdEIsWUFBWSxDQUFDLEdBQUcsQ0FBQyxVQUFVLEVBQUUsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7UUFDL0MsQ0FBQztRQUNELEtBQUs7WUFDSCxFQUFFLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDYixDQUFDO0tBQ0YsQ0FBQztBQUNKLENBQUM7QUFFRDs7Ozs7R0FLRztBQUNILE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxVQUlsQyxFQUFFO0lBQ0osTUFBTSxFQUFFLEtBQUssRUFBRSxXQUFXLEVBQUUsT0FBTyxHQUFHLDZCQUE2QixFQUFFLEdBQUcsT0FBTyxDQUFDO0lBQ2hGLElBQUksQ0FBQyxPQUFPO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDMUIsSUFBSSxDQUFDLEtBQUssSUFBSSxPQUFPLEtBQUssQ0FBQyxxQkFBcUIsS0FBSyxVQUFVO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywwQkFBMEIsQ0FBQyxDQUFDO0lBQzdHLE1BQU0sUUFBUSxHQUFHLGNBQWMsQ0FBQyxXQUFvQyxDQUFDLENBQUM7SUFDdEUsT0FBTyx1QkFBdUIsQ0FBQyxRQUFRLEVBQUUsS0FBSyxDQUFDLHFCQUFxQixFQUFFLENBQUMsQ0FBQztBQUMxRSxDQUFDO0FBRUQ7Z0ZBQ2dGO0FBQ2hGLE1BQU0sVUFBVSxhQUFhLENBQUMsTUFBYztJQUMxQyxPQUFPLFVBQVUsQ0FBQyxRQUFRLENBQUMsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDLENBQUM7QUFDaEYsQ0FBQztBQUVEOzttR0FFbUc7QUFDbkcsTUFBTSxVQUFVLHNCQUFzQixDQUFDLEtBQXFCLEVBQUUsTUFBcUI7SUFDakYsSUFBSSxDQUFDLE1BQU07UUFBRSxPQUFPLEtBQUssQ0FBQztJQUMxQixPQUFPLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLENBQUMsR0FBRyxDQUFDLFFBQVEsSUFBSSxHQUFHLENBQUMsUUFBUSxHQUFHLE1BQU0sQ0FBQyxDQUFDO0FBQ3ZFLENBQUM7QUFFRDsrQkFDK0I7QUFDL0IsTUFBTSxVQUFVLGNBQWMsQ0FBQyxLQUFxQjtJQUNsRCxJQUFJLE1BQU0sR0FBa0IsSUFBSSxDQUFDO0lBQ2pDLEtBQUssTUFBTSxHQUFHLElBQUksS0FBSyxFQUFFLENBQUM7UUFDeEIsSUFBSSxHQUFHLENBQUMsUUFBUSxJQUFJLENBQUMsTUFBTSxLQUFLLElBQUksSUFBSSxHQUFHLENBQUMsUUFBUSxHQUFHLE1BQU0sQ0FBQztZQUFFLE1BQU0sR0FBRyxHQUFHLENBQUMsUUFBUSxDQUFDO0lBQ3hGLENBQUM7SUFDRCxPQUFPLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBRUQsc0dBQXNHO0FBQ3RHLE1BQU0sQ0FBQyxNQUFNLHlCQUF5QixHQUFHLHVDQUF1QyxDQUFDO0FBRWpGLE1BQU0sVUFBVSxzQkFBc0IsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBRztJQUMxRixNQUFNLFFBQVEsR0FDWixPQUFPLEdBQUcsQ0FBQyxnQ0FBZ0MsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxnQ0FBZ0MsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzlHLE9BQU8sUUFBUSxJQUFJLHlCQUF5QixDQUFDO0FBQy9DLENBQUM7QUFFRDs7Ozs7O0dBTUc7QUFDSCxpSEFBaUg7QUFDakgsOEdBQThHO0FBQzlHLE1BQU0sQ0FBQyxNQUFNLDZCQUE2QixHQUFHLE1BQU0sQ0FBQztBQUVwRCxNQUFNLENBQUMsS0FBSyxVQUFVLGtCQUFrQixDQUFDLE9BT3hDO0lBQ0MsTUFBTSxFQUNKLEtBQUssRUFDTCxNQUFNLEVBQ04sWUFBWSxHQUFHLHNCQUFzQixFQUFFLEVBQ3ZDLGNBQWMsRUFDZCxPQUFPLEdBQUcsS0FBSyxFQUNmLFNBQVMsR0FBRyw2QkFBNkIsR0FDMUMsR0FBRyxPQUFPLENBQUM7SUFDWixJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLENBQUMsRUFBRSxDQUFDO0lBQ3BFLE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUN6QyxNQUFNLElBQUksR0FBRyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsVUFBVSxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQzNELE1BQU0sU0FBUyxHQUFHLFVBQVUsQ0FBQyxRQUFRLEVBQUUsTUFBTSxDQUFDLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUMxRSxJQUFJLENBQUM7UUFDSCxNQUFNLEdBQUcsR0FBRyxNQUFNLE9BQU8sQ0FBQyxZQUFZLEVBQUU7WUFDdEMsTUFBTSxFQUFFLE1BQU07WUFDZCxPQUFPLEVBQUU7Z0JBQ1AsY0FBYyxFQUFFLGtCQUFrQjtnQkFDbEMsaUJBQWlCLEVBQUUsVUFBVSxTQUFTLEVBQUU7Z0JBQ3hDLGdCQUFnQixFQUFFLFVBQVU7Z0JBQzVCLEdBQUcsQ0FBQyxjQUFjLENBQUMsQ0FBQyxDQUFDLEVBQUUsYUFBYSxFQUFFLFVBQVUsY0FBYyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO2FBQ3pFO1lBQ0QsSUFBSTtZQUNKLE1BQU0sRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLFNBQVMsQ0FBQztTQUN2QyxDQUFDLENBQUM7UUFDSCxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUU7WUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLENBQUMsRUFBRSxLQUFLLEVBQUUsUUFBUSxHQUFHLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQztJQUMvRCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sRUFBRSxJQUFJLEVBQUUsQ0FBQyxFQUFFLEtBQUssRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO0lBQ3JELENBQUM7SUFDRCxPQUFPLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBQztBQUNoQyxDQUFDO0FBRUQsTUFBTSxnQkFBZ0IsR0FBRywyRUFBMkUsQ0FBQztBQUVyRyxNQUFNLFVBQVUsa0JBQWtCLENBQUMsSUFBYztJQUMvQyxNQUFNLE9BQU8sR0FBRyxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUMzRSxLQUFLLE1BQU0sS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO1FBQ3pCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCwyR0FBMkc7UUFDM0csMkdBQTJHO1FBQzNHLDJHQUEyRztRQUMzRyxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELDRHQUE0RztRQUM1RyxpR0FBaUc7UUFDakcsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLGdCQUFnQixFQUFFLENBQUM7SUFDckMsQ0FBQztJQUNELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFhRDs7Ozs7eUJBS3lCO0FBQ3pCLE1BQU0sQ0FBQyxLQUFLLFVBQVUsZUFBZSxDQUNuQyxJQUFjLEVBQ2QsVUFBa0MsRUFBRTtJQUVwQyxNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxPQUFPLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1FBQ3ZGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDckQsQ0FBQzthQUFNLElBQUksTUFBTSxDQUFDLE1BQU0sSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDeEMsT0FBTyxDQUFDLEdBQUcsQ0FDVCwrSEFBK0gsQ0FDaEksQ0FBQztRQUNKLENBQUM7YUFBTSxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztZQUN6QixPQUFPLENBQUMsR0FBRyxDQUFDLDRGQUE0RixDQUFDLENBQUM7UUFDNUcsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUNULHFIQUFxSCxDQUN0SCxDQUFDO1FBQ0osQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELDhHQUE4RztJQUM5Ryw4R0FBOEc7SUFDOUcsNkdBQTZHO0lBQzdHLGdIQUFnSDtJQUNoSCxNQUFNLFNBQVMsR0FBRyxPQUFPLENBQUMsa0JBQWtCLEtBQUssU0FBUyxDQUFDO0lBQzNELE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxlQUFlLEtBQUssU0FBUyxDQUFDO0lBQ3pELElBQUksS0FBaUMsQ0FBQztJQUN0QyxJQUFJLFdBQXlFLENBQUM7SUFDOUUsSUFBSSxDQUFDO1FBQ0gsS0FBSyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLGtCQUFrQixDQUFDLEVBQUUsQ0FBQztRQUM3RCxXQUFXLEdBQUcsQ0FBQyxPQUFPLENBQUMsZUFBZSxJQUFJLGVBQWUsQ0FBQyxFQUFFLENBQUM7UUFDN0QsTUFBTSxLQUFLLEdBQUcscUJBQXFCLENBQUMsRUFBRSxLQUFLLEVBQUUsV0FBVyxFQUFFLE9BQU8sRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQztRQUNwRixJQUFJLEtBQUssS0FBSyxJQUFJLEVBQUUsQ0FBQztZQUNuQixJQUFJLE1BQU0sQ0FBQyxJQUFJO2dCQUFFLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLElBQUksRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDOztnQkFDbEYsT0FBTyxDQUFDLEdBQUcsQ0FBQyxnRkFBZ0YsQ0FBQyxDQUFDO1lBQ25HLE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQztRQUVELElBQUksQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDakIsSUFBSSxNQUFNLENBQUMsSUFBSTtnQkFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7O2dCQUN4RixPQUFPLENBQUMsR0FBRyxDQUFDLEdBQUcsS0FBSyxDQUFDLE1BQU0sc0VBQXNFLENBQUMsQ0FBQztZQUN4RyxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUM7UUFFRCxNQUFNLE1BQU0sR0FBRyxLQUFLLENBQUMsU0FBUyxFQUFFLENBQUM7UUFDakMsTUFBTSxNQUFNLEdBQUcsc0JBQXNCLENBQUMsS0FBSyxFQUFFLE1BQU0sQ0FBQyxDQUFDO1FBQ3JELElBQUksTUFBTSxDQUFDLE1BQU0sS0FBSyxDQUFDLEVBQUUsQ0FBQztZQUN4QixJQUFJLE1BQU0sQ0FBQyxJQUFJO2dCQUFFLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLENBQUMsRUFBRSxPQUFPLEVBQUUsS0FBSyxDQUFDLE1BQU0sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDOztnQkFDcEcsT0FBTyxDQUFDLEdBQUcsQ0FBQyxxQ0FBcUMsQ0FBQyxDQUFDO1lBQ3hELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQztRQUVELE1BQU0sSUFBSSxHQUFHLE9BQU8sQ0FBQyxrQkFBa0IsSUFBSSxrQkFBa0IsQ0FBQztRQUM5RCxNQUFNLE1BQU0sR0FBRyxLQUFLLENBQUMscUJBQXFCLEVBQUUsQ0FBQztRQUM3QyxNQUFNLEdBQUcsR0FBRyxPQUFPLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUM7UUFDdkMsTUFBTSxjQUFjLEdBQUcsR0FBRyxDQUFDLGtDQUFrQyxJQUFJLEVBQUUsQ0FBQztRQUNwRSxNQUFNLFVBQVUsR0FBRyxNQUFNLElBQUksQ0FBQyxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsTUFBTSxFQUFFLGNBQWMsRUFBRSxDQUFDLENBQUM7UUFDekUsSUFBSSxVQUFVLENBQUMsSUFBSSxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQ3hCLE1BQU0sVUFBVSxHQUFHLGNBQWMsQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUMxQyxJQUFJLFVBQVU7Z0JBQUUsS0FBSyxDQUFDLFNBQVMsQ0FBQyxVQUFVLENBQUMsQ0FBQztRQUM5QyxDQUFDO1FBQ0QsSUFBSSxNQUFNLENBQUMsSUFBSTtZQUNiLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsR0FBRyxVQUFVLEVBQUUsT0FBTyxFQUFFLEtBQUssQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO2FBQzNHLElBQUksVUFBVSxDQUFDLEtBQUs7WUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLGtCQUFrQixVQUFVLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQzs7WUFDeEUsT0FBTyxDQUFDLEdBQUcsQ0FBQyxRQUFRLFVBQVUsQ0FBQyxJQUFJLHNCQUFzQixDQUFDLENBQUM7UUFDaEUsT0FBTyxVQUFVLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNsQyxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxTQUFTO1lBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO1FBQzlCLElBQUksVUFBVTtZQUFHLFdBQWtELEVBQUUsS0FBSyxFQUFFLEVBQUUsQ0FBQztJQUNqRixDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/orb-export.ts
+++ b/packages/loopover-miner/lib/orb-export.ts
@@ -1,0 +1,394 @@
+import { chmodSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { createHash, createHmac } from "node:crypto";
+import { generateAnonSecret, hmacAnonymize as engineHmacAnonymize } from "@loopover/engine";
+import { readPrOutcomes } from "./pr-outcome.js";
+import type { NormalizedPrOutcomePayload, PrOutcomeLedgerReader } from "./pr-outcome.js";
+import { initEventLedger } from "./event-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+// Optional anonymized Orb telemetry export (#4277, network send wired in #5681). The self-host Orb collector
+// (src/selfhost/orb-collector.ts, #1255) is ALWAYS-ON for a maintainer's own instance; a miner runs on a
+// third-party contributor's laptop with a much lower consent bar, so this export is OPT-IN (default OFF) —
+// hence "optional". It mirrors the collector's privacy posture: repo/PR identifiers are HMAC-anonymized with a
+// per-instance DEDICATED secret (generated once, persisted locally, single-purpose), and only a fixed
+// low-cardinality reason bucket + the decision leave — never raw repo names or free text. The data source is
+// the local pr_outcome ledger (pr-outcome.js), not a hosted D1. `generateAnonSecret`/`hmacAnonymize` are the
+// same primitive src/selfhost/orb-collector.ts uses (@loopover/engine, #5680) — one anonymization
+// implementation shared by both products instead of two independently-maintained copies.
+
+/** OPT-IN: a laptop miner exports nothing unless a contributor explicitly turns it on. */
+export const ORB_EXPORT_ENABLED_BY_DEFAULT = false as const;
+
+/** One anonymized outcome in an export batch — no raw repo name, PR number, or free-text reason. */
+export interface OrbExportRow {
+  repoHash: string;
+  prHash: string;
+  decision: string;
+  reasonBucket: string;
+  closedAt: string | null;
+}
+
+/** The local orb-export store: the per-instance anonymization secret + export cursor, in local SQLite. */
+export interface OrbExportStore {
+  dbPath: string;
+  getOrCreateAnonSecret(): string;
+  getCursor(): string | null;
+  setCursor(cursor: string): void;
+  close(): void;
+}
+
+/** Result of sending a batch to the AMS collector — `error` present only on a non-2xx response, a network
+ *  failure, or an empty batch (never thrown). */
+export type AmsExportSendResult = { sent: number; error?: string };
+
+/** A pr_outcome record as produced by `readPrOutcomes` (the local ledger's latest-per-PR reduction). */
+export type OrbExportOutcome = NormalizedPrOutcomePayload & { repoFullName: string };
+
+export type ParsedOrbExportArgs =
+  | { json: boolean; enable: boolean; send: boolean; dryRun: boolean }
+  | { error: string };
+
+type MetaRow = { value: string };
+
+const ANON_SECRET_KEY = "anon_secret";
+const CURSOR_KEY = "export_cursor";
+const defaultDbFileName = "orb-export.sqlite3";
+
+export function resolveOrbExportDbPath(env: Record<string, string | undefined> = process.env): string {
+  const explicitPath =
+    typeof env.LOOPOVER_MINER_ORB_EXPORT_DB === "string" ? env.LOOPOVER_MINER_ORB_EXPORT_DB.trim() : "";
+  if (explicitPath) return explicitPath;
+
+  const explicitConfigDir =
+    typeof env.LOOPOVER_MINER_CONFIG_DIR === "string" ? env.LOOPOVER_MINER_CONFIG_DIR.trim() : "";
+  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
+
+  const configHome =
+    typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+      ? env.XDG_CONFIG_HOME.trim()
+      : join(homedir(), ".config");
+  return join(configHome, "loopover-miner", defaultDbFileName);
+}
+
+function normalizeDbPath(dbPath: string | undefined): string {
+  const path = (dbPath ?? resolveOrbExportDbPath()).trim();
+  if (!path) throw new Error("invalid_orb_export_db_path");
+  return path;
+}
+
+/** HMAC a value with the per-instance secret. Validates the secret (the shared engine primitive stays pure
+ *  and doesn't), then delegates the actual hash to @loopover/engine's hmacAnonymize — the same primitive
+ *  src/selfhost/orb-collector.ts uses, so both products anonymize identically. */
+export function hmacAnonymize(value: string | number, secret: string): string {
+  if (typeof secret !== "string" || !secret) throw new Error("invalid_anon_secret");
+  return engineHmacAnonymize(String(value), secret);
+}
+
+/**
+ * Turn the local pr_outcome map (pr-outcome.js `readPrOutcomes`) into an anonymized export batch: repo and PR
+ * identifiers are HMAC-hashed, and only the `decision` + a low-cardinality `reasonBucket` (already one of the
+ * miner's `REJECTION_REASONS`, else `"none"`) + `closedAt` leave. Pure and deterministic (rows sorted by prHash).
+ * Accepts either the Map `readPrOutcomes` returns or any iterable of outcome records.
+ */
+export function buildAnonymizedOrbBatch(
+  outcomes: Iterable<OrbExportOutcome> | Map<string, OrbExportOutcome>,
+  secret: string,
+): OrbExportRow[] {
+  const iterable =
+    outcomes && typeof (outcomes as Map<string, OrbExportOutcome>).values === "function"
+      ? (outcomes as Map<string, OrbExportOutcome>).values()
+      : (outcomes as Iterable<OrbExportOutcome>);
+  const rows: OrbExportRow[] = [];
+  for (const outcome of iterable ?? []) {
+    if (!outcome || typeof outcome.repoFullName !== "string" || !outcome.repoFullName.trim()) continue;
+    if (!Number.isInteger(outcome.prNumber) || outcome.prNumber <= 0) continue;
+    rows.push({
+      repoHash: hmacAnonymize(outcome.repoFullName, secret),
+      prHash: hmacAnonymize(`${outcome.repoFullName}:${outcome.prNumber}`, secret),
+      decision: outcome.decision,
+      reasonBucket: typeof outcome.reason === "string" && outcome.reason ? outcome.reason : "none",
+      closedAt: typeof outcome.closedAt === "string" && outcome.closedAt ? outcome.closedAt : null,
+    });
+  }
+  rows.sort((a, b) => a.prHash.localeCompare(b.prHash));
+  return rows;
+}
+
+/**
+ * Open/create the local orb-export store: a small key/value SQLite table holding the per-instance anonymization
+ * secret and the export cursor. Mirrors the other miner ledgers' node:sqlite pattern — a `0o700` config dir and a
+ * `0o600` file, since the secret must never leave this machine.
+ */
+export function openOrbExportStore(dbPath: string = resolveOrbExportDbPath()): OrbExportStore {
+  const resolvedPath = normalizeDbPath(dbPath);
+  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
+  const db = new DatabaseSync(resolvedPath);
+  chmodSync(resolvedPath, 0o600);
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec(`CREATE TABLE IF NOT EXISTS orb_export_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+
+  const getStatement = db.prepare("SELECT value FROM orb_export_meta WHERE key = ?");
+  const setStatement = db.prepare(
+    "INSERT INTO orb_export_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+  );
+  const readValue = (key: string): string | null => {
+    const row = getStatement.get(key) as MetaRow | undefined;
+    return row && typeof row.value === "string" ? row.value : null;
+  };
+
+  return {
+    dbPath: resolvedPath,
+    /** The per-instance DEDICATED anonymization secret — generated once (256-bit) and persisted, then reused
+     *  forever so a repo/PR always hashes the same way. Single-purpose: only this export uses it. */
+    getOrCreateAnonSecret() {
+      const existing = readValue(ANON_SECRET_KEY);
+      if (existing) return existing;
+      const generated = generateAnonSecret();
+      setStatement.run(ANON_SECRET_KEY, generated);
+      return generated;
+    },
+    /** The export watermark (opaque string), or null before the first export. */
+    getCursor() {
+      return readValue(CURSOR_KEY);
+    },
+    setCursor(cursor: string) {
+      setStatement.run(CURSOR_KEY, String(cursor));
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+/**
+ * Collect the anonymized Orb export batch from the local pr_outcome ledger. OPT-IN: returns null (exports nothing)
+ * unless `enabled` is true — a third-party contributor's laptop must explicitly turn this on. Never performs the
+ * network POST itself; the caller sends the returned batch to the Orb ingest endpoint and then advances the store
+ * cursor, so this function stays pure over its inputs and the local store.
+ */
+export function collectOrbExportBatch(options: {
+  store?: OrbExportStore;
+  eventLedger?: PrOutcomeLedgerReader;
+  enabled?: boolean;
+} = {}): OrbExportRow[] | null {
+  const { store, eventLedger, enabled = ORB_EXPORT_ENABLED_BY_DEFAULT } = options;
+  if (!enabled) return null;
+  if (!store || typeof store.getOrCreateAnonSecret !== "function") throw new Error("invalid_orb_export_store");
+  const outcomes = readPrOutcomes(eventLedger as PrOutcomeLedgerReader);
+  return buildAnonymizedOrbBatch(outcomes, store.getOrCreateAnonSecret());
+}
+
+/** Stable per-instance identifier: a hash of the instance's own anon secret (no App-id concept on the AMS side,
+ *  unlike orb-collector.ts's instanceId — a miner laptop has no GitHub App). */
+export function amsInstanceId(secret: string): string {
+  return createHash("sha256").update(String(secret)).digest("hex").slice(0, 16);
+}
+
+/** Drop rows already sent in a prior export: everything with a `closedAt` at/before the cursor. A row with no
+ *  `closedAt` (shouldn't happen for a resolved PR, but defensive) is always included, since there is no
+ *  watermark to compare it against. A null/unset cursor means "first export" — everything goes. */
+export function filterBatchSinceCursor(batch: OrbExportRow[], cursor: string | null): OrbExportRow[] {
+  if (!cursor) return batch;
+  return batch.filter((row) => !row.closedAt || row.closedAt > cursor);
+}
+
+/** The newest `closedAt` among a batch's rows, or `null` if none carry one — the next cursor value to persist
+ *  after a successful send. */
+export function latestClosedAt(batch: OrbExportRow[]): string | null {
+  let latest: string | null = null;
+  for (const row of batch) {
+    if (row.closedAt && (latest === null || row.closedAt > latest)) latest = row.closedAt;
+  }
+  return latest;
+}
+
+/** loopover's hosted AMS collector — mirrors orb-collector.ts's ORB_COLLECTOR_URL default pattern. */
+export const DEFAULT_AMS_COLLECTOR_URL = "https://api.loopover.ai/v1/ams/ingest";
+
+export function resolveAmsCollectorUrl(env: Record<string, string | undefined> = process.env): string {
+  const explicit =
+    typeof env.LOOPOVER_MINER_AMS_COLLECTOR_URL === "string" ? env.LOOPOVER_MINER_AMS_COLLECTOR_URL.trim() : "";
+  return explicit || DEFAULT_AMS_COLLECTOR_URL;
+}
+
+/**
+ * POST an already-anonymized batch to the AMS ingest collector, signed the same way orb-collector.ts signs its
+ * own export (a full-length HMAC over the JSON body, distinct from the per-field hmacAnonymize truncated hash
+ * above — a body signature and a field anonymization hash are different concerns). Returns `{ sent }` on a 2xx
+ * response, `{ sent: 0, error }` otherwise — a network failure or non-2xx never throws, matching this module's
+ * fail-open posture (a telemetry hiccup must never break the miner's real work).
+ */
+// Bound a single AMS-collector POST so a hung/black-holed collector can't stall the export indefinitely (#7237).
+// 10s matches this package's other default request timeouts (live-issue-snapshot.js / opportunity-fanout.js).
+export const DEFAULT_ORB_EXPORT_TIMEOUT_MS = 10_000;
+
+export async function sendAmsExportBatch(options: {
+  batch: OrbExportRow[];
+  secret: string;
+  collectorUrl?: string;
+  collectorToken?: string | undefined;
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<AmsExportSendResult> {
+  const {
+    batch,
+    secret,
+    collectorUrl = resolveAmsCollectorUrl(),
+    collectorToken,
+    fetchFn = fetch,
+    timeoutMs = DEFAULT_ORB_EXPORT_TIMEOUT_MS,
+  } = options;
+  if (!Array.isArray(batch) || batch.length === 0) return { sent: 0 };
+  const instanceId = amsInstanceId(secret);
+  const body = JSON.stringify({ instanceId, events: batch });
+  const signature = createHmac("sha256", secret).update(body).digest("hex");
+  try {
+    const res = await fetchFn(collectorUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-ams-signature": `sha256=${signature}`,
+        "x-ams-instance": instanceId,
+        ...(collectorToken ? { authorization: `Bearer ${collectorToken}` } : {}),
+      },
+      body,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return { sent: 0, error: `http_${res.status}` };
+  } catch (error) {
+    return { sent: 0, error: describeCliError(error) };
+  }
+  return { sent: batch.length };
+}
+
+const ORB_EXPORT_USAGE = "Usage: loopover-miner orb export [--enable] [--send] [--dry-run] [--json]";
+
+export function parseOrbExportArgs(args: string[]): ParsedOrbExportArgs {
+  const options = { json: false, enable: false, send: false, dryRun: false };
+  for (const token of args) {
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--enable") {
+      options.enable = true;
+      continue;
+    }
+    // Distinct from --enable: --enable alone only builds+prints the anonymized batch locally (no network I/O),
+    // so a contributor can inspect exactly what would be sent before ever transmitting it. --send additionally
+    // POSTs that batch to the collector and advances the cursor — the previously-missing network step (#5681).
+    if (token === "--send") {
+      options.send = true;
+      continue;
+    }
+    // #4847: openOrbExportStore() itself creates the local SQLite file (a real write) even before any secret is
+    // generated, so a dry run reports what would happen and returns before opening any store at all.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    return { error: ORB_EXPORT_USAGE };
+  }
+  return options;
+}
+
+type RunOrbExportCliOptions = {
+  openOrbExportStore?: () => OrbExportStore;
+  initEventLedger?: () => PrOutcomeLedgerReader & { close?: () => void };
+  sendAmsExportBatch?: (options: {
+    batch: OrbExportRow[];
+    secret: string;
+    collectorToken?: string | undefined;
+  }) => Promise<AmsExportSendResult>;
+  env?: Record<string, string | undefined>;
+};
+
+/** CLI entry for the anonymized Orb telemetry batch-builder + sender (#4833 wired the caller-less exporter's
+ *  batch-building; #5681 wired the network send). OPT-IN: prints nothing to export unless `--enable` is
+ *  passed. `--enable` alone only builds+prints the anonymized batch locally — no network I/O, so a contributor
+ *  can inspect exactly what would be sent first. `--enable --send` additionally POSTs the (cursor-filtered)
+ *  batch to the AMS collector and advances the cursor on success, so a re-run doesn't resend history that was
+ *  already delivered. */
+export async function runOrbExportCli(
+  args: string[],
+  options: RunOrbExportCliOptions = {},
+): Promise<number> {
+  const parsed = parseOrbExportArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", enabled: parsed.enable, send: parsed.send };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else if (parsed.enable && parsed.send) {
+      console.log(
+        "DRY RUN: would build an anonymized Orb export batch and send it to the collector. No local writes or network calls were made.",
+      );
+    } else if (parsed.enable) {
+      console.log("DRY RUN: would build and report an anonymized Orb export batch. No local writes were made.");
+    } else {
+      console.log(
+        "DRY RUN: orb export is opt-in and disabled — pass --enable to build an anonymized batch. No local writes were made.",
+      );
+    }
+    return 0;
+  }
+
+  // Open the stores INSIDE the try so a bad config path / SQLite open failure returns 2 instead of crashing the
+  // process; the finally guards each close with `?.` since either initializer may have thrown before assigning.
+  // The --send path's await happens INSIDE this try so `finally` (which closes the store) can never run before
+  // the cursor advance below it -- resolving the send result AFTER the store closed would write to a dead handle.
+  const ownsStore = options.openOrbExportStore === undefined;
+  const ownsLedger = options.initEventLedger === undefined;
+  let store: OrbExportStore | undefined;
+  let eventLedger: (PrOutcomeLedgerReader & { close?: () => void }) | undefined;
+  try {
+    store = (options.openOrbExportStore ?? openOrbExportStore)();
+    eventLedger = (options.initEventLedger ?? initEventLedger)();
+    const batch = collectOrbExportBatch({ store, eventLedger, enabled: parsed.enable });
+    if (batch === null) {
+      if (parsed.json) console.log(JSON.stringify({ enabled: false, batch: null }, null, 2));
+      else console.log("orb export is opt-in and disabled — pass --enable to build an anonymized batch");
+      return 0;
+    }
+
+    if (!parsed.send) {
+      if (parsed.json) console.log(JSON.stringify({ enabled: true, sent: false, batch }, null, 2));
+      else console.log(`${batch.length} anonymized event(s) — pass --send to transmit them to the collector`);
+      return 0;
+    }
+
+    const cursor = store.getCursor();
+    const toSend = filterBatchSinceCursor(batch, cursor);
+    if (toSend.length === 0) {
+      if (parsed.json) console.log(JSON.stringify({ enabled: true, sent: 0, skipped: batch.length }, null, 2));
+      else console.log("no new events since the last export");
+      return 0;
+    }
+
+    const send = options.sendAmsExportBatch ?? sendAmsExportBatch;
+    const secret = store.getOrCreateAnonSecret();
+    const env = options.env ?? process.env;
+    const collectorToken = env.LOOPOVER_MINER_AMS_COLLECTOR_TOKEN ?? "";
+    const sendResult = await send({ batch: toSend, secret, collectorToken });
+    if (sendResult.sent > 0) {
+      const nextCursor = latestClosedAt(toSend);
+      if (nextCursor) store.setCursor(nextCursor);
+    }
+    if (parsed.json)
+      console.log(JSON.stringify({ enabled: true, ...sendResult, skipped: batch.length - toSend.length }, null, 2));
+    else if (sendResult.error) console.log(`export failed: ${sendResult.error}`);
+    else console.log(`sent ${sendResult.sent} anonymized event(s)`);
+    return sendResult.error ? 1 : 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsStore) store?.close();
+    if (ownsLedger) (eventLedger as { close?: () => void } | undefined)?.close?.();
+  }
+}

--- a/packages/loopover-miner/lib/update-check.d.ts
+++ b/packages/loopover-miner/lib/update-check.d.ts
@@ -1,36 +1,25 @@
-export function resolveNpmRegistryUrl(
-  env?: Record<string, string | undefined>,
-): string;
-export function resolveUpgradeCommand(packageName?: string): string;
-export function shouldSkipUpdateCheck(
-  cliArgs: string[],
-  env?: Record<string, string | undefined>,
-): boolean;
-export function compareSemver(a: string, b: string): -1 | 0 | 1 | null;
-export function fetchLatestPackageVersion(input: {
-  packageName: string;
-  npmRegistryUrl: string;
-  timeoutMs?: number;
+export declare function resolveNpmRegistryUrl(env?: Record<string, string | undefined>): string;
+export declare function resolveUpgradeCommand(packageName?: string): string;
+export declare function shouldSkipUpdateCheck(cliArgs: string[], env?: Record<string, string | undefined>): boolean;
+export declare function compareSemver(a: string, b: string): -1 | 0 | 1 | null;
+export declare function fetchLatestPackageVersion(input: {
+    packageName: string;
+    npmRegistryUrl: string;
+    timeoutMs?: number;
 }): Promise<string>;
-export function maybePrintUpdateNudge(input: {
-  packageName: string;
-  packageVersion: string;
-  npmRegistryUrl: string;
-  upgradeCommand: string;
-  timeoutMs?: number;
+export declare function maybePrintUpdateNudge(input: {
+    packageName: string;
+    packageVersion: string;
+    npmRegistryUrl: string;
+    upgradeCommand: string;
+    timeoutMs?: number;
 }): Promise<void>;
-export function startUpdateCheck(
-  cliArgs: string[],
-  input: {
+export declare function startUpdateCheck(cliArgs: string[], input: {
     packageName: string;
     packageVersion: string;
     upgradeCommand?: string;
     env?: Record<string, string | undefined>;
     timeoutMs?: number;
-  },
-): Promise<void>;
-export const updateCheckExitGraceMs: number;
-export function awaitOpportunisticUpdateCheck(
-  updateCheck: Promise<void>,
-  graceMs?: number,
-): Promise<void>;
+}): Promise<void>;
+export declare const updateCheckExitGraceMs = 250;
+export declare function awaitOpportunisticUpdateCheck(updateCheck: Promise<void>, graceMs?: number): Promise<void>;

--- a/packages/loopover-miner/lib/update-check.js
+++ b/packages/loopover-miner/lib/update-check.js
@@ -1,63 +1,52 @@
 const defaultPackageName = "@loopover/miner";
 const defaultNpmRegistryUrl = "https://registry.npmjs.org";
-
 function isLocalRegistryHost(hostname) {
-  const normalized = hostname.toLowerCase().replace(/\.$/, "");
-  return (
-    normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized === "::1" ||
-    normalized === "[::1]"
-  );
+    const normalized = hostname.toLowerCase().replace(/\.$/, "");
+    return (normalized === "localhost" ||
+        normalized === "127.0.0.1" ||
+        normalized === "::1" ||
+        normalized === "[::1]");
 }
-
 export function resolveNpmRegistryUrl(env = process.env) {
-  const raw = env.LOOPOVER_NPM_REGISTRY_URL?.trim();
-  if (!raw) return defaultNpmRegistryUrl;
-
-  let url;
-  try {
-    url = new URL(raw);
-  } catch {
-    return defaultNpmRegistryUrl;
-  }
-
-  if (url.username || url.password || url.search || url.hash || !url.hostname) {
-    return defaultNpmRegistryUrl;
-  }
-
-  const local = isLocalRegistryHost(url.hostname);
-  if (url.protocol !== "https:" && !(url.protocol === "http:" && local)) {
-    return defaultNpmRegistryUrl;
-  }
-
-  const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
-  return `${url.origin}${path}`;
+    const raw = env.LOOPOVER_NPM_REGISTRY_URL?.trim();
+    if (!raw)
+        return defaultNpmRegistryUrl;
+    let url;
+    try {
+        url = new URL(raw);
+    }
+    catch {
+        return defaultNpmRegistryUrl;
+    }
+    if (url.username || url.password || url.search || url.hash || !url.hostname) {
+        return defaultNpmRegistryUrl;
+    }
+    const local = isLocalRegistryHost(url.hostname);
+    if (url.protocol !== "https:" && !(url.protocol === "http:" && local)) {
+        return defaultNpmRegistryUrl;
+    }
+    const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+    return `${url.origin}${path}`;
 }
-
 export function resolveUpgradeCommand(packageName = defaultPackageName) {
-  return `npm install -g ${packageName}@latest`;
+    return `npm install -g ${packageName}@latest`;
 }
-
 export function shouldSkipUpdateCheck(cliArgs, env = process.env) {
-  if (/^(1|true|yes)$/i.test(env.LOOPOVER_MINER_NO_UPDATE_CHECK ?? ""))
-    return true;
-  return cliArgs.includes("--no-update-check");
+    if (/^(1|true|yes)$/i.test(env.LOOPOVER_MINER_NO_UPDATE_CHECK ?? ""))
+        return true;
+    return cliArgs.includes("--no-update-check");
 }
-
 function parseSemver(version) {
-  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(
-    String(version ?? "").trim(),
-  );
-  if (!match) return null;
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-    prerelease: match[4] ?? null,
-  };
+    const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(String(version ?? "").trim());
+    if (!match)
+        return null;
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+        prerelease: match[4] ?? null,
+    };
 }
-
 // Numeric identifiers are compared as decimal strings, not via Number(), which loses precision beyond
 // Number.MAX_SAFE_INTEGER (2^53-1): two distinct digit strings past that width can round to the SAME float,
 // making Number(leftId) !== Number(rightId) wrongly report them as equal (mirrors the same fix already applied
@@ -65,97 +54,105 @@ function parseSemver(version) {
 // (semver's own numeric-identifier rule), a longer digit string is the larger number, and equal-length strings
 // compare lexicographically.
 function comparePrerelease(a, b) {
-  const left = a.split(".");
-  const right = b.split(".");
-  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
-    const leftId = left[index];
-    const rightId = right[index];
-    if (leftId === undefined) return -1;
-    if (rightId === undefined) return 1;
-    const leftNumeric = /^\d+$/.test(leftId);
-    const rightNumeric = /^\d+$/.test(rightId);
-    if (leftNumeric && rightNumeric) {
-      if (leftId.length !== rightId.length) return leftId.length < rightId.length ? -1 : 1;
-      if (leftId !== rightId) return leftId < rightId ? -1 : 1;
-    } else if (leftNumeric !== rightNumeric) {
-      return leftNumeric ? -1 : 1;
-    } else if (leftId !== rightId) {
-      return leftId < rightId ? -1 : 1;
+    const left = a.split(".");
+    const right = b.split(".");
+    for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+        const leftId = left[index];
+        const rightId = right[index];
+        if (leftId === undefined)
+            return -1;
+        if (rightId === undefined)
+            return 1;
+        const leftNumeric = /^\d+$/.test(leftId);
+        const rightNumeric = /^\d+$/.test(rightId);
+        if (leftNumeric && rightNumeric) {
+            if (leftId.length !== rightId.length)
+                return leftId.length < rightId.length ? -1 : 1;
+            if (leftId !== rightId)
+                return leftId < rightId ? -1 : 1;
+        }
+        else if (leftNumeric !== rightNumeric) {
+            return leftNumeric ? -1 : 1;
+        }
+        else if (leftId !== rightId) {
+            return leftId < rightId ? -1 : 1;
+        }
     }
-  }
-  return 0;
+    return 0;
 }
-
 export function compareSemver(a, b) {
-  const left = parseSemver(a);
-  const right = parseSemver(b);
-  if (!left || !right) return null;
-  for (const part of ["major", "minor", "patch"]) {
-    if (left[part] !== right[part]) return left[part] < right[part] ? -1 : 1;
-  }
-  if (left.prerelease === right.prerelease) return 0;
-  if (left.prerelease === null) return 1;
-  if (right.prerelease === null) return -1;
-  return comparePrerelease(left.prerelease, right.prerelease);
+    const left = parseSemver(a);
+    const right = parseSemver(b);
+    if (!left || !right)
+        return null;
+    for (const part of ["major", "minor", "patch"]) {
+        if (left[part] !== right[part])
+            return left[part] < right[part] ? -1 : 1;
+    }
+    if (left.prerelease === right.prerelease)
+        return 0;
+    if (left.prerelease === null)
+        return 1;
+    if (right.prerelease === null)
+        return -1;
+    return comparePrerelease(left.prerelease, right.prerelease);
 }
-
 export async function fetchLatestPackageVersion(input) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), input.timeoutMs ?? 5000);
-  const registrySlug = input.packageName.startsWith("@")
-    ? input.packageName.replace("/", "%2F")
-    : input.packageName;
-  const registryPath = `${input.npmRegistryUrl}/${registrySlug}/latest`;
-  try {
-    const response = await fetch(registryPath, {
-      signal: controller.signal,
-      headers: { accept: "application/json" },
-    });
-    const payload = await response.json().catch(() => ({}));
-    if (!response.ok || typeof payload.version !== "string")
-      throw new Error("npm_latest_version_unavailable");
-    return payload.version;
-  } finally {
-    clearTimeout(timeout);
-  }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), input.timeoutMs ?? 5000);
+    const registrySlug = input.packageName.startsWith("@")
+        ? input.packageName.replace("/", "%2F")
+        : input.packageName;
+    const registryPath = `${input.npmRegistryUrl}/${registrySlug}/latest`;
+    try {
+        const response = await fetch(registryPath, {
+            signal: controller.signal,
+            headers: { accept: "application/json" },
+        });
+        const payload = await response.json().catch(() => ({}));
+        const version = payload && typeof payload === "object" && "version" in payload
+            ? payload.version
+            : undefined;
+        if (!response.ok || typeof version !== "string")
+            throw new Error("npm_latest_version_unavailable");
+        return version;
+    }
+    finally {
+        clearTimeout(timeout);
+    }
 }
-
 // Non-blocking startup nudge: prints one upgrade line when local is behind npm latest.
 // Mirrors packages/loopover-mcp/bin/loopover-mcp.js packageVersion/npmRegistryUrl/upgradeCommand (#2331).
 export async function maybePrintUpdateNudge(input) {
-  try {
-    const latestVersion = await fetchLatestPackageVersion(input);
-    const comparison = compareSemver(input.packageVersion, latestVersion);
-    if (comparison !== null && comparison < 0) {
-      process.stderr.write(`${input.upgradeCommand}\n`);
+    try {
+        const latestVersion = await fetchLatestPackageVersion(input);
+        const comparison = compareSemver(input.packageVersion, latestVersion);
+        if (comparison !== null && comparison < 0) {
+            process.stderr.write(`${input.upgradeCommand}\n`);
+        }
     }
-  } catch {
-    // Offline or unreachable registry — never block or fail the CLI.
-  }
+    catch {
+        // Offline or unreachable registry — never block or fail the CLI.
+    }
 }
-
 export function startUpdateCheck(cliArgs, input) {
-  if (shouldSkipUpdateCheck(cliArgs, input.env)) return Promise.resolve();
-  return maybePrintUpdateNudge({
-    packageName: input.packageName,
-    packageVersion: input.packageVersion,
-    npmRegistryUrl: resolveNpmRegistryUrl(input.env),
-    upgradeCommand:
-      input.upgradeCommand ?? resolveUpgradeCommand(input.packageName),
-    timeoutMs: input.timeoutMs,
-  });
+    if (shouldSkipUpdateCheck(cliArgs, input.env))
+        return Promise.resolve();
+    return maybePrintUpdateNudge({
+        packageName: input.packageName,
+        packageVersion: input.packageVersion,
+        npmRegistryUrl: resolveNpmRegistryUrl(input.env),
+        upgradeCommand: input.upgradeCommand ?? resolveUpgradeCommand(input.packageName),
+        ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+    });
 }
-
 export const updateCheckExitGraceMs = 250;
-
 // After command output is printed, give a fast registry response time to emit the nudge
 // without waiting for the full lookup timeout on slow/offline registries.
-export async function awaitOpportunisticUpdateCheck(
-  updateCheck,
-  graceMs = updateCheckExitGraceMs,
-) {
-  await Promise.race([
-    updateCheck.catch(() => undefined),
-    new Promise((resolve) => setTimeout(resolve, graceMs)),
-  ]);
+export async function awaitOpportunisticUpdateCheck(updateCheck, graceMs = updateCheckExitGraceMs) {
+    await Promise.race([
+        updateCheck.catch(() => undefined),
+        new Promise((resolve) => setTimeout(resolve, graceMs)),
+    ]);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidXBkYXRlLWNoZWNrLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsidXBkYXRlLWNoZWNrLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE1BQU0sa0JBQWtCLEdBQUcsaUJBQWlCLENBQUM7QUFDN0MsTUFBTSxxQkFBcUIsR0FBRyw0QkFBNEIsQ0FBQztBQVMzRCxTQUFTLG1CQUFtQixDQUFDLFFBQWdCO0lBQzNDLE1BQU0sVUFBVSxHQUFHLFFBQVEsQ0FBQyxXQUFXLEVBQUUsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxDQUFDO0lBQzdELE9BQU8sQ0FDTCxVQUFVLEtBQUssV0FBVztRQUMxQixVQUFVLEtBQUssV0FBVztRQUMxQixVQUFVLEtBQUssS0FBSztRQUNwQixVQUFVLEtBQUssT0FBTyxDQUN2QixDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBRztJQUN6RixNQUFNLEdBQUcsR0FBRyxHQUFHLENBQUMseUJBQXlCLEVBQUUsSUFBSSxFQUFFLENBQUM7SUFDbEQsSUFBSSxDQUFDLEdBQUc7UUFBRSxPQUFPLHFCQUFxQixDQUFDO0lBRXZDLElBQUksR0FBUSxDQUFDO0lBQ2IsSUFBSSxDQUFDO1FBQ0gsR0FBRyxHQUFHLElBQUksR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3JCLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxPQUFPLHFCQUFxQixDQUFDO0lBQy9CLENBQUM7SUFFRCxJQUFJLEdBQUcsQ0FBQyxRQUFRLElBQUksR0FBRyxDQUFDLFFBQVEsSUFBSSxHQUFHLENBQUMsTUFBTSxJQUFJLEdBQUcsQ0FBQyxJQUFJLElBQUksQ0FBQyxHQUFHLENBQUMsUUFBUSxFQUFFLENBQUM7UUFDNUUsT0FBTyxxQkFBcUIsQ0FBQztJQUMvQixDQUFDO0lBRUQsTUFBTSxLQUFLLEdBQUcsbUJBQW1CLENBQUMsR0FBRyxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQ2hELElBQUksR0FBRyxDQUFDLFFBQVEsS0FBSyxRQUFRLElBQUksQ0FBQyxDQUFDLEdBQUcsQ0FBQyxRQUFRLEtBQUssT0FBTyxJQUFJLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDdEUsT0FBTyxxQkFBcUIsQ0FBQztJQUMvQixDQUFDO0lBRUQsTUFBTSxJQUFJLEdBQUcsR0FBRyxDQUFDLFFBQVEsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxDQUFDO0lBQzFFLE9BQU8sR0FBRyxHQUFHLENBQUMsTUFBTSxHQUFHLElBQUksRUFBRSxDQUFDO0FBQ2hDLENBQUM7QUFFRCxNQUFNLFVBQVUscUJBQXFCLENBQUMsY0FBc0Isa0JBQWtCO0lBQzVFLE9BQU8sa0JBQWtCLFdBQVcsU0FBUyxDQUFDO0FBQ2hELENBQUM7QUFFRCxNQUFNLFVBQVUscUJBQXFCLENBQ25DLE9BQWlCLEVBQ2pCLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBRXJELElBQUksaUJBQWlCLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyw4QkFBOEIsSUFBSSxFQUFFLENBQUM7UUFDbEUsT0FBTyxJQUFJLENBQUM7SUFDZCxPQUFPLE9BQU8sQ0FBQyxRQUFRLENBQUMsbUJBQW1CLENBQUMsQ0FBQztBQUMvQyxDQUFDO0FBRUQsU0FBUyxXQUFXLENBQUMsT0FBZ0I7SUFDbkMsTUFBTSxLQUFLLEdBQUcsOENBQThDLENBQUMsSUFBSSxDQUMvRCxNQUFNLENBQUMsT0FBTyxJQUFJLEVBQUUsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUM3QixDQUFDO0lBQ0YsSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN4QixPQUFPO1FBQ0wsS0FBSyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDdkIsS0FBSyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDdkIsS0FBSyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDdkIsVUFBVSxFQUFFLEtBQUssQ0FBQyxDQUFDLENBQUMsSUFBSSxJQUFJO0tBQzdCLENBQUM7QUFDSixDQUFDO0FBRUQsc0dBQXNHO0FBQ3RHLDRHQUE0RztBQUM1RywrR0FBK0c7QUFDL0csOEdBQThHO0FBQzlHLCtHQUErRztBQUMvRyw2QkFBNkI7QUFDN0IsU0FBUyxpQkFBaUIsQ0FBQyxDQUFTLEVBQUUsQ0FBUztJQUM3QyxNQUFNLElBQUksR0FBRyxDQUFDLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQzFCLE1BQU0sS0FBSyxHQUFHLENBQUMsQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDM0IsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTSxDQUFDLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQzVFLE1BQU0sTUFBTSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMzQixNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDN0IsSUFBSSxNQUFNLEtBQUssU0FBUztZQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDcEMsSUFBSSxPQUFPLEtBQUssU0FBUztZQUFFLE9BQU8sQ0FBQyxDQUFDO1FBQ3BDLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUM7UUFDekMsTUFBTSxZQUFZLEdBQUcsT0FBTyxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUMzQyxJQUFJLFdBQVcsSUFBSSxZQUFZLEVBQUUsQ0FBQztZQUNoQyxJQUFJLE1BQU0sQ0FBQyxNQUFNLEtBQUssT0FBTyxDQUFDLE1BQU07Z0JBQUUsT0FBTyxNQUFNLENBQUMsTUFBTSxHQUFHLE9BQU8sQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDckYsSUFBSSxNQUFNLEtBQUssT0FBTztnQkFBRSxPQUFPLE1BQU0sR0FBRyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDM0QsQ0FBQzthQUFNLElBQUksV0FBVyxLQUFLLFlBQVksRUFBRSxDQUFDO1lBQ3hDLE9BQU8sV0FBVyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzlCLENBQUM7YUFBTSxJQUFJLE1BQU0sS0FBSyxPQUFPLEVBQUUsQ0FBQztZQUM5QixPQUFPLE1BQU0sR0FBRyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDbkMsQ0FBQztJQUNILENBQUM7SUFDRCxPQUFPLENBQUMsQ0FBQztBQUNYLENBQUM7QUFFRCxNQUFNLFVBQVUsYUFBYSxDQUFDLENBQVMsRUFBRSxDQUFTO0lBQ2hELE1BQU0sSUFBSSxHQUFHLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUM1QixNQUFNLEtBQUssR0FBRyxXQUFXLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDN0IsSUFBSSxDQUFDLElBQUksSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLElBQUksQ0FBQztJQUNqQyxLQUFLLE1BQU0sSUFBSSxJQUFJLENBQUMsT0FBTyxFQUFFLE9BQU8sRUFBRSxPQUFPLENBQVUsRUFBRSxDQUFDO1FBQ3hELElBQUksSUFBSSxDQUFDLElBQUksQ0FBQyxLQUFLLEtBQUssQ0FBQyxJQUFJLENBQUM7WUFBRSxPQUFPLElBQUksQ0FBQyxJQUFJLENBQUMsR0FBRyxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDM0UsQ0FBQztJQUNELElBQUksSUFBSSxDQUFDLFVBQVUsS0FBSyxLQUFLLENBQUMsVUFBVTtRQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ25ELElBQUksSUFBSSxDQUFDLFVBQVUsS0FBSyxJQUFJO1FBQUUsT0FBTyxDQUFDLENBQUM7SUFDdkMsSUFBSSxLQUFLLENBQUMsVUFBVSxLQUFLLElBQUk7UUFBRSxPQUFPLENBQUMsQ0FBQyxDQUFDO0lBQ3pDLE9BQU8saUJBQWlCLENBQUMsSUFBSSxDQUFDLFVBQVUsRUFBRSxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUM7QUFDOUQsQ0FBQztBQUVELE1BQU0sQ0FBQyxLQUFLLFVBQVUseUJBQXlCLENBQUMsS0FJL0M7SUFDQyxNQUFNLFVBQVUsR0FBRyxJQUFJLGVBQWUsRUFBRSxDQUFDO0lBQ3pDLE1BQU0sT0FBTyxHQUFHLFVBQVUsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxVQUFVLENBQUMsS0FBSyxFQUFFLEVBQUUsS0FBSyxDQUFDLFNBQVMsSUFBSSxJQUFJLENBQUMsQ0FBQztJQUM5RSxNQUFNLFlBQVksR0FBRyxLQUFLLENBQUMsV0FBVyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7UUFDcEQsQ0FBQyxDQUFDLEtBQUssQ0FBQyxXQUFXLENBQUMsT0FBTyxDQUFDLEdBQUcsRUFBRSxLQUFLLENBQUM7UUFDdkMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxXQUFXLENBQUM7SUFDdEIsTUFBTSxZQUFZLEdBQUcsR0FBRyxLQUFLLENBQUMsY0FBYyxJQUFJLFlBQVksU0FBUyxDQUFDO0lBQ3RFLElBQUksQ0FBQztRQUNILE1BQU0sUUFBUSxHQUFHLE1BQU0sS0FBSyxDQUFDLFlBQVksRUFBRTtZQUN6QyxNQUFNLEVBQUUsVUFBVSxDQUFDLE1BQU07WUFDekIsT0FBTyxFQUFFLEVBQUUsTUFBTSxFQUFFLGtCQUFrQixFQUFFO1NBQ3hDLENBQUMsQ0FBQztRQUNILE1BQU0sT0FBTyxHQUFZLE1BQU0sUUFBUSxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDakUsTUFBTSxPQUFPLEdBQ1gsT0FBTyxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSSxTQUFTLElBQUksT0FBTztZQUM1RCxDQUFDLENBQUUsT0FBZ0MsQ0FBQyxPQUFPO1lBQzNDLENBQUMsQ0FBQyxTQUFTLENBQUM7UUFDaEIsSUFBSSxDQUFDLFFBQVEsQ0FBQyxFQUFFLElBQUksT0FBTyxPQUFPLEtBQUssUUFBUTtZQUM3QyxNQUFNLElBQUksS0FBSyxDQUFDLGdDQUFnQyxDQUFDLENBQUM7UUFDcEQsT0FBTyxPQUFPLENBQUM7SUFDakIsQ0FBQztZQUFTLENBQUM7UUFDVCxZQUFZLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDeEIsQ0FBQztBQUNILENBQUM7QUFFRCx1RkFBdUY7QUFDdkYsMEdBQTBHO0FBQzFHLE1BQU0sQ0FBQyxLQUFLLFVBQVUscUJBQXFCLENBQUMsS0FNM0M7SUFDQyxJQUFJLENBQUM7UUFDSCxNQUFNLGFBQWEsR0FBRyxNQUFNLHlCQUF5QixDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzdELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxLQUFLLENBQUMsY0FBYyxFQUFFLGFBQWEsQ0FBQyxDQUFDO1FBQ3RFLElBQUksVUFBVSxLQUFLLElBQUksSUFBSSxVQUFVLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsR0FBRyxLQUFLLENBQUMsY0FBYyxJQUFJLENBQUMsQ0FBQztRQUNwRCxDQUFDO0lBQ0gsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLGlFQUFpRTtJQUNuRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxnQkFBZ0IsQ0FDOUIsT0FBaUIsRUFDakIsS0FNQztJQUVELElBQUkscUJBQXFCLENBQUMsT0FBTyxFQUFFLEtBQUssQ0FBQyxHQUFHLENBQUM7UUFBRSxPQUFPLE9BQU8sQ0FBQyxPQUFPLEVBQUUsQ0FBQztJQUN4RSxPQUFPLHFCQUFxQixDQUFDO1FBQzNCLFdBQVcsRUFBRSxLQUFLLENBQUMsV0FBVztRQUM5QixjQUFjLEVBQUUsS0FBSyxDQUFDLGNBQWM7UUFDcEMsY0FBYyxFQUFFLHFCQUFxQixDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUM7UUFDaEQsY0FBYyxFQUNaLEtBQUssQ0FBQyxjQUFjLElBQUkscUJBQXFCLENBQUMsS0FBSyxDQUFDLFdBQVcsQ0FBQztRQUNsRSxHQUFHLENBQUMsS0FBSyxDQUFDLFNBQVMsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsU0FBUyxFQUFFLEtBQUssQ0FBQyxTQUFTLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0tBQ3pFLENBQUMsQ0FBQztBQUNMLENBQUM7QUFFRCxNQUFNLENBQUMsTUFBTSxzQkFBc0IsR0FBRyxHQUFHLENBQUM7QUFFMUMsd0ZBQXdGO0FBQ3hGLDBFQUEwRTtBQUMxRSxNQUFNLENBQUMsS0FBSyxVQUFVLDZCQUE2QixDQUNqRCxXQUEwQixFQUMxQixVQUFrQixzQkFBc0I7SUFFeEMsTUFBTSxPQUFPLENBQUMsSUFBSSxDQUFDO1FBQ2pCLFdBQVcsQ0FBQyxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUMsU0FBUyxDQUFDO1FBQ2xDLElBQUksT0FBTyxDQUFPLENBQUMsT0FBTyxFQUFFLEVBQUUsQ0FBQyxVQUFVLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxDQUFDO0tBQzdELENBQUMsQ0FBQztBQUNMLENBQUMifQ==

--- a/packages/loopover-miner/lib/update-check.ts
+++ b/packages/loopover-miner/lib/update-check.ts
@@ -1,0 +1,194 @@
+const defaultPackageName = "@loopover/miner";
+const defaultNpmRegistryUrl = "https://registry.npmjs.org";
+
+type SemverParts = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+};
+
+function isLocalRegistryHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
+export function resolveNpmRegistryUrl(env: Record<string, string | undefined> = process.env): string {
+  const raw = env.LOOPOVER_NPM_REGISTRY_URL?.trim();
+  if (!raw) return defaultNpmRegistryUrl;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return defaultNpmRegistryUrl;
+  }
+
+  if (url.username || url.password || url.search || url.hash || !url.hostname) {
+    return defaultNpmRegistryUrl;
+  }
+
+  const local = isLocalRegistryHost(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && local)) {
+    return defaultNpmRegistryUrl;
+  }
+
+  const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${path}`;
+}
+
+export function resolveUpgradeCommand(packageName: string = defaultPackageName): string {
+  return `npm install -g ${packageName}@latest`;
+}
+
+export function shouldSkipUpdateCheck(
+  cliArgs: string[],
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  if (/^(1|true|yes)$/i.test(env.LOOPOVER_MINER_NO_UPDATE_CHECK ?? ""))
+    return true;
+  return cliArgs.includes("--no-update-check");
+}
+
+function parseSemver(version: unknown): SemverParts | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(
+    String(version ?? "").trim(),
+  );
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  };
+}
+
+// Numeric identifiers are compared as decimal strings, not via Number(), which loses precision beyond
+// Number.MAX_SAFE_INTEGER (2^53-1): two distinct digit strings past that width can round to the SAME float,
+// making Number(leftId) !== Number(rightId) wrongly report them as equal (mirrors the same fix already applied
+// to compareMcpSemver's comparePrerelease in src/services/mcp-compatibility.ts, #3049). With no leading zeros
+// (semver's own numeric-identifier rule), a longer digit string is the larger number, and equal-length strings
+// compare lexicographically.
+function comparePrerelease(a: string, b: string): -1 | 0 | 1 {
+  const left = a.split(".");
+  const right = b.split(".");
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const leftId = left[index];
+    const rightId = right[index];
+    if (leftId === undefined) return -1;
+    if (rightId === undefined) return 1;
+    const leftNumeric = /^\d+$/.test(leftId);
+    const rightNumeric = /^\d+$/.test(rightId);
+    if (leftNumeric && rightNumeric) {
+      if (leftId.length !== rightId.length) return leftId.length < rightId.length ? -1 : 1;
+      if (leftId !== rightId) return leftId < rightId ? -1 : 1;
+    } else if (leftNumeric !== rightNumeric) {
+      return leftNumeric ? -1 : 1;
+    } else if (leftId !== rightId) {
+      return leftId < rightId ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+  const left = parseSemver(a);
+  const right = parseSemver(b);
+  if (!left || !right) return null;
+  for (const part of ["major", "minor", "patch"] as const) {
+    if (left[part] !== right[part]) return left[part] < right[part] ? -1 : 1;
+  }
+  if (left.prerelease === right.prerelease) return 0;
+  if (left.prerelease === null) return 1;
+  if (right.prerelease === null) return -1;
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+export async function fetchLatestPackageVersion(input: {
+  packageName: string;
+  npmRegistryUrl: string;
+  timeoutMs?: number;
+}): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.timeoutMs ?? 5000);
+  const registrySlug = input.packageName.startsWith("@")
+    ? input.packageName.replace("/", "%2F")
+    : input.packageName;
+  const registryPath = `${input.npmRegistryUrl}/${registrySlug}/latest`;
+  try {
+    const response = await fetch(registryPath, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    const payload: unknown = await response.json().catch(() => ({}));
+    const version =
+      payload && typeof payload === "object" && "version" in payload
+        ? (payload as { version: unknown }).version
+        : undefined;
+    if (!response.ok || typeof version !== "string")
+      throw new Error("npm_latest_version_unavailable");
+    return version;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// Non-blocking startup nudge: prints one upgrade line when local is behind npm latest.
+// Mirrors packages/loopover-mcp/bin/loopover-mcp.js packageVersion/npmRegistryUrl/upgradeCommand (#2331).
+export async function maybePrintUpdateNudge(input: {
+  packageName: string;
+  packageVersion: string;
+  npmRegistryUrl: string;
+  upgradeCommand: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  try {
+    const latestVersion = await fetchLatestPackageVersion(input);
+    const comparison = compareSemver(input.packageVersion, latestVersion);
+    if (comparison !== null && comparison < 0) {
+      process.stderr.write(`${input.upgradeCommand}\n`);
+    }
+  } catch {
+    // Offline or unreachable registry — never block or fail the CLI.
+  }
+}
+
+export function startUpdateCheck(
+  cliArgs: string[],
+  input: {
+    packageName: string;
+    packageVersion: string;
+    upgradeCommand?: string;
+    env?: Record<string, string | undefined>;
+    timeoutMs?: number;
+  },
+): Promise<void> {
+  if (shouldSkipUpdateCheck(cliArgs, input.env)) return Promise.resolve();
+  return maybePrintUpdateNudge({
+    packageName: input.packageName,
+    packageVersion: input.packageVersion,
+    npmRegistryUrl: resolveNpmRegistryUrl(input.env),
+    upgradeCommand:
+      input.upgradeCommand ?? resolveUpgradeCommand(input.packageName),
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+  });
+}
+
+export const updateCheckExitGraceMs = 250;
+
+// After command output is printed, give a fast registry response time to emit the nudge
+// without waiting for the full lookup timeout on slow/offline registries.
+export async function awaitOpportunisticUpdateCheck(
+  updateCheck: Promise<void>,
+  graceMs: number = updateCheckExitGraceMs,
+): Promise<void> {
+  await Promise.race([
+    updateCheck.catch(() => undefined),
+    new Promise<void>((resolve) => setTimeout(resolve, graceMs)),
+  ]);
+}


### PR DESCRIPTION
Closes #7301

## Summary
- Converts 8 leaf-most, lowest-fan-in `packages/loopover-miner/lib` modules from plain `.js` to real, compiler-verified TypeScript: `deployment-docs-audit`, `chat-discover-attempt-actions`, `update-check`, `init-wizard`, `deny-hook-synthesis`, `calibration-run`, `manage-poll`, `orb-export`.
- Follows the in-place-emit pattern the Phase 1 build pipeline (#7299) already wired up (`lib/foo.ts` compiles to `lib/foo.js` next to it; no import-path changes for any consumer).
- Each file's previously hand-maintained `.d.ts` sibling is now `tsc`-generated instead of hand-written.
- No behavior change.

## Scope checklist
- [x] Only touches the 8 files listed in #7301 (plus their generated `.js`/`.d.ts` output)
- [x] No `tsconfig.json` changes needed (existing `include` glob picks up new `.ts` files automatically)
- [x] No import path changes required anywhere in the workspace

## Validation checklist
- [x] `npx tsc -p packages/loopover-miner/tsconfig.json` passes clean; `node --check` on all 8 compiled outputs
- [x] Existing module tests: deployment-docs-audit, chat-discover-attempt-actions, calibration-run, manage-poll, orb-export, miner-cli (update-check), wire-cli-modules
- [x] init-wizard / deny-hook-synthesis path-separator and Windows mode assertions fail locally on win32 only (`path.join` / `0o600`); Linux CI is the gate

## Safety checklist
- [x] No secrets, tokens, wallets, hotkeys/coldkeys, trust scores, or reward/payout values touched
- [x] No changes to `site/`, `CNAME`, or `**/lovable/**`

Made with [Cursor](https://cursor.com)