### PR TITLE
test: verify engine exclusion from scoped path (temporary, will be closed)

### DIFF
--- a/packages/loopover-engine/src/miner/deny-hooks.ts
+++ b/packages/loopover-engine/src/miner/deny-hooks.ts
@@ -181,3 +181,4 @@ export function evaluateDenyHooks(toolCall: ProposedToolCall, rules: DenyRule[] 
   }
   return { allowed: true };
 }
+// engine-exclusion-live-verification-temporary


### PR DESCRIPTION
Temporary verification-only PR to confirm an engine-only diff still triggers the full unscoped suite, not the scoped fast path. Will be closed and the branch deleted once confirmed — not intended to merge.