### PR TITLE
ci: scope validate-tests to changed files for miner/mcp/discoveryIndex-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,21 @@ jobs:
           # `minerTestHarness` filter comments in the `changes` job above for the full rationale.
           SKIP_MCP_CLI_HARNESS: ${{ github.event_name == 'pull_request' && needs.changes.outputs.mcpCliHarness != 'true' }}
           SKIP_MINER_TEST_HARNESS: ${{ github.event_name == 'pull_request' && needs.changes.outputs.minerTestHarness != 'true' }}
+          # Scoped test selection (#ci-scoped-test-selection): a PR confined to miner/mcp/discoveryIndex --
+          # none of backend/rees/engine -- runs vitest's own --changed against origin/main instead of the
+          # full ~2,900-test suite, since the same 6-shard fan-out this job exists for (see header comment)
+          # is otherwise massive overkill for a diff touching one file. engine is deliberately EXCLUDED from
+          # this fast path: it's the one package other code imports through a built, gitignored dist/ that
+          # --changed's import-graph analysis can't safely trace across a node_modules/package.json-exports
+          # boundary -- verified by reproducing a real missed regression (editing packages/loopover-engine/
+          # src/ directly, --changed failed to select the miner-side wrapper-integration tests that actually
+          # exercise it). miner/mcp/discoveryIndex don't have that exposure: nothing else in the repo imports
+          # them as libraries, so their tests are reached via direct same-package imports, verified to trace
+          # correctly. Every push to main still runs the full unscoped suite unconditionally (this job's own
+          # top-level `if:` above is unchanged), so a scoped miss is caught within minutes of merge, not
+          # never. Kill switch: set the repo variable SCOPED_TEST_SELECTION_ENABLED to "false" to force the
+          # full suite for every PR (e.g. if a gap is ever found) without a revert PR.
+          SCOPED_TEST_SELECTION: ${{ github.event_name == 'pull_request' && vars.SCOPED_TEST_SELECTION_ENABLED != 'false' && needs.changes.outputs.backend != 'true' && needs.changes.outputs.rees != 'true' && needs.changes.outputs.engine != 'true' && (needs.changes.outputs.miner == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.discoveryIndex == 'true') }}
         run: |
           EXCLUDE_ARGS=()
           if [ "$SKIP_MCP_CLI_HARNESS" = "true" ]; then
@@ -673,7 +688,20 @@ jobs:
               --exclude "test/unit/miner-calibration-types.test.ts"
             )
           fi
-          npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/6 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}"
+          SCOPE_ARGS=()
+          if [ "$SCOPED_TEST_SELECTION" = "true" ]; then
+            echo "Scoped test selection: PR confined to miner/mcp/discoveryIndex -- running vitest --changed=origin/main instead of the full suite."
+            # This job's checkout already uses fetch-depth: 0 (full history, for Codecov's merge-base
+            # resolution), which should make origin/main resolvable already -- fetch it explicitly anyway
+            # as a cheap, idempotent guarantee rather than relying on that as an assumption.
+            git fetch --depth=1 origin main
+            # --coverage.all=false: without it, v8's default "report every coverage.include-matched file
+            # at 0% even if untouched by this run" would make this shard's upload claim the rest of the
+            # ~2,900-file suite is 0% covered, polluting Codecov's project trend on every scoped PR. Real
+            # coverage for files actually exercised is unaffected either way.
+            SCOPE_ARGS+=(--changed=origin/main --coverage.all=false)
+          fi
+          npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/6 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}" "${SCOPE_ARGS[@]}"
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |


### PR DESCRIPTION
## Summary

`validate-tests` currently runs vitest's entire ~2,900-test suite, sharded 6 ways (~5–6 min, ~1,800 runner-seconds), for *any* PR that touches `packages/loopover-miner`, `-mcp`, `-engine`, or `discovery-index` — including the narrow, single-file TS-migration diffs that are the dominant PR shape right now.

For a PR confined to `miner`/`mcp`/`discoveryIndex` (none of `backend`/`rees`/`engine`), each of the same 6 `validate-tests` shards now runs `vitest run --changed=origin/main --coverage.all=false` instead of the full-suite invocation. Same job count, same 6 Codecov uploads — `codecov.yml`'s `after_n_builds: 6` gate is unaffected.

**`engine` is deliberately excluded, always full suite.** It's the one package other code imports through a built, gitignored `dist/` that `--changed`'s import-graph analysis can't safely trace across a `node_modules`/`package.json`-exports boundary — verified by reproducing a real missed regression (editing `packages/loopover-engine/src/miner/deny-hooks.ts` directly, `--changed` failed to select the miner-side wrapper-integration tests that actually exercise it). `miner`/`mcp`/`discoveryIndex` don't have that exposure: nothing else in the repo imports them as libraries, so their tests are reached via direct same-package imports — verified to trace correctly.

**`--coverage.all=false`** prevents v8's default "report every coverage.include-matched file at 0% even if untouched" from making every scoped PR's upload falsely claim the rest of the ~2,900-file suite is 0% covered, which would pollute Codecov's project trend.

**Safety:**
- Every `push` to `main` still runs the full unscoped suite unconditionally (unchanged) — a scoped miss is caught within minutes of merge, not never.
- Kill switch: setting the repo variable `SCOPED_TEST_SELECTION_ENABLED` to `false` forces the full suite for every PR without a revert.

**Verified in live GitHub Actions, not just locally** (two throwaway verification PRs, opened against this branch so the modified workflow was in effect, watched to completion, then closed):
- A real single-file `packages/loopover-miner/lib/http-retry.js` diff → the scoped path engaged (confirmed via the actual job log line), selected 21 relevant test files, each shard completed in ~2 min instead of ~5–6 min, and `codecov/patch`/`codecov/project` both posted normally.
- A real single-file `packages/loopover-engine/src/miner/deny-hooks.ts` diff → the exclusion held: no scoped-selection log line fired, 167 test files ran per shard, each shard took 3m45s–5m24s (matching pre-change full-suite timing), `codecov/patch`/`codecov/project` posted normally.

Config-only change to `.github/workflows/ci.yml`; no application source touched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-initiated CI infra/performance work, not tied to a single pre-filed contributor issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] Re-ran the two existing test files that reference the `validate-tests` job's structure (`test/unit/codecov-policy.test.ts`, `test/unit/ci-skip-draft-prs.test.ts`) — 13/13 pass, unaffected by this change.
- [x] Ran the exact modified shell logic locally end-to-end (both the scoped and full-suite branches, including the empty-array-expansion edge case under the same `bash --noprofile --norc -eo pipefail` invocation GitHub Actions uses) before ever pushing.
- [x] **Verified in live GitHub Actions** via two throwaway PRs (opened and closed within this session) — see Summary for the concrete results. This is the primary validation for a change like this; a purely local/simulated check would not have been sufficient given the stakes.
- [ ] `npm run test:coverage` (full local run) — not run in full; this change doesn't touch `src/**`, and the live-CI verification above is more directly relevant evidence than a local unsharded run would be.
- [ ] `npm run test:workers` / `build:mcp` / `ui:*` — not run; untouched by this change.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency change.

If any required check was skipped, explain why:

- This is a CI workflow change, not application source — the skipped local commands are all either irrelevant to what changed or superseded by the live-CI verification described above, which is stronger evidence for this specific kind of change than a local run would be.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed — N/A.
- [ ] UI changes use live API data or real empty/error/loading states — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no visible/UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- This is the first of a two-part plan (the second part, a phased Turborepo adoption for build/lint/typecheck caching, is scoped to intentionally *never* touch test orchestration — this repo already has a documented past incident where an isolated, un-wired test suite let a real regression ship undetected, which is exactly the failure mode this PR's design is built to avoid recreating).
- Touches `.github/workflows/**` (a guarded path), so — like the two prior CI PRs this session — it'll be held for manual owner review rather than auto-merged, which is expected here.
