### PR TITLE
feat(visual): capture hover/click/drag interactions as animated GIF evidence

### DIFF
--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -688,19 +688,23 @@ review:
 #     # SELF-HOST ONLY (no effect on the hosted service) and the heaviest capture mode here — up to 6 extra
 #     # renders per side, ~4s wall-clock per side measured in practice. Bool. Default: false (no scroll capture).
 #     gif: false
-#     # Specific elements to interact with (hover/click) and capture as animated evidence — for behavior a
-#     # static screenshot AND a scroll-through GIF can't show: a hover-triggered popover, a click-triggered
-#     # state change, a CSS transition. Rendered as its own "Interaction preview" section, one row per entry
-#     # (never multiplied by viewport/theme, unlike the static matrix above — an interaction is rarely
-#     # breakpoint- or theme-dependent). Empty/default ⇒ byte-identical to today, no interaction capture.
-#     # SELF-HOST ONLY (same gate as `gif` above) and capped at 5 configured / 3 actually captured per PR.
-#     # `drag` is deliberately not supported — see src/review/visual/shot.ts's captureInteractionFrames doc
-#     # comment for why.
+#     # Specific elements to interact with (hover/click/drag) and capture as animated evidence — for
+#     # behavior a static screenshot AND a scroll-through GIF can't show: a hover-triggered popover, a
+#     # click-triggered state change, a drag-and-drop reorder, a CSS transition. Rendered as its own
+#     # "Interaction preview" section, one row per entry (never multiplied by viewport/theme, unlike the
+#     # static matrix above — an interaction is rarely breakpoint- or theme-dependent). Empty/default ⇒
+#     # byte-identical to today, no interaction capture. SELF-HOST ONLY (same gate as `gif` above) and
+#     # capped at 5 configured / 3 actually captured per PR.
 #     interactions:
-#       - selector: ".blocks-table-row"  # CSS selector for the element to interact with. Required.
-#         action: hover                  # "hover" or "click". Required.
+#       - selector: ".blocks-table-row"  # CSS selector for the element to interact with (drag SOURCE for "drag"). Required.
+#         action: hover                  # "hover", "click", or "drag". Required.
 #         path: "/blocks"                # Route this interaction lives on. String or null. Default: "/".
 #         label: "Blocks table row hover" # PR-comment row caption. String or null. Default: the selector itself.
+#       - selector: ".kanban-card"       # A second entry showing the "drag" shape:
+#         action: drag
+#         drag_to: ".done-column"        # Drag DESTINATION selector. Required when action is "drag"; an entry
+#                                         #   missing it is dropped at parse time. Ignored for hover/click.
+#         label: "Reorder card into Done"
 #     # Config-as-code enable/disable for this repo, layered ON TOP OF (never a replacement for) the
 #     # LOOPOVER_REVIEW_SCREENSHOTS + per-repo cutover-allowlist env-var gate above (#4083). Bool or null.
 #     # Default: null (unset) ⇒ defers entirely to that env-var gate's own decision -- byte-identical to today.

--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -688,6 +688,19 @@ review:
 #     # SELF-HOST ONLY (no effect on the hosted service) and the heaviest capture mode here — up to 6 extra
 #     # renders per side, ~4s wall-clock per side measured in practice. Bool. Default: false (no scroll capture).
 #     gif: false
+#     # Specific elements to interact with (hover/click) and capture as animated evidence — for behavior a
+#     # static screenshot AND a scroll-through GIF can't show: a hover-triggered popover, a click-triggered
+#     # state change, a CSS transition. Rendered as its own "Interaction preview" section, one row per entry
+#     # (never multiplied by viewport/theme, unlike the static matrix above — an interaction is rarely
+#     # breakpoint- or theme-dependent). Empty/default ⇒ byte-identical to today, no interaction capture.
+#     # SELF-HOST ONLY (same gate as `gif` above) and capped at 5 configured / 3 actually captured per PR.
+#     # `drag` is deliberately not supported — see src/review/visual/shot.ts's captureInteractionFrames doc
+#     # comment for why.
+#     interactions:
+#       - selector: ".blocks-table-row"  # CSS selector for the element to interact with. Required.
+#         action: hover                  # "hover" or "click". Required.
+#         path: "/blocks"                # Route this interaction lives on. String or null. Default: "/".
+#         label: "Blocks table row hover" # PR-comment row caption. String or null. Default: the selector itself.
 #     # Config-as-code enable/disable for this repo, layered ON TOP OF (never a replacement for) the
 #     # LOOPOVER_REVIEW_SCREENSHOTS + per-repo cutover-allowlist env-var gate above (#4083). Bool or null.
 #     # Default: null (unset) ⇒ defers entirely to that env-var gate's own decision -- byte-identical to today.

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -702,19 +702,23 @@ review:
 #     # SELF-HOST ONLY (no effect on the hosted service) and the heaviest capture mode here — up to 6 extra
 #     # renders per side, ~4s wall-clock per side measured in practice. Bool. Default: false (no scroll capture).
 #     gif: false
-#     # Specific elements to interact with (hover/click) and capture as animated evidence — for behavior a
-#     # static screenshot AND a scroll-through GIF can't show: a hover-triggered popover, a click-triggered
-#     # state change, a CSS transition. Rendered as its own "Interaction preview" section, one row per entry
-#     # (never multiplied by viewport/theme, unlike the static matrix above — an interaction is rarely
-#     # breakpoint- or theme-dependent). Empty/default ⇒ byte-identical to today, no interaction capture.
-#     # SELF-HOST ONLY (same gate as `gif` above) and capped at 5 configured / 3 actually captured per PR.
-#     # `drag` is deliberately not supported — see src/review/visual/shot.ts's captureInteractionFrames doc
-#     # comment for why.
+#     # Specific elements to interact with (hover/click/drag) and capture as animated evidence — for
+#     # behavior a static screenshot AND a scroll-through GIF can't show: a hover-triggered popover, a
+#     # click-triggered state change, a drag-and-drop reorder, a CSS transition. Rendered as its own
+#     # "Interaction preview" section, one row per entry (never multiplied by viewport/theme, unlike the
+#     # static matrix above — an interaction is rarely breakpoint- or theme-dependent). Empty/default ⇒
+#     # byte-identical to today, no interaction capture. SELF-HOST ONLY (same gate as `gif` above) and
+#     # capped at 5 configured / 3 actually captured per PR.
 #     interactions:
-#       - selector: ".blocks-table-row"  # CSS selector for the element to interact with. Required.
-#         action: hover                  # "hover" or "click". Required.
+#       - selector: ".blocks-table-row"  # CSS selector for the element to interact with (drag SOURCE for "drag"). Required.
+#         action: hover                  # "hover", "click", or "drag". Required.
 #         path: "/blocks"                # Route this interaction lives on. String or null. Default: "/".
 #         label: "Blocks table row hover" # PR-comment row caption. String or null. Default: the selector itself.
+#       - selector: ".kanban-card"       # A second entry showing the "drag" shape:
+#         action: drag
+#         drag_to: ".done-column"        # Drag DESTINATION selector. Required when action is "drag"; an entry
+#                                         #   missing it is dropped at parse time. Ignored for hover/click.
+#         label: "Reorder card into Done"
 #     # Config-as-code enable/disable for this repo, layered ON TOP OF (never a replacement for) the
 #     # LOOPOVER_REVIEW_SCREENSHOTS + per-repo cutover-allowlist env-var gate above (#4083). Bool or null.
 #     # Default: null (unset) ⇒ defers entirely to that env-var gate's own decision -- byte-identical to today.

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -702,6 +702,19 @@ review:
 #     # SELF-HOST ONLY (no effect on the hosted service) and the heaviest capture mode here — up to 6 extra
 #     # renders per side, ~4s wall-clock per side measured in practice. Bool. Default: false (no scroll capture).
 #     gif: false
+#     # Specific elements to interact with (hover/click) and capture as animated evidence — for behavior a
+#     # static screenshot AND a scroll-through GIF can't show: a hover-triggered popover, a click-triggered
+#     # state change, a CSS transition. Rendered as its own "Interaction preview" section, one row per entry
+#     # (never multiplied by viewport/theme, unlike the static matrix above — an interaction is rarely
+#     # breakpoint- or theme-dependent). Empty/default ⇒ byte-identical to today, no interaction capture.
+#     # SELF-HOST ONLY (same gate as `gif` above) and capped at 5 configured / 3 actually captured per PR.
+#     # `drag` is deliberately not supported — see src/review/visual/shot.ts's captureInteractionFrames doc
+#     # comment for why.
+#     interactions:
+#       - selector: ".blocks-table-row"  # CSS selector for the element to interact with. Required.
+#         action: hover                  # "hover" or "click". Required.
+#         path: "/blocks"                # Route this interaction lives on. String or null. Default: "/".
+#         label: "Blocks table row hover" # PR-comment row caption. String or null. Default: the selector itself.
 #     # Config-as-code enable/disable for this repo, layered ON TOP OF (never a replacement for) the
 #     # LOOPOVER_REVIEW_SCREENSHOTS + per-repo cutover-allowlist env-var gate above (#4083). Bool or null.
 #     # Default: null (unset) ⇒ defers entirely to that env-var gate's own decision -- byte-identical to today.

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -3660,6 +3660,15 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
     if (review.visual.themeStorageKey !== null) visual.theme_storage_key = review.visual.themeStorageKey;
     if (review.visual.actionsFallback) visual.actions_fallback = true;
     if (review.visual.bugAnalysis) visual.bug_analysis = true;
+    if (review.visual.interactions.length > 0) {
+      visual.interactions = review.visual.interactions.map((interaction) => {
+        const entry: Record<string, JsonValue> = { selector: interaction.selector, action: interaction.action };
+        if (interaction.dragTo !== null) entry.drag_to = interaction.dragTo;
+        if (interaction.path !== null) entry.path = interaction.path;
+        if (interaction.label !== null) entry.label = interaction.label;
+        return entry;
+      });
+    }
     out.visual = visual;
   }
   if (review.linkedIssueSatisfaction !== null) out.linkedIssueSatisfaction = review.linkedIssueSatisfaction;

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -1014,22 +1014,26 @@ export type VisualConfig = {
 export type VisualTheme = "light" | "dark";
 
 /** The interaction to perform on `selector` before capturing the "after" frames of a `VisualInteraction` —
- *  a hover-triggered popover or CSS transition (`hover`), or a click-triggered state change (`click`). Drag
- *  interactions are deliberately not supported yet — see `src/review/visual/shot.ts`'s
- *  `captureInteractionFrames` doc comment for why. */
-export type VisualInteractionAction = "hover" | "click";
+ *  a hover-triggered popover or CSS transition (`hover`), a click-triggered state change (`click`), or a
+ *  drag from `selector` onto `dragTo` (`drag`, e.g. a reorderable list/kanban card or a slider handle). */
+export type VisualInteractionAction = "hover" | "click" | "drag";
 
 /** One `review.visual.interactions[]` entry — a specific element to interact with and capture as animated
  *  evidence, for behavior a static screenshot can't show: a hover-triggered popover, a CSS transition, a
- *  click-triggered state change. Rendered as its own "Interaction preview" row (one per entry, not
+ *  click-triggered state change, or a drag. Rendered as its own "Interaction preview" row (one per entry, not
  *  multiplied by viewport/theme — mirrors the contributor-facing animated-evidence contract documented in
  *  e.g. metagraphed's SKILL.md), alongside (never replacing) the static before/after table. */
 export type VisualInteraction = {
-  /** CSS selector for the element to interact with. A selector that matches nothing on the captured page
-   *  yields no frames for that entry — fails open, never blocks capture of the rest of the PR. */
+  /** CSS selector for the element to interact with — the drag SOURCE when `action` is `drag`. A selector
+   *  that matches nothing on the captured page yields no frames for that entry — fails open, never blocks
+   *  capture of the rest of the PR. */
   selector: string;
-  /** The interaction to perform: `hover` (mouse over `selector`) or `click`. */
+  /** The interaction to perform: `hover` (mouse over `selector`), `click`, or `drag` (requires `dragTo`). */
   action: VisualInteractionAction;
+  /** The drag DESTINATION selector — required when `action` is `drag` (an entry missing it is dropped at
+   *  parse time), ignored otherwise. Like `selector`, a selector matching nothing fails open (no frames for
+   *  that entry) rather than blocking capture of the rest of the PR. */
+  dragTo: string | null;
   /** The route path this interaction lives on. null (default) ⇒ "/" (the site root). */
   path: string | null;
   /** Human-readable name for the PR-comment row (e.g. "Blocks table row hover"). null (default) ⇒ the
@@ -3295,13 +3299,13 @@ function parseVisualConfig(value: JsonValue | undefined, warnings: string[]): Vi
   return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback, bugAnalysis, interactions };
 }
 
-const VISUAL_INTERACTION_ACTION_VALUES: readonly VisualInteractionAction[] = ["hover", "click"];
+const VISUAL_INTERACTION_ACTION_VALUES: readonly VisualInteractionAction[] = ["hover", "click", "drag"];
 // A hard cap so a hostile/huge manifest can't turn interaction capture into unbounded browser-render spend —
 // each entry is at least as expensive as a scroll-GIF capture (a full page render plus a settle wait).
 const MAX_VISUAL_INTERACTIONS = 5;
 
 /** Parse `review.visual.interactions` — specific elements to interact with and capture as animated evidence
- *  (hover/click), mirroring `parseReviewPreMergeChecks`'s "array of mappings" shape. A malformed/incomplete
+ *  (hover/click/drag), mirroring `parseReviewPreMergeChecks`'s "array of mappings" shape. A malformed/incomplete
  *  entry is dropped with a warning rather than failing the whole list, same as every other manifest array
  *  here — one bad entry never sinks the rest of a maintainer's config. */
 function parseVisualInteractions(value: JsonValue | undefined, warnings: string[]): VisualInteraction[] {
@@ -3328,12 +3332,17 @@ function parseVisualInteractions(value: JsonValue | undefined, warnings: string[
     }
     const rawAction = typeof e.action === "string" ? (e.action.trim().toLowerCase() as VisualInteractionAction) : undefined;
     if (!rawAction || !VISUAL_INTERACTION_ACTION_VALUES.includes(rawAction)) {
-      warnings.push(`Manifest "review.visual.interactions[${index}].action" must be "hover" or "click"; ignoring the entry.`);
+      warnings.push(`Manifest "review.visual.interactions[${index}].action" must be "hover", "click", or "drag"; ignoring the entry.`);
+      continue;
+    }
+    const dragTo = parsePublicSafeText(e.drag_to, `review.visual.interactions[${index}].drag_to`, warnings);
+    if (rawAction === "drag" && dragTo === null) {
+      warnings.push(`Manifest "review.visual.interactions[${index}].drag_to" is required when action is "drag"; ignoring the entry.`);
       continue;
     }
     const path = parsePublicSafeText(e.path, `review.visual.interactions[${index}].path`, warnings);
     const label = parsePublicSafeText(e.label, `review.visual.interactions[${index}].label`, warnings);
-    out.push({ selector, action: rawAction, path, label });
+    out.push({ selector, action: rawAction, dragTo, path, label });
   }
   return out;
 }

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -1004,10 +1004,38 @@ export type VisualConfig = {
    *  new issue for it). false (default, every existing manifest) ⇒ byte-identical to today: the original
    *  regression-only prompt, no PR context sent, no "unrelated" finding category ever produced. */
   bugAnalysis: boolean;
+  /** `review.visual.interactions`: specific elements to interact with and capture as animated evidence
+   *  (hover/click) — for behavior a static screenshot can't show that isn't scroll-linked (see `gif` above
+   *  for scroll-linked evidence). Empty (default) ⇒ byte-identical to today, no interaction capture. */
+  interactions: VisualInteraction[];
 };
 
 /** A `prefers-color-scheme` value the capture pipeline can emulate before rendering (#3678). */
 export type VisualTheme = "light" | "dark";
+
+/** The interaction to perform on `selector` before capturing the "after" frames of a `VisualInteraction` —
+ *  a hover-triggered popover or CSS transition (`hover`), or a click-triggered state change (`click`). Drag
+ *  interactions are deliberately not supported yet — see `src/review/visual/shot.ts`'s
+ *  `captureInteractionFrames` doc comment for why. */
+export type VisualInteractionAction = "hover" | "click";
+
+/** One `review.visual.interactions[]` entry — a specific element to interact with and capture as animated
+ *  evidence, for behavior a static screenshot can't show: a hover-triggered popover, a CSS transition, a
+ *  click-triggered state change. Rendered as its own "Interaction preview" row (one per entry, not
+ *  multiplied by viewport/theme — mirrors the contributor-facing animated-evidence contract documented in
+ *  e.g. metagraphed's SKILL.md), alongside (never replacing) the static before/after table. */
+export type VisualInteraction = {
+  /** CSS selector for the element to interact with. A selector that matches nothing on the captured page
+   *  yields no frames for that entry — fails open, never blocks capture of the rest of the PR. */
+  selector: string;
+  /** The interaction to perform: `hover` (mouse over `selector`) or `click`. */
+  action: VisualInteractionAction;
+  /** The route path this interaction lives on. null (default) ⇒ "/" (the site root). */
+  path: string | null;
+  /** Human-readable name for the PR-comment row (e.g. "Blocks table row hover"). null (default) ⇒ the
+   *  selector itself is shown. */
+  label: string | null;
+};
 
 export type VisualPreviewConfig = {
   /** `review.visual.preview.url_template`: the repo's "after" preview URL, with `{number}` (PR number),
@@ -1046,6 +1074,7 @@ export const EMPTY_VISUAL_CONFIG: VisualConfig = {
   themeStorageKey: null,
   actionsFallback: false,
   bugAnalysis: false,
+  interactions: [],
 };
 
 /** One `review.path_instructions[]` entry: a manifest path glob + the public-safe instructions to apply when a
@@ -2952,6 +2981,7 @@ function overlayVisualConfig(base: VisualConfig, override: VisualConfig): Visual
     themeStorageKey: pickOverlayNullable(override.themeStorageKey, base.themeStorageKey),
     actionsFallback: override.actionsFallback ? override.actionsFallback : base.actionsFallback,
     bugAnalysis: override.bugAnalysis ? override.bugAnalysis : base.bugAnalysis,
+    interactions: override.interactions.length > 0 ? [...override.interactions] : [...base.interactions],
   };
 }
 
@@ -3157,7 +3187,8 @@ function visualConfigPresent(config: VisualConfig): boolean {
     config.enabled !== null ||
     config.themeStorageKey !== null ||
     config.actionsFallback ||
-    config.bugAnalysis
+    config.bugAnalysis ||
+    config.interactions.length > 0
   );
 }
 
@@ -3259,8 +3290,52 @@ function parseVisualConfig(value: JsonValue | undefined, warnings: string[]): Vi
   const themeStorageKey = parsePublicSafeText(record.theme_storage_key, "review.visual.theme_storage_key", warnings);
   const actionsFallback = normalizeOptionalBoolean(record.actions_fallback, "review.visual.actions_fallback", warnings) === true;
   const bugAnalysis = normalizeOptionalBoolean(record.bug_analysis, "review.visual.bug_analysis", warnings) === true;
+  const interactions = parseVisualInteractions(record.interactions, warnings);
 
-  return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback, bugAnalysis };
+  return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback, bugAnalysis, interactions };
+}
+
+const VISUAL_INTERACTION_ACTION_VALUES: readonly VisualInteractionAction[] = ["hover", "click"];
+// A hard cap so a hostile/huge manifest can't turn interaction capture into unbounded browser-render spend —
+// each entry is at least as expensive as a scroll-GIF capture (a full page render plus a settle wait).
+const MAX_VISUAL_INTERACTIONS = 5;
+
+/** Parse `review.visual.interactions` — specific elements to interact with and capture as animated evidence
+ *  (hover/click), mirroring `parseReviewPreMergeChecks`'s "array of mappings" shape. A malformed/incomplete
+ *  entry is dropped with a warning rather than failing the whole list, same as every other manifest array
+ *  here — one bad entry never sinks the rest of a maintainer's config. */
+function parseVisualInteractions(value: JsonValue | undefined, warnings: string[]): VisualInteraction[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    warnings.push(`Manifest "review.visual.interactions" must be a list of interactions; ignoring it.`);
+    return [];
+  }
+  const out: VisualInteraction[] = [];
+  for (const [index, entry] of value.entries()) {
+    if (out.length >= MAX_VISUAL_INTERACTIONS) {
+      warnings.push(`Manifest "review.visual.interactions" is capped at ${MAX_VISUAL_INTERACTIONS} entries; dropping the rest.`);
+      break;
+    }
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      warnings.push(`Manifest "review.visual.interactions[${index}]" must be a mapping; ignoring it.`);
+      continue;
+    }
+    const e = entry as Record<string, JsonValue>;
+    const selector = parsePublicSafeText(e.selector, `review.visual.interactions[${index}].selector`, warnings);
+    if (selector === null) {
+      warnings.push(`Manifest "review.visual.interactions[${index}].selector" is required; ignoring the entry.`);
+      continue;
+    }
+    const rawAction = typeof e.action === "string" ? (e.action.trim().toLowerCase() as VisualInteractionAction) : undefined;
+    if (!rawAction || !VISUAL_INTERACTION_ACTION_VALUES.includes(rawAction)) {
+      warnings.push(`Manifest "review.visual.interactions[${index}].action" must be "hover" or "click"; ignoring the entry.`);
+      continue;
+    }
+    const path = parsePublicSafeText(e.path, `review.visual.interactions[${index}].path`, warnings);
+    const label = parsePublicSafeText(e.label, `review.visual.interactions[${index}].label`, warnings);
+    out.push({ selector, action: rawAction, path, label });
+  }
+  return out;
 }
 
 function parseAutoReviewTitleKeywords(value: JsonValue | undefined, warnings: string[]): string[] {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -448,7 +448,7 @@ export {
 // Nothing in this file calls processJob itself, so this is a pure re-export (no separate import needed).
 export { processJob } from "./job-dispatch";
 import { isVisualPath } from "../review/visual/paths";
-import { buildCapture, fetchExternalScreenshotContentBlock, fetchShotContentBlock, hasSuccessfulBotCapture, resolveVisualRoutes, type CaptureRoute } from "../review/visual/capture";
+import { buildCapture, fetchExternalScreenshotContentBlock, fetchShotContentBlock, hasSuccessfulBotCapture, resolveVisualRoutes, type CaptureInteractionRoute, type CaptureRoute } from "../review/visual/capture";
 import { MAX_PREVIEW_POLL_ATTEMPTS } from "../review/visual/preview-poll-budget";
 import {
   clearFallbackDispatchMarker,
@@ -10321,6 +10321,7 @@ async function maybePublishPrPublicSurface(
       // declared-outer/assigned-inner pattern. false (unresolved, or resolution never ran) ⇒ byte-identical
       // default-prompt behavior, same fail-safe direction as every other config-as-code read here.
       let bugAnalysisEnabled = false;
+      let interactionPreviews: CaptureInteractionRoute[] = [];
       const visualFiles = unifiedFiles
         .map((file) => file.path)
         .filter(isVisualPath);
@@ -10349,9 +10350,10 @@ async function maybePublishPrPublicSurface(
           // ordinary "nothing found" capture would, with no separate code path to maintain.
           const capture =
             reviewVisualConfig.enabled === false
-              ? { routes: [], previewPending: false }
+              ? { routes: [], interactions: [], previewPending: false }
               : await buildCapture(env, token, captureTarget, visualFiles, githubRateLimitAdmissionKeyForInstallation(installationId), reviewVisualConfig);
           beforeAfter = capture.routes;
+          interactionPreviews = capture.interactions;
           // Screenshot-table gate satisfaction (#4110): a successful capture (a real before+after render pair
           // on at least one route) is evidence equivalent to a hand-authored before/after table -- persist the
           // head SHA it was proven at so the LATER maintenance pass (runAgentMaintenancePlanAndExecute, which
@@ -10557,6 +10559,7 @@ async function maybePublishPrPublicSurface(
           ? { generateTestsLabel: `${PR_PANEL_GENERATE_TESTS_MARKER} **[BETA]** Generate an AI Playwright test for this PR` }
           : {}),
         ...(beforeAfter.length > 0 ? { beforeAfter } : {}),
+        ...(interactionPreviews.length > 0 ? { interactions: interactionPreviews } : {}),
         ...(changedFilesSummaryEnabledForReview
           ? {
               changedFilesSummary: unifiedFiles.map((file) => ({

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -23,7 +23,7 @@ import type { AdvisoryFinding } from "../types";
 import type { GateCheckConclusion, GateCheckEvaluation } from "../rules/advisory";
 import type { PublicPrPanelSignalRow } from "../signals/engine";
 import { formatManifestValidationNotice } from "../signals/focus-manifest";
-import type { CaptureRoute } from "./visual/capture";
+import type { CaptureInteractionRoute, CaptureRoute } from "./visual/capture";
 import { VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE } from "./visual/visual-findings";
 // Single-source the panel marker from its canonical home (the upsert reads it there); re-export so existing
 // importers of `PR_PANEL_COMMENT_MARKER` from this module keep working. The unified body MUST prepend this
@@ -356,6 +356,7 @@ export type UnifiedCommentBridgeArgs = {
    *  Public-safe: only URLs + route paths — no private terms. Default OFF (the processor passes this only
    *  when screenshotsAllowed + the PR touches web-visible files). */
   beforeAfter?: CaptureRoute[] | undefined;
+  interactions?: CaptureInteractionRoute[] | undefined;
   /** Changed-file path + additions/deletions, one entry per file (review.changed_files_summary port). When
    *  present + non-empty, a "Changed files" collapsible (one row per source/test/docs/config/generated
    *  category, with file counts and +/- totals) is appended. Deterministic, no AI. Default OFF (the processor
@@ -537,6 +538,41 @@ export function buildScrollPreviewCollapsible(routes: CaptureRoute[]): UnifiedCo
     "_A short scroll-through clip (desktop) — click either thumbnail to open the full animation. Evidence for scroll-linked behavior a single screenshot can't show._",
   ].join("\n");
   return { title: "Scroll preview", body, rawHtml: true };
+}
+
+/**
+ * Build the "Interaction preview" collapsible from captured hover/click interaction GIFs
+ * (`review.visual.interactions`) — rendered ALONGSIDE "Visual preview"/"Scroll preview", never replacing
+ * them, since a hover-triggered popover or click-driven state change isn't visible in a static screenshot
+ * OR a scroll-through clip. One row per configured interaction TARGET (not per viewport/theme — an
+ * interaction is rarely breakpoint- or theme-dependent, mirroring the contributor-facing animated-evidence
+ * contract's own "one row per interaction target" shape), captioned with the interaction's `label` when
+ * configured, falling back to its raw CSS `selector` otherwise. Self-host only (see capture.ts's
+ * `isScrollGifAvailable` gate) — off, byte-identical to today, for every repo that hasn't opted in. Same
+ * clickable-thumbnail markup and public-safety argument as `buildScrollPreviewCollapsible`. Returns null
+ * when no interaction produced a GIF, so the section is omitted entirely.
+ */
+export function buildInteractionPreviewCollapsible(interactions: CaptureInteractionRoute[]): UnifiedCollapsible | null {
+  const attr = (value: string): string =>
+    value.replace(/[&"<>]/g, (char) => ({ "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" })[char] as string);
+  // #6324: same visible one-line caption convention as buildBeforeAfterCollapsible/buildScrollPreviewCollapsible.
+  const cell = (url: string | undefined, label: string): string =>
+    url ? `<a href="${attr(url)}" target="_blank" rel="noopener"><img width="380" alt="${attr(label)}" src="${attr(url)}"></a><br><sub>${attr(label)}</sub>` : "—";
+  const rows: string[] = [];
+  for (const interaction of interactions) {
+    if (!interaction.beforeGifUrl && !interaction.afterGifUrl) continue;
+    const target = interaction.label && interaction.label.trim() ? interaction.label.trim() : interaction.selector;
+    rows.push(`| ${attr(target)} | ${cell(interaction.beforeGifUrl, `before ${target}`)} | ${cell(interaction.afterGifUrl, `after ${target}`)} |`);
+  }
+  if (rows.length === 0) return null;
+  const body = [
+    "| Target | Before | After |",
+    "| --- | --- | --- |",
+    ...rows,
+    "",
+    "_Static screenshots can't show pointer-driven behavior — click either thumbnail to open the full interaction clip._",
+  ].join("\n");
+  return { title: "Interaction preview", body, rawHtml: true };
 }
 
 /** A changed file's path + line deltas — everything `buildChangedFilesSummaryCollapsible` needs to group and
@@ -904,7 +940,12 @@ export function buildUnifiedCommentBody(args: UnifiedCommentBridgeArgs): string 
   // #3612: "Scroll preview" renders ALONGSIDE "Visual preview" (never replacing it) — self-host + gif:true
   // only, so this is null (no section, no behavior change) for every repo that hasn't opted in.
   const scrollCollapsible = args.beforeAfter && args.beforeAfter.length > 0 ? buildScrollPreviewCollapsible(args.beforeAfter) : null;
-  const extraCollapsibles = scrollCollapsible !== null ? [...(withVisual ?? []), scrollCollapsible] : withVisual;
+  const withScroll = scrollCollapsible !== null ? [...(withVisual ?? []), scrollCollapsible] : withVisual;
+  // #interaction-gif-capture: "Interaction preview" renders ALONGSIDE "Visual preview"/"Scroll preview"
+  // (never replacing them) — self-host + review.visual.interactions only, so this is null (no section, no
+  // behavior change) for every repo that hasn't opted in.
+  const interactionCollapsible = args.interactions && args.interactions.length > 0 ? buildInteractionPreviewCollapsible(args.interactions) : null;
+  const extraCollapsibles = interactionCollapsible !== null ? [...(withScroll ?? []), interactionCollapsible] : withScroll;
 
   const body = renderWithinBudget(
     input,

--- a/src/review/visual/capture.ts
+++ b/src/review/visual/capture.ts
@@ -523,8 +523,23 @@ async function captureInteractionGif(
 ): Promise<string | undefined> {
   if (!page) return undefined;
   if (!env.REVIEW_AUDIT || (!env.PUBLIC_API_ORIGIN && !env.REVIEW_AUDIT_S3_PUBLIC_URL)) return undefined;
+  // JSON.stringify an array (not bare `:`-joined interpolation, unlike captureScrollGif's fingerprint above,
+  // which has no arbitrary-text fields) -- selector/dragTo are maintainer-authored free text that can itself
+  // contain ":", so a bare-delimiter join can collide (`{selector:"x:drag", dragTo:"y"}` and
+  // `{selector:"x", dragTo:"drag:y"}` would otherwise both produce "...x:drag:drag:y..."). JSON's own string
+  // quoting makes each array element self-delimiting, so two distinct field tuples can never hash identically.
   const fingerprint = await sha256Hex(
-    `${target.headSha ?? target.prNumber}:interactiongif:${slot}:${interaction.selector}:${interaction.action}${interaction.action === "drag" && interaction.dragTo ? `:${interaction.dragTo}` : ""}:${page}${theme ? `:${theme}` : ""}${theme && themeStorageKey ? `:${themeStorageKey}` : ""}`,
+    JSON.stringify([
+      target.headSha ?? target.prNumber,
+      "interactiongif",
+      slot,
+      interaction.selector,
+      interaction.action,
+      interaction.action === "drag" ? (interaction.dragTo ?? null) : null,
+      page,
+      theme ?? null,
+      theme && themeStorageKey ? themeStorageKey : null,
+    ]),
   );
   const key = `${NAMESPACE}/shots/${fingerprint.slice(0, 40)}.gif`;
   const url = resolveShotUrl(env, key);
@@ -778,14 +793,27 @@ export async function buildCapture(env: Env, token: string, target: CaptureTarge
   // a GIF -- self-host only, same as the scroll-GIF path above.
   const interactionsConfigured = (visualConfig?.interactions ?? []).slice(0, MAX_INTERACTIONS);
   const interactionRoutes: CaptureInteractionRoute[] = [];
+  // Interactions aren't multiplied per-theme (see comment above) -- when review.visual.themes configures more
+  // than one, the first configured theme is what interaction GIFs render in; themes[0] is `undefined` by
+  // default (no theme config), matching every other un-emulated default capture in this file.
+  const interactionTheme = themes[0];
   if (interactionsConfigured.length > 0 && isScrollGifAvailable()) {
     for (const interaction of interactionsConfigured) {
       const interactionPath = interaction.path ?? "/";
-      const beforePage = prodBase ? joinUrl(prodBase, interactionPath) : "";
       const afterPage = previewBase ? joinUrl(previewBase, interactionPath) : "";
+      // SECURITY (#interaction-gif-capture): click/drag are real, state-mutating browser actions -- a genuine
+      // click event, or a real mouse-down/move/up drag sequence -- unlike hover, which can never trigger a
+      // click handler, form submit, or same-origin mutating request. Running click/drag against `prodBase`
+      // (the repo's PRODUCTION origin, see this function's own "before = production" comment above) would
+      // fire that real action against the LIVE SITE on every qualifying commit of every PR that touches a
+      // visual path, for as long as a maintainer has one configured -- the existing isSafeHttpUrl/
+      // isAllowedUrl SSRF guard only validates a URL is safe to NAVIGATE to, it has no concept of "this
+      // specific action is safe to perform" once there. hover never mutates state, so it's the only action
+      // still captured against production (real before/after comparison value); click/drag are preview-only.
+      const beforePage = interaction.action === "hover" && prodBase ? joinUrl(prodBase, interactionPath) : "";
       const [beforeGifUrl, afterGifUrl] = await Promise.all([
-        captureInteractionGif(env, target, beforePage, "before", interaction),
-        afterPage ? captureInteractionGif(env, target, afterPage, "after", interaction) : Promise.resolve<string | undefined>(undefined),
+        beforePage ? captureInteractionGif(env, target, beforePage, "before", interaction, interactionTheme, themeStorageKey) : Promise.resolve<string | undefined>(undefined),
+        afterPage ? captureInteractionGif(env, target, afterPage, "after", interaction, interactionTheme, themeStorageKey) : Promise.resolve<string | undefined>(undefined),
       ]);
       if (beforeGifUrl || afterGifUrl) {
         interactionRoutes.push({

--- a/src/review/visual/capture.ts
+++ b/src/review/visual/capture.ts
@@ -500,6 +500,8 @@ async function captureScrollGif(
 export type VisualInteractionInput = {
   selector: string;
   action: InteractionAction;
+  /** The drag destination selector — required when `action` is `"drag"`, ignored otherwise. */
+  dragTo?: string | null | undefined;
   path?: string | null | undefined;
   label?: string | null | undefined;
 };
@@ -522,7 +524,7 @@ async function captureInteractionGif(
   if (!page) return undefined;
   if (!env.REVIEW_AUDIT || (!env.PUBLIC_API_ORIGIN && !env.REVIEW_AUDIT_S3_PUBLIC_URL)) return undefined;
   const fingerprint = await sha256Hex(
-    `${target.headSha ?? target.prNumber}:interactiongif:${slot}:${interaction.selector}:${interaction.action}:${page}${theme ? `:${theme}` : ""}${theme && themeStorageKey ? `:${themeStorageKey}` : ""}`,
+    `${target.headSha ?? target.prNumber}:interactiongif:${slot}:${interaction.selector}:${interaction.action}${interaction.action === "drag" && interaction.dragTo ? `:${interaction.dragTo}` : ""}:${page}${theme ? `:${theme}` : ""}${theme && themeStorageKey ? `:${themeStorageKey}` : ""}`,
   );
   const key = `${NAMESPACE}/shots/${fingerprint.slice(0, 40)}.gif`;
   const url = resolveShotUrl(env, key);
@@ -535,6 +537,7 @@ async function captureInteractionGif(
     interaction.action,
     DESKTOP_VIEWPORT,
     theme ? { theme, ...(themeStorageKey ? { themeStorageKey } : {}) } : {},
+    interaction.dragTo ?? undefined,
   ).catch(() => ({ frames: [] as Uint8Array[], authWalled: false }));
   if (authWalled || frames.length === 0) return undefined;
   const gifBytes = await encodeScrollGif(

--- a/src/review/visual/capture.ts
+++ b/src/review/visual/capture.ts
@@ -28,7 +28,7 @@ import {
   getPreviewBuildState,
   parseRepo,
 } from "./preview-url";
-import { captureScrollFrames, captureShot, DESKTOP_VIEWPORT, MOBILE_VIEWPORT, type ShotTheme, type Viewport } from "./shot";
+import { captureInteractionFrames, captureScrollFrames, captureShot, DESKTOP_VIEWPORT, MOBILE_VIEWPORT, type InteractionAction, type ShotTheme, type Viewport } from "./shot";
 import { compareCapturedScreenshots, isVisualDiffAvailable, type VisualDiffOutcome } from "./pixel-diff";
 import { encodeScrollGif, isScrollGifAvailable } from "./scroll-gif";
 
@@ -75,9 +75,12 @@ export interface CaptureRoute {
   afterGifUrl?: string | undefined;
 }
 
-/** The capture pipeline's result: the rendered routes, plus whether a preview build is still pending. */
+/** The capture pipeline's result: the rendered routes, any captured interaction GIFs, plus whether a
+ *  preview build is still pending. `interactions` is always `[]` when `review.visual.interactions` is
+ *  unconfigured — byte-identical to today for every repo that hasn't opted in. */
 export interface CaptureResult {
   routes: CaptureRoute[];
+  interactions: CaptureInteractionRoute[];
   previewPending: boolean;
 }
 
@@ -493,6 +496,74 @@ async function captureScrollGif(
   return url;
 }
 
+/** One `review.visual.interactions[]` entry, as resolved by the caller from the manifest. */
+export type VisualInteractionInput = {
+  selector: string;
+  action: InteractionAction;
+  path?: string | null | undefined;
+  label?: string | null | undefined;
+};
+
+/** Capture `interaction` for `page` and assemble it into a GIF, or undefined when there's no page, the
+ *  selector never matches / the render fails/auth-walls, storage is unavailable, or this build can't
+ *  assemble GIFs at all (isScrollGifAvailable — reused here; the encode step is frame-source-agnostic, see
+ *  scroll-gif.ts). Same fingerprint-cache scheme as `captureScrollGif`, with the selector+action folded into
+ *  the key so two different interactions on the same page never collide.
+ */
+async function captureInteractionGif(
+  env: Env,
+  target: CaptureTarget,
+  page: string,
+  slot: "before" | "after",
+  interaction: VisualInteractionInput,
+  theme?: ShotTheme | undefined,
+  themeStorageKey?: string | undefined,
+): Promise<string | undefined> {
+  if (!page) return undefined;
+  if (!env.REVIEW_AUDIT || (!env.PUBLIC_API_ORIGIN && !env.REVIEW_AUDIT_S3_PUBLIC_URL)) return undefined;
+  const fingerprint = await sha256Hex(
+    `${target.headSha ?? target.prNumber}:interactiongif:${slot}:${interaction.selector}:${interaction.action}:${page}${theme ? `:${theme}` : ""}${theme && themeStorageKey ? `:${themeStorageKey}` : ""}`,
+  );
+  const key = `${NAMESPACE}/shots/${fingerprint.slice(0, 40)}.gif`;
+  const url = resolveShotUrl(env, key);
+  const cached = await env.REVIEW_AUDIT.get(key).catch(() => null);
+  if (cached) return url;
+  const { frames, authWalled } = await captureInteractionFrames(
+    env,
+    page,
+    interaction.selector,
+    interaction.action,
+    DESKTOP_VIEWPORT,
+    theme ? { theme, ...(themeStorageKey ? { themeStorageKey } : {}) } : {},
+  ).catch(() => ({ frames: [] as Uint8Array[], authWalled: false }));
+  if (authWalled || frames.length === 0) return undefined;
+  const gifBytes = await encodeScrollGif(
+    frames.map((png) => ({ png })),
+    GIF_FRAME_DELAY_MS,
+  );
+  if (!gifBytes) return undefined;
+  await env.REVIEW_AUDIT.put(key, gifBytes, { httpMetadata: { contentType: "image/gif" } }).catch(() => undefined);
+  return url;
+}
+
+/** One `review.visual.interactions[]` entry's captured result (#interaction-gif-capture) — before/after GIF
+ *  URLs for a specific hover/click interaction. Rendered as its own "Interaction preview" row, one per
+ *  configured interaction (never multiplied by viewport/theme, unlike `CaptureRoute`). `selector`/`label`
+ *  round-trip the input config so the comment can show a human-readable target without re-reading config. */
+export interface CaptureInteractionRoute {
+  selector: string;
+  label?: string | undefined;
+  beforeGifUrl?: string | undefined;
+  afterGifUrl?: string | undefined;
+}
+
+// Bounds how many configured interactions actually get captured per PR — mirrors MAX_ROUTES's wall-clock
+// reasoning (each interaction is at least as expensive as a scroll-GIF capture: a full render plus 3+ extra
+// frames per side). parseVisualInteractions (packages/loopover-engine) already caps the CONFIG list itself
+// at 5; this is a second, independent bound on what actually executes, so a future config-cap change can't
+// silently blow the capture budget without a matching review here.
+const MAX_INTERACTIONS = 3;
+
 /** Per-repo `review.visual` config, as resolved by the caller from the manifest (#3609 / #3610 / #3678 /
  *  #3612 / #4109). Absent ⇒ byte-identical to today (GitHub-native discovery, automatic route inference,
  *  single default-theme capture, built-in route cap, no scroll-GIF, no localStorage theme forcing). */
@@ -514,6 +585,11 @@ export type VisualCaptureConfig = {
   /** `review.visual.actions_fallback` (#4112): dispatch the GitHub-Actions build-and-serve fallback when NO
    *  preview at all was found for this PR. false/absent (default) ⇒ byte-identical to today. */
   actionsFallback?: boolean | null | undefined;
+  /** `review.visual.interactions`: specific elements to interact with (hover/click) and capture as animated
+   *  evidence, for behavior a static screenshot can't show that isn't scroll-linked. Empty/absent (default)
+   *  ⇒ byte-identical to today, no interaction capture. Capped at MAX_INTERACTIONS regardless of how many
+   *  are configured. */
+  interactions?: readonly VisualInteractionInput[] | null | undefined;
 };
 
 /**
@@ -690,5 +766,34 @@ export async function buildCapture(env: Env, token: string, target: CaptureTarge
       });
     }
   }
-  return { routes: captureRoutes, previewPending };
+
+  // Interaction capture (#interaction-gif-capture): NOT multiplied by theme/route the way captureRoutes is
+  // above -- a hover/click interaction is captured once per configured entry, against its OWN `path` (not
+  // every route this PR touches), mirroring the contributor-facing animated-evidence contract's "one row per
+  // interaction target" shape. Gated on isScrollGifAvailable() (reused: the encode step is frame-source-
+  // agnostic, see scroll-gif.ts) since there is no point capturing frames this build can never assemble into
+  // a GIF -- self-host only, same as the scroll-GIF path above.
+  const interactionsConfigured = (visualConfig?.interactions ?? []).slice(0, MAX_INTERACTIONS);
+  const interactionRoutes: CaptureInteractionRoute[] = [];
+  if (interactionsConfigured.length > 0 && isScrollGifAvailable()) {
+    for (const interaction of interactionsConfigured) {
+      const interactionPath = interaction.path ?? "/";
+      const beforePage = prodBase ? joinUrl(prodBase, interactionPath) : "";
+      const afterPage = previewBase ? joinUrl(previewBase, interactionPath) : "";
+      const [beforeGifUrl, afterGifUrl] = await Promise.all([
+        captureInteractionGif(env, target, beforePage, "before", interaction),
+        afterPage ? captureInteractionGif(env, target, afterPage, "after", interaction) : Promise.resolve<string | undefined>(undefined),
+      ]);
+      if (beforeGifUrl || afterGifUrl) {
+        interactionRoutes.push({
+          selector: interaction.selector,
+          ...(interaction.label ? { label: interaction.label } : {}),
+          ...(beforeGifUrl ? { beforeGifUrl } : {}),
+          ...(afterGifUrl ? { afterGifUrl } : {}),
+        });
+      }
+    }
+  }
+
+  return { routes: captureRoutes, interactions: interactionRoutes, previewPending };
 }

--- a/src/review/visual/capture.ts
+++ b/src/review/visual/capture.ts
@@ -811,8 +811,11 @@ export async function buildCapture(env: Env, token: string, target: CaptureTarge
       // specific action is safe to perform" once there. hover never mutates state, so it's the only action
       // still captured against production (real before/after comparison value); click/drag are preview-only.
       const beforePage = interaction.action === "hover" && prodBase ? joinUrl(prodBase, interactionPath) : "";
+      // beforePage is passed unconditionally (relying on captureInteractionGif's own `!page` guard) rather
+      // than ternary-gated here -- mirrors captureScrollGif's call above (line 767), which does the same for
+      // its own "before" side.
       const [beforeGifUrl, afterGifUrl] = await Promise.all([
-        beforePage ? captureInteractionGif(env, target, beforePage, "before", interaction, interactionTheme, themeStorageKey) : Promise.resolve<string | undefined>(undefined),
+        captureInteractionGif(env, target, beforePage, "before", interaction, interactionTheme, themeStorageKey),
         afterPage ? captureInteractionGif(env, target, afterPage, "after", interaction, interactionTheme, themeStorageKey) : Promise.resolve<string | undefined>(undefined),
       ]);
       if (beforeGifUrl || afterGifUrl) {

--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -446,7 +446,6 @@ export async function captureScrollFrames(env: Env, url: string, viewport: Viewp
 // into an unbounded "record everything" system. One extra frame at rest (step 0, before the interaction
 // fires) plus 3 post-interaction frames covers "mid-transition" and "settled" without much added cost.
 const MAX_INTERACTION_STEPS = 4;
-const INTERACTION_SETTLE_MS = 350;
 const INTERACTION_ELEMENT_TIMEOUT_MS = 3_000;
 // A drag needs enough intermediate mouse-move events for a drag-and-drop library's own dragover/mousemove
 // listeners to register motion (a single instant jump from source to destination often fails to trigger a
@@ -457,22 +456,29 @@ const DRAG_MOVE_STEPS = 8;
 
 export type InteractionAction = "hover" | "click" | "drag";
 
-async function waitForInteractionSettle(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, INTERACTION_SETTLE_MS));
-}
-
 /** Drag `source` onto `destination` via a real mouse-down → interpolated-move → mouse-up sequence, using each
  *  element's own bounding-box CENTER as the drag/drop point. A `null` bounding box (a display:none or
  *  zero-size element) means there is nothing visibly draggable to animate — a no-op, not an error, matching
  *  this whole capture mode's fail-open contract. Interpolating {@link DRAG_MOVE_STEPS} intermediate positions
  *  (rather than one instant jump) mirrors how a real user drags and is what most drag-and-drop libraries'
- *  own dragover/mousemove listeners need to actually register motion and highlight a drop target. */
+ *  own dragover/mousemove listeners need to actually register motion and highlight a drop target.
+ *
+ *  Scrolls each element into view (sequentially, before reading ITS OWN bounding box) the same way Puppeteer's
+ *  own `hover()`/`click()` do internally for a single element — `boundingBox()` alone does not scroll, so a
+ *  drag source/destination below the fold (the documented use case: "a reorderable list/kanban card") would
+ *  otherwise read a stale/off-viewport position and target the wrong screen point. Scrolling to the
+ *  destination after already reading the source's box is safe even if it scrolls the source back out of
+ *  view — the source's coordinates were already captured and the mouse sequence below uses those fixed
+ *  numbers, not a live re-query. */
 async function performDrag(
   page: { mouse: { move: (x: number, y: number) => Promise<void>; down: () => Promise<void>; up: () => Promise<void> } },
-  source: { boundingBox: () => Promise<{ x: number; y: number; width: number; height: number } | null> },
-  destination: { boundingBox: () => Promise<{ x: number; y: number; width: number; height: number } | null> },
+  source: { boundingBox: () => Promise<{ x: number; y: number; width: number; height: number } | null>; scrollIntoViewIfNeeded?: () => Promise<void> },
+  destination: { boundingBox: () => Promise<{ x: number; y: number; width: number; height: number } | null>; scrollIntoViewIfNeeded?: () => Promise<void> },
 ): Promise<void> {
-  const [sourceBox, destinationBox] = await Promise.all([source.boundingBox(), destination.boundingBox()]);
+  await source.scrollIntoViewIfNeeded?.().catch(() => undefined);
+  const sourceBox = await source.boundingBox();
+  await destination.scrollIntoViewIfNeeded?.().catch(() => undefined);
+  const destinationBox = await destination.boundingBox();
   if (!sourceBox || !destinationBox) return;
   const sourceX = sourceBox.x + sourceBox.width / 2;
   const sourceY = sourceBox.y + sourceBox.height / 2;
@@ -585,7 +591,10 @@ export async function captureInteractionFrames(
       await performDrag(page, element, dragToElement!);
     }
     for (let step = 1; step < MAX_INTERACTION_STEPS; step++) {
-      await waitForInteractionSettle();
+      // Reuses captureScrollFrames' own settle delay (SCROLL_SETTLE_MS/waitForScrollSettle above) rather than
+      // a second, numerically-identical constant+function -- same 350ms "long enough for a typical transition,
+      // short enough to stay a quick evidence clip" reasoning applies to a post-interaction frame too.
+      await waitForScrollSettle();
       frames.push((await page.screenshot({ type: "png", fullPage: false })) as Uint8Array);
     }
     return { frames, authWalled: false };

--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -448,27 +448,57 @@ export async function captureScrollFrames(env: Env, url: string, viewport: Viewp
 const MAX_INTERACTION_STEPS = 4;
 const INTERACTION_SETTLE_MS = 350;
 const INTERACTION_ELEMENT_TIMEOUT_MS = 3_000;
+// A drag needs enough intermediate mouse-move events for a drag-and-drop library's own dragover/mousemove
+// listeners to register motion (a single instant jump from source to destination often fails to trigger a
+// library's drop-target highlighting) — 8 steps is a cheap, smooth-enough interpolation without materially
+// adding to this capture mode's already-heaviest-in-class cost (mirrors MAX_SCROLL_STEPS's reasoning: enough
+// to be convincing evidence, not a frame-perfect recording).
+const DRAG_MOVE_STEPS = 8;
 
-export type InteractionAction = "hover" | "click";
+export type InteractionAction = "hover" | "click" | "drag";
 
 async function waitForInteractionSettle(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, INTERACTION_SETTLE_MS));
 }
 
+/** Drag `source` onto `destination` via a real mouse-down → interpolated-move → mouse-up sequence, using each
+ *  element's own bounding-box CENTER as the drag/drop point. A `null` bounding box (a display:none or
+ *  zero-size element) means there is nothing visibly draggable to animate — a no-op, not an error, matching
+ *  this whole capture mode's fail-open contract. Interpolating {@link DRAG_MOVE_STEPS} intermediate positions
+ *  (rather than one instant jump) mirrors how a real user drags and is what most drag-and-drop libraries'
+ *  own dragover/mousemove listeners need to actually register motion and highlight a drop target. */
+async function performDrag(
+  page: { mouse: { move: (x: number, y: number) => Promise<void>; down: () => Promise<void>; up: () => Promise<void> } },
+  source: { boundingBox: () => Promise<{ x: number; y: number; width: number; height: number } | null> },
+  destination: { boundingBox: () => Promise<{ x: number; y: number; width: number; height: number } | null> },
+): Promise<void> {
+  const [sourceBox, destinationBox] = await Promise.all([source.boundingBox(), destination.boundingBox()]);
+  if (!sourceBox || !destinationBox) return;
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const destinationX = destinationBox.x + destinationBox.width / 2;
+  const destinationY = destinationBox.y + destinationBox.height / 2;
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  for (let step = 1; step <= DRAG_MOVE_STEPS; step++) {
+    const t = step / DRAG_MOVE_STEPS;
+    await page.mouse.move(sourceX + (destinationX - sourceX) * t, sourceY + (destinationY - sourceY) * t);
+  }
+  await page.mouse.up();
+}
+
 /**
  * Capture a short sequence of frames around a specific interaction: one frame at rest, then trigger `action`
- * on `selector`, then a few more frames at intervals to catch a CSS transition or JS-driven state change
- * mid-flight and settled — evidence for a hover-triggered popover, a click-triggered state change, or
- * similar behavior a single static screenshot can't show. Deliberately narrow, mirroring
- * `captureScrollFrames`'s own scope note: `hover`/`click` only — a `drag` interaction needs a coordinate-
- * based mouse-down/move/up sequence with no reliable way to infer a drop target from a CSS selector alone,
- * so it's out of scope here rather than shipped half-working.
+ * on `selector` (a drag onto `dragTo` when `action` is `"drag"`), then a few more frames at intervals to
+ * catch a CSS transition or JS-driven state change mid-flight and settled — evidence for a hover-triggered
+ * popover, a click-triggered state change, a drag-and-drop reorder, or similar behavior a single static
+ * screenshot can't show.
  *
  * Mirrors `captureScrollFrames`'s SSRF guard, sub-request interception, and auth-wall detection exactly
- * (duplicated rather than shared — see that function's own doc comment for why). `selector` matching nothing
- * on the page is NOT an error — it's a normal "this interaction doesn't apply to this side" outcome (e.g. an
- * element only present after the PR's change adds it): returns empty frames, the same fail-open contract as
- * every other capture failure here.
+ * (duplicated rather than shared — see that function's own doc comment for why). `selector`/`dragTo` matching
+ * nothing on the page is NOT an error — it's a normal "this interaction doesn't apply to this side" outcome
+ * (e.g. an element only present after the PR's change adds it): returns empty frames, the same fail-open
+ * contract as every other capture failure here.
  */
 export async function captureInteractionFrames(
   env: Env,
@@ -477,6 +507,7 @@ export async function captureInteractionFrames(
   action: InteractionAction,
   viewport: Viewport = VIEWPORT,
   opts: CaptureShotOptions = {},
+  dragTo?: string | undefined,
 ): Promise<{ frames: Uint8Array[]; authWalled: boolean }> {
   if (!url || !isSafeHttpUrl(url) || (opts.isAllowedUrl && !opts.isAllowedUrl(url))) {
     console.log(JSON.stringify({ event: "render_interaction_frames_blocked", url: String(url).slice(0, 120) }));
@@ -531,13 +562,27 @@ export async function captureInteractionFrames(
       console.log(JSON.stringify({ event: "render_interaction_frames_selector_not_found", url, selector: selector.slice(0, 120) }));
       return { frames: [], authWalled: false };
     }
+    let dragToElement: typeof element | null = null;
+    if (action === "drag") {
+      if (!dragTo) {
+        console.log(JSON.stringify({ event: "render_interaction_frames_missing_drag_target", url, selector: selector.slice(0, 120) }));
+        return { frames: [], authWalled: false };
+      }
+      dragToElement = await page.waitForSelector(dragTo, { timeout: INTERACTION_ELEMENT_TIMEOUT_MS }).catch(() => null);
+      if (!dragToElement) {
+        console.log(JSON.stringify({ event: "render_interaction_frames_drag_target_not_found", url, dragTo: dragTo.slice(0, 120) }));
+        return { frames: [], authWalled: false };
+      }
+    }
     const frames: Uint8Array[] = [];
     // Frame 0: the at-rest state, before the interaction fires — the "before" half of the animated evidence.
     frames.push((await page.screenshot({ type: "png", fullPage: false })) as Uint8Array);
     if (action === "hover") {
       await element.hover();
-    } else {
+    } else if (action === "click") {
       await element.click();
+    } else {
+      await performDrag(page, element, dragToElement!);
     }
     for (let step = 1; step < MAX_INTERACTION_STEPS; step++) {
       await waitForInteractionSettle();

--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -441,6 +441,117 @@ export async function captureScrollFrames(env: Env, url: string, viewport: Viewp
   }
 }
 
+// Mirrors MAX_SCROLL_STEPS/SCROLL_SETTLE_MS's reasoning above: a fixed, small number of post-interaction
+// frames is enough evidence for a hover/click-triggered CSS transition or state change without turning this
+// into an unbounded "record everything" system. One extra frame at rest (step 0, before the interaction
+// fires) plus 3 post-interaction frames covers "mid-transition" and "settled" without much added cost.
+const MAX_INTERACTION_STEPS = 4;
+const INTERACTION_SETTLE_MS = 350;
+const INTERACTION_ELEMENT_TIMEOUT_MS = 3_000;
+
+export type InteractionAction = "hover" | "click";
+
+async function waitForInteractionSettle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, INTERACTION_SETTLE_MS));
+}
+
+/**
+ * Capture a short sequence of frames around a specific interaction: one frame at rest, then trigger `action`
+ * on `selector`, then a few more frames at intervals to catch a CSS transition or JS-driven state change
+ * mid-flight and settled — evidence for a hover-triggered popover, a click-triggered state change, or
+ * similar behavior a single static screenshot can't show. Deliberately narrow, mirroring
+ * `captureScrollFrames`'s own scope note: `hover`/`click` only — a `drag` interaction needs a coordinate-
+ * based mouse-down/move/up sequence with no reliable way to infer a drop target from a CSS selector alone,
+ * so it's out of scope here rather than shipped half-working.
+ *
+ * Mirrors `captureScrollFrames`'s SSRF guard, sub-request interception, and auth-wall detection exactly
+ * (duplicated rather than shared — see that function's own doc comment for why). `selector` matching nothing
+ * on the page is NOT an error — it's a normal "this interaction doesn't apply to this side" outcome (e.g. an
+ * element only present after the PR's change adds it): returns empty frames, the same fail-open contract as
+ * every other capture failure here.
+ */
+export async function captureInteractionFrames(
+  env: Env,
+  url: string,
+  selector: string,
+  action: InteractionAction,
+  viewport: Viewport = VIEWPORT,
+  opts: CaptureShotOptions = {},
+): Promise<{ frames: Uint8Array[]; authWalled: boolean }> {
+  if (!url || !isSafeHttpUrl(url) || (opts.isAllowedUrl && !opts.isAllowedUrl(url))) {
+    console.log(JSON.stringify({ event: "render_interaction_frames_blocked", url: String(url).slice(0, 120) }));
+    return { frames: [], authWalled: false };
+  }
+  if (!env.BROWSER) return { frames: [], authWalled: false };
+  let browser: Awaited<ReturnType<typeof puppeteer.launch>> | null = null;
+  try {
+    browser = await puppeteer.launch(env.BROWSER as unknown as Parameters<typeof puppeteer.launch>[0]);
+    const page = await browser.newPage();
+    await page.setRequestInterception(true);
+    page.on("request", (request: ScreenshotRequest) => {
+      const requestUrl = request.url();
+      let protocol = "";
+      try {
+        protocol = new URL(requestUrl).protocol;
+      } catch {
+        request.abort().catch(() => undefined);
+        return;
+      }
+      if (protocol === "http:" || protocol === "https:") {
+        const isAllowedNavigation = !request.isNavigationRequest() || !opts.isAllowedUrl || opts.isAllowedUrl(requestUrl);
+        if (!isSafeHttpUrl(requestUrl) || !isAllowedNavigation) {
+          console.log(JSON.stringify({ event: "render_interaction_frames_request_blocked", url: requestUrl.slice(0, 120) }));
+          request.abort().catch(() => undefined);
+          return;
+        }
+      }
+      request.continue().catch(() => undefined);
+    });
+    await page.setViewport(viewport);
+    if (opts.theme) await page.emulateMediaFeatures([{ name: "prefers-color-scheme", value: opts.theme }]);
+    await page.goto(url, { waitUntil: "networkidle0", timeout: 20000 });
+    if (!isSafeHttpUrl(page.url()) || (opts.isAllowedUrl && !opts.isAllowedUrl(page.url()))) {
+      console.log(JSON.stringify({ event: "render_interaction_frames_redirect_blocked", url, final: page.url().slice(0, 200) }));
+      return { frames: [], authWalled: false };
+    }
+    if (isAuthWallUrl(page.url()) && !isAuthWallUrl(url)) {
+      console.log(JSON.stringify({ event: "render_interaction_frames_auth_walled", url, final: page.url().slice(0, 200) }));
+      return { frames: [], authWalled: true };
+    }
+    // A configured themeStorageKey (#4109) ALSO forces the theme via localStorage, then reloads -- mirrors
+    // captureShot's own fallback exactly (see CaptureShotOptions.theme's doc for what this fixes and why).
+    if (opts.theme && opts.themeStorageKey) {
+      const storageKey = opts.themeStorageKey;
+      const storageValue = opts.theme;
+      if (!(await forceThemeStorage(page, storageKey, storageValue))) return { frames: [], authWalled: false };
+      await page.reload({ waitUntil: "networkidle0", timeout: THEME_STORAGE_RELOAD_TIMEOUT_MS });
+    }
+    const element = await page.waitForSelector(selector, { timeout: INTERACTION_ELEMENT_TIMEOUT_MS }).catch(() => null);
+    if (!element) {
+      console.log(JSON.stringify({ event: "render_interaction_frames_selector_not_found", url, selector: selector.slice(0, 120) }));
+      return { frames: [], authWalled: false };
+    }
+    const frames: Uint8Array[] = [];
+    // Frame 0: the at-rest state, before the interaction fires — the "before" half of the animated evidence.
+    frames.push((await page.screenshot({ type: "png", fullPage: false })) as Uint8Array);
+    if (action === "hover") {
+      await element.hover();
+    } else {
+      await element.click();
+    }
+    for (let step = 1; step < MAX_INTERACTION_STEPS; step++) {
+      await waitForInteractionSettle();
+      frames.push((await page.screenshot({ type: "png", fullPage: false })) as Uint8Array);
+    }
+    return { frames, authWalled: false };
+  } catch (error) {
+    console.log(JSON.stringify({ event: "render_interaction_frames_error", mode: "binding", url, message: String(error).slice(0, 200) }));
+    return { frames: [], authWalled: false };
+  } finally {
+    if (browser) await browser.close().catch(() => undefined);
+  }
+}
+
 export async function handleShot(request: Request, env: Env, opts: ShotOptions = {}): Promise<Response> {
   const params = new URL(request.url).searchParams;
   const r2Prefix = `${opts.namespace ?? "loopover"}/shots/`;

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -88,6 +88,8 @@ export {
   type ReviewProfile,
   type SelfHostAiModelConfig,
   type VisualConfig,
+  type VisualInteraction,
+  type VisualInteractionAction,
   type VisualPreviewConfig,
   type VisualRoutesConfig,
   type VisualTheme,

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -5341,6 +5341,102 @@ describe("review.visual.bugAnalysis (PR-intent-aware vision + out-of-scope issue
   });
 });
 
+describe("review.visual.interactions (#interaction-gif-capture)", () => {
+  it("parses a hover entry (selector + action + label), marks present, and round-trips", () => {
+    const m = parseFocusManifest({
+      review: { visual: { interactions: [{ selector: ".blocks-row", action: "hover", label: "Blocks row hover" }] } },
+    });
+    expect(m.review.visual.interactions).toEqual([{ selector: ".blocks-row", action: "hover", dragTo: null, path: null, label: "Blocks row hover" }]);
+    expect(m.review.present).toBe(true);
+    expect(reviewConfigToJson(m.review)).toEqual({ visual: { interactions: [{ selector: ".blocks-row", action: "hover", label: "Blocks row hover" }] } });
+  });
+
+  it("parses a drag entry (selector + action + drag_to + path), and round-trips drag_to/path too", () => {
+    const m = parseFocusManifest({
+      review: { visual: { interactions: [{ selector: ".card", action: "drag", drag_to: ".done-column", path: "/board" }] } },
+    });
+    expect(m.review.visual.interactions).toEqual([{ selector: ".card", action: "drag", dragTo: ".done-column", path: "/board", label: null }]);
+    expect(reviewConfigToJson(m.review)).toEqual({ visual: { interactions: [{ selector: ".card", action: "drag", drag_to: ".done-column", path: "/board" }] } });
+  });
+
+  it("absent interactions defaults to [] and does not mark review present on its own", () => {
+    expect(parseFocusManifest({}).review.visual.interactions).toEqual([]);
+    expect(parseFocusManifest({ review: { visual: {} } }).review.present).toBe(false);
+  });
+
+  it("interactions: [] does not mark review present, so the whole review block round-trips to null", () => {
+    const m = parseFocusManifest({ review: { visual: { interactions: [] } } });
+    expect(m.review.visual.interactions).toEqual([]);
+    expect(reviewConfigToJson(m.review)).toBeNull();
+  });
+
+  it("warns and drops the whole list when review.visual.interactions is not an array", () => {
+    const bad = parseFocusManifest({ review: { visual: { interactions: "nope" } } });
+    expect(bad.review.visual.interactions).toEqual([]);
+    expect(bad.warnings.some((w) => /review\.visual\.interactions.*must be a list of interactions/.test(w))).toBe(true);
+  });
+
+  it("warns and drops a non-mapping entry (a primitive or an array) rather than failing the whole list", () => {
+    const bad = parseFocusManifest({ review: { visual: { interactions: [null, "nope", ["nested"], { selector: ".ok", action: "click" }] } } });
+    expect(bad.review.visual.interactions).toEqual([{ selector: ".ok", action: "click", dragTo: null, path: null, label: null }]);
+    expect(bad.warnings.filter((w) => /review\.visual\.interactions\[\d+\].*must be a mapping/.test(w))).toHaveLength(3);
+  });
+
+  it("warns and drops an entry with a missing selector", () => {
+    const bad = parseFocusManifest({ review: { visual: { interactions: [{ action: "hover" }] } } });
+    expect(bad.review.visual.interactions).toEqual([]);
+    expect(bad.warnings.some((w) => /review\.visual\.interactions\[0\]\.selector.*is required/.test(w))).toBe(true);
+  });
+
+  it("warns and drops an entry with a missing or non-string action", () => {
+    const missing = parseFocusManifest({ review: { visual: { interactions: [{ selector: ".x" }] } } });
+    expect(missing.review.visual.interactions).toEqual([]);
+    expect(missing.warnings.some((w) => /review\.visual\.interactions\[0\]\.action.*must be "hover", "click", or "drag"/.test(w))).toBe(true);
+
+    const nonString = parseFocusManifest({ review: { visual: { interactions: [{ selector: ".x", action: 42 }] } } });
+    expect(nonString.review.visual.interactions).toEqual([]);
+    expect(nonString.warnings.some((w) => /review\.visual\.interactions\[0\]\.action.*must be "hover", "click", or "drag"/.test(w))).toBe(true);
+  });
+
+  it("warns and drops an entry with an unrecognized action string", () => {
+    const bad = parseFocusManifest({ review: { visual: { interactions: [{ selector: ".x", action: "swipe" }] } } });
+    expect(bad.review.visual.interactions).toEqual([]);
+    expect(bad.warnings.some((w) => /review\.visual\.interactions\[0\]\.action.*must be "hover", "click", or "drag"/.test(w))).toBe(true);
+  });
+
+  it("warns and drops a drag entry missing drag_to", () => {
+    const bad = parseFocusManifest({ review: { visual: { interactions: [{ selector: ".card", action: "drag" }] } } });
+    expect(bad.review.visual.interactions).toEqual([]);
+    expect(bad.warnings.some((w) => /review\.visual\.interactions\[0\]\.drag_to.*is required when action is "drag"/.test(w))).toBe(true);
+  });
+
+  it("caps the manifest-level list at MAX_VISUAL_INTERACTIONS (5), warning about the rest", () => {
+    const entries = Array.from({ length: 7 }, (_, i) => ({ selector: `.item-${i}`, action: "hover" }));
+    const m = parseFocusManifest({ review: { visual: { interactions: entries } } });
+    expect(m.review.visual.interactions).toHaveLength(5);
+    expect(m.review.visual.interactions.map((i) => i.selector)).toEqual([".item-0", ".item-1", ".item-2", ".item-3", ".item-4"]);
+    expect(m.warnings.some((w) => /review\.visual\.interactions.*capped at 5 entries/.test(w))).toBe(true);
+  });
+
+  it("resolveReviewVisualConfig passes a configured interactions list through", () => {
+    const manifest = parseFocusManifest({ review: { visual: { interactions: [{ selector: ".x", action: "hover" }] } } });
+    expect(resolveReviewVisualConfig(manifest).interactions).toEqual([{ selector: ".x", action: "hover", dragTo: null, path: null, label: null }]);
+  });
+
+  it("overlay: a per-repo interactions list wins over a global-default list", () => {
+    const globalDefault = parseReviewConfigMapping({ visual: { interactions: [{ selector: ".global", action: "hover" }] } }, []);
+    const perRepo = parseReviewConfigMapping({ visual: { interactions: [{ selector: ".repo", action: "click" }] } }, []);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.interactions).toEqual([{ selector: ".repo", action: "click", dragTo: null, path: null, label: null }]);
+  });
+
+  it("overlay: an unset per-repo interactions list falls back to the global-default list", () => {
+    const globalDefault = parseReviewConfigMapping({ visual: { interactions: [{ selector: ".global", action: "hover" }] } }, []);
+    const perRepo = parseReviewConfigMapping({ visual: { routes: { paths: ["/app"] } } }, []);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.interactions).toEqual([{ selector: ".global", action: "hover", dragTo: null, path: null, label: null }]);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.routes.paths).toEqual(["/app"]);
+  });
+});
+
 describe("review.pre_merge_checks (#review-pre-merge-checks)", () => {
   it("parses checks (name + assertions + when_paths + enforce), marks present, and round-trips", () => {
     const m = parseFocusManifest({

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -4863,6 +4863,7 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
       themeStorageKey: null,
       actionsFallback: false,
       bugAnalysis: false,
+      interactions: [],
     });
     expect(m.review.present).toBe(true);
     expect(parseFocusManifest({ review: reviewConfigToJson(m.review) }).review.visual).toEqual(m.review.visual);
@@ -4958,7 +4959,7 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
   it("resolveReviewVisualConfig: null manifest yields empty defaults; a set manifest passes through", () => {
     expect(resolveReviewVisualConfig(null)).toEqual({ ...EMPTY_VISUAL_CONFIG });
     const manifest = parseFocusManifest({ review: { visual: { routes: { paths: ["/app"] } } } });
-    expect(resolveReviewVisualConfig(manifest)).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: ["/app"], maxRoutes: null }, themes: [], gif: false, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false });
+    expect(resolveReviewVisualConfig(manifest)).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: ["/app"], maxRoutes: null }, themes: [], gif: false, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false, interactions: [] });
   });
 });
 
@@ -5104,7 +5105,7 @@ describe("review.visual.gif (#3612 scroll-through GIF capture)", () => {
 
   it("composes with themes — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { gif: true, themes: ["dark"] } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false, interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { themes: ["dark"], gif: true } });
   });
 
@@ -5207,7 +5208,7 @@ describe("review.visual.theme_storage_key (#4109 localStorage theme-forcing fall
 
   it("composes with themes — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { themes: ["dark"], theme_storage_key: "theme" } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: false, enabled: null, themeStorageKey: "theme", actionsFallback: false, bugAnalysis: false });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: false, enabled: null, themeStorageKey: "theme", actionsFallback: false, bugAnalysis: false, interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { themes: ["dark"], theme_storage_key: "theme" } });
   });
 
@@ -5262,7 +5263,7 @@ describe("review.visual.actions_fallback (#4112 GitHub-Actions build-and-serve f
 
   it("composes with gif — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { actions_fallback: true, gif: true } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: true, bugAnalysis: false });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: true, bugAnalysis: false, interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { gif: true, actions_fallback: true } });
   });
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -5318,7 +5318,7 @@ describe("review.visual.bugAnalysis (PR-intent-aware vision + out-of-scope issue
 
   it("composes with gif — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { bug_analysis: true, gif: true } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: true });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: true, interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { gif: true, bug_analysis: true } });
   });
 

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -65,6 +65,8 @@ import { aiReviewCacheInputFingerprint } from "../../src/review/ai-review-cache-
 import { fingerprint as reviewMemoryFingerprint } from "../../src/review/review-memory-match";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import * as pixelDiffModule from "../../src/review/visual/pixel-diff";
+import * as scrollGifModule from "../../src/review/visual/scroll-gif";
+import * as shotModule from "../../src/review/visual/shot";
 import * as focusManifestLoaderModule from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -3696,6 +3698,180 @@ describe("queue processors", () => {
       liveCiSpy.mockRestore();
       isVisualDiffAvailableSpy.mockRestore();
       compareScreenshotsSpy.mockRestore();
+    }
+  });
+
+  // review.visual.interactions (config-as-code): threads all the way from the real .loopover.yml raw-fetch
+  // through resolveVisualCaptureConfig -> buildCapture's interaction-GIF branch -> the `let interactionPreviews`
+  // declared outside the capture try/catch -> the PR panel's `interactions` field -> unified-comment-bridge's
+  // "Interaction preview" collapsible. Unlike visual-capture.test.ts / visual-collapsible.test.ts (which call
+  // buildCapture / buildUnifiedCommentBody directly with an interactions array already populated) this is the
+  // ONLY test that proves interactionPreviews.length > 0 is ever actually reached through the real webhook
+  // path -- every other processors.ts test leaves review.visual.interactions unconfigured, so the
+  // `interactionPreviews.length > 0 ? { interactions: interactionPreviews } : {}` ternary in processors.ts
+  // only ever takes its false branch elsewhere. hover is used (not click/drag) so the interaction fires
+  // against PUBLIC_SITE_ORIGIN directly, without needing a real discovered preview deploy (this fixture's
+  // deployment/checks/PR-comment discovery all 404, same as the sibling wiring test above).
+  it("threads review.visual.interactions from the real .loopover.yml into the capture pipeline and renders an Interaction preview section", async () => {
+    const gifStore = new Map<string, Uint8Array>();
+    const reviewAudit = {
+      async get(key: string) {
+        const bytes = gifStore.get(key);
+        return bytes ? ({ body: new Response(bytes).body } as unknown as R2ObjectBody) : null;
+      },
+      async put(key: string, value: unknown) {
+        const bytes = new Uint8Array(await new Response(value as BodyInit).arrayBuffer());
+        gifStore.set(key, bytes);
+        return { key } as unknown as R2Object;
+      },
+    } as unknown as R2Bucket;
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      LOOPOVER_REVIEW_SCREENSHOTS: "true",
+      PUBLIC_API_ORIGIN: "https://worker.example",
+      PUBLIC_SITE_ORIGIN: "https://prod.example.com",
+      REVIEW_AUDIT: reviewAudit,
+    });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autoLabelEnabled: false,
+      autonomy: { update_branch: "auto" },
+    });
+    let postedBody = "";
+    const isScrollGifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionFramesSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
+      authWalled: false,
+    });
+    const encodeScrollGifSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "passed",
+      hasPending: false,
+      hasVisiblePending: false,
+      hasMissingRequiredContext: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      advisoryHoldDetails: [],
+      ciCompletenessWarning: null,
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.loopover.yml") {
+        return new Response(
+          "settings:\n  commentMode: detected_contributors_only\n  publicAudienceMode: gittensor_only\n  publicSignalLevel: standard\n  publicSurface: comment_and_label\n  checkRunMode: \"off\"\n  checkRunDetailLevel: minimal\n  backfillEnabled: true\nreview:\n  visual:\n    interactions:\n      - selector: \".menu-button\"\n        action: hover\n        label: \"Menu hover\"\n",
+        );
+      }
+      if (url === "https://api.gittensor.io/miners") {
+        return Response.json([
+          {
+            uid: 7,
+            githubUsername: "oktofeesh1",
+            githubId: "123",
+            totalPrs: 4,
+            totalMergedPrs: 3,
+            totalOpenPrs: 1,
+            totalClosedPrs: 0,
+            totalOpenIssues: 0,
+            totalClosedIssues: 0,
+            totalSolvedIssues: 0,
+            totalValidSolvedIssues: 0,
+            isEligible: true,
+            credibility: 1,
+            eligibleRepoCount: 1,
+            hotkey: "must-not-leak",
+          },
+        ]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") {
+        return Response.json({
+          repositories: [
+            {
+              repositoryFullName: "JSONbored/gittensory",
+              totalPrs: "4",
+              totalMergedPrs: "3",
+              totalOpenPrs: "1",
+              totalClosedPrs: "0",
+              totalOpenIssues: "0",
+              totalClosedIssues: "0",
+              isEligible: true,
+              credibility: "1.000000",
+            },
+          ],
+        });
+      }
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/oktofeesh1")) return Response.json({ login: "oktofeesh1", public_repos: 2, followers: 1 });
+      if (url.includes("/users/oktofeesh1/repos")) return Response.json([{ language: "TypeScript" }]);
+      if (url.includes("/access_tokens")) {
+        return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
+      }
+      if (url.includes("/pulls/3/files")) {
+        return Response.json([{ filename: "apps/loopover-ui/src/routes/app.index.tsx", additions: 5, deletions: 1, status: "modified" }]);
+      }
+      if (/\/pulls\/3(?:\?|$)/.test(url)) return Response.json({ number: 3, mergeable_state: "clean" });
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 901 }, { status: 201 });
+      if (url.includes("/check-runs/901") && method === "PATCH") return Response.json({ id: 901 });
+      if (url.includes("/issues/3/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/3/comments") && method === "POST") {
+        postedBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 1, html_url: "https://github.com/comment/1" }, { status: 201 });
+      }
+      // Preview discovery (deployments / commit checks / PR comments): none configured for this fixture, so
+      // the interaction's "after" (preview) side never captures -- only its "before" (production, via
+      // PUBLIC_SITE_ORIGIN) side does, which is enough on its own to prove the field threads through end to
+      // end (buildInteractionPreviewCollapsible renders a row when EITHER side has a GIF).
+      return new Response("not found", { status: 404 });
+    });
+
+    try {
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "pr-interactions-wiring",
+        eventName: "pull_request",
+        payload: {
+          action: "synchronize",
+          installation: {
+            id: 123,
+            account: { login: "JSONbored", id: 1, type: "User" },
+            repository_selection: "selected",
+            permissions: { metadata: "read", pull_requests: "read", issues: "write", checks: "write" },
+            events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+          },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: {
+            number: 3,
+            title: "Add a hoverable menu button",
+            state: "open",
+            user: { login: "oktofeesh1" },
+            head: { sha: "interactionswiring123" },
+            labels: [{ name: "bug" }],
+            body: "Fixes #1\n\nValidation: npm test",
+          },
+        },
+      });
+
+      // The real webhook path resolved review.visual.interactions from the fetched .loopover.yml, captured a
+      // hover GIF via the real buildCapture -> captureInteractionGif chain, and threaded the result through
+      // processors.ts's interactionPreviews variable into the rendered unified comment.
+      expect(postedBody).toContain("Interaction preview");
+      expect(postedBody).toContain("Menu hover");
+      expect(postedBody).toContain("Visual preview");
+    } finally {
+      liveCiSpy.mockRestore();
+      isScrollGifAvailableSpy.mockRestore();
+      captureInteractionFramesSpy.mockRestore();
+      encodeScrollGifSpy.mockRestore();
     }
   });
 

--- a/test/unit/visual-capture.test.ts
+++ b/test/unit/visual-capture.test.ts
@@ -1825,7 +1825,94 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
         undefined,
         { interactions: [{ selector: "#menu", action: "click", path: "/settings" }] },
       );
-      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/settings", "#menu", "click", expect.anything(), {}, undefined);
+      // "click" is preview-only (SECURITY: never fires against production, see the "click/drag are
+      // preview-only" tests below) -- the interaction's own `path` still threads through correctly for
+      // the one call that does happen.
+      expect(captureInteractionSpy).toHaveBeenCalledTimes(1);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/settings", "#menu", "click", expect.anything(), {}, undefined);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("SECURITY: hover interactions still capture BOTH production and preview (non-mutating, safe to run against the live site)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 58, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(captureInteractionSpy).toHaveBeenCalledTimes(2);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".x", "hover", expect.anything(), {}, undefined);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".x", "hover", expect.anything(), {}, undefined);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("SECURITY: click interactions NEVER fire against production, only the PR's own preview deploy", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 59, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: "#confirm-delete", action: "click" }] },
+      );
+      // Exactly one call, for the preview URL only -- proves click never reaches production (with 1 call
+      // total and the one call pinned to the preview origin, there is no room for a second, production call).
+      expect(captureInteractionSpy).toHaveBeenCalledTimes(1);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", "#confirm-delete", "click", expect.anything(), {}, undefined);
+      expect(result.interactions[0]?.beforeGifUrl).toBeUndefined();
+      expect(result.interactions[0]?.afterGifUrl).toContain("/loopover/shot?key=");
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("threads the resolved theme + themeStorageKey into interaction capture", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 60, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }], themes: ["dark"], themeStorageKey: "theme" },
+      );
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".x", "hover", expect.anything(), { theme: "dark", themeStorageKey: "theme" }, undefined);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".x", "hover", expect.anything(), { theme: "dark", themeStorageKey: "theme" }, undefined);
     } finally {
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();
@@ -1896,8 +1983,11 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
       );
       expect(result.interactions).toHaveLength(1);
       expect(result.interactions[0]?.label).toBe("Reorder card");
-      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".card", "drag", expect.anything(), {}, ".done-column");
+      // "drag" is preview-only too (same SECURITY reasoning as "click" — a real drag-and-drop can persist a
+      // reorder via a same-origin mutating request, so it must never run against production).
+      expect(captureInteractionSpy).toHaveBeenCalledTimes(1);
       expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".card", "drag", expect.anything(), {}, ".done-column");
+      expect(result.interactions[0]?.beforeGifUrl).toBeUndefined();
     } finally {
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();
@@ -1935,6 +2025,79 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();
       encodeSpy.mockRestore();
+    }
+  });
+
+  it("reuses a cached interaction GIF without re-capturing frames on the next review of the same head", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const target = { repoFullName: "owner/repo", prNumber: 61, previewUrl: "https://preview.example.com" };
+      const files = ["apps/loopover-ui/src/routes/app.index.tsx"];
+      const interactionConfig = { interactions: [{ selector: ".x", action: "hover" as const }] };
+      const first = await buildCapture(env, "installation-token", target, files, undefined, interactionConfig);
+      expect(captureInteractionSpy).toHaveBeenCalledTimes(2); // before + after
+      const second = await buildCapture(env, "installation-token", target, files, undefined, interactionConfig);
+      expect(captureInteractionSpy).toHaveBeenCalledTimes(2); // no NEW calls — both slots served from cache
+      expect(second.interactions[0]?.beforeGifUrl).toBe(first.interactions[0]?.beforeGifUrl);
+      expect(second.interactions[0]?.afterGifUrl).toBe(first.interactions[0]?.afterGifUrl);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("does not upload an interaction GIF when frames come back non-empty but the page is auth-walled", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: true,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif");
+    try {
+      const result = await buildCapture(
+        createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() }),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 62, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(encodeSpy).not.toHaveBeenCalled();
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("does not capture interaction frames when there is no REVIEW_AUDIT storage, even with interactions configured and isScrollGifAvailable true", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames");
+    try {
+      const result = await buildCapture(
+        // No REVIEW_AUDIT and no PUBLIC_API_ORIGIN/REVIEW_AUDIT_S3_PUBLIC_URL — storage genuinely unavailable,
+        // as opposed to the outer buildCapture-level gate (interactionsConfigured.length > 0 &&
+        // isScrollGifAvailable()), which is satisfied here so this exercises captureInteractionGif's OWN guard.
+        createTestEnv({}),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 63, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(captureInteractionSpy).not.toHaveBeenCalled();
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
     }
   });
 });

--- a/test/unit/visual-capture.test.ts
+++ b/test/unit/visual-capture.test.ts
@@ -1799,8 +1799,8 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
       expect(result.interactions[0]?.label).toBe("Blocks row hover");
       expect(result.interactions[0]?.beforeGifUrl).toContain("/loopover/shot?key=");
       expect(result.interactions[0]?.afterGifUrl).toContain("/loopover/shot?key=");
-      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".blocks-row", "hover", expect.anything(), {});
-      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".blocks-row", "hover", expect.anything(), {});
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".blocks-row", "hover", expect.anything(), {}, undefined);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".blocks-row", "hover", expect.anything(), {}, undefined);
     } finally {
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();
@@ -1825,7 +1825,7 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
         undefined,
         { interactions: [{ selector: "#menu", action: "click", path: "/settings" }] },
       );
-      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/settings", "#menu", "click", expect.anything(), {});
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/settings", "#menu", "click", expect.anything(), {}, undefined);
     } finally {
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();
@@ -1870,6 +1870,67 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
         { interactions: Array.from({ length: 5 }, (_, i) => ({ selector: `.item-${i}`, action: "hover" as const })) },
       );
       expect(result.interactions).toHaveLength(3);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("threads dragTo through to captureInteractionFrames for a drag action", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 56, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/board.tsx"],
+        undefined,
+        { interactions: [{ selector: ".card", action: "drag", dragTo: ".done-column", label: "Reorder card" }] },
+      );
+      expect(result.interactions).toHaveLength(1);
+      expect(result.interactions[0]?.label).toBe("Reorder card");
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".card", "drag", expect.anything(), {}, ".done-column");
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".card", "drag", expect.anything(), {}, ".done-column");
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("gives a drag interaction its own fingerprint distinct from a hover/click on the same selector (no cache collision)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const dragResult = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 57, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/board.tsx"],
+        undefined,
+        { interactions: [{ selector: ".card", action: "drag", dragTo: ".done-column" }] },
+      );
+      const clickResult = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 57, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/board.tsx"],
+        undefined,
+        { interactions: [{ selector: ".card", action: "click" }] },
+      );
+      expect(dragResult.interactions[0]?.afterGifUrl).not.toBe(clickResult.interactions[0]?.afterGifUrl);
     } finally {
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();

--- a/test/unit/visual-capture.test.ts
+++ b/test/unit/visual-capture.test.ts
@@ -1738,6 +1738,146 @@ describe("buildCapture scroll-GIF wiring (#3612)", () => {
   });
 });
 
+describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () => {
+  it("never captures interaction frames when review.visual.interactions is unset, even when isScrollGifAvailable is true", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames");
+    try {
+      const result = await buildCapture(
+        createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com" }),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 50, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+      );
+      expect(captureInteractionSpy).not.toHaveBeenCalled();
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+    }
+  });
+
+  it("never captures interaction frames when interactions are configured but this build can't assemble GIFs (hosted mode)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(false);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames");
+    try {
+      const result = await buildCapture(
+        createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com" }),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 51, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(captureInteractionSpy).not.toHaveBeenCalled();
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+    }
+  });
+
+  it("captures + uploads both a before and after interaction GIF when interactions are configured and isScrollGifAvailable is true", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 52, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".blocks-row", action: "hover", label: "Blocks row hover" }] },
+      );
+      expect(result.interactions).toHaveLength(1);
+      expect(result.interactions[0]?.selector).toBe(".blocks-row");
+      expect(result.interactions[0]?.label).toBe("Blocks row hover");
+      expect(result.interactions[0]?.beforeGifUrl).toContain("/loopover/shot?key=");
+      expect(result.interactions[0]?.afterGifUrl).toContain("/loopover/shot?key=");
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".blocks-row", "hover", expect.anything(), {});
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".blocks-row", "hover", expect.anything(), {});
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("uses the interaction's own path, defaulting to '/' when unset, independent of the PR's changed-file routes", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 53, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/settings.tsx"],
+        undefined,
+        { interactions: [{ selector: "#menu", action: "click", path: "/settings" }] },
+      );
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/settings", "#menu", "click", expect.anything(), {});
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("omits an interaction entry entirely when neither side produces a GIF", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({ frames: [], authWalled: false });
+    try {
+      const result = await buildCapture(
+        createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() }),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 54, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+    }
+  });
+
+  it("caps capture at MAX_INTERACTIONS even when more are configured", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 55, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: Array.from({ length: 5 }, (_, i) => ({ selector: `.item-${i}`, action: "hover" as const })) },
+      );
+      expect(result.interactions).toHaveLength(3);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+});
+
 describe("hasSuccessfulBotCapture (#4110)", () => {
   const REAL_BEFORE = "https://api.example/loopover/shot?key=loopover%2Fshots%2Fbefore.png";
   const REAL_AFTER = "https://api.example/loopover/shot?key=loopover%2Fshots%2Fafter.png";

--- a/test/unit/visual-capture.test.ts
+++ b/test/unit/visual-capture.test.ts
@@ -1920,6 +1920,32 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
     }
   });
 
+  it("threads a configured theme WITHOUT a themeStorageKey into interaction capture (media-emulation only, no forced localStorage)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 70, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }], themes: ["dark"] },
+      );
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://prod.example.com/", ".x", "hover", expect.anything(), { theme: "dark" }, undefined);
+      expect(captureInteractionSpy).toHaveBeenCalledWith(env, "https://preview.example.com/", ".x", "hover", expect.anything(), { theme: "dark" }, undefined);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
   it("omits an interaction entry entirely when neither side produces a GIF", async () => {
     const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
     const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({ frames: [], authWalled: false });
@@ -2098,6 +2124,150 @@ describe("buildCapture interaction-GIF wiring (#interaction-gif-capture)", () =>
     } finally {
       gifAvailableSpy.mockRestore();
       captureInteractionSpy.mockRestore();
+    }
+  });
+
+  it("does not capture interaction frames when REVIEW_AUDIT is configured but neither PUBLIC_API_ORIGIN nor REVIEW_AUDIT_S3_PUBLIC_URL is (no way to construct a servable GIF URL)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames");
+    try {
+      const result = await buildCapture(
+        createTestEnv({ PUBLIC_API_ORIGIN: "", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() }),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 64, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(captureInteractionSpy).not.toHaveBeenCalled();
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+    }
+  });
+
+  it("REGRESSION: does not throw computing the fingerprint for a drag interaction missing dragTo (manifest-level parsing normally requires it, but buildCapture's own config type allows it null/absent)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    try {
+      const result = await buildCapture(
+        createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", REVIEW_AUDIT: memoryReviewAudit() }),
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 65, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/board.tsx"],
+        undefined,
+        { interactions: [{ selector: ".card", action: "drag" }] },
+      );
+      // env.BROWSER is unavailable in this unit-test environment, so the real captureInteractionFrames
+      // fails open (no frames) regardless -- this test only proves the fingerprint computation itself
+      // (which reads interaction.dragTo before any drag-specific validation runs) never throws.
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+    }
+  });
+
+  it("degrades to a fresh interaction capture (never throws) when the GIF cache lookup itself fails", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({
+        PUBLIC_API_ORIGIN: "https://worker.example",
+        PUBLIC_SITE_ORIGIN: "https://prod.example.com",
+        REVIEW_AUDIT: memoryReviewAudit({ failGet: true }),
+      });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 67, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(captureInteractionSpy).toHaveBeenCalled(); // cache lookup failed -> falls through to a fresh capture
+      expect(result.interactions[0]?.beforeGifUrl).toContain("/loopover/shot?key=");
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("degrades to no interaction GIF (never throws) when captureInteractionFrames itself rejects", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockRejectedValue(new Error("browser binding exhausted"));
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 68, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+    }
+  });
+
+  it("still returns the interaction GIF URL even when persisting it fails (fire-and-forget put, mirrors uploadDiffImage/captureScrollGif's own pattern)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(new Uint8Array([7, 8, 9]));
+    try {
+      const env = createTestEnv({
+        PUBLIC_API_ORIGIN: "https://worker.example",
+        PUBLIC_SITE_ORIGIN: "https://prod.example.com",
+        REVIEW_AUDIT: memoryReviewAudit({ failPut: true }),
+      });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 69, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(result.interactions[0]?.beforeGifUrl).toContain("/loopover/shot?key=");
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("does not upload an interaction GIF when encodeScrollGif itself returns null (encode failure)", async () => {
+    const gifAvailableSpy = vi.spyOn(scrollGifModule, "isScrollGifAvailable").mockReturnValue(true);
+    const captureInteractionSpy = vi.spyOn(shotModule, "captureInteractionFrames").mockResolvedValue({
+      frames: [new Uint8Array([1, 2, 3])],
+      authWalled: false,
+    });
+    const encodeSpy = vi.spyOn(scrollGifModule, "encodeScrollGif").mockResolvedValue(null);
+    try {
+      const env = createTestEnv({ PUBLIC_API_ORIGIN: "https://worker.example", PUBLIC_SITE_ORIGIN: "https://prod.example.com", REVIEW_AUDIT: memoryReviewAudit() });
+      const result = await buildCapture(
+        env,
+        "installation-token",
+        { repoFullName: "owner/repo", prNumber: 66, previewUrl: "https://preview.example.com" },
+        ["apps/loopover-ui/src/routes/app.index.tsx"],
+        undefined,
+        { interactions: [{ selector: ".x", action: "hover" }] },
+      );
+      expect(result.interactions).toEqual([]);
+    } finally {
+      gifAvailableSpy.mockRestore();
+      captureInteractionSpy.mockRestore();
+      encodeSpy.mockRestore();
     }
   });
 });

--- a/test/unit/visual-collapsible.test.ts
+++ b/test/unit/visual-collapsible.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildBeforeAfterCollapsible, buildScrollPreviewCollapsible, buildUnifiedCommentBody } from "../../src/review/unified-comment-bridge";
+import { buildBeforeAfterCollapsible, buildInteractionPreviewCollapsible, buildScrollPreviewCollapsible, buildUnifiedCommentBody } from "../../src/review/unified-comment-bridge";
 import type { GateCheckEvaluation } from "../../src/rules/advisory";
 import type { PublicPrPanelSignalRow } from "../../src/signals/engine";
 import type { CaptureRoute } from "../../src/review/visual/capture";
@@ -248,6 +248,85 @@ describe("buildScrollPreviewCollapsible (#3612)", () => {
     expect(c?.body).toContain("`/p\\`&lt;h2&gt;✅ FORGED APPROVAL&lt;/h2&gt;&lt;a href=x&gt;maintainer click here&lt;/a&gt;`");
     expect(c?.body).not.toContain("<h2>✅ FORGED APPROVAL</h2>");
     expect(c?.body).not.toContain("<a href=x>maintainer click here</a>");
+  });
+});
+
+describe("buildInteractionPreviewCollapsible (#interaction-gif-capture)", () => {
+  it("renders an 'Interaction preview' table with a Target column when an interaction has a GIF", () => {
+    const c = buildInteractionPreviewCollapsible([
+      {
+        selector: ".blocks-row",
+        label: "Blocks row hover",
+        beforeGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/before.gif",
+        afterGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/after.gif",
+      },
+    ]);
+    expect(c).not.toBeNull();
+    expect(c?.title).toBe("Interaction preview");
+    expect(c?.rawHtml).toBe(true);
+    expect(c?.body).toContain("| Target | Before | After |");
+    expect(c?.body).toContain("| Blocks row hover |");
+    expect(c?.body).toContain('<a href="https://api.example.dev/loopover/shot?key=loopover/shots/before.gif"');
+    expect(c?.body).toContain('alt="before Blocks row hover"');
+    expect(c?.body).toContain('alt="after Blocks row hover"');
+    expect(c?.body).toContain("<br><sub>before Blocks row hover</sub>");
+    expect(c?.body).toContain("<br><sub>after Blocks row hover</sub>");
+  });
+
+  it("falls back to the raw selector as the target when no label is configured", () => {
+    const c = buildInteractionPreviewCollapsible([
+      { selector: "#menu-button", afterGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/x.gif" },
+    ]);
+    expect(c?.body).toContain("| #menu-button |");
+  });
+
+  it("returns null when no interaction has a GIF — byte-identical to today for every non-opted-in repo", () => {
+    expect(buildInteractionPreviewCollapsible([])).toBeNull();
+    expect(buildInteractionPreviewCollapsible([{ selector: ".x" }])).toBeNull();
+  });
+
+  it("renders a dash when only one side has a GIF", () => {
+    const c = buildInteractionPreviewCollapsible([{ selector: ".x", afterGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/x.gif" }]);
+    expect(c?.body).toContain("| .x | — | <a href=");
+  });
+
+  it("escapes an untrusted label before embedding it in the trusted raw HTML table", () => {
+    const c = buildInteractionPreviewCollapsible([
+      {
+        selector: ".x",
+        label: "<h2>✅ FORGED APPROVAL</h2><a href=x>maintainer click here</a>",
+        afterGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/x.gif",
+      },
+    ]);
+    expect(c?.body).toContain("&lt;h2&gt;✅ FORGED APPROVAL&lt;/h2&gt;&lt;a href=x&gt;maintainer click here&lt;/a&gt;");
+    expect(c?.body).not.toContain("<h2>✅ FORGED APPROVAL</h2>");
+    expect(c?.body).not.toContain("<a href=x>maintainer click here</a>");
+  });
+});
+
+describe("buildUnifiedCommentBody interaction-GIF wiring (#interaction-gif-capture)", () => {
+  const base = {
+    gate: gate(),
+    panelRows,
+    readinessTotal: 90,
+    changedFiles: 3,
+    footerMarkdown: footer,
+  };
+
+  it("appends 'Interaction preview' ALONGSIDE 'Visual preview'/'Scroll preview' when an interaction has a GIF", () => {
+    const body = buildUnifiedCommentBody({
+      ...base,
+      beforeAfter: routes,
+      interactions: [{ selector: ".x", label: "Menu hover", afterGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/x.gif" }],
+    });
+    expect(body).toContain("Visual preview");
+    expect(body).toContain("Interaction preview");
+    expect(body.indexOf("Interaction preview")).toBeGreaterThan(body.indexOf("Visual preview"));
+  });
+
+  it("does NOT add an Interaction preview section when no interaction has a GIF (flag-OFF parity)", () => {
+    const body = buildUnifiedCommentBody({ ...base, beforeAfter: routes });
+    expect(body).not.toContain("Interaction preview");
   });
 });
 

--- a/test/unit/visual-collapsible.test.ts
+++ b/test/unit/visual-collapsible.test.ts
@@ -328,6 +328,16 @@ describe("buildUnifiedCommentBody interaction-GIF wiring (#interaction-gif-captu
     const body = buildUnifiedCommentBody({ ...base, beforeAfter: routes });
     expect(body).not.toContain("Interaction preview");
   });
+
+  it("renders Interaction preview as the ONLY visual section when no beforeAfter/scroll routes are configured at all (no prior collapsible to spread onto)", () => {
+    const body = buildUnifiedCommentBody({
+      ...base,
+      interactions: [{ selector: ".x", label: "Menu hover", afterGifUrl: "https://api.example.dev/loopover/shot?key=loopover/shots/x.gif" }],
+    });
+    expect(body).not.toContain("Visual preview");
+    expect(body).not.toContain("Scroll preview");
+    expect(body).toContain("Interaction preview");
+  });
 });
 
 describe("buildUnifiedCommentBody scroll-GIF wiring (#3612)", () => {

--- a/test/unit/visual-config-wiring.test.ts
+++ b/test/unit/visual-config-wiring.test.ts
@@ -85,25 +85,46 @@ describe("review.visual wiring (#3609 / #3610)", () => {
     await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({
       ...EMPTY_VISUAL_CONFIG,
       interactions: [
-        { selector: ".hover-target", action: "hover", path: null, label: "Blocks row hover" },
-        { selector: "#menu-button", action: "click", path: null, label: null },
+        { selector: ".hover-target", action: "hover", dragTo: null, path: null, label: "Blocks row hover" },
+        { selector: "#menu-button", action: "click", dragTo: null, path: null, label: null },
       ],
     });
     loadSpy.mockRestore();
   });
 
-  it("drops an interactions entry with a missing selector or an invalid action", async () => {
+  it("resolves a review.visual.interactions drag entry with drag_to from the repo's focus manifest", async () => {
     const manifest = parseFocusManifest({
       review: {
         visual: {
-          interactions: [{ action: "hover" }, { selector: ".ok", action: "drag" }, { selector: ".also-ok", action: "click" }],
+          interactions: [{ selector: ".card", action: "drag", drag_to: ".done-column", label: "Reorder card" }],
         },
       },
     });
     const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
     await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({
       ...EMPTY_VISUAL_CONFIG,
-      interactions: [{ selector: ".also-ok", action: "click", path: null, label: null }],
+      interactions: [{ selector: ".card", action: "drag", dragTo: ".done-column", path: null, label: "Reorder card" }],
+    });
+    loadSpy.mockRestore();
+  });
+
+  it("drops an interactions entry with a missing selector, an invalid action, or a drag action missing drag_to", async () => {
+    const manifest = parseFocusManifest({
+      review: {
+        visual: {
+          interactions: [
+            { action: "hover" },
+            { selector: ".unknown-action", action: "swipe" },
+            { selector: ".drag-no-target", action: "drag" },
+            { selector: ".also-ok", action: "click" },
+          ],
+        },
+      },
+    });
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
+    await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({
+      ...EMPTY_VISUAL_CONFIG,
+      interactions: [{ selector: ".also-ok", action: "click", dragTo: null, path: null, label: null }],
     });
     loadSpy.mockRestore();
   });

--- a/test/unit/visual-config-wiring.test.ts
+++ b/test/unit/visual-config-wiring.test.ts
@@ -25,6 +25,7 @@ describe("review.visual wiring (#3609 / #3610)", () => {
       themeStorageKey: null,
       actionsFallback: false,
       bugAnalysis: false,
+      interactions: [],
     });
     expect(loadSpy).toHaveBeenCalledWith(expect.anything(), "acme/widgets");
     loadSpy.mockRestore();
@@ -66,6 +67,44 @@ describe("review.visual wiring (#3609 / #3610)", () => {
   it("bug_analysis defaults to false, byte-identical to today, when unset", async () => {
     const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(parseFocusManifest({ review: { visual: { gif: true } } }));
     await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({ ...EMPTY_VISUAL_CONFIG, gif: true, bugAnalysis: false });
+    loadSpy.mockRestore();
+  });
+
+  it("resolves review.visual.interactions from the repo's focus manifest", async () => {
+    const manifest = parseFocusManifest({
+      review: {
+        visual: {
+          interactions: [
+            { selector: ".hover-target", action: "hover", label: "Blocks row hover" },
+            { selector: "#menu-button", action: "click" },
+          ],
+        },
+      },
+    });
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
+    await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({
+      ...EMPTY_VISUAL_CONFIG,
+      interactions: [
+        { selector: ".hover-target", action: "hover", path: null, label: "Blocks row hover" },
+        { selector: "#menu-button", action: "click", path: null, label: null },
+      ],
+    });
+    loadSpy.mockRestore();
+  });
+
+  it("drops an interactions entry with a missing selector or an invalid action", async () => {
+    const manifest = parseFocusManifest({
+      review: {
+        visual: {
+          interactions: [{ action: "hover" }, { selector: ".ok", action: "drag" }, { selector: ".also-ok", action: "click" }],
+        },
+      },
+    });
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
+    await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({
+      ...EMPTY_VISUAL_CONFIG,
+      interactions: [{ selector: ".also-ok", action: "click", path: null, label: null }],
+    });
     loadSpy.mockRestore();
   });
 });

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   hover: vi.fn(async () => undefined),
   click: vi.fn(async () => undefined),
   boundingBox: vi.fn(async (): Promise<{ x: number; y: number; width: number; height: number } | null> => ({ x: 0, y: 0, width: 100, height: 40 })),
+  scrollIntoViewIfNeeded: vi.fn(async () => undefined),
   mouseMove: vi.fn(async () => undefined),
   mouseDown: vi.fn(async () => undefined),
   mouseUp: vi.fn(async () => undefined),
@@ -603,7 +604,7 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
     vi.clearAllMocks();
     mocks.finalUrl = "https://preview.pages.dev/page";
     mocks.evaluateCallCount = 0;
-    mocks.waitForSelector.mockResolvedValue({ hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox });
+    mocks.waitForSelector.mockResolvedValue({ hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox, scrollIntoViewIfNeeded: mocks.scrollIntoViewIfNeeded });
     mocks.boundingBox.mockResolvedValue({ x: 0, y: 0, width: 100, height: 40 });
     mocks.evaluate.mockImplementation(async (fn: (...fnArgs: unknown[]) => unknown, ...fnArgs: unknown[]) => {
       mocks.evaluateCallCount++;
@@ -714,6 +715,53 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
     expect(mocks.close).toHaveBeenCalled();
   });
 
+  it("returns no frames when a redirect leads to a private endpoint", async () => {
+    mocks.finalUrl = "http://127.0.0.1/admin";
+    const result = await captureInteractionFrames(env(), "https://attacker.workers.dev/redirect", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+    expect(mocks.close).toHaveBeenCalled();
+  });
+
+  it("aborts a sub-request whose URL fails to parse", async () => {
+    mocks.finalUrl = "::::not-a-url";
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+  });
+
+  it("swallows continue() and abort() rejections on the allowed + unparseable sub-requests", async () => {
+    mocks.continue.mockRejectedValueOnce(new Error("continue failed"));
+    mocks.abort.mockRejectedValueOnce(new Error("abort failed"));
+    mocks.finalUrl = "::::not-a-url";
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+  });
+
+  it("swallows an abort() rejection on an unsafe-host sub-request", async () => {
+    mocks.abort.mockRejectedValueOnce(new Error("abort failed"));
+    mocks.finalUrl = "http://127.0.0.1/admin";
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+  });
+
+  it("does not apply the http SSRF check to a non-http(s) sub-request protocol", async () => {
+    mocks.finalUrl = "ftp://files.example.com/x";
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false }); // final url is non-http(s) -> redirect-blocked downstream
+    expect(mocks.continue).toHaveBeenCalled();
+  });
+
+  it("aborts a sub-request whose navigation isAllowedUrl disallows, even though the host itself is otherwise safe", async () => {
+    const isAllowedUrl = vi.fn((candidate: string) => candidate === "https://preview.pages.dev/page");
+    mocks.finalUrl = "https://preview.pages.dev/other-page";
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 }, { isAllowedUrl });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+  });
+
   describe("drag action (#interaction-gif-capture drag support)", () => {
     it("drags the source onto the destination via mouse down/interpolated-move/up, using each element's bounding-box center", async () => {
       mocks.boundingBox.mockResolvedValueOnce({ x: 0, y: 0, width: 100, height: 40 }).mockResolvedValueOnce({ x: 400, y: 200, width: 60, height: 60 });
@@ -755,6 +803,32 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
       expect(result.frames).toHaveLength(4);
       expect(mocks.mouseDown).not.toHaveBeenCalled();
       expect(mocks.mouseUp).not.toHaveBeenCalled();
+    });
+
+    it("no-ops the drag when only the SOURCE has no bounding box (destination alone is not enough)", async () => {
+      mocks.boundingBox.mockResolvedValueOnce(null).mockResolvedValueOnce({ x: 400, y: 200, width: 60, height: 60 });
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result.frames).toHaveLength(4);
+      expect(mocks.mouseDown).not.toHaveBeenCalled();
+    });
+
+    it("no-ops the drag when only the DESTINATION has no bounding box (source alone is not enough)", async () => {
+      mocks.boundingBox.mockResolvedValueOnce({ x: 0, y: 0, width: 100, height: 40 }).mockResolvedValueOnce(null);
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result.frames).toHaveLength(4);
+      expect(mocks.mouseDown).not.toHaveBeenCalled();
+    });
+
+    it("scrolls both the source and destination into view before reading their bounding boxes", async () => {
+      await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(mocks.scrollIntoViewIfNeeded).toHaveBeenCalledTimes(2);
+    });
+
+    it("still performs the drag (never throws) when scrollIntoViewIfNeeded itself rejects", async () => {
+      mocks.scrollIntoViewIfNeeded.mockRejectedValueOnce(new Error("scroll failed"));
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result.frames).toHaveLength(4);
+      expect(mocks.mouseDown).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -14,6 +14,10 @@ const mocks = vi.hoisted(() => ({
   waitForSelector: vi.fn(),
   hover: vi.fn(async () => undefined),
   click: vi.fn(async () => undefined),
+  boundingBox: vi.fn(async (): Promise<{ x: number; y: number; width: number; height: number } | null> => ({ x: 0, y: 0, width: 100, height: 40 })),
+  mouseMove: vi.fn(async () => undefined),
+  mouseDown: vi.fn(async () => undefined),
+  mouseUp: vi.fn(async () => undefined),
   // captureScrollFrames' FIRST page.evaluate() call queries scrollHeight; every later call (scrollTo, the
   // settle delay) discards its return value — so only the first call's resolved value matters to the code
   // under test, regardless of exactly how many scroll/settle evaluate() calls happen after it. captureShot's
@@ -599,7 +603,8 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
     vi.clearAllMocks();
     mocks.finalUrl = "https://preview.pages.dev/page";
     mocks.evaluateCallCount = 0;
-    mocks.waitForSelector.mockResolvedValue({ hover: mocks.hover, click: mocks.click });
+    mocks.waitForSelector.mockResolvedValue({ hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox });
+    mocks.boundingBox.mockResolvedValue({ x: 0, y: 0, width: 100, height: 40 });
     mocks.evaluate.mockImplementation(async (fn: (...fnArgs: unknown[]) => unknown, ...fnArgs: unknown[]) => {
       mocks.evaluateCallCount++;
       try {
@@ -628,6 +633,7 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
           screenshot: mocks.screenshot,
           evaluate: mocks.evaluate,
           waitForSelector: mocks.waitForSelector,
+          mouse: { move: mocks.mouseMove, down: mocks.mouseDown, up: mocks.mouseUp },
         }),
         close: mocks.close,
       };
@@ -706,6 +712,50 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
     const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
     expect(result).toEqual({ frames: [], authWalled: false });
     expect(mocks.close).toHaveBeenCalled();
+  });
+
+  describe("drag action (#interaction-gif-capture drag support)", () => {
+    it("drags the source onto the destination via mouse down/interpolated-move/up, using each element's bounding-box center", async () => {
+      mocks.boundingBox.mockResolvedValueOnce({ x: 0, y: 0, width: 100, height: 40 }).mockResolvedValueOnce({ x: 400, y: 200, width: 60, height: 60 });
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result.authWalled).toBe(false);
+      expect(result.frames).toHaveLength(4);
+      expect(mocks.waitForSelector).toHaveBeenCalledWith(".card", { timeout: 3_000 });
+      expect(mocks.waitForSelector).toHaveBeenCalledWith(".done-column", { timeout: 3_000 });
+      // source center (50, 20) -> destination center (430, 230): down at the source, up at the destination,
+      // with 8 interpolated positions in between (DRAG_MOVE_STEPS).
+      expect(mocks.mouseMove).toHaveBeenCalledWith(50, 20);
+      expect(mocks.mouseDown).toHaveBeenCalledTimes(1);
+      expect(mocks.mouseMove).toHaveBeenLastCalledWith(430, 230);
+      expect(mocks.mouseUp).toHaveBeenCalledTimes(1);
+      // 1 initial move to the source + 8 interpolation steps = 9 total move() calls.
+      expect(mocks.mouseMove).toHaveBeenCalledTimes(9);
+    });
+
+    it("returns no frames (fails open) when drag_to is not provided for a drag action", async () => {
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 });
+      expect(result).toEqual({ frames: [], authWalled: false });
+      expect(mocks.mouseDown).not.toHaveBeenCalled();
+    });
+
+    it("returns no frames (fails open) when the drag destination selector matches nothing on the page", async () => {
+      mocks.waitForSelector.mockImplementation(async (selector: string) =>
+        selector === ".done-column" ? null : { hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox },
+      );
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result).toEqual({ frames: [], authWalled: false });
+      expect(mocks.mouseDown).not.toHaveBeenCalled();
+    });
+
+    it("no-ops the drag (never throws) when either element has no bounding box (display:none / zero-size)", async () => {
+      mocks.boundingBox.mockResolvedValue(null);
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      // Frame capture still proceeds (the drag itself is a no-op, not a capture failure) — one at-rest frame
+      // plus the post-interaction settle frames, same shape as a successful hover/click.
+      expect(result.frames).toHaveLength(4);
+      expect(mocks.mouseDown).not.toHaveBeenCalled();
+      expect(mocks.mouseUp).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { captureScrollFrames, captureShot, handleShot } from "../../src/review/visual/shot";
+import { captureInteractionFrames, captureScrollFrames, captureShot, handleShot } from "../../src/review/visual/shot";
 
 const mocks = vi.hoisted(() => ({
   finalUrl: "https://preview.pages.dev/page",
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   emulateMediaFeatures: vi.fn(async () => undefined),
   reload: vi.fn(async () => undefined),
   evaluate: vi.fn(),
+  waitForSelector: vi.fn(),
+  hover: vi.fn(async () => undefined),
+  click: vi.fn(async () => undefined),
   // captureScrollFrames' FIRST page.evaluate() call queries scrollHeight; every later call (scrollTo, the
   // settle delay) discards its return value — so only the first call's resolved value matters to the code
   // under test, regardless of exactly how many scroll/settle evaluate() calls happen after it. captureShot's
@@ -588,6 +591,121 @@ describe("captureScrollFrames (#3612 scroll-through GIF evidence)", () => {
     expect(result).toEqual({ frames: [], authWalled: false });
     expect(mocks.abort).toHaveBeenCalled();
     expect(mocks.screenshot).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureInteractionFrames (#interaction-gif-capture)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.finalUrl = "https://preview.pages.dev/page";
+    mocks.evaluateCallCount = 0;
+    mocks.waitForSelector.mockResolvedValue({ hover: mocks.hover, click: mocks.click });
+    mocks.evaluate.mockImplementation(async (fn: (...fnArgs: unknown[]) => unknown, ...fnArgs: unknown[]) => {
+      mocks.evaluateCallCount++;
+      try {
+        fn(...fnArgs);
+      } catch {
+        // expected — see the shared mock comment above.
+      }
+      return undefined;
+    });
+    mocks.launch.mockImplementation(async () => {
+      let onRequest: ((request: ReturnType<typeof makeRequest>) => void) | undefined;
+      return {
+        newPage: async () => ({
+          setRequestInterception: vi.fn(async () => undefined),
+          on: vi.fn((event: string, callback: (request: ReturnType<typeof makeRequest>) => void) => {
+            if (event === "request") onRequest = callback;
+          }),
+          setViewport: vi.fn(async () => undefined),
+          emulateMediaFeatures: mocks.emulateMediaFeatures,
+          goto: vi.fn(async (url: string) => {
+            onRequest?.(makeRequest(url));
+            if (mocks.finalUrl !== url) onRequest?.(makeRequest(mocks.finalUrl));
+          }),
+          reload: mocks.reload,
+          url: vi.fn(() => mocks.finalUrl),
+          screenshot: mocks.screenshot,
+          evaluate: mocks.evaluate,
+          waitForSelector: mocks.waitForSelector,
+        }),
+        close: mocks.close,
+      };
+    });
+  });
+
+  it("rejects an unsafe target before launching the browser", async () => {
+    const result = await captureInteractionFrames(env(), "http://127.0.0.1/admin", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.launch).not.toHaveBeenCalled();
+  });
+
+  it("captures an at-rest frame plus MAX_INTERACTION_STEPS-1 post-interaction frames for a hover", async () => {
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".blocks-row", "hover", { width: 1440, height: 900 });
+    expect(result.authWalled).toBe(false);
+    expect(result.frames).toHaveLength(4);
+    expect(mocks.screenshot).toHaveBeenCalledTimes(4);
+    expect(mocks.screenshot).toHaveBeenCalledWith({ type: "png", fullPage: false });
+    expect(mocks.hover).toHaveBeenCalledTimes(1);
+    expect(mocks.click).not.toHaveBeenCalled();
+  });
+
+  it("clicks (not hovers) the element when action is 'click'", async () => {
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", "#menu-button", "click", { width: 1440, height: 900 });
+    expect(result.frames).toHaveLength(4);
+    expect(mocks.click).toHaveBeenCalledTimes(1);
+    expect(mocks.hover).not.toHaveBeenCalled();
+  });
+
+  it("returns no frames (fails open) when the selector matches nothing on the page", async () => {
+    mocks.waitForSelector.mockResolvedValue(null);
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".does-not-exist", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+  });
+
+  it("returns no frames when there is no BROWSER binding", async () => {
+    const result = await captureInteractionFrames({} as Env, "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.launch).not.toHaveBeenCalled();
+  });
+
+  it("emulates prefers-color-scheme when a theme is requested, same as captureScrollFrames/captureShot", async () => {
+    await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 }, { theme: "dark" });
+    expect(mocks.emulateMediaFeatures).toHaveBeenCalledWith([{ name: "prefers-color-scheme", value: "dark" }]);
+  });
+
+  it("forces the theme via localStorage.setItem + reload when both theme and themeStorageKey are set, mirroring captureScrollFrames (#4109)", async () => {
+    await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 }, { theme: "dark", themeStorageKey: "theme" });
+    expect(mocks.evaluate).toHaveBeenCalledWith(expect.any(Function), "theme", "dark");
+    expect(mocks.reload).toHaveBeenCalledWith({ waitUntil: "networkidle0", timeout: 20000 });
+  });
+
+  it("flags authWalled and captures no frames on a login-page redirect", async () => {
+    mocks.finalUrl = "https://preview.pages.dev/login";
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/dashboard", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: true });
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+  });
+
+  it("degrades to no frames (never throws) when the browser throws mid-capture", async () => {
+    mocks.launch.mockRejectedValue(new Error("binding exhausted"));
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+  });
+
+  it("rejects the target up front when isAllowedUrl disallows it, before launching the browser", async () => {
+    const isAllowedUrl = vi.fn(() => false);
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 }, { isAllowedUrl });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.launch).not.toHaveBeenCalled();
+  });
+
+  it("closes the browser even when waitForSelector throws", async () => {
+    mocks.waitForSelector.mockRejectedValue(new Error("timed out"));
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result).toEqual({ frames: [], authWalled: false });
+    expect(mocks.close).toHaveBeenCalled();
   });
 });
 

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -688,6 +688,31 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
     expect(mocks.reload).toHaveBeenCalledWith({ waitUntil: "networkidle0", timeout: 20000 });
   });
 
+  it("REGRESSION (security review): times out a hostile theme localStorage write before reload, mirroring captureShot/captureScrollFrames", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.evaluate.mockImplementation((fn: (...fnArgs: unknown[]) => unknown, ...fnArgs: unknown[]) => {
+        if (fnArgs.length > 0) return new Promise(() => undefined);
+        try {
+          fn(...fnArgs);
+        } catch {
+          // expected — see default mock comment above.
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const result = captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 }, { theme: "dark", themeStorageKey: "theme" });
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      await expect(result).resolves.toEqual({ frames: [], authWalled: false });
+      expect(mocks.reload).not.toHaveBeenCalled();
+      expect(mocks.screenshot).not.toHaveBeenCalled();
+      expect(mocks.close).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("flags authWalled and captures no frames on a login-page redirect", async () => {
     mocks.finalUrl = "https://preview.pages.dev/login";
     const result = await captureInteractionFrames(env(), "https://preview.pages.dev/dashboard", ".x", "hover", { width: 1440, height: 900 });
@@ -762,6 +787,13 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
     expect(mocks.screenshot).not.toHaveBeenCalled();
   });
 
+  it("swallows a close() rejection in the finally block", async () => {
+    mocks.close.mockRejectedValueOnce(new Error("close failed"));
+    const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".x", "hover", { width: 1440, height: 900 });
+    expect(result.authWalled).toBe(false);
+    expect(mocks.close).toHaveBeenCalled();
+  });
+
   describe("drag action (#interaction-gif-capture drag support)", () => {
     it("drags the source onto the destination via mouse down/interpolated-move/up, using each element's bounding-box center", async () => {
       mocks.boundingBox.mockResolvedValueOnce({ x: 0, y: 0, width: 100, height: 40 }).mockResolvedValueOnce({ x: 400, y: 200, width: 60, height: 60 });
@@ -790,6 +822,16 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
       mocks.waitForSelector.mockImplementation(async (selector: string) =>
         selector === ".done-column" ? null : { hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox },
       );
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result).toEqual({ frames: [], authWalled: false });
+      expect(mocks.mouseDown).not.toHaveBeenCalled();
+    });
+
+    it("returns no frames (fails open, never throws) when waiting for the drag destination selector itself rejects", async () => {
+      mocks.waitForSelector.mockImplementation(async (selector: string) => {
+        if (selector === ".done-column") throw new Error("timed out");
+        return { hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox };
+      });
       const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
       expect(result).toEqual({ frames: [], authWalled: false });
       expect(mocks.mouseDown).not.toHaveBeenCalled();
@@ -824,11 +866,30 @@ describe("captureInteractionFrames (#interaction-gif-capture)", () => {
       expect(mocks.scrollIntoViewIfNeeded).toHaveBeenCalledTimes(2);
     });
 
-    it("still performs the drag (never throws) when scrollIntoViewIfNeeded itself rejects", async () => {
-      mocks.scrollIntoViewIfNeeded.mockRejectedValueOnce(new Error("scroll failed"));
+    it("still performs the drag (never throws) when scrollIntoViewIfNeeded itself rejects, for BOTH the source and the destination", async () => {
+      // mockRejectedValue (not -Once) rejects every call — both the source's scrollIntoViewIfNeeded (before
+      // reading its bounding box) and the destination's (a separate call, same shared element mock) reject,
+      // exercising both catch sites independently rather than just the first one reached.
+      mocks.scrollIntoViewIfNeeded.mockRejectedValue(new Error("scroll failed"));
       const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
       expect(result.frames).toHaveLength(4);
       expect(mocks.mouseDown).toHaveBeenCalledTimes(1);
+      expect(mocks.scrollIntoViewIfNeeded).toHaveBeenCalledTimes(2);
+    });
+
+    it("still performs the drag when an element has no scrollIntoViewIfNeeded method at all (optional per the ElementHandle-subset type)", async () => {
+      mocks.waitForSelector.mockImplementation(async (selector: string) =>
+        selector === ".done-column"
+          ? { hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox }
+          : { hover: mocks.hover, click: mocks.click, boundingBox: mocks.boundingBox, scrollIntoViewIfNeeded: mocks.scrollIntoViewIfNeeded },
+      );
+      const result = await captureInteractionFrames(env(), "https://preview.pages.dev/page", ".card", "drag", { width: 1440, height: 900 }, {}, ".done-column");
+      expect(result.frames).toHaveLength(4);
+      // Source still scrolls (it has the method); destination has none, so optional chaining short-circuits
+      // to undefined rather than throwing — the drag itself still completes using its bounding box as-is.
+      expect(mocks.scrollIntoViewIfNeeded).toHaveBeenCalledTimes(1);
+      expect(mocks.mouseDown).toHaveBeenCalledTimes(1);
+      expect(mocks.mouseUp).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `review.visual.interactions[]` (global + per-repo, config-as-code): specific CSS selectors the bot hovers, clicks, or drags on a live page to capture before/after animated GIF evidence for behavior a static screenshot can't show — a hover-triggered popover, a click-triggered state change, or a drag-and-drop reorder.
- Reuses the existing self-host scroll-GIF encode pipeline (frame-source-agnostic) rather than building a new one.
- New "Interaction preview" comment section, alongside (never replacing) the static before/after table and scroll preview.
- **Security**: `click`/`drag` only ever run against the PR's own preview deploy, never production — they're real, state-mutating browser actions (a genuine click event / mouse-down-move-up drag), unlike `hover`, which still captures both before+after since it can never trigger a side effect.
- Off by default (`review.visual.interactions` empty/unset) — byte-identical to today for every repo that hasn't opted in.

This PR includes a follow-up commit addressing an internal adversarial review pass: a critical bug where `interactions` config was never round-tripped through `reviewConfigToJson` (silently reverting the whole feature to `[]` after the manifest cache expired), a GIF cache-fingerprint collision fix, a drag `scrollIntoViewIfNeeded` fix, theme threading, and 9 closed test-coverage gaps (SSRF sub-request branches, malformed manifest input, isolated bounding-box cases, cache-hit reuse, etc.).

Closes #7334

## Test plan
- [x] `npm run typecheck`
- [x] `npm run engine-parity:drift-check`
- [x] `npm run docs:drift-check`
- [x] Full unit suite (`npx vitest run test/unit`) — 18,374 tests passing
- [x] New/updated tests cover: hover/click/drag capture, the production-vs-preview security restriction, drag scroll-into-view + isolated bounding-box cases, manifest parsing (malformed input, caps, drag_to validation), GIF fingerprint collision, cache-hit reuse, and JSON round-trip