### PR TITLE
feat(visual): PR-intent-aware vision bug analysis + out-of-scope issue flagging

### DIFF
--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -704,6 +704,15 @@ review:
 #     # dispatch, byte-identical to today). Not needed for loopover-ui / metagraphed, which already have
 #     # their own preview-deploy pipeline. (#4112, part of the #3607 visual-capture convergence epic)
 #     actions_fallback: false
+#     # PR-intent-aware vision analysis + out-of-scope issue flagging. When true, the SAME before/after
+#     # vision call above (gated on pixel-diff + reputation + a vision-capable provider, see
+#     # evaluateVisualVisionGate) uses an enhanced prompt that also sees this PR's own stated title/
+#     # description, and separates a genuine defect THIS PR introduced ("regression", rendered exactly as
+#     # today) from a pre-existing problem the screenshots happen to reveal that has nothing to do with the
+#     # PR's stated change ("unrelated" — its own advisory finding, suggesting a NEW issue be opened for it
+#     # rather than reading like something this PR broke). Never a gate blocker either way. Bool. Default:
+#     # false (the original regression-only prompt, no PR context sent, byte-identical to pre-bugAnalysis).
+#     bug_analysis: false
 #   # Maintainer overrides for the public review-panel CONTENT (not what loopover measures). The
 #   # Gittensor attribution + register link is always appended to the footer regardless; maintainer text
 #   # failing the public-safe filter is dropped, never published.

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -718,6 +718,15 @@ review:
 #     # dispatch, byte-identical to today). Not needed for loopover-ui / metagraphed, which already have
 #     # their own preview-deploy pipeline. (#4112, part of the #3607 visual-capture convergence epic)
 #     actions_fallback: false
+#     # PR-intent-aware vision analysis + out-of-scope issue flagging. When true, the SAME before/after
+#     # vision call above (gated on pixel-diff + reputation + a vision-capable provider, see
+#     # evaluateVisualVisionGate) uses an enhanced prompt that also sees this PR's own stated title/
+#     # description, and separates a genuine defect THIS PR introduced ("regression", rendered exactly as
+#     # today) from a pre-existing problem the screenshots happen to reveal that has nothing to do with the
+#     # PR's stated change ("unrelated" — its own advisory finding, suggesting a NEW issue be opened for it
+#     # rather than reading like something this PR broke). Never a gate blocker either way. Bool. Default:
+#     # false (the original regression-only prompt, no PR context sent, byte-identical to pre-bugAnalysis).
+#     bug_analysis: false
 #   # Maintainer overrides for the public review-panel CONTENT (not what loopover measures). The
 #   # Gittensor attribution + register link is always appended to the footer regardless; maintainer text
 #   # failing the public-safe filter is dropped, never published.

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -996,6 +996,14 @@ export type VisualConfig = {
    *  (see the workflow's own header comment for setup); a repo without it just never gets a fallback run, same
    *  as leaving this unset. (#3607 visual-capture convergence epic) */
   actionsFallback: boolean;
+  /** `review.visual.bugAnalysis`: use the enhanced, PR-intent-aware vision prompt
+   *  (`VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT`, src/review/visual/visual-findings.ts) instead of the default
+   *  regression-only one — it's told the PR's own stated title/description and asked to separate a genuine
+   *  defect THIS PR introduced ("regression") from a pre-existing problem the screenshots happen to reveal
+   *  that has nothing to do with the PR's stated change ("unrelated", surfaced with a suggestion to open a
+   *  new issue for it). false (default, every existing manifest) ⇒ byte-identical to today: the original
+   *  regression-only prompt, no PR context sent, no "unrelated" finding category ever produced. */
+  bugAnalysis: boolean;
 };
 
 /** A `prefers-color-scheme` value the capture pipeline can emulate before rendering (#3678). */
@@ -1037,6 +1045,7 @@ export const EMPTY_VISUAL_CONFIG: VisualConfig = {
   enabled: null,
   themeStorageKey: null,
   actionsFallback: false,
+  bugAnalysis: false,
 };
 
 /** One `review.path_instructions[]` entry: a manifest path glob + the public-safe instructions to apply when a
@@ -2942,6 +2951,7 @@ function overlayVisualConfig(base: VisualConfig, override: VisualConfig): Visual
     enabled: pickOverlayNullable(override.enabled, base.enabled),
     themeStorageKey: pickOverlayNullable(override.themeStorageKey, base.themeStorageKey),
     actionsFallback: override.actionsFallback ? override.actionsFallback : base.actionsFallback,
+    bugAnalysis: override.bugAnalysis ? override.bugAnalysis : base.bugAnalysis,
   };
 }
 
@@ -3146,7 +3156,8 @@ function visualConfigPresent(config: VisualConfig): boolean {
     config.gif ||
     config.enabled !== null ||
     config.themeStorageKey !== null ||
-    config.actionsFallback
+    config.actionsFallback ||
+    config.bugAnalysis
   );
 }
 
@@ -3247,8 +3258,9 @@ function parseVisualConfig(value: JsonValue | undefined, warnings: string[]): Vi
   const enabled = normalizeOptionalBoolean(record.enabled, "review.visual.enabled", warnings);
   const themeStorageKey = parsePublicSafeText(record.theme_storage_key, "review.visual.theme_storage_key", warnings);
   const actionsFallback = normalizeOptionalBoolean(record.actions_fallback, "review.visual.actions_fallback", warnings) === true;
+  const bugAnalysis = normalizeOptionalBoolean(record.bug_analysis, "review.visual.bug_analysis", warnings) === true;
 
-  return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback };
+  return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback, bugAnalysis };
 }
 
 function parseAutoReviewTitleKeywords(value: JsonValue | undefined, warnings: string[]): string[] {
@@ -3563,6 +3575,7 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
     if (review.visual.enabled !== null) visual.enabled = review.visual.enabled;
     if (review.visual.themeStorageKey !== null) visual.theme_storage_key = review.visual.themeStorageKey;
     if (review.visual.actionsFallback) visual.actions_fallback = true;
+    if (review.visual.bugAnalysis) visual.bug_analysis = true;
     out.visual = visual;
   }
   if (review.linkedIssueSatisfaction !== null) out.linkedIssueSatisfaction = review.linkedIssueSatisfaction;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -459,10 +459,12 @@ import {
   parseFallbackRunCorrelation,
 } from "../review/visual/actions-fallback";
 import {
+  buildVisualBugAnalysisUserPrompt,
   buildVisualRegressionFindings,
   buildVisualVisionUserPrompt,
   evaluateVisualVisionGate,
   parseVisualVisionResponse,
+  VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT,
   VISUAL_VISION_SYSTEM_PROMPT,
 } from "../review/visual/visual-findings";
 import { incr, observe, REVIEW_LATENCY_BUCKETS } from "../selfhost/metrics";
@@ -7280,12 +7282,20 @@ export async function runVisualVisionForAdvisory(
     // must never reach the vision-model call below.
     mode: AgentActionMode;
     repoFullName: string;
-    pr: { number: number };
+    // title/body are OPTIONAL and only ever read when bugAnalysisEnabled is true (VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT
+    // is the only prompt that uses PR context at all) -- a caller that doesn't pass them still gets the exact
+    // same default-prompt behavior as before this field existed.
+    pr: { number: number; title?: string | null | undefined; body?: string | null | undefined };
     author: string | null;
     confirmedContributor: boolean;
     settings: RepositorySettings;
     advisory: { findings: AdvisoryFinding[] };
     routes: readonly CaptureRoute[];
+    // review.visual.bugAnalysis (config-as-code, resolved by the caller from resolveVisualCaptureConfig) --
+    // absent/false ⇒ byte-identical to today: VISUAL_VISION_SYSTEM_PROMPT, no PR context, no "unrelated"
+    // finding category ever produced. See visual-findings.ts's VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT doc comment
+    // for why this is a separate prompt rather than an always-on superset.
+    bugAnalysisEnabled?: boolean;
   },
 ): Promise<void> {
   if (args.mode === "paused" || args.routes.length === 0) return;
@@ -7366,10 +7376,17 @@ export async function runVisualVisionForAdvisory(
       if (afterBlock) images.push(afterBlock);
     }
     if (images.length === 0) return;
+    // review.visual.bugAnalysis (config-as-code): swap in the PR-intent-aware, dual-category prompt + a
+    // user-turn that also names the PR's own stated title/description. Absent/false ⇒ the exact same
+    // VISUAL_VISION_SYSTEM_PROMPT/buildVisualVisionUserPrompt call every existing caller already makes.
+    const visionSystemPrompt = args.bugAnalysisEnabled ? VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT : VISUAL_VISION_SYSTEM_PROMPT;
+    const visionUserPrompt = args.bugAnalysisEnabled
+      ? buildVisualBugAnalysisUserPrompt(visionGate.routes, { title: args.pr.title, body: args.pr.body })
+      : buildVisualVisionUserPrompt(visionGate.routes);
     let visionText: string | null;
     let visionUsage: AiReviewActualUsage | undefined;
     if (visionProviderKey) {
-      const visionResponse = await callAiProvider(visionProviderKey, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), 600, images);
+      const visionResponse = await callAiProvider(visionProviderKey, visionSystemPrompt, visionUserPrompt, 600, images);
       visionText = visionResponse.text;
       visionUsage = visionResponse.usage;
       if (!visionText) {
@@ -7390,7 +7407,7 @@ export async function runVisualVisionForAdvisory(
         return;
       }
     } else {
-      const selfHostResult = await runSelfHostVisualVision(env, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), images);
+      const selfHostResult = await runSelfHostVisualVision(env, visionSystemPrompt, visionUserPrompt, images);
       visionText = selfHostResult.text;
       visionUsage = selfHostResult.usage;
       if (!visionText) {
@@ -10298,6 +10315,12 @@ async function maybePublishPrPublicSurface(
       // NEVER sink the review — it just omits the "Visual preview" section. Flag-OFF (default) ⇒ this block is
       // skipped entirely and the unified comment is byte-identical.
       let beforeAfter: CaptureRoute[] = [];
+      // review.visual.bugAnalysis — resolved inside the try block below alongside the rest of reviewVisualConfig,
+      // but needed at the runVisualVisionForAdvisory call OUTSIDE that block's scope (that call is deliberately
+      // independent of the capture try/catch above, see its own comment) — mirrors beforeAfter's own
+      // declared-outer/assigned-inner pattern. false (unresolved, or resolution never ran) ⇒ byte-identical
+      // default-prompt behavior, same fail-safe direction as every other config-as-code read here.
+      let bugAnalysisEnabled = false;
       const visualFiles = unifiedFiles
         .map((file) => file.path)
         .filter(isVisualPath);
@@ -10308,6 +10331,7 @@ async function maybePublishPrPublicSurface(
           // (the default for every repo today) ⇒ EMPTY_VISUAL_CONFIG ⇒ buildCapture's discovery/inference
           // behavior is byte-identical to pre-#3609.
           const reviewVisualConfig = await resolveVisualCaptureConfig(env, repoFullName);
+          bugAnalysisEnabled = reviewVisualConfig.bugAnalysis === true;
           const captureTarget = {
             repoFullName,
             prNumber: pr.number,
@@ -10399,6 +10423,7 @@ async function maybePublishPrPublicSurface(
         settings,
         advisory,
         routes: beforeAfter,
+        bugAnalysisEnabled,
       });
       // Vision-verify a contributor-pasted screenshot-table (#4366 wiring) — see runScreenshotTableVisionForAdvisory's
       // own doc comment. Independent of the bot-capture vision block above: this checks the CONTRIBUTOR's own

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -24,7 +24,7 @@ import type { GateCheckConclusion, GateCheckEvaluation } from "../rules/advisory
 import type { PublicPrPanelSignalRow } from "../signals/engine";
 import { formatManifestValidationNotice } from "../signals/focus-manifest";
 import type { CaptureRoute } from "./visual/capture";
-import { VISUAL_REGRESSION_FINDING_CODE } from "./visual/visual-findings";
+import { VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE } from "./visual/visual-findings";
 // Single-source the panel marker from its canonical home (the upsert reads it there); re-export so existing
 // importers of `PR_PANEL_COMMENT_MARKER` from this module keep working. The unified body MUST prepend this
 // verbatim or `createOrUpdatePrIntelligenceComment` posts a DUPLICATE instead of updating in place.
@@ -247,12 +247,12 @@ export function buildDualReviewNotes(args: {
   // raw warning findings). Scrub each with the private-term boundary and DROP any that still leaks. See
   // PRIVATE_FORBIDDEN_TERMS above. (The consensus-defect blocker is already public-safe via toPublicSafe; the
   // gate blockers above go through the SAME scrub as Nits.)
-  // `visual_regression_finding` is excluded here the same way `ai_consensus_defect` is excluded from
-  // gateBlockerLines above — it renders in its OWN "Visual findings" collapsible (see
-  // `visualFindingsFromFindings`/`buildVisualFindingsCollapsible`), so folding it into generic Nits too would
-  // render it twice.
+  // `visual_regression_finding`/`visual_unrelated_issue_finding` are excluded here the same way
+  // `ai_consensus_defect` is excluded from gateBlockerLines above — they render in their OWN "Visual
+  // findings" collapsible (see `visualFindingsFromFindings`/`buildVisualFindingsCollapsible`), so folding
+  // them into generic Nits too would render them twice.
   const gateNits = (args.warnings ?? [])
-    .filter((warning) => !isBoilerplateNit(warning) && warning.code !== VISUAL_REGRESSION_FINDING_CODE)
+    .filter((warning) => !isBoilerplateNit(warning) && warning.code !== VISUAL_REGRESSION_FINDING_CODE && warning.code !== VISUAL_UNRELATED_ISSUE_FINDING_CODE)
     .map((warning) => `${warning.title}${warning.action ? ` — ${warning.action}` : ""}`.trim())
     .filter(Boolean)
     .map((line) => publicSafeNit(line))
@@ -287,16 +287,20 @@ export function consensusDefectFromFindings(findings: AdvisoryFinding[] | undefi
   return { title: found.title, detail: found.detail };
 }
 
-/** Recover the advisory-only visual-regression findings (#4111 — AI-vision analysis of before/after visual
- *  captures) from the SAME advisory findings array `consensusDefectFromFindings` reads above — feeding the
- *  identical pipeline every other AI-judgment finding rides, so a visual finding is suppressible by
- *  review.memory, audited the same way, and — critically — can NEVER become a gate blocker:
- *  `visual_regression_finding` is not one of the codes `isConfiguredGateBlocker` (src/rules/advisory.ts)
- *  recognizes, so it always stays a warning. Formatted `title: detail`, scrubbed through the same
- *  `publicSafeNit` defense-in-depth boundary as every other bridge-recovered string. */
+/** Recover the advisory-only visual-regression AND visual-unrelated-issue findings (#4111 / `review.visual.
+ *  bugAnalysis` — AI-vision analysis of before/after visual captures) from the SAME advisory findings array
+ *  `consensusDefectFromFindings` reads above — feeding the identical pipeline every other AI-judgment finding
+ *  rides, so a visual finding is suppressible by review.memory, audited the same way, and — critically — can
+ *  NEVER become a gate blocker: neither `visual_regression_finding` nor `visual_unrelated_issue_finding` is
+ *  one of the codes `isConfiguredGateBlocker` (src/rules/advisory.ts) recognizes, so both always stay a
+ *  warning. Both codes share the SAME collapsible/rendering path — each finding's own title/action text
+ *  (see `buildVisualRegressionFindings`) already makes the distinction ("possible regression" vs "possible
+ *  unrelated issue — consider opening a new issue") without needing a separate section here. Formatted
+ *  `title: detail`, scrubbed through the same `publicSafeNit` defense-in-depth boundary as every other
+ *  bridge-recovered string. */
 export function visualFindingsFromFindings(findings: AdvisoryFinding[] | undefined): string[] {
   return (findings ?? [])
-    .filter((finding) => finding.code === VISUAL_REGRESSION_FINDING_CODE)
+    .filter((finding) => finding.code === VISUAL_REGRESSION_FINDING_CODE || finding.code === VISUAL_UNRELATED_ISSUE_FINDING_CODE)
     .map((finding) => `${finding.title}: ${finding.detail}`.trim())
     .map((line) => publicSafeNit(line))
     .filter((line): line is string => line !== null);

--- a/src/review/visual/visual-findings.ts
+++ b/src/review/visual/visual-findings.ts
@@ -152,14 +152,17 @@ export const VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT = [
  *  a valid prompt (the model falls back to judging purely from what it sees) — this is a best-effort context
  *  addition, not a hard requirement. */
 export function buildVisualBugAnalysisUserPrompt(routes: readonly { path: string }[], pr: { title?: string | null | undefined; body?: string | null | undefined }): string {
-  const paths = routes.map((route) => `- ${route.path}`).join("\n");
-  const title = pr.title?.trim();
-  const body = pr.body?.trim();
+  // title has no server-side length guarantee this codebase controls the way GitHub's own PR-title field
+  // does in practice -- capped defensively, mirroring body's existing .slice(0, 2000), even though the
+  // downstream JSON-schema-constrained response + public-safe filtering already bounds the blast radius of
+  // an oversized/hostile value reaching this prompt.
+  const title = pr.title?.trim().slice(0, 2000);
+  const body = pr.body?.trim().slice(0, 2000);
   const prContext =
-    title || body
-      ? `Pull request's stated change:\n${title ? `Title: ${title}\n` : ""}${body ? `Description: ${body.slice(0, 2000)}\n` : ""}\n`
-      : "";
-  return `${prContext}Route(s) under review:\n${paths}\n\nEach route's images are attached in before, after order.`;
+    title || body ? `Pull request's stated change:\n${title ? `Title: ${title}\n` : ""}${body ? `Description: ${body}\n` : ""}\n` : "";
+  // Composes buildVisualVisionUserPrompt's own route-listing text rather than recomputing it, so the two
+  // prompts' "Route(s) under review" section can never silently drift apart.
+  return `${prContext}${buildVisualVisionUserPrompt(routes)}`;
 }
 
 /** Parse the model's structured vision response into public-safe findings, dropping anything unparseable, a

--- a/src/review/visual/visual-findings.ts
+++ b/src/review/visual/visual-findings.ts
@@ -22,6 +22,14 @@ import type { CaptureRoute } from "./capture";
  *  from `isConfiguredGateBlocker`'s allowlist (src/rules/advisory.ts) — see this file's header. */
 export const VISUAL_REGRESSION_FINDING_CODE = "visual_regression_finding";
 
+/** The advisory finding code an "unrelated" (pre-existing, out-of-scope) visual observation is published
+ *  under (`review.visual.bugAnalysis`) — rides the identical strictly-advisory contract as
+ *  {@link VISUAL_REGRESSION_FINDING_CODE} (this file's header), also deliberately absent from
+ *  `isConfiguredGateBlocker`'s allowlist. Distinct from the regression code so the unified comment / any
+ *  future automation can tell "this PR broke something" apart from "this PR's screenshots happen to show a
+ *  pre-existing problem" — the latter is never this PR's fault and should never read like a blocker. */
+export const VISUAL_UNRELATED_ISSUE_FINDING_CODE = "visual_unrelated_issue_finding";
+
 /** Bound on how many routes a single review ever sends to vision, independent of how many the capture
  *  pipeline rendered — a vision call is the most expensive AI request this codebase makes per-route (an
  *  image attachment, not just text), so an unbounded capture set must never translate into unbounded spend. */
@@ -84,9 +92,15 @@ export function evaluateVisualVisionGate(input: {
   return { run: true, routes };
 }
 
-/** One vision observation the model reported for a specific route — both fields already public-safe (see
- *  {@link parseVisualVisionResponse}). */
-export type VisualVisionFinding = { path: string; body: string };
+/** One vision observation the model reported for a specific route — `path`/`body` already public-safe (see
+ *  {@link parseVisualVisionResponse}). `category` is only ever populated when the caller used
+ *  {@link VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT} (`review.visual.bugAnalysis`) — the default prompt
+ *  ({@link VISUAL_VISION_SYSTEM_PROMPT}) never asks the model for one, so it's absent (parsed as
+ *  `"regression"`, {@link buildVisualRegressionFindings}'s default) for every repo that hasn't opted in,
+ *  byte-identical to pre-bugAnalysis behavior. `"regression"` = a defect this PR's own change introduced;
+ *  `"unrelated"` = a pre-existing problem visible in either screenshot that has nothing to do with this PR's
+ *  stated change. */
+export type VisualVisionFinding = { path: string; body: string; category?: "regression" | "unrelated" };
 
 /** Cap on findings kept from a single vision response — mirrors `composeAdvisoryNotes`'s selectivity so a
  *  verbose model can't pad the comment with a long list of minor observations. */
@@ -110,10 +124,51 @@ export function buildVisualVisionUserPrompt(routes: readonly { path: string }[])
   return `Route(s) under review:\n${paths}\n\nEach route's images are attached in before, after order.`;
 }
 
+/** `review.visual.bugAnalysis`'s enhanced vision prompt — same before/after image contract as
+ *  {@link VISUAL_VISION_SYSTEM_PROMPT}, but PR-intent-aware and dual-category: it reports a genuine defect
+ *  the PR's OWN change introduced ("regression") separately from a pre-existing problem the screenshots
+ *  happen to reveal that has nothing to do with the PR's stated intent ("unrelated") — e.g. broken styling on
+ *  a neighboring component the diff never touches. This is deliberately a SEPARATE prompt from the default,
+ *  not a superset toggle on it: a repo that hasn't opted in must see byte-identical model behavior, and this
+ *  prompt's added PR-context/category instructions are exactly the kind of thing that could otherwise subtly
+ *  shift a model's existing regression-detection behavior even when the caller never intended a change. */
+export const VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT = [
+  "You are reviewing a BEFORE (production) vs AFTER (this pull request's preview deploy) screenshot pair for the same route,",
+  "with the pull request's own stated title/description as context for what this change is supposed to do.",
+  'Respond with ONLY a JSON object of this exact shape (no prose, no code fence): {"findings": [{"path": string, "body": string, "category": "regression" | "unrelated"}]}.',
+  'Report a "regression" finding ONLY for a genuine, visually-confirmable defect that this PR\'s OWN change introduced —',
+  "broken layout, overlapping/clipped/unstyled content, a missing or misplaced element, unreadable contrast, or obvious",
+  'placeholder content. Report an "unrelated" finding for a genuine visual problem you can see in EITHER screenshot that has',
+  "nothing to do with the PR's stated change — a pre-existing bug on the same page the diff never touches. Judge relatedness",
+  "against the stated title/description, not against which pixels happen to differ. Do NOT report a color/spacing/copy change",
+  "that still looks like a normal, intentional part of the stated change. Each body is ONE sentence, specific to what you SEE.",
+  "Return an empty findings array when the AFTER screenshot looks like a legitimate, correctly-rendered page with nothing",
+  "else visibly wrong. Never mention rewards, payouts, wallets, hotkeys, coldkeys, or trust scores.",
+].join(" ");
+
+/** Build the user-turn text for {@link VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT} — same route-listing contract as
+ *  {@link buildVisualVisionUserPrompt}, plus the PR's own stated title/description (when available) so the
+ *  model can judge whether an observation is in- or out-of-scope. A null/blank title AND body still produces
+ *  a valid prompt (the model falls back to judging purely from what it sees) — this is a best-effort context
+ *  addition, not a hard requirement. */
+export function buildVisualBugAnalysisUserPrompt(routes: readonly { path: string }[], pr: { title?: string | null | undefined; body?: string | null | undefined }): string {
+  const paths = routes.map((route) => `- ${route.path}`).join("\n");
+  const title = pr.title?.trim();
+  const body = pr.body?.trim();
+  const prContext =
+    title || body
+      ? `Pull request's stated change:\n${title ? `Title: ${title}\n` : ""}${body ? `Description: ${body.slice(0, 2000)}\n` : ""}\n`
+      : "";
+  return `${prContext}Route(s) under review:\n${paths}\n\nEach route's images are attached in before, after order.`;
+}
+
 /** Parse the model's structured vision response into public-safe findings, dropping anything unparseable, a
  *  blank path/body, or a body that trips the public/private boundary (`toPublicSafe`). Bounded to
  *  {@link MAX_VISUAL_FINDINGS}. Never throws — an unparseable response degrades to `[]`, the same fail-safe
- *  convention `parseModelReview` uses. */
+ *  convention `parseModelReview` uses. `category` is parsed permissively: absent/unrecognized ⇒ undefined
+ *  (treated as `"regression"` by every caller, e.g. {@link buildVisualRegressionFindings}) — the default
+ *  prompt never asks for one, so this keeps that path byte-identical while still accepting a valid category
+ *  from the bug-analysis prompt. */
 export function parseVisualVisionResponse(text: string): VisualVisionFinding[] {
   const raw = extractLastJsonObject(text);
   if (!raw) return [];
@@ -134,22 +189,36 @@ export function parseVisualVisionResponse(text: string): VisualVisionFinding[] {
     const rawBody = typeof record.body === "string" ? record.body : "";
     const body = toPublicSafe(rawBody);
     if (!path || !body) continue;
-    out.push({ path, body });
+    const category = record.category === "regression" || record.category === "unrelated" ? record.category : undefined;
+    out.push(category ? { path, body, category } : { path, body });
   }
   return out;
 }
 
-/** Build the ADVISORY-ONLY findings for the unified comment (#4111) — one per vision observation, feeding the
- *  SAME `advisory.findings` pipeline `ai_consensus_defect`/`ai_review_split` already ride (see this file's
- *  header for why `visual_regression_finding` can never become a blocker). `severity: "warning"` is required,
- *  not incidental — `evaluateGateCheckCore` (src/rules/advisory.ts) only carries `"warning"`-severity findings
- *  into `gate.warnings` at all, so anything else would silently vanish from the rendered comment. */
+/** Build the ADVISORY-ONLY findings for the unified comment (#4111 / `review.visual.bugAnalysis`) — one per
+ *  vision observation, feeding the SAME `advisory.findings` pipeline `ai_consensus_defect`/`ai_review_split`
+ *  already ride (see this file's header for why neither finding code can ever become a blocker).
+ *  `severity: "warning"` is required, not incidental — `evaluateGateCheckCore` (src/rules/advisory.ts) only
+ *  carries `"warning"`-severity findings into `gate.warnings` at all, so anything else would silently vanish
+ *  from the rendered comment. An `"unrelated"`-category finding (only ever produced by
+ *  {@link VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT}) gets its own code + a distinct message suggesting the observer
+ *  open a separate issue, since it is — by construction — not this PR's fault and must never read like one. */
 export function buildVisualRegressionFindings(findings: readonly VisualVisionFinding[]): AdvisoryFinding[] {
-  return findings.map((finding) => ({
-    code: VISUAL_REGRESSION_FINDING_CODE,
-    severity: "warning",
-    title: `Possible visual regression: ${finding.path}`,
-    detail: finding.body,
-    action: "Advisory only — verify against the Visual preview screenshots before deciding.",
-  }));
+  return findings.map((finding) =>
+    finding.category === "unrelated"
+      ? {
+          code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
+          severity: "warning",
+          title: `Possible unrelated visual issue: ${finding.path}`,
+          detail: finding.body,
+          action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+        }
+      : {
+          code: VISUAL_REGRESSION_FINDING_CODE,
+          severity: "warning",
+          title: `Possible visual regression: ${finding.path}`,
+          detail: finding.body,
+          action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+        },
+  );
 }

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -4862,6 +4862,7 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
       enabled: null,
       themeStorageKey: null,
       actionsFallback: false,
+      bugAnalysis: false,
     });
     expect(m.review.present).toBe(true);
     expect(parseFocusManifest({ review: reviewConfigToJson(m.review) }).review.visual).toEqual(m.review.visual);
@@ -4957,7 +4958,7 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
   it("resolveReviewVisualConfig: null manifest yields empty defaults; a set manifest passes through", () => {
     expect(resolveReviewVisualConfig(null)).toEqual({ ...EMPTY_VISUAL_CONFIG });
     const manifest = parseFocusManifest({ review: { visual: { routes: { paths: ["/app"] } } } });
-    expect(resolveReviewVisualConfig(manifest)).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: ["/app"], maxRoutes: null }, themes: [], gif: false, enabled: null, themeStorageKey: null, actionsFallback: false });
+    expect(resolveReviewVisualConfig(manifest)).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: ["/app"], maxRoutes: null }, themes: [], gif: false, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false });
   });
 });
 
@@ -5103,7 +5104,7 @@ describe("review.visual.gif (#3612 scroll-through GIF capture)", () => {
 
   it("composes with themes — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { gif: true, themes: ["dark"] } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { themes: ["dark"], gif: true } });
   });
 
@@ -5206,7 +5207,7 @@ describe("review.visual.theme_storage_key (#4109 localStorage theme-forcing fall
 
   it("composes with themes — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { themes: ["dark"], theme_storage_key: "theme" } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: false, enabled: null, themeStorageKey: "theme", actionsFallback: false });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: false, enabled: null, themeStorageKey: "theme", actionsFallback: false, bugAnalysis: false });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { themes: ["dark"], theme_storage_key: "theme" } });
   });
 
@@ -5261,7 +5262,7 @@ describe("review.visual.actions_fallback (#4112 GitHub-Actions build-and-serve f
 
   it("composes with gif — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { actions_fallback: true, gif: true } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: true });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: true, bugAnalysis: false });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { gif: true, actions_fallback: true } });
   });
 
@@ -5280,6 +5281,61 @@ describe("review.visual.actions_fallback (#4112 GitHub-Actions build-and-serve f
     const globalDefault = parseReviewConfigMapping({ visual: { actions_fallback: true } }, []);
     const perRepo = parseReviewConfigMapping({ visual: { routes: { paths: ["/app"] } } }, []);
     expect(overlayReviewConfig(globalDefault, perRepo).visual.actionsFallback).toBe(true);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.routes.paths).toEqual(["/app"]);
+  });
+});
+
+describe("review.visual.bugAnalysis (PR-intent-aware vision + out-of-scope issue flagging)", () => {
+  it("parses bug_analysis: true, marks present, and round-trips", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis: true } } });
+    expect(m.review.visual.bugAnalysis).toBe(true);
+    expect(m.review.present).toBe(true);
+    expect(reviewConfigToJson(m.review)).toEqual({ visual: { bug_analysis: true } });
+  });
+
+  it("absent bug_analysis defaults to false and does not mark review present on its own", () => {
+    expect(parseFocusManifest({}).review.visual.bugAnalysis).toBe(false);
+    expect(parseFocusManifest({ review: { visual: {} } }).review.present).toBe(false);
+  });
+
+  it("bug_analysis: false does not mark review present, so the whole review block round-trips to null", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis: false } } });
+    expect(m.review.visual.bugAnalysis).toBe(false);
+    expect(reviewConfigToJson(m.review)).toBeNull();
+  });
+
+  it("warns and defaults to false when bug_analysis is not a boolean", () => {
+    const bad = parseFocusManifest({ review: { visual: { bug_analysis: "yes" } } });
+    expect(bad.review.visual.bugAnalysis).toBe(false);
+    expect(bad.warnings.some((w) => /review\.visual\.bug_analysis.*must be a boolean/.test(w))).toBe(true);
+  });
+
+  it("marks present via bug_analysis alone (preview + routes + themes + gif + enabled all empty)", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis: true } } });
+    expect(m.review.present).toBe(true);
+  });
+
+  it("composes with gif — both configured independently and both round-trip", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis: true, gif: true } } });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: true });
+    expect(reviewConfigToJson(m.review)).toEqual({ visual: { gif: true, bug_analysis: true } });
+  });
+
+  it("resolveReviewVisualConfig passes a configured bug_analysis: true through", () => {
+    const manifest = parseFocusManifest({ review: { visual: { bug_analysis: true } } });
+    expect(resolveReviewVisualConfig(manifest).bugAnalysis).toBe(true);
+  });
+
+  it("overlay: a per-repo bug_analysis: true wins over a global-default false", () => {
+    const globalDefault = parseReviewConfigMapping({ visual: { bug_analysis: false } }, []);
+    const perRepo = parseReviewConfigMapping({ visual: { bug_analysis: true } }, []);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.bugAnalysis).toBe(true);
+  });
+
+  it("overlay: an unset per-repo bug_analysis falls back to the global-default true — this is how the operator turns it on fleet-wide from the global-default .loopover.yml", () => {
+    const globalDefault = parseReviewConfigMapping({ visual: { bug_analysis: true } }, []);
+    const perRepo = parseReviewConfigMapping({ visual: { routes: { paths: ["/app"] } } }, []);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.bugAnalysis).toBe(true);
     expect(overlayReviewConfig(globalDefault, perRepo).visual.routes.paths).toEqual(["/app"]);
   });
 });

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -64,6 +64,7 @@ import type { PullRequestRecord } from "../../src/types";
 import { aiReviewCacheInputFingerprint } from "../../src/review/ai-review-cache-input";
 import { fingerprint as reviewMemoryFingerprint } from "../../src/review/review-memory-match";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
+import * as pixelDiffModule from "../../src/review/visual/pixel-diff";
 import * as focusManifestLoaderModule from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -3502,6 +3503,199 @@ describe("queue processors", () => {
       expect(postedBody).not.toContain("Visual preview");
     } finally {
       liveCiSpy.mockRestore();
+    }
+  });
+
+  // review.visual.bugAnalysis (config-as-code): threads all the way from the real .loopover.yml raw-fetch
+  // through resolveVisualCaptureConfig -> the `let bugAnalysisEnabled = false` declared OUTSIDE the capture
+  // try/catch -> the real runVisualVisionForAdvisory call below it. Unlike the sibling wiring tests (visual-
+  // config-wiring.test.ts asserts resolveVisualCaptureConfig alone; visual-vision-wiring.test.ts calls
+  // runVisualVisionForAdvisory directly with bugAnalysisEnabled passed as a literal) this is the ONLY test
+  // that proves the actual assignment/threading between those two halves is correct via the real webhook
+  // path -- a copy-paste field-name bug or an early-return before the assignment would slip through every
+  // other existing test untouched. Forces a real pixel-diff "changed" route (isVisualDiffAvailable is
+  // Worker-safe-false by default, so no route would otherwise carry a diffUrl to unblock
+  // evaluateVisualVisionGate) and a BYOK vision provider, then asserts the captured request body sent to the
+  // provider contains the PR's own title -- which only happens when bugAnalysisEnabled actually reached true.
+  it("threads review.visual.bug_analysis: true from the real .loopover.yml into the live vision-provider call", async () => {
+    // A minimal in-memory R2 stub for REVIEW_AUDIT -- uploadDiffImage (capture.ts) requires REVIEW_AUDIT plus
+    // PUBLIC_API_ORIGIN/REVIEW_AUDIT_S3_PUBLIC_URL to persist a diffUrl at all; without it, no route would ever
+    // carry a diffUrl regardless of the pixel-diff spy below, and evaluateVisualVisionGate would never unblock.
+    const diffStore = new Map<string, Uint8Array>();
+    const reviewAudit = {
+      async get(key: string) {
+        const bytes = diffStore.get(key);
+        return bytes ? ({ body: new Response(bytes).body } as unknown as R2ObjectBody) : null;
+      },
+      async put(key: string, value: unknown) {
+        const bytes = new Uint8Array(await new Response(value as BodyInit).arrayBuffer());
+        diffStore.set(key, bytes);
+        return { key } as unknown as R2Object;
+      },
+    } as unknown as R2Bucket;
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      LOOPOVER_REVIEW_SCREENSHOTS: "true",
+      TOKEN_ENCRYPTION_SECRET: "bug-analysis-wiring-test-encryption-secret",
+      PUBLIC_API_ORIGIN: "https://worker.example",
+      REVIEW_AUDIT: reviewAudit,
+    });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autoLabelEnabled: false,
+      reviewCheckMode: "required",
+      autonomy: { update_branch: "auto" },
+      aiReviewByok: true,
+    });
+    await upsertRepositoryAiKey(env, { repoFullName: "JSONbored/gittensory", provider: "anthropic", key: "sk-ant-bug-analysis-wiring-key", model: null });
+    const isVisualDiffAvailableSpy = vi.spyOn(pixelDiffModule, "isVisualDiffAvailable").mockReturnValue(true);
+    const compareScreenshotsSpy = vi.spyOn(pixelDiffModule, "compareCapturedScreenshots").mockResolvedValue({
+      status: "changed",
+      changedPixelPercent: 12,
+      diffImagePng: new Uint8Array([1, 2, 3]),
+    });
+    let postedBody = "";
+    let visionProviderRequestBody = "";
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "passed",
+      hasPending: false,
+      hasVisiblePending: false,
+      hasMissingRequiredContext: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      advisoryHoldDetails: [],
+      ciCompletenessWarning: null,
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.loopover.yml") {
+        return new Response(
+          "settings:\n  commentMode: detected_contributors_only\n  publicAudienceMode: gittensor_only\n  publicSignalLevel: standard\n  publicSurface: comment_and_label\n  checkRunMode: \"off\"\n  checkRunDetailLevel: minimal\n  backfillEnabled: true\ngate:\n  aiReview:\n    byok: true\nreview:\n  visual:\n    bug_analysis: true\n",
+        );
+      }
+      if (url === "https://api.anthropic.com/v1/messages") {
+        visionProviderRequestBody = String(init?.body ?? "");
+        return Response.json({ content: [{ type: "text", text: '{"findings": []}' }] });
+      }
+      // Every /loopover/shot URL (the on-demand ?url= before-render, the cached ?key= diff image, and the
+      // placeholder=loading after-cell) -- runVisualVisionForAdvisory's fetchShotContentBlock needs a real
+      // 2xx image response for BOTH before and after to build any images[] at all, or it bails before ever
+      // reaching the provider call.
+      if (url.includes("/loopover/shot")) {
+        return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), { status: 200, headers: { "content-type": "image/png" } });
+      }
+      if (url === "https://api.gittensor.io/miners") {
+        return Response.json([
+          {
+            uid: 7,
+            githubUsername: "oktofeesh1",
+            githubId: "123",
+            totalPrs: 4,
+            totalMergedPrs: 3,
+            totalOpenPrs: 1,
+            totalClosedPrs: 0,
+            totalOpenIssues: 0,
+            totalClosedIssues: 0,
+            totalSolvedIssues: 0,
+            totalValidSolvedIssues: 0,
+            isEligible: true,
+            credibility: 1,
+            eligibleRepoCount: 1,
+            hotkey: "must-not-leak",
+          },
+        ]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") {
+        return Response.json({
+          repositories: [
+            {
+              repositoryFullName: "JSONbored/gittensory",
+              totalPrs: "4",
+              totalMergedPrs: "3",
+              totalOpenPrs: "1",
+              totalClosedPrs: "0",
+              totalOpenIssues: "0",
+              totalClosedIssues: "0",
+              isEligible: true,
+              credibility: "1.000000",
+            },
+          ],
+        });
+      }
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/oktofeesh1")) return Response.json({ login: "oktofeesh1", public_repos: 2, followers: 1 });
+      if (url.includes("/users/oktofeesh1/repos")) return Response.json([{ language: "TypeScript" }]);
+      if (url.includes("/access_tokens")) {
+        return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
+      }
+      if (url.includes("/pulls/3/files")) {
+        return Response.json([{ filename: "apps/loopover-ui/src/routes/app.index.tsx", additions: 5, deletions: 1, status: "modified" }]);
+      }
+      if (/\/pulls\/3(?:\?|$)/.test(url)) return Response.json({ number: 3, mergeable_state: "clean" });
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 901 }, { status: 201 });
+      if (url.includes("/check-runs/901") && method === "PATCH") return Response.json({ id: 901 });
+      if (url.includes("/issues/3/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/3/comments") && method === "POST") {
+        postedBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 1, html_url: "https://github.com/comment/1" }, { status: 201 });
+      }
+      // Preview discovery + shot fetches: no real deploy configured for this fixture, so buildCapture falls
+      // back to placeholders for the "after" shot, and shot-content fetches for the vision call 404 -- wrapped
+      // in its own try/catch, degrading gracefully rather than failing the review.
+      return new Response("not found", { status: 404 });
+    });
+
+    try {
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "pr-bug-analysis-wiring",
+        eventName: "pull_request",
+        payload: {
+          action: "synchronize",
+          installation: {
+            id: 123,
+            account: { login: "JSONbored", id: 1, type: "User" },
+            repository_selection: "selected",
+            permissions: { metadata: "read", pull_requests: "read", issues: "write", checks: "write" },
+            events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+          },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: {
+            number: 3,
+            title: "Distinctive bug-analysis-wiring PR title",
+            state: "open",
+            user: { login: "oktofeesh1" },
+            head: { sha: "buganalysiswiring123" },
+            labels: [{ name: "bug" }],
+            body: "Fixes #1\n\nValidation: npm test",
+          },
+        },
+      });
+
+      // The real webhook path resolved bug_analysis: true from the fetched .loopover.yml and threaded it all
+      // the way into the live vision-provider call -- only reachable if the enhanced, PR-context-aware prompt
+      // was selected (the default prompt never sends the PR title at all).
+      expect(visionProviderRequestBody).toContain("Distinctive bug-analysis-wiring PR title");
+      // Confirms the ENHANCED (bug-analysis) prompt was selected, not the default -- the default prompt never
+      // mentions the PR's stated change or asks for a category at all.
+      expect(visionProviderRequestBody).toContain("Pull request's stated change");
+      expect(visionProviderRequestBody).toContain("category");
+      expect(postedBody).toContain("Visual preview");
+    } finally {
+      liveCiSpy.mockRestore();
+      isVisualDiffAvailableSpy.mockRestore();
+      compareScreenshotsSpy.mockRestore();
     }
   });
 

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -13,7 +13,7 @@ import {
   verdictToRecommendation,
   visualFindingsFromFindings,
 } from "../../src/review/unified-comment-bridge";
-import { VISUAL_REGRESSION_FINDING_CODE } from "../../src/review/visual/visual-findings";
+import { VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE } from "../../src/review/visual/visual-findings";
 import { PR_PANEL_COMMENT_MARKER as MARKER_FROM_COMMENTS } from "../../src/github/comments";
 import { deriveUnifiedStatus, type MergeReadiness, type UnifiedCollapsible, type UnifiedCommentStatus } from "../../src/review/unified-comment";
 import type { GateCheckEvaluation } from "../../src/rules/advisory";
@@ -133,6 +133,32 @@ describe("visualFindingsFromFindings (#4111 — advisory-only AI-vision analysis
     const [line] = visualFindingsFromFindings(findings);
     expect(line).not.toMatch(/trust score/i);
     expect(line).toContain("[context]");
+  });
+
+  it("ALSO recovers visual_unrelated_issue_finding entries (review.visual.bugAnalysis), same format as a regression finding", () => {
+    const findings: AdvisoryFinding[] = [
+      { code: "missing_linked_issue", severity: "warning", title: "No linked issue", detail: "..." },
+      {
+        code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
+        severity: "warning",
+        title: "Possible unrelated visual issue: /footer",
+        detail: "The footer logo is stretched, unrelated to this change.",
+      },
+    ];
+    expect(visualFindingsFromFindings(findings)).toEqual([
+      "Possible unrelated visual issue: /footer: The footer logo is stretched, unrelated to this change.",
+    ]);
+  });
+
+  it("recovers a mix of regression and unrelated-issue findings, in original order", () => {
+    const findings: AdvisoryFinding[] = [
+      { code: VISUAL_REGRESSION_FINDING_CODE, severity: "warning", title: "Possible visual regression: /pricing", detail: "Broke." },
+      { code: VISUAL_UNRELATED_ISSUE_FINDING_CODE, severity: "warning", title: "Possible unrelated visual issue: /footer", detail: "Stretched." },
+    ];
+    expect(visualFindingsFromFindings(findings)).toEqual([
+      "Possible visual regression: /pricing: Broke.",
+      "Possible unrelated visual issue: /footer: Stretched.",
+    ]);
   });
 });
 
@@ -1003,6 +1029,28 @@ describe("buildUnifiedCommentBody: visual findings render in their OWN section, 
       footerMarkdown: footer,
     });
     expect(body).not.toContain("Visual findings");
+  });
+
+  it("renders a visual_unrelated_issue_finding (review.visual.bugAnalysis) in the SAME 'Visual findings' section, also never duplicated as a generic Nit", () => {
+    const unrelatedFinding: AdvisoryFinding = {
+      code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
+      severity: "warning",
+      title: "Possible unrelated visual issue: /footer",
+      detail: "The footer logo is stretched, unrelated to this change.",
+      action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+    };
+    const body = buildUnifiedCommentBody({
+      gate: gate({ warnings: [unrelatedFinding] }),
+      advisoryFindings: [unrelatedFinding],
+      panelRows,
+      readinessTotal: 80,
+      changedFiles: 2,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("Visual findings");
+    expect(body).toContain("Possible unrelated visual issue: /footer: The footer logo is stretched, unrelated to this change.");
+    expect(body.split("Possible unrelated visual issue: /footer").length - 1).toBe(1);
+    expect(body).toContain("Suggested Action - Approve/Merge");
   });
 });
 

--- a/test/unit/visual-config-wiring.test.ts
+++ b/test/unit/visual-config-wiring.test.ts
@@ -24,6 +24,7 @@ describe("review.visual wiring (#3609 / #3610)", () => {
       enabled: null,
       themeStorageKey: null,
       actionsFallback: false,
+      bugAnalysis: false,
     });
     expect(loadSpy).toHaveBeenCalledWith(expect.anything(), "acme/widgets");
     loadSpy.mockRestore();
@@ -52,6 +53,19 @@ describe("review.visual wiring (#3609 / #3610)", () => {
     const manifest = parseFocusManifest({ review: { visual: { actions_fallback: true } } });
     const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
     await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({ ...EMPTY_VISUAL_CONFIG, actionsFallback: true });
+    loadSpy.mockRestore();
+  });
+
+  it("resolves a configured bug_analysis: true from the repo's focus manifest", async () => {
+    const manifest = parseFocusManifest({ review: { visual: { bug_analysis: true } } });
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
+    await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({ ...EMPTY_VISUAL_CONFIG, bugAnalysis: true });
+    loadSpy.mockRestore();
+  });
+
+  it("bug_analysis defaults to false, byte-identical to today, when unset", async () => {
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(parseFocusManifest({ review: { visual: { gif: true } } }));
+    await expect(resolveVisualCaptureConfig({} as Env, "acme/widgets")).resolves.toEqual({ ...EMPTY_VISUAL_CONFIG, gif: true, bugAnalysis: false });
     loadSpy.mockRestore();
   });
 });

--- a/test/unit/visual-findings.test.ts
+++ b/test/unit/visual-findings.test.ts
@@ -148,6 +148,19 @@ describe("buildVisualBugAnalysisUserPrompt", () => {
     expect(prompt).not.toContain("x".repeat(2001));
   });
 
+  it("also defensively truncates an overlong title to 2000 chars, same as the description", () => {
+    const longTitle = "y".repeat(3000);
+    const prompt = buildVisualBugAnalysisUserPrompt([{ path: "/" }], { title: longTitle, body: null });
+    expect(prompt).toContain(`Title: ${"y".repeat(2000)}`);
+    expect(prompt).not.toContain("y".repeat(2001));
+  });
+
+  it("composes buildVisualVisionUserPrompt's own route-listing text rather than duplicating it", () => {
+    const routes = [{ path: "/pricing" }, { path: "/about" }];
+    const withoutContext = buildVisualBugAnalysisUserPrompt(routes, {});
+    expect(withoutContext).toBe(buildVisualVisionUserPrompt(routes));
+  });
+
   it("omits the title line when only a body is set, and vice versa", () => {
     const bodyOnly = buildVisualBugAnalysisUserPrompt([{ path: "/" }], { body: "Just a description." });
     expect(bodyOnly).not.toContain("Title:");

--- a/test/unit/visual-findings.test.ts
+++ b/test/unit/visual-findings.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildVisualBugAnalysisUserPrompt,
   buildVisualRegressionFindings,
   buildVisualVisionUserPrompt,
   evaluateVisualVisionGate,
   parseVisualVisionResponse,
   routeHasConfirmedVisualRegression,
   selectRoutesForVisualVision,
+  VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT,
   VISUAL_REGRESSION_FINDING_CODE,
+  VISUAL_UNRELATED_ISSUE_FINDING_CODE,
 } from "../../src/review/visual/visual-findings";
 import type { CaptureRoute } from "../../src/review/visual/capture";
 import type { AiReviewProviderKey } from "../../src/services/ai-review";
@@ -114,6 +117,47 @@ describe("buildVisualVisionUserPrompt", () => {
   });
 });
 
+describe("VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT (review.visual.bugAnalysis)", () => {
+  it("is a distinct prompt from VISUAL_VISION_SYSTEM_PROMPT, asking for a category per finding", () => {
+    expect(VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT).toContain('"category"');
+    expect(VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT).toContain("regression");
+    expect(VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT).toContain("unrelated");
+    expect(VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT).toContain("stated title/description");
+  });
+});
+
+describe("buildVisualBugAnalysisUserPrompt", () => {
+  it("renders one bullet per route path plus the PR's stated title and description", () => {
+    const prompt = buildVisualBugAnalysisUserPrompt([{ path: "/pricing" }], { title: "Fix pricing table overflow", body: "Truncates the discount column on narrow screens." });
+    expect(prompt).toContain("- /pricing");
+    expect(prompt).toContain("Title: Fix pricing table overflow");
+    expect(prompt).toContain("Description: Truncates the discount column on narrow screens.");
+    expect(prompt).toContain("before, after order");
+  });
+
+  it("still produces a valid prompt with no title/body at all — a best-effort context addition, not a requirement", () => {
+    const prompt = buildVisualBugAnalysisUserPrompt([{ path: "/" }], {});
+    expect(prompt).not.toContain("Pull request's stated change");
+    expect(prompt).toContain("Route(s) under review:\n- /");
+  });
+
+  it("truncates an overlong description to 2000 chars rather than sending it unbounded", () => {
+    const longBody = "x".repeat(3000);
+    const prompt = buildVisualBugAnalysisUserPrompt([{ path: "/" }], { title: null, body: longBody });
+    expect(prompt).toContain(`Description: ${"x".repeat(2000)}`);
+    expect(prompt).not.toContain("x".repeat(2001));
+  });
+
+  it("omits the title line when only a body is set, and vice versa", () => {
+    const bodyOnly = buildVisualBugAnalysisUserPrompt([{ path: "/" }], { body: "Just a description." });
+    expect(bodyOnly).not.toContain("Title:");
+    expect(bodyOnly).toContain("Description: Just a description.");
+    const titleOnly = buildVisualBugAnalysisUserPrompt([{ path: "/" }], { title: "Just a title" });
+    expect(titleOnly).toContain("Title: Just a title");
+    expect(titleOnly).not.toContain("Description:");
+  });
+});
+
 describe("parseVisualVisionResponse", () => {
   it("parses a valid findings array into public-safe entries", () => {
     const text = JSON.stringify({ findings: [{ path: "/pricing", body: "The third column lost its border." }] });
@@ -159,6 +203,30 @@ describe("parseVisualVisionResponse", () => {
     const findings = Array.from({ length: 5 }, (_, i) => ({ path: `/r${i}`, body: `Issue ${i}.` }));
     expect(parseVisualVisionResponse(JSON.stringify({ findings }))).toHaveLength(3);
   });
+
+  it("parses a valid 'unrelated' category (review.visual.bugAnalysis)", () => {
+    const text = JSON.stringify({ findings: [{ path: "/pricing", body: "The footer logo is stretched, unrelated to this change.", category: "unrelated" }] });
+    expect(parseVisualVisionResponse(text)).toEqual([
+      { path: "/pricing", body: "The footer logo is stretched, unrelated to this change.", category: "unrelated" },
+    ]);
+  });
+
+  it("parses an explicit 'regression' category the same as omitting it", () => {
+    const text = JSON.stringify({ findings: [{ path: "/pricing", body: "Broke on this PR's change.", category: "regression" }] });
+    expect(parseVisualVisionResponse(text)).toEqual([{ path: "/pricing", body: "Broke on this PR's change.", category: "regression" }]);
+  });
+
+  it("drops an unrecognized category value, keeping the finding with category left undefined (defaults to regression downstream)", () => {
+    const text = JSON.stringify({ findings: [{ path: "/pricing", body: "Something's off.", category: "cosmetic" }] });
+    expect(parseVisualVisionResponse(text)).toEqual([{ path: "/pricing", body: "Something's off." }]);
+  });
+
+  it("leaves category undefined when absent, byte-identical to the pre-bugAnalysis response shape", () => {
+    const text = JSON.stringify({ findings: [{ path: "/pricing", body: "The third column lost its border." }] });
+    const parsed = parseVisualVisionResponse(text);
+    expect(parsed).toEqual([{ path: "/pricing", body: "The third column lost its border." }]);
+    expect(parsed[0]).not.toHaveProperty("category");
+  });
 });
 
 describe("buildVisualRegressionFindings", () => {
@@ -177,6 +245,33 @@ describe("buildVisualRegressionFindings", () => {
 
   it("returns [] for an empty findings list", () => {
     expect(buildVisualRegressionFindings([])).toEqual([]);
+  });
+
+  it("maps a category:'regression' finding the SAME as an uncategorized one — byte-identical output", () => {
+    const uncategorized = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }]);
+    const explicit = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke.", category: "regression" }]);
+    expect(explicit).toEqual(uncategorized);
+  });
+
+  it("maps a category:'unrelated' finding to its OWN code + a suggestion to open a new issue", () => {
+    const findings = buildVisualRegressionFindings([{ path: "/footer", body: "The footer logo is stretched.", category: "unrelated" }]);
+    expect(findings).toEqual([
+      {
+        code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
+        severity: "warning",
+        title: "Possible unrelated visual issue: /footer",
+        detail: "The footer logo is stretched.",
+        action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+      },
+    ]);
+  });
+
+  it("handles a mixed regression + unrelated findings list, each mapped to its own code", () => {
+    const findings = buildVisualRegressionFindings([
+      { path: "/pricing", body: "This PR broke the layout.", category: "regression" },
+      { path: "/footer", body: "Pre-existing stretched logo.", category: "unrelated" },
+    ]);
+    expect(findings.map((f) => f.code)).toEqual([VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE]);
   });
 });
 
@@ -198,6 +293,39 @@ describe("REGRESSION (#4111): a visual-regression finding can NEVER become a gat
     };
     // Even a maximally permissive/aggressive policy (every optional gate mode set to "block") must not promote
     // visual_regression_finding — it simply is not one of the codes isConfiguredGateBlocker recognizes.
+    const result = evaluateGateCheck(advisory, {
+      confirmedContributor: true,
+      linkedIssueGateMode: "block",
+      duplicatePrGateMode: "block",
+      aiReviewGateMode: "block",
+      manifestPolicyGateMode: "block",
+      selfAuthoredLinkedIssueGateMode: "block",
+      linkedIssueSatisfactionGateMode: "block",
+      lockfileIntegrityGateMode: "block",
+      claGateMode: "block",
+    });
+    expect(result.conclusion).toBe("success");
+    expect(result.blockers).toEqual([]);
+    expect(result.warnings).toEqual(advisory.findings);
+  });
+});
+
+describe("REGRESSION: a visual-UNRELATED-issue finding can NEVER become a gate blocker either", () => {
+  it("stays in gate.warnings (never gate.blockers) and the gate conclusion stays 'success' regardless of policy", () => {
+    const advisory: Advisory = {
+      id: "advisory-visual-unrelated",
+      targetType: "pull_request",
+      targetKey: "owner/repo#10",
+      repoFullName: "owner/repo",
+      pullNumber: 10,
+      headSha: "sha10",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "LoopOver advisory available",
+      summary: "1 advisory finding generated.",
+      findings: buildVisualRegressionFindings([{ path: "/footer", body: "Pre-existing stretched logo.", category: "unrelated" }]),
+      generatedAt: "2026-07-07T00:00:00.000Z",
+    };
     const result = evaluateGateCheck(advisory, {
       confirmedContributor: true,
       linkedIssueGateMode: "block",

--- a/test/unit/visual-vision-wiring.test.ts
+++ b/test/unit/visual-vision-wiring.test.ts
@@ -348,6 +348,97 @@ describe("runVisualVisionForAdvisory", () => {
     ]);
   });
 
+  it("review.visual.bugAnalysis OFF (default): sends the original prompt with no PR context, byte-identical to pre-bugAnalysis", async () => {
+    const env = byokEnv();
+    await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-vision-key", model: null });
+    let capturedBody: string | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://api.anthropic.com/v1/messages") {
+        capturedBody = String(init?.body ?? "");
+        return anthropicOk(findingsResponse([{ path: "/app", body: "Broke." }]));
+      }
+      if (url.includes("/loopover/shot")) return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+      return new Response("not found", { status: 404 });
+    }));
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      mode: "live",
+      repoFullName,
+      pr: { number: 3, title: "Fix pricing overflow", body: "Description text." },
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings(),
+      advisory: adv,
+      routes: [route({ path: "/app", diffUrl: "https://x/loopover/shot?key=diff", beforeUrl: "https://x/loopover/shot?key=b", afterUrl: "https://x/loopover/shot?key=a" })],
+      // bugAnalysisEnabled deliberately omitted — defaults to the pre-bugAnalysis prompt/behavior.
+    });
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody).not.toContain("category");
+    expect(capturedBody).not.toContain("Fix pricing overflow");
+    expect(adv.findings).toEqual([
+      {
+        code: "visual_regression_finding",
+        severity: "warning",
+        title: "Possible visual regression: /app",
+        detail: "Broke.",
+        action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+      },
+    ]);
+  });
+
+  it("review.visual.bugAnalysis ON: sends the PR title/body as context and correctly routes an 'unrelated' finding to its own code", async () => {
+    const env = byokEnv();
+    await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-vision-key", model: null });
+    let capturedBody: string | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://api.anthropic.com/v1/messages") {
+        capturedBody = String(init?.body ?? "");
+        return anthropicOk(
+          JSON.stringify({
+            findings: [
+              { path: "/app", body: "This PR's own change clipped the submit button.", category: "regression" },
+              { path: "/app", body: "The footer logo is stretched, unrelated to this change.", category: "unrelated" },
+            ],
+          }),
+        );
+      }
+      if (url.includes("/loopover/shot")) return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+      return new Response("not found", { status: 404 });
+    }));
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      mode: "live",
+      repoFullName,
+      pr: { number: 3, title: "Fix pricing overflow", body: "Description text." },
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings(),
+      advisory: adv,
+      routes: [route({ path: "/app", diffUrl: "https://x/loopover/shot?key=diff", beforeUrl: "https://x/loopover/shot?key=b", afterUrl: "https://x/loopover/shot?key=a" })],
+      bugAnalysisEnabled: true,
+    });
+    expect(capturedBody).toContain("Fix pricing overflow");
+    expect(capturedBody).toContain("Description text.");
+    expect(adv.findings).toEqual([
+      {
+        code: "visual_regression_finding",
+        severity: "warning",
+        title: "Possible visual regression: /app",
+        detail: "This PR's own change clipped the submit button.",
+        action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+      },
+      {
+        code: "visual_unrelated_issue_finding",
+        severity: "warning",
+        title: "Possible unrelated visual issue: /app",
+        detail: "The footer logo is stretched, unrelated to this change.",
+        action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+      },
+    ]);
+  });
+
   it("uses the mobile viewport's shots when only diffUrlMobile (not diffUrl) crossed the threshold", async () => {
     const env = byokEnv();
     await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-vision-key", model: null });


### PR DESCRIPTION
## Summary
- Adds `review.visual.bugAnalysis` (global + per-repo, config-as-code): when enabled, the existing before/after AI-vision regression check also sees the PR's own stated title/description and classifies each finding as:
  - `regression` — a genuine defect this PR's own change introduced (rendered identically to today)
  - `unrelated` — a real visual problem visible in either screenshot that has nothing to do with this PR's stated change, surfaced with a suggestion to open a **separate** issue rather than reading like something this PR broke
- Both finding types stay strictly advisory — neither can ever become a gate blocker (regression-tested against `isConfiguredGateBlocker` with every gate mode set to `block`).
- Default `false` is byte-identical to the existing regression-only prompt: no PR context sent, no `unrelated` category ever produced.

This PR includes a follow-up commit addressing an internal adversarial review pass: composes the new prompt's route-listing text from the existing helper instead of duplicating it, defensively caps the PR title length, and adds a real end-to-end test proving the config threads from the actual fetched `.loopover.yml` all the way into the live vision-provider request body (the one seam the narrower unit tests couldn't catch a copy-paste bug in).

Closes #7335

## Test plan
- [x] `npm run typecheck`
- [x] `npm run engine-parity:drift-check`
- [x] `npm run docs:drift-check`
- [x] Full unit suite (`npx vitest run test/unit`) — 18,343 tests passing
- [x] New/updated tests cover: category parsing/branching, the gate-blocker-never invariant for both finding codes, prompt composition, title/body truncation, and the real webhook-path wiring test (manifest → config → live provider call)