### PR TITLE
chore(miner): migrate TypeScript batch 2.4 leaf utilities

### DIFF
--- a/packages/loopover-miner/lib/attempt-input-builder.d.ts
+++ b/packages/loopover-miner/lib/attempt-input-builder.d.ts
@@ -1,33 +1,42 @@
-import type {
-  AmsPolicySpec,
-  CodingAgentExecutionMode,
-  IterateLoopInput,
-  PortfolioConvergenceInput,
-  RepoOutcomeHistory,
-  SelfReviewContext,
-} from "@loopover/engine";
+import type { AmsPolicySpec, CodingAgentExecutionMode, IterateLoopInput, PortfolioConvergenceInput, RepoOutcomeHistory, SelfReviewContext } from "@loopover/engine";
 import type { AttemptGovernorContext } from "./attempt-runner.js";
 import type { CodingTaskSpecResult } from "./coding-task-spec.js";
-
-export function buildAttemptGovernorContext(
-  env: Record<string, string | undefined>,
-  amsPolicySpec: AmsPolicySpec,
-  repoPaused?: boolean,
-  convergenceInput?: PortfolioConvergenceInput,
-  reputationHistory?: RepoOutcomeHistory,
-): AttemptGovernorContext;
-
+/**
+ * Assemble the real Governor chokepoint context for one attempt. rateLimitBuckets/rateLimitBackoffAttempts/
+ * capUsage are deliberately omitted -- evaluateGovernorChokepointGatePersisted (#5134) auto-loads them from
+ * the persisted governor-state store when absent.
+ *
+ * `repoPaused` (#5392) is the caller's own resolved `MinerGoalSpec.killSwitch.paused` for the target repo
+ * (miner-goal-spec.js's resolveMinerGoalSpec) -- this composer stays pure and just threads whatever the
+ * caller already resolved through; passing nothing keeps the prior fails-open-on-that-axis-only behavior.
+ *
+ * `convergenceInput` (#5654) is the caller's own real portfolio-queue.js `getAttemptHistory` read -- this
+ * composer stays pure and just threads it through, same as `repoPaused`. Omitted (never fabricated) falls
+ * back to the honest first-attempt-shaped zero-state, so a caller that hasn't wired a real read yet (or an
+ * item genuinely absent from the queue) still produces a well-formed `PortfolioConvergenceInput`.
+ *
+ * `reputationHistory` (#5675) is the caller's own real governor-state.js `loadReputationHistory` read for the
+ * target repo. Optional and threaded through unchanged: when omitted the field is left off entirely, which
+ * chokepoint.ts treats as "skip the self-reputation throttle" -- an honest absence, never a fabricated clean
+ * history.
+ */
+export declare function buildAttemptGovernorContext(env: Record<string, string | undefined>, amsPolicySpec: AmsPolicySpec, repoPaused?: boolean, convergenceInput?: PortfolioConvergenceInput, reputationHistory?: RepoOutcomeHistory): AttemptGovernorContext;
 export type BuildAttemptLoopInputInput = {
-  codingTaskSpec: Extract<CodingTaskSpecResult, { ready: true }>;
-  reviewContext: SelfReviewContext;
-  worktreePath: string;
-  attemptId: string;
-  mode: CodingAgentExecutionMode;
-  repoFullName: string;
-  minerLogin: string;
-  rejectionSignaled: boolean;
-  amsPolicySpec: AmsPolicySpec;
-  branchRef?: string;
+    codingTaskSpec: Extract<CodingTaskSpecResult, {
+        ready: true;
+    }>;
+    reviewContext: SelfReviewContext;
+    worktreePath: string;
+    attemptId: string;
+    mode: CodingAgentExecutionMode;
+    repoFullName: string;
+    minerLogin: string;
+    rejectionSignaled: boolean;
+    amsPolicySpec: AmsPolicySpec;
+    branchRef?: string;
 };
-
-export function buildAttemptLoopInput(input: BuildAttemptLoopInputInput): IterateLoopInput;
+/**
+ * Assemble the real IterateLoopInput for one attempt from every already-computed real dependency. Pure --
+ * throws nothing itself (callers are expected to have already validated `codingTaskSpec.ready`).
+ */
+export declare function buildAttemptLoopInput(input: BuildAttemptLoopInputInput): IterateLoopInput;

--- a/packages/loopover-miner/lib/attempt-input-builder.js
+++ b/packages/loopover-miner/lib/attempt-input-builder.js
@@ -1,5 +1,4 @@
 import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/engine";
-
 // Pure composers for runMinerAttempt's real input (#5132, Wave 3.5 -- the final assembly). Everything here is
 // a plain in/out transform over already-fetched/already-computed real data (coding-task-spec, #5239;
 // self-review-context, #5145; worktree preparation, #5237/#5252; AmsPolicySpec, #5249) -- no fetching, no IO,
@@ -14,7 +13,6 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
 // getAttemptHistory and governor-state.js's loadReputationHistory and passes them in here, this composer staying
 // pure over them same as every other already-computed dependency below. An omitted argument stays an honest
 // absence (zero-state convergence / skipped reputation throttle), never a fabricated clean history.
-
 /**
  * Assemble the real Governor chokepoint context for one attempt. rateLimitBuckets/rateLimitBackoffAttempts/
  * capUsage are deliberately omitted -- evaluateGovernorChokepointGatePersisted (#5134) auto-loads them from
@@ -33,74 +31,53 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
  * target repo. Optional and threaded through unchanged: when omitted the field is left off entirely, which
  * chokepoint.ts treats as "skip the self-reputation throttle" -- an honest absence, never a fabricated clean
  * history.
- *
- * @param {Record<string, string | undefined>} env
- * @param {import("@loopover/engine").AmsPolicySpec} amsPolicySpec
- * @param {boolean} [repoPaused]
- * @param {import("@loopover/engine").PortfolioConvergenceInput} [convergenceInput]
- * @param {import("@loopover/engine").RepoOutcomeHistory} [reputationHistory]
- * @returns {import("./attempt-runner.js").AttemptGovernorContext}
  */
 export function buildAttemptGovernorContext(env, amsPolicySpec, repoPaused, convergenceInput, reputationHistory) {
-  return {
-    killSwitchGlobal: isGlobalMinerKillSwitch(env),
-    killSwitchRepoPaused: repoPaused,
-    liveModeGlobalOptIn: isGlobalMinerLiveModeOptIn(env),
-    capLimits: amsPolicySpec.capLimits,
-    convergenceInput: convergenceInput ?? { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
-    ...(reputationHistory === undefined ? {} : { reputationHistory }),
-  };
+    return {
+        killSwitchGlobal: isGlobalMinerKillSwitch(env),
+        killSwitchRepoPaused: repoPaused,
+        liveModeGlobalOptIn: isGlobalMinerLiveModeOptIn(env),
+        capLimits: amsPolicySpec.capLimits,
+        convergenceInput: convergenceInput ?? { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
+        ...(reputationHistory === undefined ? {} : { reputationHistory }),
+    };
 }
-
 /**
  * Assemble the real IterateLoopInput for one attempt from every already-computed real dependency. Pure --
  * throws nothing itself (callers are expected to have already validated `codingTaskSpec.ready`).
- *
- * @param {{
- *   codingTaskSpec: Extract<import("./coding-task-spec.js").CodingTaskSpecResult, { ready: true }>,
- *   reviewContext: import("@loopover/engine").SelfReviewContext,
- *   worktreePath: string,
- *   attemptId: string,
- *   mode: import("@loopover/engine").CodingAgentExecutionMode,
- *   repoFullName: string,
- *   minerLogin: string,
- *   rejectionSignaled: boolean,
- *   amsPolicySpec: import("@loopover/engine").AmsPolicySpec,
- *   branchRef?: string,
- * }} input
- * @returns {import("@loopover/engine").IterateLoopInput}
  */
 export function buildAttemptLoopInput(input) {
-  return {
-    attemptId: input.attemptId,
-    workingDirectory: input.worktreePath,
-    acceptanceCriteriaPath: input.codingTaskSpec.acceptanceCriteriaPath,
-    instructions: input.codingTaskSpec.instructions,
-    mode: input.mode,
-    maxIterations: input.amsPolicySpec.maxIterations,
-    maxTurnsPerIteration: input.amsPolicySpec.maxTurnsPerIteration,
-    // Real mid-attempt budget (#5395): the SAME Governor cap ceilings that already bound cross-cycle spend
-    // (loop-cli.js's after-the-fact governorState.saveCapUsage) now also bound this ONE attempt in progress,
-    // via the engine's real accumulateAttemptUsage/evaluateAttemptBudget -- a runaway attempt can no longer
-    // burn through the entire cross-cycle budget before anything reacts. No maxTokens: every driver now
-    // reports a real per-iteration token count (#5653), but no policy field sets a token ceiling yet -- that
-    // axis genuinely has no real ceiling to set today, never fabricated.
-    budget: {
-      maxTurns: input.amsPolicySpec.capLimits.turns,
-      maxWallClockMs: input.amsPolicySpec.capLimits.elapsedMs,
-      maxCostUsd: input.amsPolicySpec.capLimits.budget,
-    },
-    repoFullName: input.repoFullName,
-    contributorLogin: input.minerLogin,
-    title: input.codingTaskSpec.title,
-    body: input.codingTaskSpec.body,
-    labels: input.codingTaskSpec.labels,
-    linkedIssues: input.codingTaskSpec.linkedIssues,
-    branchRef: input.branchRef,
-    reviewContext: input.reviewContext,
-    rejectionSignaled: input.rejectionSignaled,
-    // #6560: the operator's configured self-loop autonomy level reaches the policy the same way every other
-    // AmsPolicySpec knob above does. It gates only the pass->handoff transition inside iterate-policy.js.
-    autonomyLevel: input.amsPolicySpec.selfLoopAutonomy,
-  };
+    return {
+        attemptId: input.attemptId,
+        workingDirectory: input.worktreePath,
+        acceptanceCriteriaPath: input.codingTaskSpec.acceptanceCriteriaPath,
+        instructions: input.codingTaskSpec.instructions,
+        mode: input.mode,
+        maxIterations: input.amsPolicySpec.maxIterations,
+        maxTurnsPerIteration: input.amsPolicySpec.maxTurnsPerIteration,
+        // Real mid-attempt budget (#5395): the SAME Governor cap ceilings that already bound cross-cycle spend
+        // (loop-cli.js's after-the-fact governorState.saveCapUsage) now also bound this ONE attempt in progress,
+        // via the engine's real accumulateAttemptUsage/evaluateAttemptBudget -- a runaway attempt can no longer
+        // burn through the entire cross-cycle budget before anything reacts. No maxTokens: every driver now
+        // reports a real per-iteration token count (#5653), but no policy field sets a token ceiling yet -- that
+        // axis genuinely has no real ceiling to set today, never fabricated.
+        budget: {
+            maxTurns: input.amsPolicySpec.capLimits.turns,
+            maxWallClockMs: input.amsPolicySpec.capLimits.elapsedMs,
+            maxCostUsd: input.amsPolicySpec.capLimits.budget,
+        },
+        repoFullName: input.repoFullName,
+        contributorLogin: input.minerLogin,
+        title: input.codingTaskSpec.title,
+        body: input.codingTaskSpec.body,
+        labels: input.codingTaskSpec.labels,
+        linkedIssues: input.codingTaskSpec.linkedIssues,
+        branchRef: input.branchRef,
+        reviewContext: input.reviewContext,
+        rejectionSignaled: input.rejectionSignaled,
+        // #6560: the operator's configured self-loop autonomy level reaches the policy the same way every other
+        // AmsPolicySpec knob above does. It gates only the pass->handoff transition inside iterate-policy.js.
+        autonomyLevel: input.amsPolicySpec.selfLoopAutonomy,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYXR0ZW1wdC1pbnB1dC1idWlsZGVyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiYXR0ZW1wdC1pbnB1dC1idWlsZGVyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSwwQkFBMEIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBWXZGLDhHQUE4RztBQUM5RyxxR0FBcUc7QUFDckcsOEdBQThHO0FBQzlHLDBEQUEwRDtBQUMxRCxFQUFFO0FBQ0YseUZBQXlGO0FBQ3pGLDhHQUE4RztBQUM5RywwR0FBMEc7QUFDMUcsRUFBRTtBQUNGLGlIQUFpSDtBQUNqSCxpSEFBaUg7QUFDakgsaUhBQWlIO0FBQ2pILDRHQUE0RztBQUM1RyxvR0FBb0c7QUFFcEc7Ozs7Ozs7Ozs7Ozs7Ozs7OztHQWtCRztBQUNILE1BQU0sVUFBVSwyQkFBMkIsQ0FDekMsR0FBdUMsRUFDdkMsYUFBNEIsRUFDNUIsVUFBb0IsRUFDcEIsZ0JBQTRDLEVBQzVDLGlCQUFzQztJQUV0QyxPQUFPO1FBQ0wsZ0JBQWdCLEVBQUUsdUJBQXVCLENBQUMsR0FBRyxDQUFDO1FBQzlDLG9CQUFvQixFQUFFLFVBQVU7UUFDaEMsbUJBQW1CLEVBQUUsMEJBQTBCLENBQUMsR0FBRyxDQUFDO1FBQ3BELFNBQVMsRUFBRSxhQUFhLENBQUMsU0FBUztRQUNsQyxnQkFBZ0IsRUFBRSxnQkFBZ0IsSUFBSSxFQUFFLFFBQVEsRUFBRSxDQUFDLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQyxFQUFFLFVBQVUsRUFBRSxDQUFDLEVBQUUsV0FBVyxFQUFFLEtBQUssRUFBRTtRQUNoSCxHQUFHLENBQUMsaUJBQWlCLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsaUJBQWlCLEVBQUUsQ0FBQztLQUNsRSxDQUFDO0FBQ0osQ0FBQztBQWVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxLQUFpQztJQUNyRSxPQUFPO1FBQ0wsU0FBUyxFQUFFLEtBQUssQ0FBQyxTQUFTO1FBQzFCLGdCQUFnQixFQUFFLEtBQUssQ0FBQyxZQUFZO1FBQ3BDLHNCQUFzQixFQUFFLEtBQUssQ0FBQyxjQUFjLENBQUMsc0JBQXNCO1FBQ25FLFlBQVksRUFBRSxLQUFLLENBQUMsY0FBYyxDQUFDLFlBQVk7UUFDL0MsSUFBSSxFQUFFLEtBQUssQ0FBQyxJQUFJO1FBQ2hCLGFBQWEsRUFBRSxLQUFLLENBQUMsYUFBYSxDQUFDLGFBQWE7UUFDaEQsb0JBQW9CLEVBQUUsS0FBSyxDQUFDLGFBQWEsQ0FBQyxvQkFBb0I7UUFDOUQsdUdBQXVHO1FBQ3ZHLHlHQUF5RztRQUN6Ryx3R0FBd0c7UUFDeEcsb0dBQW9HO1FBQ3BHLHlHQUF5RztRQUN6RyxxRUFBcUU7UUFDckUsTUFBTSxFQUFFO1lBQ04sUUFBUSxFQUFFLEtBQUssQ0FBQyxhQUFhLENBQUMsU0FBUyxDQUFDLEtBQUs7WUFDN0MsY0FBYyxFQUFFLEtBQUssQ0FBQyxhQUFhLENBQUMsU0FBUyxDQUFDLFNBQVM7WUFDdkQsVUFBVSxFQUFFLEtBQUssQ0FBQyxhQUFhLENBQUMsU0FBUyxDQUFDLE1BQU07U0FDakQ7UUFDRCxZQUFZLEVBQUUsS0FBSyxDQUFDLFlBQVk7UUFDaEMsZ0JBQWdCLEVBQUUsS0FBSyxDQUFDLFVBQVU7UUFDbEMsS0FBSyxFQUFFLEtBQUssQ0FBQyxjQUFjLENBQUMsS0FBSztRQUNqQyxJQUFJLEVBQUUsS0FBSyxDQUFDLGNBQWMsQ0FBQyxJQUFJO1FBQy9CLE1BQU0sRUFBRSxLQUFLLENBQUMsY0FBYyxDQUFDLE1BQU07UUFDbkMsWUFBWSxFQUFFLEtBQUssQ0FBQyxjQUFjLENBQUMsWUFBWTtRQUMvQyxTQUFTLEVBQUUsS0FBSyxDQUFDLFNBQVM7UUFDMUIsYUFBYSxFQUFFLEtBQUssQ0FBQyxhQUFhO1FBQ2xDLGlCQUFpQixFQUFFLEtBQUssQ0FBQyxpQkFBaUI7UUFDMUMsd0dBQXdHO1FBQ3hHLHNHQUFzRztRQUN0RyxhQUFhLEVBQUUsS0FBSyxDQUFDLGFBQWEsQ0FBQyxnQkFBZ0I7S0FDcEQsQ0FBQztBQUNKLENBQUMifQ==

--- a/packages/loopover-miner/lib/attempt-input-builder.ts
+++ b/packages/loopover-miner/lib/attempt-input-builder.ts
@@ -1,0 +1,114 @@
+import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/engine";
+import type {
+  AmsPolicySpec,
+  CodingAgentExecutionMode,
+  IterateLoopInput,
+  PortfolioConvergenceInput,
+  RepoOutcomeHistory,
+  SelfReviewContext,
+} from "@loopover/engine";
+import type { AttemptGovernorContext } from "./attempt-runner.js";
+import type { CodingTaskSpecResult } from "./coding-task-spec.js";
+
+// Pure composers for runMinerAttempt's real input (#5132, Wave 3.5 -- the final assembly). Everything here is
+// a plain in/out transform over already-fetched/already-computed real data (coding-task-spec, #5239;
+// self-review-context, #5145; worktree preparation, #5237/#5252; AmsPolicySpec, #5249) -- no fetching, no IO,
+// same discipline as coding-task-spec.js's own composers.
+//
+// KNOWN, DOCUMENTED GAPS (not fabricated -- explicitly left as real, narrow follow-ups):
+//   - governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted, which chokepoint.ts's own
+//     design treats as "skip that stage entirely" -- an honest absence, not a fabricated "clean" verdict.
+//
+// governor.convergenceInput is now a REAL per-issue attempt-history query (#5654) and governor.reputationHistory
+// a REAL per-repo governor-state query (#5675): the caller (attempt-cli.js) reads them from portfolio-queue.js's
+// getAttemptHistory and governor-state.js's loadReputationHistory and passes them in here, this composer staying
+// pure over them same as every other already-computed dependency below. An omitted argument stays an honest
+// absence (zero-state convergence / skipped reputation throttle), never a fabricated clean history.
+
+/**
+ * Assemble the real Governor chokepoint context for one attempt. rateLimitBuckets/rateLimitBackoffAttempts/
+ * capUsage are deliberately omitted -- evaluateGovernorChokepointGatePersisted (#5134) auto-loads them from
+ * the persisted governor-state store when absent.
+ *
+ * `repoPaused` (#5392) is the caller's own resolved `MinerGoalSpec.killSwitch.paused` for the target repo
+ * (miner-goal-spec.js's resolveMinerGoalSpec) -- this composer stays pure and just threads whatever the
+ * caller already resolved through; passing nothing keeps the prior fails-open-on-that-axis-only behavior.
+ *
+ * `convergenceInput` (#5654) is the caller's own real portfolio-queue.js `getAttemptHistory` read -- this
+ * composer stays pure and just threads it through, same as `repoPaused`. Omitted (never fabricated) falls
+ * back to the honest first-attempt-shaped zero-state, so a caller that hasn't wired a real read yet (or an
+ * item genuinely absent from the queue) still produces a well-formed `PortfolioConvergenceInput`.
+ *
+ * `reputationHistory` (#5675) is the caller's own real governor-state.js `loadReputationHistory` read for the
+ * target repo. Optional and threaded through unchanged: when omitted the field is left off entirely, which
+ * chokepoint.ts treats as "skip the self-reputation throttle" -- an honest absence, never a fabricated clean
+ * history.
+ */
+export function buildAttemptGovernorContext(
+  env: Record<string, string | undefined>,
+  amsPolicySpec: AmsPolicySpec,
+  repoPaused?: boolean,
+  convergenceInput?: PortfolioConvergenceInput,
+  reputationHistory?: RepoOutcomeHistory,
+): AttemptGovernorContext {
+  return {
+    killSwitchGlobal: isGlobalMinerKillSwitch(env),
+    killSwitchRepoPaused: repoPaused,
+    liveModeGlobalOptIn: isGlobalMinerLiveModeOptIn(env),
+    capLimits: amsPolicySpec.capLimits,
+    convergenceInput: convergenceInput ?? { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
+    ...(reputationHistory === undefined ? {} : { reputationHistory }),
+  };
+}
+
+export type BuildAttemptLoopInputInput = {
+  codingTaskSpec: Extract<CodingTaskSpecResult, { ready: true }>;
+  reviewContext: SelfReviewContext;
+  worktreePath: string;
+  attemptId: string;
+  mode: CodingAgentExecutionMode;
+  repoFullName: string;
+  minerLogin: string;
+  rejectionSignaled: boolean;
+  amsPolicySpec: AmsPolicySpec;
+  branchRef?: string;
+};
+
+/**
+ * Assemble the real IterateLoopInput for one attempt from every already-computed real dependency. Pure --
+ * throws nothing itself (callers are expected to have already validated `codingTaskSpec.ready`).
+ */
+export function buildAttemptLoopInput(input: BuildAttemptLoopInputInput): IterateLoopInput {
+  return {
+    attemptId: input.attemptId,
+    workingDirectory: input.worktreePath,
+    acceptanceCriteriaPath: input.codingTaskSpec.acceptanceCriteriaPath,
+    instructions: input.codingTaskSpec.instructions,
+    mode: input.mode,
+    maxIterations: input.amsPolicySpec.maxIterations,
+    maxTurnsPerIteration: input.amsPolicySpec.maxTurnsPerIteration,
+    // Real mid-attempt budget (#5395): the SAME Governor cap ceilings that already bound cross-cycle spend
+    // (loop-cli.js's after-the-fact governorState.saveCapUsage) now also bound this ONE attempt in progress,
+    // via the engine's real accumulateAttemptUsage/evaluateAttemptBudget -- a runaway attempt can no longer
+    // burn through the entire cross-cycle budget before anything reacts. No maxTokens: every driver now
+    // reports a real per-iteration token count (#5653), but no policy field sets a token ceiling yet -- that
+    // axis genuinely has no real ceiling to set today, never fabricated.
+    budget: {
+      maxTurns: input.amsPolicySpec.capLimits.turns,
+      maxWallClockMs: input.amsPolicySpec.capLimits.elapsedMs,
+      maxCostUsd: input.amsPolicySpec.capLimits.budget,
+    },
+    repoFullName: input.repoFullName,
+    contributorLogin: input.minerLogin,
+    title: input.codingTaskSpec.title,
+    body: input.codingTaskSpec.body,
+    labels: input.codingTaskSpec.labels,
+    linkedIssues: input.codingTaskSpec.linkedIssues,
+    branchRef: input.branchRef,
+    reviewContext: input.reviewContext,
+    rejectionSignaled: input.rejectionSignaled,
+    // #6560: the operator's configured self-loop autonomy level reaches the policy the same way every other
+    // AmsPolicySpec knob above does. It gates only the pass->handoff transition inside iterate-policy.js.
+    autonomyLevel: input.amsPolicySpec.selfLoopAutonomy,
+  };
+}

--- a/packages/loopover-miner/lib/calibration.d.ts
+++ b/packages/loopover-miner/lib/calibration.d.ts
@@ -1,24 +1,13 @@
-import type {
-  CalibrationReport,
-  ObservedOutcomeRecord,
-  PredictedVerdictRecord,
-} from "./calibration-types.js";
-
-export type {
-  CalibrationReport,
-  CalibrationRow,
-  ObservedOutcomeRecord,
-  PredictedVerdictRecord,
-} from "./calibration-types.js";
-
-export {
-  isCalibrationReport,
-  isCalibrationRow,
-  isObservedOutcomeRecord,
-  isPredictedVerdictRecord,
-} from "./calibration-types.js";
-
-export function buildCalibrationReport(
-  predictions: PredictedVerdictRecord[],
-  outcomes: ObservedOutcomeRecord[],
-): CalibrationReport;
+import { isCalibrationReport, isCalibrationRow, isObservedOutcomeRecord, isPredictedVerdictRecord } from "./calibration-types.js";
+import type { CalibrationReport, ObservedOutcomeRecord, PredictedVerdictRecord } from "./calibration-types.js";
+export type { CalibrationReport, CalibrationRow, ObservedOutcomeRecord, PredictedVerdictRecord, } from "./calibration-types.js";
+export { isCalibrationReport, isCalibrationRow, isObservedOutcomeRecord, isPredictedVerdictRecord };
+/**
+ * Join predicted-verdict records with realized-outcome records into a per-project calibration report. Pure and
+ * read-only. A prediction counts as "decided" only when a realized outcome for the SAME `(project, targetId)`
+ * exists AND resolves to a clear `merge` or `close`; a still-pending prediction (no outcome) or one whose outcome
+ * is unrecognized is skipped. Per project it tallies the confusion matrix (would-merge/close vs confirmed/false,
+ * plus holds) and derives merge/close precision (null below one relevant sample). Malformed records on either
+ * side are ignored. Rows are sorted by project for a stable render.
+ */
+export declare function buildCalibrationReport(predictions: PredictedVerdictRecord[], outcomes: ObservedOutcomeRecord[]): CalibrationReport;

--- a/packages/loopover-miner/lib/calibration.js
+++ b/packages/loopover-miner/lib/calibration.js
@@ -1,50 +1,43 @@
 // Calibration report: join the miner's own predicted gate verdicts with the realized outcomes it later observed
 // (#4849). Read-only aggregation only — it never touches the live scoring/calibration logic that feeds the gate
 // (maintainer-owned). Builds on the types-only scaffolding in calibration-types.js.
-import {
-  isCalibrationReport,
-  isCalibrationRow,
-  isObservedOutcomeRecord,
-  isPredictedVerdictRecord,
-} from "./calibration-types.js";
-
+import { isCalibrationReport, isCalibrationRow, isObservedOutcomeRecord, isPredictedVerdictRecord, } from "./calibration-types.js";
 export { isCalibrationReport, isCalibrationRow, isObservedOutcomeRecord, isPredictedVerdictRecord };
-
 /** Normalize a decision string to the calibration vocabulary (`merge` / `close` / `hold`), or `""` when it is
  *  unrecognized. `value` is always the already-validated non-empty string field of a record (the type guards run
  *  first), so no non-string handling is needed here. Accepts both the predicted (`merge`/`close`/`hold`) and the
  *  realized (`merged`/`closed`) forms. */
 function normalizeDecision(value) {
-  const decision = value.trim().toLowerCase();
-  if (decision === "merge" || decision === "merged") return "merge";
-  if (decision === "close" || decision === "closed") return "close";
-  if (decision === "hold") return "hold";
-  return "";
+    const decision = value.trim().toLowerCase();
+    if (decision === "merge" || decision === "merged")
+        return "merge";
+    if (decision === "close" || decision === "closed")
+        return "close";
+    if (decision === "hold")
+        return "hold";
+    return "";
 }
-
 function emptyRow(project) {
-  return {
-    project,
-    wouldMerge: 0,
-    mergeConfirmed: 0,
-    mergeFalse: 0,
-    wouldClose: 0,
-    closeConfirmed: 0,
-    closeFalse: 0,
-    hold: 0,
-    decided: 0,
-    mergePrecision: null,
-    closePrecision: null,
-  };
+    return {
+        project,
+        wouldMerge: 0,
+        mergeConfirmed: 0,
+        mergeFalse: 0,
+        wouldClose: 0,
+        closeConfirmed: 0,
+        closeFalse: 0,
+        hold: 0,
+        decided: 0,
+        mergePrecision: null,
+        closePrecision: null,
+    };
 }
-
 // Key a record by its (project, targetId). Project and targetId are validated non-empty strings; the space
 // separator is fine for keying (collisions across different (project, targetId) pairs are astronomically
 // unlikely and would only merge two projects' tallies, never fabricate a false one).
 function recordKey(project, targetId) {
-  return `${project} ${targetId}`;
+    return `${project} ${targetId}`;
 }
-
 /**
  * Join predicted-verdict records with realized-outcome records into a per-project calibration report. Pure and
  * read-only. A prediction counts as "decided" only when a realized outcome for the SAME `(project, targetId)`
@@ -52,48 +45,52 @@ function recordKey(project, targetId) {
  * is unrecognized is skipped. Per project it tallies the confusion matrix (would-merge/close vs confirmed/false,
  * plus holds) and derives merge/close precision (null below one relevant sample). Malformed records on either
  * side are ignored. Rows are sorted by project for a stable render.
- *
- * @param {import("./calibration-types.js").PredictedVerdictRecord[]} predictions
- * @param {import("./calibration-types.js").ObservedOutcomeRecord[]} outcomes
- * @returns {import("./calibration-types.js").CalibrationReport}
  */
 export function buildCalibrationReport(predictions, outcomes) {
-  const outcomeByKey = new Map();
-  for (const outcome of Array.isArray(outcomes) ? outcomes : []) {
-    if (!isObservedOutcomeRecord(outcome)) continue;
-    outcomeByKey.set(recordKey(outcome.project, outcome.targetId), normalizeDecision(outcome.outcomeDecision));
-  }
-
-  const byProject = new Map();
-  for (const prediction of Array.isArray(predictions) ? predictions : []) {
-    if (!isPredictedVerdictRecord(prediction)) continue;
-    const observed = outcomeByKey.get(recordKey(prediction.project, prediction.targetId));
-    if (observed !== "merge" && observed !== "close") continue; // pending or unclassifiable outcome
-    let row = byProject.get(prediction.project);
-    if (!row) {
-      row = emptyRow(prediction.project);
-      byProject.set(prediction.project, row);
+    const outcomeByKey = new Map();
+    for (const outcome of Array.isArray(outcomes) ? outcomes : []) {
+        if (!isObservedOutcomeRecord(outcome))
+            continue;
+        outcomeByKey.set(recordKey(outcome.project, outcome.targetId), normalizeDecision(outcome.outcomeDecision));
     }
-    row.decided += 1;
-    const predicted = normalizeDecision(prediction.predictedDecision);
-    if (predicted === "merge") {
-      row.wouldMerge += 1;
-      if (observed === "merge") row.mergeConfirmed += 1;
-      else row.mergeFalse += 1;
-    } else if (predicted === "close") {
-      row.wouldClose += 1;
-      if (observed === "close") row.closeConfirmed += 1;
-      else row.closeFalse += 1;
-    } else if (predicted === "hold") {
-      row.hold += 1;
+    const byProject = new Map();
+    for (const prediction of Array.isArray(predictions) ? predictions : []) {
+        if (!isPredictedVerdictRecord(prediction))
+            continue;
+        const observed = outcomeByKey.get(recordKey(prediction.project, prediction.targetId));
+        if (observed !== "merge" && observed !== "close")
+            continue; // pending or unclassifiable outcome
+        let row = byProject.get(prediction.project);
+        if (!row) {
+            row = emptyRow(prediction.project);
+            byProject.set(prediction.project, row);
+        }
+        row.decided += 1;
+        const predicted = normalizeDecision(prediction.predictedDecision);
+        if (predicted === "merge") {
+            row.wouldMerge += 1;
+            if (observed === "merge")
+                row.mergeConfirmed += 1;
+            else
+                row.mergeFalse += 1;
+        }
+        else if (predicted === "close") {
+            row.wouldClose += 1;
+            if (observed === "close")
+                row.closeConfirmed += 1;
+            else
+                row.closeFalse += 1;
+        }
+        else if (predicted === "hold") {
+            row.hold += 1;
+        }
     }
-  }
-
-  const rows = [...byProject.values()].sort((a, b) => a.project.localeCompare(b.project));
-  for (const row of rows) {
-    row.mergePrecision = row.wouldMerge > 0 ? row.mergeConfirmed / row.wouldMerge : null;
-    row.closePrecision = row.wouldClose > 0 ? row.closeConfirmed / row.wouldClose : null;
-  }
-  // Signal exists once any project carries at least one decided (predicted-then-realized) sample.
-  return { hasSignal: rows.length > 0, rows };
+    const rows = [...byProject.values()].sort((a, b) => a.project.localeCompare(b.project));
+    for (const row of rows) {
+        row.mergePrecision = row.wouldMerge > 0 ? row.mergeConfirmed / row.wouldMerge : null;
+        row.closePrecision = row.wouldClose > 0 ? row.closeConfirmed / row.wouldClose : null;
+    }
+    // Signal exists once any project carries at least one decided (predicted-then-realized) sample.
+    return { hasSignal: rows.length > 0, rows };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2FsaWJyYXRpb24uanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJjYWxpYnJhdGlvbi50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxnSEFBZ0g7QUFDaEgsZ0hBQWdIO0FBQ2hILG9GQUFvRjtBQUNwRixPQUFPLEVBQ0wsbUJBQW1CLEVBQ25CLGdCQUFnQixFQUNoQix1QkFBdUIsRUFDdkIsd0JBQXdCLEdBQ3pCLE1BQU0sd0JBQXdCLENBQUM7QUFlaEMsT0FBTyxFQUFFLG1CQUFtQixFQUFFLGdCQUFnQixFQUFFLHVCQUF1QixFQUFFLHdCQUF3QixFQUFFLENBQUM7QUFFcEc7OzswQ0FHMEM7QUFDMUMsU0FBUyxpQkFBaUIsQ0FBQyxLQUFhO0lBQ3RDLE1BQU0sUUFBUSxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQztJQUM1QyxJQUFJLFFBQVEsS0FBSyxPQUFPLElBQUksUUFBUSxLQUFLLFFBQVE7UUFBRSxPQUFPLE9BQU8sQ0FBQztJQUNsRSxJQUFJLFFBQVEsS0FBSyxPQUFPLElBQUksUUFBUSxLQUFLLFFBQVE7UUFBRSxPQUFPLE9BQU8sQ0FBQztJQUNsRSxJQUFJLFFBQVEsS0FBSyxNQUFNO1FBQUUsT0FBTyxNQUFNLENBQUM7SUFDdkMsT0FBTyxFQUFFLENBQUM7QUFDWixDQUFDO0FBRUQsU0FBUyxRQUFRLENBQUMsT0FBZTtJQUMvQixPQUFPO1FBQ0wsT0FBTztRQUNQLFVBQVUsRUFBRSxDQUFDO1FBQ2IsY0FBYyxFQUFFLENBQUM7UUFDakIsVUFBVSxFQUFFLENBQUM7UUFDYixVQUFVLEVBQUUsQ0FBQztRQUNiLGNBQWMsRUFBRSxDQUFDO1FBQ2pCLFVBQVUsRUFBRSxDQUFDO1FBQ2IsSUFBSSxFQUFFLENBQUM7UUFDUCxPQUFPLEVBQUUsQ0FBQztRQUNWLGNBQWMsRUFBRSxJQUFJO1FBQ3BCLGNBQWMsRUFBRSxJQUFJO0tBQ3JCLENBQUM7QUFDSixDQUFDO0FBRUQsMkdBQTJHO0FBQzNHLHlHQUF5RztBQUN6RyxxRkFBcUY7QUFDckYsU0FBUyxTQUFTLENBQUMsT0FBZSxFQUFFLFFBQWdCO0lBQ2xELE9BQU8sR0FBRyxPQUFPLElBQUksUUFBUSxFQUFFLENBQUM7QUFDbEMsQ0FBQztBQUVEOzs7Ozs7O0dBT0c7QUFDSCxNQUFNLFVBQVUsc0JBQXNCLENBQ3BDLFdBQXFDLEVBQ3JDLFFBQWlDO0lBRWpDLE1BQU0sWUFBWSxHQUFHLElBQUksR0FBRyxFQUEyQyxDQUFDO0lBQ3hFLEtBQUssTUFBTSxPQUFPLElBQUksS0FBSyxDQUFDLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQztRQUM5RCxJQUFJLENBQUMsdUJBQXVCLENBQUMsT0FBTyxDQUFDO1lBQUUsU0FBUztRQUNoRCxZQUFZLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQyxPQUFPLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxRQUFRLENBQUMsRUFBRSxpQkFBaUIsQ0FBQyxPQUFPLENBQUMsZUFBZSxDQUFDLENBQUMsQ0FBQztJQUM3RyxDQUFDO0lBRUQsTUFBTSxTQUFTLEdBQUcsSUFBSSxHQUFHLEVBQTBCLENBQUM7SUFDcEQsS0FBSyxNQUFNLFVBQVUsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxXQUFXLENBQUMsQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ3ZFLElBQUksQ0FBQyx3QkFBd0IsQ0FBQyxVQUFVLENBQUM7WUFBRSxTQUFTO1FBQ3BELE1BQU0sUUFBUSxHQUFHLFlBQVksQ0FBQyxHQUFHLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxPQUFPLEVBQUUsVUFBVSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDdEYsSUFBSSxRQUFRLEtBQUssT0FBTyxJQUFJLFFBQVEsS0FBSyxPQUFPO1lBQUUsU0FBUyxDQUFDLG9DQUFvQztRQUNoRyxJQUFJLEdBQUcsR0FBRyxTQUFTLENBQUMsR0FBRyxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUM1QyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUM7WUFDVCxHQUFHLEdBQUcsUUFBUSxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsQ0FBQztZQUNuQyxTQUFTLENBQUMsR0FBRyxDQUFDLFVBQVUsQ0FBQyxPQUFPLEVBQUUsR0FBRyxDQUFDLENBQUM7UUFDekMsQ0FBQztRQUNELEdBQUcsQ0FBQyxPQUFPLElBQUksQ0FBQyxDQUFDO1FBQ2pCLE1BQU0sU0FBUyxHQUFHLGlCQUFpQixDQUFDLFVBQVUsQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDO1FBQ2xFLElBQUksU0FBUyxLQUFLLE9BQU8sRUFBRSxDQUFDO1lBQzFCLEdBQUcsQ0FBQyxVQUFVLElBQUksQ0FBQyxDQUFDO1lBQ3BCLElBQUksUUFBUSxLQUFLLE9BQU87Z0JBQUUsR0FBRyxDQUFDLGNBQWMsSUFBSSxDQUFDLENBQUM7O2dCQUM3QyxHQUFHLENBQUMsVUFBVSxJQUFJLENBQUMsQ0FBQztRQUMzQixDQUFDO2FBQU0sSUFBSSxTQUFTLEtBQUssT0FBTyxFQUFFLENBQUM7WUFDakMsR0FBRyxDQUFDLFVBQVUsSUFBSSxDQUFDLENBQUM7WUFDcEIsSUFBSSxRQUFRLEtBQUssT0FBTztnQkFBRSxHQUFHLENBQUMsY0FBYyxJQUFJLENBQUMsQ0FBQzs7Z0JBQzdDLEdBQUcsQ0FBQyxVQUFVLElBQUksQ0FBQyxDQUFDO1FBQzNCLENBQUM7YUFBTSxJQUFJLFNBQVMsS0FBSyxNQUFNLEVBQUUsQ0FBQztZQUNoQyxHQUFHLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQztRQUNoQixDQUFDO0lBQ0gsQ0FBQztJQUVELE1BQU0sSUFBSSxHQUFHLENBQUMsR0FBRyxTQUFTLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQztJQUN4RixLQUFLLE1BQU0sR0FBRyxJQUFJLElBQUksRUFBRSxDQUFDO1FBQ3ZCLEdBQUcsQ0FBQyxjQUFjLEdBQUcsR0FBRyxDQUFDLFVBQVUsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxjQUFjLEdBQUcsR0FBRyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO1FBQ3JGLEdBQUcsQ0FBQyxjQUFjLEdBQUcsR0FBRyxDQUFDLFVBQVUsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxjQUFjLEdBQUcsR0FBRyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ3ZGLENBQUM7SUFDRCxnR0FBZ0c7SUFDaEcsT0FBTyxFQUFFLFNBQVMsRUFBRSxJQUFJLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxJQUFJLEVBQUUsQ0FBQztBQUM5QyxDQUFDIn0=

--- a/packages/loopover-miner/lib/calibration.ts
+++ b/packages/loopover-miner/lib/calibration.ts
@@ -1,0 +1,111 @@
+// Calibration report: join the miner's own predicted gate verdicts with the realized outcomes it later observed
+// (#4849). Read-only aggregation only — it never touches the live scoring/calibration logic that feeds the gate
+// (maintainer-owned). Builds on the types-only scaffolding in calibration-types.js.
+import {
+  isCalibrationReport,
+  isCalibrationRow,
+  isObservedOutcomeRecord,
+  isPredictedVerdictRecord,
+} from "./calibration-types.js";
+import type {
+  CalibrationReport,
+  CalibrationRow,
+  ObservedOutcomeRecord,
+  PredictedVerdictRecord,
+} from "./calibration-types.js";
+
+export type {
+  CalibrationReport,
+  CalibrationRow,
+  ObservedOutcomeRecord,
+  PredictedVerdictRecord,
+} from "./calibration-types.js";
+
+export { isCalibrationReport, isCalibrationRow, isObservedOutcomeRecord, isPredictedVerdictRecord };
+
+/** Normalize a decision string to the calibration vocabulary (`merge` / `close` / `hold`), or `""` when it is
+ *  unrecognized. `value` is always the already-validated non-empty string field of a record (the type guards run
+ *  first), so no non-string handling is needed here. Accepts both the predicted (`merge`/`close`/`hold`) and the
+ *  realized (`merged`/`closed`) forms. */
+function normalizeDecision(value: string): "merge" | "close" | "hold" | "" {
+  const decision = value.trim().toLowerCase();
+  if (decision === "merge" || decision === "merged") return "merge";
+  if (decision === "close" || decision === "closed") return "close";
+  if (decision === "hold") return "hold";
+  return "";
+}
+
+function emptyRow(project: string): CalibrationRow {
+  return {
+    project,
+    wouldMerge: 0,
+    mergeConfirmed: 0,
+    mergeFalse: 0,
+    wouldClose: 0,
+    closeConfirmed: 0,
+    closeFalse: 0,
+    hold: 0,
+    decided: 0,
+    mergePrecision: null,
+    closePrecision: null,
+  };
+}
+
+// Key a record by its (project, targetId). Project and targetId are validated non-empty strings; the space
+// separator is fine for keying (collisions across different (project, targetId) pairs are astronomically
+// unlikely and would only merge two projects' tallies, never fabricate a false one).
+function recordKey(project: string, targetId: string): string {
+  return `${project} ${targetId}`;
+}
+
+/**
+ * Join predicted-verdict records with realized-outcome records into a per-project calibration report. Pure and
+ * read-only. A prediction counts as "decided" only when a realized outcome for the SAME `(project, targetId)`
+ * exists AND resolves to a clear `merge` or `close`; a still-pending prediction (no outcome) or one whose outcome
+ * is unrecognized is skipped. Per project it tallies the confusion matrix (would-merge/close vs confirmed/false,
+ * plus holds) and derives merge/close precision (null below one relevant sample). Malformed records on either
+ * side are ignored. Rows are sorted by project for a stable render.
+ */
+export function buildCalibrationReport(
+  predictions: PredictedVerdictRecord[],
+  outcomes: ObservedOutcomeRecord[],
+): CalibrationReport {
+  const outcomeByKey = new Map<string, "merge" | "close" | "hold" | "">();
+  for (const outcome of Array.isArray(outcomes) ? outcomes : []) {
+    if (!isObservedOutcomeRecord(outcome)) continue;
+    outcomeByKey.set(recordKey(outcome.project, outcome.targetId), normalizeDecision(outcome.outcomeDecision));
+  }
+
+  const byProject = new Map<string, CalibrationRow>();
+  for (const prediction of Array.isArray(predictions) ? predictions : []) {
+    if (!isPredictedVerdictRecord(prediction)) continue;
+    const observed = outcomeByKey.get(recordKey(prediction.project, prediction.targetId));
+    if (observed !== "merge" && observed !== "close") continue; // pending or unclassifiable outcome
+    let row = byProject.get(prediction.project);
+    if (!row) {
+      row = emptyRow(prediction.project);
+      byProject.set(prediction.project, row);
+    }
+    row.decided += 1;
+    const predicted = normalizeDecision(prediction.predictedDecision);
+    if (predicted === "merge") {
+      row.wouldMerge += 1;
+      if (observed === "merge") row.mergeConfirmed += 1;
+      else row.mergeFalse += 1;
+    } else if (predicted === "close") {
+      row.wouldClose += 1;
+      if (observed === "close") row.closeConfirmed += 1;
+      else row.closeFalse += 1;
+    } else if (predicted === "hold") {
+      row.hold += 1;
+    }
+  }
+
+  const rows = [...byProject.values()].sort((a, b) => a.project.localeCompare(b.project));
+  for (const row of rows) {
+    row.mergePrecision = row.wouldMerge > 0 ? row.mergeConfirmed / row.wouldMerge : null;
+    row.closePrecision = row.wouldClose > 0 ? row.closeConfirmed / row.wouldClose : null;
+  }
+  // Signal exists once any project carries at least one decided (predicted-then-realized) sample.
+  return { hasSignal: rows.length > 0, rows };
+}

--- a/packages/loopover-miner/lib/coding-agent-construction.d.ts
+++ b/packages/loopover-miner/lib/coding-agent-construction.d.ts
@@ -1,17 +1,34 @@
-import type { AgentSdkHooks, AgentSdkQueryFn, CliSubprocessSpawnFn, CodingAgentDriver } from "@loopover/engine";
-
-export function createRealCliSubprocessSpawn(): CliSubprocessSpawnFn;
-
+import { type AgentSdkHooks, type AgentSdkQueryFn, type CliSubprocessSpawnFn, type CodingAgentDriver } from "@loopover/engine";
+import { type HouseRulesConfig, type HouseRulesOptions } from "./coding-agent-house-rules.js";
+/**
+ * Real `child_process.spawn`-backed implementation of the engine's `CliSubprocessSpawnFn` contract. Captures
+ * stdout/stderr and RESOLVES (never rejects) on timeout or spawn error, so the caller always sees whatever
+ * output accumulated rather than an unhandled rejection -- mirrors `src/selfhost/ai.ts`'s `defaultSpawn`'s own
+ * resolve-not-reject rationale (a killed/errored subprocess's partial output may hold the real diagnosable
+ * error, e.g. an auth failure line on stderr).
+ */
+export declare function createRealCliSubprocessSpawn(): CliSubprocessSpawnFn;
 export type ConstructProductionCodingAgentDriverOptions = {
-  spawn?: CliSubprocessSpawnFn;
-  query?: AgentSdkQueryFn;
-  hooks?: AgentSdkHooks;
-  listChangedFiles?: (cwd: string) => Promise<string[]>;
-  houseRulesConfig?: unknown;
-  houseRulesOptions?: unknown;
+    spawn?: CliSubprocessSpawnFn;
+    query?: AgentSdkQueryFn;
+    hooks?: AgentSdkHooks;
+    listChangedFiles?: (cwd: string) => Promise<string[]>;
+    houseRulesConfig?: HouseRulesConfig;
+    houseRulesOptions?: HouseRulesOptions;
 };
-
-export function constructProductionCodingAgentDriver(
-  env: Record<string, string | undefined>,
-  options?: ConstructProductionCodingAgentDriverOptions,
-): CodingAgentDriver;
+/**
+ * Resolve `MINER_CODING_AGENT_PROVIDER` from `env` and construct a REAL, production `CodingAgentDriver` —
+ * house-rule-enforced by default (#2343) via `buildHouseRulesAgentSdkHooks`, matching the same
+ * automatic-enforcement guarantee `runHouseRulesEnforcedCodingAgentAttempt` gives task-level callers, but at
+ * the raw driver-construction level `attempt-runner.js`'s `deps.driver` actually needs.
+ *
+ * The default only applies to `agent-sdk`, the one provider with a real hook-registration surface. CLI
+ * subprocess providers (`claude-cli`/`codex-cli`) have none, and the engine's `createCliProvider` fails closed
+ * if `hooks` is supplied at all (driver-factory.ts) -- filling the default for them here would make every CLI
+ * construction throw. An explicitly-supplied `options.hooks` always wins and is forwarded as-is, so a caller
+ * that deliberately asks a CLI provider to enforce hooks still gets that same fail-closed rejection.
+ *
+ * Fails closed (throws) when no provider is configured, or when a CLI provider is selected without a real
+ * spawn available — never silently falls back to a driver that can never run.
+ */
+export declare function constructProductionCodingAgentDriver(env: Record<string, string | undefined>, options?: ConstructProductionCodingAgentDriverOptions): CodingAgentDriver;

--- a/packages/loopover-miner/lib/coding-agent-construction.js
+++ b/packages/loopover-miner/lib/coding-agent-construction.js
@@ -6,56 +6,50 @@
 // those are reviewer-CLI-specific concerns this driver doesn't share) and resolves + constructs a real
 // `CodingAgentDriver` from `MINER_CODING_AGENT_PROVIDER`, with house-rule enforcement (#2343) wired in by
 // default via `buildHouseRulesAgentSdkHooks` -- a caller never has to remember to attach it by hand.
-
 import { spawn as nodeSpawn } from "node:child_process";
-import { createCodingAgentDriver, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
-import { buildHouseRulesAgentSdkHooks } from "./coding-agent-house-rules.js";
-
+import { createCodingAgentDriver, resolveFirstConfiguredCodingAgentDriverName, } from "@loopover/engine";
+import { buildHouseRulesAgentSdkHooks, } from "./coding-agent-house-rules.js";
 /**
  * Real `child_process.spawn`-backed implementation of the engine's `CliSubprocessSpawnFn` contract. Captures
  * stdout/stderr and RESOLVES (never rejects) on timeout or spawn error, so the caller always sees whatever
  * output accumulated rather than an unhandled rejection -- mirrors `src/selfhost/ai.ts`'s `defaultSpawn`'s own
  * resolve-not-reject rationale (a killed/errored subprocess's partial output may hold the real diagnosable
  * error, e.g. an auth failure line on stderr).
- *
- * @returns {import("@loopover/engine").CliSubprocessSpawnFn}
  */
 export function createRealCliSubprocessSpawn() {
-  return (cmd, args, opts) =>
-    new Promise((resolve) => {
-      const child = nodeSpawn(cmd, args, { cwd: opts.cwd, env: opts.env, stdio: ["ignore", "pipe", "pipe"] });
-      let stdout = "";
-      let stderr = "";
-      // Unlike src/selfhost/ai.ts's defaultSpawn (a fixed ~120s default, genuinely untestable without a real
-      // wait), `opts.timeoutMs` here is always CALLER-supplied per CliSubprocessSpawnFn's contract -- a test can
-      // pass a short value against a genuinely long-lived child, so this path is exercised directly rather than
-      // v8-ignored. No "already settled" guard is needed: Promise resolution is idempotent (a second `resolve()`
-      // is a no-op) and clearing an already-fired timer is a harmless no-op too, so `close`/`error` firing after
-      // the timeout already resolved is safe without extra bookkeeping.
-      const timer = setTimeout(() => {
-        child.kill("SIGKILL");
-        resolve({ stdout, code: null, stderr, timedOut: true });
-      }, opts.timeoutMs);
-      child.stdout?.on("data", (chunk) => {
-        stdout += chunk.toString("utf8");
-      });
-      child.stderr?.on("data", (chunk) => {
-        stderr += chunk.toString("utf8");
-      });
-      child.on("error", (err) => {
-        // A spawn-level error (e.g. ENOENT) fires before the child ever produces output, so `stderr` is always
-        // "" here in practice; Node guarantees this listener receives a real Error with `.message` (the
-        // documented contract for ChildProcess's own "error" event), so no optional chaining/fallback is needed.
-        clearTimeout(timer);
-        resolve({ stdout, code: null, stderr: err.message });
-      });
-      child.on("close", (code) => {
-        clearTimeout(timer);
-        resolve({ stdout, code, stderr });
-      });
+    return (cmd, args, opts) => new Promise((resolve) => {
+        const child = nodeSpawn(cmd, args, { cwd: opts.cwd, env: opts.env, stdio: ["ignore", "pipe", "pipe"] });
+        let stdout = "";
+        let stderr = "";
+        // Unlike src/selfhost/ai.ts's defaultSpawn (a fixed ~120s default, genuinely untestable without a real
+        // wait), `opts.timeoutMs` here is always CALLER-supplied per CliSubprocessSpawnFn's contract -- a test can
+        // pass a short value against a genuinely long-lived child, so this path is exercised directly rather than
+        // v8-ignored. No "already settled" guard is needed: Promise resolution is idempotent (a second `resolve()`
+        // is a no-op) and clearing an already-fired timer is a harmless no-op too, so `close`/`error` firing after
+        // the timeout already resolved is safe without extra bookkeeping.
+        const timer = setTimeout(() => {
+            child.kill("SIGKILL");
+            resolve({ stdout, code: null, stderr, timedOut: true });
+        }, opts.timeoutMs);
+        child.stdout?.on("data", (chunk) => {
+            stdout += chunk.toString("utf8");
+        });
+        child.stderr?.on("data", (chunk) => {
+            stderr += chunk.toString("utf8");
+        });
+        child.on("error", (err) => {
+            // A spawn-level error (e.g. ENOENT) fires before the child ever produces output, so `stderr` is always
+            // "" here in practice; Node guarantees this listener receives a real Error with `.message` (the
+            // documented contract for ChildProcess's own "error" event), so no optional chaining/fallback is needed.
+            clearTimeout(timer);
+            resolve({ stdout, code: null, stderr: err.message });
+        });
+        child.on("close", (code) => {
+            clearTimeout(timer);
+            resolve({ stdout, code, stderr });
+        });
     });
 }
-
 /**
  * Resolve `MINER_CODING_AGENT_PROVIDER` from `env` and construct a REAL, production `CodingAgentDriver` —
  * house-rule-enforced by default (#2343) via `buildHouseRulesAgentSdkHooks`, matching the same
@@ -70,34 +64,23 @@ export function createRealCliSubprocessSpawn() {
  *
  * Fails closed (throws) when no provider is configured, or when a CLI provider is selected without a real
  * spawn available — never silently falls back to a driver that can never run.
- *
- * @param {Record<string, string | undefined>} env
- * @param {{
- *   spawn?: import("@loopover/engine").CliSubprocessSpawnFn,
- *   query?: import("@loopover/engine").AgentSdkQueryFn,
- *   hooks?: import("@loopover/engine").AgentSdkHooks,
- *   listChangedFiles?: (cwd: string) => Promise<string[]>,
- *   houseRulesConfig?: unknown,
- *   houseRulesOptions?: unknown,
- * }} [options]
- * @returns {import("@loopover/engine").CodingAgentDriver}
  */
 export function constructProductionCodingAgentDriver(env, options = {}) {
-  const providerName = resolveFirstConfiguredCodingAgentDriverName(env);
-  if (!providerName) {
-    throw new Error("unconfigured_coding_agent_driver:no_provider_in_MINER_CODING_AGENT_PROVIDER");
-  }
-  const hooks =
-    options.hooks ??
-    (providerName.trim().toLowerCase() === "agent-sdk"
-      ? buildHouseRulesAgentSdkHooks(options.houseRulesConfig, options.houseRulesOptions)
-      : undefined);
-  return createCodingAgentDriver({
-    providerName,
-    env,
-    spawn: options.spawn ?? createRealCliSubprocessSpawn(),
-    ...(options.query !== undefined ? { query: options.query } : {}),
-    ...(hooks !== undefined ? { hooks } : {}),
-    ...(options.listChangedFiles !== undefined ? { listChangedFiles: options.listChangedFiles } : {}),
-  });
+    const providerName = resolveFirstConfiguredCodingAgentDriverName(env);
+    if (!providerName) {
+        throw new Error("unconfigured_coding_agent_driver:no_provider_in_MINER_CODING_AGENT_PROVIDER");
+    }
+    const hooks = options.hooks ??
+        (providerName.trim().toLowerCase() === "agent-sdk"
+            ? buildHouseRulesAgentSdkHooks(options.houseRulesConfig, options.houseRulesOptions)
+            : undefined);
+    return createCodingAgentDriver({
+        providerName,
+        env,
+        spawn: options.spawn ?? createRealCliSubprocessSpawn(),
+        ...(options.query !== undefined ? { query: options.query } : {}),
+        ...(hooks !== undefined ? { hooks } : {}),
+        ...(options.listChangedFiles !== undefined ? { listChangedFiles: options.listChangedFiles } : {}),
+    });
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY29kaW5nLWFnZW50LWNvbnN0cnVjdGlvbi5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImNvZGluZy1hZ2VudC1jb25zdHJ1Y3Rpb24udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEseUdBQXlHO0FBQ3pHLG1HQUFtRztBQUNuRywwR0FBMEc7QUFDMUcsK0dBQStHO0FBQy9HLCtHQUErRztBQUMvRyx1R0FBdUc7QUFDdkcsMEdBQTBHO0FBQzFHLHFHQUFxRztBQUVyRyxPQUFPLEVBQUUsS0FBSyxJQUFJLFNBQVMsRUFBRSxNQUFNLG9CQUFvQixDQUFDO0FBQ3hELE9BQU8sRUFDTCx1QkFBdUIsRUFDdkIsMkNBQTJDLEdBSzVDLE1BQU0sa0JBQWtCLENBQUM7QUFDMUIsT0FBTyxFQUNMLDRCQUE0QixHQUc3QixNQUFNLCtCQUErQixDQUFDO0FBRXZDOzs7Ozs7R0FNRztBQUNILE1BQU0sVUFBVSw0QkFBNEI7SUFDMUMsT0FBTyxDQUFDLEdBQUcsRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLEVBQUUsQ0FDekIsSUFBSSxPQUFPLENBQUMsQ0FBQyxPQUFPLEVBQUUsRUFBRTtRQUN0QixNQUFNLEtBQUssR0FBRyxTQUFTLENBQUMsR0FBRyxFQUFFLElBQUksRUFBRSxFQUFFLEdBQUcsRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLEdBQUcsRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLEtBQUssRUFBRSxDQUFDLFFBQVEsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLEVBQUUsQ0FBQyxDQUFDO1FBQ3hHLElBQUksTUFBTSxHQUFHLEVBQUUsQ0FBQztRQUNoQixJQUFJLE1BQU0sR0FBRyxFQUFFLENBQUM7UUFDaEIsdUdBQXVHO1FBQ3ZHLDJHQUEyRztRQUMzRywwR0FBMEc7UUFDMUcsMkdBQTJHO1FBQzNHLDJHQUEyRztRQUMzRyxrRUFBa0U7UUFDbEUsTUFBTSxLQUFLLEdBQUcsVUFBVSxDQUFDLEdBQUcsRUFBRTtZQUM1QixLQUFLLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1lBQ3RCLE9BQU8sQ0FBQyxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxRQUFRLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQztRQUMxRCxDQUFDLEVBQUUsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1FBQ25CLEtBQUssQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLE1BQU0sRUFBRSxDQUFDLEtBQXNCLEVBQUUsRUFBRTtZQUNsRCxNQUFNLElBQUksS0FBSyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUNuQyxDQUFDLENBQUMsQ0FBQztRQUNILEtBQUssQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLE1BQU0sRUFBRSxDQUFDLEtBQXNCLEVBQUUsRUFBRTtZQUNsRCxNQUFNLElBQUksS0FBSyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUNuQyxDQUFDLENBQUMsQ0FBQztRQUNILEtBQUssQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFLENBQUMsR0FBVSxFQUFFLEVBQUU7WUFDL0IsdUdBQXVHO1lBQ3ZHLGdHQUFnRztZQUNoRyx5R0FBeUc7WUFDekcsWUFBWSxDQUFDLEtBQUssQ0FBQyxDQUFDO1lBQ3BCLE9BQU8sQ0FBQyxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxHQUFHLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQztRQUN2RCxDQUFDLENBQUMsQ0FBQztRQUNILEtBQUssQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFLENBQUMsSUFBbUIsRUFBRSxFQUFFO1lBQ3hDLFlBQVksQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUNwQixPQUFPLENBQUMsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxDQUFDLENBQUM7UUFDcEMsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDLENBQUMsQ0FBQztBQUNQLENBQUM7QUFXRDs7Ozs7Ozs7Ozs7Ozs7R0FjRztBQUNILE1BQU0sVUFBVSxvQ0FBb0MsQ0FDbEQsR0FBdUMsRUFDdkMsVUFBdUQsRUFBRTtJQUV6RCxNQUFNLFlBQVksR0FBRywyQ0FBMkMsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUN0RSxJQUFJLENBQUMsWUFBWSxFQUFFLENBQUM7UUFDbEIsTUFBTSxJQUFJLEtBQUssQ0FBQyw2RUFBNkUsQ0FBQyxDQUFDO0lBQ2pHLENBQUM7SUFDRCxNQUFNLEtBQUssR0FDVCxPQUFPLENBQUMsS0FBSztRQUNiLENBQUMsWUFBWSxDQUFDLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxLQUFLLFdBQVc7WUFDaEQsQ0FBQyxDQUFDLDRCQUE0QixDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsRUFBRSxPQUFPLENBQUMsaUJBQWlCLENBQUM7WUFDbkYsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ2pCLE9BQU8sdUJBQXVCLENBQUM7UUFDN0IsWUFBWTtRQUNaLEdBQUc7UUFDSCxLQUFLLEVBQUUsT0FBTyxDQUFDLEtBQUssSUFBSSw0QkFBNEIsRUFBRTtRQUN0RCxHQUFHLENBQUMsT0FBTyxDQUFDLEtBQUssS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsS0FBSyxFQUFFLE9BQU8sQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ2hFLEdBQUcsQ0FBQyxLQUFLLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7UUFDekMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsZ0JBQWdCLEVBQUUsT0FBTyxDQUFDLGdCQUFnQixFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztLQUNsRyxDQUFDLENBQUM7QUFDTCxDQUFDIn0=

--- a/packages/loopover-miner/lib/coding-agent-construction.ts
+++ b/packages/loopover-miner/lib/coding-agent-construction.ts
@@ -1,0 +1,113 @@
+// Production coding-agent driver construction (#5131, Wave 3.5 follow-up to #2337/#2343). Closes the gap
+// coding-agent-house-rules.js's own header names explicitly: "nothing in this package constructs a
+// coding-agent driver in production yet ... that is separate, larger follow-up work." This module IS that
+// call site -- it provides a real `child_process`-backed spawn (mirroring src/selfhost/ai.ts's `defaultSpawn`,
+// simplified to the engine's smaller `CliSubprocessSpawnFn` contract: no `firstOutputTimeoutMs`/`input`, since
+// those are reviewer-CLI-specific concerns this driver doesn't share) and resolves + constructs a real
+// `CodingAgentDriver` from `MINER_CODING_AGENT_PROVIDER`, with house-rule enforcement (#2343) wired in by
+// default via `buildHouseRulesAgentSdkHooks` -- a caller never has to remember to attach it by hand.
+
+import { spawn as nodeSpawn } from "node:child_process";
+import {
+  createCodingAgentDriver,
+  resolveFirstConfiguredCodingAgentDriverName,
+  type AgentSdkHooks,
+  type AgentSdkQueryFn,
+  type CliSubprocessSpawnFn,
+  type CodingAgentDriver,
+} from "@loopover/engine";
+import {
+  buildHouseRulesAgentSdkHooks,
+  type HouseRulesConfig,
+  type HouseRulesOptions,
+} from "./coding-agent-house-rules.js";
+
+/**
+ * Real `child_process.spawn`-backed implementation of the engine's `CliSubprocessSpawnFn` contract. Captures
+ * stdout/stderr and RESOLVES (never rejects) on timeout or spawn error, so the caller always sees whatever
+ * output accumulated rather than an unhandled rejection -- mirrors `src/selfhost/ai.ts`'s `defaultSpawn`'s own
+ * resolve-not-reject rationale (a killed/errored subprocess's partial output may hold the real diagnosable
+ * error, e.g. an auth failure line on stderr).
+ */
+export function createRealCliSubprocessSpawn(): CliSubprocessSpawnFn {
+  return (cmd, args, opts) =>
+    new Promise((resolve) => {
+      const child = nodeSpawn(cmd, args, { cwd: opts.cwd, env: opts.env, stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      // Unlike src/selfhost/ai.ts's defaultSpawn (a fixed ~120s default, genuinely untestable without a real
+      // wait), `opts.timeoutMs` here is always CALLER-supplied per CliSubprocessSpawnFn's contract -- a test can
+      // pass a short value against a genuinely long-lived child, so this path is exercised directly rather than
+      // v8-ignored. No "already settled" guard is needed: Promise resolution is idempotent (a second `resolve()`
+      // is a no-op) and clearing an already-fired timer is a harmless no-op too, so `close`/`error` firing after
+      // the timeout already resolved is safe without extra bookkeeping.
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolve({ stdout, code: null, stderr, timedOut: true });
+      }, opts.timeoutMs);
+      child.stdout?.on("data", (chunk: Buffer | string) => {
+        stdout += chunk.toString("utf8");
+      });
+      child.stderr?.on("data", (chunk: Buffer | string) => {
+        stderr += chunk.toString("utf8");
+      });
+      child.on("error", (err: Error) => {
+        // A spawn-level error (e.g. ENOENT) fires before the child ever produces output, so `stderr` is always
+        // "" here in practice; Node guarantees this listener receives a real Error with `.message` (the
+        // documented contract for ChildProcess's own "error" event), so no optional chaining/fallback is needed.
+        clearTimeout(timer);
+        resolve({ stdout, code: null, stderr: err.message });
+      });
+      child.on("close", (code: number | null) => {
+        clearTimeout(timer);
+        resolve({ stdout, code, stderr });
+      });
+    });
+}
+
+export type ConstructProductionCodingAgentDriverOptions = {
+  spawn?: CliSubprocessSpawnFn;
+  query?: AgentSdkQueryFn;
+  hooks?: AgentSdkHooks;
+  listChangedFiles?: (cwd: string) => Promise<string[]>;
+  houseRulesConfig?: HouseRulesConfig;
+  houseRulesOptions?: HouseRulesOptions;
+};
+
+/**
+ * Resolve `MINER_CODING_AGENT_PROVIDER` from `env` and construct a REAL, production `CodingAgentDriver` —
+ * house-rule-enforced by default (#2343) via `buildHouseRulesAgentSdkHooks`, matching the same
+ * automatic-enforcement guarantee `runHouseRulesEnforcedCodingAgentAttempt` gives task-level callers, but at
+ * the raw driver-construction level `attempt-runner.js`'s `deps.driver` actually needs.
+ *
+ * The default only applies to `agent-sdk`, the one provider with a real hook-registration surface. CLI
+ * subprocess providers (`claude-cli`/`codex-cli`) have none, and the engine's `createCliProvider` fails closed
+ * if `hooks` is supplied at all (driver-factory.ts) -- filling the default for them here would make every CLI
+ * construction throw. An explicitly-supplied `options.hooks` always wins and is forwarded as-is, so a caller
+ * that deliberately asks a CLI provider to enforce hooks still gets that same fail-closed rejection.
+ *
+ * Fails closed (throws) when no provider is configured, or when a CLI provider is selected without a real
+ * spawn available — never silently falls back to a driver that can never run.
+ */
+export function constructProductionCodingAgentDriver(
+  env: Record<string, string | undefined>,
+  options: ConstructProductionCodingAgentDriverOptions = {},
+): CodingAgentDriver {
+  const providerName = resolveFirstConfiguredCodingAgentDriverName(env);
+  if (!providerName) {
+    throw new Error("unconfigured_coding_agent_driver:no_provider_in_MINER_CODING_AGENT_PROVIDER");
+  }
+  const hooks =
+    options.hooks ??
+    (providerName.trim().toLowerCase() === "agent-sdk"
+      ? buildHouseRulesAgentSdkHooks(options.houseRulesConfig, options.houseRulesOptions)
+      : undefined);
+  return createCodingAgentDriver({
+    providerName,
+    env,
+    spawn: options.spawn ?? createRealCliSubprocessSpawn(),
+    ...(options.query !== undefined ? { query: options.query } : {}),
+    ...(hooks !== undefined ? { hooks } : {}),
+    ...(options.listChangedFiles !== undefined ? { listChangedFiles: options.listChangedFiles } : {}),
+  });
+}

--- a/packages/loopover-miner/lib/coding-agent-house-rules.d.ts
+++ b/packages/loopover-miner/lib/coding-agent-house-rules.d.ts
@@ -1,24 +1,43 @@
-import type { AgentSdkHooks, CodingAgentDriverResult, CodingAgentExecutionMode, LintGuardResult, RunCodingAgentAttemptOptions } from "@loopover/engine";
+import { type AgentSdkHooks, type CodingAgentDriverResult, type CodingAgentExecutionMode, type LintGuardResult, type RunCodingAgentAttemptOptions } from "@loopover/engine";
 import type { DenyRule } from "./deny-hooks.js";
 import type { appendGovernorEvent } from "./governor-ledger.js";
-
 export type HouseRulesConfig = {
-  rules?: readonly DenyRule[];
-  repoFullName?: string;
+    rules?: readonly DenyRule[];
+    repoFullName?: string;
 };
-
 export type HouseRulesOptions = {
-  append?: typeof appendGovernorEvent;
+    append?: typeof appendGovernorEvent;
 };
-
 /** The concrete shape {@link buildHouseRulesAgentSdkHooks} returns -- a single PreToolUse matcher group
  *  holding the one house-rules callback. Structurally assignable to the engine's opaque `AgentSdkHooks`. */
 export type HouseRulesAgentSdkHooks = AgentSdkHooks & {
-  PreToolUse: Array<{ hooks: Array<(input: unknown, toolUseId?: string, context?: unknown) => Promise<Record<string, unknown>>> }>;
+    PreToolUse: Array<{
+        hooks: Array<(input: unknown, toolUseId?: string, context?: unknown) => Promise<Record<string, unknown>>>;
+    }>;
 };
-
-export function buildHouseRulesAgentSdkHooks(config?: HouseRulesConfig, options?: HouseRulesOptions): HouseRulesAgentSdkHooks;
-
-export function runHouseRulesEnforcedCodingAgentAttempt(
-  options: RunCodingAgentAttemptOptions & { houseRulesConfig?: HouseRulesConfig; houseRulesOptions?: HouseRulesOptions },
-): Promise<{ mode: CodingAgentExecutionMode; result: CodingAgentDriverResult & { lintGuard?: LintGuardResult } }>;
+/**
+ * Wrap {@link buildHouseRulesPreToolUseHook}'s callback into the Claude Agent SDK's own `hooks.PreToolUse`
+ * registration shape (an array of matcher groups, each holding an array of hook callbacks) -- the exact
+ * contract `agent-sdk-driver.ts`'s own doc comment names as "#2343's stated attachment point", and the shape
+ * `packages/loopover-engine/test/agent-sdk-driver.test.ts` asserts is forwarded to the SDK verbatim.
+ */
+export declare function buildHouseRulesAgentSdkHooks(config?: HouseRulesConfig, options?: HouseRulesOptions): HouseRulesAgentSdkHooks;
+/**
+ * Drop-in replacement for the engine's `runCodingAgentAttempt` that defaults `hooks` to
+ * {@link buildHouseRulesAgentSdkHooks} for the `agent-sdk` provider, so house-rule enforcement (#2343) is ON
+ * by default rather than opt-in. An explicitly-supplied `hooks` option always wins (e.g. a test injecting its
+ * own hook double, or a caller composing additional hooks of its own) -- this only fills the gap when the
+ * caller omitted it entirely. CLI providers (`claude-cli`, `codex-cli`) have no hook-registration surface, and
+ * the engine fails closed if `hooks` is supplied to them at all -- so the default is scoped to `agent-sdk`
+ * only; a CLI attempt with no explicit `hooks` gets none (today's inert no-op), while one that explicitly
+ * supplies `hooks` still gets the engine's real fail-closed rejection instead of a silently unenforced run.
+ */
+export declare function runHouseRulesEnforcedCodingAgentAttempt(options: RunCodingAgentAttemptOptions & {
+    houseRulesConfig?: HouseRulesConfig;
+    houseRulesOptions?: HouseRulesOptions;
+}): Promise<{
+    mode: CodingAgentExecutionMode;
+    result: CodingAgentDriverResult & {
+        lintGuard?: LintGuardResult;
+    };
+}>;

--- a/packages/loopover-miner/lib/coding-agent-house-rules.ts
+++ b/packages/loopover-miner/lib/coding-agent-house-rules.ts
@@ -19,25 +19,61 @@
 // anticipated). `runHouseRulesEnforcedCodingAgentAttempt` itself remains real, tested, and callable, but has
 // no production caller today -- it's a lower-level composable for a hypothetical caller that wants the
 // non-iterate-loop path, not something this package currently needs.
-import { runCodingAgentAttempt, } from "@loopover/engine";
+
+import {
+  runCodingAgentAttempt,
+  type AgentSdkHooks,
+  type CodingAgentDriverResult,
+  type CodingAgentExecutionMode,
+  type LintGuardResult,
+  type RunCodingAgentAttemptOptions,
+} from "@loopover/engine";
 import { buildHouseRulesPreToolUseHook } from "./pretooluse-hook.js";
+import type { DenyRule } from "./deny-hooks.js";
+import type { appendGovernorEvent } from "./governor-ledger.js";
+
+export type HouseRulesConfig = {
+  rules?: readonly DenyRule[];
+  repoFullName?: string;
+};
+
+export type HouseRulesOptions = {
+  append?: typeof appendGovernorEvent;
+};
+
+/** The concrete shape {@link buildHouseRulesAgentSdkHooks} returns -- a single PreToolUse matcher group
+ *  holding the one house-rules callback. Structurally assignable to the engine's opaque `AgentSdkHooks`. */
+export type HouseRulesAgentSdkHooks = AgentSdkHooks & {
+  PreToolUse: Array<{
+    hooks: Array<(input: unknown, toolUseId?: string, context?: unknown) => Promise<Record<string, unknown>>>;
+  }>;
+};
+
 /**
  * Wrap {@link buildHouseRulesPreToolUseHook}'s callback into the Claude Agent SDK's own `hooks.PreToolUse`
  * registration shape (an array of matcher groups, each holding an array of hook callbacks) -- the exact
  * contract `agent-sdk-driver.ts`'s own doc comment names as "#2343's stated attachment point", and the shape
  * `packages/loopover-engine/test/agent-sdk-driver.test.ts` asserts is forwarded to the SDK verbatim.
  */
-export function buildHouseRulesAgentSdkHooks(config = {}, options = {}) {
-    return {
-        PreToolUse: [
-            {
-                hooks: [
-                    buildHouseRulesPreToolUseHook(config, options),
-                ],
-            },
+export function buildHouseRulesAgentSdkHooks(
+  config: HouseRulesConfig = {},
+  options: HouseRulesOptions = {},
+): HouseRulesAgentSdkHooks {
+  return {
+    PreToolUse: [
+      {
+        hooks: [
+          buildHouseRulesPreToolUseHook(config, options) as (
+            input: unknown,
+            toolUseId?: string,
+            context?: unknown,
+          ) => Promise<Record<string, unknown>>,
         ],
-    };
+      },
+    ],
+  };
 }
+
 /**
  * Drop-in replacement for the engine's `runCodingAgentAttempt` that defaults `hooks` to
  * {@link buildHouseRulesAgentSdkHooks} for the `agent-sdk` provider, so house-rule enforcement (#2343) is ON
@@ -48,12 +84,17 @@ export function buildHouseRulesAgentSdkHooks(config = {}, options = {}) {
  * only; a CLI attempt with no explicit `hooks` gets none (today's inert no-op), while one that explicitly
  * supplies `hooks` still gets the engine's real fail-closed rejection instead of a silently unenforced run.
  */
-export function runHouseRulesEnforcedCodingAgentAttempt(options) {
-    const { houseRulesConfig, houseRulesOptions, ...attemptOptions } = options;
-    const hooks = attemptOptions.hooks ??
-        (attemptOptions.providerName.trim().toLowerCase() === "agent-sdk"
-            ? buildHouseRulesAgentSdkHooks(houseRulesConfig, houseRulesOptions)
-            : undefined);
-    return runCodingAgentAttempt({ ...attemptOptions, ...(hooks !== undefined ? { hooks } : {}) });
+export function runHouseRulesEnforcedCodingAgentAttempt(
+  options: RunCodingAgentAttemptOptions & {
+    houseRulesConfig?: HouseRulesConfig;
+    houseRulesOptions?: HouseRulesOptions;
+  },
+): Promise<{ mode: CodingAgentExecutionMode; result: CodingAgentDriverResult & { lintGuard?: LintGuardResult } }> {
+  const { houseRulesConfig, houseRulesOptions, ...attemptOptions } = options;
+  const hooks =
+    attemptOptions.hooks ??
+    (attemptOptions.providerName.trim().toLowerCase() === "agent-sdk"
+      ? buildHouseRulesAgentSdkHooks(houseRulesConfig, houseRulesOptions)
+      : undefined);
+  return runCodingAgentAttempt({ ...attemptOptions, ...(hooks !== undefined ? { hooks } : {}) });
 }
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY29kaW5nLWFnZW50LWhvdXNlLXJ1bGVzLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiY29kaW5nLWFnZW50LWhvdXNlLXJ1bGVzLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLGtHQUFrRztBQUNsRywyRkFBMkY7QUFDM0YsdUdBQXVHO0FBQ3ZHLCtGQUErRjtBQUMvRix5R0FBeUc7QUFDekcsNkdBQTZHO0FBQzdHLCtGQUErRjtBQUMvRiwrR0FBK0c7QUFDL0csRUFBRTtBQUNGLHdHQUF3RztBQUN4RywwR0FBMEc7QUFDMUcsNEdBQTRHO0FBQzVHLDJGQUEyRjtBQUMzRiw4R0FBOEc7QUFDOUcsMkdBQTJHO0FBQzNHLHNGQUFzRjtBQUN0RixzR0FBc0c7QUFDdEcsMEdBQTBHO0FBQzFHLDZHQUE2RztBQUM3Ryx1R0FBdUc7QUFDdkcscUVBQXFFO0FBRXJFLE9BQU8sRUFDTCxxQkFBcUIsR0FNdEIsTUFBTSxrQkFBa0IsQ0FBQztBQUMxQixPQUFPLEVBQUUsNkJBQTZCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQXFCckU7Ozs7O0dBS0c7QUFDSCxNQUFNLFVBQVUsNEJBQTRCLENBQzFDLFNBQTJCLEVBQUUsRUFDN0IsVUFBNkIsRUFBRTtJQUUvQixPQUFPO1FBQ0wsVUFBVSxFQUFFO1lBQ1Y7Z0JBQ0UsS0FBSyxFQUFFO29CQUNMLDZCQUE2QixDQUFDLE1BQU0sRUFBRSxPQUFPLENBSVI7aUJBQ3RDO2FBQ0Y7U0FDRjtLQUNGLENBQUM7QUFDSixDQUFDO0FBRUQ7Ozs7Ozs7OztHQVNHO0FBQ0gsTUFBTSxVQUFVLHVDQUF1QyxDQUNyRCxPQUdDO0lBRUQsTUFBTSxFQUFFLGdCQUFnQixFQUFFLGlCQUFpQixFQUFFLEdBQUcsY0FBYyxFQUFFLEdBQUcsT0FBTyxDQUFDO0lBQzNFLE1BQU0sS0FBSyxHQUNULGNBQWMsQ0FBQyxLQUFLO1FBQ3BCLENBQUMsY0FBYyxDQUFDLFlBQVksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsS0FBSyxXQUFXO1lBQy9ELENBQUMsQ0FBQyw0QkFBNEIsQ0FBQyxnQkFBZ0IsRUFBRSxpQkFBaUIsQ0FBQztZQUNuRSxDQUFDLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDakIsT0FBTyxxQkFBcUIsQ0FBQyxFQUFFLEdBQUcsY0FBYyxFQUFFLEdBQUcsQ0FBQyxLQUFLLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLENBQUM7QUFDakcsQ0FBQyJ9

--- a/packages/loopover-miner/lib/governor-run-halt.d.ts
+++ b/packages/loopover-miner/lib/governor-run-halt.d.ts
@@ -1,37 +1,29 @@
-import type {
-  GovernorCapLimits,
-  GovernorCapUsage,
-  PortfolioConvergenceInput,
-  PortfolioConvergenceThresholds,
-  RunLoopHaltVerdict,
-} from "@loopover/engine";
+import { type GovernorCapLimits, type GovernorCapUsage, type PortfolioConvergenceInput, type PortfolioConvergenceThresholds, type RunLoopHaltVerdict } from "@loopover/engine";
 import type { AppendGovernorEventInput, GovernorLedgerEntry } from "./governor-ledger.js";
 import type { QueueEntry } from "./portfolio-queue.js";
-
 export type RunLoopInFlightItem = {
-  repoFullName: string;
-  identifier: string;
+    repoFullName: string;
+    identifier: string;
 };
-
 export type EvaluateRunLoopBoundaryGateInput = {
-  runHalted?: boolean;
-  usage: GovernorCapUsage;
-  limits: GovernorCapLimits;
-  convergence: PortfolioConvergenceInput;
-  convergenceThresholds?: PortfolioConvergenceThresholds;
-  inFlightItem?: RunLoopInFlightItem | null;
-  markFailed?: (repoFullName: string, identifier: string) => QueueEntry | null;
+    runHalted?: boolean;
+    usage: GovernorCapUsage;
+    limits: GovernorCapLimits;
+    convergence: PortfolioConvergenceInput;
+    convergenceThresholds?: PortfolioConvergenceThresholds;
+    inFlightItem?: RunLoopInFlightItem | null;
+    markFailed?: (repoFullName: string, identifier: string) => QueueEntry | null;
 };
-
 export type EvaluateRunLoopBoundaryGateResult = {
-  verdict: RunLoopHaltVerdict;
-  recorded: GovernorLedgerEntry | null;
-  runHalted: boolean;
-  canClaimNext: boolean;
-  releasedItem: QueueEntry | null;
+    verdict: RunLoopHaltVerdict;
+    recorded: GovernorLedgerEntry | null;
+    runHalted: boolean;
+    canClaimNext: boolean;
+    releasedItem: QueueEntry | null;
 };
-
-export function evaluateRunLoopBoundaryGate(
-  input: EvaluateRunLoopBoundaryGateInput,
-  options?: { append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry },
-): EvaluateRunLoopBoundaryGateResult;
+/**
+ * Evaluate run-loop halt signals before claiming the next portfolio item.
+ */
+export declare function evaluateRunLoopBoundaryGate(input: EvaluateRunLoopBoundaryGateInput, options?: {
+    append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry;
+}): EvaluateRunLoopBoundaryGateResult;

--- a/packages/loopover-miner/lib/governor-run-halt.js
+++ b/packages/loopover-miner/lib/governor-run-halt.js
@@ -1,58 +1,39 @@
 // Governor run-loop halt gate (#2347). Consults non-convergence + budget caps at each iteration boundary,
 // releases in-flight portfolio items on a fresh halt, and records the decision to the governor ledger.
-
-import {
-  buildRunLoopHaltGovernorLedgerEvent,
-  evaluateRunLoopHalt,
-} from "@loopover/engine";
+import { buildRunLoopHaltGovernorLedgerEvent, evaluateRunLoopHalt, } from "@loopover/engine";
 import { appendGovernorEvent } from "./governor-ledger.js";
-
 /**
  * Evaluate run-loop halt signals before claiming the next portfolio item.
- *
- * @param {object} input
- * @param {boolean} [input.runHalted] whether the run is already halted
- * @param {import("@loopover/engine").GovernorCapUsage} input.usage cumulative run usage
- * @param {import("@loopover/engine").GovernorCapLimits} input.limits run ceilings
- * @param {import("@loopover/engine").PortfolioConvergenceInput} input.convergence in-flight item history
- * @param {import("@loopover/engine").PortfolioConvergenceThresholds} [input.convergenceThresholds]
- * @param {{ repoFullName: string, identifier: string } | null | undefined} [input.inFlightItem]
- * @param {(repoFullName: string, identifier: string) => import("./portfolio-queue.js").QueueEntry | null} [input.markFailed]
- * @param {{ append?: typeof appendGovernorEvent }} [options]
  */
 export function evaluateRunLoopBoundaryGate(input, options = {}) {
-  const append = options.append ?? appendGovernorEvent;
-  const wasHalted = Boolean(input.runHalted);
-  const verdict = evaluateRunLoopHalt({
-    runHalted: wasHalted,
-    usage: input.usage,
-    limits: input.limits,
-    convergence: input.convergence,
-    convergenceThresholds: input.convergenceThresholds,
-  });
-
-  const newlyHalted = !wasHalted && verdict.shouldHalt;
-  let releasedItem = null;
-  if (newlyHalted && input.inFlightItem && typeof input.markFailed === "function") {
-    releasedItem = input.markFailed(input.inFlightItem.repoFullName, input.inFlightItem.identifier);
-  }
-
-  const recorded =
-    newlyHalted || (!wasHalted && !verdict.shouldHalt)
-      ? append(
-          buildRunLoopHaltGovernorLedgerEvent(
-            input.inFlightItem?.repoFullName ?? null,
-            input.inFlightItem?.identifier ?? null,
-            verdict,
-          ),
-        )
-      : null;
-
-  return {
-    verdict,
-    recorded,
-    runHalted: verdict.shouldHalt,
-    canClaimNext: verdict.canClaimNext,
-    releasedItem,
-  };
+    const append = options.append ?? appendGovernorEvent;
+    const wasHalted = Boolean(input.runHalted);
+    const verdict = evaluateRunLoopHalt({
+        runHalted: wasHalted,
+        usage: input.usage,
+        limits: input.limits,
+        convergence: input.convergence,
+        ...(input.convergenceThresholds !== undefined
+            ? { convergenceThresholds: input.convergenceThresholds }
+            : {}),
+    });
+    const newlyHalted = !wasHalted && verdict.shouldHalt;
+    let releasedItem = null;
+    if (newlyHalted && input.inFlightItem && typeof input.markFailed === "function") {
+        releasedItem = input.markFailed(input.inFlightItem.repoFullName, input.inFlightItem.identifier);
+    }
+    const recorded = newlyHalted || (!wasHalted && !verdict.shouldHalt)
+        ? append(
+        // Engine ledger events allow explicit `undefined` on optional fields; the miner append
+        // contract uses exactOptionalPropertyTypes (`?: T` without `| undefined`).
+        buildRunLoopHaltGovernorLedgerEvent(input.inFlightItem?.repoFullName ?? null, input.inFlightItem?.identifier ?? null, verdict))
+        : null;
+    return {
+        verdict,
+        recorded,
+        runHalted: verdict.shouldHalt,
+        canClaimNext: verdict.canClaimNext,
+        releasedItem,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItcnVuLWhhbHQuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJnb3Zlcm5vci1ydW4taGFsdC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSwwR0FBMEc7QUFDMUcsdUdBQXVHO0FBRXZHLE9BQU8sRUFDTCxtQ0FBbUMsRUFDbkMsbUJBQW1CLEdBTXBCLE1BQU0sa0JBQWtCLENBQUM7QUFDMUIsT0FBTyxFQUFFLG1CQUFtQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUEyQjNEOztHQUVHO0FBQ0gsTUFBTSxVQUFVLDJCQUEyQixDQUN6QyxLQUF1QyxFQUN2QyxVQUFpRixFQUFFO0lBRW5GLE1BQU0sTUFBTSxHQUFHLE9BQU8sQ0FBQyxNQUFNLElBQUksbUJBQW1CLENBQUM7SUFDckQsTUFBTSxTQUFTLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUMzQyxNQUFNLE9BQU8sR0FBRyxtQkFBbUIsQ0FBQztRQUNsQyxTQUFTLEVBQUUsU0FBUztRQUNwQixLQUFLLEVBQUUsS0FBSyxDQUFDLEtBQUs7UUFDbEIsTUFBTSxFQUFFLEtBQUssQ0FBQyxNQUFNO1FBQ3BCLFdBQVcsRUFBRSxLQUFLLENBQUMsV0FBVztRQUM5QixHQUFHLENBQUMsS0FBSyxDQUFDLHFCQUFxQixLQUFLLFNBQVM7WUFDM0MsQ0FBQyxDQUFDLEVBQUUscUJBQXFCLEVBQUUsS0FBSyxDQUFDLHFCQUFxQixFQUFFO1lBQ3hELENBQUMsQ0FBQyxFQUFFLENBQUM7S0FDUixDQUFDLENBQUM7SUFFSCxNQUFNLFdBQVcsR0FBRyxDQUFDLFNBQVMsSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDO0lBQ3JELElBQUksWUFBWSxHQUFzQixJQUFJLENBQUM7SUFDM0MsSUFBSSxXQUFXLElBQUksS0FBSyxDQUFDLFlBQVksSUFBSSxPQUFPLEtBQUssQ0FBQyxVQUFVLEtBQUssVUFBVSxFQUFFLENBQUM7UUFDaEYsWUFBWSxHQUFHLEtBQUssQ0FBQyxVQUFVLENBQUMsS0FBSyxDQUFDLFlBQVksQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFlBQVksQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUNsRyxDQUFDO0lBRUQsTUFBTSxRQUFRLEdBQ1osV0FBVyxJQUFJLENBQUMsQ0FBQyxTQUFTLElBQUksQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDO1FBQ2hELENBQUMsQ0FBQyxNQUFNO1FBQ0osdUZBQXVGO1FBQ3ZGLDJFQUEyRTtRQUMzRSxtQ0FBbUMsQ0FDakMsS0FBSyxDQUFDLFlBQVksRUFBRSxZQUFZLElBQUksSUFBSSxFQUN4QyxLQUFLLENBQUMsWUFBWSxFQUFFLFVBQVUsSUFBSSxJQUFJLEVBQ3RDLE9BQU8sQ0FDb0IsQ0FDOUI7UUFDSCxDQUFDLENBQUMsSUFBSSxDQUFDO0lBRVgsT0FBTztRQUNMLE9BQU87UUFDUCxRQUFRO1FBQ1IsU0FBUyxFQUFFLE9BQU8sQ0FBQyxVQUFVO1FBQzdCLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWTtRQUNsQyxZQUFZO0tBQ2IsQ0FBQztBQUNKLENBQUMifQ==

--- a/packages/loopover-miner/lib/governor-run-halt.ts
+++ b/packages/loopover-miner/lib/governor-run-halt.ts
@@ -1,0 +1,85 @@
+// Governor run-loop halt gate (#2347). Consults non-convergence + budget caps at each iteration boundary,
+// releases in-flight portfolio items on a fresh halt, and records the decision to the governor ledger.
+
+import {
+  buildRunLoopHaltGovernorLedgerEvent,
+  evaluateRunLoopHalt,
+  type GovernorCapLimits,
+  type GovernorCapUsage,
+  type PortfolioConvergenceInput,
+  type PortfolioConvergenceThresholds,
+  type RunLoopHaltVerdict,
+} from "@loopover/engine";
+import { appendGovernorEvent } from "./governor-ledger.js";
+import type { AppendGovernorEventInput, GovernorLedgerEntry } from "./governor-ledger.js";
+import type { QueueEntry } from "./portfolio-queue.js";
+
+export type RunLoopInFlightItem = {
+  repoFullName: string;
+  identifier: string;
+};
+
+export type EvaluateRunLoopBoundaryGateInput = {
+  runHalted?: boolean;
+  usage: GovernorCapUsage;
+  limits: GovernorCapLimits;
+  convergence: PortfolioConvergenceInput;
+  convergenceThresholds?: PortfolioConvergenceThresholds;
+  inFlightItem?: RunLoopInFlightItem | null;
+  markFailed?: (repoFullName: string, identifier: string) => QueueEntry | null;
+};
+
+export type EvaluateRunLoopBoundaryGateResult = {
+  verdict: RunLoopHaltVerdict;
+  recorded: GovernorLedgerEntry | null;
+  runHalted: boolean;
+  canClaimNext: boolean;
+  releasedItem: QueueEntry | null;
+};
+
+/**
+ * Evaluate run-loop halt signals before claiming the next portfolio item.
+ */
+export function evaluateRunLoopBoundaryGate(
+  input: EvaluateRunLoopBoundaryGateInput,
+  options: { append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry } = {},
+): EvaluateRunLoopBoundaryGateResult {
+  const append = options.append ?? appendGovernorEvent;
+  const wasHalted = Boolean(input.runHalted);
+  const verdict = evaluateRunLoopHalt({
+    runHalted: wasHalted,
+    usage: input.usage,
+    limits: input.limits,
+    convergence: input.convergence,
+    ...(input.convergenceThresholds !== undefined
+      ? { convergenceThresholds: input.convergenceThresholds }
+      : {}),
+  });
+
+  const newlyHalted = !wasHalted && verdict.shouldHalt;
+  let releasedItem: QueueEntry | null = null;
+  if (newlyHalted && input.inFlightItem && typeof input.markFailed === "function") {
+    releasedItem = input.markFailed(input.inFlightItem.repoFullName, input.inFlightItem.identifier);
+  }
+
+  const recorded =
+    newlyHalted || (!wasHalted && !verdict.shouldHalt)
+      ? append(
+          // Engine ledger events allow explicit `undefined` on optional fields; the miner append
+          // contract uses exactOptionalPropertyTypes (`?: T` without `| undefined`).
+          buildRunLoopHaltGovernorLedgerEvent(
+            input.inFlightItem?.repoFullName ?? null,
+            input.inFlightItem?.identifier ?? null,
+            verdict,
+          ) as AppendGovernorEventInput,
+        )
+      : null;
+
+  return {
+    verdict,
+    recorded,
+    runHalted: verdict.shouldHalt,
+    canClaimNext: verdict.canClaimNext,
+    releasedItem,
+  };
+}

--- a/packages/loopover-miner/lib/loop-closure.d.ts
+++ b/packages/loopover-miner/lib/loop-closure.d.ts
@@ -1,35 +1,48 @@
 export interface LoopClosureEventLedger {
-  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ seq?: number; type?: unknown; repoFullName?: string | null }>;
+    readEvents(filter?: {
+        since?: number;
+        repoFullName?: string;
+    }): Array<{
+        seq?: number;
+        type?: unknown;
+        repoFullName?: string | null;
+    }>;
 }
-
 export interface LoopClosurePortfolioQueue {
-  listQueue(repoFullName: string | null): Array<{ status?: unknown }>;
+    listQueue(repoFullName: string | null): Array<{
+        status?: unknown;
+    }>;
 }
-
 export interface LoopClosureRunState {
-  getRunState(repoFullName: string): string | null;
+    getRunState(repoFullName: string): string | null;
 }
-
 export interface LoopClosureSources {
-  eventLedger: LoopClosureEventLedger;
-  portfolioQueue: LoopClosurePortfolioQueue;
-  runState?: LoopClosureRunState;
+    eventLedger: LoopClosureEventLedger;
+    portfolioQueue: LoopClosurePortfolioQueue;
+    runState?: LoopClosureRunState;
 }
-
 export interface LoopClosureOptions {
-  /** Event-ledger seq at the END of the prior cycle; events with a strictly greater seq are "this cycle". */
-  sinceSeq?: number;
-  /** Scope the summary to a single repo (its events and queue entries) when set. */
-  repoFullName?: string;
+    /** Event-ledger seq at the END of the prior cycle; events with a strictly greater seq are "this cycle". */
+    sinceSeq?: number;
+    /** Scope the summary to a single repo (its events and queue entries) when set. */
+    repoFullName?: string;
 }
-
 export interface LoopClosureSummary {
-  sinceSeq: number | null;
-  /** Highest event seq observed this cycle (>= sinceSeq); the boundary a caller passes as the next cycle's sinceSeq. */
-  lastSeq: number;
-  events: { total: number; byType: Record<string, number> };
-  queue: { total: number; byStatus: Record<string, number> };
-  runState: string | null;
+    sinceSeq: number | null;
+    /** Highest event seq observed this cycle (>= sinceSeq); the boundary a caller passes as the next cycle's sinceSeq. */
+    lastSeq: number;
+    events: {
+        total: number;
+        byType: Record<string, number>;
+    };
+    queue: {
+        total: number;
+        byStatus: Record<string, number>;
+    };
+    runState: string | null;
 }
-
-export function buildLoopClosureSummary(sources: LoopClosureSources, options?: LoopClosureOptions): LoopClosureSummary;
+/**
+ * Build a read-only loop-closure summary from local-state sources. Pure: reads `sources` + `options` and returns a
+ * structured summary, mutating nothing.
+ */
+export declare function buildLoopClosureSummary(sources: LoopClosureSources, options?: LoopClosureOptions): LoopClosureSummary;

--- a/packages/loopover-miner/lib/loop-closure.js
+++ b/packages/loopover-miner/lib/loop-closure.js
@@ -12,55 +12,50 @@
 // OPEN type vocabulary (only the phase writers define concrete types), so events are tallied GENERICALLY by `type`;
 // new phase event types (plans built, PRs prepared/opened, outcomes recorded — landing via sibling issues) surface
 // in the tally automatically without a hardcoded list here.
-
 /**
  * Build a read-only loop-closure summary from local-state sources. Pure: reads `sources` + `options` and returns a
  * structured summary, mutating nothing.
- *
- * @param {{ eventLedger: { readEvents: Function }, portfolioQueue: { listQueue: Function }, runState?: { getRunState: Function } }} sources
- * @param {{ sinceSeq?: number, repoFullName?: string }} [options]
- * @returns {{ sinceSeq: number|null, lastSeq: number, events: { total: number, byType: Record<string, number> }, queue: { total: number, byStatus: Record<string, number> }, runState: string|null }}
  */
 export function buildLoopClosureSummary(sources, options = {}) {
-  const eventLedger = sources?.eventLedger;
-  const portfolioQueue = sources?.portfolioQueue;
-  const runState = sources?.runState;
-  if (!eventLedger || typeof eventLedger.readEvents !== "function") throw new Error("invalid_event_ledger");
-  if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") throw new Error("invalid_portfolio_queue");
-
-  const repoFullName = typeof options.repoFullName === "string" && options.repoFullName.length > 0 ? options.repoFullName : null;
-  const sinceSeq = Number.isInteger(options.sinceSeq) && options.sinceSeq >= 0 ? options.sinceSeq : null;
-
-  // Bound "this cycle" to events after the prior cycle's ending seq; event-ledger applies the `since`/repo filter.
-  const filter = {};
-  if (repoFullName !== null) filter.repoFullName = repoFullName;
-  if (sinceSeq !== null) filter.since = sinceSeq;
-  const events = eventLedger.readEvents(filter);
-
-  const byType = {};
-  let lastSeq = sinceSeq ?? 0;
-  for (const event of events) {
-    const type = typeof event?.type === "string" && event.type.length > 0 ? event.type : "unknown";
-    byType[type] = (byType[type] ?? 0) + 1;
-    if (Number.isInteger(event?.seq) && event.seq > lastSeq) lastSeq = event.seq;
-  }
-
-  const byStatus = {};
-  const queueEntries = portfolioQueue.listQueue(repoFullName);
-  for (const entry of queueEntries) {
-    const status = typeof entry?.status === "string" && entry.status.length > 0 ? entry.status : "unknown";
-    byStatus[status] = (byStatus[status] ?? 0) + 1;
-  }
-
-  const currentRunState = runState && typeof runState.getRunState === "function" && repoFullName !== null
-    ? runState.getRunState(repoFullName)
-    : null;
-
-  return {
-    sinceSeq,
-    lastSeq,
-    events: { total: events.length, byType },
-    queue: { total: queueEntries.length, byStatus },
-    runState: currentRunState ?? null,
-  };
+    const eventLedger = sources?.eventLedger;
+    const portfolioQueue = sources?.portfolioQueue;
+    const runState = sources?.runState;
+    if (!eventLedger || typeof eventLedger.readEvents !== "function")
+        throw new Error("invalid_event_ledger");
+    if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function")
+        throw new Error("invalid_portfolio_queue");
+    const repoFullName = typeof options.repoFullName === "string" && options.repoFullName.length > 0 ? options.repoFullName : null;
+    const sinceSeq = Number.isInteger(options.sinceSeq) && options.sinceSeq >= 0 ? options.sinceSeq : null;
+    // Bound "this cycle" to events after the prior cycle's ending seq; event-ledger applies the `since`/repo filter.
+    const filter = {};
+    if (repoFullName !== null)
+        filter.repoFullName = repoFullName;
+    if (sinceSeq !== null)
+        filter.since = sinceSeq;
+    const events = eventLedger.readEvents(filter);
+    const byType = {};
+    let lastSeq = sinceSeq ?? 0;
+    for (const event of events) {
+        const type = typeof event?.type === "string" && event.type.length > 0 ? event.type : "unknown";
+        byType[type] = (byType[type] ?? 0) + 1;
+        if (Number.isInteger(event?.seq) && event.seq > lastSeq)
+            lastSeq = event.seq;
+    }
+    const byStatus = {};
+    const queueEntries = portfolioQueue.listQueue(repoFullName);
+    for (const entry of queueEntries) {
+        const status = typeof entry?.status === "string" && entry.status.length > 0 ? entry.status : "unknown";
+        byStatus[status] = (byStatus[status] ?? 0) + 1;
+    }
+    const currentRunState = runState && typeof runState.getRunState === "function" && repoFullName !== null
+        ? runState.getRunState(repoFullName)
+        : null;
+    return {
+        sinceSeq,
+        lastSeq,
+        events: { total: events.length, byType },
+        queue: { total: queueEntries.length, byStatus },
+        runState: currentRunState ?? null,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9vcC1jbG9zdXJlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsibG9vcC1jbG9zdXJlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLHFHQUFxRztBQUNyRyxFQUFFO0FBQ0Ysb0hBQW9IO0FBQ3BILG1HQUFtRztBQUNuRyxnSEFBZ0g7QUFDaEgsaUhBQWlIO0FBQ2pILHFGQUFxRjtBQUNyRixFQUFFO0FBQ0YscUhBQXFIO0FBQ3JILGlIQUFpSDtBQUNqSCxtSEFBbUg7QUFDbkgsb0hBQW9IO0FBQ3BILG1IQUFtSDtBQUNuSCw0REFBNEQ7QUF3QzVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSx1QkFBdUIsQ0FDckMsT0FBMkIsRUFDM0IsVUFBOEIsRUFBRTtJQUVoQyxNQUFNLFdBQVcsR0FBRyxPQUFPLEVBQUUsV0FBVyxDQUFDO0lBQ3pDLE1BQU0sY0FBYyxHQUFHLE9BQU8sRUFBRSxjQUFjLENBQUM7SUFDL0MsTUFBTSxRQUFRLEdBQUcsT0FBTyxFQUFFLFFBQVEsQ0FBQztJQUNuQyxJQUFJLENBQUMsV0FBVyxJQUFJLE9BQU8sV0FBVyxDQUFDLFVBQVUsS0FBSyxVQUFVO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDO0lBQzFHLElBQUksQ0FBQyxjQUFjLElBQUksT0FBTyxjQUFjLENBQUMsU0FBUyxLQUFLLFVBQVU7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHlCQUF5QixDQUFDLENBQUM7SUFFbEgsTUFBTSxZQUFZLEdBQ2hCLE9BQU8sT0FBTyxDQUFDLFlBQVksS0FBSyxRQUFRLElBQUksT0FBTyxDQUFDLFlBQVksQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDNUcsTUFBTSxRQUFRLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQyxPQUFPLENBQUMsUUFBUSxDQUFDLElBQUssT0FBTyxDQUFDLFFBQW1CLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsUUFBUyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFFcEgsaUhBQWlIO0lBQ2pILE1BQU0sTUFBTSxHQUE4QyxFQUFFLENBQUM7SUFDN0QsSUFBSSxZQUFZLEtBQUssSUFBSTtRQUFFLE1BQU0sQ0FBQyxZQUFZLEdBQUcsWUFBWSxDQUFDO0lBQzlELElBQUksUUFBUSxLQUFLLElBQUk7UUFBRSxNQUFNLENBQUMsS0FBSyxHQUFHLFFBQVEsQ0FBQztJQUMvQyxNQUFNLE1BQU0sR0FBRyxXQUFXLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBRTlDLE1BQU0sTUFBTSxHQUEyQixFQUFFLENBQUM7SUFDMUMsSUFBSSxPQUFPLEdBQUcsUUFBUSxJQUFJLENBQUMsQ0FBQztJQUM1QixLQUFLLE1BQU0sS0FBSyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQzNCLE1BQU0sSUFBSSxHQUFHLE9BQU8sS0FBSyxFQUFFLElBQUksS0FBSyxRQUFRLElBQUksS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7UUFDL0YsTUFBTSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUN2QyxJQUFJLE1BQU0sQ0FBQyxTQUFTLENBQUMsS0FBSyxFQUFFLEdBQUcsQ0FBQyxJQUFLLEtBQUssQ0FBQyxHQUFjLEdBQUcsT0FBTztZQUFFLE9BQU8sR0FBRyxLQUFLLENBQUMsR0FBYSxDQUFDO0lBQ3JHLENBQUM7SUFFRCxNQUFNLFFBQVEsR0FBMkIsRUFBRSxDQUFDO0lBQzVDLE1BQU0sWUFBWSxHQUFHLGNBQWMsQ0FBQyxTQUFTLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDNUQsS0FBSyxNQUFNLEtBQUssSUFBSSxZQUFZLEVBQUUsQ0FBQztRQUNqQyxNQUFNLE1BQU0sR0FBRyxPQUFPLEtBQUssRUFBRSxNQUFNLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxNQUFNLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO1FBQ3ZHLFFBQVEsQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDakQsQ0FBQztJQUVELE1BQU0sZUFBZSxHQUNuQixRQUFRLElBQUksT0FBTyxRQUFRLENBQUMsV0FBVyxLQUFLLFVBQVUsSUFBSSxZQUFZLEtBQUssSUFBSTtRQUM3RSxDQUFDLENBQUMsUUFBUSxDQUFDLFdBQVcsQ0FBQyxZQUFZLENBQUM7UUFDcEMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUVYLE9BQU87UUFDTCxRQUFRO1FBQ1IsT0FBTztRQUNQLE1BQU0sRUFBRSxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLE1BQU0sRUFBRTtRQUN4QyxLQUFLLEVBQUUsRUFBRSxLQUFLLEVBQUUsWUFBWSxDQUFDLE1BQU0sRUFBRSxRQUFRLEVBQUU7UUFDL0MsUUFBUSxFQUFFLGVBQWUsSUFBSSxJQUFJO0tBQ2xDLENBQUM7QUFDSixDQUFDIn0=

--- a/packages/loopover-miner/lib/loop-closure.ts
+++ b/packages/loopover-miner/lib/loop-closure.ts
@@ -1,0 +1,105 @@
+// Loop-closure summary builder (pure, read-only) — #4282, Wave 2 tracker #2353 (miner-manage phase).
+//
+// A pure, read-only aggregator in the spirit of manage-status.js's collectManageStatus: read across the local-state
+// primitives (event ledger, portfolio queue, run-state) and summarize what happened in a completed
+// discover→plan→prepare→manage cycle BEFORE the miner loop considers re-entering (idle → discovering again). It
+// never calls GitHub, never writes a local store, and never decides whether to re-enter or performs the re-entry
+// itself — it only builds the summary a future caller reads before making that call.
+//
+// Cycle boundary is CALLER-SUPPLIED (deliberately, per the issue): `options.sinceSeq` is the event-ledger seq at the
+// END of the prior cycle, so events with a STRICTLY greater seq are "this cycle" — reusing event-ledger.js's own
+// `readEvents({ since })` cursor rather than inventing a new persisted cycle-boundary marker. The ledger stores an
+// OPEN type vocabulary (only the phase writers define concrete types), so events are tallied GENERICALLY by `type`;
+// new phase event types (plans built, PRs prepared/opened, outcomes recorded — landing via sibling issues) surface
+// in the tally automatically without a hardcoded list here.
+
+export interface LoopClosureEventLedger {
+  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{
+    seq?: number;
+    type?: unknown;
+    repoFullName?: string | null;
+  }>;
+}
+
+export interface LoopClosurePortfolioQueue {
+  listQueue(repoFullName: string | null): Array<{ status?: unknown }>;
+}
+
+export interface LoopClosureRunState {
+  getRunState(repoFullName: string): string | null;
+}
+
+export interface LoopClosureSources {
+  eventLedger: LoopClosureEventLedger;
+  portfolioQueue: LoopClosurePortfolioQueue;
+  runState?: LoopClosureRunState;
+}
+
+export interface LoopClosureOptions {
+  /** Event-ledger seq at the END of the prior cycle; events with a strictly greater seq are "this cycle". */
+  sinceSeq?: number;
+  /** Scope the summary to a single repo (its events and queue entries) when set. */
+  repoFullName?: string;
+}
+
+export interface LoopClosureSummary {
+  sinceSeq: number | null;
+  /** Highest event seq observed this cycle (>= sinceSeq); the boundary a caller passes as the next cycle's sinceSeq. */
+  lastSeq: number;
+  events: { total: number; byType: Record<string, number> };
+  queue: { total: number; byStatus: Record<string, number> };
+  runState: string | null;
+}
+
+/**
+ * Build a read-only loop-closure summary from local-state sources. Pure: reads `sources` + `options` and returns a
+ * structured summary, mutating nothing.
+ */
+export function buildLoopClosureSummary(
+  sources: LoopClosureSources,
+  options: LoopClosureOptions = {},
+): LoopClosureSummary {
+  const eventLedger = sources?.eventLedger;
+  const portfolioQueue = sources?.portfolioQueue;
+  const runState = sources?.runState;
+  if (!eventLedger || typeof eventLedger.readEvents !== "function") throw new Error("invalid_event_ledger");
+  if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") throw new Error("invalid_portfolio_queue");
+
+  const repoFullName =
+    typeof options.repoFullName === "string" && options.repoFullName.length > 0 ? options.repoFullName : null;
+  const sinceSeq = Number.isInteger(options.sinceSeq) && (options.sinceSeq as number) >= 0 ? options.sinceSeq! : null;
+
+  // Bound "this cycle" to events after the prior cycle's ending seq; event-ledger applies the `since`/repo filter.
+  const filter: { since?: number; repoFullName?: string } = {};
+  if (repoFullName !== null) filter.repoFullName = repoFullName;
+  if (sinceSeq !== null) filter.since = sinceSeq;
+  const events = eventLedger.readEvents(filter);
+
+  const byType: Record<string, number> = {};
+  let lastSeq = sinceSeq ?? 0;
+  for (const event of events) {
+    const type = typeof event?.type === "string" && event.type.length > 0 ? event.type : "unknown";
+    byType[type] = (byType[type] ?? 0) + 1;
+    if (Number.isInteger(event?.seq) && (event.seq as number) > lastSeq) lastSeq = event.seq as number;
+  }
+
+  const byStatus: Record<string, number> = {};
+  const queueEntries = portfolioQueue.listQueue(repoFullName);
+  for (const entry of queueEntries) {
+    const status = typeof entry?.status === "string" && entry.status.length > 0 ? entry.status : "unknown";
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+  }
+
+  const currentRunState =
+    runState && typeof runState.getRunState === "function" && repoFullName !== null
+      ? runState.getRunState(repoFullName)
+      : null;
+
+  return {
+    sinceSeq,
+    lastSeq,
+    events: { total: events.length, byType },
+    queue: { total: queueEntries.length, byStatus },
+    runState: currentRunState ?? null,
+  };
+}

--- a/packages/loopover-miner/lib/portfolio-dashboard.d.ts
+++ b/packages/loopover-miner/lib/portfolio-dashboard.d.ts
@@ -1,31 +1,48 @@
 export interface PortfolioRepoSummary {
-  apiBaseUrl: string;
-  repoFullName: string;
-  byStatus: { queued: number; in_progress: number; done: number };
-  total: number;
+    apiBaseUrl: string;
+    repoFullName: string;
+    byStatus: {
+        queued: number;
+        in_progress: number;
+        done: number;
+    };
+    total: number;
 }
-
 export interface PortfolioDashboardSummary {
-  total: number;
-  byStatus: { queued: number; in_progress: number; done: number };
-  repos: PortfolioRepoSummary[];
-  oldestQueuedAgeMs: number | null;
+    total: number;
+    byStatus: {
+        queued: number;
+        in_progress: number;
+        done: number;
+    };
+    repos: PortfolioRepoSummary[];
+    oldestQueuedAgeMs: number | null;
 }
-
 export interface PortfolioDashboardSources {
-  portfolioQueue: { listQueue(repoFullName?: string | null): unknown[] };
+    portfolioQueue: {
+        listQueue(repoFullName?: string | null): unknown[];
+    };
 }
-
-export function collectPortfolioDashboard(
-  sources: PortfolioDashboardSources,
-  options?: { nowMs?: number },
-): PortfolioDashboardSummary;
-
-export function renderPortfolioDashboardTable(summary: PortfolioDashboardSummary | null | undefined): string;
-
-export function parsePortfolioDashboardArgs(args?: string[]): { json: boolean } | { error: string };
-
-export function runPortfolioDashboard(
-  args?: string[],
-  options?: { initPortfolioQueue?: () => { listQueue(repoFullName: string | null): unknown[]; close(): void }; nowMs?: number },
-): number;
+/**
+ * Pure aggregator over an injected portfolio-queue store (mirrors manage-status.js's `collectManageStatus`).
+ * Read-only. Returns global + per-repo status counts and, when a clock is supplied via `options.nowMs`, the age in
+ * ms of the oldest still-`queued` item (null when no clock is given or nothing is queued).
+ */
+export declare function collectPortfolioDashboard(sources: PortfolioDashboardSources, options?: {
+    nowMs?: number;
+}): PortfolioDashboardSummary;
+/** Plain-text render of a dashboard summary (mirrors manage-status.js's `renderManageStatusTable`). */
+export declare function renderPortfolioDashboardTable(summary: PortfolioDashboardSummary | null | undefined): string;
+export declare function parsePortfolioDashboardArgs(args?: string[]): {
+    json: boolean;
+} | {
+    error: string;
+};
+/** CLI glue for `loopover-miner queue dashboard [--json]` (mirrors manage-status.js's `runManageStatus`). */
+export declare function runPortfolioDashboard(args?: string[], options?: {
+    initPortfolioQueue?: () => {
+        listQueue(repoFullName: string | null): unknown[];
+        close(): void;
+    };
+    nowMs?: number;
+}): number;

--- a/packages/loopover-miner/lib/portfolio-dashboard.js
+++ b/packages/loopover-miner/lib/portfolio-dashboard.js
@@ -7,107 +7,113 @@
 // The extension-panel half named in the issue is a forward dependency, not delivered here: the miner's queue is a
 // local SQLite file with no local-reachable channel a GitHub-page content script can read today. The pure
 // collector below is factored so it is directly reusable once such a channel exists.
-
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { argsWantJson, reportCliFailure } from "./cli-error.js";
-
 const QUEUE_STATUS_KEYS = ["queued", "in_progress", "done"];
-
 function emptyCounts() {
-  return { queued: 0, in_progress: 0, done: 0 };
+    return { queued: 0, in_progress: 0, done: 0 };
 }
-
+function isQueueStatusKey(status) {
+    return typeof status === "string" && QUEUE_STATUS_KEYS.includes(status);
+}
 /**
  * Pure aggregator over an injected portfolio-queue store (mirrors manage-status.js's `collectManageStatus`).
  * Read-only. Returns global + per-repo status counts and, when a clock is supplied via `options.nowMs`, the age in
  * ms of the oldest still-`queued` item (null when no clock is given or nothing is queued).
  */
 export function collectPortfolioDashboard(sources, options = {}) {
-  const portfolioQueue = sources?.portfolioQueue;
-  if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") throw new Error("invalid_portfolio_queue");
-  const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : null;
-
-  const byStatus = emptyCounts();
-  const perRepo = new Map();
-  let total = 0;
-  let oldestQueuedMs = null;
-
-  for (const entry of portfolioQueue.listQueue(null)) {
-    const status = entry?.status;
-    if (!QUEUE_STATUS_KEYS.includes(status)) continue;
-    const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName : "";
-    // #7225: key per-repo backlogs by (apiBaseUrl, repoFullName) so two forge hosts sharing a repo name keep
-    // independent counts instead of silently merging. The composite map key uses "\n" — never valid in either
-    // component — so distinct (host, repo) pairs can never collide.
-    const apiBaseUrl = typeof entry.apiBaseUrl === "string" ? entry.apiBaseUrl : "";
-    total += 1;
-    byStatus[status] += 1;
-    const key = `${apiBaseUrl}\n${repoFullName}`;
-    let repo = perRepo.get(key);
-    if (!repo) {
-      repo = { apiBaseUrl, repoFullName, byStatus: emptyCounts(), total: 0 };
-      perRepo.set(key, repo);
+    const portfolioQueue = sources?.portfolioQueue;
+    if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function")
+        throw new Error("invalid_portfolio_queue");
+    const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : null;
+    const byStatus = emptyCounts();
+    const perRepo = new Map();
+    let total = 0;
+    let oldestQueuedMs = null;
+    for (const raw of portfolioQueue.listQueue(null)) {
+        const entry = raw;
+        const status = entry?.status;
+        if (!isQueueStatusKey(status))
+            continue;
+        const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName : "";
+        // #7225: key per-repo backlogs by (apiBaseUrl, repoFullName) so two forge hosts sharing a repo name keep
+        // independent counts instead of silently merging. The composite map key uses "\n" — never valid in either
+        // component — so distinct (host, repo) pairs can never collide.
+        const apiBaseUrl = typeof entry.apiBaseUrl === "string" ? entry.apiBaseUrl : "";
+        total += 1;
+        byStatus[status] += 1;
+        const key = `${apiBaseUrl}\n${repoFullName}`;
+        let repo = perRepo.get(key);
+        if (!repo) {
+            repo = { apiBaseUrl, repoFullName, byStatus: emptyCounts(), total: 0 };
+            perRepo.set(key, repo);
+        }
+        repo.byStatus[status] += 1;
+        repo.total += 1;
+        if (status === "queued") {
+            const ms = Date.parse(String(entry.enqueuedAt));
+            if (Number.isFinite(ms) && (oldestQueuedMs === null || ms < oldestQueuedMs))
+                oldestQueuedMs = ms;
+        }
     }
-    repo.byStatus[status] += 1;
-    repo.total += 1;
-    if (status === "queued") {
-      const ms = Date.parse(entry.enqueuedAt);
-      if (Number.isFinite(ms) && (oldestQueuedMs === null || ms < oldestQueuedMs)) oldestQueuedMs = ms;
-    }
-  }
-
-  const repos = [...perRepo.values()].sort(
-    (left, right) => left.repoFullName.localeCompare(right.repoFullName) || left.apiBaseUrl.localeCompare(right.apiBaseUrl),
-  );
-  const oldestQueuedAgeMs = nowMs !== null && oldestQueuedMs !== null ? Math.max(0, nowMs - oldestQueuedMs) : null;
-  return { total, byStatus, repos, oldestQueuedAgeMs };
+    const repos = [...perRepo.values()].sort((left, right) => left.repoFullName.localeCompare(right.repoFullName) || left.apiBaseUrl.localeCompare(right.apiBaseUrl));
+    const oldestQueuedAgeMs = nowMs !== null && oldestQueuedMs !== null ? Math.max(0, nowMs - oldestQueuedMs) : null;
+    return { total, byStatus, repos, oldestQueuedAgeMs };
 }
-
 /** Plain-text render of a dashboard summary (mirrors manage-status.js's `renderManageStatusTable`). */
 export function renderPortfolioDashboardTable(summary) {
-  if (!summary || summary.total === 0) return "portfolio queue is empty";
-  const age = summary.oldestQueuedAgeMs !== null ? `  oldest-queued: ${Math.round(summary.oldestQueuedAgeMs / 60000)}m` : "";
-  const header = ["repo".padEnd(28), "host".padEnd(30), "queued".padStart(7), "in_prog".padStart(8), "done".padStart(6), "total".padStart(6)].join(" ");
-  const lines = summary.repos.map((repo) =>
-    [
-      repo.repoFullName.padEnd(28),
-      String(repo.apiBaseUrl).padEnd(30),
-      String(repo.byStatus.queued).padStart(7),
-      String(repo.byStatus.in_progress).padStart(8),
-      String(repo.byStatus.done).padStart(6),
-      String(repo.total).padStart(6),
-    ].join(" "),
-  );
-  return [
-    `total: ${summary.total}  queued: ${summary.byStatus.queued}  in_progress: ${summary.byStatus.in_progress}  done: ${summary.byStatus.done}${age}`,
-    "",
-    header,
-    ...lines,
-  ].join("\n");
+    if (!summary || summary.total === 0)
+        return "portfolio queue is empty";
+    const age = summary.oldestQueuedAgeMs !== null ? `  oldest-queued: ${Math.round(summary.oldestQueuedAgeMs / 60000)}m` : "";
+    const header = [
+        "repo".padEnd(28),
+        "host".padEnd(30),
+        "queued".padStart(7),
+        "in_prog".padStart(8),
+        "done".padStart(6),
+        "total".padStart(6),
+    ].join(" ");
+    const lines = summary.repos.map((repo) => [
+        repo.repoFullName.padEnd(28),
+        String(repo.apiBaseUrl).padEnd(30),
+        String(repo.byStatus.queued).padStart(7),
+        String(repo.byStatus.in_progress).padStart(8),
+        String(repo.byStatus.done).padStart(6),
+        String(repo.total).padStart(6),
+    ].join(" "));
+    return [
+        `total: ${summary.total}  queued: ${summary.byStatus.queued}  in_progress: ${summary.byStatus.in_progress}  done: ${summary.byStatus.done}${age}`,
+        "",
+        header,
+        ...lines,
+    ].join("\n");
 }
-
 export function parsePortfolioDashboardArgs(args = []) {
-  for (const token of args) {
-    if (token === "--json") continue;
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    return { error: "Usage: loopover-miner queue dashboard [--json]" };
-  }
-  return { json: args.includes("--json") };
+    for (const token of args) {
+        if (token === "--json")
+            continue;
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        return { error: "Usage: loopover-miner queue dashboard [--json]" };
+    }
+    return { json: args.includes("--json") };
 }
-
 /** CLI glue for `loopover-miner queue dashboard [--json]` (mirrors manage-status.js's `runManageStatus`). */
 export function runPortfolioDashboard(args = [], options = {}) {
-  const parsed = parsePortfolioDashboardArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-  const ownsQueue = options.initPortfolioQueue === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  try {
-    const summary = collectPortfolioDashboard({ portfolioQueue }, { nowMs: Number.isFinite(options.nowMs) ? options.nowMs : Date.now() });
-    console.log(parsed.json ? JSON.stringify(summary, null, 2) : renderPortfolioDashboardTable(summary));
-    return 0;
-  } finally {
-    if (ownsQueue) portfolioQueue.close();
-  }
+    const parsed = parsePortfolioDashboardArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    const ownsQueue = options.initPortfolioQueue === undefined;
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    try {
+        const summary = collectPortfolioDashboard({ portfolioQueue }, { nowMs: Number.isFinite(options.nowMs) ? options.nowMs : Date.now() });
+        console.log(parsed.json ? JSON.stringify(summary, null, 2) : renderPortfolioDashboardTable(summary));
+        return 0;
+    }
+    finally {
+        if (ownsQueue)
+            portfolioQueue.close();
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGZvbGlvLWRhc2hib2FyZC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInBvcnRmb2xpby1kYXNoYm9hcmQudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsd0dBQXdHO0FBQ3hHLGdIQUFnSDtBQUNoSCxtSEFBbUg7QUFDbkgscUhBQXFIO0FBQ3JILDREQUE0RDtBQUM1RCxFQUFFO0FBQ0Ysa0hBQWtIO0FBQ2xILDBHQUEwRztBQUMxRyxxRkFBcUY7QUFFckYsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDL0QsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBRWhFLE1BQU0saUJBQWlCLEdBQUcsQ0FBQyxRQUFRLEVBQUUsYUFBYSxFQUFFLE1BQU0sQ0FBVSxDQUFDO0FBNEJyRSxTQUFTLFdBQVc7SUFDbEIsT0FBTyxFQUFFLE1BQU0sRUFBRSxDQUFDLEVBQUUsV0FBVyxFQUFFLENBQUMsRUFBRSxJQUFJLEVBQUUsQ0FBQyxFQUFFLENBQUM7QUFDaEQsQ0FBQztBQUVELFNBQVMsZ0JBQWdCLENBQUMsTUFBZTtJQUN2QyxPQUFPLE9BQU8sTUFBTSxLQUFLLFFBQVEsSUFBSyxpQkFBdUMsQ0FBQyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUM7QUFDakcsQ0FBQztBQUVEOzs7O0dBSUc7QUFDSCxNQUFNLFVBQVUseUJBQXlCLENBQ3ZDLE9BQWtDLEVBQ2xDLFVBQThCLEVBQUU7SUFFaEMsTUFBTSxjQUFjLEdBQUcsT0FBTyxFQUFFLGNBQWMsQ0FBQztJQUMvQyxJQUFJLENBQUMsY0FBYyxJQUFJLE9BQU8sY0FBYyxDQUFDLFNBQVMsS0FBSyxVQUFVO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO0lBQ2xILE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxRQUFRLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBRSxPQUFPLENBQUMsS0FBZ0IsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBRWhGLE1BQU0sUUFBUSxHQUFHLFdBQVcsRUFBRSxDQUFDO0lBQy9CLE1BQU0sT0FBTyxHQUFHLElBQUksR0FBRyxFQUFnQyxDQUFDO0lBQ3hELElBQUksS0FBSyxHQUFHLENBQUMsQ0FBQztJQUNkLElBQUksY0FBYyxHQUFrQixJQUFJLENBQUM7SUFFekMsS0FBSyxNQUFNLEdBQUcsSUFBSSxjQUFjLENBQUMsU0FBUyxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDakQsTUFBTSxLQUFLLEdBQUcsR0FBcUIsQ0FBQztRQUNwQyxNQUFNLE1BQU0sR0FBRyxLQUFLLEVBQUUsTUFBTSxDQUFDO1FBQzdCLElBQUksQ0FBQyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUM7WUFBRSxTQUFTO1FBQ3hDLE1BQU0sWUFBWSxHQUFHLE9BQU8sS0FBSyxDQUFDLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUN0Rix5R0FBeUc7UUFDekcsMEdBQTBHO1FBQzFHLGdFQUFnRTtRQUNoRSxNQUFNLFVBQVUsR0FBRyxPQUFPLEtBQUssQ0FBQyxVQUFVLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7UUFDaEYsS0FBSyxJQUFJLENBQUMsQ0FBQztRQUNYLFFBQVEsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDdEIsTUFBTSxHQUFHLEdBQUcsR0FBRyxVQUFVLEtBQUssWUFBWSxFQUFFLENBQUM7UUFDN0MsSUFBSSxJQUFJLEdBQUcsT0FBTyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUM1QixJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDVixJQUFJLEdBQUcsRUFBRSxVQUFVLEVBQUUsWUFBWSxFQUFFLFFBQVEsRUFBRSxXQUFXLEVBQUUsRUFBRSxLQUFLLEVBQUUsQ0FBQyxFQUFFLENBQUM7WUFDdkUsT0FBTyxDQUFDLEdBQUcsQ0FBQyxHQUFHLEVBQUUsSUFBSSxDQUFDLENBQUM7UUFDekIsQ0FBQztRQUNELElBQUksQ0FBQyxRQUFRLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDO1FBQzNCLElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxDQUFDO1FBQ2hCLElBQUksTUFBTSxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3hCLE1BQU0sRUFBRSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO1lBQ2hELElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxFQUFFLENBQUMsSUFBSSxDQUFDLGNBQWMsS0FBSyxJQUFJLElBQUksRUFBRSxHQUFHLGNBQWMsQ0FBQztnQkFBRSxjQUFjLEdBQUcsRUFBRSxDQUFDO1FBQ25HLENBQUM7SUFDSCxDQUFDO0lBRUQsTUFBTSxLQUFLLEdBQUcsQ0FBQyxHQUFHLE9BQU8sQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FDdEMsQ0FBQyxJQUFJLEVBQUUsS0FBSyxFQUFFLEVBQUUsQ0FDZCxJQUFJLENBQUMsWUFBWSxDQUFDLGFBQWEsQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxhQUFhLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUN6RyxDQUFDO0lBQ0YsTUFBTSxpQkFBaUIsR0FBRyxLQUFLLEtBQUssSUFBSSxJQUFJLGNBQWMsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLEtBQUssR0FBRyxjQUFjLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ2pILE9BQU8sRUFBRSxLQUFLLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxpQkFBaUIsRUFBRSxDQUFDO0FBQ3ZELENBQUM7QUFFRCx1R0FBdUc7QUFDdkcsTUFBTSxVQUFVLDZCQUE2QixDQUFDLE9BQXFEO0lBQ2pHLElBQUksQ0FBQyxPQUFPLElBQUksT0FBTyxDQUFDLEtBQUssS0FBSyxDQUFDO1FBQUUsT0FBTywwQkFBMEIsQ0FBQztJQUN2RSxNQUFNLEdBQUcsR0FDUCxPQUFPLENBQUMsaUJBQWlCLEtBQUssSUFBSSxDQUFDLENBQUMsQ0FBQyxvQkFBb0IsSUFBSSxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsaUJBQWlCLEdBQUcsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ2pILE1BQU0sTUFBTSxHQUFHO1FBQ2IsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsUUFBUSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDcEIsU0FBUyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDckIsTUFBTSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDbEIsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7S0FDcEIsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDWixNQUFNLEtBQUssR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQ3ZDO1FBQ0UsSUFBSSxDQUFDLFlBQVksQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzVCLE1BQU0sQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNsQyxNQUFNLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQ3hDLE1BQU0sQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLFdBQVcsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDN0MsTUFBTSxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUN0QyxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7S0FDL0IsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQ1osQ0FBQztJQUNGLE9BQU87UUFDTCxVQUFVLE9BQU8sQ0FBQyxLQUFLLGFBQWEsT0FBTyxDQUFDLFFBQVEsQ0FBQyxNQUFNLGtCQUFrQixPQUFPLENBQUMsUUFBUSxDQUFDLFdBQVcsV0FBVyxPQUFPLENBQUMsUUFBUSxDQUFDLElBQUksR0FBRyxHQUFHLEVBQUU7UUFDakosRUFBRTtRQUNGLE1BQU07UUFDTixHQUFHLEtBQUs7S0FDVCxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUNmLENBQUM7QUFFRCxNQUFNLFVBQVUsMkJBQTJCLENBQUMsT0FBaUIsRUFBRTtJQUM3RCxLQUFLLE1BQU0sS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO1FBQ3pCLElBQUksS0FBSyxLQUFLLFFBQVE7WUFBRSxTQUFTO1FBQ2pDLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQ3hFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0RBQWdELEVBQUUsQ0FBQztJQUNyRSxDQUFDO0lBQ0QsT0FBTyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxFQUFFLENBQUM7QUFDM0MsQ0FBQztBQUVELDZHQUE2RztBQUM3RyxNQUFNLFVBQVUscUJBQXFCLENBQ25DLE9BQWlCLEVBQUUsRUFDbkIsVUFHSSxFQUFFO0lBRU4sTUFBTSxNQUFNLEdBQUcsMkJBQTJCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDakQsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFDRCxNQUFNLFNBQVMsR0FBRyxPQUFPLENBQUMsa0JBQWtCLEtBQUssU0FBUyxDQUFDO0lBQzNELE1BQU0sY0FBYyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLHVCQUF1QixDQUFDLEVBQUUsQ0FBQztJQUNqRixJQUFJLENBQUM7UUFDSCxNQUFNLE9BQU8sR0FBRyx5QkFBeUIsQ0FDdkMsRUFBRSxjQUFjLEVBQUUsRUFDbEIsRUFBRSxLQUFLLEVBQUUsTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFFLE9BQU8sQ0FBQyxLQUFnQixDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLEVBQUUsQ0FDbkYsQ0FBQztRQUNGLE9BQU8sQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxPQUFPLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyw2QkFBNkIsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1FBQ3JHLE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztZQUFTLENBQUM7UUFDVCxJQUFJLFNBQVM7WUFBRSxjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7SUFDeEMsQ0FBQztBQUNILENBQUMifQ==

--- a/packages/loopover-miner/lib/portfolio-dashboard.ts
+++ b/packages/loopover-miner/lib/portfolio-dashboard.ts
@@ -1,0 +1,165 @@
+// Read-only portfolio-queue dashboard (#4287). Aggregates the miner's OWN local portfolio-queue backlog
+// (packages/loopover-miner/lib/portfolio-queue.js) into summary stats — counts by status globally and per repo,
+// plus the oldest queued item's age. Same three-layer shape as manage-status.js (pure collect → pure render → thin
+// CLI glue), but scoped to the backlog/queue rather than per-PR manage state. 100% client-side, read-only — it never
+// mutates queue state and never gates or enforces anything.
+//
+// The extension-panel half named in the issue is a forward dependency, not delivered here: the miner's queue is a
+// local SQLite file with no local-reachable channel a GitHub-page content script can read today. The pure
+// collector below is factored so it is directly reusable once such a channel exists.
+
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
+
+const QUEUE_STATUS_KEYS = ["queued", "in_progress", "done"] as const;
+type QueueStatusKey = (typeof QUEUE_STATUS_KEYS)[number];
+
+export interface PortfolioRepoSummary {
+  apiBaseUrl: string;
+  repoFullName: string;
+  byStatus: { queued: number; in_progress: number; done: number };
+  total: number;
+}
+
+export interface PortfolioDashboardSummary {
+  total: number;
+  byStatus: { queued: number; in_progress: number; done: number };
+  repos: PortfolioRepoSummary[];
+  oldestQueuedAgeMs: number | null;
+}
+
+export interface PortfolioDashboardSources {
+  portfolioQueue: { listQueue(repoFullName?: string | null): unknown[] };
+}
+
+type QueueEntryLike = {
+  status?: unknown;
+  repoFullName?: unknown;
+  apiBaseUrl?: unknown;
+  enqueuedAt?: unknown;
+};
+
+function emptyCounts(): { queued: number; in_progress: number; done: number } {
+  return { queued: 0, in_progress: 0, done: 0 };
+}
+
+function isQueueStatusKey(status: unknown): status is QueueStatusKey {
+  return typeof status === "string" && (QUEUE_STATUS_KEYS as readonly string[]).includes(status);
+}
+
+/**
+ * Pure aggregator over an injected portfolio-queue store (mirrors manage-status.js's `collectManageStatus`).
+ * Read-only. Returns global + per-repo status counts and, when a clock is supplied via `options.nowMs`, the age in
+ * ms of the oldest still-`queued` item (null when no clock is given or nothing is queued).
+ */
+export function collectPortfolioDashboard(
+  sources: PortfolioDashboardSources,
+  options: { nowMs?: number } = {},
+): PortfolioDashboardSummary {
+  const portfolioQueue = sources?.portfolioQueue;
+  if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") throw new Error("invalid_portfolio_queue");
+  const nowMs = Number.isFinite(options.nowMs) ? (options.nowMs as number) : null;
+
+  const byStatus = emptyCounts();
+  const perRepo = new Map<string, PortfolioRepoSummary>();
+  let total = 0;
+  let oldestQueuedMs: number | null = null;
+
+  for (const raw of portfolioQueue.listQueue(null)) {
+    const entry = raw as QueueEntryLike;
+    const status = entry?.status;
+    if (!isQueueStatusKey(status)) continue;
+    const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName : "";
+    // #7225: key per-repo backlogs by (apiBaseUrl, repoFullName) so two forge hosts sharing a repo name keep
+    // independent counts instead of silently merging. The composite map key uses "\n" — never valid in either
+    // component — so distinct (host, repo) pairs can never collide.
+    const apiBaseUrl = typeof entry.apiBaseUrl === "string" ? entry.apiBaseUrl : "";
+    total += 1;
+    byStatus[status] += 1;
+    const key = `${apiBaseUrl}\n${repoFullName}`;
+    let repo = perRepo.get(key);
+    if (!repo) {
+      repo = { apiBaseUrl, repoFullName, byStatus: emptyCounts(), total: 0 };
+      perRepo.set(key, repo);
+    }
+    repo.byStatus[status] += 1;
+    repo.total += 1;
+    if (status === "queued") {
+      const ms = Date.parse(String(entry.enqueuedAt));
+      if (Number.isFinite(ms) && (oldestQueuedMs === null || ms < oldestQueuedMs)) oldestQueuedMs = ms;
+    }
+  }
+
+  const repos = [...perRepo.values()].sort(
+    (left, right) =>
+      left.repoFullName.localeCompare(right.repoFullName) || left.apiBaseUrl.localeCompare(right.apiBaseUrl),
+  );
+  const oldestQueuedAgeMs = nowMs !== null && oldestQueuedMs !== null ? Math.max(0, nowMs - oldestQueuedMs) : null;
+  return { total, byStatus, repos, oldestQueuedAgeMs };
+}
+
+/** Plain-text render of a dashboard summary (mirrors manage-status.js's `renderManageStatusTable`). */
+export function renderPortfolioDashboardTable(summary: PortfolioDashboardSummary | null | undefined): string {
+  if (!summary || summary.total === 0) return "portfolio queue is empty";
+  const age =
+    summary.oldestQueuedAgeMs !== null ? `  oldest-queued: ${Math.round(summary.oldestQueuedAgeMs / 60000)}m` : "";
+  const header = [
+    "repo".padEnd(28),
+    "host".padEnd(30),
+    "queued".padStart(7),
+    "in_prog".padStart(8),
+    "done".padStart(6),
+    "total".padStart(6),
+  ].join(" ");
+  const lines = summary.repos.map((repo) =>
+    [
+      repo.repoFullName.padEnd(28),
+      String(repo.apiBaseUrl).padEnd(30),
+      String(repo.byStatus.queued).padStart(7),
+      String(repo.byStatus.in_progress).padStart(8),
+      String(repo.byStatus.done).padStart(6),
+      String(repo.total).padStart(6),
+    ].join(" "),
+  );
+  return [
+    `total: ${summary.total}  queued: ${summary.byStatus.queued}  in_progress: ${summary.byStatus.in_progress}  done: ${summary.byStatus.done}${age}`,
+    "",
+    header,
+    ...lines,
+  ].join("\n");
+}
+
+export function parsePortfolioDashboardArgs(args: string[] = []): { json: boolean } | { error: string } {
+  for (const token of args) {
+    if (token === "--json") continue;
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    return { error: "Usage: loopover-miner queue dashboard [--json]" };
+  }
+  return { json: args.includes("--json") };
+}
+
+/** CLI glue for `loopover-miner queue dashboard [--json]` (mirrors manage-status.js's `runManageStatus`). */
+export function runPortfolioDashboard(
+  args: string[] = [],
+  options: {
+    initPortfolioQueue?: () => { listQueue(repoFullName: string | null): unknown[]; close(): void };
+    nowMs?: number;
+  } = {},
+): number {
+  const parsed = parsePortfolioDashboardArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+  const ownsQueue = options.initPortfolioQueue === undefined;
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  try {
+    const summary = collectPortfolioDashboard(
+      { portfolioQueue },
+      { nowMs: Number.isFinite(options.nowMs) ? (options.nowMs as number) : Date.now() },
+    );
+    console.log(parsed.json ? JSON.stringify(summary, null, 2) : renderPortfolioDashboardTable(summary));
+    return 0;
+  } finally {
+    if (ownsQueue) portfolioQueue.close();
+  }
+}

--- a/packages/loopover-miner/lib/pretooluse-hook.d.ts
+++ b/packages/loopover-miner/lib/pretooluse-hook.d.ts
@@ -1,31 +1,33 @@
-import type { DenyRule } from "./deny-hooks.js";
+import { type DenyRule } from "./deny-hooks.js";
 import type { AppendGovernorEventInput, GovernorLedgerEntry } from "./governor-ledger.js";
-
 export type BuildHouseRulesPreToolUseHookConfig = {
-  rules?: readonly DenyRule[];
-  repoFullName?: string;
+    rules?: readonly DenyRule[];
+    repoFullName?: string;
 };
-
 export type BuildHouseRulesPreToolUseHookOptions = {
-  append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry;
+    append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry;
 };
-
 /** Minimal shape this module reads from the real Agent SDK `PreToolUseHookInput`. */
 export type PreToolUseHookLikeInput = {
-  tool_name?: string;
-  tool_input?: Record<string, unknown>;
-  hook_event_name?: string;
+    tool_name?: string;
+    tool_input?: Record<string, unknown>;
+    hook_event_name?: string;
 };
-
 export type PreToolUseHookJSONOutput = {
-  hookSpecificOutput?: {
-    hookEventName: "PreToolUse";
-    permissionDecision: "deny";
-    permissionDecisionReason: string;
-  };
+    hookSpecificOutput?: {
+        hookEventName: "PreToolUse";
+        permissionDecision: "deny";
+        permissionDecisionReason: string;
+    };
 };
-
-export function buildHouseRulesPreToolUseHook(
-  config?: BuildHouseRulesPreToolUseHookConfig,
-  options?: BuildHouseRulesPreToolUseHookOptions,
-): (input: PreToolUseHookLikeInput, toolUseId?: string, context?: unknown) => Promise<PreToolUseHookJSONOutput | Record<string, never>>;
+/**
+ * Build a Claude Agent SDK `PreToolUse` hook callback enforcing the house-rule denylist. Register the
+ * returned function under `options.hooks.PreToolUse` (e.g. `{ hooks: [PreToolUse: [{ hooks: [built] }]] }`
+ * on the object passed to `createAgentSdkCodingAgentDriver({ hooks })`).
+ *
+ * House rules are sourced from a single, auditable list: {@link DEFAULT_DENY_RULES} by default, or an
+ * effective rule set built by the caller (e.g. `resolveEffectiveDenyRules` from deny-hook-synthesis.js,
+ * merging in maintainer-approved synthesized rules) — this module composes whatever rule set it is given,
+ * it does not own deriving one.
+ */
+export declare function buildHouseRulesPreToolUseHook(config?: BuildHouseRulesPreToolUseHookConfig, options?: BuildHouseRulesPreToolUseHookOptions): (input: PreToolUseHookLikeInput, toolUseId?: string, context?: unknown) => Promise<PreToolUseHookJSONOutput | Record<string, never>>;

--- a/packages/loopover-miner/lib/pretooluse-hook.js
+++ b/packages/loopover-miner/lib/pretooluse-hook.js
@@ -14,37 +14,34 @@
 //
 // FAIL CLOSED: any internal error (a malformed tool-call shape, a governor-ledger append failure) denies
 // rather than silently allowing.
-
 import { DEFAULT_DENY_RULES, evaluateDenyHooks } from "./deny-hooks.js";
 import { appendGovernorEvent } from "./governor-ledger.js";
-
 function recordDenial(append, repoFullName, reason, payload) {
-  try {
-    append({
-      eventType: "denied",
-      repoFullName: repoFullName ?? null,
-      actionClass: "pretooluse_hook",
-      decision: "deny",
-      reason,
-      payload,
-    });
-  } catch {
-    // A ledger append failure must never suppress or alter the deny decision itself -- the tool call is
-    // still blocked even if the audit write fails. Silently allowing on a logging failure would be a far
-    // worse outcome for a security boundary than an unrecorded (but still enforced) denial.
-  }
+    try {
+        append({
+            eventType: "denied",
+            repoFullName: repoFullName ?? null,
+            actionClass: "pretooluse_hook",
+            decision: "deny",
+            reason,
+            payload,
+        });
+    }
+    catch {
+        // A ledger append failure must never suppress or alter the deny decision itself -- the tool call is
+        // still blocked even if the audit write fails. Silently allowing on a logging failure would be a far
+        // worse outcome for a security boundary than an unrecorded (but still enforced) denial.
+    }
 }
-
 function denyOutput(reason) {
-  return {
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: reason,
-    },
-  };
+    return {
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason,
+        },
+    };
 }
-
 /**
  * Build a Claude Agent SDK `PreToolUse` hook callback enforcing the house-rule denylist. Register the
  * returned function under `options.hooks.PreToolUse` (e.g. `{ hooks: [PreToolUse: [{ hooks: [built] }]] }`
@@ -54,40 +51,34 @@ function denyOutput(reason) {
  * effective rule set built by the caller (e.g. `resolveEffectiveDenyRules` from deny-hook-synthesis.js,
  * merging in maintainer-approved synthesized rules) — this module composes whatever rule set it is given,
  * it does not own deriving one.
- *
- * @param {object} [config]
- * @param {ReadonlyArray<import("./deny-hooks.js").DenyRule>} [config.rules] defaults to DEFAULT_DENY_RULES
- * @param {string} [config.repoFullName] target repo, for governor-ledger scoping of recorded denials
- * @param {{ append?: typeof appendGovernorEvent }} [options]
- * @returns {(input: unknown, toolUseId?: string, context?: unknown) => Promise<Record<string, unknown>>}
  */
 export function buildHouseRulesPreToolUseHook(config = {}, options = {}) {
-  const rules = config.rules ?? DEFAULT_DENY_RULES;
-  const repoFullName = config.repoFullName;
-  const append = options.append ?? appendGovernorEvent;
-
-  return async function houseRulesPreToolUseHook(input) {
-    try {
-      const toolName = input && typeof input === "object" ? input.tool_name : undefined;
-      const toolInput = input && typeof input === "object" ? input.tool_input : undefined;
-      const verdict = evaluateDenyHooks({ name: toolName, input: toolInput }, rules);
-
-      if (verdict.allowed) return {};
-
-      // `verdict.blockedBy` is always set together with `!verdict.allowed` (evaluateDenyHooks's only two return
-      // shapes), and `.matcher` is always a defined string on it (ruleMatches gates every match on
-      // `typeof rule.matcher === "string"` -- a rule can never become `blockedBy` otherwise). `.reason` has no
-      // equivalent gate, so a caller-supplied custom rule omitting it is a real, reachable case.
-      const reason = verdict.blockedBy.reason ?? "House rule denylist match.";
-      recordDenial(append, repoFullName, reason, {
-        toolName: typeof toolName === "string" ? toolName : null,
-        matcher: verdict.blockedBy.matcher,
-      });
-      return denyOutput(reason);
-    } catch (error) {
-      const reason = `pretooluse_hook_internal_error: ${error instanceof Error ? error.message : String(error)}`;
-      recordDenial(append, repoFullName, reason, {});
-      return denyOutput(reason);
-    }
-  };
+    const rules = config.rules ?? DEFAULT_DENY_RULES;
+    const repoFullName = config.repoFullName;
+    const append = options.append ?? appendGovernorEvent;
+    return async function houseRulesPreToolUseHook(input) {
+        try {
+            const toolName = input && typeof input === "object" ? input.tool_name : undefined;
+            const toolInput = input && typeof input === "object" ? input.tool_input : undefined;
+            const verdict = evaluateDenyHooks({ name: toolName, input: toolInput }, [...rules]);
+            if (verdict.allowed)
+                return {};
+            // `verdict.blockedBy` is always set together with `!verdict.allowed` (evaluateDenyHooks's only two return
+            // shapes), and `.matcher` is always a defined string on it (ruleMatches gates every match on
+            // `typeof rule.matcher === "string"` -- a rule can never become `blockedBy` otherwise). `.reason` has no
+            // equivalent gate, so a caller-supplied custom rule omitting it is a real, reachable case.
+            const reason = verdict.blockedBy.reason ?? "House rule denylist match.";
+            recordDenial(append, repoFullName, reason, {
+                toolName: typeof toolName === "string" ? toolName : null,
+                matcher: verdict.blockedBy.matcher,
+            });
+            return denyOutput(reason);
+        }
+        catch (error) {
+            const reason = `pretooluse_hook_internal_error: ${error instanceof Error ? error.message : String(error)}`;
+            recordDenial(append, repoFullName, reason, {});
+            return denyOutput(reason);
+        }
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHJldG9vbHVzZS1ob29rLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicHJldG9vbHVzZS1ob29rLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLHFHQUFxRztBQUNyRyxrR0FBa0c7QUFDbEcscUdBQXFHO0FBQ3JHLG9HQUFvRztBQUNwRyxFQUFFO0FBQ0Ysd0dBQXdHO0FBQ3hHLHVHQUF1RztBQUN2RyxrR0FBa0c7QUFDbEcsNEZBQTRGO0FBQzVGLHNHQUFzRztBQUN0RyxxR0FBcUc7QUFDckcsc0dBQXNHO0FBQ3RHLHlCQUF5QjtBQUN6QixFQUFFO0FBQ0YseUdBQXlHO0FBQ3pHLGlDQUFpQztBQUVqQyxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsaUJBQWlCLEVBQWlCLE1BQU0saUJBQWlCLENBQUM7QUFDdkYsT0FBTyxFQUFFLG1CQUFtQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUEyQjNELFNBQVMsWUFBWSxDQUNuQixNQUFnRSxFQUNoRSxZQUFnQyxFQUNoQyxNQUFjLEVBQ2QsT0FBZ0M7SUFFaEMsSUFBSSxDQUFDO1FBQ0gsTUFBTSxDQUFDO1lBQ0wsU0FBUyxFQUFFLFFBQVE7WUFDbkIsWUFBWSxFQUFFLFlBQVksSUFBSSxJQUFJO1lBQ2xDLFdBQVcsRUFBRSxpQkFBaUI7WUFDOUIsUUFBUSxFQUFFLE1BQU07WUFDaEIsTUFBTTtZQUNOLE9BQU87U0FDUixDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1Asb0dBQW9HO1FBQ3BHLHFHQUFxRztRQUNyRyx3RkFBd0Y7SUFDMUYsQ0FBQztBQUNILENBQUM7QUFFRCxTQUFTLFVBQVUsQ0FBQyxNQUFjO0lBQ2hDLE9BQU87UUFDTCxrQkFBa0IsRUFBRTtZQUNsQixhQUFhLEVBQUUsWUFBWTtZQUMzQixrQkFBa0IsRUFBRSxNQUFNO1lBQzFCLHdCQUF3QixFQUFFLE1BQU07U0FDakM7S0FDRixDQUFDO0FBQ0osQ0FBQztBQUVEOzs7Ozs7Ozs7R0FTRztBQUNILE1BQU0sVUFBVSw2QkFBNkIsQ0FDM0MsU0FBOEMsRUFBRSxFQUNoRCxVQUFnRCxFQUFFO0lBTWxELE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxLQUFLLElBQUksa0JBQWtCLENBQUM7SUFDakQsTUFBTSxZQUFZLEdBQUcsTUFBTSxDQUFDLFlBQVksQ0FBQztJQUN6QyxNQUFNLE1BQU0sR0FBRyxPQUFPLENBQUMsTUFBTSxJQUFJLG1CQUFtQixDQUFDO0lBRXJELE9BQU8sS0FBSyxVQUFVLHdCQUF3QixDQUFDLEtBQUs7UUFDbEQsSUFBSSxDQUFDO1lBQ0gsTUFBTSxRQUFRLEdBQUcsS0FBSyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO1lBQ2xGLE1BQU0sU0FBUyxHQUFHLEtBQUssSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQztZQUNwRixNQUFNLE9BQU8sR0FBRyxpQkFBaUIsQ0FDL0IsRUFBRSxJQUFJLEVBQUUsUUFBa0IsRUFBRSxLQUFLLEVBQUUsU0FBb0MsRUFBRSxFQUN6RSxDQUFDLEdBQUcsS0FBSyxDQUFDLENBQ1gsQ0FBQztZQUVGLElBQUksT0FBTyxDQUFDLE9BQU87Z0JBQUUsT0FBTyxFQUFFLENBQUM7WUFFL0IsMEdBQTBHO1lBQzFHLDZGQUE2RjtZQUM3Rix5R0FBeUc7WUFDekcsMkZBQTJGO1lBQzNGLE1BQU0sTUFBTSxHQUFHLE9BQU8sQ0FBQyxTQUFVLENBQUMsTUFBTSxJQUFJLDRCQUE0QixDQUFDO1lBQ3pFLFlBQVksQ0FBQyxNQUFNLEVBQUUsWUFBWSxFQUFFLE1BQU0sRUFBRTtnQkFDekMsUUFBUSxFQUFFLE9BQU8sUUFBUSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxJQUFJO2dCQUN4RCxPQUFPLEVBQUUsT0FBTyxDQUFDLFNBQVUsQ0FBQyxPQUFPO2FBQ3BDLENBQUMsQ0FBQztZQUNILE9BQU8sVUFBVSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQzVCLENBQUM7UUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1lBQ2YsTUFBTSxNQUFNLEdBQUcsbUNBQW1DLEtBQUssWUFBWSxLQUFLLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1lBQzNHLFlBQVksQ0FBQyxNQUFNLEVBQUUsWUFBWSxFQUFFLE1BQU0sRUFBRSxFQUFFLENBQUMsQ0FBQztZQUMvQyxPQUFPLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUM1QixDQUFDO0lBQ0gsQ0FBQyxDQUFDO0FBQ0osQ0FBQyJ9

--- a/packages/loopover-miner/lib/pretooluse-hook.ts
+++ b/packages/loopover-miner/lib/pretooluse-hook.ts
@@ -1,0 +1,127 @@
+// PreToolUse-hook-enforced house rules (#2343). Wraps the pure `evaluateDenyHooks` decision function
+// (deny-hooks.js, #2295) into a real Claude Agent SDK PreToolUse hook callback -- the actual live
+// interception point a CodingAgentDriver session registers via `options.hooks.PreToolUse` (the exact
+// seam `agent-sdk-driver.ts`'s `hooks` passthrough documents as "#2343's stated attachment point").
+//
+// WHY THIS HOLDS EVEN UNDER bypassPermissions: per the Agent SDK's own documented permission-evaluation
+// order (https://code.claude.com/docs/en/agent-sdk/permissions), hooks run FIRST -- before deny rules,
+// ask rules, the permission mode check, and allow rules -- and "Hooks still execute and can block
+// operations if needed" even when `permissionMode: 'bypassPermissions'` is set: "Deny rules
+// (disallowed_tools), explicit ask rules, and hooks are evaluated before the mode check and can still
+// block a tool." This module does not implement that guarantee -- the SDK does. This module's job is
+// only to return a correctly-shaped, fail-closed deny decision every time; the SDK is what makes that
+// decision unbypassable.
+//
+// FAIL CLOSED: any internal error (a malformed tool-call shape, a governor-ledger append failure) denies
+// rather than silently allowing.
+
+import { DEFAULT_DENY_RULES, evaluateDenyHooks, type DenyRule } from "./deny-hooks.js";
+import { appendGovernorEvent } from "./governor-ledger.js";
+import type { AppendGovernorEventInput, GovernorLedgerEntry } from "./governor-ledger.js";
+
+export type BuildHouseRulesPreToolUseHookConfig = {
+  rules?: readonly DenyRule[];
+  repoFullName?: string;
+};
+
+export type BuildHouseRulesPreToolUseHookOptions = {
+  append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry;
+};
+
+/** Minimal shape this module reads from the real Agent SDK `PreToolUseHookInput`. */
+export type PreToolUseHookLikeInput = {
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  hook_event_name?: string;
+};
+
+export type PreToolUseHookJSONOutput = {
+  hookSpecificOutput?: {
+    hookEventName: "PreToolUse";
+    permissionDecision: "deny";
+    permissionDecisionReason: string;
+  };
+};
+
+function recordDenial(
+  append: (event: AppendGovernorEventInput) => GovernorLedgerEntry,
+  repoFullName: string | undefined,
+  reason: string,
+  payload: Record<string, unknown>,
+): void {
+  try {
+    append({
+      eventType: "denied",
+      repoFullName: repoFullName ?? null,
+      actionClass: "pretooluse_hook",
+      decision: "deny",
+      reason,
+      payload,
+    });
+  } catch {
+    // A ledger append failure must never suppress or alter the deny decision itself -- the tool call is
+    // still blocked even if the audit write fails. Silently allowing on a logging failure would be a far
+    // worse outcome for a security boundary than an unrecorded (but still enforced) denial.
+  }
+}
+
+function denyOutput(reason: string): PreToolUseHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+/**
+ * Build a Claude Agent SDK `PreToolUse` hook callback enforcing the house-rule denylist. Register the
+ * returned function under `options.hooks.PreToolUse` (e.g. `{ hooks: [PreToolUse: [{ hooks: [built] }]] }`
+ * on the object passed to `createAgentSdkCodingAgentDriver({ hooks })`).
+ *
+ * House rules are sourced from a single, auditable list: {@link DEFAULT_DENY_RULES} by default, or an
+ * effective rule set built by the caller (e.g. `resolveEffectiveDenyRules` from deny-hook-synthesis.js,
+ * merging in maintainer-approved synthesized rules) — this module composes whatever rule set it is given,
+ * it does not own deriving one.
+ */
+export function buildHouseRulesPreToolUseHook(
+  config: BuildHouseRulesPreToolUseHookConfig = {},
+  options: BuildHouseRulesPreToolUseHookOptions = {},
+): (
+  input: PreToolUseHookLikeInput,
+  toolUseId?: string,
+  context?: unknown,
+) => Promise<PreToolUseHookJSONOutput | Record<string, never>> {
+  const rules = config.rules ?? DEFAULT_DENY_RULES;
+  const repoFullName = config.repoFullName;
+  const append = options.append ?? appendGovernorEvent;
+
+  return async function houseRulesPreToolUseHook(input) {
+    try {
+      const toolName = input && typeof input === "object" ? input.tool_name : undefined;
+      const toolInput = input && typeof input === "object" ? input.tool_input : undefined;
+      const verdict = evaluateDenyHooks(
+        { name: toolName as string, input: toolInput as Record<string, unknown> },
+        [...rules],
+      );
+
+      if (verdict.allowed) return {};
+
+      // `verdict.blockedBy` is always set together with `!verdict.allowed` (evaluateDenyHooks's only two return
+      // shapes), and `.matcher` is always a defined string on it (ruleMatches gates every match on
+      // `typeof rule.matcher === "string"` -- a rule can never become `blockedBy` otherwise). `.reason` has no
+      // equivalent gate, so a caller-supplied custom rule omitting it is a real, reachable case.
+      const reason = verdict.blockedBy!.reason ?? "House rule denylist match.";
+      recordDenial(append, repoFullName, reason, {
+        toolName: typeof toolName === "string" ? toolName : null,
+        matcher: verdict.blockedBy!.matcher,
+      });
+      return denyOutput(reason);
+    } catch (error) {
+      const reason = `pretooluse_hook_internal_error: ${error instanceof Error ? error.message : String(error)}`;
+      recordDenial(append, repoFullName, reason, {});
+      return denyOutput(reason);
+    }
+  };
+}

--- a/test/unit/miner-governor-run-halt.test.ts
+++ b/test/unit/miner-governor-run-halt.test.ts
@@ -8,18 +8,28 @@ vi.mock("@loopover/engine", async () => {
 });
 
 import { evaluateRunLoopBoundaryGate } from "../../packages/loopover-miner/lib/governor-run-halt.js";
-import { initGovernorLedger } from "../../packages/loopover-miner/lib/governor-ledger.js";
+import {
+  closeDefaultGovernorLedger,
+  initGovernorLedger,
+} from "../../packages/loopover-miner/lib/governor-ledger.js";
 import { initPortfolioQueueManager } from "../../packages/loopover-miner/lib/portfolio-queue-manager.js";
 import { initPortfolioQueueStore } from "../../packages/loopover-miner/lib/portfolio-queue.js";
 
 const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 const stores: Array<{ close(): void }> = [];
+const previousConfigDirs: Array<string | undefined> = [];
 
 afterEach(() => {
   for (const ledger of ledgers.splice(0)) ledger.close();
   for (const store of stores.splice(0)) store.close();
+  closeDefaultGovernorLedger();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  if (previousConfigDirs.length > 0) {
+    const previousConfigDir = previousConfigDirs.pop();
+    if (previousConfigDir === undefined) delete process.env.LOOPOVER_MINER_CONFIG_DIR;
+    else process.env.LOOPOVER_MINER_CONFIG_DIR = previousConfigDir;
+  }
 });
 
 const LIMITS = { budget: 100, turns: 5, elapsedMs: 60_000 };
@@ -144,5 +154,46 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
     expect(second.recorded).toBeNull();
     expect(second.canClaimNext).toBe(false);
     expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards custom convergenceThresholds and records via the default ledger append", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-thresholds-"));
+    roots.push(root);
+    previousConfigDirs.push(process.env.LOOPOVER_MINER_CONFIG_DIR);
+    process.env.LOOPOVER_MINER_CONFIG_DIR = root;
+
+    // Defaults would halt on consecutiveFailures: 3; raised thresholds keep the run healthy.
+    const healthy = evaluateRunLoopBoundaryGate({
+      runHalted: false,
+      usage: HEALTHY_USAGE,
+      limits: LIMITS,
+      convergence: { attempts: 4, consecutiveFailures: 3, reenqueues: 0, reachedDone: false },
+      convergenceThresholds: { maxConsecutiveFailures: 10, maxReenqueues: 10 },
+    });
+    expect(healthy.runHalted).toBe(false);
+    expect(healthy.canClaimNext).toBe(true);
+    expect(healthy.recorded?.eventType).toBe("allowed");
+    expect(healthy.releasedItem).toBeNull();
+  });
+
+  it("halts on a fresh boundary without releasing when markFailed is omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-no-mark-"));
+    roots.push(root);
+    const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
+    ledgers.push(ledger);
+
+    const halted = evaluateRunLoopBoundaryGate(
+      {
+        runHalted: false,
+        usage: { budgetSpent: 100, turnsTaken: 1, elapsedMs: 1_000 },
+        limits: LIMITS,
+        convergence: HEALTHY_CONVERGENCE,
+        inFlightItem: { repoFullName: "acme/repo-a", identifier: "issue:7" },
+      },
+      { append: (event) => ledger.appendGovernorEvent(event) },
+    );
+    expect(halted.runHalted).toBe(true);
+    expect(halted.releasedItem).toBeNull();
+    expect(halted.recorded?.eventType).toBe("denied");
   });
 });

--- a/test/unit/miner-portfolio-dashboard.test.ts
+++ b/test/unit/miner-portfolio-dashboard.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectPortfolioDashboard,
@@ -8,8 +11,18 @@ import {
 
 const mockQueue = (entries: unknown[]): { listQueue: () => unknown[]; close: () => void } => ({ listQueue: () => entries, close: () => {} });
 const NOW = Date.parse("2026-07-10T00:00:00.000Z");
+const roots: string[] = [];
+const previousConfigDirs: Array<string | undefined> = [];
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  if (previousConfigDirs.length > 0) {
+    const previousConfigDir = previousConfigDirs.pop();
+    if (previousConfigDir === undefined) delete process.env.LOOPOVER_MINER_CONFIG_DIR;
+    else process.env.LOOPOVER_MINER_CONFIG_DIR = previousConfigDir;
+  }
+});
 
 describe("collectPortfolioDashboard (#4287)", () => {
   it("throws when the injected portfolio queue is unusable", () => {
@@ -66,6 +79,32 @@ describe("collectPortfolioDashboard (#4287)", () => {
     expect(
       collectPortfolioDashboard({ portfolioQueue: mockQueue([{ repoFullName: "a/b", status: "done", enqueuedAt: "x" }]) }, { nowMs: NOW }).oldestQueuedAgeMs,
     ).toBeNull(); // nothing queued
+    expect(
+      collectPortfolioDashboard({ portfolioQueue: mockQueue(entries) }, { nowMs: Number.NaN }).oldestQueuedAgeMs,
+    ).toBeNull(); // non-finite clock
+  });
+
+  it("floors a negative oldest-queued age to zero when the clock is before the enqueue time", () => {
+    const summary = collectPortfolioDashboard(
+      {
+        portfolioQueue: mockQueue([
+          { repoFullName: "a/b", status: "queued", enqueuedAt: "2026-07-01T00:00:00.000Z" },
+        ]),
+      },
+      { nowMs: Date.parse("2026-06-01T00:00:00.000Z") },
+    );
+    expect(summary.oldestQueuedAgeMs).toBe(0);
+  });
+
+  it("coerces a non-string apiBaseUrl the same way as a missing host", () => {
+    const summary = collectPortfolioDashboard({
+      portfolioQueue: mockQueue([
+        { apiBaseUrl: 42, repoFullName: "acme/a", status: "done", enqueuedAt: "2026-07-01T00:00:00.000Z" },
+      ]),
+    });
+    expect(summary.repos).toEqual([
+      { apiBaseUrl: "", repoFullName: "acme/a", byStatus: { queued: 0, in_progress: 0, done: 1 }, total: 1 },
+    ]);
   });
 });
 
@@ -129,5 +168,19 @@ describe("runPortfolioDashboard (#4287)", () => {
       error: expect.stringContaining("Unknown option"),
     });
     expect(err).not.toHaveBeenCalled();
+  });
+
+  it("opens and closes the default portfolio queue, falling back to Date.now when nowMs is omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-dashboard-default-"));
+    roots.push(root);
+    previousConfigDirs.push(process.env.LOOPOVER_MINER_CONFIG_DIR);
+    process.env.LOOPOVER_MINER_CONFIG_DIR = root;
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(runPortfolioDashboard([])).toBe(0);
+    expect(String(log.mock.calls[0]?.[0])).toContain("portfolio queue is empty");
+    log.mockClear();
+    // Non-finite nowMs also falls through to Date.now() on the CLI path.
+    expect(runPortfolioDashboard([], { initPortfolioQueue: () => mockQueue([]), nowMs: Number.NaN })).toBe(0);
+    expect(String(log.mock.calls[0]?.[0])).toContain("portfolio queue is empty");
   });
 });


### PR DESCRIPTION
## Summary

- Converts 8 leaf-most miner lib modules from hand-maintained `.js`+`.d.ts` to real `.ts` (in-place `tsc` emit).
- Removes hand-maintained `.d.ts` siblings; compiler regenerates them.
- No intentional behavior change.
- Follow-up to auto-closed #7353: adds unit coverage for the four codecov/patch branch partials (`convergenceThresholds` / default ledger append in `governor-run-halt`, owns-queue + `Date.now` fallback in `portfolio-dashboard`).

Closes #7303

## Files

- `governor-run-halt`, `coding-agent-house-rules`, `loop-closure`, `pretooluse-hook`
- `calibration`, `coding-agent-construction`, `attempt-input-builder`, `portfolio-dashboard`

## Test plan

- [x] `npm --workspace @loopover/miner run build`
- [x] Related miner unit tests passed locally (governor-run-halt + portfolio-dashboard now 100% branch)
- [ ] CI green