### PR TITLE
chore(miner): migrate CLI command loopover-miner/lib modules to TypeScript

### DIFF
--- a/packages/loopover-miner/lib/claim-ledger-cli.d.ts
+++ b/packages/loopover-miner/lib/claim-ledger-cli.d.ts
@@ -1,59 +1,39 @@
 import type { ClaimEntry, ClaimLedger, ClaimStatus } from "./claim-ledger.js";
-
-export type ParsedClaimClaimArgs =
-  | {
-      repoFullName: string;
-      issueNumber: number;
-      note: string | undefined;
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export type ParsedClaimReleaseArgs =
-  | {
-      repoFullName: string;
-      issueNumber: number;
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export type ParsedClaimListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-      status: ClaimStatus | null;
-    }
-  | { error: string };
-
-export function parseClaimClaimArgs(args: string[]): ParsedClaimClaimArgs;
-
-export function parseClaimReleaseArgs(args: string[]): ParsedClaimReleaseArgs;
-
-export function parseClaimListArgs(args: string[]): ParsedClaimListArgs;
-
-export function renderClaimsTable(entries: ClaimEntry[]): string;
-
-export function runClaimClaim(
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
-
-export function runClaimRelease(
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
-
-export function runClaimList(
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
-
-export function runClaimCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
+export type ParsedClaimClaimArgs = {
+    repoFullName: string;
+    issueNumber: number;
+    note: string | undefined;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedClaimReleaseArgs = {
+    repoFullName: string;
+    issueNumber: number;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedClaimListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+    status: ClaimStatus | null;
+} | {
+    error: string;
+};
+type ClaimCliOptions = {
+    openClaimLedger?: () => ClaimLedger;
+};
+export declare function parseClaimClaimArgs(args: string[]): ParsedClaimClaimArgs;
+export declare function parseClaimReleaseArgs(args: string[]): ParsedClaimReleaseArgs;
+export declare function parseClaimListArgs(args: string[]): ParsedClaimListArgs;
+export declare function renderClaimsTable(entries: ClaimEntry[]): string;
+export declare function runClaimClaim(args: string[], options?: ClaimCliOptions): number;
+export declare function runClaimRelease(args: string[], options?: ClaimCliOptions): number;
+export declare function runClaimList(args: string[], options?: ClaimCliOptions): number;
+export declare function runClaimCli(subcommand: string | undefined, args: string[], options?: ClaimCliOptions): number;
+export {};

--- a/packages/loopover-miner/lib/claim-ledger-cli.js
+++ b/packages/loopover-miner/lib/claim-ledger-cli.js
@@ -1,321 +1,318 @@
 import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { isValidRepoSegment } from "./repo-clone.js";
-
-const CLAIM_CLAIM_USAGE =
-  "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
-const CLAIM_RELEASE_USAGE =
-  "Usage: loopover-miner claim release <owner/repo> <issue#> [--api-base-url <url>] [--dry-run] [--json]";
-const CLAIM_LIST_USAGE =
-  "Usage: loopover-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]";
-
+const CLAIM_CLAIM_USAGE = "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_RELEASE_USAGE = "Usage: loopover-miner claim release <owner/repo> <issue#> [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_LIST_USAGE = "Usage: loopover-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 function parseIssueNumberArg(value, usage) {
-  if (!value) return { error: usage };
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1) {
-    return { error: "issue number must be a positive integer." };
-  }
-  return { issueNumber: parsed };
+    if (!value)
+        return { error: usage };
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        return { error: "issue number must be a positive integer." };
+    }
+    return { issueNumber: parsed };
 }
-
 export function parseClaimClaimArgs(args) {
-  const options = { json: false, note: undefined, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        note: undefined,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what a real claim would do and returns before opening the claim ledger at all.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--note") {
+            const note = args[index + 1];
+            if (!note || note.startsWith("-")) {
+                return { error: CLAIM_CLAIM_USAGE };
+            }
+            options.note = note;
+            index += 1;
+            continue;
+        }
+        // #5563: scope the claim to a non-default forge host, so it doesn't collide with (or get confused for) a
+        // same-named repo on the default github.com host.
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: CLAIM_CLAIM_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #4847: reports what a real claim would do and returns before opening the claim ledger at all.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--note") {
-      const note = args[index + 1];
-      if (!note || note.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: CLAIM_CLAIM_USAGE };
-      }
-      options.note = note;
-      index += 1;
-      continue;
     }
-    // #5563: scope the claim to a non-default forge host, so it doesn't collide with (or get confused for) a
-    // same-named repo on the default github.com host.
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
-        return { error: CLAIM_CLAIM_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: CLAIM_CLAIM_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], CLAIM_CLAIM_USAGE);
-  if ("error" in repo) return repo;
-  const issue = parseIssueNumberArg(positional[1], CLAIM_CLAIM_USAGE);
-  if ("error" in issue) return issue;
-
-  return {
-    repoFullName: repo.repoFullName,
-    issueNumber: issue.issueNumber,
-    note: options.note,
-    dryRun: options.dryRun,
-    json: options.json,
-    apiBaseUrl: options.apiBaseUrl,
-  };
+    const repo = parseRepoArg(positional[0], CLAIM_CLAIM_USAGE);
+    if ("error" in repo)
+        return repo;
+    const issue = parseIssueNumberArg(positional[1], CLAIM_CLAIM_USAGE);
+    if ("error" in issue)
+        return issue;
+    return {
+        repoFullName: repo.repoFullName,
+        issueNumber: issue.issueNumber,
+        note: options.note,
+        dryRun: options.dryRun,
+        json: options.json,
+        apiBaseUrl: options.apiBaseUrl,
+    };
 }
-
 export function parseClaimReleaseArgs(args) {
-  const options = { json: false, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: CLAIM_RELEASE_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: CLAIM_RELEASE_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: CLAIM_RELEASE_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], CLAIM_RELEASE_USAGE);
-  if ("error" in repo) return repo;
-  const issue = parseIssueNumberArg(positional[1], CLAIM_RELEASE_USAGE);
-  if ("error" in issue) return issue;
-
-  return {
-    repoFullName: repo.repoFullName,
-    issueNumber: issue.issueNumber,
-    dryRun: options.dryRun,
-    json: options.json,
-    apiBaseUrl: options.apiBaseUrl,
-  };
+    const repo = parseRepoArg(positional[0], CLAIM_RELEASE_USAGE);
+    if ("error" in repo)
+        return repo;
+    const issue = parseIssueNumberArg(positional[1], CLAIM_RELEASE_USAGE);
+    if ("error" in issue)
+        return issue;
+    return {
+        repoFullName: repo.repoFullName,
+        issueNumber: issue.issueNumber,
+        dryRun: options.dryRun,
+        json: options.json,
+        apiBaseUrl: options.apiBaseUrl,
+    };
 }
-
 export function parseClaimListArgs(args) {
-  const options = { json: false, repoFullName: null, status: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        repoFullName: null,
+        status: null,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-")) {
+                return { error: CLAIM_LIST_USAGE };
+            }
+            const repo = parseRepoArg(repoArg, CLAIM_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token === "--status") {
+            const statusArg = args[index + 1];
+            if (!statusArg || statusArg.startsWith("-")) {
+                return { error: CLAIM_LIST_USAGE };
+            }
+            if (!CLAIM_STATUSES.includes(statusArg)) {
+                return { error: `status must be one of: ${CLAIM_STATUSES.join(", ")}.` };
+            }
+            options.status = statusArg;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) {
+    if (positional.length > 0) {
         return { error: CLAIM_LIST_USAGE };
-      }
-      const repo = parseRepoArg(repoArg, CLAIM_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
     }
-    if (token === "--status") {
-      const statusArg = args[index + 1];
-      if (!statusArg || statusArg.startsWith("-")) {
-        return { error: CLAIM_LIST_USAGE };
-      }
-      if (!CLAIM_STATUSES.includes(statusArg)) {
-        return { error: `status must be one of: ${CLAIM_STATUSES.join(", ")}.` };
-      }
-      options.status = statusArg;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length > 0) {
-    return { error: CLAIM_LIST_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderClaimsTable(entries) {
-  if (!Array.isArray(entries) || entries.length === 0) return "no claim ledger entries";
-  const header = [
-    "repo".padEnd(24),
-    "issue".padStart(6),
-    "status".padEnd(10),
-    "claimed-at".padEnd(24),
-    "note".padEnd(16),
-  ].join(" ");
-  const lines = entries.map((entry) =>
-    [
-      entry.repoFullName.padEnd(24),
-      display(entry.issueNumber).padStart(6),
-      entry.status.padEnd(10),
-      display(entry.claimedAt).padEnd(24),
-      display(entry.note).padEnd(16),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(entries) || entries.length === 0)
+        return "no claim ledger entries";
+    const header = [
+        "repo".padEnd(24),
+        "issue".padStart(6),
+        "status".padEnd(10),
+        "claimed-at".padEnd(24),
+        "note".padEnd(16),
+    ].join(" ");
+    const lines = entries.map((entry) => [
+        entry.repoFullName.padEnd(24),
+        display(entry.issueNumber).padStart(6),
+        entry.status.padEnd(10),
+        display(entry.claimedAt).padEnd(24),
+        display(entry.note).padEnd(16),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 function withClaimLedger(options, run) {
-  const ownsLedger = options.openClaimLedger === undefined;
-  const claimLedger = (options.openClaimLedger ?? openClaimLedger)();
-  try {
-    return run(claimLedger);
-  } finally {
-    if (ownsLedger) claimLedger.close();
-  }
+    const ownsLedger = options.openClaimLedger === undefined;
+    const claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+    try {
+        return run(claimLedger);
+    }
+    finally {
+        if (ownsLedger)
+            claimLedger.close();
+    }
 }
-
 export function runClaimClaim(args, options = {}) {
-  const parsed = parseClaimClaimArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, note: parsed.note ?? null };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(
-        `DRY RUN: would claim ${parsed.repoFullName}#${parsed.issueNumber}${parsed.note ? ` (note: ${parsed.note})` : ""}. No claim-ledger write was made.`,
-      );
+    const parsed = parseClaimClaimArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withClaimLedger(options, (claimLedger) => {
-      const claim = claimLedger.claimIssue(
-        parsed.repoFullName,
-        parsed.issueNumber,
-        parsed.note,
-        parsed.apiBaseUrl,
-      );
-      if (parsed.json) {
-        console.log(JSON.stringify({ claim }, null, 2));
-      } else {
-        console.log(claim.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, note: parsed.note ?? null };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would claim ${parsed.repoFullName}#${parsed.issueNumber}${parsed.note ? ` (note: ${parsed.note})` : ""}. No claim-ledger write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withClaimLedger(options, (claimLedger) => {
+            const claim = claimLedger.claimIssue(parsed.repoFullName, parsed.issueNumber, parsed.note, parsed.apiBaseUrl);
+            if (parsed.json) {
+                console.log(JSON.stringify({ claim }, null, 2));
+            }
+            else {
+                console.log(claim.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runClaimRelease(args, options = {}) {
-  const parsed = parseClaimReleaseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would release the claim on ${parsed.repoFullName}#${parsed.issueNumber}. No claim-ledger write was made.`);
+    const parsed = parseClaimReleaseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withClaimLedger(options, (claimLedger) => {
-      const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber, parsed.apiBaseUrl);
-      if (!claim) {
-        return reportCliFailure(parsed.json, "claim_not_found");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ claim }, null, 2));
-      } else {
-        console.log(claim.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would release the claim on ${parsed.repoFullName}#${parsed.issueNumber}. No claim-ledger write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withClaimLedger(options, (claimLedger) => {
+            const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber, parsed.apiBaseUrl);
+            if (!claim) {
+                return reportCliFailure(parsed.json, "claim_not_found");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ claim }, null, 2));
+            }
+            else {
+                console.log(claim.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runClaimList(args, options = {}) {
-  const parsed = parseClaimListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withClaimLedger(options, (claimLedger) => {
-      const filter = {};
-      if (parsed.repoFullName !== null) filter.repoFullName = parsed.repoFullName;
-      if (parsed.status !== null) filter.status = parsed.status;
-      const claims = claimLedger.listClaims(filter);
-      if (parsed.json) {
-        console.log(JSON.stringify({ claims }, null, 2));
-      } else {
-        console.log(renderClaimsTable(claims));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseClaimListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withClaimLedger(options, (claimLedger) => {
+            const filter = {};
+            if (parsed.repoFullName !== null)
+                filter.repoFullName = parsed.repoFullName;
+            if (parsed.status !== null)
+                filter.status = parsed.status;
+            const claims = claimLedger.listClaims(filter);
+            if (parsed.json) {
+                console.log(JSON.stringify({ claims }, null, 2));
+            }
+            else {
+                console.log(renderClaimsTable(claims));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runClaimCli(subcommand, args, options = {}) {
-  if (subcommand === "claim") return runClaimClaim(args, options);
-  if (subcommand === "release") return runClaimRelease(args, options);
-  if (subcommand === "list") return runClaimList(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
+    if (subcommand === "claim")
+        return runClaimClaim(args, options);
+    if (subcommand === "release")
+        return runClaimRelease(args, options);
+    if (subcommand === "list")
+        return runClaimList(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2xhaW0tbGVkZ2VyLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImNsYWltLWxlZGdlci1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGNBQWMsRUFBRSxlQUFlLEVBQUUsTUFBTSxtQkFBbUIsQ0FBQztBQUVwRSxPQUFPLEVBQUUsWUFBWSxFQUFFLGdCQUFnQixFQUFFLGdCQUFnQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbEYsT0FBTyxFQUFFLGtCQUFrQixFQUFFLE1BQU0saUJBQWlCLENBQUM7QUFFckQsTUFBTSxpQkFBaUIsR0FDckIscUhBQXFILENBQUM7QUFDeEgsTUFBTSxtQkFBbUIsR0FDdkIsdUdBQXVHLENBQUM7QUFDMUcsTUFBTSxnQkFBZ0IsR0FDcEIsb0dBQW9HLENBQUM7QUFtQ3ZHLFNBQVMsWUFBWSxDQUFDLEtBQXlCLEVBQUUsS0FBYTtJQUM1RCxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLE9BQU8sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDaEQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUyxJQUFJLENBQUMsa0JBQWtCLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3RHLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxTQUFTLG1CQUFtQixDQUFDLEtBQXlCLEVBQUUsS0FBYTtJQUNuRSxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzdCLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLE1BQU0sQ0FBQyxJQUFJLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUM1QyxPQUFPLEVBQUUsS0FBSyxFQUFFLDBDQUEwQyxFQUFFLENBQUM7SUFDL0QsQ0FBQztJQUNELE9BQU8sRUFBRSxXQUFXLEVBQUUsTUFBTSxFQUFFLENBQUM7QUFDakMsQ0FBQztBQUVELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxJQUFjO0lBQ2hELE1BQU0sT0FBTyxHQUFpRztRQUM1RyxJQUFJLEVBQUUsS0FBSztRQUNYLElBQUksRUFBRSxTQUFTO1FBQ2YsTUFBTSxFQUFFLEtBQUs7UUFDYixVQUFVLEVBQUUsU0FBUztLQUN0QixDQUFDO0lBQ0YsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxnR0FBZ0c7UUFDaEcsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLElBQUksR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzdCLElBQUksQ0FBQyxJQUFJLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNsQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDdEMsQ0FBQztZQUNELE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELHlHQUF5RztRQUN6RyxrREFBa0Q7UUFDbEQsSUFBSSxLQUFLLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQztZQUMvQixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNwQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDdEMsQ0FBQztZQUNELE9BQU8sQ0FBQyxVQUFVLEdBQUcsS0FBSyxDQUFDO1lBQzNCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDL0MsQ0FBQztRQUNELFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUM1QixPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7SUFDdEMsQ0FBQztJQUVELE1BQU0sSUFBSSxHQUFHLFlBQVksQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztJQUM1RCxJQUFJLE9BQU8sSUFBSSxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDakMsTUFBTSxLQUFLLEdBQUcsbUJBQW1CLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLGlCQUFpQixDQUFDLENBQUM7SUFDcEUsSUFBSSxPQUFPLElBQUksS0FBSztRQUFFLE9BQU8sS0FBSyxDQUFDO0lBRW5DLE9BQU87UUFDTCxZQUFZLEVBQUUsSUFBSSxDQUFDLFlBQVk7UUFDL0IsV0FBVyxFQUFFLEtBQUssQ0FBQyxXQUFXO1FBQzlCLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtRQUNsQixNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU07UUFDdEIsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO1FBQ2xCLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtLQUMvQixDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxJQUFjO0lBQ2xELE1BQU0sT0FBTyxHQUF1RTtRQUNsRixJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsVUFBVSxFQUFFLFNBQVM7S0FDdEIsQ0FBQztJQUNGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxnQkFBZ0IsRUFBRSxDQUFDO1lBQy9CLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3BDLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztZQUN4QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQzVCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztJQUN4QyxDQUFDO0lBRUQsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxtQkFBbUIsQ0FBQyxDQUFDO0lBQzlELElBQUksT0FBTyxJQUFJLElBQUk7UUFBRSxPQUFPLElBQUksQ0FBQztJQUNqQyxNQUFNLEtBQUssR0FBRyxtQkFBbUIsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsbUJBQW1CLENBQUMsQ0FBQztJQUN0RSxJQUFJLE9BQU8sSUFBSSxLQUFLO1FBQUUsT0FBTyxLQUFLLENBQUM7SUFFbkMsT0FBTztRQUNMLFlBQVksRUFBRSxJQUFJLENBQUMsWUFBWTtRQUMvQixXQUFXLEVBQUUsS0FBSyxDQUFDLFdBQVc7UUFDOUIsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNO1FBQ3RCLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtRQUNsQixVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVU7S0FDL0IsQ0FBQztBQUNKLENBQUM7QUFFRCxNQUFNLFVBQVUsa0JBQWtCLENBQUMsSUFBYztJQUMvQyxNQUFNLE9BQU8sR0FBK0U7UUFDMUYsSUFBSSxFQUFFLEtBQUs7UUFDWCxZQUFZLEVBQUUsSUFBSTtRQUNsQixNQUFNLEVBQUUsSUFBSTtLQUNiLENBQUM7SUFDRixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDaEMsSUFBSSxDQUFDLE9BQU8sSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3hDLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztZQUNyQyxDQUFDO1lBQ0QsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sRUFBRSxnQkFBZ0IsQ0FBQyxDQUFDO1lBQ3JELElBQUksT0FBTyxJQUFJLElBQUk7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFDakMsT0FBTyxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsWUFBWSxDQUFDO1lBQ3pDLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFVBQVUsRUFBRSxDQUFDO1lBQ3pCLE1BQU0sU0FBUyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDbEMsSUFBSSxDQUFDLFNBQVMsSUFBSSxTQUFTLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQzVDLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztZQUNyQyxDQUFDO1lBQ0QsSUFBSSxDQUFFLGNBQW9DLENBQUMsUUFBUSxDQUFDLFNBQVMsQ0FBQyxFQUFFLENBQUM7Z0JBQy9ELE9BQU8sRUFBRSxLQUFLLEVBQUUsMEJBQTBCLGNBQWMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO1lBQzNFLENBQUM7WUFDRCxPQUFPLENBQUMsTUFBTSxHQUFHLFNBQXdCLENBQUM7WUFDMUMsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxDQUFDO1FBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztJQUNyQyxDQUFDO0lBRUQsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVELFNBQVMsT0FBTyxDQUFDLEtBQWM7SUFDN0IsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxHQUFHLENBQUM7SUFDdEQsT0FBTyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDdkIsQ0FBQztBQUVELE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxPQUFxQjtJQUNyRCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLHlCQUF5QixDQUFDO0lBQ3RGLE1BQU0sTUFBTSxHQUFHO1FBQ2IsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDbkIsUUFBUSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkIsWUFBWSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDdkIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDbEIsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDWixNQUFNLEtBQUssR0FBRyxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FDbEM7UUFDRSxLQUFLLENBQUMsWUFBWSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDN0IsT0FBTyxDQUFDLEtBQUssQ0FBQyxXQUFXLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQ3RDLEtBQUssQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN2QixPQUFPLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkMsT0FBTyxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQy9CLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxPQUF3QixFQUFFLEdBQXlDO0lBQzFGLE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxlQUFlLEtBQUssU0FBUyxDQUFDO0lBQ3pELE1BQU0sV0FBVyxHQUFHLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUMsRUFBRSxDQUFDO0lBQ25FLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLFdBQVcsQ0FBQyxDQUFDO0lBQzFCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxVQUFVO1lBQUUsV0FBVyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3RDLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGFBQWEsQ0FBQyxJQUFjLEVBQUUsVUFBMkIsRUFBRTtJQUN6RSxNQUFNLE1BQU0sR0FBRyxtQkFBbUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN6QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksSUFBSSxJQUFJLEVBQUUsQ0FBQztRQUMzSSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FDVCx3QkFBd0IsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVyxHQUFHLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLFdBQVcsTUFBTSxDQUFDLElBQUksR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLG1DQUFtQyxDQUNwSixDQUFDO1FBQ0osQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxVQUFVLENBQ2xDLE1BQU0sQ0FBQyxZQUFZLEVBQ25CLE1BQU0sQ0FBQyxXQUFXLEVBQ2xCLE1BQU0sQ0FBQyxJQUFJLEVBQ1gsTUFBTSxDQUFDLFVBQVUsQ0FDbEIsQ0FBQztZQUNGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNsRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUM7WUFDNUIsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGVBQWUsQ0FBQyxJQUFjLEVBQUUsVUFBMkIsRUFBRTtJQUMzRSxNQUFNLE1BQU0sR0FBRyxxQkFBcUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUMzQyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRSxDQUFDO1FBQ2hILElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDckQsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHVDQUF1QyxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLG1DQUFtQyxDQUFDLENBQUM7UUFDbkksQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQztZQUNuRyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUM7Z0JBQ1gsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGlCQUFpQixDQUFDLENBQUM7WUFDMUQsQ0FBQztZQUNELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNsRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUM7WUFDNUIsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFlBQVksQ0FBQyxJQUFjLEVBQUUsVUFBMkIsRUFBRTtJQUN4RSxNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sTUFBTSxHQUFvRCxFQUFFLENBQUM7WUFDbkUsSUFBSSxNQUFNLENBQUMsWUFBWSxLQUFLLElBQUk7Z0JBQUUsTUFBTSxDQUFDLFlBQVksR0FBRyxNQUFNLENBQUMsWUFBWSxDQUFDO1lBQzVFLElBQUksTUFBTSxDQUFDLE1BQU0sS0FBSyxJQUFJO2dCQUFFLE1BQU0sQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQztZQUMxRCxNQUFNLE1BQU0sR0FBRyxXQUFXLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzlDLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxNQUFNLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNuRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxpQkFBaUIsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO1lBQ3pDLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsVUFBOEIsRUFBRSxJQUFjLEVBQUUsVUFBMkIsRUFBRTtJQUN2RyxJQUFJLFVBQVUsS0FBSyxPQUFPO1FBQUUsT0FBTyxhQUFhLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ2hFLElBQUksVUFBVSxLQUFLLFNBQVM7UUFBRSxPQUFPLGVBQWUsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDcEUsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sWUFBWSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM5RCxPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSw2QkFBNkIsVUFBVSxJQUFJLEVBQUUsS0FBSyxnQkFBZ0IsRUFBRSxDQUFDLENBQUM7QUFDcEgsQ0FBQyJ9

--- a/packages/loopover-miner/lib/claim-ledger-cli.ts
+++ b/packages/loopover-miner/lib/claim-ledger-cli.ts
@@ -1,0 +1,368 @@
+import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
+import type { ClaimEntry, ClaimLedger, ClaimStatus } from "./claim-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
+
+const CLAIM_CLAIM_USAGE =
+  "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_RELEASE_USAGE =
+  "Usage: loopover-miner claim release <owner/repo> <issue#> [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_LIST_USAGE =
+  "Usage: loopover-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]";
+
+export type ParsedClaimClaimArgs =
+  | {
+      repoFullName: string;
+      issueNumber: number;
+      note: string | undefined;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedClaimReleaseArgs =
+  | {
+      repoFullName: string;
+      issueNumber: number;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedClaimListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+      status: ClaimStatus | null;
+    }
+  | { error: string };
+
+type RepoArgResult = { error: string } | { repoFullName: string };
+type IssueNumberArgResult = { error: string } | { issueNumber: number };
+type ClaimCliOptions = { openClaimLedger?: () => ClaimLedger };
+
+function parseRepoArg(value: string | undefined, usage: string): RepoArgResult {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+function parseIssueNumberArg(value: string | undefined, usage: string): IssueNumberArgResult {
+  if (!value) return { error: usage };
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return { error: "issue number must be a positive integer." };
+  }
+  return { issueNumber: parsed };
+}
+
+export function parseClaimClaimArgs(args: string[]): ParsedClaimClaimArgs {
+  const options: { json: boolean; note: string | undefined; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    note: undefined,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what a real claim would do and returns before opening the claim ledger at all.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--note") {
+      const note = args[index + 1];
+      if (!note || note.startsWith("-")) {
+        return { error: CLAIM_CLAIM_USAGE };
+      }
+      options.note = note;
+      index += 1;
+      continue;
+    }
+    // #5563: scope the claim to a non-default forge host, so it doesn't collide with (or get confused for) a
+    // same-named repo on the default github.com host.
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: CLAIM_CLAIM_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: CLAIM_CLAIM_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], CLAIM_CLAIM_USAGE);
+  if ("error" in repo) return repo;
+  const issue = parseIssueNumberArg(positional[1], CLAIM_CLAIM_USAGE);
+  if ("error" in issue) return issue;
+
+  return {
+    repoFullName: repo.repoFullName,
+    issueNumber: issue.issueNumber,
+    note: options.note,
+    dryRun: options.dryRun,
+    json: options.json,
+    apiBaseUrl: options.apiBaseUrl,
+  };
+}
+
+export function parseClaimReleaseArgs(args: string[]): ParsedClaimReleaseArgs {
+  const options: { json: boolean; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: CLAIM_RELEASE_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: CLAIM_RELEASE_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], CLAIM_RELEASE_USAGE);
+  if ("error" in repo) return repo;
+  const issue = parseIssueNumberArg(positional[1], CLAIM_RELEASE_USAGE);
+  if ("error" in issue) return issue;
+
+  return {
+    repoFullName: repo.repoFullName,
+    issueNumber: issue.issueNumber,
+    dryRun: options.dryRun,
+    json: options.json,
+    apiBaseUrl: options.apiBaseUrl,
+  };
+}
+
+export function parseClaimListArgs(args: string[]): ParsedClaimListArgs {
+  const options: { json: boolean; repoFullName: string | null; status: ClaimStatus | null } = {
+    json: false,
+    repoFullName: null,
+    status: null,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) {
+        return { error: CLAIM_LIST_USAGE };
+      }
+      const repo = parseRepoArg(repoArg, CLAIM_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token === "--status") {
+      const statusArg = args[index + 1];
+      if (!statusArg || statusArg.startsWith("-")) {
+        return { error: CLAIM_LIST_USAGE };
+      }
+      if (!(CLAIM_STATUSES as readonly string[]).includes(statusArg)) {
+        return { error: `status must be one of: ${CLAIM_STATUSES.join(", ")}.` };
+      }
+      options.status = statusArg as ClaimStatus;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    return { error: CLAIM_LIST_USAGE };
+  }
+
+  return options;
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderClaimsTable(entries: ClaimEntry[]): string {
+  if (!Array.isArray(entries) || entries.length === 0) return "no claim ledger entries";
+  const header = [
+    "repo".padEnd(24),
+    "issue".padStart(6),
+    "status".padEnd(10),
+    "claimed-at".padEnd(24),
+    "note".padEnd(16),
+  ].join(" ");
+  const lines = entries.map((entry) =>
+    [
+      entry.repoFullName.padEnd(24),
+      display(entry.issueNumber).padStart(6),
+      entry.status.padEnd(10),
+      display(entry.claimedAt).padEnd(24),
+      display(entry.note).padEnd(16),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function withClaimLedger(options: ClaimCliOptions, run: (claimLedger: ClaimLedger) => number): number {
+  const ownsLedger = options.openClaimLedger === undefined;
+  const claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+  try {
+    return run(claimLedger);
+  } finally {
+    if (ownsLedger) claimLedger.close();
+  }
+}
+
+export function runClaimClaim(args: string[], options: ClaimCliOptions = {}): number {
+  const parsed = parseClaimClaimArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, note: parsed.note ?? null };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(
+        `DRY RUN: would claim ${parsed.repoFullName}#${parsed.issueNumber}${parsed.note ? ` (note: ${parsed.note})` : ""}. No claim-ledger write was made.`,
+      );
+    }
+    return 0;
+  }
+
+  try {
+    return withClaimLedger(options, (claimLedger) => {
+      const claim = claimLedger.claimIssue(
+        parsed.repoFullName,
+        parsed.issueNumber,
+        parsed.note,
+        parsed.apiBaseUrl,
+      );
+      if (parsed.json) {
+        console.log(JSON.stringify({ claim }, null, 2));
+      } else {
+        console.log(claim.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runClaimRelease(args: string[], options: ClaimCliOptions = {}): number {
+  const parsed = parseClaimReleaseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would release the claim on ${parsed.repoFullName}#${parsed.issueNumber}. No claim-ledger write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withClaimLedger(options, (claimLedger) => {
+      const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber, parsed.apiBaseUrl);
+      if (!claim) {
+        return reportCliFailure(parsed.json, "claim_not_found");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ claim }, null, 2));
+      } else {
+        console.log(claim.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runClaimList(args: string[], options: ClaimCliOptions = {}): number {
+  const parsed = parseClaimListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withClaimLedger(options, (claimLedger) => {
+      const filter: { repoFullName?: string; status?: ClaimStatus } = {};
+      if (parsed.repoFullName !== null) filter.repoFullName = parsed.repoFullName;
+      if (parsed.status !== null) filter.status = parsed.status;
+      const claims = claimLedger.listClaims(filter);
+      if (parsed.json) {
+        console.log(JSON.stringify({ claims }, null, 2));
+      } else {
+        console.log(renderClaimsTable(claims));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runClaimCli(subcommand: string | undefined, args: string[], options: ClaimCliOptions = {}): number {
+  if (subcommand === "claim") return runClaimClaim(args, options);
+  if (subcommand === "release") return runClaimRelease(args, options);
+  if (subcommand === "list") return runClaimList(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
+}

--- a/packages/loopover-miner/lib/event-ledger-cli.d.ts
+++ b/packages/loopover-miner/lib/event-ledger-cli.d.ts
@@ -1,82 +1,69 @@
 import type { EventLedger, LedgerEntry } from "./event-ledger.js";
-
-export type ParsedLedgerListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-      since: number | null;
-      type: string | null;
-    }
-  | { error: string };
-
-export function parseLedgerListArgs(args: string[]): ParsedLedgerListArgs;
-
-export function filterLedgerEvents(
-  events: LedgerEntry[],
-  options?: { type?: string | null },
-): LedgerEntry[];
-
-export const AUDIT_FEED_ENTRY_FIELDS: readonly [
-  "eventType",
-  "repoFullName",
-  "outcome",
-  "actor",
-  "detail",
-  "createdAt",
-];
-
-export function projectLedgerEventToAuditFeedEntry(entry: LedgerEntry): {
-  eventType: string;
-  repoFullName: string | null;
-  outcome: string | null;
-  actor: string | null;
-  detail: string | null;
-  createdAt: string;
+export type ParsedLedgerListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+    since: number | null;
+    type: string | null;
+} | {
+    error: string;
 };
-
-export type AuditFeedMcpFilterInput = {
-  repoFullName?: string | null;
-  since?: number | null;
-  type?: string | null;
-};
-
-export function normalizeAuditFeedMcpFilter(input?: AuditFeedMcpFilterInput): {
-  repoFullName: string | null;
-  since: number | null;
-  type: string | null;
-};
-
-export function collectEventLedgerAuditFeed(
-  eventLedger: EventLedger,
-  filter?: { repoFullName?: string | null; since?: number | null; type?: string | null },
-): {
-  repoFullName?: string;
-  events: Array<{
+export declare function parseLedgerListArgs(args: string[]): ParsedLedgerListArgs;
+export declare function filterLedgerEvents(events: LedgerEntry[], options?: {
+    type?: string | null;
+}): LedgerEntry[];
+/** Metadata-only audit-feed columns exposed by the MCP tool (#5158). */
+export declare const AUDIT_FEED_ENTRY_FIELDS: readonly ["eventType", "repoFullName", "outcome", "actor", "detail", "createdAt"];
+/** Project one ledger row to the public, metadata-only audit-feed shape — never returns payload_json. */
+export declare function projectLedgerEventToAuditFeedEntry(entry: LedgerEntry): {
     eventType: string;
     repoFullName: string | null;
     outcome: string | null;
     actor: string | null;
     detail: string | null;
     createdAt: string;
-  }>;
 };
-
-export function renderLedgerTable(events: LedgerEntry[]): string;
-
-export function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string;
-
-export function runLedgerList(
-  args: string[],
-  options?: { initEventLedger?: () => EventLedger },
-): number;
-
-export function runLedgerMetrics(
-  args: string[],
-  options?: { initEventLedger?: () => EventLedger },
-): number;
-
-export function runLedgerCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { initEventLedger?: () => EventLedger },
-): number;
+export type AuditFeedMcpFilterInput = {
+    repoFullName?: string | null;
+    since?: number | null;
+    type?: string | null;
+};
+/** Normalize optional MCP/JSON filter args into the shape `ledger list` already uses (#5158). */
+export declare function normalizeAuditFeedMcpFilter(input?: AuditFeedMcpFilterInput): {
+    repoFullName: string | null;
+    since: number | null;
+    type: string | null;
+};
+/** Read-only audit feed shared by the MCP audit-feed tool (#5158). */
+export declare function collectEventLedgerAuditFeed(eventLedger: EventLedger, filter?: {
+    repoFullName?: string | null;
+    since?: number | null;
+    type?: string | null;
+}): {
+    repoFullName?: string;
+    events: Array<{
+        eventType: string;
+        repoFullName: string | null;
+        outcome: string | null;
+        actor: string | null;
+        detail: string | null;
+        createdAt: string;
+    }>;
+};
+export declare function renderLedgerTable(events: LedgerEntry[]): string;
+/**
+ * Render event-ledger activity as Prometheus text-exposition counters: one `loopover_miner_events_total{type}`
+ * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
+ * `ledger list --json` (#4841). Pure + side-effect-free — the caller supplies the rows and prints the result;
+ * deterministic (series emitted in sorted type order); always emits HELP/TYPE so an empty ledger is still a
+ * well-formed exposition document.
+ */
+export declare function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string;
+export declare function runLedgerList(args: string[], options?: {
+    initEventLedger?: () => EventLedger;
+}): number;
+export declare function runLedgerMetrics(args: string[], options?: {
+    initEventLedger?: () => EventLedger;
+}): number;
+export declare function runLedgerCli(subcommand: string | undefined, args: string[], options?: {
+    initEventLedger?: () => EventLedger;
+}): number;

--- a/packages/loopover-miner/lib/event-ledger-cli.js
+++ b/packages/loopover-miner/lib/event-ledger-cli.js
@@ -1,189 +1,188 @@
 import { initEventLedger } from "./event-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { isValidRepoSegment } from "./repo-clone.js";
-
-const LEDGER_LIST_USAGE =
-  "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
-
+const LEDGER_LIST_USAGE = "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 function parseSinceArg(value) {
-  const since = Number(value);
-  if (!Number.isInteger(since) || since < 0) {
-    return { error: "since must be a non-negative integer seq cursor." };
-  }
-  return { since };
+    const since = Number(value);
+    if (!Number.isInteger(since) || since < 0) {
+        return { error: "since must be a non-negative integer seq cursor." };
+    }
+    return { since };
 }
-
 export function parseLedgerListArgs(args) {
-  const options = { json: false, repoFullName: null, since: null, type: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        repoFullName: null,
+        since: null,
+        type: null,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-"))
+                return { error: LEDGER_LIST_USAGE };
+            const repo = parseRepoArg(repoArg, LEDGER_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token === "--since") {
+            const sinceArg = args[index + 1];
+            if (!sinceArg || sinceArg.startsWith("--"))
+                return { error: LEDGER_LIST_USAGE };
+            const parsedSince = parseSinceArg(sinceArg);
+            if ("error" in parsedSince)
+                return parsedSince;
+            options.since = parsedSince.since;
+            index += 1;
+            continue;
+        }
+        if (token === "--type") {
+            const type = args[index + 1];
+            if (!type || type.startsWith("-"))
+                return { error: LEDGER_LIST_USAGE };
+            options.type = type.trim();
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) return { error: LEDGER_LIST_USAGE };
-      const repo = parseRepoArg(repoArg, LEDGER_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
-    }
-    if (token === "--since") {
-      const sinceArg = args[index + 1];
-      if (!sinceArg || sinceArg.startsWith("--")) return { error: LEDGER_LIST_USAGE };
-      const parsedSince = parseSinceArg(sinceArg);
-      if ("error" in parsedSince) return parsedSince;
-      options.since = parsedSince.since;
-      index += 1;
-      continue;
-    }
-    if (token === "--type") {
-      const type = args[index + 1];
-      if (!type || type.startsWith("-")) return { error: LEDGER_LIST_USAGE };
-      options.type = type.trim();
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length > 0) return { error: LEDGER_LIST_USAGE };
-  return options;
+    if (positional.length > 0)
+        return { error: LEDGER_LIST_USAGE };
+    return options;
 }
-
 export function filterLedgerEvents(events, options = {}) {
-  if (!Array.isArray(events)) return [];
-  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
-  if (!type) return events;
-  return events.filter((entry) => entry.type === type);
+    if (!Array.isArray(events))
+        return [];
+    const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+    if (!type)
+        return events;
+    return events.filter((entry) => entry.type === type);
 }
-
 /** Metadata-only audit-feed columns exposed by the MCP tool (#5158). */
 export const AUDIT_FEED_ENTRY_FIELDS = Object.freeze([
-  "eventType",
-  "repoFullName",
-  "outcome",
-  "actor",
-  "detail",
-  "createdAt",
+    "eventType",
+    "repoFullName",
+    "outcome",
+    "actor",
+    "detail",
+    "createdAt",
 ]);
-
 function optionalMetadataString(value) {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed || null;
+    if (typeof value !== "string")
+        return null;
+    const trimmed = value.trim();
+    return trimmed || null;
 }
-
 /** Project one ledger row to the public, metadata-only audit-feed shape — never returns payload_json. */
 export function projectLedgerEventToAuditFeedEntry(entry) {
-  const payload =
-    entry?.payload && typeof entry.payload === "object" && !Array.isArray(entry.payload) ? entry.payload : {};
-  return {
-    eventType: entry.type,
-    repoFullName: entry.repoFullName,
-    outcome: optionalMetadataString(payload.outcome),
-    actor: optionalMetadataString(payload.actor),
-    detail: optionalMetadataString(payload.detail),
-    createdAt: entry.createdAt,
-  };
+    const payload = entry?.payload && typeof entry.payload === "object" && !Array.isArray(entry.payload) ? entry.payload : {};
+    return {
+        eventType: entry.type,
+        repoFullName: entry.repoFullName,
+        outcome: optionalMetadataString(payload.outcome),
+        actor: optionalMetadataString(payload.actor),
+        detail: optionalMetadataString(payload.detail),
+        createdAt: entry.createdAt,
+    };
 }
-
 /** Normalize optional MCP/JSON filter args into the shape `ledger list` already uses (#5158). */
 export function normalizeAuditFeedMcpFilter(input = {}) {
-  if (input === null || typeof input !== "object" || Array.isArray(input)) {
-    throw new Error("filter must be an object");
-  }
-  const filter = { repoFullName: null, since: null, type: null };
-  if (input.repoFullName !== undefined && input.repoFullName !== null) {
-    const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
-    if ("error" in repo) throw new Error(repo.error);
-    filter.repoFullName = repo.repoFullName;
-  }
-  if (input.since !== undefined && input.since !== null) {
-    const parsedSince = parseSinceArg(String(input.since));
-    if ("error" in parsedSince) throw new Error(parsedSince.error);
-    filter.since = parsedSince.since;
-  }
-  if (input.type !== undefined && input.type !== null) {
-    const trimmed = String(input.type).trim();
-    if (!trimmed) throw new Error("type must be a non-empty string.");
-    filter.type = trimmed;
-  }
-  return filter;
+    if (input === null || typeof input !== "object" || Array.isArray(input)) {
+        throw new Error("filter must be an object");
+    }
+    const filter = {
+        repoFullName: null,
+        since: null,
+        type: null,
+    };
+    if (input.repoFullName !== undefined && input.repoFullName !== null) {
+        const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
+        if ("error" in repo)
+            throw new Error(repo.error);
+        filter.repoFullName = repo.repoFullName;
+    }
+    if (input.since !== undefined && input.since !== null) {
+        const parsedSince = parseSinceArg(String(input.since));
+        if ("error" in parsedSince)
+            throw new Error(parsedSince.error);
+        filter.since = parsedSince.since;
+    }
+    if (input.type !== undefined && input.type !== null) {
+        const trimmed = String(input.type).trim();
+        if (!trimmed)
+            throw new Error("type must be a non-empty string.");
+        filter.type = trimmed;
+    }
+    return filter;
 }
-
 /** Read-only audit feed shared by the MCP audit-feed tool (#5158). */
 export function collectEventLedgerAuditFeed(eventLedger, filter = {}) {
-  const events = filterLedgerEvents(
-    eventLedger.readEvents({
-      repoFullName: filter.repoFullName,
-      since: filter.since,
-    }),
-    { type: filter.type },
-  );
-  return {
-    ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
-    events: events.map(projectLedgerEventToAuditFeedEntry),
-  };
+    const events = filterLedgerEvents(eventLedger.readEvents({
+        repoFullName: filter.repoFullName,
+        since: filter.since,
+    }), { type: filter.type });
+    return {
+        ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
+        events: events.map(projectLedgerEventToAuditFeedEntry),
+    };
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderLedgerTable(events) {
-  if (!Array.isArray(events) || events.length === 0) return "no event ledger entries";
-  const header = [
-    "seq".padStart(4),
-    "type".padEnd(20),
-    "repo".padEnd(24),
-    "created-at".padEnd(24),
-  ].join(" ");
-  const lines = events.map((entry) =>
-    [
-      String(entry.seq).padStart(4),
-      entry.type.padEnd(20),
-      display(entry.repoFullName).padEnd(24),
-      display(entry.createdAt).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(events) || events.length === 0)
+        return "no event ledger entries";
+    const header = [
+        "seq".padStart(4),
+        "type".padEnd(20),
+        "repo".padEnd(24),
+        "created-at".padEnd(24),
+    ].join(" ");
+    const lines = events.map((entry) => [
+        String(entry.seq).padStart(4),
+        entry.type.padEnd(20),
+        display(entry.repoFullName).padEnd(24),
+        display(entry.createdAt).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 const EVENT_LEDGER_METRICS_USAGE = "Usage: loopover-miner ledger metrics";
-
 // Prometheus metric name for the per-type event-ledger counter. Mirrors the `loopover_miner_*_total` naming and
 // the HELP/TYPE/label conventions of the engine's renderMinerPredictionMetrics
 // (packages/loopover-engine/src/miner-prediction-metrics.ts) rather than importing across the package boundary.
 const MINER_EVENTS_TOTAL = "loopover_miner_events_total";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /** Prometheus label-value escaping — backslash, double-quote, newline — so an arbitrary event `type` string can
  *  never break the metric line (mirrors miner-prediction-metrics.ts's escapeLabelValue). */
 function escapeLabelValue(value) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
-
 /**
  * Render event-ledger activity as Prometheus text-exposition counters: one `loopover_miner_events_total{type}`
  * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
@@ -192,76 +191,75 @@ function escapeLabelValue(value) {
  * well-formed exposition document.
  */
 export function renderEventLedgerMetrics(events) {
-  const totalByType = new Map();
-  for (const entry of events) {
-    totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
-  }
-  const lines = [
-    `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
-    `# TYPE ${MINER_EVENTS_TOTAL} counter`,
-  ];
-  for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-    lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
-  }
-  return `${lines.join("\n")}\n`;
+    const totalByType = new Map();
+    for (const entry of events) {
+        totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
+    }
+    const lines = [
+        `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
+        `# TYPE ${MINER_EVENTS_TOTAL} counter`,
+    ];
+    for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+        lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
+    }
+    return `${lines.join("\n")}\n`;
 }
-
 function withEventLedger(options, run) {
-  const ownsLedger = options.initEventLedger === undefined;
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  try {
-    return run(eventLedger);
-  } finally {
-    if (ownsLedger) eventLedger.close();
-  }
+    const ownsLedger = options.initEventLedger === undefined;
+    const eventLedger = (options.initEventLedger ?? initEventLedger)();
+    try {
+        return run(eventLedger);
+    }
+    finally {
+        if (ownsLedger)
+            eventLedger.close();
+    }
 }
-
 export function runLedgerList(args, options = {}) {
-  const parsed = parseLedgerListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withEventLedger(options, (eventLedger) => {
-      const events = filterLedgerEvents(
-        eventLedger.readEvents({
-          repoFullName: parsed.repoFullName,
-          since: parsed.since,
-        }),
-        { type: parsed.type },
-      );
-      if (parsed.json) {
-        console.log(JSON.stringify({ events }, null, 2));
-      } else {
-        console.log(renderLedgerTable(events));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseLedgerListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withEventLedger(options, (eventLedger) => {
+            const events = filterLedgerEvents(eventLedger.readEvents({
+                repoFullName: parsed.repoFullName,
+                since: parsed.since,
+            }), { type: parsed.type });
+            if (parsed.json) {
+                console.log(JSON.stringify({ events }, null, 2));
+            }
+            else {
+                console.log(renderLedgerTable(events));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runLedgerMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
-  }
-
-  try {
-    return withEventLedger(options, (eventLedger) => {
-      // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
-      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
-      console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
+    }
+    try {
+        return withEventLedger(options, (eventLedger) => {
+            // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+            // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+            console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
-
 export function runLedgerCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runLedgerList(args, options);
-  if (subcommand === "metrics") return runLedgerMetrics(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
+    if (subcommand === "list")
+        return runLedgerList(args, options);
+    if (subcommand === "metrics")
+        return runLedgerMetrics(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXZlbnQtbGVkZ2VyLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImV2ZW50LWxlZGdlci1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRXBELE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUVyRCxNQUFNLGlCQUFpQixHQUNyQix1R0FBdUcsQ0FBQztBQUUxRyxTQUFTLFlBQVksQ0FBQyxLQUFhLEVBQUUsS0FBYTtJQUNoRCxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLE9BQU8sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDaEQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUyxJQUFJLENBQUMsa0JBQWtCLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3RHLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxTQUFTLGFBQWEsQ0FBQyxLQUFhO0lBQ2xDLE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1QixJQUFJLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDMUMsT0FBTyxFQUFFLEtBQUssRUFBRSxrREFBa0QsRUFBRSxDQUFDO0lBQ3ZFLENBQUM7SUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLENBQUM7QUFDbkIsQ0FBQztBQVdELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxJQUFjO0lBQ2hELE1BQU0sT0FBTyxHQUE4RjtRQUN6RyxJQUFJLEVBQUUsS0FBSztRQUNYLFlBQVksRUFBRSxJQUFJO1FBQ2xCLEtBQUssRUFBRSxJQUFJO1FBQ1gsSUFBSSxFQUFFLElBQUk7S0FDWCxDQUFDO0lBQ0YsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQ2hDLElBQUksQ0FBQyxPQUFPLElBQUksT0FBTyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxpQkFBaUIsRUFBRSxDQUFDO1lBQzdFLE1BQU0sSUFBSSxHQUFHLFlBQVksQ0FBQyxPQUFPLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztZQUN0RCxJQUFJLE9BQU8sSUFBSSxJQUFJO2dCQUFFLE9BQU8sSUFBSSxDQUFDO1lBQ2pDLE9BQU8sQ0FBQyxZQUFZLEdBQUcsSUFBSSxDQUFDLFlBQVksQ0FBQztZQUN6QyxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztZQUN4QixNQUFNLFFBQVEsR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQ2pDLElBQUksQ0FBQyxRQUFRLElBQUksUUFBUSxDQUFDLFVBQVUsQ0FBQyxJQUFJLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxpQkFBaUIsRUFBRSxDQUFDO1lBQ2hGLE1BQU0sV0FBVyxHQUFHLGFBQWEsQ0FBQyxRQUFRLENBQUMsQ0FBQztZQUM1QyxJQUFJLE9BQU8sSUFBSSxXQUFXO2dCQUFFLE9BQU8sV0FBVyxDQUFDO1lBQy9DLE9BQU8sQ0FBQyxLQUFLLEdBQUcsV0FBVyxDQUFDLEtBQUssQ0FBQztZQUNsQyxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLElBQUksR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzdCLElBQUksQ0FBQyxJQUFJLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxpQkFBaUIsRUFBRSxDQUFDO1lBQ3ZFLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQzNCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQ3hFLFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxpQkFBaUIsRUFBRSxDQUFDO0lBQy9ELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxNQUFNLFVBQVUsa0JBQWtCLENBQUMsTUFBcUIsRUFBRSxVQUFvQyxFQUFFO0lBQzlGLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQztRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQ3RDLE1BQU0sSUFBSSxHQUFHLE9BQU8sT0FBTyxDQUFDLElBQUksS0FBSyxRQUFRLElBQUksT0FBTyxDQUFDLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ2xHLElBQUksQ0FBQyxJQUFJO1FBQUUsT0FBTyxNQUFNLENBQUM7SUFDekIsT0FBTyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLElBQUksQ0FBQyxDQUFDO0FBQ3ZELENBQUM7QUFFRCx3RUFBd0U7QUFDeEUsTUFBTSxDQUFDLE1BQU0sdUJBQXVCLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQztJQUNuRCxXQUFXO0lBQ1gsY0FBYztJQUNkLFNBQVM7SUFDVCxPQUFPO0lBQ1AsUUFBUTtJQUNSLFdBQVc7Q0FDSCxDQUFDLENBQUM7QUFFWixTQUFTLHNCQUFzQixDQUFDLEtBQWM7SUFDNUMsSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDM0MsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE9BQU8sT0FBTyxJQUFJLElBQUksQ0FBQztBQUN6QixDQUFDO0FBRUQseUdBQXlHO0FBQ3pHLE1BQU0sVUFBVSxrQ0FBa0MsQ0FBQyxLQUFrQjtJQVFuRSxNQUFNLE9BQU8sR0FDWCxLQUFLLEVBQUUsT0FBTyxJQUFJLE9BQU8sS0FBSyxDQUFDLE9BQU8sS0FBSyxRQUFRLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzVHLE9BQU87UUFDTCxTQUFTLEVBQUUsS0FBSyxDQUFDLElBQUk7UUFDckIsWUFBWSxFQUFFLEtBQUssQ0FBQyxZQUFZO1FBQ2hDLE9BQU8sRUFBRSxzQkFBc0IsQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDO1FBQ2hELEtBQUssRUFBRSxzQkFBc0IsQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDO1FBQzVDLE1BQU0sRUFBRSxzQkFBc0IsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDO1FBQzlDLFNBQVMsRUFBRSxLQUFLLENBQUMsU0FBUztLQUMzQixDQUFDO0FBQ0osQ0FBQztBQVFELGlHQUFpRztBQUNqRyxNQUFNLFVBQVUsMkJBQTJCLENBQUMsUUFBaUMsRUFBRTtJQUs3RSxJQUFJLEtBQUssS0FBSyxJQUFJLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUN4RSxNQUFNLElBQUksS0FBSyxDQUFDLDBCQUEwQixDQUFDLENBQUM7SUFDOUMsQ0FBQztJQUNELE1BQU0sTUFBTSxHQUErRTtRQUN6RixZQUFZLEVBQUUsSUFBSTtRQUNsQixLQUFLLEVBQUUsSUFBSTtRQUNYLElBQUksRUFBRSxJQUFJO0tBQ1gsQ0FBQztJQUNGLElBQUksS0FBSyxDQUFDLFlBQVksS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLFlBQVksS0FBSyxJQUFJLEVBQUUsQ0FBQztRQUNwRSxNQUFNLElBQUksR0FBRyxZQUFZLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsRUFBRSwwQ0FBMEMsQ0FBQyxDQUFDO1FBQ2xHLElBQUksT0FBTyxJQUFJLElBQUk7WUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNqRCxNQUFNLENBQUMsWUFBWSxHQUFHLElBQUksQ0FBQyxZQUFZLENBQUM7SUFDMUMsQ0FBQztJQUNELElBQUksS0FBSyxDQUFDLEtBQUssS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLEtBQUssS0FBSyxJQUFJLEVBQUUsQ0FBQztRQUN0RCxNQUFNLFdBQVcsR0FBRyxhQUFhLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1FBQ3ZELElBQUksT0FBTyxJQUFJLFdBQVc7WUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLFdBQVcsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMvRCxNQUFNLENBQUMsS0FBSyxHQUFHLFdBQVcsQ0FBQyxLQUFLLENBQUM7SUFDbkMsQ0FBQztJQUNELElBQUksS0FBSyxDQUFDLElBQUksS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLElBQUksS0FBSyxJQUFJLEVBQUUsQ0FBQztRQUNwRCxNQUFNLE9BQU8sR0FBRyxNQUFNLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO1FBQzFDLElBQUksQ0FBQyxPQUFPO1lBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxrQ0FBa0MsQ0FBQyxDQUFDO1FBQ2xFLE1BQU0sQ0FBQyxJQUFJLEdBQUcsT0FBTyxDQUFDO0lBQ3hCLENBQUM7SUFDRCxPQUFPLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBRUQsc0VBQXNFO0FBQ3RFLE1BQU0sVUFBVSwyQkFBMkIsQ0FDekMsV0FBd0IsRUFDeEIsU0FBd0YsRUFBRTtJQVkxRixNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FDL0IsV0FBVyxDQUFDLFVBQVUsQ0FBQztRQUNyQixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7UUFDakMsS0FBSyxFQUFFLE1BQU0sQ0FBQyxLQUFLO0tBQ0EsQ0FBQyxFQUN0QixFQUFFLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSSxFQUE4QixDQUNsRCxDQUFDO0lBQ0YsT0FBTztRQUNMLEdBQUcsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUNyRSxNQUFNLEVBQUUsTUFBTSxDQUFDLEdBQUcsQ0FBQyxrQ0FBa0MsQ0FBQztLQUN2RCxDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMsT0FBTyxDQUFDLEtBQWM7SUFDN0IsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxHQUFHLENBQUM7SUFDdEQsT0FBTyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDdkIsQ0FBQztBQUVELE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxNQUFxQjtJQUNyRCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsSUFBSSxNQUFNLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLHlCQUF5QixDQUFDO0lBQ3BGLE1BQU0sTUFBTSxHQUFHO1FBQ2IsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDakIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsWUFBWSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDeEIsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDWixNQUFNLEtBQUssR0FBRyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FDakM7UUFDRSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDN0IsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3JCLE9BQU8sQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN0QyxPQUFPLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDcEMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQ1osQ0FBQztJQUNGLE9BQU8sQ0FBQyxNQUFNLEVBQUUsR0FBRyxLQUFLLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDdkMsQ0FBQztBQUVELE1BQU0sMEJBQTBCLEdBQUcsc0NBQXNDLENBQUM7QUFFMUUsZ0hBQWdIO0FBQ2hILCtFQUErRTtBQUMvRSxnSEFBZ0g7QUFDaEgsTUFBTSxrQkFBa0IsR0FBRyw2QkFBNkIsQ0FBQztBQUV6RCx1R0FBdUc7QUFDdkcsU0FBUyxjQUFjLENBQUMsSUFBWTtJQUNsQyxPQUFPLElBQUksQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLE1BQU0sQ0FBQyxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsS0FBSyxDQUFDLENBQUM7QUFDM0QsQ0FBQztBQUVEOzRGQUM0RjtBQUM1RixTQUFTLGdCQUFnQixDQUFDLEtBQWE7SUFDckMsT0FBTyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxNQUFNLENBQUMsQ0FBQyxPQUFPLENBQUMsSUFBSSxFQUFFLEtBQUssQ0FBQyxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsS0FBSyxDQUFDLENBQUM7QUFDakYsQ0FBQztBQUVEOzs7Ozs7R0FNRztBQUNILE1BQU0sVUFBVSx3QkFBd0IsQ0FBQyxNQUE4QjtJQUNyRSxNQUFNLFdBQVcsR0FBRyxJQUFJLEdBQUcsRUFBa0IsQ0FBQztJQUM5QyxLQUFLLE1BQU0sS0FBSyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQzNCLFdBQVcsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDO0lBQ3RFLENBQUM7SUFDRCxNQUFNLEtBQUssR0FBRztRQUNaLFVBQVUsa0JBQWtCLElBQUksY0FBYyxDQUFDLDZEQUE2RCxDQUFDLEVBQUU7UUFDL0csVUFBVSxrQkFBa0IsVUFBVTtLQUN2QyxDQUFDO0lBQ0YsS0FBSyxNQUFNLENBQUMsSUFBSSxFQUFFLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxXQUFXLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUNoRyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsa0JBQWtCLFVBQVUsZ0JBQWdCLENBQUMsSUFBSSxDQUFDLE1BQU0sS0FBSyxFQUFFLENBQUMsQ0FBQztJQUNqRixDQUFDO0lBQ0QsT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQztBQUNqQyxDQUFDO0FBRUQsU0FBUyxlQUFlLENBQ3RCLE9BQWdELEVBQ2hELEdBQW9DO0lBRXBDLE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxlQUFlLEtBQUssU0FBUyxDQUFDO0lBQ3pELE1BQU0sV0FBVyxHQUFHLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUMsRUFBRSxDQUFDO0lBQ25FLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLFdBQVcsQ0FBQyxDQUFDO0lBQzFCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxVQUFVO1lBQUUsV0FBVyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3RDLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGFBQWEsQ0FBQyxJQUFjLEVBQUUsVUFBbUQsRUFBRTtJQUNqRyxNQUFNLE1BQU0sR0FBRyxtQkFBbUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN6QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sTUFBTSxHQUFHLGtCQUFrQixDQUMvQixXQUFXLENBQUMsVUFBVSxDQUFDO2dCQUNyQixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLEtBQUssRUFBRSxNQUFNLENBQUMsS0FBSzthQUNwQixDQUFDLEVBQ0YsRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksRUFBRSxDQUN0QixDQUFDO1lBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE1BQU0sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ25ELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGlCQUFpQixDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7WUFDekMsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGdCQUFnQixDQUFDLElBQWMsRUFBRSxVQUFtRCxFQUFFO0lBQ3BHLElBQUksSUFBSSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNwQixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSwwQkFBMEIsQ0FBQyxDQUFDO0lBQzFFLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGVBQWUsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxXQUFXLEVBQUUsRUFBRTtZQUM5Qyx5R0FBeUc7WUFDekcsc0ZBQXNGO1lBQ3RGLE9BQU8sQ0FBQyxHQUFHLENBQUMsd0JBQXdCLENBQUMsV0FBVyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQztZQUMxRSxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ3ZFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFlBQVksQ0FDMUIsVUFBOEIsRUFDOUIsSUFBYyxFQUNkLFVBQW1ELEVBQUU7SUFFckQsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sYUFBYSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUMvRCxJQUFJLFVBQVUsS0FBSyxTQUFTO1FBQUUsT0FBTyxnQkFBZ0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDckUsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsOEJBQThCLFVBQVUsSUFBSSxFQUFFLEtBQUssaUJBQWlCLEVBQUUsQ0FBQyxDQUFDO0FBQ3RILENBQUMifQ==

--- a/packages/loopover-miner/lib/event-ledger-cli.ts
+++ b/packages/loopover-miner/lib/event-ledger-cli.ts
@@ -1,0 +1,323 @@
+import { initEventLedger } from "./event-ledger.js";
+import type { EventLedger, LedgerEntry, ReadEventsFilter } from "./event-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
+
+const LEDGER_LIST_USAGE =
+  "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
+
+function parseRepoArg(value: string, usage: string): { error: string } | { repoFullName: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+function parseSinceArg(value: string): { error: string } | { since: number } {
+  const since = Number(value);
+  if (!Number.isInteger(since) || since < 0) {
+    return { error: "since must be a non-negative integer seq cursor." };
+  }
+  return { since };
+}
+
+export type ParsedLedgerListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+      since: number | null;
+      type: string | null;
+    }
+  | { error: string };
+
+export function parseLedgerListArgs(args: string[]): ParsedLedgerListArgs {
+  const options: { json: boolean; repoFullName: string | null; since: number | null; type: string | null } = {
+    json: false,
+    repoFullName: null,
+    since: null,
+    type: null,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) return { error: LEDGER_LIST_USAGE };
+      const repo = parseRepoArg(repoArg, LEDGER_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token === "--since") {
+      const sinceArg = args[index + 1];
+      if (!sinceArg || sinceArg.startsWith("--")) return { error: LEDGER_LIST_USAGE };
+      const parsedSince = parseSinceArg(sinceArg);
+      if ("error" in parsedSince) return parsedSince;
+      options.since = parsedSince.since;
+      index += 1;
+      continue;
+    }
+    if (token === "--type") {
+      const type = args[index + 1];
+      if (!type || type.startsWith("-")) return { error: LEDGER_LIST_USAGE };
+      options.type = type.trim();
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length > 0) return { error: LEDGER_LIST_USAGE };
+  return options;
+}
+
+export function filterLedgerEvents(events: LedgerEntry[], options: { type?: string | null } = {}): LedgerEntry[] {
+  if (!Array.isArray(events)) return [];
+  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+  if (!type) return events;
+  return events.filter((entry) => entry.type === type);
+}
+
+/** Metadata-only audit-feed columns exposed by the MCP tool (#5158). */
+export const AUDIT_FEED_ENTRY_FIELDS = Object.freeze([
+  "eventType",
+  "repoFullName",
+  "outcome",
+  "actor",
+  "detail",
+  "createdAt",
+] as const);
+
+function optionalMetadataString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+/** Project one ledger row to the public, metadata-only audit-feed shape — never returns payload_json. */
+export function projectLedgerEventToAuditFeedEntry(entry: LedgerEntry): {
+  eventType: string;
+  repoFullName: string | null;
+  outcome: string | null;
+  actor: string | null;
+  detail: string | null;
+  createdAt: string;
+} {
+  const payload: Record<string, unknown> =
+    entry?.payload && typeof entry.payload === "object" && !Array.isArray(entry.payload) ? entry.payload : {};
+  return {
+    eventType: entry.type,
+    repoFullName: entry.repoFullName,
+    outcome: optionalMetadataString(payload.outcome),
+    actor: optionalMetadataString(payload.actor),
+    detail: optionalMetadataString(payload.detail),
+    createdAt: entry.createdAt,
+  };
+}
+
+export type AuditFeedMcpFilterInput = {
+  repoFullName?: string | null;
+  since?: number | null;
+  type?: string | null;
+};
+
+/** Normalize optional MCP/JSON filter args into the shape `ledger list` already uses (#5158). */
+export function normalizeAuditFeedMcpFilter(input: AuditFeedMcpFilterInput = {}): {
+  repoFullName: string | null;
+  since: number | null;
+  type: string | null;
+} {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("filter must be an object");
+  }
+  const filter: { repoFullName: string | null; since: number | null; type: string | null } = {
+    repoFullName: null,
+    since: null,
+    type: null,
+  };
+  if (input.repoFullName !== undefined && input.repoFullName !== null) {
+    const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
+    if ("error" in repo) throw new Error(repo.error);
+    filter.repoFullName = repo.repoFullName;
+  }
+  if (input.since !== undefined && input.since !== null) {
+    const parsedSince = parseSinceArg(String(input.since));
+    if ("error" in parsedSince) throw new Error(parsedSince.error);
+    filter.since = parsedSince.since;
+  }
+  if (input.type !== undefined && input.type !== null) {
+    const trimmed = String(input.type).trim();
+    if (!trimmed) throw new Error("type must be a non-empty string.");
+    filter.type = trimmed;
+  }
+  return filter;
+}
+
+/** Read-only audit feed shared by the MCP audit-feed tool (#5158). */
+export function collectEventLedgerAuditFeed(
+  eventLedger: EventLedger,
+  filter: { repoFullName?: string | null; since?: number | null; type?: string | null } = {},
+): {
+  repoFullName?: string;
+  events: Array<{
+    eventType: string;
+    repoFullName: string | null;
+    outcome: string | null;
+    actor: string | null;
+    detail: string | null;
+    createdAt: string;
+  }>;
+} {
+  const events = filterLedgerEvents(
+    eventLedger.readEvents({
+      repoFullName: filter.repoFullName,
+      since: filter.since,
+    } as ReadEventsFilter),
+    { type: filter.type } as { type?: string | null },
+  );
+  return {
+    ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
+    events: events.map(projectLedgerEventToAuditFeedEntry),
+  };
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderLedgerTable(events: LedgerEntry[]): string {
+  if (!Array.isArray(events) || events.length === 0) return "no event ledger entries";
+  const header = [
+    "seq".padStart(4),
+    "type".padEnd(20),
+    "repo".padEnd(24),
+    "created-at".padEnd(24),
+  ].join(" ");
+  const lines = events.map((entry) =>
+    [
+      String(entry.seq).padStart(4),
+      entry.type.padEnd(20),
+      display(entry.repoFullName).padEnd(24),
+      display(entry.createdAt).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+const EVENT_LEDGER_METRICS_USAGE = "Usage: loopover-miner ledger metrics";
+
+// Prometheus metric name for the per-type event-ledger counter. Mirrors the `loopover_miner_*_total` naming and
+// the HELP/TYPE/label conventions of the engine's renderMinerPredictionMetrics
+// (packages/loopover-engine/src/miner-prediction-metrics.ts) rather than importing across the package boundary.
+const MINER_EVENTS_TOTAL = "loopover_miner_events_total";
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping — backslash, double-quote, newline — so an arbitrary event `type` string can
+ *  never break the metric line (mirrors miner-prediction-metrics.ts's escapeLabelValue). */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/**
+ * Render event-ledger activity as Prometheus text-exposition counters: one `loopover_miner_events_total{type}`
+ * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
+ * `ledger list --json` (#4841). Pure + side-effect-free — the caller supplies the rows and prints the result;
+ * deterministic (series emitted in sorted type order); always emits HELP/TYPE so an empty ledger is still a
+ * well-formed exposition document.
+ */
+export function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string {
+  const totalByType = new Map<string, number>();
+  for (const entry of events) {
+    totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
+  }
+  const lines = [
+    `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
+    `# TYPE ${MINER_EVENTS_TOTAL} counter`,
+  ];
+  for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function withEventLedger<T>(
+  options: { initEventLedger?: () => EventLedger },
+  run: (eventLedger: EventLedger) => T,
+): T {
+  const ownsLedger = options.initEventLedger === undefined;
+  const eventLedger = (options.initEventLedger ?? initEventLedger)();
+  try {
+    return run(eventLedger);
+  } finally {
+    if (ownsLedger) eventLedger.close();
+  }
+}
+
+export function runLedgerList(args: string[], options: { initEventLedger?: () => EventLedger } = {}): number {
+  const parsed = parseLedgerListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withEventLedger(options, (eventLedger) => {
+      const events = filterLedgerEvents(
+        eventLedger.readEvents({
+          repoFullName: parsed.repoFullName,
+          since: parsed.since,
+        }),
+        { type: parsed.type },
+      );
+      if (parsed.json) {
+        console.log(JSON.stringify({ events }, null, 2));
+      } else {
+        console.log(renderLedgerTable(events));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runLedgerMetrics(args: string[], options: { initEventLedger?: () => EventLedger } = {}): number {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
+  }
+
+  try {
+    return withEventLedger(options, (eventLedger) => {
+      // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+      console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}
+
+export function runLedgerCli(
+  subcommand: string | undefined,
+  args: string[],
+  options: { initEventLedger?: () => EventLedger } = {},
+): number {
+  if (subcommand === "list") return runLedgerList(args, options);
+  if (subcommand === "metrics") return runLedgerMetrics(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
+}

--- a/packages/loopover-miner/lib/governor-ledger-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-ledger-cli.d.ts
@@ -1,32 +1,22 @@
-import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
 import type { GovernorPauseCliOptions } from "./governor-pause-cli.js";
-
+import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
 export type GovernorLedgerEventType = "allowed" | "denied" | "throttled" | "kill_switch";
-
-export type ParsedGovernorListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-      type: GovernorLedgerEventType | null;
-    }
-  | { error: string };
-
-export function parseGovernorListArgs(args: string[]): ParsedGovernorListArgs;
-
-export function filterGovernorEvents(
-  events: GovernorLedgerEntry[],
-  options?: { type?: string | null },
-): GovernorLedgerEntry[];
-
-export function renderGovernorTable(events: GovernorLedgerEntry[]): string;
-
-export function runGovernorList(
-  args: string[],
-  options?: { initGovernorLedger?: () => GovernorLedger },
-): Promise<number>;
-
-export function runGovernorCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { initGovernorLedger?: () => GovernorLedger; nowMs?: number } & GovernorPauseCliOptions,
-): Promise<number>;
+export type ParsedGovernorListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+    type: GovernorLedgerEventType | null;
+} | {
+    error: string;
+};
+export declare function parseGovernorListArgs(args: string[]): ParsedGovernorListArgs;
+export declare function filterGovernorEvents(events: GovernorLedgerEntry[], options?: {
+    type?: string | null;
+}): GovernorLedgerEntry[];
+export declare function renderGovernorTable(events: GovernorLedgerEntry[]): string;
+export declare function runGovernorList(args: string[], options?: {
+    initGovernorLedger?: () => GovernorLedger;
+}): Promise<number>;
+export declare function runGovernorCli(subcommand: string | undefined, args: string[], options?: {
+    initGovernorLedger?: () => GovernorLedger;
+    nowMs?: number;
+} & GovernorPauseCliOptions): Promise<number>;

--- a/packages/loopover-miner/lib/governor-ledger-cli.js
+++ b/packages/loopover-miner/lib/governor-ledger-cli.js
@@ -1,158 +1,153 @@
 import { runGovernorPause, runGovernorResume, runGovernorStatus } from "./governor-pause-cli.js";
 import { runGovernorMetrics } from "./governor-metrics-cli.js";
-
 /** Must match `GOVERNOR_LEDGER_EVENT_TYPES` in `@loopover/engine`. */
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
-  "allowed",
-  "denied",
-  "throttled",
-  "kill_switch",
+    "allowed",
+    "denied",
+    "throttled",
+    "kill_switch",
 ]);
-
-const GOVERNOR_LIST_USAGE =
-  "Usage: loopover-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]";
-
+const GOVERNOR_LIST_USAGE = "Usage: loopover-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]";
 const GOVERNOR_SUBCOMMAND_USAGE = [
-  GOVERNOR_LIST_USAGE,
-  "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
-  "       loopover-miner governor resume [--dry-run] [--json]",
-  "       loopover-miner governor status [--json]",
-  "       loopover-miner governor metrics",
+    GOVERNOR_LIST_USAGE,
+    "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
+    "       loopover-miner governor resume [--dry-run] [--json]",
+    "       loopover-miner governor status [--json]",
+    "       loopover-miner governor metrics",
 ].join("\n");
-
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parseGovernorListArgs(args) {
-  const options = { json: false, repoFullName: null, type: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, repoFullName: null, type: null };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-"))
+                return { error: GOVERNOR_LIST_USAGE };
+            const repo = parseRepoArg(repoArg, GOVERNOR_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token === "--type") {
+            const type = args[index + 1];
+            if (!type || type.startsWith("-"))
+                return { error: GOVERNOR_LIST_USAGE };
+            const trimmed = type.trim();
+            if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed)) {
+                return {
+                    error: `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
+                };
+            }
+            options.type = trimmed;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
-      const repo = parseRepoArg(repoArg, GOVERNOR_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
-    }
-    if (token === "--type") {
-      const type = args[index + 1];
-      if (!type || type.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
-      const trimmed = type.trim();
-      if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed)) {
-        return {
-          error: `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
-        };
-      }
-      options.type = trimmed;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length > 0) return { error: GOVERNOR_LIST_USAGE };
-  return options;
+    if (positional.length > 0)
+        return { error: GOVERNOR_LIST_USAGE };
+    return options;
 }
-
 export function filterGovernorEvents(events, options = {}) {
-  if (!Array.isArray(events)) return [];
-  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
-  if (!type) return events;
-  return events.filter((entry) => entry.eventType === type);
+    if (!Array.isArray(events))
+        return [];
+    const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+    if (!type)
+        return events;
+    return events.filter((entry) => entry.eventType === type);
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderGovernorTable(events) {
-  if (!Array.isArray(events) || events.length === 0) return "no governor ledger entries";
-  const header = [
-    "id".padStart(4),
-    "type".padEnd(12),
-    "repo".padEnd(24),
-    "action".padEnd(10),
-    "decision".padEnd(10),
-    "ts".padEnd(24),
-  ].join(" ");
-  const lines = events.map((entry) =>
-    [
-      String(entry.id).padStart(4),
-      entry.eventType.padEnd(12),
-      display(entry.repoFullName).padEnd(24),
-      entry.actionClass.padEnd(10),
-      entry.decision.padEnd(10),
-      display(entry.ts).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(events) || events.length === 0)
+        return "no governor ledger entries";
+    const header = [
+        "id".padStart(4),
+        "type".padEnd(12),
+        "repo".padEnd(24),
+        "action".padEnd(10),
+        "decision".padEnd(10),
+        "ts".padEnd(24),
+    ].join(" ");
+    const lines = events.map((entry) => [
+        String(entry.id).padStart(4),
+        entry.eventType.padEnd(12),
+        display(entry.repoFullName).padEnd(24),
+        entry.actionClass.padEnd(10),
+        entry.decision.padEnd(10),
+        display(entry.ts).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 async function withGovernorLedger(options, run) {
-  const ownsLedger = options.initGovernorLedger === undefined;
-  const initGovernorLedger =
-    options.initGovernorLedger ?? (await import("./governor-ledger.js")).initGovernorLedger;
-  const governorLedger = initGovernorLedger();
-  try {
-    return run(governorLedger);
-  } finally {
-    if (ownsLedger) governorLedger.close();
-  }
+    const ownsLedger = options.initGovernorLedger === undefined;
+    const initGovernorLedger = options.initGovernorLedger ?? (await import("./governor-ledger.js")).initGovernorLedger;
+    const governorLedger = initGovernorLedger();
+    try {
+        return run(governorLedger);
+    }
+    finally {
+        if (ownsLedger)
+            governorLedger.close();
+    }
 }
-
 export async function runGovernorList(args, options = {}) {
-  const parsed = parseGovernorListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return await withGovernorLedger(options, (governorLedger) => {
-      const events = filterGovernorEvents(
-        governorLedger.readGovernorEvents({
-          repoFullName: parsed.repoFullName,
-        }),
-        { type: parsed.type },
-      );
-      if (parsed.json) {
-        console.log(JSON.stringify({ events }, null, 2));
-      } else {
-        console.log(renderGovernorTable(events));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseGovernorListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return await withGovernorLedger(options, (governorLedger) => {
+            const events = filterGovernorEvents(governorLedger.readGovernorEvents({
+                repoFullName: parsed.repoFullName,
+            }), { type: parsed.type });
+            if (parsed.json) {
+                console.log(JSON.stringify({ events }, null, 2));
+            }
+            else {
+                console.log(renderGovernorTable(events));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runGovernorList(args, options);
-  if (subcommand === "pause") return runGovernorPause(args, options);
-  if (subcommand === "resume") return runGovernorResume(args, options);
-  if (subcommand === "status") return runGovernorStatus(args, options);
-  if (subcommand === "metrics") return runGovernorMetrics(args, options);
-  return reportCliFailure(
-    argsWantJson(args),
-    `Unknown governor subcommand: ${subcommand ?? ""}.\n${GOVERNOR_SUBCOMMAND_USAGE}`,
-  );
+    if (subcommand === "list")
+        return runGovernorList(args, options);
+    if (subcommand === "pause")
+        return runGovernorPause(args, options);
+    if (subcommand === "resume")
+        return runGovernorResume(args, options);
+    if (subcommand === "status")
+        return runGovernorStatus(args, options);
+    if (subcommand === "metrics")
+        return runGovernorMetrics(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown governor subcommand: ${subcommand ?? ""}.\n${GOVERNOR_SUBCOMMAND_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItbGVkZ2VyLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImdvdmVybm9yLWxlZGdlci1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGdCQUFnQixFQUFFLGlCQUFpQixFQUFFLGlCQUFpQixFQUFFLE1BQU0seUJBQXlCLENBQUM7QUFFakcsT0FBTyxFQUFFLGtCQUFrQixFQUFFLE1BQU0sMkJBQTJCLENBQUM7QUFHL0Qsc0VBQXNFO0FBQ3RFLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQVlsRixNQUFNLDJCQUEyQixHQUFHLE1BQU0sQ0FBQyxNQUFNLENBQUM7SUFDaEQsU0FBUztJQUNULFFBQVE7SUFDUixXQUFXO0lBQ1gsYUFBYTtDQUNkLENBQUMsQ0FBQztBQUVILE1BQU0sbUJBQW1CLEdBQ3ZCLGtIQUFrSCxDQUFDO0FBRXJILE1BQU0seUJBQXlCLEdBQUc7SUFDaEMsbUJBQW1CO0lBQ25CLDZFQUE2RTtJQUM3RSw0REFBNEQ7SUFDNUQsZ0RBQWdEO0lBQ2hELHdDQUF3QztDQUN6QyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUViLFNBQVMsWUFBWSxDQUFDLEtBQWEsRUFBRSxLQUFhO0lBQ2hELElBQUksQ0FBQyxLQUFLO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUNwQyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDN0IsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztRQUMzQyxPQUFPLEVBQUUsS0FBSyxFQUFFLHdDQUF3QyxFQUFFLENBQUM7SUFDN0QsQ0FBQztJQUNELE9BQU8sRUFBRSxZQUFZLEVBQUUsR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLEVBQUUsQ0FBQztBQUM5QyxDQUFDO0FBRUQsTUFBTSxVQUFVLHFCQUFxQixDQUFDLElBQWM7SUFDbEQsTUFBTSxPQUFPLEdBSVQsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxDQUFDO0lBQ3BELE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsTUFBTSxPQUFPLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUNoQyxJQUFJLENBQUMsT0FBTyxJQUFJLE9BQU8sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztZQUMvRSxNQUFNLElBQUksR0FBRyxZQUFZLENBQUMsT0FBTyxFQUFFLG1CQUFtQixDQUFDLENBQUM7WUFDeEQsSUFBSSxPQUFPLElBQUksSUFBSTtnQkFBRSxPQUFPLElBQUksQ0FBQztZQUNqQyxPQUFPLENBQUMsWUFBWSxHQUFHLElBQUksQ0FBQyxZQUFZLENBQUM7WUFDekMsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsTUFBTSxJQUFJLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM3QixJQUFJLENBQUMsSUFBSSxJQUFJLElBQUksQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztZQUN6RSxNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDNUIsSUFBSSxDQUFDLDJCQUEyQixDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsRUFBRSxDQUFDO2dCQUNuRCxPQUFPO29CQUNMLEtBQUssRUFBRSxpQkFBaUIsT0FBTyxxQkFBcUIsMkJBQTJCLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxHQUFHO2lCQUM5RixDQUFDO1lBQ0osQ0FBQztZQUNELE9BQU8sQ0FBQyxJQUFJLEdBQUcsT0FBa0MsQ0FBQztZQUNsRCxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO1lBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUN4RSxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEdBQUcsQ0FBQztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztJQUNqRSxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsTUFBTSxVQUFVLG9CQUFvQixDQUNsQyxNQUE2QixFQUM3QixVQUFvQyxFQUFFO0lBRXRDLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQztRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQ3RDLE1BQU0sSUFBSSxHQUFHLE9BQU8sT0FBTyxDQUFDLElBQUksS0FBSyxRQUFRLElBQUksT0FBTyxDQUFDLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ2xHLElBQUksQ0FBQyxJQUFJO1FBQUUsT0FBTyxNQUFNLENBQUM7SUFDekIsT0FBTyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsU0FBUyxLQUFLLElBQUksQ0FBQyxDQUFDO0FBQzVELENBQUM7QUFFRCxTQUFTLE9BQU8sQ0FBQyxLQUFjO0lBQzdCLElBQUksS0FBSyxLQUFLLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE9BQU8sR0FBRyxDQUFDO0lBQ3RELE9BQU8sTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0FBQ3ZCLENBQUM7QUFFRCxNQUFNLFVBQVUsbUJBQW1CLENBQUMsTUFBNkI7SUFDL0QsSUFBSSxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLElBQUksTUFBTSxDQUFDLE1BQU0sS0FBSyxDQUFDO1FBQUUsT0FBTyw0QkFBNEIsQ0FBQztJQUN2RixNQUFNLE1BQU0sR0FBRztRQUNiLElBQUksQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQ2hCLE1BQU0sQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ2pCLE1BQU0sQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ2pCLFFBQVEsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ25CLFVBQVUsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3JCLElBQUksQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQ2hCLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ1osTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQ2pDO1FBQ0UsTUFBTSxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQzVCLEtBQUssQ0FBQyxTQUFTLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUMxQixPQUFPLENBQUMsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDdEMsS0FBSyxDQUFDLFdBQVcsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzVCLEtBQUssQ0FBQyxRQUFRLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN6QixPQUFPLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDN0IsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQ1osQ0FBQztJQUNGLE9BQU8sQ0FBQyxNQUFNLEVBQUUsR0FBRyxLQUFLLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDdkMsQ0FBQztBQUVELEtBQUssVUFBVSxrQkFBa0IsQ0FDL0IsT0FBc0QsRUFDdEQsR0FBMEM7SUFFMUMsTUFBTSxVQUFVLEdBQUcsT0FBTyxDQUFDLGtCQUFrQixLQUFLLFNBQVMsQ0FBQztJQUM1RCxNQUFNLGtCQUFrQixHQUN0QixPQUFPLENBQUMsa0JBQWtCLElBQUksQ0FBQyxNQUFNLE1BQU0sQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDLENBQUMsa0JBQWtCLENBQUM7SUFDMUYsTUFBTSxjQUFjLEdBQUcsa0JBQWtCLEVBQUUsQ0FBQztJQUM1QyxJQUFJLENBQUM7UUFDSCxPQUFPLEdBQUcsQ0FBQyxjQUFjLENBQUMsQ0FBQztJQUM3QixDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksVUFBVTtZQUFFLGNBQWMsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUN6QyxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sQ0FBQyxLQUFLLFVBQVUsZUFBZSxDQUNuQyxJQUFjLEVBQ2QsVUFBeUQsRUFBRTtJQUUzRCxNQUFNLE1BQU0sR0FBRyxxQkFBcUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUMzQyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sTUFBTSxrQkFBa0IsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxjQUFjLEVBQUUsRUFBRTtZQUMxRCxNQUFNLE1BQU0sR0FBRyxvQkFBb0IsQ0FDakMsY0FBYyxDQUFDLGtCQUFrQixDQUFDO2dCQUNoQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7YUFDbEMsQ0FBQyxFQUNGLEVBQUUsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FDdEIsQ0FBQztZQUNGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxNQUFNLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNuRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxtQkFBbUIsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO1lBQzNDLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sQ0FBQyxLQUFLLFVBQVUsY0FBYyxDQUNsQyxVQUE4QixFQUM5QixJQUFjLEVBQ2QsVUFBbUcsRUFBRTtJQUVyRyxJQUFJLFVBQVUsS0FBSyxNQUFNO1FBQUUsT0FBTyxlQUFlLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ2pFLElBQUksVUFBVSxLQUFLLE9BQU87UUFBRSxPQUFPLGdCQUFnQixDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNuRSxJQUFJLFVBQVUsS0FBSyxRQUFRO1FBQUUsT0FBTyxpQkFBaUIsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDckUsSUFBSSxVQUFVLEtBQUssUUFBUTtRQUFFLE9BQU8saUJBQWlCLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3JFLElBQUksVUFBVSxLQUFLLFNBQVM7UUFBRSxPQUFPLGtCQUFrQixDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUN2RSxPQUFPLGdCQUFnQixDQUNyQixZQUFZLENBQUMsSUFBSSxDQUFDLEVBQ2xCLGdDQUFnQyxVQUFVLElBQUksRUFBRSxNQUFNLHlCQUF5QixFQUFFLENBQ2xGLENBQUM7QUFDSixDQUFDIn0=

--- a/packages/loopover-miner/lib/governor-ledger-cli.ts
+++ b/packages/loopover-miner/lib/governor-ledger-cli.ts
@@ -1,0 +1,187 @@
+import { runGovernorPause, runGovernorResume, runGovernorStatus } from "./governor-pause-cli.js";
+import type { GovernorPauseCliOptions } from "./governor-pause-cli.js";
+import { runGovernorMetrics } from "./governor-metrics-cli.js";
+import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
+
+/** Must match `GOVERNOR_LEDGER_EVENT_TYPES` in `@loopover/engine`. */
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+export type GovernorLedgerEventType = "allowed" | "denied" | "throttled" | "kill_switch";
+
+export type ParsedGovernorListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+      type: GovernorLedgerEventType | null;
+    }
+  | { error: string };
+
+const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
+  "allowed",
+  "denied",
+  "throttled",
+  "kill_switch",
+]);
+
+const GOVERNOR_LIST_USAGE =
+  "Usage: loopover-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]";
+
+const GOVERNOR_SUBCOMMAND_USAGE = [
+  GOVERNOR_LIST_USAGE,
+  "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
+  "       loopover-miner governor resume [--dry-run] [--json]",
+  "       loopover-miner governor status [--json]",
+  "       loopover-miner governor metrics",
+].join("\n");
+
+function parseRepoArg(value: string, usage: string): { error: string } | { repoFullName: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parseGovernorListArgs(args: string[]): ParsedGovernorListArgs {
+  const options: {
+    json: boolean;
+    repoFullName: string | null;
+    type: GovernorLedgerEventType | null;
+  } = { json: false, repoFullName: null, type: null };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
+      const repo = parseRepoArg(repoArg, GOVERNOR_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token === "--type") {
+      const type = args[index + 1];
+      if (!type || type.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
+      const trimmed = type.trim();
+      if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed)) {
+        return {
+          error: `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
+        };
+      }
+      options.type = trimmed as GovernorLedgerEventType;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length > 0) return { error: GOVERNOR_LIST_USAGE };
+  return options;
+}
+
+export function filterGovernorEvents(
+  events: GovernorLedgerEntry[],
+  options: { type?: string | null } = {},
+): GovernorLedgerEntry[] {
+  if (!Array.isArray(events)) return [];
+  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+  if (!type) return events;
+  return events.filter((entry) => entry.eventType === type);
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderGovernorTable(events: GovernorLedgerEntry[]): string {
+  if (!Array.isArray(events) || events.length === 0) return "no governor ledger entries";
+  const header = [
+    "id".padStart(4),
+    "type".padEnd(12),
+    "repo".padEnd(24),
+    "action".padEnd(10),
+    "decision".padEnd(10),
+    "ts".padEnd(24),
+  ].join(" ");
+  const lines = events.map((entry) =>
+    [
+      String(entry.id).padStart(4),
+      entry.eventType.padEnd(12),
+      display(entry.repoFullName).padEnd(24),
+      entry.actionClass.padEnd(10),
+      entry.decision.padEnd(10),
+      display(entry.ts).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+async function withGovernorLedger<T>(
+  options: { initGovernorLedger?: () => GovernorLedger },
+  run: (governorLedger: GovernorLedger) => T,
+): Promise<T> {
+  const ownsLedger = options.initGovernorLedger === undefined;
+  const initGovernorLedger =
+    options.initGovernorLedger ?? (await import("./governor-ledger.js")).initGovernorLedger;
+  const governorLedger = initGovernorLedger();
+  try {
+    return run(governorLedger);
+  } finally {
+    if (ownsLedger) governorLedger.close();
+  }
+}
+
+export async function runGovernorList(
+  args: string[],
+  options: { initGovernorLedger?: () => GovernorLedger } = {},
+): Promise<number> {
+  const parsed = parseGovernorListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return await withGovernorLedger(options, (governorLedger) => {
+      const events = filterGovernorEvents(
+        governorLedger.readGovernorEvents({
+          repoFullName: parsed.repoFullName,
+        }),
+        { type: parsed.type },
+      );
+      if (parsed.json) {
+        console.log(JSON.stringify({ events }, null, 2));
+      } else {
+        console.log(renderGovernorTable(events));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorCli(
+  subcommand: string | undefined,
+  args: string[],
+  options: { initGovernorLedger?: () => GovernorLedger; nowMs?: number } & GovernorPauseCliOptions = {},
+): Promise<number> {
+  if (subcommand === "list") return runGovernorList(args, options);
+  if (subcommand === "pause") return runGovernorPause(args, options);
+  if (subcommand === "resume") return runGovernorResume(args, options);
+  if (subcommand === "status") return runGovernorStatus(args, options);
+  if (subcommand === "metrics") return runGovernorMetrics(args, options);
+  return reportCliFailure(
+    argsWantJson(args),
+    `Unknown governor subcommand: ${subcommand ?? ""}.\n${GOVERNOR_SUBCOMMAND_USAGE}`,
+  );
+}

--- a/packages/loopover-miner/lib/plan-store-cli.d.ts
+++ b/packages/loopover-miner/lib/plan-store-cli.d.ts
@@ -1,37 +1,23 @@
 import type { PlanRecord, PlanStatus, PlanStore } from "./plan-store.js";
-
-export type ParsedPlanListArgs =
-  | {
-      json: boolean;
-      status: PlanStatus | null;
-    }
-  | { error: string };
-
-export type ParsedPlanShowArgs =
-  | {
-      planId: string;
-      json: boolean;
-    }
-  | { error: string };
-
-export function parsePlanListArgs(args: string[]): ParsedPlanListArgs;
-
-export function parsePlanShowArgs(args: string[]): ParsedPlanShowArgs;
-
-export function renderPlanTable(plans: PlanRecord[]): string;
-
-export function runPlanList(
-  args: string[],
-  options?: { openPlanStore?: () => PlanStore },
-): number;
-
-export function runPlanShow(
-  args: string[],
-  options?: { openPlanStore?: () => PlanStore },
-): number;
-
-export function runPlanCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { openPlanStore?: () => PlanStore },
-): number;
+export type ParsedPlanListArgs = {
+    json: boolean;
+    status: PlanStatus | null;
+} | {
+    error: string;
+};
+export type ParsedPlanShowArgs = {
+    planId: string;
+    json: boolean;
+} | {
+    error: string;
+};
+type RunPlanOptions = {
+    openPlanStore?: () => PlanStore;
+};
+export declare function parsePlanListArgs(args: string[]): ParsedPlanListArgs;
+export declare function parsePlanShowArgs(args: string[]): ParsedPlanShowArgs;
+export declare function renderPlanTable(plans: PlanRecord[]): string;
+export declare function runPlanList(args: string[], options?: RunPlanOptions): number;
+export declare function runPlanShow(args: string[], options?: RunPlanOptions): number;
+export declare function runPlanCli(subcommand: string | undefined, args: string[], options?: RunPlanOptions): number;
+export {};

--- a/packages/loopover-miner/lib/plan-store-cli.js
+++ b/packages/loopover-miner/lib/plan-store-cli.js
@@ -1,151 +1,147 @@
 import { PLAN_STATUSES, openPlanStore } from "./plan-store.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
-const PLAN_LIST_USAGE =
-  "Usage: loopover-miner plan list [--status pending|running|completed|failed] [--json]";
+const PLAN_LIST_USAGE = "Usage: loopover-miner plan list [--status pending|running|completed|failed] [--json]";
 const PLAN_SHOW_USAGE = "Usage: loopover-miner plan show <planId> [--json]";
-
 function parseJsonFlag(args) {
-  const options = { json: false };
-  const positional = [];
-
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false };
+    const positional = [];
+    for (const token of args) {
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  return { positional, ...options };
+    return { positional, ...options };
 }
-
 export function parsePlanListArgs(args) {
-  const options = { json: false, status: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, status: null };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--status") {
+            const status = args[index + 1];
+            if (!status || status.startsWith("-"))
+                return { error: PLAN_LIST_USAGE };
+            if (!PLAN_STATUSES.includes(status)) {
+                return { error: `Invalid status: ${status}. Expected one of ${PLAN_STATUSES.join(", ")}.` };
+            }
+            options.status = status;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    if (token === "--status") {
-      const status = args[index + 1];
-      if (!status || status.startsWith("-")) return { error: PLAN_LIST_USAGE };
-      if (!PLAN_STATUSES.includes(status)) {
-        return { error: `Invalid status: ${status}. Expected one of ${PLAN_STATUSES.join(", ")}.` };
-      }
-      options.status = status;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length > 0) return { error: PLAN_LIST_USAGE };
-  return options;
+    if (positional.length > 0)
+        return { error: PLAN_LIST_USAGE };
+    return options;
 }
-
 export function parsePlanShowArgs(args) {
-  const parsed = parseJsonFlag(args);
-  if ("error" in parsed) return parsed;
-  if (parsed.positional.length !== 1) return { error: PLAN_SHOW_USAGE };
-
-  const planId = parsed.positional[0]?.trim();
-  if (!planId) return { error: PLAN_SHOW_USAGE };
-
-  return {
-    planId,
-    json: parsed.json,
-  };
+    const parsed = parseJsonFlag(args);
+    if ("error" in parsed)
+        return parsed;
+    if (parsed.positional.length !== 1)
+        return { error: PLAN_SHOW_USAGE };
+    const planId = parsed.positional[0]?.trim();
+    if (!planId)
+        return { error: PLAN_SHOW_USAGE };
+    return {
+        planId,
+        json: parsed.json,
+    };
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderPlanTable(plans) {
-  if (!Array.isArray(plans) || plans.length === 0) return "no saved plans";
-  const header = [
-    "plan-id".padEnd(20),
-    "status".padEnd(10),
-    "steps".padStart(5),
-    "updated-at".padEnd(24),
-  ].join(" ");
-  const lines = plans.map((record) =>
-    [
-      record.planId.padEnd(20),
-      record.status.padEnd(10),
-      String(record.plan.steps.length).padStart(5),
-      display(record.updatedAt).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(plans) || plans.length === 0)
+        return "no saved plans";
+    const header = [
+        "plan-id".padEnd(20),
+        "status".padEnd(10),
+        "steps".padStart(5),
+        "updated-at".padEnd(24),
+    ].join(" ");
+    const lines = plans.map((record) => [
+        record.planId.padEnd(20),
+        record.status.padEnd(10),
+        String(record.plan.steps.length).padStart(5),
+        display(record.updatedAt).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 function withPlanStore(options, run) {
-  const ownsStore = options.openPlanStore === undefined;
-  const planStore = (options.openPlanStore ?? openPlanStore)();
-  try {
-    return run(planStore);
-  } finally {
-    if (ownsStore) planStore.close();
-  }
+    const ownsStore = options.openPlanStore === undefined;
+    const planStore = (options.openPlanStore ?? openPlanStore)();
+    try {
+        return run(planStore);
+    }
+    finally {
+        if (ownsStore)
+            planStore.close();
+    }
 }
-
 export function runPlanList(args, options = {}) {
-  const parsed = parsePlanListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withPlanStore(options, (planStore) => {
-      const plans = planStore.listPlans({ status: parsed.status });
-      if (parsed.json) {
-        console.log(JSON.stringify({ plans }, null, 2));
-      } else {
-        console.log(renderPlanTable(plans));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parsePlanListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withPlanStore(options, (planStore) => {
+            const plans = planStore.listPlans({ status: parsed.status });
+            if (parsed.json) {
+                console.log(JSON.stringify({ plans }, null, 2));
+            }
+            else {
+                console.log(renderPlanTable(plans));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runPlanShow(args, options = {}) {
-  const parsed = parsePlanShowArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withPlanStore(options, (planStore) => {
-      const plan = planStore.loadPlan(parsed.planId);
-      if (!plan) {
-        return reportCliFailure(parsed.json, "plan_not_found");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ plan }, null, 2));
-      } else {
-        console.log(`${plan.status} (${plan.plan.steps.length} steps)`);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parsePlanShowArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withPlanStore(options, (planStore) => {
+            const plan = planStore.loadPlan(parsed.planId);
+            if (!plan) {
+                return reportCliFailure(parsed.json, "plan_not_found");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ plan }, null, 2));
+            }
+            else {
+                console.log(`${plan.status} (${plan.plan.steps.length} steps)`);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runPlanCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runPlanList(args, options);
-  if (subcommand === "show") return runPlanShow(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
+    if (subcommand === "list")
+        return runPlanList(args, options);
+    if (subcommand === "show")
+        return runPlanShow(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicGxhbi1zdG9yZS1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJwbGFuLXN0b3JlLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQUUsYUFBYSxFQUFFLGFBQWEsRUFBRSxNQUFNLGlCQUFpQixDQUFDO0FBRS9ELE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUVsRixNQUFNLGVBQWUsR0FDbkIsc0ZBQXNGLENBQUM7QUFDekYsTUFBTSxlQUFlLEdBQUcsbURBQW1ELENBQUM7QUFvQjVFLFNBQVMsYUFBYSxDQUFDLElBQWM7SUFDbkMsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDaEMsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssTUFBTSxLQUFLLElBQUksSUFBSSxFQUFFLENBQUM7UUFDekIsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxPQUFPLEVBQUUsVUFBVSxFQUFFLEdBQUcsT0FBTyxFQUFFLENBQUM7QUFDcEMsQ0FBQztBQUVELE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxJQUFjO0lBQzlDLE1BQU0sT0FBTyxHQUFpRCxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDO0lBQzVGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsTUFBTSxNQUFNLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUMvQixJQUFJLENBQUMsTUFBTSxJQUFJLE1BQU0sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7WUFDekUsSUFBSSxDQUFDLGFBQWEsQ0FBQyxRQUFRLENBQUMsTUFBb0IsQ0FBQyxFQUFFLENBQUM7Z0JBQ2xELE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLE1BQU0scUJBQXFCLGFBQWEsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO1lBQzlGLENBQUM7WUFDRCxPQUFPLENBQUMsTUFBTSxHQUFHLE1BQW9CLENBQUM7WUFDdEMsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDeEUsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxHQUFHLENBQUM7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGVBQWUsRUFBRSxDQUFDO0lBQzdELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxNQUFNLFVBQVUsaUJBQWlCLENBQUMsSUFBYztJQUM5QyxNQUFNLE1BQU0sR0FBRyxhQUFhLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDbkMsSUFBSSxPQUFPLElBQUksTUFBTTtRQUFFLE9BQU8sTUFBTSxDQUFDO0lBQ3JDLElBQUksTUFBTSxDQUFDLFVBQVUsQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7SUFFdEUsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxJQUFJLEVBQUUsQ0FBQztJQUM1QyxJQUFJLENBQUMsTUFBTTtRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7SUFFL0MsT0FBTztRQUNMLE1BQU07UUFDTixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7S0FDbEIsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLE9BQU8sQ0FBQyxLQUFjO0lBQzdCLElBQUksS0FBSyxLQUFLLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE9BQU8sR0FBRyxDQUFDO0lBQ3RELE9BQU8sTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0FBQ3ZCLENBQUM7QUFFRCxNQUFNLFVBQVUsZUFBZSxDQUFDLEtBQW1CO0lBQ2pELElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sZ0JBQWdCLENBQUM7SUFDekUsTUFBTSxNQUFNLEdBQUc7UUFDYixTQUFTLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNwQixRQUFRLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNuQixPQUFPLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUNuQixZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztLQUN4QixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNaLE1BQU0sS0FBSyxHQUFHLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUNqQztRQUNFLE1BQU0sQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN4QixNQUFNLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDeEIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDNUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQ3JDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxTQUFTLGFBQWEsQ0FBSSxPQUF1QixFQUFFLEdBQWdDO0lBQ2pGLE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxhQUFhLEtBQUssU0FBUyxDQUFDO0lBQ3RELE1BQU0sU0FBUyxHQUFHLENBQUMsT0FBTyxDQUFDLGFBQWEsSUFBSSxhQUFhLENBQUMsRUFBRSxDQUFDO0lBQzdELElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ3hCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxTQUFTO1lBQUUsU0FBUyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ25DLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFdBQVcsQ0FBQyxJQUFjLEVBQUUsVUFBMEIsRUFBRTtJQUN0RSxNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN2QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sYUFBYSxDQUFDLE9BQU8sRUFBRSxDQUFDLFNBQVMsRUFBRSxFQUFFO1lBQzFDLE1BQU0sS0FBSyxHQUFHLFNBQVMsQ0FBQyxTQUFTLENBQUMsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7WUFDN0QsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLEtBQUssRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2xELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGVBQWUsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1lBQ3RDLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsSUFBYyxFQUFFLFVBQTBCLEVBQUU7SUFDdEUsTUFBTSxNQUFNLEdBQUcsaUJBQWlCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDdkMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGFBQWEsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxTQUFTLEVBQUUsRUFBRTtZQUMxQyxNQUFNLElBQUksR0FBRyxTQUFTLENBQUMsUUFBUSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUMvQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ1YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLENBQUM7WUFDekQsQ0FBQztZQUNELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxJQUFJLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNqRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxNQUFNLEtBQUssSUFBSSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsTUFBTSxTQUFTLENBQUMsQ0FBQztZQUNsRSxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLFVBQVUsVUFBVSxDQUFDLFVBQThCLEVBQUUsSUFBYyxFQUFFLFVBQTBCLEVBQUU7SUFDckcsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sV0FBVyxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM3RCxJQUFJLFVBQVUsS0FBSyxNQUFNO1FBQUUsT0FBTyxXQUFXLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQzdELE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLDRCQUE0QixVQUFVLElBQUksRUFBRSxLQUFLLGVBQWUsRUFBRSxDQUFDLENBQUM7QUFDbEgsQ0FBQyJ9

--- a/packages/loopover-miner/lib/plan-store-cli.ts
+++ b/packages/loopover-miner/lib/plan-store-cli.ts
@@ -1,0 +1,170 @@
+import { PLAN_STATUSES, openPlanStore } from "./plan-store.js";
+import type { PlanRecord, PlanStatus, PlanStore } from "./plan-store.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+const PLAN_LIST_USAGE =
+  "Usage: loopover-miner plan list [--status pending|running|completed|failed] [--json]";
+const PLAN_SHOW_USAGE = "Usage: loopover-miner plan show <planId> [--json]";
+
+export type ParsedPlanListArgs =
+  | {
+      json: boolean;
+      status: PlanStatus | null;
+    }
+  | { error: string };
+
+export type ParsedPlanShowArgs =
+  | {
+      planId: string;
+      json: boolean;
+    }
+  | { error: string };
+
+type ParsedJsonFlag = { positional: string[]; json: boolean } | { error: string };
+
+type RunPlanOptions = { openPlanStore?: () => PlanStore };
+
+function parseJsonFlag(args: string[]): ParsedJsonFlag {
+  const options = { json: false };
+  const positional: string[] = [];
+
+  for (const token of args) {
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  return { positional, ...options };
+}
+
+export function parsePlanListArgs(args: string[]): ParsedPlanListArgs {
+  const options: { json: boolean; status: PlanStatus | null } = { json: false, status: null };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--status") {
+      const status = args[index + 1];
+      if (!status || status.startsWith("-")) return { error: PLAN_LIST_USAGE };
+      if (!PLAN_STATUSES.includes(status as PlanStatus)) {
+        return { error: `Invalid status: ${status}. Expected one of ${PLAN_STATUSES.join(", ")}.` };
+      }
+      options.status = status as PlanStatus;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length > 0) return { error: PLAN_LIST_USAGE };
+  return options;
+}
+
+export function parsePlanShowArgs(args: string[]): ParsedPlanShowArgs {
+  const parsed = parseJsonFlag(args);
+  if ("error" in parsed) return parsed;
+  if (parsed.positional.length !== 1) return { error: PLAN_SHOW_USAGE };
+
+  const planId = parsed.positional[0]?.trim();
+  if (!planId) return { error: PLAN_SHOW_USAGE };
+
+  return {
+    planId,
+    json: parsed.json,
+  };
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderPlanTable(plans: PlanRecord[]): string {
+  if (!Array.isArray(plans) || plans.length === 0) return "no saved plans";
+  const header = [
+    "plan-id".padEnd(20),
+    "status".padEnd(10),
+    "steps".padStart(5),
+    "updated-at".padEnd(24),
+  ].join(" ");
+  const lines = plans.map((record) =>
+    [
+      record.planId.padEnd(20),
+      record.status.padEnd(10),
+      String(record.plan.steps.length).padStart(5),
+      display(record.updatedAt).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function withPlanStore<T>(options: RunPlanOptions, run: (planStore: PlanStore) => T): T {
+  const ownsStore = options.openPlanStore === undefined;
+  const planStore = (options.openPlanStore ?? openPlanStore)();
+  try {
+    return run(planStore);
+  } finally {
+    if (ownsStore) planStore.close();
+  }
+}
+
+export function runPlanList(args: string[], options: RunPlanOptions = {}): number {
+  const parsed = parsePlanListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withPlanStore(options, (planStore) => {
+      const plans = planStore.listPlans({ status: parsed.status });
+      if (parsed.json) {
+        console.log(JSON.stringify({ plans }, null, 2));
+      } else {
+        console.log(renderPlanTable(plans));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runPlanShow(args: string[], options: RunPlanOptions = {}): number {
+  const parsed = parsePlanShowArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withPlanStore(options, (planStore) => {
+      const plan = planStore.loadPlan(parsed.planId);
+      if (!plan) {
+        return reportCliFailure(parsed.json, "plan_not_found");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ plan }, null, 2));
+      } else {
+        console.log(`${plan.status} (${plan.plan.steps.length} steps)`);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runPlanCli(subcommand: string | undefined, args: string[], options: RunPlanOptions = {}): number {
+  if (subcommand === "list") return runPlanList(args, options);
+  if (subcommand === "show") return runPlanShow(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
+}

--- a/packages/loopover-miner/lib/purge-cli.d.ts
+++ b/packages/loopover-miner/lib/purge-cli.d.ts
@@ -4,45 +4,51 @@ import type { GovernorLedger } from "./governor-ledger.js";
 import type { PredictionLedger } from "./prediction-ledger.js";
 import type { PortfolioQueueStore } from "./portfolio-queue.js";
 import type { RunStateStore } from "./run-state.js";
-
-export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE: string;
-
-export type ParsedPurgeArgs = { json: boolean; dryRun: boolean; repoFullName: string } | { error: string };
-
-export function parsePurgeArgs(args: string[]): ParsedPurgeArgs;
-
-export type PurgeStoreResult = { store: string; purged: number | null; error?: string; note?: string };
-export type PurgeDryRunStoreResult = { store: string; wouldPurge: number | null; error?: string };
-
+export declare const ATTEMPT_LOG_NOT_PURGEABLE_NOTE = "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
+export type ParsedPurgeArgs = {
+    json: boolean;
+    dryRun: boolean;
+    repoFullName: string;
+} | {
+    error: string;
+};
+export type PurgeStoreResult = {
+    store: string;
+    purged: number | null;
+    error?: string;
+    note?: string;
+};
+export type PurgeDryRunStoreResult = {
+    store: string;
+    wouldPurge: number | null;
+    error?: string;
+};
 export type PurgeDryRunResult = {
-  outcome: "dry_run";
-  repoFullName: string;
-  stores: PurgeDryRunStoreResult[];
-  attemptLogNote: string;
-  attemptLogTotalRows: number;
+    outcome: "dry_run";
+    repoFullName: string;
+    stores: PurgeDryRunStoreResult[];
+    attemptLogNote: string;
+    attemptLogTotalRows: number;
 };
-
 export type PurgeSummary = {
-  outcome: "purged" | "partial";
-  repoFullName: string;
-  totalPurged: number;
-  stores: PurgeStoreResult[];
-  purgedAt: string;
+    outcome: "purged" | "partial";
+    repoFullName: string;
+    totalPurged: number;
+    stores: PurgeStoreResult[];
+    purgedAt: string;
 };
-
 export type PurgeCliOptions = {
-  openClaimLedger?: () => ClaimLedger;
-  initEventLedger?: () => EventLedger;
-  initGovernorLedger?: () => GovernorLedger;
-  initPredictionLedger?: () => PredictionLedger;
-  initPortfolioQueueStore?: () => PortfolioQueueStore;
-  initRunStateStore?: () => RunStateStore;
-  resolveDbPaths?: Record<string, () => string>;
+    openClaimLedger?: () => ClaimLedger;
+    initEventLedger?: () => EventLedger;
+    initGovernorLedger?: () => GovernorLedger;
+    initPredictionLedger?: () => PredictionLedger;
+    initPortfolioQueueStore?: () => PortfolioQueueStore;
+    initRunStateStore?: () => RunStateStore;
+    resolveDbPaths?: Record<string, () => string>;
 };
-
-export function runPurgeDryRun(
-  parsed: { repoFullName: string; json: boolean },
-  options?: PurgeCliOptions,
-): number;
-
-export function runPurge(args: string[], options?: PurgeCliOptions): number;
+export declare function parsePurgeArgs(args: string[]): ParsedPurgeArgs;
+export declare function runPurgeDryRun(parsed: {
+    repoFullName: string;
+    json: boolean;
+}, options?: PurgeCliOptions): number;
+export declare function runPurge(args: string[], options?: PurgeCliOptions): number;

--- a/packages/loopover-miner/lib/purge-cli.js
+++ b/packages/loopover-miner/lib/purge-cli.js
@@ -22,201 +22,179 @@ import { initContributionProfileCache, resolveContributionProfileCacheDbPath } f
 import { openGovernorState, resolveGovernorStateDbPath } from "./governor-state.js";
 import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 import { resolveAttemptLogDbPath } from "./attempt-log.js";
-import {
-  CLAIM_LEDGER_PURGE_SPEC,
-  EVENT_LEDGER_PURGE_SPEC,
-  GOVERNOR_LEDGER_PURGE_SPEC,
-  PREDICTION_LEDGER_PURGE_SPEC,
-  PORTFOLIO_QUEUE_PURGE_SPEC,
-  RUN_STATE_PURGE_SPEC,
-  CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC,
-  GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC,
-  GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC,
-  POLICY_VERDICT_CACHE_PURGE_SPEC,
-  countStoreByRepo,
-  describeError,
-} from "./store-maintenance.js";
+import { CLAIM_LEDGER_PURGE_SPEC, EVENT_LEDGER_PURGE_SPEC, GOVERNOR_LEDGER_PURGE_SPEC, PREDICTION_LEDGER_PURGE_SPEC, PORTFOLIO_QUEUE_PURGE_SPEC, RUN_STATE_PURGE_SPEC, CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC, GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC, POLICY_VERDICT_CACHE_PURGE_SPEC, countStoreByRepo, describeError, } from "./store-maintenance.js";
 import { argsWantJson, reportCliFailure } from "./cli-error.js";
-
 const PURGE_USAGE = "Usage: loopover-miner purge --repo <owner/repo> [--dry-run] [--json]";
-
-export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE =
-  "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
-
+export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE = "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
 const REAL_PURGE_TARGETS = [
-  { name: "claim-ledger", optionKey: "openClaimLedger", opener: openClaimLedger, resolveDbPath: resolveClaimLedgerDbPath, spec: CLAIM_LEDGER_PURGE_SPEC },
-  { name: "event-ledger", optionKey: "initEventLedger", opener: initEventLedger, resolveDbPath: resolveEventLedgerDbPath, spec: EVENT_LEDGER_PURGE_SPEC },
-  { name: "governor-ledger", optionKey: "initGovernorLedger", opener: initGovernorLedger, resolveDbPath: resolveGovernorLedgerDbPath, spec: GOVERNOR_LEDGER_PURGE_SPEC },
-  { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
-  { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
-  { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
-  { name: "contribution-profile-cache", optionKey: "initContributionProfileCache", opener: initContributionProfileCache, resolveDbPath: resolveContributionProfileCacheDbPath, spec: CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC },
-  // governor-state holds TWO repo-scoped tables in one DB file; its store.purgeByRepo deletes both against a
-  // single handle (never reopening the file), and its dry-run count sums both via `specs` (#7091).
-  { name: "governor-state", optionKey: "openGovernorState", opener: openGovernorState, resolveDbPath: resolveGovernorStateDbPath, specs: [GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC] },
-  { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
+    { name: "claim-ledger", optionKey: "openClaimLedger", opener: openClaimLedger, resolveDbPath: resolveClaimLedgerDbPath, spec: CLAIM_LEDGER_PURGE_SPEC },
+    { name: "event-ledger", optionKey: "initEventLedger", opener: initEventLedger, resolveDbPath: resolveEventLedgerDbPath, spec: EVENT_LEDGER_PURGE_SPEC },
+    { name: "governor-ledger", optionKey: "initGovernorLedger", opener: initGovernorLedger, resolveDbPath: resolveGovernorLedgerDbPath, spec: GOVERNOR_LEDGER_PURGE_SPEC },
+    { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
+    { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
+    { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
+    { name: "contribution-profile-cache", optionKey: "initContributionProfileCache", opener: initContributionProfileCache, resolveDbPath: resolveContributionProfileCacheDbPath, spec: CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC },
+    // governor-state holds TWO repo-scoped tables in one DB file; its store.purgeByRepo deletes both against a
+    // single handle (never reopening the file), and its dry-run count sums both via `specs` (#7091).
+    { name: "governor-state", optionKey: "openGovernorState", opener: openGovernorState, resolveDbPath: resolveGovernorStateDbPath, specs: [GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC] },
+    { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
 ];
-
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parsePurgeArgs(args) {
-  const options = { json: false, dryRun: false, repoFullName: null };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false, repoFullName: null };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            // Only the flag-look-alike case is checked here ("--repo --json") -- a genuinely missing value (repoArg
+            // undefined) falls through to parseRepoArg's own `!value` guard below, the single source of truth for that.
+            if (repoArg !== undefined && repoArg.startsWith("-"))
+                return { error: PURGE_USAGE };
+            const repo = parseRepoArg(repoArg, PURGE_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        return { error: `Unknown option: ${token}` };
     }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      // Only the flag-look-alike case is checked here ("--repo --json") -- a genuinely missing value (repoArg
-      // undefined) falls through to parseRepoArg's own `!value` guard below, the single source of truth for that.
-      if (repoArg !== undefined && repoArg.startsWith("-")) return { error: PURGE_USAGE };
-      const repo = parseRepoArg(repoArg, PURGE_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
-    }
-    return { error: `Unknown option: ${token}` };
-  }
-
-  if (!options.repoFullName) return { error: PURGE_USAGE };
-  return options;
+    if (!options.repoFullName)
+        return { error: PURGE_USAGE };
+    return { json: options.json, dryRun: options.dryRun, repoFullName: options.repoFullName };
 }
-
 /** Read-only row count against an on-disk store file, for --dry-run. `{ readOnly: true }` (camelCase) is the
  *  only option node:sqlite recognizes for a driver-enforced read-only connection -- the lowercase `readonly`
  *  key is silently ignored. Never touches a store that doesn't exist yet (opening one -- even read-only --
  *  requires the file to already be there; a dry run must make zero writes). */
 function countExistingRows(dbPath, countFn) {
-  if (!existsSync(dbPath)) return 0;
-  const db = new DatabaseSync(dbPath, { readOnly: true });
-  try {
-    return countFn(db);
-  } finally {
-    db.close();
-  }
-}
-
-function renderDryRunSummary(result) {
-  const purgeableLine = result.stores
-    .map((entry) => `${entry.store}=${entry.wouldPurge}`)
-    .join(", ");
-  return [
-    `DRY RUN: would purge ${result.repoFullName} from: ${purgeableLine}. No writes were made.`,
-    `${ATTEMPT_LOG_NOT_PURGEABLE_NOTE} (${result.attemptLogTotalRows} total row(s) currently in attempt-log, all repos).`,
-  ].join("\n");
-}
-
-export function runPurgeDryRun(parsed, options = {}) {
-  const resolveDbPaths = options.resolveDbPaths ?? {};
-  const stores = REAL_PURGE_TARGETS.map((target) => {
-    const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
-    // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
-    // per-table counts against the single read-only handle so the preview matches what a real purge removes.
-    const specs = target.specs ?? [target.spec];
+    if (!existsSync(dbPath))
+        return 0;
+    const db = new DatabaseSync(dbPath, { readOnly: true });
     try {
-      const wouldPurge = countExistingRows(dbPath, (db) =>
-        specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0),
-      );
-      return { store: target.name, wouldPurge };
-    } catch (error) {
-      return { store: target.name, wouldPurge: null, error: describeError(error) };
+        return countFn(db);
     }
-  });
-
-  const attemptLogDbPath = (resolveDbPaths["attempt-log"] ?? resolveAttemptLogDbPath)();
-  const attemptLogTotalRows = countExistingRows(attemptLogDbPath, (db) =>
-    Number(db.prepare("SELECT COUNT(*) AS count FROM attempt_log_events").get().count),
-  );
-
-  const result = {
-    outcome: "dry_run",
-    repoFullName: parsed.repoFullName,
-    stores,
-    attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
-    attemptLogTotalRows,
-  };
-
-  if (parsed.json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    console.log(renderDryRunSummary(result));
-  }
-  return 0;
+    finally {
+        db.close();
+    }
 }
-
+function renderDryRunSummary(result) {
+    const purgeableLine = result.stores
+        .map((entry) => `${entry.store}=${entry.wouldPurge}`)
+        .join(", ");
+    return [
+        `DRY RUN: would purge ${result.repoFullName} from: ${purgeableLine}. No writes were made.`,
+        `${ATTEMPT_LOG_NOT_PURGEABLE_NOTE} (${result.attemptLogTotalRows} total row(s) currently in attempt-log, all repos).`,
+    ].join("\n");
+}
+export function runPurgeDryRun(parsed, options = {}) {
+    const resolveDbPaths = options.resolveDbPaths ?? {};
+    const stores = REAL_PURGE_TARGETS.map((target) => {
+        const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
+        // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
+        // per-table counts against the single read-only handle so the preview matches what a real purge removes.
+        const specs = target.specs ?? [target.spec];
+        try {
+            const wouldPurge = countExistingRows(dbPath, (db) => specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0));
+            return { store: target.name, wouldPurge };
+        }
+        catch (error) {
+            return { store: target.name, wouldPurge: null, error: describeError(error) };
+        }
+    });
+    const attemptLogDbPath = (resolveDbPaths["attempt-log"] ?? resolveAttemptLogDbPath)();
+    const attemptLogTotalRows = countExistingRows(attemptLogDbPath, (db) => Number(db.prepare("SELECT COUNT(*) AS count FROM attempt_log_events").get().count));
+    const result = {
+        outcome: "dry_run",
+        repoFullName: parsed.repoFullName,
+        stores,
+        attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+        attemptLogTotalRows,
+    };
+    if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+    }
+    else {
+        console.log(renderDryRunSummary(result));
+    }
+    return 0;
+}
 function purgeOneStore(target, options, repoFullName) {
-  const ownsStore = options[target.optionKey] === undefined;
-  let store;
-  try {
-    store = (options[target.optionKey] ?? target.opener)();
-    const purged = store.purgeByRepo(repoFullName);
-    return { store: target.name, purged };
-  } catch (error) {
-    return { store: target.name, purged: null, error: describeError(error) };
-  } finally {
-    if (ownsStore) store?.close();
-  }
+    const injectedOpener = options[target.optionKey];
+    const ownsStore = injectedOpener === undefined;
+    let store;
+    try {
+        store = (injectedOpener ?? target.opener)();
+        const purged = store.purgeByRepo(repoFullName);
+        return { store: target.name, purged };
+    }
+    catch (error) {
+        return { store: target.name, purged: null, error: describeError(error) };
+    }
+    finally {
+        if (ownsStore)
+            store?.close();
+    }
 }
-
 function renderPurgeSummary(summary) {
-  const perStore = summary.stores
-    .map((entry) => {
-      if ("error" in entry) return `${entry.store}=ERROR(${entry.error})`;
-      if (entry.purged === null) return `${entry.store}=skipped`;
-      return `${entry.store}=${entry.purged}`;
+    const perStore = summary.stores
+        .map((entry) => {
+        if ("error" in entry)
+            return `${entry.store}=ERROR(${entry.error})`;
+        if (entry.purged === null)
+            return `${entry.store}=skipped`;
+        return `${entry.store}=${entry.purged}`;
     })
-    .join(", ");
-  return [
-    `Purged ${summary.totalPurged} row(s) for ${summary.repoFullName} at ${summary.purgedAt}: ${perStore}.`,
-    ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
-  ].join(" ");
+        .join(", ");
+    return [
+        `Purged ${summary.totalPurged} row(s) for ${summary.repoFullName} at ${summary.purgedAt}: ${perStore}.`,
+        ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+    ].join(" ");
 }
-
 export function runPurge(args, options = {}) {
-  const parsed = parsePurgeArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    return runPurgeDryRun(parsed, options);
-  }
-
-  const perStoreResults = REAL_PURGE_TARGETS.map((target) => purgeOneStore(target, options, parsed.repoFullName));
-  perStoreResults.push({ store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE });
-
-  const totalPurged = perStoreResults.reduce((sum, entry) => sum + (entry.purged ?? 0), 0);
-  const hadError = perStoreResults.some((entry) => "error" in entry);
-  const summary = {
-    outcome: hadError ? "partial" : "purged",
-    repoFullName: parsed.repoFullName,
-    totalPurged,
-    stores: perStoreResults,
-    purgedAt: new Date().toISOString(),
-  };
-
-  // Audit-observable by design (#5564): print the summary in BOTH the success and partial-failure case, so a
-  // purge -- or a purge that only partly succeeded -- is never silent.
-  if (parsed.json) {
-    console.log(JSON.stringify(summary, null, 2));
-  } else {
-    console.log(renderPurgeSummary(summary));
-  }
-  return hadError ? 2 : 0;
+    const parsed = parsePurgeArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    if (parsed.dryRun) {
+        return runPurgeDryRun(parsed, options);
+    }
+    const perStoreResults = REAL_PURGE_TARGETS.map((target) => purgeOneStore(target, options, parsed.repoFullName));
+    perStoreResults.push({ store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE });
+    const totalPurged = perStoreResults.reduce((sum, entry) => sum + (entry.purged ?? 0), 0);
+    const hadError = perStoreResults.some((entry) => "error" in entry);
+    const summary = {
+        outcome: hadError ? "partial" : "purged",
+        repoFullName: parsed.repoFullName,
+        totalPurged,
+        stores: perStoreResults,
+        purgedAt: new Date().toISOString(),
+    };
+    // Audit-observable by design (#5564): print the summary in BOTH the success and partial-failure case, so a
+    // purge -- or a purge that only partly succeeded -- is never silent.
+    if (parsed.json) {
+        console.log(JSON.stringify(summary, null, 2));
+    }
+    else {
+        console.log(renderPurgeSummary(summary));
+    }
+    return hadError ? 2 : 0;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHVyZ2UtY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicHVyZ2UtY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLG1IQUFtSDtBQUNuSCx1R0FBdUc7QUFDdkcsZ0hBQWdIO0FBQ2hILDRHQUE0RztBQUM1RywyRUFBMkU7QUFDM0UsK0dBQStHO0FBQy9HLDhHQUE4RztBQUM5RywrR0FBK0c7QUFDL0csRUFBRTtBQUNGLDJHQUEyRztBQUMzRywrR0FBK0c7QUFDL0csMEdBQTBHO0FBQzFHLE9BQU8sRUFBRSxVQUFVLEVBQUUsTUFBTSxTQUFTLENBQUM7QUFDckMsT0FBTyxFQUFFLFlBQVksRUFBRSxNQUFNLGFBQWEsQ0FBQztBQUMzQyxPQUFPLEVBQUUsZUFBZSxFQUFFLHdCQUF3QixFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFDOUUsT0FBTyxFQUFFLGVBQWUsRUFBRSx3QkFBd0IsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQzlFLE9BQU8sRUFBRSxrQkFBa0IsRUFBRSwyQkFBMkIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBQ3ZGLE9BQU8sRUFBRSxvQkFBb0IsRUFBRSw2QkFBNkIsRUFBRSxNQUFNLHdCQUF3QixDQUFDO0FBQzdGLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSwyQkFBMkIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBQzVGLE9BQU8sRUFBRSxpQkFBaUIsRUFBRSxxQkFBcUIsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBQzFFLE9BQU8sRUFBRSw0QkFBNEIsRUFBRSxxQ0FBcUMsRUFBRSxNQUFNLGlDQUFpQyxDQUFDO0FBQ3RILE9BQU8sRUFBRSxpQkFBaUIsRUFBRSwwQkFBMEIsRUFBRSxNQUFNLHFCQUFxQixDQUFDO0FBQ3BGLE9BQU8sRUFBRSwyQkFBMkIsRUFBRSwrQkFBK0IsRUFBRSxNQUFNLDJCQUEyQixDQUFDO0FBQ3pHLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQzNELE9BQU8sRUFDTCx1QkFBdUIsRUFDdkIsdUJBQXVCLEVBQ3ZCLDBCQUEwQixFQUMxQiw0QkFBNEIsRUFDNUIsMEJBQTBCLEVBQzFCLG9CQUFvQixFQUNwQixxQ0FBcUMsRUFDckMsc0NBQXNDLEVBQ3RDLG1DQUFtQyxFQUNuQywrQkFBK0IsRUFDL0IsZ0JBQWdCLEVBQ2hCLGFBQWEsR0FDZCxNQUFNLHdCQUF3QixDQUFDO0FBQ2hDLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQVNoRSxNQUFNLFdBQVcsR0FBRyxzRUFBc0UsQ0FBQztBQUUzRixNQUFNLENBQUMsTUFBTSw4QkFBOEIsR0FDekMsc0dBQXNHLENBQUM7QUFrRHpHLE1BQU0sa0JBQWtCLEdBQWtCO0lBQ3hDLEVBQUUsSUFBSSxFQUFFLGNBQWMsRUFBRSxTQUFTLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxFQUFFLGVBQWUsRUFBRSxhQUFhLEVBQUUsd0JBQXdCLEVBQUUsSUFBSSxFQUFFLHVCQUF1QixFQUFFO0lBQ3ZKLEVBQUUsSUFBSSxFQUFFLGNBQWMsRUFBRSxTQUFTLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxFQUFFLGVBQWUsRUFBRSxhQUFhLEVBQUUsd0JBQXdCLEVBQUUsSUFBSSxFQUFFLHVCQUF1QixFQUFFO0lBQ3ZKLEVBQUUsSUFBSSxFQUFFLGlCQUFpQixFQUFFLFNBQVMsRUFBRSxvQkFBb0IsRUFBRSxNQUFNLEVBQUUsa0JBQWtCLEVBQUUsYUFBYSxFQUFFLDJCQUEyQixFQUFFLElBQUksRUFBRSwwQkFBMEIsRUFBRTtJQUN0SyxFQUFFLElBQUksRUFBRSxtQkFBbUIsRUFBRSxTQUFTLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSxFQUFFLG9CQUFvQixFQUFFLGFBQWEsRUFBRSw2QkFBNkIsRUFBRSxJQUFJLEVBQUUsNEJBQTRCLEVBQUU7SUFDaEwsRUFBRSxJQUFJLEVBQUUsaUJBQWlCLEVBQUUsU0FBUyxFQUFFLHlCQUF5QixFQUFFLE1BQU0sRUFBRSx1QkFBdUIsRUFBRSxhQUFhLEVBQUUsMkJBQTJCLEVBQUUsSUFBSSxFQUFFLDBCQUEwQixFQUFFO0lBQ2hMLEVBQUUsSUFBSSxFQUFFLFdBQVcsRUFBRSxTQUFTLEVBQUUsbUJBQW1CLEVBQUUsTUFBTSxFQUFFLGlCQUFpQixFQUFFLGFBQWEsRUFBRSxxQkFBcUIsRUFBRSxJQUFJLEVBQUUsb0JBQW9CLEVBQUU7SUFDbEosRUFBRSxJQUFJLEVBQUUsNEJBQTRCLEVBQUUsU0FBUyxFQUFFLDhCQUE4QixFQUFFLE1BQU0sRUFBRSw0QkFBNEIsRUFBRSxhQUFhLEVBQUUscUNBQXFDLEVBQUUsSUFBSSxFQUFFLHFDQUFxQyxFQUFFO0lBQzFOLDJHQUEyRztJQUMzRyxpR0FBaUc7SUFDakcsRUFBRSxJQUFJLEVBQUUsZ0JBQWdCLEVBQUUsU0FBUyxFQUFFLG1CQUFtQixFQUFFLE1BQU0sRUFBRSxpQkFBaUIsRUFBRSxhQUFhLEVBQUUsMEJBQTBCLEVBQUUsS0FBSyxFQUFFLENBQUMsc0NBQXNDLEVBQUUsbUNBQW1DLENBQUMsRUFBRTtJQUN0TixFQUFFLElBQUksRUFBRSxzQkFBc0IsRUFBRSxTQUFTLEVBQUUsNkJBQTZCLEVBQUUsTUFBTSxFQUFFLDJCQUEyQixFQUFFLGFBQWEsRUFBRSwrQkFBK0IsRUFBRSxJQUFJLEVBQUUsK0JBQStCLEVBQUU7Q0FDdk0sQ0FBQztBQUVGLFNBQVMsWUFBWSxDQUFDLEtBQXlCLEVBQUUsS0FBYTtJQUM1RCxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUEyQixPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3hFLElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVMsRUFBRSxDQUFDO1FBQzNDLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxNQUFNLFVBQVUsY0FBYyxDQUFDLElBQWM7SUFDM0MsTUFBTSxPQUFPLEdBQW9FLEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQztJQUVwSSxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQ2hDLHdHQUF3RztZQUN4Ryw0R0FBNEc7WUFDNUcsSUFBSSxPQUFPLEtBQUssU0FBUyxJQUFJLE9BQU8sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsV0FBVyxFQUFFLENBQUM7WUFDcEYsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sRUFBRSxXQUFXLENBQUMsQ0FBQztZQUNoRCxJQUFJLE9BQU8sSUFBSSxJQUFJO2dCQUFFLE9BQU8sSUFBSSxDQUFDO1lBQ2pDLE9BQU8sQ0FBQyxZQUFZLEdBQUcsSUFBSSxDQUFDLFlBQVksQ0FBQztZQUN6QyxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO0lBQy9DLENBQUM7SUFFRCxJQUFJLENBQUMsT0FBTyxDQUFDLFlBQVk7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFdBQVcsRUFBRSxDQUFDO0lBQ3pELE9BQU8sRUFBRSxJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUksRUFBRSxNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU0sRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxDQUFDO0FBQzVGLENBQUM7QUFFRDs7OytFQUcrRTtBQUMvRSxTQUFTLGlCQUFpQixDQUFDLE1BQWMsRUFBRSxPQUFxQztJQUM5RSxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQztRQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ2xDLE1BQU0sRUFBRSxHQUFHLElBQUksWUFBWSxDQUFDLE1BQU0sRUFBRSxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDO0lBQ3hELElBQUksQ0FBQztRQUNILE9BQU8sT0FBTyxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ3JCLENBQUM7WUFBUyxDQUFDO1FBQ1QsRUFBRSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ2IsQ0FBQztBQUNILENBQUM7QUFFRCxTQUFTLG1CQUFtQixDQUFDLE1BQXlCO0lBQ3BELE1BQU0sYUFBYSxHQUFHLE1BQU0sQ0FBQyxNQUFNO1NBQ2hDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsR0FBRyxLQUFLLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLEVBQUUsQ0FBQztTQUNwRCxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDZCxPQUFPO1FBQ0wsd0JBQXdCLE1BQU0sQ0FBQyxZQUFZLFVBQVUsYUFBYSx3QkFBd0I7UUFDMUYsR0FBRyw4QkFBOEIsS0FBSyxNQUFNLENBQUMsbUJBQW1CLHFEQUFxRDtLQUN0SCxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUNmLENBQUM7QUFFRCxNQUFNLFVBQVUsY0FBYyxDQUFDLE1BQStDLEVBQUUsVUFBMkIsRUFBRTtJQUMzRyxNQUFNLGNBQWMsR0FBRyxPQUFPLENBQUMsY0FBYyxJQUFJLEVBQUUsQ0FBQztJQUNwRCxNQUFNLE1BQU0sR0FBNkIsa0JBQWtCLENBQUMsR0FBRyxDQUFDLENBQUMsTUFBTSxFQUFFLEVBQUU7UUFDekUsTUFBTSxNQUFNLEdBQUcsQ0FBQyxjQUFjLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxJQUFJLE1BQU0sQ0FBQyxhQUFhLENBQUMsRUFBRSxDQUFDO1FBQ3ZFLHdHQUF3RztRQUN4Ryx5R0FBeUc7UUFDekcsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLEtBQUssSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFLLENBQUMsQ0FBQztRQUM3QyxJQUFJLENBQUM7WUFDSCxNQUFNLFVBQVUsR0FBRyxpQkFBaUIsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUNsRCxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUMsR0FBRyxFQUFFLElBQUksRUFBRSxFQUFFLENBQUMsR0FBRyxHQUFHLGdCQUFnQixDQUFDLEVBQUUsRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLFlBQVksQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUN0RixDQUFDO1lBQ0YsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxDQUFDO1FBQzVDLENBQUM7UUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1lBQ2YsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLGFBQWEsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQy9FLENBQUM7SUFDSCxDQUFDLENBQUMsQ0FBQztJQUVILE1BQU0sZ0JBQWdCLEdBQUcsQ0FBQyxjQUFjLENBQUMsYUFBYSxDQUFDLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQ3RGLE1BQU0sbUJBQW1CLEdBQUcsaUJBQWlCLENBQUMsZ0JBQWdCLEVBQUUsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUNyRSxNQUFNLENBQUUsRUFBRSxDQUFDLE9BQU8sQ0FBQyxrREFBa0QsQ0FBQyxDQUFDLEdBQUcsRUFBaUMsQ0FBQyxLQUFLLENBQUMsQ0FDbkgsQ0FBQztJQUVGLE1BQU0sTUFBTSxHQUFzQjtRQUNoQyxPQUFPLEVBQUUsU0FBUztRQUNsQixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7UUFDakMsTUFBTTtRQUNOLGNBQWMsRUFBRSw4QkFBOEI7UUFDOUMsbUJBQW1CO0tBQ3BCLENBQUM7SUFFRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQy9DLENBQUM7U0FBTSxDQUFDO1FBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxtQkFBbUIsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO0lBQzNDLENBQUM7SUFDRCxPQUFPLENBQUMsQ0FBQztBQUNYLENBQUM7QUFFRCxTQUFTLGFBQWEsQ0FBQyxNQUFtQixFQUFFLE9BQXdCLEVBQUUsWUFBb0I7SUFDeEYsTUFBTSxjQUFjLEdBQUksT0FBOEQsQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDekcsTUFBTSxTQUFTLEdBQUcsY0FBYyxLQUFLLFNBQVMsQ0FBQztJQUMvQyxJQUFJLEtBQWlDLENBQUM7SUFDdEMsSUFBSSxDQUFDO1FBQ0gsS0FBSyxHQUFHLENBQUMsY0FBYyxJQUFJLE1BQU0sQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzVDLE1BQU0sTUFBTSxHQUFHLEtBQUssQ0FBQyxXQUFXLENBQUMsWUFBWSxDQUFDLENBQUM7UUFDL0MsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLE1BQU0sRUFBRSxDQUFDO0lBQ3hDLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLGFBQWEsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO0lBQzNFLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxTQUFTO1lBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO0lBQ2hDLENBQUM7QUFDSCxDQUFDO0FBRUQsU0FBUyxrQkFBa0IsQ0FBQyxPQUFxQjtJQUMvQyxNQUFNLFFBQVEsR0FBRyxPQUFPLENBQUMsTUFBTTtTQUM1QixHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRTtRQUNiLElBQUksT0FBTyxJQUFJLEtBQUs7WUFBRSxPQUFPLEdBQUcsS0FBSyxDQUFDLEtBQUssVUFBVSxLQUFLLENBQUMsS0FBSyxHQUFHLENBQUM7UUFDcEUsSUFBSSxLQUFLLENBQUMsTUFBTSxLQUFLLElBQUk7WUFBRSxPQUFPLEdBQUcsS0FBSyxDQUFDLEtBQUssVUFBVSxDQUFDO1FBQzNELE9BQU8sR0FBRyxLQUFLLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBQztJQUMxQyxDQUFDLENBQUM7U0FDRCxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDZCxPQUFPO1FBQ0wsVUFBVSxPQUFPLENBQUMsV0FBVyxlQUFlLE9BQU8sQ0FBQyxZQUFZLE9BQU8sT0FBTyxDQUFDLFFBQVEsS0FBSyxRQUFRLEdBQUc7UUFDdkcsOEJBQThCO0tBQy9CLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0FBQ2QsQ0FBQztBQUVELE1BQU0sVUFBVSxRQUFRLENBQUMsSUFBYyxFQUFFLFVBQTJCLEVBQUU7SUFDcEUsTUFBTSxNQUFNLEdBQUcsY0FBYyxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3BDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsT0FBTyxjQUFjLENBQUMsTUFBTSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3pDLENBQUM7SUFFRCxNQUFNLGVBQWUsR0FBRyxrQkFBa0IsQ0FBQyxHQUFHLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLGFBQWEsQ0FBQyxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDO0lBQ2hILGVBQWUsQ0FBQyxJQUFJLENBQUMsRUFBRSxLQUFLLEVBQUUsYUFBYSxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLDhCQUE4QixFQUFFLENBQUMsQ0FBQztJQUVuRyxNQUFNLFdBQVcsR0FBRyxlQUFlLENBQUMsTUFBTSxDQUFDLENBQUMsR0FBRyxFQUFFLEtBQUssRUFBRSxFQUFFLENBQUMsR0FBRyxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sSUFBSSxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztJQUN6RixNQUFNLFFBQVEsR0FBRyxlQUFlLENBQUMsSUFBSSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxPQUFPLElBQUksS0FBSyxDQUFDLENBQUM7SUFDbkUsTUFBTSxPQUFPLEdBQWlCO1FBQzVCLE9BQU8sRUFBRSxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsUUFBUTtRQUN4QyxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7UUFDakMsV0FBVztRQUNYLE1BQU0sRUFBRSxlQUFlO1FBQ3ZCLFFBQVEsRUFBRSxJQUFJLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRTtLQUNuQyxDQUFDO0lBRUYsMkdBQTJHO0lBQzNHLHFFQUFxRTtJQUNyRSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsT0FBTyxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ2hELENBQUM7U0FBTSxDQUFDO1FBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxrQkFBa0IsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO0lBQzNDLENBQUM7SUFDRCxPQUFPLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDMUIsQ0FBQyJ9

--- a/packages/loopover-miner/lib/purge-cli.ts
+++ b/packages/loopover-miner/lib/purge-cli.ts
@@ -1,0 +1,278 @@
+// `loopover-miner purge` (#5564, #6599): an explicit, operator-invoked right-to-be-forgotten path across the local
+// ledgers. Deletes every row for one repo from the stores that have a real `repoColumn` (claim-ledger,
+// event-ledger, governor-ledger, prediction-ledger, portfolio-queue, run-state, contribution-profile-cache, and
+// governor-state's two repo-scoped tables — #7091), via each store's own `purgeByRepo` method (which reuses
+// `store-maintenance.js`'s shared, identifier-guarded `purgeStoreByRepo`).
+// `attempt-log.js` is deliberately reported as not-purgeable rather than silently skipped or approximated: its
+// payload is a free-form `Record<string, unknown>` with no dedicated repo column, so a precise per-repo match
+// isn't possible there without risking false matches -- see store-maintenance.js's own purge-spec doc comment.
+//
+// Every purge is audit-observable by design (#5564's own acceptance criteria): the real (non-dry-run) path
+// always prints a per-store summary, even under --json, so a purge can never be silent. A failure in one store
+// does not prevent reporting what succeeded in the others -- see purgeOneStore's own per-store try/catch.
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { openClaimLedger, resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import { initEventLedger, resolveEventLedgerDbPath } from "./event-ledger.js";
+import { initGovernorLedger, resolveGovernorLedgerDbPath } from "./governor-ledger.js";
+import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
+import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
+import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
+import { initContributionProfileCache, resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
+import { openGovernorState, resolveGovernorStateDbPath } from "./governor-state.js";
+import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
+import { resolveAttemptLogDbPath } from "./attempt-log.js";
+import {
+  CLAIM_LEDGER_PURGE_SPEC,
+  EVENT_LEDGER_PURGE_SPEC,
+  GOVERNOR_LEDGER_PURGE_SPEC,
+  PREDICTION_LEDGER_PURGE_SPEC,
+  PORTFOLIO_QUEUE_PURGE_SPEC,
+  RUN_STATE_PURGE_SPEC,
+  CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC,
+  GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC,
+  GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC,
+  POLICY_VERDICT_CACHE_PURGE_SPEC,
+  countStoreByRepo,
+  describeError,
+} from "./store-maintenance.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
+import type { LedgerPurgeSpec } from "./store-maintenance.js";
+import type { ClaimLedger } from "./claim-ledger.js";
+import type { EventLedger } from "./event-ledger.js";
+import type { GovernorLedger } from "./governor-ledger.js";
+import type { PredictionLedger } from "./prediction-ledger.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+import type { RunStateStore } from "./run-state.js";
+
+const PURGE_USAGE = "Usage: loopover-miner purge --repo <owner/repo> [--dry-run] [--json]";
+
+export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE =
+  "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
+
+export type ParsedPurgeArgs = { json: boolean; dryRun: boolean; repoFullName: string } | { error: string };
+
+export type PurgeStoreResult = { store: string; purged: number | null; error?: string; note?: string };
+export type PurgeDryRunStoreResult = { store: string; wouldPurge: number | null; error?: string };
+
+export type PurgeDryRunResult = {
+  outcome: "dry_run";
+  repoFullName: string;
+  stores: PurgeDryRunStoreResult[];
+  attemptLogNote: string;
+  attemptLogTotalRows: number;
+};
+
+export type PurgeSummary = {
+  outcome: "purged" | "partial";
+  repoFullName: string;
+  totalPurged: number;
+  stores: PurgeStoreResult[];
+  purgedAt: string;
+};
+
+export type PurgeCliOptions = {
+  openClaimLedger?: () => ClaimLedger;
+  initEventLedger?: () => EventLedger;
+  initGovernorLedger?: () => GovernorLedger;
+  initPredictionLedger?: () => PredictionLedger;
+  initPortfolioQueueStore?: () => PortfolioQueueStore;
+  initRunStateStore?: () => RunStateStore;
+  resolveDbPaths?: Record<string, () => string>;
+};
+
+/** The shared slice every store opener returns that this command actually touches: a per-repo purge and a
+ *  close. Each concrete store type (ClaimLedger, EventLedger, ...) is structurally a superset of this. */
+type PurgeableStore = { purgeByRepo(repoFullName: string): number; close(): void };
+type StoreOpener = () => PurgeableStore;
+type ResolveDbPath = (env?: Record<string, string | undefined>) => string;
+
+/** One entry in the REAL_PURGE_TARGETS descriptor table. A target scopes either a single repo-columned table
+ *  (`spec`) or -- for governor-state -- several tables in one DB file (`specs`); exactly one is set per row. */
+type PurgeTarget = {
+  name: string;
+  optionKey: string;
+  opener: StoreOpener;
+  resolveDbPath: ResolveDbPath;
+  spec?: LedgerPurgeSpec;
+  specs?: LedgerPurgeSpec[];
+};
+
+const REAL_PURGE_TARGETS: PurgeTarget[] = [
+  { name: "claim-ledger", optionKey: "openClaimLedger", opener: openClaimLedger, resolveDbPath: resolveClaimLedgerDbPath, spec: CLAIM_LEDGER_PURGE_SPEC },
+  { name: "event-ledger", optionKey: "initEventLedger", opener: initEventLedger, resolveDbPath: resolveEventLedgerDbPath, spec: EVENT_LEDGER_PURGE_SPEC },
+  { name: "governor-ledger", optionKey: "initGovernorLedger", opener: initGovernorLedger, resolveDbPath: resolveGovernorLedgerDbPath, spec: GOVERNOR_LEDGER_PURGE_SPEC },
+  { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
+  { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
+  { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
+  { name: "contribution-profile-cache", optionKey: "initContributionProfileCache", opener: initContributionProfileCache, resolveDbPath: resolveContributionProfileCacheDbPath, spec: CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC },
+  // governor-state holds TWO repo-scoped tables in one DB file; its store.purgeByRepo deletes both against a
+  // single handle (never reopening the file), and its dry-run count sums both via `specs` (#7091).
+  { name: "governor-state", optionKey: "openGovernorState", opener: openGovernorState, resolveDbPath: resolveGovernorStateDbPath, specs: [GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC] },
+  { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
+];
+
+function parseRepoArg(value: string | undefined, usage: string): { error: string } | { repoFullName: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra]: (string | undefined)[] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parsePurgeArgs(args: string[]): ParsedPurgeArgs {
+  const options: { json: boolean; dryRun: boolean; repoFullName: string | null } = { json: false, dryRun: false, repoFullName: null };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      // Only the flag-look-alike case is checked here ("--repo --json") -- a genuinely missing value (repoArg
+      // undefined) falls through to parseRepoArg's own `!value` guard below, the single source of truth for that.
+      if (repoArg !== undefined && repoArg.startsWith("-")) return { error: PURGE_USAGE };
+      const repo = parseRepoArg(repoArg, PURGE_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    return { error: `Unknown option: ${token}` };
+  }
+
+  if (!options.repoFullName) return { error: PURGE_USAGE };
+  return { json: options.json, dryRun: options.dryRun, repoFullName: options.repoFullName };
+}
+
+/** Read-only row count against an on-disk store file, for --dry-run. `{ readOnly: true }` (camelCase) is the
+ *  only option node:sqlite recognizes for a driver-enforced read-only connection -- the lowercase `readonly`
+ *  key is silently ignored. Never touches a store that doesn't exist yet (opening one -- even read-only --
+ *  requires the file to already be there; a dry run must make zero writes). */
+function countExistingRows(dbPath: string, countFn: (db: DatabaseSync) => number): number {
+  if (!existsSync(dbPath)) return 0;
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return countFn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function renderDryRunSummary(result: PurgeDryRunResult): string {
+  const purgeableLine = result.stores
+    .map((entry) => `${entry.store}=${entry.wouldPurge}`)
+    .join(", ");
+  return [
+    `DRY RUN: would purge ${result.repoFullName} from: ${purgeableLine}. No writes were made.`,
+    `${ATTEMPT_LOG_NOT_PURGEABLE_NOTE} (${result.attemptLogTotalRows} total row(s) currently in attempt-log, all repos).`,
+  ].join("\n");
+}
+
+export function runPurgeDryRun(parsed: { repoFullName: string; json: boolean }, options: PurgeCliOptions = {}): number {
+  const resolveDbPaths = options.resolveDbPaths ?? {};
+  const stores: PurgeDryRunStoreResult[] = REAL_PURGE_TARGETS.map((target) => {
+    const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
+    // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
+    // per-table counts against the single read-only handle so the preview matches what a real purge removes.
+    const specs = target.specs ?? [target.spec!];
+    try {
+      const wouldPurge = countExistingRows(dbPath, (db) =>
+        specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0),
+      );
+      return { store: target.name, wouldPurge };
+    } catch (error) {
+      return { store: target.name, wouldPurge: null, error: describeError(error) };
+    }
+  });
+
+  const attemptLogDbPath = (resolveDbPaths["attempt-log"] ?? resolveAttemptLogDbPath)();
+  const attemptLogTotalRows = countExistingRows(attemptLogDbPath, (db) =>
+    Number((db.prepare("SELECT COUNT(*) AS count FROM attempt_log_events").get() as { count: number | bigint }).count),
+  );
+
+  const result: PurgeDryRunResult = {
+    outcome: "dry_run",
+    repoFullName: parsed.repoFullName,
+    stores,
+    attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+    attemptLogTotalRows,
+  };
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(renderDryRunSummary(result));
+  }
+  return 0;
+}
+
+function purgeOneStore(target: PurgeTarget, options: PurgeCliOptions, repoFullName: string): PurgeStoreResult {
+  const injectedOpener = (options as unknown as Record<string, StoreOpener | undefined>)[target.optionKey];
+  const ownsStore = injectedOpener === undefined;
+  let store: PurgeableStore | undefined;
+  try {
+    store = (injectedOpener ?? target.opener)();
+    const purged = store.purgeByRepo(repoFullName);
+    return { store: target.name, purged };
+  } catch (error) {
+    return { store: target.name, purged: null, error: describeError(error) };
+  } finally {
+    if (ownsStore) store?.close();
+  }
+}
+
+function renderPurgeSummary(summary: PurgeSummary): string {
+  const perStore = summary.stores
+    .map((entry) => {
+      if ("error" in entry) return `${entry.store}=ERROR(${entry.error})`;
+      if (entry.purged === null) return `${entry.store}=skipped`;
+      return `${entry.store}=${entry.purged}`;
+    })
+    .join(", ");
+  return [
+    `Purged ${summary.totalPurged} row(s) for ${summary.repoFullName} at ${summary.purgedAt}: ${perStore}.`,
+    ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+  ].join(" ");
+}
+
+export function runPurge(args: string[], options: PurgeCliOptions = {}): number {
+  const parsed = parsePurgeArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    return runPurgeDryRun(parsed, options);
+  }
+
+  const perStoreResults = REAL_PURGE_TARGETS.map((target) => purgeOneStore(target, options, parsed.repoFullName));
+  perStoreResults.push({ store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE });
+
+  const totalPurged = perStoreResults.reduce((sum, entry) => sum + (entry.purged ?? 0), 0);
+  const hadError = perStoreResults.some((entry) => "error" in entry);
+  const summary: PurgeSummary = {
+    outcome: hadError ? "partial" : "purged",
+    repoFullName: parsed.repoFullName,
+    totalPurged,
+    stores: perStoreResults,
+    purgedAt: new Date().toISOString(),
+  };
+
+  // Audit-observable by design (#5564): print the summary in BOTH the success and partial-failure case, so a
+  // purge -- or a purge that only partly succeeded -- is never silent.
+  if (parsed.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(renderPurgeSummary(summary));
+  }
+  return hadError ? 2 : 0;
+}

--- a/packages/loopover-miner/lib/run-state-cli.d.ts
+++ b/packages/loopover-miner/lib/run-state-cli.d.ts
@@ -1,27 +1,22 @@
-export type ParsedStateGetArgs =
-  | {
-      repoFullName: string;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export type ParsedStateSetArgs =
-  | {
-      repoFullName: string;
-      state: "idle" | "discovering" | "planning" | "preparing";
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export function parseStateGetArgs(args: string[]): ParsedStateGetArgs;
-
-export function parseStateSetArgs(args: string[]): ParsedStateSetArgs;
-
-export function runStateGet(args: string[]): number;
-
-export function runStateSet(args: string[]): number;
-
-export function runStateCli(subcommand: string | undefined, args: string[]): number;
+import type { RunState } from "./run-state.js";
+export type ParsedStateGetArgs = {
+    repoFullName: string;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedStateSetArgs = {
+    repoFullName: string;
+    state: RunState;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export declare function parseStateGetArgs(args: string[]): ParsedStateGetArgs;
+export declare function parseStateSetArgs(args: string[]): ParsedStateSetArgs;
+export declare function runStateGet(args: string[]): number;
+export declare function runStateSet(args: string[]): number;
+export declare function runStateCli(subcommand: string | undefined, args: string[]): number;

--- a/packages/loopover-miner/lib/run-state-cli.js
+++ b/packages/loopover-miner/lib/run-state-cli.js
@@ -1,154 +1,148 @@
 import { RUN_STATES, getRunState, setRunState } from "./run-state.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 const STATE_GET_USAGE = "Usage: loopover-miner state get <owner/repo> [--api-base-url <url>] [--json]";
-const STATE_SET_USAGE =
-  "Usage: loopover-miner state set <owner/repo> <idle|discovering|planning|preparing> [--api-base-url <url>] [--dry-run] [--json]";
-
+const STATE_SET_USAGE = "Usage: loopover-miner state set <owner/repo> <idle|discovering|planning|preparing> [--api-base-url <url>] [--dry-run] [--json]";
 const allowedRunStates = new Set(RUN_STATES);
-
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parseStateGetArgs(args) {
-  const options = { json: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, apiBaseUrl: undefined };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #5563: scope the lookup to a non-default forge host, so it doesn't collide with (or get confused for) a
+        // same-named repo on the default github.com host.
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: STATE_GET_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #5563: scope the lookup to a non-default forge host, so it doesn't collide with (or get confused for) a
-    // same-named repo on the default github.com host.
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 1) {
         return { error: STATE_GET_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length !== 1) {
-    return { error: STATE_GET_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
-  if ("error" in repo) return repo;
-
-  return { repoFullName: repo.repoFullName, ...options };
+    const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
+    if ("error" in repo)
+        return repo;
+    return { repoFullName: repo.repoFullName, ...options };
 }
-
 export function parseStateSetArgs(args) {
-  const options = { json: false, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what a real state set would do and returns before writing to the run-state store.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: STATE_SET_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #4847: reports what a real state set would do and returns before writing to the run-state store.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: STATE_SET_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
+    const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
+    if ("error" in repo)
+        return repo;
+    const state = positional[1];
+    if (!allowedRunStates.has(state)) {
+        return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
     }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: STATE_SET_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
-  if ("error" in repo) return repo;
-
-  const state = positional[1];
-  if (!allowedRunStates.has(state)) {
-    return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
-  }
-
-  return { repoFullName: repo.repoFullName, state, ...options };
+    return { repoFullName: repo.repoFullName, state: state, ...options };
 }
-
 export function runStateGet(args) {
-  const parsed = parseStateGetArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    const state = getRunState(parsed.repoFullName, parsed.apiBaseUrl);
-    if (parsed.json) {
-      console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
-    } else {
-      console.log(state ?? "none");
+    const parsed = parseStateGetArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    try {
+        const state = getRunState(parsed.repoFullName, parsed.apiBaseUrl);
+        if (parsed.json) {
+            console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
+        }
+        else {
+            console.log(state ?? "none");
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runStateSet(args) {
-  const parsed = parseStateSetArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, state: parsed.state };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      console.log(`DRY RUN: would set ${parsed.repoFullName}'s run state to "${parsed.state}". No run-state write was made.`);
+    const parsed = parseStateSetArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    const write = setRunState(parsed.repoFullName, parsed.state, parsed.apiBaseUrl);
-    if (parsed.json) {
-      console.log(JSON.stringify(write));
-    } else {
-      console.log(write.state);
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, state: parsed.state };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            console.log(`DRY RUN: would set ${parsed.repoFullName}'s run state to "${parsed.state}". No run-state write was made.`);
+        }
+        return 0;
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    try {
+        const write = setRunState(parsed.repoFullName, parsed.state, parsed.apiBaseUrl);
+        if (parsed.json) {
+            console.log(JSON.stringify(write));
+        }
+        else {
+            console.log(write.state);
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runStateCli(subcommand, args) {
-  if (subcommand === "get") return runStateGet(args);
-  if (subcommand === "set") return runStateSet(args);
-  return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
+    if (subcommand === "get")
+        return runStateGet(args);
+    if (subcommand === "set")
+        return runStateSet(args);
+    return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicnVuLXN0YXRlLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInJ1bi1zdGF0ZS1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLFVBQVUsRUFBRSxXQUFXLEVBQUUsV0FBVyxFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFFdEUsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBb0JsRixNQUFNLGVBQWUsR0FBRyw4RUFBOEUsQ0FBQztBQUN2RyxNQUFNLGVBQWUsR0FDbkIsZ0lBQWdJLENBQUM7QUFFbkksTUFBTSxnQkFBZ0IsR0FBRyxJQUFJLEdBQUcsQ0FBUyxVQUFVLENBQUMsQ0FBQztBQUVyRCxTQUFTLFlBQVksQ0FBQyxLQUF5QixFQUFFLEtBQWE7SUFDNUQsSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO0lBQ3BDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM3QixNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2hELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVMsRUFBRSxDQUFDO1FBQzNDLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxNQUFNLFVBQVUsaUJBQWlCLENBQUMsSUFBYztJQUM5QyxNQUFNLE9BQU8sR0FBc0QsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsQ0FBQztJQUMxRyxNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELDBHQUEwRztRQUMxRyxrREFBa0Q7UUFDbEQsSUFBSSxLQUFLLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQztZQUMvQixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNwQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGVBQWUsRUFBRSxDQUFDO1lBQ3BDLENBQUM7WUFDRCxPQUFPLENBQUMsVUFBVSxHQUFHLEtBQUssQ0FBQztZQUMzQixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDNUIsT0FBTyxFQUFFLEtBQUssRUFBRSxlQUFlLEVBQUUsQ0FBQztJQUNwQyxDQUFDO0lBRUQsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxlQUFlLENBQUMsQ0FBQztJQUMxRCxJQUFJLE9BQU8sSUFBSSxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFFakMsT0FBTyxFQUFFLFlBQVksRUFBRSxJQUFJLENBQUMsWUFBWSxFQUFFLEdBQUcsT0FBTyxFQUFFLENBQUM7QUFDekQsQ0FBQztBQUVELE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxJQUFjO0lBQzlDLE1BQU0sT0FBTyxHQUF1RTtRQUNsRixJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsVUFBVSxFQUFFLFNBQVM7S0FDdEIsQ0FBQztJQUNGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsbUdBQW1HO1FBQ25HLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQztZQUMvQixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNwQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGVBQWUsRUFBRSxDQUFDO1lBQ3BDLENBQUM7WUFDRCxPQUFPLENBQUMsVUFBVSxHQUFHLEtBQUssQ0FBQztZQUMzQixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDNUIsT0FBTyxFQUFFLEtBQUssRUFBRSxlQUFlLEVBQUUsQ0FBQztJQUNwQyxDQUFDO0lBRUQsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxlQUFlLENBQUMsQ0FBQztJQUMxRCxJQUFJLE9BQU8sSUFBSSxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFFakMsTUFBTSxLQUFLLEdBQUcsVUFBVSxDQUFDLENBQUMsQ0FBRSxDQUFDO0lBQzdCLElBQUksQ0FBQyxnQkFBZ0IsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUNqQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGtCQUFrQixLQUFLLHFCQUFxQixVQUFVLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUN6RixDQUFDO0lBRUQsT0FBTyxFQUFFLFlBQVksRUFBRSxJQUFJLENBQUMsWUFBWSxFQUFFLEtBQUssRUFBRSxLQUFpQixFQUFFLEdBQUcsT0FBTyxFQUFFLENBQUM7QUFDbkYsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsSUFBYztJQUN4QyxNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN2QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxNQUFNLENBQUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQztRQUNsRSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDNUUsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLEtBQUssSUFBSSxNQUFNLENBQUMsQ0FBQztRQUMvQixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFdBQVcsQ0FBQyxJQUFjO0lBQ3hDLE1BQU0sTUFBTSxHQUFHLGlCQUFpQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3ZDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDcEcsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUM7UUFDNUMsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHNCQUFzQixNQUFNLENBQUMsWUFBWSxvQkFBb0IsTUFBTSxDQUFDLEtBQUssaUNBQWlDLENBQUMsQ0FBQztRQUMxSCxDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsTUFBTSxLQUFLLEdBQUcsV0FBVyxDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLEtBQUssRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUM7UUFDaEYsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7UUFDckMsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMzQixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFdBQVcsQ0FBQyxVQUE4QixFQUFFLElBQWM7SUFDeEUsSUFBSSxVQUFVLEtBQUssS0FBSztRQUFFLE9BQU8sV0FBVyxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ25ELElBQUksVUFBVSxLQUFLLEtBQUs7UUFBRSxPQUFPLFdBQVcsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNuRCxPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSw2QkFBNkIsVUFBVSxJQUFJLEVBQUUsS0FBSyxlQUFlLEVBQUUsQ0FBQyxDQUFDO0FBQ25ILENBQUMifQ==

--- a/packages/loopover-miner/lib/run-state-cli.ts
+++ b/packages/loopover-miner/lib/run-state-cli.ts
@@ -1,0 +1,177 @@
+import { RUN_STATES, getRunState, setRunState } from "./run-state.js";
+import type { RunState } from "./run-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+export type ParsedStateGetArgs =
+  | {
+      repoFullName: string;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedStateSetArgs =
+  | {
+      repoFullName: string;
+      state: RunState;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+const STATE_GET_USAGE = "Usage: loopover-miner state get <owner/repo> [--api-base-url <url>] [--json]";
+const STATE_SET_USAGE =
+  "Usage: loopover-miner state set <owner/repo> <idle|discovering|planning|preparing> [--api-base-url <url>] [--dry-run] [--json]";
+
+const allowedRunStates = new Set<string>(RUN_STATES);
+
+function parseRepoArg(value: string | undefined, usage: string): { repoFullName: string } | { error: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parseStateGetArgs(args: string[]): ParsedStateGetArgs {
+  const options: { json: boolean; apiBaseUrl: string | undefined } = { json: false, apiBaseUrl: undefined };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #5563: scope the lookup to a non-default forge host, so it doesn't collide with (or get confused for) a
+    // same-named repo on the default github.com host.
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: STATE_GET_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 1) {
+    return { error: STATE_GET_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
+  if ("error" in repo) return repo;
+
+  return { repoFullName: repo.repoFullName, ...options };
+}
+
+export function parseStateSetArgs(args: string[]): ParsedStateSetArgs {
+  const options: { json: boolean; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what a real state set would do and returns before writing to the run-state store.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: STATE_SET_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: STATE_SET_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
+  if ("error" in repo) return repo;
+
+  const state = positional[1]!;
+  if (!allowedRunStates.has(state)) {
+    return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
+  }
+
+  return { repoFullName: repo.repoFullName, state: state as RunState, ...options };
+}
+
+export function runStateGet(args: string[]): number {
+  const parsed = parseStateGetArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    const state = getRunState(parsed.repoFullName, parsed.apiBaseUrl);
+    if (parsed.json) {
+      console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
+    } else {
+      console.log(state ?? "none");
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runStateSet(args: string[]): number {
+  const parsed = parseStateSetArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, state: parsed.state };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      console.log(`DRY RUN: would set ${parsed.repoFullName}'s run state to "${parsed.state}". No run-state write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    const write = setRunState(parsed.repoFullName, parsed.state, parsed.apiBaseUrl);
+    if (parsed.json) {
+      console.log(JSON.stringify(write));
+    } else {
+      console.log(write.state);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runStateCli(subcommand: string | undefined, args: string[]): number {
+  if (subcommand === "get") return runStateGet(args);
+  if (subcommand === "set") return runStateSet(args);
+  return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
+}

--- a/test/unit/miner-claim-ledger-cli.test.ts
+++ b/test/unit/miner-claim-ledger-cli.test.ts
@@ -354,6 +354,57 @@ describe("loopover-miner claim ledger CLI (#4290)", () => {
     expect(log).toHaveBeenCalled();
   });
 
+  it("parsers reject empty/missing positional and flag values across every code path", () => {
+    // parseRepoArg's `if (!value)` guard: an empty positional owner/repo slot (not a shape mismatch).
+    expect(parseClaimClaimArgs(["", "42"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim claim"),
+    });
+    // parseIssueNumberArg's `if (!value)` guard: an empty positional issue slot.
+    expect(parseClaimClaimArgs(["acme/widgets", ""])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim claim"),
+    });
+
+    // Release path propagates both parseRepoArg and parseIssueNumberArg failures.
+    expect(parseClaimReleaseArgs(["acme", "7"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimReleaseArgs(["acme/widgets", "0"])).toEqual({
+      error: "issue number must be a positive integer.",
+    });
+
+    // List path propagates a malformed --repo value, and rejects a --status flag with no value.
+    expect(parseClaimListArgs(["--repo", "acme"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimListArgs(["--status"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim list"),
+    });
+    expect(parseClaimListArgs(["--status", "--json"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim list"),
+    });
+  });
+
+  it("opens and closes the real default on-disk claim ledger when no override is supplied", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-claim-ledger-cli-default-"));
+    roots.push(root);
+    const previous = process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB;
+    process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = join(root, "claim-ledger.sqlite3");
+    try {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      // No `openClaimLedger` injected: exercises the real default factory (withClaimLedger owns + closes it).
+      expect(runClaimClaim(["acme/widgets", "42", "--note", "on it"])).toBe(0);
+      expect(log).toHaveBeenCalledWith("active");
+
+      // Reopen through the same default path to confirm the owned ledger was closed and the write persisted.
+      const reopened = openClaimLedger(process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB);
+      ledgers.push(reopened);
+      expect(reopened.listClaims({ repoFullName: "acme/widgets" })).toHaveLength(1);
+    } finally {
+      if (previous === undefined) delete process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB;
+      else process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = previous;
+    }
+  });
+
   it("rejects unknown claim subcommands, options, and ledger failures", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(runClaimCli("peek", [])).toBe(2);
@@ -402,5 +453,13 @@ describe("loopover-miner claim ledger CLI (#4290)", () => {
       }),
     ).toBe(2);
     expect(error).toHaveBeenCalledWith("list_broken");
+
+    // runClaimRelease and runClaimList short-circuit on a parse error without ever opening the ledger.
+    error.mockClear();
+    expect(runClaimRelease(["acme/widgets"])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Usage: loopover-miner claim release");
+    error.mockClear();
+    expect(runClaimList(["extra"])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Usage: loopover-miner claim list");
   });
 });

--- a/test/unit/miner-cli-run-state.test.ts
+++ b/test/unit/miner-cli-run-state.test.ts
@@ -14,6 +14,7 @@ const {
   parseStateSetArgs,
   runStateGet,
   runStateSet,
+  runStateCli,
 } = await import("../../packages/loopover-miner/lib/run-state-cli.js");
 
 afterEach(() => {
@@ -129,6 +130,53 @@ describe("loopover-miner state CLI", () => {
       ok: false,
       error: "Repository must be in owner/repo form.",
     });
+  });
+
+  it("parseStateGetArgs rejects unknown flags, an empty repo token, and a malformed repo", () => {
+    expect(parseStateGetArgs(["acme/widgets", "--bogus"])).toEqual({
+      error: "Unknown option: --bogus",
+    });
+    // An empty positional token trips the falsy-value guard inside parseRepoArg.
+    expect(parseStateGetArgs([""])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner state get"),
+    });
+    expect(parseStateGetArgs(["not-a-repo"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+  });
+
+  it("parseStateSetArgs rejects unknown flags and the wrong positional count", () => {
+    expect(parseStateSetArgs(["acme/widgets", "planning", "-x"])).toEqual({
+      error: "Unknown option: -x",
+    });
+    expect(parseStateSetArgs(["acme/widgets"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner state set"),
+    });
+    expect(parseStateSetArgs(["acme/widgets", "planning", "extra"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner state set"),
+    });
+  });
+
+  it("runStateCli dispatches get and set and rejects unknown subcommands", () => {
+    getRunState.mockReturnValue(null);
+    setRunState.mockReturnValue({
+      repoFullName: "acme/widgets",
+      state: "idle",
+      updatedAt: "2026-07-03T00:00:00.000Z",
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runStateCli("get", ["acme/widgets"])).toBe(0);
+    expect(getRunState).toHaveBeenCalledWith("acme/widgets", undefined);
+    expect(runStateCli("set", ["acme/widgets", "idle"])).toBe(0);
+    expect(setRunState).toHaveBeenCalledWith("acme/widgets", "idle", undefined);
+    log.mockRestore();
+
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runStateCli("bogus", [])).toBe(2);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("Unknown state subcommand: bogus"));
+    // An undefined subcommand exercises the nullish-coalescing fallback in the message.
+    expect(runStateCli(undefined, [])).toBe(2);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("Unknown state subcommand: ."));
   });
 
   it("runStateGet returns exit code 2 when the store read fails", () => {

--- a/test/unit/miner-event-ledger-cli.test.ts
+++ b/test/unit/miner-event-ledger-cli.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../packages/loopover-miner/lib/event-ledger.js";
 import {
   filterLedgerEvents,
+  normalizeAuditFeedMcpFilter,
   parseLedgerListArgs,
   renderEventLedgerMetrics,
   renderLedgerTable,
@@ -37,6 +38,9 @@ function tempEventDbPath() {
 function metricEntry(seq: number, type: string): LedgerEntry {
   return { id: seq, seq, type, repoFullName: null, payload: {}, createdAt: "2026-07-04T12:00:00.000Z" };
 }
+
+const LEDGER_LIST_USAGE =
+  "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
 
 afterEach(() => {
   for (const ledger of ledgers.splice(0)) ledger.close();
@@ -171,6 +175,63 @@ describe("loopover-miner event ledger CLI (#2290)", () => {
       }),
     ).toBe(2);
     expect(error).toHaveBeenCalledWith("since must be a non-negative integer seq cursor.");
+  });
+
+  // #7306: cover the remaining argv-parse guards for each option flag.
+  it("parseLedgerListArgs rejects missing or flag-shaped option values", () => {
+    expect(parseLedgerListArgs(["--repo"])).toEqual({ error: LEDGER_LIST_USAGE });
+    expect(parseLedgerListArgs(["--repo", "-x"])).toEqual({ error: LEDGER_LIST_USAGE });
+    expect(parseLedgerListArgs(["--since"])).toEqual({ error: LEDGER_LIST_USAGE });
+    expect(parseLedgerListArgs(["--since", "--nope"])).toEqual({ error: LEDGER_LIST_USAGE });
+    expect(parseLedgerListArgs(["--type"])).toEqual({ error: LEDGER_LIST_USAGE });
+    expect(parseLedgerListArgs(["--type", "-x"])).toEqual({ error: LEDGER_LIST_USAGE });
+  });
+
+  it("parseLedgerListArgs rejects unknown options and stray positional arguments", () => {
+    expect(parseLedgerListArgs(["--bogus"])).toEqual({ error: "Unknown option: --bogus" });
+    expect(parseLedgerListArgs(["stray"])).toEqual({ error: LEDGER_LIST_USAGE });
+  });
+
+  it("filterLedgerEvents returns an empty array when handed a non-array", () => {
+    expect(filterLedgerEvents(null as unknown as LedgerEntry[])).toEqual([]);
+  });
+
+  it("renderLedgerTable renders '-' for a null repo column", () => {
+    const row = renderLedgerTable([
+      { id: 1, seq: 1, type: "plan_built", repoFullName: null, payload: {}, createdAt: "2026-07-04T12:00:00.000Z" },
+    ]).split("\n")[1]!;
+    expect(row).toMatch(/plan_built\s+-\s/);
+  });
+
+  it("normalizeAuditFeedMcpFilter rejects an empty repo and a non-integer since", () => {
+    expect(() => normalizeAuditFeedMcpFilter({ repoFullName: "" })).toThrow(
+      "repoFullName must be in owner/repo form.",
+    );
+    expect(() => normalizeAuditFeedMcpFilter({ since: 1.5 as unknown as number })).toThrow(
+      "since must be a non-negative integer seq cursor.",
+    );
+  });
+
+  it("runLedgerList surfaces an error thrown while reading the ledger", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      runLedgerList([], {
+        initEventLedger: () =>
+          ({
+            readEvents: () => {
+              throw new Error("event ledger is locked");
+            },
+            close: () => undefined,
+          }) as unknown as ReturnType<typeof initEventLedger>,
+      }),
+    ).toBe(2);
+    expect(error).toHaveBeenCalledWith("event ledger is locked");
+  });
+
+  it("runLedgerCli reports an undefined subcommand", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runLedgerCli(undefined, [])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Unknown ledger subcommand: .");
   });
 });
 

--- a/test/unit/miner-governor-ledger-cli.test.ts
+++ b/test/unit/miner-governor-ledger-cli.test.ts
@@ -187,4 +187,70 @@ describe("loopover-miner governor ledger CLI (#2328)", () => {
     expect(await runGovernorList(["--verbose"])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Unknown option");
   });
+
+  it("rejects --repo and --type flags whose value is missing or flag-shaped", () => {
+    const usage = expect.stringContaining("Usage: loopover-miner governor list");
+    expect(parseGovernorListArgs(["--repo"])).toEqual({ error: usage });
+    expect(parseGovernorListArgs(["--repo", "--json"])).toEqual({ error: usage });
+    expect(parseGovernorListArgs(["--type"])).toEqual({ error: usage });
+    expect(parseGovernorListArgs(["--type", "--json"])).toEqual({ error: usage });
+  });
+
+  it("rejects stray positional arguments", () => {
+    expect(parseGovernorListArgs(["extra"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner governor list"),
+    });
+  });
+
+  it("filterGovernorEvents returns [] when handed a non-array", () => {
+    expect(filterGovernorEvents(null as never)).toEqual([]);
+    expect(filterGovernorEvents(undefined as never)).toEqual([]);
+  });
+
+  it("renderGovernorTable collapses null repo and ts columns to '-' via display()", () => {
+    const events: GovernorLedgerEntry[] = [
+      {
+        id: 7,
+        ts: null as never,
+        eventType: "allowed",
+        repoFullName: null,
+        actionClass: "analyze",
+        decision: "allow",
+        reason: "no repo recorded",
+        payload: {},
+      },
+    ];
+    const table = renderGovernorTable(events);
+    // both the repo and ts columns render the display() placeholder for null/undefined.
+    expect(table.match(/-/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("runGovernorList reports a CLI failure when the ledger read throws (catch path)", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const throwingLedger = {
+      readGovernorEvents: () => {
+        throw new Error("ledger read boom");
+      },
+      close: vi.fn(),
+    };
+    expect(await runGovernorList([], { initGovernorLedger: () => throwingLedger as never })).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("ledger read boom");
+    // caller-owned ledger must not be closed by runGovernorList
+    expect(throwingLedger.close).not.toHaveBeenCalled();
+  });
+
+  it("opens and closes the real default governor ledger when no initGovernorLedger override is supplied", async () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-ledger-cli-default-"));
+    roots.push(root);
+    const previous = process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB;
+    process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB = join(root, "governor-ledger.sqlite3");
+    try {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(await runGovernorList(["--json"])).toBe(0);
+      expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ events: [] });
+    } finally {
+      if (previous === undefined) delete process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB;
+      else process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB = previous;
+    }
+  });
 });

--- a/test/unit/miner-plan-store-cli.test.ts
+++ b/test/unit/miner-plan-store-cli.test.ts
@@ -164,4 +164,76 @@ describe("loopover-miner plan store CLI (#2318)", () => {
       error: expect.stringContaining("Unknown plan subcommand"),
     });
   });
+
+  it("runPlanCli reports a missing subcommand as unknown", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runPlanCli(undefined, [])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Unknown plan subcommand");
+  });
+
+  it("parsePlanShowArgs propagates parseJsonFlag unknown-option errors", () => {
+    expect(parsePlanShowArgs(["--verbose"])).toEqual({ error: "Unknown option: --verbose" });
+  });
+
+  it("parsePlanListArgs rejects --status with a missing or flag-shaped value", () => {
+    expect(parsePlanListArgs(["--status"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner plan list"),
+    });
+    expect(parsePlanListArgs(["--status", "--json"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner plan list"),
+    });
+  });
+
+  it("parsePlanListArgs rejects unknown options and stray positionals", () => {
+    expect(parsePlanListArgs(["--bogus"])).toEqual({ error: "Unknown option: --bogus" });
+    expect(parsePlanListArgs(["extra"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner plan list"),
+    });
+  });
+
+  it("parsePlanShowArgs rejects a whitespace-only plan id", () => {
+    expect(parsePlanShowArgs(["   "])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner plan show"),
+    });
+  });
+
+  it("renderPlanTable renders '-' for a missing updated-at", () => {
+    const plans: PlanRecord[] = [
+      {
+        planId: "beta",
+        status: "pending",
+        updatedAt: null as unknown as string,
+        plan: PLAN,
+      },
+    ];
+    const rowLine = renderPlanTable(plans).split("\n")[1] ?? "";
+    expect(rowLine).toContain("beta");
+    expect(rowLine.trimEnd().endsWith("-")).toBe(true);
+  });
+
+  it("opens and closes the real default plan store when no openPlanStore override is supplied", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-plan-store-cli-default-"));
+    roots.push(root);
+    const dbPath = join(root, "plan-store.sqlite3");
+    const seeded = openPlanStore(dbPath);
+    seeded.savePlan("default-plan", PLAN);
+    seeded.close();
+
+    const previous = process.env.LOOPOVER_MINER_PLAN_STORE_DB;
+    process.env.LOOPOVER_MINER_PLAN_STORE_DB = dbPath;
+    try {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(runPlanList(["--json"])).toBe(0);
+      expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+        plans: [expect.objectContaining({ planId: "default-plan" })],
+      });
+
+      log.mockClear();
+      expect(runPlanShow(["default-plan"])).toBe(0);
+      expect(log).toHaveBeenCalledWith("running (2 steps)");
+    } finally {
+      if (previous === undefined) delete process.env.LOOPOVER_MINER_PLAN_STORE_DB;
+      else process.env.LOOPOVER_MINER_PLAN_STORE_DB = previous;
+    }
+  });
 });


### PR DESCRIPTION
chore(miner): migrate CLI command loopover-miner/lib modules to TypeScript

Batch 3.2 of the #7290 migration: converts plan-store-cli, run-state-cli,
governor-ledger-cli, purge-cli, event-ledger-cli, and claim-ledger-cli (plus
their hand-maintained .d.ts siblings) from .js to real .ts, using the
in-place-emit build pipeline Phase 1 (#7299) already wired up. No behavior
change; the existing tests continue to pass unmodified against the compiled
output, and each converted module is covered to 100% of its lines.

Closes #7306

