### PR TITLE
chore(miner): migrate batch 4.3 foundational lib modules to TypeScript

### DIFF
--- a/packages/loopover-miner/lib/governor-chokepoint.d.ts
+++ b/packages/loopover-miner/lib/governor-chokepoint.d.ts
@@ -1,14 +1,21 @@
-import type { GovernorChokepointInput, GovernorDecision, WriteRateLimitBackoffStore, WriteRateLimitBucketStore } from "@loopover/engine";
-import type { AppendGovernorEventInput, GovernorLedgerEntry } from "./governor-ledger.js";
-
+import { type GovernorChokepointInput, type GovernorDecision, type WriteRateLimitBackoffStore, type WriteRateLimitBucketStore } from "@loopover/engine";
+import { type AppendGovernorEventInput, type GovernorLedgerEntry } from "./governor-ledger.js";
 export type EvaluateGovernorChokepointGateResult = {
-  decision: GovernorDecision;
-  recorded: GovernorLedgerEntry;
-  rateLimitBuckets: WriteRateLimitBucketStore;
-  rateLimitBackoffAttempts: WriteRateLimitBackoffStore;
+    decision: GovernorDecision;
+    recorded: GovernorLedgerEntry;
+    rateLimitBuckets: WriteRateLimitBucketStore;
+    rateLimitBackoffAttempts: WriteRateLimitBackoffStore;
 };
-
-export function evaluateGovernorChokepointGate(
-  input: GovernorChokepointInput,
-  options?: { append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry },
-): EvaluateGovernorChokepointGateResult;
+/**
+ * Evaluate a write action against the full Governor precedence ladder, persist the resulting ledger event, and
+ * advance rate-limit bucket/backoff state only for the two outcomes that actually consumed (or were denied at)
+ * the rate-limit stage: a final `"allow"` verdict advances the bucket, and a `"rate_limit"`-stage denial bumps
+ * backoff. Every other stage -- kill-switch, dry-run, budget-cap, non-convergence, reputation-throttle,
+ * self-plagiarism, internal_error -- denies for a reason unrelated to rate limiting and must leave bucket/backoff
+ * state untouched, since no real write happened and the rate-limit stage's own "allowed" sub-verdict (still
+ * present in `decision.detail.rateLimit` once that stage has cleared) does not mean the action was ultimately
+ * allowed.
+ */
+export declare function evaluateGovernorChokepointGate(input: GovernorChokepointInput, options?: {
+    append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry;
+}): EvaluateGovernorChokepointGateResult;

--- a/packages/loopover-miner/lib/governor-chokepoint.js
+++ b/packages/loopover-miner/lib/governor-chokepoint.js
@@ -3,15 +3,8 @@
 // rate-limit stage actually ran) advancing/backing-off the rate-limit bucket state. This is the ONLY sanctioned
 // call site a real write action (open_pr, file_issue, apply_labels, post_eligibility_comment, create_branch,
 // delete_branch, generate_tests) should be gated through.
-
-import {
-  clearWriteRateLimitBackoff,
-  evaluateGovernorChokepoint,
-  recordWriteRateLimitAllowed,
-  recordWriteRateLimitDenied,
-} from "@loopover/engine";
+import { clearWriteRateLimitBackoff, evaluateGovernorChokepoint, recordWriteRateLimitAllowed, recordWriteRateLimitDenied, } from "@loopover/engine";
 import { appendGovernorEvent } from "./governor-ledger.js";
-
 /**
  * Evaluate a write action against the full Governor precedence ladder, persist the resulting ledger event, and
  * advance rate-limit bucket/backoff state only for the two outcomes that actually consumed (or were denied at)
@@ -21,35 +14,23 @@ import { appendGovernorEvent } from "./governor-ledger.js";
  * state untouched, since no real write happened and the rate-limit stage's own "allowed" sub-verdict (still
  * present in `decision.detail.rateLimit` once that stage has cleared) does not mean the action was ultimately
  * allowed.
- *
- * @param {import("@loopover/engine").GovernorChokepointInput} input
- * @param {{ append?: typeof appendGovernorEvent }} [options]
- * @returns {{
- *   decision: import("@loopover/engine").GovernorDecision,
- *   recorded: import("./governor-ledger.js").GovernorLedgerEntry,
- *   rateLimitBuckets: import("@loopover/engine").WriteRateLimitBucketStore,
- *   rateLimitBackoffAttempts: import("@loopover/engine").WriteRateLimitBackoffStore,
- * }}
  */
 export function evaluateGovernorChokepointGate(input, options = {}) {
-  const append = options.append ?? appendGovernorEvent;
-  const decision = evaluateGovernorChokepoint(input);
-  const recorded = append(decision.ledgerEvent);
-
-  let rateLimitBuckets = input.rateLimitBuckets;
-  let rateLimitBackoffAttempts = input.rateLimitBackoffAttempts;
-  if (decision.stage === "allow") {
-    rateLimitBuckets = recordWriteRateLimitAllowed(
-      input.rateLimitBuckets,
-      input.actionClass,
-      input.repoFullName,
-      input.nowMs,
-      input.rateLimitPolicies,
-    );
-    rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
-  } else if (decision.stage === "rate_limit") {
-    rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
-  }
-
-  return { decision, recorded, rateLimitBuckets, rateLimitBackoffAttempts };
+    const append = options.append ?? appendGovernorEvent;
+    const decision = evaluateGovernorChokepoint(input);
+    // Same wider-declared-than-actual mismatch as governor-kill-switch.ts's cast: the engine's ledgerEvent type
+    // allows an explicit `undefined` value on optional fields (never actually produced), which this module's
+    // narrower AppendGovernorEventInput rejects under `exactOptionalPropertyTypes`.
+    const recorded = append(decision.ledgerEvent);
+    let rateLimitBuckets = input.rateLimitBuckets;
+    let rateLimitBackoffAttempts = input.rateLimitBackoffAttempts;
+    if (decision.stage === "allow") {
+        rateLimitBuckets = recordWriteRateLimitAllowed(input.rateLimitBuckets, input.actionClass, input.repoFullName, input.nowMs, input.rateLimitPolicies);
+        rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
+    }
+    else if (decision.stage === "rate_limit") {
+        rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
+    }
+    return { decision, recorded, rateLimitBuckets, rateLimitBackoffAttempts };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItY2hva2Vwb2ludC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImdvdmVybm9yLWNob2tlcG9pbnQudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsNkdBQTZHO0FBQzdHLDBHQUEwRztBQUMxRyxnSEFBZ0g7QUFDaEgsNkdBQTZHO0FBQzdHLDBEQUEwRDtBQUUxRCxPQUFPLEVBQ0wsMEJBQTBCLEVBQzFCLDBCQUEwQixFQUMxQiwyQkFBMkIsRUFDM0IsMEJBQTBCLEdBSzNCLE1BQU0sa0JBQWtCLENBQUM7QUFDMUIsT0FBTyxFQUFFLG1CQUFtQixFQUEyRCxNQUFNLHNCQUFzQixDQUFDO0FBU3BIOzs7Ozs7Ozs7R0FTRztBQUNILE1BQU0sVUFBVSw4QkFBOEIsQ0FDNUMsS0FBOEIsRUFDOUIsVUFBaUYsRUFBRTtJQUVuRixNQUFNLE1BQU0sR0FBRyxPQUFPLENBQUMsTUFBTSxJQUFJLG1CQUFtQixDQUFDO0lBQ3JELE1BQU0sUUFBUSxHQUFHLDBCQUEwQixDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ25ELDRHQUE0RztJQUM1Ryx5R0FBeUc7SUFDekcsZ0ZBQWdGO0lBQ2hGLE1BQU0sUUFBUSxHQUFHLE1BQU0sQ0FBQyxRQUFRLENBQUMsV0FBdUMsQ0FBQyxDQUFDO0lBRTFFLElBQUksZ0JBQWdCLEdBQUcsS0FBSyxDQUFDLGdCQUFnQixDQUFDO0lBQzlDLElBQUksd0JBQXdCLEdBQUcsS0FBSyxDQUFDLHdCQUF3QixDQUFDO0lBQzlELElBQUksUUFBUSxDQUFDLEtBQUssS0FBSyxPQUFPLEVBQUUsQ0FBQztRQUMvQixnQkFBZ0IsR0FBRywyQkFBMkIsQ0FDNUMsS0FBSyxDQUFDLGdCQUFnQixFQUN0QixLQUFLLENBQUMsV0FBVyxFQUNqQixLQUFLLENBQUMsWUFBWSxFQUNsQixLQUFLLENBQUMsS0FBSyxFQUNYLEtBQUssQ0FBQyxpQkFBaUIsQ0FDeEIsQ0FBQztRQUNGLHdCQUF3QixHQUFHLDBCQUEwQixDQUFDLEtBQUssQ0FBQyx3QkFBd0IsRUFBRSxLQUFLLENBQUMsV0FBVyxFQUFFLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMvSCxDQUFDO1NBQU0sSUFBSSxRQUFRLENBQUMsS0FBSyxLQUFLLFlBQVksRUFBRSxDQUFDO1FBQzNDLHdCQUF3QixHQUFHLDBCQUEwQixDQUFDLEtBQUssQ0FBQyx3QkFBd0IsRUFBRSxLQUFLLENBQUMsV0FBVyxFQUFFLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMvSCxDQUFDO0lBRUQsT0FBTyxFQUFFLFFBQVEsRUFBRSxRQUFRLEVBQUUsZ0JBQWdCLEVBQUUsd0JBQXdCLEVBQUUsQ0FBQztBQUM1RSxDQUFDIn0=

--- a/packages/loopover-miner/lib/governor-chokepoint.ts
+++ b/packages/loopover-miner/lib/governor-chokepoint.ts
@@ -1,0 +1,63 @@
+// The Governor chokepoint gate (#2340). Wraps the pure `evaluateGovernorChokepoint` engine decision with the
+// two stateful side effects every caller needs: persisting the resulting ledger event, and (only when the
+// rate-limit stage actually ran) advancing/backing-off the rate-limit bucket state. This is the ONLY sanctioned
+// call site a real write action (open_pr, file_issue, apply_labels, post_eligibility_comment, create_branch,
+// delete_branch, generate_tests) should be gated through.
+
+import {
+  clearWriteRateLimitBackoff,
+  evaluateGovernorChokepoint,
+  recordWriteRateLimitAllowed,
+  recordWriteRateLimitDenied,
+  type GovernorChokepointInput,
+  type GovernorDecision,
+  type WriteRateLimitBackoffStore,
+  type WriteRateLimitBucketStore,
+} from "@loopover/engine";
+import { appendGovernorEvent, type AppendGovernorEventInput, type GovernorLedgerEntry } from "./governor-ledger.js";
+
+export type EvaluateGovernorChokepointGateResult = {
+  decision: GovernorDecision;
+  recorded: GovernorLedgerEntry;
+  rateLimitBuckets: WriteRateLimitBucketStore;
+  rateLimitBackoffAttempts: WriteRateLimitBackoffStore;
+};
+
+/**
+ * Evaluate a write action against the full Governor precedence ladder, persist the resulting ledger event, and
+ * advance rate-limit bucket/backoff state only for the two outcomes that actually consumed (or were denied at)
+ * the rate-limit stage: a final `"allow"` verdict advances the bucket, and a `"rate_limit"`-stage denial bumps
+ * backoff. Every other stage -- kill-switch, dry-run, budget-cap, non-convergence, reputation-throttle,
+ * self-plagiarism, internal_error -- denies for a reason unrelated to rate limiting and must leave bucket/backoff
+ * state untouched, since no real write happened and the rate-limit stage's own "allowed" sub-verdict (still
+ * present in `decision.detail.rateLimit` once that stage has cleared) does not mean the action was ultimately
+ * allowed.
+ */
+export function evaluateGovernorChokepointGate(
+  input: GovernorChokepointInput,
+  options: { append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry } = {},
+): EvaluateGovernorChokepointGateResult {
+  const append = options.append ?? appendGovernorEvent;
+  const decision = evaluateGovernorChokepoint(input);
+  // Same wider-declared-than-actual mismatch as governor-kill-switch.ts's cast: the engine's ledgerEvent type
+  // allows an explicit `undefined` value on optional fields (never actually produced), which this module's
+  // narrower AppendGovernorEventInput rejects under `exactOptionalPropertyTypes`.
+  const recorded = append(decision.ledgerEvent as AppendGovernorEventInput);
+
+  let rateLimitBuckets = input.rateLimitBuckets;
+  let rateLimitBackoffAttempts = input.rateLimitBackoffAttempts;
+  if (decision.stage === "allow") {
+    rateLimitBuckets = recordWriteRateLimitAllowed(
+      input.rateLimitBuckets,
+      input.actionClass,
+      input.repoFullName,
+      input.nowMs,
+      input.rateLimitPolicies,
+    );
+    rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
+  } else if (decision.stage === "rate_limit") {
+    rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
+  }
+
+  return { decision, recorded, rateLimitBuckets, rateLimitBackoffAttempts };
+}

--- a/packages/loopover-miner/lib/governor-kill-switch.d.ts
+++ b/packages/loopover-miner/lib/governor-kill-switch.d.ts
@@ -1,26 +1,29 @@
-import type { MinerKillSwitchScope } from "@loopover/engine";
-import type { AppendGovernorEventInput, GovernorLedgerEntry } from "./governor-ledger.js";
-
+import { type MinerKillSwitchScope } from "@loopover/engine";
+import { type AppendGovernorEventInput, type GovernorLedgerEntry } from "./governor-ledger.js";
 export type CheckMinerKillSwitchInput = {
-  repoPaused?: boolean;
-  env?: Record<string, string | undefined>;
+    repoPaused?: boolean;
+    env?: Record<string, string | undefined>;
 };
-
 export type CheckMinerKillSwitchResult = {
-  scope: MinerKillSwitchScope;
-  active: boolean;
+    scope: MinerKillSwitchScope;
+    active: boolean;
 };
-
-export function checkMinerKillSwitch(input?: CheckMinerKillSwitchInput): CheckMinerKillSwitchResult;
-
+/**
+ * Resolve the current kill-switch scope for a repo from process env plus a per-repo paused flag (typically
+ * `MinerGoalSpec.killSwitch.paused` from the repo's parsed `.loopover-miner.yml`).
+ */
+export declare function checkMinerKillSwitch(input?: CheckMinerKillSwitchInput): CheckMinerKillSwitchResult;
 export type RecordMinerKillSwitchTransitionInput = {
-  repoFullName?: string;
-  actionClass: string;
-  previousScope: MinerKillSwitchScope;
-  scope: MinerKillSwitchScope;
+    repoFullName?: string;
+    actionClass: string;
+    previousScope: MinerKillSwitchScope;
+    scope: MinerKillSwitchScope;
 };
-
-export function recordMinerKillSwitchTransition(
-  input: RecordMinerKillSwitchTransitionInput,
-  options?: { append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry },
-): GovernorLedgerEntry | null;
+/**
+ * Record a kill-switch state transition to the governor ledger. No-op (returns null, appends nothing) when the
+ * scope has not actually changed since the previous check — callers own tracking the previous scope (in-memory
+ * or persisted); this module holds no state of its own.
+ */
+export declare function recordMinerKillSwitchTransition(input: RecordMinerKillSwitchTransitionInput, options?: {
+    append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry;
+}): GovernorLedgerEntry | null;

--- a/packages/loopover-miner/lib/governor-kill-switch.js
+++ b/packages/loopover-miner/lib/governor-kill-switch.js
@@ -2,46 +2,33 @@
 // env, or for one repo, via its .loopover-miner.yml MinerGoalSpec) and records STATE TRANSITIONS to the
 // append-only governor ledger. Every-check allow/deny recording for a real write action is the fail-closed
 // Governor chokepoint's job (#2340), which consults this module first in its "safest wins" precedence.
-
-import {
-  buildMinerKillSwitchTransitionGovernorLedgerEvent,
-  isGlobalMinerKillSwitch,
-  isMinerKillSwitchActive,
-  resolveMinerKillSwitch,
-} from "@loopover/engine";
+import { buildMinerKillSwitchTransitionGovernorLedgerEvent, isGlobalMinerKillSwitch, isMinerKillSwitchActive, resolveMinerKillSwitch, } from "@loopover/engine";
 import { appendGovernorEvent } from "./governor-ledger.js";
-
 /**
  * Resolve the current kill-switch scope for a repo from process env plus a per-repo paused flag (typically
  * `MinerGoalSpec.killSwitch.paused` from the repo's parsed `.loopover-miner.yml`).
- *
- * @param {object} [input]
- * @param {boolean} [input.repoPaused]
- * @param {Record<string, string | undefined>} [input.env]
- * @returns {{ scope: import("@loopover/engine").MinerKillSwitchScope, active: boolean }}
  */
 export function checkMinerKillSwitch(input = {}) {
-  const env = input.env ?? process.env;
-  const global = isGlobalMinerKillSwitch(env);
-  const scope = resolveMinerKillSwitch({ global, repoPaused: input.repoPaused });
-  return { scope, active: isMinerKillSwitchActive(scope) };
+    const env = input.env ?? process.env;
+    const global = isGlobalMinerKillSwitch(env);
+    const scope = resolveMinerKillSwitch({ global, repoPaused: input.repoPaused });
+    return { scope, active: isMinerKillSwitchActive(scope) };
 }
-
 /**
  * Record a kill-switch state transition to the governor ledger. No-op (returns null, appends nothing) when the
  * scope has not actually changed since the previous check — callers own tracking the previous scope (in-memory
  * or persisted); this module holds no state of its own.
- *
- * @param {object} input
- * @param {string} [input.repoFullName]
- * @param {string} input.actionClass
- * @param {import("@loopover/engine").MinerKillSwitchScope} input.previousScope
- * @param {import("@loopover/engine").MinerKillSwitchScope} input.scope
- * @param {{ append?: typeof appendGovernorEvent }} [options]
  */
 export function recordMinerKillSwitchTransition(input, options = {}) {
-  const event = buildMinerKillSwitchTransitionGovernorLedgerEvent(input);
-  if (!event) return null;
-  const append = options.append ?? appendGovernorEvent;
-  return append(event);
+    const event = buildMinerKillSwitchTransitionGovernorLedgerEvent(input);
+    if (!event)
+        return null;
+    const append = options.append ?? appendGovernorEvent;
+    // The engine's own GovernorLedgerEvent type allows an explicit `repoFullName: undefined`/`payload: undefined`
+    // value (not just omission); this module's AppendGovernorEventInput is narrower (never an explicit
+    // `undefined`, only omitted) under this repo's `exactOptionalPropertyTypes`. The real value here is always
+    // `string | null` (built via `?? null` in buildMinerKillSwitchTransitionGovernorLedgerEvent), so the cast is
+    // safe -- only the declared type is wider than the actual runtime shape.
+    return append(event);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3Ita2lsbC1zd2l0Y2guanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJnb3Zlcm5vci1raWxsLXN3aXRjaC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSw4R0FBOEc7QUFDOUcsd0dBQXdHO0FBQ3hHLDJHQUEyRztBQUMzRyx1R0FBdUc7QUFFdkcsT0FBTyxFQUNMLGlEQUFpRCxFQUNqRCx1QkFBdUIsRUFDdkIsdUJBQXVCLEVBQ3ZCLHNCQUFzQixHQUV2QixNQUFNLGtCQUFrQixDQUFDO0FBQzFCLE9BQU8sRUFBRSxtQkFBbUIsRUFBMkQsTUFBTSxzQkFBc0IsQ0FBQztBQVlwSDs7O0dBR0c7QUFDSCxNQUFNLFVBQVUsb0JBQW9CLENBQUMsUUFBbUMsRUFBRTtJQUN4RSxNQUFNLEdBQUcsR0FBRyxLQUFLLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUM7SUFDckMsTUFBTSxNQUFNLEdBQUcsdUJBQXVCLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDNUMsTUFBTSxLQUFLLEdBQUcsc0JBQXNCLENBQUMsRUFBRSxNQUFNLEVBQUUsVUFBVSxFQUFFLEtBQUssQ0FBQyxVQUFVLEVBQUUsQ0FBQyxDQUFDO0lBQy9FLE9BQU8sRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLHVCQUF1QixDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUM7QUFDM0QsQ0FBQztBQVNEOzs7O0dBSUc7QUFDSCxNQUFNLFVBQVUsK0JBQStCLENBQzdDLEtBQTJDLEVBQzNDLFVBQWlGLEVBQUU7SUFFbkYsTUFBTSxLQUFLLEdBQUcsaURBQWlELENBQUMsS0FBSyxDQUFDLENBQUM7SUFDdkUsSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN4QixNQUFNLE1BQU0sR0FBRyxPQUFPLENBQUMsTUFBTSxJQUFJLG1CQUFtQixDQUFDO0lBQ3JELDhHQUE4RztJQUM5RyxtR0FBbUc7SUFDbkcsMkdBQTJHO0lBQzNHLDZHQUE2RztJQUM3Ryx5RUFBeUU7SUFDekUsT0FBTyxNQUFNLENBQUMsS0FBaUMsQ0FBQyxDQUFDO0FBQ25ELENBQUMifQ==

--- a/packages/loopover-miner/lib/governor-kill-switch.ts
+++ b/packages/loopover-miner/lib/governor-kill-switch.ts
@@ -1,0 +1,61 @@
+// Governor kill-switch gate (#2341). Resolves whether miner write activity is currently halted (globally, via
+// env, or for one repo, via its .loopover-miner.yml MinerGoalSpec) and records STATE TRANSITIONS to the
+// append-only governor ledger. Every-check allow/deny recording for a real write action is the fail-closed
+// Governor chokepoint's job (#2340), which consults this module first in its "safest wins" precedence.
+
+import {
+  buildMinerKillSwitchTransitionGovernorLedgerEvent,
+  isGlobalMinerKillSwitch,
+  isMinerKillSwitchActive,
+  resolveMinerKillSwitch,
+  type MinerKillSwitchScope,
+} from "@loopover/engine";
+import { appendGovernorEvent, type AppendGovernorEventInput, type GovernorLedgerEntry } from "./governor-ledger.js";
+
+export type CheckMinerKillSwitchInput = {
+  repoPaused?: boolean;
+  env?: Record<string, string | undefined>;
+};
+
+export type CheckMinerKillSwitchResult = {
+  scope: MinerKillSwitchScope;
+  active: boolean;
+};
+
+/**
+ * Resolve the current kill-switch scope for a repo from process env plus a per-repo paused flag (typically
+ * `MinerGoalSpec.killSwitch.paused` from the repo's parsed `.loopover-miner.yml`).
+ */
+export function checkMinerKillSwitch(input: CheckMinerKillSwitchInput = {}): CheckMinerKillSwitchResult {
+  const env = input.env ?? process.env;
+  const global = isGlobalMinerKillSwitch(env);
+  const scope = resolveMinerKillSwitch({ global, repoPaused: input.repoPaused });
+  return { scope, active: isMinerKillSwitchActive(scope) };
+}
+
+export type RecordMinerKillSwitchTransitionInput = {
+  repoFullName?: string;
+  actionClass: string;
+  previousScope: MinerKillSwitchScope;
+  scope: MinerKillSwitchScope;
+};
+
+/**
+ * Record a kill-switch state transition to the governor ledger. No-op (returns null, appends nothing) when the
+ * scope has not actually changed since the previous check — callers own tracking the previous scope (in-memory
+ * or persisted); this module holds no state of its own.
+ */
+export function recordMinerKillSwitchTransition(
+  input: RecordMinerKillSwitchTransitionInput,
+  options: { append?: (event: AppendGovernorEventInput) => GovernorLedgerEntry } = {},
+): GovernorLedgerEntry | null {
+  const event = buildMinerKillSwitchTransitionGovernorLedgerEvent(input);
+  if (!event) return null;
+  const append = options.append ?? appendGovernorEvent;
+  // The engine's own GovernorLedgerEvent type allows an explicit `repoFullName: undefined`/`payload: undefined`
+  // value (not just omission); this module's AppendGovernorEventInput is narrower (never an explicit
+  // `undefined`, only omitted) under this repo's `exactOptionalPropertyTypes`. The real value here is always
+  // `string | null` (built via `?? null` in buildMinerKillSwitchTransitionGovernorLedgerEvent), so the cast is
+  // safe -- only the declared type is wider than the actual runtime shape.
+  return append(event as AppendGovernorEventInput);
+}

--- a/packages/loopover-miner/lib/laptop-init.d.ts
+++ b/packages/loopover-miner/lib/laptop-init.d.ts
@@ -1,53 +1,62 @@
+type Env = Record<string, string | undefined>;
+/** Path to the laptop-mode SQLite bootstrap file inside the miner state directory. */
+export declare function resolveLaptopStateDbPath(env?: Env): string;
 export type LaptopInitResult = {
-  stateDir: string;
-  dbPath: string;
-  created: boolean;
+    stateDir: string;
+    dbPath: string;
+    created: boolean;
 };
-
+/** Create the state dir and SQLite file. Re-running is idempotent and never clobbers existing rows. */
+export declare function initLaptopState(env?: Env): LaptopInitResult;
 export type DoctorCheck = {
-  name: string;
-  ok: boolean;
-  detail: string;
+    name: string;
+    ok: boolean;
+    detail: string;
 };
-
+export declare function checkLaptopStateSqlite(env?: Env): DoctorCheck;
+/** Exported so callers that only need a presence boolean (e.g. status.js's `driver` section, #5164) can reuse
+ *  this PATH scan directly instead of duplicating it or parsing a DoctorCheck's detail string. */
+export declare function findExecutableOnPath(name: string, env?: Env): string | null;
+/** Informational only — Docker is never required for laptop mode. */
+export declare function checkDockerPresent(options?: {
+    env?: Env;
+    resolveDockerPath?: () => string | null;
+}): DoctorCheck;
+export declare function resolveCodexAuthPath(env?: Env): string;
 export type GithubTokenVerification = {
-  ok: boolean;
-  login: string | null;
-  scopes: string[];
-  detail: string;
+    ok: boolean;
+    login: string | null;
+    scopes: string[];
+    detail: string;
 };
-
-export function resolveLaptopStateDbPath(env?: Record<string, string | undefined>): string;
-
-export function initLaptopState(env?: Record<string, string | undefined>): LaptopInitResult;
-
-export function checkLaptopStateSqlite(env?: Record<string, string | undefined>): DoctorCheck;
-
-export function findExecutableOnPath(name: string, env?: Record<string, string | undefined>): string | null;
-
-export function checkDockerPresent(options?: {
-  env?: Record<string, string | undefined>;
-  resolveDockerPath?: () => string | null;
-}): DoctorCheck;
-
-export function checkClaudeCliPresent(options?: {
-  env?: Record<string, string | undefined>;
-  resolveClaudePath?: () => string | null;
-}): DoctorCheck;
-
-export function checkCodexCliPresent(options?: {
-  env?: Record<string, string | undefined>;
-  resolveCodexPath?: () => string | null;
-  resolveCodexAuthPath?: () => string;
-}): DoctorCheck;
-
-export function resolveCodexAuthPath(env?: Record<string, string | undefined>): string;
-
-export function verifyGithubToken(options?: {
-  githubToken?: string;
-  fetchImpl?: typeof fetch;
-  apiBaseUrl?: string;
-  timeoutMs?: number;
+/**
+ * Validate a GitHub token with one authenticated API call.
+ *
+ * The classic OAuth scope header is advisory when GitHub reports it: if GitHub returns `repo` or
+ * `public_repo`, we treat the token as sufficiently scoped for miner setup. If GitHub omits the classic
+ * scope header altogether, the token is still considered valid and the response is reported as "scopes not
+ * reported" — that keeps fine-grained tokens usable while still surfacing the scopes GitHub did return.
+ */
+export declare function verifyGithubToken(options?: {
+    githubToken?: string;
+    fetchImpl?: typeof fetch;
+    apiBaseUrl?: string;
+    timeoutMs?: number;
 }): Promise<GithubTokenVerification>;
-
-export function runInit(args?: string[], env?: Record<string, string | undefined>): Promise<number>;
+/** Informational unless `MINER_CODING_AGENT_PROVIDER=claude-cli` (#5165), in which case a missing CLI fails
+ *  doctor. The auth probe is read-only and never spawns the CLI: it surfaces, proactively, the SAME condition
+ *  claude checks at call time — `CLAUDE_CODE_OAUTH_TOKEN` present (see createClaudeCodeAi, src/selfhost/ai.ts). */
+export declare function checkClaudeCliPresent(options?: {
+    env?: Env;
+    resolveClaudePath?: () => string | null;
+}): DoctorCheck;
+/** Informational unless `MINER_CODING_AGENT_PROVIDER=codex-cli` (#5165), in which case a missing CLI fails
+ *  doctor — mirrors {@link checkClaudeCliPresent}. The auth probe checks the same read-only condition
+ *  assertCodexAuthConfigured uses at call time: codex's `auth.json` is readable. */
+export declare function checkCodexCliPresent(options?: {
+    env?: Env;
+    resolveCodexPath?: () => string | null;
+    resolveCodexAuthPath?: () => string;
+}): DoctorCheck;
+export declare function runInit(args?: string[], env?: Env): Promise<number>;
+export {};

--- a/packages/loopover-miner/lib/laptop-init.js
+++ b/packages/loopover-miner/lib/laptop-init.js
@@ -5,150 +5,144 @@ import { DatabaseSync } from "node:sqlite";
 import { applySchemaMigrations } from "./schema-version.js";
 import { reportCliFailure } from "./cli-error.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
-
 const githubApiBaseUrl = "https://api.github.com";
 const githubApiVersion = "2022-11-28";
 const classicRepoScopes = new Set(["repo", "public_repo"]);
 const defaultDbFileName = "laptop-state.sqlite3";
-
 /** Local state directory (mirrors `resolveMinerStateDir` in status.js — kept local to avoid import cycles). */
 function resolveMinerStateDir(env = process.env) {
-  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
-    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
-    : "";
-  if (explicitConfigDir) return explicitConfigDir;
-
-  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
-    ? env.XDG_CONFIG_HOME.trim()
-    : join(homedir(), ".config");
-  return join(configHome, "loopover-miner");
+    const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
+        ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
+        : "";
+    if (explicitConfigDir)
+        return explicitConfigDir;
+    const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+        ? env.XDG_CONFIG_HOME.trim()
+        : join(homedir(), ".config");
+    return join(configHome, "loopover-miner");
 }
-
 /** Path to the laptop-mode SQLite bootstrap file inside the miner state directory. */
 export function resolveLaptopStateDbPath(env = process.env) {
-  return join(resolveMinerStateDir(env), defaultDbFileName);
+    return join(resolveMinerStateDir(env), defaultDbFileName);
 }
-
 /** Create the state dir and SQLite file. Re-running is idempotent and never clobbers existing rows. */
 export function initLaptopState(env = process.env) {
-  const stateDir = resolveMinerStateDir(env);
-  const dbPath = resolveLaptopStateDbPath(env);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  const created = !existsSync(dbPath);
-  const db = new DatabaseSync(dbPath);
-  db.exec(`
+    const stateDir = resolveMinerStateDir(env);
+    const dbPath = resolveLaptopStateDbPath(env);
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    const created = !existsSync(dbPath);
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
     CREATE TABLE IF NOT EXISTS laptop_meta (
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL
     )
   `);
-  // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations (none yet).
-  applySchemaMigrations(db, []);
-  if (created) {
-    db.prepare("INSERT INTO laptop_meta (key, value) VALUES ('initialized_at', ?)")
-      .run(new Date().toISOString());
-  }
-  chmodSync(dbPath, 0o600);
-  db.close();
-  return { stateDir, dbPath, created };
-}
-
-export function checkLaptopStateSqlite(env = process.env) {
-  const dbPath = resolveLaptopStateDbPath(env);
-  if (!existsSync(dbPath)) {
-    return {
-      name: "laptop-state-sqlite",
-      ok: false,
-      detail: `${dbPath}: not found (run loopover-miner init)`,
-    };
-  }
-  try {
-    // `readOnly` (camelCase) -- node:sqlite silently IGNORES `readonly` (lowercase) as an unrecognized option
-    // and opens read-write anyway, which would break doctor's own "no writes, no network" contract. Same
-    // footgun already documented in claim-ledger.js's openClaimLedgerReadOnly and purge-cli.js.
-    const db = new DatabaseSync(dbPath, { readOnly: true });
-    db.prepare("SELECT 1").get();
+    // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations (none yet).
+    applySchemaMigrations(db, []);
+    if (created) {
+        db.prepare("INSERT INTO laptop_meta (key, value) VALUES ('initialized_at', ?)")
+            .run(new Date().toISOString());
+    }
+    chmodSync(dbPath, 0o600);
     db.close();
-    return { name: "laptop-state-sqlite", ok: true, detail: dbPath };
-  } catch (error) {
-    return {
-      name: "laptop-state-sqlite",
-      ok: false,
-      detail: `${dbPath}: ${error instanceof Error ? error.message : "not readable"}`,
-    };
-  }
+    return { stateDir, dbPath, created };
 }
-
+export function checkLaptopStateSqlite(env = process.env) {
+    const dbPath = resolveLaptopStateDbPath(env);
+    if (!existsSync(dbPath)) {
+        return {
+            name: "laptop-state-sqlite",
+            ok: false,
+            detail: `${dbPath}: not found (run loopover-miner init)`,
+        };
+    }
+    try {
+        // `readOnly` (camelCase) -- node:sqlite silently IGNORES `readonly` (lowercase) as an unrecognized option
+        // and opens read-write anyway, which would break doctor's own "no writes, no network" contract. Same
+        // footgun already documented in claim-ledger.js's openClaimLedgerReadOnly and purge-cli.js.
+        const db = new DatabaseSync(dbPath, { readOnly: true });
+        db.prepare("SELECT 1").get();
+        db.close();
+        return { name: "laptop-state-sqlite", ok: true, detail: dbPath };
+    }
+    catch (error) {
+        return {
+            name: "laptop-state-sqlite",
+            ok: false,
+            detail: `${dbPath}: ${error instanceof Error ? error.message : "not readable"}`,
+        };
+    }
+}
 /** Exported so callers that only need a presence boolean (e.g. status.js's `driver` section, #5164) can reuse
  *  this PATH scan directly instead of duplicating it or parsing a DoctorCheck's detail string. */
 export function findExecutableOnPath(name, env = process.env) {
-  const pathValue = typeof env.PATH === "string" ? env.PATH : "";
-  for (const pathEntry of pathValue.split(delimiter)) {
-    if (!pathEntry) continue;
-    const candidate = join(pathEntry, name);
-    try {
-      accessSync(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      // Keep scanning: PATH often contains missing or unreadable entries.
+    const pathValue = typeof env.PATH === "string" ? env.PATH : "";
+    for (const pathEntry of pathValue.split(delimiter)) {
+        if (!pathEntry)
+            continue;
+        const candidate = join(pathEntry, name);
+        try {
+            accessSync(candidate, constants.X_OK);
+            return candidate;
+        }
+        catch {
+            // Keep scanning: PATH often contains missing or unreadable entries.
+        }
     }
-  }
-  return null;
+    return null;
 }
-
 /** Informational only — Docker is never required for laptop mode. */
 export function checkDockerPresent(options = {}) {
-  const resolveDockerPath = options.resolveDockerPath
-    ?? (() => findExecutableOnPath("docker", options.env));
-  const dockerPath = resolveDockerPath();
-  return {
-    name: "docker-present",
-    ok: true,
-    detail: dockerPath ? `found at ${dockerPath}` : "not installed (optional for laptop mode)",
-  };
+    const resolveDockerPath = options.resolveDockerPath
+        ?? (() => findExecutableOnPath("docker", options.env));
+    const dockerPath = resolveDockerPath();
+    return {
+        name: "docker-present",
+        ok: true,
+        detail: dockerPath ? `found at ${dockerPath}` : "not installed (optional for laptop mode)",
+    };
 }
-
 // Codex stores credentials at `$CODEX_HOME/auth.json`, else `$HOME/.codex/auth.json` — mirrors
 // resolveCodexAuthPath in src/selfhost/ai.ts, kept local so the offline miner package never imports the
 // Worker AI module. Exported so `doctor`'s provider-credential check (status.js, #5170) resolves the SAME
 // path this file's own codex auth probe uses, instead of duplicating the location logic.
 export function resolveCodexAuthPath(env = process.env) {
-  const base = env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex");
-  return join(base, "auth.json");
+    const base = env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex");
+    return join(base, "auth.json");
 }
-
+// `githubToken` is always a string (never undefined) here -- verifyGithubToken's own
+// `typeof options.githubToken === "string"` guard already normalizes it before this is called.
 function githubHeaders(githubToken) {
-  const headers = {
-    accept: "application/vnd.github+json",
-    "user-agent": "loopover-miner",
-    "x-github-api-version": githubApiVersion,
-  };
-  const token = typeof githubToken === "string" ? githubToken.trim() : "";
-  if (token) headers.authorization = `Bearer ${token}`;
-  return headers;
+    const headers = {
+        accept: "application/vnd.github+json",
+        "user-agent": "loopover-miner",
+        "x-github-api-version": githubApiVersion,
+    };
+    const token = githubToken.trim();
+    if (token)
+        headers.authorization = `Bearer ${token}`;
+    return headers;
 }
-
 function parseScopesHeader(scopesHeader) {
-  return typeof scopesHeader === "string" && scopesHeader.trim()
-    ? scopesHeader.split(",").map((scope) => scope.trim()).filter(Boolean)
-    : [];
+    return typeof scopesHeader === "string" && scopesHeader.trim()
+        ? scopesHeader.split(",").map((scope) => scope.trim()).filter(Boolean)
+        : [];
 }
-
+// Both call sites below already guard `scopes.length > 0` before calling this, so scopes is always
+// non-empty here -- no "none reported" fallback needed (that phrasing lives inline at each call site instead).
 function formatScopes(scopes) {
-  return scopes.length > 0 ? scopes.join(", ") : "none reported";
+    return scopes.join(", ");
 }
-
 function hasRepoAccessScope(scopes) {
-  return scopes.some((scope) => classicRepoScopes.has(scope));
+    return scopes.some((scope) => classicRepoScopes.has(scope));
 }
-
 function readGithubErrorMessage(payload, status) {
-  if (payload && typeof payload === "object" && typeof payload.message === "string" && payload.message.trim()) {
-    return payload.message.trim();
-  }
-  return `GitHub returned HTTP ${status}`;
+    if (payload && typeof payload === "object" && typeof payload.message === "string" && payload.message.trim()) {
+        return payload.message.trim();
+    }
+    return `GitHub returned HTTP ${status}`;
 }
-
 /**
  * Validate a GitHub token with one authenticated API call.
  *
@@ -158,179 +152,165 @@ function readGithubErrorMessage(payload, status) {
  * reported" — that keeps fine-grained tokens usable while still surfacing the scopes GitHub did return.
  */
 export async function verifyGithubToken(options = {}) {
-  const githubToken = typeof options.githubToken === "string" ? options.githubToken.trim() : "";
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const apiBaseUrl =
-    typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim()
-      ? options.apiBaseUrl.trim().replace(/\/+$/, "") || githubApiBaseUrl
-      : githubApiBaseUrl;
-  const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0 ? options.timeoutMs : 5000;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  let response;
-  try {
-    response = await fetchImpl(`${apiBaseUrl}/user`, {
-      method: "GET",
-      headers: githubHeaders(githubToken),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    const detail = controller.signal.aborted
-      ? `timed out after ${timeoutMs}ms`
-      : error instanceof Error
-        ? error.message
-        : "request failed";
+    const githubToken = typeof options.githubToken === "string" ? options.githubToken.trim() : "";
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const apiBaseUrl = typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim()
+        ? options.apiBaseUrl.trim().replace(/\/+$/, "") || githubApiBaseUrl
+        : githubApiBaseUrl;
+    const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0 ? options.timeoutMs : 5000;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    try {
+        response = await fetchImpl(`${apiBaseUrl}/user`, {
+            method: "GET",
+            headers: githubHeaders(githubToken),
+            signal: controller.signal,
+        });
+    }
+    catch (error) {
+        const detail = controller.signal.aborted
+            ? `timed out after ${timeoutMs}ms`
+            : error instanceof Error
+                ? error.message
+                : "request failed";
+        return {
+            ok: false,
+            login: null,
+            scopes: [],
+            detail: `GITHUB_TOKEN verification failed: ${detail}`,
+        };
+    }
+    finally {
+        clearTimeout(timeout);
+    }
+    const payload = await response.json().catch(() => null);
+    const scopesHeader = response.headers.get("x-oauth-scopes");
+    const scopesHeaderPresent = response.headers.has("x-oauth-scopes");
+    const scopes = parseScopesHeader(scopesHeader);
+    const login = payload && typeof payload === "object" && typeof payload.login === "string" ? payload.login.trim() : "";
+    if (!response.ok) {
+        return {
+            ok: false,
+            login: null,
+            scopes,
+            detail: `GITHUB_TOKEN verification failed: ${readGithubErrorMessage(payload, response.status)}`,
+        };
+    }
+    if (scopesHeaderPresent && scopes.length === 0) {
+        return {
+            ok: false,
+            login: login || null,
+            scopes,
+            detail: "GITHUB_TOKEN is valid, but GitHub returned an empty x-oauth-scopes header; reissue it with repo access for miner setup.",
+        };
+    }
+    if (scopes.length > 0 && !hasRepoAccessScope(scopes)) {
+        return {
+            ok: false,
+            login: login || null,
+            scopes,
+            detail: `GITHUB_TOKEN is valid, but GitHub reported only ${formatScopes(scopes)}; reissue it with repo access for miner setup.`,
+        };
+    }
     return {
-      ok: false,
-      login: null,
-      scopes: [],
-      detail: `GITHUB_TOKEN verification failed: ${detail}`,
+        ok: true,
+        login: login || null,
+        scopes,
+        detail: scopes.length > 0
+            ? `validated GitHub token for ${login || "unknown user"}; scopes: ${formatScopes(scopes)}`
+            : `validated GitHub token for ${login || "unknown user"}; GitHub did not report classic OAuth scopes`,
     };
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  const payload = await response.json().catch(() => null);
-  const scopesHeader = response.headers.get("x-oauth-scopes");
-  const scopesHeaderPresent = response.headers.has("x-oauth-scopes");
-  const scopes = parseScopesHeader(scopesHeader);
-  const login = payload && typeof payload === "object" && typeof payload.login === "string" ? payload.login.trim() : "";
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      login: null,
-      scopes,
-      detail: `GITHUB_TOKEN verification failed: ${readGithubErrorMessage(payload, response.status)}`,
-    };
-  }
-
-  if (scopesHeaderPresent && scopes.length === 0) {
-    return {
-      ok: false,
-      login: login || null,
-      scopes,
-      detail: "GITHUB_TOKEN is valid, but GitHub returned an empty x-oauth-scopes header; reissue it with repo access for miner setup.",
-    };
-  }
-
-  if (scopes.length > 0 && !hasRepoAccessScope(scopes)) {
-    return {
-      ok: false,
-      login: login || null,
-      scopes,
-      detail: `GITHUB_TOKEN is valid, but GitHub reported only ${formatScopes(scopes)}; reissue it with repo access for miner setup.`,
-    };
-  }
-
-  return {
-    ok: true,
-    login: login || null,
-    scopes,
-    detail:
-      scopes.length > 0
-        ? `validated GitHub token for ${login || "unknown user"}; scopes: ${formatScopes(scopes)}`
-        : `validated GitHub token for ${login || "unknown user"}; GitHub did not report classic OAuth scopes`,
-  };
 }
-
 /** A coding-agent CLI is only needed once a driver provider is configured (#4289) — gated by
  *  `MINER_CODING_AGENT_PROVIDER` (#5165). When that provider is NOT the CLI being checked, absence is
  *  advisory (`ok: true`), mirroring checkDockerPresent's optional tone. When it IS configured and the CLI is
  *  missing, `ok: false` — every attempt will fail without it. The auth probe (once found) stays advisory
  *  either way, since an unauthenticated-but-installed CLI is a separate, already-visible warning. */
 function codingAgentProviderConfiguredFor(env, providerName) {
-  return env.MINER_CODING_AGENT_PROVIDER === providerName;
+    return env.MINER_CODING_AGENT_PROVIDER === providerName;
 }
-
 /** Informational unless `MINER_CODING_AGENT_PROVIDER=claude-cli` (#5165), in which case a missing CLI fails
  *  doctor. The auth probe is read-only and never spawns the CLI: it surfaces, proactively, the SAME condition
  *  claude checks at call time — `CLAUDE_CODE_OAUTH_TOKEN` present (see createClaudeCodeAi, src/selfhost/ai.ts). */
 export function checkClaudeCliPresent(options = {}) {
-  const env = options.env ?? process.env;
-  const claudePath = (options.resolveClaudePath ?? (() => findExecutableOnPath("claude", env)))();
-  if (!claudePath) {
-    const configured = codingAgentProviderConfiguredFor(env, "claude-cli");
+    const env = options.env ?? process.env;
+    const claudePath = (options.resolveClaudePath ?? (() => findExecutableOnPath("claude", env)))();
+    if (!claudePath) {
+        const configured = codingAgentProviderConfiguredFor(env, "claude-cli");
+        return {
+            name: "claude-cli-present",
+            ok: !configured,
+            detail: configured
+                ? "not installed — MINER_CODING_AGENT_PROVIDER is set to claude-cli, every attempt will fail without it"
+                : "not installed (optional until a coding-agent driver is configured)",
+        };
+    }
+    const authed = typeof env.CLAUDE_CODE_OAUTH_TOKEN === "string" && env.CLAUDE_CODE_OAUTH_TOKEN.length > 0;
     return {
-      name: "claude-cli-present",
-      ok: !configured,
-      detail: configured
-        ? "not installed — MINER_CODING_AGENT_PROVIDER is set to claude-cli, every attempt will fail without it"
-        : "not installed (optional until a coding-agent driver is configured)",
+        name: "claude-cli-present",
+        ok: true,
+        detail: authed ? `found at ${claudePath} (authenticated)` : `found at ${claudePath} (not authenticated: set CLAUDE_CODE_OAUTH_TOKEN)`,
     };
-  }
-  const authed = typeof env.CLAUDE_CODE_OAUTH_TOKEN === "string" && env.CLAUDE_CODE_OAUTH_TOKEN.length > 0;
-  return {
-    name: "claude-cli-present",
-    ok: true,
-    detail: authed ? `found at ${claudePath} (authenticated)` : `found at ${claudePath} (not authenticated: set CLAUDE_CODE_OAUTH_TOKEN)`,
-  };
 }
-
 /** Informational unless `MINER_CODING_AGENT_PROVIDER=codex-cli` (#5165), in which case a missing CLI fails
  *  doctor — mirrors {@link checkClaudeCliPresent}. The auth probe checks the same read-only condition
  *  assertCodexAuthConfigured uses at call time: codex's `auth.json` is readable. */
 export function checkCodexCliPresent(options = {}) {
-  const env = options.env ?? process.env;
-  const codexPath = (options.resolveCodexPath ?? (() => findExecutableOnPath("codex", env)))();
-  if (!codexPath) {
-    const configured = codingAgentProviderConfiguredFor(env, "codex-cli");
-    return {
-      name: "codex-cli-present",
-      ok: !configured,
-      detail: configured
-        ? "not installed — MINER_CODING_AGENT_PROVIDER is set to codex-cli, every attempt will fail without it"
-        : "not installed (optional until a coding-agent driver is configured)",
-    };
-  }
-  const authPath = (options.resolveCodexAuthPath ?? (() => resolveCodexAuthPath(env)))();
-  let authed = false;
-  try {
-    accessSync(authPath, constants.R_OK);
-    authed = true;
-  } catch {
-    // auth.json missing or unreadable — codex would fail for lack of credentials at call time.
-  }
-  if (authed) {
-    return { name: "codex-cli-present", ok: true, detail: `found at ${codexPath} (authenticated)` };
-  }
-  // codex-cli IS the configured driver but auth.json is missing/expired: a more specific, actionable remediation
-  // than the generic advisory below, mirroring ORB's codexAuthReadinessProbe/assertCodexAuthConfigured wording
-  // (#5166). `ok` stays true either way (unchanged by this issue, see #5165) since the CLI itself IS present --
-  // only the CLI-absent case is a hard doctor failure.
-  const detail = codingAgentProviderConfiguredFor(env, "codex-cli")
-    ? `found at ${codexPath} but auth.json is missing or expired — run \`codex auth\` to authenticate before attempts run`
-    : `found at ${codexPath} (not authenticated: run \`codex auth\`)`;
-  return { name: "codex-cli-present", ok: true, detail };
+    const env = options.env ?? process.env;
+    const codexPath = (options.resolveCodexPath ?? (() => findExecutableOnPath("codex", env)))();
+    if (!codexPath) {
+        const configured = codingAgentProviderConfiguredFor(env, "codex-cli");
+        return {
+            name: "codex-cli-present",
+            ok: !configured,
+            detail: configured
+                ? "not installed — MINER_CODING_AGENT_PROVIDER is set to codex-cli, every attempt will fail without it"
+                : "not installed (optional until a coding-agent driver is configured)",
+        };
+    }
+    const authPath = (options.resolveCodexAuthPath ?? (() => resolveCodexAuthPath(env)))();
+    let authed = false;
+    try {
+        accessSync(authPath, constants.R_OK);
+        authed = true;
+    }
+    catch {
+        // auth.json missing or unreadable — codex would fail for lack of credentials at call time.
+    }
+    if (authed) {
+        return { name: "codex-cli-present", ok: true, detail: `found at ${codexPath} (authenticated)` };
+    }
+    // codex-cli IS the configured driver but auth.json is missing/expired: a more specific, actionable remediation
+    // than the generic advisory below, mirroring ORB's codexAuthReadinessProbe/assertCodexAuthConfigured wording
+    // (#5166). `ok` stays true either way (unchanged by this issue, see #5165) since the CLI itself IS present --
+    // only the CLI-absent case is a hard doctor failure.
+    const detail = codingAgentProviderConfiguredFor(env, "codex-cli")
+        ? `found at ${codexPath} but auth.json is missing or expired — run \`codex auth\` to authenticate before attempts run`
+        : `found at ${codexPath} (not authenticated: run \`codex auth\`)`;
+    return { name: "codex-cli-present", ok: true, detail };
 }
-
 export async function runInit(args = [], env = process.env) {
-  const verifyToken = args.includes("--verify-token");
-  const jsonOutput = args.includes("--json");
-  let verification = null;
-  if (verifyToken) {
-    verification = await verifyGithubToken({ githubToken: (await resolveGitHubToken(env)) ?? "" });
-    if (!verification.ok) {
-      return reportCliFailure(jsonOutput, verification.detail, 1);
+    const verifyToken = args.includes("--verify-token");
+    const jsonOutput = args.includes("--json");
+    let verification = null;
+    if (verifyToken) {
+        verification = await verifyGithubToken({ githubToken: (await resolveGitHubToken(env)) ?? "" });
+        if (!verification.ok) {
+            return reportCliFailure(jsonOutput, verification.detail, 1);
+        }
     }
-  }
-
-  const result = initLaptopState(env);
-  if (jsonOutput) {
-    console.log(
-      JSON.stringify(
-        verification ? { ...result, tokenVerification: verification } : result,
-        null,
-        2,
-      ),
-    );
-  } else {
-    console.log(`initialized ${result.stateDir}`);
-    console.log(`sqlite: ${result.dbPath}${result.created ? "" : " (already existed)"}`);
-    if (verification) {
-      console.log(`token: ${verification.detail}`);
+    const result = initLaptopState(env);
+    if (jsonOutput) {
+        console.log(JSON.stringify(verification ? { ...result, tokenVerification: verification } : result, null, 2));
     }
-  }
-  return 0;
+    else {
+        console.log(`initialized ${result.stateDir}`);
+        console.log(`sqlite: ${result.dbPath}${result.created ? "" : " (already existed)"}`);
+        if (verification) {
+            console.log(`token: ${verification.detail}`);
+        }
+    }
+    return 0;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibGFwdG9wLWluaXQuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJsYXB0b3AtaW5pdC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQUUsVUFBVSxFQUFFLFNBQVMsRUFBRSxTQUFTLEVBQUUsVUFBVSxFQUFFLFNBQVMsRUFBRSxNQUFNLFNBQVMsQ0FBQztBQUNsRixPQUFPLEVBQUUsT0FBTyxFQUFFLE1BQU0sU0FBUyxDQUFDO0FBQ2xDLE9BQU8sRUFBRSxTQUFTLEVBQUUsSUFBSSxFQUFFLE1BQU0sV0FBVyxDQUFDO0FBQzVDLE9BQU8sRUFBRSxZQUFZLEVBQUUsTUFBTSxhQUFhLENBQUM7QUFDM0MsT0FBTyxFQUFFLHFCQUFxQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFDNUQsT0FBTyxFQUFFLGdCQUFnQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbEQsT0FBTyxFQUFFLGtCQUFrQixFQUFFLE1BQU0sOEJBQThCLENBQUM7QUFFbEUsTUFBTSxnQkFBZ0IsR0FBRyx3QkFBd0IsQ0FBQztBQUNsRCxNQUFNLGdCQUFnQixHQUFHLFlBQVksQ0FBQztBQUN0QyxNQUFNLGlCQUFpQixHQUFHLElBQUksR0FBRyxDQUFDLENBQUMsTUFBTSxFQUFFLGFBQWEsQ0FBQyxDQUFDLENBQUM7QUFDM0QsTUFBTSxpQkFBaUIsR0FBRyxzQkFBc0IsQ0FBQztBQUlqRCwrR0FBK0c7QUFDL0csU0FBUyxvQkFBb0IsQ0FBQyxNQUFXLE9BQU8sQ0FBQyxHQUFHO0lBQ2xELE1BQU0saUJBQWlCLEdBQUcsT0FBTyxHQUFHLENBQUMseUJBQXlCLEtBQUssUUFBUTtRQUN6RSxDQUFDLENBQUMsR0FBRyxDQUFDLHlCQUF5QixDQUFDLElBQUksRUFBRTtRQUN0QyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ1AsSUFBSSxpQkFBaUI7UUFBRSxPQUFPLGlCQUFpQixDQUFDO0lBRWhELE1BQU0sVUFBVSxHQUFHLE9BQU8sR0FBRyxDQUFDLGVBQWUsS0FBSyxRQUFRLElBQUksR0FBRyxDQUFDLGVBQWUsQ0FBQyxJQUFJLEVBQUU7UUFDdEYsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxlQUFlLENBQUMsSUFBSSxFQUFFO1FBQzVCLENBQUMsQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDL0IsT0FBTyxJQUFJLENBQUMsVUFBVSxFQUFFLGdCQUFnQixDQUFDLENBQUM7QUFDNUMsQ0FBQztBQUVELHNGQUFzRjtBQUN0RixNQUFNLFVBQVUsd0JBQXdCLENBQUMsTUFBVyxPQUFPLENBQUMsR0FBRztJQUM3RCxPQUFPLElBQUksQ0FBQyxvQkFBb0IsQ0FBQyxHQUFHLENBQUMsRUFBRSxpQkFBaUIsQ0FBQyxDQUFDO0FBQzVELENBQUM7QUFRRCx1R0FBdUc7QUFDdkcsTUFBTSxVQUFVLGVBQWUsQ0FBQyxNQUFXLE9BQU8sQ0FBQyxHQUFHO0lBQ3BELE1BQU0sUUFBUSxHQUFHLG9CQUFvQixDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQzNDLE1BQU0sTUFBTSxHQUFHLHdCQUF3QixDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQzdDLFNBQVMsQ0FBQyxRQUFRLEVBQUUsRUFBRSxTQUFTLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQ3RELE1BQU0sT0FBTyxHQUFHLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ3BDLE1BQU0sRUFBRSxHQUFHLElBQUksWUFBWSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ3BDLEVBQUUsQ0FBQyxJQUFJLENBQUM7Ozs7O0dBS1AsQ0FBQyxDQUFDO0lBQ0gseUdBQXlHO0lBQ3pHLHFCQUFxQixDQUFDLEVBQUUsRUFBRSxFQUFFLENBQUMsQ0FBQztJQUM5QixJQUFJLE9BQU8sRUFBRSxDQUFDO1FBQ1osRUFBRSxDQUFDLE9BQU8sQ0FBQyxtRUFBbUUsQ0FBQzthQUM1RSxHQUFHLENBQUMsSUFBSSxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQyxDQUFDO0lBQ25DLENBQUM7SUFDRCxTQUFTLENBQUMsTUFBTSxFQUFFLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLEVBQUUsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNYLE9BQU8sRUFBRSxRQUFRLEVBQUUsTUFBTSxFQUFFLE9BQU8sRUFBRSxDQUFDO0FBQ3ZDLENBQUM7QUFRRCxNQUFNLFVBQVUsc0JBQXNCLENBQUMsTUFBVyxPQUFPLENBQUMsR0FBRztJQUMzRCxNQUFNLE1BQU0sR0FBRyx3QkFBd0IsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUM3QyxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDeEIsT0FBTztZQUNMLElBQUksRUFBRSxxQkFBcUI7WUFDM0IsRUFBRSxFQUFFLEtBQUs7WUFDVCxNQUFNLEVBQUUsR0FBRyxNQUFNLHVDQUF1QztTQUN6RCxDQUFDO0lBQ0osQ0FBQztJQUNELElBQUksQ0FBQztRQUNILDBHQUEwRztRQUMxRyxxR0FBcUc7UUFDckcsNEZBQTRGO1FBQzVGLE1BQU0sRUFBRSxHQUFHLElBQUksWUFBWSxDQUFDLE1BQU0sRUFBRSxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDO1FBQ3hELEVBQUUsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUMsR0FBRyxFQUFFLENBQUM7UUFDN0IsRUFBRSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ1gsT0FBTyxFQUFFLElBQUksRUFBRSxxQkFBcUIsRUFBRSxFQUFFLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxNQUFNLEVBQUUsQ0FBQztJQUNuRSxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU87WUFDTCxJQUFJLEVBQUUscUJBQXFCO1lBQzNCLEVBQUUsRUFBRSxLQUFLO1lBQ1QsTUFBTSxFQUFFLEdBQUcsTUFBTSxLQUFLLEtBQUssWUFBWSxLQUFLLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLGNBQWMsRUFBRTtTQUNoRixDQUFDO0lBQ0osQ0FBQztBQUNILENBQUM7QUFFRDtrR0FDa0c7QUFDbEcsTUFBTSxVQUFVLG9CQUFvQixDQUFDLElBQVksRUFBRSxNQUFXLE9BQU8sQ0FBQyxHQUFHO0lBQ3ZFLE1BQU0sU0FBUyxHQUFHLE9BQU8sR0FBRyxDQUFDLElBQUksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUMvRCxLQUFLLE1BQU0sU0FBUyxJQUFJLFNBQVMsQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDLEVBQUUsQ0FBQztRQUNuRCxJQUFJLENBQUMsU0FBUztZQUFFLFNBQVM7UUFDekIsTUFBTSxTQUFTLEdBQUcsSUFBSSxDQUFDLFNBQVMsRUFBRSxJQUFJLENBQUMsQ0FBQztRQUN4QyxJQUFJLENBQUM7WUFDSCxVQUFVLENBQUMsU0FBUyxFQUFFLFNBQVMsQ0FBQyxJQUFJLENBQUMsQ0FBQztZQUN0QyxPQUFPLFNBQVMsQ0FBQztRQUNuQixDQUFDO1FBQUMsTUFBTSxDQUFDO1lBQ1Asb0VBQW9FO1FBQ3RFLENBQUM7SUFDSCxDQUFDO0lBQ0QsT0FBTyxJQUFJLENBQUM7QUFDZCxDQUFDO0FBRUQscUVBQXFFO0FBQ3JFLE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxVQUFrRSxFQUFFO0lBQ3JHLE1BQU0saUJBQWlCLEdBQUcsT0FBTyxDQUFDLGlCQUFpQjtXQUM5QyxDQUFDLEdBQUcsRUFBRSxDQUFDLG9CQUFvQixDQUFDLFFBQVEsRUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztJQUN6RCxNQUFNLFVBQVUsR0FBRyxpQkFBaUIsRUFBRSxDQUFDO0lBQ3ZDLE9BQU87UUFDTCxJQUFJLEVBQUUsZ0JBQWdCO1FBQ3RCLEVBQUUsRUFBRSxJQUFJO1FBQ1IsTUFBTSxFQUFFLFVBQVUsQ0FBQyxDQUFDLENBQUMsWUFBWSxVQUFVLEVBQUUsQ0FBQyxDQUFDLENBQUMsMENBQTBDO0tBQzNGLENBQUM7QUFDSixDQUFDO0FBRUQsK0ZBQStGO0FBQy9GLHdHQUF3RztBQUN4RywwR0FBMEc7QUFDMUcseUZBQXlGO0FBQ3pGLE1BQU0sVUFBVSxvQkFBb0IsQ0FBQyxNQUFXLE9BQU8sQ0FBQyxHQUFHO0lBQ3pELE1BQU0sSUFBSSxHQUFHLEdBQUcsQ0FBQyxVQUFVLElBQUksSUFBSSxDQUFDLEdBQUcsQ0FBQyxJQUFJLElBQUksT0FBTyxFQUFFLEVBQUUsUUFBUSxDQUFDLENBQUM7SUFDckUsT0FBTyxJQUFJLENBQUMsSUFBSSxFQUFFLFdBQVcsQ0FBQyxDQUFDO0FBQ2pDLENBQUM7QUFFRCxxRkFBcUY7QUFDckYsK0ZBQStGO0FBQy9GLFNBQVMsYUFBYSxDQUFDLFdBQW1CO0lBQ3hDLE1BQU0sT0FBTyxHQUEyQjtRQUN0QyxNQUFNLEVBQUUsNkJBQTZCO1FBQ3JDLFlBQVksRUFBRSxnQkFBZ0I7UUFDOUIsc0JBQXNCLEVBQUUsZ0JBQWdCO0tBQ3pDLENBQUM7SUFDRixNQUFNLEtBQUssR0FBRyxXQUFXLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDakMsSUFBSSxLQUFLO1FBQUUsT0FBTyxDQUFDLGFBQWEsR0FBRyxVQUFVLEtBQUssRUFBRSxDQUFDO0lBQ3JELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxTQUFTLGlCQUFpQixDQUFDLFlBQTJCO0lBQ3BELE9BQU8sT0FBTyxZQUFZLEtBQUssUUFBUSxJQUFJLFlBQVksQ0FBQyxJQUFJLEVBQUU7UUFDNUQsQ0FBQyxDQUFDLFlBQVksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDO1FBQ3RFLENBQUMsQ0FBQyxFQUFFLENBQUM7QUFDVCxDQUFDO0FBRUQsbUdBQW1HO0FBQ25HLCtHQUErRztBQUMvRyxTQUFTLFlBQVksQ0FBQyxNQUFnQjtJQUNwQyxPQUFPLE1BQU0sQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDM0IsQ0FBQztBQUVELFNBQVMsa0JBQWtCLENBQUMsTUFBZ0I7SUFDMUMsT0FBTyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxpQkFBaUIsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztBQUM5RCxDQUFDO0FBRUQsU0FBUyxzQkFBc0IsQ0FBQyxPQUFnQixFQUFFLE1BQWM7SUFDOUQsSUFBSSxPQUFPLElBQUksT0FBTyxPQUFPLEtBQUssUUFBUSxJQUFJLE9BQVEsT0FBaUMsQ0FBQyxPQUFPLEtBQUssUUFBUSxJQUFLLE9BQStCLENBQUMsT0FBTyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUM7UUFDaEssT0FBUSxPQUErQixDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUN6RCxDQUFDO0lBQ0QsT0FBTyx3QkFBd0IsTUFBTSxFQUFFLENBQUM7QUFDMUMsQ0FBQztBQVNEOzs7Ozs7O0dBT0c7QUFDSCxNQUFNLENBQUMsS0FBSyxVQUFVLGlCQUFpQixDQUFDLFVBS3BDLEVBQUU7SUFDSixNQUFNLFdBQVcsR0FBRyxPQUFPLE9BQU8sQ0FBQyxXQUFXLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDOUYsTUFBTSxTQUFTLEdBQUcsT0FBTyxDQUFDLFNBQVMsSUFBSSxLQUFLLENBQUM7SUFDN0MsTUFBTSxVQUFVLEdBQ2QsT0FBTyxPQUFPLENBQUMsVUFBVSxLQUFLLFFBQVEsSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDLElBQUksRUFBRTtRQUNqRSxDQUFDLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxJQUFJLGdCQUFnQjtRQUNuRSxDQUFDLENBQUMsZ0JBQWdCLENBQUM7SUFDdkIsTUFBTSxTQUFTLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLElBQUssT0FBTyxDQUFDLFNBQW9CLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBRSxPQUFPLENBQUMsU0FBb0IsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ2pJLE1BQU0sVUFBVSxHQUFHLElBQUksZUFBZSxFQUFFLENBQUM7SUFDekMsTUFBTSxPQUFPLEdBQUcsVUFBVSxDQUFDLEdBQUcsRUFBRSxDQUFDLFVBQVUsQ0FBQyxLQUFLLEVBQUUsRUFBRSxTQUFTLENBQUMsQ0FBQztJQUVoRSxJQUFJLFFBQTJDLENBQUM7SUFDaEQsSUFBSSxDQUFDO1FBQ0gsUUFBUSxHQUFHLE1BQU0sU0FBUyxDQUFDLEdBQUcsVUFBVSxPQUFPLEVBQUU7WUFDL0MsTUFBTSxFQUFFLEtBQUs7WUFDYixPQUFPLEVBQUUsYUFBYSxDQUFDLFdBQVcsQ0FBQztZQUNuQyxNQUFNLEVBQUUsVUFBVSxDQUFDLE1BQU07U0FDMUIsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixNQUFNLE1BQU0sR0FBRyxVQUFVLENBQUMsTUFBTSxDQUFDLE9BQU87WUFDdEMsQ0FBQyxDQUFDLG1CQUFtQixTQUFTLElBQUk7WUFDbEMsQ0FBQyxDQUFDLEtBQUssWUFBWSxLQUFLO2dCQUN0QixDQUFDLENBQUMsS0FBSyxDQUFDLE9BQU87Z0JBQ2YsQ0FBQyxDQUFDLGdCQUFnQixDQUFDO1FBQ3ZCLE9BQU87WUFDTCxFQUFFLEVBQUUsS0FBSztZQUNULEtBQUssRUFBRSxJQUFJO1lBQ1gsTUFBTSxFQUFFLEVBQUU7WUFDVixNQUFNLEVBQUUscUNBQXFDLE1BQU0sRUFBRTtTQUN0RCxDQUFDO0lBQ0osQ0FBQztZQUFTLENBQUM7UUFDVCxZQUFZLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDeEIsQ0FBQztJQUVELE1BQU0sT0FBTyxHQUFHLE1BQU0sUUFBUSxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4RCxNQUFNLFlBQVksR0FBRyxRQUFRLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDO0lBQzVELE1BQU0sbUJBQW1CLEdBQUcsUUFBUSxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsQ0FBQztJQUNuRSxNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMvQyxNQUFNLEtBQUssR0FBRyxPQUFPLElBQUksT0FBTyxPQUFPLEtBQUssUUFBUSxJQUFJLE9BQVEsT0FBK0IsQ0FBQyxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBRSxPQUE2QixDQUFDLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBRXRLLElBQUksQ0FBQyxRQUFRLENBQUMsRUFBRSxFQUFFLENBQUM7UUFDakIsT0FBTztZQUNMLEVBQUUsRUFBRSxLQUFLO1lBQ1QsS0FBSyxFQUFFLElBQUk7WUFDWCxNQUFNO1lBQ04sTUFBTSxFQUFFLHFDQUFxQyxzQkFBc0IsQ0FBQyxPQUFPLEVBQUUsUUFBUSxDQUFDLE1BQU0sQ0FBQyxFQUFFO1NBQ2hHLENBQUM7SUFDSixDQUFDO0lBRUQsSUFBSSxtQkFBbUIsSUFBSSxNQUFNLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQy9DLE9BQU87WUFDTCxFQUFFLEVBQUUsS0FBSztZQUNULEtBQUssRUFBRSxLQUFLLElBQUksSUFBSTtZQUNwQixNQUFNO1lBQ04sTUFBTSxFQUFFLHlIQUF5SDtTQUNsSSxDQUFDO0lBQ0osQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sR0FBRyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3JELE9BQU87WUFDTCxFQUFFLEVBQUUsS0FBSztZQUNULEtBQUssRUFBRSxLQUFLLElBQUksSUFBSTtZQUNwQixNQUFNO1lBQ04sTUFBTSxFQUFFLG1EQUFtRCxZQUFZLENBQUMsTUFBTSxDQUFDLGdEQUFnRDtTQUNoSSxDQUFDO0lBQ0osQ0FBQztJQUVELE9BQU87UUFDTCxFQUFFLEVBQUUsSUFBSTtRQUNSLEtBQUssRUFBRSxLQUFLLElBQUksSUFBSTtRQUNwQixNQUFNO1FBQ04sTUFBTSxFQUNKLE1BQU0sQ0FBQyxNQUFNLEdBQUcsQ0FBQztZQUNmLENBQUMsQ0FBQyw4QkFBOEIsS0FBSyxJQUFJLGNBQWMsYUFBYSxZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUU7WUFDMUYsQ0FBQyxDQUFDLDhCQUE4QixLQUFLLElBQUksY0FBYyw4Q0FBOEM7S0FDMUcsQ0FBQztBQUNKLENBQUM7QUFFRDs7OztxR0FJcUc7QUFDckcsU0FBUyxnQ0FBZ0MsQ0FBQyxHQUFRLEVBQUUsWUFBb0I7SUFDdEUsT0FBTyxHQUFHLENBQUMsMkJBQTJCLEtBQUssWUFBWSxDQUFDO0FBQzFELENBQUM7QUFFRDs7bUhBRW1IO0FBQ25ILE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxVQUFrRSxFQUFFO0lBQ3hHLE1BQU0sR0FBRyxHQUFHLE9BQU8sQ0FBQyxHQUFHLElBQUksT0FBTyxDQUFDLEdBQUcsQ0FBQztJQUN2QyxNQUFNLFVBQVUsR0FBRyxDQUFDLE9BQU8sQ0FBQyxpQkFBaUIsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLG9CQUFvQixDQUFDLFFBQVEsRUFBRSxHQUFHLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNoRyxJQUFJLENBQUMsVUFBVSxFQUFFLENBQUM7UUFDaEIsTUFBTSxVQUFVLEdBQUcsZ0NBQWdDLENBQUMsR0FBRyxFQUFFLFlBQVksQ0FBQyxDQUFDO1FBQ3ZFLE9BQU87WUFDTCxJQUFJLEVBQUUsb0JBQW9CO1lBQzFCLEVBQUUsRUFBRSxDQUFDLFVBQVU7WUFDZixNQUFNLEVBQUUsVUFBVTtnQkFDaEIsQ0FBQyxDQUFDLHNHQUFzRztnQkFDeEcsQ0FBQyxDQUFDLG9FQUFvRTtTQUN6RSxDQUFDO0lBQ0osQ0FBQztJQUNELE1BQU0sTUFBTSxHQUFHLE9BQU8sR0FBRyxDQUFDLHVCQUF1QixLQUFLLFFBQVEsSUFBSSxHQUFHLENBQUMsdUJBQXVCLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBQztJQUN6RyxPQUFPO1FBQ0wsSUFBSSxFQUFFLG9CQUFvQjtRQUMxQixFQUFFLEVBQUUsSUFBSTtRQUNSLE1BQU0sRUFBRSxNQUFNLENBQUMsQ0FBQyxDQUFDLFlBQVksVUFBVSxrQkFBa0IsQ0FBQyxDQUFDLENBQUMsWUFBWSxVQUFVLG1EQUFtRDtLQUN0SSxDQUFDO0FBQ0osQ0FBQztBQUVEOztvRkFFb0Y7QUFDcEYsTUFBTSxVQUFVLG9CQUFvQixDQUFDLFVBSWpDLEVBQUU7SUFDSixNQUFNLEdBQUcsR0FBRyxPQUFPLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUM7SUFDdkMsTUFBTSxTQUFTLEdBQUcsQ0FBQyxPQUFPLENBQUMsZ0JBQWdCLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxvQkFBb0IsQ0FBQyxPQUFPLEVBQUUsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDN0YsSUFBSSxDQUFDLFNBQVMsRUFBRSxDQUFDO1FBQ2YsTUFBTSxVQUFVLEdBQUcsZ0NBQWdDLENBQUMsR0FBRyxFQUFFLFdBQVcsQ0FBQyxDQUFDO1FBQ3RFLE9BQU87WUFDTCxJQUFJLEVBQUUsbUJBQW1CO1lBQ3pCLEVBQUUsRUFBRSxDQUFDLFVBQVU7WUFDZixNQUFNLEVBQUUsVUFBVTtnQkFDaEIsQ0FBQyxDQUFDLHFHQUFxRztnQkFDdkcsQ0FBQyxDQUFDLG9FQUFvRTtTQUN6RSxDQUFDO0lBQ0osQ0FBQztJQUNELE1BQU0sUUFBUSxHQUFHLENBQUMsT0FBTyxDQUFDLG9CQUFvQixJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsb0JBQW9CLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDdkYsSUFBSSxNQUFNLEdBQUcsS0FBSyxDQUFDO0lBQ25CLElBQUksQ0FBQztRQUNILFVBQVUsQ0FBQyxRQUFRLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDO1FBQ3JDLE1BQU0sR0FBRyxJQUFJLENBQUM7SUFDaEIsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLDJGQUEyRjtJQUM3RixDQUFDO0lBQ0QsSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUNYLE9BQU8sRUFBRSxJQUFJLEVBQUUsbUJBQW1CLEVBQUUsRUFBRSxFQUFFLElBQUksRUFBRSxNQUFNLEVBQUUsWUFBWSxTQUFTLGtCQUFrQixFQUFFLENBQUM7SUFDbEcsQ0FBQztJQUNELCtHQUErRztJQUMvRyw2R0FBNkc7SUFDN0csOEdBQThHO0lBQzlHLHFEQUFxRDtJQUNyRCxNQUFNLE1BQU0sR0FBRyxnQ0FBZ0MsQ0FBQyxHQUFHLEVBQUUsV0FBVyxDQUFDO1FBQy9ELENBQUMsQ0FBQyxZQUFZLFNBQVMsK0ZBQStGO1FBQ3RILENBQUMsQ0FBQyxZQUFZLFNBQVMsMENBQTBDLENBQUM7SUFDcEUsT0FBTyxFQUFFLElBQUksRUFBRSxtQkFBbUIsRUFBRSxFQUFFLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxDQUFDO0FBQ3pELENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLE9BQU8sQ0FBQyxPQUFpQixFQUFFLEVBQUUsTUFBVyxPQUFPLENBQUMsR0FBRztJQUN2RSxNQUFNLFdBQVcsR0FBRyxJQUFJLENBQUMsUUFBUSxDQUFDLGdCQUFnQixDQUFDLENBQUM7SUFDcEQsTUFBTSxVQUFVLEdBQUcsSUFBSSxDQUFDLFFBQVEsQ0FBQyxRQUFRLENBQUMsQ0FBQztJQUMzQyxJQUFJLFlBQVksR0FBbUMsSUFBSSxDQUFDO0lBQ3hELElBQUksV0FBVyxFQUFFLENBQUM7UUFDaEIsWUFBWSxHQUFHLE1BQU0saUJBQWlCLENBQUMsRUFBRSxXQUFXLEVBQUUsQ0FBQyxNQUFNLGtCQUFrQixDQUFDLEdBQXdCLENBQUMsQ0FBQyxJQUFJLEVBQUUsRUFBRSxDQUFDLENBQUM7UUFDcEgsSUFBSSxDQUFDLFlBQVksQ0FBQyxFQUFFLEVBQUUsQ0FBQztZQUNyQixPQUFPLGdCQUFnQixDQUFDLFVBQVUsRUFBRSxZQUFZLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQzlELENBQUM7SUFDSCxDQUFDO0lBRUQsTUFBTSxNQUFNLEdBQUcsZUFBZSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3BDLElBQUksVUFBVSxFQUFFLENBQUM7UUFDZixPQUFPLENBQUMsR0FBRyxDQUNULElBQUksQ0FBQyxTQUFTLENBQ1osWUFBWSxDQUFDLENBQUMsQ0FBQyxFQUFFLEdBQUcsTUFBTSxFQUFFLGlCQUFpQixFQUFFLFlBQVksRUFBRSxDQUFDLENBQUMsQ0FBQyxNQUFNLEVBQ3RFLElBQUksRUFDSixDQUFDLENBQ0YsQ0FDRixDQUFDO0lBQ0osQ0FBQztTQUFNLENBQUM7UUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGVBQWUsTUFBTSxDQUFDLFFBQVEsRUFBRSxDQUFDLENBQUM7UUFDOUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxXQUFXLE1BQU0sQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxvQkFBb0IsRUFBRSxDQUFDLENBQUM7UUFDckYsSUFBSSxZQUFZLEVBQUUsQ0FBQztZQUNqQixPQUFPLENBQUMsR0FBRyxDQUFDLFVBQVUsWUFBWSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7UUFDL0MsQ0FBQztJQUNILENBQUM7SUFDRCxPQUFPLENBQUMsQ0FBQztBQUNYLENBQUMifQ==

--- a/packages/loopover-miner/lib/laptop-init.ts
+++ b/packages/loopover-miner/lib/laptop-init.ts
@@ -1,0 +1,370 @@
+import { accessSync, chmodSync, constants, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { applySchemaMigrations } from "./schema-version.js";
+import { reportCliFailure } from "./cli-error.js";
+import { resolveGitHubToken } from "./github-token-resolution.js";
+
+const githubApiBaseUrl = "https://api.github.com";
+const githubApiVersion = "2022-11-28";
+const classicRepoScopes = new Set(["repo", "public_repo"]);
+const defaultDbFileName = "laptop-state.sqlite3";
+
+type Env = Record<string, string | undefined>;
+
+/** Local state directory (mirrors `resolveMinerStateDir` in status.js — kept local to avoid import cycles). */
+function resolveMinerStateDir(env: Env = process.env): string {
+  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
+    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
+    : "";
+  if (explicitConfigDir) return explicitConfigDir;
+
+  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME.trim()
+    : join(homedir(), ".config");
+  return join(configHome, "loopover-miner");
+}
+
+/** Path to the laptop-mode SQLite bootstrap file inside the miner state directory. */
+export function resolveLaptopStateDbPath(env: Env = process.env): string {
+  return join(resolveMinerStateDir(env), defaultDbFileName);
+}
+
+export type LaptopInitResult = {
+  stateDir: string;
+  dbPath: string;
+  created: boolean;
+};
+
+/** Create the state dir and SQLite file. Re-running is idempotent and never clobbers existing rows. */
+export function initLaptopState(env: Env = process.env): LaptopInitResult {
+  const stateDir = resolveMinerStateDir(env);
+  const dbPath = resolveLaptopStateDbPath(env);
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const created = !existsSync(dbPath);
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS laptop_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `);
+  // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations (none yet).
+  applySchemaMigrations(db, []);
+  if (created) {
+    db.prepare("INSERT INTO laptop_meta (key, value) VALUES ('initialized_at', ?)")
+      .run(new Date().toISOString());
+  }
+  chmodSync(dbPath, 0o600);
+  db.close();
+  return { stateDir, dbPath, created };
+}
+
+export type DoctorCheck = {
+  name: string;
+  ok: boolean;
+  detail: string;
+};
+
+export function checkLaptopStateSqlite(env: Env = process.env): DoctorCheck {
+  const dbPath = resolveLaptopStateDbPath(env);
+  if (!existsSync(dbPath)) {
+    return {
+      name: "laptop-state-sqlite",
+      ok: false,
+      detail: `${dbPath}: not found (run loopover-miner init)`,
+    };
+  }
+  try {
+    // `readOnly` (camelCase) -- node:sqlite silently IGNORES `readonly` (lowercase) as an unrecognized option
+    // and opens read-write anyway, which would break doctor's own "no writes, no network" contract. Same
+    // footgun already documented in claim-ledger.js's openClaimLedgerReadOnly and purge-cli.js.
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    db.prepare("SELECT 1").get();
+    db.close();
+    return { name: "laptop-state-sqlite", ok: true, detail: dbPath };
+  } catch (error) {
+    return {
+      name: "laptop-state-sqlite",
+      ok: false,
+      detail: `${dbPath}: ${error instanceof Error ? error.message : "not readable"}`,
+    };
+  }
+}
+
+/** Exported so callers that only need a presence boolean (e.g. status.js's `driver` section, #5164) can reuse
+ *  this PATH scan directly instead of duplicating it or parsing a DoctorCheck's detail string. */
+export function findExecutableOnPath(name: string, env: Env = process.env): string | null {
+  const pathValue = typeof env.PATH === "string" ? env.PATH : "";
+  for (const pathEntry of pathValue.split(delimiter)) {
+    if (!pathEntry) continue;
+    const candidate = join(pathEntry, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep scanning: PATH often contains missing or unreadable entries.
+    }
+  }
+  return null;
+}
+
+/** Informational only — Docker is never required for laptop mode. */
+export function checkDockerPresent(options: { env?: Env; resolveDockerPath?: () => string | null } = {}): DoctorCheck {
+  const resolveDockerPath = options.resolveDockerPath
+    ?? (() => findExecutableOnPath("docker", options.env));
+  const dockerPath = resolveDockerPath();
+  return {
+    name: "docker-present",
+    ok: true,
+    detail: dockerPath ? `found at ${dockerPath}` : "not installed (optional for laptop mode)",
+  };
+}
+
+// Codex stores credentials at `$CODEX_HOME/auth.json`, else `$HOME/.codex/auth.json` — mirrors
+// resolveCodexAuthPath in src/selfhost/ai.ts, kept local so the offline miner package never imports the
+// Worker AI module. Exported so `doctor`'s provider-credential check (status.js, #5170) resolves the SAME
+// path this file's own codex auth probe uses, instead of duplicating the location logic.
+export function resolveCodexAuthPath(env: Env = process.env): string {
+  const base = env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex");
+  return join(base, "auth.json");
+}
+
+// `githubToken` is always a string (never undefined) here -- verifyGithubToken's own
+// `typeof options.githubToken === "string"` guard already normalizes it before this is called.
+function githubHeaders(githubToken: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "loopover-miner",
+    "x-github-api-version": githubApiVersion,
+  };
+  const token = githubToken.trim();
+  if (token) headers.authorization = `Bearer ${token}`;
+  return headers;
+}
+
+function parseScopesHeader(scopesHeader: string | null): string[] {
+  return typeof scopesHeader === "string" && scopesHeader.trim()
+    ? scopesHeader.split(",").map((scope) => scope.trim()).filter(Boolean)
+    : [];
+}
+
+// Both call sites below already guard `scopes.length > 0` before calling this, so scopes is always
+// non-empty here -- no "none reported" fallback needed (that phrasing lives inline at each call site instead).
+function formatScopes(scopes: string[]): string {
+  return scopes.join(", ");
+}
+
+function hasRepoAccessScope(scopes: string[]): boolean {
+  return scopes.some((scope) => classicRepoScopes.has(scope));
+}
+
+function readGithubErrorMessage(payload: unknown, status: number): string {
+  if (payload && typeof payload === "object" && typeof (payload as { message?: unknown }).message === "string" && (payload as { message: string }).message.trim()) {
+    return (payload as { message: string }).message.trim();
+  }
+  return `GitHub returned HTTP ${status}`;
+}
+
+export type GithubTokenVerification = {
+  ok: boolean;
+  login: string | null;
+  scopes: string[];
+  detail: string;
+};
+
+/**
+ * Validate a GitHub token with one authenticated API call.
+ *
+ * The classic OAuth scope header is advisory when GitHub reports it: if GitHub returns `repo` or
+ * `public_repo`, we treat the token as sufficiently scoped for miner setup. If GitHub omits the classic
+ * scope header altogether, the token is still considered valid and the response is reported as "scopes not
+ * reported" — that keeps fine-grained tokens usable while still surfacing the scopes GitHub did return.
+ */
+export async function verifyGithubToken(options: {
+  githubToken?: string;
+  fetchImpl?: typeof fetch;
+  apiBaseUrl?: string;
+  timeoutMs?: number;
+} = {}): Promise<GithubTokenVerification> {
+  const githubToken = typeof options.githubToken === "string" ? options.githubToken.trim() : "";
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const apiBaseUrl =
+    typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim()
+      ? options.apiBaseUrl.trim().replace(/\/+$/, "") || githubApiBaseUrl
+      : githubApiBaseUrl;
+  const timeoutMs = Number.isFinite(options.timeoutMs) && (options.timeoutMs as number) > 0 ? (options.timeoutMs as number) : 5000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Awaited<ReturnType<typeof fetch>>;
+  try {
+    response = await fetchImpl(`${apiBaseUrl}/user`, {
+      method: "GET",
+      headers: githubHeaders(githubToken),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const detail = controller.signal.aborted
+      ? `timed out after ${timeoutMs}ms`
+      : error instanceof Error
+        ? error.message
+        : "request failed";
+    return {
+      ok: false,
+      login: null,
+      scopes: [],
+      detail: `GITHUB_TOKEN verification failed: ${detail}`,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const payload = await response.json().catch(() => null);
+  const scopesHeader = response.headers.get("x-oauth-scopes");
+  const scopesHeaderPresent = response.headers.has("x-oauth-scopes");
+  const scopes = parseScopesHeader(scopesHeader);
+  const login = payload && typeof payload === "object" && typeof (payload as { login?: unknown }).login === "string" ? (payload as { login: string }).login.trim() : "";
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      login: null,
+      scopes,
+      detail: `GITHUB_TOKEN verification failed: ${readGithubErrorMessage(payload, response.status)}`,
+    };
+  }
+
+  if (scopesHeaderPresent && scopes.length === 0) {
+    return {
+      ok: false,
+      login: login || null,
+      scopes,
+      detail: "GITHUB_TOKEN is valid, but GitHub returned an empty x-oauth-scopes header; reissue it with repo access for miner setup.",
+    };
+  }
+
+  if (scopes.length > 0 && !hasRepoAccessScope(scopes)) {
+    return {
+      ok: false,
+      login: login || null,
+      scopes,
+      detail: `GITHUB_TOKEN is valid, but GitHub reported only ${formatScopes(scopes)}; reissue it with repo access for miner setup.`,
+    };
+  }
+
+  return {
+    ok: true,
+    login: login || null,
+    scopes,
+    detail:
+      scopes.length > 0
+        ? `validated GitHub token for ${login || "unknown user"}; scopes: ${formatScopes(scopes)}`
+        : `validated GitHub token for ${login || "unknown user"}; GitHub did not report classic OAuth scopes`,
+  };
+}
+
+/** A coding-agent CLI is only needed once a driver provider is configured (#4289) — gated by
+ *  `MINER_CODING_AGENT_PROVIDER` (#5165). When that provider is NOT the CLI being checked, absence is
+ *  advisory (`ok: true`), mirroring checkDockerPresent's optional tone. When it IS configured and the CLI is
+ *  missing, `ok: false` — every attempt will fail without it. The auth probe (once found) stays advisory
+ *  either way, since an unauthenticated-but-installed CLI is a separate, already-visible warning. */
+function codingAgentProviderConfiguredFor(env: Env, providerName: string): boolean {
+  return env.MINER_CODING_AGENT_PROVIDER === providerName;
+}
+
+/** Informational unless `MINER_CODING_AGENT_PROVIDER=claude-cli` (#5165), in which case a missing CLI fails
+ *  doctor. The auth probe is read-only and never spawns the CLI: it surfaces, proactively, the SAME condition
+ *  claude checks at call time — `CLAUDE_CODE_OAUTH_TOKEN` present (see createClaudeCodeAi, src/selfhost/ai.ts). */
+export function checkClaudeCliPresent(options: { env?: Env; resolveClaudePath?: () => string | null } = {}): DoctorCheck {
+  const env = options.env ?? process.env;
+  const claudePath = (options.resolveClaudePath ?? (() => findExecutableOnPath("claude", env)))();
+  if (!claudePath) {
+    const configured = codingAgentProviderConfiguredFor(env, "claude-cli");
+    return {
+      name: "claude-cli-present",
+      ok: !configured,
+      detail: configured
+        ? "not installed — MINER_CODING_AGENT_PROVIDER is set to claude-cli, every attempt will fail without it"
+        : "not installed (optional until a coding-agent driver is configured)",
+    };
+  }
+  const authed = typeof env.CLAUDE_CODE_OAUTH_TOKEN === "string" && env.CLAUDE_CODE_OAUTH_TOKEN.length > 0;
+  return {
+    name: "claude-cli-present",
+    ok: true,
+    detail: authed ? `found at ${claudePath} (authenticated)` : `found at ${claudePath} (not authenticated: set CLAUDE_CODE_OAUTH_TOKEN)`,
+  };
+}
+
+/** Informational unless `MINER_CODING_AGENT_PROVIDER=codex-cli` (#5165), in which case a missing CLI fails
+ *  doctor — mirrors {@link checkClaudeCliPresent}. The auth probe checks the same read-only condition
+ *  assertCodexAuthConfigured uses at call time: codex's `auth.json` is readable. */
+export function checkCodexCliPresent(options: {
+  env?: Env;
+  resolveCodexPath?: () => string | null;
+  resolveCodexAuthPath?: () => string;
+} = {}): DoctorCheck {
+  const env = options.env ?? process.env;
+  const codexPath = (options.resolveCodexPath ?? (() => findExecutableOnPath("codex", env)))();
+  if (!codexPath) {
+    const configured = codingAgentProviderConfiguredFor(env, "codex-cli");
+    return {
+      name: "codex-cli-present",
+      ok: !configured,
+      detail: configured
+        ? "not installed — MINER_CODING_AGENT_PROVIDER is set to codex-cli, every attempt will fail without it"
+        : "not installed (optional until a coding-agent driver is configured)",
+    };
+  }
+  const authPath = (options.resolveCodexAuthPath ?? (() => resolveCodexAuthPath(env)))();
+  let authed = false;
+  try {
+    accessSync(authPath, constants.R_OK);
+    authed = true;
+  } catch {
+    // auth.json missing or unreadable — codex would fail for lack of credentials at call time.
+  }
+  if (authed) {
+    return { name: "codex-cli-present", ok: true, detail: `found at ${codexPath} (authenticated)` };
+  }
+  // codex-cli IS the configured driver but auth.json is missing/expired: a more specific, actionable remediation
+  // than the generic advisory below, mirroring ORB's codexAuthReadinessProbe/assertCodexAuthConfigured wording
+  // (#5166). `ok` stays true either way (unchanged by this issue, see #5165) since the CLI itself IS present --
+  // only the CLI-absent case is a hard doctor failure.
+  const detail = codingAgentProviderConfiguredFor(env, "codex-cli")
+    ? `found at ${codexPath} but auth.json is missing or expired — run \`codex auth\` to authenticate before attempts run`
+    : `found at ${codexPath} (not authenticated: run \`codex auth\`)`;
+  return { name: "codex-cli-present", ok: true, detail };
+}
+
+export async function runInit(args: string[] = [], env: Env = process.env): Promise<number> {
+  const verifyToken = args.includes("--verify-token");
+  const jsonOutput = args.includes("--json");
+  let verification: GithubTokenVerification | null = null;
+  if (verifyToken) {
+    verification = await verifyGithubToken({ githubToken: (await resolveGitHubToken(env as NodeJS.ProcessEnv)) ?? "" });
+    if (!verification.ok) {
+      return reportCliFailure(jsonOutput, verification.detail, 1);
+    }
+  }
+
+  const result = initLaptopState(env);
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        verification ? { ...result, tokenVerification: verification } : result,
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`initialized ${result.stateDir}`);
+    console.log(`sqlite: ${result.dbPath}${result.created ? "" : " (already existed)"}`);
+    if (verification) {
+      console.log(`token: ${verification.detail}`);
+    }
+  }
+  return 0;
+}

--- a/packages/loopover-miner/lib/miner-goal-spec.d.ts
+++ b/packages/loopover-miner/lib/miner-goal-spec.d.ts
@@ -1,12 +1,18 @@
-import type { ParsedMinerGoalSpec } from "@loopover/engine";
-
-export function resolveMinerGoalSpec(
-  repoPath: string,
-  options?: {
+import { type Stats } from "node:fs";
+import { type ParsedMinerGoalSpec } from "@loopover/engine";
+export type ResolveMinerGoalSpecOptions = {
     existsSync?: (path: string) => boolean;
     openSync?: (path: string, flags: number) => number;
-    fstatSync?: (fd: number) => import("node:fs").Stats;
+    fstatSync?: (fd: number) => Stats;
     readSync?: (fd: number, buffer: Buffer, offset: number, length: number, position: number | null) => number;
     closeSync?: (fd: number) => void;
-  },
-): ParsedMinerGoalSpec;
+};
+/**
+ * Resolve the real, parsed MinerGoalSpec for an already-cloned repo at `repoPath`, trying each
+ * MINER_GOAL_SPEC_FILENAMES candidate in the documented discovery order. Never throws: a missing file, an
+ * unreadable file, or malformed content all degrade to the tolerant parser's own absent/safe-default result.
+ *
+ * Injected filesystem operations receive the FULL joined path (same convention as `node:fs`'s own
+ * functions), not a repoPath-relative candidate.
+ */
+export declare function resolveMinerGoalSpec(repoPath: string, options?: ResolveMinerGoalSpecOptions): ParsedMinerGoalSpec;

--- a/packages/loopover-miner/lib/miner-goal-spec.js
+++ b/packages/loopover-miner/lib/miner-goal-spec.js
@@ -1,45 +1,37 @@
 import { closeSync, constants, existsSync, fstatSync, openSync, readSync } from "node:fs";
 import { join } from "node:path";
 import { discoverMinerGoalSpecPath, parseMinerGoalSpecContent } from "@loopover/engine";
-
 const MAX_MINER_GOAL_SPEC_BYTES = 32_768;
-
-// Real local .loopover-miner.yml resolver (#5132, Wave 3.5 follow-up). MinerGoalSpec's own discovery
-// helper (discoverMinerGoalSpecPath, packages/loopover-engine) is deliberately IO-free -- the caller
-// injects the existence check. Unlike self-review-context.js/rejection-signal.js/ams-policy.js, which fetch
-// their target repo's files live over raw.githubusercontent.com BEFORE any clone exists, this resolver reads
-// the ALREADY-CLONED repo on disk (attempt-worktree.js's prepareAttemptWorktree runs first in the real
-// attempt-cli.js flow) -- no extra network round trip needed for a file that's already sitting in the
-// worktree.
-
 // Same convention as packages/loopover-mcp/bin/loopover-mcp.js's readCliTextFile: O_NOFOLLOW on open
 // atomically rejects a symlinked path (no separate pre-open lstat -- that would be a check-then-open race, since
 // a symlink can be swapped in between the lstat and the open). Bounds the READ itself, not just fstat's
 // reported size, since a regular file can still grow between fstatSync and the read below.
 function readRegularUtf8File(path, options) {
-  const openImpl = options.openSync ?? openSync;
-  const fstatImpl = options.fstatSync ?? fstatSync;
-  const readImpl = options.readSync ?? readSync;
-  const closeImpl = options.closeSync ?? closeSync;
-
-  const fd = openImpl(path, constants.O_RDONLY | constants.O_NOFOLLOW);
-  try {
-    const stats = fstatImpl(fd);
-    if (!stats.isFile() || stats.size > MAX_MINER_GOAL_SPEC_BYTES) return null;
-    const buffer = Buffer.alloc(MAX_MINER_GOAL_SPEC_BYTES + 1);
-    let bytesRead = 0;
-    while (bytesRead < buffer.length) {
-      const n = readImpl(fd, buffer, bytesRead, buffer.length - bytesRead, null);
-      if (n === 0) break;
-      bytesRead += n;
+    const openImpl = options.openSync ?? openSync;
+    const fstatImpl = options.fstatSync ?? fstatSync;
+    const readImpl = options.readSync ?? readSync;
+    const closeImpl = options.closeSync ?? closeSync;
+    const fd = openImpl(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+        const stats = fstatImpl(fd);
+        if (!stats.isFile() || stats.size > MAX_MINER_GOAL_SPEC_BYTES)
+            return null;
+        const buffer = Buffer.alloc(MAX_MINER_GOAL_SPEC_BYTES + 1);
+        let bytesRead = 0;
+        while (bytesRead < buffer.length) {
+            const n = readImpl(fd, buffer, bytesRead, buffer.length - bytesRead, null);
+            if (n === 0)
+                break;
+            bytesRead += n;
+        }
+        if (bytesRead > MAX_MINER_GOAL_SPEC_BYTES)
+            return null;
+        return buffer.subarray(0, bytesRead).toString("utf8");
     }
-    if (bytesRead > MAX_MINER_GOAL_SPEC_BYTES) return null;
-    return buffer.subarray(0, bytesRead).toString("utf8");
-  } finally {
-    closeImpl(fd);
-  }
+    finally {
+        closeImpl(fd);
+    }
 }
-
 /**
  * Resolve the real, parsed MinerGoalSpec for an already-cloned repo at `repoPath`, trying each
  * MINER_GOAL_SPEC_FILENAMES candidate in the documented discovery order. Never throws: a missing file, an
@@ -47,21 +39,18 @@ function readRegularUtf8File(path, options) {
  *
  * Injected filesystem operations receive the FULL joined path (same convention as `node:fs`'s own
  * functions), not a repoPath-relative candidate.
- *
- * @param {string} repoPath
- * @param {{ existsSync?: (path: string) => boolean, openSync?: (path: string, flags: number) => number, fstatSync?: (fd: number) => import("node:fs").Stats, readSync?: (fd: number, buffer: Buffer, offset: number, length: number, position: number | null) => number, closeSync?: (fd: number) => void }} [options]
- * @returns {import("@loopover/engine").ParsedMinerGoalSpec}
  */
 export function resolveMinerGoalSpec(repoPath, options = {}) {
-  const existsImpl = options.existsSync ?? existsSync;
-
-  const relativePath = discoverMinerGoalSpecPath((candidate) => existsImpl(join(repoPath, candidate)));
-  if (!relativePath) return parseMinerGoalSpecContent(null);
-
-  try {
-    const content = readRegularUtf8File(join(repoPath, relativePath), options);
-    return parseMinerGoalSpecContent(content);
-  } catch {
-    return parseMinerGoalSpecContent(null);
-  }
+    const existsImpl = options.existsSync ?? existsSync;
+    const relativePath = discoverMinerGoalSpecPath((candidate) => existsImpl(join(repoPath, candidate)));
+    if (!relativePath)
+        return parseMinerGoalSpecContent(null);
+    try {
+        const content = readRegularUtf8File(join(repoPath, relativePath), options);
+        return parseMinerGoalSpecContent(content);
+    }
+    catch {
+        return parseMinerGoalSpecContent(null);
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWluZXItZ29hbC1zcGVjLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsibWluZXItZ29hbC1zcGVjLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxTQUFTLEVBQUUsU0FBUyxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsUUFBUSxFQUFFLFFBQVEsRUFBYyxNQUFNLFNBQVMsQ0FBQztBQUN0RyxPQUFPLEVBQUUsSUFBSSxFQUFFLE1BQU0sV0FBVyxDQUFDO0FBQ2pDLE9BQU8sRUFBRSx5QkFBeUIsRUFBRSx5QkFBeUIsRUFBNEIsTUFBTSxrQkFBa0IsQ0FBQztBQUVsSCxNQUFNLHlCQUF5QixHQUFHLE1BQU0sQ0FBQztBQWtCekMscUdBQXFHO0FBQ3JHLGlIQUFpSDtBQUNqSCx3R0FBd0c7QUFDeEcsMkZBQTJGO0FBQzNGLFNBQVMsbUJBQW1CLENBQUMsSUFBWSxFQUFFLE9BQW9DO0lBQzdFLE1BQU0sUUFBUSxHQUFHLE9BQU8sQ0FBQyxRQUFRLElBQUksUUFBUSxDQUFDO0lBQzlDLE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxTQUFTLElBQUksU0FBUyxDQUFDO0lBQ2pELE1BQU0sUUFBUSxHQUFHLE9BQU8sQ0FBQyxRQUFRLElBQUksUUFBUSxDQUFDO0lBQzlDLE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxTQUFTLElBQUksU0FBUyxDQUFDO0lBRWpELE1BQU0sRUFBRSxHQUFHLFFBQVEsQ0FBQyxJQUFJLEVBQUUsU0FBUyxDQUFDLFFBQVEsR0FBRyxTQUFTLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDckUsSUFBSSxDQUFDO1FBQ0gsTUFBTSxLQUFLLEdBQUcsU0FBUyxDQUFDLEVBQUUsQ0FBQyxDQUFDO1FBQzVCLElBQUksQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFLElBQUksS0FBSyxDQUFDLElBQUksR0FBRyx5QkFBeUI7WUFBRSxPQUFPLElBQUksQ0FBQztRQUMzRSxNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsS0FBSyxDQUFDLHlCQUF5QixHQUFHLENBQUMsQ0FBQyxDQUFDO1FBQzNELElBQUksU0FBUyxHQUFHLENBQUMsQ0FBQztRQUNsQixPQUFPLFNBQVMsR0FBRyxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7WUFDakMsTUFBTSxDQUFDLEdBQUcsUUFBUSxDQUFDLEVBQUUsRUFBRSxNQUFNLEVBQUUsU0FBUyxFQUFFLE1BQU0sQ0FBQyxNQUFNLEdBQUcsU0FBUyxFQUFFLElBQUksQ0FBQyxDQUFDO1lBQzNFLElBQUksQ0FBQyxLQUFLLENBQUM7Z0JBQUUsTUFBTTtZQUNuQixTQUFTLElBQUksQ0FBQyxDQUFDO1FBQ2pCLENBQUM7UUFDRCxJQUFJLFNBQVMsR0FBRyx5QkFBeUI7WUFBRSxPQUFPLElBQUksQ0FBQztRQUN2RCxPQUFPLE1BQU0sQ0FBQyxRQUFRLENBQUMsQ0FBQyxFQUFFLFNBQVMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUN4RCxDQUFDO1lBQVMsQ0FBQztRQUNULFNBQVMsQ0FBQyxFQUFFLENBQUMsQ0FBQztJQUNoQixDQUFDO0FBQ0gsQ0FBQztBQUVEOzs7Ozs7O0dBT0c7QUFDSCxNQUFNLFVBQVUsb0JBQW9CLENBQUMsUUFBZ0IsRUFBRSxVQUF1QyxFQUFFO0lBQzlGLE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxVQUFVLElBQUksVUFBVSxDQUFDO0lBRXBELE1BQU0sWUFBWSxHQUFHLHlCQUF5QixDQUFDLENBQUMsU0FBUyxFQUFFLEVBQUUsQ0FBQyxVQUFVLENBQUMsSUFBSSxDQUFDLFFBQVEsRUFBRSxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDckcsSUFBSSxDQUFDLFlBQVk7UUFBRSxPQUFPLHlCQUF5QixDQUFDLElBQUksQ0FBQyxDQUFDO0lBRTFELElBQUksQ0FBQztRQUNILE1BQU0sT0FBTyxHQUFHLG1CQUFtQixDQUFDLElBQUksQ0FBQyxRQUFRLEVBQUUsWUFBWSxDQUFDLEVBQUUsT0FBTyxDQUFDLENBQUM7UUFDM0UsT0FBTyx5QkFBeUIsQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUM1QyxDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsT0FBTyx5QkFBeUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN6QyxDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/miner-goal-spec.ts
+++ b/packages/loopover-miner/lib/miner-goal-spec.ts
@@ -1,0 +1,71 @@
+import { closeSync, constants, existsSync, fstatSync, openSync, readSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import { discoverMinerGoalSpecPath, parseMinerGoalSpecContent, type ParsedMinerGoalSpec } from "@loopover/engine";
+
+const MAX_MINER_GOAL_SPEC_BYTES = 32_768;
+
+// Real local .loopover-miner.yml resolver (#5132, Wave 3.5 follow-up). MinerGoalSpec's own discovery
+// helper (discoverMinerGoalSpecPath, packages/loopover-engine) is deliberately IO-free -- the caller
+// injects the existence check. Unlike self-review-context.js/rejection-signal.js/ams-policy.js, which fetch
+// their target repo's files live over raw.githubusercontent.com BEFORE any clone exists, this resolver reads
+// the ALREADY-CLONED repo on disk (attempt-worktree.js's prepareAttemptWorktree runs first in the real
+// attempt-cli.js flow) -- no extra network round trip needed for a file that's already sitting in the
+// worktree.
+
+export type ResolveMinerGoalSpecOptions = {
+  existsSync?: (path: string) => boolean;
+  openSync?: (path: string, flags: number) => number;
+  fstatSync?: (fd: number) => Stats;
+  readSync?: (fd: number, buffer: Buffer, offset: number, length: number, position: number | null) => number;
+  closeSync?: (fd: number) => void;
+};
+
+// Same convention as packages/loopover-mcp/bin/loopover-mcp.js's readCliTextFile: O_NOFOLLOW on open
+// atomically rejects a symlinked path (no separate pre-open lstat -- that would be a check-then-open race, since
+// a symlink can be swapped in between the lstat and the open). Bounds the READ itself, not just fstat's
+// reported size, since a regular file can still grow between fstatSync and the read below.
+function readRegularUtf8File(path: string, options: ResolveMinerGoalSpecOptions): string | null {
+  const openImpl = options.openSync ?? openSync;
+  const fstatImpl = options.fstatSync ?? fstatSync;
+  const readImpl = options.readSync ?? readSync;
+  const closeImpl = options.closeSync ?? closeSync;
+
+  const fd = openImpl(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stats = fstatImpl(fd);
+    if (!stats.isFile() || stats.size > MAX_MINER_GOAL_SPEC_BYTES) return null;
+    const buffer = Buffer.alloc(MAX_MINER_GOAL_SPEC_BYTES + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const n = readImpl(fd, buffer, bytesRead, buffer.length - bytesRead, null);
+      if (n === 0) break;
+      bytesRead += n;
+    }
+    if (bytesRead > MAX_MINER_GOAL_SPEC_BYTES) return null;
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    closeImpl(fd);
+  }
+}
+
+/**
+ * Resolve the real, parsed MinerGoalSpec for an already-cloned repo at `repoPath`, trying each
+ * MINER_GOAL_SPEC_FILENAMES candidate in the documented discovery order. Never throws: a missing file, an
+ * unreadable file, or malformed content all degrade to the tolerant parser's own absent/safe-default result.
+ *
+ * Injected filesystem operations receive the FULL joined path (same convention as `node:fs`'s own
+ * functions), not a repoPath-relative candidate.
+ */
+export function resolveMinerGoalSpec(repoPath: string, options: ResolveMinerGoalSpecOptions = {}): ParsedMinerGoalSpec {
+  const existsImpl = options.existsSync ?? existsSync;
+
+  const relativePath = discoverMinerGoalSpecPath((candidate) => existsImpl(join(repoPath, candidate)));
+  if (!relativePath) return parseMinerGoalSpecContent(null);
+
+  try {
+    const content = readRegularUtf8File(join(repoPath, relativePath), options);
+    return parseMinerGoalSpecContent(content);
+  } catch {
+    return parseMinerGoalSpecContent(null);
+  }
+}

--- a/packages/loopover-miner/lib/rejection-signal.d.ts
+++ b/packages/loopover-miner/lib/rejection-signal.d.ts
@@ -1,32 +1,53 @@
-import type { SelfReviewContextFetch } from "./self-review-context.js";
-
-type OwnRejectionHistorySubmission = { pullRequestNumber?: number | null };
-
-type ListOwnSubmissions = (filter: { repoFullName?: string }) => OwnRejectionHistorySubmission[];
-
-export interface OwnRejectionHistoryOptions {
-  listSubmissions?: ListOwnSubmissions;
-  fetchImpl?: SelfReviewContextFetch;
-  githubToken?: string;
-  githubApiBaseUrl?: string;
-  maxRejectionHistoryChecks?: number;
-}
-
-export interface RejectionSignaledOptions extends OwnRejectionHistoryOptions {
-  rawContentBaseUrl?: string;
-}
-
+export type RejectionSignalFetch = (url: string, init?: {
+    method?: string;
+    headers?: Record<string, string>;
+}) => Promise<{
+    ok: boolean;
+    status: number;
+    headers?: {
+        get?: (name: string) => string | null;
+    };
+    body?: {
+        getReader: () => ReadableStreamDefaultReader<Uint8Array>;
+    } | null;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+}>;
 export type RejectionSignaledReason = "ai_usage_policy_ban" | "own_submission_rejected";
-
-export const REJECTION_REASON_AI_USAGE_POLICY_BAN: "ai_usage_policy_ban";
-export const REJECTION_REASON_OWN_SUBMISSION_REJECTED: "own_submission_rejected";
-
-export function resolveRejectionSignaled(
-  repoFullName: string,
-  options?: RejectionSignaledOptions,
-): Promise<false | RejectionSignaledReason | true>;
-
-export function resolveOwnRejectionHistory(
-  repoFullName: string,
-  options?: OwnRejectionHistoryOptions,
-): Promise<boolean>;
+export declare const REJECTION_REASON_AI_USAGE_POLICY_BAN = "ai_usage_policy_ban";
+export declare const REJECTION_REASON_OWN_SUBMISSION_REJECTED = "own_submission_rejected";
+type OwnRejectionHistorySubmission = {
+    pullRequestNumber?: number | null;
+};
+type ListOwnSubmissions = (filter: {
+    repoFullName?: string;
+}) => OwnRejectionHistorySubmission[];
+export interface OwnRejectionHistoryOptions {
+    listSubmissions?: ListOwnSubmissions;
+    fetchImpl?: RejectionSignalFetch;
+    githubToken?: string;
+    githubApiBaseUrl?: string;
+    maxRejectionHistoryChecks?: number;
+}
+/**
+ * Resolve the SECOND `rejectionSignaled` trigger (#5655): has a prior submission from THIS miner on THIS exact
+ * repo already been closed/rejected? Reads this miner's own recorded submissions on the repo
+ * (`listRecentOwnSubmissions`, #5134), fetches each one's live PR state, and runs it through `resolveRejection`
+ * (#4278) -- returning `true` if ANY was closed without merge. Bounded (only the most recent
+ * `maxRejectionHistoryChecks` submissions with a real PR number are fetched) and fully fail-open: a wholesale
+ * failure to read submissions resolves to `false` (never fabricated as a rejection), and any single PR
+ * fetch/parse failure is skipped so it never blocks the others. Consumes both upstream modules without modifying
+ * either. Every dependency is injectable for testing.
+ */
+export declare function resolveOwnRejectionHistory(repoFullName: string, options?: OwnRejectionHistoryOptions): Promise<boolean>;
+export interface RejectionSignaledOptions extends OwnRejectionHistoryOptions {
+    rawContentBaseUrl?: string;
+}
+/**
+ * Resolve whether the target repo has signaled it does not want automated/AI-authored contributions --
+ * either trigger documented above. Returns `false` (never throws) on any fetch/parse failure for the policy
+ * docs, matching resolveAiPolicyVerdict's own fail-open default for an absent/unreadable policy doc. When a
+ * trigger fires, returns a trigger-specific reason string so callers can label audit-trail events accurately.
+ */
+export declare function resolveRejectionSignaled(repoFullName: string, options?: RejectionSignaledOptions): Promise<false | RejectionSignaledReason | true>;
+export {};

--- a/packages/loopover-miner/lib/rejection-signal.js
+++ b/packages/loopover-miner/lib/rejection-signal.js
@@ -1,104 +1,84 @@
 import { resolveAiPolicyVerdict } from "@loopover/engine";
 import { listRecentOwnSubmissions } from "./governor-state.js";
 import { resolveRejection } from "./rejection-state-machine.js";
-
-// Real rejectionSignaled resolver (#5132, Wave 3.5 follow-up). iterate-policy.ts's own doc comment: "True
-// when the target repo (or this contributor's history with it) has signaled it does not want automated/
-// AI-authored contributions -- an explicit AI-usage-policy ban, or a prior submission from this same miner
-// was closed/rejected on this exact repo. The caller resolves this ... and passes it in; this policy does
-// not compute it itself." This module resolves the FIRST trigger: a real AI-USAGE.md/CONTRIBUTING.md ban,
-// fetched live and scanned via the engine's own resolveAiPolicyVerdict -- the same check
-// opportunity-fanout.js already runs during discovery, applied here at attempt time instead.
-//
-// The SECOND trigger (a prior submission from this same miner was closed/rejected on this exact repo) is now
-// resolved by resolveOwnRejectionHistory (#5655), closing the gap this header previously documented: it checks
-// each of this miner's recorded own-submissions on the repo (governor-state.js's listRecentOwnSubmissions,
-// #5134) against its live PR outcome via rejection-state-machine.js's resolveRejection (#4278) -- consuming both
-// upstream modules without modifying either. resolveRejectionSignaled now returns a trigger-specific reason
-// string if EITHER trigger fires (or `false` when neither does), so `rejectionSignaled` finally means what
-// iterate-policy.ts's doc comment has always said.
-
-/** @typedef {"ai_usage_policy_ban" | "own_submission_rejected"} RejectionSignaledReason */
-
 export const REJECTION_REASON_AI_USAGE_POLICY_BAN = "ai_usage_policy_ban";
 export const REJECTION_REASON_OWN_SUBMISSION_REJECTED = "own_submission_rejected";
-
 const DEFAULT_RAW_CONTENT_BASE_URL = "https://raw.githubusercontent.com";
 const MAX_POLICY_DOC_BYTES = 128 * 1024;
 const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
 // Bound the per-call PR-status fetch fan-out (#5655): a miner with a long submission history on one repo must
 // not trigger an unbounded burst of GitHub API calls on every attempt -- only the N most recent are checked.
 const DEFAULT_MAX_REJECTION_HISTORY_CHECKS = 10;
-
 function parseRepoFullName(repoFullName) {
-  if (typeof repoFullName !== "string") return null;
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  return { owner, repo };
-}
-
-function normalizeOptions(options = {}) {
-  return {
-    rawContentBaseUrl:
-      typeof options.rawContentBaseUrl === "string" && options.rawContentBaseUrl.trim() ? options.rawContentBaseUrl.trim() : DEFAULT_RAW_CONTENT_BASE_URL,
-    fetchImpl: options.fetchImpl ?? fetch,
-  };
-}
-
-async function readBoundedPolicyDoc(response) {
-  const contentLength = response.headers?.get?.("content-length");
-  if (contentLength !== undefined && contentLength !== null) {
-    const parsedLength = Number.parseInt(contentLength, 10);
-    if (Number.isFinite(parsedLength) && parsedLength > MAX_POLICY_DOC_BYTES) return null;
-  }
-
-  if (!response.body?.getReader) {
-    const text = await response.text();
-    return typeof text === "string" && Buffer.byteLength(text, "utf8") <= MAX_POLICY_DOC_BYTES ? text : null;
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let totalBytes = 0;
-  let text = "";
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      totalBytes += value.byteLength;
-      if (totalBytes > MAX_POLICY_DOC_BYTES) {
-        await reader.cancel();
+    if (typeof repoFullName !== "string")
         return null;
-      }
-      text += decoder.decode(value, { stream: true });
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    return { owner, repo };
+}
+function normalizeOptions(options = {}) {
+    return {
+        rawContentBaseUrl: typeof options.rawContentBaseUrl === "string" && options.rawContentBaseUrl.trim() ? options.rawContentBaseUrl.trim() : DEFAULT_RAW_CONTENT_BASE_URL,
+        fetchImpl: options.fetchImpl ?? fetch,
+    };
+}
+async function readBoundedPolicyDoc(response) {
+    const contentLength = response.headers?.get?.("content-length");
+    if (contentLength !== undefined && contentLength !== null) {
+        const parsedLength = Number.parseInt(contentLength, 10);
+        if (Number.isFinite(parsedLength) && parsedLength > MAX_POLICY_DOC_BYTES)
+            return null;
     }
-    text += decoder.decode();
-    return text;
-  } finally {
-    reader.releaseLock();
-  }
+    if (!response.body?.getReader) {
+        const text = await response.text();
+        return typeof text === "string" && Buffer.byteLength(text, "utf8") <= MAX_POLICY_DOC_BYTES ? text : null;
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let totalBytes = 0;
+    let text = "";
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done)
+                break;
+            totalBytes += value.byteLength;
+            if (totalBytes > MAX_POLICY_DOC_BYTES) {
+                await reader.cancel();
+                return null;
+            }
+            text += decoder.decode(value, { stream: true });
+        }
+        text += decoder.decode();
+        return text;
+    }
+    finally {
+        reader.releaseLock();
+    }
 }
-
 async function fetchPolicyDoc(target, path, resolved) {
-  const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
-  try {
-    const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
-    if (!response.ok) return null;
-    return await readBoundedPolicyDoc(response);
-  } catch {
-    return null;
-  }
+    const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
+    try {
+        const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
+        if (!response.ok)
+            return null;
+        return await readBoundedPolicyDoc(response);
+    }
+    catch {
+        return null;
+    }
 }
-
 async function fetchPullRequestPayload(target, prNumber, resolved) {
-  const url = `${resolved.githubApiBaseUrl}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/pulls/${prNumber}`;
-  const headers = { accept: "application/vnd.github+json", "user-agent": "loopover-miner" };
-  if (resolved.githubToken) headers.authorization = `Bearer ${resolved.githubToken}`;
-  const response = await resolved.fetchImpl(url, { method: "GET", headers });
-  if (!response.ok) return null;
-  return await response.json();
+    const url = `${resolved.githubApiBaseUrl}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/pulls/${prNumber}`;
+    const headers = { accept: "application/vnd.github+json", "user-agent": "loopover-miner" };
+    if (resolved.githubToken)
+        headers.authorization = `Bearer ${resolved.githubToken}`;
+    const response = await resolved.fetchImpl(url, { method: "GET", headers });
+    if (!response.ok)
+        return null;
+    return await response.json();
 }
-
 /**
  * Resolve the SECOND `rejectionSignaled` trigger (#5655): has a prior submission from THIS miner on THIS exact
  * repo already been closed/rejected? Reads this miner's own recorded submissions on the repo
@@ -108,74 +88,68 @@ async function fetchPullRequestPayload(target, prNumber, resolved) {
  * failure to read submissions resolves to `false` (never fabricated as a rejection), and any single PR
  * fetch/parse failure is skipped so it never blocks the others. Consumes both upstream modules without modifying
  * either. Every dependency is injectable for testing.
- *
- * @param {string} repoFullName
- * @param {{ listSubmissions?: typeof listRecentOwnSubmissions, fetchImpl?: typeof fetch, githubToken?: string, githubApiBaseUrl?: string, maxRejectionHistoryChecks?: number }} [options]
- * @returns {Promise<boolean>}
  */
 export async function resolveOwnRejectionHistory(repoFullName, options = {}) {
-  const target = parseRepoFullName(repoFullName);
-  if (!target) return false;
-  const listSubmissions = options.listSubmissions ?? listRecentOwnSubmissions;
-  const resolved = {
-    fetchImpl: options.fetchImpl ?? fetch,
-    githubToken: typeof options.githubToken === "string" ? options.githubToken.trim() : (process.env.GITHUB_TOKEN ?? ""),
-    githubApiBaseUrl:
-      typeof options.githubApiBaseUrl === "string" && options.githubApiBaseUrl.trim() ? options.githubApiBaseUrl.trim() : DEFAULT_GITHUB_API_BASE_URL,
-    maxChecks:
-      Number.isInteger(options.maxRejectionHistoryChecks) && options.maxRejectionHistoryChecks > 0
-        ? options.maxRejectionHistoryChecks
-        : DEFAULT_MAX_REJECTION_HISTORY_CHECKS,
-  };
-
-  let submissions;
-  try {
-    submissions = listSubmissions({ repoFullName });
-  } catch {
-    return false; // wholesale failure to read own submissions -- fail open, never fabricate a rejection
-  }
-  const checkable = (Array.isArray(submissions) ? submissions : [])
-    .filter((submission) => submission && Number.isInteger(submission.pullRequestNumber) && submission.pullRequestNumber > 0)
-    .slice(0, resolved.maxChecks);
-  if (checkable.length === 0) return false; // no prior submissions on this repo -- no fetch attempted
-
-  for (const submission of checkable) {
+    const target = parseRepoFullName(repoFullName);
+    if (!target)
+        return false;
+    const listSubmissions = options.listSubmissions ?? listRecentOwnSubmissions;
+    const resolved = {
+        fetchImpl: options.fetchImpl ?? fetch,
+        githubToken: typeof options.githubToken === "string" ? options.githubToken.trim() : (process.env.GITHUB_TOKEN ?? ""),
+        githubApiBaseUrl: typeof options.githubApiBaseUrl === "string" && options.githubApiBaseUrl.trim() ? options.githubApiBaseUrl.trim() : DEFAULT_GITHUB_API_BASE_URL,
+        maxChecks: Number.isInteger(options.maxRejectionHistoryChecks) && options.maxRejectionHistoryChecks > 0
+            ? options.maxRejectionHistoryChecks
+            : DEFAULT_MAX_REJECTION_HISTORY_CHECKS,
+    };
+    let submissions;
     try {
-      const payload = await fetchPullRequestPayload(target, submission.pullRequestNumber, resolved);
-      if (!payload) continue;
-      // No signal (gate/duplicate context isn't available here) -- resolveRejection returns non-null only for a
-      // PR that is closed-without-merge, which is exactly the "was it rejected" question this check asks.
-      const rejection = resolveRejection(payload, undefined, { repoFullName, prNumber: submission.pullRequestNumber });
-      if (rejection) return true;
-    } catch {
-      // Individual PR fetch/parse/classify failure -- skip this one, keep checking the rest (fail open).
+        submissions = listSubmissions({ repoFullName });
     }
-  }
-  return false;
+    catch {
+        return false; // wholesale failure to read own submissions -- fail open, never fabricate a rejection
+    }
+    const checkable = (Array.isArray(submissions) ? submissions : [])
+        .filter((submission) => Boolean(submission) && Number.isInteger(submission.pullRequestNumber) && submission.pullRequestNumber > 0)
+        .slice(0, resolved.maxChecks);
+    if (checkable.length === 0)
+        return false; // no prior submissions on this repo -- no fetch attempted
+    for (const submission of checkable) {
+        try {
+            const payload = await fetchPullRequestPayload(target, submission.pullRequestNumber, resolved);
+            if (!payload)
+                continue;
+            // No signal (gate/duplicate context isn't available here) -- resolveRejection returns non-null only for a
+            // PR that is closed-without-merge, which is exactly the "was it rejected" question this check asks.
+            const rejection = resolveRejection(payload, undefined, { repoFullName, prNumber: submission.pullRequestNumber });
+            if (rejection)
+                return true;
+        }
+        catch {
+            // Individual PR fetch/parse/classify failure -- skip this one, keep checking the rest (fail open).
+        }
+    }
+    return false;
 }
-
 /**
  * Resolve whether the target repo has signaled it does not want automated/AI-authored contributions --
  * either trigger documented above. Returns `false` (never throws) on any fetch/parse failure for the policy
  * docs, matching resolveAiPolicyVerdict's own fail-open default for an absent/unreadable policy doc. When a
  * trigger fires, returns a trigger-specific reason string so callers can label audit-trail events accurately.
- *
- * @param {string} repoFullName
- * @param {{ rawContentBaseUrl?: string, fetchImpl?: import("./self-review-context.js").SelfReviewContextFetch }} [options]
- * @returns {Promise<false | RejectionSignaledReason>}
  */
 export async function resolveRejectionSignaled(repoFullName, options = {}) {
-  const target = parseRepoFullName(repoFullName);
-  if (!target) return false;
-  const resolved = normalizeOptions(options);
-
-  const aiUsage = await fetchPolicyDoc(target, "AI-USAGE.md", resolved);
-  const contributing = aiUsage && aiUsage.trim() ? null : await fetchPolicyDoc(target, "CONTRIBUTING.md", resolved);
-
-  const verdict = resolveAiPolicyVerdict({ aiUsage, contributing });
-  // First trigger: an explicit live AI-usage-policy ban. A ban short-circuits -- no need to also check history.
-  if (!verdict.allowed) return REJECTION_REASON_AI_USAGE_POLICY_BAN;
-  // Second trigger (#5655): a prior submission from this same miner on this exact repo was closed/rejected.
-  const ownHistoryRejected = await resolveOwnRejectionHistory(repoFullName, options);
-  return ownHistoryRejected ? REJECTION_REASON_OWN_SUBMISSION_REJECTED : false;
+    const target = parseRepoFullName(repoFullName);
+    if (!target)
+        return false;
+    const resolved = normalizeOptions(options);
+    const aiUsage = await fetchPolicyDoc(target, "AI-USAGE.md", resolved);
+    const contributing = aiUsage && aiUsage.trim() ? null : await fetchPolicyDoc(target, "CONTRIBUTING.md", resolved);
+    const verdict = resolveAiPolicyVerdict({ aiUsage, contributing });
+    // First trigger: an explicit live AI-usage-policy ban. A ban short-circuits -- no need to also check history.
+    if (!verdict.allowed)
+        return REJECTION_REASON_AI_USAGE_POLICY_BAN;
+    // Second trigger (#5655): a prior submission from this same miner on this exact repo was closed/rejected.
+    const ownHistoryRejected = await resolveOwnRejectionHistory(repoFullName, options);
+    return ownHistoryRejected ? REJECTION_REASON_OWN_SUBMISSION_REJECTED : false;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmVqZWN0aW9uLXNpZ25hbC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInJlamVjdGlvbi1zaWduYWwudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLHNCQUFzQixFQUFFLE1BQU0sa0JBQWtCLENBQUM7QUFDMUQsT0FBTyxFQUFFLHdCQUF3QixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFDL0QsT0FBTyxFQUFFLGdCQUFnQixFQUFFLE1BQU0sOEJBQThCLENBQUM7QUFvQ2hFLE1BQU0sQ0FBQyxNQUFNLG9DQUFvQyxHQUFHLHFCQUFxQixDQUFDO0FBQzFFLE1BQU0sQ0FBQyxNQUFNLHdDQUF3QyxHQUFHLHlCQUF5QixDQUFDO0FBRWxGLE1BQU0sNEJBQTRCLEdBQUcsbUNBQW1DLENBQUM7QUFDekUsTUFBTSxvQkFBb0IsR0FBRyxHQUFHLEdBQUcsSUFBSSxDQUFDO0FBQ3hDLE1BQU0sMkJBQTJCLEdBQUcsd0JBQXdCLENBQUM7QUFDN0QsOEdBQThHO0FBQzlHLDZHQUE2RztBQUM3RyxNQUFNLG9DQUFvQyxHQUFHLEVBQUUsQ0FBQztBQUloRCxTQUFTLGlCQUFpQixDQUFDLFlBQXFCO0lBQzlDLElBQUksT0FBTyxZQUFZLEtBQUssUUFBUTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ2xELE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLFlBQVksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDckQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ3hELE9BQU8sRUFBRSxLQUFLLEVBQUUsSUFBSSxFQUFFLENBQUM7QUFDekIsQ0FBQztBQU9ELFNBQVMsZ0JBQWdCLENBQUMsVUFBb0MsRUFBRTtJQUM5RCxPQUFPO1FBQ0wsaUJBQWlCLEVBQ2YsT0FBTyxPQUFPLENBQUMsaUJBQWlCLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxpQkFBaUIsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLGlCQUFpQixDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyw0QkFBNEI7UUFDckosU0FBUyxFQUFFLE9BQU8sQ0FBQyxTQUFTLElBQUssS0FBeUM7S0FDM0UsQ0FBQztBQUNKLENBQUM7QUFFRCxLQUFLLFVBQVUsb0JBQW9CLENBQUMsUUFBbUQ7SUFDckYsTUFBTSxhQUFhLEdBQUcsUUFBUSxDQUFDLE9BQU8sRUFBRSxHQUFHLEVBQUUsQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDO0lBQ2hFLElBQUksYUFBYSxLQUFLLFNBQVMsSUFBSSxhQUFhLEtBQUssSUFBSSxFQUFFLENBQUM7UUFDMUQsTUFBTSxZQUFZLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxhQUFhLEVBQUUsRUFBRSxDQUFDLENBQUM7UUFDeEQsSUFBSSxNQUFNLENBQUMsUUFBUSxDQUFDLFlBQVksQ0FBQyxJQUFJLFlBQVksR0FBRyxvQkFBb0I7WUFBRSxPQUFPLElBQUksQ0FBQztJQUN4RixDQUFDO0lBRUQsSUFBSSxDQUFDLFFBQVEsQ0FBQyxJQUFJLEVBQUUsU0FBUyxFQUFFLENBQUM7UUFDOUIsTUFBTSxJQUFJLEdBQUcsTUFBTSxRQUFRLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDbkMsT0FBTyxPQUFPLElBQUksS0FBSyxRQUFRLElBQUksTUFBTSxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksb0JBQW9CLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQzNHLENBQUM7SUFFRCxNQUFNLE1BQU0sR0FBRyxRQUFRLENBQUMsSUFBSSxDQUFDLFNBQVMsRUFBRSxDQUFDO0lBQ3pDLE1BQU0sT0FBTyxHQUFHLElBQUksV0FBVyxFQUFFLENBQUM7SUFDbEMsSUFBSSxVQUFVLEdBQUcsQ0FBQyxDQUFDO0lBQ25CLElBQUksSUFBSSxHQUFHLEVBQUUsQ0FBQztJQUNkLElBQUksQ0FBQztRQUNILFNBQVMsQ0FBQztZQUNSLE1BQU0sRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLEdBQUcsTUFBTSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDNUMsSUFBSSxJQUFJO2dCQUFFLE1BQU07WUFDaEIsVUFBVSxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUM7WUFDL0IsSUFBSSxVQUFVLEdBQUcsb0JBQW9CLEVBQUUsQ0FBQztnQkFDdEMsTUFBTSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7Z0JBQ3RCLE9BQU8sSUFBSSxDQUFDO1lBQ2QsQ0FBQztZQUNELElBQUksSUFBSSxPQUFPLENBQUMsTUFBTSxDQUFDLEtBQUssRUFBRSxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDO1FBQ2xELENBQUM7UUFDRCxJQUFJLElBQUksT0FBTyxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ3pCLE9BQU8sSUFBSSxDQUFDO0lBQ2QsQ0FBQztZQUFTLENBQUM7UUFDVCxNQUFNLENBQUMsV0FBVyxFQUFFLENBQUM7SUFDdkIsQ0FBQztBQUNILENBQUM7QUFFRCxLQUFLLFVBQVUsY0FBYyxDQUFDLE1BQWtCLEVBQUUsSUFBWSxFQUFFLFFBQTJCO0lBQ3pGLE1BQU0sR0FBRyxHQUFHLEdBQUcsUUFBUSxDQUFDLGlCQUFpQixJQUFJLGtCQUFrQixDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsSUFBSSxrQkFBa0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLFNBQVMsSUFBSSxFQUFFLENBQUM7SUFDaEksSUFBSSxDQUFDO1FBQ0gsTUFBTSxRQUFRLEdBQUcsTUFBTSxRQUFRLENBQUMsU0FBUyxDQUFDLEdBQUcsRUFBRSxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFFLEVBQUUsTUFBTSxFQUFFLGtCQUFrQixFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxFQUFFLENBQUMsQ0FBQztRQUMzSSxJQUFJLENBQUMsUUFBUSxDQUFDLEVBQUU7WUFBRSxPQUFPLElBQUksQ0FBQztRQUM5QixPQUFPLE1BQU0sb0JBQW9CLENBQUMsUUFBUSxDQUFDLENBQUM7SUFDOUMsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLE9BQU8sSUFBSSxDQUFDO0lBQ2QsQ0FBQztBQUNILENBQUM7QUFTRCxLQUFLLFVBQVUsdUJBQXVCLENBQUMsTUFBa0IsRUFBRSxRQUFnQixFQUFFLFFBQTRDO0lBQ3ZILE1BQU0sR0FBRyxHQUFHLEdBQUcsUUFBUSxDQUFDLGdCQUFnQixVQUFVLGtCQUFrQixDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsSUFBSSxrQkFBa0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLFVBQVUsUUFBUSxFQUFFLENBQUM7SUFDMUksTUFBTSxPQUFPLEdBQTJCLEVBQUUsTUFBTSxFQUFFLDZCQUE2QixFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxDQUFDO0lBQ2xILElBQUksUUFBUSxDQUFDLFdBQVc7UUFBRSxPQUFPLENBQUMsYUFBYSxHQUFHLFVBQVUsUUFBUSxDQUFDLFdBQVcsRUFBRSxDQUFDO0lBQ25GLE1BQU0sUUFBUSxHQUFHLE1BQU0sUUFBUSxDQUFDLFNBQVMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLE9BQU8sRUFBRSxDQUFDLENBQUM7SUFDM0UsSUFBSSxDQUFDLFFBQVEsQ0FBQyxFQUFFO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDOUIsT0FBTyxNQUFNLFFBQVEsQ0FBQyxJQUFJLEVBQUUsQ0FBQztBQUMvQixDQUFDO0FBY0Q7Ozs7Ozs7OztHQVNHO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSwwQkFBMEIsQ0FBQyxZQUFvQixFQUFFLFVBQXNDLEVBQUU7SUFDN0csTUFBTSxNQUFNLEdBQUcsaUJBQWlCLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDL0MsSUFBSSxDQUFDLE1BQU07UUFBRSxPQUFPLEtBQUssQ0FBQztJQUMxQixNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsZUFBZSxJQUFJLHdCQUF3QixDQUFDO0lBQzVFLE1BQU0sUUFBUSxHQUF1QztRQUNuRCxTQUFTLEVBQUUsT0FBTyxDQUFDLFNBQVMsSUFBSyxLQUF5QztRQUMxRSxXQUFXLEVBQUUsT0FBTyxPQUFPLENBQUMsV0FBVyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLFlBQVksSUFBSSxFQUFFLENBQUM7UUFDcEgsZ0JBQWdCLEVBQ2QsT0FBTyxPQUFPLENBQUMsZ0JBQWdCLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLGdCQUFnQixDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQywyQkFBMkI7UUFDakosU0FBUyxFQUNQLE1BQU0sQ0FBQyxTQUFTLENBQUMsT0FBTyxDQUFDLHlCQUF5QixDQUFDLElBQUssT0FBTyxDQUFDLHlCQUFvQyxHQUFHLENBQUM7WUFDdEcsQ0FBQyxDQUFFLE9BQU8sQ0FBQyx5QkFBb0M7WUFDL0MsQ0FBQyxDQUFDLG9DQUFvQztLQUMzQyxDQUFDO0lBRUYsSUFBSSxXQUFvQixDQUFDO0lBQ3pCLElBQUksQ0FBQztRQUNILFdBQVcsR0FBRyxlQUFlLENBQUMsRUFBRSxZQUFZLEVBQUUsQ0FBQyxDQUFDO0lBQ2xELENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxPQUFPLEtBQUssQ0FBQyxDQUFDLHNGQUFzRjtJQUN0RyxDQUFDO0lBQ0QsTUFBTSxTQUFTLEdBQUcsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxXQUFXLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztTQUM5RCxNQUFNLENBQUMsQ0FBQyxVQUFVLEVBQStDLEVBQUUsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLElBQUksTUFBTSxDQUFDLFNBQVMsQ0FBQyxVQUFVLENBQUMsaUJBQWlCLENBQUMsSUFBSSxVQUFVLENBQUMsaUJBQWlCLEdBQUcsQ0FBQyxDQUFDO1NBQzlLLEtBQUssQ0FBQyxDQUFDLEVBQUUsUUFBUSxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ2hDLElBQUksU0FBUyxDQUFDLE1BQU0sS0FBSyxDQUFDO1FBQUUsT0FBTyxLQUFLLENBQUMsQ0FBQywwREFBMEQ7SUFFcEcsS0FBSyxNQUFNLFVBQVUsSUFBSSxTQUFTLEVBQUUsQ0FBQztRQUNuQyxJQUFJLENBQUM7WUFDSCxNQUFNLE9BQU8sR0FBRyxNQUFNLHVCQUF1QixDQUFDLE1BQU0sRUFBRSxVQUFVLENBQUMsaUJBQWlCLEVBQUUsUUFBUSxDQUFDLENBQUM7WUFDOUYsSUFBSSxDQUFDLE9BQU87Z0JBQUUsU0FBUztZQUN2QiwwR0FBMEc7WUFDMUcsb0dBQW9HO1lBQ3BHLE1BQU0sU0FBUyxHQUFHLGdCQUFnQixDQUFDLE9BQU8sRUFBRSxTQUFTLEVBQUUsRUFBRSxZQUFZLEVBQUUsUUFBUSxFQUFFLFVBQVUsQ0FBQyxpQkFBaUIsRUFBRSxDQUFDLENBQUM7WUFDakgsSUFBSSxTQUFTO2dCQUFFLE9BQU8sSUFBSSxDQUFDO1FBQzdCLENBQUM7UUFBQyxNQUFNLENBQUM7WUFDUCxtR0FBbUc7UUFDckcsQ0FBQztJQUNILENBQUM7SUFDRCxPQUFPLEtBQUssQ0FBQztBQUNmLENBQUM7QUFNRDs7Ozs7R0FLRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsd0JBQXdCLENBQzVDLFlBQW9CLEVBQ3BCLFVBQW9DLEVBQUU7SUFFdEMsTUFBTSxNQUFNLEdBQUcsaUJBQWlCLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDL0MsSUFBSSxDQUFDLE1BQU07UUFBRSxPQUFPLEtBQUssQ0FBQztJQUMxQixNQUFNLFFBQVEsR0FBRyxnQkFBZ0IsQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUUzQyxNQUFNLE9BQU8sR0FBRyxNQUFNLGNBQWMsQ0FBQyxNQUFNLEVBQUUsYUFBYSxFQUFFLFFBQVEsQ0FBQyxDQUFDO0lBQ3RFLE1BQU0sWUFBWSxHQUFHLE9BQU8sSUFBSSxPQUFPLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsTUFBTSxjQUFjLENBQUMsTUFBTSxFQUFFLGlCQUFpQixFQUFFLFFBQVEsQ0FBQyxDQUFDO0lBRWxILE1BQU0sT0FBTyxHQUFHLHNCQUFzQixDQUFDLEVBQUUsT0FBTyxFQUFFLFlBQVksRUFBRSxDQUFDLENBQUM7SUFDbEUsOEdBQThHO0lBQzlHLElBQUksQ0FBQyxPQUFPLENBQUMsT0FBTztRQUFFLE9BQU8sb0NBQW9DLENBQUM7SUFDbEUsMEdBQTBHO0lBQzFHLE1BQU0sa0JBQWtCLEdBQUcsTUFBTSwwQkFBMEIsQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDbkYsT0FBTyxrQkFBa0IsQ0FBQyxDQUFDLENBQUMsd0NBQXdDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQztBQUMvRSxDQUFDIn0=

--- a/packages/loopover-miner/lib/rejection-signal.ts
+++ b/packages/loopover-miner/lib/rejection-signal.ts
@@ -1,0 +1,222 @@
+import { resolveAiPolicyVerdict } from "@loopover/engine";
+import { listRecentOwnSubmissions } from "./governor-state.js";
+import { resolveRejection } from "./rejection-state-machine.js";
+
+// A narrower shape than `typeof fetch` on purpose -- same rationale as self-review-context.js's own
+// SelfReviewContextFetch/live-issue-snapshot.js's LiveIssueSnapshotFetch, widened just enough to cover this
+// module's own two response shapes: a plain JSON PR payload (json/text only) and a policy-doc text response
+// that may additionally carry `headers`/`body` for the bounded-read path in readBoundedPolicyDoc.
+export type RejectionSignalFetch = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  headers?: { get?: (name: string) => string | null };
+  body?: { getReader: () => ReadableStreamDefaultReader<Uint8Array> } | null;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}>;
+
+// Real rejectionSignaled resolver (#5132, Wave 3.5 follow-up). iterate-policy.ts's own doc comment: "True
+// when the target repo (or this contributor's history with it) has signaled it does not want automated/
+// AI-authored contributions -- an explicit AI-usage-policy ban, or a prior submission from this same miner
+// was closed/rejected on this exact repo. The caller resolves this ... and passes it in; this policy does
+// not compute it itself." This module resolves the FIRST trigger: a real AI-USAGE.md/CONTRIBUTING.md ban,
+// fetched live and scanned via the engine's own resolveAiPolicyVerdict -- the same check
+// opportunity-fanout.js already runs during discovery, applied here at attempt time instead.
+//
+// The SECOND trigger (a prior submission from this same miner was closed/rejected on this exact repo) is now
+// resolved by resolveOwnRejectionHistory (#5655), closing the gap this header previously documented: it checks
+// each of this miner's recorded own-submissions on the repo (governor-state.js's listRecentOwnSubmissions,
+// #5134) against its live PR outcome via rejection-state-machine.js's resolveRejection (#4278) -- consuming both
+// upstream modules without modifying either. resolveRejectionSignaled now returns a trigger-specific reason
+// string if EITHER trigger fires (or `false` when neither does), so `rejectionSignaled` finally means what
+// iterate-policy.ts's doc comment has always said.
+
+export type RejectionSignaledReason = "ai_usage_policy_ban" | "own_submission_rejected";
+
+export const REJECTION_REASON_AI_USAGE_POLICY_BAN = "ai_usage_policy_ban";
+export const REJECTION_REASON_OWN_SUBMISSION_REJECTED = "own_submission_rejected";
+
+const DEFAULT_RAW_CONTENT_BASE_URL = "https://raw.githubusercontent.com";
+const MAX_POLICY_DOC_BYTES = 128 * 1024;
+const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
+// Bound the per-call PR-status fetch fan-out (#5655): a miner with a long submission history on one repo must
+// not trigger an unbounded burst of GitHub API calls on every attempt -- only the N most recent are checked.
+const DEFAULT_MAX_REJECTION_HISTORY_CHECKS = 10;
+
+type RepoTarget = { owner: string; repo: string };
+
+function parseRepoFullName(repoFullName: unknown): RepoTarget | null {
+  if (typeof repoFullName !== "string") return null;
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return { owner, repo };
+}
+
+type NormalizedOptions = {
+  rawContentBaseUrl: string;
+  fetchImpl: RejectionSignalFetch;
+};
+
+function normalizeOptions(options: RejectionSignaledOptions = {}): NormalizedOptions {
+  return {
+    rawContentBaseUrl:
+      typeof options.rawContentBaseUrl === "string" && options.rawContentBaseUrl.trim() ? options.rawContentBaseUrl.trim() : DEFAULT_RAW_CONTENT_BASE_URL,
+    fetchImpl: options.fetchImpl ?? (fetch as unknown as RejectionSignalFetch),
+  };
+}
+
+async function readBoundedPolicyDoc(response: Awaited<ReturnType<RejectionSignalFetch>>): Promise<string | null> {
+  const contentLength = response.headers?.get?.("content-length");
+  if (contentLength !== undefined && contentLength !== null) {
+    const parsedLength = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_POLICY_DOC_BYTES) return null;
+  }
+
+  if (!response.body?.getReader) {
+    const text = await response.text();
+    return typeof text === "string" && Buffer.byteLength(text, "utf8") <= MAX_POLICY_DOC_BYTES ? text : null;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_POLICY_DOC_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function fetchPolicyDoc(target: RepoTarget, path: string, resolved: NormalizedOptions): Promise<string | null> {
+  const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
+  try {
+    const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
+    if (!response.ok) return null;
+    return await readBoundedPolicyDoc(response);
+  } catch {
+    return null;
+  }
+}
+
+type ResolvedOwnRejectionHistoryOptions = {
+  fetchImpl: RejectionSignalFetch;
+  githubToken: string;
+  githubApiBaseUrl: string;
+  maxChecks: number;
+};
+
+async function fetchPullRequestPayload(target: RepoTarget, prNumber: number, resolved: ResolvedOwnRejectionHistoryOptions): Promise<unknown> {
+  const url = `${resolved.githubApiBaseUrl}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/pulls/${prNumber}`;
+  const headers: Record<string, string> = { accept: "application/vnd.github+json", "user-agent": "loopover-miner" };
+  if (resolved.githubToken) headers.authorization = `Bearer ${resolved.githubToken}`;
+  const response = await resolved.fetchImpl(url, { method: "GET", headers });
+  if (!response.ok) return null;
+  return await response.json();
+}
+
+type OwnRejectionHistorySubmission = { pullRequestNumber?: number | null };
+
+type ListOwnSubmissions = (filter: { repoFullName?: string }) => OwnRejectionHistorySubmission[];
+
+export interface OwnRejectionHistoryOptions {
+  listSubmissions?: ListOwnSubmissions;
+  fetchImpl?: RejectionSignalFetch;
+  githubToken?: string;
+  githubApiBaseUrl?: string;
+  maxRejectionHistoryChecks?: number;
+}
+
+/**
+ * Resolve the SECOND `rejectionSignaled` trigger (#5655): has a prior submission from THIS miner on THIS exact
+ * repo already been closed/rejected? Reads this miner's own recorded submissions on the repo
+ * (`listRecentOwnSubmissions`, #5134), fetches each one's live PR state, and runs it through `resolveRejection`
+ * (#4278) -- returning `true` if ANY was closed without merge. Bounded (only the most recent
+ * `maxRejectionHistoryChecks` submissions with a real PR number are fetched) and fully fail-open: a wholesale
+ * failure to read submissions resolves to `false` (never fabricated as a rejection), and any single PR
+ * fetch/parse failure is skipped so it never blocks the others. Consumes both upstream modules without modifying
+ * either. Every dependency is injectable for testing.
+ */
+export async function resolveOwnRejectionHistory(repoFullName: string, options: OwnRejectionHistoryOptions = {}): Promise<boolean> {
+  const target = parseRepoFullName(repoFullName);
+  if (!target) return false;
+  const listSubmissions = options.listSubmissions ?? listRecentOwnSubmissions;
+  const resolved: ResolvedOwnRejectionHistoryOptions = {
+    fetchImpl: options.fetchImpl ?? (fetch as unknown as RejectionSignalFetch),
+    githubToken: typeof options.githubToken === "string" ? options.githubToken.trim() : (process.env.GITHUB_TOKEN ?? ""),
+    githubApiBaseUrl:
+      typeof options.githubApiBaseUrl === "string" && options.githubApiBaseUrl.trim() ? options.githubApiBaseUrl.trim() : DEFAULT_GITHUB_API_BASE_URL,
+    maxChecks:
+      Number.isInteger(options.maxRejectionHistoryChecks) && (options.maxRejectionHistoryChecks as number) > 0
+        ? (options.maxRejectionHistoryChecks as number)
+        : DEFAULT_MAX_REJECTION_HISTORY_CHECKS,
+  };
+
+  let submissions: unknown;
+  try {
+    submissions = listSubmissions({ repoFullName });
+  } catch {
+    return false; // wholesale failure to read own submissions -- fail open, never fabricate a rejection
+  }
+  const checkable = (Array.isArray(submissions) ? submissions : [])
+    .filter((submission): submission is { pullRequestNumber: number } => Boolean(submission) && Number.isInteger(submission.pullRequestNumber) && submission.pullRequestNumber > 0)
+    .slice(0, resolved.maxChecks);
+  if (checkable.length === 0) return false; // no prior submissions on this repo -- no fetch attempted
+
+  for (const submission of checkable) {
+    try {
+      const payload = await fetchPullRequestPayload(target, submission.pullRequestNumber, resolved);
+      if (!payload) continue;
+      // No signal (gate/duplicate context isn't available here) -- resolveRejection returns non-null only for a
+      // PR that is closed-without-merge, which is exactly the "was it rejected" question this check asks.
+      const rejection = resolveRejection(payload, undefined, { repoFullName, prNumber: submission.pullRequestNumber });
+      if (rejection) return true;
+    } catch {
+      // Individual PR fetch/parse/classify failure -- skip this one, keep checking the rest (fail open).
+    }
+  }
+  return false;
+}
+
+export interface RejectionSignaledOptions extends OwnRejectionHistoryOptions {
+  rawContentBaseUrl?: string;
+}
+
+/**
+ * Resolve whether the target repo has signaled it does not want automated/AI-authored contributions --
+ * either trigger documented above. Returns `false` (never throws) on any fetch/parse failure for the policy
+ * docs, matching resolveAiPolicyVerdict's own fail-open default for an absent/unreadable policy doc. When a
+ * trigger fires, returns a trigger-specific reason string so callers can label audit-trail events accurately.
+ */
+export async function resolveRejectionSignaled(
+  repoFullName: string,
+  options: RejectionSignaledOptions = {},
+): Promise<false | RejectionSignaledReason | true> {
+  const target = parseRepoFullName(repoFullName);
+  if (!target) return false;
+  const resolved = normalizeOptions(options);
+
+  const aiUsage = await fetchPolicyDoc(target, "AI-USAGE.md", resolved);
+  const contributing = aiUsage && aiUsage.trim() ? null : await fetchPolicyDoc(target, "CONTRIBUTING.md", resolved);
+
+  const verdict = resolveAiPolicyVerdict({ aiUsage, contributing });
+  // First trigger: an explicit live AI-usage-policy ban. A ban short-circuits -- no need to also check history.
+  if (!verdict.allowed) return REJECTION_REASON_AI_USAGE_POLICY_BAN;
+  // Second trigger (#5655): a prior submission from this same miner on this exact repo was closed/rejected.
+  const ownHistoryRejected = await resolveOwnRejectionHistory(repoFullName, options);
+  return ownHistoryRejected ? REJECTION_REASON_OWN_SUBMISSION_REJECTED : false;
+}

--- a/packages/loopover-miner/lib/replay-objective-anchor.d.ts
+++ b/packages/loopover-miner/lib/replay-objective-anchor.d.ts
@@ -1,79 +1,50 @@
-export type ChangeKind =
-  | "feature"
-  | "fix"
-  | "refactor"
-  | "docs"
-  | "test"
-  | "chore"
-  | "perf"
-  | "build"
-  | "ci"
-  | "style"
-  | "other";
-
-export const CHANGE_KINDS: readonly ChangeKind[];
-export const MODULE_OVERLAP_WEIGHT: number;
-export const CHANGE_KIND_WEIGHT: number;
-
+export type ChangeKind = "feature" | "fix" | "refactor" | "docs" | "test" | "chore" | "perf" | "build" | "ci" | "style" | "other";
+export declare const CHANGE_KINDS: readonly ChangeKind[];
+export declare const MODULE_OVERLAP_WEIGHT = 0.7;
+export declare const CHANGE_KIND_WEIGHT = 0.3;
 export type ReplayPlanInput = {
-  pathsTouched?: unknown;
-  changeKind?: unknown;
-  title?: unknown;
+    pathsTouched?: unknown;
+    changeKind?: unknown;
+    title?: unknown;
 };
-
 export type RevealedHistoryEntry = {
-  pathsTouched?: unknown;
-  changeKind?: unknown;
-  title?: unknown;
+    pathsTouched?: unknown;
+    changeKind?: unknown;
+    title?: unknown;
 };
-
+export declare function classifyChangeKind(value: unknown): ChangeKind;
 export type ReplayTargetFeatures = {
-  modules: string[];
-  changeKind: ChangeKind;
+    modules: string[];
+    changeKind: ChangeKind;
 };
-
+export declare function extractReplayTargetFeatures(plan: ReplayPlanInput | null | undefined): ReplayTargetFeatures;
 export type RevealedFeatures = {
-  modules: string[];
-  changeKinds: ChangeKind[];
+    modules: string[];
+    changeKinds: ChangeKind[];
 };
-
+export declare function extractRevealedFeatures(history: readonly unknown[] | RevealedHistoryEntry | null | undefined): RevealedFeatures;
 export type ObjectiveAnchorBreakdown = {
-  score: number;
-  moduleOverlap: number;
-  changeKindMatch: 0 | 1;
-  replayChangeKind: ChangeKind;
-  revealedChangeKinds: ChangeKind[];
-  sharedModules: string[];
-  replayOnlyModules: string[];
-  revealedOnlyModules: string[];
+    score: number;
+    moduleOverlap: number;
+    changeKindMatch: 0 | 1;
+    replayChangeKind: ChangeKind;
+    revealedChangeKinds: ChangeKind[];
+    sharedModules: string[];
+    replayOnlyModules: string[];
+    revealedOnlyModules: string[];
 };
-
+export declare function scoreObjectiveAnchor(replayFeatures: {
+    modules?: unknown;
+    changeKind?: unknown;
+} | null | undefined, revealedFeatures: {
+    modules?: unknown;
+    changeKinds?: unknown;
+} | null | undefined): ObjectiveAnchorBreakdown;
 export type ObjectiveAnchorResult = ObjectiveAnchorBreakdown & {
-  replayFeatures: ReplayTargetFeatures;
-  revealedFeatures: RevealedFeatures;
+    replayFeatures: ReplayTargetFeatures;
+    revealedFeatures: RevealedFeatures;
 };
-
-export function classifyChangeKind(value: unknown): ChangeKind;
-
-export function extractReplayTargetFeatures(
-  plan: ReplayPlanInput | null | undefined,
-): ReplayTargetFeatures;
-
-export function extractRevealedFeatures(
-  history: readonly unknown[] | RevealedHistoryEntry | null | undefined,
-): RevealedFeatures;
-
-export function scoreObjectiveAnchor(
-  replayFeatures: { modules?: unknown; changeKind?: unknown } | null | undefined,
-  revealedFeatures: { modules?: unknown; changeKinds?: unknown } | null | undefined,
-): ObjectiveAnchorBreakdown;
-
-export function computeObjectiveAnchor(
-  input:
-    | {
-        replayPlan?: ReplayPlanInput | null;
-        revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
-      }
-    | null
-    | undefined,
-): ObjectiveAnchorResult;
+export declare function computeObjectiveAnchor(input: {
+    replayPlan?: ReplayPlanInput | null;
+    revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
+} | null | undefined): ObjectiveAnchorResult;

--- a/packages/loopover-miner/lib/replay-objective-anchor.js
+++ b/packages/loopover-miner/lib/replay-objective-anchor.js
@@ -6,174 +6,170 @@
 // against what the revealed post-T history *actually* changed, and returns a reproducible `[0, 1]` score plus
 // a full audit breakdown. There is no model call in this path — given the same two feature sets it is
 // byte-for-byte reproducible.
-
 // Fixed change-kind vocabulary. Conventional-Commit types collapse onto these buckets; anything unrecognized
 // degrades to "other" so a novel prefix lowers the signal instead of throwing.
 export const CHANGE_KINDS = Object.freeze([
-  "feature",
-  "fix",
-  "refactor",
-  "docs",
-  "test",
-  "chore",
-  "perf",
-  "build",
-  "ci",
-  "style",
-  "other",
+    "feature",
+    "fix",
+    "refactor",
+    "docs",
+    "test",
+    "chore",
+    "perf",
+    "build",
+    "ci",
+    "style",
+    "other",
 ]);
-
 const CONVENTIONAL_TYPE_TO_KIND = new Map([
-  ["feat", "feature"],
-  ["feature", "feature"],
-  ["fix", "fix"],
-  ["bugfix", "fix"],
-  ["refactor", "refactor"],
-  ["docs", "docs"],
-  ["doc", "docs"],
-  ["test", "test"],
-  ["tests", "test"],
-  ["chore", "chore"],
-  ["perf", "perf"],
-  ["build", "build"],
-  ["ci", "ci"],
-  ["style", "style"],
+    ["feat", "feature"],
+    ["feature", "feature"],
+    ["fix", "fix"],
+    ["bugfix", "fix"],
+    ["refactor", "refactor"],
+    ["docs", "docs"],
+    ["doc", "docs"],
+    ["test", "test"],
+    ["tests", "test"],
+    ["chore", "chore"],
+    ["perf", "perf"],
+    ["build", "build"],
+    ["ci", "ci"],
+    ["style", "style"],
 ]);
-
 // Fixed weights for the two structural components. They sum to 1 so the composed score stays in [0, 1].
 export const MODULE_OVERLAP_WEIGHT = 0.7;
 export const CHANGE_KIND_WEIGHT = 0.3;
-
 const SCORE_PRECISION = 1e4;
-
 function roundScore(value) {
-  return Math.round(value * SCORE_PRECISION) / SCORE_PRECISION;
+    return Math.round(value * SCORE_PRECISION) / SCORE_PRECISION;
 }
-
 // A path's "module" is its directory (everything before the final slash); a bare filename is its own module.
 // Grouping by directory is what makes two different files in one directory a *partial* overlap, not a miss.
 function pathToModule(path) {
-  const trimmed = path.trim().replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
-  if (!trimmed) return null;
-  const slash = trimmed.lastIndexOf("/");
-  return slash === -1 ? trimmed : trimmed.slice(0, slash);
+    const trimmed = path.trim().replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    if (!trimmed)
+        return null;
+    const slash = trimmed.lastIndexOf("/");
+    return slash === -1 ? trimmed : trimmed.slice(0, slash);
 }
-
 function normalizeModules(pathsTouched) {
-  if (!Array.isArray(pathsTouched)) return [];
-  const modules = new Set();
-  for (const entry of pathsTouched) {
-    if (typeof entry !== "string") continue;
-    const module = pathToModule(entry);
-    if (module) modules.add(module);
-  }
-  return [...modules].sort();
+    if (!Array.isArray(pathsTouched))
+        return [];
+    const modules = new Set();
+    for (const entry of pathsTouched) {
+        if (typeof entry !== "string")
+            continue;
+        const module = pathToModule(entry);
+        if (module)
+            modules.add(module);
+    }
+    return [...modules].sort();
 }
-
 function normalizeKindList(value) {
-  if (!Array.isArray(value)) return [];
-  const kinds = new Set();
-  for (const entry of value) {
-    if (typeof entry === "string" && CHANGE_KINDS.includes(entry)) kinds.add(entry);
-  }
-  return [...kinds].sort();
+    if (!Array.isArray(value))
+        return [];
+    const kinds = new Set();
+    for (const entry of value) {
+        if (typeof entry === "string" && CHANGE_KINDS.includes(entry))
+            kinds.add(entry);
+    }
+    return [...kinds].sort();
 }
-
 function normalizeModuleList(value) {
-  if (!Array.isArray(value)) return [];
-  const modules = new Set();
-  for (const entry of value) {
-    if (typeof entry === "string" && entry) modules.add(entry);
-  }
-  return [...modules].sort();
+    if (!Array.isArray(value))
+        return [];
+    const modules = new Set();
+    for (const entry of value) {
+        if (typeof entry === "string" && entry)
+            modules.add(entry);
+    }
+    return [...modules].sort();
 }
-
 // Deterministically map a Conventional-Commit-style subject (`feat(scope)!: …`) to a change-kind bucket.
 // Missing prefix, unknown type, or non-string input all resolve to "other" rather than throwing.
 export function classifyChangeKind(value) {
-  if (typeof value !== "string") return "other";
-  const match = /^\s*([A-Za-z]+)\s*(?:\([^)]*\))?\s*!?\s*:/.exec(value);
-  if (!match) return "other";
-  return CONVENTIONAL_TYPE_TO_KIND.get(match[1].toLowerCase()) ?? "other";
+    if (typeof value !== "string")
+        return "other";
+    const match = /^\s*([A-Za-z]+)\s*(?:\([^)]*\))?\s*!?\s*:/.exec(value);
+    if (!match)
+        return "other";
+    return CONVENTIONAL_TYPE_TO_KIND.get(match[1].toLowerCase()) ?? "other";
 }
-
 function resolveChangeKind(entry) {
-  if (entry && typeof entry.changeKind === "string") {
-    const explicit = entry.changeKind.trim().toLowerCase();
-    if (CHANGE_KINDS.includes(explicit)) return explicit;
-  }
-  return classifyChangeKind(entry?.title);
+    if (entry && typeof entry.changeKind === "string") {
+        const explicit = entry.changeKind.trim().toLowerCase();
+        if (CHANGE_KINDS.includes(explicit))
+            return explicit;
+    }
+    return classifyChangeKind(entry?.title);
 }
-
 // Structural features of the miner's replayed plan/PR: the sorted, de-duplicated set of modules it targeted
 // and its single change kind (explicit `changeKind` wins; otherwise classified from `title`).
 export function extractReplayTargetFeatures(plan) {
-  return {
-    modules: normalizeModules(plan?.pathsTouched),
-    changeKind: resolveChangeKind(plan),
-  };
+    return {
+        modules: normalizeModules(plan?.pathsTouched),
+        changeKind: resolveChangeKind(plan),
+    };
 }
-
 // Structural features of the revealed post-T history. The history is a list of commits/PRs (a single object
 // is tolerated as a one-element list); modules are unioned and change kinds collected into a set, since the
 // revealed side legitimately spans several changes.
 export function extractRevealedFeatures(history) {
-  const entries = Array.isArray(history) ? history : history ? [history] : [];
-  const modules = new Set();
-  const changeKinds = new Set();
-  for (const entry of entries) {
-    if (!entry || typeof entry !== "object") continue;
-    for (const module of normalizeModules(entry.pathsTouched)) modules.add(module);
-    changeKinds.add(resolveChangeKind(entry));
-  }
-  return {
-    modules: [...modules].sort(),
-    changeKinds: [...changeKinds].sort(),
-  };
+    const entries = Array.isArray(history) ? history : history ? [history] : [];
+    const modules = new Set();
+    const changeKinds = new Set();
+    for (const entry of entries) {
+        if (!entry || typeof entry !== "object")
+            continue;
+        const typedEntry = entry;
+        for (const module of normalizeModules(typedEntry.pathsTouched))
+            modules.add(module);
+        changeKinds.add(resolveChangeKind(typedEntry));
+    }
+    return {
+        modules: [...modules].sort(),
+        changeKinds: [...changeKinds].sort(),
+    };
 }
-
 // Deterministic objective-anchor score from two already-extracted feature sets. No LLM, no clock, no
 // randomness — identical inputs always yield an identical breakdown. A zero-overlap comparison (disjoint
 // modules and a change kind the revealed side never shows) resolves to the score floor `0`, never an error.
 export function scoreObjectiveAnchor(replayFeatures, revealedFeatures) {
-  const replayModules = normalizeModuleList(replayFeatures?.modules);
-  const revealedModules = normalizeModuleList(revealedFeatures?.modules);
-  const replayChangeKind =
-    typeof replayFeatures?.changeKind === "string" && CHANGE_KINDS.includes(replayFeatures.changeKind)
-      ? replayFeatures.changeKind
-      : "other";
-  const revealedChangeKinds = normalizeKindList(revealedFeatures?.changeKinds);
-
-  const replaySet = new Set(replayModules);
-  const revealedSet = new Set(revealedModules);
-  const sharedModules = replayModules.filter((module) => revealedSet.has(module));
-  const replayOnlyModules = replayModules.filter((module) => !revealedSet.has(module));
-  const revealedOnlyModules = revealedModules.filter((module) => !replaySet.has(module));
-
-  const unionSize = replayModules.length + revealedModules.length - sharedModules.length;
-  const moduleOverlap = unionSize === 0 ? 0 : sharedModules.length / unionSize;
-  const changeKindMatch = revealedChangeKinds.includes(replayChangeKind) ? 1 : 0;
-
-  return {
-    score: roundScore(MODULE_OVERLAP_WEIGHT * moduleOverlap + CHANGE_KIND_WEIGHT * changeKindMatch),
-    moduleOverlap: roundScore(moduleOverlap),
-    changeKindMatch,
-    replayChangeKind,
-    revealedChangeKinds,
-    sharedModules,
-    replayOnlyModules,
-    revealedOnlyModules,
-  };
+    const replayModules = normalizeModuleList(replayFeatures?.modules);
+    const revealedModules = normalizeModuleList(revealedFeatures?.modules);
+    const replayChangeKind = typeof replayFeatures?.changeKind === "string" && CHANGE_KINDS.includes(replayFeatures.changeKind)
+        ? replayFeatures.changeKind
+        : "other";
+    const revealedChangeKinds = normalizeKindList(revealedFeatures?.changeKinds);
+    const replaySet = new Set(replayModules);
+    const revealedSet = new Set(revealedModules);
+    const sharedModules = replayModules.filter((module) => revealedSet.has(module));
+    const replayOnlyModules = replayModules.filter((module) => !revealedSet.has(module));
+    const revealedOnlyModules = revealedModules.filter((module) => !replaySet.has(module));
+    const unionSize = replayModules.length + revealedModules.length - sharedModules.length;
+    const moduleOverlap = unionSize === 0 ? 0 : sharedModules.length / unionSize;
+    const changeKindMatch = revealedChangeKinds.includes(replayChangeKind) ? 1 : 0;
+    return {
+        score: roundScore(MODULE_OVERLAP_WEIGHT * moduleOverlap + CHANGE_KIND_WEIGHT * changeKindMatch),
+        moduleOverlap: roundScore(moduleOverlap),
+        changeKindMatch,
+        replayChangeKind,
+        revealedChangeKinds,
+        sharedModules,
+        replayOnlyModules,
+        revealedOnlyModules,
+    };
 }
-
 // One-shot entry point: extract both sides, score them, and return the score together with the extracted
 // feature sets so a low score is auditable after the fact without re-running the extraction.
 export function computeObjectiveAnchor(input) {
-  const replayFeatures = extractReplayTargetFeatures(input?.replayPlan);
-  const revealedFeatures = extractRevealedFeatures(input?.revealedHistory);
-  return {
-    ...scoreObjectiveAnchor(replayFeatures, revealedFeatures),
-    replayFeatures,
-    revealedFeatures,
-  };
+    const replayFeatures = extractReplayTargetFeatures(input?.replayPlan);
+    const revealedFeatures = extractRevealedFeatures(input?.revealedHistory);
+    return {
+        ...scoreObjectiveAnchor(replayFeatures, revealedFeatures),
+        replayFeatures,
+        revealedFeatures,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmVwbGF5LW9iamVjdGl2ZS1hbmNob3IuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJyZXBsYXktb2JqZWN0aXZlLWFuY2hvci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSwyR0FBMkc7QUFDM0csRUFBRTtBQUNGLDRHQUE0RztBQUM1Ryw4R0FBOEc7QUFDOUcsMkdBQTJHO0FBQzNHLDhHQUE4RztBQUM5RyxzR0FBc0c7QUFDdEcsOEJBQThCO0FBZTlCLDZHQUE2RztBQUM3RywrRUFBK0U7QUFDL0UsTUFBTSxDQUFDLE1BQU0sWUFBWSxHQUEwQixNQUFNLENBQUMsTUFBTSxDQUFDO0lBQy9ELFNBQVM7SUFDVCxLQUFLO0lBQ0wsVUFBVTtJQUNWLE1BQU07SUFDTixNQUFNO0lBQ04sT0FBTztJQUNQLE1BQU07SUFDTixPQUFPO0lBQ1AsSUFBSTtJQUNKLE9BQU87SUFDUCxPQUFPO0NBQ1IsQ0FBQyxDQUFDO0FBRUgsTUFBTSx5QkFBeUIsR0FBRyxJQUFJLEdBQUcsQ0FBcUI7SUFDNUQsQ0FBQyxNQUFNLEVBQUUsU0FBUyxDQUFDO0lBQ25CLENBQUMsU0FBUyxFQUFFLFNBQVMsQ0FBQztJQUN0QixDQUFDLEtBQUssRUFBRSxLQUFLLENBQUM7SUFDZCxDQUFDLFFBQVEsRUFBRSxLQUFLLENBQUM7SUFDakIsQ0FBQyxVQUFVLEVBQUUsVUFBVSxDQUFDO0lBQ3hCLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQztJQUNoQixDQUFDLEtBQUssRUFBRSxNQUFNLENBQUM7SUFDZixDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUM7SUFDaEIsQ0FBQyxPQUFPLEVBQUUsTUFBTSxDQUFDO0lBQ2pCLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQztJQUNsQixDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUM7SUFDaEIsQ0FBQyxPQUFPLEVBQUUsT0FBTyxDQUFDO0lBQ2xCLENBQUMsSUFBSSxFQUFFLElBQUksQ0FBQztJQUNaLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQztDQUNuQixDQUFDLENBQUM7QUFFSCx3R0FBd0c7QUFDeEcsTUFBTSxDQUFDLE1BQU0scUJBQXFCLEdBQUcsR0FBRyxDQUFDO0FBQ3pDLE1BQU0sQ0FBQyxNQUFNLGtCQUFrQixHQUFHLEdBQUcsQ0FBQztBQUV0QyxNQUFNLGVBQWUsR0FBRyxHQUFHLENBQUM7QUFFNUIsU0FBUyxVQUFVLENBQUMsS0FBYTtJQUMvQixPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsS0FBSyxHQUFHLGVBQWUsQ0FBQyxHQUFHLGVBQWUsQ0FBQztBQUMvRCxDQUFDO0FBRUQsNkdBQTZHO0FBQzdHLDRHQUE0RztBQUM1RyxTQUFTLFlBQVksQ0FBQyxJQUFZO0lBQ2hDLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLEVBQUUsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLENBQUM7SUFDMUUsSUFBSSxDQUFDLE9BQU87UUFBRSxPQUFPLElBQUksQ0FBQztJQUMxQixNQUFNLEtBQUssR0FBRyxPQUFPLENBQUMsV0FBVyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3ZDLE9BQU8sS0FBSyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsQ0FBQyxFQUFFLEtBQUssQ0FBQyxDQUFDO0FBQzFELENBQUM7QUFFRCxTQUFTLGdCQUFnQixDQUFDLFlBQXFCO0lBQzdDLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLFlBQVksQ0FBQztRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQzVDLE1BQU0sT0FBTyxHQUFHLElBQUksR0FBRyxFQUFVLENBQUM7SUFDbEMsS0FBSyxNQUFNLEtBQUssSUFBSSxZQUFZLEVBQUUsQ0FBQztRQUNqQyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVE7WUFBRSxTQUFTO1FBQ3hDLE1BQU0sTUFBTSxHQUFHLFlBQVksQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNuQyxJQUFJLE1BQU07WUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ2xDLENBQUM7SUFDRCxPQUFPLENBQUMsR0FBRyxPQUFPLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztBQUM3QixDQUFDO0FBRUQsU0FBUyxpQkFBaUIsQ0FBQyxLQUFjO0lBQ3ZDLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQztRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQ3JDLE1BQU0sS0FBSyxHQUFHLElBQUksR0FBRyxFQUFjLENBQUM7SUFDcEMsS0FBSyxNQUFNLEtBQUssSUFBSSxLQUFLLEVBQUUsQ0FBQztRQUMxQixJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsSUFBSyxZQUFrQyxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUM7WUFBRSxLQUFLLENBQUMsR0FBRyxDQUFDLEtBQW1CLENBQUMsQ0FBQztJQUN2SCxDQUFDO0lBQ0QsT0FBTyxDQUFDLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7QUFDM0IsQ0FBQztBQUVELFNBQVMsbUJBQW1CLENBQUMsS0FBYztJQUN6QyxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUM7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUNyQyxNQUFNLE9BQU8sR0FBRyxJQUFJLEdBQUcsRUFBVSxDQUFDO0lBQ2xDLEtBQUssTUFBTSxLQUFLLElBQUksS0FBSyxFQUFFLENBQUM7UUFDMUIsSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRLElBQUksS0FBSztZQUFFLE9BQU8sQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDN0QsQ0FBQztJQUNELE9BQU8sQ0FBQyxHQUFHLE9BQU8sQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO0FBQzdCLENBQUM7QUFjRCx5R0FBeUc7QUFDekcsaUdBQWlHO0FBQ2pHLE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxLQUFjO0lBQy9DLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUTtRQUFFLE9BQU8sT0FBTyxDQUFDO0lBQzlDLE1BQU0sS0FBSyxHQUFHLDJDQUEyQyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN0RSxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sT0FBTyxDQUFDO0lBQzNCLE9BQU8seUJBQXlCLENBQUMsR0FBRyxDQUFFLEtBQUssQ0FBQyxDQUFDLENBQVksQ0FBQyxXQUFXLEVBQUUsQ0FBQyxJQUFJLE9BQU8sQ0FBQztBQUN0RixDQUFDO0FBRUQsU0FBUyxpQkFBaUIsQ0FBQyxLQUFtRTtJQUM1RixJQUFJLEtBQUssSUFBSSxPQUFPLEtBQUssQ0FBQyxVQUFVLEtBQUssUUFBUSxFQUFFLENBQUM7UUFDbEQsTUFBTSxRQUFRLEdBQUcsS0FBSyxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQztRQUN2RCxJQUFLLFlBQWtDLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQztZQUFFLE9BQU8sUUFBc0IsQ0FBQztJQUM1RixDQUFDO0lBQ0QsT0FBTyxrQkFBa0IsQ0FBQyxLQUFLLEVBQUUsS0FBSyxDQUFDLENBQUM7QUFDMUMsQ0FBQztBQU9ELDRHQUE0RztBQUM1Ryw4RkFBOEY7QUFDOUYsTUFBTSxVQUFVLDJCQUEyQixDQUFDLElBQXdDO0lBQ2xGLE9BQU87UUFDTCxPQUFPLEVBQUUsZ0JBQWdCLENBQUMsSUFBSSxFQUFFLFlBQVksQ0FBQztRQUM3QyxVQUFVLEVBQUUsaUJBQWlCLENBQUMsSUFBSSxDQUFDO0tBQ3BDLENBQUM7QUFDSixDQUFDO0FBT0QsNEdBQTRHO0FBQzVHLDRHQUE0RztBQUM1RyxvREFBb0Q7QUFDcEQsTUFBTSxVQUFVLHVCQUF1QixDQUNyQyxPQUFxRTtJQUVyRSxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzVFLE1BQU0sT0FBTyxHQUFHLElBQUksR0FBRyxFQUFVLENBQUM7SUFDbEMsTUFBTSxXQUFXLEdBQUcsSUFBSSxHQUFHLEVBQWMsQ0FBQztJQUMxQyxLQUFLLE1BQU0sS0FBSyxJQUFJLE9BQU8sRUFBRSxDQUFDO1FBQzVCLElBQUksQ0FBQyxLQUFLLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUTtZQUFFLFNBQVM7UUFDbEQsTUFBTSxVQUFVLEdBQUcsS0FBNkIsQ0FBQztRQUNqRCxLQUFLLE1BQU0sTUFBTSxJQUFJLGdCQUFnQixDQUFDLFVBQVUsQ0FBQyxZQUFZLENBQUM7WUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQ3BGLFdBQVcsQ0FBQyxHQUFHLENBQUMsaUJBQWlCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztJQUNqRCxDQUFDO0lBQ0QsT0FBTztRQUNMLE9BQU8sRUFBRSxDQUFDLEdBQUcsT0FBTyxDQUFDLENBQUMsSUFBSSxFQUFFO1FBQzVCLFdBQVcsRUFBRSxDQUFDLEdBQUcsV0FBVyxDQUFDLENBQUMsSUFBSSxFQUFFO0tBQ3JDLENBQUM7QUFDSixDQUFDO0FBYUQscUdBQXFHO0FBQ3JHLHlHQUF5RztBQUN6Ryw0R0FBNEc7QUFDNUcsTUFBTSxVQUFVLG9CQUFvQixDQUNsQyxjQUE4RSxFQUM5RSxnQkFBaUY7SUFFakYsTUFBTSxhQUFhLEdBQUcsbUJBQW1CLENBQUMsY0FBYyxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ25FLE1BQU0sZUFBZSxHQUFHLG1CQUFtQixDQUFDLGdCQUFnQixFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3ZFLE1BQU0sZ0JBQWdCLEdBQ3BCLE9BQU8sY0FBYyxFQUFFLFVBQVUsS0FBSyxRQUFRLElBQUssWUFBa0MsQ0FBQyxRQUFRLENBQUMsY0FBYyxDQUFDLFVBQVUsQ0FBQztRQUN2SCxDQUFDLENBQUUsY0FBYyxDQUFDLFVBQXlCO1FBQzNDLENBQUMsQ0FBQyxPQUFPLENBQUM7SUFDZCxNQUFNLG1CQUFtQixHQUFHLGlCQUFpQixDQUFDLGdCQUFnQixFQUFFLFdBQVcsQ0FBQyxDQUFDO0lBRTdFLE1BQU0sU0FBUyxHQUFHLElBQUksR0FBRyxDQUFDLGFBQWEsQ0FBQyxDQUFDO0lBQ3pDLE1BQU0sV0FBVyxHQUFHLElBQUksR0FBRyxDQUFDLGVBQWUsQ0FBQyxDQUFDO0lBQzdDLE1BQU0sYUFBYSxHQUFHLGFBQWEsQ0FBQyxNQUFNLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQztJQUNoRixNQUFNLGlCQUFpQixHQUFHLGFBQWEsQ0FBQyxNQUFNLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDLENBQUMsV0FBVyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO0lBQ3JGLE1BQU0sbUJBQW1CLEdBQUcsZUFBZSxDQUFDLE1BQU0sQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUMsQ0FBQyxTQUFTLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7SUFFdkYsTUFBTSxTQUFTLEdBQUcsYUFBYSxDQUFDLE1BQU0sR0FBRyxlQUFlLENBQUMsTUFBTSxHQUFHLGFBQWEsQ0FBQyxNQUFNLENBQUM7SUFDdkYsTUFBTSxhQUFhLEdBQUcsU0FBUyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxhQUFhLENBQUMsTUFBTSxHQUFHLFNBQVMsQ0FBQztJQUM3RSxNQUFNLGVBQWUsR0FBVSxtQkFBbUIsQ0FBQyxRQUFRLENBQUMsZ0JBQWdCLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFFdEYsT0FBTztRQUNMLEtBQUssRUFBRSxVQUFVLENBQUMscUJBQXFCLEdBQUcsYUFBYSxHQUFHLGtCQUFrQixHQUFHLGVBQWUsQ0FBQztRQUMvRixhQUFhLEVBQUUsVUFBVSxDQUFDLGFBQWEsQ0FBQztRQUN4QyxlQUFlO1FBQ2YsZ0JBQWdCO1FBQ2hCLG1CQUFtQjtRQUNuQixhQUFhO1FBQ2IsaUJBQWlCO1FBQ2pCLG1CQUFtQjtLQUNwQixDQUFDO0FBQ0osQ0FBQztBQU9ELHlHQUF5RztBQUN6Ryw2RkFBNkY7QUFDN0YsTUFBTSxVQUFVLHNCQUFzQixDQUNwQyxLQU1hO0lBRWIsTUFBTSxjQUFjLEdBQUcsMkJBQTJCLENBQUMsS0FBSyxFQUFFLFVBQVUsQ0FBQyxDQUFDO0lBQ3RFLE1BQU0sZ0JBQWdCLEdBQUcsdUJBQXVCLENBQUMsS0FBSyxFQUFFLGVBQWUsQ0FBQyxDQUFDO0lBQ3pFLE9BQU87UUFDTCxHQUFHLG9CQUFvQixDQUFDLGNBQWMsRUFBRSxnQkFBZ0IsQ0FBQztRQUN6RCxjQUFjO1FBQ2QsZ0JBQWdCO0tBQ2pCLENBQUM7QUFDSixDQUFDIn0=

--- a/packages/loopover-miner/lib/replay-objective-anchor.ts
+++ b/packages/loopover-miner/lib/replay-objective-anchor.ts
@@ -1,0 +1,244 @@
+// Deterministic structural "objective-anchor" score for the historical-replay calibration harness (#3012).
+//
+// Once a replay run produces a plan/PR against a frozen snapshot, half of the calibration score is meant to
+// come from a deterministic, auditable structural comparison rather than an LLM judgment. This module is that
+// structural half: it compares what the miner's replayed output *targeted* (modules touched + change kind)
+// against what the revealed post-T history *actually* changed, and returns a reproducible `[0, 1]` score plus
+// a full audit breakdown. There is no model call in this path — given the same two feature sets it is
+// byte-for-byte reproducible.
+
+export type ChangeKind =
+  | "feature"
+  | "fix"
+  | "refactor"
+  | "docs"
+  | "test"
+  | "chore"
+  | "perf"
+  | "build"
+  | "ci"
+  | "style"
+  | "other";
+
+// Fixed change-kind vocabulary. Conventional-Commit types collapse onto these buckets; anything unrecognized
+// degrades to "other" so a novel prefix lowers the signal instead of throwing.
+export const CHANGE_KINDS: readonly ChangeKind[] = Object.freeze([
+  "feature",
+  "fix",
+  "refactor",
+  "docs",
+  "test",
+  "chore",
+  "perf",
+  "build",
+  "ci",
+  "style",
+  "other",
+]);
+
+const CONVENTIONAL_TYPE_TO_KIND = new Map<string, ChangeKind>([
+  ["feat", "feature"],
+  ["feature", "feature"],
+  ["fix", "fix"],
+  ["bugfix", "fix"],
+  ["refactor", "refactor"],
+  ["docs", "docs"],
+  ["doc", "docs"],
+  ["test", "test"],
+  ["tests", "test"],
+  ["chore", "chore"],
+  ["perf", "perf"],
+  ["build", "build"],
+  ["ci", "ci"],
+  ["style", "style"],
+]);
+
+// Fixed weights for the two structural components. They sum to 1 so the composed score stays in [0, 1].
+export const MODULE_OVERLAP_WEIGHT = 0.7;
+export const CHANGE_KIND_WEIGHT = 0.3;
+
+const SCORE_PRECISION = 1e4;
+
+function roundScore(value: number): number {
+  return Math.round(value * SCORE_PRECISION) / SCORE_PRECISION;
+}
+
+// A path's "module" is its directory (everything before the final slash); a bare filename is its own module.
+// Grouping by directory is what makes two different files in one directory a *partial* overlap, not a miss.
+function pathToModule(path: string): string | null {
+  const trimmed = path.trim().replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+  if (!trimmed) return null;
+  const slash = trimmed.lastIndexOf("/");
+  return slash === -1 ? trimmed : trimmed.slice(0, slash);
+}
+
+function normalizeModules(pathsTouched: unknown): string[] {
+  if (!Array.isArray(pathsTouched)) return [];
+  const modules = new Set<string>();
+  for (const entry of pathsTouched) {
+    if (typeof entry !== "string") continue;
+    const module = pathToModule(entry);
+    if (module) modules.add(module);
+  }
+  return [...modules].sort();
+}
+
+function normalizeKindList(value: unknown): ChangeKind[] {
+  if (!Array.isArray(value)) return [];
+  const kinds = new Set<ChangeKind>();
+  for (const entry of value) {
+    if (typeof entry === "string" && (CHANGE_KINDS as readonly string[]).includes(entry)) kinds.add(entry as ChangeKind);
+  }
+  return [...kinds].sort();
+}
+
+function normalizeModuleList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const modules = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry === "string" && entry) modules.add(entry);
+  }
+  return [...modules].sort();
+}
+
+export type ReplayPlanInput = {
+  pathsTouched?: unknown;
+  changeKind?: unknown;
+  title?: unknown;
+};
+
+export type RevealedHistoryEntry = {
+  pathsTouched?: unknown;
+  changeKind?: unknown;
+  title?: unknown;
+};
+
+// Deterministically map a Conventional-Commit-style subject (`feat(scope)!: …`) to a change-kind bucket.
+// Missing prefix, unknown type, or non-string input all resolve to "other" rather than throwing.
+export function classifyChangeKind(value: unknown): ChangeKind {
+  if (typeof value !== "string") return "other";
+  const match = /^\s*([A-Za-z]+)\s*(?:\([^)]*\))?\s*!?\s*:/.exec(value);
+  if (!match) return "other";
+  return CONVENTIONAL_TYPE_TO_KIND.get((match[1] as string).toLowerCase()) ?? "other";
+}
+
+function resolveChangeKind(entry: { changeKind?: unknown; title?: unknown } | null | undefined): ChangeKind {
+  if (entry && typeof entry.changeKind === "string") {
+    const explicit = entry.changeKind.trim().toLowerCase();
+    if ((CHANGE_KINDS as readonly string[]).includes(explicit)) return explicit as ChangeKind;
+  }
+  return classifyChangeKind(entry?.title);
+}
+
+export type ReplayTargetFeatures = {
+  modules: string[];
+  changeKind: ChangeKind;
+};
+
+// Structural features of the miner's replayed plan/PR: the sorted, de-duplicated set of modules it targeted
+// and its single change kind (explicit `changeKind` wins; otherwise classified from `title`).
+export function extractReplayTargetFeatures(plan: ReplayPlanInput | null | undefined): ReplayTargetFeatures {
+  return {
+    modules: normalizeModules(plan?.pathsTouched),
+    changeKind: resolveChangeKind(plan),
+  };
+}
+
+export type RevealedFeatures = {
+  modules: string[];
+  changeKinds: ChangeKind[];
+};
+
+// Structural features of the revealed post-T history. The history is a list of commits/PRs (a single object
+// is tolerated as a one-element list); modules are unioned and change kinds collected into a set, since the
+// revealed side legitimately spans several changes.
+export function extractRevealedFeatures(
+  history: readonly unknown[] | RevealedHistoryEntry | null | undefined,
+): RevealedFeatures {
+  const entries = Array.isArray(history) ? history : history ? [history] : [];
+  const modules = new Set<string>();
+  const changeKinds = new Set<ChangeKind>();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const typedEntry = entry as RevealedHistoryEntry;
+    for (const module of normalizeModules(typedEntry.pathsTouched)) modules.add(module);
+    changeKinds.add(resolveChangeKind(typedEntry));
+  }
+  return {
+    modules: [...modules].sort(),
+    changeKinds: [...changeKinds].sort(),
+  };
+}
+
+export type ObjectiveAnchorBreakdown = {
+  score: number;
+  moduleOverlap: number;
+  changeKindMatch: 0 | 1;
+  replayChangeKind: ChangeKind;
+  revealedChangeKinds: ChangeKind[];
+  sharedModules: string[];
+  replayOnlyModules: string[];
+  revealedOnlyModules: string[];
+};
+
+// Deterministic objective-anchor score from two already-extracted feature sets. No LLM, no clock, no
+// randomness — identical inputs always yield an identical breakdown. A zero-overlap comparison (disjoint
+// modules and a change kind the revealed side never shows) resolves to the score floor `0`, never an error.
+export function scoreObjectiveAnchor(
+  replayFeatures: { modules?: unknown; changeKind?: unknown } | null | undefined,
+  revealedFeatures: { modules?: unknown; changeKinds?: unknown } | null | undefined,
+): ObjectiveAnchorBreakdown {
+  const replayModules = normalizeModuleList(replayFeatures?.modules);
+  const revealedModules = normalizeModuleList(revealedFeatures?.modules);
+  const replayChangeKind: ChangeKind =
+    typeof replayFeatures?.changeKind === "string" && (CHANGE_KINDS as readonly string[]).includes(replayFeatures.changeKind)
+      ? (replayFeatures.changeKind as ChangeKind)
+      : "other";
+  const revealedChangeKinds = normalizeKindList(revealedFeatures?.changeKinds);
+
+  const replaySet = new Set(replayModules);
+  const revealedSet = new Set(revealedModules);
+  const sharedModules = replayModules.filter((module) => revealedSet.has(module));
+  const replayOnlyModules = replayModules.filter((module) => !revealedSet.has(module));
+  const revealedOnlyModules = revealedModules.filter((module) => !replaySet.has(module));
+
+  const unionSize = replayModules.length + revealedModules.length - sharedModules.length;
+  const moduleOverlap = unionSize === 0 ? 0 : sharedModules.length / unionSize;
+  const changeKindMatch: 0 | 1 = revealedChangeKinds.includes(replayChangeKind) ? 1 : 0;
+
+  return {
+    score: roundScore(MODULE_OVERLAP_WEIGHT * moduleOverlap + CHANGE_KIND_WEIGHT * changeKindMatch),
+    moduleOverlap: roundScore(moduleOverlap),
+    changeKindMatch,
+    replayChangeKind,
+    revealedChangeKinds,
+    sharedModules,
+    replayOnlyModules,
+    revealedOnlyModules,
+  };
+}
+
+export type ObjectiveAnchorResult = ObjectiveAnchorBreakdown & {
+  replayFeatures: ReplayTargetFeatures;
+  revealedFeatures: RevealedFeatures;
+};
+
+// One-shot entry point: extract both sides, score them, and return the score together with the extracted
+// feature sets so a low score is auditable after the fact without re-running the extraction.
+export function computeObjectiveAnchor(
+  input:
+    | {
+        replayPlan?: ReplayPlanInput | null;
+        revealedHistory?: RevealedHistoryEntry[] | RevealedHistoryEntry | null;
+      }
+    | null
+    | undefined,
+): ObjectiveAnchorResult {
+  const replayFeatures = extractReplayTargetFeatures(input?.replayPlan);
+  const revealedFeatures = extractRevealedFeatures(input?.revealedHistory);
+  return {
+    ...scoreObjectiveAnchor(replayFeatures, revealedFeatures),
+    replayFeatures,
+    revealedFeatures,
+  };
+}

--- a/packages/loopover-miner/lib/replay-snapshot.d.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.d.ts
@@ -1,41 +1,65 @@
-import type { WorktreeExecFn, WorktreeRemoveResult } from "@loopover/engine";
-
-export const REPLAY_SNAPSHOT_SUBDIR: ".loopover-replay-snapshots";
-
-export type ReplaySnapshotCommit = { sha: string; date: string; subject: string };
-export type ReplaySnapshotTag = { name: string; date: string; targetSha: string };
-export type ReplaySnapshotReadme = { filename: string; content: string };
-
+import { type WorktreeExecFn, type WorktreeRemoveResult } from "@loopover/engine";
+export declare function resolveReplaySnapshotDbPath(env?: Record<string, string | undefined>): string;
+/** Worktree exports live under this dir inside the repo, mirroring worktree-allocator.ts's WORKTREE_SUBDIR. */
+export declare const REPLAY_SNAPSHOT_SUBDIR = ".loopover-replay-snapshots";
+/** PURE: the deterministic on-disk location for a (repo, commit) replay export -- same pair -> same path. */
+export declare function planReplaySnapshotPath(input: {
+    repoPath: string;
+    commitSha: string;
+}): string;
+export type ReplaySnapshotCommit = {
+    sha: string;
+    date: string;
+    subject: string;
+};
+export type ReplaySnapshotTag = {
+    name: string;
+    date: string;
+    targetSha: string;
+};
+export type ReplaySnapshotReadme = {
+    filename: string;
+    content: string;
+};
 export type ReplaySnapshot = {
-  repoFullName: string;
-  commitSha: string;
-  worktreePath: string;
-  targetDate: string;
-  commits: ReplaySnapshotCommit[];
-  tags: ReplaySnapshotTag[];
-  readme: ReplaySnapshotReadme | null;
-  exportedAt: string;
+    repoFullName: string;
+    commitSha: string;
+    worktreePath: string;
+    targetDate: string;
+    commits: ReplaySnapshotCommit[];
+    tags: ReplaySnapshotTag[];
+    readme: ReplaySnapshotReadme | null;
+    exportedAt: string;
 };
-
-export function resolveReplaySnapshotDbPath(env?: NodeJS.ProcessEnv): string;
-
-export function planReplaySnapshotPath(input: { repoPath: string; commitSha: string }): string;
-
-export function validateSnapshotFreshness(input: { targetDate: string; commits: ReplaySnapshotCommit[]; tags: ReplaySnapshotTag[] }): void;
-
+/** PURE: fails fast (throws) if any exported commit or tag carries a date LATER than the target commit's own
+ *  date. Returns nothing on success. */
+export declare function validateSnapshotFreshness(input: {
+    targetDate: string;
+    commits: ReplaySnapshotCommit[];
+    tags: ReplaySnapshotTag[];
+}): void;
 export type ReplaySnapshotStore = {
-  dbPath: string;
-  getSnapshot(repoFullName: string, commitSha: string): ReplaySnapshot | null;
-  saveSnapshot(snapshot: Omit<ReplaySnapshot, "exportedAt">): ReplaySnapshot;
-  close(): void;
+    dbPath: string;
+    getSnapshot(repoFullName: string, commitSha: string): ReplaySnapshot | null;
+    saveSnapshot(snapshot: Omit<ReplaySnapshot, "exportedAt">): ReplaySnapshot;
+    close(): void;
 };
-
-export function openReplaySnapshotStore(dbPath?: string): ReplaySnapshotStore;
-export function closeDefaultReplaySnapshotStore(): void;
-
-export function exportReplaySnapshot(
-  input: { repoPath: string; repoFullName: string; commitSha: string },
-  deps: { exec: WorktreeExecFn; store?: ReplaySnapshotStore },
-): Promise<ReplaySnapshot>;
-
-export function removeReplaySnapshotWorktree(exec: WorktreeExecFn, repoPath: string, worktreePath: string): Promise<WorktreeRemoveResult>;
+export declare function openReplaySnapshotStore(dbPath?: string): ReplaySnapshotStore;
+export declare function closeDefaultReplaySnapshotStore(): void;
+/**
+ * Export a frozen, reproducible replay snapshot for (repoFullName, commitSha): a detached working-tree checkout
+ * at that commit plus a context bundle (commit history, reachable tags, README-at-commit). Returns the CACHED
+ * snapshot without touching git again if one already exists for this exact (repo, commit) pair.
+ */
+export declare function exportReplaySnapshot(input: {
+    repoPath: string;
+    repoFullName: string;
+    commitSha: string;
+}, deps: {
+    exec: WorktreeExecFn;
+    store?: ReplaySnapshotStore;
+}): Promise<ReplaySnapshot>;
+/** Tear down a replay snapshot's working-tree export (the cached context-bundle row is left in place -- it is
+ *  cheap, commit-keyed, and re-usable even after the on-disk tree is removed; only re-adding the worktree would
+ *  require the tree again, which is out of this function's scope). */
+export declare function removeReplaySnapshotWorktree(exec: WorktreeExecFn, repoPath: string, worktreePath: string): Promise<WorktreeRemoveResult>;

--- a/packages/loopover-miner/lib/replay-snapshot.js
+++ b/packages/loopover-miner/lib/replay-snapshot.js
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 import { removeWorktree } from "@loopover/engine";
 import { openLocalStoreDb, resolveLocalStoreDbPath, normalizeLocalStoreDbPath } from "./local-store.js";
-
 // Freeze/snapshot mechanism for historical replay targets (#3010). Given a repo and a commit SHA T, exports:
 //  (a) the full working tree checked out AT T via a DETACHED git worktree -- the same isolation primitive
 //      worktree-allocator.ts (#4269) uses for attempt isolation, just detached rather than on a new branch,
@@ -30,77 +29,68 @@ import { openLocalStoreDb, resolveLocalStoreDbPath, normalizeLocalStoreDbPath } 
 // re-exporting the same (repo, T) pair returns the identical cached row rather than re-running git, which is
 // both how "byte-reproducible" holds trivially and avoids redundant work on repeat replay runs. The working-
 // tree export itself is git-content-addressed already (the same commit SHA always checks out identical files).
-
 const defaultDbFileName = "replay-snapshot.sqlite3";
 let defaultDb = null;
-
 export function resolveReplaySnapshotDbPath(env = process.env) {
-  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_REPLAY_SNAPSHOT_DB", env);
+    return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_REPLAY_SNAPSHOT_DB", env);
 }
-
 function normalizeDbPath(dbPath) {
-  return normalizeLocalStoreDbPath(dbPath, resolveReplaySnapshotDbPath(), "invalid_replay_snapshot_db_path");
+    return normalizeLocalStoreDbPath(dbPath, resolveReplaySnapshotDbPath(), "invalid_replay_snapshot_db_path");
 }
-
 const FIELD_SEP = "\x1f";
 const README_NAME_PATTERN = /^readme(\.\w+)?$/i;
-
 function normalizeRepoFullName(repoFullName) {
-  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
-  const [owner, repo, extra] = repoFullName.trim().split("/");
-  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
-  return `${owner}/${repo}`;
+    if (typeof repoFullName !== "string")
+        throw new Error("invalid_repo_full_name");
+    const [owner, repo, extra] = repoFullName.trim().split("/");
+    if (!owner || !repo || extra !== undefined)
+        throw new Error("invalid_repo_full_name");
+    return `${owner}/${repo}`;
 }
-
 function normalizeCommitSha(commitSha) {
-  if (typeof commitSha !== "string" || !commitSha.trim()) throw new Error("invalid_commit_sha");
-  return commitSha.trim();
+    if (typeof commitSha !== "string" || !commitSha.trim())
+        throw new Error("invalid_commit_sha");
+    return commitSha.trim();
 }
-
 /** Worktree exports live under this dir inside the repo, mirroring worktree-allocator.ts's WORKTREE_SUBDIR. */
 export const REPLAY_SNAPSHOT_SUBDIR = ".loopover-replay-snapshots";
-
 /** PURE: the deterministic on-disk location for a (repo, commit) replay export -- same pair -> same path. */
 export function planReplaySnapshotPath(input) {
-  const commitSha = normalizeCommitSha(input.commitSha);
-  return join(input.repoPath, REPLAY_SNAPSHOT_SUBDIR, commitSha);
+    const commitSha = normalizeCommitSha(input.commitSha);
+    return join(input.repoPath, REPLAY_SNAPSHOT_SUBDIR, commitSha);
 }
-
 function assertExecResult(result, description) {
-  if (result.code !== 0) {
-    const detail = (result.stderr ?? "").trim() || `exit_${result.code}`;
-    throw new Error(`${description}: ${detail}`);
-  }
-  return result.stdout ?? "";
+    if (result.code !== 0) {
+        const detail = (result.stderr ?? "").trim() || `exit_${result.code}`;
+        throw new Error(`${description}: ${detail}`);
+    }
+    return result.stdout ?? "";
 }
-
 /** Detached checkout at commitSha via `git worktree add --detach` -- never creates a branch, never touches the
  *  caller's own checkout. Idempotent in effect: `git worktree add` itself fails if the path already has a
  *  worktree, which callers avoid by checking the store cache first (see exportReplaySnapshot). */
 async function addDetachedWorktree(exec, repoPath, worktreePath, commitSha) {
-  const result = await exec("git", ["worktree", "add", "--detach", worktreePath, commitSha], { cwd: repoPath });
-  assertExecResult(result, "git_worktree_add_failed");
+    const result = await exec("git", ["worktree", "add", "--detach", worktreePath, commitSha], { cwd: repoPath });
+    assertExecResult(result, "git_worktree_add_failed");
 }
-
 async function readTargetCommitDate(exec, repoPath, commitSha) {
-  const result = await exec("git", ["log", "-1", "--format=%cI", commitSha], { cwd: repoPath });
-  const stdout = assertExecResult(result, "git_log_target_failed").trim();
-  if (!stdout) throw new Error(`git_log_target_failed: no commit found for ${commitSha}`);
-  return stdout;
+    const result = await exec("git", ["log", "-1", "--format=%cI", commitSha], { cwd: repoPath });
+    const stdout = assertExecResult(result, "git_log_target_failed").trim();
+    if (!stdout)
+        throw new Error(`git_log_target_failed: no commit found for ${commitSha}`);
+    return stdout;
 }
-
 async function readCommitHistory(exec, repoPath, commitSha) {
-  const result = await exec("git", ["log", commitSha, `--format=%H${FIELD_SEP}%cI${FIELD_SEP}%s`], { cwd: repoPath });
-  const stdout = assertExecResult(result, "git_log_history_failed");
-  return stdout
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .map((line) => {
-      const [sha, date, subject] = line.split(FIELD_SEP);
-      return { sha, date, subject: subject ?? "" };
+    const result = await exec("git", ["log", commitSha, `--format=%H${FIELD_SEP}%cI${FIELD_SEP}%s`], { cwd: repoPath });
+    const stdout = assertExecResult(result, "git_log_history_failed");
+    return stdout
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => {
+        const [sha, date, subject] = line.split(FIELD_SEP);
+        return { sha: sha, date: date, subject: subject ?? "" };
     });
 }
-
 // Lightweight tags have no tag object of their own, so `%(creatordate)` falls back to the POINTED-TO commit's
 // date rather than a genuine tag-creation date -- git has no record of when a lightweight tag was actually
 // created at all. That means a lightweight tag added long after T, but pointing at an ancestor of T, would
@@ -109,58 +99,54 @@ async function readCommitHistory(exec, repoPath, commitSha) {
 // entirely -- `%(objecttype)` is "tag" only for an annotated tag's own tag object, "commit" for a lightweight
 // tag's direct target, which is how the two are told apart.
 async function readReachableTags(exec, repoPath, commitSha) {
-  const result = await exec(
-    "git",
-    ["tag", "--merged", commitSha, `--format=%(refname:short)${FIELD_SEP}%(creatordate:iso-strict)${FIELD_SEP}%(objectname)${FIELD_SEP}%(objecttype)`],
-    { cwd: repoPath },
-  );
-  const stdout = assertExecResult(result, "git_tag_merged_failed");
-  return stdout
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .map((line) => {
-      const [name, date, targetSha, objectType] = line.split(FIELD_SEP);
-      return { name, date, targetSha, objectType };
+    const result = await exec("git", ["tag", "--merged", commitSha, `--format=%(refname:short)${FIELD_SEP}%(creatordate:iso-strict)${FIELD_SEP}%(objectname)${FIELD_SEP}%(objecttype)`], { cwd: repoPath });
+    const stdout = assertExecResult(result, "git_tag_merged_failed");
+    return stdout
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => {
+        const [name, date, targetSha, objectType] = line.split(FIELD_SEP);
+        return { name: name, date: date, targetSha: targetSha, objectType: objectType };
     })
-    .filter((tag) => tag.objectType === "tag")
-    .map(({ objectType, ...tag }) => tag);
+        .filter((tag) => tag.objectType === "tag")
+        .map(({ objectType: _objectType, ...tag }) => tag);
 }
-
 /** Finds the repo-root README (any casing/extension) at commitSha and returns its content, or null if none
  *  exists at that commit. Uses `git ls-tree` to find the real filename rather than guessing a fixed spelling
  *  list. */
 async function readReadmeAtCommit(exec, repoPath, commitSha) {
-  const listing = await exec("git", ["ls-tree", "--name-only", commitSha], { cwd: repoPath });
-  const stdout = assertExecResult(listing, "git_ls_tree_failed");
-  const filename = stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .find((line) => README_NAME_PATTERN.test(line));
-  if (!filename) return null;
-
-  const shown = await exec("git", ["show", `${commitSha}:${filename}`], { cwd: repoPath });
-  const content = assertExecResult(shown, "git_show_readme_failed");
-  return { filename, content };
+    const listing = await exec("git", ["ls-tree", "--name-only", commitSha], { cwd: repoPath });
+    const stdout = assertExecResult(listing, "git_ls_tree_failed");
+    const filename = stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => README_NAME_PATTERN.test(line));
+    if (!filename)
+        return null;
+    const shown = await exec("git", ["show", `${commitSha}:${filename}`], { cwd: repoPath });
+    const content = assertExecResult(shown, "git_show_readme_failed");
+    return { filename, content };
 }
-
 /** PURE: fails fast (throws) if any exported commit or tag carries a date LATER than the target commit's own
  *  date. Returns nothing on success. */
 export function validateSnapshotFreshness(input) {
-  const targetMs = Date.parse(input.targetDate);
-  const violations = [];
-  for (const commit of input.commits) {
-    if (Date.parse(commit.date) > targetMs) violations.push(`commit ${commit.sha} dated ${commit.date} is after target ${input.targetDate}`);
-  }
-  for (const tag of input.tags) {
-    if (Date.parse(tag.date) > targetMs) violations.push(`tag ${tag.name} dated ${tag.date} is after target ${input.targetDate}`);
-  }
-  if (violations.length > 0) throw new Error(`replay_snapshot_freshness_violation: ${violations.join("; ")}`);
+    const targetMs = Date.parse(input.targetDate);
+    const violations = [];
+    for (const commit of input.commits) {
+        if (Date.parse(commit.date) > targetMs)
+            violations.push(`commit ${commit.sha} dated ${commit.date} is after target ${input.targetDate}`);
+    }
+    for (const tag of input.tags) {
+        if (Date.parse(tag.date) > targetMs)
+            violations.push(`tag ${tag.name} dated ${tag.date} is after target ${input.targetDate}`);
+    }
+    if (violations.length > 0)
+        throw new Error(`replay_snapshot_freshness_violation: ${violations.join("; ")}`);
 }
-
 export function openReplaySnapshotStore(dbPath = resolveReplaySnapshotDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  const db = openLocalStoreDb(resolvedPath);
-  db.exec(`
+    const resolvedPath = normalizeDbPath(dbPath);
+    const db = openLocalStoreDb(resolvedPath);
+    db.exec(`
     CREATE TABLE IF NOT EXISTS replay_snapshots (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       repo_full_name TEXT NOT NULL,
@@ -175,114 +161,96 @@ export function openReplaySnapshotStore(dbPath = resolveReplaySnapshotDbPath()) 
       UNIQUE (repo_full_name, commit_sha)
     )
   `);
-  const getStatement = db.prepare("SELECT * FROM replay_snapshots WHERE repo_full_name = ? AND commit_sha = ?");
-  const insertStatement = db.prepare(`
+    const getStatement = db.prepare("SELECT * FROM replay_snapshots WHERE repo_full_name = ? AND commit_sha = ?");
+    const insertStatement = db.prepare(`
     INSERT INTO replay_snapshots
       (repo_full_name, commit_sha, worktree_path, target_date, commits_json, tags_json, readme_filename, readme_content, exported_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
-
-  function rowToSnapshot(row) {
+    function rowToSnapshot(row) {
+        return {
+            repoFullName: row.repo_full_name,
+            commitSha: row.commit_sha,
+            worktreePath: row.worktree_path,
+            targetDate: row.target_date,
+            commits: JSON.parse(row.commits_json),
+            tags: JSON.parse(row.tags_json),
+            readme: row.readme_filename ? { filename: row.readme_filename, content: row.readme_content } : null,
+            exportedAt: row.exported_at,
+        };
+    }
     return {
-      repoFullName: row.repo_full_name,
-      commitSha: row.commit_sha,
-      worktreePath: row.worktree_path,
-      targetDate: row.target_date,
-      commits: JSON.parse(row.commits_json),
-      tags: JSON.parse(row.tags_json),
-      readme: row.readme_filename ? { filename: row.readme_filename, content: row.readme_content } : null,
-      exportedAt: row.exported_at,
+        dbPath: resolvedPath,
+        getSnapshot(repoFullName, commitSha) {
+            const row = getStatement.get(normalizeRepoFullName(repoFullName), normalizeCommitSha(commitSha));
+            return row ? rowToSnapshot(row) : null;
+        },
+        saveSnapshot(snapshot) {
+            const repoFullName = normalizeRepoFullName(snapshot.repoFullName);
+            const commitSha = normalizeCommitSha(snapshot.commitSha);
+            insertStatement.run(repoFullName, commitSha, snapshot.worktreePath, snapshot.targetDate, JSON.stringify(snapshot.commits), JSON.stringify(snapshot.tags), snapshot.readme?.filename ?? null, snapshot.readme?.content ?? null, new Date().toISOString());
+            return this.getSnapshot(repoFullName, commitSha);
+        },
+        close() {
+            db.close();
+        },
     };
-  }
-
-  return {
-    dbPath: resolvedPath,
-    getSnapshot(repoFullName, commitSha) {
-      const row = getStatement.get(normalizeRepoFullName(repoFullName), normalizeCommitSha(commitSha));
-      return row ? rowToSnapshot(row) : null;
-    },
-    saveSnapshot(snapshot) {
-      const repoFullName = normalizeRepoFullName(snapshot.repoFullName);
-      const commitSha = normalizeCommitSha(snapshot.commitSha);
-      insertStatement.run(
-        repoFullName,
-        commitSha,
-        snapshot.worktreePath,
-        snapshot.targetDate,
-        JSON.stringify(snapshot.commits),
-        JSON.stringify(snapshot.tags),
-        snapshot.readme?.filename ?? null,
-        snapshot.readme?.content ?? null,
-        new Date().toISOString(),
-      );
-      return this.getSnapshot(repoFullName, commitSha);
-    },
-    close() {
-      db.close();
-    },
-  };
 }
-
 function getDefaultReplaySnapshotStore() {
-  defaultDb ??= openReplaySnapshotStore();
-  return defaultDb;
+    defaultDb ??= openReplaySnapshotStore();
+    return defaultDb;
 }
-
 export function closeDefaultReplaySnapshotStore() {
-  if (!defaultDb) return;
-  defaultDb.close();
-  defaultDb = null;
+    if (!defaultDb)
+        return;
+    defaultDb.close();
+    defaultDb = null;
 }
-
 /**
  * Export a frozen, reproducible replay snapshot for (repoFullName, commitSha): a detached working-tree checkout
  * at that commit plus a context bundle (commit history, reachable tags, README-at-commit). Returns the CACHED
  * snapshot without touching git again if one already exists for this exact (repo, commit) pair.
- *
- * @param {{ repoPath: string, repoFullName: string, commitSha: string }} input
- * @param {{ exec: import("./worktree-allocator.js").WorktreeExecFn, store?: ReturnType<typeof openReplaySnapshotStore> }} deps
  */
 export async function exportReplaySnapshot(input, deps) {
-  if (!input || typeof input !== "object") throw new Error("invalid_replay_snapshot_input");
-  const repoFullName = normalizeRepoFullName(input.repoFullName);
-  const commitSha = normalizeCommitSha(input.commitSha);
-  if (typeof input.repoPath !== "string" || !input.repoPath.trim()) throw new Error("invalid_repo_path");
-  const repoPath = input.repoPath.trim();
-
-  if (!deps || typeof deps !== "object" || typeof deps.exec !== "function") throw new Error("invalid_exec");
-  const { exec } = deps;
-  const store = deps.store ?? getDefaultReplaySnapshotStore();
-
-  const cached = store.getSnapshot(repoFullName, commitSha);
-  if (cached) return cached;
-
-  const worktreePath = planReplaySnapshotPath({ repoPath, commitSha });
-  await addDetachedWorktree(exec, repoPath, worktreePath, commitSha);
-
-  // Everything below can fail (a bad git read, or a deliberate freshness violation) after the worktree already
-  // exists on disk at the deterministic path above. Left behind, a retry for the same (repo, commit) pair would
-  // hit `git worktree add`'s own "path already exists" refusal instead of the real error, permanently masking
-  // it. Clean up the worktree on any failure here before rethrowing, so a retry starts from a clean slate.
-  try {
-    const targetDate = await readTargetCommitDate(exec, repoPath, commitSha);
-    const commits = await readCommitHistory(exec, repoPath, commitSha);
-    const tags = await readReachableTags(exec, repoPath, commitSha);
-    const readme = await readReadmeAtCommit(exec, repoPath, commitSha);
-
-    validateSnapshotFreshness({ targetDate, commits, tags });
-
-    return store.saveSnapshot({ repoFullName, commitSha, worktreePath, targetDate, commits, tags, readme });
-  } catch (error) {
-    await removeReplaySnapshotWorktree(exec, repoPath, worktreePath).catch(() => {
-      /* best-effort cleanup -- the original error below is the one that matters to the caller */
-    });
-    throw error;
-  }
+    if (!input || typeof input !== "object")
+        throw new Error("invalid_replay_snapshot_input");
+    const repoFullName = normalizeRepoFullName(input.repoFullName);
+    const commitSha = normalizeCommitSha(input.commitSha);
+    if (typeof input.repoPath !== "string" || !input.repoPath.trim())
+        throw new Error("invalid_repo_path");
+    const repoPath = input.repoPath.trim();
+    if (!deps || typeof deps !== "object" || typeof deps.exec !== "function")
+        throw new Error("invalid_exec");
+    const { exec } = deps;
+    const store = deps.store ?? getDefaultReplaySnapshotStore();
+    const cached = store.getSnapshot(repoFullName, commitSha);
+    if (cached)
+        return cached;
+    const worktreePath = planReplaySnapshotPath({ repoPath, commitSha });
+    await addDetachedWorktree(exec, repoPath, worktreePath, commitSha);
+    // Everything below can fail (a bad git read, or a deliberate freshness violation) after the worktree already
+    // exists on disk at the deterministic path above. Left behind, a retry for the same (repo, commit) pair would
+    // hit `git worktree add`'s own "path already exists" refusal instead of the real error, permanently masking
+    // it. Clean up the worktree on any failure here before rethrowing, so a retry starts from a clean slate.
+    try {
+        const targetDate = await readTargetCommitDate(exec, repoPath, commitSha);
+        const commits = await readCommitHistory(exec, repoPath, commitSha);
+        const tags = await readReachableTags(exec, repoPath, commitSha);
+        const readme = await readReadmeAtCommit(exec, repoPath, commitSha);
+        validateSnapshotFreshness({ targetDate, commits, tags });
+        return store.saveSnapshot({ repoFullName, commitSha, worktreePath, targetDate, commits, tags, readme });
+    }
+    catch (error) {
+        await removeReplaySnapshotWorktree(exec, repoPath, worktreePath).catch(() => {
+            /* best-effort cleanup -- the original error below is the one that matters to the caller */
+        });
+        throw error;
+    }
 }
-
 /** Tear down a replay snapshot's working-tree export (the cached context-bundle row is left in place -- it is
  *  cheap, commit-keyed, and re-usable even after the on-disk tree is removed; only re-adding the worktree would
  *  require the tree again, which is out of this function's scope). */
 export async function removeReplaySnapshotWorktree(exec, repoPath, worktreePath) {
-  return removeWorktree({ exec, repoPath, worktreePath });
+    return removeWorktree({ exec, repoPath, worktreePath });
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmVwbGF5LXNuYXBzaG90LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicmVwbGF5LXNuYXBzaG90LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxJQUFJLEVBQUUsTUFBTSxXQUFXLENBQUM7QUFDakMsT0FBTyxFQUFFLGNBQWMsRUFBMkUsTUFBTSxrQkFBa0IsQ0FBQztBQUMzSCxPQUFPLEVBQUUsZ0JBQWdCLEVBQUUsdUJBQXVCLEVBQUUseUJBQXlCLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUV4Ryw2R0FBNkc7QUFDN0csMEdBQTBHO0FBQzFHLDRHQUE0RztBQUM1RywyR0FBMkc7QUFDM0csd0JBQXdCO0FBQ3hCLCtHQUErRztBQUMvRyw4R0FBOEc7QUFDOUcsOEdBQThHO0FBQzlHLGdIQUFnSDtBQUNoSCxFQUFFO0FBQ0YsNEdBQTRHO0FBQzVHLDhHQUE4RztBQUM5RywyR0FBMkc7QUFDM0csdUdBQXVHO0FBQ3ZHLGdHQUFnRztBQUNoRywyRkFBMkY7QUFDM0Ysd0VBQXdFO0FBQ3hFLEVBQUU7QUFDRix1R0FBdUc7QUFDdkcsNkdBQTZHO0FBQzdHLDBHQUEwRztBQUMxRyw4R0FBOEc7QUFDOUcsdUdBQXVHO0FBQ3ZHLEVBQUU7QUFDRixnSEFBZ0g7QUFDaEgsNkdBQTZHO0FBQzdHLDZHQUE2RztBQUM3RywrR0FBK0c7QUFFL0csTUFBTSxpQkFBaUIsR0FBRyx5QkFBeUIsQ0FBQztBQUNwRCxJQUFJLFNBQVMsR0FBK0IsSUFBSSxDQUFDO0FBRWpELE1BQU0sVUFBVSwyQkFBMkIsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBeUM7SUFDckksT0FBTyx1QkFBdUIsQ0FBQyxpQkFBaUIsRUFBRSxtQ0FBbUMsRUFBRSxHQUFHLENBQUMsQ0FBQztBQUM5RixDQUFDO0FBRUQsU0FBUyxlQUFlLENBQUMsTUFBaUM7SUFDeEQsT0FBTyx5QkFBeUIsQ0FBQyxNQUFNLEVBQUUsMkJBQTJCLEVBQUUsRUFBRSxpQ0FBaUMsQ0FBQyxDQUFDO0FBQzdHLENBQUM7QUFFRCxNQUFNLFNBQVMsR0FBRyxNQUFNLENBQUM7QUFDekIsTUFBTSxtQkFBbUIsR0FBRyxtQkFBbUIsQ0FBQztBQUVoRCxTQUFTLHFCQUFxQixDQUFDLFlBQXFCO0lBQ2xELElBQUksT0FBTyxZQUFZLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQztJQUNoRixNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQzVELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7SUFDdEYsT0FBTyxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsQ0FBQztBQUM1QixDQUFDO0FBRUQsU0FBUyxrQkFBa0IsQ0FBQyxTQUFrQjtJQUM1QyxJQUFJLE9BQU8sU0FBUyxLQUFLLFFBQVEsSUFBSSxDQUFDLFNBQVMsQ0FBQyxJQUFJLEVBQUU7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLG9CQUFvQixDQUFDLENBQUM7SUFDOUYsT0FBTyxTQUFTLENBQUMsSUFBSSxFQUFFLENBQUM7QUFDMUIsQ0FBQztBQUVELCtHQUErRztBQUMvRyxNQUFNLENBQUMsTUFBTSxzQkFBc0IsR0FBRyw0QkFBNEIsQ0FBQztBQUVuRSw2R0FBNkc7QUFDN0csTUFBTSxVQUFVLHNCQUFzQixDQUFDLEtBQThDO0lBQ25GLE1BQU0sU0FBUyxHQUFHLGtCQUFrQixDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUN0RCxPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsUUFBUSxFQUFFLHNCQUFzQixFQUFFLFNBQVMsQ0FBQyxDQUFDO0FBQ2pFLENBQUM7QUFFRCxTQUFTLGdCQUFnQixDQUFDLE1BQTBCLEVBQUUsV0FBbUI7SUFDdkUsSUFBSSxNQUFNLENBQUMsSUFBSSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQ3RCLE1BQU0sTUFBTSxHQUFHLENBQUMsTUFBTSxDQUFDLE1BQU0sSUFBSSxFQUFFLENBQUMsQ0FBQyxJQUFJLEVBQUUsSUFBSSxRQUFRLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNyRSxNQUFNLElBQUksS0FBSyxDQUFDLEdBQUcsV0FBVyxLQUFLLE1BQU0sRUFBRSxDQUFDLENBQUM7SUFDL0MsQ0FBQztJQUNELE9BQU8sTUFBTSxDQUFDLE1BQU0sSUFBSSxFQUFFLENBQUM7QUFDN0IsQ0FBQztBQUVEOztrR0FFa0c7QUFDbEcsS0FBSyxVQUFVLG1CQUFtQixDQUFDLElBQW9CLEVBQUUsUUFBZ0IsRUFBRSxZQUFvQixFQUFFLFNBQWlCO0lBQ2hILE1BQU0sTUFBTSxHQUFHLE1BQU0sSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLFVBQVUsRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFFLFlBQVksRUFBRSxTQUFTLENBQUMsRUFBRSxFQUFFLEdBQUcsRUFBRSxRQUFRLEVBQUUsQ0FBQyxDQUFDO0lBQzlHLGdCQUFnQixDQUFDLE1BQU0sRUFBRSx5QkFBeUIsQ0FBQyxDQUFDO0FBQ3RELENBQUM7QUFFRCxLQUFLLFVBQVUsb0JBQW9CLENBQUMsSUFBb0IsRUFBRSxRQUFnQixFQUFFLFNBQWlCO0lBQzNGLE1BQU0sTUFBTSxHQUFHLE1BQU0sSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsY0FBYyxFQUFFLFNBQVMsQ0FBQyxFQUFFLEVBQUUsR0FBRyxFQUFFLFFBQVEsRUFBRSxDQUFDLENBQUM7SUFDOUYsTUFBTSxNQUFNLEdBQUcsZ0JBQWdCLENBQUMsTUFBTSxFQUFFLHVCQUF1QixDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDeEUsSUFBSSxDQUFDLE1BQU07UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLDhDQUE4QyxTQUFTLEVBQUUsQ0FBQyxDQUFDO0lBQ3hGLE9BQU8sTUFBTSxDQUFDO0FBQ2hCLENBQUM7QUFFRCxLQUFLLFVBQVUsaUJBQWlCLENBQUMsSUFBb0IsRUFBRSxRQUFnQixFQUFFLFNBQWlCO0lBQ3hGLE1BQU0sTUFBTSxHQUFHLE1BQU0sSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLEtBQUssRUFBRSxTQUFTLEVBQUUsY0FBYyxTQUFTLE1BQU0sU0FBUyxJQUFJLENBQUMsRUFBRSxFQUFFLEdBQUcsRUFBRSxRQUFRLEVBQUUsQ0FBQyxDQUFDO0lBQ3BILE1BQU0sTUFBTSxHQUFHLGdCQUFnQixDQUFDLE1BQU0sRUFBRSx3QkFBd0IsQ0FBQyxDQUFDO0lBQ2xFLE9BQU8sTUFBTTtTQUNWLEtBQUssQ0FBQyxJQUFJLENBQUM7U0FDWCxNQUFNLENBQUMsQ0FBQyxJQUFJLEVBQUUsRUFBRSxDQUFDLElBQUksQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDO1NBQ2pDLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFO1FBQ1osTUFBTSxDQUFDLEdBQUcsRUFBRSxJQUFJLEVBQUUsT0FBTyxDQUFDLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQztRQUNuRCxPQUFPLEVBQUUsR0FBRyxFQUFFLEdBQWEsRUFBRSxJQUFJLEVBQUUsSUFBYyxFQUFFLE9BQU8sRUFBRSxPQUFPLElBQUksRUFBRSxFQUFFLENBQUM7SUFDOUUsQ0FBQyxDQUFDLENBQUM7QUFDUCxDQUFDO0FBRUQsOEdBQThHO0FBQzlHLDJHQUEyRztBQUMzRywyR0FBMkc7QUFDM0csNEdBQTRHO0FBQzVHLDZHQUE2RztBQUM3Ryw4R0FBOEc7QUFDOUcsNERBQTREO0FBQzVELEtBQUssVUFBVSxpQkFBaUIsQ0FBQyxJQUFvQixFQUFFLFFBQWdCLEVBQUUsU0FBaUI7SUFDeEYsTUFBTSxNQUFNLEdBQUcsTUFBTSxJQUFJLENBQ3ZCLEtBQUssRUFDTCxDQUFDLEtBQUssRUFBRSxVQUFVLEVBQUUsU0FBUyxFQUFFLDRCQUE0QixTQUFTLDRCQUE0QixTQUFTLGdCQUFnQixTQUFTLGVBQWUsQ0FBQyxFQUNsSixFQUFFLEdBQUcsRUFBRSxRQUFRLEVBQUUsQ0FDbEIsQ0FBQztJQUNGLE1BQU0sTUFBTSxHQUFHLGdCQUFnQixDQUFDLE1BQU0sRUFBRSx1QkFBdUIsQ0FBQyxDQUFDO0lBQ2pFLE9BQU8sTUFBTTtTQUNWLEtBQUssQ0FBQyxJQUFJLENBQUM7U0FDWCxNQUFNLENBQUMsQ0FBQyxJQUFJLEVBQUUsRUFBRSxDQUFDLElBQUksQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDO1NBQ2pDLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFO1FBQ1osTUFBTSxDQUFDLElBQUksRUFBRSxJQUFJLEVBQUUsU0FBUyxFQUFFLFVBQVUsQ0FBQyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDLENBQUM7UUFDbEUsT0FBTyxFQUFFLElBQUksRUFBRSxJQUFjLEVBQUUsSUFBSSxFQUFFLElBQWMsRUFBRSxTQUFTLEVBQUUsU0FBbUIsRUFBRSxVQUFVLEVBQUUsVUFBb0IsRUFBRSxDQUFDO0lBQzFILENBQUMsQ0FBQztTQUNELE1BQU0sQ0FBQyxDQUFDLEdBQUcsRUFBRSxFQUFFLENBQUMsR0FBRyxDQUFDLFVBQVUsS0FBSyxLQUFLLENBQUM7U0FDekMsR0FBRyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsV0FBVyxFQUFFLEdBQUcsR0FBRyxFQUFFLEVBQUUsRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0FBQ3ZELENBQUM7QUFFRDs7WUFFWTtBQUNaLEtBQUssVUFBVSxrQkFBa0IsQ0FBQyxJQUFvQixFQUFFLFFBQWdCLEVBQUUsU0FBaUI7SUFDekYsTUFBTSxPQUFPLEdBQUcsTUFBTSxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsU0FBUyxFQUFFLGFBQWEsRUFBRSxTQUFTLENBQUMsRUFBRSxFQUFFLEdBQUcsRUFBRSxRQUFRLEVBQUUsQ0FBQyxDQUFDO0lBQzVGLE1BQU0sTUFBTSxHQUFHLGdCQUFnQixDQUFDLE9BQU8sRUFBRSxvQkFBb0IsQ0FBQyxDQUFDO0lBQy9ELE1BQU0sUUFBUSxHQUFHLE1BQU07U0FDcEIsS0FBSyxDQUFDLElBQUksQ0FBQztTQUNYLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDO1NBQzFCLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsbUJBQW1CLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUM7SUFDbEQsSUFBSSxDQUFDLFFBQVE7UUFBRSxPQUFPLElBQUksQ0FBQztJQUUzQixNQUFNLEtBQUssR0FBRyxNQUFNLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxNQUFNLEVBQUUsR0FBRyxTQUFTLElBQUksUUFBUSxFQUFFLENBQUMsRUFBRSxFQUFFLEdBQUcsRUFBRSxRQUFRLEVBQUUsQ0FBQyxDQUFDO0lBQ3pGLE1BQU0sT0FBTyxHQUFHLGdCQUFnQixDQUFDLEtBQUssRUFBRSx3QkFBd0IsQ0FBQyxDQUFDO0lBQ2xFLE9BQU8sRUFBRSxRQUFRLEVBQUUsT0FBTyxFQUFFLENBQUM7QUFDL0IsQ0FBQztBQWlCRDt3Q0FDd0M7QUFDeEMsTUFBTSxVQUFVLHlCQUF5QixDQUFDLEtBQXlGO0lBQ2pJLE1BQU0sUUFBUSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzlDLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUNoQyxLQUFLLE1BQU0sTUFBTSxJQUFJLEtBQUssQ0FBQyxPQUFPLEVBQUUsQ0FBQztRQUNuQyxJQUFJLElBQUksQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxHQUFHLFFBQVE7WUFBRSxVQUFVLENBQUMsSUFBSSxDQUFDLFVBQVUsTUFBTSxDQUFDLEdBQUcsVUFBVSxNQUFNLENBQUMsSUFBSSxvQkFBb0IsS0FBSyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUM7SUFDM0ksQ0FBQztJQUNELEtBQUssTUFBTSxHQUFHLElBQUksS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO1FBQzdCLElBQUksSUFBSSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLEdBQUcsUUFBUTtZQUFFLFVBQVUsQ0FBQyxJQUFJLENBQUMsT0FBTyxHQUFHLENBQUMsSUFBSSxVQUFVLEdBQUcsQ0FBQyxJQUFJLG9CQUFvQixLQUFLLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQztJQUNoSSxDQUFDO0lBQ0QsSUFBSSxVQUFVLENBQUMsTUFBTSxHQUFHLENBQUM7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdDQUF3QyxVQUFVLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUMsQ0FBQztBQUM5RyxDQUFDO0FBcUJELE1BQU0sVUFBVSx1QkFBdUIsQ0FBQyxTQUFpQiwyQkFBMkIsRUFBRTtJQUNwRixNQUFNLFlBQVksR0FBRyxlQUFlLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDN0MsTUFBTSxFQUFFLEdBQUcsZ0JBQWdCLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDMUMsRUFBRSxDQUFDLElBQUksQ0FBQzs7Ozs7Ozs7Ozs7Ozs7R0FjUCxDQUFDLENBQUM7SUFDSCxNQUFNLFlBQVksR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDLDRFQUE0RSxDQUFDLENBQUM7SUFDOUcsTUFBTSxlQUFlLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FBQzs7OztHQUlsQyxDQUFDLENBQUM7SUFFSCxTQUFTLGFBQWEsQ0FBQyxHQUFzQjtRQUMzQyxPQUFPO1lBQ0wsWUFBWSxFQUFFLEdBQUcsQ0FBQyxjQUFjO1lBQ2hDLFNBQVMsRUFBRSxHQUFHLENBQUMsVUFBVTtZQUN6QixZQUFZLEVBQUUsR0FBRyxDQUFDLGFBQWE7WUFDL0IsVUFBVSxFQUFFLEdBQUcsQ0FBQyxXQUFXO1lBQzNCLE9BQU8sRUFBRSxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUM7WUFDckMsSUFBSSxFQUFFLElBQUksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQztZQUMvQixNQUFNLEVBQUUsR0FBRyxDQUFDLGVBQWUsQ0FBQyxDQUFDLENBQUMsRUFBRSxRQUFRLEVBQUUsR0FBRyxDQUFDLGVBQWUsRUFBRSxPQUFPLEVBQUUsR0FBRyxDQUFDLGNBQXdCLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSTtZQUM3RyxVQUFVLEVBQUUsR0FBRyxDQUFDLFdBQVc7U0FDNUIsQ0FBQztJQUNKLENBQUM7SUFFRCxPQUFPO1FBQ0wsTUFBTSxFQUFFLFlBQVk7UUFDcEIsV0FBVyxDQUFDLFlBQW9CLEVBQUUsU0FBaUI7WUFDakQsTUFBTSxHQUFHLEdBQUcsWUFBWSxDQUFDLEdBQUcsQ0FBQyxxQkFBcUIsQ0FBQyxZQUFZLENBQUMsRUFBRSxrQkFBa0IsQ0FBQyxTQUFTLENBQUMsQ0FBa0MsQ0FBQztZQUNsSSxPQUFPLEdBQUcsQ0FBQyxDQUFDLENBQUMsYUFBYSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7UUFDekMsQ0FBQztRQUNELFlBQVksQ0FBQyxRQUE0QztZQUN2RCxNQUFNLFlBQVksR0FBRyxxQkFBcUIsQ0FBQyxRQUFRLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDbEUsTUFBTSxTQUFTLEdBQUcsa0JBQWtCLENBQUMsUUFBUSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1lBQ3pELGVBQWUsQ0FBQyxHQUFHLENBQ2pCLFlBQVksRUFDWixTQUFTLEVBQ1QsUUFBUSxDQUFDLFlBQVksRUFDckIsUUFBUSxDQUFDLFVBQVUsRUFDbkIsSUFBSSxDQUFDLFNBQVMsQ0FBQyxRQUFRLENBQUMsT0FBTyxDQUFDLEVBQ2hDLElBQUksQ0FBQyxTQUFTLENBQUMsUUFBUSxDQUFDLElBQUksQ0FBQyxFQUM3QixRQUFRLENBQUMsTUFBTSxFQUFFLFFBQVEsSUFBSSxJQUFJLEVBQ2pDLFFBQVEsQ0FBQyxNQUFNLEVBQUUsT0FBTyxJQUFJLElBQUksRUFDaEMsSUFBSSxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FDekIsQ0FBQztZQUNGLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxZQUFZLEVBQUUsU0FBUyxDQUFtQixDQUFDO1FBQ3JFLENBQUM7UUFDRCxLQUFLO1lBQ0gsRUFBRSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ2IsQ0FBQztLQUNGLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyw2QkFBNkI7SUFDcEMsU0FBUyxLQUFLLHVCQUF1QixFQUFFLENBQUM7SUFDeEMsT0FBTyxTQUFTLENBQUM7QUFDbkIsQ0FBQztBQUVELE1BQU0sVUFBVSwrQkFBK0I7SUFDN0MsSUFBSSxDQUFDLFNBQVM7UUFBRSxPQUFPO0lBQ3ZCLFNBQVMsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNsQixTQUFTLEdBQUcsSUFBSSxDQUFDO0FBQ25CLENBQUM7QUFFRDs7OztHQUlHO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSxvQkFBb0IsQ0FDeEMsS0FBb0UsRUFDcEUsSUFBMkQ7SUFFM0QsSUFBSSxDQUFDLEtBQUssSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywrQkFBK0IsQ0FBQyxDQUFDO0lBQzFGLE1BQU0sWUFBWSxHQUFHLHFCQUFxQixDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMvRCxNQUFNLFNBQVMsR0FBRyxrQkFBa0IsQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDdEQsSUFBSSxPQUFPLEtBQUssQ0FBQyxRQUFRLEtBQUssUUFBUSxJQUFJLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxJQUFJLEVBQUU7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLG1CQUFtQixDQUFDLENBQUM7SUFDdkcsTUFBTSxRQUFRLEdBQUcsS0FBSyxDQUFDLFFBQVEsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUV2QyxJQUFJLENBQUMsSUFBSSxJQUFJLE9BQU8sSUFBSSxLQUFLLFFBQVEsSUFBSSxPQUFPLElBQUksQ0FBQyxJQUFJLEtBQUssVUFBVTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsY0FBYyxDQUFDLENBQUM7SUFDMUcsTUFBTSxFQUFFLElBQUksRUFBRSxHQUFHLElBQUksQ0FBQztJQUN0QixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxJQUFJLDZCQUE2QixFQUFFLENBQUM7SUFFNUQsTUFBTSxNQUFNLEdBQUcsS0FBSyxDQUFDLFdBQVcsQ0FBQyxZQUFZLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDMUQsSUFBSSxNQUFNO1FBQUUsT0FBTyxNQUFNLENBQUM7SUFFMUIsTUFBTSxZQUFZLEdBQUcsc0JBQXNCLENBQUMsRUFBRSxRQUFRLEVBQUUsU0FBUyxFQUFFLENBQUMsQ0FBQztJQUNyRSxNQUFNLG1CQUFtQixDQUFDLElBQUksRUFBRSxRQUFRLEVBQUUsWUFBWSxFQUFFLFNBQVMsQ0FBQyxDQUFDO0lBRW5FLDZHQUE2RztJQUM3Ryw4R0FBOEc7SUFDOUcsNEdBQTRHO0lBQzVHLHlHQUF5RztJQUN6RyxJQUFJLENBQUM7UUFDSCxNQUFNLFVBQVUsR0FBRyxNQUFNLG9CQUFvQixDQUFDLElBQUksRUFBRSxRQUFRLEVBQUUsU0FBUyxDQUFDLENBQUM7UUFDekUsTUFBTSxPQUFPLEdBQUcsTUFBTSxpQkFBaUIsQ0FBQyxJQUFJLEVBQUUsUUFBUSxFQUFFLFNBQVMsQ0FBQyxDQUFDO1FBQ25FLE1BQU0sSUFBSSxHQUFHLE1BQU0saUJBQWlCLENBQUMsSUFBSSxFQUFFLFFBQVEsRUFBRSxTQUFTLENBQUMsQ0FBQztRQUNoRSxNQUFNLE1BQU0sR0FBRyxNQUFNLGtCQUFrQixDQUFDLElBQUksRUFBRSxRQUFRLEVBQUUsU0FBUyxDQUFDLENBQUM7UUFFbkUseUJBQXlCLENBQUMsRUFBRSxVQUFVLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxDQUFDLENBQUM7UUFFekQsT0FBTyxLQUFLLENBQUMsWUFBWSxDQUFDLEVBQUUsWUFBWSxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsVUFBVSxFQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsTUFBTSxFQUFFLENBQUMsQ0FBQztJQUMxRyxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE1BQU0sNEJBQTRCLENBQUMsSUFBSSxFQUFFLFFBQVEsRUFBRSxZQUFZLENBQUMsQ0FBQyxLQUFLLENBQUMsR0FBRyxFQUFFO1lBQzFFLDJGQUEyRjtRQUM3RixDQUFDLENBQUMsQ0FBQztRQUNILE1BQU0sS0FBSyxDQUFDO0lBQ2QsQ0FBQztBQUNILENBQUM7QUFFRDs7c0VBRXNFO0FBQ3RFLE1BQU0sQ0FBQyxLQUFLLFVBQVUsNEJBQTRCLENBQUMsSUFBb0IsRUFBRSxRQUFnQixFQUFFLFlBQW9CO0lBQzdHLE9BQU8sY0FBYyxDQUFDLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxZQUFZLEVBQUUsQ0FBQyxDQUFDO0FBQzFELENBQUMifQ==

--- a/packages/loopover-miner/lib/replay-snapshot.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.ts
@@ -1,0 +1,322 @@
+import { join } from "node:path";
+import { removeWorktree, type WorktreeExecFn, type WorktreeExecResult, type WorktreeRemoveResult } from "@loopover/engine";
+import { openLocalStoreDb, resolveLocalStoreDbPath, normalizeLocalStoreDbPath } from "./local-store.js";
+
+// Freeze/snapshot mechanism for historical replay targets (#3010). Given a repo and a commit SHA T, exports:
+//  (a) the full working tree checked out AT T via a DETACHED git worktree -- the same isolation primitive
+//      worktree-allocator.ts (#4269) uses for attempt isolation, just detached rather than on a new branch,
+//      since a replay target is read-only, never a place to commit -- so it never mutates the caller's own
+//      checkout/branch.
+//  (b) a context bundle: commit history up to and including T (by ANCESTRY, via `git log T` -- walking the DAG
+//      is the tamper-resistant way to bound "up to T", since a commit's committer date is user-controlled and
+//      can't be trusted alone), tags reachable from T (`git tag --merged T`), and the README as it existed at
+//      T (`git ls-tree` + `git show T:<name>`, matched case-insensitively rather than a guessed filename list).
+//
+// REUSE NOTE: this issue's own text frames "the discover and analyze phases... already read git history" as
+// the reuse starting point. Grepped both packages (git log/git tag/commits/tags/releases) before writing this
+// and found no such utility anywhere -- opportunity-fanout.js reads GitHub API issue `updated_at`, not git
+// commit/tag history at all. The one genuinely reusable piece is worktree-allocator.ts's injected-exec
+// convention (WorktreeExecFn) and its removeWorktree -- both reused directly below (import from
+// @loopover/engine), rather than inventing a THIRD "inject the git subprocess" abstraction
+// alongside cli-subprocess-driver.ts's and worktree-allocator.ts's own.
+//
+// FAIL-FAST VALIDATION: ancestry-walking (git log T) already excludes anything NOT reachable from T by
+// construction, but a tag can point at a commit that IS an ancestor of T while the TAG's own creation/tagger
+// date is LATER (e.g. a tag added long after the commit it points to), and commit committer-dates are not
+// strictly monotonic along the DAG in general (rebases, clock skew). So checking every exported commit's date
+// and every exported tag's date against T's own commit date is a genuine, not merely defensive, check.
+//
+// PERSISTENCE: the context bundle is cached in the local store, UNIQUE-keyed on (repo_full_name, commit_sha) --
+// re-exporting the same (repo, T) pair returns the identical cached row rather than re-running git, which is
+// both how "byte-reproducible" holds trivially and avoids redundant work on repeat replay runs. The working-
+// tree export itself is git-content-addressed already (the same commit SHA always checks out identical files).
+
+const defaultDbFileName = "replay-snapshot.sqlite3";
+let defaultDb: ReplaySnapshotStore | null = null;
+
+export function resolveReplaySnapshotDbPath(env: Record<string, string | undefined> = process.env as Record<string, string | undefined>): string {
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_REPLAY_SNAPSHOT_DB", env);
+}
+
+function normalizeDbPath(dbPath: string | null | undefined): string {
+  return normalizeLocalStoreDbPath(dbPath, resolveReplaySnapshotDbPath(), "invalid_replay_snapshot_db_path");
+}
+
+const FIELD_SEP = "\x1f";
+const README_NAME_PATTERN = /^readme(\.\w+)?$/i;
+
+function normalizeRepoFullName(repoFullName: unknown): string {
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const [owner, repo, extra] = repoFullName.trim().split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  return `${owner}/${repo}`;
+}
+
+function normalizeCommitSha(commitSha: unknown): string {
+  if (typeof commitSha !== "string" || !commitSha.trim()) throw new Error("invalid_commit_sha");
+  return commitSha.trim();
+}
+
+/** Worktree exports live under this dir inside the repo, mirroring worktree-allocator.ts's WORKTREE_SUBDIR. */
+export const REPLAY_SNAPSHOT_SUBDIR = ".loopover-replay-snapshots";
+
+/** PURE: the deterministic on-disk location for a (repo, commit) replay export -- same pair -> same path. */
+export function planReplaySnapshotPath(input: { repoPath: string; commitSha: string }): string {
+  const commitSha = normalizeCommitSha(input.commitSha);
+  return join(input.repoPath, REPLAY_SNAPSHOT_SUBDIR, commitSha);
+}
+
+function assertExecResult(result: WorktreeExecResult, description: string): string {
+  if (result.code !== 0) {
+    const detail = (result.stderr ?? "").trim() || `exit_${result.code}`;
+    throw new Error(`${description}: ${detail}`);
+  }
+  return result.stdout ?? "";
+}
+
+/** Detached checkout at commitSha via `git worktree add --detach` -- never creates a branch, never touches the
+ *  caller's own checkout. Idempotent in effect: `git worktree add` itself fails if the path already has a
+ *  worktree, which callers avoid by checking the store cache first (see exportReplaySnapshot). */
+async function addDetachedWorktree(exec: WorktreeExecFn, repoPath: string, worktreePath: string, commitSha: string): Promise<void> {
+  const result = await exec("git", ["worktree", "add", "--detach", worktreePath, commitSha], { cwd: repoPath });
+  assertExecResult(result, "git_worktree_add_failed");
+}
+
+async function readTargetCommitDate(exec: WorktreeExecFn, repoPath: string, commitSha: string): Promise<string> {
+  const result = await exec("git", ["log", "-1", "--format=%cI", commitSha], { cwd: repoPath });
+  const stdout = assertExecResult(result, "git_log_target_failed").trim();
+  if (!stdout) throw new Error(`git_log_target_failed: no commit found for ${commitSha}`);
+  return stdout;
+}
+
+async function readCommitHistory(exec: WorktreeExecFn, repoPath: string, commitSha: string): Promise<ReplaySnapshotCommit[]> {
+  const result = await exec("git", ["log", commitSha, `--format=%H${FIELD_SEP}%cI${FIELD_SEP}%s`], { cwd: repoPath });
+  const stdout = assertExecResult(result, "git_log_history_failed");
+  return stdout
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [sha, date, subject] = line.split(FIELD_SEP);
+      return { sha: sha as string, date: date as string, subject: subject ?? "" };
+    });
+}
+
+// Lightweight tags have no tag object of their own, so `%(creatordate)` falls back to the POINTED-TO commit's
+// date rather than a genuine tag-creation date -- git has no record of when a lightweight tag was actually
+// created at all. That means a lightweight tag added long after T, but pointing at an ancestor of T, would
+// silently pass validateSnapshotFreshness's date check every time (its reported "date" is always <= T's, by
+// construction of --merged). Since this can never be verified, lightweight tags are excluded from the export
+// entirely -- `%(objecttype)` is "tag" only for an annotated tag's own tag object, "commit" for a lightweight
+// tag's direct target, which is how the two are told apart.
+async function readReachableTags(exec: WorktreeExecFn, repoPath: string, commitSha: string): Promise<ReplaySnapshotTag[]> {
+  const result = await exec(
+    "git",
+    ["tag", "--merged", commitSha, `--format=%(refname:short)${FIELD_SEP}%(creatordate:iso-strict)${FIELD_SEP}%(objectname)${FIELD_SEP}%(objecttype)`],
+    { cwd: repoPath },
+  );
+  const stdout = assertExecResult(result, "git_tag_merged_failed");
+  return stdout
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [name, date, targetSha, objectType] = line.split(FIELD_SEP);
+      return { name: name as string, date: date as string, targetSha: targetSha as string, objectType: objectType as string };
+    })
+    .filter((tag) => tag.objectType === "tag")
+    .map(({ objectType: _objectType, ...tag }) => tag);
+}
+
+/** Finds the repo-root README (any casing/extension) at commitSha and returns its content, or null if none
+ *  exists at that commit. Uses `git ls-tree` to find the real filename rather than guessing a fixed spelling
+ *  list. */
+async function readReadmeAtCommit(exec: WorktreeExecFn, repoPath: string, commitSha: string): Promise<ReplaySnapshotReadme | null> {
+  const listing = await exec("git", ["ls-tree", "--name-only", commitSha], { cwd: repoPath });
+  const stdout = assertExecResult(listing, "git_ls_tree_failed");
+  const filename = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => README_NAME_PATTERN.test(line));
+  if (!filename) return null;
+
+  const shown = await exec("git", ["show", `${commitSha}:${filename}`], { cwd: repoPath });
+  const content = assertExecResult(shown, "git_show_readme_failed");
+  return { filename, content };
+}
+
+export type ReplaySnapshotCommit = { sha: string; date: string; subject: string };
+export type ReplaySnapshotTag = { name: string; date: string; targetSha: string };
+export type ReplaySnapshotReadme = { filename: string; content: string };
+
+export type ReplaySnapshot = {
+  repoFullName: string;
+  commitSha: string;
+  worktreePath: string;
+  targetDate: string;
+  commits: ReplaySnapshotCommit[];
+  tags: ReplaySnapshotTag[];
+  readme: ReplaySnapshotReadme | null;
+  exportedAt: string;
+};
+
+/** PURE: fails fast (throws) if any exported commit or tag carries a date LATER than the target commit's own
+ *  date. Returns nothing on success. */
+export function validateSnapshotFreshness(input: { targetDate: string; commits: ReplaySnapshotCommit[]; tags: ReplaySnapshotTag[] }): void {
+  const targetMs = Date.parse(input.targetDate);
+  const violations: string[] = [];
+  for (const commit of input.commits) {
+    if (Date.parse(commit.date) > targetMs) violations.push(`commit ${commit.sha} dated ${commit.date} is after target ${input.targetDate}`);
+  }
+  for (const tag of input.tags) {
+    if (Date.parse(tag.date) > targetMs) violations.push(`tag ${tag.name} dated ${tag.date} is after target ${input.targetDate}`);
+  }
+  if (violations.length > 0) throw new Error(`replay_snapshot_freshness_violation: ${violations.join("; ")}`);
+}
+
+type ReplaySnapshotRow = {
+  repo_full_name: string;
+  commit_sha: string;
+  worktree_path: string;
+  target_date: string;
+  commits_json: string;
+  tags_json: string;
+  readme_filename: string | null;
+  readme_content: string | null;
+  exported_at: string;
+};
+
+export type ReplaySnapshotStore = {
+  dbPath: string;
+  getSnapshot(repoFullName: string, commitSha: string): ReplaySnapshot | null;
+  saveSnapshot(snapshot: Omit<ReplaySnapshot, "exportedAt">): ReplaySnapshot;
+  close(): void;
+};
+
+export function openReplaySnapshotStore(dbPath: string = resolveReplaySnapshotDbPath()): ReplaySnapshotStore {
+  const resolvedPath = normalizeDbPath(dbPath);
+  const db = openLocalStoreDb(resolvedPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS replay_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repo_full_name TEXT NOT NULL,
+      commit_sha TEXT NOT NULL,
+      worktree_path TEXT NOT NULL,
+      target_date TEXT NOT NULL,
+      commits_json TEXT NOT NULL,
+      tags_json TEXT NOT NULL,
+      readme_filename TEXT,
+      readme_content TEXT,
+      exported_at TEXT NOT NULL,
+      UNIQUE (repo_full_name, commit_sha)
+    )
+  `);
+  const getStatement = db.prepare("SELECT * FROM replay_snapshots WHERE repo_full_name = ? AND commit_sha = ?");
+  const insertStatement = db.prepare(`
+    INSERT INTO replay_snapshots
+      (repo_full_name, commit_sha, worktree_path, target_date, commits_json, tags_json, readme_filename, readme_content, exported_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  function rowToSnapshot(row: ReplaySnapshotRow): ReplaySnapshot {
+    return {
+      repoFullName: row.repo_full_name,
+      commitSha: row.commit_sha,
+      worktreePath: row.worktree_path,
+      targetDate: row.target_date,
+      commits: JSON.parse(row.commits_json),
+      tags: JSON.parse(row.tags_json),
+      readme: row.readme_filename ? { filename: row.readme_filename, content: row.readme_content as string } : null,
+      exportedAt: row.exported_at,
+    };
+  }
+
+  return {
+    dbPath: resolvedPath,
+    getSnapshot(repoFullName: string, commitSha: string): ReplaySnapshot | null {
+      const row = getStatement.get(normalizeRepoFullName(repoFullName), normalizeCommitSha(commitSha)) as ReplaySnapshotRow | undefined;
+      return row ? rowToSnapshot(row) : null;
+    },
+    saveSnapshot(snapshot: Omit<ReplaySnapshot, "exportedAt">): ReplaySnapshot {
+      const repoFullName = normalizeRepoFullName(snapshot.repoFullName);
+      const commitSha = normalizeCommitSha(snapshot.commitSha);
+      insertStatement.run(
+        repoFullName,
+        commitSha,
+        snapshot.worktreePath,
+        snapshot.targetDate,
+        JSON.stringify(snapshot.commits),
+        JSON.stringify(snapshot.tags),
+        snapshot.readme?.filename ?? null,
+        snapshot.readme?.content ?? null,
+        new Date().toISOString(),
+      );
+      return this.getSnapshot(repoFullName, commitSha) as ReplaySnapshot;
+    },
+    close(): void {
+      db.close();
+    },
+  };
+}
+
+function getDefaultReplaySnapshotStore(): ReplaySnapshotStore {
+  defaultDb ??= openReplaySnapshotStore();
+  return defaultDb;
+}
+
+export function closeDefaultReplaySnapshotStore(): void {
+  if (!defaultDb) return;
+  defaultDb.close();
+  defaultDb = null;
+}
+
+/**
+ * Export a frozen, reproducible replay snapshot for (repoFullName, commitSha): a detached working-tree checkout
+ * at that commit plus a context bundle (commit history, reachable tags, README-at-commit). Returns the CACHED
+ * snapshot without touching git again if one already exists for this exact (repo, commit) pair.
+ */
+export async function exportReplaySnapshot(
+  input: { repoPath: string; repoFullName: string; commitSha: string },
+  deps: { exec: WorktreeExecFn; store?: ReplaySnapshotStore },
+): Promise<ReplaySnapshot> {
+  if (!input || typeof input !== "object") throw new Error("invalid_replay_snapshot_input");
+  const repoFullName = normalizeRepoFullName(input.repoFullName);
+  const commitSha = normalizeCommitSha(input.commitSha);
+  if (typeof input.repoPath !== "string" || !input.repoPath.trim()) throw new Error("invalid_repo_path");
+  const repoPath = input.repoPath.trim();
+
+  if (!deps || typeof deps !== "object" || typeof deps.exec !== "function") throw new Error("invalid_exec");
+  const { exec } = deps;
+  const store = deps.store ?? getDefaultReplaySnapshotStore();
+
+  const cached = store.getSnapshot(repoFullName, commitSha);
+  if (cached) return cached;
+
+  const worktreePath = planReplaySnapshotPath({ repoPath, commitSha });
+  await addDetachedWorktree(exec, repoPath, worktreePath, commitSha);
+
+  // Everything below can fail (a bad git read, or a deliberate freshness violation) after the worktree already
+  // exists on disk at the deterministic path above. Left behind, a retry for the same (repo, commit) pair would
+  // hit `git worktree add`'s own "path already exists" refusal instead of the real error, permanently masking
+  // it. Clean up the worktree on any failure here before rethrowing, so a retry starts from a clean slate.
+  try {
+    const targetDate = await readTargetCommitDate(exec, repoPath, commitSha);
+    const commits = await readCommitHistory(exec, repoPath, commitSha);
+    const tags = await readReachableTags(exec, repoPath, commitSha);
+    const readme = await readReadmeAtCommit(exec, repoPath, commitSha);
+
+    validateSnapshotFreshness({ targetDate, commits, tags });
+
+    return store.saveSnapshot({ repoFullName, commitSha, worktreePath, targetDate, commits, tags, readme });
+  } catch (error) {
+    await removeReplaySnapshotWorktree(exec, repoPath, worktreePath).catch(() => {
+      /* best-effort cleanup -- the original error below is the one that matters to the caller */
+    });
+    throw error;
+  }
+}
+
+/** Tear down a replay snapshot's working-tree export (the cached context-bundle row is left in place -- it is
+ *  cheap, commit-keyed, and re-usable even after the on-disk tree is removed; only re-adding the worktree would
+ *  require the tree again, which is out of this function's scope). */
+export async function removeReplaySnapshotWorktree(exec: WorktreeExecFn, repoPath: string, worktreePath: string): Promise<WorktreeRemoveResult> {
+  return removeWorktree({ exec, repoPath, worktreePath });
+}

--- a/packages/loopover-miner/lib/replay-task-generation.d.ts
+++ b/packages/loopover-miner/lib/replay-task-generation.d.ts
@@ -1,126 +1,82 @@
-export const FORWARD_REF_PLACEHOLDER: string;
-
+export declare const FORWARD_REF_PLACEHOLDER = "[redacted-forward-ref]";
 export type RecencyPool = "recent" | "older";
-export const RECENCY_POOLS: readonly RecencyPool[];
-
+export declare const RECENCY_POOLS: readonly RecencyPool[];
 export type ForwardReference = {
-  kind: "link" | "hashref" | "sha" | "bare-issue-number";
-  value: string | number;
+    kind: "link" | "hashref" | "sha" | "bare-issue-number";
+    value: string | number;
 };
-
 export type ForwardRefContext = {
-  knownIssueMax?: number;
-  knownCommitShas?: string[];
-  revealedIssueNumbers?: number[];
+    knownIssueMax?: number;
+    knownCommitShas?: string[];
+    revealedIssueNumbers?: number[];
 };
-
 export type DetectedForwardReferences = {
-  scrubbable: ForwardReference[];
-  unscrubbable: ForwardReference[];
+    scrubbable: ForwardReference[];
+    unscrubbable: ForwardReference[];
 };
-
+export declare function detectForwardReferences(text: unknown, context: ForwardRefContext | null | undefined): DetectedForwardReferences;
 export type ScrubResult = {
-  scrubbed: string;
-  removed: ForwardReference[];
-  residual: ForwardReference[];
+    scrubbed: string;
+    removed: ForwardReference[];
+    residual: ForwardReference[];
 };
-
+export declare function scrubForwardReferences(text: unknown, context: ForwardRefContext | null | undefined): ScrubResult;
 export type LintResult = {
-  ok: boolean;
-  residual: ForwardReference[];
+    ok: boolean;
+    residual: ForwardReference[];
 };
-
+export declare function lintFrozenContext(texts: unknown, context: ForwardRefContext | null | undefined): LintResult;
 export type FreezePointThresholds = {
-  minPriorCommits?: number;
-  minRevealedCommits?: number;
+    minPriorCommits?: number;
+    minRevealedCommits?: number;
 };
-
 export type FreezePointCandidate = {
-  repo?: string;
-  commitT?: string;
-  priorCommitCount?: number;
-  revealedCommitCount?: number;
-  lastActivityAt?: string;
-  frozenContextTexts?: unknown[];
-  revealedGroundTruth?: unknown;
+    repo?: string;
+    commitT?: string;
+    priorCommitCount?: number;
+    revealedCommitCount?: number;
+    lastActivityAt?: string;
+    frozenContextTexts?: unknown[];
+    revealedGroundTruth?: unknown;
 };
-
 export type FreezePointSelection = {
-  eligible: boolean;
-  reasons: string[];
-  priorCommitCount: number;
-  revealedCommitCount: number;
+    eligible: boolean;
+    reasons: string[];
+    priorCommitCount: number;
+    revealedCommitCount: number;
 };
-
+export declare function selectFreezePoint(candidate: FreezePointCandidate | null | undefined, thresholds: FreezePointThresholds | null | undefined): FreezePointSelection;
+export declare function classifyRecencyPool(candidate: FreezePointCandidate | null | undefined, options: {
+    modelCutoffIso?: string;
+} | null | undefined): RecencyPool;
 export type ReplayTaskOptions = {
-  thresholds?: FreezePointThresholds;
-  modelCutoffIso?: string;
+    thresholds?: FreezePointThresholds;
+    modelCutoffIso?: string;
 };
-
 export type ReplayTaskRejected = {
-  eligible: false;
-  rejected: "selection" | "unscrubbable_forward_reference";
-  reasons?: string[];
-  residual?: ForwardReference[];
+    eligible: false;
+    rejected: "selection" | "unscrubbable_forward_reference";
+    reasons?: string[];
+    residual?: ForwardReference[];
 };
-
 export type ReplayTask = {
-  eligible: true;
-  pool: RecencyPool;
-  frozen: {
-    repo: string | null;
-    commitT: string | null;
-    contextTexts: string[];
-  };
+    eligible: true;
+    pool: RecencyPool;
+    frozen: {
+        repo: string | null;
+        commitT: string | null;
+        contextTexts: string[];
+    };
 };
-
+export declare function generateReplayTask(candidate: FreezePointCandidate | null | undefined, context: ForwardRefContext | null | undefined, options: ReplayTaskOptions | null | undefined): ReplayTask | ReplayTaskRejected;
 export type ReplayScoringKey = {
-  eligible: true;
-  commitCount: number;
-  groundTruth: unknown;
+    eligible: true;
+    commitCount: number;
+    groundTruth: unknown;
 };
-
-// generateReplayScoringKey never lints/scrubs frozen context (it doesn't touch context text at all), so
-// unlike ReplayTaskRejected it can only ever reject on selection -- narrower than reusing ReplayTaskRejected,
-// which would advertise an "unscrubbable_forward_reference" branch this function can never actually produce.
 export type ReplayScoringKeyRejected = {
-  eligible: false;
-  rejected: "selection";
-  reasons: string[];
+    eligible: false;
+    rejected: "selection";
+    reasons: string[];
 };
-
-export function detectForwardReferences(
-  text: unknown,
-  context: ForwardRefContext | null | undefined,
-): DetectedForwardReferences;
-
-export function scrubForwardReferences(
-  text: unknown,
-  context: ForwardRefContext | null | undefined,
-): ScrubResult;
-
-export function lintFrozenContext(
-  texts: unknown,
-  context: ForwardRefContext | null | undefined,
-): LintResult;
-
-export function selectFreezePoint(
-  candidate: FreezePointCandidate | null | undefined,
-  thresholds: FreezePointThresholds | null | undefined,
-): FreezePointSelection;
-
-export function classifyRecencyPool(
-  candidate: FreezePointCandidate | null | undefined,
-  options: { modelCutoffIso?: string } | null | undefined,
-): RecencyPool;
-
-export function generateReplayTask(
-  candidate: FreezePointCandidate | null | undefined,
-  context: ForwardRefContext | null | undefined,
-  options: ReplayTaskOptions | null | undefined,
-): ReplayTask | ReplayTaskRejected;
-
-export function generateReplayScoringKey(
-  candidate: FreezePointCandidate | null | undefined,
-  options: ReplayTaskOptions | null | undefined,
-): ReplayScoringKey | ReplayScoringKeyRejected;
+export declare function generateReplayScoringKey(candidate: FreezePointCandidate | null | undefined, options: ReplayTaskOptions | null | undefined): ReplayScoringKey | ReplayScoringKeyRejected;

--- a/packages/loopover-miner/lib/replay-task-generation.js
+++ b/packages/loopover-miner/lib/replay-task-generation.js
@@ -8,44 +8,39 @@
 // function so replay execution never has to hold both sides at once. Every function here is pure and
 // deterministic — no clock, no randomness, no IO — so a given (candidate, context) always yields an
 // identical task.
-
 // What a scrubbed-away forward reference is replaced with. A fixed, self-delimiting token so the scrubbed
 // text stays readable and the substitution is itself deterministic.
 export const FORWARD_REF_PLACEHOLDER = "[redacted-forward-ref]";
-
 // Recency pools. Freeze points are mixed across these bands so a judge/planner that has memorized recent
 // public history cannot dominate the calibration signal.
 export const RECENCY_POOLS = Object.freeze(["recent", "older"]);
-
 function toIssueNumberSet(values) {
-  const set = new Set();
-  if (Array.isArray(values)) {
-    for (const value of values) {
-      if (Number.isInteger(value) && value > 0) set.add(value);
+    const set = new Set();
+    if (Array.isArray(values)) {
+        for (const value of values) {
+            if (Number.isInteger(value) && value > 0)
+                set.add(value);
+        }
     }
-  }
-  return set;
+    return set;
 }
-
 function toShaSet(values) {
-  const set = new Set();
-  if (Array.isArray(values)) {
-    for (const value of values) {
-      if (typeof value === "string" && /^[0-9a-f]{7,40}$/i.test(value)) set.add(value.toLowerCase());
+    const set = new Set();
+    if (Array.isArray(values)) {
+        for (const value of values) {
+            if (typeof value === "string" && /^[0-9a-f]{7,40}$/i.test(value))
+                set.add(value.toLowerCase());
+        }
     }
-  }
-  return set;
+    return set;
 }
-
 function resolveContext(context) {
-  return {
-    knownIssueMax:
-      Number.isInteger(context?.knownIssueMax) && context.knownIssueMax >= 0 ? context.knownIssueMax : 0,
-    knownCommitShas: toShaSet(context?.knownCommitShas),
-    revealedIssueNumbers: toIssueNumberSet(context?.revealedIssueNumbers),
-  };
+    return {
+        knownIssueMax: Number.isInteger(context?.knownIssueMax) && context?.knownIssueMax >= 0 ? context?.knownIssueMax : 0,
+        knownCommitShas: toShaSet(context?.knownCommitShas),
+        revealedIssueNumbers: toIssueNumberSet(context?.revealedIssueNumbers),
+    };
 }
-
 // Core scanner shared by scrub/detect/lint. Walks a text in a fixed priority order (deep-links first, so an
 // issue/PR/commit URL is handled before its inner number/SHA can match a barer pattern) and classifies each
 // forward reference as either:
@@ -55,149 +50,128 @@ function resolveContext(context) {
 //     blanket-removed without destroying legitimate pre-T numbers (versions, counts), so it is detected but
 //     left in place — its presence must fail the freeze point rather than be silently mangled.
 function processForwardReferences(rawText, context) {
-  const resolved = resolveContext(context);
-  const removed = [];
-
-  const text = typeof rawText === "string" ? rawText : "";
-
-  // 1. GitHub issue/pull deep-links whose number is after T.
-  let scrubbed = text.replace(
-    /https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/(\d+)\b/gi,
-    (match, digits) => {
-      if (Number(digits) > resolved.knownIssueMax) {
-        removed.push({ kind: "link", value: match });
-        return FORWARD_REF_PLACEHOLDER;
-      }
-      return match;
-    },
-  );
-
-  // 2. GitHub commit deep-links whose SHA is not in pre-T history.
-  scrubbed = scrubbed.replace(
-    /https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/commit\/([0-9a-f]{7,40})\b/gi,
-    (match, sha) => {
-      if (!resolved.knownCommitShas.has(sha.toLowerCase())) {
-        removed.push({ kind: "link", value: match });
-        return FORWARD_REF_PLACEHOLDER;
-      }
-      return match;
-    },
-  );
-
-  // 3. Bare `#123` issue/PR references after T (not already inside a now-removed link).
-  scrubbed = scrubbed.replace(/(^|[^\w/])#(\d+)\b/g, (match, prefix, digits) => {
-    if (Number(digits) > resolved.knownIssueMax) {
-      removed.push({ kind: "hashref", value: `#${digits}` });
-      return `${prefix}${FORWARD_REF_PLACEHOLDER}`;
+    const resolved = resolveContext(context);
+    const removed = [];
+    const text = typeof rawText === "string" ? rawText : "";
+    // 1. GitHub issue/pull deep-links whose number is after T.
+    let scrubbed = text.replace(/https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/(\d+)\b/gi, (match, digits) => {
+        if (Number(digits) > resolved.knownIssueMax) {
+            removed.push({ kind: "link", value: match });
+            return FORWARD_REF_PLACEHOLDER;
+        }
+        return match;
+    });
+    // 2. GitHub commit deep-links whose SHA is not in pre-T history.
+    scrubbed = scrubbed.replace(/https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/commit\/([0-9a-f]{7,40})\b/gi, (match, sha) => {
+        if (!resolved.knownCommitShas.has(sha.toLowerCase())) {
+            removed.push({ kind: "link", value: match });
+            return FORWARD_REF_PLACEHOLDER;
+        }
+        return match;
+    });
+    // 3. Bare `#123` issue/PR references after T (not already inside a now-removed link).
+    scrubbed = scrubbed.replace(/(^|[^\w/])#(\d+)\b/g, (match, prefix, digits) => {
+        if (Number(digits) > resolved.knownIssueMax) {
+            removed.push({ kind: "hashref", value: `#${digits}` });
+            return `${prefix}${FORWARD_REF_PLACEHOLDER}`;
+        }
+        return match;
+    });
+    // 4. Raw commit SHAs not in pre-T history. Require at least one hex letter so a plain decimal number is
+    //    never misread as a SHA — those flow to the bare-issue-number residual check below instead.
+    scrubbed = scrubbed.replace(/(^|[^\w/#])([0-9a-f]{7,40})\b/gi, (match, prefix, sha) => {
+        if (!/[a-f]/i.test(sha))
+            return match;
+        if (!resolved.knownCommitShas.has(sha.toLowerCase())) {
+            removed.push({ kind: "sha", value: sha });
+            return `${prefix}${FORWARD_REF_PLACEHOLDER}`;
+        }
+        return match;
+    });
+    // Residual: bare integers that name a real post-T issue and so leak the future, but cannot be safely
+    // auto-removed. Detected against the surviving text — if any remain, the freeze point is not usable as-is.
+    const residual = [];
+    if (resolved.revealedIssueNumbers.size > 0) {
+        for (const bareMatch of scrubbed.matchAll(/(?:^|[^\w#/])(\d+)\b/g)) {
+            const value = Number(bareMatch[1]);
+            if (resolved.revealedIssueNumbers.has(value)) {
+                residual.push({ kind: "bare-issue-number", value });
+            }
+        }
     }
-    return match;
-  });
-
-  // 4. Raw commit SHAs not in pre-T history. Require at least one hex letter so a plain decimal number is
-  //    never misread as a SHA — those flow to the bare-issue-number residual check below instead.
-  scrubbed = scrubbed.replace(/(^|[^\w/#])([0-9a-f]{7,40})\b/gi, (match, prefix, sha) => {
-    if (!/[a-f]/i.test(sha)) return match;
-    if (!resolved.knownCommitShas.has(sha.toLowerCase())) {
-      removed.push({ kind: "sha", value: sha });
-      return `${prefix}${FORWARD_REF_PLACEHOLDER}`;
-    }
-    return match;
-  });
-
-  // Residual: bare integers that name a real post-T issue and so leak the future, but cannot be safely
-  // auto-removed. Detected against the surviving text — if any remain, the freeze point is not usable as-is.
-  const residual = [];
-  if (resolved.revealedIssueNumbers.size > 0) {
-    for (const bareMatch of scrubbed.matchAll(/(?:^|[^\w#/])(\d+)\b/g)) {
-      const value = Number(bareMatch[1]);
-      if (resolved.revealedIssueNumbers.has(value)) {
-        residual.push({ kind: "bare-issue-number", value });
-      }
-    }
-  }
-
-  return { scrubbed, removed, residual };
+    return { scrubbed, removed, residual };
 }
-
 // Detect forward references in text without modifying it, split by whether they can be safely scrubbed.
 export function detectForwardReferences(text, context) {
-  const { removed, residual } = processForwardReferences(text, context);
-  return { scrubbable: removed, unscrubbable: residual };
+    const { removed, residual } = processForwardReferences(text, context);
+    return { scrubbable: removed, unscrubbable: residual };
 }
-
 // Scrub the safely-removable forward references from text, returning the cleaned text, what was removed, and
 // any unscrubbable references that remain (a non-empty `residual` means the text still leaks the future).
 export function scrubForwardReferences(text, context) {
-  return processForwardReferences(text, context);
+    return processForwardReferences(text, context);
 }
-
 // A freeze point's frozen context is clean iff every provided text scrubs to zero residual forward references.
 export function lintFrozenContext(texts, context) {
-  const list = Array.isArray(texts) ? texts : texts == null ? [] : [texts];
-  const residual = [];
-  for (const text of list) {
-    residual.push(...processForwardReferences(text, context).residual);
-  }
-  return { ok: residual.length === 0, residual };
+    const list = Array.isArray(texts) ? texts : texts == null ? [] : [texts];
+    const residual = [];
+    for (const text of list) {
+        residual.push(...processForwardReferences(text, context).residual);
+    }
+    return { ok: residual.length === 0, residual };
 }
-
 // Selection: a freeze point is calibration-worthy only with enough real history on both sides of T.
 export function selectFreezePoint(candidate, thresholds) {
-  const minPriorCommits = Number.isInteger(thresholds?.minPriorCommits) ? thresholds.minPriorCommits : 0;
-  const minRevealedCommits = Number.isInteger(thresholds?.minRevealedCommits)
-    ? thresholds.minRevealedCommits
-    : 0;
-  const priorCommitCount = Number.isInteger(candidate?.priorCommitCount) ? candidate.priorCommitCount : 0;
-  const revealedCommitCount = Number.isInteger(candidate?.revealedCommitCount)
-    ? candidate.revealedCommitCount
-    : 0;
-
-  const reasons = [];
-  if (priorCommitCount < minPriorCommits) reasons.push("insufficient_prior_history");
-  if (revealedCommitCount < minRevealedCommits) reasons.push("insufficient_revealed_history");
-
-  return { eligible: reasons.length === 0, reasons, priorCommitCount, revealedCommitCount };
+    const minPriorCommits = Number.isInteger(thresholds?.minPriorCommits) ? thresholds?.minPriorCommits : 0;
+    const minRevealedCommits = Number.isInteger(thresholds?.minRevealedCommits)
+        ? thresholds?.minRevealedCommits
+        : 0;
+    const priorCommitCount = Number.isInteger(candidate?.priorCommitCount) ? candidate?.priorCommitCount : 0;
+    const revealedCommitCount = Number.isInteger(candidate?.revealedCommitCount)
+        ? candidate?.revealedCommitCount
+        : 0;
+    const reasons = [];
+    if (priorCommitCount < minPriorCommits)
+        reasons.push("insufficient_prior_history");
+    if (revealedCommitCount < minRevealedCommits)
+        reasons.push("insufficient_revealed_history");
+    return { eligible: reasons.length === 0, reasons, priorCommitCount, revealedCommitCount };
 }
-
 // Pool provenance: a freeze point whose last activity is at/after the calibration run's model cutoff is
 // "recent" (higher memorization risk); everything else, including an unknown date, is "older". ISO-8601
 // timestamps sort lexicographically, so no clock is needed.
 export function classifyRecencyPool(candidate, options) {
-  const modelCutoffIso = typeof options?.modelCutoffIso === "string" ? options.modelCutoffIso : "";
-  const lastActivityAt = typeof candidate?.lastActivityAt === "string" ? candidate.lastActivityAt : "";
-  if (!modelCutoffIso || !lastActivityAt) return "older";
-  return lastActivityAt >= modelCutoffIso ? "recent" : "older";
+    const modelCutoffIso = typeof options?.modelCutoffIso === "string" ? options.modelCutoffIso : "";
+    const lastActivityAt = typeof candidate?.lastActivityAt === "string" ? candidate.lastActivityAt : "";
+    if (!modelCutoffIso || !lastActivityAt)
+        return "older";
+    return lastActivityAt >= modelCutoffIso ? "recent" : "older";
 }
-
 // One-shot replay generator. Applies selection, then scrubs and lints the frozen context, then returns only
 // the frozen replay task. Revealed post-T ground truth is intentionally available only through
 // generateReplayScoringKey, so a replay worker/serializer/logger/model call never receives both sides.
 export function generateReplayTask(candidate, context, options) {
-  const selection = selectFreezePoint(candidate, options?.thresholds);
-  if (!selection.eligible) {
-    return { eligible: false, rejected: "selection", reasons: selection.reasons };
-  }
-
-  const frozenTexts = Array.isArray(candidate?.frozenContextTexts) ? candidate.frozenContextTexts : [];
-  const lint = lintFrozenContext(frozenTexts, context);
-  if (!lint.ok) {
-    return { eligible: false, rejected: "unscrubbable_forward_reference", residual: lint.residual };
-  }
-
-  const pool = classifyRecencyPool(candidate, options);
-  const scrubbedTexts = frozenTexts.map((text) => processForwardReferences(text, context).scrubbed);
-
-  return {
-    eligible: true,
-    pool,
-    frozen: {
-      repo: typeof candidate?.repo === "string" ? candidate.repo : null,
-      commitT: typeof candidate?.commitT === "string" ? candidate.commitT : null,
-      contextTexts: scrubbedTexts,
-    },
-  };
+    const selection = selectFreezePoint(candidate, options?.thresholds);
+    if (!selection.eligible) {
+        return { eligible: false, rejected: "selection", reasons: selection.reasons };
+    }
+    const frozenTexts = Array.isArray(candidate?.frozenContextTexts) ? candidate?.frozenContextTexts : [];
+    const lint = lintFrozenContext(frozenTexts, context);
+    if (!lint.ok) {
+        return { eligible: false, rejected: "unscrubbable_forward_reference", residual: lint.residual };
+    }
+    const pool = classifyRecencyPool(candidate, options);
+    const scrubbedTexts = frozenTexts.map((text) => processForwardReferences(text, context).scrubbed);
+    return {
+        eligible: true,
+        pool,
+        frozen: {
+            repo: typeof candidate?.repo === "string" ? candidate.repo : null,
+            commitT: typeof candidate?.commitT === "string" ? candidate.commitT : null,
+            contextTexts: scrubbedTexts,
+        },
+    };
 }
-
 // Scoring-only accessor. Call this from the isolated scorer path after replay execution has finished; do not
 // pass its result to replay workers. It deliberately shares only selection eligibility with generateReplayTask
 // and never carries frozen context.
@@ -210,14 +184,14 @@ export function generateReplayTask(candidate, context, options) {
 // must not assume a scoring key implies a replay task was ever generated for the same candidate; check
 // generateReplayTask's own result independently before treating the two as a matched pair.
 export function generateReplayScoringKey(candidate, options) {
-  const selection = selectFreezePoint(candidate, options?.thresholds);
-  if (!selection.eligible) {
-    return { eligible: false, rejected: "selection", reasons: selection.reasons };
-  }
-
-  return {
-    eligible: true,
-    commitCount: selection.revealedCommitCount,
-    groundTruth: candidate?.revealedGroundTruth ?? null,
-  };
+    const selection = selectFreezePoint(candidate, options?.thresholds);
+    if (!selection.eligible) {
+        return { eligible: false, rejected: "selection", reasons: selection.reasons };
+    }
+    return {
+        eligible: true,
+        commitCount: selection.revealedCommitCount,
+        groundTruth: candidate?.revealedGroundTruth ?? null,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmVwbGF5LXRhc2stZ2VuZXJhdGlvbi5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInJlcGxheS10YXNrLWdlbmVyYXRpb24udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsc0ZBQXNGO0FBQ3RGLEVBQUU7QUFDRix1R0FBdUc7QUFDdkcsMkdBQTJHO0FBQzNHLDJHQUEyRztBQUMzRywyR0FBMkc7QUFDM0csOEdBQThHO0FBQzlHLHFHQUFxRztBQUNyRyxvR0FBb0c7QUFDcEcsa0JBQWtCO0FBRWxCLDBHQUEwRztBQUMxRyxvRUFBb0U7QUFDcEUsTUFBTSxDQUFDLE1BQU0sdUJBQXVCLEdBQUcsd0JBQXdCLENBQUM7QUFJaEUseUdBQXlHO0FBQ3pHLHlEQUF5RDtBQUN6RCxNQUFNLENBQUMsTUFBTSxhQUFhLEdBQTJCLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxRQUFRLEVBQUUsT0FBTyxDQUFDLENBQUMsQ0FBQztBQW1CeEYsU0FBUyxnQkFBZ0IsQ0FBQyxNQUFlO0lBQ3ZDLE1BQU0sR0FBRyxHQUFHLElBQUksR0FBRyxFQUFVLENBQUM7SUFDOUIsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDMUIsS0FBSyxNQUFNLEtBQUssSUFBSSxNQUFNLEVBQUUsQ0FBQztZQUMzQixJQUFJLE1BQU0sQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLElBQUksS0FBSyxHQUFHLENBQUM7Z0JBQUUsR0FBRyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMzRCxDQUFDO0lBQ0gsQ0FBQztJQUNELE9BQU8sR0FBRyxDQUFDO0FBQ2IsQ0FBQztBQUVELFNBQVMsUUFBUSxDQUFDLE1BQWU7SUFDL0IsTUFBTSxHQUFHLEdBQUcsSUFBSSxHQUFHLEVBQVUsQ0FBQztJQUM5QixJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUMxQixLQUFLLE1BQU0sS0FBSyxJQUFJLE1BQU0sRUFBRSxDQUFDO1lBQzNCLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLG1CQUFtQixDQUFDLElBQUksQ0FBQyxLQUFLLENBQUM7Z0JBQUUsR0FBRyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQztRQUNqRyxDQUFDO0lBQ0gsQ0FBQztJQUNELE9BQU8sR0FBRyxDQUFDO0FBQ2IsQ0FBQztBQUVELFNBQVMsY0FBYyxDQUFDLE9BQTZDO0lBQ25FLE9BQU87UUFDTCxhQUFhLEVBQ1gsTUFBTSxDQUFDLFNBQVMsQ0FBQyxPQUFPLEVBQUUsYUFBYSxDQUFDLElBQUssT0FBTyxFQUFFLGFBQXdCLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBRSxPQUFPLEVBQUUsYUFBd0IsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUM5SCxlQUFlLEVBQUUsUUFBUSxDQUFDLE9BQU8sRUFBRSxlQUFlLENBQUM7UUFDbkQsb0JBQW9CLEVBQUUsZ0JBQWdCLENBQUMsT0FBTyxFQUFFLG9CQUFvQixDQUFDO0tBQ3RFLENBQUM7QUFDSixDQUFDO0FBUUQsNEdBQTRHO0FBQzVHLDRHQUE0RztBQUM1RywrQkFBK0I7QUFDL0IsNkdBQTZHO0FBQzdHLHdGQUF3RjtBQUN4RiwrR0FBK0c7QUFDL0csNEdBQTRHO0FBQzVHLCtGQUErRjtBQUMvRixTQUFTLHdCQUF3QixDQUFDLE9BQWdCLEVBQUUsT0FBNkM7SUFDL0YsTUFBTSxRQUFRLEdBQUcsY0FBYyxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ3pDLE1BQU0sT0FBTyxHQUF1QixFQUFFLENBQUM7SUFFdkMsTUFBTSxJQUFJLEdBQUcsT0FBTyxPQUFPLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUV4RCwyREFBMkQ7SUFDM0QsSUFBSSxRQUFRLEdBQUcsSUFBSSxDQUFDLE9BQU8sQ0FDekIsc0VBQXNFLEVBQ3RFLENBQUMsS0FBSyxFQUFFLE1BQU0sRUFBRSxFQUFFO1FBQ2hCLElBQUksTUFBTSxDQUFDLE1BQU0sQ0FBQyxHQUFHLFFBQVEsQ0FBQyxhQUFhLEVBQUUsQ0FBQztZQUM1QyxPQUFPLENBQUMsSUFBSSxDQUFDLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztZQUM3QyxPQUFPLHVCQUF1QixDQUFDO1FBQ2pDLENBQUM7UUFDRCxPQUFPLEtBQUssQ0FBQztJQUNmLENBQUMsQ0FDRixDQUFDO0lBRUYsaUVBQWlFO0lBQ2pFLFFBQVEsR0FBRyxRQUFRLENBQUMsT0FBTyxDQUN6Qix3RUFBd0UsRUFDeEUsQ0FBQyxLQUFLLEVBQUUsR0FBRyxFQUFFLEVBQUU7UUFDYixJQUFJLENBQUMsUUFBUSxDQUFDLGVBQWUsQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLFdBQVcsRUFBRSxDQUFDLEVBQUUsQ0FBQztZQUNyRCxPQUFPLENBQUMsSUFBSSxDQUFDLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztZQUM3QyxPQUFPLHVCQUF1QixDQUFDO1FBQ2pDLENBQUM7UUFDRCxPQUFPLEtBQUssQ0FBQztJQUNmLENBQUMsQ0FDRixDQUFDO0lBRUYsc0ZBQXNGO0lBQ3RGLFFBQVEsR0FBRyxRQUFRLENBQUMsT0FBTyxDQUFDLHFCQUFxQixFQUFFLENBQUMsS0FBSyxFQUFFLE1BQU0sRUFBRSxNQUFNLEVBQUUsRUFBRTtRQUMzRSxJQUFJLE1BQU0sQ0FBQyxNQUFNLENBQUMsR0FBRyxRQUFRLENBQUMsYUFBYSxFQUFFLENBQUM7WUFDNUMsT0FBTyxDQUFDLElBQUksQ0FBQyxFQUFFLElBQUksRUFBRSxTQUFTLEVBQUUsS0FBSyxFQUFFLElBQUksTUFBTSxFQUFFLEVBQUUsQ0FBQyxDQUFDO1lBQ3ZELE9BQU8sR0FBRyxNQUFNLEdBQUcsdUJBQXVCLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsT0FBTyxLQUFLLENBQUM7SUFDZixDQUFDLENBQUMsQ0FBQztJQUVILHdHQUF3RztJQUN4RyxnR0FBZ0c7SUFDaEcsUUFBUSxHQUFHLFFBQVEsQ0FBQyxPQUFPLENBQUMsaUNBQWlDLEVBQUUsQ0FBQyxLQUFLLEVBQUUsTUFBTSxFQUFFLEdBQUcsRUFBRSxFQUFFO1FBQ3BGLElBQUksQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sS0FBSyxDQUFDO1FBQ3RDLElBQUksQ0FBQyxRQUFRLENBQUMsZUFBZSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsV0FBVyxFQUFFLENBQUMsRUFBRSxDQUFDO1lBQ3JELE9BQU8sQ0FBQyxJQUFJLENBQUMsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1lBQzFDLE9BQU8sR0FBRyxNQUFNLEdBQUcsdUJBQXVCLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsT0FBTyxLQUFLLENBQUM7SUFDZixDQUFDLENBQUMsQ0FBQztJQUVILHFHQUFxRztJQUNyRywyR0FBMkc7SUFDM0csTUFBTSxRQUFRLEdBQXVCLEVBQUUsQ0FBQztJQUN4QyxJQUFJLFFBQVEsQ0FBQyxvQkFBb0IsQ0FBQyxJQUFJLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDM0MsS0FBSyxNQUFNLFNBQVMsSUFBSSxRQUFRLENBQUMsUUFBUSxDQUFDLHVCQUF1QixDQUFDLEVBQUUsQ0FBQztZQUNuRSxNQUFNLEtBQUssR0FBRyxNQUFNLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbkMsSUFBSSxRQUFRLENBQUMsb0JBQW9CLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUM7Z0JBQzdDLFFBQVEsQ0FBQyxJQUFJLENBQUMsRUFBRSxJQUFJLEVBQUUsbUJBQW1CLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztZQUN0RCxDQUFDO1FBQ0gsQ0FBQztJQUNILENBQUM7SUFFRCxPQUFPLEVBQUUsUUFBUSxFQUFFLE9BQU8sRUFBRSxRQUFRLEVBQUUsQ0FBQztBQUN6QyxDQUFDO0FBT0Qsd0dBQXdHO0FBQ3hHLE1BQU0sVUFBVSx1QkFBdUIsQ0FBQyxJQUFhLEVBQUUsT0FBNkM7SUFDbEcsTUFBTSxFQUFFLE9BQU8sRUFBRSxRQUFRLEVBQUUsR0FBRyx3QkFBd0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDdEUsT0FBTyxFQUFFLFVBQVUsRUFBRSxPQUFPLEVBQUUsWUFBWSxFQUFFLFFBQVEsRUFBRSxDQUFDO0FBQ3pELENBQUM7QUFRRCw2R0FBNkc7QUFDN0csMEdBQTBHO0FBQzFHLE1BQU0sVUFBVSxzQkFBc0IsQ0FBQyxJQUFhLEVBQUUsT0FBNkM7SUFDakcsT0FBTyx3QkFBd0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7QUFDakQsQ0FBQztBQU9ELCtHQUErRztBQUMvRyxNQUFNLFVBQVUsaUJBQWlCLENBQUMsS0FBYyxFQUFFLE9BQTZDO0lBQzdGLE1BQU0sSUFBSSxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsS0FBSyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pFLE1BQU0sUUFBUSxHQUF1QixFQUFFLENBQUM7SUFDeEMsS0FBSyxNQUFNLElBQUksSUFBSSxJQUFJLEVBQUUsQ0FBQztRQUN4QixRQUFRLENBQUMsSUFBSSxDQUFDLEdBQUcsd0JBQXdCLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQ3JFLENBQUM7SUFDRCxPQUFPLEVBQUUsRUFBRSxFQUFFLFFBQVEsQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLFFBQVEsRUFBRSxDQUFDO0FBQ2pELENBQUM7QUF3QkQsb0dBQW9HO0FBQ3BHLE1BQU0sVUFBVSxpQkFBaUIsQ0FDL0IsU0FBa0QsRUFDbEQsVUFBb0Q7SUFFcEQsTUFBTSxlQUFlLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQyxVQUFVLEVBQUUsZUFBZSxDQUFDLENBQUMsQ0FBQyxDQUFFLFVBQVUsRUFBRSxlQUEwQixDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDcEgsTUFBTSxrQkFBa0IsR0FBRyxNQUFNLENBQUMsU0FBUyxDQUFDLFVBQVUsRUFBRSxrQkFBa0IsQ0FBQztRQUN6RSxDQUFDLENBQUUsVUFBVSxFQUFFLGtCQUE2QjtRQUM1QyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ04sTUFBTSxnQkFBZ0IsR0FBRyxNQUFNLENBQUMsU0FBUyxDQUFDLFNBQVMsRUFBRSxnQkFBZ0IsQ0FBQyxDQUFDLENBQUMsQ0FBRSxTQUFTLEVBQUUsZ0JBQTJCLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNySCxNQUFNLG1CQUFtQixHQUFHLE1BQU0sQ0FBQyxTQUFTLENBQUMsU0FBUyxFQUFFLG1CQUFtQixDQUFDO1FBQzFFLENBQUMsQ0FBRSxTQUFTLEVBQUUsbUJBQThCO1FBQzVDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFFTixNQUFNLE9BQU8sR0FBYSxFQUFFLENBQUM7SUFDN0IsSUFBSSxnQkFBZ0IsR0FBRyxlQUFlO1FBQUUsT0FBTyxDQUFDLElBQUksQ0FBQyw0QkFBNEIsQ0FBQyxDQUFDO0lBQ25GLElBQUksbUJBQW1CLEdBQUcsa0JBQWtCO1FBQUUsT0FBTyxDQUFDLElBQUksQ0FBQywrQkFBK0IsQ0FBQyxDQUFDO0lBRTVGLE9BQU8sRUFBRSxRQUFRLEVBQUUsT0FBTyxDQUFDLE1BQU0sS0FBSyxDQUFDLEVBQUUsT0FBTyxFQUFFLGdCQUFnQixFQUFFLG1CQUFtQixFQUFFLENBQUM7QUFDNUYsQ0FBQztBQUVELHdHQUF3RztBQUN4Ryx3R0FBd0c7QUFDeEcsNERBQTREO0FBQzVELE1BQU0sVUFBVSxtQkFBbUIsQ0FDakMsU0FBa0QsRUFDbEQsT0FBdUQ7SUFFdkQsTUFBTSxjQUFjLEdBQUcsT0FBTyxPQUFPLEVBQUUsY0FBYyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLGNBQWMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ2pHLE1BQU0sY0FBYyxHQUFHLE9BQU8sU0FBUyxFQUFFLGNBQWMsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxjQUFjLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNyRyxJQUFJLENBQUMsY0FBYyxJQUFJLENBQUMsY0FBYztRQUFFLE9BQU8sT0FBTyxDQUFDO0lBQ3ZELE9BQU8sY0FBYyxJQUFJLGNBQWMsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUM7QUFDL0QsQ0FBQztBQXdCRCw0R0FBNEc7QUFDNUcsK0ZBQStGO0FBQy9GLHVHQUF1RztBQUN2RyxNQUFNLFVBQVUsa0JBQWtCLENBQ2hDLFNBQWtELEVBQ2xELE9BQTZDLEVBQzdDLE9BQTZDO0lBRTdDLE1BQU0sU0FBUyxHQUFHLGlCQUFpQixDQUFDLFNBQVMsRUFBRSxPQUFPLEVBQUUsVUFBVSxDQUFDLENBQUM7SUFDcEUsSUFBSSxDQUFDLFNBQVMsQ0FBQyxRQUFRLEVBQUUsQ0FBQztRQUN4QixPQUFPLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxRQUFRLEVBQUUsV0FBVyxFQUFFLE9BQU8sRUFBRSxTQUFTLENBQUMsT0FBTyxFQUFFLENBQUM7SUFDaEYsQ0FBQztJQUVELE1BQU0sV0FBVyxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsU0FBUyxFQUFFLGtCQUFrQixDQUFDLENBQUMsQ0FBQyxDQUFFLFNBQVMsRUFBRSxrQkFBZ0MsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ3JILE1BQU0sSUFBSSxHQUFHLGlCQUFpQixDQUFDLFdBQVcsRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNyRCxJQUFJLENBQUMsSUFBSSxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ2IsT0FBTyxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsUUFBUSxFQUFFLGdDQUFnQyxFQUFFLFFBQVEsRUFBRSxJQUFJLENBQUMsUUFBUSxFQUFFLENBQUM7SUFDbEcsQ0FBQztJQUVELE1BQU0sSUFBSSxHQUFHLG1CQUFtQixDQUFDLFNBQVMsRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNyRCxNQUFNLGFBQWEsR0FBRyxXQUFXLENBQUMsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyx3QkFBd0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUM7SUFFbEcsT0FBTztRQUNMLFFBQVEsRUFBRSxJQUFJO1FBQ2QsSUFBSTtRQUNKLE1BQU0sRUFBRTtZQUNOLElBQUksRUFBRSxPQUFPLFNBQVMsRUFBRSxJQUFJLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxJQUFJO1lBQ2pFLE9BQU8sRUFBRSxPQUFPLFNBQVMsRUFBRSxPQUFPLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxJQUFJO1lBQzFFLFlBQVksRUFBRSxhQUFhO1NBQzVCO0tBQ0YsQ0FBQztBQUNKLENBQUM7QUFpQkQsNkdBQTZHO0FBQzdHLCtHQUErRztBQUMvRyxvQ0FBb0M7QUFDcEMsRUFBRTtBQUNGLDJHQUEyRztBQUMzRyw4R0FBOEc7QUFDOUcsK0ZBQStGO0FBQy9GLDJHQUEyRztBQUMzRyw4R0FBOEc7QUFDOUcsdUdBQXVHO0FBQ3ZHLDJGQUEyRjtBQUMzRixNQUFNLFVBQVUsd0JBQXdCLENBQ3RDLFNBQWtELEVBQ2xELE9BQTZDO0lBRTdDLE1BQU0sU0FBUyxHQUFHLGlCQUFpQixDQUFDLFNBQVMsRUFBRSxPQUFPLEVBQUUsVUFBVSxDQUFDLENBQUM7SUFDcEUsSUFBSSxDQUFDLFNBQVMsQ0FBQyxRQUFRLEVBQUUsQ0FBQztRQUN4QixPQUFPLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxRQUFRLEVBQUUsV0FBVyxFQUFFLE9BQU8sRUFBRSxTQUFTLENBQUMsT0FBTyxFQUFFLENBQUM7SUFDaEYsQ0FBQztJQUVELE9BQU87UUFDTCxRQUFRLEVBQUUsSUFBSTtRQUNkLFdBQVcsRUFBRSxTQUFTLENBQUMsbUJBQW1CO1FBQzFDLFdBQVcsRUFBRSxTQUFTLEVBQUUsbUJBQW1CLElBQUksSUFBSTtLQUNwRCxDQUFDO0FBQ0osQ0FBQyJ9

--- a/packages/loopover-miner/lib/replay-task-generation.ts
+++ b/packages/loopover-miner/lib/replay-task-generation.ts
@@ -1,0 +1,336 @@
+// Leakage-safe task generation for the historical-replay calibration harness (#3011).
+//
+// A frozen snapshot at commit T is only useful for calibration if (a) the freeze point has enough real
+// history on both sides to be worth scoring, and (b) nothing in the frozen context lets a replay run infer
+// the future by pattern-matching text rather than reasoning. This module selects calibration-worthy freeze
+// points, scrubs forward references out of the frozen context, tags each point's recency pool, and returns
+// the frozen replay task without the revealed post-T ground truth. Scoring data is exposed through a separate
+// function so replay execution never has to hold both sides at once. Every function here is pure and
+// deterministic — no clock, no randomness, no IO — so a given (candidate, context) always yields an
+// identical task.
+
+// What a scrubbed-away forward reference is replaced with. A fixed, self-delimiting token so the scrubbed
+// text stays readable and the substitution is itself deterministic.
+export const FORWARD_REF_PLACEHOLDER = "[redacted-forward-ref]";
+
+export type RecencyPool = "recent" | "older";
+
+// Recency pools. Freeze points are mixed across these bands so a judge/planner that has memorized recent
+// public history cannot dominate the calibration signal.
+export const RECENCY_POOLS: readonly RecencyPool[] = Object.freeze(["recent", "older"]);
+
+export type ForwardReference = {
+  kind: "link" | "hashref" | "sha" | "bare-issue-number";
+  value: string | number;
+};
+
+export type ForwardRefContext = {
+  knownIssueMax?: number;
+  knownCommitShas?: string[];
+  revealedIssueNumbers?: number[];
+};
+
+type ResolvedForwardRefContext = {
+  knownIssueMax: number;
+  knownCommitShas: Set<string>;
+  revealedIssueNumbers: Set<number>;
+};
+
+function toIssueNumberSet(values: unknown): Set<number> {
+  const set = new Set<number>();
+  if (Array.isArray(values)) {
+    for (const value of values) {
+      if (Number.isInteger(value) && value > 0) set.add(value);
+    }
+  }
+  return set;
+}
+
+function toShaSet(values: unknown): Set<string> {
+  const set = new Set<string>();
+  if (Array.isArray(values)) {
+    for (const value of values) {
+      if (typeof value === "string" && /^[0-9a-f]{7,40}$/i.test(value)) set.add(value.toLowerCase());
+    }
+  }
+  return set;
+}
+
+function resolveContext(context: ForwardRefContext | null | undefined): ResolvedForwardRefContext {
+  return {
+    knownIssueMax:
+      Number.isInteger(context?.knownIssueMax) && (context?.knownIssueMax as number) >= 0 ? (context?.knownIssueMax as number) : 0,
+    knownCommitShas: toShaSet(context?.knownCommitShas),
+    revealedIssueNumbers: toIssueNumberSet(context?.revealedIssueNumbers),
+  };
+}
+
+type ProcessForwardReferencesResult = {
+  scrubbed: string;
+  removed: ForwardReference[];
+  residual: ForwardReference[];
+};
+
+// Core scanner shared by scrub/detect/lint. Walks a text in a fixed priority order (deep-links first, so an
+// issue/PR/commit URL is handled before its inner number/SHA can match a barer pattern) and classifies each
+// forward reference as either:
+//   - scrubbable: a self-delimited token (`#123`, a GitHub issues/pull/commit URL, or a raw commit SHA) that
+//     resolves only to post-T state and can be safely replaced with the placeholder; or
+//   - unscrubbable: a *bare* integer that exactly matches a known post-T issue number. A bare number cannot be
+//     blanket-removed without destroying legitimate pre-T numbers (versions, counts), so it is detected but
+//     left in place — its presence must fail the freeze point rather than be silently mangled.
+function processForwardReferences(rawText: unknown, context: ForwardRefContext | null | undefined): ProcessForwardReferencesResult {
+  const resolved = resolveContext(context);
+  const removed: ForwardReference[] = [];
+
+  const text = typeof rawText === "string" ? rawText : "";
+
+  // 1. GitHub issue/pull deep-links whose number is after T.
+  let scrubbed = text.replace(
+    /https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/(\d+)\b/gi,
+    (match, digits) => {
+      if (Number(digits) > resolved.knownIssueMax) {
+        removed.push({ kind: "link", value: match });
+        return FORWARD_REF_PLACEHOLDER;
+      }
+      return match;
+    },
+  );
+
+  // 2. GitHub commit deep-links whose SHA is not in pre-T history.
+  scrubbed = scrubbed.replace(
+    /https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/commit\/([0-9a-f]{7,40})\b/gi,
+    (match, sha) => {
+      if (!resolved.knownCommitShas.has(sha.toLowerCase())) {
+        removed.push({ kind: "link", value: match });
+        return FORWARD_REF_PLACEHOLDER;
+      }
+      return match;
+    },
+  );
+
+  // 3. Bare `#123` issue/PR references after T (not already inside a now-removed link).
+  scrubbed = scrubbed.replace(/(^|[^\w/])#(\d+)\b/g, (match, prefix, digits) => {
+    if (Number(digits) > resolved.knownIssueMax) {
+      removed.push({ kind: "hashref", value: `#${digits}` });
+      return `${prefix}${FORWARD_REF_PLACEHOLDER}`;
+    }
+    return match;
+  });
+
+  // 4. Raw commit SHAs not in pre-T history. Require at least one hex letter so a plain decimal number is
+  //    never misread as a SHA — those flow to the bare-issue-number residual check below instead.
+  scrubbed = scrubbed.replace(/(^|[^\w/#])([0-9a-f]{7,40})\b/gi, (match, prefix, sha) => {
+    if (!/[a-f]/i.test(sha)) return match;
+    if (!resolved.knownCommitShas.has(sha.toLowerCase())) {
+      removed.push({ kind: "sha", value: sha });
+      return `${prefix}${FORWARD_REF_PLACEHOLDER}`;
+    }
+    return match;
+  });
+
+  // Residual: bare integers that name a real post-T issue and so leak the future, but cannot be safely
+  // auto-removed. Detected against the surviving text — if any remain, the freeze point is not usable as-is.
+  const residual: ForwardReference[] = [];
+  if (resolved.revealedIssueNumbers.size > 0) {
+    for (const bareMatch of scrubbed.matchAll(/(?:^|[^\w#/])(\d+)\b/g)) {
+      const value = Number(bareMatch[1]);
+      if (resolved.revealedIssueNumbers.has(value)) {
+        residual.push({ kind: "bare-issue-number", value });
+      }
+    }
+  }
+
+  return { scrubbed, removed, residual };
+}
+
+export type DetectedForwardReferences = {
+  scrubbable: ForwardReference[];
+  unscrubbable: ForwardReference[];
+};
+
+// Detect forward references in text without modifying it, split by whether they can be safely scrubbed.
+export function detectForwardReferences(text: unknown, context: ForwardRefContext | null | undefined): DetectedForwardReferences {
+  const { removed, residual } = processForwardReferences(text, context);
+  return { scrubbable: removed, unscrubbable: residual };
+}
+
+export type ScrubResult = {
+  scrubbed: string;
+  removed: ForwardReference[];
+  residual: ForwardReference[];
+};
+
+// Scrub the safely-removable forward references from text, returning the cleaned text, what was removed, and
+// any unscrubbable references that remain (a non-empty `residual` means the text still leaks the future).
+export function scrubForwardReferences(text: unknown, context: ForwardRefContext | null | undefined): ScrubResult {
+  return processForwardReferences(text, context);
+}
+
+export type LintResult = {
+  ok: boolean;
+  residual: ForwardReference[];
+};
+
+// A freeze point's frozen context is clean iff every provided text scrubs to zero residual forward references.
+export function lintFrozenContext(texts: unknown, context: ForwardRefContext | null | undefined): LintResult {
+  const list = Array.isArray(texts) ? texts : texts == null ? [] : [texts];
+  const residual: ForwardReference[] = [];
+  for (const text of list) {
+    residual.push(...processForwardReferences(text, context).residual);
+  }
+  return { ok: residual.length === 0, residual };
+}
+
+export type FreezePointThresholds = {
+  minPriorCommits?: number;
+  minRevealedCommits?: number;
+};
+
+export type FreezePointCandidate = {
+  repo?: string;
+  commitT?: string;
+  priorCommitCount?: number;
+  revealedCommitCount?: number;
+  lastActivityAt?: string;
+  frozenContextTexts?: unknown[];
+  revealedGroundTruth?: unknown;
+};
+
+export type FreezePointSelection = {
+  eligible: boolean;
+  reasons: string[];
+  priorCommitCount: number;
+  revealedCommitCount: number;
+};
+
+// Selection: a freeze point is calibration-worthy only with enough real history on both sides of T.
+export function selectFreezePoint(
+  candidate: FreezePointCandidate | null | undefined,
+  thresholds: FreezePointThresholds | null | undefined,
+): FreezePointSelection {
+  const minPriorCommits = Number.isInteger(thresholds?.minPriorCommits) ? (thresholds?.minPriorCommits as number) : 0;
+  const minRevealedCommits = Number.isInteger(thresholds?.minRevealedCommits)
+    ? (thresholds?.minRevealedCommits as number)
+    : 0;
+  const priorCommitCount = Number.isInteger(candidate?.priorCommitCount) ? (candidate?.priorCommitCount as number) : 0;
+  const revealedCommitCount = Number.isInteger(candidate?.revealedCommitCount)
+    ? (candidate?.revealedCommitCount as number)
+    : 0;
+
+  const reasons: string[] = [];
+  if (priorCommitCount < minPriorCommits) reasons.push("insufficient_prior_history");
+  if (revealedCommitCount < minRevealedCommits) reasons.push("insufficient_revealed_history");
+
+  return { eligible: reasons.length === 0, reasons, priorCommitCount, revealedCommitCount };
+}
+
+// Pool provenance: a freeze point whose last activity is at/after the calibration run's model cutoff is
+// "recent" (higher memorization risk); everything else, including an unknown date, is "older". ISO-8601
+// timestamps sort lexicographically, so no clock is needed.
+export function classifyRecencyPool(
+  candidate: FreezePointCandidate | null | undefined,
+  options: { modelCutoffIso?: string } | null | undefined,
+): RecencyPool {
+  const modelCutoffIso = typeof options?.modelCutoffIso === "string" ? options.modelCutoffIso : "";
+  const lastActivityAt = typeof candidate?.lastActivityAt === "string" ? candidate.lastActivityAt : "";
+  if (!modelCutoffIso || !lastActivityAt) return "older";
+  return lastActivityAt >= modelCutoffIso ? "recent" : "older";
+}
+
+export type ReplayTaskOptions = {
+  thresholds?: FreezePointThresholds;
+  modelCutoffIso?: string;
+};
+
+export type ReplayTaskRejected = {
+  eligible: false;
+  rejected: "selection" | "unscrubbable_forward_reference";
+  reasons?: string[];
+  residual?: ForwardReference[];
+};
+
+export type ReplayTask = {
+  eligible: true;
+  pool: RecencyPool;
+  frozen: {
+    repo: string | null;
+    commitT: string | null;
+    contextTexts: string[];
+  };
+};
+
+// One-shot replay generator. Applies selection, then scrubs and lints the frozen context, then returns only
+// the frozen replay task. Revealed post-T ground truth is intentionally available only through
+// generateReplayScoringKey, so a replay worker/serializer/logger/model call never receives both sides.
+export function generateReplayTask(
+  candidate: FreezePointCandidate | null | undefined,
+  context: ForwardRefContext | null | undefined,
+  options: ReplayTaskOptions | null | undefined,
+): ReplayTask | ReplayTaskRejected {
+  const selection = selectFreezePoint(candidate, options?.thresholds);
+  if (!selection.eligible) {
+    return { eligible: false, rejected: "selection", reasons: selection.reasons };
+  }
+
+  const frozenTexts = Array.isArray(candidate?.frozenContextTexts) ? (candidate?.frozenContextTexts as unknown[]) : [];
+  const lint = lintFrozenContext(frozenTexts, context);
+  if (!lint.ok) {
+    return { eligible: false, rejected: "unscrubbable_forward_reference", residual: lint.residual };
+  }
+
+  const pool = classifyRecencyPool(candidate, options);
+  const scrubbedTexts = frozenTexts.map((text) => processForwardReferences(text, context).scrubbed);
+
+  return {
+    eligible: true,
+    pool,
+    frozen: {
+      repo: typeof candidate?.repo === "string" ? candidate.repo : null,
+      commitT: typeof candidate?.commitT === "string" ? candidate.commitT : null,
+      contextTexts: scrubbedTexts,
+    },
+  };
+}
+
+export type ReplayScoringKey = {
+  eligible: true;
+  commitCount: number;
+  groundTruth: unknown;
+};
+
+// generateReplayScoringKey never lints/scrubs frozen context (it doesn't touch context text at all), so
+// unlike ReplayTaskRejected it can only ever reject on selection -- narrower than reusing ReplayTaskRejected,
+// which would advertise an "unscrubbable_forward_reference" branch this function can never actually produce.
+export type ReplayScoringKeyRejected = {
+  eligible: false;
+  rejected: "selection";
+  reasons: string[];
+};
+
+// Scoring-only accessor. Call this from the isolated scorer path after replay execution has finished; do not
+// pass its result to replay workers. It deliberately shares only selection eligibility with generateReplayTask
+// and never carries frozen context.
+//
+// IMPORTANT: `eligible: true` here means only that selectFreezePoint accepted the candidate -- it does NOT
+// mean generateReplayTask would also produce a usable frozen task for it. generateReplayTask can still reject
+// a selection-eligible candidate afterward (`rejected: "unscrubbable_forward_reference"`, from
+// lintFrozenContext), because scrub/lint eligibility is about the FROZEN CONTEXT TEXT, which this function
+// never touches -- it only reveals commitCount/groundTruth, so lint/scrub has nothing to check here. A caller
+// must not assume a scoring key implies a replay task was ever generated for the same candidate; check
+// generateReplayTask's own result independently before treating the two as a matched pair.
+export function generateReplayScoringKey(
+  candidate: FreezePointCandidate | null | undefined,
+  options: ReplayTaskOptions | null | undefined,
+): ReplayScoringKey | ReplayScoringKeyRejected {
+  const selection = selectFreezePoint(candidate, options?.thresholds);
+  if (!selection.eligible) {
+    return { eligible: false, rejected: "selection", reasons: selection.reasons };
+  }
+
+  return {
+    eligible: true,
+    commitCount: selection.revealedCommitCount,
+    groundTruth: candidate?.revealedGroundTruth ?? null,
+  };
+}

--- a/test/unit/miner-cli-doctor-checks.test.ts
+++ b/test/unit/miner-cli-doctor-checks.test.ts
@@ -57,6 +57,20 @@ describe("loopover-miner doctor — coding-agent CLI checks (#4304)", () => {
     expect(check.detail).toMatch(/^not installed \(optional/);
   });
 
+  it("claude: defaults to process.env when the env option is omitted", () => {
+    const check = checkClaudeCliPresent({ resolveClaudePath: () => null });
+    expect(check.ok).toBe(true);
+    expect(check.detail).toMatch(/^not installed \(optional/);
+  });
+
+  it("codex: defaults to process.env when the env option is omitted, and to the real resolveCodexAuthPath when that option is omitted too", () => {
+    const check = checkCodexCliPresent({ resolveCodexPath: () => "/usr/bin/codex" });
+    expect(check.ok).toBe(true);
+    // The real, non-injected resolveCodexAuthPath resolves under $HOME/.codex or $CODEX_HOME by default --
+    // on a machine with no such auth.json present this reports the unauthenticated advisory, not a throw.
+    expect(check.detail).toMatch(/^found at \/usr\/bin\/codex/);
+  });
+
   it("runDoctorChecks includes both coding-agent CLI checks", () => {
     const names = runDoctorChecks({ LOOPOVER_MINER_CONFIG_DIR: tempRoot() }).map((check) => check.name);
     expect(names).toContain("claude-cli-present");

--- a/test/unit/miner-governor-chokepoint.test.ts
+++ b/test/unit/miner-governor-chokepoint.test.ts
@@ -8,7 +8,7 @@ vi.mock("@loopover/engine", async () => {
 });
 
 import { evaluateGovernorChokepointGate } from "../../packages/loopover-miner/lib/governor-chokepoint.js";
-import { initGovernorLedger } from "../../packages/loopover-miner/lib/governor-ledger.js";
+import { closeDefaultGovernorLedger, initGovernorLedger, readGovernorEvents } from "../../packages/loopover-miner/lib/governor-ledger.js";
 
 const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
@@ -69,6 +69,20 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
     expect(result.recorded.eventType).toBe("allowed");
     expect(result.rateLimitBuckets.global.open_pr?.count).toBe(1);
     expect(ledger.readGovernorEvents({ repoFullName: "acme/widgets" })).toHaveLength(1);
+  });
+
+  it("defaults to the real appendGovernorEvent (the default ledger) when no append option is given", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-chokepoint-default-append-"));
+    roots.push(root);
+    vi.stubEnv("LOOPOVER_MINER_GOVERNOR_LEDGER_DB", join(root, "governor-ledger.sqlite3"));
+    try {
+      const result = evaluateGovernorChokepointGate(baseInput());
+      expect(result.decision.allowed).toBe(true);
+      expect(readGovernorEvents({ repoFullName: "acme/widgets" })).toHaveLength(1);
+    } finally {
+      closeDefaultGovernorLedger();
+      vi.unstubAllEnvs();
+    }
   });
 
   it("a kill-switch denial records to the ledger and leaves rate-limit bucket state untouched", () => {

--- a/test/unit/miner-governor-kill-switch.test.ts
+++ b/test/unit/miner-governor-kill-switch.test.ts
@@ -8,7 +8,7 @@ vi.mock("@loopover/engine", async () => {
 });
 
 import { checkMinerKillSwitch, recordMinerKillSwitchTransition } from "../../packages/loopover-miner/lib/governor-kill-switch.js";
-import { initGovernorLedger } from "../../packages/loopover-miner/lib/governor-ledger.js";
+import { closeDefaultGovernorLedger, initGovernorLedger, readGovernorEvents } from "../../packages/loopover-miner/lib/governor-ledger.js";
 
 const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
@@ -87,6 +87,25 @@ describe("recordMinerKillSwitchTransition (#2341)", () => {
     const rows = ledger.readGovernorEvents({});
     expect(rows).toHaveLength(1);
     expect(rows[0]?.repoFullName).toBeNull();
+  });
+
+  it("defaults to the real appendGovernorEvent (the default ledger) when no append option is given", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-kill-switch-default-append-"));
+    roots.push(root);
+    vi.stubEnv("LOOPOVER_MINER_GOVERNOR_LEDGER_DB", join(root, "governor-ledger.sqlite3"));
+    try {
+      const tripped = recordMinerKillSwitchTransition({
+        repoFullName: "acme/widgets",
+        actionClass: "open_pr",
+        previousScope: "none",
+        scope: "repo",
+      });
+      expect(tripped?.eventType).toBe("kill_switch");
+      expect(readGovernorEvents({ repoFullName: "acme/widgets" })).toHaveLength(1);
+    } finally {
+      closeDefaultGovernorLedger();
+      vi.unstubAllEnvs();
+    }
   });
 
   it("is a no-op and appends nothing when the scope has not changed", () => {

--- a/test/unit/miner-init-verify-token.test.ts
+++ b/test/unit/miner-init-verify-token.test.ts
@@ -152,6 +152,93 @@ describe("verifyGithubToken", () => {
     expect(result.detail).toContain("ECONNRESET");
   });
 
+  it("defaults a missing githubToken to blank, still omitting the Authorization header", async () => {
+    const requests: Array<{ headers: Record<string, string> }> = [];
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      requests.push({ headers: Object.fromEntries(new Headers(init?.headers).entries()) });
+      return mockJsonResponse({ login: "octocat" }, { headers: { "x-oauth-scopes": "repo" } });
+    };
+
+    const result = await verifyGithubToken({ fetchImpl });
+
+    expect(result.ok).toBe(true);
+    expect(requests[0]?.headers.authorization).toBeUndefined();
+  });
+
+  it("falls back to the default API base when a slashes-only apiBaseUrl strips to empty", async () => {
+    const requests: string[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      requests.push(String(input));
+      return mockJsonResponse({ login: "octocat" }, { headers: { "x-oauth-scopes": "repo" } });
+    };
+
+    await verifyGithubToken({ githubToken: "token-value", apiBaseUrl: "///", fetchImpl });
+
+    expect(requests).toEqual(["https://api.github.com/user"]);
+  });
+
+  it("surfaces a non-Error network rejection as a validation failure (request failed)", async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw "connection reset";
+    };
+
+    const result = await verifyGithubToken({ githubToken: "token-value", fetchImpl });
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("request failed");
+  });
+
+  it("treats an unparsable JSON body as a null payload rather than throwing", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("not json", { status: 200, headers: { "x-oauth-scopes": "repo" } });
+
+    const result = await verifyGithubToken({ githubToken: "token-value", fetchImpl });
+
+    expect(result.ok).toBe(true);
+    expect(result.login).toBeNull();
+  });
+
+  it("reports a null login (rather than an empty string) when the success payload omits it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockJsonResponse({}, { headers: { "x-oauth-scopes": "repo" } }),
+    );
+
+    const result = await verifyGithubToken({ githubToken: "token-value" });
+
+    expect(result.ok).toBe(true);
+    expect(result.login).toBeNull();
+    expect(result.detail).toContain("unknown user");
+  });
+
+  it("reports a null login when the success payload omits it and GitHub reports no scopes at all", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonResponse({}));
+
+    const result = await verifyGithubToken({ githubToken: "token-value" });
+
+    expect(result.ok).toBe(true);
+    expect(result.login).toBeNull();
+    expect(result.detail).toContain("unknown user");
+    expect(result.detail).toContain("did not report classic OAuth scopes");
+  });
+
+  it("reports a null login on the empty-scopes-header failure when the payload omits it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonResponse({}, { headers: { "x-oauth-scopes": "" } }));
+
+    const result = await verifyGithubToken({ githubToken: "token-value" });
+
+    expect(result.ok).toBe(false);
+    expect(result.login).toBeNull();
+  });
+
+  it("reports a null login on the non-repo-scopes failure when the payload omits it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonResponse({}, { headers: { "x-oauth-scopes": "read:org" } }));
+
+    const result = await verifyGithubToken({ githubToken: "token-value" });
+
+    expect(result.ok).toBe(false);
+    expect(result.login).toBeNull();
+  });
+
   it("times out when the GitHub request never settles", async () => {
     const fetchImpl: typeof fetch = async (_input, init) =>
       new Promise<Response>((_resolve, reject) => {

--- a/test/unit/miner-laptop-init.test.ts
+++ b/test/unit/miner-laptop-init.test.ts
@@ -15,7 +15,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 /** Records every `new DatabaseSync(path, options)` the module under test performs, so a test can assert the
  *  OPTIONS it opens with (#6765) -- checkLaptopStateSqlite never exposes its own handle. The subclass just
  *  records and delegates, so every other test's behavior is unchanged. */
-const { databaseSyncOptions } = vi.hoisted(() => ({ databaseSyncOptions: [] as Array<Record<string, unknown> | undefined> }));
+const { databaseSyncOptions, throwNonErrorOnOpen } = vi.hoisted(() => ({
+  databaseSyncOptions: [] as Array<Record<string, unknown> | undefined>,
+  throwNonErrorOnOpen: { value: false },
+}));
 
 vi.mock("node:sqlite", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:sqlite")>();
@@ -24,6 +27,13 @@ vi.mock("node:sqlite", async (importOriginal) => {
     // every existing `new DatabaseSync(path)` caller must reach super with its original arity.
     constructor(...args: ConstructorParameters<typeof actual.DatabaseSync>) {
       databaseSyncOptions.push(args[1] as Record<string, unknown> | undefined);
+      // Test-only escape hatch (#6765 follow-up): checkLaptopStateSqlite's catch branch must degrade a
+      // non-Error throw to "not readable" too, not just a real sqlite Error -- node:sqlite itself only ever
+      // throws real Errors, so this is the only way to reach that defensive branch without weakening it.
+      if (throwNonErrorOnOpen.value) {
+        throwNonErrorOnOpen.value = false;
+        throw "not a real Error instance";
+      }
       super(...args);
     }
   }
@@ -33,6 +43,7 @@ import {
   checkDockerPresent,
   checkLaptopStateSqlite,
   initLaptopState,
+  resolveCodexAuthPath,
   resolveLaptopStateDbPath,
   runInit,
 } from "../../packages/loopover-miner/lib/laptop-init.js";
@@ -57,6 +68,19 @@ describe("loopover-miner laptop init (#2329)", () => {
       .toBe("/custom/state/laptop-state.sqlite3");
     expect(resolveLaptopStateDbPath({ XDG_CONFIG_HOME: "/xdg" }))
       .toBe("/xdg/loopover-miner/laptop-state.sqlite3");
+  });
+
+  it("falls all the way back to ~/.config/loopover-miner when neither override is set", () => {
+    const path = resolveLaptopStateDbPath({});
+    expect(path.replaceAll("\\", "/")).toMatch(/\/\.config\/loopover-miner\/laptop-state\.sqlite3$/);
+  });
+
+  it("resolveCodexAuthPath: CODEX_HOME wins, then $HOME/.codex, then the real homedir", () => {
+    expect(resolveCodexAuthPath({ CODEX_HOME: "/custom/codex" }).replaceAll("\\", "/"))
+      .toBe("/custom/codex/auth.json");
+    expect(resolveCodexAuthPath({ HOME: "/home/miner" }).replaceAll("\\", "/"))
+      .toBe("/home/miner/.codex/auth.json");
+    expect(resolveCodexAuthPath({}).replaceAll("\\", "/")).toMatch(/\/\.codex\/auth\.json$/);
   });
 
   it("fresh init creates the state dir and SQLite file", () => {
@@ -135,6 +159,18 @@ describe("loopover-miner laptop init (#2329)", () => {
     const check = checkLaptopStateSqlite(env);
     expect(check.ok).toBe(false);
     expect(check.detail).toContain(dbPath);
+  });
+
+  it("doctor sqlite check degrades a non-Error throw to 'not readable' too", () => {
+    const root = tempRoot();
+    const env = { LOOPOVER_MINER_CONFIG_DIR: join(root, "state") };
+    initLaptopState(env);
+    throwNonErrorOnOpen.value = true;
+
+    const check = checkLaptopStateSqlite(env);
+
+    expect(check.ok).toBe(false);
+    expect(check.detail).toContain("not readable");
   });
 
   it("doctor reports absent Docker gracefully (informational, always ok)", () => {

--- a/test/unit/miner-rejection-signal.test.ts
+++ b/test/unit/miner-rejection-signal.test.ts
@@ -221,6 +221,13 @@ describe("resolveRejectionSignaled (#5132)", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("returns false for a non-string repoFullName, without calling fetch", async () => {
+    const fetchImpl = vi.fn();
+    const result = await resolveRejectionSignaled(42 as unknown as string, { fetchImpl });
+    expect(result).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("uses a custom rawContentBaseUrl when provided", async () => {
     const calledUrls: string[] = [];
     const fetchImpl = async (url: string) => {

--- a/test/unit/miner-replay-objective-anchor.test.ts
+++ b/test/unit/miner-replay-objective-anchor.test.ts
@@ -168,6 +168,12 @@ describe("loopover-miner replay objective-anchor scoring (#3012)", () => {
       expect(result.replayOnlyModules).toEqual([]); // replay modules coerced to []
       expect(result.revealedOnlyModules).toEqual(["src/a"]);
     });
+
+    it("coerces a non-array revealed changeKinds (missing or wrong type) to an empty set", () => {
+      const result = scoreObjectiveAnchor({ modules: ["src/a"], changeKind: "feature" }, { modules: ["src/a"] });
+      expect(result.revealedChangeKinds).toEqual([]);
+      expect(result.changeKindMatch).toBe(0);
+    });
   });
 
   describe("computeObjectiveAnchor", () => {

--- a/test/unit/miner-replay-task-generation.test.ts
+++ b/test/unit/miner-replay-task-generation.test.ts
@@ -51,6 +51,46 @@ describe("loopover-miner leakage-safe replay task generation (#3011)", () => {
       const { scrubbable } = detectForwardReferences("build 12345678 shipped", { knownCommitShas: [] });
       expect(scrubbable).toEqual([]);
     });
+
+    it("keeps a pre-T github issue/pull deep-link untouched", () => {
+      const { scrubbable } = detectForwardReferences("see https://github.com/o/r/issues/42 for context", CONTEXT);
+      expect(scrubbable).toEqual([]);
+    });
+
+    it("scrubs a commit deep-link whose SHA is unknown, and keeps one whose SHA is pre-T", () => {
+      const unknown = detectForwardReferences("fixed in https://github.com/o/r/commit/c0ffee123456", CONTEXT);
+      expect(unknown.scrubbable.map((ref) => ref.value)).toContain("https://github.com/o/r/commit/c0ffee123456");
+
+      const known = detectForwardReferences("fixed in https://github.com/o/r/commit/abc1234def", CONTEXT);
+      expect(known.scrubbable).toEqual([]);
+    });
+
+    it("leaves a bare integer that does NOT name a revealed post-T issue in place, not as residual", () => {
+      const { scrubbable, unscrubbable } = detectForwardReferences("random count 55 appears here", CONTEXT);
+      expect(scrubbable).toEqual([]);
+      expect(unscrubbable).toEqual([]);
+    });
+
+    it("normalizes a non-array or invalid-entry knownCommitShas to the empty set", () => {
+      // No knownCommitShas key at all → toShaSet's Array.isArray guard takes its false branch.
+      const missing = detectForwardReferences("see https://github.com/o/r/commit/abc1234def", { knownIssueMax: 100 });
+      expect(missing.scrubbable.map((ref) => ref.value)).toContain("https://github.com/o/r/commit/abc1234def");
+
+      // A mix of valid and invalid entries → the per-entry type/shape guard takes both branches.
+      const mixed = detectForwardReferences("see https://github.com/o/r/commit/abc1234def", {
+        knownIssueMax: 100,
+        knownCommitShas: ["abc1234def", 42, "not-a-sha!"] as unknown as string[],
+      });
+      expect(mixed.scrubbable).toEqual([]); // abc1234def survived the mixed-validity filter and is still known
+    });
+
+    it("normalizes a non-integer or non-positive revealedIssueNumbers entry to the empty set", () => {
+      const { unscrubbable } = detectForwardReferences("the count reached 300 last week", {
+        knownIssueMax: 100,
+        revealedIssueNumbers: [300, "abc", -5, 12.5] as unknown as number[],
+      });
+      expect(unscrubbable).toEqual([{ kind: "bare-issue-number", value: 300 }]);
+    });
   });
 
   describe("scrubForwardReferences", () => {
@@ -95,6 +135,14 @@ describe("loopover-miner leakage-safe replay task generation (#3011)", () => {
       expect(lint.ok).toBe(false);
       expect(lint.residual).toEqual([{ kind: "bare-issue-number", value: 250 }]);
     });
+
+    it("treats nullish texts as an empty list and wraps a single non-array text", () => {
+      expect(lintFrozenContext(null, CONTEXT)).toEqual({ ok: true, residual: [] });
+      expect(lintFrozenContext(undefined, CONTEXT)).toEqual({ ok: true, residual: [] });
+      const single = lintFrozenContext("leaks 250 in prose", CONTEXT);
+      expect(single.ok).toBe(false);
+      expect(single.residual).toEqual([{ kind: "bare-issue-number", value: 250 }]);
+    });
   });
 
   describe("selectFreezePoint", () => {
@@ -110,6 +158,14 @@ describe("loopover-miner leakage-safe replay task generation (#3011)", () => {
       const result = selectFreezePoint({}, { minPriorCommits: 10, minRevealedCommits: 5 });
       expect(result.eligible).toBe(false);
       expect(result.reasons).toEqual(["insufficient_prior_history", "insufficient_revealed_history"]);
+    });
+
+    it("defaults missing/non-integer thresholds to 0, so any non-negative count clears them", () => {
+      const noThresholds = selectFreezePoint({ priorCommitCount: 1, revealedCommitCount: 1 }, undefined);
+      expect(noThresholds).toEqual({ eligible: true, reasons: [], priorCommitCount: 1, revealedCommitCount: 1 });
+
+      const emptyThresholds = selectFreezePoint({ priorCommitCount: 0, revealedCommitCount: 0 }, {});
+      expect(emptyThresholds.eligible).toBe(true);
     });
   });
 
@@ -243,6 +299,22 @@ describe("loopover-miner leakage-safe replay task generation (#3011)", () => {
         commitCount: 10,
         groundTruth: { merged: true, approach: "refactor" },
       });
+    });
+
+    it("defaults frozenContextTexts/repo/commitT when the candidate omits them", () => {
+      const task = generateReplayTask(
+        { priorCommitCount: 50, revealedCommitCount: 10 },
+        CONTEXT,
+        options,
+      );
+      if (!task.eligible) throw new Error(`expected eligible task, got ${JSON.stringify(task)}`);
+      expect(task.frozen).toEqual({ repo: null, commitT: null, contextTexts: [] });
+    });
+
+    it("defaults a missing revealedGroundTruth to null in the scoring key", () => {
+      const scoringKey = generateReplayScoringKey({ priorCommitCount: 50, revealedCommitCount: 10 }, options);
+      if (!scoringKey.eligible) throw new Error(`expected eligible scoring key, got ${JSON.stringify(scoringKey)}`);
+      expect(scoringKey.groundTruth).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Convert 8 `packages/loopover-miner/lib` modules from plain `.js` + a hand-maintained `.d.ts` sibling to real, `tsc`-compiled TypeScript, following the in-place-emit pattern the earlier Phase 1/2/4 batches already established (`.ts` source, `tsc` emits `.js`+`.d.ts` back in place): `replay-objective-anchor.js`, `rejection-signal.js`, `replay-task-generation.js`, `replay-snapshot.js`, `laptop-init.js`, `governor-kill-switch.js`, `governor-chokepoint.js`, `miner-goal-spec.js`.
- No behavior change. Every function signature matches its former hand-maintained `.d.ts` exactly (one exception, noted below); existing tests for these modules pass unmodified except for the added coverage cases.
- Added targeted tests to close every previously-untested defensive/fallback branch flagged by `codecov/patch`'s branch-coverage requirement. Two genuinely-unreachable dead branches (in `laptop-init.ts`'s private `githubHeaders`/`formatScopes` helpers — both only ever called with an already-guarded, non-empty/string argument) were simplified away instead of faked with a test, per this repo's honesty clause.
- One intentional type-signature exception: `rejection-signal.ts`'s `resolveRejectionSignaled` keeps the original `.d.ts`'s wider `Promise<false | RejectionSignaledReason | true>` return type (rather than narrowing to what the implementation actually returns) because `attempt-cli.d.ts` imports this type via `typeof resolveRejectionSignaled` for its injectable dependency, and an existing regression test (`test/unit/miner-attempt-cli.test.ts`, "REGRESSION (#6055): maps legacy boolean true...") injects a mock returning literal `true` to test `attempt-cli.js`'s own backward-compat handling — narrowing the type would have broken that unrelated, currently-passing test.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #7311`.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — all 8 converted files individually and in the combined targeted run (29 test files, 529 tests) show **100% statements/branches/functions/lines**, well above the 99% `codecov/patch` bar.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint` (0 errors; only pre-existing warnings in untouched UI route files)
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build` — not run (this PR touches no UI/`apps/loopover-ui` code; `ui:typecheck`/`ui:lint`/`ui:openapi:check` above all pass)
- [x] `npm audit --audit-level=moderate` — 2 pre-existing high-severity findings in `github-actionlint`'s transitive `adm-zip` dependency, "No fix available" upstream; unrelated to this change (a dev-only tool dependency, not touched here)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Also ran, beyond the template's list, since this repo's `test:ci` includes them: `npm run db:migrations:check`, `npm run db:schema-drift:check`, `npm run selfhost:env-reference:check`, `npm run selfhost:validate-observability`, `npm run cf-typegen:check`, `npm run test:engine-parity`, `npm run test:live-gate-parity`, `npm run test:driver-parity`, `npm run test --workspace @loopover/engine`, `npm run test:miner-pack`, `npm run test:miner-deployment-docs-audit`, `npm run rees:test`, `npm run ui:openapi:settings-parity`, `npm run ui:version-audit`, `npm run docs:drift-check`, `npm run branding-drift:check`, `npm run manifest:drift-check`, `npm run engine-parity:drift-check`, `npm run release-manifest:sync:check`, `npm run command-reference:check`, `npm run miner:env-reference:check` — all clean.

If any required check was skipped, explain why:

- `npm run ui:build` skipped as noted above (no UI files touched; the three faster UI checks all pass).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes in this PR.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no visible/UI changes (see below).
- [ ] Public docs/changelogs are updated where needed — N/A, no doc-facing behavior changed; `docs:drift-check` confirms no doc is now stale.

## UI Evidence

N/A — this PR only converts internal `packages/loopover-miner/lib` modules from `.js` to `.ts` with zero behavior change; there is no visible or UI-facing change to capture.

## Notes

- Followed the same conversion pattern as the merged Phase 1 (#7299) and Phase 4 batch 4.6/4.7 (#7314→#7336, #7315→#7319) PRs: `.ts` source with real type annotations (merging the prior hand-maintained `.d.ts`'s types into the implementation), hand-maintained `.d.ts` removed, then `npm run build --workspace @loopover/engine && npm run build --workspace @loopover/miner` regenerates the in-place `.js`+`.d.ts` compiled output, which is committed alongside the `.ts` source (matching every already-merged batch).
- `governor-kill-switch.ts` and `governor-chokepoint.ts` needed one small, narrow `as AppendGovernorEventInput` cast each at their `append(...)` call site: the `@loopover/engine` event types they consume declare `repoFullName`/`payload` as accepting an explicit `undefined` value under this repo's `exactOptionalPropertyTypes`, while this package's own narrower `AppendGovernorEventInput` (never an explicit `undefined`, only omission) does not — the real runtime value is always `string | null` (built via `?? null` upstream), so the cast is safe and only bridges a declared-type width mismatch that pre-existed (silently, since plain `.js` never type-checked it) before this conversion.
- Manually confirmed these 8 files' actual call sites (`governor-kill-switch`/`governor-chokepoint` gate every real write action via the chat-action/attempt-cli/governor-* modules; `miner-goal-spec` resolves `.loopover-miner.yml` for every attempt) are unaffected in behavior — same signatures, same defaults, same error handling, verified via the existing + new tests plus a clean `npm run build --workspace @loopover/miner` (`tsc` + full `node --check` syntax verification across all 121 `bin/`+`lib/` files).
