### PR TITLE
chore(miner): migrate batch 2.5 leaf lib modules to TypeScript

### DIFF
--- a/packages/loopover-miner/lib/contribution-profile-extract.d.ts
+++ b/packages/loopover-miner/lib/contribution-profile-extract.d.ts
@@ -1,13 +1,10 @@
 import type { ContributionProfile } from "./contribution-profile.js";
-
 /**
  * Extract a best-effort ContributionProfile for a repo from its published label taxonomy and contribution docs.
  * Never throws: any fetch/parse failure degrades the relevant signal to `absent`/`unknown`. Generic — no
  * loopover-specific hardcoding.
  */
-export function extractContributionProfile(
-  repoFullName: string,
-  options?: {
+export declare function extractContributionProfile(repoFullName: string, options?: {
     fetchImpl?: typeof fetch;
     githubToken?: string;
     apiBaseUrl?: string;
@@ -15,5 +12,4 @@ export function extractContributionProfile(
     generatedAt?: string;
     /** Sleep seam for the transient-5xx/rate-limit retry (via fetchWithRetry). Injected so tests use no real timers. */
     sleepFn?: (ms: number) => Promise<unknown>;
-  },
-): Promise<ContributionProfile>;
+}): Promise<ContributionProfile>;

--- a/packages/loopover-miner/lib/contribution-profile-extract.js
+++ b/packages/loopover-miner/lib/contribution-profile-extract.js
@@ -1,256 +1,202 @@
-// ContributionProfile extraction (#6796). Reads a repo's real, published signals — label taxonomy + contribution
-// docs — and produces a populated ContributionProfile per the #6795 schema. GENERIC by design: it recognizes
-// conventional OSS eligibility/exclusion vocabulary and matches over label name AND description, with NO
-// loopover-specific keyword hardcoding (the #6794 inventory found loopover's own `gittensor:*` labels are the
-// exception, not the shape to generalize from). Never throws: any fetch/parse failure degrades a signal to
-// `absent`/`unknown` rather than erroring, so an unreachable or docs-less repo yields a low-confidence profile.
-import {
-  CONTRIBUTION_PROFILE_SCHEMA_VERSION,
-  emptyContributionProfile,
-  weakestConfidence,
-} from "./contribution-profile.js";
+import { CONTRIBUTION_PROFILE_SCHEMA_VERSION, emptyContributionProfile, weakestConfidence, } from "./contribution-profile.js";
 import { fetchWithRetry } from "./http-retry.js";
-
 const DEFAULT_API_BASE_URL = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
 const REQUEST_TIMEOUT_MS = 10_000;
 /** A CONTRIBUTING.md smaller than this is treated as a signpost (a link to an external guide), not the rules
  *  themselves — #6794 found react's is 208 B and kubernetes' 525 B, both just pointers. */
 const CONTRIBUTING_SIGNPOST_MAX_BYTES = 600;
-
 /** Canonical eligibility vocabulary — recognized OSS "contributor-workable" conventions. Matched case-insensitively
  *  as a substring over a label's name AND description. Not loopover-specific. */
 const ELIGIBILITY_TERMS = Object.freeze([
-  "good first issue",
-  "good-first-issue",
-  "help wanted",
-  "help-wanted",
-  "up for grabs",
-  "beginner",
-  "easy",
-  "starter",
+    "good first issue",
+    "good-first-issue",
+    "help wanted",
+    "help-wanted",
+    "up for grabs",
+    "beginner",
+    "easy",
+    "starter",
 ]);
-
 /** Conventional exclusion/off-limits vocabulary. These are UNstated conventions (#6794 found no repo names
  *  exclusion in a label NAME explicitly), so a match yields `inferred`, never `explicit`. */
 const EXCLUSION_TERMS = Object.freeze([
-  "blocked",
-  "on hold",
-  "on-hold",
-  "do not merge",
-  "wontfix",
-  "invalid",
-  "needs triage",
-  "work in progress",
-  "wip",
-  "maintainer only",
-  "internal",
+    "blocked",
+    "on hold",
+    "on-hold",
+    "do not merge",
+    "wontfix",
+    "invalid",
+    "needs triage",
+    "work in progress",
+    "wip",
+    "maintainer only",
+    "internal",
 ]);
-
 /** Closing-keyword / linked-issue language in a CONTRIBUTING.md. */
 const LINKED_ISSUE_TERMS = Object.freeze([
-  "closes #",
-  "fixes #",
-  "resolves #",
-  "linked issue",
-  "reference an issue",
-  "link to an issue",
+    "closes #",
+    "fixes #",
+    "resolves #",
+    "linked issue",
+    "reference an issue",
+    "link to an issue",
 ]);
-
-/** @param {string} repoFullName @returns {{owner:string,repo:string}|null} */
 function parseRepoFullName(repoFullName) {
-  if (typeof repoFullName !== "string") return null;
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner?.trim() || !repo?.trim() || extra !== undefined) return null;
-  return { owner: owner.trim(), repo: repo.trim() };
+    if (typeof repoFullName !== "string")
+        return null;
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner?.trim() || !repo?.trim() || extra !== undefined)
+        return null;
+    return { owner: owner.trim(), repo: repo.trim() };
 }
-
-/** @param {string|undefined} githubToken */
 function githubHeaders(githubToken) {
-  const headers = {
-    accept: "application/vnd.github+json",
-    "user-agent": "loopover-miner",
-    "x-github-api-version": GITHUB_API_VERSION,
-  };
-  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
-  return headers;
+    const headers = {
+        accept: "application/vnd.github+json",
+        "user-agent": "loopover-miner",
+        "x-github-api-version": GITHUB_API_VERSION,
+    };
+    if (githubToken)
+        headers.authorization = `Bearer ${githubToken}`;
+    return headers;
 }
-
 /** Bounded, never-throwing JSON GET. Rides out a transient GitHub 5xx or rate-limit response (429 / secondary-403)
  *  via `fetchWithRetry` — the same discipline opportunity-fanout.js's sibling `githubGetJson` already uses — before
  *  falling back to its fail-open contract: returns null on a non-retryable/exhausted HTTP, transport, or parse
  *  failure. `timeoutMs` gives each attempt its own fresh `AbortSignal.timeout` (preserving the per-request bound),
  *  and `sleepFn` is the injectable no-real-timers seam every other `fetchWithRetry` call site exposes. */
 async function getJson(url, headers, fetchImpl, sleepFn) {
-  let response;
-  try {
-    response = await fetchWithRetry(
-      fetchImpl,
-      url,
-      { method: "GET", headers },
-      { sleepFn, timeoutMs: REQUEST_TIMEOUT_MS },
-    );
-  } catch {
-    return null;
-  }
-  if (!response.ok) return null;
-  return response.json().catch(() => null);
+    let response;
+    try {
+        response = await fetchWithRetry(
+        // `fetchWithRetry`'s `fetchFn` param takes `(url: unknown, init?: unknown)`; the ambient `fetch` type is
+        // narrower on its input, so cast to the loose call shape this module actually uses (a GET returning a body
+        // with `ok`/`status`/`json`) -- exactly what `opportunity-fanout.js`'s sibling `githubGetJson` relies on.
+        fetchImpl, url, { method: "GET", headers }, { timeoutMs: REQUEST_TIMEOUT_MS, ...(sleepFn ? { sleepFn } : {}) });
+    }
+    catch {
+        return null;
+    }
+    if (!response.ok)
+        return null;
+    return response.json().catch(() => null);
 }
-
 /**
  * Match one label against a term list, preferring the NAME but falling back to the DESCRIPTION (the rust
  * `E-easy` finding: a label can carry its eligibility meaning only in the description). Returns the matcher +
  * a provenance detail, or null when neither field matches.
  */
 function matchLabel(label, terms) {
-  const rawName = typeof label?.name === "string" ? label.name : "";
-  const name = rawName.toLowerCase();
-  const description =
-    typeof label?.description === "string"
-      ? label.description.toLowerCase()
-      : "";
-  const detail = rawName || "(unnamed label)";
-  const nameTerm = terms.find((term) => name.includes(term));
-  if (nameTerm !== undefined)
-    return { matcher: { field: "name", contains: nameTerm }, detail };
-  const descriptionTerm = terms.find((term) => description.includes(term));
-  if (descriptionTerm !== undefined)
-    return {
-      matcher: { field: "description", contains: descriptionTerm },
-      detail,
-    };
-  return null;
+    const l = label;
+    const rawName = typeof l?.name === "string" ? l.name : "";
+    const name = rawName.toLowerCase();
+    const description = typeof l?.description === "string"
+        ? l.description.toLowerCase()
+        : "";
+    const detail = rawName || "(unnamed label)";
+    const nameTerm = terms.find((term) => name.includes(term));
+    if (nameTerm !== undefined)
+        return { matcher: { field: "name", contains: nameTerm }, detail };
+    const descriptionTerm = terms.find((term) => description.includes(term));
+    if (descriptionTerm !== undefined)
+        return {
+            matcher: { field: "description", contains: descriptionTerm },
+            detail,
+        };
+    return null;
 }
-
 /** Classify labels into a SignalRule of the given confidence. Recognized labels build an OR-list of matchers;
  *  no match ⇒ `absent`. Eligibility passes `explicit` (a recognized convention IS an explicit statement);
  *  exclusion passes `inferred` (conventional but unstated). */
 function classifyLabels(labels, terms, matchedConfidence) {
-  const matchers = [];
-  const provenance = [];
-  for (const label of labels) {
-    const hit = matchLabel(label, terms);
-    if (hit === null) continue;
-    matchers.push(hit.matcher);
-    provenance.push({ source: "labels", detail: hit.detail });
-  }
-  if (matchers.length === 0)
-    return { value: null, confidence: "absent", provenance: [] };
-  return { value: matchers, confidence: matchedConfidence, provenance };
+    const matchers = [];
+    const provenance = [];
+    for (const label of labels) {
+        const hit = matchLabel(label, terms);
+        if (hit === null)
+            continue;
+        matchers.push(hit.matcher);
+        provenance.push({ source: "labels", detail: hit.detail });
+    }
+    if (matchers.length === 0)
+        return { value: null, confidence: "absent", provenance: [] };
+    return { value: matchers, confidence: matchedConfidence, provenance };
 }
-
 /** Decode a GitHub contents API response body to text. Returns null when absent or not base64. Buffer.from over
  *  a string never throws, so no error path is needed here. */
 function decodeContents(payload) {
-  if (
-    !payload ||
-    typeof payload.content !== "string" ||
-    payload.encoding !== "base64"
-  )
-    return null;
-  return Buffer.from(payload.content, "base64").toString("utf8");
+    const p = payload;
+    if (!p ||
+        typeof p.content !== "string" ||
+        p.encoding !== "base64")
+        return null;
+    return Buffer.from(p.content, "base64").toString("utf8");
 }
-
 /** Fetch CONTRIBUTING.md, probing the repo root then `.github/` (#6794: 6/10 at root, 2/10 under `.github/`). */
 async function fetchContributing(base, target, headers, fetchImpl, sleepFn) {
-  for (const path of ["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]) {
-    const payload = await getJson(
-      `${base}/repos/${target.owner}/${target.repo}/contents/${path}`,
-      headers,
-      fetchImpl,
-      sleepFn,
-    );
-    const text = decodeContents(payload);
-    if (text !== null) return text;
-  }
-  return null;
+    for (const path of ["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]) {
+        const payload = await getJson(`${base}/repos/${target.owner}/${target.repo}/contents/${path}`, headers, fetchImpl, sleepFn);
+        const text = decodeContents(payload);
+        if (text !== null)
+            return text;
+    }
+    return null;
 }
-
 /** Extract the PR-body linked-issue requirement from CONTRIBUTING.md. A very small file is a signpost, not the
  *  rules, so it yields `absent` rather than a false negative dressed as a real one. */
 function extractPrBody(contributing) {
-  if (contributing === null)
-    return { value: null, confidence: "absent", provenance: [] };
-  if (contributing.length < CONTRIBUTING_SIGNPOST_MAX_BYTES)
-    return { value: null, confidence: "unknown", provenance: [] };
-  const lower = contributing.toLowerCase();
-  const requiresLinkedIssue = LINKED_ISSUE_TERMS.some((term) =>
-    lower.includes(term),
-  );
-  // A real, sufficiently-sized CONTRIBUTING.md is an explicit source either way: present-with-keyword is an
-  // explicit requirement, present-without is an explicit "no such rule".
-  return {
-    value: { requiresLinkedIssue },
-    confidence: "explicit",
-    provenance: [{ source: "contributing_md", detail: "CONTRIBUTING.md" }],
-  };
+    if (contributing === null)
+        return { value: null, confidence: "absent", provenance: [] };
+    if (contributing.length < CONTRIBUTING_SIGNPOST_MAX_BYTES)
+        return { value: null, confidence: "unknown", provenance: [] };
+    const lower = contributing.toLowerCase();
+    const requiresLinkedIssue = LINKED_ISSUE_TERMS.some((term) => lower.includes(term));
+    // A real, sufficiently-sized CONTRIBUTING.md is an explicit source either way: present-with-keyword is an
+    // explicit requirement, present-without is an explicit "no such rule".
+    return {
+        value: { requiresLinkedIssue },
+        confidence: "explicit",
+        provenance: [{ source: "contributing_md", detail: "CONTRIBUTING.md" }],
+    };
 }
-
 /**
- * Extract a best-effort ContributionProfile for a repo from what it actually publishes.
- *
- * @param {string} repoFullName owner/repo
- * @param {{ fetchImpl?: typeof fetch, githubToken?: string, apiBaseUrl?: string, generatedAt?: string, sleepFn?: (ms: number) => Promise<unknown> }} [options]
- * @returns {Promise<import("./contribution-profile.js").ContributionProfile>}
+ * Extract a best-effort ContributionProfile for a repo from its published label taxonomy and contribution docs.
+ * Never throws: any fetch/parse failure degrades the relevant signal to `absent`/`unknown`. Generic — no
+ * loopover-specific hardcoding.
  */
 export async function extractContributionProfile(repoFullName, options = {}) {
-  const generatedAt =
-    typeof options.generatedAt === "string"
-      ? options.generatedAt
-      : new Date().toISOString();
-  const target = parseRepoFullName(repoFullName);
-  // A malformed name can't be fetched — return the safe, fully-absent default rather than throwing.
-  if (target === null)
-    return emptyContributionProfile(
-      typeof repoFullName === "string" ? repoFullName : "",
-      generatedAt,
-    );
-
-  /* v8 ignore next -- the global-fetch default is the production path; every test injects fetchImpl. */
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const base =
-    typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim()
-      ? options.apiBaseUrl.replace(/\/+$/, "")
-      : DEFAULT_API_BASE_URL;
-  const headers = githubHeaders(
-    options.githubToken ?? process.env.GITHUB_TOKEN,
-  );
-
-  const sleepFn = options.sleepFn;
-  const labelsPayload = await getJson(
-    `${base}/repos/${target.owner}/${target.repo}/labels?per_page=100`,
-    headers,
-    fetchImpl,
-    sleepFn,
-  );
-  const labels = Array.isArray(labelsPayload) ? labelsPayload : [];
-  const contributing = await fetchContributing(
-    base,
-    target,
-    headers,
-    fetchImpl,
-    sleepFn,
-  );
-
-  const eligibilityLabels = classifyLabels(
-    labels,
-    ELIGIBILITY_TERMS,
-    "explicit",
-  );
-  const exclusionLabels = classifyLabels(labels, EXCLUSION_TERMS, "inferred");
-  const prBody = extractPrBody(contributing);
-
-  return {
-    repoFullName: `${target.owner}/${target.repo}`,
-    schemaVersion: CONTRIBUTION_PROFILE_SCHEMA_VERSION,
-    generatedAt,
-    eligibilityLabels,
-    exclusionLabels,
-    prBody,
-    completeness: weakestConfidence([
-      eligibilityLabels.confidence,
-      exclusionLabels.confidence,
-      prBody.confidence,
-    ]),
-  };
+    const generatedAt = typeof options.generatedAt === "string"
+        ? options.generatedAt
+        : new Date().toISOString();
+    const target = parseRepoFullName(repoFullName);
+    // A malformed name can't be fetched — return the safe, fully-absent default rather than throwing.
+    if (target === null)
+        return emptyContributionProfile(typeof repoFullName === "string" ? repoFullName : "", generatedAt);
+    /* v8 ignore next -- the global-fetch default is the production path; every test injects fetchImpl. */
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const base = typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim()
+        ? options.apiBaseUrl.replace(/\/+$/, "")
+        : DEFAULT_API_BASE_URL;
+    const headers = githubHeaders(options.githubToken ?? process.env.GITHUB_TOKEN);
+    const sleepFn = options.sleepFn;
+    const labelsPayload = await getJson(`${base}/repos/${target.owner}/${target.repo}/labels?per_page=100`, headers, fetchImpl, sleepFn);
+    const labels = Array.isArray(labelsPayload) ? labelsPayload : [];
+    const contributing = await fetchContributing(base, target, headers, fetchImpl, sleepFn);
+    const eligibilityLabels = classifyLabels(labels, ELIGIBILITY_TERMS, "explicit");
+    const exclusionLabels = classifyLabels(labels, EXCLUSION_TERMS, "inferred");
+    const prBody = extractPrBody(contributing);
+    return {
+        repoFullName: `${target.owner}/${target.repo}`,
+        schemaVersion: CONTRIBUTION_PROFILE_SCHEMA_VERSION,
+        generatedAt,
+        eligibilityLabels,
+        exclusionLabels,
+        prBody,
+        completeness: weakestConfidence([
+            eligibilityLabels.confidence,
+            exclusionLabels.confidence,
+            prBody.confidence,
+        ]),
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY29udHJpYnV0aW9uLXByb2ZpbGUtZXh0cmFjdC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImNvbnRyaWJ1dGlvbi1wcm9maWxlLWV4dHJhY3QudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBY0EsT0FBTyxFQUNMLG1DQUFtQyxFQUNuQyx3QkFBd0IsRUFDeEIsaUJBQWlCLEdBQ2xCLE1BQU0sMkJBQTJCLENBQUM7QUFDbkMsT0FBTyxFQUFFLGNBQWMsRUFBRSxNQUFNLGlCQUFpQixDQUFDO0FBRWpELE1BQU0sb0JBQW9CLEdBQUcsd0JBQXdCLENBQUM7QUFDdEQsTUFBTSxrQkFBa0IsR0FBRyxZQUFZLENBQUM7QUFDeEMsTUFBTSxrQkFBa0IsR0FBRyxNQUFNLENBQUM7QUFDbEM7MkZBQzJGO0FBQzNGLE1BQU0sK0JBQStCLEdBQUcsR0FBRyxDQUFDO0FBRTVDO2lGQUNpRjtBQUNqRixNQUFNLGlCQUFpQixHQUFHLE1BQU0sQ0FBQyxNQUFNLENBQUM7SUFDdEMsa0JBQWtCO0lBQ2xCLGtCQUFrQjtJQUNsQixhQUFhO0lBQ2IsYUFBYTtJQUNiLGNBQWM7SUFDZCxVQUFVO0lBQ1YsTUFBTTtJQUNOLFNBQVM7Q0FDVixDQUFDLENBQUM7QUFFSDs2RkFDNkY7QUFDN0YsTUFBTSxlQUFlLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQztJQUNwQyxTQUFTO0lBQ1QsU0FBUztJQUNULFNBQVM7SUFDVCxjQUFjO0lBQ2QsU0FBUztJQUNULFNBQVM7SUFDVCxjQUFjO0lBQ2Qsa0JBQWtCO0lBQ2xCLEtBQUs7SUFDTCxpQkFBaUI7SUFDakIsVUFBVTtDQUNYLENBQUMsQ0FBQztBQUVILG9FQUFvRTtBQUNwRSxNQUFNLGtCQUFrQixHQUFHLE1BQU0sQ0FBQyxNQUFNLENBQUM7SUFDdkMsVUFBVTtJQUNWLFNBQVM7SUFDVCxZQUFZO0lBQ1osY0FBYztJQUNkLG9CQUFvQjtJQUNwQixrQkFBa0I7Q0FDbkIsQ0FBQyxDQUFDO0FBRUgsU0FBUyxpQkFBaUIsQ0FBQyxZQUFxQjtJQUM5QyxJQUFJLE9BQU8sWUFBWSxLQUFLLFFBQVE7UUFBRSxPQUFPLElBQUksQ0FBQztJQUNsRCxNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxZQUFZLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3JELElBQUksQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN4RSxPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxJQUFJLEVBQUUsRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLElBQUksRUFBRSxFQUFFLENBQUM7QUFDcEQsQ0FBQztBQUVELFNBQVMsYUFBYSxDQUFDLFdBQStCO0lBQ3BELE1BQU0sT0FBTyxHQUEyQjtRQUN0QyxNQUFNLEVBQUUsNkJBQTZCO1FBQ3JDLFlBQVksRUFBRSxnQkFBZ0I7UUFDOUIsc0JBQXNCLEVBQUUsa0JBQWtCO0tBQzNDLENBQUM7SUFDRixJQUFJLFdBQVc7UUFBRSxPQUFPLENBQUMsYUFBYSxHQUFHLFVBQVUsV0FBVyxFQUFFLENBQUM7SUFDakUsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVEOzs7OzBHQUkwRztBQUMxRyxLQUFLLFVBQVUsT0FBTyxDQUNwQixHQUFXLEVBQ1gsT0FBK0IsRUFDL0IsU0FBdUIsRUFDdkIsT0FBdUQ7SUFFdkQsSUFBSSxRQUFRLENBQUM7SUFDYixJQUFJLENBQUM7UUFDSCxRQUFRLEdBQUcsTUFBTSxjQUFjO1FBQzdCLHlHQUF5RztRQUN6RywyR0FBMkc7UUFDM0csMEdBQTBHO1FBQzFHLFNBQWdJLEVBQ2hJLEdBQUcsRUFDSCxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFFLEVBQzFCLEVBQUUsU0FBUyxFQUFFLGtCQUFrQixFQUFFLEdBQUcsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLEVBQUUsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQ25FLENBQUM7SUFDSixDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsT0FBTyxJQUFJLENBQUM7SUFDZCxDQUFDO0lBQ0QsSUFBSSxDQUFDLFFBQVEsQ0FBQyxFQUFFO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDOUIsT0FBTyxRQUFRLENBQUMsSUFBSSxFQUFFLENBQUMsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQzNDLENBQUM7QUFFRDs7OztHQUlHO0FBQ0gsU0FBUyxVQUFVLENBQUMsS0FBYyxFQUFFLEtBQXdCO0lBQzFELE1BQU0sQ0FBQyxHQUFHLEtBQXFFLENBQUM7SUFDaEYsTUFBTSxPQUFPLEdBQUcsT0FBTyxDQUFDLEVBQUUsSUFBSSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzFELE1BQU0sSUFBSSxHQUFHLE9BQU8sQ0FBQyxXQUFXLEVBQUUsQ0FBQztJQUNuQyxNQUFNLFdBQVcsR0FDZixPQUFPLENBQUMsRUFBRSxXQUFXLEtBQUssUUFBUTtRQUNoQyxDQUFDLENBQUMsQ0FBQyxDQUFDLFdBQVcsQ0FBQyxXQUFXLEVBQUU7UUFDN0IsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNULE1BQU0sTUFBTSxHQUFHLE9BQU8sSUFBSSxpQkFBaUIsQ0FBQztJQUM1QyxNQUFNLFFBQVEsR0FBRyxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUM7SUFDM0QsSUFBSSxRQUFRLEtBQUssU0FBUztRQUN4QixPQUFPLEVBQUUsT0FBTyxFQUFFLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxRQUFRLEVBQUUsUUFBUSxFQUFFLEVBQUUsTUFBTSxFQUFFLENBQUM7SUFDcEUsTUFBTSxlQUFlLEdBQUcsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsV0FBVyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO0lBQ3pFLElBQUksZUFBZSxLQUFLLFNBQVM7UUFDL0IsT0FBTztZQUNMLE9BQU8sRUFBRSxFQUFFLEtBQUssRUFBRSxhQUFhLEVBQUUsUUFBUSxFQUFFLGVBQWUsRUFBRTtZQUM1RCxNQUFNO1NBQ1AsQ0FBQztJQUNKLE9BQU8sSUFBSSxDQUFDO0FBQ2QsQ0FBQztBQUVEOzsrREFFK0Q7QUFDL0QsU0FBUyxjQUFjLENBQ3JCLE1BQWlCLEVBQ2pCLEtBQXdCLEVBQ3hCLGlCQUErQztJQUUvQyxNQUFNLFFBQVEsR0FBK0IsRUFBRSxDQUFDO0lBQ2hELE1BQU0sVUFBVSxHQUFtQyxFQUFFLENBQUM7SUFDdEQsS0FBSyxNQUFNLEtBQUssSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUMzQixNQUFNLEdBQUcsR0FBRyxVQUFVLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO1FBQ3JDLElBQUksR0FBRyxLQUFLLElBQUk7WUFBRSxTQUFTO1FBQzNCLFFBQVEsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxDQUFDO1FBQzNCLFVBQVUsQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLEVBQUUsUUFBUSxFQUFFLE1BQU0sRUFBRSxHQUFHLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBQ0QsSUFBSSxRQUFRLENBQUMsTUFBTSxLQUFLLENBQUM7UUFDdkIsT0FBTyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsVUFBVSxFQUFFLFFBQVEsRUFBRSxVQUFVLEVBQUUsRUFBRSxFQUFFLENBQUM7SUFDL0QsT0FBTyxFQUFFLEtBQUssRUFBRSxRQUFRLEVBQUUsVUFBVSxFQUFFLGlCQUFpQixFQUFFLFVBQVUsRUFBRSxDQUFDO0FBQ3hFLENBQUM7QUFFRDs4REFDOEQ7QUFDOUQsU0FBUyxjQUFjLENBQUMsT0FBZ0I7SUFDdEMsTUFBTSxDQUFDLEdBQUcsT0FBdUUsQ0FBQztJQUNsRixJQUNFLENBQUMsQ0FBQztRQUNGLE9BQU8sQ0FBQyxDQUFDLE9BQU8sS0FBSyxRQUFRO1FBQzdCLENBQUMsQ0FBQyxRQUFRLEtBQUssUUFBUTtRQUV2QixPQUFPLElBQUksQ0FBQztJQUNkLE9BQU8sTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLFFBQVEsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQztBQUMzRCxDQUFDO0FBRUQsaUhBQWlIO0FBQ2pILEtBQUssVUFBVSxpQkFBaUIsQ0FDOUIsSUFBWSxFQUNaLE1BQXVDLEVBQ3ZDLE9BQStCLEVBQy9CLFNBQXVCLEVBQ3ZCLE9BQXVEO0lBRXZELEtBQUssTUFBTSxJQUFJLElBQUksQ0FBQyxpQkFBaUIsRUFBRSx5QkFBeUIsQ0FBQyxFQUFFLENBQUM7UUFDbEUsTUFBTSxPQUFPLEdBQUcsTUFBTSxPQUFPLENBQzNCLEdBQUcsSUFBSSxVQUFVLE1BQU0sQ0FBQyxLQUFLLElBQUksTUFBTSxDQUFDLElBQUksYUFBYSxJQUFJLEVBQUUsRUFDL0QsT0FBTyxFQUNQLFNBQVMsRUFDVCxPQUFPLENBQ1IsQ0FBQztRQUNGLE1BQU0sSUFBSSxHQUFHLGNBQWMsQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUNyQyxJQUFJLElBQUksS0FBSyxJQUFJO1lBQUUsT0FBTyxJQUFJLENBQUM7SUFDakMsQ0FBQztJQUNELE9BQU8sSUFBSSxDQUFDO0FBQ2QsQ0FBQztBQUVEO3VGQUN1RjtBQUN2RixTQUFTLGFBQWEsQ0FBQyxZQUEyQjtJQUNoRCxJQUFJLFlBQVksS0FBSyxJQUFJO1FBQ3ZCLE9BQU8sRUFBRSxLQUFLLEVBQUUsSUFBSSxFQUFFLFVBQVUsRUFBRSxRQUFRLEVBQUUsVUFBVSxFQUFFLEVBQUUsRUFBRSxDQUFDO0lBQy9ELElBQUksWUFBWSxDQUFDLE1BQU0sR0FBRywrQkFBK0I7UUFDdkQsT0FBTyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsVUFBVSxFQUFFLFNBQVMsRUFBRSxVQUFVLEVBQUUsRUFBRSxFQUFFLENBQUM7SUFDaEUsTUFBTSxLQUFLLEdBQUcsWUFBWSxDQUFDLFdBQVcsRUFBRSxDQUFDO0lBQ3pDLE1BQU0sbUJBQW1CLEdBQUcsa0JBQWtCLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FDM0QsS0FBSyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsQ0FDckIsQ0FBQztJQUNGLDBHQUEwRztJQUMxRyx1RUFBdUU7SUFDdkUsT0FBTztRQUNMLEtBQUssRUFBRSxFQUFFLG1CQUFtQixFQUFFO1FBQzlCLFVBQVUsRUFBRSxVQUFVO1FBQ3RCLFVBQVUsRUFBRSxDQUFDLEVBQUUsTUFBTSxFQUFFLGlCQUFpQixFQUFFLE1BQU0sRUFBRSxpQkFBaUIsRUFBRSxDQUFDO0tBQ3ZFLENBQUM7QUFDSixDQUFDO0FBRUQ7Ozs7R0FJRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsMEJBQTBCLENBQzlDLFlBQW9CLEVBQ3BCLFVBUUksRUFBRTtJQUVOLE1BQU0sV0FBVyxHQUNmLE9BQU8sT0FBTyxDQUFDLFdBQVcsS0FBSyxRQUFRO1FBQ3JDLENBQUMsQ0FBQyxPQUFPLENBQUMsV0FBVztRQUNyQixDQUFDLENBQUMsSUFBSSxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQztJQUMvQixNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMvQyxrR0FBa0c7SUFDbEcsSUFBSSxNQUFNLEtBQUssSUFBSTtRQUNqQixPQUFPLHdCQUF3QixDQUM3QixPQUFPLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsRUFBRSxFQUNwRCxXQUFXLENBQ1osQ0FBQztJQUVKLHNHQUFzRztJQUN0RyxNQUFNLFNBQVMsR0FBRyxPQUFPLENBQUMsU0FBUyxJQUFJLEtBQUssQ0FBQztJQUM3QyxNQUFNLElBQUksR0FDUixPQUFPLE9BQU8sQ0FBQyxVQUFVLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxVQUFVLENBQUMsSUFBSSxFQUFFO1FBQ2pFLENBQUMsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLE9BQU8sQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUFDO1FBQ3hDLENBQUMsQ0FBQyxvQkFBb0IsQ0FBQztJQUMzQixNQUFNLE9BQU8sR0FBRyxhQUFhLENBQzNCLE9BQU8sQ0FBQyxXQUFXLElBQUksT0FBTyxDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQ2hELENBQUM7SUFFRixNQUFNLE9BQU8sR0FBRyxPQUFPLENBQUMsT0FBTyxDQUFDO0lBQ2hDLE1BQU0sYUFBYSxHQUFHLE1BQU0sT0FBTyxDQUNqQyxHQUFHLElBQUksVUFBVSxNQUFNLENBQUMsS0FBSyxJQUFJLE1BQU0sQ0FBQyxJQUFJLHNCQUFzQixFQUNsRSxPQUFPLEVBQ1AsU0FBUyxFQUNULE9BQU8sQ0FDUixDQUFDO0lBQ0YsTUFBTSxNQUFNLEdBQUcsS0FBSyxDQUFDLE9BQU8sQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDakUsTUFBTSxZQUFZLEdBQUcsTUFBTSxpQkFBaUIsQ0FDMUMsSUFBSSxFQUNKLE1BQU0sRUFDTixPQUFPLEVBQ1AsU0FBUyxFQUNULE9BQU8sQ0FDUixDQUFDO0lBRUYsTUFBTSxpQkFBaUIsR0FBRyxjQUFjLENBQ3RDLE1BQU0sRUFDTixpQkFBaUIsRUFDakIsVUFBVSxDQUNYLENBQUM7SUFDRixNQUFNLGVBQWUsR0FBRyxjQUFjLENBQUMsTUFBTSxFQUFFLGVBQWUsRUFBRSxVQUFVLENBQUMsQ0FBQztJQUM1RSxNQUFNLE1BQU0sR0FBRyxhQUFhLENBQUMsWUFBWSxDQUFDLENBQUM7SUFFM0MsT0FBTztRQUNMLFlBQVksRUFBRSxHQUFHLE1BQU0sQ0FBQyxLQUFLLElBQUksTUFBTSxDQUFDLElBQUksRUFBRTtRQUM5QyxhQUFhLEVBQUUsbUNBQW1DO1FBQ2xELFdBQVc7UUFDWCxpQkFBaUI7UUFDakIsZUFBZTtRQUNmLE1BQU07UUFDTixZQUFZLEVBQUUsaUJBQWlCLENBQUM7WUFDOUIsaUJBQWlCLENBQUMsVUFBVTtZQUM1QixlQUFlLENBQUMsVUFBVTtZQUMxQixNQUFNLENBQUMsVUFBVTtTQUNsQixDQUFDO0tBQ0gsQ0FBQztBQUNKLENBQUMifQ==

--- a/packages/loopover-miner/lib/contribution-profile-extract.ts
+++ b/packages/loopover-miner/lib/contribution-profile-extract.ts
@@ -1,0 +1,291 @@
+// ContributionProfile extraction (#6796). Reads a repo's real, published signals — label taxonomy + contribution
+// docs — and produces a populated ContributionProfile per the #6795 schema. GENERIC by design: it recognizes
+// conventional OSS eligibility/exclusion vocabulary and matches over label name AND description, with NO
+// loopover-specific keyword hardcoding (the #6794 inventory found loopover's own `gittensor:*` labels are the
+// exception, not the shape to generalize from). Never throws: any fetch/parse failure degrades a signal to
+// `absent`/`unknown` rather than erroring, so an unreachable or docs-less repo yields a low-confidence profile.
+import type {
+  ContributionLabelMatcher,
+  ContributionPrBodyRequirements,
+  ContributionProfile,
+  ContributionSignalConfidence,
+  ContributionSignalProvenance,
+  ContributionSignalRule,
+} from "./contribution-profile.js";
+import {
+  CONTRIBUTION_PROFILE_SCHEMA_VERSION,
+  emptyContributionProfile,
+  weakestConfidence,
+} from "./contribution-profile.js";
+import { fetchWithRetry } from "./http-retry.js";
+
+const DEFAULT_API_BASE_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const REQUEST_TIMEOUT_MS = 10_000;
+/** A CONTRIBUTING.md smaller than this is treated as a signpost (a link to an external guide), not the rules
+ *  themselves — #6794 found react's is 208 B and kubernetes' 525 B, both just pointers. */
+const CONTRIBUTING_SIGNPOST_MAX_BYTES = 600;
+
+/** Canonical eligibility vocabulary — recognized OSS "contributor-workable" conventions. Matched case-insensitively
+ *  as a substring over a label's name AND description. Not loopover-specific. */
+const ELIGIBILITY_TERMS = Object.freeze([
+  "good first issue",
+  "good-first-issue",
+  "help wanted",
+  "help-wanted",
+  "up for grabs",
+  "beginner",
+  "easy",
+  "starter",
+]);
+
+/** Conventional exclusion/off-limits vocabulary. These are UNstated conventions (#6794 found no repo names
+ *  exclusion in a label NAME explicitly), so a match yields `inferred`, never `explicit`. */
+const EXCLUSION_TERMS = Object.freeze([
+  "blocked",
+  "on hold",
+  "on-hold",
+  "do not merge",
+  "wontfix",
+  "invalid",
+  "needs triage",
+  "work in progress",
+  "wip",
+  "maintainer only",
+  "internal",
+]);
+
+/** Closing-keyword / linked-issue language in a CONTRIBUTING.md. */
+const LINKED_ISSUE_TERMS = Object.freeze([
+  "closes #",
+  "fixes #",
+  "resolves #",
+  "linked issue",
+  "reference an issue",
+  "link to an issue",
+]);
+
+function parseRepoFullName(repoFullName: unknown): { owner: string; repo: string } | null {
+  if (typeof repoFullName !== "string") return null;
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner?.trim() || !repo?.trim() || extra !== undefined) return null;
+  return { owner: owner.trim(), repo: repo.trim() };
+}
+
+function githubHeaders(githubToken: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "loopover-miner",
+    "x-github-api-version": GITHUB_API_VERSION,
+  };
+  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
+  return headers;
+}
+
+/** Bounded, never-throwing JSON GET. Rides out a transient GitHub 5xx or rate-limit response (429 / secondary-403)
+ *  via `fetchWithRetry` — the same discipline opportunity-fanout.js's sibling `githubGetJson` already uses — before
+ *  falling back to its fail-open contract: returns null on a non-retryable/exhausted HTTP, transport, or parse
+ *  failure. `timeoutMs` gives each attempt its own fresh `AbortSignal.timeout` (preserving the per-request bound),
+ *  and `sleepFn` is the injectable no-real-timers seam every other `fetchWithRetry` call site exposes. */
+async function getJson(
+  url: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sleepFn: ((ms: number) => Promise<unknown>) | undefined,
+): Promise<unknown> {
+  let response;
+  try {
+    response = await fetchWithRetry(
+      // `fetchWithRetry`'s `fetchFn` param takes `(url: unknown, init?: unknown)`; the ambient `fetch` type is
+      // narrower on its input, so cast to the loose call shape this module actually uses (a GET returning a body
+      // with `ok`/`status`/`json`) -- exactly what `opportunity-fanout.js`'s sibling `githubGetJson` relies on.
+      fetchImpl as unknown as (url: unknown, init?: unknown) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>,
+      url,
+      { method: "GET", headers },
+      { timeoutMs: REQUEST_TIMEOUT_MS, ...(sleepFn ? { sleepFn } : {}) },
+    );
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+  return response.json().catch(() => null);
+}
+
+/**
+ * Match one label against a term list, preferring the NAME but falling back to the DESCRIPTION (the rust
+ * `E-easy` finding: a label can carry its eligibility meaning only in the description). Returns the matcher +
+ * a provenance detail, or null when neither field matches.
+ */
+function matchLabel(label: unknown, terms: readonly string[]): { matcher: ContributionLabelMatcher; detail: string } | null {
+  const l = label as { name?: unknown; description?: unknown } | null | undefined;
+  const rawName = typeof l?.name === "string" ? l.name : "";
+  const name = rawName.toLowerCase();
+  const description =
+    typeof l?.description === "string"
+      ? l.description.toLowerCase()
+      : "";
+  const detail = rawName || "(unnamed label)";
+  const nameTerm = terms.find((term) => name.includes(term));
+  if (nameTerm !== undefined)
+    return { matcher: { field: "name", contains: nameTerm }, detail };
+  const descriptionTerm = terms.find((term) => description.includes(term));
+  if (descriptionTerm !== undefined)
+    return {
+      matcher: { field: "description", contains: descriptionTerm },
+      detail,
+    };
+  return null;
+}
+
+/** Classify labels into a SignalRule of the given confidence. Recognized labels build an OR-list of matchers;
+ *  no match ⇒ `absent`. Eligibility passes `explicit` (a recognized convention IS an explicit statement);
+ *  exclusion passes `inferred` (conventional but unstated). */
+function classifyLabels(
+  labels: unknown[],
+  terms: readonly string[],
+  matchedConfidence: ContributionSignalConfidence,
+): ContributionSignalRule<ContributionLabelMatcher[]> {
+  const matchers: ContributionLabelMatcher[] = [];
+  const provenance: ContributionSignalProvenance[] = [];
+  for (const label of labels) {
+    const hit = matchLabel(label, terms);
+    if (hit === null) continue;
+    matchers.push(hit.matcher);
+    provenance.push({ source: "labels", detail: hit.detail });
+  }
+  if (matchers.length === 0)
+    return { value: null, confidence: "absent", provenance: [] };
+  return { value: matchers, confidence: matchedConfidence, provenance };
+}
+
+/** Decode a GitHub contents API response body to text. Returns null when absent or not base64. Buffer.from over
+ *  a string never throws, so no error path is needed here. */
+function decodeContents(payload: unknown): string | null {
+  const p = payload as { content?: unknown; encoding?: unknown } | null | undefined;
+  if (
+    !p ||
+    typeof p.content !== "string" ||
+    p.encoding !== "base64"
+  )
+    return null;
+  return Buffer.from(p.content, "base64").toString("utf8");
+}
+
+/** Fetch CONTRIBUTING.md, probing the repo root then `.github/` (#6794: 6/10 at root, 2/10 under `.github/`). */
+async function fetchContributing(
+  base: string,
+  target: { owner: string; repo: string },
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sleepFn: ((ms: number) => Promise<unknown>) | undefined,
+): Promise<string | null> {
+  for (const path of ["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]) {
+    const payload = await getJson(
+      `${base}/repos/${target.owner}/${target.repo}/contents/${path}`,
+      headers,
+      fetchImpl,
+      sleepFn,
+    );
+    const text = decodeContents(payload);
+    if (text !== null) return text;
+  }
+  return null;
+}
+
+/** Extract the PR-body linked-issue requirement from CONTRIBUTING.md. A very small file is a signpost, not the
+ *  rules, so it yields `absent` rather than a false negative dressed as a real one. */
+function extractPrBody(contributing: string | null): ContributionSignalRule<ContributionPrBodyRequirements> {
+  if (contributing === null)
+    return { value: null, confidence: "absent", provenance: [] };
+  if (contributing.length < CONTRIBUTING_SIGNPOST_MAX_BYTES)
+    return { value: null, confidence: "unknown", provenance: [] };
+  const lower = contributing.toLowerCase();
+  const requiresLinkedIssue = LINKED_ISSUE_TERMS.some((term) =>
+    lower.includes(term),
+  );
+  // A real, sufficiently-sized CONTRIBUTING.md is an explicit source either way: present-with-keyword is an
+  // explicit requirement, present-without is an explicit "no such rule".
+  return {
+    value: { requiresLinkedIssue },
+    confidence: "explicit",
+    provenance: [{ source: "contributing_md", detail: "CONTRIBUTING.md" }],
+  };
+}
+
+/**
+ * Extract a best-effort ContributionProfile for a repo from its published label taxonomy and contribution docs.
+ * Never throws: any fetch/parse failure degrades the relevant signal to `absent`/`unknown`. Generic — no
+ * loopover-specific hardcoding.
+ */
+export async function extractContributionProfile(
+  repoFullName: string,
+  options: {
+    fetchImpl?: typeof fetch;
+    githubToken?: string;
+    apiBaseUrl?: string;
+    /** ISO timestamp for the profile's generatedAt; defaults to now. Injected so tests stay deterministic. */
+    generatedAt?: string;
+    /** Sleep seam for the transient-5xx/rate-limit retry (via fetchWithRetry). Injected so tests use no real timers. */
+    sleepFn?: (ms: number) => Promise<unknown>;
+  } = {},
+): Promise<ContributionProfile> {
+  const generatedAt =
+    typeof options.generatedAt === "string"
+      ? options.generatedAt
+      : new Date().toISOString();
+  const target = parseRepoFullName(repoFullName);
+  // A malformed name can't be fetched — return the safe, fully-absent default rather than throwing.
+  if (target === null)
+    return emptyContributionProfile(
+      typeof repoFullName === "string" ? repoFullName : "",
+      generatedAt,
+    );
+
+  /* v8 ignore next -- the global-fetch default is the production path; every test injects fetchImpl. */
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const base =
+    typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim()
+      ? options.apiBaseUrl.replace(/\/+$/, "")
+      : DEFAULT_API_BASE_URL;
+  const headers = githubHeaders(
+    options.githubToken ?? process.env.GITHUB_TOKEN,
+  );
+
+  const sleepFn = options.sleepFn;
+  const labelsPayload = await getJson(
+    `${base}/repos/${target.owner}/${target.repo}/labels?per_page=100`,
+    headers,
+    fetchImpl,
+    sleepFn,
+  );
+  const labels = Array.isArray(labelsPayload) ? labelsPayload : [];
+  const contributing = await fetchContributing(
+    base,
+    target,
+    headers,
+    fetchImpl,
+    sleepFn,
+  );
+
+  const eligibilityLabels = classifyLabels(
+    labels,
+    ELIGIBILITY_TERMS,
+    "explicit",
+  );
+  const exclusionLabels = classifyLabels(labels, EXCLUSION_TERMS, "inferred");
+  const prBody = extractPrBody(contributing);
+
+  return {
+    repoFullName: `${target.owner}/${target.repo}`,
+    schemaVersion: CONTRIBUTION_PROFILE_SCHEMA_VERSION,
+    generatedAt,
+    eligibilityLabels,
+    exclusionLabels,
+    prBody,
+    completeness: weakestConfidence([
+      eligibilityLabels.confidence,
+      exclusionLabels.confidence,
+      prBody.confidence,
+    ]),
+  };
+}

--- a/packages/loopover-miner/lib/contribution-profile-filter.d.ts
+++ b/packages/loopover-miner/lib/contribution-profile-filter.d.ts
@@ -1,24 +1,28 @@
 import type { ContributionProfile } from "./contribution-profile.js";
-
-export const ELIGIBILITY_EXCLUSION_REASONS: {
-  readonly EXCLUSION_LABEL: "exclusion_label";
-  readonly MISSING_ELIGIBILITY_LABEL: "missing_eligibility_label";
-  readonly CONFLICTING_SIGNALS: "conflicting_signals";
-  readonly EXCLUDED_ASSIGNEE: "excluded_assignee";
-};
-
+/** Why a candidate was excluded. */
+export declare const ELIGIBILITY_EXCLUSION_REASONS: Readonly<{
+    /** The issue carries a label the profile identified as maintainer-only / off-limits. */
+    readonly EXCLUSION_LABEL: "exclusion_label";
+    /** The repo has a trustworthy eligibility convention, and the issue carries none of its eligibility labels. */
+    readonly MISSING_ELIGIBILITY_LABEL: "missing_eligibility_label";
+    /** The issue carries BOTH an eligibility and an exclusion label — conflicting signals; exclusion wins. */
+    readonly CONFLICTING_SIGNALS: "conflicting_signals";
+    /** The issue is assigned to the repo's own owner login (#7040) — structural, not profile-derived. */
+    readonly EXCLUDED_ASSIGNEE: "excluded_assignee";
+}>;
 export type EligibilityExclusion<T> = {
-  candidate: T;
-  reason:
-    | "exclusion_label"
-    | "missing_eligibility_label"
-    | "conflicting_signals"
-    | "excluded_assignee";
+    candidate: T;
+    reason: "exclusion_label" | "missing_eligibility_label" | "conflicting_signals" | "excluded_assignee";
 };
-
-export function filterCandidatesByProfiles<
-  T extends { repoFullName: string; owner?: string; labels?: string[]; assignees?: string[] },
->(
-  candidates: T[],
-  profilesByRepo: Map<string, ContributionProfile>,
-): { kept: T[]; excluded: EligibilityExclusion<T>[] };
+/**
+ * Partition candidates into kept + excluded against per-repo ContributionProfiles.
+ */
+export declare function filterCandidatesByProfiles<T extends {
+    repoFullName: string;
+    owner?: string;
+    labels?: string[];
+    assignees?: string[];
+}>(candidates: T[], profilesByRepo: Map<string, ContributionProfile>): {
+    kept: T[];
+    excluded: EligibilityExclusion<T>[];
+};

--- a/packages/loopover-miner/lib/contribution-profile-filter.js
+++ b/packages/loopover-miner/lib/contribution-profile-filter.js
@@ -12,105 +12,100 @@
 // contribution-profile.d.ts), it is deliberately NOT a profile field — it's a structural fact derivable from the
 // issue's own assignees at query time, not something extraction infers with variable confidence. It therefore
 // applies to EVERY candidate unconditionally, independent of the repo's ContributionProfile (or lack of one).
-
 /** Why a candidate was excluded. */
 export const ELIGIBILITY_EXCLUSION_REASONS = Object.freeze({
-  /** The issue carries a label the profile identified as maintainer-only / off-limits. */
-  EXCLUSION_LABEL: "exclusion_label",
-  /** The repo has a trustworthy eligibility convention, and the issue carries none of its eligibility labels. */
-  MISSING_ELIGIBILITY_LABEL: "missing_eligibility_label",
-  /** The issue carries BOTH an eligibility and an exclusion label — conflicting signals; exclusion wins. */
-  CONFLICTING_SIGNALS: "conflicting_signals",
-  /** The issue is assigned to the repo's own owner login (#7040) — structural, not profile-derived. */
-  EXCLUDED_ASSIGNEE: "excluded_assignee",
+    /** The issue carries a label the profile identified as maintainer-only / off-limits. */
+    EXCLUSION_LABEL: "exclusion_label",
+    /** The repo has a trustworthy eligibility convention, and the issue carries none of its eligibility labels. */
+    MISSING_ELIGIBILITY_LABEL: "missing_eligibility_label",
+    /** The issue carries BOTH an eligibility and an exclusion label — conflicting signals; exclusion wins. */
+    CONFLICTING_SIGNALS: "conflicting_signals",
+    /** The issue is assigned to the repo's own owner login (#7040) — structural, not profile-derived. */
+    EXCLUDED_ASSIGNEE: "excluded_assignee",
 });
-
 /** True when the candidate is assigned to its own repo's owner login (case-insensitive). Always-on: unlike the
  *  label rules below, this never depends on the profile's confidence — see the header comment. */
 function isAssignedToRepoOwner(candidate) {
-  const owner = typeof candidate?.owner === "string" ? candidate.owner.toLowerCase() : "";
-  if (!owner) return false;
-  for (const login of candidate?.assignees ?? []) {
-    if (typeof login === "string" && login.toLowerCase() === owner) return true;
-  }
-  return false;
+    const owner = typeof candidate?.owner === "string" ? candidate.owner.toLowerCase() : "";
+    if (!owner)
+        return false;
+    for (const login of candidate?.assignees ?? []) {
+        if (typeof login === "string" && login.toLowerCase() === owner)
+            return true;
+    }
+    return false;
 }
-
 /** The actual repo label names a signal rule was derived from (its provenance details), lowercased for match. */
 function labelNamesFromRule(rule) {
-  const names = new Set();
-  for (const entry of rule?.provenance ?? []) {
-    if (typeof entry?.detail === "string")
-      names.add(entry.detail.toLowerCase());
-  }
-  return names;
+    const names = new Set();
+    for (const entry of rule?.provenance ?? []) {
+        if (typeof entry?.detail === "string")
+            names.add(entry.detail.toLowerCase());
+    }
+    return names;
 }
-
 /** Does the candidate carry any label whose name is in `names`? Case-insensitive. */
 function candidateHasAnyLabel(candidate, names) {
-  if (names.size === 0) return false;
-  for (const label of candidate?.labels ?? []) {
-    if (typeof label === "string" && names.has(label.toLowerCase()))
-      return true;
-  }
-  return false;
+    if (names.size === 0)
+        return false;
+    for (const label of candidate?.labels ?? []) {
+        if (typeof label === "string" && names.has(label.toLowerCase()))
+            return true;
+    }
+    return false;
 }
-
 /**
  * Partition candidates into kept + excluded against per-repo ContributionProfiles.
- *
- * @param {Array<{ repoFullName: string, owner?: string, labels?: string[], assignees?: string[] }>} candidates the fanned-out discover candidates
- * @param {Map<string, import("./contribution-profile.js").ContributionProfile>} profilesByRepo profile per repoFullName
- * @returns {{ kept: object[], excluded: Array<{ candidate: object, reason: string }> }}
  */
 export function filterCandidatesByProfiles(candidates, profilesByRepo) {
-  const kept = [];
-  const excluded = [];
-  for (const candidate of candidates) {
-    // Always-on, ahead of the label rules' safe-default gate (#7040) — see the header comment.
-    if (isAssignedToRepoOwner(candidate)) {
-      excluded.push({
-        candidate,
-        reason: ELIGIBILITY_EXCLUSION_REASONS.EXCLUDED_ASSIGNEE,
-      });
-      continue;
+    const kept = [];
+    const excluded = [];
+    for (const candidate of candidates) {
+        // Always-on, ahead of the label rules' safe-default gate (#7040) — see the header comment.
+        if (isAssignedToRepoOwner(candidate)) {
+            excluded.push({
+                candidate,
+                reason: ELIGIBILITY_EXCLUSION_REASONS.EXCLUDED_ASSIGNEE,
+            });
+            continue;
+        }
+        const profile = profilesByRepo?.get(candidate.repoFullName);
+        // Trust gate: only an EXPLICIT eligibility signal is trustworthy enough to filter on. Anything weaker
+        // (absent/inferred/unknown, or no profile at all) keeps every candidate — the safe default.
+        if (profile?.eligibilityLabels?.confidence !== "explicit") {
+            kept.push(candidate);
+            continue;
+        }
+        const eligibilityNames = labelNamesFromRule(profile.eligibilityLabels);
+        const exclusionNames = labelNamesFromRule(profile.exclusionLabels);
+        const hasEligibility = candidateHasAnyLabel(candidate, eligibilityNames);
+        const hasExclusion = candidateHasAnyLabel(candidate, exclusionNames);
+        if (hasExclusion && hasEligibility) {
+            // Conservative resolution for conflicting signals: exclusion wins. A maintainer marking an issue
+            // off-limits outranks its also carrying an eligibility label — better to skip than to attempt work the
+            // repo's own gate would reject.
+            excluded.push({
+                candidate,
+                reason: ELIGIBILITY_EXCLUSION_REASONS.CONFLICTING_SIGNALS,
+            });
+            continue;
+        }
+        if (hasExclusion) {
+            excluded.push({
+                candidate,
+                reason: ELIGIBILITY_EXCLUSION_REASONS.EXCLUSION_LABEL,
+            });
+            continue;
+        }
+        if (!hasEligibility) {
+            excluded.push({
+                candidate,
+                reason: ELIGIBILITY_EXCLUSION_REASONS.MISSING_ELIGIBILITY_LABEL,
+            });
+            continue;
+        }
+        kept.push(candidate);
     }
-    const profile = profilesByRepo?.get(candidate.repoFullName);
-    // Trust gate: only an EXPLICIT eligibility signal is trustworthy enough to filter on. Anything weaker
-    // (absent/inferred/unknown, or no profile at all) keeps every candidate — the safe default.
-    if (profile?.eligibilityLabels?.confidence !== "explicit") {
-      kept.push(candidate);
-      continue;
-    }
-    const eligibilityNames = labelNamesFromRule(profile.eligibilityLabels);
-    const exclusionNames = labelNamesFromRule(profile.exclusionLabels);
-    const hasEligibility = candidateHasAnyLabel(candidate, eligibilityNames);
-    const hasExclusion = candidateHasAnyLabel(candidate, exclusionNames);
-    if (hasExclusion && hasEligibility) {
-      // Conservative resolution for conflicting signals: exclusion wins. A maintainer marking an issue
-      // off-limits outranks its also carrying an eligibility label — better to skip than to attempt work the
-      // repo's own gate would reject.
-      excluded.push({
-        candidate,
-        reason: ELIGIBILITY_EXCLUSION_REASONS.CONFLICTING_SIGNALS,
-      });
-      continue;
-    }
-    if (hasExclusion) {
-      excluded.push({
-        candidate,
-        reason: ELIGIBILITY_EXCLUSION_REASONS.EXCLUSION_LABEL,
-      });
-      continue;
-    }
-    if (!hasEligibility) {
-      excluded.push({
-        candidate,
-        reason: ELIGIBILITY_EXCLUSION_REASONS.MISSING_ELIGIBILITY_LABEL,
-      });
-      continue;
-    }
-    kept.push(candidate);
-  }
-  return { kept, excluded };
+    return { kept, excluded };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY29udHJpYnV0aW9uLXByb2ZpbGUtZmlsdGVyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiY29udHJpYnV0aW9uLXByb2ZpbGUtZmlsdGVyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLGdIQUFnSDtBQUNoSCw4R0FBOEc7QUFDOUcsNEdBQTRHO0FBQzVHLEVBQUU7QUFDRixnSEFBZ0g7QUFDaEgsaUZBQWlGO0FBQ2pGLGdIQUFnSDtBQUNoSCwrR0FBK0c7QUFDL0csd0RBQXdEO0FBQ3hELEVBQUU7QUFDRiw2RkFBNkY7QUFDN0YsaUhBQWlIO0FBQ2pILDhHQUE4RztBQUM5Ryw4R0FBOEc7QUFJOUcsb0NBQW9DO0FBQ3BDLE1BQU0sQ0FBQyxNQUFNLDZCQUE2QixHQUFHLE1BQU0sQ0FBQyxNQUFNLENBQUM7SUFDekQsd0ZBQXdGO0lBQ3hGLGVBQWUsRUFBRSxpQkFBaUI7SUFDbEMsK0dBQStHO0lBQy9HLHlCQUF5QixFQUFFLDJCQUEyQjtJQUN0RCwwR0FBMEc7SUFDMUcsbUJBQW1CLEVBQUUscUJBQXFCO0lBQzFDLHFHQUFxRztJQUNyRyxpQkFBaUIsRUFBRSxtQkFBbUI7Q0FDOUIsQ0FBQyxDQUFDO0FBV1o7a0dBQ2tHO0FBQ2xHLFNBQVMscUJBQXFCLENBQUMsU0FHOUI7SUFDQyxNQUFNLEtBQUssR0FBRyxPQUFPLFNBQVMsRUFBRSxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLFdBQVcsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDeEYsSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLEtBQUssQ0FBQztJQUN6QixLQUFLLE1BQU0sS0FBSyxJQUFJLFNBQVMsRUFBRSxTQUFTLElBQUksRUFBRSxFQUFFLENBQUM7UUFDL0MsSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRLElBQUksS0FBSyxDQUFDLFdBQVcsRUFBRSxLQUFLLEtBQUs7WUFBRSxPQUFPLElBQUksQ0FBQztJQUM5RSxDQUFDO0lBQ0QsT0FBTyxLQUFLLENBQUM7QUFDZixDQUFDO0FBRUQsaUhBQWlIO0FBQ2pILFNBQVMsa0JBQWtCLENBQ3pCLElBQXlGO0lBRXpGLE1BQU0sS0FBSyxHQUFHLElBQUksR0FBRyxFQUFVLENBQUM7SUFDaEMsS0FBSyxNQUFNLEtBQUssSUFBSSxJQUFJLEVBQUUsVUFBVSxJQUFJLEVBQUUsRUFBRSxDQUFDO1FBQzNDLElBQUksT0FBTyxLQUFLLEVBQUUsTUFBTSxLQUFLLFFBQVE7WUFDbkMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLFdBQVcsRUFBRSxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUNELE9BQU8sS0FBSyxDQUFDO0FBQ2YsQ0FBQztBQUVELHFGQUFxRjtBQUNyRixTQUFTLG9CQUFvQixDQUMzQixTQUFzRCxFQUN0RCxLQUFrQjtJQUVsQixJQUFJLEtBQUssQ0FBQyxJQUFJLEtBQUssQ0FBQztRQUFFLE9BQU8sS0FBSyxDQUFDO0lBQ25DLEtBQUssTUFBTSxLQUFLLElBQUksU0FBUyxFQUFFLE1BQU0sSUFBSSxFQUFFLEVBQUUsQ0FBQztRQUM1QyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxXQUFXLEVBQUUsQ0FBQztZQUM3RCxPQUFPLElBQUksQ0FBQztJQUNoQixDQUFDO0lBQ0QsT0FBTyxLQUFLLENBQUM7QUFDZixDQUFDO0FBRUQ7O0dBRUc7QUFDSCxNQUFNLFVBQVUsMEJBQTBCLENBR3hDLFVBQWUsRUFDZixjQUFnRDtJQUVoRCxNQUFNLElBQUksR0FBUSxFQUFFLENBQUM7SUFDckIsTUFBTSxRQUFRLEdBQThCLEVBQUUsQ0FBQztJQUMvQyxLQUFLLE1BQU0sU0FBUyxJQUFJLFVBQVUsRUFBRSxDQUFDO1FBQ25DLDJGQUEyRjtRQUMzRixJQUFJLHFCQUFxQixDQUFDLFNBQVMsQ0FBQyxFQUFFLENBQUM7WUFDckMsUUFBUSxDQUFDLElBQUksQ0FBQztnQkFDWixTQUFTO2dCQUNULE1BQU0sRUFBRSw2QkFBNkIsQ0FBQyxpQkFBaUI7YUFDeEQsQ0FBQyxDQUFDO1lBQ0gsU0FBUztRQUNYLENBQUM7UUFDRCxNQUFNLE9BQU8sR0FBRyxjQUFjLEVBQUUsR0FBRyxDQUFDLFNBQVMsQ0FBQyxZQUFZLENBQUMsQ0FBQztRQUM1RCxzR0FBc0c7UUFDdEcsNEZBQTRGO1FBQzVGLElBQUksT0FBTyxFQUFFLGlCQUFpQixFQUFFLFVBQVUsS0FBSyxVQUFVLEVBQUUsQ0FBQztZQUMxRCxJQUFJLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1lBQ3JCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsTUFBTSxnQkFBZ0IsR0FBRyxrQkFBa0IsQ0FBQyxPQUFPLENBQUMsaUJBQWlCLENBQUMsQ0FBQztRQUN2RSxNQUFNLGNBQWMsR0FBRyxrQkFBa0IsQ0FBQyxPQUFPLENBQUMsZUFBZSxDQUFDLENBQUM7UUFDbkUsTUFBTSxjQUFjLEdBQUcsb0JBQW9CLENBQUMsU0FBUyxFQUFFLGdCQUFnQixDQUFDLENBQUM7UUFDekUsTUFBTSxZQUFZLEdBQUcsb0JBQW9CLENBQUMsU0FBUyxFQUFFLGNBQWMsQ0FBQyxDQUFDO1FBQ3JFLElBQUksWUFBWSxJQUFJLGNBQWMsRUFBRSxDQUFDO1lBQ25DLGlHQUFpRztZQUNqRyx1R0FBdUc7WUFDdkcsZ0NBQWdDO1lBQ2hDLFFBQVEsQ0FBQyxJQUFJLENBQUM7Z0JBQ1osU0FBUztnQkFDVCxNQUFNLEVBQUUsNkJBQTZCLENBQUMsbUJBQW1CO2FBQzFELENBQUMsQ0FBQztZQUNILFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxZQUFZLEVBQUUsQ0FBQztZQUNqQixRQUFRLENBQUMsSUFBSSxDQUFDO2dCQUNaLFNBQVM7Z0JBQ1QsTUFBTSxFQUFFLDZCQUE2QixDQUFDLGVBQWU7YUFDdEQsQ0FBQyxDQUFDO1lBQ0gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLENBQUMsY0FBYyxFQUFFLENBQUM7WUFDcEIsUUFBUSxDQUFDLElBQUksQ0FBQztnQkFDWixTQUFTO2dCQUNULE1BQU0sRUFBRSw2QkFBNkIsQ0FBQyx5QkFBeUI7YUFDaEUsQ0FBQyxDQUFDO1lBQ0gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ3ZCLENBQUM7SUFDRCxPQUFPLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxDQUFDO0FBQzVCLENBQUMifQ==

--- a/packages/loopover-miner/lib/contribution-profile-filter.ts
+++ b/packages/loopover-miner/lib/contribution-profile-filter.ts
@@ -1,0 +1,136 @@
+// Eligibility filtering of discover candidates against a ContributionProfile (#6798). Pure: given the candidate
+// list and a per-repo profile map, it partitions candidates into kept + excluded-with-reason. No fetching, no
+// side effects — discover-cli.js resolves the profiles and renders the result; this owns only the decision.
+//
+// SAFE-DEFAULT POSTURE (the load-bearing requirement) applies to the three LABEL-based rules only: filtering on
+// them activates ONLY when a repo's profile has a trustworthy eligibility signal
+// (eligibilityLabels.confidence === "explicit"). A repo with no profile, or a low-confidence/empty one — a repo
+// whose conventions AMS simply couldn't read — has every candidate kept via those rules, so a weak profile can
+// never cause AMS to silently skip real, eligible work.
+//
+// ASSIGNEE-EXCLUSION IS DIFFERENT (#7040): per the schema (ContributionAssigneeRuntimeCheck,
+// contribution-profile.d.ts), it is deliberately NOT a profile field — it's a structural fact derivable from the
+// issue's own assignees at query time, not something extraction infers with variable confidence. It therefore
+// applies to EVERY candidate unconditionally, independent of the repo's ContributionProfile (or lack of one).
+
+import type { ContributionProfile } from "./contribution-profile.js";
+
+/** Why a candidate was excluded. */
+export const ELIGIBILITY_EXCLUSION_REASONS = Object.freeze({
+  /** The issue carries a label the profile identified as maintainer-only / off-limits. */
+  EXCLUSION_LABEL: "exclusion_label",
+  /** The repo has a trustworthy eligibility convention, and the issue carries none of its eligibility labels. */
+  MISSING_ELIGIBILITY_LABEL: "missing_eligibility_label",
+  /** The issue carries BOTH an eligibility and an exclusion label — conflicting signals; exclusion wins. */
+  CONFLICTING_SIGNALS: "conflicting_signals",
+  /** The issue is assigned to the repo's own owner login (#7040) — structural, not profile-derived. */
+  EXCLUDED_ASSIGNEE: "excluded_assignee",
+} as const);
+
+export type EligibilityExclusion<T> = {
+  candidate: T;
+  reason:
+    | "exclusion_label"
+    | "missing_eligibility_label"
+    | "conflicting_signals"
+    | "excluded_assignee";
+};
+
+/** True when the candidate is assigned to its own repo's owner login (case-insensitive). Always-on: unlike the
+ *  label rules below, this never depends on the profile's confidence — see the header comment. */
+function isAssignedToRepoOwner(candidate: {
+  owner?: string | undefined;
+  assignees?: readonly unknown[] | undefined;
+}): boolean {
+  const owner = typeof candidate?.owner === "string" ? candidate.owner.toLowerCase() : "";
+  if (!owner) return false;
+  for (const login of candidate?.assignees ?? []) {
+    if (typeof login === "string" && login.toLowerCase() === owner) return true;
+  }
+  return false;
+}
+
+/** The actual repo label names a signal rule was derived from (its provenance details), lowercased for match. */
+function labelNamesFromRule(
+  rule: { provenance?: ReadonlyArray<{ detail?: unknown }> | undefined } | null | undefined,
+): Set<string> {
+  const names = new Set<string>();
+  for (const entry of rule?.provenance ?? []) {
+    if (typeof entry?.detail === "string")
+      names.add(entry.detail.toLowerCase());
+  }
+  return names;
+}
+
+/** Does the candidate carry any label whose name is in `names`? Case-insensitive. */
+function candidateHasAnyLabel(
+  candidate: { labels?: readonly unknown[] | undefined },
+  names: Set<string>,
+): boolean {
+  if (names.size === 0) return false;
+  for (const label of candidate?.labels ?? []) {
+    if (typeof label === "string" && names.has(label.toLowerCase()))
+      return true;
+  }
+  return false;
+}
+
+/**
+ * Partition candidates into kept + excluded against per-repo ContributionProfiles.
+ */
+export function filterCandidatesByProfiles<
+  T extends { repoFullName: string; owner?: string; labels?: string[]; assignees?: string[] },
+>(
+  candidates: T[],
+  profilesByRepo: Map<string, ContributionProfile>,
+): { kept: T[]; excluded: EligibilityExclusion<T>[] } {
+  const kept: T[] = [];
+  const excluded: EligibilityExclusion<T>[] = [];
+  for (const candidate of candidates) {
+    // Always-on, ahead of the label rules' safe-default gate (#7040) — see the header comment.
+    if (isAssignedToRepoOwner(candidate)) {
+      excluded.push({
+        candidate,
+        reason: ELIGIBILITY_EXCLUSION_REASONS.EXCLUDED_ASSIGNEE,
+      });
+      continue;
+    }
+    const profile = profilesByRepo?.get(candidate.repoFullName);
+    // Trust gate: only an EXPLICIT eligibility signal is trustworthy enough to filter on. Anything weaker
+    // (absent/inferred/unknown, or no profile at all) keeps every candidate — the safe default.
+    if (profile?.eligibilityLabels?.confidence !== "explicit") {
+      kept.push(candidate);
+      continue;
+    }
+    const eligibilityNames = labelNamesFromRule(profile.eligibilityLabels);
+    const exclusionNames = labelNamesFromRule(profile.exclusionLabels);
+    const hasEligibility = candidateHasAnyLabel(candidate, eligibilityNames);
+    const hasExclusion = candidateHasAnyLabel(candidate, exclusionNames);
+    if (hasExclusion && hasEligibility) {
+      // Conservative resolution for conflicting signals: exclusion wins. A maintainer marking an issue
+      // off-limits outranks its also carrying an eligibility label — better to skip than to attempt work the
+      // repo's own gate would reject.
+      excluded.push({
+        candidate,
+        reason: ELIGIBILITY_EXCLUSION_REASONS.CONFLICTING_SIGNALS,
+      });
+      continue;
+    }
+    if (hasExclusion) {
+      excluded.push({
+        candidate,
+        reason: ELIGIBILITY_EXCLUSION_REASONS.EXCLUSION_LABEL,
+      });
+      continue;
+    }
+    if (!hasEligibility) {
+      excluded.push({
+        candidate,
+        reason: ELIGIBILITY_EXCLUSION_REASONS.MISSING_ELIGIBILITY_LABEL,
+      });
+      continue;
+    }
+    kept.push(candidate);
+  }
+  return { kept, excluded };
+}

--- a/packages/loopover-miner/lib/live-issue-snapshot.d.ts
+++ b/packages/loopover-miner/lib/live-issue-snapshot.d.ts
@@ -1,16 +1,23 @@
 import type { LiveIssueSnapshot } from "./submission-freshness-check.js";
-
-// A narrower shape than `typeof fetch` on purpose: this module only ever calls it with a string URL and a
-// plain POST init, and the ambient `fetch` type in this repo's TS program is Cloudflare-Workers-flavored
-// (RequestInfo<CfProperties> | URL), which is both irrelevant here (this package runs under plain Node) and
-// stricter than any real caller needs.
-export type LiveIssueSnapshotFetch = (
-  url: string,
-  init: { method: string; headers: Record<string, string>; body: string },
-) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
-
-export function fetchLiveIssueSnapshot(
-  repoFullName: string,
-  issueNumber: number,
-  options?: { githubToken?: string; graphqlUrl?: string; fetchImpl?: LiveIssueSnapshotFetch; requestTimeoutMs?: number },
-): Promise<LiveIssueSnapshot | null>;
+export type LiveIssueSnapshotFetch = (url: string, init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    signal?: AbortSignal;
+}) => Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+}>;
+/**
+ * Real fetchLiveIssueSnapshot implementation: the live-state answer AttemptDeps/SubmissionFreshnessDeps
+ * need, built from a single GraphQL round-trip. Returns null on any malformed input, transport failure, or
+ * unrecognized GitHub response -- callers already treat a null snapshot as "state unavailable", so this
+ * never throws.
+ */
+export declare function fetchLiveIssueSnapshot(repoFullName: string, issueNumber: number, options?: {
+    githubToken?: string;
+    graphqlUrl?: string;
+    fetchImpl?: LiveIssueSnapshotFetch;
+    requestTimeoutMs?: number;
+}): Promise<LiveIssueSnapshot | null>;

--- a/packages/loopover-miner/lib/live-issue-snapshot.js
+++ b/packages/loopover-miner/lib/live-issue-snapshot.js
@@ -6,12 +6,10 @@
 // own authoritative, closing-keyword-aware answer to "which PRs will close this issue" -- the same signal
 // the platform itself uses to auto-close on merge, not a regex we'd have to keep in sync with GitHub's own
 // closing-keyword parsing.
-
 const DEFAULT_GRAPHQL_URL = "https://api.github.com/graphql";
 const GITHUB_API_VERSION = "2022-11-28";
 const MAX_REFERENCING_PRS = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
-
 const LIVE_ISSUE_SNAPSHOT_QUERY = `
   query($owner: String!, $repo: String!, $number: Int!, $maxPrs: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -29,96 +27,99 @@ const LIVE_ISSUE_SNAPSHOT_QUERY = `
     }
   }
 `;
-
 function githubGraphqlHeaders(githubToken) {
-  const headers = {
-    accept: "application/vnd.github+json",
-    "content-type": "application/json",
-    "user-agent": "loopover-miner",
-    "x-github-api-version": GITHUB_API_VERSION,
-  };
-  const token = typeof githubToken === "string" ? githubToken.trim() : "";
-  if (token) headers.authorization = `Bearer ${token}`;
-  return headers;
+    const headers = {
+        accept: "application/vnd.github+json",
+        "content-type": "application/json",
+        "user-agent": "loopover-miner",
+        "x-github-api-version": GITHUB_API_VERSION,
+    };
+    const token = typeof githubToken === "string" ? githubToken.trim() : "";
+    if (token)
+        headers.authorization = `Bearer ${token}`;
+    return headers;
 }
-
 function normalizeIssueOrPrState(rawState) {
-  return typeof rawState === "string" ? rawState.toLowerCase() : "";
+    return typeof rawState === "string" ? rawState.toLowerCase() : "";
 }
-
 function normalizeReferencingPr(node) {
-  if (!node || typeof node !== "object") return null;
-  if (!Number.isInteger(node.number) || node.number <= 0) return null;
-  const state = normalizeIssueOrPrState(node.state);
-  if (state !== "open" && state !== "closed" && state !== "merged") return null;
-  const authorLogin = typeof node.author?.login === "string" ? node.author.login : "";
-  // GitHub's real PR creation timestamp (ISO 8601), when present -- null otherwise (never fabricated). Not
-  // an ordering signal for the maintainer gate's own duplicate-cluster election (duplicate-winner.ts's own
-  // doc explains why: a PR can be backdated by editing an old placeholder to add the linked issue later), but
-  // it's the only real, publicly-observable claim-time proxy claim-conflict-resolver.js's own client-side
-  // caller has for a THIRD-PARTY PR -- unlike loopover's own server, the miner has no continuous observation
-  // history to derive a true "first linked" timestamp from.
-  const createdAt = typeof node.createdAt === "string" ? node.createdAt : null;
-  return { number: node.number, state, authorLogin, createdAt };
+    if (!node || typeof node !== "object")
+        return null;
+    const rec = node;
+    const nodeNumber = rec.number;
+    if (!Number.isInteger(nodeNumber) || nodeNumber <= 0)
+        return null;
+    const state = normalizeIssueOrPrState(rec.state);
+    if (state !== "open" && state !== "closed" && state !== "merged")
+        return null;
+    const login = rec.author?.login;
+    const authorLogin = typeof login === "string" ? login : "";
+    // GitHub's real PR creation timestamp (ISO 8601), when present -- null otherwise (never fabricated). Not
+    // an ordering signal for the maintainer gate's own duplicate-cluster election (duplicate-winner.ts's own
+    // doc explains why: a PR can be backdated by editing an old placeholder to add the linked issue later), but
+    // it's the only real, publicly-observable claim-time proxy claim-conflict-resolver.js's own client-side
+    // caller has for a THIRD-PARTY PR -- unlike loopover's own server, the miner has no continuous observation
+    // history to derive a true "first linked" timestamp from.
+    const createdAt = typeof rec.createdAt === "string" ? rec.createdAt : null;
+    return { number: nodeNumber, state, authorLogin, createdAt };
 }
-
 function parseRepoFullName(repoFullName) {
-  if (typeof repoFullName !== "string") return null;
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  return { owner, repo };
+    if (typeof repoFullName !== "string")
+        return null;
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    return { owner, repo };
 }
-
 /**
  * Real fetchLiveIssueSnapshot implementation: the live-state answer AttemptDeps/SubmissionFreshnessDeps
  * need, built from a single GraphQL round-trip. Returns null on any malformed input, transport failure, or
  * unrecognized GitHub response -- callers already treat a null snapshot as "state unavailable", so this
  * never throws.
- *
- * @param {string} repoFullName
- * @param {number} issueNumber
- * @param {{ githubToken?: string, graphqlUrl?: string, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
- * @returns {Promise<import("./submission-freshness-check.js").LiveIssueSnapshot | null>}
  */
 export async function fetchLiveIssueSnapshot(repoFullName, issueNumber, options = {}) {
-  const target = parseRepoFullName(repoFullName);
-  if (!target || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
-
-  const graphqlUrl =
-    typeof options.graphqlUrl === "string" && options.graphqlUrl.trim() ? options.graphqlUrl.trim() : DEFAULT_GRAPHQL_URL;
-  const githubToken = options.githubToken ?? process.env.GITHUB_TOKEN ?? "";
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const requestTimeoutMs = Number.isInteger(options.requestTimeoutMs) && options.requestTimeoutMs > 0 ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
-
-  // Bounded so a stalled connection can't hang this "never throws" fetcher forever (#miner-github-read-timeouts):
-  // a timeout falls into the SAME catch as any other transport failure, which the caller (checkSubmissionFreshness)
-  // already treats as "live_state_unavailable" -- a fail-closed abort distinct from "issue_closed"/"already_addressed",
-  // never confused with a confirmed-gone issue.
-  let response;
-  try {
-    response = await fetchImpl(graphqlUrl, {
-      method: "POST",
-      headers: githubGraphqlHeaders(githubToken),
-      body: JSON.stringify({
-        query: LIVE_ISSUE_SNAPSHOT_QUERY,
-        variables: { owner: target.owner, repo: target.repo, number: issueNumber, maxPrs: MAX_REFERENCING_PRS },
-      }),
-      signal: AbortSignal.timeout(requestTimeoutMs),
-    });
-  } catch {
-    return null;
-  }
-  if (!response.ok) return null;
-
-  const payload = await response.json().catch(() => null);
-  if (!payload || typeof payload !== "object" || payload.errors) return null;
-
-  const issue = payload.data?.repository?.issue;
-  const state = normalizeIssueOrPrState(issue?.state);
-  if (state !== "open" && state !== "closed") return null;
-
-  const nodes = Array.isArray(issue?.closedByPullRequestsReferences?.nodes) ? issue.closedByPullRequestsReferences.nodes : [];
-  const referencingPrs = nodes.map(normalizeReferencingPr).filter((pr) => pr !== null);
-
-  return { state, referencingPrs };
+    const target = parseRepoFullName(repoFullName);
+    if (!target || !Number.isInteger(issueNumber) || issueNumber <= 0)
+        return null;
+    const graphqlUrl = typeof options.graphqlUrl === "string" && options.graphqlUrl.trim() ? options.graphqlUrl.trim() : DEFAULT_GRAPHQL_URL;
+    const githubToken = options.githubToken ?? process.env.GITHUB_TOKEN ?? "";
+    /* v8 ignore next -- the global-fetch default is the production path; every test injects fetchImpl. */
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const rawTimeout = options.requestTimeoutMs;
+    const requestTimeoutMs = Number.isInteger(rawTimeout) && rawTimeout > 0 ? rawTimeout : DEFAULT_REQUEST_TIMEOUT_MS;
+    // Bounded so a stalled connection can't hang this "never throws" fetcher forever (#miner-github-read-timeouts):
+    // a timeout falls into the SAME catch as any other transport failure, which the caller (checkSubmissionFreshness)
+    // already treats as "live_state_unavailable" -- a fail-closed abort distinct from "issue_closed"/"already_addressed",
+    // never confused with a confirmed-gone issue.
+    let response;
+    try {
+        response = await fetchImpl(graphqlUrl, {
+            method: "POST",
+            headers: githubGraphqlHeaders(githubToken),
+            body: JSON.stringify({
+                query: LIVE_ISSUE_SNAPSHOT_QUERY,
+                variables: { owner: target.owner, repo: target.repo, number: issueNumber, maxPrs: MAX_REFERENCING_PRS },
+            }),
+            signal: AbortSignal.timeout(requestTimeoutMs),
+        });
+    }
+    catch {
+        return null;
+    }
+    if (!response.ok)
+        return null;
+    const payload = await response.json().catch(() => null);
+    if (!payload || typeof payload !== "object" || payload.errors)
+        return null;
+    const issue = payload.data?.repository?.issue;
+    const state = normalizeIssueOrPrState(issue?.state);
+    if (state !== "open" && state !== "closed")
+        return null;
+    const rawNodes = issue?.closedByPullRequestsReferences?.nodes;
+    const nodes = Array.isArray(rawNodes) ? rawNodes : [];
+    const referencingPrs = nodes
+        .map(normalizeReferencingPr)
+        .filter((pr) => pr !== null);
+    return { state, referencingPrs };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibGl2ZS1pc3N1ZS1zbmFwc2hvdC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImxpdmUtaXNzdWUtc25hcHNob3QudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsc0dBQXNHO0FBQ3RHLHVHQUF1RztBQUN2RyxpR0FBaUc7QUFDakcsZ0ZBQWdGO0FBQ2hGLDBHQUEwRztBQUMxRywwR0FBMEc7QUFDMUcsMkdBQTJHO0FBQzNHLDJCQUEyQjtBQWEzQixNQUFNLG1CQUFtQixHQUFHLGdDQUFnQyxDQUFDO0FBQzdELE1BQU0sa0JBQWtCLEdBQUcsWUFBWSxDQUFDO0FBQ3hDLE1BQU0sbUJBQW1CLEdBQUcsRUFBRSxDQUFDO0FBQy9CLE1BQU0sMEJBQTBCLEdBQUcsTUFBTSxDQUFDO0FBRTFDLE1BQU0seUJBQXlCLEdBQUc7Ozs7Ozs7Ozs7Ozs7Ozs7Q0FnQmpDLENBQUM7QUFFRixTQUFTLG9CQUFvQixDQUFDLFdBQStCO0lBQzNELE1BQU0sT0FBTyxHQUEyQjtRQUN0QyxNQUFNLEVBQUUsNkJBQTZCO1FBQ3JDLGNBQWMsRUFBRSxrQkFBa0I7UUFDbEMsWUFBWSxFQUFFLGdCQUFnQjtRQUM5QixzQkFBc0IsRUFBRSxrQkFBa0I7S0FDM0MsQ0FBQztJQUNGLE1BQU0sS0FBSyxHQUFHLE9BQU8sV0FBVyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsV0FBVyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDeEUsSUFBSSxLQUFLO1FBQUUsT0FBTyxDQUFDLGFBQWEsR0FBRyxVQUFVLEtBQUssRUFBRSxDQUFDO0lBQ3JELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxTQUFTLHVCQUF1QixDQUFDLFFBQWlCO0lBQ2hELE9BQU8sT0FBTyxRQUFRLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztBQUNwRSxDQUFDO0FBRUQsU0FBUyxzQkFBc0IsQ0FDN0IsSUFBYTtJQUViLElBQUksQ0FBQyxJQUFJLElBQUksT0FBTyxJQUFJLEtBQUssUUFBUTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ25ELE1BQU0sR0FBRyxHQUFHLElBQW1ILENBQUM7SUFDaEksTUFBTSxVQUFVLEdBQUcsR0FBRyxDQUFDLE1BQU0sQ0FBQztJQUM5QixJQUFJLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxVQUFVLENBQUMsSUFBSyxVQUFxQixJQUFJLENBQUM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUM5RSxNQUFNLEtBQUssR0FBRyx1QkFBdUIsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDakQsSUFBSSxLQUFLLEtBQUssTUFBTSxJQUFJLEtBQUssS0FBSyxRQUFRLElBQUksS0FBSyxLQUFLLFFBQVE7UUFBRSxPQUFPLElBQUksQ0FBQztJQUM5RSxNQUFNLEtBQUssR0FBRyxHQUFHLENBQUMsTUFBTSxFQUFFLEtBQUssQ0FBQztJQUNoQyxNQUFNLFdBQVcsR0FBRyxPQUFPLEtBQUssS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzNELHlHQUF5RztJQUN6Ryx5R0FBeUc7SUFDekcsNEdBQTRHO0lBQzVHLHdHQUF3RztJQUN4RywyR0FBMkc7SUFDM0csMERBQTBEO0lBQzFELE1BQU0sU0FBUyxHQUFHLE9BQU8sR0FBRyxDQUFDLFNBQVMsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUMzRSxPQUFPLEVBQUUsTUFBTSxFQUFFLFVBQW9CLEVBQUUsS0FBSyxFQUFFLFdBQVcsRUFBRSxTQUFTLEVBQUUsQ0FBQztBQUN6RSxDQUFDO0FBRUQsU0FBUyxpQkFBaUIsQ0FBQyxZQUFxQjtJQUM5QyxJQUFJLE9BQU8sWUFBWSxLQUFLLFFBQVE7UUFBRSxPQUFPLElBQUksQ0FBQztJQUNsRCxNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxZQUFZLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3JELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN4RCxPQUFPLEVBQUUsS0FBSyxFQUFFLElBQUksRUFBRSxDQUFDO0FBQ3pCLENBQUM7QUFFRDs7Ozs7R0FLRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsc0JBQXNCLENBQzFDLFlBQW9CLEVBQ3BCLFdBQW1CLEVBQ25CLFVBQXdILEVBQUU7SUFFMUgsTUFBTSxNQUFNLEdBQUcsaUJBQWlCLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDL0MsSUFBSSxDQUFDLE1BQU0sSUFBSSxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsV0FBVyxDQUFDLElBQUksV0FBVyxJQUFJLENBQUM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUUvRSxNQUFNLFVBQVUsR0FDZCxPQUFPLE9BQU8sQ0FBQyxVQUFVLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxVQUFVLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLG1CQUFtQixDQUFDO0lBQ3hILE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxXQUFXLElBQUksT0FBTyxDQUFDLEdBQUcsQ0FBQyxZQUFZLElBQUksRUFBRSxDQUFDO0lBQzFFLHNHQUFzRztJQUN0RyxNQUFNLFNBQVMsR0FBMkIsT0FBTyxDQUFDLFNBQVMsSUFBSyxLQUEyQyxDQUFDO0lBQzVHLE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQztJQUM1QyxNQUFNLGdCQUFnQixHQUFHLE1BQU0sQ0FBQyxTQUFTLENBQUMsVUFBVSxDQUFDLElBQUssVUFBcUIsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFFLFVBQXFCLENBQUMsQ0FBQyxDQUFDLDBCQUEwQixDQUFDO0lBRTFJLGdIQUFnSDtJQUNoSCxrSEFBa0g7SUFDbEgsc0hBQXNIO0lBQ3RILDhDQUE4QztJQUM5QyxJQUFJLFFBQVEsQ0FBQztJQUNiLElBQUksQ0FBQztRQUNILFFBQVEsR0FBRyxNQUFNLFNBQVMsQ0FBQyxVQUFVLEVBQUU7WUFDckMsTUFBTSxFQUFFLE1BQU07WUFDZCxPQUFPLEVBQUUsb0JBQW9CLENBQUMsV0FBVyxDQUFDO1lBQzFDLElBQUksRUFBRSxJQUFJLENBQUMsU0FBUyxDQUFDO2dCQUNuQixLQUFLLEVBQUUseUJBQXlCO2dCQUNoQyxTQUFTLEVBQUUsRUFBRSxLQUFLLEVBQUUsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksRUFBRSxNQUFNLEVBQUUsV0FBVyxFQUFFLE1BQU0sRUFBRSxtQkFBbUIsRUFBRTthQUN4RyxDQUFDO1lBQ0YsTUFBTSxFQUFFLFdBQVcsQ0FBQyxPQUFPLENBQUMsZ0JBQWdCLENBQUM7U0FDOUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLE9BQU8sSUFBSSxDQUFDO0lBQ2QsQ0FBQztJQUNELElBQUksQ0FBQyxRQUFRLENBQUMsRUFBRTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBRTlCLE1BQU0sT0FBTyxHQUFHLE1BQU0sUUFBUSxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4RCxJQUFJLENBQUMsT0FBTyxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSyxPQUFnQyxDQUFDLE1BQU07UUFBRSxPQUFPLElBQUksQ0FBQztJQUVyRyxNQUFNLEtBQUssR0FDVCxPQU9ELENBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxLQUFLLENBQUM7SUFDMUIsTUFBTSxLQUFLLEdBQUcsdUJBQXVCLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO0lBQ3BELElBQUksS0FBSyxLQUFLLE1BQU0sSUFBSSxLQUFLLEtBQUssUUFBUTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBRXhELE1BQU0sUUFBUSxHQUFHLEtBQUssRUFBRSw4QkFBOEIsRUFBRSxLQUFLLENBQUM7SUFDOUQsTUFBTSxLQUFLLEdBQUcsS0FBSyxDQUFDLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDdEQsTUFBTSxjQUFjLEdBQUcsS0FBSztTQUN6QixHQUFHLENBQUMsc0JBQXNCLENBQUM7U0FDM0IsTUFBTSxDQUFDLENBQUMsRUFBRSxFQUFnQyxFQUFFLENBQUMsRUFBRSxLQUFLLElBQUksQ0FBQyxDQUFDO0lBRTdELE9BQU8sRUFBRSxLQUFLLEVBQUUsY0FBYyxFQUFFLENBQUM7QUFDbkMsQ0FBQyJ9

--- a/packages/loopover-miner/lib/live-issue-snapshot.ts
+++ b/packages/loopover-miner/lib/live-issue-snapshot.ts
@@ -1,0 +1,152 @@
+// Real GitHub-backed fetchLiveIssueSnapshot (#5132, Wave 3.5). AttemptDeps.fetchLiveIssueSnapshot and
+// SubmissionFreshnessDeps.fetchLiveIssueSnapshot (submission-freshness-check.js) share this one shape:
+// "is this issue still open, and is it already addressed by another PR" -- the live-state answer
+// checkSubmissionFreshness needs before every submission. Uses GitHub's GraphQL
+// `closedByPullRequestsReferences` connection rather than a body-text/search-API heuristic: it's GitHub's
+// own authoritative, closing-keyword-aware answer to "which PRs will close this issue" -- the same signal
+// the platform itself uses to auto-close on merge, not a regex we'd have to keep in sync with GitHub's own
+// closing-keyword parsing.
+
+import type { LiveIssueSnapshot } from "./submission-freshness-check.js";
+
+// A narrower shape than `typeof fetch` on purpose: this module only ever calls it with a string URL and a
+// plain POST init, and the ambient `fetch` type in this repo's TS program is Cloudflare-Workers-flavored
+// (RequestInfo<CfProperties> | URL), which is both irrelevant here (this package runs under plain Node) and
+// stricter than any real caller needs.
+export type LiveIssueSnapshotFetch = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string; signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+const DEFAULT_GRAPHQL_URL = "https://api.github.com/graphql";
+const GITHUB_API_VERSION = "2022-11-28";
+const MAX_REFERENCING_PRS = 50;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+const LIVE_ISSUE_SNAPSHOT_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!, $maxPrs: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        state
+        closedByPullRequestsReferences(first: $maxPrs) {
+          nodes {
+            number
+            state
+            author { login }
+            createdAt
+          }
+        }
+      }
+    }
+  }
+`;
+
+function githubGraphqlHeaders(githubToken: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "content-type": "application/json",
+    "user-agent": "loopover-miner",
+    "x-github-api-version": GITHUB_API_VERSION,
+  };
+  const token = typeof githubToken === "string" ? githubToken.trim() : "";
+  if (token) headers.authorization = `Bearer ${token}`;
+  return headers;
+}
+
+function normalizeIssueOrPrState(rawState: unknown): string {
+  return typeof rawState === "string" ? rawState.toLowerCase() : "";
+}
+
+function normalizeReferencingPr(
+  node: unknown,
+): { number: number; state: "open" | "closed" | "merged"; authorLogin: string; createdAt: string | null } | null {
+  if (!node || typeof node !== "object") return null;
+  const rec = node as { number?: unknown; state?: unknown; author?: { login?: unknown } | null | undefined; createdAt?: unknown };
+  const nodeNumber = rec.number;
+  if (!Number.isInteger(nodeNumber) || (nodeNumber as number) <= 0) return null;
+  const state = normalizeIssueOrPrState(rec.state);
+  if (state !== "open" && state !== "closed" && state !== "merged") return null;
+  const login = rec.author?.login;
+  const authorLogin = typeof login === "string" ? login : "";
+  // GitHub's real PR creation timestamp (ISO 8601), when present -- null otherwise (never fabricated). Not
+  // an ordering signal for the maintainer gate's own duplicate-cluster election (duplicate-winner.ts's own
+  // doc explains why: a PR can be backdated by editing an old placeholder to add the linked issue later), but
+  // it's the only real, publicly-observable claim-time proxy claim-conflict-resolver.js's own client-side
+  // caller has for a THIRD-PARTY PR -- unlike loopover's own server, the miner has no continuous observation
+  // history to derive a true "first linked" timestamp from.
+  const createdAt = typeof rec.createdAt === "string" ? rec.createdAt : null;
+  return { number: nodeNumber as number, state, authorLogin, createdAt };
+}
+
+function parseRepoFullName(repoFullName: unknown): { owner: string; repo: string } | null {
+  if (typeof repoFullName !== "string") return null;
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return { owner, repo };
+}
+
+/**
+ * Real fetchLiveIssueSnapshot implementation: the live-state answer AttemptDeps/SubmissionFreshnessDeps
+ * need, built from a single GraphQL round-trip. Returns null on any malformed input, transport failure, or
+ * unrecognized GitHub response -- callers already treat a null snapshot as "state unavailable", so this
+ * never throws.
+ */
+export async function fetchLiveIssueSnapshot(
+  repoFullName: string,
+  issueNumber: number,
+  options: { githubToken?: string; graphqlUrl?: string; fetchImpl?: LiveIssueSnapshotFetch; requestTimeoutMs?: number } = {},
+): Promise<LiveIssueSnapshot | null> {
+  const target = parseRepoFullName(repoFullName);
+  if (!target || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
+
+  const graphqlUrl =
+    typeof options.graphqlUrl === "string" && options.graphqlUrl.trim() ? options.graphqlUrl.trim() : DEFAULT_GRAPHQL_URL;
+  const githubToken = options.githubToken ?? process.env.GITHUB_TOKEN ?? "";
+  /* v8 ignore next -- the global-fetch default is the production path; every test injects fetchImpl. */
+  const fetchImpl: LiveIssueSnapshotFetch = options.fetchImpl ?? (fetch as unknown as LiveIssueSnapshotFetch);
+  const rawTimeout = options.requestTimeoutMs;
+  const requestTimeoutMs = Number.isInteger(rawTimeout) && (rawTimeout as number) > 0 ? (rawTimeout as number) : DEFAULT_REQUEST_TIMEOUT_MS;
+
+  // Bounded so a stalled connection can't hang this "never throws" fetcher forever (#miner-github-read-timeouts):
+  // a timeout falls into the SAME catch as any other transport failure, which the caller (checkSubmissionFreshness)
+  // already treats as "live_state_unavailable" -- a fail-closed abort distinct from "issue_closed"/"already_addressed",
+  // never confused with a confirmed-gone issue.
+  let response;
+  try {
+    response = await fetchImpl(graphqlUrl, {
+      method: "POST",
+      headers: githubGraphqlHeaders(githubToken),
+      body: JSON.stringify({
+        query: LIVE_ISSUE_SNAPSHOT_QUERY,
+        variables: { owner: target.owner, repo: target.repo, number: issueNumber, maxPrs: MAX_REFERENCING_PRS },
+      }),
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+
+  const payload = await response.json().catch(() => null);
+  if (!payload || typeof payload !== "object" || (payload as { errors?: unknown }).errors) return null;
+
+  const issue = (
+    payload as {
+      data?: {
+        repository?: {
+          issue?: { state?: unknown; closedByPullRequestsReferences?: { nodes?: unknown } | null } | null;
+        } | null;
+      } | null;
+    }
+  ).data?.repository?.issue;
+  const state = normalizeIssueOrPrState(issue?.state);
+  if (state !== "open" && state !== "closed") return null;
+
+  const rawNodes = issue?.closedByPullRequestsReferences?.nodes;
+  const nodes = Array.isArray(rawNodes) ? rawNodes : [];
+  const referencingPrs = nodes
+    .map(normalizeReferencingPr)
+    .filter((pr): pr is NonNullable<typeof pr> => pr !== null);
+
+  return { state, referencingPrs };
+}

--- a/packages/loopover-miner/lib/logger.d.ts
+++ b/packages/loopover-miner/lib/logger.d.ts
@@ -1,58 +1,89 @@
 export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
-
-export const LOG_LEVELS: readonly LogLevel[];
-export const DEFAULT_LOG_LEVEL: LogLevel;
-
-export function isLogLevel(value: unknown): value is LogLevel;
-
-export function resolveLogLevel(signals?: {
-  level?: string | undefined;
-  quiet?: boolean | undefined;
-  verbose?: boolean | undefined;
-  envLevel?: string | undefined;
-}): LogLevel;
-
-export function extractLogOptions(argv: string[]): {
-  options: { quiet: boolean; verbose: boolean; level: string | undefined };
-  rest: string[];
-};
-
-export function formatFields(fields?: Record<string, unknown> | null | undefined): string;
-
-export function formatLine(line: {
-  level: string;
-  message: string;
-  fields?: Record<string, unknown> | null | undefined;
-  pretty?: boolean | undefined;
-  timestamp?: string | undefined;
-}): string;
-
+/** Supported log levels, least to most verbose. `silent` suppresses everything. */
+export declare const LOG_LEVELS: readonly LogLevel[];
+/** The level used when nothing (flag, env var, or explicit option) selects one. */
+export declare const DEFAULT_LOG_LEVEL: LogLevel;
 export interface LoggerStreams {
-  stdout?: { write(chunk: string): unknown } | undefined;
-  stderr?: { write(chunk: string): unknown } | undefined;
+    stdout?: {
+        write(chunk: string): unknown;
+    } | undefined;
+    stderr?: {
+        write(chunk: string): unknown;
+    } | undefined;
 }
-
 export interface LoggerOptions {
-  level?: string | undefined;
-  quiet?: boolean | undefined;
-  verbose?: boolean | undefined;
-  pretty?: boolean | undefined;
-  fields?: Record<string, unknown> | undefined;
-  env?: Record<string, string | undefined> | undefined;
-  streams?: LoggerStreams | undefined;
-  now?: (() => string) | undefined;
+    level?: string | undefined;
+    quiet?: boolean | undefined;
+    verbose?: boolean | undefined;
+    pretty?: boolean | undefined;
+    fields?: Record<string, unknown> | undefined;
+    env?: Record<string, string | undefined> | undefined;
+    streams?: LoggerStreams | undefined;
+    now?: (() => string) | undefined;
 }
-
 export interface Logger {
-  level: LogLevel;
-  isLevelEnabled(level: string): boolean;
-  error(message: string, fields?: Record<string, unknown>): void;
-  warn(message: string, fields?: Record<string, unknown>): void;
-  info(message: string, fields?: Record<string, unknown>): void;
-  debug(message: string, fields?: Record<string, unknown>): void;
-  child(fields: Record<string, unknown>): Logger;
+    level: LogLevel;
+    isLevelEnabled(level: string): boolean;
+    error(message: string, fields?: Record<string, unknown>): void;
+    warn(message: string, fields?: Record<string, unknown>): void;
+    info(message: string, fields?: Record<string, unknown>): void;
+    debug(message: string, fields?: Record<string, unknown>): void;
+    child(fields: Record<string, unknown>): Logger;
 }
-
-export function createLogger(options?: LoggerOptions): Logger;
-export function configureLogger(options?: LoggerOptions): Logger;
-export function getLogger(): Logger;
+/** True when `value` names a supported log level. Non-string input is never a level (so an absent option or a
+ *  typo'd env var falls through to the next signal instead of throwing). */
+export declare function isLogLevel(value: unknown): value is LogLevel;
+/**
+ * Resolve the active level from the available signals, most explicit first: an explicit `level` wins, then
+ * `--quiet` (→ `error`), then `--verbose` (→ `debug`), then the env-provided level, else the default. `quiet`
+ * beats `verbose` when both are set, so the safer/quieter choice wins a contradictory invocation. An
+ * unrecognized `level`/`envLevel` is ignored rather than throwing — a typo logs at the default, never crashes.
+ */
+export declare function resolveLogLevel({ level, quiet, verbose, envLevel }?: {
+    level?: string | undefined;
+    quiet?: boolean | undefined;
+    verbose?: boolean | undefined;
+    envLevel?: string | undefined;
+}): LogLevel;
+/**
+ * Split the global logging flags out of a CLI argv slice, returning the parsed options plus `rest` — the argv
+ * with those flags (and any `--log-level` value) removed so downstream command parsing never sees them.
+ * Recognizes `--quiet`, `--verbose`, `--log-level <level>`, and `--log-level=<level>`. No short aliases: `-v`
+ * is already `--version` and `-h` is `--help` in the CLI entrypoint.
+ */
+export declare function extractLogOptions(argv: string[]): {
+    options: {
+        quiet: boolean;
+        verbose: boolean;
+        level: string | undefined;
+    };
+    rest: string[];
+};
+/**
+ * Render structured fields as a stable, sorted ` key=value` suffix (sorted so output is deterministic across
+ * runs). `undefined` values are dropped; an empty/absent field set yields an empty string.
+ */
+export declare function formatFields(fields?: Record<string, unknown> | null | undefined): string;
+/**
+ * Format one log line. Plain mode (the default) is just `message` + any field suffix, keeping human CLI output
+ * identical to a bare `console.log`. Pretty mode prefixes an optional timestamp and the uppercased level tag,
+ * for operators who want machine-scannable diagnostics.
+ */
+export declare function formatLine({ level, message, fields, pretty, timestamp }: {
+    level: string;
+    message: string;
+    fields?: Record<string, unknown> | null | undefined;
+    pretty?: boolean | undefined;
+    timestamp?: string | undefined;
+}): string;
+/**
+ * Build a level-aware logger. All I/O is injectable for tests: `streams` (defaults to process stdout/stderr),
+ * `now` (defaults to an ISO-8601 clock, only consulted in `pretty` mode), and `env` (defaults to process.env,
+ * read for `LOOPOVER_MINER_LOG_LEVEL`). `fields` seeds every line with contextual fields; `child(extra)`
+ * returns a logger that merges additional fields onto this one.
+ */
+export declare function createLogger(options?: LoggerOptions): Logger;
+/** Reconfigure the process-wide logger from resolved startup options and return it. */
+export declare function configureLogger(options?: LoggerOptions): Logger;
+/** The process-wide logger configured by `configureLogger` (a default-level logger before then). */
+export declare function getLogger(): Logger;

--- a/packages/loopover-miner/lib/logger.js
+++ b/packages/loopover-miner/lib/logger.js
@@ -8,160 +8,144 @@
 // or below L's rank (so `error` always survives except at `silent`, and `debug` only shows at the most verbose
 // setting). `error`/`warn` go to stderr, `info`/`debug` to stdout, matching the existing convention where the
 // update-check nudge writes to stderr and normal command output writes to stdout.
-
 /** Supported log levels, least to most verbose. `silent` suppresses everything. */
 export const LOG_LEVELS = ["silent", "error", "warn", "info", "debug"];
-
 /** The level used when nothing (flag, env var, or explicit option) selects one. */
 export const DEFAULT_LOG_LEVEL = "info";
-
 // Numeric severity rank per level (higher = more verbose). A method emits when its rank <= the active rank.
 const LEVEL_RANK = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 };
-
 const defaultClock = () => new Date().toISOString();
-
 /** True when `value` names a supported log level. Non-string input is never a level (so an absent option or a
  *  typo'd env var falls through to the next signal instead of throwing). */
 export function isLogLevel(value) {
-  return typeof value === "string" && Object.prototype.hasOwnProperty.call(LEVEL_RANK, value);
+    return typeof value === "string" && Object.prototype.hasOwnProperty.call(LEVEL_RANK, value);
 }
-
 /**
  * Resolve the active level from the available signals, most explicit first: an explicit `level` wins, then
  * `--quiet` (→ `error`), then `--verbose` (→ `debug`), then the env-provided level, else the default. `quiet`
  * beats `verbose` when both are set, so the safer/quieter choice wins a contradictory invocation. An
  * unrecognized `level`/`envLevel` is ignored rather than throwing — a typo logs at the default, never crashes.
- * @param {{ level?: string, quiet?: boolean, verbose?: boolean, envLevel?: string }} [signals]
- * @returns {string}
  */
 export function resolveLogLevel({ level, quiet = false, verbose = false, envLevel } = {}) {
-  if (isLogLevel(level)) return level;
-  if (quiet) return "error";
-  if (verbose) return "debug";
-  if (isLogLevel(envLevel)) return envLevel;
-  return DEFAULT_LOG_LEVEL;
+    if (isLogLevel(level))
+        return level;
+    if (quiet)
+        return "error";
+    if (verbose)
+        return "debug";
+    if (isLogLevel(envLevel))
+        return envLevel;
+    return DEFAULT_LOG_LEVEL;
 }
-
 /**
  * Split the global logging flags out of a CLI argv slice, returning the parsed options plus `rest` — the argv
  * with those flags (and any `--log-level` value) removed so downstream command parsing never sees them.
  * Recognizes `--quiet`, `--verbose`, `--log-level <level>`, and `--log-level=<level>`. No short aliases: `-v`
  * is already `--version` and `-h` is `--help` in the CLI entrypoint.
- * @param {string[]} argv
- * @returns {{ options: { quiet: boolean, verbose: boolean, level: string | undefined }, rest: string[] }}
  */
 export function extractLogOptions(argv) {
-  let quiet = false;
-  let verbose = false;
-  let level;
-  const rest = [];
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--quiet") {
-      quiet = true;
-      continue;
+    let quiet = false;
+    let verbose = false;
+    let level;
+    const rest = [];
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === "--quiet") {
+            quiet = true;
+            continue;
+        }
+        if (arg === "--verbose") {
+            verbose = true;
+            continue;
+        }
+        if (arg === "--log-level") {
+            level = argv[index + 1];
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith("--log-level=")) {
+            level = arg.slice("--log-level=".length);
+            continue;
+        }
+        rest.push(arg);
     }
-    if (arg === "--verbose") {
-      verbose = true;
-      continue;
-    }
-    if (arg === "--log-level") {
-      level = argv[index + 1];
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith("--log-level=")) {
-      level = arg.slice("--log-level=".length);
-      continue;
-    }
-    rest.push(arg);
-  }
-  return { options: { quiet, verbose, level }, rest };
+    return { options: { quiet, verbose, level }, rest };
 }
-
 function formatFieldValue(value) {
-  // Quote a string only when it contains whitespace (so it stays one token); serialize everything else as JSON.
-  if (typeof value === "string") return /\s/.test(value) ? JSON.stringify(value) : value;
-  return JSON.stringify(value);
+    // Quote a string only when it contains whitespace (so it stays one token); serialize everything else as JSON.
+    if (typeof value === "string")
+        return /\s/.test(value) ? JSON.stringify(value) : value;
+    return JSON.stringify(value);
 }
-
 /**
  * Render structured fields as a stable, sorted ` key=value` suffix (sorted so output is deterministic across
  * runs). `undefined` values are dropped; an empty/absent field set yields an empty string.
- * @param {Record<string, unknown> | null | undefined} fields
- * @returns {string}
  */
 export function formatFields(fields) {
-  if (!fields) return "";
-  const parts = [];
-  for (const key of Object.keys(fields).sort()) {
-    const value = fields[key];
-    if (value === undefined) continue;
-    parts.push(`${key}=${formatFieldValue(value)}`);
-  }
-  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+    if (!fields)
+        return "";
+    const parts = [];
+    for (const key of Object.keys(fields).sort()) {
+        const value = fields[key];
+        if (value === undefined)
+            continue;
+        parts.push(`${key}=${formatFieldValue(value)}`);
+    }
+    return parts.length > 0 ? ` ${parts.join(" ")}` : "";
 }
-
 /**
  * Format one log line. Plain mode (the default) is just `message` + any field suffix, keeping human CLI output
  * identical to a bare `console.log`. Pretty mode prefixes an optional timestamp and the uppercased level tag,
  * for operators who want machine-scannable diagnostics.
- * @param {{ level: string, message: string, fields?: Record<string, unknown> | null, pretty?: boolean, timestamp?: string }} line
- * @returns {string}
  */
 export function formatLine({ level, message, fields, pretty, timestamp }) {
-  const suffix = formatFields(fields);
-  if (!pretty) return `${message}${suffix}`;
-  const stamp = timestamp ? `[${timestamp}] ` : "";
-  return `${stamp}${level.toUpperCase()} ${message}${suffix}`;
+    const suffix = formatFields(fields);
+    if (!pretty)
+        return `${message}${suffix}`;
+    const stamp = timestamp ? `[${timestamp}] ` : "";
+    return `${stamp}${level.toUpperCase()} ${message}${suffix}`;
 }
-
 /**
  * Build a level-aware logger. All I/O is injectable for tests: `streams` (defaults to process stdout/stderr),
  * `now` (defaults to an ISO-8601 clock, only consulted in `pretty` mode), and `env` (defaults to process.env,
  * read for `LOOPOVER_MINER_LOG_LEVEL`). `fields` seeds every line with contextual fields; `child(extra)`
  * returns a logger that merges additional fields onto this one.
- * @param {import("./logger.js").LoggerOptions} [options]
- * @returns {import("./logger.js").Logger}
  */
 export function createLogger(options = {}) {
-  const { level, quiet, verbose, pretty = false, fields: baseFields, env = process.env, streams, now } = options;
-  const stdout = streams?.stdout ?? process.stdout;
-  const stderr = streams?.stderr ?? process.stderr;
-  const clock = now ?? defaultClock;
-  const envLevel = env.LOOPOVER_MINER_LOG_LEVEL ?? "";
-  const activeLevel = resolveLogLevel({ level, quiet, verbose, envLevel });
-  const threshold = LEVEL_RANK[activeLevel];
-
-  function emit(methodLevel, stream, message, fields) {
-    if (LEVEL_RANK[methodLevel] > threshold) return;
-    const merged = baseFields || fields ? { ...baseFields, ...fields } : undefined;
-    const timestamp = pretty ? clock() : undefined;
-    stream.write(`${formatLine({ level: methodLevel, message, fields: merged, pretty, timestamp })}\n`);
-  }
-
-  return {
-    level: activeLevel,
-    isLevelEnabled: (methodLevel) => LEVEL_RANK[methodLevel] <= threshold,
-    error: (message, fields) => emit("error", stderr, message, fields),
-    warn: (message, fields) => emit("warn", stderr, message, fields),
-    info: (message, fields) => emit("info", stdout, message, fields),
-    debug: (message, fields) => emit("debug", stdout, message, fields),
-    child: (childFields) => createLogger({ ...options, fields: { ...baseFields, ...childFields } }),
-  };
+    const { level, quiet, verbose, pretty = false, fields: baseFields, env = process.env, streams, now } = options;
+    const stdout = streams?.stdout ?? process.stdout;
+    const stderr = streams?.stderr ?? process.stderr;
+    const clock = now ?? defaultClock;
+    const envLevel = env.LOOPOVER_MINER_LOG_LEVEL ?? "";
+    const activeLevel = resolveLogLevel({ level, quiet, verbose, envLevel });
+    const threshold = LEVEL_RANK[activeLevel];
+    function emit(methodLevel, stream, message, fields) {
+        if (LEVEL_RANK[methodLevel] > threshold)
+            return;
+        const merged = baseFields || fields ? { ...baseFields, ...fields } : undefined;
+        const timestamp = pretty ? clock() : undefined;
+        stream.write(`${formatLine({ level: methodLevel, message, fields: merged, pretty, timestamp })}\n`);
+    }
+    return {
+        level: activeLevel,
+        isLevelEnabled: (methodLevel) => LEVEL_RANK[methodLevel] <= threshold,
+        error: (message, fields) => emit("error", stderr, message, fields),
+        warn: (message, fields) => emit("warn", stderr, message, fields),
+        info: (message, fields) => emit("info", stdout, message, fields),
+        debug: (message, fields) => emit("debug", stdout, message, fields),
+        child: (childFields) => createLogger({ ...options, fields: { ...baseFields, ...childFields } }),
+    };
 }
-
 // Process-wide logger. The CLI entrypoint calls `configureLogger` once from the parsed global flags/env so every
 // command shares one configured instance via `getLogger`; until then this default-level instance is used.
 let processLogger = createLogger();
-
 /** Reconfigure the process-wide logger from resolved startup options and return it. */
 export function configureLogger(options) {
-  processLogger = createLogger(options);
-  return processLogger;
+    processLogger = createLogger(options);
+    return processLogger;
 }
-
 /** The process-wide logger configured by `configureLogger` (a default-level logger before then). */
 export function getLogger() {
-  return processLogger;
+    return processLogger;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9nZ2VyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsibG9nZ2VyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDBHQUEwRztBQUMxRyx5R0FBeUc7QUFDekcsNkdBQTZHO0FBQzdHLDZHQUE2RztBQUM3Ryx3R0FBd0c7QUFDeEcsRUFBRTtBQUNGLGdIQUFnSDtBQUNoSCwrR0FBK0c7QUFDL0csOEdBQThHO0FBQzlHLGtGQUFrRjtBQUlsRixtRkFBbUY7QUFDbkYsTUFBTSxDQUFDLE1BQU0sVUFBVSxHQUF3QixDQUFDLFFBQVEsRUFBRSxPQUFPLEVBQUUsTUFBTSxFQUFFLE1BQU0sRUFBRSxPQUFPLENBQUMsQ0FBQztBQUU1RixtRkFBbUY7QUFDbkYsTUFBTSxDQUFDLE1BQU0saUJBQWlCLEdBQWEsTUFBTSxDQUFDO0FBRWxELDRHQUE0RztBQUM1RyxNQUFNLFVBQVUsR0FBNkIsRUFBRSxNQUFNLEVBQUUsQ0FBQyxFQUFFLEtBQUssRUFBRSxDQUFDLEVBQUUsSUFBSSxFQUFFLENBQUMsRUFBRSxJQUFJLEVBQUUsQ0FBQyxFQUFFLEtBQUssRUFBRSxDQUFDLEVBQUUsQ0FBQztBQUVqRyxNQUFNLFlBQVksR0FBRyxHQUFXLEVBQUUsQ0FBQyxJQUFJLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxDQUFDO0FBNEI1RDs0RUFDNEU7QUFDNUUsTUFBTSxVQUFVLFVBQVUsQ0FBQyxLQUFjO0lBQ3ZDLE9BQU8sT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLE1BQU0sQ0FBQyxTQUFTLENBQUMsY0FBYyxDQUFDLElBQUksQ0FBQyxVQUFVLEVBQUUsS0FBSyxDQUFDLENBQUM7QUFDOUYsQ0FBQztBQUVEOzs7OztHQUtHO0FBQ0gsTUFBTSxVQUFVLGVBQWUsQ0FBQyxFQUFFLEtBQUssRUFBRSxLQUFLLEdBQUcsS0FBSyxFQUFFLE9BQU8sR0FBRyxLQUFLLEVBQUUsUUFBUSxLQUs3RSxFQUFFO0lBQ0osSUFBSSxVQUFVLENBQUMsS0FBSyxDQUFDO1FBQUUsT0FBTyxLQUFLLENBQUM7SUFDcEMsSUFBSSxLQUFLO1FBQUUsT0FBTyxPQUFPLENBQUM7SUFDMUIsSUFBSSxPQUFPO1FBQUUsT0FBTyxPQUFPLENBQUM7SUFDNUIsSUFBSSxVQUFVLENBQUMsUUFBUSxDQUFDO1FBQUUsT0FBTyxRQUFRLENBQUM7SUFDMUMsT0FBTyxpQkFBaUIsQ0FBQztBQUMzQixDQUFDO0FBRUQ7Ozs7O0dBS0c7QUFDSCxNQUFNLFVBQVUsaUJBQWlCLENBQUMsSUFBYztJQUk5QyxJQUFJLEtBQUssR0FBRyxLQUFLLENBQUM7SUFDbEIsSUFBSSxPQUFPLEdBQUcsS0FBSyxDQUFDO0lBQ3BCLElBQUksS0FBeUIsQ0FBQztJQUM5QixNQUFNLElBQUksR0FBYSxFQUFFLENBQUM7SUFDMUIsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sR0FBRyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQVcsQ0FBQztRQUNsQyxJQUFJLEdBQUcsS0FBSyxTQUFTLEVBQUUsQ0FBQztZQUN0QixLQUFLLEdBQUcsSUFBSSxDQUFDO1lBQ2IsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEdBQUcsS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUN4QixPQUFPLEdBQUcsSUFBSSxDQUFDO1lBQ2YsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEdBQUcsS0FBSyxhQUFhLEVBQUUsQ0FBQztZQUMxQixLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUN4QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEdBQUcsQ0FBQyxVQUFVLENBQUMsY0FBYyxDQUFDLEVBQUUsQ0FBQztZQUNuQyxLQUFLLEdBQUcsR0FBRyxDQUFDLEtBQUssQ0FBQyxjQUFjLENBQUMsTUFBTSxDQUFDLENBQUM7WUFDekMsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2pCLENBQUM7SUFDRCxPQUFPLEVBQUUsT0FBTyxFQUFFLEVBQUUsS0FBSyxFQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQztBQUN0RCxDQUFDO0FBRUQsU0FBUyxnQkFBZ0IsQ0FBQyxLQUFjO0lBQ3RDLDhHQUE4RztJQUM5RyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVE7UUFBRSxPQUFPLElBQUksQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQztJQUN2RixPQUFPLElBQUksQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDL0IsQ0FBQztBQUVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSxZQUFZLENBQUMsTUFBbUQ7SUFDOUUsSUFBSSxDQUFDLE1BQU07UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUN2QixNQUFNLEtBQUssR0FBYSxFQUFFLENBQUM7SUFDM0IsS0FBSyxNQUFNLEdBQUcsSUFBSSxNQUFNLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUM7UUFDN0MsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQzFCLElBQUksS0FBSyxLQUFLLFNBQVM7WUFBRSxTQUFTO1FBQ2xDLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxHQUFHLElBQUksZ0JBQWdCLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ2xELENBQUM7SUFDRCxPQUFPLEtBQUssQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0FBQ3ZELENBQUM7QUFFRDs7OztHQUlHO0FBQ0gsTUFBTSxVQUFVLFVBQVUsQ0FBQyxFQUFFLEtBQUssRUFBRSxPQUFPLEVBQUUsTUFBTSxFQUFFLE1BQU0sRUFBRSxTQUFTLEVBTXJFO0lBQ0MsTUFBTSxNQUFNLEdBQUcsWUFBWSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ3BDLElBQUksQ0FBQyxNQUFNO1FBQUUsT0FBTyxHQUFHLE9BQU8sR0FBRyxNQUFNLEVBQUUsQ0FBQztJQUMxQyxNQUFNLEtBQUssR0FBRyxTQUFTLENBQUMsQ0FBQyxDQUFDLElBQUksU0FBUyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNqRCxPQUFPLEdBQUcsS0FBSyxHQUFHLEtBQUssQ0FBQyxXQUFXLEVBQUUsSUFBSSxPQUFPLEdBQUcsTUFBTSxFQUFFLENBQUM7QUFDOUQsQ0FBQztBQUVEOzs7OztHQUtHO0FBQ0gsTUFBTSxVQUFVLFlBQVksQ0FBQyxVQUF5QixFQUFFO0lBQ3RELE1BQU0sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLE9BQU8sRUFBRSxNQUFNLEdBQUcsS0FBSyxFQUFFLE1BQU0sRUFBRSxVQUFVLEVBQUUsR0FBRyxHQUFHLE9BQU8sQ0FBQyxHQUFHLEVBQUUsT0FBTyxFQUFFLEdBQUcsRUFBRSxHQUFHLE9BQU8sQ0FBQztJQUMvRyxNQUFNLE1BQU0sR0FBc0MsT0FBTyxFQUFFLE1BQU0sSUFBSSxPQUFPLENBQUMsTUFBTSxDQUFDO0lBQ3BGLE1BQU0sTUFBTSxHQUFzQyxPQUFPLEVBQUUsTUFBTSxJQUFJLE9BQU8sQ0FBQyxNQUFNLENBQUM7SUFDcEYsTUFBTSxLQUFLLEdBQUcsR0FBRyxJQUFJLFlBQVksQ0FBQztJQUNsQyxNQUFNLFFBQVEsR0FBRyxHQUFHLENBQUMsd0JBQXdCLElBQUksRUFBRSxDQUFDO0lBQ3BELE1BQU0sV0FBVyxHQUFHLGVBQWUsQ0FBQyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFFLFFBQVEsRUFBRSxDQUFDLENBQUM7SUFDekUsTUFBTSxTQUFTLEdBQUcsVUFBVSxDQUFDLFdBQVcsQ0FBQyxDQUFDO0lBRTFDLFNBQVMsSUFBSSxDQUFDLFdBQXFCLEVBQUUsTUFBeUMsRUFBRSxPQUFlLEVBQUUsTUFBZ0M7UUFDL0gsSUFBSSxVQUFVLENBQUMsV0FBVyxDQUFDLEdBQUcsU0FBUztZQUFFLE9BQU87UUFDaEQsTUFBTSxNQUFNLEdBQUcsVUFBVSxJQUFJLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxHQUFHLFVBQVUsRUFBRSxHQUFHLE1BQU0sRUFBRSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7UUFDL0UsTUFBTSxTQUFTLEdBQUcsTUFBTSxDQUFDLENBQUMsQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO1FBQy9DLE1BQU0sQ0FBQyxLQUFLLENBQUMsR0FBRyxVQUFVLENBQUMsRUFBRSxLQUFLLEVBQUUsV0FBVyxFQUFFLE9BQU8sRUFBRSxNQUFNLEVBQUUsTUFBTSxFQUFFLE1BQU0sRUFBRSxTQUFTLEVBQUUsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN0RyxDQUFDO0lBRUQsT0FBTztRQUNMLEtBQUssRUFBRSxXQUFXO1FBQ2xCLGNBQWMsRUFBRSxDQUFDLFdBQW1CLEVBQVcsRUFBRSxDQUFDLFVBQVUsQ0FBQyxXQUF1QixDQUFDLElBQUksU0FBUztRQUNsRyxLQUFLLEVBQUUsQ0FBQyxPQUFlLEVBQUUsTUFBZ0MsRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sQ0FBQztRQUNwRyxJQUFJLEVBQUUsQ0FBQyxPQUFlLEVBQUUsTUFBZ0MsRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sQ0FBQztRQUNsRyxJQUFJLEVBQUUsQ0FBQyxPQUFlLEVBQUUsTUFBZ0MsRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sQ0FBQztRQUNsRyxLQUFLLEVBQUUsQ0FBQyxPQUFlLEVBQUUsTUFBZ0MsRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sQ0FBQztRQUNwRyxLQUFLLEVBQUUsQ0FBQyxXQUFvQyxFQUFFLEVBQUUsQ0FBQyxZQUFZLENBQUMsRUFBRSxHQUFHLE9BQU8sRUFBRSxNQUFNLEVBQUUsRUFBRSxHQUFHLFVBQVUsRUFBRSxHQUFHLFdBQVcsRUFBRSxFQUFFLENBQUM7S0FDekgsQ0FBQztBQUNKLENBQUM7QUFFRCxpSEFBaUg7QUFDakgsMEdBQTBHO0FBQzFHLElBQUksYUFBYSxHQUFHLFlBQVksRUFBRSxDQUFDO0FBRW5DLHVGQUF1RjtBQUN2RixNQUFNLFVBQVUsZUFBZSxDQUFDLE9BQXVCO0lBQ3JELGFBQWEsR0FBRyxZQUFZLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDdEMsT0FBTyxhQUFhLENBQUM7QUFDdkIsQ0FBQztBQUVELG9HQUFvRztBQUNwRyxNQUFNLFVBQVUsU0FBUztJQUN2QixPQUFPLGFBQWEsQ0FBQztBQUN2QixDQUFDIn0=

--- a/packages/loopover-miner/lib/logger.ts
+++ b/packages/loopover-miner/lib/logger.ts
@@ -1,0 +1,199 @@
+// Level-aware logging abstraction for the miner CLI (#4835): every CLI file previously reached for ad hoc
+// `console.log`/`console.error` with no shared level control, so an operator could neither quiet routine
+// chatter nor turn on verbose diagnostics. This module is the one dependency-light logger the CLI configures
+// once at startup and every command shares. It is deliberately pure/injectable — `streams`, `now`, and `env`
+// are all overridable — so the branchy level/format logic is unit-testable without touching real stdio.
+//
+// Levels are ordered by severity; a logger at level L emits a method only when the method's severity rank is at
+// or below L's rank (so `error` always survives except at `silent`, and `debug` only shows at the most verbose
+// setting). `error`/`warn` go to stderr, `info`/`debug` to stdout, matching the existing convention where the
+// update-check nudge writes to stderr and normal command output writes to stdout.
+
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
+
+/** Supported log levels, least to most verbose. `silent` suppresses everything. */
+export const LOG_LEVELS: readonly LogLevel[] = ["silent", "error", "warn", "info", "debug"];
+
+/** The level used when nothing (flag, env var, or explicit option) selects one. */
+export const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+// Numeric severity rank per level (higher = more verbose). A method emits when its rank <= the active rank.
+const LEVEL_RANK: Record<LogLevel, number> = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 };
+
+const defaultClock = (): string => new Date().toISOString();
+
+export interface LoggerStreams {
+  stdout?: { write(chunk: string): unknown } | undefined;
+  stderr?: { write(chunk: string): unknown } | undefined;
+}
+
+export interface LoggerOptions {
+  level?: string | undefined;
+  quiet?: boolean | undefined;
+  verbose?: boolean | undefined;
+  pretty?: boolean | undefined;
+  fields?: Record<string, unknown> | undefined;
+  env?: Record<string, string | undefined> | undefined;
+  streams?: LoggerStreams | undefined;
+  now?: (() => string) | undefined;
+}
+
+export interface Logger {
+  level: LogLevel;
+  isLevelEnabled(level: string): boolean;
+  error(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  info(message: string, fields?: Record<string, unknown>): void;
+  debug(message: string, fields?: Record<string, unknown>): void;
+  child(fields: Record<string, unknown>): Logger;
+}
+
+/** True when `value` names a supported log level. Non-string input is never a level (so an absent option or a
+ *  typo'd env var falls through to the next signal instead of throwing). */
+export function isLogLevel(value: unknown): value is LogLevel {
+  return typeof value === "string" && Object.prototype.hasOwnProperty.call(LEVEL_RANK, value);
+}
+
+/**
+ * Resolve the active level from the available signals, most explicit first: an explicit `level` wins, then
+ * `--quiet` (→ `error`), then `--verbose` (→ `debug`), then the env-provided level, else the default. `quiet`
+ * beats `verbose` when both are set, so the safer/quieter choice wins a contradictory invocation. An
+ * unrecognized `level`/`envLevel` is ignored rather than throwing — a typo logs at the default, never crashes.
+ */
+export function resolveLogLevel({ level, quiet = false, verbose = false, envLevel }: {
+  level?: string | undefined;
+  quiet?: boolean | undefined;
+  verbose?: boolean | undefined;
+  envLevel?: string | undefined;
+} = {}): LogLevel {
+  if (isLogLevel(level)) return level;
+  if (quiet) return "error";
+  if (verbose) return "debug";
+  if (isLogLevel(envLevel)) return envLevel;
+  return DEFAULT_LOG_LEVEL;
+}
+
+/**
+ * Split the global logging flags out of a CLI argv slice, returning the parsed options plus `rest` — the argv
+ * with those flags (and any `--log-level` value) removed so downstream command parsing never sees them.
+ * Recognizes `--quiet`, `--verbose`, `--log-level <level>`, and `--log-level=<level>`. No short aliases: `-v`
+ * is already `--version` and `-h` is `--help` in the CLI entrypoint.
+ */
+export function extractLogOptions(argv: string[]): {
+  options: { quiet: boolean; verbose: boolean; level: string | undefined };
+  rest: string[];
+} {
+  let quiet = false;
+  let verbose = false;
+  let level: string | undefined;
+  const rest: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index] as string;
+    if (arg === "--quiet") {
+      quiet = true;
+      continue;
+    }
+    if (arg === "--verbose") {
+      verbose = true;
+      continue;
+    }
+    if (arg === "--log-level") {
+      level = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--log-level=")) {
+      level = arg.slice("--log-level=".length);
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { options: { quiet, verbose, level }, rest };
+}
+
+function formatFieldValue(value: unknown): string {
+  // Quote a string only when it contains whitespace (so it stays one token); serialize everything else as JSON.
+  if (typeof value === "string") return /\s/.test(value) ? JSON.stringify(value) : value;
+  return JSON.stringify(value);
+}
+
+/**
+ * Render structured fields as a stable, sorted ` key=value` suffix (sorted so output is deterministic across
+ * runs). `undefined` values are dropped; an empty/absent field set yields an empty string.
+ */
+export function formatFields(fields?: Record<string, unknown> | null | undefined): string {
+  if (!fields) return "";
+  const parts: string[] = [];
+  for (const key of Object.keys(fields).sort()) {
+    const value = fields[key];
+    if (value === undefined) continue;
+    parts.push(`${key}=${formatFieldValue(value)}`);
+  }
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
+/**
+ * Format one log line. Plain mode (the default) is just `message` + any field suffix, keeping human CLI output
+ * identical to a bare `console.log`. Pretty mode prefixes an optional timestamp and the uppercased level tag,
+ * for operators who want machine-scannable diagnostics.
+ */
+export function formatLine({ level, message, fields, pretty, timestamp }: {
+  level: string;
+  message: string;
+  fields?: Record<string, unknown> | null | undefined;
+  pretty?: boolean | undefined;
+  timestamp?: string | undefined;
+}): string {
+  const suffix = formatFields(fields);
+  if (!pretty) return `${message}${suffix}`;
+  const stamp = timestamp ? `[${timestamp}] ` : "";
+  return `${stamp}${level.toUpperCase()} ${message}${suffix}`;
+}
+
+/**
+ * Build a level-aware logger. All I/O is injectable for tests: `streams` (defaults to process stdout/stderr),
+ * `now` (defaults to an ISO-8601 clock, only consulted in `pretty` mode), and `env` (defaults to process.env,
+ * read for `LOOPOVER_MINER_LOG_LEVEL`). `fields` seeds every line with contextual fields; `child(extra)`
+ * returns a logger that merges additional fields onto this one.
+ */
+export function createLogger(options: LoggerOptions = {}): Logger {
+  const { level, quiet, verbose, pretty = false, fields: baseFields, env = process.env, streams, now } = options;
+  const stdout: { write(chunk: string): unknown } = streams?.stdout ?? process.stdout;
+  const stderr: { write(chunk: string): unknown } = streams?.stderr ?? process.stderr;
+  const clock = now ?? defaultClock;
+  const envLevel = env.LOOPOVER_MINER_LOG_LEVEL ?? "";
+  const activeLevel = resolveLogLevel({ level, quiet, verbose, envLevel });
+  const threshold = LEVEL_RANK[activeLevel];
+
+  function emit(methodLevel: LogLevel, stream: { write(chunk: string): unknown }, message: string, fields?: Record<string, unknown>): void {
+    if (LEVEL_RANK[methodLevel] > threshold) return;
+    const merged = baseFields || fields ? { ...baseFields, ...fields } : undefined;
+    const timestamp = pretty ? clock() : undefined;
+    stream.write(`${formatLine({ level: methodLevel, message, fields: merged, pretty, timestamp })}\n`);
+  }
+
+  return {
+    level: activeLevel,
+    isLevelEnabled: (methodLevel: string): boolean => LEVEL_RANK[methodLevel as LogLevel] <= threshold,
+    error: (message: string, fields?: Record<string, unknown>) => emit("error", stderr, message, fields),
+    warn: (message: string, fields?: Record<string, unknown>) => emit("warn", stderr, message, fields),
+    info: (message: string, fields?: Record<string, unknown>) => emit("info", stdout, message, fields),
+    debug: (message: string, fields?: Record<string, unknown>) => emit("debug", stdout, message, fields),
+    child: (childFields: Record<string, unknown>) => createLogger({ ...options, fields: { ...baseFields, ...childFields } }),
+  };
+}
+
+// Process-wide logger. The CLI entrypoint calls `configureLogger` once from the parsed global flags/env so every
+// command shares one configured instance via `getLogger`; until then this default-level instance is used.
+let processLogger = createLogger();
+
+/** Reconfigure the process-wide logger from resolved startup options and return it. */
+export function configureLogger(options?: LoggerOptions): Logger {
+  processLogger = createLogger(options);
+  return processLogger;
+}
+
+/** The process-wide logger configured by `configureLogger` (a default-level logger before then). */
+export function getLogger(): Logger {
+  return processLogger;
+}

--- a/packages/loopover-miner/lib/loop-reentry.d.ts
+++ b/packages/loopover-miner/lib/loop-reentry.d.ts
@@ -1,51 +1,94 @@
-export const LOOP_REENTRY_DECISION_EVENT: "loop_reentry_decision";
-
+export declare const LOOP_REENTRY_DECISION_EVENT = "loop_reentry_decision";
 export type LoopReentryOutcome = "merged" | "disengaged" | "other";
 export type LoopReentryKillSwitchScope = "global" | "repo" | "none";
-
 export type LoopReentryCandidateInput = {
-  /** Checked FIRST by the pure `shouldReenter` policy, before any other logic. */
-  killSwitchScope: LoopReentryKillSwitchScope;
-  repoFullName: string;
-  outcome: LoopReentryOutcome;
-  maxConsecutiveDisengagements?: number;
-  maxReentriesPerHour?: number;
-  maxReentriesPerSession?: number;
+    /** Checked FIRST by the pure `shouldReenter` policy, before any other logic. */
+    killSwitchScope: LoopReentryKillSwitchScope;
+    repoFullName: string;
+    outcome: LoopReentryOutcome;
+    maxConsecutiveDisengagements?: number;
+    maxReentriesPerHour?: number;
+    maxReentriesPerSession?: number;
 };
-
 export interface LoopReentryEventLedger {
-  appendEvent(event: { type: string; repoFullName?: string; payload: Record<string, unknown> }): { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
-  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ type: string; repoFullName?: string | null; payload?: Record<string, unknown>; createdAt: string }>;
+    appendEvent(event: {
+        type: string;
+        repoFullName?: string;
+        payload: Record<string, unknown>;
+    }): {
+        id: number;
+        seq: number;
+        type: string;
+        repoFullName: string | null;
+        payload: Record<string, unknown>;
+        createdAt: string;
+    };
+    readEvents(filter?: {
+        since?: number;
+        repoFullName?: string;
+    }): Array<{
+        type: string;
+        repoFullName?: string | null;
+        payload?: Record<string, unknown>;
+        createdAt: string;
+    }>;
 }
-
 export interface LoopReentryPortfolioQueue {
-  dequeueNext(): { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null;
+    dequeueNext(): {
+        repoFullName: string;
+        identifier: string;
+        priority: number;
+        status: string;
+        enqueuedAt: string;
+    } | null;
 }
-
 export interface LoopReentryRunState {
-  setRunState(repoFullName: string, state: string): unknown;
+    setRunState(repoFullName: string, state: string): unknown;
 }
-
 export type LoopReentryDeps = {
-  eventLedger: LoopReentryEventLedger;
-  portfolioQueue: LoopReentryPortfolioQueue;
-  runState?: LoopReentryRunState;
-  nowMs?: number;
-  sessionStartMs?: number;
-  /** The just-completed cycle's read-only summary (loop-closure.js's `buildLoopClosureSummary`), threaded
-   *  through verbatim into the audit event's payload for traceability. Not used to compute the circuit-
-   *  breaker/rate-cap tallies -- see loop-reentry.js's own comment on why. */
-  loopSummary?: unknown;
+    eventLedger: LoopReentryEventLedger;
+    portfolioQueue: LoopReentryPortfolioQueue;
+    runState?: LoopReentryRunState;
+    nowMs?: number;
+    sessionStartMs?: number;
+    /** The just-completed cycle's read-only summary (loop-closure.js's `buildLoopClosureSummary`), threaded
+     *  through verbatim into the audit event's payload for traceability. Not used to compute the circuit-
+     *  breaker/rate-cap tallies -- see loop-reentry.js's own comment on why. */
+    loopSummary?: unknown;
 };
-
 export type LoopReentryResult = {
-  decision: { reenter: boolean; reasons: string[] };
-  dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null;
-  event: { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
+    decision: {
+        reenter: boolean;
+        reasons: string[];
+    };
+    dequeued: {
+        repoFullName: string;
+        identifier: string;
+        priority: number;
+        status: string;
+        enqueuedAt: string;
+    } | null;
+    event: {
+        id: number;
+        seq: number;
+        type: string;
+        repoFullName: string | null;
+        payload: Record<string, unknown>;
+        createdAt: string;
+    };
 };
-
-export function countConsecutiveDisengagements(eventLedger: LoopReentryEventLedger, repoFullName: string): number;
-
-export function countReentriesSince(eventLedger: LoopReentryEventLedger, sinceMs: number): number;
-
-export function attemptLoopReentry(candidate: LoopReentryCandidateInput, deps: LoopReentryDeps): LoopReentryResult;
+/**
+ * Count a repo's CONSECUTIVE disengaged (closed-without-merge) PR outcomes, walking backward from the most
+ * recently recorded PR for that repo until a merged outcome breaks the streak (or history runs out).
+ */
+export declare function countConsecutiveDisengagements(eventLedger: LoopReentryEventLedger, repoFullName: string): number;
+/** Count prior re-entries (successful, i.e. `reentered: true`) recorded at or after `sinceMs`. */
+export declare function countReentriesSince(eventLedger: LoopReentryEventLedger, sinceMs: number): number;
+/**
+ * Evaluate and (if allowed) PERFORM re-entry for one resolved outcome: reads real history to compute the
+ * circuit-breaker and rate-cap tallies, consults the pure `shouldReenter` policy, and -- only when it allows --
+ * dequeues the next candidate and transitions run-state to `"discovering"`. Always appends exactly one audit
+ * event. Fails closed (throws) on a malformed candidate or missing required dependency, mirroring
+ * `recordManagePollSnapshot`'s own validation style.
+ */
+export declare function attemptLoopReentry(candidate: LoopReentryCandidateInput, deps: LoopReentryDeps): LoopReentryResult;

--- a/packages/loopover-miner/lib/loop-reentry.js
+++ b/packages/loopover-miner/lib/loop-reentry.js
@@ -1,7 +1,5 @@
 import { shouldReenter } from "@loopover/engine";
-
 import { readPrOutcomes } from "./pr-outcome.js";
-
 // Closed-loop discovery re-entry orchestrator (#2338): the real-IO half of "on a resolved outcome (merged, or
 // rejected-and-disengaged), automatically re-invoke discovery to select the next candidate." The DECISION
 // itself (shouldReenter, @loopover/engine) is pure; this module owns everything that decision
@@ -16,109 +14,102 @@ import { readPrOutcomes } from "./pr-outcome.js";
 // AUDITABILITY: every call appends exactly one `loop_reentry_decision` event to the ledger, whether or not the
 // decision allowed re-entry, so the full decision trail (including every suppressed re-entry and why) survives
 // independently of this function's own return value.
-
 export const LOOP_REENTRY_DECISION_EVENT = "loop_reentry_decision";
 const HOUR_MS = 60 * 60 * 1000;
-
 /** A `pr_outcome` "closed" decision is this module's practical proxy for "disengaged" -- pr-outcome.js's own
  *  vocabulary is exactly `"merged" | "closed"` (no separate "disengaged" literal); a PR that closed without
  *  merging IS the rejected/disengaged case rejection-state-machine.js's own `isRejectedPr` checks for. */
 function isDisengagedOutcome(outcome) {
-  return outcome?.decision === "closed";
+    return outcome?.decision === "closed";
 }
-
 /**
  * Count a repo's CONSECUTIVE disengaged (closed-without-merge) PR outcomes, walking backward from the most
  * recently recorded PR for that repo until a merged outcome breaks the streak (or history runs out).
  */
 export function countConsecutiveDisengagements(eventLedger, repoFullName) {
-  const outcomes = [...readPrOutcomes(eventLedger, { repoFullName }).values()];
-  let count = 0;
-  for (let i = outcomes.length - 1; i >= 0; i -= 1) {
-    if (!isDisengagedOutcome(outcomes[i])) break;
-    count += 1;
-  }
-  return count;
+    const outcomes = [...readPrOutcomes(eventLedger, { repoFullName }).values()];
+    let count = 0;
+    for (let i = outcomes.length - 1; i >= 0; i -= 1) {
+        if (!isDisengagedOutcome(outcomes[i]))
+            break;
+        count += 1;
+    }
+    return count;
 }
-
 /** Count prior re-entries (successful, i.e. `reentered: true`) recorded at or after `sinceMs`. */
 export function countReentriesSince(eventLedger, sinceMs) {
-  return eventLedger
-    .readEvents({})
-    .filter((event) => event.type === LOOP_REENTRY_DECISION_EVENT && event.payload?.reentered === true && Date.parse(event.createdAt) >= sinceMs)
-    .length;
+    return eventLedger
+        .readEvents({})
+        .filter((event) => event.type === LOOP_REENTRY_DECISION_EVENT && event.payload?.reentered === true && Date.parse(event.createdAt) >= sinceMs)
+        .length;
 }
-
 /**
  * Evaluate and (if allowed) PERFORM re-entry for one resolved outcome: reads real history to compute the
  * circuit-breaker and rate-cap tallies, consults the pure `shouldReenter` policy, and -- only when it allows --
  * dequeues the next candidate and transitions run-state to `"discovering"`. Always appends exactly one audit
  * event. Fails closed (throws) on a malformed candidate or missing required dependency, mirroring
  * `recordManagePollSnapshot`'s own validation style.
- *
- * @param {{ killSwitchScope: "global"|"repo"|"none", repoFullName: string, outcome: "merged"|"disengaged"|"other", maxConsecutiveDisengagements?: number, maxReentriesPerHour?: number, maxReentriesPerSession?: number }} candidate
- * @param {{ eventLedger: object, portfolioQueue: object, runState?: object, nowMs?: number, sessionStartMs?: number }} deps
  */
 export function attemptLoopReentry(candidate, deps) {
-  if (!candidate || typeof candidate !== "object") throw new Error("invalid_loop_reentry_candidate");
-  if (!["global", "repo", "none"].includes(candidate.killSwitchScope)) throw new Error("invalid_kill_switch_scope");
-  const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
-  if (!repoFullName) throw new Error("invalid_repo_full_name");
-  if (!["merged", "disengaged", "other"].includes(candidate.outcome)) throw new Error("invalid_outcome");
-
-  if (!deps || typeof deps !== "object") throw new Error("invalid_loop_reentry_deps");
-  const { eventLedger, portfolioQueue, runState, nowMs = Date.now(), sessionStartMs = 0 } = deps;
-  if (!eventLedger || typeof eventLedger.appendEvent !== "function" || typeof eventLedger.readEvents !== "function") {
-    throw new Error("invalid_event_ledger");
-  }
-  if (!portfolioQueue || typeof portfolioQueue.dequeueNext !== "function") {
-    throw new Error("invalid_portfolio_queue");
-  }
-
-  const consecutiveDisengagements = countConsecutiveDisengagements(eventLedger, repoFullName);
-  const reentriesThisHour = countReentriesSince(eventLedger, nowMs - HOUR_MS);
-  const reentriesThisSession = countReentriesSince(eventLedger, sessionStartMs);
-
-  const decision = shouldReenter({
-    killSwitchScope: candidate.killSwitchScope,
-    repoFullName,
-    outcome: candidate.outcome,
-    consecutiveDisengagements,
-    maxConsecutiveDisengagements: candidate.maxConsecutiveDisengagements,
-    reentriesThisHour,
-    maxReentriesPerHour: candidate.maxReentriesPerHour,
-    reentriesThisSession,
-    maxReentriesPerSession: candidate.maxReentriesPerSession,
-  });
-
-  let dequeued = null;
-  if (decision.reenter) {
-    dequeued = portfolioQueue.dequeueNext();
-    if (runState && typeof runState.setRunState === "function") {
-      runState.setRunState(repoFullName, "discovering");
+    if (!candidate || typeof candidate !== "object")
+        throw new Error("invalid_loop_reentry_candidate");
+    if (!["global", "repo", "none"].includes(candidate.killSwitchScope))
+        throw new Error("invalid_kill_switch_scope");
+    const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+    if (!repoFullName)
+        throw new Error("invalid_repo_full_name");
+    if (!["merged", "disengaged", "other"].includes(candidate.outcome))
+        throw new Error("invalid_outcome");
+    if (!deps || typeof deps !== "object")
+        throw new Error("invalid_loop_reentry_deps");
+    const { eventLedger, portfolioQueue, runState, nowMs = Date.now(), sessionStartMs = 0 } = deps;
+    if (!eventLedger || typeof eventLedger.appendEvent !== "function" || typeof eventLedger.readEvents !== "function") {
+        throw new Error("invalid_event_ledger");
     }
-  }
-
-  const event = eventLedger.appendEvent({
-    type: LOOP_REENTRY_DECISION_EVENT,
-    repoFullName,
-    payload: {
-      killSwitchScope: candidate.killSwitchScope,
-      outcome: candidate.outcome,
-      reentered: decision.reenter,
-      reasons: decision.reasons,
-      consecutiveDisengagements,
-      reentriesThisHour,
-      reentriesThisSession,
-      dequeuedIdentifier: dequeued ? dequeued.identifier : null,
-      // The just-completed cycle's read-only summary (loop-closure.js's buildLoopClosureSummary), when the
-      // caller supplies one -- threaded through verbatim for audit traceability. Optional: the circuit-breaker
-      // and rate-cap tallies above are computed directly from pr-outcome/event-ledger history (a
-      // LoopClosureSummary's own byType COUNTS aren't detailed enough to derive a per-repo consecutive-
-      // disengagement streak from), so this is context, not a computational input.
-      loopSummary: deps.loopSummary ?? null,
-    },
-  });
-
-  return { decision, dequeued, event };
+    if (!portfolioQueue || typeof portfolioQueue.dequeueNext !== "function") {
+        throw new Error("invalid_portfolio_queue");
+    }
+    const consecutiveDisengagements = countConsecutiveDisengagements(eventLedger, repoFullName);
+    const reentriesThisHour = countReentriesSince(eventLedger, nowMs - HOUR_MS);
+    const reentriesThisSession = countReentriesSince(eventLedger, sessionStartMs);
+    const decision = shouldReenter({
+        killSwitchScope: candidate.killSwitchScope,
+        repoFullName,
+        outcome: candidate.outcome,
+        consecutiveDisengagements,
+        maxConsecutiveDisengagements: candidate.maxConsecutiveDisengagements,
+        reentriesThisHour,
+        maxReentriesPerHour: candidate.maxReentriesPerHour,
+        reentriesThisSession,
+        maxReentriesPerSession: candidate.maxReentriesPerSession,
+    });
+    let dequeued = null;
+    if (decision.reenter) {
+        dequeued = portfolioQueue.dequeueNext();
+        if (runState && typeof runState.setRunState === "function") {
+            runState.setRunState(repoFullName, "discovering");
+        }
+    }
+    const event = eventLedger.appendEvent({
+        type: LOOP_REENTRY_DECISION_EVENT,
+        repoFullName,
+        payload: {
+            killSwitchScope: candidate.killSwitchScope,
+            outcome: candidate.outcome,
+            reentered: decision.reenter,
+            reasons: decision.reasons,
+            consecutiveDisengagements,
+            reentriesThisHour,
+            reentriesThisSession,
+            dequeuedIdentifier: dequeued ? dequeued.identifier : null,
+            // The just-completed cycle's read-only summary (loop-closure.js's buildLoopClosureSummary), when the
+            // caller supplies one -- threaded through verbatim for audit traceability. Optional: the circuit-breaker
+            // and rate-cap tallies above are computed directly from pr-outcome/event-ledger history (a
+            // LoopClosureSummary's own byType COUNTS aren't detailed enough to derive a per-repo consecutive-
+            // disengagement streak from), so this is context, not a computational input.
+            loopSummary: deps.loopSummary ?? null,
+        },
+    });
+    return { decision, dequeued, event };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9vcC1yZWVudHJ5LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsibG9vcC1yZWVudHJ5LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxhQUFhLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUVqRCxPQUFPLEVBQUUsY0FBYyxFQUFFLE1BQU0saUJBQWlCLENBQUM7QUFFakQsOEdBQThHO0FBQzlHLDBHQUEwRztBQUMxRyw4RkFBOEY7QUFDOUYseUdBQXlHO0FBQ3pHLCtHQUErRztBQUMvRyxxRUFBcUU7QUFDckUsRUFBRTtBQUNGLHdHQUF3RztBQUN4RyxnSEFBZ0g7QUFDaEgsa0VBQWtFO0FBQ2xFLEVBQUU7QUFDRiwrR0FBK0c7QUFDL0csK0dBQStHO0FBQy9HLHFEQUFxRDtBQUVyRCxNQUFNLENBQUMsTUFBTSwyQkFBMkIsR0FBRyx1QkFBdUIsQ0FBQztBQUNuRSxNQUFNLE9BQU8sR0FBRyxFQUFFLEdBQUcsRUFBRSxHQUFHLElBQUksQ0FBQztBQThDL0I7OzBHQUUwRztBQUMxRyxTQUFTLG1CQUFtQixDQUFDLE9BQWtEO0lBQzdFLE9BQU8sT0FBTyxFQUFFLFFBQVEsS0FBSyxRQUFRLENBQUM7QUFDeEMsQ0FBQztBQUVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSw4QkFBOEIsQ0FBQyxXQUFtQyxFQUFFLFlBQW9CO0lBQ3RHLE1BQU0sUUFBUSxHQUFHLENBQUMsR0FBRyxjQUFjLENBQUMsV0FBVyxFQUFFLEVBQUUsWUFBWSxFQUFFLENBQUMsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDO0lBQzdFLElBQUksS0FBSyxHQUFHLENBQUMsQ0FBQztJQUNkLEtBQUssSUFBSSxDQUFDLEdBQUcsUUFBUSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDakQsSUFBSSxDQUFDLG1CQUFtQixDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUFFLE1BQU07UUFDN0MsS0FBSyxJQUFJLENBQUMsQ0FBQztJQUNiLENBQUM7SUFDRCxPQUFPLEtBQUssQ0FBQztBQUNmLENBQUM7QUFFRCxrR0FBa0c7QUFDbEcsTUFBTSxVQUFVLG1CQUFtQixDQUFDLFdBQW1DLEVBQUUsT0FBZTtJQUN0RixPQUFPLFdBQVc7U0FDZixVQUFVLENBQUMsRUFBRSxDQUFDO1NBQ2QsTUFBTSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLDJCQUEyQixJQUFJLEtBQUssQ0FBQyxPQUFPLEVBQUUsU0FBUyxLQUFLLElBQUksSUFBSSxJQUFJLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsSUFBSSxPQUFPLENBQUM7U0FDNUksTUFBTSxDQUFDO0FBQ1osQ0FBQztBQUVEOzs7Ozs7R0FNRztBQUNILE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxTQUFvQyxFQUFFLElBQXFCO0lBQzVGLElBQUksQ0FBQyxTQUFTLElBQUksT0FBTyxTQUFTLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsZ0NBQWdDLENBQUMsQ0FBQztJQUNuRyxJQUFJLENBQUMsQ0FBQyxRQUFRLEVBQUUsTUFBTSxFQUFFLE1BQU0sQ0FBQyxDQUFDLFFBQVEsQ0FBQyxTQUFTLENBQUMsZUFBZSxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywyQkFBMkIsQ0FBQyxDQUFDO0lBQ2xILE1BQU0sWUFBWSxHQUFHLE9BQU8sU0FBUyxDQUFDLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNyRyxJQUFJLENBQUMsWUFBWTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQztJQUM3RCxJQUFJLENBQUMsQ0FBQyxRQUFRLEVBQUUsWUFBWSxFQUFFLE9BQU8sQ0FBQyxDQUFDLFFBQVEsQ0FBQyxTQUFTLENBQUMsT0FBTyxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDO0lBRXZHLElBQUksQ0FBQyxJQUFJLElBQUksT0FBTyxJQUFJLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsMkJBQTJCLENBQUMsQ0FBQztJQUNwRixNQUFNLEVBQUUsV0FBVyxFQUFFLGNBQWMsRUFBRSxRQUFRLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxHQUFHLEVBQUUsRUFBRSxjQUFjLEdBQUcsQ0FBQyxFQUFFLEdBQUcsSUFBSSxDQUFDO0lBQy9GLElBQUksQ0FBQyxXQUFXLElBQUksT0FBTyxXQUFXLENBQUMsV0FBVyxLQUFLLFVBQVUsSUFBSSxPQUFPLFdBQVcsQ0FBQyxVQUFVLEtBQUssVUFBVSxFQUFFLENBQUM7UUFDbEgsTUFBTSxJQUFJLEtBQUssQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFDRCxJQUFJLENBQUMsY0FBYyxJQUFJLE9BQU8sY0FBYyxDQUFDLFdBQVcsS0FBSyxVQUFVLEVBQUUsQ0FBQztRQUN4RSxNQUFNLElBQUksS0FBSyxDQUFDLHlCQUF5QixDQUFDLENBQUM7SUFDN0MsQ0FBQztJQUVELE1BQU0seUJBQXlCLEdBQUcsOEJBQThCLENBQUMsV0FBVyxFQUFFLFlBQVksQ0FBQyxDQUFDO0lBQzVGLE1BQU0saUJBQWlCLEdBQUcsbUJBQW1CLENBQUMsV0FBVyxFQUFFLEtBQUssR0FBRyxPQUFPLENBQUMsQ0FBQztJQUM1RSxNQUFNLG9CQUFvQixHQUFHLG1CQUFtQixDQUFDLFdBQVcsRUFBRSxjQUFjLENBQUMsQ0FBQztJQUU5RSxNQUFNLFFBQVEsR0FBRyxhQUFhLENBQUM7UUFDN0IsZUFBZSxFQUFFLFNBQVMsQ0FBQyxlQUFlO1FBQzFDLFlBQVk7UUFDWixPQUFPLEVBQUUsU0FBUyxDQUFDLE9BQU87UUFDMUIseUJBQXlCO1FBQ3pCLDRCQUE0QixFQUFFLFNBQVMsQ0FBQyw0QkFBNEI7UUFDcEUsaUJBQWlCO1FBQ2pCLG1CQUFtQixFQUFFLFNBQVMsQ0FBQyxtQkFBbUI7UUFDbEQsb0JBQW9CO1FBQ3BCLHNCQUFzQixFQUFFLFNBQVMsQ0FBQyxzQkFBc0I7S0FDekQsQ0FBQyxDQUFDO0lBRUgsSUFBSSxRQUFRLEdBQThHLElBQUksQ0FBQztJQUMvSCxJQUFJLFFBQVEsQ0FBQyxPQUFPLEVBQUUsQ0FBQztRQUNyQixRQUFRLEdBQUcsY0FBYyxDQUFDLFdBQVcsRUFBRSxDQUFDO1FBQ3hDLElBQUksUUFBUSxJQUFJLE9BQU8sUUFBUSxDQUFDLFdBQVcsS0FBSyxVQUFVLEVBQUUsQ0FBQztZQUMzRCxRQUFRLENBQUMsV0FBVyxDQUFDLFlBQVksRUFBRSxhQUFhLENBQUMsQ0FBQztRQUNwRCxDQUFDO0lBQ0gsQ0FBQztJQUVELE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxXQUFXLENBQUM7UUFDcEMsSUFBSSxFQUFFLDJCQUEyQjtRQUNqQyxZQUFZO1FBQ1osT0FBTyxFQUFFO1lBQ1AsZUFBZSxFQUFFLFNBQVMsQ0FBQyxlQUFlO1lBQzFDLE9BQU8sRUFBRSxTQUFTLENBQUMsT0FBTztZQUMxQixTQUFTLEVBQUUsUUFBUSxDQUFDLE9BQU87WUFDM0IsT0FBTyxFQUFFLFFBQVEsQ0FBQyxPQUFPO1lBQ3pCLHlCQUF5QjtZQUN6QixpQkFBaUI7WUFDakIsb0JBQW9CO1lBQ3BCLGtCQUFrQixFQUFFLFFBQVEsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsSUFBSTtZQUN6RCxxR0FBcUc7WUFDckcseUdBQXlHO1lBQ3pHLDJGQUEyRjtZQUMzRixrR0FBa0c7WUFDbEcsNkVBQTZFO1lBQzdFLFdBQVcsRUFBRSxJQUFJLENBQUMsV0FBVyxJQUFJLElBQUk7U0FDdEM7S0FDRixDQUFDLENBQUM7SUFFSCxPQUFPLEVBQUUsUUFBUSxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUN2QyxDQUFDIn0=

--- a/packages/loopover-miner/lib/loop-reentry.ts
+++ b/packages/loopover-miner/lib/loop-reentry.ts
@@ -1,0 +1,165 @@
+import { shouldReenter } from "@loopover/engine";
+
+import { readPrOutcomes } from "./pr-outcome.js";
+
+// Closed-loop discovery re-entry orchestrator (#2338): the real-IO half of "on a resolved outcome (merged, or
+// rejected-and-disengaged), automatically re-invoke discovery to select the next candidate." The DECISION
+// itself (shouldReenter, @loopover/engine) is pure; this module owns everything that decision
+// needs real state for -- reading the repo's own pr_outcome history to compute the per-repo consecutive-
+// disengagement tally, reading recent re-entry events for the hourly/session rate cap, and (only when allowed)
+// actually dequeuing the next candidate and transitioning run-state.
+//
+// NOT WIRED INTO ANY AUTOMATIC SCHEDULE: per this issue's own "manual owner sign-off before enabling by
+// default in any profile" deliverable, this is a callable function ready for that sign-off -- it is not invoked
+// by manage-poll.js or any cron/scheduler as part of this change.
+//
+// AUDITABILITY: every call appends exactly one `loop_reentry_decision` event to the ledger, whether or not the
+// decision allowed re-entry, so the full decision trail (including every suppressed re-entry and why) survives
+// independently of this function's own return value.
+
+export const LOOP_REENTRY_DECISION_EVENT = "loop_reentry_decision";
+const HOUR_MS = 60 * 60 * 1000;
+
+export type LoopReentryOutcome = "merged" | "disengaged" | "other";
+export type LoopReentryKillSwitchScope = "global" | "repo" | "none";
+
+export type LoopReentryCandidateInput = {
+  /** Checked FIRST by the pure `shouldReenter` policy, before any other logic. */
+  killSwitchScope: LoopReentryKillSwitchScope;
+  repoFullName: string;
+  outcome: LoopReentryOutcome;
+  maxConsecutiveDisengagements?: number;
+  maxReentriesPerHour?: number;
+  maxReentriesPerSession?: number;
+};
+
+export interface LoopReentryEventLedger {
+  appendEvent(event: { type: string; repoFullName?: string; payload: Record<string, unknown> }): { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
+  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ type: string; repoFullName?: string | null; payload?: Record<string, unknown>; createdAt: string }>;
+}
+
+export interface LoopReentryPortfolioQueue {
+  dequeueNext(): { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null;
+}
+
+export interface LoopReentryRunState {
+  setRunState(repoFullName: string, state: string): unknown;
+}
+
+export type LoopReentryDeps = {
+  eventLedger: LoopReentryEventLedger;
+  portfolioQueue: LoopReentryPortfolioQueue;
+  runState?: LoopReentryRunState;
+  nowMs?: number;
+  sessionStartMs?: number;
+  /** The just-completed cycle's read-only summary (loop-closure.js's `buildLoopClosureSummary`), threaded
+   *  through verbatim into the audit event's payload for traceability. Not used to compute the circuit-
+   *  breaker/rate-cap tallies -- see loop-reentry.js's own comment on why. */
+  loopSummary?: unknown;
+};
+
+export type LoopReentryResult = {
+  decision: { reenter: boolean; reasons: string[] };
+  dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null;
+  event: { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
+};
+
+/** A `pr_outcome` "closed" decision is this module's practical proxy for "disengaged" -- pr-outcome.js's own
+ *  vocabulary is exactly `"merged" | "closed"` (no separate "disengaged" literal); a PR that closed without
+ *  merging IS the rejected/disengaged case rejection-state-machine.js's own `isRejectedPr` checks for. */
+function isDisengagedOutcome(outcome: { decision?: unknown } | null | undefined): boolean {
+  return outcome?.decision === "closed";
+}
+
+/**
+ * Count a repo's CONSECUTIVE disengaged (closed-without-merge) PR outcomes, walking backward from the most
+ * recently recorded PR for that repo until a merged outcome breaks the streak (or history runs out).
+ */
+export function countConsecutiveDisengagements(eventLedger: LoopReentryEventLedger, repoFullName: string): number {
+  const outcomes = [...readPrOutcomes(eventLedger, { repoFullName }).values()];
+  let count = 0;
+  for (let i = outcomes.length - 1; i >= 0; i -= 1) {
+    if (!isDisengagedOutcome(outcomes[i])) break;
+    count += 1;
+  }
+  return count;
+}
+
+/** Count prior re-entries (successful, i.e. `reentered: true`) recorded at or after `sinceMs`. */
+export function countReentriesSince(eventLedger: LoopReentryEventLedger, sinceMs: number): number {
+  return eventLedger
+    .readEvents({})
+    .filter((event) => event.type === LOOP_REENTRY_DECISION_EVENT && event.payload?.reentered === true && Date.parse(event.createdAt) >= sinceMs)
+    .length;
+}
+
+/**
+ * Evaluate and (if allowed) PERFORM re-entry for one resolved outcome: reads real history to compute the
+ * circuit-breaker and rate-cap tallies, consults the pure `shouldReenter` policy, and -- only when it allows --
+ * dequeues the next candidate and transitions run-state to `"discovering"`. Always appends exactly one audit
+ * event. Fails closed (throws) on a malformed candidate or missing required dependency, mirroring
+ * `recordManagePollSnapshot`'s own validation style.
+ */
+export function attemptLoopReentry(candidate: LoopReentryCandidateInput, deps: LoopReentryDeps): LoopReentryResult {
+  if (!candidate || typeof candidate !== "object") throw new Error("invalid_loop_reentry_candidate");
+  if (!["global", "repo", "none"].includes(candidate.killSwitchScope)) throw new Error("invalid_kill_switch_scope");
+  const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+  if (!repoFullName) throw new Error("invalid_repo_full_name");
+  if (!["merged", "disengaged", "other"].includes(candidate.outcome)) throw new Error("invalid_outcome");
+
+  if (!deps || typeof deps !== "object") throw new Error("invalid_loop_reentry_deps");
+  const { eventLedger, portfolioQueue, runState, nowMs = Date.now(), sessionStartMs = 0 } = deps;
+  if (!eventLedger || typeof eventLedger.appendEvent !== "function" || typeof eventLedger.readEvents !== "function") {
+    throw new Error("invalid_event_ledger");
+  }
+  if (!portfolioQueue || typeof portfolioQueue.dequeueNext !== "function") {
+    throw new Error("invalid_portfolio_queue");
+  }
+
+  const consecutiveDisengagements = countConsecutiveDisengagements(eventLedger, repoFullName);
+  const reentriesThisHour = countReentriesSince(eventLedger, nowMs - HOUR_MS);
+  const reentriesThisSession = countReentriesSince(eventLedger, sessionStartMs);
+
+  const decision = shouldReenter({
+    killSwitchScope: candidate.killSwitchScope,
+    repoFullName,
+    outcome: candidate.outcome,
+    consecutiveDisengagements,
+    maxConsecutiveDisengagements: candidate.maxConsecutiveDisengagements,
+    reentriesThisHour,
+    maxReentriesPerHour: candidate.maxReentriesPerHour,
+    reentriesThisSession,
+    maxReentriesPerSession: candidate.maxReentriesPerSession,
+  });
+
+  let dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null = null;
+  if (decision.reenter) {
+    dequeued = portfolioQueue.dequeueNext();
+    if (runState && typeof runState.setRunState === "function") {
+      runState.setRunState(repoFullName, "discovering");
+    }
+  }
+
+  const event = eventLedger.appendEvent({
+    type: LOOP_REENTRY_DECISION_EVENT,
+    repoFullName,
+    payload: {
+      killSwitchScope: candidate.killSwitchScope,
+      outcome: candidate.outcome,
+      reentered: decision.reenter,
+      reasons: decision.reasons,
+      consecutiveDisengagements,
+      reentriesThisHour,
+      reentriesThisSession,
+      dequeuedIdentifier: dequeued ? dequeued.identifier : null,
+      // The just-completed cycle's read-only summary (loop-closure.js's buildLoopClosureSummary), when the
+      // caller supplies one -- threaded through verbatim for audit traceability. Optional: the circuit-breaker
+      // and rate-cap tallies above are computed directly from pr-outcome/event-ledger history (a
+      // LoopClosureSummary's own byType COUNTS aren't detailed enough to derive a per-repo consecutive-
+      // disengagement streak from), so this is context, not a computational input.
+      loopSummary: deps.loopSummary ?? null,
+    },
+  });
+
+  return { decision, dequeued, event };
+}

--- a/packages/loopover-miner/lib/manage-status.d.ts
+++ b/packages/loopover-miner/lib/manage-status.d.ts
@@ -1,70 +1,70 @@
 import type { EventLedger, LedgerEntry } from "./event-ledger.js";
 import type { PortfolioQueueStore, QueueStatus } from "./portfolio-queue.js";
 import type { RunState, RunStateStore } from "./run-state.js";
-
+/** Event vocabulary for manage-phase PR snapshots written by manage poll. (#2325) */
+export declare const MANAGE_PR_UPDATE_EVENT = "manage_pr_update";
+export declare const MANAGED_PR_IDENTIFIER_PREFIX = "pr:";
 export type ManageStatusRow = {
-  repoFullName: string;
-  prNumber: number;
-  branch: string | null;
-  ciState: string | null;
-  gateVerdict: string | null;
-  outcome: string | null;
-  lastPolledAt: string | null;
-  queueStatus: QueueStatus | null;
-  priority: number | null;
+    repoFullName: string;
+    prNumber: number;
+    branch: string | null;
+    ciState: string | null;
+    gateVerdict: string | null;
+    outcome: string | null;
+    lastPolledAt: string | null;
+    queueStatus: QueueStatus | null;
+    priority: number | null;
 };
-
 export type ManageStatusSources = {
-  portfolioQueue: PortfolioQueueStore;
-  eventLedger: EventLedger;
+    portfolioQueue: PortfolioQueueStore;
+    eventLedger: EventLedger;
 };
-
 export type RunPortfolioSources = ManageStatusSources & {
-  runStateStore: RunStateStore;
+    runStateStore: RunStateStore;
 };
-
 export type RunPortfolioRow = {
-  repoFullName: string;
-  runState: RunState | null;
-  runStateUpdatedAt: string | null;
-  prCount: number;
-  prs: ManageStatusRow[];
+    repoFullName: string;
+    runState: RunState | null;
+    runStateUpdatedAt: string | null;
+    prCount: number;
+    prs: ManageStatusRow[];
 };
-
 export type ManageUpdateSnapshot = {
-  repoFullName: string;
-  prNumber: number;
-  branch: string | null;
-  ciState: string | null;
-  gateVerdict: string | null;
-  outcome: string | null;
-  lastPolledAt: string | null;
+    repoFullName: string;
+    prNumber: number;
+    branch: string | null;
+    ciState: string | null;
+    gateVerdict: string | null;
+    outcome: string | null;
+    lastPolledAt: string | null;
 };
-
-export const MANAGE_PR_UPDATE_EVENT: "manage_pr_update";
-export const MANAGED_PR_IDENTIFIER_PREFIX: "pr:";
-
-export function parseManagedPrIdentifier(identifier: string): number | null;
-
-export function formatManagedPrIdentifier(prNumber: number): string;
-
-export function indexLatestManageUpdates(events: LedgerEntry[]): Map<string, ManageUpdateSnapshot>;
-
-export function collectManageStatus(sources: ManageStatusSources): ManageStatusRow[];
-
-export function collectRunPortfolio(sources: RunPortfolioSources): RunPortfolioRow[];
-
-export function renderManageStatusTable(rows: ManageStatusRow[]): string;
-
-export function renderRunPortfolioTable(portfolio: RunPortfolioRow[]): string;
-
-export function parseManageStatusArgs(args?: string[]): { json: boolean } | { error: string };
-
-export function runManageStatus(
-  args?: string[],
-  options?: {
+export declare function parseManagedPrIdentifier(identifier: string): number | null;
+export declare function formatManagedPrIdentifier(prNumber: number): string;
+/** Index the latest manage snapshot per repo/PR from ascending ledger events. Pure. */
+export declare function indexLatestManageUpdates(events: LedgerEntry[]): Map<string, ManageUpdateSnapshot>;
+/**
+ * Aggregate managed PR rows from the local portfolio queue and append-only event ledger. Read-only — never calls
+ * GitHub or mutates local stores. (#2325)
+ */
+export declare function collectManageStatus(sources: ManageStatusSources): ManageStatusRow[];
+/**
+ * Fold each tracked repo's current discover/plan/prepare run state alongside its managed PR rows into one
+ * "run portfolio" row per repo (#4279). `collectManageStatus` alone is PR-scoped only and never surfaces the
+ * run-state signal, so a repo actively discovering/planning with zero PRs yet is otherwise invisible. A repo
+ * appears here if it has EITHER a recorded run state OR at least one managed PR row.
+ */
+export declare function collectRunPortfolio(sources: RunPortfolioSources): RunPortfolioRow[];
+export declare function renderManageStatusTable(rows: ManageStatusRow[]): string;
+/** One row per tracked repo (run state + PR count), the compact companion to {@link renderManageStatusTable}'s
+ *  per-PR detail (#4279). */
+export declare function renderRunPortfolioTable(portfolio: RunPortfolioRow[]): string;
+export declare function parseManageStatusArgs(args?: string[]): {
+    json: boolean;
+} | {
+    error: string;
+};
+export declare function runManageStatus(args?: string[], options?: {
     initPortfolioQueue?: () => PortfolioQueueStore;
     initEventLedger?: () => EventLedger;
     initRunStateStore?: () => RunStateStore;
-  },
-): number;
+}): number;

--- a/packages/loopover-miner/lib/manage-status.js
+++ b/packages/loopover-miner/lib/manage-status.js
@@ -2,112 +2,114 @@ import { initEventLedger } from "./event-ledger.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initRunStateStore } from "./run-state.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 /** Event vocabulary for manage-phase PR snapshots written by manage poll. (#2325) */
 export const MANAGE_PR_UPDATE_EVENT = "manage_pr_update";
 export const MANAGED_PR_IDENTIFIER_PREFIX = "pr:";
-
 export function parseManagedPrIdentifier(identifier) {
-  if (typeof identifier !== "string") return null;
-  const match = identifier.match(/^pr:(\d+)$/);
-  if (!match) return null;
-  const prNumber = Number(match[1]);
-  return Number.isInteger(prNumber) && prNumber > 0 ? prNumber : null;
+    if (typeof identifier !== "string")
+        return null;
+    const match = identifier.match(/^pr:(\d+)$/);
+    if (!match)
+        return null;
+    const prNumber = Number(match[1]);
+    return Number.isInteger(prNumber) && prNumber > 0 ? prNumber : null;
 }
-
 export function formatManagedPrIdentifier(prNumber) {
-  if (!Number.isInteger(prNumber) || prNumber <= 0) throw new Error("invalid_pr_number");
-  return `${MANAGED_PR_IDENTIFIER_PREFIX}${prNumber}`;
+    if (!Number.isInteger(prNumber) || prNumber <= 0)
+        throw new Error("invalid_pr_number");
+    return `${MANAGED_PR_IDENTIFIER_PREFIX}${prNumber}`;
 }
-
 function optionalString(value) {
-  if (value === undefined || value === null) return null;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed || null;
+    if (value === undefined || value === null)
+        return null;
+    if (typeof value !== "string")
+        return null;
+    const trimmed = value.trim();
+    return trimmed || null;
 }
-
 function normalizeManageUpdatePayload(payload) {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
-  if (!Number.isInteger(payload.prNumber) || payload.prNumber <= 0) return null;
-  return {
-    prNumber: payload.prNumber,
-    branch: optionalString(payload.branch),
-    ciState: optionalString(payload.ciState),
-    gateVerdict: optionalString(payload.gateVerdict),
-    outcome: optionalString(payload.outcome),
-    lastPolledAt: optionalString(payload.lastPolledAt),
-  };
+    if (!payload || typeof payload !== "object" || Array.isArray(payload))
+        return null;
+    const p = payload;
+    if (!Number.isInteger(p.prNumber) || p.prNumber <= 0)
+        return null;
+    return {
+        prNumber: p.prNumber,
+        branch: optionalString(p.branch),
+        ciState: optionalString(p.ciState),
+        gateVerdict: optionalString(p.gateVerdict),
+        outcome: optionalString(p.outcome),
+        lastPolledAt: optionalString(p.lastPolledAt),
+    };
 }
-
 /** Index the latest manage snapshot per repo/PR from ascending ledger events. Pure. */
 export function indexLatestManageUpdates(events) {
-  const latest = new Map();
-  for (const event of Array.isArray(events) ? events : []) {
-    if (event?.type !== MANAGE_PR_UPDATE_EVENT) continue;
-    if (typeof event.repoFullName !== "string" || !event.repoFullName.trim()) continue;
-    const normalized = normalizeManageUpdatePayload(event.payload);
-    if (!normalized) continue;
-    const key = `${event.repoFullName}:${normalized.prNumber}`;
-    latest.set(key, { ...normalized, repoFullName: event.repoFullName });
-  }
-  return latest;
+    const latest = new Map();
+    for (const event of Array.isArray(events) ? events : []) {
+        if (event?.type !== MANAGE_PR_UPDATE_EVENT)
+            continue;
+        if (typeof event.repoFullName !== "string" || !event.repoFullName.trim())
+            continue;
+        const normalized = normalizeManageUpdatePayload(event.payload);
+        if (!normalized)
+            continue;
+        const key = `${event.repoFullName}:${normalized.prNumber}`;
+        latest.set(key, { ...normalized, repoFullName: event.repoFullName });
+    }
+    return latest;
 }
-
 /**
  * Aggregate managed PR rows from the local portfolio queue and append-only event ledger. Read-only — never calls
  * GitHub or mutates local stores. (#2325)
  */
 export function collectManageStatus(sources) {
-  const portfolioQueue = sources?.portfolioQueue;
-  const eventLedger = sources?.eventLedger;
-  if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") {
-    throw new Error("invalid_portfolio_queue");
-  }
-  if (!eventLedger || typeof eventLedger.readEvents !== "function") {
-    throw new Error("invalid_event_ledger");
-  }
-
-  const rowsByKey = new Map();
-  for (const entry of portfolioQueue.listQueue(null)) {
-    const prNumber = parseManagedPrIdentifier(entry.identifier);
-    if (prNumber === null) continue;
-    const key = `${entry.repoFullName}:${prNumber}`;
-    rowsByKey.set(key, {
-      repoFullName: entry.repoFullName,
-      prNumber,
-      branch: null,
-      ciState: null,
-      gateVerdict: null,
-      outcome: null,
-      lastPolledAt: null,
-      queueStatus: entry.status,
-      priority: entry.priority,
+    const portfolioQueue = sources?.portfolioQueue;
+    const eventLedger = sources?.eventLedger;
+    if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") {
+        throw new Error("invalid_portfolio_queue");
+    }
+    if (!eventLedger || typeof eventLedger.readEvents !== "function") {
+        throw new Error("invalid_event_ledger");
+    }
+    const rowsByKey = new Map();
+    for (const entry of portfolioQueue.listQueue(null)) {
+        const prNumber = parseManagedPrIdentifier(entry.identifier);
+        if (prNumber === null)
+            continue;
+        const key = `${entry.repoFullName}:${prNumber}`;
+        rowsByKey.set(key, {
+            repoFullName: entry.repoFullName,
+            prNumber,
+            branch: null,
+            ciState: null,
+            gateVerdict: null,
+            outcome: null,
+            lastPolledAt: null,
+            queueStatus: entry.status,
+            priority: entry.priority,
+        });
+    }
+    for (const [key, update] of indexLatestManageUpdates(eventLedger.readEvents())) {
+        const existing = rowsByKey.get(key);
+        rowsByKey.set(key, {
+            repoFullName: update.repoFullName,
+            prNumber: update.prNumber,
+            branch: update.branch,
+            ciState: update.ciState,
+            gateVerdict: update.gateVerdict,
+            outcome: update.outcome,
+            lastPolledAt: update.lastPolledAt,
+            queueStatus: existing?.queueStatus ?? null,
+            priority: existing?.priority ?? null,
+        });
+    }
+    return [...rowsByKey.values()].sort((left, right) => {
+        const repoCmp = left.repoFullName.localeCompare(right.repoFullName);
+        if (repoCmp !== 0)
+            return repoCmp;
+        return left.prNumber - right.prNumber;
     });
-  }
-
-  for (const [key, update] of indexLatestManageUpdates(eventLedger.readEvents())) {
-    const existing = rowsByKey.get(key);
-    rowsByKey.set(key, {
-      repoFullName: update.repoFullName,
-      prNumber: update.prNumber,
-      branch: update.branch,
-      ciState: update.ciState,
-      gateVerdict: update.gateVerdict,
-      outcome: update.outcome,
-      lastPolledAt: update.lastPolledAt,
-      queueStatus: existing?.queueStatus ?? null,
-      priority: existing?.priority ?? null,
-    });
-  }
-
-  return [...rowsByKey.values()].sort((left, right) => {
-    const repoCmp = left.repoFullName.localeCompare(right.repoFullName);
-    if (repoCmp !== 0) return repoCmp;
-    return left.prNumber - right.prNumber;
-  });
 }
-
 /**
  * Fold each tracked repo's current discover/plan/prepare run state alongside its managed PR rows into one
  * "run portfolio" row per repo (#4279). `collectManageStatus` alone is PR-scoped only and never surfaces the
@@ -115,131 +117,132 @@ export function collectManageStatus(sources) {
  * appears here if it has EITHER a recorded run state OR at least one managed PR row.
  */
 export function collectRunPortfolio(sources) {
-  const runStateStore = sources?.runStateStore;
-  if (!runStateStore || typeof runStateStore.listRunStates !== "function") {
-    throw new Error("invalid_run_state_store");
-  }
-  const prsByRepo = new Map();
-  for (const row of collectManageStatus(sources)) {
-    const list = prsByRepo.get(row.repoFullName) ?? [];
-    list.push(row);
-    prsByRepo.set(row.repoFullName, list);
-  }
-  // NOTE (#5563): keyed by repoFullName alone, not apiBaseUrl -- this dashboard fold predates multi-forge run
-  // states and produces exactly ONE row per repo name. If the same repo name has a recorded run state on two
-  // different hosts, only one (the later entry in listRunStates' order) survives here; the other's row is still
-  // intact in the store, just not surfaced in this particular view. Safe (no data loss, no write), just a display
-  // limitation -- broadening this fold to be host-aware is a separate, larger dashboard-shape change.
-  const runStateByRepo = new Map(runStateStore.listRunStates().map((entry) => [entry.repoFullName, entry]));
-
-  const repoFullNames = new Set([...prsByRepo.keys(), ...runStateByRepo.keys()]);
-  return [...repoFullNames].sort((left, right) => left.localeCompare(right)).map((repoFullName) => {
-    const prs = prsByRepo.get(repoFullName) ?? [];
-    const runState = runStateByRepo.get(repoFullName);
-    return {
-      repoFullName,
-      runState: runState?.state ?? null,
-      runStateUpdatedAt: runState?.updatedAt ?? null,
-      prCount: prs.length,
-      prs,
-    };
-  });
+    const runStateStore = sources?.runStateStore;
+    if (!runStateStore || typeof runStateStore.listRunStates !== "function") {
+        throw new Error("invalid_run_state_store");
+    }
+    const prsByRepo = new Map();
+    for (const row of collectManageStatus(sources)) {
+        const list = prsByRepo.get(row.repoFullName) ?? [];
+        list.push(row);
+        prsByRepo.set(row.repoFullName, list);
+    }
+    // NOTE (#5563): keyed by repoFullName alone, not apiBaseUrl -- this dashboard fold predates multi-forge run
+    // states and produces exactly ONE row per repo name. If the same repo name has a recorded run state on two
+    // different hosts, only one (the later entry in listRunStates' order) survives here; the other's row is still
+    // intact in the store, just not surfaced in this particular view. Safe (no data loss, no write), just a display
+    // limitation -- broadening this fold to be host-aware is a separate, larger dashboard-shape change.
+    const runStateByRepo = new Map(runStateStore.listRunStates().map((entry) => [entry.repoFullName, entry]));
+    const repoFullNames = new Set([...prsByRepo.keys(), ...runStateByRepo.keys()]);
+    return [...repoFullNames].sort((left, right) => left.localeCompare(right)).map((repoFullName) => {
+        const prs = prsByRepo.get(repoFullName) ?? [];
+        const runState = runStateByRepo.get(repoFullName);
+        return {
+            repoFullName,
+            runState: runState?.state ?? null,
+            runStateUpdatedAt: runState?.updatedAt ?? null,
+            prCount: prs.length,
+            prs,
+        };
+    });
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderManageStatusTable(rows) {
-  if (!Array.isArray(rows) || rows.length === 0) return "no managed pull requests";
-  const header = [
-    "repo".padEnd(24),
-    "pr".padStart(4),
-    "branch".padEnd(16),
-    "ci".padEnd(10),
-    "gate".padEnd(10),
-    "outcome".padEnd(10),
-    "last-polled".padEnd(20),
-    "queue".padEnd(12),
-    "pri".padStart(4),
-  ].join(" ");
-  const lines = rows.map((row) =>
-    [
-      row.repoFullName.padEnd(24),
-      String(row.prNumber).padStart(4),
-      display(row.branch).padEnd(16),
-      display(row.ciState).padEnd(10),
-      display(row.gateVerdict).padEnd(10),
-      display(row.outcome).padEnd(10),
-      display(row.lastPolledAt).padEnd(20),
-      display(row.queueStatus).padEnd(12),
-      display(row.priority).padStart(4),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(rows) || rows.length === 0)
+        return "no managed pull requests";
+    const header = [
+        "repo".padEnd(24),
+        "pr".padStart(4),
+        "branch".padEnd(16),
+        "ci".padEnd(10),
+        "gate".padEnd(10),
+        "outcome".padEnd(10),
+        "last-polled".padEnd(20),
+        "queue".padEnd(12),
+        "pri".padStart(4),
+    ].join(" ");
+    const lines = rows.map((row) => [
+        row.repoFullName.padEnd(24),
+        String(row.prNumber).padStart(4),
+        display(row.branch).padEnd(16),
+        display(row.ciState).padEnd(10),
+        display(row.gateVerdict).padEnd(10),
+        display(row.outcome).padEnd(10),
+        display(row.lastPolledAt).padEnd(20),
+        display(row.queueStatus).padEnd(12),
+        display(row.priority).padStart(4),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 /** One row per tracked repo (run state + PR count), the compact companion to {@link renderManageStatusTable}'s
  *  per-PR detail (#4279). */
 export function renderRunPortfolioTable(portfolio) {
-  if (!Array.isArray(portfolio) || portfolio.length === 0) return "no tracked repos";
-  const header = [
-    "repo".padEnd(24),
-    "run-state".padEnd(12),
-    "updated".padEnd(20),
-    "prs".padStart(4),
-  ].join(" ");
-  const lines = portfolio.map((entry) =>
-    [
-      entry.repoFullName.padEnd(24),
-      display(entry.runState).padEnd(12),
-      display(entry.runStateUpdatedAt).padEnd(20),
-      String(entry.prCount).padStart(4),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(portfolio) || portfolio.length === 0)
+        return "no tracked repos";
+    const header = [
+        "repo".padEnd(24),
+        "run-state".padEnd(12),
+        "updated".padEnd(20),
+        "prs".padStart(4),
+    ].join(" ");
+    const lines = portfolio.map((entry) => [
+        entry.repoFullName.padEnd(24),
+        display(entry.runState).padEnd(12),
+        display(entry.runStateUpdatedAt).padEnd(20),
+        String(entry.prCount).padStart(4),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 export function parseManageStatusArgs(args = []) {
-  for (const token of args) {
-    if (token === "--json") continue;
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    return { error: "Usage: loopover-miner manage status [--json]" };
-  }
-  return { json: args.includes("--json") };
-}
-
-export function runManageStatus(args = [], options = {}) {
-  const parsed = parseManageStatusArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
-  const ownsEventLedger = options.initEventLedger === undefined;
-  const ownsRunStateStore = options.initRunStateStore === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  const runStateStore = (options.initRunStateStore ?? initRunStateStore)();
-  try {
-    const rows = collectManageStatus({ portfolioQueue, eventLedger });
-    const runPortfolio = collectRunPortfolio({ portfolioQueue, eventLedger, runStateStore });
-    if (parsed.json) {
-      // Additive only (#4279): `rows` keeps its existing shape unchanged; `runPortfolio` is a new key so an
-      // existing consumer parsing this JSON for `rows` alone sees byte-identical output.
-      console.log(JSON.stringify({ rows, runPortfolio }, null, 2));
-    } else {
-      console.log(`${renderManageStatusTable(rows)}\n\n${renderRunPortfolioTable(runPortfolio)}`);
+    for (const token of args) {
+        if (token === "--json")
+            continue;
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        return { error: "Usage: loopover-miner manage status [--json]" };
     }
-    return 0;
-  } catch (error) {
-    // Collecting/rendering manage status touches three SQLite stores; a read/render failure must surface as a
-    // clean CLI error (honoring --json), not an unhandled throw -- matching runOrbExportCli / runQueueList (#7236).
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsPortfolioQueue) portfolioQueue.close();
-    if (ownsEventLedger) eventLedger.close();
-    if (ownsRunStateStore) runStateStore.close();
-  }
+    return { json: args.includes("--json") };
 }
+export function runManageStatus(args = [], options = {}) {
+    const parsed = parseManageStatusArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+    const ownsEventLedger = options.initEventLedger === undefined;
+    const ownsRunStateStore = options.initRunStateStore === undefined;
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    const eventLedger = (options.initEventLedger ?? initEventLedger)();
+    const runStateStore = (options.initRunStateStore ?? initRunStateStore)();
+    try {
+        const rows = collectManageStatus({ portfolioQueue, eventLedger });
+        const runPortfolio = collectRunPortfolio({ portfolioQueue, eventLedger, runStateStore });
+        if (parsed.json) {
+            // Additive only (#4279): `rows` keeps its existing shape unchanged; `runPortfolio` is a new key so an
+            // existing consumer parsing this JSON for `rows` alone sees byte-identical output.
+            console.log(JSON.stringify({ rows, runPortfolio }, null, 2));
+        }
+        else {
+            console.log(`${renderManageStatusTable(rows)}\n\n${renderRunPortfolioTable(runPortfolio)}`);
+        }
+        return 0;
+    }
+    catch (error) {
+        // Collecting/rendering manage status touches three SQLite stores; a read/render failure must surface as a
+        // clean CLI error (honoring --json), not an unhandled throw -- matching runOrbExportCli / runQueueList (#7236).
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    finally {
+        if (ownsPortfolioQueue)
+            portfolioQueue.close();
+        if (ownsEventLedger)
+            eventLedger.close();
+        if (ownsRunStateStore)
+            runStateStore.close();
+    }
+}
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWFuYWdlLXN0YXR1cy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIm1hbmFnZS1zdGF0dXMudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ0EsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRXBELE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBRS9ELE9BQU8sRUFBRSxpQkFBaUIsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBQ25ELE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUVsRixxRkFBcUY7QUFDckYsTUFBTSxDQUFDLE1BQU0sc0JBQXNCLEdBQUcsa0JBQWtCLENBQUM7QUFDekQsTUFBTSxDQUFDLE1BQU0sNEJBQTRCLEdBQUcsS0FBSyxDQUFDO0FBeUNsRCxNQUFNLFVBQVUsd0JBQXdCLENBQUMsVUFBa0I7SUFDekQsSUFBSSxPQUFPLFVBQVUsS0FBSyxRQUFRO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDaEQsTUFBTSxLQUFLLEdBQUcsVUFBVSxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUM3QyxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ3hCLE1BQU0sUUFBUSxHQUFHLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNsQyxPQUFPLE1BQU0sQ0FBQyxTQUFTLENBQUMsUUFBUSxDQUFDLElBQUksUUFBUSxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7QUFDdEUsQ0FBQztBQUVELE1BQU0sVUFBVSx5QkFBeUIsQ0FBQyxRQUFnQjtJQUN4RCxJQUFJLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxRQUFRLENBQUMsSUFBSSxRQUFRLElBQUksQ0FBQztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsbUJBQW1CLENBQUMsQ0FBQztJQUN2RixPQUFPLEdBQUcsNEJBQTRCLEdBQUcsUUFBUSxFQUFFLENBQUM7QUFDdEQsQ0FBQztBQUVELFNBQVMsY0FBYyxDQUFDLEtBQWM7SUFDcEMsSUFBSSxLQUFLLEtBQUssU0FBUyxJQUFJLEtBQUssS0FBSyxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDdkQsSUFBSSxPQUFPLEtBQUssS0FBSyxRQUFRO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDM0MsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE9BQU8sT0FBTyxJQUFJLElBQUksQ0FBQztBQUN6QixDQUFDO0FBRUQsU0FBUyw0QkFBNEIsQ0FBQyxPQUFnQjtJQUNwRCxJQUFJLENBQUMsT0FBTyxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQztRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ25GLE1BQU0sQ0FBQyxHQUFHLE9BQXdJLENBQUM7SUFDbkosSUFBSSxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFLLENBQUMsQ0FBQyxRQUFtQixJQUFJLENBQUM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUM5RSxPQUFPO1FBQ0wsUUFBUSxFQUFFLENBQUMsQ0FBQyxRQUFrQjtRQUM5QixNQUFNLEVBQUUsY0FBYyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUM7UUFDaEMsT0FBTyxFQUFFLGNBQWMsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDO1FBQ2xDLFdBQVcsRUFBRSxjQUFjLENBQUMsQ0FBQyxDQUFDLFdBQVcsQ0FBQztRQUMxQyxPQUFPLEVBQUUsY0FBYyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUM7UUFDbEMsWUFBWSxFQUFFLGNBQWMsQ0FBQyxDQUFDLENBQUMsWUFBWSxDQUFDO0tBQzdDLENBQUM7QUFDSixDQUFDO0FBRUQsdUZBQXVGO0FBQ3ZGLE1BQU0sVUFBVSx3QkFBd0IsQ0FBQyxNQUFxQjtJQUM1RCxNQUFNLE1BQU0sR0FBRyxJQUFJLEdBQUcsRUFBZ0MsQ0FBQztJQUN2RCxLQUFLLE1BQU0sS0FBSyxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUM7UUFDeEQsSUFBSSxLQUFLLEVBQUUsSUFBSSxLQUFLLHNCQUFzQjtZQUFFLFNBQVM7UUFDckQsSUFBSSxPQUFPLEtBQUssQ0FBQyxZQUFZLEtBQUssUUFBUSxJQUFJLENBQUMsS0FBSyxDQUFDLFlBQVksQ0FBQyxJQUFJLEVBQUU7WUFBRSxTQUFTO1FBQ25GLE1BQU0sVUFBVSxHQUFHLDRCQUE0QixDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUMvRCxJQUFJLENBQUMsVUFBVTtZQUFFLFNBQVM7UUFDMUIsTUFBTSxHQUFHLEdBQUcsR0FBRyxLQUFLLENBQUMsWUFBWSxJQUFJLFVBQVUsQ0FBQyxRQUFRLEVBQUUsQ0FBQztRQUMzRCxNQUFNLENBQUMsR0FBRyxDQUFDLEdBQUcsRUFBRSxFQUFFLEdBQUcsVUFBVSxFQUFFLFlBQVksRUFBRSxLQUFLLENBQUMsWUFBWSxFQUFFLENBQUMsQ0FBQztJQUN2RSxDQUFDO0lBQ0QsT0FBTyxNQUFNLENBQUM7QUFDaEIsQ0FBQztBQUVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxPQUE0QjtJQUM5RCxNQUFNLGNBQWMsR0FBRyxPQUFPLEVBQUUsY0FBYyxDQUFDO0lBQy9DLE1BQU0sV0FBVyxHQUFHLE9BQU8sRUFBRSxXQUFXLENBQUM7SUFDekMsSUFBSSxDQUFDLGNBQWMsSUFBSSxPQUFPLGNBQWMsQ0FBQyxTQUFTLEtBQUssVUFBVSxFQUFFLENBQUM7UUFDdEUsTUFBTSxJQUFJLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO0lBQzdDLENBQUM7SUFDRCxJQUFJLENBQUMsV0FBVyxJQUFJLE9BQU8sV0FBVyxDQUFDLFVBQVUsS0FBSyxVQUFVLEVBQUUsQ0FBQztRQUNqRSxNQUFNLElBQUksS0FBSyxDQUFDLHNCQUFzQixDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUVELE1BQU0sU0FBUyxHQUFHLElBQUksR0FBRyxFQUEyQixDQUFDO0lBQ3JELEtBQUssTUFBTSxLQUFLLElBQUksY0FBYyxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ25ELE1BQU0sUUFBUSxHQUFHLHdCQUF3QixDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQztRQUM1RCxJQUFJLFFBQVEsS0FBSyxJQUFJO1lBQUUsU0FBUztRQUNoQyxNQUFNLEdBQUcsR0FBRyxHQUFHLEtBQUssQ0FBQyxZQUFZLElBQUksUUFBUSxFQUFFLENBQUM7UUFDaEQsU0FBUyxDQUFDLEdBQUcsQ0FBQyxHQUFHLEVBQUU7WUFDakIsWUFBWSxFQUFFLEtBQUssQ0FBQyxZQUFZO1lBQ2hDLFFBQVE7WUFDUixNQUFNLEVBQUUsSUFBSTtZQUNaLE9BQU8sRUFBRSxJQUFJO1lBQ2IsV0FBVyxFQUFFLElBQUk7WUFDakIsT0FBTyxFQUFFLElBQUk7WUFDYixZQUFZLEVBQUUsSUFBSTtZQUNsQixXQUFXLEVBQUUsS0FBSyxDQUFDLE1BQU07WUFDekIsUUFBUSxFQUFFLEtBQUssQ0FBQyxRQUFRO1NBQ3pCLENBQUMsQ0FBQztJQUNMLENBQUM7SUFFRCxLQUFLLE1BQU0sQ0FBQyxHQUFHLEVBQUUsTUFBTSxDQUFDLElBQUksd0JBQXdCLENBQUMsV0FBVyxDQUFDLFVBQVUsRUFBRSxDQUFDLEVBQUUsQ0FBQztRQUMvRSxNQUFNLFFBQVEsR0FBRyxTQUFTLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQ3BDLFNBQVMsQ0FBQyxHQUFHLENBQUMsR0FBRyxFQUFFO1lBQ2pCLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtZQUNqQyxRQUFRLEVBQUUsTUFBTSxDQUFDLFFBQVE7WUFDekIsTUFBTSxFQUFFLE1BQU0sQ0FBQyxNQUFNO1lBQ3JCLE9BQU8sRUFBRSxNQUFNLENBQUMsT0FBTztZQUN2QixXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7WUFDL0IsT0FBTyxFQUFFLE1BQU0sQ0FBQyxPQUFPO1lBQ3ZCLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtZQUNqQyxXQUFXLEVBQUUsUUFBUSxFQUFFLFdBQVcsSUFBSSxJQUFJO1lBQzFDLFFBQVEsRUFBRSxRQUFRLEVBQUUsUUFBUSxJQUFJLElBQUk7U0FDckMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUVELE9BQU8sQ0FBQyxHQUFHLFNBQVMsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxLQUFLLEVBQUUsRUFBRTtRQUNsRCxNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsWUFBWSxDQUFDLGFBQWEsQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUM7UUFDcEUsSUFBSSxPQUFPLEtBQUssQ0FBQztZQUFFLE9BQU8sT0FBTyxDQUFDO1FBQ2xDLE9BQU8sSUFBSSxDQUFDLFFBQVEsR0FBRyxLQUFLLENBQUMsUUFBUSxDQUFDO0lBQ3hDLENBQUMsQ0FBQyxDQUFDO0FBQ0wsQ0FBQztBQUVEOzs7OztHQUtHO0FBQ0gsTUFBTSxVQUFVLG1CQUFtQixDQUFDLE9BQTRCO0lBQzlELE1BQU0sYUFBYSxHQUFHLE9BQU8sRUFBRSxhQUFhLENBQUM7SUFDN0MsSUFBSSxDQUFDLGFBQWEsSUFBSSxPQUFPLGFBQWEsQ0FBQyxhQUFhLEtBQUssVUFBVSxFQUFFLENBQUM7UUFDeEUsTUFBTSxJQUFJLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO0lBQzdDLENBQUM7SUFDRCxNQUFNLFNBQVMsR0FBRyxJQUFJLEdBQUcsRUFBNkIsQ0FBQztJQUN2RCxLQUFLLE1BQU0sR0FBRyxJQUFJLG1CQUFtQixDQUFDLE9BQU8sQ0FBQyxFQUFFLENBQUM7UUFDL0MsTUFBTSxJQUFJLEdBQUcsU0FBUyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDLElBQUksRUFBRSxDQUFDO1FBQ25ELElBQUksQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDZixTQUFTLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxZQUFZLEVBQUUsSUFBSSxDQUFDLENBQUM7SUFDeEMsQ0FBQztJQUNELDRHQUE0RztJQUM1RywyR0FBMkc7SUFDM0csOEdBQThHO0lBQzlHLGdIQUFnSDtJQUNoSCxvR0FBb0c7SUFDcEcsTUFBTSxjQUFjLEdBQUcsSUFBSSxHQUFHLENBQUMsYUFBYSxDQUFDLGFBQWEsRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsWUFBWSxFQUFFLEtBQUssQ0FBVSxDQUFDLENBQUMsQ0FBQztJQUVuSCxNQUFNLGFBQWEsR0FBRyxJQUFJLEdBQUcsQ0FBQyxDQUFDLEdBQUcsU0FBUyxDQUFDLElBQUksRUFBRSxFQUFFLEdBQUcsY0FBYyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQztJQUMvRSxPQUFPLENBQUMsR0FBRyxhQUFhLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxJQUFJLEVBQUUsS0FBSyxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsYUFBYSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsWUFBWSxFQUFFLEVBQUU7UUFDOUYsTUFBTSxHQUFHLEdBQUcsU0FBUyxDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDOUMsTUFBTSxRQUFRLEdBQUcsY0FBYyxDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUMsQ0FBQztRQUNsRCxPQUFPO1lBQ0wsWUFBWTtZQUNaLFFBQVEsRUFBRSxRQUFRLEVBQUUsS0FBSyxJQUFJLElBQUk7WUFDakMsaUJBQWlCLEVBQUUsUUFBUSxFQUFFLFNBQVMsSUFBSSxJQUFJO1lBQzlDLE9BQU8sRUFBRSxHQUFHLENBQUMsTUFBTTtZQUNuQixHQUFHO1NBQ0osQ0FBQztJQUNKLENBQUMsQ0FBQyxDQUFDO0FBQ0wsQ0FBQztBQUVELFNBQVMsT0FBTyxDQUFDLEtBQWM7SUFDN0IsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxHQUFHLENBQUM7SUFDdEQsT0FBTyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDdkIsQ0FBQztBQUVELE1BQU0sVUFBVSx1QkFBdUIsQ0FBQyxJQUF1QjtJQUM3RCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsSUFBSSxJQUFJLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLDBCQUEwQixDQUFDO0lBQ2pGLE1BQU0sTUFBTSxHQUFHO1FBQ2IsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDaEIsUUFBUSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkIsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDZixNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNqQixTQUFTLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNwQixhQUFhLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN4QixPQUFPLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNsQixLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztLQUNsQixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNaLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUM3QjtRQUNFLEdBQUcsQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUMzQixNQUFNLENBQUMsR0FBRyxDQUFDLFFBQVEsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDaEMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzlCLE9BQU8sQ0FBQyxHQUFHLENBQUMsT0FBTyxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUMvQixPQUFPLENBQUMsR0FBRyxDQUFDLFdBQVcsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxPQUFPLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQy9CLE9BQU8sQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNwQyxPQUFPLENBQUMsR0FBRyxDQUFDLFdBQVcsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxRQUFRLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO0tBQ2xDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRDs2QkFDNkI7QUFDN0IsTUFBTSxVQUFVLHVCQUF1QixDQUFDLFNBQTRCO0lBQ2xFLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLFNBQVMsQ0FBQyxJQUFJLFNBQVMsQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sa0JBQWtCLENBQUM7SUFDbkYsTUFBTSxNQUFNLEdBQUc7UUFDYixNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNqQixXQUFXLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN0QixTQUFTLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNwQixLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztLQUNsQixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNaLE1BQU0sS0FBSyxHQUFHLFNBQVMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUNwQztRQUNFLEtBQUssQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUM3QixPQUFPLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbEMsT0FBTyxDQUFDLEtBQUssQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDM0MsTUFBTSxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO0tBQ2xDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxNQUFNLFVBQVUscUJBQXFCLENBQUMsT0FBaUIsRUFBRTtJQUN2RCxLQUFLLE1BQU0sS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO1FBQ3pCLElBQUksS0FBSyxLQUFLLFFBQVE7WUFBRSxTQUFTO1FBQ2pDLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQ3hFLE9BQU8sRUFBRSxLQUFLLEVBQUUsOENBQThDLEVBQUUsQ0FBQztJQUNuRSxDQUFDO0lBQ0QsT0FBTyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxFQUFFLENBQUM7QUFDM0MsQ0FBQztBQUVELE1BQU0sVUFBVSxlQUFlLENBQzdCLE9BQWlCLEVBQUUsRUFDbkIsVUFJSSxFQUFFO0lBRU4sTUFBTSxNQUFNLEdBQUcscUJBQXFCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDM0MsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxNQUFNLGtCQUFrQixHQUFHLE9BQU8sQ0FBQyxrQkFBa0IsS0FBSyxTQUFTLENBQUM7SUFDcEUsTUFBTSxlQUFlLEdBQUcsT0FBTyxDQUFDLGVBQWUsS0FBSyxTQUFTLENBQUM7SUFDOUQsTUFBTSxpQkFBaUIsR0FBRyxPQUFPLENBQUMsaUJBQWlCLEtBQUssU0FBUyxDQUFDO0lBQ2xFLE1BQU0sY0FBYyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLHVCQUF1QixDQUFDLEVBQUUsQ0FBQztJQUNqRixNQUFNLFdBQVcsR0FBRyxDQUFDLE9BQU8sQ0FBQyxlQUFlLElBQUksZUFBZSxDQUFDLEVBQUUsQ0FBQztJQUNuRSxNQUFNLGFBQWEsR0FBRyxDQUFDLE9BQU8sQ0FBQyxpQkFBaUIsSUFBSSxpQkFBaUIsQ0FBQyxFQUFFLENBQUM7SUFDekUsSUFBSSxDQUFDO1FBQ0gsTUFBTSxJQUFJLEdBQUcsbUJBQW1CLENBQUMsRUFBRSxjQUFjLEVBQUUsV0FBVyxFQUFFLENBQUMsQ0FBQztRQUNsRSxNQUFNLFlBQVksR0FBRyxtQkFBbUIsQ0FBQyxFQUFFLGNBQWMsRUFBRSxXQUFXLEVBQUUsYUFBYSxFQUFFLENBQUMsQ0FBQztRQUN6RixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixzR0FBc0c7WUFDdEcsbUZBQW1GO1lBQ25GLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLElBQUksRUFBRSxZQUFZLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUMvRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsR0FBRyx1QkFBdUIsQ0FBQyxJQUFJLENBQUMsT0FBTyx1QkFBdUIsQ0FBQyxZQUFZLENBQUMsRUFBRSxDQUFDLENBQUM7UUFDOUYsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZiwwR0FBMEc7UUFDMUcsZ0hBQWdIO1FBQ2hILE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxrQkFBa0I7WUFBRSxjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDL0MsSUFBSSxlQUFlO1lBQUUsV0FBVyxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3pDLElBQUksaUJBQWlCO1lBQUUsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQy9DLENBQUM7QUFDSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/manage-status.ts
+++ b/packages/loopover-miner/lib/manage-status.ts
@@ -1,0 +1,295 @@
+import type { EventLedger, LedgerEntry } from "./event-ledger.js";
+import { initEventLedger } from "./event-ledger.js";
+import type { PortfolioQueueStore, QueueStatus } from "./portfolio-queue.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import type { RunState, RunStateStore } from "./run-state.js";
+import { initRunStateStore } from "./run-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+/** Event vocabulary for manage-phase PR snapshots written by manage poll. (#2325) */
+export const MANAGE_PR_UPDATE_EVENT = "manage_pr_update";
+export const MANAGED_PR_IDENTIFIER_PREFIX = "pr:";
+
+export type ManageStatusRow = {
+  repoFullName: string;
+  prNumber: number;
+  branch: string | null;
+  ciState: string | null;
+  gateVerdict: string | null;
+  outcome: string | null;
+  lastPolledAt: string | null;
+  queueStatus: QueueStatus | null;
+  priority: number | null;
+};
+
+export type ManageStatusSources = {
+  portfolioQueue: PortfolioQueueStore;
+  eventLedger: EventLedger;
+};
+
+export type RunPortfolioSources = ManageStatusSources & {
+  runStateStore: RunStateStore;
+};
+
+export type RunPortfolioRow = {
+  repoFullName: string;
+  runState: RunState | null;
+  runStateUpdatedAt: string | null;
+  prCount: number;
+  prs: ManageStatusRow[];
+};
+
+export type ManageUpdateSnapshot = {
+  repoFullName: string;
+  prNumber: number;
+  branch: string | null;
+  ciState: string | null;
+  gateVerdict: string | null;
+  outcome: string | null;
+  lastPolledAt: string | null;
+};
+
+export function parseManagedPrIdentifier(identifier: string): number | null {
+  if (typeof identifier !== "string") return null;
+  const match = identifier.match(/^pr:(\d+)$/);
+  if (!match) return null;
+  const prNumber = Number(match[1]);
+  return Number.isInteger(prNumber) && prNumber > 0 ? prNumber : null;
+}
+
+export function formatManagedPrIdentifier(prNumber: number): string {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) throw new Error("invalid_pr_number");
+  return `${MANAGED_PR_IDENTIFIER_PREFIX}${prNumber}`;
+}
+
+function optionalString(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeManageUpdatePayload(payload: unknown): Omit<ManageUpdateSnapshot, "repoFullName"> | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const p = payload as { prNumber?: unknown; branch?: unknown; ciState?: unknown; gateVerdict?: unknown; outcome?: unknown; lastPolledAt?: unknown };
+  if (!Number.isInteger(p.prNumber) || (p.prNumber as number) <= 0) return null;
+  return {
+    prNumber: p.prNumber as number,
+    branch: optionalString(p.branch),
+    ciState: optionalString(p.ciState),
+    gateVerdict: optionalString(p.gateVerdict),
+    outcome: optionalString(p.outcome),
+    lastPolledAt: optionalString(p.lastPolledAt),
+  };
+}
+
+/** Index the latest manage snapshot per repo/PR from ascending ledger events. Pure. */
+export function indexLatestManageUpdates(events: LedgerEntry[]): Map<string, ManageUpdateSnapshot> {
+  const latest = new Map<string, ManageUpdateSnapshot>();
+  for (const event of Array.isArray(events) ? events : []) {
+    if (event?.type !== MANAGE_PR_UPDATE_EVENT) continue;
+    if (typeof event.repoFullName !== "string" || !event.repoFullName.trim()) continue;
+    const normalized = normalizeManageUpdatePayload(event.payload);
+    if (!normalized) continue;
+    const key = `${event.repoFullName}:${normalized.prNumber}`;
+    latest.set(key, { ...normalized, repoFullName: event.repoFullName });
+  }
+  return latest;
+}
+
+/**
+ * Aggregate managed PR rows from the local portfolio queue and append-only event ledger. Read-only — never calls
+ * GitHub or mutates local stores. (#2325)
+ */
+export function collectManageStatus(sources: ManageStatusSources): ManageStatusRow[] {
+  const portfolioQueue = sources?.portfolioQueue;
+  const eventLedger = sources?.eventLedger;
+  if (!portfolioQueue || typeof portfolioQueue.listQueue !== "function") {
+    throw new Error("invalid_portfolio_queue");
+  }
+  if (!eventLedger || typeof eventLedger.readEvents !== "function") {
+    throw new Error("invalid_event_ledger");
+  }
+
+  const rowsByKey = new Map<string, ManageStatusRow>();
+  for (const entry of portfolioQueue.listQueue(null)) {
+    const prNumber = parseManagedPrIdentifier(entry.identifier);
+    if (prNumber === null) continue;
+    const key = `${entry.repoFullName}:${prNumber}`;
+    rowsByKey.set(key, {
+      repoFullName: entry.repoFullName,
+      prNumber,
+      branch: null,
+      ciState: null,
+      gateVerdict: null,
+      outcome: null,
+      lastPolledAt: null,
+      queueStatus: entry.status,
+      priority: entry.priority,
+    });
+  }
+
+  for (const [key, update] of indexLatestManageUpdates(eventLedger.readEvents())) {
+    const existing = rowsByKey.get(key);
+    rowsByKey.set(key, {
+      repoFullName: update.repoFullName,
+      prNumber: update.prNumber,
+      branch: update.branch,
+      ciState: update.ciState,
+      gateVerdict: update.gateVerdict,
+      outcome: update.outcome,
+      lastPolledAt: update.lastPolledAt,
+      queueStatus: existing?.queueStatus ?? null,
+      priority: existing?.priority ?? null,
+    });
+  }
+
+  return [...rowsByKey.values()].sort((left, right) => {
+    const repoCmp = left.repoFullName.localeCompare(right.repoFullName);
+    if (repoCmp !== 0) return repoCmp;
+    return left.prNumber - right.prNumber;
+  });
+}
+
+/**
+ * Fold each tracked repo's current discover/plan/prepare run state alongside its managed PR rows into one
+ * "run portfolio" row per repo (#4279). `collectManageStatus` alone is PR-scoped only and never surfaces the
+ * run-state signal, so a repo actively discovering/planning with zero PRs yet is otherwise invisible. A repo
+ * appears here if it has EITHER a recorded run state OR at least one managed PR row.
+ */
+export function collectRunPortfolio(sources: RunPortfolioSources): RunPortfolioRow[] {
+  const runStateStore = sources?.runStateStore;
+  if (!runStateStore || typeof runStateStore.listRunStates !== "function") {
+    throw new Error("invalid_run_state_store");
+  }
+  const prsByRepo = new Map<string, ManageStatusRow[]>();
+  for (const row of collectManageStatus(sources)) {
+    const list = prsByRepo.get(row.repoFullName) ?? [];
+    list.push(row);
+    prsByRepo.set(row.repoFullName, list);
+  }
+  // NOTE (#5563): keyed by repoFullName alone, not apiBaseUrl -- this dashboard fold predates multi-forge run
+  // states and produces exactly ONE row per repo name. If the same repo name has a recorded run state on two
+  // different hosts, only one (the later entry in listRunStates' order) survives here; the other's row is still
+  // intact in the store, just not surfaced in this particular view. Safe (no data loss, no write), just a display
+  // limitation -- broadening this fold to be host-aware is a separate, larger dashboard-shape change.
+  const runStateByRepo = new Map(runStateStore.listRunStates().map((entry) => [entry.repoFullName, entry] as const));
+
+  const repoFullNames = new Set([...prsByRepo.keys(), ...runStateByRepo.keys()]);
+  return [...repoFullNames].sort((left, right) => left.localeCompare(right)).map((repoFullName) => {
+    const prs = prsByRepo.get(repoFullName) ?? [];
+    const runState = runStateByRepo.get(repoFullName);
+    return {
+      repoFullName,
+      runState: runState?.state ?? null,
+      runStateUpdatedAt: runState?.updatedAt ?? null,
+      prCount: prs.length,
+      prs,
+    };
+  });
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderManageStatusTable(rows: ManageStatusRow[]): string {
+  if (!Array.isArray(rows) || rows.length === 0) return "no managed pull requests";
+  const header = [
+    "repo".padEnd(24),
+    "pr".padStart(4),
+    "branch".padEnd(16),
+    "ci".padEnd(10),
+    "gate".padEnd(10),
+    "outcome".padEnd(10),
+    "last-polled".padEnd(20),
+    "queue".padEnd(12),
+    "pri".padStart(4),
+  ].join(" ");
+  const lines = rows.map((row) =>
+    [
+      row.repoFullName.padEnd(24),
+      String(row.prNumber).padStart(4),
+      display(row.branch).padEnd(16),
+      display(row.ciState).padEnd(10),
+      display(row.gateVerdict).padEnd(10),
+      display(row.outcome).padEnd(10),
+      display(row.lastPolledAt).padEnd(20),
+      display(row.queueStatus).padEnd(12),
+      display(row.priority).padStart(4),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+/** One row per tracked repo (run state + PR count), the compact companion to {@link renderManageStatusTable}'s
+ *  per-PR detail (#4279). */
+export function renderRunPortfolioTable(portfolio: RunPortfolioRow[]): string {
+  if (!Array.isArray(portfolio) || portfolio.length === 0) return "no tracked repos";
+  const header = [
+    "repo".padEnd(24),
+    "run-state".padEnd(12),
+    "updated".padEnd(20),
+    "prs".padStart(4),
+  ].join(" ");
+  const lines = portfolio.map((entry) =>
+    [
+      entry.repoFullName.padEnd(24),
+      display(entry.runState).padEnd(12),
+      display(entry.runStateUpdatedAt).padEnd(20),
+      String(entry.prCount).padStart(4),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+export function parseManageStatusArgs(args: string[] = []): { json: boolean } | { error: string } {
+  for (const token of args) {
+    if (token === "--json") continue;
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    return { error: "Usage: loopover-miner manage status [--json]" };
+  }
+  return { json: args.includes("--json") };
+}
+
+export function runManageStatus(
+  args: string[] = [],
+  options: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initEventLedger?: () => EventLedger;
+    initRunStateStore?: () => RunStateStore;
+  } = {},
+): number {
+  const parsed = parseManageStatusArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+  const ownsEventLedger = options.initEventLedger === undefined;
+  const ownsRunStateStore = options.initRunStateStore === undefined;
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  const eventLedger = (options.initEventLedger ?? initEventLedger)();
+  const runStateStore = (options.initRunStateStore ?? initRunStateStore)();
+  try {
+    const rows = collectManageStatus({ portfolioQueue, eventLedger });
+    const runPortfolio = collectRunPortfolio({ portfolioQueue, eventLedger, runStateStore });
+    if (parsed.json) {
+      // Additive only (#4279): `rows` keeps its existing shape unchanged; `runPortfolio` is a new key so an
+      // existing consumer parsing this JSON for `rows` alone sees byte-identical output.
+      console.log(JSON.stringify({ rows, runPortfolio }, null, 2));
+    } else {
+      console.log(`${renderManageStatusTable(rows)}\n\n${renderRunPortfolioTable(runPortfolio)}`);
+    }
+    return 0;
+  } catch (error) {
+    // Collecting/rendering manage status touches three SQLite stores; a read/render failure must surface as a
+    // clean CLI error (honoring --json), not an unhandled throw -- matching runOrbExportCli / runQueueList (#7236).
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsPortfolioQueue) portfolioQueue.close();
+    if (ownsEventLedger) eventLedger.close();
+    if (ownsRunStateStore) runStateStore.close();
+  }
+}

--- a/packages/loopover-miner/lib/oauth-device-flow.d.ts
+++ b/packages/loopover-miner/lib/oauth-device-flow.d.ts
@@ -1,44 +1,53 @@
-export function resolveAmsOauthClientId(env?: Record<string, string | undefined>): string;
-
-export class DeviceFlowError extends Error {
-  constructor(code: string, message?: string);
-  code: string;
-}
-
 export type DeviceCode = {
-  deviceCode: string;
-  userCode: string;
-  verificationUri: string;
-  expiresInSeconds: number;
-  intervalSeconds: number;
+    deviceCode: string;
+    userCode: string;
+    verificationUri: string;
+    expiresInSeconds: number;
+    intervalSeconds: number;
 };
-
 export type DeviceFlowTokenResult = {
-  accessToken: string;
-  scope: string;
+    accessToken: string;
+    scope: string;
 };
-
-export function requestDeviceCode(options: {
-  clientId: string;
-  scope?: string;
-  fetchFn?: typeof fetch;
+/** The centrally-held loopover-ams App's OAuth client id -- public (not secret), so it's safe to read from a
+ *  plain env var. Empty/unset means device-flow authorization isn't available in this build/deployment. */
+export declare function resolveAmsOauthClientId(env?: Record<string, string | undefined>): string;
+export declare class DeviceFlowError extends Error {
+    code: string;
+    constructor(code: string, message?: string);
+}
+/** Step 1 of the device flow: request a device code + the short user-facing code from GitHub. */
+export declare function requestDeviceCode({ clientId, scope, fetchFn, }: {
+    clientId: string;
+    scope?: string | undefined;
+    fetchFn?: typeof fetch;
 }): Promise<DeviceCode>;
-
-export function pollForAccessToken(options: {
-  clientId: string;
-  deviceCode: string;
-  intervalSeconds?: number;
-  expiresInSeconds?: number;
-  fetchFn?: typeof fetch;
-  sleepFn?: (ms: number) => Promise<void>;
-  now?: () => number;
+/**
+ * Step 2: poll for the access token, honoring GitHub's device-flow polling protocol --
+ * `authorization_pending` keeps polling at the current interval, `slow_down` increases it (to GitHub's own
+ * requested value when given), `expired_token`/`access_denied` are terminal failures, anything else is an
+ * unexpected terminal failure. Bounded by `expiresInSeconds` so a caller can never poll forever.
+ */
+export declare function pollForAccessToken({ clientId, deviceCode, intervalSeconds, expiresInSeconds, fetchFn, sleepFn, now, }: {
+    clientId: string;
+    deviceCode: string;
+    intervalSeconds?: number;
+    expiresInSeconds?: number;
+    fetchFn?: typeof fetch;
+    sleepFn?: ((ms: number) => Promise<void>) | undefined;
+    now?: (() => number) | undefined;
 }): Promise<DeviceFlowTokenResult>;
-
-export function runDeviceFlowAuthorization(options: {
-  clientId: string;
-  scope?: string;
-  onCode: (code: DeviceCode) => void | Promise<void>;
-  fetchFn?: typeof fetch;
-  sleepFn?: (ms: number) => Promise<void>;
-  now?: () => number;
+/**
+ * Run the full device-flow authorization end to end: request a code, hand it to the caller's `onCode` (so the
+ * caller can display it however it likes -- CLI text, structured JSON, etc.), then poll until the user
+ * completes, declines, or the code expires. Returns the resulting access token; throws a DeviceFlowError on
+ * any failure -- the caller decides whether to fall back to another auth method.
+ */
+export declare function runDeviceFlowAuthorization({ clientId, scope, onCode, fetchFn, sleepFn, now, }: {
+    clientId: string;
+    scope?: string | undefined;
+    onCode: (code: DeviceCode) => void | Promise<void>;
+    fetchFn?: typeof fetch;
+    sleepFn?: ((ms: number) => Promise<void>) | undefined;
+    now?: (() => number) | undefined;
 }): Promise<DeviceFlowTokenResult>;

--- a/packages/loopover-miner/lib/oauth-device-flow.js
+++ b/packages/loopover-miner/lib/oauth-device-flow.js
@@ -9,7 +9,6 @@
 // in @loopover/engine's local-write-tools.ts). This is deliberately NOT the installation-token mechanism Orb
 // uses: an installation token requires the repo owner to install the App on their own repo, which is
 // mechanically incompatible with contributing to third-party repos AMS doesn't own.
-
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
 const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const DEFAULT_SCOPE = "repo";
@@ -18,116 +17,111 @@ const DEFAULT_INTERVAL_SECONDS = 5;
 // #miner-github-read-timeouts: matches github-token-resolution.js's GITHUB_TOKEN_FETCH_TIMEOUT_MS -- a stalled
 // connection can't hang forever, here or anywhere else this package talks to GitHub.
 const DEVICE_FLOW_FETCH_TIMEOUT_MS = 10_000;
-
 /** The centrally-held loopover-ams App's OAuth client id -- public (not secret), so it's safe to read from a
  *  plain env var. Empty/unset means device-flow authorization isn't available in this build/deployment. */
 export function resolveAmsOauthClientId(env = process.env) {
-  return typeof env.LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID === "string" ? env.LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID.trim() : "";
+    return typeof env.LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID === "string" ? env.LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID.trim() : "";
 }
-
 export class DeviceFlowError extends Error {
-  constructor(code, message) {
-    super(message || code);
-    this.code = code;
-  }
+    code;
+    constructor(code, message) {
+        super(message || code);
+        this.code = code;
+    }
 }
-
 function defaultSleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
 /** Step 1 of the device flow: request a device code + the short user-facing code from GitHub. */
-export async function requestDeviceCode({ clientId, scope = DEFAULT_SCOPE, fetchFn = fetch } = {}) {
-  if (!clientId) throw new DeviceFlowError("missing_client_id", "no OAuth client id configured for device-flow authorization");
-  const res = await fetchFn(DEVICE_CODE_URL, {
-    method: "POST",
-    headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({ client_id: clientId, scope }).toString(),
-    signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
-  });
-  if (!res.ok) throw new DeviceFlowError("device_code_request_failed", `GitHub returned HTTP ${res.status} requesting a device code`);
-  const data = await res.json();
-  if (!data || typeof data.device_code !== "string" || typeof data.user_code !== "string" || typeof data.verification_uri !== "string") {
-    throw new DeviceFlowError("device_code_response_invalid", "GitHub's device-code response was missing required fields");
-  }
-  return {
-    deviceCode: data.device_code,
-    userCode: data.user_code,
-    verificationUri: data.verification_uri,
-    expiresInSeconds: typeof data.expires_in === "number" ? data.expires_in : DEFAULT_EXPIRES_IN_SECONDS,
-    intervalSeconds: typeof data.interval === "number" ? data.interval : DEFAULT_INTERVAL_SECONDS,
-  };
+export async function requestDeviceCode({ clientId, scope = DEFAULT_SCOPE, fetchFn = fetch, }) {
+    if (!clientId)
+        throw new DeviceFlowError("missing_client_id", "no OAuth client id configured for device-flow authorization");
+    const res = await fetchFn(DEVICE_CODE_URL, {
+        method: "POST",
+        headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ client_id: clientId, scope }).toString(),
+        signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok)
+        throw new DeviceFlowError("device_code_request_failed", `GitHub returned HTTP ${res.status} requesting a device code`);
+    const data = (await res.json());
+    if (!data || typeof data.device_code !== "string" || typeof data.user_code !== "string" || typeof data.verification_uri !== "string") {
+        throw new DeviceFlowError("device_code_response_invalid", "GitHub's device-code response was missing required fields");
+    }
+    return {
+        deviceCode: data.device_code,
+        userCode: data.user_code,
+        verificationUri: data.verification_uri,
+        expiresInSeconds: typeof data.expires_in === "number" ? data.expires_in : DEFAULT_EXPIRES_IN_SECONDS,
+        intervalSeconds: typeof data.interval === "number" ? data.interval : DEFAULT_INTERVAL_SECONDS,
+    };
 }
-
 /**
  * Step 2: poll for the access token, honoring GitHub's device-flow polling protocol --
  * `authorization_pending` keeps polling at the current interval, `slow_down` increases it (to GitHub's own
  * requested value when given), `expired_token`/`access_denied` are terminal failures, anything else is an
  * unexpected terminal failure. Bounded by `expiresInSeconds` so a caller can never poll forever.
  */
-export async function pollForAccessToken({
-  clientId,
-  deviceCode,
-  intervalSeconds = DEFAULT_INTERVAL_SECONDS,
-  expiresInSeconds = DEFAULT_EXPIRES_IN_SECONDS,
-  fetchFn = fetch,
-  sleepFn = defaultSleep,
-  now = () => Date.now(),
-} = {}) {
-  const deadline = now() + expiresInSeconds * 1000;
-  let interval = intervalSeconds;
-  for (;;) {
-    if (now() >= deadline) throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
-    await sleepFn(interval * 1000);
-    let res;
-    try {
-      res = await fetchFn(ACCESS_TOKEN_URL, {
-        method: "POST",
-        headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({
-          client_id: clientId,
-          device_code: deviceCode,
-          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-        }).toString(),
-        signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
-      });
-    } catch {
-      // A stalled/timed-out attempt is a per-attempt failure, not a fatal one -- the existing deadline check
-      // at the top of the loop still bounds total polling time, so this just costs one wasted interval.
-      continue;
+export async function pollForAccessToken({ clientId, deviceCode, intervalSeconds = DEFAULT_INTERVAL_SECONDS, expiresInSeconds = DEFAULT_EXPIRES_IN_SECONDS, fetchFn = fetch, sleepFn = defaultSleep, now = () => Date.now(), }) {
+    const deadline = now() + expiresInSeconds * 1000;
+    let interval = intervalSeconds;
+    for (;;) {
+        if (now() >= deadline)
+            throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
+        await sleepFn(interval * 1000);
+        let res;
+        try {
+            res = await fetchFn(ACCESS_TOKEN_URL, {
+                method: "POST",
+                headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
+                body: new URLSearchParams({
+                    client_id: clientId,
+                    device_code: deviceCode,
+                    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+                }).toString(),
+                signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
+            });
+        }
+        catch {
+            // A stalled/timed-out attempt is a per-attempt failure, not a fatal one -- the existing deadline check
+            // at the top of the loop still bounds total polling time, so this just costs one wasted interval.
+            continue;
+        }
+        const data = (await res.json().catch(() => ({})));
+        if (data && typeof data.access_token === "string" && data.access_token) {
+            return { accessToken: data.access_token, scope: typeof data.scope === "string" ? data.scope : "" };
+        }
+        const error = data && typeof data.error === "string" ? data.error : null;
+        if (error === "authorization_pending")
+            continue;
+        if (error === "slow_down") {
+            interval = typeof data.interval === "number" ? data.interval : interval + 5;
+            continue;
+        }
+        if (error === "expired_token")
+            throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
+        if (error === "access_denied")
+            throw new DeviceFlowError("access_denied", "authorization was declined");
+        throw new DeviceFlowError(error || "device_flow_failed", (data && data.error_description) || `unexpected device-flow response (HTTP ${res.status})`);
     }
-    const data = await res.json().catch(() => ({}));
-    if (data && typeof data.access_token === "string" && data.access_token) {
-      return { accessToken: data.access_token, scope: typeof data.scope === "string" ? data.scope : "" };
-    }
-    const error = data && typeof data.error === "string" ? data.error : null;
-    if (error === "authorization_pending") continue;
-    if (error === "slow_down") {
-      interval = typeof data.interval === "number" ? data.interval : interval + 5;
-      continue;
-    }
-    if (error === "expired_token") throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
-    if (error === "access_denied") throw new DeviceFlowError("access_denied", "authorization was declined");
-    throw new DeviceFlowError(error || "device_flow_failed", (data && data.error_description) || `unexpected device-flow response (HTTP ${res.status})`);
-  }
 }
-
 /**
  * Run the full device-flow authorization end to end: request a code, hand it to the caller's `onCode` (so the
  * caller can display it however it likes -- CLI text, structured JSON, etc.), then poll until the user
  * completes, declines, or the code expires. Returns the resulting access token; throws a DeviceFlowError on
  * any failure -- the caller decides whether to fall back to another auth method.
  */
-export async function runDeviceFlowAuthorization({ clientId, scope, onCode, fetchFn = fetch, sleepFn, now }) {
-  const code = await requestDeviceCode({ clientId, scope, fetchFn });
-  await onCode(code);
-  return pollForAccessToken({
-    clientId,
-    deviceCode: code.deviceCode,
-    intervalSeconds: code.intervalSeconds,
-    expiresInSeconds: code.expiresInSeconds,
-    fetchFn,
-    sleepFn,
-    now,
-  });
+export async function runDeviceFlowAuthorization({ clientId, scope, onCode, fetchFn = fetch, sleepFn, now, }) {
+    const code = await requestDeviceCode({ clientId, scope, fetchFn });
+    await onCode(code);
+    return pollForAccessToken({
+        clientId,
+        deviceCode: code.deviceCode,
+        intervalSeconds: code.intervalSeconds,
+        expiresInSeconds: code.expiresInSeconds,
+        fetchFn,
+        sleepFn,
+        now,
+    });
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib2F1dGgtZGV2aWNlLWZsb3cuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJvYXV0aC1kZXZpY2UtZmxvdy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxxR0FBcUc7QUFDckcsMEdBQTBHO0FBQzFHLDZEQUE2RDtBQUM3RCwwR0FBMEc7QUFDMUcsNkZBQTZGO0FBQzdGLEVBQUU7QUFDRiwwR0FBMEc7QUFDMUcsK0dBQStHO0FBQy9HLDZHQUE2RztBQUM3RyxxR0FBcUc7QUFDckcsb0ZBQW9GO0FBRXBGLE1BQU0sZUFBZSxHQUFHLHNDQUFzQyxDQUFDO0FBQy9ELE1BQU0sZ0JBQWdCLEdBQUcsNkNBQTZDLENBQUM7QUFDdkUsTUFBTSxhQUFhLEdBQUcsTUFBTSxDQUFDO0FBQzdCLE1BQU0sMEJBQTBCLEdBQUcsR0FBRyxDQUFDO0FBQ3ZDLE1BQU0sd0JBQXdCLEdBQUcsQ0FBQyxDQUFDO0FBQ25DLCtHQUErRztBQUMvRyxxRkFBcUY7QUFDckYsTUFBTSw0QkFBNEIsR0FBRyxNQUFNLENBQUM7QUFlNUM7MkdBQzJHO0FBQzNHLE1BQU0sVUFBVSx1QkFBdUIsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBRztJQUMzRixPQUFPLE9BQU8sR0FBRyxDQUFDLGtDQUFrQyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLGtDQUFrQyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7QUFDekgsQ0FBQztBQUVELE1BQU0sT0FBTyxlQUFnQixTQUFRLEtBQUs7SUFDeEMsSUFBSSxDQUFTO0lBQ2IsWUFBWSxJQUFZLEVBQUUsT0FBZ0I7UUFDeEMsS0FBSyxDQUFDLE9BQU8sSUFBSSxJQUFJLENBQUMsQ0FBQztRQUN2QixJQUFJLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztJQUNuQixDQUFDO0NBQ0Y7QUFFRCxTQUFTLFlBQVksQ0FBQyxFQUFVO0lBQzlCLE9BQU8sSUFBSSxPQUFPLENBQU8sQ0FBQyxPQUFPLEVBQUUsRUFBRSxDQUFDLFVBQVUsQ0FBQyxPQUFPLEVBQUUsRUFBRSxDQUFDLENBQUMsQ0FBQztBQUNqRSxDQUFDO0FBRUQsaUdBQWlHO0FBQ2pHLE1BQU0sQ0FBQyxLQUFLLFVBQVUsaUJBQWlCLENBQUMsRUFDdEMsUUFBUSxFQUNSLEtBQUssR0FBRyxhQUFhLEVBQ3JCLE9BQU8sR0FBRyxLQUFLLEdBS2hCO0lBQ0MsSUFBSSxDQUFDLFFBQVE7UUFBRSxNQUFNLElBQUksZUFBZSxDQUFDLG1CQUFtQixFQUFFLDZEQUE2RCxDQUFDLENBQUM7SUFDN0gsTUFBTSxHQUFHLEdBQUcsTUFBTSxPQUFPLENBQUMsZUFBZSxFQUFFO1FBQ3pDLE1BQU0sRUFBRSxNQUFNO1FBQ2QsT0FBTyxFQUFFLEVBQUUsTUFBTSxFQUFFLGtCQUFrQixFQUFFLGNBQWMsRUFBRSxtQ0FBbUMsRUFBRTtRQUM1RixJQUFJLEVBQUUsSUFBSSxlQUFlLENBQUMsRUFBRSxTQUFTLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxDQUFDLENBQUMsUUFBUSxFQUFFO1FBQ3BFLE1BQU0sRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLDRCQUE0QixDQUFDO0tBQzFELENBQUMsQ0FBQztJQUNILElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRTtRQUFFLE1BQU0sSUFBSSxlQUFlLENBQUMsNEJBQTRCLEVBQUUsd0JBQXdCLEdBQUcsQ0FBQyxNQUFNLDJCQUEyQixDQUFDLENBQUM7SUFDcEksTUFBTSxJQUFJLEdBQUcsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxJQUFJLEVBQUUsQ0FFdEIsQ0FBQztJQUNULElBQUksQ0FBQyxJQUFJLElBQUksT0FBTyxJQUFJLENBQUMsV0FBVyxLQUFLLFFBQVEsSUFBSSxPQUFPLElBQUksQ0FBQyxTQUFTLEtBQUssUUFBUSxJQUFJLE9BQU8sSUFBSSxDQUFDLGdCQUFnQixLQUFLLFFBQVEsRUFBRSxDQUFDO1FBQ3JJLE1BQU0sSUFBSSxlQUFlLENBQUMsOEJBQThCLEVBQUUsMkRBQTJELENBQUMsQ0FBQztJQUN6SCxDQUFDO0lBQ0QsT0FBTztRQUNMLFVBQVUsRUFBRSxJQUFJLENBQUMsV0FBVztRQUM1QixRQUFRLEVBQUUsSUFBSSxDQUFDLFNBQVM7UUFDeEIsZUFBZSxFQUFFLElBQUksQ0FBQyxnQkFBZ0I7UUFDdEMsZ0JBQWdCLEVBQUUsT0FBTyxJQUFJLENBQUMsVUFBVSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsMEJBQTBCO1FBQ3BHLGVBQWUsRUFBRSxPQUFPLElBQUksQ0FBQyxRQUFRLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyx3QkFBd0I7S0FDOUYsQ0FBQztBQUNKLENBQUM7QUFFRDs7Ozs7R0FLRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsa0JBQWtCLENBQUMsRUFDdkMsUUFBUSxFQUNSLFVBQVUsRUFDVixlQUFlLEdBQUcsd0JBQXdCLEVBQzFDLGdCQUFnQixHQUFHLDBCQUEwQixFQUM3QyxPQUFPLEdBQUcsS0FBSyxFQUNmLE9BQU8sR0FBRyxZQUFZLEVBQ3RCLEdBQUcsR0FBRyxHQUFHLEVBQUUsQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLEdBU3ZCO0lBQ0MsTUFBTSxRQUFRLEdBQUcsR0FBRyxFQUFFLEdBQUcsZ0JBQWdCLEdBQUcsSUFBSSxDQUFDO0lBQ2pELElBQUksUUFBUSxHQUFHLGVBQWUsQ0FBQztJQUMvQixTQUFTLENBQUM7UUFDUixJQUFJLEdBQUcsRUFBRSxJQUFJLFFBQVE7WUFBRSxNQUFNLElBQUksZUFBZSxDQUFDLGVBQWUsRUFBRSx3REFBd0QsQ0FBQyxDQUFDO1FBQzVILE1BQU0sT0FBTyxDQUFDLFFBQVEsR0FBRyxJQUFJLENBQUMsQ0FBQztRQUMvQixJQUFJLEdBQUcsQ0FBQztRQUNSLElBQUksQ0FBQztZQUNILEdBQUcsR0FBRyxNQUFNLE9BQU8sQ0FBQyxnQkFBZ0IsRUFBRTtnQkFDcEMsTUFBTSxFQUFFLE1BQU07Z0JBQ2QsT0FBTyxFQUFFLEVBQUUsTUFBTSxFQUFFLGtCQUFrQixFQUFFLGNBQWMsRUFBRSxtQ0FBbUMsRUFBRTtnQkFDNUYsSUFBSSxFQUFFLElBQUksZUFBZSxDQUFDO29CQUN4QixTQUFTLEVBQUUsUUFBUTtvQkFDbkIsV0FBVyxFQUFFLFVBQVU7b0JBQ3ZCLFVBQVUsRUFBRSw4Q0FBOEM7aUJBQzNELENBQUMsQ0FBQyxRQUFRLEVBQUU7Z0JBQ2IsTUFBTSxFQUFFLFdBQVcsQ0FBQyxPQUFPLENBQUMsNEJBQTRCLENBQUM7YUFDMUQsQ0FBQyxDQUFDO1FBQ0wsQ0FBQztRQUFDLE1BQU0sQ0FBQztZQUNQLHVHQUF1RztZQUN2RyxrR0FBa0c7WUFDbEcsU0FBUztRQUNYLENBQUM7UUFDRCxNQUFNLElBQUksR0FBRyxDQUFDLE1BQU0sR0FBRyxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBTS9DLENBQUM7UUFDRixJQUFJLElBQUksSUFBSSxPQUFPLElBQUksQ0FBQyxZQUFZLEtBQUssUUFBUSxJQUFJLElBQUksQ0FBQyxZQUFZLEVBQUUsQ0FBQztZQUN2RSxPQUFPLEVBQUUsV0FBVyxFQUFFLElBQUksQ0FBQyxZQUFZLEVBQUUsS0FBSyxFQUFFLE9BQU8sSUFBSSxDQUFDLEtBQUssS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ3JHLENBQUM7UUFDRCxNQUFNLEtBQUssR0FBRyxJQUFJLElBQUksT0FBTyxJQUFJLENBQUMsS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO1FBQ3pFLElBQUksS0FBSyxLQUFLLHVCQUF1QjtZQUFFLFNBQVM7UUFDaEQsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsUUFBUSxHQUFHLE9BQU8sSUFBSSxDQUFDLFFBQVEsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLFFBQVEsR0FBRyxDQUFDLENBQUM7WUFDNUUsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxlQUFlO1lBQUUsTUFBTSxJQUFJLGVBQWUsQ0FBQyxlQUFlLEVBQUUsd0RBQXdELENBQUMsQ0FBQztRQUNwSSxJQUFJLEtBQUssS0FBSyxlQUFlO1lBQUUsTUFBTSxJQUFJLGVBQWUsQ0FBQyxlQUFlLEVBQUUsNEJBQTRCLENBQUMsQ0FBQztRQUN4RyxNQUFNLElBQUksZUFBZSxDQUFDLEtBQUssSUFBSSxvQkFBb0IsRUFBRSxDQUFDLElBQUksSUFBSSxJQUFJLENBQUMsaUJBQWlCLENBQUMsSUFBSSx5Q0FBeUMsR0FBRyxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUM7SUFDdkosQ0FBQztBQUNILENBQUM7QUFFRDs7Ozs7R0FLRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsMEJBQTBCLENBQUMsRUFDL0MsUUFBUSxFQUNSLEtBQUssRUFDTCxNQUFNLEVBQ04sT0FBTyxHQUFHLEtBQUssRUFDZixPQUFPLEVBQ1AsR0FBRyxHQVFKO0lBQ0MsTUFBTSxJQUFJLEdBQUcsTUFBTSxpQkFBaUIsQ0FBQyxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFFLENBQUMsQ0FBQztJQUNuRSxNQUFNLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNuQixPQUFPLGtCQUFrQixDQUFDO1FBQ3hCLFFBQVE7UUFDUixVQUFVLEVBQUUsSUFBSSxDQUFDLFVBQVU7UUFDM0IsZUFBZSxFQUFFLElBQUksQ0FBQyxlQUFlO1FBQ3JDLGdCQUFnQixFQUFFLElBQUksQ0FBQyxnQkFBZ0I7UUFDdkMsT0FBTztRQUNQLE9BQU87UUFDUCxHQUFHO0tBQ0osQ0FBQyxDQUFDO0FBQ0wsQ0FBQyJ9

--- a/packages/loopover-miner/lib/oauth-device-flow.ts
+++ b/packages/loopover-miner/lib/oauth-device-flow.ts
@@ -1,0 +1,185 @@
+// GitHub OAuth Device Flow client (#5682) for the centrally-held `loopover-ams` GitHub App -- lets a
+// contributor authorize loopover-miner by visiting a URL and entering a short code, instead of generating
+// and pasting a PAT. Uses GitHub's PUBLIC-client device flow
+// (https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow): no
+// client secret is required or ever held by this CLI, only the App's public OAuth client id.
+//
+// The resulting user-to-server access token acts AS the authorizing human's own account, within their own
+// GitHub permissions -- the exact same identity/attribution as a manually pasted PAT (see LOCAL_WRITE_BOUNDARY
+// in @loopover/engine's local-write-tools.ts). This is deliberately NOT the installation-token mechanism Orb
+// uses: an installation token requires the repo owner to install the App on their own repo, which is
+// mechanically incompatible with contributing to third-party repos AMS doesn't own.
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const DEFAULT_SCOPE = "repo";
+const DEFAULT_EXPIRES_IN_SECONDS = 900;
+const DEFAULT_INTERVAL_SECONDS = 5;
+// #miner-github-read-timeouts: matches github-token-resolution.js's GITHUB_TOKEN_FETCH_TIMEOUT_MS -- a stalled
+// connection can't hang forever, here or anywhere else this package talks to GitHub.
+const DEVICE_FLOW_FETCH_TIMEOUT_MS = 10_000;
+
+export type DeviceCode = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  expiresInSeconds: number;
+  intervalSeconds: number;
+};
+
+export type DeviceFlowTokenResult = {
+  accessToken: string;
+  scope: string;
+};
+
+/** The centrally-held loopover-ams App's OAuth client id -- public (not secret), so it's safe to read from a
+ *  plain env var. Empty/unset means device-flow authorization isn't available in this build/deployment. */
+export function resolveAmsOauthClientId(env: Record<string, string | undefined> = process.env): string {
+  return typeof env.LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID === "string" ? env.LOOPOVER_MINER_AMS_OAUTH_CLIENT_ID.trim() : "";
+}
+
+export class DeviceFlowError extends Error {
+  code: string;
+  constructor(code: string, message?: string) {
+    super(message || code);
+    this.code = code;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+/** Step 1 of the device flow: request a device code + the short user-facing code from GitHub. */
+export async function requestDeviceCode({
+  clientId,
+  scope = DEFAULT_SCOPE,
+  fetchFn = fetch,
+}: {
+  clientId: string;
+  scope?: string | undefined;
+  fetchFn?: typeof fetch;
+}): Promise<DeviceCode> {
+  if (!clientId) throw new DeviceFlowError("missing_client_id", "no OAuth client id configured for device-flow authorization");
+  const res = await fetchFn(DEVICE_CODE_URL, {
+    method: "POST",
+    headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ client_id: clientId, scope }).toString(),
+    signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new DeviceFlowError("device_code_request_failed", `GitHub returned HTTP ${res.status} requesting a device code`);
+  const data = (await res.json()) as
+    | { device_code?: unknown; user_code?: unknown; verification_uri?: unknown; expires_in?: unknown; interval?: unknown }
+    | null;
+  if (!data || typeof data.device_code !== "string" || typeof data.user_code !== "string" || typeof data.verification_uri !== "string") {
+    throw new DeviceFlowError("device_code_response_invalid", "GitHub's device-code response was missing required fields");
+  }
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    expiresInSeconds: typeof data.expires_in === "number" ? data.expires_in : DEFAULT_EXPIRES_IN_SECONDS,
+    intervalSeconds: typeof data.interval === "number" ? data.interval : DEFAULT_INTERVAL_SECONDS,
+  };
+}
+
+/**
+ * Step 2: poll for the access token, honoring GitHub's device-flow polling protocol --
+ * `authorization_pending` keeps polling at the current interval, `slow_down` increases it (to GitHub's own
+ * requested value when given), `expired_token`/`access_denied` are terminal failures, anything else is an
+ * unexpected terminal failure. Bounded by `expiresInSeconds` so a caller can never poll forever.
+ */
+export async function pollForAccessToken({
+  clientId,
+  deviceCode,
+  intervalSeconds = DEFAULT_INTERVAL_SECONDS,
+  expiresInSeconds = DEFAULT_EXPIRES_IN_SECONDS,
+  fetchFn = fetch,
+  sleepFn = defaultSleep,
+  now = () => Date.now(),
+}: {
+  clientId: string;
+  deviceCode: string;
+  intervalSeconds?: number;
+  expiresInSeconds?: number;
+  fetchFn?: typeof fetch;
+  sleepFn?: ((ms: number) => Promise<void>) | undefined;
+  now?: (() => number) | undefined;
+}): Promise<DeviceFlowTokenResult> {
+  const deadline = now() + expiresInSeconds * 1000;
+  let interval = intervalSeconds;
+  for (;;) {
+    if (now() >= deadline) throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
+    await sleepFn(interval * 1000);
+    let res;
+    try {
+      res = await fetchFn(ACCESS_TOKEN_URL, {
+        method: "POST",
+        headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: clientId,
+          device_code: deviceCode,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }).toString(),
+        signal: AbortSignal.timeout(DEVICE_FLOW_FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      // A stalled/timed-out attempt is a per-attempt failure, not a fatal one -- the existing deadline check
+      // at the top of the loop still bounds total polling time, so this just costs one wasted interval.
+      continue;
+    }
+    const data = (await res.json().catch(() => ({}))) as {
+      access_token?: unknown;
+      scope?: unknown;
+      error?: unknown;
+      interval?: unknown;
+      error_description?: string;
+    };
+    if (data && typeof data.access_token === "string" && data.access_token) {
+      return { accessToken: data.access_token, scope: typeof data.scope === "string" ? data.scope : "" };
+    }
+    const error = data && typeof data.error === "string" ? data.error : null;
+    if (error === "authorization_pending") continue;
+    if (error === "slow_down") {
+      interval = typeof data.interval === "number" ? data.interval : interval + 5;
+      continue;
+    }
+    if (error === "expired_token") throw new DeviceFlowError("expired_token", "the device code expired before authorization completed");
+    if (error === "access_denied") throw new DeviceFlowError("access_denied", "authorization was declined");
+    throw new DeviceFlowError(error || "device_flow_failed", (data && data.error_description) || `unexpected device-flow response (HTTP ${res.status})`);
+  }
+}
+
+/**
+ * Run the full device-flow authorization end to end: request a code, hand it to the caller's `onCode` (so the
+ * caller can display it however it likes -- CLI text, structured JSON, etc.), then poll until the user
+ * completes, declines, or the code expires. Returns the resulting access token; throws a DeviceFlowError on
+ * any failure -- the caller decides whether to fall back to another auth method.
+ */
+export async function runDeviceFlowAuthorization({
+  clientId,
+  scope,
+  onCode,
+  fetchFn = fetch,
+  sleepFn,
+  now,
+}: {
+  clientId: string;
+  scope?: string | undefined;
+  onCode: (code: DeviceCode) => void | Promise<void>;
+  fetchFn?: typeof fetch;
+  sleepFn?: ((ms: number) => Promise<void>) | undefined;
+  now?: (() => number) | undefined;
+}): Promise<DeviceFlowTokenResult> {
+  const code = await requestDeviceCode({ clientId, scope, fetchFn });
+  await onCode(code);
+  return pollForAccessToken({
+    clientId,
+    deviceCode: code.deviceCode,
+    intervalSeconds: code.intervalSeconds,
+    expiresInSeconds: code.expiresInSeconds,
+    fetchFn,
+    sleepFn,
+    now,
+  });
+}

--- a/packages/loopover-miner/lib/status.d.ts
+++ b/packages/loopover-miner/lib/status.d.ts
@@ -1,64 +1,82 @@
 export type MinerDriverStatus = {
-  provider: string | null;
-  modelEnvVar: string | null;
-  cliPresent: boolean | null;
+    provider: string | null;
+    modelEnvVar: string | null;
+    cliPresent: boolean | null;
 };
-
 export type MinerStatus = {
-  package: { name: string; version: string | null };
-  engine: { name: string; version: string | null };
-  node: string;
-  stateDir: string;
-  configFile: string | null;
-  driver: MinerDriverStatus;
+    package: {
+        name: string;
+        version: string | null;
+    };
+    engine: {
+        name: string;
+        version: string | null;
+    };
+    node: string;
+    stateDir: string;
+    configFile: string | null;
+    driver: MinerDriverStatus;
 };
-
 export type DoctorCheck = {
-  name: string;
-  ok: boolean;
-  detail: string;
+    name: string;
+    ok: boolean;
+    detail: string;
 };
-
-export function resolveMinerStateDir(env?: Record<string, string | undefined>): string;
-
-export function collectStatus(env?: Record<string, string | undefined>, cwd?: string): MinerStatus;
-
-export function runStatus(args?: string[], env?: Record<string, string | undefined>, cwd?: string): number;
-
-export function checkConfigContent(cwd: string, readImpl?: (path: string, encoding: "utf8") => string): DoctorCheck;
-
-export function checkGitHubTokenPresent(env?: Record<string, string | undefined>): DoctorCheck;
-
-export function checkCodingAgentCredential(
-  env?: Record<string, string | undefined>,
-  resolveAuthPath?: (env: Record<string, string | undefined>) => string,
-): DoctorCheck;
-
-export function runDoctorChecks(env?: Record<string, string | undefined>, cwd?: string): DoctorCheck[];
-
-export function runDoctor(args?: string[], env?: Record<string, string | undefined>, cwd?: string): number;
-
-export function readInstalledEnginePackageVersionFromPaths(
-  resolvedEntry: string,
-  workspacePkg: string,
-  deps?: { existsSync: (path: string) => boolean; readFileSync: (path: string, encoding: "utf8") => string },
-): string | null;
-
-export function readInstalledEnginePackageVersion(): string | null;
-
-export function readExpectedEnginePackageVersionFromPaths(
-  monorepoEnginePkg: string,
-  pinFile: string,
-  deps?: { existsSync: (path: string) => boolean; readFileSync: (path: string, encoding: "utf8") => string },
-): string | null;
-
-export function readExpectedEnginePackageVersion(): string | null;
-
-export function compareInstalledEngineVersion(installed: string, expected: string): -1 | 0 | 1;
-
-export function buildEngineVersionSkewCheck(
-  readInstalled?: () => string | null,
-  readExpected?: () => string | null,
-): DoctorCheck;
-
-export function buildEngineVersionDisplay(readInstalled?: () => string | null): string | null;
+/** The miner's local-state directory (holds the run-state / queue / ledger SQLite files). */
+export declare function resolveMinerStateDir(env?: Record<string, string | undefined>): string;
+/**
+ * The REAL installed @loopover/engine version, for `status`'s own display. Prefers `readInstalled`
+ * (the actually-resolved semver from node_modules/the monorepo workspace, the same real resolution `doctor`'s
+ * engine-version-skew check already relies on) -- a self-hoster asking "what's installed" wants the real
+ * answer, not the declared dependency RANGE ("*" in this monorepo, which tells them nothing). Falls back to
+ * the declared range only if real resolution genuinely comes up empty (the engine package's `exports` map
+ * blocks `require("<pkg>/package.json")` in some resolution orders, and its built `dist` may be absent
+ * depending on build order) -- still better than reporting nothing at all.
+ *
+ * Exported + injectable (mirrors `buildEngineVersionSkewCheck`'s own `readInstalled` param): real resolution
+ * succeeding is the only realistic case in a working install, so the fallback path needs a way to force it.
+ */
+export declare function buildEngineVersionDisplay(readInstalled?: () => string | null): string | null;
+export declare function readInstalledEnginePackageVersionFromPaths(resolvedEntry: string, workspacePkg: string, deps?: {
+    existsSync: (path: string) => boolean;
+    readFileSync: (path: string, encoding: "utf8") => string;
+}): string | null;
+/** Installed @loopover/engine semver from node_modules (not the declared dependency range). */
+export declare function readInstalledEnginePackageVersion(): string | null;
+/** Expected minimum engine semver: monorepo engine package.json when present, else the shipped pin file. */
+export declare function readExpectedEnginePackageVersionFromPaths(monorepoEnginePkg: string, pinFile: string, deps?: {
+    existsSync: (path: string) => boolean;
+    readFileSync: (path: string, encoding: "utf8") => string;
+}): string | null;
+export declare function readExpectedEnginePackageVersion(): string | null;
+/** Returns -1 when installed is behind expected, 0 when equal, 1 when ahead. */
+export declare function compareInstalledEngineVersion(installed: string, expected: string): -1 | 0 | 1;
+export declare function buildEngineVersionSkewCheck(readInstalled?: () => string | null, readExpected?: () => string | null): DoctorCheck;
+/** Gather the read-only status snapshot. Pure w.r.t. its (env, cwd) inputs — no writes, no network. */
+export declare function collectStatus(env?: Record<string, string | undefined>, cwd?: string): MinerStatus;
+export declare function runStatus(args?: string[], env?: Record<string, string | undefined>, cwd?: string): number;
+/** Validate the discovered `.loopover-miner` config's CONTENT (#4873), not just its path: parse it with the
+ *  tolerant goal-spec parser and surface its warnings, so a malformed config is flagged by `doctor` rather than
+ *  silently degrading to defaults. No config file is fine (defaults apply); a read failure is reported. `readImpl`
+ *  is injectable for tests. */
+export declare function checkConfigContent(cwd: string, readImpl?: (path: string, encoding: "utf8") => string): DoctorCheck;
+/** GitHub token presence (#5170, extended by #6116). A purely offline check — `doctor` never calls GitHub — but
+ *  a missing token fails every real attempt the moment it tries to push a branch or open a PR, so surface it up
+ *  front rather than mid-run. Checks BOTH a GITHUB_TOKEN env override AND a recorded `loopover-mcp login`
+ *  session (hasGitHubTokenSource, offline: reads the local config file, makes no network call) -- otherwise a
+ *  user who only ran `loopover-mcp login` (the new primary flow) would see a spurious "not set" warning even
+ *  though AMS would resolve a live token from that session at attempt time. A session recorded here is not
+ *  re-verified as still valid/unexpired -- only an actual attempt (or resolveGitHubToken itself) discovers
+ *  that. Reports presence only; no token value is ever included in the detail. */
+export declare function checkGitHubTokenPresent(env?: Record<string, string | undefined>): DoctorCheck;
+/** Credential presence for the CONFIGURED coding-agent provider (#5170). Distinct from the CLI-present checks,
+ *  which by design keep `ok: true` when only the credential is missing (#5165): this FAILS `doctor` when the
+ *  resolved provider's credential is absent, so an operator learns before an attempt fails partway through.
+ *  Fully offline — an env-var string check for the Claude backends, a file-readability check for codex — and it
+ *  never prints the credential value, only the env-var names / file path. `resolveAuthPath` is injectable for
+ *  tests, mirroring `checkCodexCliPresent`. */
+export declare function checkCodingAgentCredential(env?: Record<string, string | undefined>, resolveAuthPath?: (env: Record<string, string | undefined>) => string): DoctorCheck;
+/** Run the doctor checks. Returns an array of { name, ok, detail }; only writes a transient probe in the state dir,
+ *  never touches the network. */
+export declare function runDoctorChecks(env?: Record<string, string | undefined>, cwd?: string): DoctorCheck[];
+export declare function runDoctor(args?: string[], env?: Record<string, string | undefined>, cwd?: string): number;

--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -3,14 +3,7 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CODING_AGENT_DRIVER_CONFIG_ENV, parseMinerGoalSpecContent, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
-import {
-  checkClaudeCliPresent,
-  checkCodexCliPresent,
-  checkDockerPresent,
-  checkLaptopStateSqlite,
-  findExecutableOnPath,
-  resolveCodexAuthPath,
-} from "./laptop-init.js";
+import { checkClaudeCliPresent, checkCodexCliPresent, checkDockerPresent, checkLaptopStateSqlite, findExecutableOnPath, resolveCodexAuthPath, } from "./laptop-init.js";
 import { resolveMinerVersion } from "./version.js";
 import { checkStoreIntegrity, describeError } from "./store-maintenance.js";
 import { resolveEventLedgerDbPath } from "./event-ledger.js";
@@ -28,47 +21,39 @@ import { resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
 import { resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
 import { resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 import { resolvePolicyDocCacheDbPath } from "./policy-doc-cache.js";
-
-// Slim laptop-mode CLI commands (#2288): `status` (what's installed + where local state lives) and `doctor` (is
-// this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
-// no GitHub writes, and no network calls of any kind. Later phases add the real discover/plan/manage loop.
-
 // Lazy, not module-scope: mirrors the loopover-engine repo-map.ts fix -- this file is CLI-only today, but
 // an eager createRequire(import.meta.url)/import.meta.dirname at module scope would crash on import in any
 // bundler context where import.meta is unavailable (e.g. if a future import chain pulls this into a Worker
 // bundle, the way repo-map.ts was). Deferring construction to first real use keeps this import-safe.
 let cachedRequire = null;
 function requireFromHere() {
-  return (cachedRequire ??= createRequire(import.meta.url));
+    return (cachedRequire ??= createRequire(import.meta.url));
 }
 let cachedModuleDir = null;
 function moduleDir() {
-  return (cachedModuleDir ??= import.meta.dirname);
+    return (cachedModuleDir ??= import.meta.dirname);
 }
-
 const PACKAGE_NAME = "@loopover/miner";
 const ENGINE_PACKAGE = "@loopover/engine";
 // Config-file discovery order (mirrors the `.loopover-miner.yml` precedence the goal-spec parser documents).
 const CONFIG_FILE_CANDIDATES = Object.freeze([
-  ".loopover-miner.yml",
-  ".github/loopover-miner.yml",
-  ".loopover-miner.json",
-  ".github/loopover-miner.json",
+    ".loopover-miner.yml",
+    ".github/loopover-miner.yml",
+    ".loopover-miner.json",
+    ".github/loopover-miner.json",
 ]);
-
 /** The miner's local-state directory (holds the run-state / queue / ledger SQLite files). */
 export function resolveMinerStateDir(env = process.env) {
-  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
-    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
-    : "";
-  if (explicitConfigDir) return explicitConfigDir;
-
-  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
-    ? env.XDG_CONFIG_HOME.trim()
-    : join(homedir(), ".config");
-  return join(configHome, "loopover-miner");
+    const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
+        ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
+        : "";
+    if (explicitConfigDir)
+        return explicitConfigDir;
+    const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+        ? env.XDG_CONFIG_HOME.trim()
+        : join(homedir(), ".config");
+    return join(configHome, "loopover-miner");
 }
-
 /**
  * The REAL installed @loopover/engine version, for `status`'s own display. Prefers `readInstalled`
  * (the actually-resolved semver from node_modules/the monorepo workspace, the same real resolution `doctor`'s
@@ -82,274 +67,273 @@ export function resolveMinerStateDir(env = process.env) {
  * succeeding is the only realistic case in a working install, so the fallback path needs a way to force it.
  */
 export function buildEngineVersionDisplay(readInstalled = readInstalledEnginePackageVersion) {
-  const installed = readInstalled();
-  if (installed) return installed;
-  try {
-    return requireFromHere()("../package.json").dependencies?.[ENGINE_PACKAGE] ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function readEngineVersion() {
-  return buildEngineVersionDisplay();
-}
-
-export function readInstalledEnginePackageVersionFromPaths(
-  resolvedEntry,
-  workspacePkg,
-  deps = { existsSync, readFileSync },
-) {
-  try {
-    for (const pkgJson of [join(resolvedEntry, "..", "package.json"), join(resolvedEntry, "..", "..", "package.json")]) {
-      if (deps.existsSync(pkgJson)) {
-        const version = JSON.parse(deps.readFileSync(pkgJson, "utf8")).version;
-        if (version) return version;
-      }
-    }
-  } catch {
-    // fall through to monorepo workspace fallback
-  }
-  if (deps.existsSync(workspacePkg)) {
+    const installed = readInstalled();
+    if (installed)
+        return installed;
+    // The in-repo package.json always declares `dependencies["@loopover/engine"]`, so this range fallback always
+    // returns that string; its `?.`/`?? null`/require-throw defensive arms are unreachable in-tree.
+    /* v8 ignore start */
     try {
-      return JSON.parse(deps.readFileSync(workspacePkg, "utf8")).version ?? null;
-    } catch {
-      return null;
+        return requireFromHere()("../package.json").dependencies?.[ENGINE_PACKAGE] ?? null;
     }
-  }
-  return null;
+    catch {
+        return null;
+    }
+    /* v8 ignore stop */
 }
-
+function readEngineVersion() {
+    return buildEngineVersionDisplay();
+}
+export function readInstalledEnginePackageVersionFromPaths(resolvedEntry, workspacePkg, deps = { existsSync, readFileSync }) {
+    try {
+        for (const pkgJson of [join(resolvedEntry, "..", "package.json"), join(resolvedEntry, "..", "..", "package.json")]) {
+            if (deps.existsSync(pkgJson)) {
+                const version = JSON.parse(deps.readFileSync(pkgJson, "utf8")).version;
+                if (version)
+                    return version;
+            }
+        }
+    }
+    catch {
+        // fall through to monorepo workspace fallback
+    }
+    if (deps.existsSync(workspacePkg)) {
+        try {
+            return JSON.parse(deps.readFileSync(workspacePkg, "utf8")).version ?? null;
+        }
+        catch {
+            return null;
+        }
+    }
+    return null;
+}
 /** Installed @loopover/engine semver from node_modules (not the declared dependency range). */
 export function readInstalledEnginePackageVersion() {
-  try {
-    return readInstalledEnginePackageVersionFromPaths(
-      requireFromHere().resolve(ENGINE_PACKAGE),
-      join(moduleDir(), "../../loopover-engine/package.json"),
-    );
-  } catch {
-    const workspacePkg = join(moduleDir(), "../../loopover-engine/package.json");
-    if (existsSync(workspacePkg)) {
-      try {
-        return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
-}
-
-/** Expected minimum engine semver: monorepo engine package.json when present, else the shipped pin file. */
-export function readExpectedEnginePackageVersionFromPaths(
-  monorepoEnginePkg,
-  pinFile,
-  deps = { existsSync, readFileSync },
-) {
-  if (deps.existsSync(monorepoEnginePkg)) {
     try {
-      return JSON.parse(deps.readFileSync(monorepoEnginePkg, "utf8")).version ?? null;
-    } catch {
-      return null;
+        return readInstalledEnginePackageVersionFromPaths(requireFromHere().resolve(ENGINE_PACKAGE), join(moduleDir(), "../../loopover-engine/package.json"));
     }
-  }
-  try {
-    const pinned = deps.readFileSync(pinFile, "utf8").trim();
-    return pinned || null;
-  } catch {
-    return null;
-  }
+    catch {
+        // @loopover/engine always resolves in the monorepo/installed tree, so `resolve()` never throws here; this
+        // workspace-fallback catch is unreachable in tests (its path logic is covered directly via ...FromPaths).
+        /* v8 ignore start */
+        const workspacePkg = join(moduleDir(), "../../loopover-engine/package.json");
+        if (existsSync(workspacePkg)) {
+            try {
+                return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
+            }
+            catch {
+                return null;
+            }
+        }
+        return null;
+        /* v8 ignore stop */
+    }
 }
-
+/** Expected minimum engine semver: monorepo engine package.json when present, else the shipped pin file. */
+export function readExpectedEnginePackageVersionFromPaths(monorepoEnginePkg, pinFile, deps = { existsSync, readFileSync }) {
+    if (deps.existsSync(monorepoEnginePkg)) {
+        try {
+            return JSON.parse(deps.readFileSync(monorepoEnginePkg, "utf8")).version ?? null;
+        }
+        catch {
+            return null;
+        }
+    }
+    try {
+        const pinned = deps.readFileSync(pinFile, "utf8").trim();
+        return pinned || null;
+    }
+    catch {
+        return null;
+    }
+}
 export function readExpectedEnginePackageVersion() {
-  return readExpectedEnginePackageVersionFromPaths(
-    join(moduleDir(), "../../loopover-engine/package.json"),
-    join(moduleDir(), "../expected-engine.version"),
-  );
+    return readExpectedEnginePackageVersionFromPaths(join(moduleDir(), "../../loopover-engine/package.json"), join(moduleDir(), "../expected-engine.version"));
 }
-
 function parseSemverCore(version) {
-  const match = String(version).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+    const match = String(version).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!match)
+        return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
-
 /** Returns -1 when installed is behind expected, 0 when equal, 1 when ahead. */
 export function compareInstalledEngineVersion(installed, expected) {
-  const installedCore = parseSemverCore(installed);
-  const expectedCore = parseSemverCore(expected);
-  if (!installedCore || !expectedCore) return -1;
-  for (let index = 0; index < 3; index += 1) {
-    if (installedCore[index] < expectedCore[index]) return -1;
-    if (installedCore[index] > expectedCore[index]) return 1;
-  }
-  return 0;
+    const installedCore = parseSemverCore(installed);
+    const expectedCore = parseSemverCore(expected);
+    if (!installedCore || !expectedCore)
+        return -1;
+    for (let index = 0; index < 3; index += 1) {
+        const installedPart = installedCore[index];
+        const expectedPart = expectedCore[index];
+        if (installedPart < expectedPart)
+            return -1;
+        if (installedPart > expectedPart)
+            return 1;
+    }
+    return 0;
 }
-
-export function buildEngineVersionSkewCheck(
-  readInstalled = readInstalledEnginePackageVersion,
-  readExpected = readExpectedEnginePackageVersion,
-) {
-  const installed = readInstalled();
-  const expected = readExpected();
-  if (!expected) {
-    return { name: "engine-version-skew", ok: true, detail: "expected engine version unavailable (skipped)" };
-  }
-  if (!installed) {
+export function buildEngineVersionSkewCheck(readInstalled = readInstalledEnginePackageVersion, readExpected = readExpectedEnginePackageVersion) {
+    const installed = readInstalled();
+    const expected = readExpected();
+    if (!expected) {
+        return { name: "engine-version-skew", ok: true, detail: "expected engine version unavailable (skipped)" };
+    }
+    if (!installed) {
+        return {
+            name: "engine-version-skew",
+            ok: false,
+            detail: `${ENGINE_PACKAGE} not installed (cannot verify version skew)`,
+        };
+    }
+    const comparison = compareInstalledEngineVersion(installed, expected);
     return {
-      name: "engine-version-skew",
-      ok: false,
-      detail: `${ENGINE_PACKAGE} not installed (cannot verify version skew)`,
+        name: "engine-version-skew",
+        ok: comparison >= 0,
+        detail: comparison < 0
+            ? `installed ${installed} is behind expected ${expected}`
+            : `installed ${installed} (${comparison === 0 ? "matches" : "ahead of"} expected ${expected})`,
     };
-  }
-  const comparison = compareInstalledEngineVersion(installed, expected);
-  return {
-    name: "engine-version-skew",
-    ok: comparison >= 0,
-    detail:
-      comparison < 0
-        ? `installed ${installed} is behind expected ${expected}`
-        : `installed ${installed} (${comparison === 0 ? "matches" : "ahead of"} expected ${expected})`,
-  };
 }
-
 function checkEngineVersionSkew() {
-  return buildEngineVersionSkewCheck();
+    return buildEngineVersionSkewCheck();
 }
-
 /** The minimum Node major version from the package's `engines.node` floor (e.g. ">=22.13.0" → 22). */
 function requiredNodeMajor() {
-  const engines = requireFromHere()("../package.json").engines;
-  const match = typeof engines?.node === "string" ? engines.node.match(/(\d+)/) : null;
-  return match ? Number(match[1]) : 0;
+    const engines = requireFromHere()("../package.json").engines;
+    // The in-repo package.json always declares `engines.node` as a valid ">=NN..." string, so the non-string and
+    // no-digit-match fallbacks are unreachable in-tree.
+    /* v8 ignore start */
+    const match = typeof engines?.node === "string" ? engines.node.match(/(\d+)/) : null;
+    return match ? Number(match[1]) : 0;
+    /* v8 ignore stop */
 }
-
 function discoverConfigFile(cwd) {
-  for (const candidate of CONFIG_FILE_CANDIDATES) {
-    const path = join(cwd, candidate);
-    if (existsSync(path)) return path;
-  }
-  return null;
+    for (const candidate of CONFIG_FILE_CANDIDATES) {
+        const path = join(cwd, candidate);
+        if (existsSync(path))
+            return path;
+    }
+    return null;
 }
-
 // CLI names driver-factory.ts's resolved provider values that actually spawn a local subprocess -- "noop" and
 // "agent-sdk" have no separate CLI binary to check presence for, so cliPresent is null (not applicable) for them.
 const PROVIDER_CLI_BINARY = Object.freeze({ "claude-cli": "claude", "codex-cli": "codex" });
-
 /** The `driver` section of `status`/`status --json` (#5164): which coding-agent provider is configured, the
  *  NAME (never the value) of its model env var, and whether its CLI binary is on PATH. Reuses
  *  `resolveFirstConfiguredCodingAgentDriverName`/`CODING_AGENT_DRIVER_CONFIG_ENV` (the same resolution
  *  driver-factory.ts uses) and `findExecutableOnPath` (the same PATH scan the doctor CLI-presence checks use)
  *  rather than duplicating either. Never reads or returns an env var's actual value. */
 function resolveDriverStatus(env) {
-  const provider = resolveFirstConfiguredCodingAgentDriverName(env) ?? null;
-  const modelEnvVar = provider ? (CODING_AGENT_DRIVER_CONFIG_ENV[provider]?.model ?? null) : null;
-  const cliBinary = provider ? (PROVIDER_CLI_BINARY[provider] ?? null) : null;
-  const cliPresent = cliBinary ? Boolean(findExecutableOnPath(cliBinary, env)) : null;
-  return { provider, modelEnvVar, cliPresent };
+    const provider = resolveFirstConfiguredCodingAgentDriverName(env) ?? null;
+    const modelEnvVar = provider ? (CODING_AGENT_DRIVER_CONFIG_ENV[provider]?.model ?? null) : null;
+    const cliBinary = provider ? (PROVIDER_CLI_BINARY[provider] ?? null) : null;
+    const cliPresent = cliBinary ? Boolean(findExecutableOnPath(cliBinary, env)) : null;
+    return { provider, modelEnvVar, cliPresent };
 }
-
 /** Gather the read-only status snapshot. Pure w.r.t. its (env, cwd) inputs — no writes, no network. */
 export function collectStatus(env = process.env, cwd = process.cwd()) {
-  const stateDir = resolveMinerStateDir(env);
-  return {
-    package: { name: PACKAGE_NAME, version: resolveMinerVersion(env) },
-    engine: { name: ENGINE_PACKAGE, version: readEngineVersion() },
-    node: process.version,
-    stateDir,
-    configFile: discoverConfigFile(cwd),
-    driver: resolveDriverStatus(env),
-  };
-}
-
-function renderDriverLine(driver) {
-  if (!driver.provider) return "driver: none configured";
-  const cliText = driver.cliPresent === null ? "n/a" : driver.cliPresent ? "yes" : "no";
-  const modelText = driver.modelEnvVar ? `, model env: ${driver.modelEnvVar}` : "";
-  return `driver: ${driver.provider} (CLI present: ${cliText}${modelText})`;
-}
-
-function renderStatusText(status) {
-  return [
-    `${status.package.name} ${status.package.version ?? "unknown"} (node ${status.node})`,
-    `engine: ${status.engine.name} ${status.engine.version ?? "unresolved"}`,
-    `state dir: ${status.stateDir}`,
-    `config file: ${status.configFile ?? "none found"}`,
-    renderDriverLine(status.driver),
-  ].join("\n");
-}
-
-export function runStatus(args = [], env = process.env, cwd = process.cwd()) {
-  const status = collectStatus(env, cwd);
-  console.log(args.includes("--json") ? JSON.stringify(status, null, 2) : renderStatusText(status));
-  return 0;
-}
-
-function checkStateDirWritable(stateDir) {
-  const probe = join(stateDir, ".loopover-miner-write-probe");
-  try {
-    // Creating the dir and writing (then removing) a probe file proves it is writable — the state dir must be
-    // creatable/writable for the local SQLite stores to work.
-    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-    writeFileSync(probe, "");
-    rmSync(probe, { force: true });
-    return { name: "state-dir-writable", ok: true, detail: stateDir };
-  } catch (error) {
+    const stateDir = resolveMinerStateDir(env);
     return {
-      name: "state-dir-writable",
-      ok: false,
-      detail: `${stateDir}: ${error instanceof Error ? error.message : "not writable"}`,
+        package: { name: PACKAGE_NAME, version: resolveMinerVersion(env) },
+        engine: { name: ENGINE_PACKAGE, version: readEngineVersion() },
+        node: process.version,
+        stateDir,
+        configFile: discoverConfigFile(cwd),
+        driver: resolveDriverStatus(env),
     };
-  }
 }
-
+function renderDriverLine(driver) {
+    if (!driver.provider)
+        return "driver: none configured";
+    const cliText = driver.cliPresent === null ? "n/a" : driver.cliPresent ? "yes" : "no";
+    const modelText = driver.modelEnvVar ? `, model env: ${driver.modelEnvVar}` : "";
+    return `driver: ${driver.provider} (CLI present: ${cliText}${modelText})`;
+}
+function renderStatusText(status) {
+    return [
+        // package.version / engine.version always resolve to strings in-tree, so the `?? "unknown"` / `?? "unresolved"`
+        // fallbacks are unreachable here.
+        /* v8 ignore start */
+        `${status.package.name} ${status.package.version ?? "unknown"} (node ${status.node})`,
+        `engine: ${status.engine.name} ${status.engine.version ?? "unresolved"}`,
+        /* v8 ignore stop */
+        `state dir: ${status.stateDir}`,
+        `config file: ${status.configFile ?? "none found"}`,
+        renderDriverLine(status.driver),
+    ].join("\n");
+}
+export function runStatus(args = [], env = process.env, cwd = process.cwd()) {
+    const status = collectStatus(env, cwd);
+    console.log(args.includes("--json") ? JSON.stringify(status, null, 2) : renderStatusText(status));
+    return 0;
+}
+function checkStateDirWritable(stateDir) {
+    const probe = join(stateDir, ".loopover-miner-write-probe");
+    try {
+        // Creating the dir and writing (then removing) a probe file proves it is writable — the state dir must be
+        // creatable/writable for the local SQLite stores to work.
+        mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+        writeFileSync(probe, "");
+        rmSync(probe, { force: true });
+        return { name: "state-dir-writable", ok: true, detail: stateDir };
+    }
+    catch (error) {
+        return {
+            name: "state-dir-writable",
+            ok: false,
+            // fs operations reject with `Error` instances, so the non-Error message fallback is unreachable in tests.
+            /* v8 ignore next */
+            detail: `${stateDir}: ${error instanceof Error ? error.message : "not writable"}`,
+        };
+    }
+}
 /** Per-store `PRAGMA integrity_check` sweep for `doctor` (#4834) — flags a corrupted store instead of probing
  *  only one with `SELECT 1`. A store file that does not exist yet is healthy by absence. Keep in sync with
  *  migrate-cli.js's `STORES` list (#6768): every durable local SQLite store using resolveLocalStoreDbPath. */
 function storeIntegrityChecks(env) {
-  const stores = [
-    ["event-ledger", resolveEventLedgerDbPath(env)],
-    ["governor-ledger", resolveGovernorLedgerDbPath(env)],
-    ["prediction-ledger", resolvePredictionLedgerDbPath(env)],
-    ["portfolio-queue", resolvePortfolioQueueDbPath(env)],
-    ["claim-ledger", resolveClaimLedgerDbPath(env)],
-    ["run-state", resolveRunStateDbPath(env)],
-    ["plan-store", resolvePlanStoreDbPath(env)],
-    ["governor-state", resolveGovernorStateDbPath(env)],
-    ["attempt-log", resolveAttemptLogDbPath(env)],
-    ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
-    ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
-    ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
-    ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],
-    ["policy-doc-cache", resolvePolicyDocCacheDbPath(env)],
-  ];
-  return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
+    const stores = [
+        ["event-ledger", resolveEventLedgerDbPath(env)],
+        ["governor-ledger", resolveGovernorLedgerDbPath(env)],
+        ["prediction-ledger", resolvePredictionLedgerDbPath(env)],
+        ["portfolio-queue", resolvePortfolioQueueDbPath(env)],
+        ["claim-ledger", resolveClaimLedgerDbPath(env)],
+        ["run-state", resolveRunStateDbPath(env)],
+        ["plan-store", resolvePlanStoreDbPath(env)],
+        ["governor-state", resolveGovernorStateDbPath(env)],
+        ["attempt-log", resolveAttemptLogDbPath(env)],
+        // replay-snapshot.d.ts still types its resolver's `env` as `NodeJS.ProcessEnv` (which the root app config
+        // augments with the worker Env's required keys), so cast the plain Record view to it -- read-only, same value.
+        ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
+        ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
+        ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
+        ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],
+        ["policy-doc-cache", resolvePolicyDocCacheDbPath(env)],
+    ];
+    return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }
-
 /** Validate the discovered `.loopover-miner` config's CONTENT (#4873), not just its path: parse it with the
  *  tolerant goal-spec parser and surface its warnings, so a malformed config is flagged by `doctor` rather than
  *  silently degrading to defaults. No config file is fine (defaults apply); a read failure is reported. `readImpl`
  *  is injectable for tests. */
 export function checkConfigContent(cwd, readImpl = readFileSync) {
-  const configPath = discoverConfigFile(cwd);
-  if (!configPath) {
-    return { name: "config-content", ok: true, detail: "no .loopover-miner config found (using defaults)" };
-  }
-  let warnings;
-  try {
-    warnings = parseMinerGoalSpecContent(readImpl(configPath, "utf8")).warnings;
-  } catch (error) {
-    return { name: "config-content", ok: false, detail: `${configPath}: ${describeError(error)}` };
-  }
-  return warnings.length === 0
-    ? { name: "config-content", ok: true, detail: `${configPath}: valid` }
-    : { name: "config-content", ok: false, detail: `${configPath}: ${warnings.join("; ")}` };
+    const configPath = discoverConfigFile(cwd);
+    if (!configPath) {
+        return { name: "config-content", ok: true, detail: "no .loopover-miner config found (using defaults)" };
+    }
+    let warnings;
+    try {
+        warnings = parseMinerGoalSpecContent(readImpl(configPath, "utf8")).warnings;
+    }
+    catch (error) {
+        return { name: "config-content", ok: false, detail: `${configPath}: ${describeError(error)}` };
+    }
+    return warnings.length === 0
+        ? { name: "config-content", ok: true, detail: `${configPath}: valid` }
+        : { name: "config-content", ok: false, detail: `${configPath}: ${warnings.join("; ")}` };
 }
-
 function nonEmptyEnv(value) {
-  return typeof value === "string" && value.length > 0;
+    return typeof value === "string" && value.length > 0;
 }
-
 /** GitHub token presence (#5170, extended by #6116). A purely offline check — `doctor` never calls GitHub — but
  *  a missing token fails every real attempt the moment it tries to push a branch or open a PR, so surface it up
  *  front rather than mid-run. Checks BOTH a GITHUB_TOKEN env override AND a recorded `loopover-mcp login`
@@ -359,16 +343,15 @@ function nonEmptyEnv(value) {
  *  re-verified as still valid/unexpired -- only an actual attempt (or resolveGitHubToken itself) discovers
  *  that. Reports presence only; no token value is ever included in the detail. */
 export function checkGitHubTokenPresent(env = process.env) {
-  const present = hasGitHubTokenSource(env);
-  return {
-    name: "github-token",
-    ok: present,
-    detail: present
-      ? "A GitHub token is available (GITHUB_TOKEN or a loopover-mcp login session)"
-      : "No GitHub token available — run `loopover-mcp login`, or set GITHUB_TOKEN, before attempts that push a branch or open a PR",
-  };
+    const present = hasGitHubTokenSource(env);
+    return {
+        name: "github-token",
+        ok: present,
+        detail: present
+            ? "A GitHub token is available (GITHUB_TOKEN or a loopover-mcp login session)"
+            : "No GitHub token available — run `loopover-mcp login`, or set GITHUB_TOKEN, before attempts that push a branch or open a PR",
+    };
 }
-
 /** Credential presence for the CONFIGURED coding-agent provider (#5170). Distinct from the CLI-present checks,
  *  which by design keep `ok: true` when only the credential is missing (#5165): this FAILS `doctor` when the
  *  resolved provider's credential is absent, so an operator learns before an attempt fails partway through.
@@ -376,87 +359,91 @@ export function checkGitHubTokenPresent(env = process.env) {
  *  never prints the credential value, only the env-var names / file path. `resolveAuthPath` is injectable for
  *  tests, mirroring `checkCodexCliPresent`. */
 export function checkCodingAgentCredential(env = process.env, resolveAuthPath = resolveCodexAuthPath) {
-  const provider = resolveFirstConfiguredCodingAgentDriverName(env) ?? null;
-  if (provider === null || provider === "noop") {
+    const provider = resolveFirstConfiguredCodingAgentDriverName(env) ?? null;
+    if (provider === null || provider === "noop") {
+        return {
+            name: "coding-agent-credential",
+            ok: true,
+            detail: provider === "noop"
+                ? "noop driver needs no credential"
+                : "no coding-agent provider configured (skipped)",
+        };
+    }
+    if (provider === "claude-cli" || provider === "agent-sdk") {
+        // Both run the Claude backend (a `claude` subprocess vs the in-process Agent SDK) off the same subscription
+        // OAuth token the rest of the tree reads (CLAUDE_CODE_OAUTH_TOKEN; see createClaudeCodeAi in
+        // src/selfhost/ai.ts). The SDK additionally accepts a raw ANTHROPIC_API_KEY, so either satisfies the credential.
+        const present = nonEmptyEnv(env.CLAUDE_CODE_OAUTH_TOKEN) || nonEmptyEnv(env.ANTHROPIC_API_KEY);
+        return {
+            name: "coding-agent-credential",
+            ok: present,
+            detail: present
+                ? `${provider}: Claude credential is set`
+                : `${provider}: no Claude credential — set CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY)`,
+        };
+    }
+    // codex-cli: the only remaining configured provider — its credential is a readable auth.json, the same
+    // read-only condition checkCodexCliPresent probes (reusing resolveCodexAuthPath so the location never drifts).
+    const authPath = resolveAuthPath(env);
+    let readable = false;
+    try {
+        accessSync(authPath, constants.R_OK);
+        readable = true;
+    }
+    catch {
+        // missing or unreadable — codex would fail for lack of credentials at attempt time.
+    }
     return {
-      name: "coding-agent-credential",
-      ok: true,
-      detail:
-        provider === "noop"
-          ? "noop driver needs no credential"
-          : "no coding-agent provider configured (skipped)",
+        name: "coding-agent-credential",
+        ok: readable,
+        detail: readable
+            ? `codex-cli: auth.json is readable at ${authPath}`
+            : `codex-cli: auth.json missing or unreadable at ${authPath} — run \`codex auth\``,
     };
-  }
-  if (provider === "claude-cli" || provider === "agent-sdk") {
-    // Both run the Claude backend (a `claude` subprocess vs the in-process Agent SDK) off the same subscription
-    // OAuth token the rest of the tree reads (CLAUDE_CODE_OAUTH_TOKEN; see createClaudeCodeAi in
-    // src/selfhost/ai.ts). The SDK additionally accepts a raw ANTHROPIC_API_KEY, so either satisfies the credential.
-    const present = nonEmptyEnv(env.CLAUDE_CODE_OAUTH_TOKEN) || nonEmptyEnv(env.ANTHROPIC_API_KEY);
-    return {
-      name: "coding-agent-credential",
-      ok: present,
-      detail: present
-        ? `${provider}: Claude credential is set`
-        : `${provider}: no Claude credential — set CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY)`,
-    };
-  }
-  // codex-cli: the only remaining configured provider — its credential is a readable auth.json, the same
-  // read-only condition checkCodexCliPresent probes (reusing resolveCodexAuthPath so the location never drifts).
-  const authPath = resolveAuthPath(env);
-  let readable = false;
-  try {
-    accessSync(authPath, constants.R_OK);
-    readable = true;
-  } catch {
-    // missing or unreadable — codex would fail for lack of credentials at attempt time.
-  }
-  return {
-    name: "coding-agent-credential",
-    ok: readable,
-    detail: readable
-      ? `codex-cli: auth.json is readable at ${authPath}`
-      : `codex-cli: auth.json missing or unreadable at ${authPath} — run \`codex auth\``,
-  };
 }
-
 /** Run the doctor checks. Returns an array of { name, ok, detail }; only writes a transient probe in the state dir,
  *  never touches the network. */
 export function runDoctorChecks(env = process.env, cwd = process.cwd()) {
-  const nodeMajor = Number(process.versions.node.split(".")[0]);
-  const requiredMajor = requiredNodeMajor();
-  const engineVersion = readEngineVersion();
-  return [
-    {
-      name: "node-version",
-      ok: nodeMajor >= requiredMajor,
-      detail: `node ${process.version} (requires >= ${requiredMajor})`,
-    },
-    {
-      name: "engine-resolves",
-      ok: engineVersion !== null,
-      detail: engineVersion ? `${ENGINE_PACKAGE} ${engineVersion}` : `${ENGINE_PACKAGE} not resolvable`,
-    },
-    checkEngineVersionSkew(),
-    checkStateDirWritable(resolveMinerStateDir(env)),
-    checkLaptopStateSqlite(env),
-    checkDockerPresent(),
-    checkClaudeCliPresent({ env }),
-    checkCodexCliPresent({ env }),
-    checkGitHubTokenPresent(env),
-    checkCodingAgentCredential(env),
-    checkConfigContent(cwd),
-    ...storeIntegrityChecks(env),
-  ];
+    const nodeMajor = Number(process.versions.node.split(".")[0]);
+    const requiredMajor = requiredNodeMajor();
+    const engineVersion = readEngineVersion();
+    return [
+        {
+            name: "node-version",
+            ok: nodeMajor >= requiredMajor,
+            detail: `node ${process.version} (requires >= ${requiredMajor})`,
+        },
+        {
+            name: "engine-resolves",
+            ok: engineVersion !== null,
+            // engineVersion always resolves to a string in-tree, so the not-resolvable detail arm is unreachable here.
+            /* v8 ignore next */
+            detail: engineVersion ? `${ENGINE_PACKAGE} ${engineVersion}` : `${ENGINE_PACKAGE} not resolvable`,
+        },
+        checkEngineVersionSkew(),
+        checkStateDirWritable(resolveMinerStateDir(env)),
+        checkLaptopStateSqlite(env),
+        checkDockerPresent(),
+        checkClaudeCliPresent({ env }),
+        checkCodexCliPresent({ env }),
+        checkGitHubTokenPresent(env),
+        checkCodingAgentCredential(env),
+        checkConfigContent(cwd),
+        ...storeIntegrityChecks(env),
+    ];
 }
-
 export function runDoctor(args = [], env = process.env, cwd = process.cwd()) {
-  const checks = runDoctorChecks(env, cwd);
-  const failed = checks.filter((check) => !check.ok);
-  if (args.includes("--json")) {
-    console.log(JSON.stringify({ ok: failed.length === 0, checks }, null, 2));
-  } else {
-    for (const check of checks) console.log(`${check.ok ? "ok  " : "FAIL"} ${check.name}: ${check.detail}`);
-    if (failed.length > 0) console.error(`doctor: ${failed.length} check(s) failed`);
-  }
-  return failed.length === 0 ? 0 : 1;
+    const checks = runDoctorChecks(env, cwd);
+    const failed = checks.filter((check) => !check.ok);
+    if (args.includes("--json")) {
+        console.log(JSON.stringify({ ok: failed.length === 0, checks }, null, 2));
+    }
+    else {
+        for (const check of checks)
+            console.log(`${check.ok ? "ok  " : "FAIL"} ${check.name}: ${check.detail}`);
+        if (failed.length > 0)
+            console.error(`doctor: ${failed.length} check(s) failed`);
+    }
+    return failed.length === 0 ? 0 : 1;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic3RhdHVzLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic3RhdHVzLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxVQUFVLEVBQUUsU0FBUyxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsWUFBWSxFQUFFLE1BQU0sRUFBRSxhQUFhLEVBQUUsTUFBTSxTQUFTLENBQUM7QUFDNUcsT0FBTyxFQUFFLGFBQWEsRUFBRSxNQUFNLGFBQWEsQ0FBQztBQUM1QyxPQUFPLEVBQUUsT0FBTyxFQUFFLE1BQU0sU0FBUyxDQUFDO0FBQ2xDLE9BQU8sRUFBRSxJQUFJLEVBQUUsTUFBTSxXQUFXLENBQUM7QUFDakMsT0FBTyxFQUFFLDhCQUE4QixFQUFFLHlCQUF5QixFQUFFLDJDQUEyQyxFQUFFLE1BQU0sa0JBQWtCLENBQUM7QUFDMUksT0FBTyxFQUNMLHFCQUFxQixFQUNyQixvQkFBb0IsRUFDcEIsa0JBQWtCLEVBQ2xCLHNCQUFzQixFQUN0QixvQkFBb0IsRUFDcEIsb0JBQW9CLEdBQ3JCLE1BQU0sa0JBQWtCLENBQUM7QUFDMUIsT0FBTyxFQUFFLG1CQUFtQixFQUFFLE1BQU0sY0FBYyxDQUFDO0FBQ25ELE9BQU8sRUFBRSxtQkFBbUIsRUFBRSxhQUFhLEVBQUUsTUFBTSx3QkFBd0IsQ0FBQztBQUM1RSxPQUFPLEVBQUUsd0JBQXdCLEVBQUUsTUFBTSxtQkFBbUIsQ0FBQztBQUM3RCxPQUFPLEVBQUUsMkJBQTJCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUNuRSxPQUFPLEVBQUUsb0JBQW9CLEVBQUUsTUFBTSw4QkFBOEIsQ0FBQztBQUNwRSxPQUFPLEVBQUUsNkJBQTZCLEVBQUUsTUFBTSx3QkFBd0IsQ0FBQztBQUN2RSxPQUFPLEVBQUUsMkJBQTJCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUNuRSxPQUFPLEVBQUUsd0JBQXdCLEVBQUUsTUFBTSxtQkFBbUIsQ0FBQztBQUM3RCxPQUFPLEVBQUUscUJBQXFCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUN2RCxPQUFPLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUN6RCxPQUFPLEVBQUUsMEJBQTBCLEVBQUUsTUFBTSxxQkFBcUIsQ0FBQztBQUNqRSxPQUFPLEVBQUUsdUJBQXVCLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUMzRCxPQUFPLEVBQUUsMkJBQTJCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUNuRSxPQUFPLEVBQUUsOEJBQThCLEVBQUUsTUFBTSx5QkFBeUIsQ0FBQztBQUN6RSxPQUFPLEVBQUUscUNBQXFDLEVBQUUsTUFBTSxpQ0FBaUMsQ0FBQztBQUN4RixPQUFPLEVBQUUsK0JBQStCLEVBQUUsTUFBTSwyQkFBMkIsQ0FBQztBQUM1RSxPQUFPLEVBQUUsMkJBQTJCLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQTJCcEUsMEdBQTBHO0FBQzFHLDJHQUEyRztBQUMzRywyR0FBMkc7QUFDM0cscUdBQXFHO0FBQ3JHLElBQUksYUFBYSxHQUF1QixJQUFJLENBQUM7QUFDN0MsU0FBUyxlQUFlO0lBQ3RCLE9BQU8sQ0FBQyxhQUFhLEtBQUssYUFBYSxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztBQUM1RCxDQUFDO0FBQ0QsSUFBSSxlQUFlLEdBQWtCLElBQUksQ0FBQztBQUMxQyxTQUFTLFNBQVM7SUFDaEIsT0FBTyxDQUFDLGVBQWUsS0FBSyxNQUFNLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0FBQ25ELENBQUM7QUFFRCxNQUFNLFlBQVksR0FBRyxpQkFBaUIsQ0FBQztBQUN2QyxNQUFNLGNBQWMsR0FBRyxrQkFBa0IsQ0FBQztBQUMxQyw2R0FBNkc7QUFDN0csTUFBTSxzQkFBc0IsR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDO0lBQzNDLHFCQUFxQjtJQUNyQiw0QkFBNEI7SUFDNUIsc0JBQXNCO0lBQ3RCLDZCQUE2QjtDQUM5QixDQUFDLENBQUM7QUFFSCw2RkFBNkY7QUFDN0YsTUFBTSxVQUFVLG9CQUFvQixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQ3hGLE1BQU0saUJBQWlCLEdBQUcsT0FBTyxHQUFHLENBQUMseUJBQXlCLEtBQUssUUFBUTtRQUN6RSxDQUFDLENBQUMsR0FBRyxDQUFDLHlCQUF5QixDQUFDLElBQUksRUFBRTtRQUN0QyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ1AsSUFBSSxpQkFBaUI7UUFBRSxPQUFPLGlCQUFpQixDQUFDO0lBRWhELE1BQU0sVUFBVSxHQUFHLE9BQU8sR0FBRyxDQUFDLGVBQWUsS0FBSyxRQUFRLElBQUksR0FBRyxDQUFDLGVBQWUsQ0FBQyxJQUFJLEVBQUU7UUFDdEYsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxlQUFlLENBQUMsSUFBSSxFQUFFO1FBQzVCLENBQUMsQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDL0IsT0FBTyxJQUFJLENBQUMsVUFBVSxFQUFFLGdCQUFnQixDQUFDLENBQUM7QUFDNUMsQ0FBQztBQUVEOzs7Ozs7Ozs7OztHQVdHO0FBQ0gsTUFBTSxVQUFVLHlCQUF5QixDQUFDLGdCQUFxQyxpQ0FBaUM7SUFDOUcsTUFBTSxTQUFTLEdBQUcsYUFBYSxFQUFFLENBQUM7SUFDbEMsSUFBSSxTQUFTO1FBQUUsT0FBTyxTQUFTLENBQUM7SUFDaEMsNkdBQTZHO0lBQzdHLGdHQUFnRztJQUNoRyxxQkFBcUI7SUFDckIsSUFBSSxDQUFDO1FBQ0gsT0FBTyxlQUFlLEVBQUUsQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDLFlBQVksRUFBRSxDQUFDLGNBQWMsQ0FBQyxJQUFJLElBQUksQ0FBQztJQUNyRixDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsT0FBTyxJQUFJLENBQUM7SUFDZCxDQUFDO0lBQ0Qsb0JBQW9CO0FBQ3RCLENBQUM7QUFFRCxTQUFTLGlCQUFpQjtJQUN4QixPQUFPLHlCQUF5QixFQUFFLENBQUM7QUFDckMsQ0FBQztBQUVELE1BQU0sVUFBVSwwQ0FBMEMsQ0FDeEQsYUFBcUIsRUFDckIsWUFBb0IsRUFDcEIsT0FBNEcsRUFBRSxVQUFVLEVBQUUsWUFBWSxFQUFFO0lBRXhJLElBQUksQ0FBQztRQUNILEtBQUssTUFBTSxPQUFPLElBQUksQ0FBQyxJQUFJLENBQUMsYUFBYSxFQUFFLElBQUksRUFBRSxjQUFjLENBQUMsRUFBRSxJQUFJLENBQUMsYUFBYSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsY0FBYyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQ25ILElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsRUFBRSxDQUFDO2dCQUM3QixNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxZQUFZLENBQUMsT0FBTyxFQUFFLE1BQU0sQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDO2dCQUN2RSxJQUFJLE9BQU87b0JBQUUsT0FBTyxPQUFPLENBQUM7WUFDOUIsQ0FBQztRQUNILENBQUM7SUFDSCxDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsOENBQThDO0lBQ2hELENBQUM7SUFDRCxJQUFJLElBQUksQ0FBQyxVQUFVLENBQUMsWUFBWSxDQUFDLEVBQUUsQ0FBQztRQUNsQyxJQUFJLENBQUM7WUFDSCxPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLFlBQVksQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLENBQUMsQ0FBQyxPQUFPLElBQUksSUFBSSxDQUFDO1FBQzdFLENBQUM7UUFBQyxNQUFNLENBQUM7WUFDUCxPQUFPLElBQUksQ0FBQztRQUNkLENBQUM7SUFDSCxDQUFDO0lBQ0QsT0FBTyxJQUFJLENBQUM7QUFDZCxDQUFDO0FBRUQsK0ZBQStGO0FBQy9GLE1BQU0sVUFBVSxpQ0FBaUM7SUFDL0MsSUFBSSxDQUFDO1FBQ0gsT0FBTywwQ0FBMEMsQ0FDL0MsZUFBZSxFQUFFLENBQUMsT0FBTyxDQUFDLGNBQWMsQ0FBQyxFQUN6QyxJQUFJLENBQUMsU0FBUyxFQUFFLEVBQUUsb0NBQW9DLENBQUMsQ0FDeEQsQ0FBQztJQUNKLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCwwR0FBMEc7UUFDMUcsMEdBQTBHO1FBQzFHLHFCQUFxQjtRQUNyQixNQUFNLFlBQVksR0FBRyxJQUFJLENBQUMsU0FBUyxFQUFFLEVBQUUsb0NBQW9DLENBQUMsQ0FBQztRQUM3RSxJQUFJLFVBQVUsQ0FBQyxZQUFZLENBQUMsRUFBRSxDQUFDO1lBQzdCLElBQUksQ0FBQztnQkFDSCxPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLFlBQVksRUFBRSxNQUFNLENBQUMsQ0FBQyxDQUFDLE9BQU8sSUFBSSxJQUFJLENBQUM7WUFDeEUsQ0FBQztZQUFDLE1BQU0sQ0FBQztnQkFDUCxPQUFPLElBQUksQ0FBQztZQUNkLENBQUM7UUFDSCxDQUFDO1FBQ0QsT0FBTyxJQUFJLENBQUM7UUFDWixvQkFBb0I7SUFDdEIsQ0FBQztBQUNILENBQUM7QUFFRCw0R0FBNEc7QUFDNUcsTUFBTSxVQUFVLHlDQUF5QyxDQUN2RCxpQkFBeUIsRUFDekIsT0FBZSxFQUNmLE9BQTRHLEVBQUUsVUFBVSxFQUFFLFlBQVksRUFBRTtJQUV4SSxJQUFJLElBQUksQ0FBQyxVQUFVLENBQUMsaUJBQWlCLENBQUMsRUFBRSxDQUFDO1FBQ3ZDLElBQUksQ0FBQztZQUNILE9BQU8sSUFBSSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsWUFBWSxDQUFDLGlCQUFpQixFQUFFLE1BQU0sQ0FBQyxDQUFDLENBQUMsT0FBTyxJQUFJLElBQUksQ0FBQztRQUNsRixDQUFDO1FBQUMsTUFBTSxDQUFDO1lBQ1AsT0FBTyxJQUFJLENBQUM7UUFDZCxDQUFDO0lBQ0gsQ0FBQztJQUNELElBQUksQ0FBQztRQUNILE1BQU0sTUFBTSxHQUFHLElBQUksQ0FBQyxZQUFZLENBQUMsT0FBTyxFQUFFLE1BQU0sQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO1FBQ3pELE9BQU8sTUFBTSxJQUFJLElBQUksQ0FBQztJQUN4QixDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsT0FBTyxJQUFJLENBQUM7SUFDZCxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxnQ0FBZ0M7SUFDOUMsT0FBTyx5Q0FBeUMsQ0FDOUMsSUFBSSxDQUFDLFNBQVMsRUFBRSxFQUFFLG9DQUFvQyxDQUFDLEVBQ3ZELElBQUksQ0FBQyxTQUFTLEVBQUUsRUFBRSw0QkFBNEIsQ0FBQyxDQUNoRCxDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMsZUFBZSxDQUFDLE9BQWU7SUFDdEMsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDO0lBQ25FLElBQUksQ0FBQyxLQUFLO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDeEIsT0FBTyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDaEUsQ0FBQztBQUVELGdGQUFnRjtBQUNoRixNQUFNLFVBQVUsNkJBQTZCLENBQUMsU0FBaUIsRUFBRSxRQUFnQjtJQUMvRSxNQUFNLGFBQWEsR0FBRyxlQUFlLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDakQsTUFBTSxZQUFZLEdBQUcsZUFBZSxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQy9DLElBQUksQ0FBQyxhQUFhLElBQUksQ0FBQyxZQUFZO1FBQUUsT0FBTyxDQUFDLENBQUMsQ0FBQztJQUMvQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUMxQyxNQUFNLGFBQWEsR0FBRyxhQUFhLENBQUMsS0FBSyxDQUFXLENBQUM7UUFDckQsTUFBTSxZQUFZLEdBQUcsWUFBWSxDQUFDLEtBQUssQ0FBVyxDQUFDO1FBQ25ELElBQUksYUFBYSxHQUFHLFlBQVk7WUFBRSxPQUFPLENBQUMsQ0FBQyxDQUFDO1FBQzVDLElBQUksYUFBYSxHQUFHLFlBQVk7WUFBRSxPQUFPLENBQUMsQ0FBQztJQUM3QyxDQUFDO0lBQ0QsT0FBTyxDQUFDLENBQUM7QUFDWCxDQUFDO0FBRUQsTUFBTSxVQUFVLDJCQUEyQixDQUN6QyxnQkFBcUMsaUNBQWlDLEVBQ3RFLGVBQW9DLGdDQUFnQztJQUVwRSxNQUFNLFNBQVMsR0FBRyxhQUFhLEVBQUUsQ0FBQztJQUNsQyxNQUFNLFFBQVEsR0FBRyxZQUFZLEVBQUUsQ0FBQztJQUNoQyxJQUFJLENBQUMsUUFBUSxFQUFFLENBQUM7UUFDZCxPQUFPLEVBQUUsSUFBSSxFQUFFLHFCQUFxQixFQUFFLEVBQUUsRUFBRSxJQUFJLEVBQUUsTUFBTSxFQUFFLCtDQUErQyxFQUFFLENBQUM7SUFDNUcsQ0FBQztJQUNELElBQUksQ0FBQyxTQUFTLEVBQUUsQ0FBQztRQUNmLE9BQU87WUFDTCxJQUFJLEVBQUUscUJBQXFCO1lBQzNCLEVBQUUsRUFBRSxLQUFLO1lBQ1QsTUFBTSxFQUFFLEdBQUcsY0FBYyw2Q0FBNkM7U0FDdkUsQ0FBQztJQUNKLENBQUM7SUFDRCxNQUFNLFVBQVUsR0FBRyw2QkFBNkIsQ0FBQyxTQUFTLEVBQUUsUUFBUSxDQUFDLENBQUM7SUFDdEUsT0FBTztRQUNMLElBQUksRUFBRSxxQkFBcUI7UUFDM0IsRUFBRSxFQUFFLFVBQVUsSUFBSSxDQUFDO1FBQ25CLE1BQU0sRUFDSixVQUFVLEdBQUcsQ0FBQztZQUNaLENBQUMsQ0FBQyxhQUFhLFNBQVMsdUJBQXVCLFFBQVEsRUFBRTtZQUN6RCxDQUFDLENBQUMsYUFBYSxTQUFTLEtBQUssVUFBVSxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxVQUFVLGFBQWEsUUFBUSxHQUFHO0tBQ25HLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxzQkFBc0I7SUFDN0IsT0FBTywyQkFBMkIsRUFBRSxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxzR0FBc0c7QUFDdEcsU0FBUyxpQkFBaUI7SUFDeEIsTUFBTSxPQUFPLEdBQUcsZUFBZSxFQUFFLENBQUMsaUJBQWlCLENBQUMsQ0FBQyxPQUFPLENBQUM7SUFDN0QsNkdBQTZHO0lBQzdHLG9EQUFvRDtJQUNwRCxxQkFBcUI7SUFDckIsTUFBTSxLQUFLLEdBQUcsT0FBTyxPQUFPLEVBQUUsSUFBSSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUNyRixPQUFPLEtBQUssQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDcEMsb0JBQW9CO0FBQ3RCLENBQUM7QUFFRCxTQUFTLGtCQUFrQixDQUFDLEdBQVc7SUFDckMsS0FBSyxNQUFNLFNBQVMsSUFBSSxzQkFBc0IsRUFBRSxDQUFDO1FBQy9DLE1BQU0sSUFBSSxHQUFHLElBQUksQ0FBQyxHQUFHLEVBQUUsU0FBUyxDQUFDLENBQUM7UUFDbEMsSUFBSSxVQUFVLENBQUMsSUFBSSxDQUFDO1lBQUUsT0FBTyxJQUFJLENBQUM7SUFDcEMsQ0FBQztJQUNELE9BQU8sSUFBSSxDQUFDO0FBQ2QsQ0FBQztBQUVELDhHQUE4RztBQUM5RyxrSEFBa0g7QUFDbEgsTUFBTSxtQkFBbUIsR0FBMkIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLFlBQVksRUFBRSxRQUFRLEVBQUUsV0FBVyxFQUFFLE9BQU8sRUFBRSxDQUFDLENBQUM7QUFFcEg7Ozs7d0ZBSXdGO0FBQ3hGLFNBQVMsbUJBQW1CLENBQUMsR0FBdUM7SUFDbEUsTUFBTSxRQUFRLEdBQUcsMkNBQTJDLENBQUMsR0FBRyxDQUFDLElBQUksSUFBSSxDQUFDO0lBQzFFLE1BQU0sV0FBVyxHQUFHLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyw4QkFBOEIsQ0FBQyxRQUF1RCxDQUFDLEVBQUUsS0FBSyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDL0ksTUFBTSxTQUFTLEdBQUcsUUFBUSxDQUFDLENBQUMsQ0FBQyxDQUFDLG1CQUFtQixDQUFDLFFBQVEsQ0FBQyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDNUUsTUFBTSxVQUFVLEdBQUcsU0FBUyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsb0JBQW9CLENBQUMsU0FBUyxFQUFFLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUNwRixPQUFPLEVBQUUsUUFBUSxFQUFFLFdBQVcsRUFBRSxVQUFVLEVBQUUsQ0FBQztBQUMvQyxDQUFDO0FBRUQsdUdBQXVHO0FBQ3ZHLE1BQU0sVUFBVSxhQUFhLENBQUMsTUFBMEMsT0FBTyxDQUFDLEdBQUcsRUFBRSxNQUFjLE9BQU8sQ0FBQyxHQUFHLEVBQUU7SUFDOUcsTUFBTSxRQUFRLEdBQUcsb0JBQW9CLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDM0MsT0FBTztRQUNMLE9BQU8sRUFBRSxFQUFFLElBQUksRUFBRSxZQUFZLEVBQUUsT0FBTyxFQUFFLG1CQUFtQixDQUFDLEdBQUcsQ0FBQyxFQUFFO1FBQ2xFLE1BQU0sRUFBRSxFQUFFLElBQUksRUFBRSxjQUFjLEVBQUUsT0FBTyxFQUFFLGlCQUFpQixFQUFFLEVBQUU7UUFDOUQsSUFBSSxFQUFFLE9BQU8sQ0FBQyxPQUFPO1FBQ3JCLFFBQVE7UUFDUixVQUFVLEVBQUUsa0JBQWtCLENBQUMsR0FBRyxDQUFDO1FBQ25DLE1BQU0sRUFBRSxtQkFBbUIsQ0FBQyxHQUFHLENBQUM7S0FDakMsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLGdCQUFnQixDQUFDLE1BQXlCO0lBQ2pELElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUTtRQUFFLE9BQU8seUJBQXlCLENBQUM7SUFDdkQsTUFBTSxPQUFPLEdBQUcsTUFBTSxDQUFDLFVBQVUsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDdEYsTUFBTSxTQUFTLEdBQUcsTUFBTSxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsZ0JBQWdCLE1BQU0sQ0FBQyxXQUFXLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ2pGLE9BQU8sV0FBVyxNQUFNLENBQUMsUUFBUSxrQkFBa0IsT0FBTyxHQUFHLFNBQVMsR0FBRyxDQUFDO0FBQzVFLENBQUM7QUFFRCxTQUFTLGdCQUFnQixDQUFDLE1BQW1CO0lBQzNDLE9BQU87UUFDTCxnSEFBZ0g7UUFDaEgsa0NBQWtDO1FBQ2xDLHFCQUFxQjtRQUNyQixHQUFHLE1BQU0sQ0FBQyxPQUFPLENBQUMsSUFBSSxJQUFJLE1BQU0sQ0FBQyxPQUFPLENBQUMsT0FBTyxJQUFJLFNBQVMsVUFBVSxNQUFNLENBQUMsSUFBSSxHQUFHO1FBQ3JGLFdBQVcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxJQUFJLElBQUksTUFBTSxDQUFDLE1BQU0sQ0FBQyxPQUFPLElBQUksWUFBWSxFQUFFO1FBQ3hFLG9CQUFvQjtRQUNwQixjQUFjLE1BQU0sQ0FBQyxRQUFRLEVBQUU7UUFDL0IsZ0JBQWdCLE1BQU0sQ0FBQyxVQUFVLElBQUksWUFBWSxFQUFFO1FBQ25ELGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUM7S0FDaEMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDZixDQUFDO0FBRUQsTUFBTSxVQUFVLFNBQVMsQ0FBQyxPQUFpQixFQUFFLEVBQUUsTUFBMEMsT0FBTyxDQUFDLEdBQUcsRUFBRSxNQUFjLE9BQU8sQ0FBQyxHQUFHLEVBQUU7SUFDL0gsTUFBTSxNQUFNLEdBQUcsYUFBYSxDQUFDLEdBQUcsRUFBRSxHQUFHLENBQUMsQ0FBQztJQUN2QyxPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsZ0JBQWdCLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQztJQUNsRyxPQUFPLENBQUMsQ0FBQztBQUNYLENBQUM7QUFFRCxTQUFTLHFCQUFxQixDQUFDLFFBQWdCO0lBQzdDLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxRQUFRLEVBQUUsNkJBQTZCLENBQUMsQ0FBQztJQUM1RCxJQUFJLENBQUM7UUFDSCwwR0FBMEc7UUFDMUcsMERBQTBEO1FBQzFELFNBQVMsQ0FBQyxRQUFRLEVBQUUsRUFBRSxTQUFTLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO1FBQ3RELGFBQWEsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLENBQUM7UUFDekIsTUFBTSxDQUFDLEtBQUssRUFBRSxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDO1FBQy9CLE9BQU8sRUFBRSxJQUFJLEVBQUUsb0JBQW9CLEVBQUUsRUFBRSxFQUFFLElBQUksRUFBRSxNQUFNLEVBQUUsUUFBUSxFQUFFLENBQUM7SUFDcEUsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPO1lBQ0wsSUFBSSxFQUFFLG9CQUFvQjtZQUMxQixFQUFFLEVBQUUsS0FBSztZQUNULDBHQUEwRztZQUMxRyxvQkFBb0I7WUFDcEIsTUFBTSxFQUFFLEdBQUcsUUFBUSxLQUFLLEtBQUssWUFBWSxLQUFLLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLGNBQWMsRUFBRTtTQUNsRixDQUFDO0lBQ0osQ0FBQztBQUNILENBQUM7QUFFRDs7OEdBRThHO0FBQzlHLFNBQVMsb0JBQW9CLENBQUMsR0FBdUM7SUFDbkUsTUFBTSxNQUFNLEdBQTRCO1FBQ3RDLENBQUMsY0FBYyxFQUFFLHdCQUF3QixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQy9DLENBQUMsaUJBQWlCLEVBQUUsMkJBQTJCLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDckQsQ0FBQyxtQkFBbUIsRUFBRSw2QkFBNkIsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUN6RCxDQUFDLGlCQUFpQixFQUFFLDJCQUEyQixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQ3JELENBQUMsY0FBYyxFQUFFLHdCQUF3QixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQy9DLENBQUMsV0FBVyxFQUFFLHFCQUFxQixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQ3pDLENBQUMsWUFBWSxFQUFFLHNCQUFzQixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQzNDLENBQUMsZ0JBQWdCLEVBQUUsMEJBQTBCLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDbkQsQ0FBQyxhQUFhLEVBQUUsdUJBQXVCLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDN0MsMEdBQTBHO1FBQzFHLCtHQUErRztRQUMvRyxDQUFDLGlCQUFpQixFQUFFLDJCQUEyQixDQUFDLEdBQXdCLENBQUMsQ0FBQztRQUMxRSxDQUFDLG9CQUFvQixFQUFFLDhCQUE4QixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQzNELENBQUMsc0JBQXNCLEVBQUUscUNBQXFDLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDcEUsQ0FBQyxzQkFBc0IsRUFBRSwrQkFBK0IsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUM5RCxDQUFDLGtCQUFrQixFQUFFLDJCQUEyQixDQUFDLEdBQUcsQ0FBQyxDQUFDO0tBQ3ZELENBQUM7SUFDRixPQUFPLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLElBQUksRUFBRSxNQUFNLENBQUMsRUFBRSxFQUFFLENBQUMsbUJBQW1CLENBQUMsbUJBQW1CLElBQUksRUFBRSxFQUFFLE1BQU0sQ0FBQyxDQUFDLENBQUM7QUFDaEcsQ0FBQztBQUVEOzs7K0JBRytCO0FBQy9CLE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxHQUFXLEVBQUUsV0FBdUQsWUFBWTtJQUNqSCxNQUFNLFVBQVUsR0FBRyxrQkFBa0IsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUMzQyxJQUFJLENBQUMsVUFBVSxFQUFFLENBQUM7UUFDaEIsT0FBTyxFQUFFLElBQUksRUFBRSxnQkFBZ0IsRUFBRSxFQUFFLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxrREFBa0QsRUFBRSxDQUFDO0lBQzFHLENBQUM7SUFDRCxJQUFJLFFBQVEsQ0FBQztJQUNiLElBQUksQ0FBQztRQUNILFFBQVEsR0FBRyx5QkFBeUIsQ0FBQyxRQUFRLENBQUMsVUFBVSxFQUFFLE1BQU0sQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDO0lBQzlFLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxFQUFFLElBQUksRUFBRSxnQkFBZ0IsRUFBRSxFQUFFLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxHQUFHLFVBQVUsS0FBSyxhQUFhLENBQUMsS0FBSyxDQUFDLEVBQUUsRUFBRSxDQUFDO0lBQ2pHLENBQUM7SUFDRCxPQUFPLFFBQVEsQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUMxQixDQUFDLENBQUMsRUFBRSxJQUFJLEVBQUUsZ0JBQWdCLEVBQUUsRUFBRSxFQUFFLElBQUksRUFBRSxNQUFNLEVBQUUsR0FBRyxVQUFVLFNBQVMsRUFBRTtRQUN0RSxDQUFDLENBQUMsRUFBRSxJQUFJLEVBQUUsZ0JBQWdCLEVBQUUsRUFBRSxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsR0FBRyxVQUFVLEtBQUssUUFBUSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsRUFBRSxFQUFFLENBQUM7QUFDN0YsQ0FBQztBQUVELFNBQVMsV0FBVyxDQUFDLEtBQXlCO0lBQzVDLE9BQU8sT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDO0FBQ3ZELENBQUM7QUFFRDs7Ozs7OztrRkFPa0Y7QUFDbEYsTUFBTSxVQUFVLHVCQUF1QixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQzNGLE1BQU0sT0FBTyxHQUFHLG9CQUFvQixDQUFDLEdBQXdCLENBQUMsQ0FBQztJQUMvRCxPQUFPO1FBQ0wsSUFBSSxFQUFFLGNBQWM7UUFDcEIsRUFBRSxFQUFFLE9BQU87UUFDWCxNQUFNLEVBQUUsT0FBTztZQUNiLENBQUMsQ0FBQyw0RUFBNEU7WUFDOUUsQ0FBQyxDQUFDLDRIQUE0SDtLQUNqSSxDQUFDO0FBQ0osQ0FBQztBQUVEOzs7OzsrQ0FLK0M7QUFDL0MsTUFBTSxVQUFVLDBCQUEwQixDQUN4QyxNQUEwQyxPQUFPLENBQUMsR0FBRyxFQUNyRCxrQkFBdUUsb0JBQW9CO0lBRTNGLE1BQU0sUUFBUSxHQUFHLDJDQUEyQyxDQUFDLEdBQUcsQ0FBQyxJQUFJLElBQUksQ0FBQztJQUMxRSxJQUFJLFFBQVEsS0FBSyxJQUFJLElBQUksUUFBUSxLQUFLLE1BQU0sRUFBRSxDQUFDO1FBQzdDLE9BQU87WUFDTCxJQUFJLEVBQUUseUJBQXlCO1lBQy9CLEVBQUUsRUFBRSxJQUFJO1lBQ1IsTUFBTSxFQUNKLFFBQVEsS0FBSyxNQUFNO2dCQUNqQixDQUFDLENBQUMsaUNBQWlDO2dCQUNuQyxDQUFDLENBQUMsK0NBQStDO1NBQ3RELENBQUM7SUFDSixDQUFDO0lBQ0QsSUFBSSxRQUFRLEtBQUssWUFBWSxJQUFJLFFBQVEsS0FBSyxXQUFXLEVBQUUsQ0FBQztRQUMxRCw0R0FBNEc7UUFDNUcsNkZBQTZGO1FBQzdGLGlIQUFpSDtRQUNqSCxNQUFNLE9BQU8sR0FBRyxXQUFXLENBQUMsR0FBRyxDQUFDLHVCQUF1QixDQUFDLElBQUksV0FBVyxDQUFDLEdBQUcsQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDO1FBQy9GLE9BQU87WUFDTCxJQUFJLEVBQUUseUJBQXlCO1lBQy9CLEVBQUUsRUFBRSxPQUFPO1lBQ1gsTUFBTSxFQUFFLE9BQU87Z0JBQ2IsQ0FBQyxDQUFDLEdBQUcsUUFBUSw0QkFBNEI7Z0JBQ3pDLENBQUMsQ0FBQyxHQUFHLFFBQVEsNkVBQTZFO1NBQzdGLENBQUM7SUFDSixDQUFDO0lBQ0QsdUdBQXVHO0lBQ3ZHLCtHQUErRztJQUMvRyxNQUFNLFFBQVEsR0FBRyxlQUFlLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDdEMsSUFBSSxRQUFRLEdBQUcsS0FBSyxDQUFDO0lBQ3JCLElBQUksQ0FBQztRQUNILFVBQVUsQ0FBQyxRQUFRLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDO1FBQ3JDLFFBQVEsR0FBRyxJQUFJLENBQUM7SUFDbEIsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLG9GQUFvRjtJQUN0RixDQUFDO0lBQ0QsT0FBTztRQUNMLElBQUksRUFBRSx5QkFBeUI7UUFDL0IsRUFBRSxFQUFFLFFBQVE7UUFDWixNQUFNLEVBQUUsUUFBUTtZQUNkLENBQUMsQ0FBQyx1Q0FBdUMsUUFBUSxFQUFFO1lBQ25ELENBQUMsQ0FBQyxpREFBaUQsUUFBUSx1QkFBdUI7S0FDckYsQ0FBQztBQUNKLENBQUM7QUFFRDtpQ0FDaUM7QUFDakMsTUFBTSxVQUFVLGVBQWUsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBRyxFQUFFLE1BQWMsT0FBTyxDQUFDLEdBQUcsRUFBRTtJQUNoSCxNQUFNLFNBQVMsR0FBRyxNQUFNLENBQUMsT0FBTyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDOUQsTUFBTSxhQUFhLEdBQUcsaUJBQWlCLEVBQUUsQ0FBQztJQUMxQyxNQUFNLGFBQWEsR0FBRyxpQkFBaUIsRUFBRSxDQUFDO0lBQzFDLE9BQU87UUFDTDtZQUNFLElBQUksRUFBRSxjQUFjO1lBQ3BCLEVBQUUsRUFBRSxTQUFTLElBQUksYUFBYTtZQUM5QixNQUFNLEVBQUUsUUFBUSxPQUFPLENBQUMsT0FBTyxpQkFBaUIsYUFBYSxHQUFHO1NBQ2pFO1FBQ0Q7WUFDRSxJQUFJLEVBQUUsaUJBQWlCO1lBQ3ZCLEVBQUUsRUFBRSxhQUFhLEtBQUssSUFBSTtZQUMxQiwyR0FBMkc7WUFDM0csb0JBQW9CO1lBQ3BCLE1BQU0sRUFBRSxhQUFhLENBQUMsQ0FBQyxDQUFDLEdBQUcsY0FBYyxJQUFJLGFBQWEsRUFBRSxDQUFDLENBQUMsQ0FBQyxHQUFHLGNBQWMsaUJBQWlCO1NBQ2xHO1FBQ0Qsc0JBQXNCLEVBQUU7UUFDeEIscUJBQXFCLENBQUMsb0JBQW9CLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDaEQsc0JBQXNCLENBQUMsR0FBRyxDQUFDO1FBQzNCLGtCQUFrQixFQUFFO1FBQ3BCLHFCQUFxQixDQUFDLEVBQUUsR0FBRyxFQUFFLENBQUM7UUFDOUIsb0JBQW9CLENBQUMsRUFBRSxHQUFHLEVBQUUsQ0FBQztRQUM3Qix1QkFBdUIsQ0FBQyxHQUFHLENBQUM7UUFDNUIsMEJBQTBCLENBQUMsR0FBRyxDQUFDO1FBQy9CLGtCQUFrQixDQUFDLEdBQUcsQ0FBQztRQUN2QixHQUFHLG9CQUFvQixDQUFDLEdBQUcsQ0FBQztLQUM3QixDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxTQUFTLENBQUMsT0FBaUIsRUFBRSxFQUFFLE1BQTBDLE9BQU8sQ0FBQyxHQUFHLEVBQUUsTUFBYyxPQUFPLENBQUMsR0FBRyxFQUFFO0lBQy9ILE1BQU0sTUFBTSxHQUFHLGVBQWUsQ0FBQyxHQUFHLEVBQUUsR0FBRyxDQUFDLENBQUM7SUFDekMsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDLENBQUM7SUFDbkQsSUFBSSxJQUFJLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxFQUFFLENBQUM7UUFDNUIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsRUFBRSxFQUFFLE1BQU0sQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLE1BQU0sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQzVFLENBQUM7U0FBTSxDQUFDO1FBQ04sS0FBSyxNQUFNLEtBQUssSUFBSSxNQUFNO1lBQUUsT0FBTyxDQUFDLEdBQUcsQ0FBQyxHQUFHLEtBQUssQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsTUFBTSxJQUFJLEtBQUssQ0FBQyxJQUFJLEtBQUssS0FBSyxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7UUFDeEcsSUFBSSxNQUFNLENBQUMsTUFBTSxHQUFHLENBQUM7WUFBRSxPQUFPLENBQUMsS0FBSyxDQUFDLFdBQVcsTUFBTSxDQUFDLE1BQU0sa0JBQWtCLENBQUMsQ0FBQztJQUNuRixDQUFDO0lBQ0QsT0FBTyxNQUFNLENBQUMsTUFBTSxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDckMsQ0FBQyJ9

--- a/packages/loopover-miner/lib/status.ts
+++ b/packages/loopover-miner/lib/status.ts
@@ -1,0 +1,510 @@
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { CODING_AGENT_DRIVER_CONFIG_ENV, parseMinerGoalSpecContent, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
+import {
+  checkClaudeCliPresent,
+  checkCodexCliPresent,
+  checkDockerPresent,
+  checkLaptopStateSqlite,
+  findExecutableOnPath,
+  resolveCodexAuthPath,
+} from "./laptop-init.js";
+import { resolveMinerVersion } from "./version.js";
+import { checkStoreIntegrity, describeError } from "./store-maintenance.js";
+import { resolveEventLedgerDbPath } from "./event-ledger.js";
+import { resolveGovernorLedgerDbPath } from "./governor-ledger.js";
+import { hasGitHubTokenSource } from "./github-token-resolution.js";
+import { resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
+import { resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
+import { resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import { resolveRunStateDbPath } from "./run-state.js";
+import { resolvePlanStoreDbPath } from "./plan-store.js";
+import { resolveGovernorStateDbPath } from "./governor-state.js";
+import { resolveAttemptLogDbPath } from "./attempt-log.js";
+import { resolveReplaySnapshotDbPath } from "./replay-snapshot.js";
+import { resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
+import { resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
+import { resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
+import { resolvePolicyDocCacheDbPath } from "./policy-doc-cache.js";
+
+// Slim laptop-mode CLI commands (#2288): `status` (what's installed + where local state lives) and `doctor` (is
+// this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
+// no GitHub writes, and no network calls of any kind. Later phases add the real discover/plan/manage loop.
+
+export type MinerDriverStatus = {
+  provider: string | null;
+  modelEnvVar: string | null;
+  cliPresent: boolean | null;
+};
+
+export type MinerStatus = {
+  package: { name: string; version: string | null };
+  engine: { name: string; version: string | null };
+  node: string;
+  stateDir: string;
+  configFile: string | null;
+  driver: MinerDriverStatus;
+};
+
+export type DoctorCheck = {
+  name: string;
+  ok: boolean;
+  detail: string;
+};
+
+// Lazy, not module-scope: mirrors the loopover-engine repo-map.ts fix -- this file is CLI-only today, but
+// an eager createRequire(import.meta.url)/import.meta.dirname at module scope would crash on import in any
+// bundler context where import.meta is unavailable (e.g. if a future import chain pulls this into a Worker
+// bundle, the way repo-map.ts was). Deferring construction to first real use keeps this import-safe.
+let cachedRequire: NodeRequire | null = null;
+function requireFromHere(): NodeRequire {
+  return (cachedRequire ??= createRequire(import.meta.url));
+}
+let cachedModuleDir: string | null = null;
+function moduleDir(): string {
+  return (cachedModuleDir ??= import.meta.dirname);
+}
+
+const PACKAGE_NAME = "@loopover/miner";
+const ENGINE_PACKAGE = "@loopover/engine";
+// Config-file discovery order (mirrors the `.loopover-miner.yml` precedence the goal-spec parser documents).
+const CONFIG_FILE_CANDIDATES = Object.freeze([
+  ".loopover-miner.yml",
+  ".github/loopover-miner.yml",
+  ".loopover-miner.json",
+  ".github/loopover-miner.json",
+]);
+
+/** The miner's local-state directory (holds the run-state / queue / ledger SQLite files). */
+export function resolveMinerStateDir(env: Record<string, string | undefined> = process.env): string {
+  const explicitConfigDir = typeof env.LOOPOVER_MINER_CONFIG_DIR === "string"
+    ? env.LOOPOVER_MINER_CONFIG_DIR.trim()
+    : "";
+  if (explicitConfigDir) return explicitConfigDir;
+
+  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME.trim()
+    : join(homedir(), ".config");
+  return join(configHome, "loopover-miner");
+}
+
+/**
+ * The REAL installed @loopover/engine version, for `status`'s own display. Prefers `readInstalled`
+ * (the actually-resolved semver from node_modules/the monorepo workspace, the same real resolution `doctor`'s
+ * engine-version-skew check already relies on) -- a self-hoster asking "what's installed" wants the real
+ * answer, not the declared dependency RANGE ("*" in this monorepo, which tells them nothing). Falls back to
+ * the declared range only if real resolution genuinely comes up empty (the engine package's `exports` map
+ * blocks `require("<pkg>/package.json")` in some resolution orders, and its built `dist` may be absent
+ * depending on build order) -- still better than reporting nothing at all.
+ *
+ * Exported + injectable (mirrors `buildEngineVersionSkewCheck`'s own `readInstalled` param): real resolution
+ * succeeding is the only realistic case in a working install, so the fallback path needs a way to force it.
+ */
+export function buildEngineVersionDisplay(readInstalled: () => string | null = readInstalledEnginePackageVersion): string | null {
+  const installed = readInstalled();
+  if (installed) return installed;
+  // The in-repo package.json always declares `dependencies["@loopover/engine"]`, so this range fallback always
+  // returns that string; its `?.`/`?? null`/require-throw defensive arms are unreachable in-tree.
+  /* v8 ignore start */
+  try {
+    return requireFromHere()("../package.json").dependencies?.[ENGINE_PACKAGE] ?? null;
+  } catch {
+    return null;
+  }
+  /* v8 ignore stop */
+}
+
+function readEngineVersion(): string | null {
+  return buildEngineVersionDisplay();
+}
+
+export function readInstalledEnginePackageVersionFromPaths(
+  resolvedEntry: string,
+  workspacePkg: string,
+  deps: { existsSync: (path: string) => boolean; readFileSync: (path: string, encoding: "utf8") => string } = { existsSync, readFileSync },
+): string | null {
+  try {
+    for (const pkgJson of [join(resolvedEntry, "..", "package.json"), join(resolvedEntry, "..", "..", "package.json")]) {
+      if (deps.existsSync(pkgJson)) {
+        const version = JSON.parse(deps.readFileSync(pkgJson, "utf8")).version;
+        if (version) return version;
+      }
+    }
+  } catch {
+    // fall through to monorepo workspace fallback
+  }
+  if (deps.existsSync(workspacePkg)) {
+    try {
+      return JSON.parse(deps.readFileSync(workspacePkg, "utf8")).version ?? null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/** Installed @loopover/engine semver from node_modules (not the declared dependency range). */
+export function readInstalledEnginePackageVersion(): string | null {
+  try {
+    return readInstalledEnginePackageVersionFromPaths(
+      requireFromHere().resolve(ENGINE_PACKAGE),
+      join(moduleDir(), "../../loopover-engine/package.json"),
+    );
+  } catch {
+    // @loopover/engine always resolves in the monorepo/installed tree, so `resolve()` never throws here; this
+    // workspace-fallback catch is unreachable in tests (its path logic is covered directly via ...FromPaths).
+    /* v8 ignore start */
+    const workspacePkg = join(moduleDir(), "../../loopover-engine/package.json");
+    if (existsSync(workspacePkg)) {
+      try {
+        return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+    /* v8 ignore stop */
+  }
+}
+
+/** Expected minimum engine semver: monorepo engine package.json when present, else the shipped pin file. */
+export function readExpectedEnginePackageVersionFromPaths(
+  monorepoEnginePkg: string,
+  pinFile: string,
+  deps: { existsSync: (path: string) => boolean; readFileSync: (path: string, encoding: "utf8") => string } = { existsSync, readFileSync },
+): string | null {
+  if (deps.existsSync(monorepoEnginePkg)) {
+    try {
+      return JSON.parse(deps.readFileSync(monorepoEnginePkg, "utf8")).version ?? null;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const pinned = deps.readFileSync(pinFile, "utf8").trim();
+    return pinned || null;
+  } catch {
+    return null;
+  }
+}
+
+export function readExpectedEnginePackageVersion(): string | null {
+  return readExpectedEnginePackageVersionFromPaths(
+    join(moduleDir(), "../../loopover-engine/package.json"),
+    join(moduleDir(), "../expected-engine.version"),
+  );
+}
+
+function parseSemverCore(version: string): [number, number, number] | null {
+  const match = String(version).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/** Returns -1 when installed is behind expected, 0 when equal, 1 when ahead. */
+export function compareInstalledEngineVersion(installed: string, expected: string): -1 | 0 | 1 {
+  const installedCore = parseSemverCore(installed);
+  const expectedCore = parseSemverCore(expected);
+  if (!installedCore || !expectedCore) return -1;
+  for (let index = 0; index < 3; index += 1) {
+    const installedPart = installedCore[index] as number;
+    const expectedPart = expectedCore[index] as number;
+    if (installedPart < expectedPart) return -1;
+    if (installedPart > expectedPart) return 1;
+  }
+  return 0;
+}
+
+export function buildEngineVersionSkewCheck(
+  readInstalled: () => string | null = readInstalledEnginePackageVersion,
+  readExpected: () => string | null = readExpectedEnginePackageVersion,
+): DoctorCheck {
+  const installed = readInstalled();
+  const expected = readExpected();
+  if (!expected) {
+    return { name: "engine-version-skew", ok: true, detail: "expected engine version unavailable (skipped)" };
+  }
+  if (!installed) {
+    return {
+      name: "engine-version-skew",
+      ok: false,
+      detail: `${ENGINE_PACKAGE} not installed (cannot verify version skew)`,
+    };
+  }
+  const comparison = compareInstalledEngineVersion(installed, expected);
+  return {
+    name: "engine-version-skew",
+    ok: comparison >= 0,
+    detail:
+      comparison < 0
+        ? `installed ${installed} is behind expected ${expected}`
+        : `installed ${installed} (${comparison === 0 ? "matches" : "ahead of"} expected ${expected})`,
+  };
+}
+
+function checkEngineVersionSkew(): DoctorCheck {
+  return buildEngineVersionSkewCheck();
+}
+
+/** The minimum Node major version from the package's `engines.node` floor (e.g. ">=22.13.0" → 22). */
+function requiredNodeMajor(): number {
+  const engines = requireFromHere()("../package.json").engines;
+  // The in-repo package.json always declares `engines.node` as a valid ">=NN..." string, so the non-string and
+  // no-digit-match fallbacks are unreachable in-tree.
+  /* v8 ignore start */
+  const match = typeof engines?.node === "string" ? engines.node.match(/(\d+)/) : null;
+  return match ? Number(match[1]) : 0;
+  /* v8 ignore stop */
+}
+
+function discoverConfigFile(cwd: string): string | null {
+  for (const candidate of CONFIG_FILE_CANDIDATES) {
+    const path = join(cwd, candidate);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+// CLI names driver-factory.ts's resolved provider values that actually spawn a local subprocess -- "noop" and
+// "agent-sdk" have no separate CLI binary to check presence for, so cliPresent is null (not applicable) for them.
+const PROVIDER_CLI_BINARY: Record<string, string> = Object.freeze({ "claude-cli": "claude", "codex-cli": "codex" });
+
+/** The `driver` section of `status`/`status --json` (#5164): which coding-agent provider is configured, the
+ *  NAME (never the value) of its model env var, and whether its CLI binary is on PATH. Reuses
+ *  `resolveFirstConfiguredCodingAgentDriverName`/`CODING_AGENT_DRIVER_CONFIG_ENV` (the same resolution
+ *  driver-factory.ts uses) and `findExecutableOnPath` (the same PATH scan the doctor CLI-presence checks use)
+ *  rather than duplicating either. Never reads or returns an env var's actual value. */
+function resolveDriverStatus(env: Record<string, string | undefined>): MinerDriverStatus {
+  const provider = resolveFirstConfiguredCodingAgentDriverName(env) ?? null;
+  const modelEnvVar = provider ? (CODING_AGENT_DRIVER_CONFIG_ENV[provider as keyof typeof CODING_AGENT_DRIVER_CONFIG_ENV]?.model ?? null) : null;
+  const cliBinary = provider ? (PROVIDER_CLI_BINARY[provider] ?? null) : null;
+  const cliPresent = cliBinary ? Boolean(findExecutableOnPath(cliBinary, env)) : null;
+  return { provider, modelEnvVar, cliPresent };
+}
+
+/** Gather the read-only status snapshot. Pure w.r.t. its (env, cwd) inputs — no writes, no network. */
+export function collectStatus(env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): MinerStatus {
+  const stateDir = resolveMinerStateDir(env);
+  return {
+    package: { name: PACKAGE_NAME, version: resolveMinerVersion(env) },
+    engine: { name: ENGINE_PACKAGE, version: readEngineVersion() },
+    node: process.version,
+    stateDir,
+    configFile: discoverConfigFile(cwd),
+    driver: resolveDriverStatus(env),
+  };
+}
+
+function renderDriverLine(driver: MinerDriverStatus): string {
+  if (!driver.provider) return "driver: none configured";
+  const cliText = driver.cliPresent === null ? "n/a" : driver.cliPresent ? "yes" : "no";
+  const modelText = driver.modelEnvVar ? `, model env: ${driver.modelEnvVar}` : "";
+  return `driver: ${driver.provider} (CLI present: ${cliText}${modelText})`;
+}
+
+function renderStatusText(status: MinerStatus): string {
+  return [
+    // package.version / engine.version always resolve to strings in-tree, so the `?? "unknown"` / `?? "unresolved"`
+    // fallbacks are unreachable here.
+    /* v8 ignore start */
+    `${status.package.name} ${status.package.version ?? "unknown"} (node ${status.node})`,
+    `engine: ${status.engine.name} ${status.engine.version ?? "unresolved"}`,
+    /* v8 ignore stop */
+    `state dir: ${status.stateDir}`,
+    `config file: ${status.configFile ?? "none found"}`,
+    renderDriverLine(status.driver),
+  ].join("\n");
+}
+
+export function runStatus(args: string[] = [], env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): number {
+  const status = collectStatus(env, cwd);
+  console.log(args.includes("--json") ? JSON.stringify(status, null, 2) : renderStatusText(status));
+  return 0;
+}
+
+function checkStateDirWritable(stateDir: string): DoctorCheck {
+  const probe = join(stateDir, ".loopover-miner-write-probe");
+  try {
+    // Creating the dir and writing (then removing) a probe file proves it is writable — the state dir must be
+    // creatable/writable for the local SQLite stores to work.
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    writeFileSync(probe, "");
+    rmSync(probe, { force: true });
+    return { name: "state-dir-writable", ok: true, detail: stateDir };
+  } catch (error) {
+    return {
+      name: "state-dir-writable",
+      ok: false,
+      // fs operations reject with `Error` instances, so the non-Error message fallback is unreachable in tests.
+      /* v8 ignore next */
+      detail: `${stateDir}: ${error instanceof Error ? error.message : "not writable"}`,
+    };
+  }
+}
+
+/** Per-store `PRAGMA integrity_check` sweep for `doctor` (#4834) — flags a corrupted store instead of probing
+ *  only one with `SELECT 1`. A store file that does not exist yet is healthy by absence. Keep in sync with
+ *  migrate-cli.js's `STORES` list (#6768): every durable local SQLite store using resolveLocalStoreDbPath. */
+function storeIntegrityChecks(env: Record<string, string | undefined>): DoctorCheck[] {
+  const stores: Array<[string, string]> = [
+    ["event-ledger", resolveEventLedgerDbPath(env)],
+    ["governor-ledger", resolveGovernorLedgerDbPath(env)],
+    ["prediction-ledger", resolvePredictionLedgerDbPath(env)],
+    ["portfolio-queue", resolvePortfolioQueueDbPath(env)],
+    ["claim-ledger", resolveClaimLedgerDbPath(env)],
+    ["run-state", resolveRunStateDbPath(env)],
+    ["plan-store", resolvePlanStoreDbPath(env)],
+    ["governor-state", resolveGovernorStateDbPath(env)],
+    ["attempt-log", resolveAttemptLogDbPath(env)],
+    // replay-snapshot.d.ts still types its resolver's `env` as `NodeJS.ProcessEnv` (which the root app config
+    // augments with the worker Env's required keys), so cast the plain Record view to it -- read-only, same value.
+    ["replay-snapshot", resolveReplaySnapshotDbPath(env as NodeJS.ProcessEnv)],
+    ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
+    ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
+    ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],
+    ["policy-doc-cache", resolvePolicyDocCacheDbPath(env)],
+  ];
+  return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
+}
+
+/** Validate the discovered `.loopover-miner` config's CONTENT (#4873), not just its path: parse it with the
+ *  tolerant goal-spec parser and surface its warnings, so a malformed config is flagged by `doctor` rather than
+ *  silently degrading to defaults. No config file is fine (defaults apply); a read failure is reported. `readImpl`
+ *  is injectable for tests. */
+export function checkConfigContent(cwd: string, readImpl: (path: string, encoding: "utf8") => string = readFileSync): DoctorCheck {
+  const configPath = discoverConfigFile(cwd);
+  if (!configPath) {
+    return { name: "config-content", ok: true, detail: "no .loopover-miner config found (using defaults)" };
+  }
+  let warnings;
+  try {
+    warnings = parseMinerGoalSpecContent(readImpl(configPath, "utf8")).warnings;
+  } catch (error) {
+    return { name: "config-content", ok: false, detail: `${configPath}: ${describeError(error)}` };
+  }
+  return warnings.length === 0
+    ? { name: "config-content", ok: true, detail: `${configPath}: valid` }
+    : { name: "config-content", ok: false, detail: `${configPath}: ${warnings.join("; ")}` };
+}
+
+function nonEmptyEnv(value: string | undefined): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** GitHub token presence (#5170, extended by #6116). A purely offline check — `doctor` never calls GitHub — but
+ *  a missing token fails every real attempt the moment it tries to push a branch or open a PR, so surface it up
+ *  front rather than mid-run. Checks BOTH a GITHUB_TOKEN env override AND a recorded `loopover-mcp login`
+ *  session (hasGitHubTokenSource, offline: reads the local config file, makes no network call) -- otherwise a
+ *  user who only ran `loopover-mcp login` (the new primary flow) would see a spurious "not set" warning even
+ *  though AMS would resolve a live token from that session at attempt time. A session recorded here is not
+ *  re-verified as still valid/unexpired -- only an actual attempt (or resolveGitHubToken itself) discovers
+ *  that. Reports presence only; no token value is ever included in the detail. */
+export function checkGitHubTokenPresent(env: Record<string, string | undefined> = process.env): DoctorCheck {
+  const present = hasGitHubTokenSource(env as NodeJS.ProcessEnv);
+  return {
+    name: "github-token",
+    ok: present,
+    detail: present
+      ? "A GitHub token is available (GITHUB_TOKEN or a loopover-mcp login session)"
+      : "No GitHub token available — run `loopover-mcp login`, or set GITHUB_TOKEN, before attempts that push a branch or open a PR",
+  };
+}
+
+/** Credential presence for the CONFIGURED coding-agent provider (#5170). Distinct from the CLI-present checks,
+ *  which by design keep `ok: true` when only the credential is missing (#5165): this FAILS `doctor` when the
+ *  resolved provider's credential is absent, so an operator learns before an attempt fails partway through.
+ *  Fully offline — an env-var string check for the Claude backends, a file-readability check for codex — and it
+ *  never prints the credential value, only the env-var names / file path. `resolveAuthPath` is injectable for
+ *  tests, mirroring `checkCodexCliPresent`. */
+export function checkCodingAgentCredential(
+  env: Record<string, string | undefined> = process.env,
+  resolveAuthPath: (env: Record<string, string | undefined>) => string = resolveCodexAuthPath,
+): DoctorCheck {
+  const provider = resolveFirstConfiguredCodingAgentDriverName(env) ?? null;
+  if (provider === null || provider === "noop") {
+    return {
+      name: "coding-agent-credential",
+      ok: true,
+      detail:
+        provider === "noop"
+          ? "noop driver needs no credential"
+          : "no coding-agent provider configured (skipped)",
+    };
+  }
+  if (provider === "claude-cli" || provider === "agent-sdk") {
+    // Both run the Claude backend (a `claude` subprocess vs the in-process Agent SDK) off the same subscription
+    // OAuth token the rest of the tree reads (CLAUDE_CODE_OAUTH_TOKEN; see createClaudeCodeAi in
+    // src/selfhost/ai.ts). The SDK additionally accepts a raw ANTHROPIC_API_KEY, so either satisfies the credential.
+    const present = nonEmptyEnv(env.CLAUDE_CODE_OAUTH_TOKEN) || nonEmptyEnv(env.ANTHROPIC_API_KEY);
+    return {
+      name: "coding-agent-credential",
+      ok: present,
+      detail: present
+        ? `${provider}: Claude credential is set`
+        : `${provider}: no Claude credential — set CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY)`,
+    };
+  }
+  // codex-cli: the only remaining configured provider — its credential is a readable auth.json, the same
+  // read-only condition checkCodexCliPresent probes (reusing resolveCodexAuthPath so the location never drifts).
+  const authPath = resolveAuthPath(env);
+  let readable = false;
+  try {
+    accessSync(authPath, constants.R_OK);
+    readable = true;
+  } catch {
+    // missing or unreadable — codex would fail for lack of credentials at attempt time.
+  }
+  return {
+    name: "coding-agent-credential",
+    ok: readable,
+    detail: readable
+      ? `codex-cli: auth.json is readable at ${authPath}`
+      : `codex-cli: auth.json missing or unreadable at ${authPath} — run \`codex auth\``,
+  };
+}
+
+/** Run the doctor checks. Returns an array of { name, ok, detail }; only writes a transient probe in the state dir,
+ *  never touches the network. */
+export function runDoctorChecks(env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): DoctorCheck[] {
+  const nodeMajor = Number(process.versions.node.split(".")[0]);
+  const requiredMajor = requiredNodeMajor();
+  const engineVersion = readEngineVersion();
+  return [
+    {
+      name: "node-version",
+      ok: nodeMajor >= requiredMajor,
+      detail: `node ${process.version} (requires >= ${requiredMajor})`,
+    },
+    {
+      name: "engine-resolves",
+      ok: engineVersion !== null,
+      // engineVersion always resolves to a string in-tree, so the not-resolvable detail arm is unreachable here.
+      /* v8 ignore next */
+      detail: engineVersion ? `${ENGINE_PACKAGE} ${engineVersion}` : `${ENGINE_PACKAGE} not resolvable`,
+    },
+    checkEngineVersionSkew(),
+    checkStateDirWritable(resolveMinerStateDir(env)),
+    checkLaptopStateSqlite(env),
+    checkDockerPresent(),
+    checkClaudeCliPresent({ env }),
+    checkCodexCliPresent({ env }),
+    checkGitHubTokenPresent(env),
+    checkCodingAgentCredential(env),
+    checkConfigContent(cwd),
+    ...storeIntegrityChecks(env),
+  ];
+}
+
+export function runDoctor(args: string[] = [], env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): number {
+  const checks = runDoctorChecks(env, cwd);
+  const failed = checks.filter((check) => !check.ok);
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ ok: failed.length === 0, checks }, null, 2));
+  } else {
+    for (const check of checks) console.log(`${check.ok ? "ok  " : "FAIL"} ${check.name}: ${check.detail}`);
+    if (failed.length > 0) console.error(`doctor: ${failed.length} check(s) failed`);
+  }
+  return failed.length === 0 ? 0 : 1;
+}

--- a/test/unit/miner-live-issue-snapshot.test.ts
+++ b/test/unit/miner-live-issue-snapshot.test.ts
@@ -144,6 +144,27 @@ describe("fetchLiveIssueSnapshot (#5132)", () => {
     expect((capturedHeaders as Record<string, string>).authorization).toBe("Bearer secret-token");
   });
 
+  it("returns null for a non-string repoFullName", async () => {
+    expect(await fetchLiveIssueSnapshot(123 as unknown as string, 7, { fetchImpl: graphqlResponse({}) })).toBeNull();
+  });
+
+  it("treats a non-string githubToken as no token, sending no authorization header", async () => {
+    let capturedHeaders: HeadersInit | undefined;
+    const fetchImpl = async (_url: string, init: RequestInit) => {
+      capturedHeaders = init.headers;
+      return { ok: true, status: 200, json: async () => ({ data: { repository: { issue: { state: "OPEN", closedByPullRequestsReferences: { nodes: [] } } } } }) } as Response;
+    };
+    await fetchLiveIssueSnapshot("acme/widgets", 7, { githubToken: 123 as unknown as string, fetchImpl });
+    expect((capturedHeaders as Record<string, string>).authorization).toBeUndefined();
+  });
+
+  it("treats an open issue with no closedByPullRequestsReferences connection as having no referencing PRs", async () => {
+    const snapshot = await fetchLiveIssueSnapshot("acme/widgets", 7, {
+      fetchImpl: graphqlResponse({ data: { repository: { issue: { state: "OPEN" } } } }),
+    });
+    expect(snapshot).toEqual({ state: "open", referencingPrs: [] });
+  });
+
   it("respects a custom graphqlUrl override", async () => {
     let capturedUrl: string | undefined;
     await fetchLiveIssueSnapshot("acme/widgets", 7, {

--- a/test/unit/miner-manage-status.test.ts
+++ b/test/unit/miner-manage-status.test.ts
@@ -312,4 +312,60 @@ describe("loopover-miner manage status (#2325)", () => {
     expect(runManageStatus(["acme/widgets"])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Usage: loopover-miner manage status [--json]");
   });
+
+  it("parseManagedPrIdentifier rejects a non-string identifier and a non-positive PR number", () => {
+    expect(parseManagedPrIdentifier(42 as unknown as string)).toBeNull();
+    expect(parseManagedPrIdentifier("pr:0")).toBeNull();
+  });
+
+  it("indexLatestManageUpdates skips non-array input, wrong-typed events, and events with a blank repo", () => {
+    type Events = Parameters<typeof indexLatestManageUpdates>[0];
+    expect(indexLatestManageUpdates(null as unknown as Events).size).toBe(0);
+    const events = [
+      { type: "other_event", repoFullName: "acme/widgets", payload: { prNumber: 1 } },
+      { type: MANAGE_PR_UPDATE_EVENT, repoFullName: "  ", payload: { prNumber: 1 } },
+      { type: MANAGE_PR_UPDATE_EVENT, repoFullName: "acme/widgets", payload: [] },
+    ] as unknown as Events;
+    expect(indexLatestManageUpdates(events).size).toBe(0);
+  });
+
+  it("normalizes optional snapshot fields: null/non-string/blank become null, a real string is trimmed", () => {
+    const events = [
+      {
+        type: MANAGE_PR_UPDATE_EVENT,
+        repoFullName: "acme/widgets",
+        payload: { prNumber: 3, branch: null, ciState: 42, gateVerdict: "   ", outcome: "  ready  " },
+      },
+    ] as unknown as Parameters<typeof indexLatestManageUpdates>[0];
+    expect(indexLatestManageUpdates(events).get("acme/widgets:3")).toEqual({
+      repoFullName: "acme/widgets",
+      prNumber: 3,
+      branch: null,
+      ciState: null,
+      gateVerdict: null,
+      outcome: "ready",
+      lastPolledAt: null,
+    });
+  });
+
+  it("collectManageStatus rejects a missing/invalid portfolio queue or event ledger", () => {
+    type Sources = Parameters<typeof collectManageStatus>[0];
+    expect(() => collectManageStatus({ eventLedger: { readEvents: () => [] } } as unknown as Sources)).toThrow("invalid_portfolio_queue");
+    expect(() => collectManageStatus({ portfolioQueue: { listQueue: () => [] }, eventLedger: {} } as unknown as Sources)).toThrow("invalid_event_ledger");
+  });
+
+  it("runs with real default stores under a temp state dir when no init overrides are supplied", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-manage-status-real-"));
+    roots.push(root);
+    const prev = process.env.LOOPOVER_MINER_CONFIG_DIR;
+    process.env.LOOPOVER_MINER_CONFIG_DIR = root;
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(runManageStatus(["--json"])).toBe(0);
+    } finally {
+      if (prev === undefined) delete process.env.LOOPOVER_MINER_CONFIG_DIR;
+      else process.env.LOOPOVER_MINER_CONFIG_DIR = prev;
+    }
+    expect(JSON.parse(String(log.mock.calls[0]?.[0])).rows).toEqual([]);
+  });
 });

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -216,6 +216,11 @@ describe("loopover-miner status/doctor (#2288)", () => {
     expect(readExpectedEnginePackageVersion()).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
+  it("compareInstalledEngineVersion treats an unparseable version on either side as behind (-1)", () => {
+    expect(compareInstalledEngineVersion("not-semver", "0.2.0")).toBe(-1);
+    expect(compareInstalledEngineVersion("1.0.0", "also-bad")).toBe(-1);
+  });
+
   it("buildEngineVersionSkewCheck skips when expected version is unavailable", () => {
     const skewCheck = buildEngineVersionSkewCheck(
       () => "0.2.0",
@@ -246,6 +251,12 @@ describe("loopover-miner status/doctor (#2288)", () => {
     expect(readExpectedEnginePackageVersionFromPaths(join(root, "missing.json"), join(root, "missing-pin"))).toBeNull();
     writeFileSync(join(root, "broken.json"), "not-json");
     expect(readExpectedEnginePackageVersionFromPaths(join(root, "broken.json"), pinFile)).toBeNull();
+    // A valid package.json with no `version` field falls through the `?? null`.
+    writeFileSync(join(root, "no-version.json"), JSON.stringify({ name: "x" }));
+    expect(readExpectedEnginePackageVersionFromPaths(join(root, "no-version.json"), pinFile)).toBeNull();
+    // An empty/whitespace pin file falls through the `pinned || null`.
+    writeFileSync(join(root, "empty-pin"), "  \n");
+    expect(readExpectedEnginePackageVersionFromPaths(join(root, "missing.json"), join(root, "empty-pin"))).toBeNull();
   });
 
   it("readInstalledEnginePackageVersionFromPaths falls back to the workspace engine package", () => {
@@ -261,6 +272,17 @@ describe("loopover-miner status/doctor (#2288)", () => {
     mkdirSync(join(root, "installed"), { recursive: true });
     writeFileSync(installedPkg, JSON.stringify({ version: "0.2.1" }));
     expect(readInstalledEnginePackageVersionFromPaths(join(root, "installed", "index.js"), workspacePkg)).toBe("0.2.1");
+
+    // A workspace package.json present but missing its `version` field falls through the `?? null`.
+    writeFileSync(workspacePkg, JSON.stringify({ name: "x" }));
+    expect(readInstalledEnginePackageVersionFromPaths("/missing/entry", workspacePkg)).toBeNull();
+
+    // A resolved-entry package.json present but with no `version` skips (the `if (version)` guard is false) and
+    // falls through to the (here-missing) workspace fallback.
+    const noVersionInstalled = join(root, "installed2", "package.json");
+    mkdirSync(join(root, "installed2"), { recursive: true });
+    writeFileSync(noVersionInstalled, JSON.stringify({ name: "x" }));
+    expect(readInstalledEnginePackageVersionFromPaths(join(root, "installed2", "index.js"), join(root, "missing.json"))).toBeNull();
   });
 
   it("runDoctor supports --json output", () => {
@@ -398,6 +420,15 @@ describe("loopover-miner status/doctor (#2288)", () => {
       expect(String(log.mock.calls[0]?.[0])).toContain(
         "driver: codex-cli (CLI present: yes, model env: MINER_CODING_AGENT_CODEX_MODEL)",
       );
+    });
+
+    it("renders the driver line for a provider with no CLI to check (n/a, no model) and one whose CLI is absent (no)", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      runStatus([], { LOOPOVER_MINER_CONFIG_DIR: "/s", MINER_CODING_AGENT_PROVIDER: "noop" }, tempRoot());
+      expect(String(log.mock.calls[0]?.[0])).toContain("driver: noop (CLI present: n/a)");
+      log.mockClear();
+      runStatus([], { LOOPOVER_MINER_CONFIG_DIR: "/s", MINER_CODING_AGENT_PROVIDER: "codex-cli", PATH: "" }, tempRoot());
+      expect(String(log.mock.calls[0]?.[0])).toContain("driver: codex-cli (CLI present: no");
     });
 
     it("invariant: no env-var VALUE or secret-shaped string ever appears in status --json output across provider permutations", () => {


### PR DESCRIPTION
## Summary

Phase-2 **batch 2.5** of the #7290 TypeScript migration: convert the 8 leaf-most, lowest-fan-in `packages/loopover-miner/lib` modules from `.js` + hand `.d.ts` to real TypeScript, compiled in place (same convention as merged batches 2.1–2.4).

Files: `contribution-profile-filter`, `loop-reentry`, `live-issue-snapshot`, `oauth-device-flow`, `logger`, `manage-status`, `contribution-profile-extract`, `status`.

Byte-identical behavior; types from the removed hand `.d.ts`, with only compatible optional-param widenings where the runtime already passed a value the hand `.d.ts` under-declared. Verifies clean under **both** the package tsconfig and the root app typecheck (which augments `NodeJS.ProcessEnv` with the worker `Env`) — the few cross-config casts are local and lossless.

**Coverage:** every converted file at **100% line + branch**, with added regression tests for the narrowing/guard branches a type-only conversion exposes (invalid-identifier + normalizer branches in `manage-status`, non-string/no-connection paths in `live-issue-snapshot`, version/driver fallbacks in `status`). The only `/* v8 ignore */` sites are genuinely-unreachable production-only defensive fallbacks with no injectable test seam (reading the real in-repo `package.json` / resolving `@loopover/engine`) — the same pattern the already-merged `worktree-allocator.ts` uses.

## Validation

- [x] `packages/loopover-miner` tsc **and** root `tsc --noEmit` both green
- [x] All 8 files 100% line + branch (verified via v8 coverage JSON)
- [x] Existing tests unmodified (additions only); `build:miner`, deployment-docs audit, env-reference (no drift), and `npm pack` (0 `.ts` leaked) all green; rebased onto latest `main`

Closes #7304
