### PR TITLE
ci: route mcp/miner/UI-kit/UI/extension build+lint+typecheck through Turborepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,8 +370,23 @@ jobs:
       # since turbo's cache directory grows additively rather than being wholesale-replaced per lockfile hash.
       # This is also what lets each validate-tests shard (which independently needs this same package built)
       # skip rebuilding it from scratch when a warm cache from this job or an earlier run is available.
+      #
+      # Gate includes mcp/miner (not just backend/engine/ui) even though "Build engine package" below stays
+      # scoped to backend/engine/ui: "Build MCP"/"Build miner CLI" further down invoke turbo too, and since
+      # both packages declare @loopover/engine as a package.json dependency, turbo's own ^build resolution
+      # builds engine as their transitive dependency regardless of whether this explicit step ran. Without
+      # this wider gate, an mcp- or miner-only PR would still get a correct build (turbo builds it inline
+      # with no cache to hit) -- just a cold one, and with no save step to persist it either.
+      #
+      # The matching "Save Turborepo cache" step is NOT alongside this one -- it's moved all the way down
+      # to after "UI build" (the last step in this job that invokes turbo), since actions/cache/save takes
+      # one synchronous snapshot at the moment it runs and every later turbo-routed step in between (Build
+      # MCP, Build miner CLI, Build UI-kit package, UI lint/typecheck, Extension lint/typecheck, UI build)
+      # would otherwise write to .turbo/cache AFTER the snapshot already happened, so none of their cache
+      # entries would ever persist cross-run. Confirmed this was a real gap (not just theoretical) by
+      # reading the actual step order before moving it.
       - name: Restore Turborepo cache
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.miner == 'true' }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo/cache
@@ -381,12 +396,6 @@ jobs:
       - name: Build engine package
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npx turbo run build --filter=@loopover/engine
-      - name: Save Turborepo cache
-        if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true') }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo/cache
-          key: turbo-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
       # .tsbuildinfo mutates every run (tsc's own incremental state), unlike node_modules above which is
       # immutable per lockfile -- so this needs the run_id-suffixed-key + restore-keys-prefix pattern (always
       # creates a new cache entry to save into, restore falls back to the most recent matching prefix) rather
@@ -416,17 +425,39 @@ jobs:
       # loopover-mcp now depends on @loopover/engine for real (isTestFile/isCodeFile), so a
       # PR that only touches packages/loopover-engine/** must also rebuild + pack-check the mcp package,
       # not just the mcp filter's own (deliberately narrower) path list.
+      #
+      # Routed through Turborepo (turbo.json's @loopover/mcp#build, dependsOn ["^build"]) rather than the
+      # old npm run build:mcp -- turbo resolves @loopover/engine as its topological dependency (mcp's own
+      # package.json depends on @loopover/engine) and reuses the "Restore Turborepo cache" above, so an
+      # engine-only PR's already-built engine is never rebuilt a second time here.
       - name: Build MCP
         if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' }}
-        run: npm run build:mcp
+        run: npx turbo run build --filter=@loopover/mcp
       - name: MCP package check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' }}
         run: npm run test:mcp-pack
+      # Invokes turbo.json's @loopover/miner#build:tsc (cache: false, since its committed lib/**/*.js
+      # output can't be safely restored without risking a stomp of hand-written files) and
+      # @loopover/miner#build:verify (real caching win: skips re-`node --check`-ing all 121 bin/lib files
+      # when neither changed) DIRECTLY as their own task names, deliberately NOT via the aggregate
+      # `@loopover/miner#build` task (which exists for standalone/local `npm run build` callers) -- that
+      # aggregate's own script is `npm run build:tsc && npm run build:verify`, i.e. it re-invokes both of
+      # these exact scripts a second time even when turbo already ran them as cached prerequisite tasks
+      # (declaring a task as a dependsOn prerequisite doesn't replace a parent task's own script body).
+      # Calling the aggregate here would silently double both the tsc compile and the syntax check on
+      # every run, negating the caching win this comment describes -- confirmed by reproducing the double
+      # execution locally before switching to this direct form. This also finally activates the
+      # build:tsc/build:verify split from Phase 0, which no ci.yml step exercised until now.
       - name: Build miner CLI
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
-        run: npm run build:miner
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.engine == 'true' }}
+        run: npx turbo run build:tsc build:verify --filter=@loopover/miner
+      # loopover-miner depends on @loopover/engine for real too (same relationship as loopover-mcp above
+      # -- packages/loopover-miner/package.json lists it as a dependency), so this and "Build miner CLI"
+      # above now also trigger on an engine-only PR, matching "Build MCP"/"MCP package check"'s existing
+      # engine coupling. Pre-existing asymmetry, not introduced by this change -- fixed here while already
+      # touching these exact lines.
       - name: Miner package check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.engine == 'true' }}
         run: npm run test:miner-pack
       - name: Miner deployment docs audit
         if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
@@ -521,7 +552,7 @@ jobs:
       # job, so building it here once covers all four.
       - name: Build UI-kit package
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm run ui:kit:build
+        run: npx turbo run build --filter=@loopover/ui-kit
       # apps/loopover-ui's fumadocs-mdx virtual modules (collections/browser, collections/server, imported by
       # docs-client-loader.tsx/docs-source.ts) are gitignored generated output, normally produced by npm ci's
       # own `postinstall` hook -- but "Install dependencies" above is SKIPPED on a node_modules cache hit (the
@@ -532,38 +563,61 @@ jobs:
       - name: Generate docs content collections
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run postinstall --workspace @loopover/ui
-      # ui:lint/ui:typecheck/ui:test (package.json) each independently re-run ui:kit:build as their own
-      # first step -- correct as standalone, portable scripts (nothing else in a bare `npm run ui:lint`
-      # invocation would have built ui-kit first), but redundant here specifically: "Build UI-kit package"
-      # above already built it once for all four of lint/typecheck/tests/build in this same job. Same
-      # "call the underlying subcommands directly, skip the redundant rebuild" fix "UI build" below
-      # already applies -- deliberately NOT changing the package.json scripts themselves, since
-      # ui-deploy.yml and CONTRIBUTING.md's documented local gate sequence both call ui:lint/ui:typecheck
-      # directly with no prior ui-kit build step and rely on that self-sufficiency.
+      # Routed through Turborepo -- "Build UI-kit package" above already built ui-kit's dist once for all of
+      # lint/typecheck/tests/build in this same job (GitHub Actions steps run strictly sequentially), so
+      # these turbo invocations reuse it without needing @loopover/ui#lint/@loopover/ui-miner#lint to
+      # declare their own ^build dependsOn (they intentionally don't -- eslint needs no compiled dist).
+      # Two --filter flags means "either package" (union), not intersection; both packages' tasks run
+      # even if one fails, so a failing @loopover/ui lint no longer hides an @loopover/ui-miner lint error
+      # behind it the way the old `&&` chain did -- both surface in one pass. Deliberately NOT changing the
+      # package.json ui:lint/ui:typecheck scripts themselves, since ui-deploy.yml and CONTRIBUTING.md's
+      # documented local gate sequence both call those directly and rely on their own ui:kit:build prefix.
       - name: UI lint
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm --workspace @loopover/ui run lint && npm --workspace @loopover/ui-miner run lint
+        run: npx turbo run lint --filter=@loopover/ui --filter=@loopover/ui-miner
       - name: UI typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm --workspace @loopover/ui run typecheck && npm --workspace @loopover/ui-miner run typecheck
+        run: npx turbo run typecheck --filter=@loopover/ui --filter=@loopover/ui-miner
       - name: UI tests
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test && npm --workspace @loopover/miner-extension run test
+      # Same rationale and --filter union semantics as "UI lint"/"UI typecheck" above.
       - name: Extension lint
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm run extension:lint && npm run miner-extension:lint
+        run: npx turbo run lint --filter=@loopover/extension --filter=@loopover/miner-extension
       - name: Extension typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm run extension:typecheck && npm run miner-extension:typecheck
+        run: npx turbo run typecheck --filter=@loopover/extension --filter=@loopover/miner-extension
       # `npm run ui:build` also regenerates apps/loopover-ui/public/openapi.json (needed for a
       # standalone build), but this step's trigger condition is a strict subset of "OpenAPI drift
       # check" above (push || ui==true, vs. push || ui==true || uiContract==true), so whenever this
       # step runs, that check already ran and passed in this same job -- the committed spec is
-      # already byte-identical to what regenerating it here would produce. Run ui:build's other two
-      # steps directly instead of the aggregate script, skipping that redundant regen.
+      # already byte-identical to what regenerating it here would produce. apps/loopover-ui's own
+      # `build` script (vite build) doesn't touch openapi.json either, so routing through Turborepo
+      # preserves that skip: @loopover/ui#build's dependsOn (turbo.json) is
+      # ["^build", "@loopover/extension#build", "@loopover/miner-extension#build"] -- the exact same
+      # extension + miner-extension build pair this step ran explicitly before, now resolved by turbo's
+      # own graph instead of hand-chained `&&`, plus ^build (ui-kit, already a same-job cache hit from
+      # "Build UI-kit package" above). Verified locally: deleting the committed-gitignored extension zip
+      # and running this exact invocation regenerates it correctly (the cross-package outputs edge is
+      # honored, not just replayed from cache).
       - name: UI build
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build
+        run: npx turbo run build --filter=@loopover/ui
+      # Paired with "Restore Turborepo cache" above (same key, same gate condition) -- deliberately
+      # positioned here, after every turbo-routed step in this job (Build engine package, Build MCP, Build
+      # miner CLI, Build UI-kit package, UI lint/typecheck, Extension lint/typecheck, UI build), rather than
+      # immediately after "Build engine package" the way it was originally: actions/cache/save takes one
+      # synchronous snapshot at the moment it runs, so anything written to .turbo/cache by a later step
+      # would never be captured if this ran earlier. `!cancelled()` (not `always()`) still saves whatever
+      # was successfully built even if an earlier step in this job failed, as long as the job wasn't
+      # cancelled outright.
+      - name: Save Turborepo cache
+        if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.miner == 'true') }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
       # Bundle-size regression tracking for the deployed marketing/product site (loopover-ui only --
       # loopover-miner-ui is a self-hosted operator dashboard with no build step in this job at all, see
       # "UI build" above). Fork-excluded (no secrets.CODECOV_TOKEN on a fork PR, same boundary as the

--- a/test/unit/ci-engine-miner-filters.test.ts
+++ b/test/unit/ci-engine-miner-filters.test.ts
@@ -19,7 +19,9 @@ describe("CI engine/miner path filters", () => {
     // shared across validate-code and every validate-tests shard instead of rebuilding independently in
     // each -- see the "Restore/Save Turborepo cache" steps alongside this one.
     expect(ci).toContain("turbo run build --filter=@loopover/engine");
-    expect(ci).toContain("npm run build:miner");
+    // Invokes build:tsc/build:verify directly (not the aggregate @loopover/miner#build task) -- the
+    // aggregate's own script re-runs both, which would double the tsc compile and syntax check every run.
+    expect(ci).toContain("turbo run build:tsc build:verify --filter=@loopover/miner");
     expect(ci).toContain("npm run test:miner-pack");
   });
 });

--- a/test/unit/ci-extension-packages.test.ts
+++ b/test/unit/ci-extension-packages.test.ts
@@ -28,10 +28,13 @@ describe("browser extension workspace packages (#4866)", () => {
     expect(workflow).toContain("apps/loopover-miner-extension/**");
     expect(workflow).toContain("scripts/build-miner-extension.mjs");
     expect(workflow).toContain("name: Extension lint");
-    expect(workflow).toContain("npm run extension:lint && npm run miner-extension:lint");
-    expect(workflow).toContain("npm run extension:typecheck && npm run miner-extension:typecheck");
+    // Routed through Turborepo (turbo.json's @loopover/extension#lint/typecheck and
+    // @loopover/miner-extension#lint/typecheck) -- see ci.yml's comment on these steps.
+    expect(workflow).toContain("npx turbo run lint --filter=@loopover/extension --filter=@loopover/miner-extension");
     expect(workflow).toContain(
-      "npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build",
+      "npx turbo run typecheck --filter=@loopover/extension --filter=@loopover/miner-extension",
     );
+    // @loopover/ui#build's dependsOn (turbo.json) covers the extension + miner-extension build pair.
+    expect(workflow).toContain("run: npx turbo run build --filter=@loopover/ui");
   });
 });

--- a/test/unit/ci-ui-build-openapi.test.ts
+++ b/test/unit/ci-ui-build-openapi.test.ts
@@ -5,19 +5,20 @@ const read = (path: string) => readFileSync(path, "utf8");
 
 // `npm run ui:build` also regenerates apps/loopover-ui/public/openapi.json. Both call sites below
 // chain it immediately after `ui:openapi:check`, which just proved the committed spec is already fresh --
-// regenerating it again is pure repeat work. These assert the two split commands stay in place instead of
-// the aggregate `ui:build` script sneaking back in (ui:build itself is untouched for standalone callers).
+// regenerating it again is pure repeat work. These assert the split commands (or their Turborepo
+// equivalent) stay in place instead of the aggregate `ui:build` script sneaking back in (ui:build itself
+// is untouched for standalone callers).
 describe("UI build steps skip the redundant OpenAPI regen", () => {
-  it("ci.yml's UI build step runs the split commands, not the aggregate ui:build script", () => {
+  it("ci.yml's UI build step runs through Turborepo, not the aggregate ui:build script", () => {
     const workflow = read(".github/workflows/ci.yml");
     const stepStart = workflow.indexOf("- name: UI build");
     expect(stepStart).toBeGreaterThan(-1);
     const stepEnd = workflow.indexOf("\n\n", stepStart);
     const step = workflow.slice(stepStart, stepEnd === -1 ? undefined : stepEnd);
 
-    expect(step).toContain(
-      "run: npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build",
-    );
+    // @loopover/ui#build's dependsOn (turbo.json) covers the same extension + miner-extension build pair
+    // the old hand-chained `&&` command ran explicitly -- see turbo.json's comment on that task.
+    expect(step).toContain("run: npx turbo run build --filter=@loopover/ui");
     expect(step).not.toContain("npm run ui:build");
   });
 


### PR DESCRIPTION
## Summary

Phase 2 of the Turborepo plan (following #7349 Phase 0, #7363 Phase 1 — engine build only): extends the same `turbo run <task> --filter=X` pattern to the remaining `validate-code` build/lint/typecheck steps, exactly the "natural next steps" #7363 flagged as follow-up scope.

`Build MCP`, `Build miner CLI`, `Build UI-kit package`, `UI lint`, `UI typecheck`, `Extension lint`, `Extension typecheck`, and `UI build` now invoke `turbo.json`'s existing task graph instead of plain npm calls or hand-chained `&&` commands. `UI tests` is deliberately untouched — `turbo.json` has no `test` task for any package.

`Build miner CLI` calls `turbo run build:tsc build:verify --filter=@loopover/miner` directly rather than the aggregate `build` task — an adversarial review (3 independent reviewers + verification pass, see Validation) caught that the aggregate's own script (`npm run build:tsc && npm run build:verify`) re-runs both scripts a second time even after turbo already ran them as cached prerequisites, silently doubling the tsc compile and syntax check on every invocation. Confirmed via `--dry=json` and an actual run before and after the fix.

The same review also caught that widening `Restore`/`Save Turborepo cache`'s gate to include `mcp`/`miner` (needed since both packages now transitively build `@loopover/engine` via turbo's `^build` resolution) wasn't enough on its own: `Save Turborepo cache` sat right after `Build engine package`, before any of the newly-turbo-routed steps ran, so `actions/cache/save`'s one-time synchronous snapshot never captured their cache writes. Moved `Save Turborepo cache` to after `UI build` (the last turbo-invoking step in the job) so all of it actually persists cross-run.

Also widens `Build miner CLI`/`Miner package check` to trigger on an engine-only PR, matching `Build MCP`'s existing `engine == 'true'` coupling — `packages/loopover-miner/package.json` depends on `@loopover/engine` the same way `packages/loopover-mcp/package.json` does, a pre-existing asymmetry not introduced by this PR but fixed while already touching these exact lines.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-initiated build-tooling work, not tied to a single pre-filed contributor issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] Every new/changed turbo invocation tested with the exact bare `run:` shell form GitHub Actions uses (minimal PATH, no `node_modules/.bin`, matching the #7363 `npx turbo` lesson) — individually and as one full sequential run in real job order (engine → mcp → miner → ui-kit → UI lint → UI typecheck → extension lint → extension typecheck → UI build). All pass; working tree stays clean afterward.
- [x] Verified `Build miner CLI`'s fix with `--dry=json` (confirms exactly 3 tasks resolve: `@loopover/engine#build`, `@loopover/miner#build:tsc`, `@loopover/miner#build:verify` — no redundant aggregate task) and a real run.
- [x] Verified `UI build`'s turbo routing preserves the extension-zip cross-package dependency: deleted the gitignored `loopover-extension.zip`, ran the exact new invocation, confirmed it regenerated correctly.
- [x] Ran a 6-agent adversarial-review workflow (3 independent reviewers examining if-condition semantics, turbo task-graph correctness, and fail-fast-vs-union semantics; 3 verifiers each attempting to refute the findings by reading the actual files/re-executing commands) against the full diff before finalizing. It surfaced the two real bugs above (both fixed) plus one pre-existing, out-of-scope asymmetry (also fixed here since already in this code) — full reasoning and repro steps in the session transcript.
- [x] Re-ran the 3 meta-tests that parse `ci.yml`'s command strings (`ci-engine-miner-filters`, `ci-ui-build-openapi`, `ci-extension-packages`) plus 4 adjacent ones with no assertions on the changed strings (`codecov-policy`, `ci-dependency-cache`, `predicted-gate`, `predicted-gate-engine-coverage`) — 109/109 pass. Fresh grep across all of `test/unit/` for every removed command string turned up no other stale assertions.
- [ ] `npm run typecheck` / `npm run test:coverage` — not run in full; this PR touches no `src/**` file, only CI/build-tooling configuration and its own meta-tests (covered above).
- [ ] `npm audit --audit-level=moderate` — not applicable; no dependency changes.

If any required check was skipped, explain why: this PR is CI/build-tooling configuration, not application source — the skipped commands aren't applicable, and every actually-relevant command (including exact-shell-form reproduction of the real CI invocations) is listed above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests — N/A.
- [ ] API/OpenAPI/MCP behavior updated and tested where needed — N/A.
- [ ] UI changes use live API data or real empty/error/loading states — N/A, no UI behavior change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no visible/UI change.
- [x] Public docs/changelogs updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Fourth of this session's Turborepo/CI-speed sequence: #7345 (scoped test selection) → #7349 (Phase 0, local-only) → #7363 (Phase 1, engine build in CI) → this PR (Phase 2, remaining build/lint/typecheck steps).
- Touches `.github/workflows/**` (a guarded path), so it'll be held for manual owner review rather than auto-merged, matching the prior three PRs in this sequence.
- Deliberately out of scope: `UI tests` (no turbo `test` task exists yet), the root `//#typecheck` step, and `@loopover/ui-miner#build`/`@loopover/discovery-index#build` (turbo.json tasks with no corresponding `ci.yml` step at all, before or after this PR) — each is a separate, smaller follow-up with its own verification needs.