### PR TITLE
fix(turbo): correct //#typecheck's inputs to cover its real cross-package surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,15 @@ jobs:
           key: tsbuildinfo-${{ hashFiles('tsconfig.json', 'package-lock.json') }}-${{ github.run_id }}
           restore-keys: |
             tsbuildinfo-${{ hashFiles('tsconfig.json', 'package-lock.json') }}-
+      # Deliberately NOT routed through Turborepo's //#typecheck task, unlike every other build/lint/
+      # typecheck step in this job -- investigated and rejected, not just skipped. test/** (tsconfig.json's
+      # own "include") reaches via relative imports into six other workspace packages/apps (see turbo.json's
+      # //#typecheck comment for the full audit), so a turbo.json inputs list correct enough to avoid a
+      # stale-cache-masks-a-real-error bug here would need to track that sprawling, growing cross-package
+      # surface by hand. tsc's own --incremental engine (below) already tracks the exact real dependency
+      # graph natively and precisely, with zero drift risk, and already delivers the actual measured
+      # speedup (~13.5s cold vs ~3.6s warm) -- wrapping it in turbo would layer a cruder, hand-maintained
+      # approximation on top of a mechanism that's already strictly more correct for this specific task.
       - name: Typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run typecheck

--- a/turbo.json
+++ b/turbo.json
@@ -3,10 +3,30 @@
   "tasks": {
     "//#typecheck": {
       "dependsOn": ["@loopover/engine#build"],
-      // Root tsconfig.json's own "include" list, plus the config files that change what it does.
-      // Without this, an unscoped root task defaults to hashing the ENTIRE repository (every doc,
-      // workflow file, README, etc.) as its input set -- confirmed via `turbo run typecheck --dry=json`
-      // during development, which is effectively "never cache-hits in practice" while looking configured.
+      // Root tsconfig.json's own "include" list ("src", "test", plus a handful of named config files) is
+      // NOT a complete accounting of what tsc actually type-checks: "include" only seeds the starting file
+      // set, and tsc's real surface expands to everything transitively imported from there, regardless of
+      // whether the imported file physically lives inside src/ or test/. test/** (deliberately included so
+      // Codecov's codecov/patch has one source of truth, see the plan doc referenced in ci.yml) turned out
+      // to reach via relative-path imports into six other workspace packages/apps -- confirmed by grepping
+      // every import in src/+test/ that crosses a packages/**or apps/** boundary, not just spot-checked:
+      // packages/loopover-miner/{lib,bin}/**, packages/loopover-mcp/package.json (JSON import), packages/
+      // discovery-index/src/**, apps/loopover-ui/src/lib/**, apps/loopover-extension/**, and apps/loopover-
+      // miner-extension/**. Before this was added, none of those six were hashed, so an edit to (say)
+      // packages/loopover-miner/lib/opportunity-fanout.js could silently leave a stale cache HIT here even
+      // though a real `tsc --noEmit` would fail -- exactly the class of bug PR #5082 (see ci.yml's "Build
+      // engine package" comment) already burned this repo on once. packages/loopover-mcp/bin/** is
+      // deliberately NOT listed: every test reference to it is a runtime path string
+      // (`join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js")`, spawned as a subprocess or
+      // read as raw text), never a static import, so its contents don't affect tsc's type-checked surface.
+      // This list is a snapshot of test/'s real cross-package reach as of the audit that added it, not a
+      // structural guarantee -- a future test file importing from a NOT-yet-listed package/app would
+      // reopen the same silent-stale-cache gap. Re-run the same grep (every src/+test/ import crossing a
+      // packages/**or apps/** boundary) before trusting this list again, especially before ever wiring the
+      // "Typecheck" ci.yml step through this task (it still calls plain `npm run typecheck` today,
+      // specifically because tsc's own --incremental engine already tracks this exact transitive graph
+      // precisely and correctly, without needing a hand-maintained approximation of it here at all -- see
+      // that step's own comment in ci.yml).
       "inputs": [
         "src/**",
         "test/**",
@@ -17,7 +37,14 @@
         "drizzle.config.ts",
         "tsconfig.json",
         "package.json",
-        "package-lock.json"
+        "package-lock.json",
+        "packages/loopover-miner/lib/**",
+        "packages/loopover-miner/bin/**",
+        "packages/loopover-mcp/package.json",
+        "packages/discovery-index/src/**",
+        "apps/loopover-ui/src/lib/**",
+        "apps/loopover-extension/**",
+        "apps/loopover-miner-extension/**"
       ],
       "outputs": []
     },


### PR DESCRIPTION
## Summary

Investigated swapping `ci.yml`'s root `Typecheck` step to Turborepo — the last remaining plain-npm build/lint/typecheck step after #7368 — and found a latent correctness bug in `turbo.json`'s `//#typecheck` task instead of a clean swap candidate.

Root `tsconfig.json`'s `include` (`src`, `test`, plus a few named config files) only seeds `tsc`'s starting file set; the real type-checked surface expands to everything transitively imported from there, regardless of whether it physically lives in `src/`/`test/`. Grepping every import in `src/`+`test/` that crosses a `packages/**`/`apps/**` boundary found `test/**` reaches via relative-path imports into six other workspace packages/apps that `//#typecheck`'s declared `inputs` never accounted for: `packages/loopover-miner/{lib,bin}/**`, `packages/loopover-mcp/package.json`, `packages/discovery-index/src/**`, `apps/loopover-ui/src/lib/**`, `apps/loopover-extension/**`, and `apps/loopover-miner-extension/**`. A stale cache hit here would mask a real type error — exactly the failure mode PR #5082 already burned this repo on once (see `ci.yml`'s "Build engine package" comment).

**The bug is currently inert** — `ci.yml`'s `Typecheck` step still calls plain `npm run typecheck`, so nothing consults this task's cache in production today. Fixed anyway: it's a real landmine for whoever next attempts this swap without redoing the same audit, and `turbo.json` is shared infrastructure other tasks already depend on.

**Deliberately did NOT swap the `ci.yml` step itself.** `tsc`'s own `--incremental` engine already tracks this exact transitive dependency graph precisely and with zero drift risk (that's what incremental compilation *is* — a native, exact dependency graph, not a hand-maintained glob approximation), and it already delivers the real measured speedup (~13.5s cold vs ~3.6s warm) via the existing `.tsbuildinfo` GH Actions cache pair. Wrapping this specific step in Turborepo would layer a cruder, hand-maintained approximation of the same graph on top of a mechanism that's already strictly more correct here — and given how sprawling `test/**`'s real reach is, a *correctly* scoped Turborepo `inputs` list would need to keep tracking that growing cross-package surface by hand indefinitely. Documented the reasoning in both `turbo.json` and `ci.yml` so this isn't re-litigated blind by a future pass.

With this, the Turborepo build/lint/typecheck migration (#7349 → #7363 → #7368 → this PR) is complete for every step where the swap is actually a net improvement: engine, mcp, miner, ui-kit, ui, ui-miner, extension, and miner-extension all route through turbo's task graph; root typecheck deliberately stays on tsc's own incremental engine; `UI tests` stays untouched (no turbo `test` task exists for any package).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-initiated build-tooling work, not tied to a single pre-filed contributor issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` (root, clean — verifies the actual tsc invocation this PR keeps in place still passes)
- [x] Verified the bug empirically, not just by inspection: ran `npx turbo run typecheck --filter=// --dry=json` before the fix, appended a line to `packages/loopover-miner/lib/opportunity-fanout.js`, re-ran the dry-run — hash was unchanged (the bug). After the fix, the same touch changes the hash (`8b80138d50e18bc0` → `d6a36412f54f5e96`), and reverting the touch returns it to the original hash — confirmed the fix actually closes the gap, not just that it looks plausible.
- [x] Confirmed `packages/loopover-mcp/bin/**` is correctly excluded: every reference to it in `test/` is a runtime path string (`join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js")`, spawned as a subprocess or read as raw text via `readFileSync`), never a static import — so its contents don't affect tsc's type-checked surface.
- [x] Grepped for any test/unit assertion on `turbo.json`'s content — none exist (one unrelated hit in `path-matchers.test.ts` just uses `"turbo.json"` as a filename example in a path-classification test).
- [x] Re-ran the 8 meta-tests that parse `ci.yml`/`turbo.json` — 161/161 pass.
- [ ] `npm run test:coverage` — not run in full; this PR touches no `src/**` file, only CI/build-tooling configuration.
- [ ] `npm audit --audit-level=moderate` — not applicable; no dependency changes.

If any required check was skipped, explain why: this PR is CI/build-tooling configuration, not application source — the skipped commands aren't applicable, and every actually-relevant command (including an empirical before/after repro of the bug and its fix) is listed above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests — N/A.
- [ ] API/OpenAPI/MCP behavior updated and tested where needed — N/A.
- [ ] UI changes use live API data or real empty/error/loading states — N/A, no UI behavior change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no visible/UI change.
- [x] Public docs/changelogs updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Fifth of this session's Turborepo/CI-speed sequence: #7345 → #7349 (Phase 0) → #7363 (Phase 1) → #7368 (Phase 2) → this PR.
- Touches `.github/workflows/**` (a guarded path), so it'll be held for manual owner review rather than auto-merged, matching the prior PRs in this sequence.
- Still deliberately out of scope, unchanged by this PR: `UI tests` (no turbo `test` task exists), and `@loopover/ui-miner#build`/`@loopover/discovery-index#build` (turbo.json tasks with no corresponding `ci.yml` step at all, before or after this PR — a CI-coverage question, not a caching-optimization one, and a different kind of change from everything else in this sequence).