### PR TITLE
fix(ci): close Turborepo cache-correctness gaps and CI merge-safety gate holes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,9 +299,13 @@ jobs:
       # apps/loopover-ui/src/lib/ams-env-reference.ts had gone stale). Confirmed harmful live: this
       # exact gap let a stale env-reference block an unrelated MCP npm release, since the release
       # workflow was the only place this check ever ran. Gated on `ui` too, same reason as its sibling:
-      # the generated UI-side file lives under apps/loopover-ui/**.
+      # the generated UI-side file lives under apps/loopover-ui/**. Also gated on `engine`:
+      # DEFAULT_SOURCE_ROOTS in generate-env-reference.mjs explicitly includes
+      # packages/loopover-engine/src/miner (the coding-agent driver's env vars live there, not under
+      # packages/loopover-miner itself), so an engine-only PR touching that directory used to skip this
+      # check entirely.
       - name: Miner env-reference drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.engine == 'true' }}
         run: npm run miner:env-reference:check
       # Same generated-artifact-drift class, extracted from src/github/commands.ts's command catalogs (#3046).
       # Also local-only until now; same backend-or-ui gating rationale as the step above.
@@ -312,9 +316,14 @@ jobs:
       # modes) -- see the script's own header comment. Also local-only until now; gated on `ui` as well as
       # `backend` since the docs pages it validates are themselves UI-side content that can drift on their
       # own (a docs-only edit that renames/drops a documented flag/command/gate-mode) with no backend change
-      # to trigger a re-check otherwise.
+      # to trigger a re-check otherwise. Also gated on `engine`, unlike its two siblings above (`Selfhost
+      # env-reference drift check`/`Command reference drift check`): this script's readFileSync reads
+      # packages/loopover-engine/src/focus-manifest.ts directly to cross-check FocusManifest fields against
+      # .loopover.yml.example, a dependency the other two generated-artifact-drift checks don't share, so
+      # deliberately NOT kept uniform with them here (test/unit/ci-generated-artifact-drift-checks.test.ts
+      # asserts backend||ui is a SUBSET of every condition, not that all three are byte-identical).
       - name: Docs drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.engine == 'true' }}
         run: npm run docs:drift-check
       # Cross-checks the bundled fallback YAML in src/config/loopover-repo-focus-manifest.ts against the
       # real root .loopover.yml -- see the script's own header comment. Same local-only-until-now gap as
@@ -326,16 +335,21 @@ jobs:
         run: npm run manifest:drift-check
       # Mechanical drift tripwire for the hand-duplicated src/{review,settings,signals} <-> loopover-engine
       # twin files, plus a version-skew check on the installed @loopover/engine (#4260). Same
-      # local-only-until-now gap as the drift checks above.
+      # local-only-until-now gap as the drift checks above. Also gated on `miner`: the reverse-direction
+      # version pin this script checks, packages/loopover-miner/expected-engine.version, lives under the
+      # miner package, not engine or backend -- a PR editing only that one pin file used to skip its own
+      # consistency check entirely.
       - name: Engine-parity drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' }}
         run: npm run engine-parity:drift-check
       # Guards against the "gittensory" branding creeping back into runtime source after the LoopOver
       # rebrand -- see the script's own header comment (#6786 is the concrete incident this was written
       # for). Scoped broadly (src/** plus every workspace package's bin/lib/src/scripts dirs), so it's
-      # gated broadly to match; same local-only-until-now gap as the drift checks above.
+      # gated broadly to match; same local-only-until-now gap as the drift checks above. Also gated on
+      # `discoveryIndex`: BRANDING_DRIFT_PATHSPECS includes "packages/*/src/**/*.ts", which matches
+      # packages/discovery-index/src/**.
       - name: Branding drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.discoveryIndex == 'true' }}
         run: npm run branding-drift:check
       # .release-please-manifest.json is release-please's own state file -- it normally keeps this in
       # sync itself when its generated Release PR merges, but the documented human-override path for
@@ -348,8 +362,13 @@ jobs:
       - name: Release-please manifest sync check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run release-manifest:sync:check
+      # Not gated on `backend`: read the full script -- it only ever reads grafana/dashboards/*.json and
+      # prometheus/rules/alerts.yml, both fully covered by the `observability` filter above, with zero
+      # reference to any src/, test/, or other backend path. The `backend` clause had no structural
+      # justification and made this run on every backend PR (the highest-volume PR shape in the repo) for
+      # nothing.
       - name: Validate observability configs
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.observability == 'true' }}
         env:
           NODE_OPTIONS: ""
         run: node scripts/validate-observability-configs.mjs
@@ -385,14 +404,25 @@ jobs:
       # would otherwise write to .turbo/cache AFTER the snapshot already happened, so none of their cache
       # entries would ever persist cross-run. Confirmed this was a real gap (not just theoretical) by
       # reading the actual step order before moving it.
+      #
+      # Key uses a "turbo-code-" prefix, distinct from validate-tests' "turbo-tests-" prefix below, even
+      # though both jobs cache the same .turbo/cache path and both build @loopover/engine -- they used to
+      # share one "turbo-" prefix, which meant all 7 jobs in a single run (this one plus 6 validate-tests
+      # shards) raced for the SAME cache key. actions/cache/save no-ops on a duplicate key within a run (see
+      # the comment on validate-tests' own Save step below), and a validate-tests shard reaches its Save
+      # step after only ~6 steps versus this job's ~20+, so a shard almost always won the race -- meaning
+      # the richer cache this job builds (engine + mcp + miner + ui-kit + ui + extension) was very likely
+      # silently discarded in favor of a shard's much leaner engine-only save, defeating most of the point
+      # of the Save-repositioning fix above. Splitting the prefixes gives each job's Restore/Save pair its
+      # own independent lineage instead of racing.
       - name: Restore Turborepo cache
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.miner == 'true' }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo/cache
-          key: turbo-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
+          key: turbo-code-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
           restore-keys: |
-            turbo-${{ hashFiles('package-lock.json') }}-
+            turbo-code-${{ hashFiles('package-lock.json') }}-
       - name: Build engine package
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npx turbo run build --filter=@loopover/engine
@@ -419,8 +449,16 @@ jobs:
       # graph natively and precisely, with zero drift risk, and already delivers the actual measured
       # speedup (~13.5s cold vs ~3.6s warm) -- wrapping it in turbo would layer a cruder, hand-maintained
       # approximation on top of a mechanism that's already strictly more correct for this specific task.
+      # Gated on engine/mcp/miner too, not just backend: root src/** genuinely imports across those three
+      # package boundaries (~57 files import @loopover/engine directly; src/mcp/find-opportunities.ts
+      # imports packages/loopover-miner/lib/opportunity-fanout.js and opportunity-ranker.js;
+      # src/services/mcp-compatibility.ts imports packages/loopover-mcp/package.json), so a type-only
+      # regression introduced in any of those three packages, on a PR that touches only that package, used
+      # to skip this check entirely -- not caught until the push-triggered run on main, after this repo's
+      # auto-merge gate had already merged it. tsc's own --incremental engine (unaffected by this widening;
+      # see its own comment two steps up) already tracks the real graph regardless of which trigger fired.
       - name: Typecheck
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.miner == 'true' }}
         run: npm run typecheck
       - name: Save TypeScript incremental build cache
         if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true') }}
@@ -428,8 +466,14 @@ jobs:
         with:
           path: .tsbuildinfo
           key: tsbuildinfo-${{ hashFiles('tsconfig.json', 'package-lock.json') }}-${{ github.run_id }}
+      # Same engine/mcp/miner gap as Typecheck above, and more consequential here: test/workers/worker-
+      # runtime.test.ts (vitest.config.ts excludes it from the main "Test with coverage" run below, so
+      # nothing else in CI runs it) imports src/index and src/api/routes, which themselves import
+      # find-opportunities.ts (miner) and mcp-compatibility.ts (mcp) -- this is the only test in all of CI
+      # that boots the real Cloudflare Workers runtime end-to-end, and it used to never run at all on an
+      # engine/mcp/miner-only PR.
       - name: Worker runtime tests
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.miner == 'true' }}
         run: npm run test:workers
       # loopover-mcp now depends on @loopover/engine for real (isTestFile/isCodeFile), so a
       # PR that only touches packages/loopover-engine/** must also rebuild + pack-check the mcp package,
@@ -468,8 +512,11 @@ jobs:
       - name: Miner package check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.engine == 'true' }}
         run: npm run test:miner-pack
+      # scripts/check-miner-deployment-docs.mjs reads packages/loopover-engine/src/miner/**/*.ts
+      # (ENGINE_MINER_DIR) to build the registered-commands list checked against DEPLOYMENT.md, so an
+      # engine-only PR touching that directory used to skip this audit entirely.
       - name: Miner deployment docs audit
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.engine == 'true' }}
         run: npm run test:miner-deployment-docs-audit
       # review-enrichment is not an npm workspace member (its own package-lock.json), so it needs its own
       # cache entry -- same restore/save-after-success pattern and fork/trusted key split as the root
@@ -587,9 +634,25 @@ jobs:
       - name: UI typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npx turbo run typecheck --filter=@loopover/ui --filter=@loopover/ui-miner
-      - name: UI tests
+      # Split into 3 independent steps (was one `&&`-chained step) -- turbo.json deliberately has no `test`
+      # task for any package (per the plan doc: test orchestration stays out of Turborepo entirely, so
+      # Codecov's codecov/patch keeps one centralized source of truth), so this can't use the same
+      # union-`--filter` fix already applied to "UI lint"/"UI typecheck" two steps above. Plain `&&` meant a
+      # failing @loopover/ui test silently prevented @loopover/ui-miner's and @loopover/miner-extension's
+      # tests from ever running in that invocation -- same class of failure-masking bug those two steps'
+      # own comment already describes, just still present here. `!cancelled()` on steps 2/3 (not `always()`)
+      # matches the pattern already used by "Save Turborepo cache"/"Save TypeScript incremental build
+      # cache" elsewhere in this file: still run after an earlier step's failure, just not after the job
+      # was cancelled outright. The job as a whole still fails if any of the three fails.
+      - name: UI tests (ui)
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test && npm --workspace @loopover/miner-extension run test
+        run: npm --workspace @loopover/ui run test
+      - name: UI tests (ui-miner)
+        if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.ui == 'true') }}
+        run: npm --workspace @loopover/ui-miner run test
+      - name: UI tests (miner-extension)
+        if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.ui == 'true') }}
+        run: npm --workspace @loopover/miner-extension run test
       # Same rationale and --filter union semantics as "UI lint"/"UI typecheck" above.
       - name: Extension lint
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
@@ -626,7 +689,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo/cache
-          key: turbo-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
+          key: turbo-code-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
       # Bundle-size regression tracking for the deployed marketing/product site (loopover-ui only --
       # loopover-miner-ui is a self-hosted operator dashboard with no build step in this job at all, see
       # "UI build" above). Fork-excluded (no secrets.CODECOV_TOKEN on a fork PR, same boundary as the
@@ -725,16 +788,24 @@ jobs:
           key: ${{ steps.node-modules-cache.outputs.cache-primary-key }}
       # Any backend test run needs the engine package's dist/ built first -- see the identical step's
       # comment in validate-code (#ci-engine-build-order) for why. Same accumulating .turbo/cache
-      # restore/save pattern as validate-code's identical pair, sharing the same key lineage -- whichever
-      # job (this shard or another, in this run or an earlier one) saved a warm cache first, the rest can
-      # reuse it. Correctness is turbo's own content-hashing, not this restore -- see validate-code's comment.
+      # restore/save pattern as validate-code's pair, but a DIFFERENT key prefix ("turbo-tests-" vs.
+      # validate-code's "turbo-code-"): these two jobs used to share one plain "turbo-" prefix, which meant
+      # all 7 jobs in a single run (validate-code plus these 6 shards) raced for the same cache slot, and
+      # actions/cache/save no-ops on a duplicate key within a run -- see the shard-vs-shard version of that
+      # same race below. Because a shard reaches its own Save after only ~6 steps versus validate-code's
+      # ~20+, a shard almost always won that race, meaning validate-code's much richer cache (engine + mcp +
+      # miner + ui-kit + ui + extension) was very likely discarded every run in favor of a shard's
+      # engine-only one. Splitting the prefixes gives each job's own lineage instead of racing; within THIS
+      # prefix, the 6 shards below still race each other for one slot, which is fine since they all save the
+      # exact same content (only @loopover/engine#build runs in this job) -- whichever shard wins, the
+      # content is equivalent, unlike the cross-job case this split just fixed.
       - name: Restore Turborepo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo/cache
-          key: turbo-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
+          key: turbo-tests-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
           restore-keys: |
-            turbo-${{ hashFiles('package-lock.json') }}-
+            turbo-tests-${{ hashFiles('package-lock.json') }}-
       - name: Build engine package
         run: npx turbo run build --filter=@loopover/engine
       - name: Save Turborepo cache
@@ -742,7 +813,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo/cache
-          key: turbo-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
+          key: turbo-tests-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
       - name: Test with coverage (shard ${{ matrix.shard }}/6)

--- a/packages/discovery-index/tsconfig.json
+++ b/packages/discovery-index/tsconfig.json
@@ -7,7 +7,17 @@
     "declaration": false,
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    // Without this, the inherited root value (tsconfig.json:24, "./.tsbuildinfo") resolves relative to the
+    // ROOT config's location, not this one -- this package's build and the root Typecheck step would then
+    // read/write the exact same cache file at the repo root and corrupt each other's incremental state,
+    // same collision packages/loopover-engine/tsconfig.json and packages/loopover-miner/tsconfig.json
+    // already document and fix the same way. Confirmed empirically: `rm .tsbuildinfo && tsc -p
+    // packages/discovery-index/tsconfig.json` wrote the repo-root .tsbuildinfo, not a package-local one,
+    // and a subsequent root `tsc --noEmit` then paid the full ~14s cold-recheck cost instead of the
+    // documented ~3.6s warm one -- silent perf regression, not a correctness bug (TS safely discards a
+    // mismatched buildinfo and rechecks from scratch), but real on every local `npm run test:ci`.
+    "tsBuildInfoFile": "./.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/test/unit/ci-generated-artifact-drift-checks.test.ts
+++ b/test/unit/ci-generated-artifact-drift-checks.test.ts
@@ -54,16 +54,25 @@ describe("generated-artifact drift checks are wired into CI, not just local test
     expect(condition).toContain("needs.changes.outputs.ui == 'true'");
   });
 
-  it("all three drift-check steps share the exact same gating condition", () => {
+  // Docs drift check additionally reads packages/loopover-engine/src/focus-manifest.ts (cross-checked
+  // against .loopover.yml.example), a dependency its two siblings don't share -- so its condition is a
+  // deliberate superset (backend || ui || engine) rather than byte-identical to theirs. The invariant this
+  // test enforces is "every check still fires on backend OR ui at minimum" (already covered by the
+  // it.each above), not "all three conditions are identical" -- padding `engine` onto the other two just
+  // to preserve exact-string uniformity would misrepresent what they actually depend on.
+  it("Docs drift check's condition is engine-widened; its two siblings stay on backend||ui only", () => {
     const workflow = readYaml(".github/workflows/ci.yml");
     const validateCode = record(record(workflow.jobs, "workflow.jobs")["validate-code"], "workflow.jobs.validate-code");
     const steps = recordArray(validateCode.steps, "jobs.validate-code.steps");
 
-    const conditions = checks.map(({ stepName }) => {
+    const conditionFor = (stepName: string) => {
       const step = steps.find((entry) => entry.name === stepName);
       expect(step).toBeDefined();
       return String(step!.if);
-    });
-    expect(new Set(conditions).size).toBe(1);
+    };
+
+    expect(conditionFor("Docs drift check")).toContain("needs.changes.outputs.engine == 'true'");
+    expect(conditionFor("Selfhost env-reference drift check")).not.toContain("needs.changes.outputs.engine");
+    expect(conditionFor("Command reference drift check")).not.toContain("needs.changes.outputs.engine");
   });
 });

--- a/test/unit/observability-ci.test.ts
+++ b/test/unit/observability-ci.test.ts
@@ -45,9 +45,11 @@ describe("observability config CI guard", () => {
     expect(neutralizeStep).toBeDefined();
     expect(neutralizeStep!.run).toBe("rm -f .npmrc");
     expect(validateStep).toBeDefined();
-    expect(String(validateStep!.if)).toBe(
-      "${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}",
-    );
+    // Not gated on `backend`: scripts/validate-observability-configs.mjs only ever reads
+    // grafana/dashboards/*.json and prometheus/rules/alerts.yml, both fully covered by the
+    // `observability` filter checked above -- a `backend` clause had no structural justification and ran
+    // this on every backend PR (the highest-volume PR shape in the repo) for nothing.
+    expect(String(validateStep!.if)).toBe("${{ github.event_name == 'push' || needs.changes.outputs.observability == 'true' }}");
     expect(record(validateStep!.env, "validateStep.env").NODE_OPTIONS).toBe("");
     expect(validateStep!.run).toBe("node scripts/validate-observability-configs.mjs");
   });

--- a/turbo.json
+++ b/turbo.json
@@ -61,31 +61,71 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    // apps/loopover-ui/src also imports three files this app has no formal package.json dependency on:
+    // root src/signals/redaction.ts (from lib/browser-sentry.ts), root src/signals/focus-manifest.ts (from
+    // lib/registration-workspace.ts) -- both real, always-bundled production imports -- and
+    // packages/loopover-engine/src/miner/driver-factory.ts (from a .test.tsx file, so typecheck-only, not
+    // build). None of these were hashed before, so a change to any of them with apps/loopover-ui itself
+    // unchanged could give a false cache HIT on this task -- the same class of bug already found and fixed
+    // in the root //#typecheck task, just missed here during that audit. Confirmed via grep: `grep -rn
+    // "\.\./\.\./\.\./\.\./" apps/loopover-ui/src` finds exactly these three cross-boundary imports, no
+    // others. @loopover/engine#build is added as an explicit dependsOn edge (rather than hand-listing
+    // driver-factory.ts as an input) since engine has no default inputs override -- its whole src/** is
+    // already hashed by that task, so depending on it transitively covers this file (and any other engine
+    // file a future test might import) without needing to track individual paths here too.
     "@loopover/ui#typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@loopover/engine#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/worker-configuration.d.ts",
-        "$TURBO_ROOT$/src/env.d.ts"
+        "$TURBO_ROOT$/src/env.d.ts",
+        "$TURBO_ROOT$/src/signals/redaction.ts",
+        "$TURBO_ROOT$/src/signals/focus-manifest.ts"
       ],
       "outputs": []
     },
     "@loopover/ui#lint": {
       "outputs": []
     },
+    // Same two root src/signals files as @loopover/ui#typecheck above -- both real production imports
+    // (src/client.ts and src/routes/__root.tsx transitively pull them in), so vite's actual bundle depends
+    // on them. Previously had no inputs override at all (bare $TURBO_DEFAULT$, own directory only). Does
+    // NOT need the engine dependsOn edge @loopover/ui#typecheck has: the only file reaching into
+    // packages/loopover-engine is imported from a .test.tsx file, which isn't part of the production build.
     "@loopover/ui#build": {
       "dependsOn": ["^build", "@loopover/extension#build", "@loopover/miner-extension#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/src/signals/redaction.ts",
+        "$TURBO_ROOT$/src/signals/focus-manifest.ts"
+      ],
       "outputs": ["dist/**"]
     },
+    // apps/loopover-miner-ui/src (typecheck) imports from packages/loopover-miner/lib/chat-action-registry
+    // /chat-action-dispatch/chat-governor-actions -- 5 files reaching in via relative path, with no
+    // package.json dependency on @loopover/miner to create a ^build edge, and no existing inputs override
+    // (bare $TURBO_DEFAULT$). Same class of bug as @loopover/ui#typecheck above. Scoped to the whole
+    // packages/loopover-miner/lib/** directory (not the 5 specific files) to match the same "don't
+    // hand-track an ever-growing cross-package surface" reasoning already applied to //#typecheck's fix --
+    // this UI already imports 5 files from that one directory, more is a matter of when, not if.
     "@loopover/ui-miner#typecheck": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/loopover-miner/lib/**"],
       "outputs": []
     },
     "@loopover/ui-miner#lint": {
       "outputs": []
     },
+    // apps/loopover-miner-ui's root-level vite-*-api.ts dev-server plugins (vite-attempt-api.ts,
+    // vite-chat-api.ts, and 7 others) contain 14 dynamic import()s reaching into
+    // packages/loopover-miner/lib/** and one into packages/loopover-engine/dist/index.js -- same
+    // directory added defensively as @loopover/ui-miner#typecheck above. These execute inside vite's
+    // configureServer request-handler hooks (vite dev only), so they likely don't affect this task's
+    // actual `vite build` bundle output -- but that's inference from reading the plugin code, not proven
+    // the way the typecheck gap above was, so the input is added here too rather than left asymmetric.
     "@loopover/ui-miner#build": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/loopover-miner/lib/**"],
       "outputs": ["dist/**"]
     },
     "@loopover/extension#lint": {


### PR DESCRIPTION
## Summary

After the Turborepo build/lint/typecheck migration (#7349 → #7363 → #7368 → #7371), ran a 4-agent exhaustive audit asking one question: is everything actually optimized and correct, or did the same class of bug already found once in `//#typecheck` (undeclared cross-package cache inputs) slip through anywhere else? It had — in three more places — plus a cache-key collision that was quietly undoing #7368's own fix, and eight CI trigger-gating gaps unrelated to Turborepo. This PR closes all of them.

**Turborepo cache correctness (`turbo.json`):**
- `@loopover/ui#typecheck`, `@loopover/ui#build`, and `@loopover/ui-miner#typecheck` each had undeclared cross-package inputs (root `src/signals/*.ts`, `packages/loopover-engine/src/miner/driver-factory.ts`, and `packages/loopover-miner/lib/**` respectively) — a false cache HIT on any of these is a false pass on this repo's actual merge gate. Every fix verified empirically: touch the file, confirm the task's hash changes; revert, confirm it changes back.
- `@loopover/ui-miner#build` gets the same `packages/loopover-miner/lib/**` input defensively — its dynamic imports of that directory likely only execute in `vite dev`, not `build`, but that's inference from reading plugin code, not proven the way the typecheck gap was.
- `packages/discovery-index/tsconfig.json` was missing the `tsBuildInfoFile` override `packages/loopover-engine` and `packages/loopover-miner` already have — its build silently wrote the repo-root `.tsbuildinfo` instead of its own, corrupting the root Typecheck step's incremental cache on every local `npm run test:ci` run. Confirmed empirically before/after.

**Turborepo GH Actions cache-key collision (`ci.yml`):**
- `validate-code` and `validate-tests` had two *separate* `.turbo/cache` restore/save pairs using the *identical* key, so all 7 jobs in one run (validate-code + 6 validate-tests shards) raced for the same cache slot. A shard reaches its own Save after ~6 steps vs. validate-code's ~20+, so a shard almost always won — meaning validate-code's much richer cache (engine+mcp+miner+ui-kit+ui+extension) was very likely discarded every run in favor of a shard's engine-only save, silently defeating most of the point of #7368's Save-repositioning fix. Split into distinct `turbo-code-`/`turbo-tests-` prefixes.

**CI merge-safety gate gaps (`ci.yml`)** — this repo auto-merges on green CI, so a skipped check is a real gap, not just noise:
- `Typecheck` and `Worker runtime tests` were gated on `backend` only, but root `src/**` genuinely imports across engine/mcp/miner boundaries (~57 files import `@loopover/engine`; `find-opportunities.ts` imports miner lib files; `mcp-compatibility.ts` imports the mcp package.json) — an engine/mcp/miner-only PR skipped both entirely, including the only test in CI that boots the real Cloudflare Workers runtime end-to-end.
- `Miner deployment docs audit`, `Miner env-reference drift check`, and `Docs drift check` were each missing `engine`: their scripts read `packages/loopover-engine/src/{miner,focus-manifest.ts}` directly.
- `Engine-parity drift check` was missing `miner` (reverse direction): it checks `packages/loopover-miner/expected-engine.version`.
- `Branding drift check` was missing `discoveryIndex`: its pathspecs include `packages/*/src/**`, matching `packages/discovery-index/src/**`.
- `Validate observability configs` had an unjustified `backend` clause — the script only reads `grafana/dashboards`/`prometheus/rules`, both already covered by the `observability` filter — removed so it stops running on every backend PR (the highest-volume PR shape) for nothing.
- `UI tests` still used a `&&` chain, unlike its sibling `UI lint`/`UI typecheck` (fixed in #7368 to run independently via turbo's union `--filter`): a failing `@loopover/ui` test silently hid `@loopover/ui-miner`'s and `@loopover/miner-extension`'s results. `turbo.json` deliberately has no `test` task (test orchestration stays out of Turborepo per the original plan doc), so split into 3 independent steps using the same `!cancelled()` pattern already used elsewhere in this file.

`test/unit/ci-generated-artifact-drift-checks.test.ts`'s "all three drift checks share one condition" assertion was updated to check that `backend||ui` is a *subset* of each (not that all three are byte-identical) — Docs drift check's added `engine` dependency isn't shared by its two siblings, and padding it onto them too would misrepresent what they actually read. `test/unit/observability-ci.test.ts`'s exact-condition-string assertion was updated to match.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-initiated build-tooling work, not tied to a single pre-filed contributor issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` (root, real invocation, clean)
- [x] Every turbo cache-input fix verified empirically with real (non-dry) `npx turbo run ...` invocations: touched the specific file the fix covers, confirmed the task's hash/cache behavior changed; reverted, confirmed it changed back. Also ran every touched task's real (non-dry) invocation end-to-end (`ui#typecheck`, `ui-miner#typecheck`, `ui-miner#build`, `ui#build`) to confirm they still succeed, not just resolve.
- [x] `discovery-index`'s `tsBuildInfoFile` fix verified by deleting both `.tsbuildinfo` files, running the exact `tsc -p packages/discovery-index/tsconfig.json` command its build script runs, and confirming it now writes `packages/discovery-index/.tsbuildinfo` instead of the repo-root one.
- [x] Ran the full local `test/unit` suite (not just targeted files, given the scope of this change): 977 test files, 18,477 tests, all passing.
- [x] Re-ran the 13 meta-tests that parse `ci.yml`/`turbo.json` content after every edit; 2 required updates to match intentionally-corrected behavior (`ci-generated-artifact-drift-checks.test.ts`, `observability-ci.test.ts`) — both updated to check the corrected invariant, not weakened.
- [ ] `npm run test:coverage` — not run in full; this PR touches no `src/**` file except `.tsbuildinfo`-adjacent config, only CI/build-tooling configuration and its own meta-tests (covered above).
- [ ] `npm audit --audit-level=moderate` — not applicable; no dependency changes.

If any required check was skipped, explain why: this PR is CI/build-tooling configuration, not application source — the skipped commands aren't applicable, and every actually-relevant command (including empirical before/after repros for every cache-correctness fix, and a full local test suite run) is listed above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests — N/A.
- [ ] API/OpenAPI/MCP behavior updated and tested where needed — N/A.
- [ ] UI changes use live API data or real empty/error/loading states — N/A, no UI behavior change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no visible/UI change.
- [x] Public docs/changelogs updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Sixth of this session's Turborepo/CI-speed sequence: #7345 → #7349 (Phase 0) → #7363 (Phase 1) → #7368 (Phase 2) → #7371 (Phase 3, `//#typecheck` fix) → this PR (Phase 4, full-audit follow-up).
- Touches `.github/workflows/**` (a guarded path), so it'll be held for manual owner review rather than auto-merged, matching every prior PR in this sequence.
- Prompted by an explicit "is everything 100% optimized" request — this PR is the answer, not a partial pass: every finding from the 4-agent audit that was independently confirmed real is fixed here. Findings deemed genuinely clean/intentional (e.g. `@loopover/ui-kit#typecheck` correctly unused since "Build UI-kit package" already fully compiles it; `publish-*.yml` release workflows deliberately staying off turbo) are not touched.