### PR TITLE
feat(visual): maintainer-notify follow-up comment for unrelated visual findings

### DIFF
--- a/.loopover.yml.example
+++ b/.loopover.yml.example
@@ -730,6 +730,13 @@ review:
 #     # rather than reading like something this PR broke). Never a gate blocker either way. Bool. Default:
 #     # false (the original regression-only prompt, no PR context sent, byte-identical to pre-bugAnalysis).
 #     bug_analysis: false
+#     # GitHub logins to @-mention on the standalone follow-up comment posted when a PR with a recorded
+#     # "unrelated" bug_analysis finding above is merged OR closed — describes each finding with its before/
+#     # after screenshots, formatted so GitHub's own "..." -> "Reference in new issue" action can spin one off
+#     # in one click. List of strings. Default: [] (empty) -- NOT hardcoded to a specific user; falls back at
+#     # RUNTIME to this repo's owner + the ADMIN_GITHUB_LOGINS fleet-operator allowlist, the same "maintainer"
+#     # resolution used elsewhere. Capped at 10 entries. (#7372)
+#     bug_analysis_notify: []
 #   # Maintainer overrides for the public review-panel CONTENT (not what loopover measures). The
 #   # Gittensor attribution + register link is always appended to the footer regardless; maintainer text
 #   # failing the public-safe filter is dropped, never published.

--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -744,6 +744,13 @@ review:
 #     # rather than reading like something this PR broke). Never a gate blocker either way. Bool. Default:
 #     # false (the original regression-only prompt, no PR context sent, byte-identical to pre-bugAnalysis).
 #     bug_analysis: false
+#     # GitHub logins to @-mention on the standalone follow-up comment posted when a PR with a recorded
+#     # "unrelated" bug_analysis finding above is merged OR closed — describes each finding with its before/
+#     # after screenshots, formatted so GitHub's own "..." -> "Reference in new issue" action can spin one off
+#     # in one click. List of strings. Default: [] (empty) -- NOT hardcoded to a specific user; falls back at
+#     # RUNTIME to this repo's owner + the ADMIN_GITHUB_LOGINS fleet-operator allowlist, the same "maintainer"
+#     # resolution used elsewhere. Capped at 10 entries. (#7372)
+#     bug_analysis_notify: []
 #   # Maintainer overrides for the public review-panel CONTENT (not what loopover measures). The
 #   # Gittensor attribution + register link is always appended to the footer regardless; maintainer text
 #   # failing the public-safe filter is dropped, never published.

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -1004,6 +1004,14 @@ export type VisualConfig = {
    *  new issue for it). false (default, every existing manifest) ⇒ byte-identical to today: the original
    *  regression-only prompt, no PR context sent, no "unrelated" finding category ever produced. */
   bugAnalysis: boolean;
+  /** `review.visual.bugAnalysisNotify` (#7372): GitHub logins to @-mention on the standalone follow-up
+   *  comment posted when a PR with recorded `visual_unrelated_issue_finding` advisory findings is merged or
+   *  closed — a maintainer-tagging, screenshot-carrying digest formatted so GitHub's own "..." → "Reference in
+   *  new issue" action can spin one off in one click. Empty (default, every existing manifest) ⇒ falls back
+   *  to the repo owner + the `ADMIN_GITHUB_LOGINS` fleet-operator allowlist at RUNTIME (the same "maintainer"
+   *  resolution `linked-issue-label-propagation-fetch.ts` already uses) — deliberately never a literal
+   *  hardcoded username baked into this manifest field's own default. */
+  bugAnalysisNotify: readonly string[];
   /** `review.visual.interactions`: specific elements to interact with and capture as animated evidence
    *  (hover/click) — for behavior a static screenshot can't show that isn't scroll-linked (see `gif` above
    *  for scroll-linked evidence). Empty (default) ⇒ byte-identical to today, no interaction capture. */
@@ -1078,6 +1086,7 @@ export const EMPTY_VISUAL_CONFIG: VisualConfig = {
   themeStorageKey: null,
   actionsFallback: false,
   bugAnalysis: false,
+  bugAnalysisNotify: [],
   interactions: [],
 };
 
@@ -2985,6 +2994,7 @@ function overlayVisualConfig(base: VisualConfig, override: VisualConfig): Visual
     themeStorageKey: pickOverlayNullable(override.themeStorageKey, base.themeStorageKey),
     actionsFallback: override.actionsFallback ? override.actionsFallback : base.actionsFallback,
     bugAnalysis: override.bugAnalysis ? override.bugAnalysis : base.bugAnalysis,
+    bugAnalysisNotify: pickOverlayStringList(override.bugAnalysisNotify, base.bugAnalysisNotify),
     interactions: override.interactions.length > 0 ? [...override.interactions] : [...base.interactions],
   };
 }
@@ -3192,6 +3202,7 @@ function visualConfigPresent(config: VisualConfig): boolean {
     config.themeStorageKey !== null ||
     config.actionsFallback ||
     config.bugAnalysis ||
+    config.bugAnalysisNotify.length > 0 ||
     config.interactions.length > 0
   );
 }
@@ -3294,9 +3305,49 @@ function parseVisualConfig(value: JsonValue | undefined, warnings: string[]): Vi
   const themeStorageKey = parsePublicSafeText(record.theme_storage_key, "review.visual.theme_storage_key", warnings);
   const actionsFallback = normalizeOptionalBoolean(record.actions_fallback, "review.visual.actions_fallback", warnings) === true;
   const bugAnalysis = normalizeOptionalBoolean(record.bug_analysis, "review.visual.bug_analysis", warnings) === true;
+  const bugAnalysisNotify = parseVisualBugAnalysisNotify(record.bug_analysis_notify, warnings);
   const interactions = parseVisualInteractions(record.interactions, warnings);
 
-  return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback, bugAnalysis, interactions };
+  return { productionUrl, preview: { urlTemplate }, routes: { paths, maxRoutes }, themes, gif, enabled, themeStorageKey, actionsFallback, bugAnalysis, bugAnalysisNotify, interactions };
+}
+
+// A hard cap so a hostile/huge manifest can't turn every PR close into a giant @-mention blast — mirrors
+// MAX_VISUAL_INTERACTIONS's "bound the list, don't fail the whole manifest" reasoning, sized generously since
+// a login is cheap to store/render (unlike an interaction capture) but a maintainer list this large would be
+// a config mistake either way.
+const MAX_VISUAL_BUG_ANALYSIS_NOTIFY = 10;
+// Standard GitHub username shape: alphanumeric + single hyphens, never starting/ending with one, 1-39 chars.
+const GITHUB_LOGIN_PATTERN = /^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/;
+
+/** Parse `review.visual.bug_analysis_notify` (#7372) — GitHub logins to @-mention on the PR-closed
+ *  maintainer-notify follow-up comment. A non-list, non-string, or malformed-login entry is dropped with a
+ *  warning rather than failing the whole list, same as every other manifest array here. Case-insensitively
+ *  deduped and lowercased (GitHub logins are case-insensitive; storing one canonical case avoids the same
+ *  maintainer appearing twice under different casing across the global-default + per-repo overlay). */
+function parseVisualBugAnalysisNotify(value: JsonValue | undefined, warnings: string[]): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    warnings.push(`Manifest "review.visual.bug_analysis_notify" must be a list of GitHub logins; ignoring it.`);
+    return [];
+  }
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, entry] of value.entries()) {
+    if (out.length >= MAX_VISUAL_BUG_ANALYSIS_NOTIFY) {
+      warnings.push(`Manifest "review.visual.bug_analysis_notify" is capped at ${MAX_VISUAL_BUG_ANALYSIS_NOTIFY} entries; dropping the rest.`);
+      break;
+    }
+    const raw = typeof entry === "string" ? entry.trim().replace(/^@/, "") : "";
+    if (!raw || !GITHUB_LOGIN_PATTERN.test(raw)) {
+      warnings.push(`Manifest "review.visual.bug_analysis_notify[${index}]" must be a valid GitHub login; ignoring it.`);
+      continue;
+    }
+    const login = raw.toLowerCase();
+    if (seen.has(login)) continue;
+    seen.add(login);
+    out.push(login);
+  }
+  return out;
 }
 
 const VISUAL_INTERACTION_ACTION_VALUES: readonly VisualInteractionAction[] = ["hover", "click", "drag"];
@@ -3660,6 +3711,7 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
     if (review.visual.themeStorageKey !== null) visual.theme_storage_key = review.visual.themeStorageKey;
     if (review.visual.actionsFallback) visual.actions_fallback = true;
     if (review.visual.bugAnalysis) visual.bug_analysis = true;
+    if (review.visual.bugAnalysisNotify.length > 0) visual.bug_analysis_notify = [...review.visual.bugAnalysisNotify];
     if (review.visual.interactions.length > 0) {
       visual.interactions = review.visual.interactions.map((interaction) => {
         const entry: Record<string, JsonValue> = { selector: interaction.selector, action: interaction.action };

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4780,6 +4780,27 @@ export async function persistAdvisory(env: Env, advisory: Advisory): Promise<voi
   });
 }
 
+/** The most recently PERSISTED advisory for a pull request (#7372) — `persistAdvisory` above writes ONE
+ *  append-only row per review pass (a fresh `crypto.randomUUID()` id every call, see
+ *  `buildPullRequestAdvisory`), so the table has no single "current" row without an explicit ORDER BY; this
+ *  is the first reader that needs one, for the PR-closed maintainer-notify follow-up comment to see whatever
+ *  findings the LAST review pass recorded (including any `visual_unrelated_issue_finding`s). Queries by
+ *  `target_key` (the SAME `${repoFullName}#${pullNumber}` key `buildPullRequestAdvisory` derives) rather than
+ *  `repo_full_name` + `pull_number` separately, so this reuses the existing `advisories_target_idx` index
+ *  instead of the coarser repo-only one. Orders by `updated_at DESC, rowid DESC` — the rowid tiebreak matters
+ *  because `updated_at` is millisecond-precision text and two review passes for the same PR (a rapid
+ *  synchronize burst) can genuinely tie on it; rowid, SQLite's own monotonic insertion-order column, always
+ *  breaks the tie toward whichever row was actually written last. No row ⇒ null (a PR that never got a review
+ *  pass, or predates this table). */
+export async function getLatestAdvisoryForPullRequest(env: Env, repoFullName: string, pullNumber: number): Promise<{ findings: AdvisoryFinding[]; headSha: string | null } | null> {
+  const row = await env.DB
+    .prepare("SELECT findings_json AS findingsJson, head_sha AS headSha FROM advisories WHERE target_type = 'pull_request' AND target_key = ? ORDER BY updated_at DESC, rowid DESC LIMIT 1")
+    .bind(`${repoFullName}#${pullNumber}`)
+    .first<{ findingsJson: string | null; headSha: string | null }>();
+  if (!row) return null;
+  return { findings: parseJson<AdvisoryFinding[]>(row.findingsJson, []), headSha: row.headSha };
+}
+
 /** #1 self-host AI-review cache. Returns the cached AI review for this exact (repo, pull, head SHA) ONLY when the
  *  stored review mode matches — the LLM output changes only with the code (head SHA) or the review mode, so a re-run
  *  at the same SHA+mode reuses it instead of re-spending the call. A nullish head SHA (no commit to key on) is a miss.

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -7,6 +7,10 @@ export const PR_INTELLIGENCE_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
 export const AGENT_COMMAND_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
 const LEGACY_PR_INTELLIGENCE_COMMENT_MARKER = "<!-- gittensory-pr-intelligence -->";
 const LEGACY_AGENT_COMMAND_COMMENT_MARKER = "<!-- gittensory-agent-command -->";
+/** #7372: the PR-closed maintainer-notify follow-up comment's own marker — deliberately a DIFFERENT comment
+ *  thread from the sticky PR panel above (that comment stops being useful the moment the PR closes), so this
+ *  must never collapse into `PR_PANEL_COMMENT_MARKER`'s aliases the way the two constants above do. */
+export const VISUAL_FOLLOWUP_COMMENT_MARKER = "<!-- loopover:visual-unrelated-followup -->";
 // Bound the marker-comment search at 10 pages (up to 1,000 comments), matching src/github's other pagination
 // caps (app.ts's MAX_WORKFLOW_RUN_LIST_PAGES, pr-actions.ts's REVIEW_PAGE_LIMIT). The old cap of 3 (300 comments)
 // let a PR/issue that accrued >300 comments before LoopOver's own marker comment hide it from this search, so
@@ -33,6 +37,23 @@ export async function createOrUpdatePrIntelligenceComment(
   options: { createIfMissing?: boolean | undefined; mode?: AgentActionMode } = {},
 ): Promise<{ id: number; html_url?: string; changed: boolean } | null> {
   return createOrUpdateIssueCommentWithMarker(env, installationId, repoFullName, pullNumber, body, PR_INTELLIGENCE_COMMENT_MARKER, options);
+}
+
+/** The PR-closed maintainer-notify follow-up comment (#7372, review.visual.bugAnalysisNotify) — its own
+ *  comment thread, separate from the sticky PR panel above. `createOrUpdate` (not create-only) so a PR that
+ *  cycles closed -> reopened -> closed again with a DIFFERENT set of unrelated findings the second time
+ *  updates the same comment instead of posting a confusing duplicate; a same-body repeat (a retried `closed`
+ *  webhook delivery) is a genuine no-op via the same byte-identical-body skip every other marker comment here
+ *  already gets. */
+export async function createOrUpdateVisualFollowupComment(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  pullNumber: number,
+  body: string,
+  mode: AgentActionMode = "live",
+): Promise<{ id: number; html_url?: string; changed: boolean } | null> {
+  return createOrUpdateIssueCommentWithMarker(env, installationId, repoFullName, pullNumber, body, VISUAL_FOLLOWUP_COMMENT_MARKER, { mode });
 }
 
 export async function createOrUpdateAgentCommandComment(
@@ -144,6 +165,12 @@ async function deleteDuplicateMarkerComments(
   );
 }
 
-function markerAliases(_marker: string): string[] {
-  return [PR_PANEL_COMMENT_MARKER, LEGACY_PR_INTELLIGENCE_COMMENT_MARKER, LEGACY_AGENT_COMMAND_COMMENT_MARKER];
+// #7372: only PR_PANEL_COMMENT_MARKER (and its two legacy predecessors) collapse into one shared search set —
+// PR_INTELLIGENCE_COMMENT_MARKER/AGENT_COMMAND_COMMENT_MARKER are literally that SAME string value (see their
+// `= PR_PANEL_COMMENT_MARKER` aliases above), so this preserves their existing behavior exactly. Any OTHER
+// marker (e.g. VISUAL_FOLLOWUP_COMMENT_MARKER) searches for itself alone — collapsing it into the panel's own
+// alias set here would make createOrUpdateIssueCommentWithMarker find and PATCH the sticky PANEL comment
+// instead of that marker's own comment thread, silently corrupting it.
+function markerAliases(marker: string): string[] {
+  return marker === PR_PANEL_COMMENT_MARKER ? [PR_PANEL_COMMENT_MARKER, LEGACY_PR_INTELLIGENCE_COMMENT_MARKER, LEGACY_AGENT_COMMAND_COMMENT_MARKER] : [marker];
 }

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -88,6 +88,7 @@ import {
   upsertIssueFromGitHub,
   upsertPullRequestFromGitHub,
   upsertRepositoryFromGitHub,
+  getLatestAdvisoryForPullRequest,
 } from "../db/repositories";
 import { renameRepositoryIdentity } from "../db/repo-identity-rename";
 import {
@@ -144,6 +145,7 @@ import {
   AGENT_COMMAND_COMMENT_MARKER,
   createOrUpdateAgentCommandComment,
   createOrUpdatePrIntelligenceComment,
+  createOrUpdateVisualFollowupComment,
   PR_PANEL_COMMENT_MARKER,
 } from "../github/comments";
 import {
@@ -467,6 +469,7 @@ import {
   VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT,
   VISUAL_VISION_SYSTEM_PROMPT,
 } from "../review/visual/visual-findings";
+import { buildVisualFollowupComment, resolveVisualFollowupNotifyLogins } from "../review/visual/visual-followup";
 import { incr, observe, REVIEW_LATENCY_BUCKETS } from "../selfhost/metrics";
 import { withAdvisoryAiEnv } from "../selfhost/ai";
 import {
@@ -5806,11 +5809,17 @@ async function handlePullRequestWebhookEvent(
       });
       return true;
     }
-    const [repo, cachedOtherOpenPullRequests, { linkedIssueAuthorLogins, confirmedNoOpenLinkedIssue }] =
+    // #7372: read BEFORE buildPullRequestAdvisory/persistAdvisory below overwrite "most recent" with THIS
+    // pass's own fresh (visual-finding-less) advisory row -- the advisories table has no separate "current"
+    // column, so reading late would always see this pass's own bookkeeping write instead of the real prior
+    // review pass's recorded visual_unrelated_issue_finding. Gated on `closed` (the only action
+    // maybePostVisualFollowupComment ever fires for) so every other action skips this read entirely.
+    const [repo, cachedOtherOpenPullRequests, { linkedIssueAuthorLogins, confirmedNoOpenLinkedIssue }, priorAdvisoryForVisualFollowup] =
       await Promise.all([
         getRepository(env, repoFullName),
         listOtherOpenPullRequests(env, repoFullName, pr.number),
         resolveLinkedIssueAdvisoryContext(env, installationId, repoFullName, pr.linkedIssues, settings),
+        payload.action === "closed" && installationId ? getLatestAdvisoryForPullRequest(env, repoFullName, pr.number) : Promise.resolve(null),
       ]);
     // #dup-winner / audit #15: drop any cached-open duplicate sibling already closed on GitHub before the
     // advisory (and the disposition) elect the cluster winner, so the real lowest-OPEN PR is never auto-closed.
@@ -5864,6 +5873,14 @@ async function handlePullRequestWebhookEvent(
         payload,
         settings,
       );
+    }
+    // PR-closed maintainer-notify follow-up (#7372, review.visual.bugAnalysisNotify): fires on EITHER a
+    // genuine merge OR an ordinary close -- unlike maybeEnqueueSiblingRegateForMergedPr above, this is NOT
+    // merge-only, since an "unrelated" visual finding is just as real and just as easy to lose track of
+    // either way. Independent of every review-evasion/draft-dodge guard around it; those enforce close
+    // POLICY, this just makes sure an already-recorded advisory finding gets one last chance to be seen.
+    if (payload.action === "closed" && installationId) {
+      await maybePostVisualFollowupComment(env, installationId, repoFullName, pr.number, priorAdvisoryForVisualFollowup);
     }
     // Draft-dodge guard (#converted-to-draft): a contributor converting an OPEN PR to draft cannot use
     // draft state to keep a gate-rejected PR alive. When a prior gate failure exists for the PR's current
@@ -7416,7 +7433,7 @@ export async function runVisualVisionForAdvisory(
       }
     }
     const visionFindings = parseVisualVisionResponse(visionText);
-    const findings = buildVisualRegressionFindings(visionFindings);
+    const findings = buildVisualRegressionFindings(visionFindings, args.routes);
     args.advisory.findings.push(...findings);
     await recordVisualVisionUsage(
       env,
@@ -7462,6 +7479,48 @@ async function recordVisualVisionUsage(
     detail,
     metadata: { repoFullName: args.repoFullName, pullNumber: args.pr.number },
   });
+}
+
+/**
+ * PR-closed maintainer-notify follow-up (#7372, review.visual.bugAnalysisNotify): when a PR closes (merged
+ * OR not -- either outcome leaves the same unrelated-but-real issue behind, so this is not merge-only) and its
+ * last recorded advisory (`priorAdvisory`, read by the caller BEFORE this same webhook pass's own
+ * `buildPullRequestAdvisory`/`persistAdvisory` calls overwrite "most recent" -- see the call site's own
+ * comment for why that ordering matters) carried at least one `visual_unrelated_issue_finding`, post a
+ * standalone comment describing each one with its screenshot evidence, @-mentioning the configured (or
+ * default-maintainer) notify list. Gated on `review.visual.bugAnalysis` being on for this repo -- off (the
+ * default) means no unrelated finding was ever produced in the first place, so this is a cheap no-op for
+ * every repo that hasn't opted in. `createOrUpdateVisualFollowupComment` is itself idempotent (its own
+ * marker, create-or-update, byte-identical-body skip), so a retried "closed" delivery is a safe no-op rather
+ * than a duplicate post. Best-effort: any failure here is logged and swallowed, never lets a comment-posting
+ * error block or retry the rest of this webhook delivery.
+ */
+async function maybePostVisualFollowupComment(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  pullNumber: number,
+  priorAdvisory: { findings: AdvisoryFinding[] } | null,
+): Promise<void> {
+  try {
+    if (!priorAdvisory || priorAdvisory.findings.length === 0) return;
+    const visualConfig = await resolveVisualCaptureConfig(env, repoFullName);
+    if (!visualConfig.bugAnalysis) return;
+    const { owner } = repoParts(repoFullName);
+    const notifyLogins = resolveVisualFollowupNotifyLogins(visualConfig.bugAnalysisNotify, owner, parseGitHubLoginList(env.ADMIN_GITHUB_LOGINS));
+    const body = buildVisualFollowupComment(priorAdvisory.findings, notifyLogins);
+    if (!body) return;
+    await createOrUpdateVisualFollowupComment(env, installationId, repoFullName, pullNumber, body);
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        event: "visual_followup_comment_error",
+        repoFullName,
+        pullNumber,
+        message: errorMessage(error).slice(0, 200),
+      }),
+    );
+  }
 }
 
 async function recordScreenshotTableVisionUsage(

--- a/src/review/visual/visual-findings.ts
+++ b/src/review/visual/visual-findings.ts
@@ -198,6 +198,19 @@ export function parseVisualVisionResponse(text: string): VisualVisionFinding[] {
   return out;
 }
 
+/** Find the captured route `finding.path` refers to and lift its public shot URLs into a finding's
+ *  `visualEvidence` (#7372: the PR-closed maintainer-notify follow-up comment embeds these directly, without
+ *  re-deriving them from the capture routes at close time). No match, or a route with neither a before nor
+ *  an after URL at all, ⇒ undefined (omit the field entirely) rather than an evidence-less placeholder. */
+function findVisualEvidence(path: string, routes: readonly CaptureRoute[]): AdvisoryFinding["visualEvidence"] {
+  const route = routes.find((candidate) => candidate.path === path);
+  if (!route) return undefined;
+  const beforeUrl = route.beforeUrl || route.beforeUrlMobile || undefined;
+  const afterUrl = route.afterUrl || route.afterUrlMobile || undefined;
+  if (!beforeUrl && !afterUrl) return undefined;
+  return { path, ...(beforeUrl ? { beforeUrl } : {}), ...(afterUrl ? { afterUrl } : {}) };
+}
+
 /** Build the ADVISORY-ONLY findings for the unified comment (#4111 / `review.visual.bugAnalysis`) — one per
  *  vision observation, feeding the SAME `advisory.findings` pipeline `ai_consensus_defect`/`ai_review_split`
  *  already ride (see this file's header for why neither finding code can ever become a blocker).
@@ -205,16 +218,21 @@ export function parseVisualVisionResponse(text: string): VisualVisionFinding[] {
  *  carries `"warning"`-severity findings into `gate.warnings` at all, so anything else would silently vanish
  *  from the rendered comment. An `"unrelated"`-category finding (only ever produced by
  *  {@link VISUAL_BUG_ANALYSIS_SYSTEM_PROMPT}) gets its own code + a distinct message suggesting the observer
- *  open a separate issue, since it is — by construction — not this PR's fault and must never read like one. */
-export function buildVisualRegressionFindings(findings: readonly VisualVisionFinding[]): AdvisoryFinding[] {
-  return findings.map((finding) =>
-    finding.category === "unrelated"
+ *  open a separate issue, since it is — by construction — not this PR's fault and must never read like one.
+ *  `routes` (#7372) is the SAME capture-route list the vision call was built from — used only to attach
+ *  `visualEvidence` (screenshot URLs) to each finding; passing `[]` (or routes with no matching path) is safe
+ *  and simply omits evidence, matching this function's pre-#7372 behavior exactly. */
+export function buildVisualRegressionFindings(findings: readonly VisualVisionFinding[], routes: readonly CaptureRoute[] = []): AdvisoryFinding[] {
+  return findings.map((finding) => {
+    const visualEvidence = findVisualEvidence(finding.path, routes);
+    return finding.category === "unrelated"
       ? {
           code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
           severity: "warning",
           title: `Possible unrelated visual issue: ${finding.path}`,
           detail: finding.body,
           action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+          ...(visualEvidence ? { visualEvidence } : {}),
         }
       : {
           code: VISUAL_REGRESSION_FINDING_CODE,
@@ -222,6 +240,7 @@ export function buildVisualRegressionFindings(findings: readonly VisualVisionFin
           title: `Possible visual regression: ${finding.path}`,
           detail: finding.body,
           action: "Advisory only — verify against the Visual preview screenshots before deciding.",
-        },
-  );
+          ...(visualEvidence ? { visualEvidence } : {}),
+        };
+  });
 }

--- a/src/review/visual/visual-followup.ts
+++ b/src/review/visual/visual-followup.ts
@@ -1,0 +1,69 @@
+// PR-closed maintainer-notify follow-up comment (#7372, review.visual.bugAnalysisNotify) — PURE decision +
+// message-shape logic ONLY, mirroring visual-findings.ts's own "no DB, no GitHub API" convention: a caller
+// resolves the persisted advisory + repo owner + ADMIN_GITHUB_LOGINS, and posts the built comment itself.
+//
+// A `review.visual.bugAnalysis` finding with category "unrelated" (VISUAL_UNRELATED_ISSUE_FINDING_CODE) is
+// advisory-only and easy to lose track of once the PR that surfaced it closes -- nothing about it is
+// actionable, and nobody is notified once the PR itself is done. When a PR with at least one recorded
+// unrelated finding is merged OR closed, this builds a STANDALONE follow-up comment (never folded into the
+// unified sticky comment, which stops being useful once the PR is closed) that @-mentions a configurable
+// maintainer list, describes each finding with its screenshot evidence, and is formatted so GitHub's own
+// "..." -> "Reference in new issue" action can spin one off in a single click.
+
+import type { AdvisoryFinding } from "../../types";
+import { VISUAL_FOLLOWUP_COMMENT_MARKER } from "../../github/comments";
+import { VISUAL_UNRELATED_ISSUE_FINDING_CODE } from "./visual-findings";
+
+/** The subset of `findings` this follow-up comment cares about — `visual_unrelated_issue_finding` only. A
+ *  `visual_regression_finding` is THIS PR's own fault and was already fully surfaced in the unified review
+ *  comment while the PR was open; repeating it here after close would be redundant, not helpful. */
+export function selectUnrelatedVisualFindings(findings: readonly AdvisoryFinding[]): AdvisoryFinding[] {
+  return findings.filter((finding) => finding.code === VISUAL_UNRELATED_ISSUE_FINDING_CODE);
+}
+
+/** Resolve the GitHub logins to @-mention on the follow-up comment. A configured `review.visual.
+ *  bugAnalysisNotify` list (global-default or per-repo, already parsed/lowercased/deduped by the manifest
+ *  layer) always wins. Empty/absent — the manifest default, deliberately never a hardcoded username — falls
+ *  back to this repo's owner plus the `ADMIN_GITHUB_LOGINS` fleet-operator allowlist, the SAME "maintainer"
+ *  resolution `linked-issue-label-propagation-fetch.ts` already uses elsewhere in this codebase. */
+export function resolveVisualFollowupNotifyLogins(configured: readonly string[], repoOwner: string, adminLogins: ReadonlySet<string>): string[] {
+  if (configured.length > 0) return [...configured];
+  const logins = new Set<string>(adminLogins);
+  const owner = repoOwner.trim().toLowerCase();
+  if (owner) logins.add(owner);
+  return [...logins];
+}
+
+/** Build the standalone follow-up comment body, or null when there is nothing worth posting (no unrelated
+ *  findings, or no login resolved to notify) — the caller must never post an empty/pointless comment. Each
+ *  finding gets its own heading + description + a Before/After screenshot row (a dash when a side has no
+ *  shot URL — a capture failure, not an error); multiple findings are separated by a rule. Plain markdown
+ *  (not raw HTML) throughout, since `finding.detail`/`title` are already public-safe filtered text and GitHub
+ *  natively renders `![alt](url)` — matches exactly what "Reference in new issue" quotes back into a draft. */
+export function buildVisualFollowupComment(findings: readonly AdvisoryFinding[], notifyLogins: readonly string[]): string | null {
+  const unrelated = selectUnrelatedVisualFindings(findings);
+  if (unrelated.length === 0 || notifyLogins.length === 0) return null;
+  const mentions = notifyLogins.map((login) => `@${login}`).join(" ");
+  const sections = unrelated.map((finding) => {
+    const lines = [`### ${finding.title}`, "", finding.detail];
+    const evidence = finding.visualEvidence;
+    if (evidence?.beforeUrl || evidence?.afterUrl) {
+      lines.push(
+        "",
+        "| Before | After |",
+        "| --- | --- |",
+        `| ${evidence.beforeUrl ? `![before](${evidence.beforeUrl})` : "—"} | ${evidence.afterUrl ? `![after](${evidence.afterUrl})` : "—"} |`,
+      );
+    }
+    return lines.join("\n");
+  });
+  return [
+    `${mentions} — while reviewing this PR, LoopOver noticed the following visual issue(s) that don't look related to its stated change. Flagging these here now that the PR is closed, so they don't get lost.`,
+    "",
+    sections.join("\n\n---\n\n"),
+    "",
+    `Click the **⋯** menu above and choose **"Reference in new issue"** to track any of these separately.`,
+    "",
+    VISUAL_FOLLOWUP_COMMENT_MARKER,
+  ].join("\n");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,6 +500,14 @@ export type AdvisoryFinding = {
    *  no model confidence); an absent/unparseable reviewer confidence degrades to 1.0 upstream, so omitting it here
    *  behaves exactly like an at-or-above-floor confidence. */
   confidence?: number;
+  /** Public-safe screenshot evidence for a `visual_regression_finding` / `visual_unrelated_issue_finding`
+   *  (`review.visual.bugAnalysis`) — the SAME shot URLs already rendered in the "Visual preview" collapsible,
+   *  carried alongside the finding (not just referenced by route path) so a later consumer — the PR-closed
+   *  maintainer-notify follow-up comment — can embed them directly without re-deriving from the capture
+   *  routes, which are never re-fetched at close time and may reference an expired/rotated preview deploy by
+   *  then. Absent for every non-visual finding, and for a visual finding whose route carried no shot URL at
+   *  all (a capture failure — nothing to show). */
+  visualEvidence?: { path: string; beforeUrl?: string; afterUrl?: string };
 };
 
 export type Advisory = {

--- a/test/unit/advisory-persistence.test.ts
+++ b/test/unit/advisory-persistence.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { getLatestAdvisoryForPullRequest, persistAdvisory } from "../../src/db/repositories";
+import type { Advisory, AdvisoryFinding } from "../../src/types";
+import { createTestEnv } from "../helpers/d1";
+
+const finding = (code: string, detail: string): AdvisoryFinding => ({
+  code,
+  title: `Finding: ${code}`,
+  severity: "warning",
+  detail,
+});
+
+const advisory = (overrides: Partial<Advisory> = {}): Advisory => ({
+  id: crypto.randomUUID(),
+  targetType: "pull_request",
+  targetKey: "owner/repo#42",
+  repoFullName: "owner/repo",
+  pullNumber: 42,
+  headSha: "sha1",
+  conclusion: "neutral",
+  severity: "warning",
+  title: "LoopOver advisory available",
+  summary: "1 advisory finding generated.",
+  findings: [finding("visual_unrelated_issue_finding", "The footer logo is stretched.")],
+  generatedAt: "2026-07-19T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("getLatestAdvisoryForPullRequest (#7372)", () => {
+  it("returns null when no advisory has ever been persisted for this PR", async () => {
+    const env = createTestEnv();
+    expect(await getLatestAdvisoryForPullRequest(env, "owner/repo", 42)).toBeNull();
+  });
+
+  it("returns the findings + headSha of the persisted advisory", async () => {
+    const env = createTestEnv();
+    await persistAdvisory(env, advisory());
+    const result = await getLatestAdvisoryForPullRequest(env, "owner/repo", 42);
+    expect(result?.headSha).toBe("sha1");
+    expect(result?.findings).toEqual([finding("visual_unrelated_issue_finding", "The footer logo is stretched.")]);
+  });
+
+  it("returns the MOST RECENTLY persisted row when multiple review passes each wrote their own append-only row", async () => {
+    const env = createTestEnv();
+    await persistAdvisory(env, advisory({ headSha: "sha1", findings: [finding("visual_unrelated_issue_finding", "First pass finding.")] }));
+    await persistAdvisory(env, advisory({ headSha: "sha2", findings: [finding("visual_unrelated_issue_finding", "Second pass finding.")] }));
+    const result = await getLatestAdvisoryForPullRequest(env, "owner/repo", 42);
+    expect(result?.headSha).toBe("sha2");
+    expect(result?.findings).toEqual([finding("visual_unrelated_issue_finding", "Second pass finding.")]);
+  });
+
+  it("scopes strictly to the requested repo + pull number, ignoring a sibling PR's advisory", async () => {
+    const env = createTestEnv();
+    await persistAdvisory(env, advisory({ pullNumber: 43, targetKey: "owner/repo#43", findings: [finding("visual_unrelated_issue_finding", "Sibling PR's finding.")] }));
+    expect(await getLatestAdvisoryForPullRequest(env, "owner/repo", 42)).toBeNull();
+  });
+
+  it("scopes strictly to the requested repo, ignoring a same-numbered PR in a different repo", async () => {
+    const env = createTestEnv();
+    await persistAdvisory(env, advisory({ repoFullName: "other/repo", targetKey: "other/repo#42", findings: [finding("visual_unrelated_issue_finding", "Other repo's finding.")] }));
+    expect(await getLatestAdvisoryForPullRequest(env, "owner/repo", 42)).toBeNull();
+  });
+
+  it("ignores an issue-targeted advisory sharing the same repo/number space", async () => {
+    const env = createTestEnv();
+    const { pullNumber: _pullNumber, ...withoutPullNumber } = advisory();
+    await persistAdvisory(env, { ...withoutPullNumber, targetType: "issue", targetKey: "owner/repo#42", issueNumber: 42 });
+    expect(await getLatestAdvisoryForPullRequest(env, "owner/repo", 42)).toBeNull();
+  });
+
+  it("returns [] (not the whole advisory's findings) when the latest pass recorded no findings at all", async () => {
+    const env = createTestEnv();
+    await persistAdvisory(env, advisory({ findings: [], conclusion: "success", summary: "No advisory findings." }));
+    const result = await getLatestAdvisoryForPullRequest(env, "owner/repo", 42);
+    expect(result?.findings).toEqual([]);
+  });
+});

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -4863,6 +4863,7 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
       themeStorageKey: null,
       actionsFallback: false,
       bugAnalysis: false,
+      bugAnalysisNotify: [],
       interactions: [],
     });
     expect(m.review.present).toBe(true);
@@ -4959,7 +4960,7 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
   it("resolveReviewVisualConfig: null manifest yields empty defaults; a set manifest passes through", () => {
     expect(resolveReviewVisualConfig(null)).toEqual({ ...EMPTY_VISUAL_CONFIG });
     const manifest = parseFocusManifest({ review: { visual: { routes: { paths: ["/app"] } } } });
-    expect(resolveReviewVisualConfig(manifest)).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: ["/app"], maxRoutes: null }, themes: [], gif: false, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false, interactions: [] });
+    expect(resolveReviewVisualConfig(manifest)).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: ["/app"], maxRoutes: null }, themes: [], gif: false, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false, bugAnalysisNotify: [], interactions: [] });
   });
 });
 
@@ -5105,7 +5106,7 @@ describe("review.visual.gif (#3612 scroll-through GIF capture)", () => {
 
   it("composes with themes — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { gif: true, themes: ["dark"] } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false, interactions: [] });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: false, bugAnalysisNotify: [], interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { themes: ["dark"], gif: true } });
   });
 
@@ -5208,7 +5209,7 @@ describe("review.visual.theme_storage_key (#4109 localStorage theme-forcing fall
 
   it("composes with themes — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { themes: ["dark"], theme_storage_key: "theme" } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: false, enabled: null, themeStorageKey: "theme", actionsFallback: false, bugAnalysis: false, interactions: [] });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: ["dark"], gif: false, enabled: null, themeStorageKey: "theme", actionsFallback: false, bugAnalysis: false, bugAnalysisNotify: [], interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { themes: ["dark"], theme_storage_key: "theme" } });
   });
 
@@ -5263,7 +5264,7 @@ describe("review.visual.actions_fallback (#4112 GitHub-Actions build-and-serve f
 
   it("composes with gif — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { actions_fallback: true, gif: true } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: true, bugAnalysis: false, interactions: [] });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: true, bugAnalysis: false, bugAnalysisNotify: [], interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { gif: true, actions_fallback: true } });
   });
 
@@ -5318,7 +5319,7 @@ describe("review.visual.bugAnalysis (PR-intent-aware vision + out-of-scope issue
 
   it("composes with gif — both configured independently and both round-trip", () => {
     const m = parseFocusManifest({ review: { visual: { bug_analysis: true, gif: true } } });
-    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: true, interactions: [] });
+    expect(m.review.visual).toEqual({ productionUrl: null, preview: { urlTemplate: null }, routes: { paths: [], maxRoutes: null }, themes: [], gif: true, enabled: null, themeStorageKey: null, actionsFallback: false, bugAnalysis: true, bugAnalysisNotify: [], interactions: [] });
     expect(reviewConfigToJson(m.review)).toEqual({ visual: { gif: true, bug_analysis: true } });
   });
 
@@ -5337,6 +5338,69 @@ describe("review.visual.bugAnalysis (PR-intent-aware vision + out-of-scope issue
     const globalDefault = parseReviewConfigMapping({ visual: { bug_analysis: true } }, []);
     const perRepo = parseReviewConfigMapping({ visual: { routes: { paths: ["/app"] } } }, []);
     expect(overlayReviewConfig(globalDefault, perRepo).visual.bugAnalysis).toBe(true);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.routes.paths).toEqual(["/app"]);
+  });
+});
+
+describe("review.visual.bugAnalysisNotify (#7372: maintainer-tagging PR-closed follow-up)", () => {
+  it("parses a list of logins, marks present, and round-trips", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis_notify: ["jsonbored", "octocat"] } } });
+    expect(m.review.visual.bugAnalysisNotify).toEqual(["jsonbored", "octocat"]);
+    expect(m.review.present).toBe(true);
+    expect(reviewConfigToJson(m.review)).toEqual({ visual: { bug_analysis_notify: ["jsonbored", "octocat"] } });
+  });
+
+  it("absent bug_analysis_notify defaults to [] and does not mark review present on its own — the runtime maintainer fallback is NOT baked into the manifest default", () => {
+    expect(parseFocusManifest({}).review.visual.bugAnalysisNotify).toEqual([]);
+    expect(parseFocusManifest({ review: { visual: {} } }).review.present).toBe(false);
+  });
+
+  it("bug_analysis_notify: [] does not mark review present, so the whole review block round-trips to null", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis_notify: [] } } });
+    expect(m.review.visual.bugAnalysisNotify).toEqual([]);
+    expect(reviewConfigToJson(m.review)).toBeNull();
+  });
+
+  it("warns and drops the whole list when review.visual.bug_analysis_notify is not an array", () => {
+    const bad = parseFocusManifest({ review: { visual: { bug_analysis_notify: "jsonbored" } } });
+    expect(bad.review.visual.bugAnalysisNotify).toEqual([]);
+    expect(bad.warnings.some((w) => /review\.visual\.bug_analysis_notify.*must be a list of GitHub logins/.test(w))).toBe(true);
+  });
+
+  it("strips a leading '@', lowercases, and dedupes case-insensitively", () => {
+    const m = parseFocusManifest({ review: { visual: { bug_analysis_notify: ["@JSONbored", "jsonbored", "Octocat"] } } });
+    expect(m.review.visual.bugAnalysisNotify).toEqual(["jsonbored", "octocat"]);
+  });
+
+  it("warns and drops an entry that isn't a valid GitHub login (blank, non-string, or invalid characters)", () => {
+    const bad = parseFocusManifest({ review: { visual: { bug_analysis_notify: ["", 42, "-leading-hyphen", "trailing-hyphen-", "valid-login"] } } });
+    expect(bad.review.visual.bugAnalysisNotify).toEqual(["valid-login"]);
+    expect(bad.warnings.filter((w) => /review\.visual\.bug_analysis_notify\[\d+\].*must be a valid GitHub login/.test(w))).toHaveLength(4);
+  });
+
+  it("caps the manifest-level list at MAX_VISUAL_BUG_ANALYSIS_NOTIFY (10), warning about the rest", () => {
+    const logins = Array.from({ length: 12 }, (_, i) => `user-${i}`);
+    const m = parseFocusManifest({ review: { visual: { bug_analysis_notify: logins } } });
+    expect(m.review.visual.bugAnalysisNotify).toHaveLength(10);
+    expect(m.review.visual.bugAnalysisNotify).toEqual(logins.slice(0, 10));
+    expect(m.warnings.some((w) => /review\.visual\.bug_analysis_notify.*capped at 10 entries/.test(w))).toBe(true);
+  });
+
+  it("resolveReviewVisualConfig passes a configured bug_analysis_notify list through", () => {
+    const manifest = parseFocusManifest({ review: { visual: { bug_analysis_notify: ["jsonbored"] } } });
+    expect(resolveReviewVisualConfig(manifest).bugAnalysisNotify).toEqual(["jsonbored"]);
+  });
+
+  it("overlay: a per-repo bug_analysis_notify list wins over a global-default list", () => {
+    const globalDefault = parseReviewConfigMapping({ visual: { bug_analysis_notify: ["global-maintainer"] } }, []);
+    const perRepo = parseReviewConfigMapping({ visual: { bug_analysis_notify: ["repo-maintainer"] } }, []);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.bugAnalysisNotify).toEqual(["repo-maintainer"]);
+  });
+
+  it("overlay: an unset per-repo bug_analysis_notify falls back to the global-default list — this is how the operator sets it fleet-wide from the global-default .loopover.yml", () => {
+    const globalDefault = parseReviewConfigMapping({ visual: { bug_analysis_notify: ["global-maintainer"] } }, []);
+    const perRepo = parseReviewConfigMapping({ visual: { routes: { paths: ["/app"] } } }, []);
+    expect(overlayReviewConfig(globalDefault, perRepo).visual.bugAnalysisNotify).toEqual(["global-maintainer"]);
     expect(overlayReviewConfig(globalDefault, perRepo).visual.routes.paths).toEqual(["/app"]);
   });
 });

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createOrUpdatePrIntelligenceComment, PR_INTELLIGENCE_COMMENT_MARKER } from "../../src/github/comments";
+import { createOrUpdatePrIntelligenceComment, createOrUpdateVisualFollowupComment, PR_INTELLIGENCE_COMMENT_MARKER, VISUAL_FOLLOWUP_COMMENT_MARKER } from "../../src/github/comments";
 import { createTestEnv } from "../helpers/d1";
 
 describe("GitHub PR intelligence comments", () => {
@@ -421,6 +421,78 @@ describe("GitHub PR intelligence comments", () => {
 
   it("rejects invalid repository names before calling GitHub", async () => {
     await expect(createOrUpdatePrIntelligenceComment(createTestEnv(), 123, "invalid", 12, "body")).rejects.toThrow(/Invalid repository full name/);
+  });
+
+  describe("createOrUpdateVisualFollowupComment (#7372)", () => {
+    it("creates its OWN comment thread even when a sticky PR panel comment already exists — never finds/PATCHes it", async () => {
+      const privateKey = await generatePrivateKeyPem();
+      const calls: string[] = [];
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${url}`);
+        if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+        if (url.includes("/issues/12/comments") && method === "GET") {
+          // The sticky PR panel comment (a DIFFERENT marker) is present -- if markerAliases ever regressed
+          // back to ignoring its argument, this would be found as "canonical" and PATCHed, corrupting it.
+          return Response.json([{ id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nsticky panel`, user: { login: "loopover-orb[bot]", type: "Bot" } }]);
+        }
+        if (url.includes("/issues/12/comments") && method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { body: string };
+          expect(body.body).toContain(VISUAL_FOLLOWUP_COMMENT_MARKER);
+          return Response.json({ id: 909, html_url: "https://github.com/comment/909" });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const result = await createOrUpdateVisualFollowupComment(
+        createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }),
+        123,
+        "JSONbored/gittensory",
+        12,
+        `@jsonbored — found something.\n\n${VISUAL_FOLLOWUP_COMMENT_MARKER}`,
+      );
+
+      expect(result?.id).toBe(909);
+      // A POST (new comment), never a PATCH against the sticky panel's id 101.
+      expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(true);
+      expect(calls.some((call) => call.includes("/issues/comments/101"))).toBe(false);
+    });
+
+    it("updates its OWN prior follow-up comment on a second close, without touching the sticky panel", async () => {
+      const privateKey = await generatePrivateKeyPem();
+      const calls: string[] = [];
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${url}`);
+        if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+        if (url.includes("/issues/12/comments") && method === "GET") {
+          return Response.json([
+            { id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nsticky panel`, user: { login: "loopover-orb[bot]", type: "Bot" } },
+            { id: 909, body: `@jsonbored — old finding.\n\n${VISUAL_FOLLOWUP_COMMENT_MARKER}`, user: { login: "loopover-orb[bot]", type: "Bot" } },
+          ]);
+        }
+        if (url.includes("/issues/comments/909") && method === "PATCH") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { body: string };
+          expect(body.body).toContain("new finding");
+          return Response.json({ id: 909, html_url: "https://github.com/comment/909" });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const result = await createOrUpdateVisualFollowupComment(
+        createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }),
+        123,
+        "JSONbored/gittensory",
+        12,
+        `@jsonbored — new finding.\n\n${VISUAL_FOLLOWUP_COMMENT_MARKER}`,
+      );
+
+      expect(result?.id).toBe(909);
+      expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/909"))).toBe(true);
+      expect(calls.some((call) => call.includes("/issues/comments/101"))).toBe(false);
+    });
   });
 
   it("rejects a malformed three-segment repository name instead of silently truncating it", async () => {

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -58,6 +58,7 @@ import {
   recordReviewSuppression,
   listReviewSuppressions,
   setGlobalAgentFrozen,
+  persistAdvisory,
 } from "../../src/db/repositories";
 import { agentMaintenanceHeadMatchesGate, changedPathsForGuardrail, claimAiReviewLock, claimPrActuationLock, contributorEvidenceBatchSize, enrichOpenPullRequestsWithChangedFiles, processJob, reconcileLiveDuplicateSiblings, releaseAiReviewLock, releasePrActuationLock, reviewDurationMsSince, SWEEP_FANOUT_RESOLUTION_CONCURRENCY } from "../../src/queue/processors";
 import type { PullRequestRecord } from "../../src/types";
@@ -3699,6 +3700,269 @@ describe("queue processors", () => {
       isVisualDiffAvailableSpy.mockRestore();
       compareScreenshotsSpy.mockRestore();
     }
+  });
+
+  // review.visual.bugAnalysisNotify (#7372): threads from the real .loopover.yml raw-fetch through
+  // resolveVisualCaptureConfig -> maybePostVisualFollowupComment -> a standalone, @-mention, screenshot-
+  // carrying comment on the PR's REAL "closed" webhook action -- not merge-only (no merged_at on this
+  // fixture's pull_request payload). The advisory itself is persisted directly via persistAdvisory rather
+  // than re-driving a live vision-provider call (already proven end-to-end by the sibling wiring test above)
+  // -- this test isolates the NEW code this feature actually adds: the closed-webhook hook, the latest-
+  // advisory read, the default-maintainer fallback resolution, and the follow-up comment's own content.
+  it("posts a maintainer-notify follow-up comment with screenshots when a PR with an unrelated visual finding is closed (not merged)", async () => {
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      LOOPOVER_REVIEW_SCREENSHOTS: "true",
+    });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autoLabelEnabled: false,
+      autonomy: { update_branch: "auto" },
+    });
+    // The PREVIOUS review pass (a synchronize this fixture doesn't re-drive) already recorded an unrelated
+    // visual finding for this PR — exactly the shape buildVisualRegressionFindings (visual-findings.ts)
+    // produces, screenshot evidence included.
+    await persistAdvisory(env, {
+      id: crypto.randomUUID(),
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#43",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 43,
+      headSha: "closed123",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "LoopOver advisory available",
+      summary: "1 advisory finding generated.",
+      findings: [
+        {
+          code: "visual_unrelated_issue_finding",
+          severity: "warning",
+          title: "Possible unrelated visual issue: /footer",
+          detail: "The footer logo is stretched, unrelated to this change.",
+          action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+          visualEvidence: { path: "/footer", beforeUrl: "https://api.example.dev/loopover/shot?key=before", afterUrl: "https://api.example.dev/loopover/shot?key=after" },
+        },
+      ],
+      generatedAt: "2026-05-23T00:00:00.000Z",
+    });
+    let followupCommentBody = "";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.loopover.yml") {
+        return new Response("review:\n  visual:\n    bug_analysis: true\n");
+      }
+      if (url.includes("/access_tokens")) {
+        return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
+      }
+      if (url.includes("/issues/43/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/43/comments") && method === "POST") {
+        followupCommentBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 909, html_url: "https://github.com/comment/909" }, { status: 201 });
+      }
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 901 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pr-visual-followup-closed",
+      eventName: "pull_request",
+      payload: {
+        action: "closed",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        // No merged_at — an ORDINARY close, not a merge, proving this fires on either outcome.
+        pull_request: { number: 43, title: "Add a footer redesign", state: "closed", user: { login: "contributor" }, head: { sha: "closed123" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    // Default-maintainer fallback: no bug_analysis_notify configured, so the repo owner ("JSONbored",
+    // lowercased) is who gets @-mentioned — never a hardcoded username.
+    expect(followupCommentBody).toContain("@jsonbored");
+    expect(followupCommentBody).toContain("Possible unrelated visual issue: /footer");
+    expect(followupCommentBody).toContain("The footer logo is stretched, unrelated to this change.");
+    expect(followupCommentBody).toContain("![before](https://api.example.dev/loopover/shot?key=before)");
+    expect(followupCommentBody).toContain("![after](https://api.example.dev/loopover/shot?key=after)");
+    expect(followupCommentBody).toContain("Reference in new issue");
+    expect(followupCommentBody).toContain("<!-- loopover:visual-unrelated-followup -->");
+  });
+
+  it("does NOT post a follow-up comment on close when review.visual.bugAnalysis is off, even with a recorded unrelated finding (stale from before the operator turned it off)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_SCREENSHOTS: "true" });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, autonomy: { update_branch: "auto" } });
+    await persistAdvisory(env, {
+      id: crypto.randomUUID(),
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#44",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 44,
+      headSha: "closed124",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "LoopOver advisory available",
+      summary: "1 advisory finding generated.",
+      findings: [{ code: "visual_unrelated_issue_finding", severity: "warning", title: "Possible unrelated visual issue: /footer", detail: "Stale finding." }],
+      generatedAt: "2026-05-23T00:00:00.000Z",
+    });
+    let commentPosted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.loopover.yml") return new Response("settings: {}\n");
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
+      if (url.includes("/issues/44/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/44/comments") && method === "POST") {
+        commentPosted = true;
+        return Response.json({ id: 910 }, { status: 201 });
+      }
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 901 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pr-visual-followup-off",
+      eventName: "pull_request",
+      payload: {
+        action: "closed",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 44, title: "Add a footer redesign", state: "closed", user: { login: "contributor" }, head: { sha: "closed124" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    expect(commentPosted).toBe(false);
+  });
+
+  it("does NOT post a follow-up comment when the prior advisory has findings but NONE are visual_unrelated_issue_finding", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_SCREENSHOTS: "true" });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, autonomy: { update_branch: "auto" } });
+    await persistAdvisory(env, {
+      id: crypto.randomUUID(),
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#45",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 45,
+      headSha: "closed125",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "LoopOver advisory available",
+      summary: "1 advisory finding generated.",
+      // A visual_regression_finding (THIS PR's own fault, already surfaced while open) — never worth a
+      // follow-up comment, unlike visual_unrelated_issue_finding.
+      findings: [{ code: "visual_regression_finding", severity: "warning", title: "Possible visual regression: /pricing", detail: "This PR broke the layout." }],
+      generatedAt: "2026-05-23T00:00:00.000Z",
+    });
+    let commentPosted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.loopover.yml") return new Response("review:\n  visual:\n    bug_analysis: true\n");
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
+      if (url.includes("/issues/45/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/45/comments") && method === "POST") {
+        commentPosted = true;
+        return Response.json({ id: 911 }, { status: 201 });
+      }
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 901 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pr-visual-followup-no-unrelated",
+      eventName: "pull_request",
+      payload: {
+        action: "closed",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 45, title: "Fix the pricing layout", state: "closed", user: { login: "contributor" }, head: { sha: "closed125" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    expect(commentPosted).toBe(false);
+  });
+
+  it("swallows a follow-up comment posting failure (never lets it throw or block the rest of the closed webhook)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), LOOPOVER_REVIEW_SCREENSHOTS: "true" });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autoLabelEnabled: false, autonomy: { update_branch: "auto" } });
+    await persistAdvisory(env, {
+      id: crypto.randomUUID(),
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#46",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 46,
+      headSha: "closed126",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "LoopOver advisory available",
+      summary: "1 advisory finding generated.",
+      findings: [{ code: "visual_unrelated_issue_finding", severity: "warning", title: "Possible unrelated visual issue: /footer", detail: "The footer logo is stretched." }],
+      generatedAt: "2026-05-23T00:00:00.000Z",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.loopover.yml") return new Response("review:\n  visual:\n    bug_analysis: true\n");
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
+      // The comment-search GET itself fails -- createOrUpdateVisualFollowupComment propagates this rejection,
+      // which maybePostVisualFollowupComment's own try/catch must swallow.
+      if (url.includes("/issues/46/comments") && method === "GET") throw new Error("network unreachable");
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 901 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    // The webhook delivery completes normally (no throw) despite the follow-up comment's own failure.
+    await expect(
+      processJob(env, {
+        type: "github-webhook",
+        deliveryId: "pr-visual-followup-post-fails",
+        eventName: "pull_request",
+        payload: {
+          action: "closed",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 46, title: "Add a footer redesign", state: "closed", user: { login: "contributor" }, head: { sha: "closed126" }, labels: [], body: "Fixes #1" },
+        },
+      }),
+    ).resolves.not.toThrow();
   });
 
   // review.visual.interactions (config-as-code): threads all the way from the real .loopover.yml raw-fetch

--- a/test/unit/visual-config-wiring.test.ts
+++ b/test/unit/visual-config-wiring.test.ts
@@ -25,6 +25,7 @@ describe("review.visual wiring (#3609 / #3610)", () => {
       themeStorageKey: null,
       actionsFallback: false,
       bugAnalysis: false,
+      bugAnalysisNotify: [],
       interactions: [],
     });
     expect(loadSpy).toHaveBeenCalledWith(expect.anything(), "acme/widgets");

--- a/test/unit/visual-findings.test.ts
+++ b/test/unit/visual-findings.test.ts
@@ -286,6 +286,77 @@ describe("buildVisualRegressionFindings", () => {
     ]);
     expect(findings.map((f) => f.code)).toEqual([VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE]);
   });
+
+  describe("visualEvidence (#7372: screenshot evidence for the PR-closed maintainer-notify follow-up)", () => {
+    it("attaches the matching route's before/after shot URLs by path", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }], [changedRoute("/pricing")]);
+      expect(findings[0]?.visualEvidence).toEqual({
+        path: "/pricing",
+        beforeUrl: "https://api.example.dev/loopover/shot?key=before-/pricing",
+        afterUrl: "https://api.example.dev/loopover/shot?key=after-/pricing",
+      });
+    });
+
+    it("omits visualEvidence entirely when no route argument is passed (pre-#7372 call sites stay byte-identical)", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }]);
+      expect(findings[0]).not.toHaveProperty("visualEvidence");
+    });
+
+    it("omits visualEvidence when no route matches the finding's path", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }], [changedRoute("/footer")]);
+      expect(findings[0]).not.toHaveProperty("visualEvidence");
+    });
+
+    it("omits visualEvidence when the matching route has neither a before nor an after URL", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }], [{ path: "/pricing" }]);
+      expect(findings[0]).not.toHaveProperty("visualEvidence");
+    });
+
+    it("falls back to the mobile shot URLs when the desktop before/after URLs are absent", () => {
+      const findings = buildVisualRegressionFindings(
+        [{ path: "/pricing", body: "Broke." }],
+        [{ path: "/pricing", beforeUrlMobile: "https://api.example.dev/loopover/shot?key=before-mobile", afterUrlMobile: "https://api.example.dev/loopover/shot?key=after-mobile" }],
+      );
+      expect(findings[0]?.visualEvidence).toEqual({
+        path: "/pricing",
+        beforeUrl: "https://api.example.dev/loopover/shot?key=before-mobile",
+        afterUrl: "https://api.example.dev/loopover/shot?key=after-mobile",
+      });
+    });
+
+    it("omits afterUrl entirely (not an empty string) when only beforeUrl is available on the route", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }], [{ path: "/pricing", beforeUrl: "https://api.example.dev/loopover/shot?key=before" }]);
+      expect(findings[0]?.visualEvidence).toEqual({ path: "/pricing", beforeUrl: "https://api.example.dev/loopover/shot?key=before" });
+      expect(findings[0]?.visualEvidence).not.toHaveProperty("afterUrl");
+    });
+
+    it("omits beforeUrl entirely (not an empty string) when only afterUrl is available on the route", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/pricing", body: "Broke." }], [{ path: "/pricing", afterUrl: "https://api.example.dev/loopover/shot?key=after" }]);
+      expect(findings[0]?.visualEvidence).toEqual({ path: "/pricing", afterUrl: "https://api.example.dev/loopover/shot?key=after" });
+      expect(findings[0]?.visualEvidence).not.toHaveProperty("beforeUrl");
+    });
+
+    it("attaches evidence to an 'unrelated' finding just the same as a 'regression' one", () => {
+      const findings = buildVisualRegressionFindings([{ path: "/footer", body: "Pre-existing stretched logo.", category: "unrelated" }], [changedRoute("/footer")]);
+      expect(findings[0]?.visualEvidence).toEqual({
+        path: "/footer",
+        beforeUrl: "https://api.example.dev/loopover/shot?key=before-/footer",
+        afterUrl: "https://api.example.dev/loopover/shot?key=after-/footer",
+      });
+    });
+
+    it("matches each finding against its OWN path in a mixed multi-route list, not just the first route", () => {
+      const findings = buildVisualRegressionFindings(
+        [
+          { path: "/pricing", body: "Broke A.", category: "regression" },
+          { path: "/footer", body: "Broke B.", category: "unrelated" },
+        ],
+        [changedRoute("/pricing"), changedRoute("/footer")],
+      );
+      expect(findings[0]?.visualEvidence?.path).toBe("/pricing");
+      expect(findings[1]?.visualEvidence?.path).toBe("/footer");
+    });
+  });
 });
 
 describe("REGRESSION (#4111): a visual-regression finding can NEVER become a gate blocker", () => {

--- a/test/unit/visual-followup.test.ts
+++ b/test/unit/visual-followup.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVisualFollowupComment,
+  resolveVisualFollowupNotifyLogins,
+  selectUnrelatedVisualFindings,
+} from "../../src/review/visual/visual-followup";
+import { VISUAL_FOLLOWUP_COMMENT_MARKER } from "../../src/github/comments";
+import { VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE } from "../../src/review/visual/visual-findings";
+import type { AdvisoryFinding } from "../../src/types";
+
+const unrelatedFinding = (overrides: Partial<AdvisoryFinding> = {}): AdvisoryFinding => ({
+  code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
+  severity: "warning",
+  title: "Possible unrelated visual issue: /footer",
+  detail: "The footer logo is stretched, unrelated to this change.",
+  action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+  visualEvidence: { path: "/footer", beforeUrl: "https://x/loopover/shot?key=before", afterUrl: "https://x/loopover/shot?key=after" },
+  ...overrides,
+});
+
+const regressionFinding = (): AdvisoryFinding => ({
+  code: VISUAL_REGRESSION_FINDING_CODE,
+  severity: "warning",
+  title: "Possible visual regression: /pricing",
+  detail: "This PR broke the layout.",
+  action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+});
+
+describe("selectUnrelatedVisualFindings", () => {
+  it("keeps only visual_unrelated_issue_finding entries", () => {
+    expect(selectUnrelatedVisualFindings([regressionFinding(), unrelatedFinding()])).toEqual([unrelatedFinding()]);
+  });
+
+  it("returns [] when there are no findings, or none are unrelated", () => {
+    expect(selectUnrelatedVisualFindings([])).toEqual([]);
+    expect(selectUnrelatedVisualFindings([regressionFinding()])).toEqual([]);
+  });
+
+  it("ignores an unrelated non-visual finding code that happens to share a similar shape", () => {
+    expect(selectUnrelatedVisualFindings([{ code: "ai_consensus_defect", severity: "critical", title: "t", detail: "d" }])).toEqual([]);
+  });
+});
+
+describe("resolveVisualFollowupNotifyLogins", () => {
+  it("uses the configured list as-is when non-empty, ignoring repo owner + admin logins entirely", () => {
+    expect(resolveVisualFollowupNotifyLogins(["repo-maintainer"], "someowner", new Set(["admin1"]))).toEqual(["repo-maintainer"]);
+  });
+
+  it("falls back to repo owner + ADMIN_GITHUB_LOGINS when the configured list is empty — never a hardcoded username", () => {
+    const result = resolveVisualFollowupNotifyLogins([], "someowner", new Set(["admin1", "admin2"]));
+    expect(new Set(result)).toEqual(new Set(["someowner", "admin1", "admin2"]));
+  });
+
+  it("dedupes the repo owner against an admin login that is already the same account", () => {
+    const result = resolveVisualFollowupNotifyLogins([], "admin1", new Set(["admin1"]));
+    expect(result).toEqual(["admin1"]);
+  });
+
+  it("lowercases the repo owner before adding it, so casing never produces a duplicate mention", () => {
+    const result = resolveVisualFollowupNotifyLogins([], "AdMin1", new Set(["admin1"]));
+    expect(result).toEqual(["admin1"]);
+  });
+
+  it("falls back to just ADMIN_GITHUB_LOGINS when the repo owner is blank", () => {
+    expect(resolveVisualFollowupNotifyLogins([], "", new Set(["admin1"]))).toEqual(["admin1"]);
+  });
+
+  it("returns [] when the configured list is empty, the repo owner is blank, AND there are no admin logins", () => {
+    expect(resolveVisualFollowupNotifyLogins([], "", new Set())).toEqual([]);
+  });
+});
+
+describe("buildVisualFollowupComment", () => {
+  it("returns null when there are no unrelated findings, even with notify logins resolved", () => {
+    expect(buildVisualFollowupComment([regressionFinding()], ["jsonbored"])).toBeNull();
+  });
+
+  it("returns null when there ARE unrelated findings but no login resolved to notify", () => {
+    expect(buildVisualFollowupComment([unrelatedFinding()], [])).toBeNull();
+  });
+
+  it("returns null when both are empty", () => {
+    expect(buildVisualFollowupComment([], [])).toBeNull();
+  });
+
+  it("@-mentions every notify login and includes the idempotency marker", () => {
+    const body = buildVisualFollowupComment([unrelatedFinding()], ["jsonbored", "octocat"]);
+    expect(body).toContain("@jsonbored @octocat");
+    expect(body).toContain(VISUAL_FOLLOWUP_COMMENT_MARKER);
+  });
+
+  it("renders the finding's title + detail and a Before/After screenshot row", () => {
+    const body = buildVisualFollowupComment([unrelatedFinding()], ["jsonbored"]);
+    expect(body).toContain("### Possible unrelated visual issue: /footer");
+    expect(body).toContain("The footer logo is stretched, unrelated to this change.");
+    expect(body).toContain("| Before | After |");
+    expect(body).toContain("![before](https://x/loopover/shot?key=before)");
+    expect(body).toContain("![after](https://x/loopover/shot?key=after)");
+  });
+
+  it("renders a dash for whichever side has no shot URL", () => {
+    const onlyAfter = buildVisualFollowupComment([unrelatedFinding({ visualEvidence: { path: "/footer", afterUrl: "https://x/loopover/shot?key=after" } })], ["jsonbored"]);
+    expect(onlyAfter).toContain("| — | ![after](https://x/loopover/shot?key=after) |");
+    const onlyBefore = buildVisualFollowupComment([unrelatedFinding({ visualEvidence: { path: "/footer", beforeUrl: "https://x/loopover/shot?key=before" } })], ["jsonbored"]);
+    expect(onlyBefore).toContain("| ![before](https://x/loopover/shot?key=before) | — |");
+  });
+
+  it("omits the screenshot table entirely when the finding has no visualEvidence at all", () => {
+    const findingWithoutEvidence: AdvisoryFinding = {
+      code: VISUAL_UNRELATED_ISSUE_FINDING_CODE,
+      severity: "warning",
+      title: "Possible unrelated visual issue: /footer",
+      detail: "The footer logo is stretched, unrelated to this change.",
+    };
+    const body = buildVisualFollowupComment([findingWithoutEvidence], ["jsonbored"]);
+    expect(body).not.toContain("| Before | After |");
+    expect(body).toContain("The footer logo is stretched, unrelated to this change.");
+  });
+
+  it("separates multiple findings with a horizontal rule, one heading each", () => {
+    const second = unrelatedFinding({ title: "Possible unrelated visual issue: /pricing", detail: "The pricing table lost its border." });
+    const body = buildVisualFollowupComment([unrelatedFinding(), second], ["jsonbored"]);
+    expect(body).toContain("### Possible unrelated visual issue: /footer");
+    expect(body).toContain("### Possible unrelated visual issue: /pricing");
+    expect(body).toContain("\n\n---\n\n");
+  });
+
+  it("mentions GitHub's own Reference in new issue action", () => {
+    const body = buildVisualFollowupComment([unrelatedFinding()], ["jsonbored"]);
+    expect(body).toContain('Reference in new issue');
+  });
+
+  it("filters out a regression finding mixed in alongside unrelated ones, mentioning only the unrelated one", () => {
+    const body = buildVisualFollowupComment([regressionFinding(), unrelatedFinding()], ["jsonbored"]);
+    expect(body).not.toContain("Possible visual regression");
+    expect(body).toContain("Possible unrelated visual issue");
+  });
+});

--- a/test/unit/visual-vision-wiring.test.ts
+++ b/test/unit/visual-vision-wiring.test.ts
@@ -344,6 +344,7 @@ describe("runVisualVisionForAdvisory", () => {
         title: "Possible visual regression: /app",
         detail: "The submit button is clipped on the right edge.",
         action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+        visualEvidence: { path: "/app", beforeUrl: "https://x/loopover/shot?key=before-desktop", afterUrl: "https://x/loopover/shot?key=after-desktop" },
       },
     ]);
   });
@@ -383,6 +384,7 @@ describe("runVisualVisionForAdvisory", () => {
         title: "Possible visual regression: /app",
         detail: "Broke.",
         action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+        visualEvidence: { path: "/app", beforeUrl: "https://x/loopover/shot?key=b", afterUrl: "https://x/loopover/shot?key=a" },
       },
     ]);
   });
@@ -428,6 +430,7 @@ describe("runVisualVisionForAdvisory", () => {
         title: "Possible visual regression: /app",
         detail: "This PR's own change clipped the submit button.",
         action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+        visualEvidence: { path: "/app", beforeUrl: "https://x/loopover/shot?key=b", afterUrl: "https://x/loopover/shot?key=a" },
       },
       {
         code: "visual_unrelated_issue_finding",
@@ -435,6 +438,7 @@ describe("runVisualVisionForAdvisory", () => {
         title: "Possible unrelated visual issue: /app",
         detail: "The footer logo is stretched, unrelated to this change.",
         action: "Advisory only — this doesn't look related to this PR's stated change. Consider opening a new issue to track it separately.",
+        visualEvidence: { path: "/app", beforeUrl: "https://x/loopover/shot?key=b", afterUrl: "https://x/loopover/shot?key=a" },
       },
     ]);
   });
@@ -683,6 +687,7 @@ describe("runVisualVisionForAdvisory: self-host local vision provider (#4335)", 
         title: "Possible visual regression: /app",
         detail: "Nav bar overlaps the logo on the AFTER screenshot.",
         action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+        visualEvidence: { path: "/app", beforeUrl: "https://x/loopover/shot?key=before", afterUrl: "https://x/loopover/shot?key=after" },
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- Closes #7372.
- When a PR with a recorded `review.visual.bugAnalysis` "unrelated" finding is merged or closed, post a standalone comment describing each one with its before/after screenshots and @-mentioning a configurable maintainer list — formatted so GitHub's own "..." → "Reference in new issue" action can spin one off in a single click.
- `review.visual.bug_analysis_notify` is config-as-code (global-default + per-repo), and is never hardcoded to a specific user: an empty/absent list falls back at runtime to the repo owner plus the existing `ADMIN_GITHUB_LOGINS` fleet-operator allowlist.
- Also fixes a latent bug in the marker-comment search (`markerAliases` ignored its own parameter and always searched for the sticky PR panel's markers), which this feature's new, distinct comment thread would otherwise have silently found and corrupted.

## Test plan
- [x] `npm run typecheck`
- [x] Full unit suite (`npx vitest run test/unit`) — 18,526 tests passing
- [x] `npm run docs:drift-check` / `manifest:drift-check` / `engine-parity:drift-check`
- [x] Contract parity suites (`engine-parity`, `live-gate-parity`, `coding-agent-driver-parity`)
- [x] Scoped coverage confirms 100% patch coverage on every changed line/branch
- [x] New end-to-end webhook tests proving: the follow-up comment posts on a real (non-merge) close with the default-maintainer fallback and screenshot evidence; it's a no-op when `bug_analysis` is off, when no finding is unrelated, and it fails safe (never throws) when posting itself fails