### PR TITLE
chore(orb): bump target version to 3.2.0

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Source of truth for the self-hostable loopover-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.mjs and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## Summary
- Bumps \`orb-manifest.json\`'s target version from \`3.1.0\` to \`3.2.0\`, matching what \`scripts/check-orb-release-due.mjs\` infers from the \`feat\` commits landed since \`orb-v3.1.0\` (interaction/GIF capture #7347, PR-intent-aware bug analysis #7348, maintainer-notify follow-up #7376).
- Unblocks the automated beta channel (\`orb-beta-release.yml\`), which intentionally refuses to cut a new snapshot while the manifest is stale relative to the real commit history — confirmed locally: \`due\` flips from \`false\` to \`true\`, next tag resolves to \`orb-v3.2.0-beta.1\`.

## Test plan
- [x] \`node scripts/check-orb-release-due.mjs --json\` now reports \`"due": true, "manifestStale": false\`
- [x] \`npm run release-manifest:sync:check\` (unaffected, different manifest set)