### PR TITLE
ci: duration-aware test sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,6 +739,21 @@ jobs:
           key: turbo-tests-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
+      # Restore-only -- this job never saves it, test-timing-refresh.yml is the sole writer, on its own
+      # schedule (pulling from Codecov's Test Analytics API, which already pools per-test durations
+      # across every push-to-main run). key never actually matches (no save ever uses this literal
+      # string); it exists only so the step always falls through to the restore-keys prefix match,
+      # picking whatever the most recent refresh wrote. A cache MISS here is always safe: see
+      # scripts/compute-test-shards.mjs's fallback -- it splits evenly across shards when no timing
+      # data is available for a file (or none at all), the same balance vitest's own --shard already
+      # gives today, so this can only make shard balance better than today's baseline, never worse.
+      - name: Restore test timing cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: test-timing.json
+          key: test-timing-unused
+          restore-keys: |
+            test-timing-
       - name: Test with coverage (shard ${{ matrix.shard }}/6)
         id: coverage
         env:
@@ -795,8 +810,22 @@ jobs:
             # ~2,900-file suite is 0% covered, polluting Codecov's project trend on every scoped PR. Real
             # coverage for files actually exercised is unaffected either way.
             SCOPE_ARGS+=(--changed=origin/main --coverage.all=false)
+            npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/6 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}" "${SCOPE_ARGS[@]}"
+          else
+            # Duration-aware sharding (#ci-duration-aware-sharding), full-suite case only: vitest's own
+            # --shard splits by file COUNT alone, no duration awareness -- confirmed via real per-shard CI
+            # timing data to produce a consistent ~20-30% gap between the slowest and fastest of the 6
+            # shards, every run sampled. Deliberately not applied to the scoped-selection branch above:
+            # that file set isn't known until vitest resolves --changed itself, so a precomputed
+            # assignment can't cover it without duplicating vitest's own dependency-graph resolution here.
+            # compute-test-shards.mjs enforces its own hard invariant (the union of all 6 shards' files
+            # must exactly equal the discovered file set, no file missing or duplicated) and refuses to
+            # write output at all if that's ever violated, so a bug here fails this step loudly rather
+            # than silently dropping a test file from CI.
+            node scripts/compute-test-shards.mjs --shards=6 --timing=test-timing.json --output=shard-assignment.json
+            mapfile -t SHARD_FILES < <(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-assignment.json','utf8'))['${{ matrix.shard }}'].join('\n'))")
+            npm run test:coverage -- --maxWorkers=4 "${SHARD_FILES[@]}" --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}"
           fi
-          npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/6 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}" "${SCOPE_ARGS[@]}"
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |

--- a/.github/workflows/test-timing-refresh.yml
+++ b/.github/workflows/test-timing-refresh.yml
@@ -1,0 +1,47 @@
+name: Test timing refresh
+
+# Pulls per-test-file historical duration data from Codecov's Test Analytics API (see
+# scripts/fetch-test-timing.mjs) and caches it for validate-tests' duration-aware shard bin-packer
+# (scripts/compute-test-shards.mjs, ci.yml's "Test with coverage" step) to consume. Runs on a schedule
+# rather than per-PR: Codecov doesn't publish a numeric rate limit for this read endpoint, and this
+# repo's PR volume (hundreds/day) makes "query fresh on every PR" a real risk of hitting one, for data
+# that doesn't meaningfully change run-to-run anyway.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-timing-refresh
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: refresh
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+      - name: Fetch test timing from Codecov
+        env:
+          CODECOV_API_TOKEN: ${{ secrets.CODECOV_API_TOKEN }}
+        run: node scripts/fetch-test-timing.mjs --output=test-timing.json
+      # Run_id-suffixed key (always a fresh entry, never a re-save of an existing one) + prefix
+      # restore-keys fallback on the consuming side (ci.yml's "Restore test timing cache" step) -- same
+      # accumulating-cache pattern already used for .turbo/cache and .tsbuildinfo elsewhere in this repo,
+      # since this data changes every run rather than being wholesale-replaced per some fixed input hash.
+      - name: Save test timing cache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: test-timing.json
+          key: test-timing-${{ github.run_id }}

--- a/scripts/compute-test-shards.mjs
+++ b/scripts/compute-test-shards.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// Bin-packs the full test/**/*.test.ts file set into N balanced shards by historical duration (greedy
+// LPT -- Longest Processing Time first: sort files descending by duration, repeatedly assign the next
+// file to whichever shard currently has the smallest total), replacing vitest's own --shard (file
+// COUNT only, no duration awareness -- confirmed this session via real per-shard CI timing data to
+// produce a consistent ~20-30% gap between the slowest and fastest of 6 shards, every sampled run).
+//
+// Deliberately scoped to the full-suite case only -- see ci.yml's "Test with coverage" step for how
+// this output is (and is NOT) consumed. A PR using scoped test selection (--changed=origin/main)
+// keeps vitest's own native --shard: that file set isn't known until vitest resolves --changed
+// itself, so a precomputed assignment can't apply to it without duplicating vitest's own dependency-
+// graph resolution here.
+//
+// HARD INVARIANT, checked before any output is written: the union of every shard's file list must
+// equal EXACTLY the discovered test file set, with no file in more than one shard. A violation means
+// this script would make CI silently never run some test file at all -- exactly the failure class that
+// this whole session's Codecov-enforcement work exists to prevent, just introduced by the tool meant
+// to speed that same pipeline up. This refuses to write ANY output if the invariant doesn't hold,
+// rather than risk it: a hard failure here (a broken CI step everyone sees) is a wildly better outcome
+// than a silent one (missing coverage nobody notices until something ships broken).
+
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_ROOT = "test";
+const EXCLUDED_DIR = join(TEST_ROOT, "workers"); // mirrors vitest.config.ts's exclude: ["test/workers/**/*.test.ts"]
+
+const shardsArg = Number(process.argv.find((a) => a.startsWith("--shards="))?.split("=")[1] ?? 6);
+const timingArg = process.argv.find((a) => a.startsWith("--timing="))?.split("=")[1];
+const outputArg = process.argv.find((a) => a.startsWith("--output="))?.split("=")[1];
+if (!outputArg) throw new Error("--output=<path> is required");
+
+function discoverTestFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (full === EXCLUDED_DIR) continue;
+      results.push(...discoverTestFiles(full));
+    } else if (entry.name.endsWith(".test.ts")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function loadTimingData(path) {
+  if (!path || !existsSync(path)) return {};
+  const parsed = JSON.parse(readFileSync(path, "utf8"));
+  return parsed.averageSecondsByFile ?? {};
+}
+
+function median(values) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function packShards(files, durationByFile, shardCount) {
+  // New/untracked files (no historical row -- a file added since the last timing refresh, or the
+  // refresh workflow hasn't run yet at all) get the median of known files' durations rather than 0:
+  // treating an unknown file as free would let a burst of newly-added heavy test files land in the
+  // same shard unbalanced, silently reintroducing the exact imbalance this script exists to remove.
+  // If NO file has any known duration at all (the real state before the first timing refresh has ever
+  // run), median() of an empty array is 0 -- every file would tie at the same weight, which matters
+  // below, not just as an edge case: see the tie-break comment.
+  const knownDurations = Object.values(durationByFile);
+  const fallback = median(knownDurations);
+
+  const weighted = files
+    .map((file) => ({ file, duration: durationByFile[file] ?? fallback }))
+    .sort((a, b) => b.duration - a.duration);
+
+  const shards = Array.from({ length: shardCount }, (_unused, index) => ({ index, files: [], total: 0 }));
+  // Picking the lightest shard via a plain reduce always resolves ties in favor of the FIRST shard
+  // (shard.total < min.total is never true between two equal totals, so the running minimum never
+  // moves off its starting candidate) -- harmless when durations vary, but catastrophic whenever many
+  // files tie at the same weight: every one of them would collapse onto shard 1 while the rest stay
+  // empty. This is the real, common case, not a theoretical one -- it's exactly what happens on this
+  // script's very first run, before any timing data has ever been fetched (every file falls back to
+  // the same value, verified by running this script with no --timing argument against this repo's
+  // real ~1000 test files: without the rotation below, 100% of them landed in shard 1). Rotating the
+  // tie-break starting point after every assignment makes N equal-weight files distribute round-robin
+  // across all shards instead, regardless of whether the tied weight happens to be zero or not.
+  let tiebreakStart = 0;
+  for (const { file, duration } of weighted) {
+    let lightest = shards[tiebreakStart];
+    for (let offset = 1; offset < shardCount; offset += 1) {
+      const candidate = shards[(tiebreakStart + offset) % shardCount];
+      if (candidate.total < lightest.total) lightest = candidate;
+    }
+    lightest.files.push(file);
+    lightest.total += duration;
+    tiebreakStart = (lightest.index + 1) % shardCount;
+  }
+  return shards;
+}
+
+function assertInvariant(files, shards) {
+  const original = new Set(files);
+  const seen = new Set();
+  const duplicates = [];
+  for (const shard of shards) {
+    for (const file of shard.files) {
+      if (seen.has(file)) duplicates.push(file);
+      seen.add(file);
+    }
+  }
+  const missing = files.filter((file) => !seen.has(file));
+  const extra = [...seen].filter((file) => !original.has(file));
+
+  if (missing.length > 0 || extra.length > 0 || duplicates.length > 0) {
+    const details = [
+      missing.length > 0 ? `missing from every shard: ${JSON.stringify(missing)}` : null,
+      duplicates.length > 0 ? `assigned to more than one shard: ${JSON.stringify(duplicates)}` : null,
+      extra.length > 0 ? `assigned but not in the discovered file set: ${JSON.stringify(extra)}` : null,
+    ]
+      .filter(Boolean)
+      .join("; ");
+    throw new Error(`compute-test-shards: shard-assignment invariant violated -- ${details}`);
+  }
+}
+
+if (!existsSync(TEST_ROOT)) {
+  throw new Error(`compute-test-shards: ${TEST_ROOT}/ does not exist -- run this from the repo root`);
+}
+const files = discoverTestFiles(TEST_ROOT).sort(); // sorted for deterministic ordering before weighting
+if (files.length === 0) throw new Error(`compute-test-shards: discovered zero test files under ${TEST_ROOT}/ -- refusing to write an empty assignment`);
+
+const durationByFile = loadTimingData(timingArg);
+const shards = packShards(files, durationByFile, shardsArg);
+assertInvariant(files, shards);
+
+const assignment = {};
+shards.forEach((shard, index) => {
+  assignment[String(index + 1)] = shard.files;
+});
+
+writeFileSync(outputArg, JSON.stringify(assignment));
+
+const knownCount = files.filter((f) => f in durationByFile).length;
+console.log(`Assigned ${files.length} files to ${shardsArg} shards (${knownCount} with known timing, ${files.length - knownCount} using the fallback estimate).`);
+shards.forEach((shard, index) => {
+  console.log(`  shard ${index + 1}: ${shard.files.length} files, ~${shard.total.toFixed(1)}s estimated`);
+});

--- a/scripts/fetch-test-timing.mjs
+++ b/scripts/fetch-test-timing.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Fetches per-test-file historical duration data from Codecov's Test Analytics API and aggregates it
+// into a per-file average, for the test-shard bin-packer (scripts/compute-test-shards.mjs) to consume.
+// Codecov already ingests a JUnit report per shard on every push to main (see ci.yml's coverage-upload
+// steps, report_type: test_results) and pools it across runs -- this reads that pooled history back
+// out instead of this repo tracking its own duration history from scratch.
+//
+// Filtered to branch=main deliberately: a PR's own JUnit upload is override_branch'd to that PR's own
+// branch name (see ci.yml's upload steps), not "main" -- so branch=main naturally selects only
+// push-triggered, full-unscoped-suite runs, which is exactly the population the shard bin-packer needs
+// (duration-aware sharding only applies to the full-suite case; see compute-test-shards.mjs).
+//
+// Requires a Codecov personal API access token (Codecov Settings -> Access -> Generate Token), NOT the
+// existing CODECOV_TOKEN secret -- that one is an upload-only token and doesn't authenticate this read
+// API. Codecov's docs don't publish a numeric rate limit for this endpoint, so this is deliberately run
+// on a schedule (test-timing-refresh.yml), not per-PR.
+
+import { writeFileSync } from "node:fs";
+
+const MAX_PAGES = Number(process.argv.find((a) => a.startsWith("--max-pages="))?.split("=")[1] ?? 20);
+const outputArg = process.argv.find((a) => a.startsWith("--output="));
+const OUTPUT_PATH = outputArg ? outputArg.split("=")[1] : null;
+
+const repo = process.env.GITHUB_REPOSITORY;
+if (!repo) throw new Error("GITHUB_REPOSITORY is required (e.g. JSONbored/loopover)");
+const [owner, repoName] = repo.split("/");
+const token = process.env.CODECOV_API_TOKEN;
+if (!token) throw new Error("CODECOV_API_TOKEN is required");
+
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+async function fetchWithRetry(url, maxAttempts = 4) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const response = await fetch(url, {
+      headers: { Authorization: `bearer ${token}`, Accept: "application/json" },
+    });
+    if (response.ok) return response.json();
+    if (!RETRYABLE_STATUS.has(response.status) || attempt === maxAttempts) {
+      throw new Error(`Codecov API error ${response.status} on ${url}: ${await response.text()}`);
+    }
+    const delayMs = 2 ** attempt * 1000;
+    console.warn(`Codecov API returned ${response.status} (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw new Error("unreachable");
+}
+
+async function fetchAllTestRuns() {
+  const rows = [];
+  let url = `https://api.codecov.io/api/v2/gh/${owner}/repos/${repoName}/test-results/?branch=main&page_size=100`;
+  let pages = 0;
+  while (url && pages < MAX_PAGES) {
+    const body = await fetchWithRetry(url);
+    rows.push(...body.results);
+    url = body.next;
+    pages += 1;
+  }
+  return { rows, truncated: url !== null };
+}
+
+function aggregateByFile(rows) {
+  // Per-file duration must be averaged ACROSS RUNS, not just summed across every row: a file with many
+  // test cases would otherwise dwarf a file with few, and a file that appears in many historical rows
+  // (many runs) would inflate further with each additional run pooled in -- neither reflects "how long
+  // does this file actually take in a single run." So first sum each file's rows *within* a single
+  // commit (that commit's real per-run file duration), then average those per-commit totals across all
+  // commits the file appears in.
+  const perCommitTotals = new Map(); // filename -> Map(commit_sha -> totalSeconds)
+  for (const row of rows) {
+    if (!row.filename || row.duration_seconds == null) continue;
+    if (!perCommitTotals.has(row.filename)) perCommitTotals.set(row.filename, new Map());
+    const commits = perCommitTotals.get(row.filename);
+    commits.set(row.commit_sha, (commits.get(row.commit_sha) ?? 0) + row.duration_seconds);
+  }
+
+  const averages = {};
+  for (const [filename, commits] of perCommitTotals) {
+    const totals = [...commits.values()];
+    averages[filename] = totals.reduce((sum, value) => sum + value, 0) / totals.length;
+  }
+  return averages;
+}
+
+const { rows, truncated } = await fetchAllTestRuns();
+const averageSecondsByFile = aggregateByFile(rows);
+
+const report = {
+  fetchedAt: new Date().toISOString(),
+  sourceRowCount: rows.length,
+  fileCount: Object.keys(averageSecondsByFile).length,
+  truncated, // true if MAX_PAGES was hit before the API ran out of pages -- more history existed than was pulled
+  averageSecondsByFile,
+};
+
+const json = JSON.stringify(report, null, 2);
+if (OUTPUT_PATH) {
+  writeFileSync(OUTPUT_PATH, json);
+  console.log(`Wrote ${report.fileCount} files' timing data (from ${report.sourceRowCount} rows) to ${OUTPUT_PATH}`);
+} else {
+  process.stdout.write(`${json}\n`);
+}

--- a/test/unit/compute-test-shards.test.ts
+++ b/test/unit/compute-test-shards.test.ts
@@ -1,0 +1,119 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = join(process.cwd(), "scripts/compute-test-shards.mjs");
+
+function run(args: string[]) {
+  return spawnSync("node", [SCRIPT, ...args], { cwd: process.cwd(), encoding: "utf8" });
+}
+
+function discoverRealTestFiles(): string[] {
+  // Independent re-implementation (not importing the script's own discoverTestFiles) so this test
+  // can't pass merely because both sides share the same bug.
+  const results: string[] = [];
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (full === join("test", "workers")) continue;
+        walk(full);
+      } else if (entry.name.endsWith(".test.ts")) {
+        results.push(full);
+      }
+    }
+  }
+  walk("test");
+  return results;
+}
+
+let tmpDir: string;
+afterEach(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("compute-test-shards.mjs", () => {
+  it("with no timing data, splits the real repo's test files evenly across shards (round-robin fallback)", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shard-test-"));
+    const outputPath = join(tmpDir, "assignment.json");
+    const result = run([`--shards=6`, `--output=${outputPath}`]);
+    expect(result.status, result.stderr).toBe(0);
+
+    const assignment = JSON.parse(readFileSync(outputPath, "utf8")) as Record<string, string[]>;
+    const shardCounts = Object.values(assignment).map((files) => files.length);
+    const expected = discoverRealTestFiles();
+    const total = shardCounts.reduce((sum, count) => sum + count, 0);
+
+    expect(total).toBe(expected.length);
+    // Regression test (#ci-duration-aware-sharding): before the tie-break rotation fix, every file with
+    // an identical (fallback) duration collapsed onto shard 1, leaving shards 2-6 completely empty --
+    // the real, common case here (no timing data has ever been fetched yet). Assert every shard got a
+    // roughly even share, not just that the total is right.
+    for (const count of shardCounts) {
+      expect(count).toBeGreaterThan(Math.floor(expected.length / 6) - 2);
+      expect(count).toBeLessThan(Math.ceil(expected.length / 6) + 2);
+    }
+  });
+
+  it("the union of all shards exactly equals the discovered file set, with no file duplicated", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shard-test-"));
+    const outputPath = join(tmpDir, "assignment.json");
+    const result = run([`--shards=6`, `--output=${outputPath}`]);
+    expect(result.status, result.stderr).toBe(0);
+
+    const assignment = JSON.parse(readFileSync(outputPath, "utf8")) as Record<string, string[]>;
+    const allAssigned = Object.values(assignment).flat();
+    const expected = discoverRealTestFiles();
+
+    expect(new Set(allAssigned).size).toBe(allAssigned.length); // no duplicates
+    expect(new Set(allAssigned)).toEqual(new Set(expected)); // exact set match, nothing missing or extra
+  });
+
+  it("balances weighted (real-shaped) synthetic durations far more evenly than an unweighted split would", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shard-test-"));
+    const timingPath = join(tmpDir, "timing.json");
+    const outputPath = join(tmpDir, "assignment.json");
+
+    const files = discoverRealTestFiles();
+    const averageSecondsByFile: Record<string, number> = {};
+    files.forEach((file, index) => {
+      // A handful of heavy outliers (every 47th file), everything else small -- shaped like a real
+      // suite (most files fast, a few slow ones dominate wall-clock if they land in the same shard).
+      averageSecondsByFile[file] = index % 47 === 0 ? 20 : 0.5;
+    });
+    writeFileSync(timingPath, JSON.stringify({ averageSecondsByFile }));
+
+    const result = run([`--shards=6`, `--timing=${timingPath}`, `--output=${outputPath}`]);
+    expect(result.status, result.stderr).toBe(0);
+
+    const assignment = JSON.parse(readFileSync(outputPath, "utf8")) as Record<string, string[]>;
+    const shardTotals = Object.values(assignment).map((shardFiles) =>
+      shardFiles.reduce((sum, file) => sum + (averageSecondsByFile[file] ?? 0), 0),
+    );
+    const maxTotal = Math.max(...shardTotals);
+    const minTotal = Math.min(...shardTotals);
+    // LPT bin-packing's worst-case bound is well under 34% over optimal; require well inside that,
+    // since real per-file variance here is much smaller than the pathological cases that bound covers.
+    expect((maxTotal - minTotal) / maxTotal).toBeLessThan(0.15);
+  });
+
+  it("refuses to write output when test/ exists but contains zero test files", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shard-test-"));
+    const outputPath = join(tmpDir, "assignment.json");
+    mkdirSync(join(tmpDir, "test"));
+    const result = spawnSync("node", [SCRIPT, "--shards=6", `--output=${outputPath}`], { cwd: tmpDir, encoding: "utf8" });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("discovered zero test files");
+  });
+
+  it("fails with a clear error, not a raw ENOENT stack trace, when test/ doesn't exist at all", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shard-test-"));
+    const outputPath = join(tmpDir, "assignment.json");
+    const result = spawnSync("node", [SCRIPT, "--shards=6", `--output=${outputPath}`], { cwd: tmpDir, encoding: "utf8" });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("does not exist -- run this from the repo root");
+    expect(result.stderr).not.toContain("ENOENT");
+  });
+});


### PR DESCRIPTION
## Summary

The last, largest item from the "is everything 100% optimized" audit. Replaces vitest's own `--shard` (splits test files by COUNT only, zero duration awareness) with an explicit, historically-duration-balanced file list per shard for the full-suite case.

**Why:** confirmed this session via real per-shard timing pulled from multiple CI runs — shard 4 consistently runs ~20-30% longer than shard 5 (the fastest), every run sampled. Since `validate-tests-merge` waits on all 6 shards, the whole job's wall-clock is set by the slowest one, not the average. This is a structural artifact of hash-sort-and-slice sharding (the same heavy files land in the same bucket every time), not noise.

**How:**
- `scripts/fetch-test-timing.mjs` pulls real per-test-file historical duration from Codecov's Test Analytics API (`test-results/`), which already pools JUnit uploads across every push-to-main run — no self-tracked history needed from scratch. Requires a Codecov personal API access token (`CODECOV_API_TOKEN`, already added as a repo secret — distinct from the existing upload-only `CODECOV_TOKEN`). Fetched on a schedule (`.github/workflows/test-timing-refresh.yml`, every 6 hours) rather than per-PR, since Codecov doesn't publish a rate limit for this endpoint and this repo's real PR volume (hundreds/day, confirmed) made "query fresh on every PR" a real risk.
- `scripts/compute-test-shards.mjs` bin-packs the full `test/**/*.test.ts` set into 6 balanced shards via greedy LPT (sort files descending by duration, assign each to the currently-lightest shard). Verified against this repo's real ~1000 test files and against synthetic realistic-shaped durations (a few heavy outliers, mostly small files): balances to within ~0.1s across all 6 shards.

**The safety net:** a hard invariant, checked before any output is written — the union of every shard's file list must equal EXACTLY the discovered file set, no file missing, no file in more than one shard. A violation refuses to write output at all. A bug here would otherwise mean a test file silently never runs in CI — the exact failure class this session's earlier Codecov-enforcement work exists to prevent, just introduced by the tool meant to speed that same pipeline up. Verified the check actually fires on a missing/duplicated/phantom file, not just that it exists.

**A real bug was caught by this verification, not shipped:** the initial greedy "pick the lightest shard" logic always resolved ties in favor of shard 1 (equal totals never satisfy `<`). This is the common case, not theoretical — it's exactly what happens on this feature's own first run, before any timing data has ever been fetched, when every file falls back to the same weight. Without the fix, 100% of ~1000 files landed in shard 1 while shards 2-6 stayed empty, reproduced by running the script against this repo's real file set before it ever touched `ci.yml`. Fixed by rotating the tie-break starting shard after every assignment.

**Deliberately out of scope:** PRs using scoped test selection (`--changed=origin/main`, for miner/mcp/discoveryIndex-only diffs) keep vitest's own native `--shard` unchanged — that file set isn't known until vitest resolves `--changed` itself, so a precomputed assignment can't cover it without duplicating vitest's own dependency-graph resolution here.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — CI/build-tooling only, no application code.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-initiated build-tooling work.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` (the new test file typechecks clean under this repo's strict settings, including `noUncheckedIndexedAccess`)
- [x] The Codecov aggregation math (`aggregateByFile` in `fetch-test-timing.mjs`) verified against synthetic data matching the documented API schema — confirms per-file averaging is across-commit, not a raw sum that would over-weight files appearing in more historical rows.
- [x] The bin-packer verified three ways: (1) against this repo's real ~1000 test files with no timing data (round-robin fallback, exactly balanced); (2) against synthetic realistic-shaped weighted data (balances to ~0.1s across shards); (3) the invariant deliberately fed corrupted inputs (missing/duplicate/phantom files) to confirm it actually fails loud rather than trusting the check exists.
- [x] Ran the **exact combined shell logic** from `ci.yml`'s "Test with coverage" step locally end-to-end (bin-pack → extract this shard's files via the same `mapfile`/`node` one-liner → real vitest execution → JUnit output) — not just each piece tested in isolation.
- [x] New `test/unit/compute-test-shards.test.ts` (5 tests: round-robin fallback distribution, exact-set-match with no duplicates, weighted-balance quality bound, and both of the invariant's failure-mode error paths) — found and fixed a real edge case during this: a missing `test/` directory produced a raw ENOENT stack trace instead of a clear error, now fixed.
- [x] Full local `test/unit` suite (979 files, 18,487 tests) — all passing.
- [ ] `npm run test:coverage` — not run in full; this PR's only `src/**`-adjacent-shaped file is the new standalone `.mjs`/test files, not part of the typechecked/coverage-graded backend.
- [ ] `npm audit --audit-level=moderate` — not applicable; no dependency changes.

If any required check was skipped, explain why: this PR is CI/build-tooling configuration — the skipped commands aren't applicable, and every actually-relevant command (including a from-scratch bug repro and fix, and an end-to-end local dry run of the exact CI shell logic) is listed above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. `CODECOV_API_TOKEN` was added directly to GitHub secrets by the repo owner, never passed through or seen by this session.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests — N/A.
- [ ] API/OpenAPI/MCP behavior updated and tested where needed — N/A.
- [ ] UI changes use live API data or real empty/error/loading states — N/A, no UI behavior change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no visible/UI change.
- [x] Public docs/changelogs updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Touches `.github/workflows/**` (a guarded path), so it'll be held for manual owner review rather than auto-merged.
- This is the highest-risk change of everything shipped in this session's CI-optimization sequence: it's the only one touching the actual test-execution path (versus build/lint/typecheck caching or purely additive tooling). If anything looks off in this PR's own CI run, worth stopping and looking closely rather than assuming it's fine because the local verification was thorough — a bug in test-completeness is exactly the failure mode that's hardest to notice from a green checkmark alone.
- Closes out the full "is everything 100% optimized" audit from earlier this session: every item from that report is now either shipped, or explicitly investigated-and-declined with reasoning (documented in the earlier PRs' descriptions).