### PR TITLE
chore(miner): migrate CLI command lib modules to TypeScript (batch 3.2 of 4)

### DIFF
--- a/packages/loopover-miner/lib/claim-ledger-cli.d.ts
+++ b/packages/loopover-miner/lib/claim-ledger-cli.d.ts
@@ -1,59 +1,38 @@
 import type { ClaimEntry, ClaimLedger, ClaimStatus } from "./claim-ledger.js";
-
-export type ParsedClaimClaimArgs =
-  | {
-      repoFullName: string;
-      issueNumber: number;
-      note: string | undefined;
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export type ParsedClaimReleaseArgs =
-  | {
-      repoFullName: string;
-      issueNumber: number;
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export type ParsedClaimListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-      status: ClaimStatus | null;
-    }
-  | { error: string };
-
-export function parseClaimClaimArgs(args: string[]): ParsedClaimClaimArgs;
-
-export function parseClaimReleaseArgs(args: string[]): ParsedClaimReleaseArgs;
-
-export function parseClaimListArgs(args: string[]): ParsedClaimListArgs;
-
-export function renderClaimsTable(entries: ClaimEntry[]): string;
-
-export function runClaimClaim(
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
-
-export function runClaimRelease(
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
-
-export function runClaimList(
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
-
-export function runClaimCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { openClaimLedger?: () => ClaimLedger },
-): number;
+export type ParsedClaimClaimArgs = {
+    repoFullName: string;
+    issueNumber: number;
+    note: string | undefined;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedClaimReleaseArgs = {
+    repoFullName: string;
+    issueNumber: number;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedClaimListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+    status: ClaimStatus | null;
+} | {
+    error: string;
+};
+export type ClaimLedgerCliOptions = {
+    openClaimLedger?: () => ClaimLedger;
+};
+export declare function parseClaimClaimArgs(args: string[]): ParsedClaimClaimArgs;
+export declare function parseClaimReleaseArgs(args: string[]): ParsedClaimReleaseArgs;
+export declare function parseClaimListArgs(args: string[]): ParsedClaimListArgs;
+export declare function renderClaimsTable(entries: ClaimEntry[]): string;
+export declare function runClaimClaim(args: string[], options?: ClaimLedgerCliOptions): number;
+export declare function runClaimRelease(args: string[], options?: ClaimLedgerCliOptions): number;
+export declare function runClaimList(args: string[], options?: ClaimLedgerCliOptions): number;
+export declare function runClaimCli(subcommand: string | undefined, args: string[], options?: ClaimLedgerCliOptions): number;

--- a/packages/loopover-miner/lib/claim-ledger-cli.js
+++ b/packages/loopover-miner/lib/claim-ledger-cli.js
@@ -1,321 +1,318 @@
 import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { isValidRepoSegment } from "./repo-clone.js";
-
-const CLAIM_CLAIM_USAGE =
-  "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
-const CLAIM_RELEASE_USAGE =
-  "Usage: loopover-miner claim release <owner/repo> <issue#> [--api-base-url <url>] [--dry-run] [--json]";
-const CLAIM_LIST_USAGE =
-  "Usage: loopover-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]";
-
+const CLAIM_CLAIM_USAGE = "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_RELEASE_USAGE = "Usage: loopover-miner claim release <owner/repo> <issue#> [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_LIST_USAGE = "Usage: loopover-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 function parseIssueNumberArg(value, usage) {
-  if (!value) return { error: usage };
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1) {
-    return { error: "issue number must be a positive integer." };
-  }
-  return { issueNumber: parsed };
+    if (!value)
+        return { error: usage };
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        return { error: "issue number must be a positive integer." };
+    }
+    return { issueNumber: parsed };
 }
-
 export function parseClaimClaimArgs(args) {
-  const options = { json: false, note: undefined, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        note: undefined,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what a real claim would do and returns before opening the claim ledger at all.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--note") {
+            const note = args[index + 1];
+            if (!note || note.startsWith("-")) {
+                return { error: CLAIM_CLAIM_USAGE };
+            }
+            options.note = note;
+            index += 1;
+            continue;
+        }
+        // #5563: scope the claim to a non-default forge host, so it doesn't collide with (or get confused for) a
+        // same-named repo on the default github.com host.
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: CLAIM_CLAIM_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #4847: reports what a real claim would do and returns before opening the claim ledger at all.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--note") {
-      const note = args[index + 1];
-      if (!note || note.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: CLAIM_CLAIM_USAGE };
-      }
-      options.note = note;
-      index += 1;
-      continue;
     }
-    // #5563: scope the claim to a non-default forge host, so it doesn't collide with (or get confused for) a
-    // same-named repo on the default github.com host.
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
-        return { error: CLAIM_CLAIM_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: CLAIM_CLAIM_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], CLAIM_CLAIM_USAGE);
-  if ("error" in repo) return repo;
-  const issue = parseIssueNumberArg(positional[1], CLAIM_CLAIM_USAGE);
-  if ("error" in issue) return issue;
-
-  return {
-    repoFullName: repo.repoFullName,
-    issueNumber: issue.issueNumber,
-    note: options.note,
-    dryRun: options.dryRun,
-    json: options.json,
-    apiBaseUrl: options.apiBaseUrl,
-  };
+    const repo = parseRepoArg(positional[0], CLAIM_CLAIM_USAGE);
+    if ("error" in repo)
+        return repo;
+    const issue = parseIssueNumberArg(positional[1], CLAIM_CLAIM_USAGE);
+    if ("error" in issue)
+        return issue;
+    return {
+        repoFullName: repo.repoFullName,
+        issueNumber: issue.issueNumber,
+        note: options.note,
+        dryRun: options.dryRun,
+        json: options.json,
+        apiBaseUrl: options.apiBaseUrl,
+    };
 }
-
 export function parseClaimReleaseArgs(args) {
-  const options = { json: false, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: CLAIM_RELEASE_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: CLAIM_RELEASE_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: CLAIM_RELEASE_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], CLAIM_RELEASE_USAGE);
-  if ("error" in repo) return repo;
-  const issue = parseIssueNumberArg(positional[1], CLAIM_RELEASE_USAGE);
-  if ("error" in issue) return issue;
-
-  return {
-    repoFullName: repo.repoFullName,
-    issueNumber: issue.issueNumber,
-    dryRun: options.dryRun,
-    json: options.json,
-    apiBaseUrl: options.apiBaseUrl,
-  };
+    const repo = parseRepoArg(positional[0], CLAIM_RELEASE_USAGE);
+    if ("error" in repo)
+        return repo;
+    const issue = parseIssueNumberArg(positional[1], CLAIM_RELEASE_USAGE);
+    if ("error" in issue)
+        return issue;
+    return {
+        repoFullName: repo.repoFullName,
+        issueNumber: issue.issueNumber,
+        dryRun: options.dryRun,
+        json: options.json,
+        apiBaseUrl: options.apiBaseUrl,
+    };
 }
-
 export function parseClaimListArgs(args) {
-  const options = { json: false, repoFullName: null, status: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        repoFullName: null,
+        status: null,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-")) {
+                return { error: CLAIM_LIST_USAGE };
+            }
+            const repo = parseRepoArg(repoArg, CLAIM_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token === "--status") {
+            const statusArg = args[index + 1];
+            if (!statusArg || statusArg.startsWith("-")) {
+                return { error: CLAIM_LIST_USAGE };
+            }
+            if (!CLAIM_STATUSES.includes(statusArg)) {
+                return { error: `status must be one of: ${CLAIM_STATUSES.join(", ")}.` };
+            }
+            options.status = statusArg;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) {
+    if (positional.length > 0) {
         return { error: CLAIM_LIST_USAGE };
-      }
-      const repo = parseRepoArg(repoArg, CLAIM_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
     }
-    if (token === "--status") {
-      const statusArg = args[index + 1];
-      if (!statusArg || statusArg.startsWith("-")) {
-        return { error: CLAIM_LIST_USAGE };
-      }
-      if (!CLAIM_STATUSES.includes(statusArg)) {
-        return { error: `status must be one of: ${CLAIM_STATUSES.join(", ")}.` };
-      }
-      options.status = statusArg;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length > 0) {
-    return { error: CLAIM_LIST_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderClaimsTable(entries) {
-  if (!Array.isArray(entries) || entries.length === 0) return "no claim ledger entries";
-  const header = [
-    "repo".padEnd(24),
-    "issue".padStart(6),
-    "status".padEnd(10),
-    "claimed-at".padEnd(24),
-    "note".padEnd(16),
-  ].join(" ");
-  const lines = entries.map((entry) =>
-    [
-      entry.repoFullName.padEnd(24),
-      display(entry.issueNumber).padStart(6),
-      entry.status.padEnd(10),
-      display(entry.claimedAt).padEnd(24),
-      display(entry.note).padEnd(16),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(entries) || entries.length === 0)
+        return "no claim ledger entries";
+    const header = [
+        "repo".padEnd(24),
+        "issue".padStart(6),
+        "status".padEnd(10),
+        "claimed-at".padEnd(24),
+        "note".padEnd(16),
+    ].join(" ");
+    const lines = entries.map((entry) => [
+        entry.repoFullName.padEnd(24),
+        display(entry.issueNumber).padStart(6),
+        entry.status.padEnd(10),
+        display(entry.claimedAt).padEnd(24),
+        display(entry.note).padEnd(16),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 function withClaimLedger(options, run) {
-  const ownsLedger = options.openClaimLedger === undefined;
-  const claimLedger = (options.openClaimLedger ?? openClaimLedger)();
-  try {
-    return run(claimLedger);
-  } finally {
-    if (ownsLedger) claimLedger.close();
-  }
+    const ownsLedger = options.openClaimLedger === undefined;
+    const claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+    try {
+        return run(claimLedger);
+    }
+    finally {
+        if (ownsLedger)
+            claimLedger.close();
+    }
 }
-
 export function runClaimClaim(args, options = {}) {
-  const parsed = parseClaimClaimArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, note: parsed.note ?? null };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(
-        `DRY RUN: would claim ${parsed.repoFullName}#${parsed.issueNumber}${parsed.note ? ` (note: ${parsed.note})` : ""}. No claim-ledger write was made.`,
-      );
+    const parsed = parseClaimClaimArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withClaimLedger(options, (claimLedger) => {
-      const claim = claimLedger.claimIssue(
-        parsed.repoFullName,
-        parsed.issueNumber,
-        parsed.note,
-        parsed.apiBaseUrl,
-      );
-      if (parsed.json) {
-        console.log(JSON.stringify({ claim }, null, 2));
-      } else {
-        console.log(claim.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, note: parsed.note ?? null };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would claim ${parsed.repoFullName}#${parsed.issueNumber}${parsed.note ? ` (note: ${parsed.note})` : ""}. No claim-ledger write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withClaimLedger(options, (claimLedger) => {
+            const claim = claimLedger.claimIssue(parsed.repoFullName, parsed.issueNumber, parsed.note, parsed.apiBaseUrl);
+            if (parsed.json) {
+                console.log(JSON.stringify({ claim }, null, 2));
+            }
+            else {
+                console.log(claim.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runClaimRelease(args, options = {}) {
-  const parsed = parseClaimReleaseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would release the claim on ${parsed.repoFullName}#${parsed.issueNumber}. No claim-ledger write was made.`);
+    const parsed = parseClaimReleaseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withClaimLedger(options, (claimLedger) => {
-      const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber, parsed.apiBaseUrl);
-      if (!claim) {
-        return reportCliFailure(parsed.json, "claim_not_found");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ claim }, null, 2));
-      } else {
-        console.log(claim.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would release the claim on ${parsed.repoFullName}#${parsed.issueNumber}. No claim-ledger write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withClaimLedger(options, (claimLedger) => {
+            const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber, parsed.apiBaseUrl);
+            if (!claim) {
+                return reportCliFailure(parsed.json, "claim_not_found");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ claim }, null, 2));
+            }
+            else {
+                console.log(claim.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runClaimList(args, options = {}) {
-  const parsed = parseClaimListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withClaimLedger(options, (claimLedger) => {
-      const filter = {};
-      if (parsed.repoFullName !== null) filter.repoFullName = parsed.repoFullName;
-      if (parsed.status !== null) filter.status = parsed.status;
-      const claims = claimLedger.listClaims(filter);
-      if (parsed.json) {
-        console.log(JSON.stringify({ claims }, null, 2));
-      } else {
-        console.log(renderClaimsTable(claims));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseClaimListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withClaimLedger(options, (claimLedger) => {
+            const filter = {};
+            if (parsed.repoFullName !== null)
+                filter.repoFullName = parsed.repoFullName;
+            if (parsed.status !== null)
+                filter.status = parsed.status;
+            const claims = claimLedger.listClaims(filter);
+            if (parsed.json) {
+                console.log(JSON.stringify({ claims }, null, 2));
+            }
+            else {
+                console.log(renderClaimsTable(claims));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runClaimCli(subcommand, args, options = {}) {
-  if (subcommand === "claim") return runClaimClaim(args, options);
-  if (subcommand === "release") return runClaimRelease(args, options);
-  if (subcommand === "list") return runClaimList(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
+    if (subcommand === "claim")
+        return runClaimClaim(args, options);
+    if (subcommand === "release")
+        return runClaimRelease(args, options);
+    if (subcommand === "list")
+        return runClaimList(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2xhaW0tbGVkZ2VyLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImNsYWltLWxlZGdlci1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGNBQWMsRUFBRSxlQUFlLEVBQUUsTUFBTSxtQkFBbUIsQ0FBQztBQUVwRSxPQUFPLEVBQUUsWUFBWSxFQUFFLGdCQUFnQixFQUFFLGdCQUFnQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbEYsT0FBTyxFQUFFLGtCQUFrQixFQUFFLE1BQU0saUJBQWlCLENBQUM7QUFFckQsTUFBTSxpQkFBaUIsR0FDckIscUhBQXFILENBQUM7QUFDeEgsTUFBTSxtQkFBbUIsR0FDdkIsdUdBQXVHLENBQUM7QUFDMUcsTUFBTSxnQkFBZ0IsR0FDcEIsb0dBQW9HLENBQUM7QUFvQ3ZHLFNBQVMsWUFBWSxDQUFDLEtBQXlCLEVBQUUsS0FBYTtJQUM1RCxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLE9BQU8sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDaEQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUyxJQUFJLENBQUMsa0JBQWtCLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3RHLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxTQUFTLG1CQUFtQixDQUFDLEtBQXlCLEVBQUUsS0FBYTtJQUNuRSxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzdCLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLE1BQU0sQ0FBQyxJQUFJLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUM1QyxPQUFPLEVBQUUsS0FBSyxFQUFFLDBDQUEwQyxFQUFFLENBQUM7SUFDL0QsQ0FBQztJQUNELE9BQU8sRUFBRSxXQUFXLEVBQUUsTUFBTSxFQUFFLENBQUM7QUFDakMsQ0FBQztBQUVELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxJQUFjO0lBQ2hELE1BQU0sT0FBTyxHQUFpRztRQUM1RyxJQUFJLEVBQUUsS0FBSztRQUNYLElBQUksRUFBRSxTQUFTO1FBQ2YsTUFBTSxFQUFFLEtBQUs7UUFDYixVQUFVLEVBQUUsU0FBUztLQUN0QixDQUFDO0lBQ0YsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxnR0FBZ0c7UUFDaEcsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLElBQUksR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzdCLElBQUksQ0FBQyxJQUFJLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNsQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDdEMsQ0FBQztZQUNELE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELHlHQUF5RztRQUN6RyxrREFBa0Q7UUFDbEQsSUFBSSxLQUFLLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQztZQUMvQixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNwQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDdEMsQ0FBQztZQUNELE9BQU8sQ0FBQyxVQUFVLEdBQUcsS0FBSyxDQUFDO1lBQzNCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDL0MsQ0FBQztRQUNELFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUM1QixPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7SUFDdEMsQ0FBQztJQUVELE1BQU0sSUFBSSxHQUFHLFlBQVksQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztJQUM1RCxJQUFJLE9BQU8sSUFBSSxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDakMsTUFBTSxLQUFLLEdBQUcsbUJBQW1CLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLGlCQUFpQixDQUFDLENBQUM7SUFDcEUsSUFBSSxPQUFPLElBQUksS0FBSztRQUFFLE9BQU8sS0FBSyxDQUFDO0lBRW5DLE9BQU87UUFDTCxZQUFZLEVBQUUsSUFBSSxDQUFDLFlBQVk7UUFDL0IsV0FBVyxFQUFFLEtBQUssQ0FBQyxXQUFXO1FBQzlCLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtRQUNsQixNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU07UUFDdEIsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO1FBQ2xCLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtLQUMvQixDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxJQUFjO0lBQ2xELE1BQU0sT0FBTyxHQUF1RTtRQUNsRixJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsVUFBVSxFQUFFLFNBQVM7S0FDdEIsQ0FBQztJQUNGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxnQkFBZ0IsRUFBRSxDQUFDO1lBQy9CLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3BDLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztZQUN4QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQzVCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEVBQUUsQ0FBQztJQUN4QyxDQUFDO0lBRUQsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxtQkFBbUIsQ0FBQyxDQUFDO0lBQzlELElBQUksT0FBTyxJQUFJLElBQUk7UUFBRSxPQUFPLElBQUksQ0FBQztJQUNqQyxNQUFNLEtBQUssR0FBRyxtQkFBbUIsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsbUJBQW1CLENBQUMsQ0FBQztJQUN0RSxJQUFJLE9BQU8sSUFBSSxLQUFLO1FBQUUsT0FBTyxLQUFLLENBQUM7SUFFbkMsT0FBTztRQUNMLFlBQVksRUFBRSxJQUFJLENBQUMsWUFBWTtRQUMvQixXQUFXLEVBQUUsS0FBSyxDQUFDLFdBQVc7UUFDOUIsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNO1FBQ3RCLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtRQUNsQixVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVU7S0FDL0IsQ0FBQztBQUNKLENBQUM7QUFFRCxNQUFNLFVBQVUsa0JBQWtCLENBQUMsSUFBYztJQUMvQyxNQUFNLE9BQU8sR0FBK0U7UUFDMUYsSUFBSSxFQUFFLEtBQUs7UUFDWCxZQUFZLEVBQUUsSUFBSTtRQUNsQixNQUFNLEVBQUUsSUFBSTtLQUNiLENBQUM7SUFDRixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDaEMsSUFBSSxDQUFDLE9BQU8sSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3hDLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztZQUNyQyxDQUFDO1lBQ0QsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sRUFBRSxnQkFBZ0IsQ0FBQyxDQUFDO1lBQ3JELElBQUksT0FBTyxJQUFJLElBQUk7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFDakMsT0FBTyxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsWUFBWSxDQUFDO1lBQ3pDLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFVBQVUsRUFBRSxDQUFDO1lBQ3pCLE1BQU0sU0FBUyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDbEMsSUFBSSxDQUFDLFNBQVMsSUFBSSxTQUFTLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQzVDLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztZQUNyQyxDQUFDO1lBQ0QsSUFBSSxDQUFDLGNBQWMsQ0FBQyxRQUFRLENBQUMsU0FBd0IsQ0FBQyxFQUFFLENBQUM7Z0JBQ3ZELE9BQU8sRUFBRSxLQUFLLEVBQUUsMEJBQTBCLGNBQWMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO1lBQzNFLENBQUM7WUFDRCxPQUFPLENBQUMsTUFBTSxHQUFHLFNBQXdCLENBQUM7WUFDMUMsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxDQUFDO1FBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztJQUNyQyxDQUFDO0lBRUQsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVELFNBQVMsT0FBTyxDQUFDLEtBQWM7SUFDN0IsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxHQUFHLENBQUM7SUFDdEQsT0FBTyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDdkIsQ0FBQztBQUVELE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxPQUFxQjtJQUNyRCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLHlCQUF5QixDQUFDO0lBQ3RGLE1BQU0sTUFBTSxHQUFHO1FBQ2IsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDbkIsUUFBUSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkIsWUFBWSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDdkIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDbEIsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDWixNQUFNLEtBQUssR0FBRyxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FDbEM7UUFDRSxLQUFLLENBQUMsWUFBWSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDN0IsT0FBTyxDQUFDLEtBQUssQ0FBQyxXQUFXLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQ3RDLEtBQUssQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN2QixPQUFPLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkMsT0FBTyxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQy9CLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBSSxPQUE4QixFQUFFLEdBQW9DO0lBQzlGLE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxlQUFlLEtBQUssU0FBUyxDQUFDO0lBQ3pELE1BQU0sV0FBVyxHQUFHLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUMsRUFBRSxDQUFDO0lBQ25FLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLFdBQVcsQ0FBQyxDQUFDO0lBQzFCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxVQUFVO1lBQUUsV0FBVyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3RDLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGFBQWEsQ0FBQyxJQUFjLEVBQUUsVUFBaUMsRUFBRTtJQUMvRSxNQUFNLE1BQU0sR0FBRyxtQkFBbUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN6QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksSUFBSSxJQUFJLEVBQUUsQ0FBQztRQUMzSSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FDVCx3QkFBd0IsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVyxHQUFHLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLFdBQVcsTUFBTSxDQUFDLElBQUksR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLG1DQUFtQyxDQUNwSixDQUFDO1FBQ0osQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxVQUFVLENBQ2xDLE1BQU0sQ0FBQyxZQUFZLEVBQ25CLE1BQU0sQ0FBQyxXQUFXLEVBQ2xCLE1BQU0sQ0FBQyxJQUFJLEVBQ1gsTUFBTSxDQUFDLFVBQVUsQ0FDbEIsQ0FBQztZQUNGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNsRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUM7WUFDNUIsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGVBQWUsQ0FBQyxJQUFjLEVBQUUsVUFBaUMsRUFBRTtJQUNqRixNQUFNLE1BQU0sR0FBRyxxQkFBcUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUMzQyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRSxDQUFDO1FBQ2hILElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDckQsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHVDQUF1QyxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLG1DQUFtQyxDQUFDLENBQUM7UUFDbkksQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQztZQUNuRyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUM7Z0JBQ1gsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGlCQUFpQixDQUFDLENBQUM7WUFDMUQsQ0FBQztZQUNELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNsRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUM7WUFDNUIsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFlBQVksQ0FBQyxJQUFjLEVBQUUsVUFBaUMsRUFBRTtJQUM5RSxNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sTUFBTSxHQUFvRCxFQUFFLENBQUM7WUFDbkUsSUFBSSxNQUFNLENBQUMsWUFBWSxLQUFLLElBQUk7Z0JBQUUsTUFBTSxDQUFDLFlBQVksR0FBRyxNQUFNLENBQUMsWUFBWSxDQUFDO1lBQzVFLElBQUksTUFBTSxDQUFDLE1BQU0sS0FBSyxJQUFJO2dCQUFFLE1BQU0sQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQztZQUMxRCxNQUFNLE1BQU0sR0FBRyxXQUFXLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzlDLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxNQUFNLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNuRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxpQkFBaUIsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO1lBQ3pDLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsVUFBOEIsRUFBRSxJQUFjLEVBQUUsVUFBaUMsRUFBRTtJQUM3RyxJQUFJLFVBQVUsS0FBSyxPQUFPO1FBQUUsT0FBTyxhQUFhLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ2hFLElBQUksVUFBVSxLQUFLLFNBQVM7UUFBRSxPQUFPLGVBQWUsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDcEUsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sWUFBWSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM5RCxPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSw2QkFBNkIsVUFBVSxJQUFJLEVBQUUsS0FBSyxnQkFBZ0IsRUFBRSxDQUFDLENBQUM7QUFDcEgsQ0FBQyJ9

--- a/packages/loopover-miner/lib/claim-ledger-cli.ts
+++ b/packages/loopover-miner/lib/claim-ledger-cli.ts
@@ -1,0 +1,369 @@
+import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
+import type { ClaimEntry, ClaimLedger, ClaimStatus } from "./claim-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
+
+const CLAIM_CLAIM_USAGE =
+  "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_RELEASE_USAGE =
+  "Usage: loopover-miner claim release <owner/repo> <issue#> [--api-base-url <url>] [--dry-run] [--json]";
+const CLAIM_LIST_USAGE =
+  "Usage: loopover-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]";
+
+export type ParsedClaimClaimArgs =
+  | {
+      repoFullName: string;
+      issueNumber: number;
+      note: string | undefined;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedClaimReleaseArgs =
+  | {
+      repoFullName: string;
+      issueNumber: number;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedClaimListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+      status: ClaimStatus | null;
+    }
+  | { error: string };
+
+export type ClaimLedgerCliOptions = { openClaimLedger?: () => ClaimLedger };
+
+type ParsedRepoArg = { repoFullName: string } | { error: string };
+type ParsedIssueNumberArg = { issueNumber: number } | { error: string };
+
+function parseRepoArg(value: string | undefined, usage: string): ParsedRepoArg {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+function parseIssueNumberArg(value: string | undefined, usage: string): ParsedIssueNumberArg {
+  if (!value) return { error: usage };
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return { error: "issue number must be a positive integer." };
+  }
+  return { issueNumber: parsed };
+}
+
+export function parseClaimClaimArgs(args: string[]): ParsedClaimClaimArgs {
+  const options: { json: boolean; note: string | undefined; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    note: undefined,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what a real claim would do and returns before opening the claim ledger at all.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--note") {
+      const note = args[index + 1];
+      if (!note || note.startsWith("-")) {
+        return { error: CLAIM_CLAIM_USAGE };
+      }
+      options.note = note;
+      index += 1;
+      continue;
+    }
+    // #5563: scope the claim to a non-default forge host, so it doesn't collide with (or get confused for) a
+    // same-named repo on the default github.com host.
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: CLAIM_CLAIM_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: CLAIM_CLAIM_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], CLAIM_CLAIM_USAGE);
+  if ("error" in repo) return repo;
+  const issue = parseIssueNumberArg(positional[1], CLAIM_CLAIM_USAGE);
+  if ("error" in issue) return issue;
+
+  return {
+    repoFullName: repo.repoFullName,
+    issueNumber: issue.issueNumber,
+    note: options.note,
+    dryRun: options.dryRun,
+    json: options.json,
+    apiBaseUrl: options.apiBaseUrl,
+  };
+}
+
+export function parseClaimReleaseArgs(args: string[]): ParsedClaimReleaseArgs {
+  const options: { json: boolean; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: CLAIM_RELEASE_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: CLAIM_RELEASE_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], CLAIM_RELEASE_USAGE);
+  if ("error" in repo) return repo;
+  const issue = parseIssueNumberArg(positional[1], CLAIM_RELEASE_USAGE);
+  if ("error" in issue) return issue;
+
+  return {
+    repoFullName: repo.repoFullName,
+    issueNumber: issue.issueNumber,
+    dryRun: options.dryRun,
+    json: options.json,
+    apiBaseUrl: options.apiBaseUrl,
+  };
+}
+
+export function parseClaimListArgs(args: string[]): ParsedClaimListArgs {
+  const options: { json: boolean; repoFullName: string | null; status: ClaimStatus | null } = {
+    json: false,
+    repoFullName: null,
+    status: null,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) {
+        return { error: CLAIM_LIST_USAGE };
+      }
+      const repo = parseRepoArg(repoArg, CLAIM_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token === "--status") {
+      const statusArg = args[index + 1];
+      if (!statusArg || statusArg.startsWith("-")) {
+        return { error: CLAIM_LIST_USAGE };
+      }
+      if (!CLAIM_STATUSES.includes(statusArg as ClaimStatus)) {
+        return { error: `status must be one of: ${CLAIM_STATUSES.join(", ")}.` };
+      }
+      options.status = statusArg as ClaimStatus;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    return { error: CLAIM_LIST_USAGE };
+  }
+
+  return options;
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderClaimsTable(entries: ClaimEntry[]): string {
+  if (!Array.isArray(entries) || entries.length === 0) return "no claim ledger entries";
+  const header = [
+    "repo".padEnd(24),
+    "issue".padStart(6),
+    "status".padEnd(10),
+    "claimed-at".padEnd(24),
+    "note".padEnd(16),
+  ].join(" ");
+  const lines = entries.map((entry) =>
+    [
+      entry.repoFullName.padEnd(24),
+      display(entry.issueNumber).padStart(6),
+      entry.status.padEnd(10),
+      display(entry.claimedAt).padEnd(24),
+      display(entry.note).padEnd(16),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function withClaimLedger<T>(options: ClaimLedgerCliOptions, run: (claimLedger: ClaimLedger) => T): T {
+  const ownsLedger = options.openClaimLedger === undefined;
+  const claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+  try {
+    return run(claimLedger);
+  } finally {
+    if (ownsLedger) claimLedger.close();
+  }
+}
+
+export function runClaimClaim(args: string[], options: ClaimLedgerCliOptions = {}): number {
+  const parsed = parseClaimClaimArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, note: parsed.note ?? null };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(
+        `DRY RUN: would claim ${parsed.repoFullName}#${parsed.issueNumber}${parsed.note ? ` (note: ${parsed.note})` : ""}. No claim-ledger write was made.`,
+      );
+    }
+    return 0;
+  }
+
+  try {
+    return withClaimLedger(options, (claimLedger) => {
+      const claim = claimLedger.claimIssue(
+        parsed.repoFullName,
+        parsed.issueNumber,
+        parsed.note,
+        parsed.apiBaseUrl,
+      );
+      if (parsed.json) {
+        console.log(JSON.stringify({ claim }, null, 2));
+      } else {
+        console.log(claim.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runClaimRelease(args: string[], options: ClaimLedgerCliOptions = {}): number {
+  const parsed = parseClaimReleaseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would release the claim on ${parsed.repoFullName}#${parsed.issueNumber}. No claim-ledger write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withClaimLedger(options, (claimLedger) => {
+      const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber, parsed.apiBaseUrl);
+      if (!claim) {
+        return reportCliFailure(parsed.json, "claim_not_found");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ claim }, null, 2));
+      } else {
+        console.log(claim.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runClaimList(args: string[], options: ClaimLedgerCliOptions = {}): number {
+  const parsed = parseClaimListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withClaimLedger(options, (claimLedger) => {
+      const filter: { repoFullName?: string; status?: ClaimStatus } = {};
+      if (parsed.repoFullName !== null) filter.repoFullName = parsed.repoFullName;
+      if (parsed.status !== null) filter.status = parsed.status;
+      const claims = claimLedger.listClaims(filter);
+      if (parsed.json) {
+        console.log(JSON.stringify({ claims }, null, 2));
+      } else {
+        console.log(renderClaimsTable(claims));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runClaimCli(subcommand: string | undefined, args: string[], options: ClaimLedgerCliOptions = {}): number {
+  if (subcommand === "claim") return runClaimClaim(args, options);
+  if (subcommand === "release") return runClaimRelease(args, options);
+  if (subcommand === "list") return runClaimList(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
+}

--- a/packages/loopover-miner/lib/event-ledger-cli.d.ts
+++ b/packages/loopover-miner/lib/event-ledger-cli.d.ts
@@ -1,82 +1,62 @@
 import type { EventLedger, LedgerEntry } from "./event-ledger.js";
-
-export type ParsedLedgerListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-      since: number | null;
-      type: string | null;
-    }
-  | { error: string };
-
-export function parseLedgerListArgs(args: string[]): ParsedLedgerListArgs;
-
-export function filterLedgerEvents(
-  events: LedgerEntry[],
-  options?: { type?: string | null },
-): LedgerEntry[];
-
-export const AUDIT_FEED_ENTRY_FIELDS: readonly [
-  "eventType",
-  "repoFullName",
-  "outcome",
-  "actor",
-  "detail",
-  "createdAt",
-];
-
-export function projectLedgerEventToAuditFeedEntry(entry: LedgerEntry): {
-  eventType: string;
-  repoFullName: string | null;
-  outcome: string | null;
-  actor: string | null;
-  detail: string | null;
-  createdAt: string;
+export type ParsedLedgerListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+    since: number | null;
+    type: string | null;
+} | {
+    error: string;
 };
-
-export type AuditFeedMcpFilterInput = {
-  repoFullName?: string | null;
-  since?: number | null;
-  type?: string | null;
+export type EventLedgerCliOptions = {
+    initEventLedger?: () => EventLedger;
 };
-
-export function normalizeAuditFeedMcpFilter(input?: AuditFeedMcpFilterInput): {
-  repoFullName: string | null;
-  since: number | null;
-  type: string | null;
-};
-
-export function collectEventLedgerAuditFeed(
-  eventLedger: EventLedger,
-  filter?: { repoFullName?: string | null; since?: number | null; type?: string | null },
-): {
-  repoFullName?: string;
-  events: Array<{
+export declare function parseLedgerListArgs(args: string[]): ParsedLedgerListArgs;
+export declare function filterLedgerEvents(events: LedgerEntry[], options?: {
+    type?: string | null;
+}): LedgerEntry[];
+/** Metadata-only audit-feed columns exposed by the MCP tool (#5158). */
+export declare const AUDIT_FEED_ENTRY_FIELDS: readonly ["eventType", "repoFullName", "outcome", "actor", "detail", "createdAt"];
+type AuditFeedEntry = {
     eventType: string;
     repoFullName: string | null;
     outcome: string | null;
     actor: string | null;
     detail: string | null;
     createdAt: string;
-  }>;
 };
-
-export function renderLedgerTable(events: LedgerEntry[]): string;
-
-export function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string;
-
-export function runLedgerList(
-  args: string[],
-  options?: { initEventLedger?: () => EventLedger },
-): number;
-
-export function runLedgerMetrics(
-  args: string[],
-  options?: { initEventLedger?: () => EventLedger },
-): number;
-
-export function runLedgerCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { initEventLedger?: () => EventLedger },
-): number;
+/** Project one ledger row to the public, metadata-only audit-feed shape — never returns payload_json. */
+export declare function projectLedgerEventToAuditFeedEntry(entry: LedgerEntry): AuditFeedEntry;
+export type AuditFeedMcpFilterInput = {
+    repoFullName?: string | null;
+    since?: number | null;
+    type?: string | null;
+};
+type NormalizedAuditFeedFilter = {
+    repoFullName: string | null;
+    since: number | null;
+    type: string | null;
+};
+/** Normalize optional MCP/JSON filter args into the shape `ledger list` already uses (#5158). */
+export declare function normalizeAuditFeedMcpFilter(input?: AuditFeedMcpFilterInput): NormalizedAuditFeedFilter;
+/** Read-only audit feed shared by the MCP audit-feed tool (#5158). */
+export declare function collectEventLedgerAuditFeed(eventLedger: EventLedger, filter?: {
+    repoFullName?: string | null;
+    since?: number | null;
+    type?: string | null;
+}): {
+    repoFullName?: string;
+    events: AuditFeedEntry[];
+};
+export declare function renderLedgerTable(events: LedgerEntry[]): string;
+/**
+ * Render event-ledger activity as Prometheus text-exposition counters: one `loopover_miner_events_total{type}`
+ * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
+ * `ledger list --json` (#4841). Pure + side-effect-free — the caller supplies the rows and prints the result;
+ * deterministic (series emitted in sorted type order); always emits HELP/TYPE so an empty ledger is still a
+ * well-formed exposition document.
+ */
+export declare function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string;
+export declare function runLedgerList(args: string[], options?: EventLedgerCliOptions): number;
+export declare function runLedgerMetrics(args: string[], options?: EventLedgerCliOptions): number;
+export declare function runLedgerCli(subcommand: string | undefined, args: string[], options?: EventLedgerCliOptions): number;
+export {};

--- a/packages/loopover-miner/lib/event-ledger-cli.js
+++ b/packages/loopover-miner/lib/event-ledger-cli.js
@@ -1,189 +1,184 @@
 import { initEventLedger } from "./event-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { isValidRepoSegment } from "./repo-clone.js";
-
-const LEDGER_LIST_USAGE =
-  "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
-
+const LEDGER_LIST_USAGE = "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 function parseSinceArg(value) {
-  const since = Number(value);
-  if (!Number.isInteger(since) || since < 0) {
-    return { error: "since must be a non-negative integer seq cursor." };
-  }
-  return { since };
+    const since = Number(value);
+    if (!Number.isInteger(since) || since < 0) {
+        return { error: "since must be a non-negative integer seq cursor." };
+    }
+    return { since };
 }
-
 export function parseLedgerListArgs(args) {
-  const options = { json: false, repoFullName: null, since: null, type: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        repoFullName: null,
+        since: null,
+        type: null,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-"))
+                return { error: LEDGER_LIST_USAGE };
+            const repo = parseRepoArg(repoArg, LEDGER_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token === "--since") {
+            const sinceArg = args[index + 1];
+            if (!sinceArg || sinceArg.startsWith("--"))
+                return { error: LEDGER_LIST_USAGE };
+            const parsedSince = parseSinceArg(sinceArg);
+            if ("error" in parsedSince)
+                return parsedSince;
+            options.since = parsedSince.since;
+            index += 1;
+            continue;
+        }
+        if (token === "--type") {
+            const type = args[index + 1];
+            if (!type || type.startsWith("-"))
+                return { error: LEDGER_LIST_USAGE };
+            options.type = type.trim();
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) return { error: LEDGER_LIST_USAGE };
-      const repo = parseRepoArg(repoArg, LEDGER_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
-    }
-    if (token === "--since") {
-      const sinceArg = args[index + 1];
-      if (!sinceArg || sinceArg.startsWith("--")) return { error: LEDGER_LIST_USAGE };
-      const parsedSince = parseSinceArg(sinceArg);
-      if ("error" in parsedSince) return parsedSince;
-      options.since = parsedSince.since;
-      index += 1;
-      continue;
-    }
-    if (token === "--type") {
-      const type = args[index + 1];
-      if (!type || type.startsWith("-")) return { error: LEDGER_LIST_USAGE };
-      options.type = type.trim();
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length > 0) return { error: LEDGER_LIST_USAGE };
-  return options;
+    if (positional.length > 0)
+        return { error: LEDGER_LIST_USAGE };
+    return options;
 }
-
 export function filterLedgerEvents(events, options = {}) {
-  if (!Array.isArray(events)) return [];
-  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
-  if (!type) return events;
-  return events.filter((entry) => entry.type === type);
+    if (!Array.isArray(events))
+        return [];
+    const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+    if (!type)
+        return events;
+    return events.filter((entry) => entry.type === type);
 }
-
 /** Metadata-only audit-feed columns exposed by the MCP tool (#5158). */
 export const AUDIT_FEED_ENTRY_FIELDS = Object.freeze([
-  "eventType",
-  "repoFullName",
-  "outcome",
-  "actor",
-  "detail",
-  "createdAt",
+    "eventType",
+    "repoFullName",
+    "outcome",
+    "actor",
+    "detail",
+    "createdAt",
 ]);
-
 function optionalMetadataString(value) {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed || null;
+    if (typeof value !== "string")
+        return null;
+    const trimmed = value.trim();
+    return trimmed || null;
 }
-
 /** Project one ledger row to the public, metadata-only audit-feed shape — never returns payload_json. */
 export function projectLedgerEventToAuditFeedEntry(entry) {
-  const payload =
-    entry?.payload && typeof entry.payload === "object" && !Array.isArray(entry.payload) ? entry.payload : {};
-  return {
-    eventType: entry.type,
-    repoFullName: entry.repoFullName,
-    outcome: optionalMetadataString(payload.outcome),
-    actor: optionalMetadataString(payload.actor),
-    detail: optionalMetadataString(payload.detail),
-    createdAt: entry.createdAt,
-  };
+    const payload = entry?.payload && typeof entry.payload === "object" && !Array.isArray(entry.payload) ? entry.payload : {};
+    return {
+        eventType: entry.type,
+        repoFullName: entry.repoFullName,
+        outcome: optionalMetadataString(payload.outcome),
+        actor: optionalMetadataString(payload.actor),
+        detail: optionalMetadataString(payload.detail),
+        createdAt: entry.createdAt,
+    };
 }
-
 /** Normalize optional MCP/JSON filter args into the shape `ledger list` already uses (#5158). */
 export function normalizeAuditFeedMcpFilter(input = {}) {
-  if (input === null || typeof input !== "object" || Array.isArray(input)) {
-    throw new Error("filter must be an object");
-  }
-  const filter = { repoFullName: null, since: null, type: null };
-  if (input.repoFullName !== undefined && input.repoFullName !== null) {
-    const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
-    if ("error" in repo) throw new Error(repo.error);
-    filter.repoFullName = repo.repoFullName;
-  }
-  if (input.since !== undefined && input.since !== null) {
-    const parsedSince = parseSinceArg(String(input.since));
-    if ("error" in parsedSince) throw new Error(parsedSince.error);
-    filter.since = parsedSince.since;
-  }
-  if (input.type !== undefined && input.type !== null) {
-    const trimmed = String(input.type).trim();
-    if (!trimmed) throw new Error("type must be a non-empty string.");
-    filter.type = trimmed;
-  }
-  return filter;
+    if (input === null || typeof input !== "object" || Array.isArray(input)) {
+        throw new Error("filter must be an object");
+    }
+    const filter = { repoFullName: null, since: null, type: null };
+    if (input.repoFullName !== undefined && input.repoFullName !== null) {
+        const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
+        if ("error" in repo)
+            throw new Error(repo.error);
+        filter.repoFullName = repo.repoFullName;
+    }
+    if (input.since !== undefined && input.since !== null) {
+        const parsedSince = parseSinceArg(String(input.since));
+        if ("error" in parsedSince)
+            throw new Error(parsedSince.error);
+        filter.since = parsedSince.since;
+    }
+    if (input.type !== undefined && input.type !== null) {
+        const trimmed = String(input.type).trim();
+        if (!trimmed)
+            throw new Error("type must be a non-empty string.");
+        filter.type = trimmed;
+    }
+    return filter;
 }
-
 /** Read-only audit feed shared by the MCP audit-feed tool (#5158). */
 export function collectEventLedgerAuditFeed(eventLedger, filter = {}) {
-  const events = filterLedgerEvents(
-    eventLedger.readEvents({
-      repoFullName: filter.repoFullName,
-      since: filter.since,
-    }),
-    { type: filter.type },
-  );
-  return {
-    ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
-    events: events.map(projectLedgerEventToAuditFeedEntry),
-  };
+    const events = filterLedgerEvents(eventLedger.readEvents({
+        ...(filter.repoFullName !== undefined ? { repoFullName: filter.repoFullName } : {}),
+        ...(filter.since !== undefined ? { since: filter.since } : {}),
+    }), { ...(filter.type !== undefined ? { type: filter.type } : {}) });
+    return {
+        ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
+        events: events.map(projectLedgerEventToAuditFeedEntry),
+    };
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderLedgerTable(events) {
-  if (!Array.isArray(events) || events.length === 0) return "no event ledger entries";
-  const header = [
-    "seq".padStart(4),
-    "type".padEnd(20),
-    "repo".padEnd(24),
-    "created-at".padEnd(24),
-  ].join(" ");
-  const lines = events.map((entry) =>
-    [
-      String(entry.seq).padStart(4),
-      entry.type.padEnd(20),
-      display(entry.repoFullName).padEnd(24),
-      display(entry.createdAt).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(events) || events.length === 0)
+        return "no event ledger entries";
+    const header = [
+        "seq".padStart(4),
+        "type".padEnd(20),
+        "repo".padEnd(24),
+        "created-at".padEnd(24),
+    ].join(" ");
+    const lines = events.map((entry) => [
+        String(entry.seq).padStart(4),
+        entry.type.padEnd(20),
+        display(entry.repoFullName).padEnd(24),
+        display(entry.createdAt).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 const EVENT_LEDGER_METRICS_USAGE = "Usage: loopover-miner ledger metrics";
-
 // Prometheus metric name for the per-type event-ledger counter. Mirrors the `loopover_miner_*_total` naming and
 // the HELP/TYPE/label conventions of the engine's renderMinerPredictionMetrics
 // (packages/loopover-engine/src/miner-prediction-metrics.ts) rather than importing across the package boundary.
 const MINER_EVENTS_TOTAL = "loopover_miner_events_total";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /** Prometheus label-value escaping — backslash, double-quote, newline — so an arbitrary event `type` string can
  *  never break the metric line (mirrors miner-prediction-metrics.ts's escapeLabelValue). */
 function escapeLabelValue(value) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
-
 /**
  * Render event-ledger activity as Prometheus text-exposition counters: one `loopover_miner_events_total{type}`
  * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
@@ -192,76 +187,75 @@ function escapeLabelValue(value) {
  * well-formed exposition document.
  */
 export function renderEventLedgerMetrics(events) {
-  const totalByType = new Map();
-  for (const entry of events) {
-    totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
-  }
-  const lines = [
-    `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
-    `# TYPE ${MINER_EVENTS_TOTAL} counter`,
-  ];
-  for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-    lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
-  }
-  return `${lines.join("\n")}\n`;
+    const totalByType = new Map();
+    for (const entry of events) {
+        totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
+    }
+    const lines = [
+        `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
+        `# TYPE ${MINER_EVENTS_TOTAL} counter`,
+    ];
+    for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+        lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
+    }
+    return `${lines.join("\n")}\n`;
 }
-
 function withEventLedger(options, run) {
-  const ownsLedger = options.initEventLedger === undefined;
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  try {
-    return run(eventLedger);
-  } finally {
-    if (ownsLedger) eventLedger.close();
-  }
+    const ownsLedger = options.initEventLedger === undefined;
+    const eventLedger = (options.initEventLedger ?? initEventLedger)();
+    try {
+        return run(eventLedger);
+    }
+    finally {
+        if (ownsLedger)
+            eventLedger.close();
+    }
 }
-
 export function runLedgerList(args, options = {}) {
-  const parsed = parseLedgerListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withEventLedger(options, (eventLedger) => {
-      const events = filterLedgerEvents(
-        eventLedger.readEvents({
-          repoFullName: parsed.repoFullName,
-          since: parsed.since,
-        }),
-        { type: parsed.type },
-      );
-      if (parsed.json) {
-        console.log(JSON.stringify({ events }, null, 2));
-      } else {
-        console.log(renderLedgerTable(events));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseLedgerListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withEventLedger(options, (eventLedger) => {
+            const events = filterLedgerEvents(eventLedger.readEvents({
+                repoFullName: parsed.repoFullName,
+                since: parsed.since,
+            }), { type: parsed.type });
+            if (parsed.json) {
+                console.log(JSON.stringify({ events }, null, 2));
+            }
+            else {
+                console.log(renderLedgerTable(events));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runLedgerMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
-  }
-
-  try {
-    return withEventLedger(options, (eventLedger) => {
-      // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
-      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
-      console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
+    }
+    try {
+        return withEventLedger(options, (eventLedger) => {
+            // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+            // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+            console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
-
 export function runLedgerCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runLedgerList(args, options);
-  if (subcommand === "metrics") return runLedgerMetrics(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
+    if (subcommand === "list")
+        return runLedgerList(args, options);
+    if (subcommand === "metrics")
+        return runLedgerMetrics(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXZlbnQtbGVkZ2VyLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImV2ZW50LWxlZGdlci1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRXBELE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUVyRCxNQUFNLGlCQUFpQixHQUNyQix1R0FBdUcsQ0FBQztBQWdCMUcsU0FBUyxZQUFZLENBQUMsS0FBeUIsRUFBRSxLQUFhO0lBQzVELElBQUksQ0FBQyxLQUFLO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUNwQyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDN0IsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLGtCQUFrQixDQUFDLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDdEcsT0FBTyxFQUFFLEtBQUssRUFBRSx3Q0FBd0MsRUFBRSxDQUFDO0lBQzdELENBQUM7SUFDRCxPQUFPLEVBQUUsWUFBWSxFQUFFLEdBQUcsS0FBSyxJQUFJLElBQUksRUFBRSxFQUFFLENBQUM7QUFDOUMsQ0FBQztBQUVELFNBQVMsYUFBYSxDQUFDLEtBQWE7SUFDbEMsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVCLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUMxQyxPQUFPLEVBQUUsS0FBSyxFQUFFLGtEQUFrRCxFQUFFLENBQUM7SUFDdkUsQ0FBQztJQUNELE9BQU8sRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUNuQixDQUFDO0FBRUQsTUFBTSxVQUFVLG1CQUFtQixDQUFDLElBQWM7SUFDaEQsTUFBTSxPQUFPLEdBQThGO1FBQ3pHLElBQUksRUFBRSxLQUFLO1FBQ1gsWUFBWSxFQUFFLElBQUk7UUFDbEIsS0FBSyxFQUFFLElBQUk7UUFDWCxJQUFJLEVBQUUsSUFBSTtLQUNYLENBQUM7SUFDRixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDaEMsSUFBSSxDQUFDLE9BQU8sSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDN0UsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sRUFBRSxpQkFBaUIsQ0FBQyxDQUFDO1lBQ3RELElBQUksT0FBTyxJQUFJLElBQUk7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFDakMsT0FBTyxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsWUFBWSxDQUFDO1lBQ3pDLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFNBQVMsRUFBRSxDQUFDO1lBQ3hCLE1BQU0sUUFBUSxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDakMsSUFBSSxDQUFDLFFBQVEsSUFBSSxRQUFRLENBQUMsVUFBVSxDQUFDLElBQUksQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDaEYsTUFBTSxXQUFXLEdBQUcsYUFBYSxDQUFDLFFBQVEsQ0FBQyxDQUFDO1lBQzVDLElBQUksT0FBTyxJQUFJLFdBQVc7Z0JBQUUsT0FBTyxXQUFXLENBQUM7WUFDL0MsT0FBTyxDQUFDLEtBQUssR0FBRyxXQUFXLENBQUMsS0FBSyxDQUFDO1lBQ2xDLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sSUFBSSxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDN0IsSUFBSSxDQUFDLElBQUksSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7WUFDdkUsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDeEUsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxHQUFHLENBQUM7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGlCQUFpQixFQUFFLENBQUM7SUFDL0QsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVELE1BQU0sVUFBVSxrQkFBa0IsQ0FDaEMsTUFBcUIsRUFDckIsVUFBb0MsRUFBRTtJQUV0QyxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUM7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUN0QyxNQUFNLElBQUksR0FBRyxPQUFPLE9BQU8sQ0FBQyxJQUFJLEtBQUssUUFBUSxJQUFJLE9BQU8sQ0FBQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUNsRyxJQUFJLENBQUMsSUFBSTtRQUFFLE9BQU8sTUFBTSxDQUFDO0lBQ3pCLE9BQU8sTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLElBQUksS0FBSyxJQUFJLENBQUMsQ0FBQztBQUN2RCxDQUFDO0FBRUQsd0VBQXdFO0FBQ3hFLE1BQU0sQ0FBQyxNQUFNLHVCQUF1QixHQUFHLE1BQU0sQ0FBQyxNQUFNLENBQUM7SUFDbkQsV0FBVztJQUNYLGNBQWM7SUFDZCxTQUFTO0lBQ1QsT0FBTztJQUNQLFFBQVE7SUFDUixXQUFXO0NBQ0gsQ0FBQyxDQUFDO0FBRVosU0FBUyxzQkFBc0IsQ0FBQyxLQUFjO0lBQzVDLElBQUksT0FBTyxLQUFLLEtBQUssUUFBUTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQzNDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM3QixPQUFPLE9BQU8sSUFBSSxJQUFJLENBQUM7QUFDekIsQ0FBQztBQVdELHlHQUF5RztBQUN6RyxNQUFNLFVBQVUsa0NBQWtDLENBQUMsS0FBa0I7SUFDbkUsTUFBTSxPQUFPLEdBQ1gsS0FBSyxFQUFFLE9BQU8sSUFBSSxPQUFPLEtBQUssQ0FBQyxPQUFPLEtBQUssUUFBUSxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUM1RyxPQUFPO1FBQ0wsU0FBUyxFQUFFLEtBQUssQ0FBQyxJQUFJO1FBQ3JCLFlBQVksRUFBRSxLQUFLLENBQUMsWUFBWTtRQUNoQyxPQUFPLEVBQUUsc0JBQXNCLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQztRQUNoRCxLQUFLLEVBQUUsc0JBQXNCLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQztRQUM1QyxNQUFNLEVBQUUsc0JBQXNCLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQztRQUM5QyxTQUFTLEVBQUUsS0FBSyxDQUFDLFNBQVM7S0FDM0IsQ0FBQztBQUNKLENBQUM7QUFjRCxpR0FBaUc7QUFDakcsTUFBTSxVQUFVLDJCQUEyQixDQUFDLFFBQWlDLEVBQUU7SUFDN0UsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDeEUsTUFBTSxJQUFJLEtBQUssQ0FBQywwQkFBMEIsQ0FBQyxDQUFDO0lBQzlDLENBQUM7SUFDRCxNQUFNLE1BQU0sR0FBOEIsRUFBRSxZQUFZLEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxDQUFDO0lBQzFGLElBQUksS0FBSyxDQUFDLFlBQVksS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLFlBQVksS0FBSyxJQUFJLEVBQUUsQ0FBQztRQUNwRSxNQUFNLElBQUksR0FBRyxZQUFZLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsRUFBRSwwQ0FBMEMsQ0FBQyxDQUFDO1FBQ2xHLElBQUksT0FBTyxJQUFJLElBQUk7WUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNqRCxNQUFNLENBQUMsWUFBWSxHQUFHLElBQUksQ0FBQyxZQUFZLENBQUM7SUFDMUMsQ0FBQztJQUNELElBQUksS0FBSyxDQUFDLEtBQUssS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLEtBQUssS0FBSyxJQUFJLEVBQUUsQ0FBQztRQUN0RCxNQUFNLFdBQVcsR0FBRyxhQUFhLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1FBQ3ZELElBQUksT0FBTyxJQUFJLFdBQVc7WUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLFdBQVcsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMvRCxNQUFNLENBQUMsS0FBSyxHQUFHLFdBQVcsQ0FBQyxLQUFLLENBQUM7SUFDbkMsQ0FBQztJQUNELElBQUksS0FBSyxDQUFDLElBQUksS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLElBQUksS0FBSyxJQUFJLEVBQUUsQ0FBQztRQUNwRCxNQUFNLE9BQU8sR0FBRyxNQUFNLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO1FBQzFDLElBQUksQ0FBQyxPQUFPO1lBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxrQ0FBa0MsQ0FBQyxDQUFDO1FBQ2xFLE1BQU0sQ0FBQyxJQUFJLEdBQUcsT0FBTyxDQUFDO0lBQ3hCLENBQUM7SUFDRCxPQUFPLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBRUQsc0VBQXNFO0FBQ3RFLE1BQU0sVUFBVSwyQkFBMkIsQ0FDekMsV0FBd0IsRUFDeEIsU0FBd0YsRUFBRTtJQUUxRixNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FDL0IsV0FBVyxDQUFDLFVBQVUsQ0FBQztRQUNyQixHQUFHLENBQUMsTUFBTSxDQUFDLFlBQVksS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ25GLEdBQUcsQ0FBQyxNQUFNLENBQUMsS0FBSyxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxLQUFLLEVBQUUsTUFBTSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7S0FDL0QsQ0FBQyxFQUNGLEVBQUUsR0FBRyxDQUFDLE1BQU0sQ0FBQyxJQUFJLEtBQUssU0FBUyxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQ2hFLENBQUM7SUFDRixPQUFPO1FBQ0wsR0FBRyxDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3JFLE1BQU0sRUFBRSxNQUFNLENBQUMsR0FBRyxDQUFDLGtDQUFrQyxDQUFDO0tBQ3ZELENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxPQUFPLENBQUMsS0FBYztJQUM3QixJQUFJLEtBQUssS0FBSyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLEdBQUcsQ0FBQztJQUN0RCxPQUFPLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztBQUN2QixDQUFDO0FBRUQsTUFBTSxVQUFVLGlCQUFpQixDQUFDLE1BQXFCO0lBQ3JELElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8seUJBQXlCLENBQUM7SUFDcEYsTUFBTSxNQUFNLEdBQUc7UUFDYixLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUNqQixNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNqQixNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNqQixZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztLQUN4QixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNaLE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUNqQztRQUNFLE1BQU0sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUM3QixLQUFLLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDckIsT0FBTyxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3RDLE9BQU8sQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztLQUNwQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FDWixDQUFDO0lBQ0YsT0FBTyxDQUFDLE1BQU0sRUFBRSxHQUFHLEtBQUssQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUN2QyxDQUFDO0FBRUQsTUFBTSwwQkFBMEIsR0FBRyxzQ0FBc0MsQ0FBQztBQUUxRSxnSEFBZ0g7QUFDaEgsK0VBQStFO0FBQy9FLGdIQUFnSDtBQUNoSCxNQUFNLGtCQUFrQixHQUFHLDZCQUE2QixDQUFDO0FBRXpELHVHQUF1RztBQUN2RyxTQUFTLGNBQWMsQ0FBQyxJQUFZO0lBQ2xDLE9BQU8sSUFBSSxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsTUFBTSxDQUFDLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsQ0FBQztBQUMzRCxDQUFDO0FBRUQ7NEZBQzRGO0FBQzVGLFNBQVMsZ0JBQWdCLENBQUMsS0FBYTtJQUNyQyxPQUFPLEtBQUssQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLE1BQU0sQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsS0FBSyxDQUFDLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsQ0FBQztBQUNqRixDQUFDO0FBRUQ7Ozs7OztHQU1HO0FBQ0gsTUFBTSxVQUFVLHdCQUF3QixDQUFDLE1BQThCO0lBQ3JFLE1BQU0sV0FBVyxHQUFHLElBQUksR0FBRyxFQUFrQixDQUFDO0lBQzlDLEtBQUssTUFBTSxLQUFLLElBQUksTUFBTSxFQUFFLENBQUM7UUFDM0IsV0FBVyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUMsV0FBVyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUM7SUFDdEUsQ0FBQztJQUNELE1BQU0sS0FBSyxHQUFHO1FBQ1osVUFBVSxrQkFBa0IsSUFBSSxjQUFjLENBQUMsNkRBQTZELENBQUMsRUFBRTtRQUMvRyxVQUFVLGtCQUFrQixVQUFVO0tBQ3ZDLENBQUM7SUFDRixLQUFLLE1BQU0sQ0FBQyxJQUFJLEVBQUUsS0FBSyxDQUFDLElBQUksQ0FBQyxHQUFHLFdBQVcsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ2hHLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxrQkFBa0IsVUFBVSxnQkFBZ0IsQ0FBQyxJQUFJLENBQUMsTUFBTSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQ2pGLENBQUM7SUFDRCxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDO0FBQ2pDLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBSSxPQUE4QixFQUFFLEdBQW9DO0lBQzlGLE1BQU0sVUFBVSxHQUFHLE9BQU8sQ0FBQyxlQUFlLEtBQUssU0FBUyxDQUFDO0lBQ3pELE1BQU0sV0FBVyxHQUFHLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUMsRUFBRSxDQUFDO0lBQ25FLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLFdBQVcsQ0FBQyxDQUFDO0lBQzFCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxVQUFVO1lBQUUsV0FBVyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3RDLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGFBQWEsQ0FBQyxJQUFjLEVBQUUsVUFBaUMsRUFBRTtJQUMvRSxNQUFNLE1BQU0sR0FBRyxtQkFBbUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN6QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sZUFBZSxDQUFDLE9BQU8sRUFBRSxDQUFDLFdBQVcsRUFBRSxFQUFFO1lBQzlDLE1BQU0sTUFBTSxHQUFHLGtCQUFrQixDQUMvQixXQUFXLENBQUMsVUFBVSxDQUFDO2dCQUNyQixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLEtBQUssRUFBRSxNQUFNLENBQUMsS0FBSzthQUNwQixDQUFDLEVBQ0YsRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUksRUFBRSxDQUN0QixDQUFDO1lBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE1BQU0sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ25ELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGlCQUFpQixDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7WUFDekMsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLGdCQUFnQixDQUFDLElBQWMsRUFBRSxVQUFpQyxFQUFFO0lBQ2xGLElBQUksSUFBSSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNwQixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSwwQkFBMEIsQ0FBQyxDQUFDO0lBQzFFLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGVBQWUsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxXQUFXLEVBQUUsRUFBRTtZQUM5Qyx5R0FBeUc7WUFDekcsc0ZBQXNGO1lBQ3RGLE9BQU8sQ0FBQyxHQUFHLENBQUMsd0JBQXdCLENBQUMsV0FBVyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQztZQUMxRSxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ3ZFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFlBQVksQ0FBQyxVQUE4QixFQUFFLElBQWMsRUFBRSxVQUFpQyxFQUFFO0lBQzlHLElBQUksVUFBVSxLQUFLLE1BQU07UUFBRSxPQUFPLGFBQWEsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDL0QsSUFBSSxVQUFVLEtBQUssU0FBUztRQUFFLE9BQU8sZ0JBQWdCLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3JFLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLDhCQUE4QixVQUFVLElBQUksRUFBRSxLQUFLLGlCQUFpQixFQUFFLENBQUMsQ0FBQztBQUN0SCxDQUFDIn0=

--- a/packages/loopover-miner/lib/event-ledger-cli.ts
+++ b/packages/loopover-miner/lib/event-ledger-cli.ts
@@ -1,0 +1,314 @@
+import { initEventLedger } from "./event-ledger.js";
+import type { EventLedger, LedgerEntry } from "./event-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
+
+const LEDGER_LIST_USAGE =
+  "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
+
+export type ParsedLedgerListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+      since: number | null;
+      type: string | null;
+    }
+  | { error: string };
+
+export type EventLedgerCliOptions = { initEventLedger?: () => EventLedger };
+
+type ParsedRepoArg = { repoFullName: string } | { error: string };
+type ParsedSinceArg = { since: number } | { error: string };
+
+function parseRepoArg(value: string | undefined, usage: string): ParsedRepoArg {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+function parseSinceArg(value: string): ParsedSinceArg {
+  const since = Number(value);
+  if (!Number.isInteger(since) || since < 0) {
+    return { error: "since must be a non-negative integer seq cursor." };
+  }
+  return { since };
+}
+
+export function parseLedgerListArgs(args: string[]): ParsedLedgerListArgs {
+  const options: { json: boolean; repoFullName: string | null; since: number | null; type: string | null } = {
+    json: false,
+    repoFullName: null,
+    since: null,
+    type: null,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) return { error: LEDGER_LIST_USAGE };
+      const repo = parseRepoArg(repoArg, LEDGER_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token === "--since") {
+      const sinceArg = args[index + 1];
+      if (!sinceArg || sinceArg.startsWith("--")) return { error: LEDGER_LIST_USAGE };
+      const parsedSince = parseSinceArg(sinceArg);
+      if ("error" in parsedSince) return parsedSince;
+      options.since = parsedSince.since;
+      index += 1;
+      continue;
+    }
+    if (token === "--type") {
+      const type = args[index + 1];
+      if (!type || type.startsWith("-")) return { error: LEDGER_LIST_USAGE };
+      options.type = type.trim();
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length > 0) return { error: LEDGER_LIST_USAGE };
+  return options;
+}
+
+export function filterLedgerEvents(
+  events: LedgerEntry[],
+  options: { type?: string | null } = {},
+): LedgerEntry[] {
+  if (!Array.isArray(events)) return [];
+  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+  if (!type) return events;
+  return events.filter((entry) => entry.type === type);
+}
+
+/** Metadata-only audit-feed columns exposed by the MCP tool (#5158). */
+export const AUDIT_FEED_ENTRY_FIELDS = Object.freeze([
+  "eventType",
+  "repoFullName",
+  "outcome",
+  "actor",
+  "detail",
+  "createdAt",
+] as const);
+
+function optionalMetadataString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+type AuditFeedEntry = {
+  eventType: string;
+  repoFullName: string | null;
+  outcome: string | null;
+  actor: string | null;
+  detail: string | null;
+  createdAt: string;
+};
+
+/** Project one ledger row to the public, metadata-only audit-feed shape — never returns payload_json. */
+export function projectLedgerEventToAuditFeedEntry(entry: LedgerEntry): AuditFeedEntry {
+  const payload: Record<string, unknown> =
+    entry?.payload && typeof entry.payload === "object" && !Array.isArray(entry.payload) ? entry.payload : {};
+  return {
+    eventType: entry.type,
+    repoFullName: entry.repoFullName,
+    outcome: optionalMetadataString(payload.outcome),
+    actor: optionalMetadataString(payload.actor),
+    detail: optionalMetadataString(payload.detail),
+    createdAt: entry.createdAt,
+  };
+}
+
+export type AuditFeedMcpFilterInput = {
+  repoFullName?: string | null;
+  since?: number | null;
+  type?: string | null;
+};
+
+type NormalizedAuditFeedFilter = {
+  repoFullName: string | null;
+  since: number | null;
+  type: string | null;
+};
+
+/** Normalize optional MCP/JSON filter args into the shape `ledger list` already uses (#5158). */
+export function normalizeAuditFeedMcpFilter(input: AuditFeedMcpFilterInput = {}): NormalizedAuditFeedFilter {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("filter must be an object");
+  }
+  const filter: NormalizedAuditFeedFilter = { repoFullName: null, since: null, type: null };
+  if (input.repoFullName !== undefined && input.repoFullName !== null) {
+    const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
+    if ("error" in repo) throw new Error(repo.error);
+    filter.repoFullName = repo.repoFullName;
+  }
+  if (input.since !== undefined && input.since !== null) {
+    const parsedSince = parseSinceArg(String(input.since));
+    if ("error" in parsedSince) throw new Error(parsedSince.error);
+    filter.since = parsedSince.since;
+  }
+  if (input.type !== undefined && input.type !== null) {
+    const trimmed = String(input.type).trim();
+    if (!trimmed) throw new Error("type must be a non-empty string.");
+    filter.type = trimmed;
+  }
+  return filter;
+}
+
+/** Read-only audit feed shared by the MCP audit-feed tool (#5158). */
+export function collectEventLedgerAuditFeed(
+  eventLedger: EventLedger,
+  filter: { repoFullName?: string | null; since?: number | null; type?: string | null } = {},
+): { repoFullName?: string; events: AuditFeedEntry[] } {
+  const events = filterLedgerEvents(
+    eventLedger.readEvents({
+      ...(filter.repoFullName !== undefined ? { repoFullName: filter.repoFullName } : {}),
+      ...(filter.since !== undefined ? { since: filter.since } : {}),
+    }),
+    { ...(filter.type !== undefined ? { type: filter.type } : {}) },
+  );
+  return {
+    ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
+    events: events.map(projectLedgerEventToAuditFeedEntry),
+  };
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderLedgerTable(events: LedgerEntry[]): string {
+  if (!Array.isArray(events) || events.length === 0) return "no event ledger entries";
+  const header = [
+    "seq".padStart(4),
+    "type".padEnd(20),
+    "repo".padEnd(24),
+    "created-at".padEnd(24),
+  ].join(" ");
+  const lines = events.map((entry) =>
+    [
+      String(entry.seq).padStart(4),
+      entry.type.padEnd(20),
+      display(entry.repoFullName).padEnd(24),
+      display(entry.createdAt).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+const EVENT_LEDGER_METRICS_USAGE = "Usage: loopover-miner ledger metrics";
+
+// Prometheus metric name for the per-type event-ledger counter. Mirrors the `loopover_miner_*_total` naming and
+// the HELP/TYPE/label conventions of the engine's renderMinerPredictionMetrics
+// (packages/loopover-engine/src/miner-prediction-metrics.ts) rather than importing across the package boundary.
+const MINER_EVENTS_TOTAL = "loopover_miner_events_total";
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping — backslash, double-quote, newline — so an arbitrary event `type` string can
+ *  never break the metric line (mirrors miner-prediction-metrics.ts's escapeLabelValue). */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/**
+ * Render event-ledger activity as Prometheus text-exposition counters: one `loopover_miner_events_total{type}`
+ * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
+ * `ledger list --json` (#4841). Pure + side-effect-free — the caller supplies the rows and prints the result;
+ * deterministic (series emitted in sorted type order); always emits HELP/TYPE so an empty ledger is still a
+ * well-formed exposition document.
+ */
+export function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string {
+  const totalByType = new Map<string, number>();
+  for (const entry of events) {
+    totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
+  }
+  const lines = [
+    `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
+    `# TYPE ${MINER_EVENTS_TOTAL} counter`,
+  ];
+  for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function withEventLedger<T>(options: EventLedgerCliOptions, run: (eventLedger: EventLedger) => T): T {
+  const ownsLedger = options.initEventLedger === undefined;
+  const eventLedger = (options.initEventLedger ?? initEventLedger)();
+  try {
+    return run(eventLedger);
+  } finally {
+    if (ownsLedger) eventLedger.close();
+  }
+}
+
+export function runLedgerList(args: string[], options: EventLedgerCliOptions = {}): number {
+  const parsed = parseLedgerListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withEventLedger(options, (eventLedger) => {
+      const events = filterLedgerEvents(
+        eventLedger.readEvents({
+          repoFullName: parsed.repoFullName,
+          since: parsed.since,
+        }),
+        { type: parsed.type },
+      );
+      if (parsed.json) {
+        console.log(JSON.stringify({ events }, null, 2));
+      } else {
+        console.log(renderLedgerTable(events));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runLedgerMetrics(args: string[], options: EventLedgerCliOptions = {}): number {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
+  }
+
+  try {
+    return withEventLedger(options, (eventLedger) => {
+      // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+      console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}
+
+export function runLedgerCli(subcommand: string | undefined, args: string[], options: EventLedgerCliOptions = {}): number {
+  if (subcommand === "list") return runLedgerList(args, options);
+  if (subcommand === "metrics") return runLedgerMetrics(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
+}

--- a/packages/loopover-miner/lib/governor-ledger-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-ledger-cli.d.ts
@@ -1,32 +1,21 @@
-import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
 import type { GovernorPauseCliOptions } from "./governor-pause-cli.js";
-
+import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
 export type GovernorLedgerEventType = "allowed" | "denied" | "throttled" | "kill_switch";
-
-export type ParsedGovernorListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-      type: GovernorLedgerEventType | null;
-    }
-  | { error: string };
-
-export function parseGovernorListArgs(args: string[]): ParsedGovernorListArgs;
-
-export function filterGovernorEvents(
-  events: GovernorLedgerEntry[],
-  options?: { type?: string | null },
-): GovernorLedgerEntry[];
-
-export function renderGovernorTable(events: GovernorLedgerEntry[]): string;
-
-export function runGovernorList(
-  args: string[],
-  options?: { initGovernorLedger?: () => GovernorLedger },
-): Promise<number>;
-
-export function runGovernorCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { initGovernorLedger?: () => GovernorLedger; nowMs?: number } & GovernorPauseCliOptions,
-): Promise<number>;
+export type ParsedGovernorListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+    type: GovernorLedgerEventType | null;
+} | {
+    error: string;
+};
+export type GovernorCliOptions = {
+    initGovernorLedger?: () => GovernorLedger;
+    nowMs?: number;
+} & GovernorPauseCliOptions;
+export declare function parseGovernorListArgs(args: string[]): ParsedGovernorListArgs;
+export declare function filterGovernorEvents(events: GovernorLedgerEntry[], options?: {
+    type?: string | null;
+}): GovernorLedgerEntry[];
+export declare function renderGovernorTable(events: GovernorLedgerEntry[]): string;
+export declare function runGovernorList(args: string[], options?: GovernorCliOptions): Promise<number>;
+export declare function runGovernorCli(subcommand: string | undefined, args: string[], options?: GovernorCliOptions): Promise<number>;

--- a/packages/loopover-miner/lib/governor-ledger-cli.js
+++ b/packages/loopover-miner/lib/governor-ledger-cli.js
@@ -1,158 +1,157 @@
 import { runGovernorPause, runGovernorResume, runGovernorStatus } from "./governor-pause-cli.js";
 import { runGovernorMetrics } from "./governor-metrics-cli.js";
-
 /** Must match `GOVERNOR_LEDGER_EVENT_TYPES` in `@loopover/engine`. */
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
-  "allowed",
-  "denied",
-  "throttled",
-  "kill_switch",
+    "allowed",
+    "denied",
+    "throttled",
+    "kill_switch",
 ]);
-
-const GOVERNOR_LIST_USAGE =
-  "Usage: loopover-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]";
-
+const GOVERNOR_LIST_USAGE = "Usage: loopover-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]";
 const GOVERNOR_SUBCOMMAND_USAGE = [
-  GOVERNOR_LIST_USAGE,
-  "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
-  "       loopover-miner governor resume [--dry-run] [--json]",
-  "       loopover-miner governor status [--json]",
-  "       loopover-miner governor metrics",
+    GOVERNOR_LIST_USAGE,
+    "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
+    "       loopover-miner governor resume [--dry-run] [--json]",
+    "       loopover-miner governor status [--json]",
+    "       loopover-miner governor metrics",
 ].join("\n");
-
-function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+// The sole caller (the --repo branch of parseGovernorListArgs below) always checks `repoArg` is a
+// truthy, non-flag-looking string before calling this, so `value` is never empty here.
+function parseRepoArg(value) {
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parseGovernorListArgs(args) {
-  const options = { json: false, repoFullName: null, type: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        repoFullName: null,
+        type: null,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-"))
+                return { error: GOVERNOR_LIST_USAGE };
+            const repo = parseRepoArg(repoArg);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token === "--type") {
+            const type = args[index + 1];
+            if (!type || type.startsWith("-"))
+                return { error: GOVERNOR_LIST_USAGE };
+            const trimmed = type.trim();
+            if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed)) {
+                return {
+                    error: `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
+                };
+            }
+            options.type = trimmed;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
-      const repo = parseRepoArg(repoArg, GOVERNOR_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
-    }
-    if (token === "--type") {
-      const type = args[index + 1];
-      if (!type || type.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
-      const trimmed = type.trim();
-      if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed)) {
-        return {
-          error: `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
-        };
-      }
-      options.type = trimmed;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length > 0) return { error: GOVERNOR_LIST_USAGE };
-  return options;
+    if (positional.length > 0)
+        return { error: GOVERNOR_LIST_USAGE };
+    return options;
 }
-
 export function filterGovernorEvents(events, options = {}) {
-  if (!Array.isArray(events)) return [];
-  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
-  if (!type) return events;
-  return events.filter((entry) => entry.eventType === type);
+    if (!Array.isArray(events))
+        return [];
+    const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+    if (!type)
+        return events;
+    return events.filter((entry) => entry.eventType === type);
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderGovernorTable(events) {
-  if (!Array.isArray(events) || events.length === 0) return "no governor ledger entries";
-  const header = [
-    "id".padStart(4),
-    "type".padEnd(12),
-    "repo".padEnd(24),
-    "action".padEnd(10),
-    "decision".padEnd(10),
-    "ts".padEnd(24),
-  ].join(" ");
-  const lines = events.map((entry) =>
-    [
-      String(entry.id).padStart(4),
-      entry.eventType.padEnd(12),
-      display(entry.repoFullName).padEnd(24),
-      entry.actionClass.padEnd(10),
-      entry.decision.padEnd(10),
-      display(entry.ts).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(events) || events.length === 0)
+        return "no governor ledger entries";
+    const header = [
+        "id".padStart(4),
+        "type".padEnd(12),
+        "repo".padEnd(24),
+        "action".padEnd(10),
+        "decision".padEnd(10),
+        "ts".padEnd(24),
+    ].join(" ");
+    const lines = events.map((entry) => [
+        String(entry.id).padStart(4),
+        entry.eventType.padEnd(12),
+        display(entry.repoFullName).padEnd(24),
+        entry.actionClass.padEnd(10),
+        entry.decision.padEnd(10),
+        display(entry.ts).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 async function withGovernorLedger(options, run) {
-  const ownsLedger = options.initGovernorLedger === undefined;
-  const initGovernorLedger =
-    options.initGovernorLedger ?? (await import("./governor-ledger.js")).initGovernorLedger;
-  const governorLedger = initGovernorLedger();
-  try {
-    return run(governorLedger);
-  } finally {
-    if (ownsLedger) governorLedger.close();
-  }
+    const ownsLedger = options.initGovernorLedger === undefined;
+    const initGovernorLedger = options.initGovernorLedger ?? (await import("./governor-ledger.js")).initGovernorLedger;
+    const governorLedger = initGovernorLedger();
+    try {
+        return run(governorLedger);
+    }
+    finally {
+        if (ownsLedger)
+            governorLedger.close();
+    }
 }
-
 export async function runGovernorList(args, options = {}) {
-  const parsed = parseGovernorListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return await withGovernorLedger(options, (governorLedger) => {
-      const events = filterGovernorEvents(
-        governorLedger.readGovernorEvents({
-          repoFullName: parsed.repoFullName,
-        }),
-        { type: parsed.type },
-      );
-      if (parsed.json) {
-        console.log(JSON.stringify({ events }, null, 2));
-      } else {
-        console.log(renderGovernorTable(events));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseGovernorListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return await withGovernorLedger(options, (governorLedger) => {
+            const events = filterGovernorEvents(governorLedger.readGovernorEvents({
+                repoFullName: parsed.repoFullName,
+            }), { type: parsed.type });
+            if (parsed.json) {
+                console.log(JSON.stringify({ events }, null, 2));
+            }
+            else {
+                console.log(renderGovernorTable(events));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runGovernorList(args, options);
-  if (subcommand === "pause") return runGovernorPause(args, options);
-  if (subcommand === "resume") return runGovernorResume(args, options);
-  if (subcommand === "status") return runGovernorStatus(args, options);
-  if (subcommand === "metrics") return runGovernorMetrics(args, options);
-  return reportCliFailure(
-    argsWantJson(args),
-    `Unknown governor subcommand: ${subcommand ?? ""}.\n${GOVERNOR_SUBCOMMAND_USAGE}`,
-  );
+    if (subcommand === "list")
+        return runGovernorList(args, options);
+    if (subcommand === "pause")
+        return runGovernorPause(args, options);
+    if (subcommand === "resume")
+        return runGovernorResume(args, options);
+    if (subcommand === "status")
+        return runGovernorStatus(args, options);
+    if (subcommand === "metrics")
+        return runGovernorMetrics(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown governor subcommand: ${subcommand ?? ""}.\n${GOVERNOR_SUBCOMMAND_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItbGVkZ2VyLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImdvdmVybm9yLWxlZGdlci1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGdCQUFnQixFQUFFLGlCQUFpQixFQUFFLGlCQUFpQixFQUFFLE1BQU0seUJBQXlCLENBQUM7QUFFakcsT0FBTyxFQUFFLGtCQUFrQixFQUFFLE1BQU0sMkJBQTJCLENBQUM7QUFFL0Qsc0VBQXNFO0FBQ3RFLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUtsRixNQUFNLDJCQUEyQixHQUF1QyxNQUFNLENBQUMsTUFBTSxDQUFDO0lBQ3BGLFNBQVM7SUFDVCxRQUFRO0lBQ1IsV0FBVztJQUNYLGFBQWE7Q0FDZCxDQUFDLENBQUM7QUFFSCxNQUFNLG1CQUFtQixHQUN2QixrSEFBa0gsQ0FBQztBQUVySCxNQUFNLHlCQUF5QixHQUFHO0lBQ2hDLG1CQUFtQjtJQUNuQiw2RUFBNkU7SUFDN0UsNERBQTREO0lBQzVELGdEQUFnRDtJQUNoRCx3Q0FBd0M7Q0FDekMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFpQmIsa0dBQWtHO0FBQ2xHLHVGQUF1RjtBQUN2RixTQUFTLFlBQVksQ0FBQyxLQUFhO0lBQ2pDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM3QixNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2hELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVMsRUFBRSxDQUFDO1FBQzNDLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxNQUFNLFVBQVUscUJBQXFCLENBQUMsSUFBYztJQUNsRCxNQUFNLE9BQU8sR0FBeUY7UUFDcEcsSUFBSSxFQUFFLEtBQUs7UUFDWCxZQUFZLEVBQUUsSUFBSTtRQUNsQixJQUFJLEVBQUUsSUFBSTtLQUNYLENBQUM7SUFDRixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDaEMsSUFBSSxDQUFDLE9BQU8sSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixFQUFFLENBQUM7WUFDL0UsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sQ0FBQyxDQUFDO1lBQ25DLElBQUksT0FBTyxJQUFJLElBQUk7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFDakMsT0FBTyxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsWUFBWSxDQUFDO1lBQ3pDLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sSUFBSSxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDN0IsSUFBSSxDQUFDLElBQUksSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixFQUFFLENBQUM7WUFDekUsTUFBTSxPQUFPLEdBQUcsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQzVCLElBQUksQ0FBQywyQkFBMkIsQ0FBQyxRQUFRLENBQUMsT0FBa0MsQ0FBQyxFQUFFLENBQUM7Z0JBQzlFLE9BQU87b0JBQ0wsS0FBSyxFQUFFLGlCQUFpQixPQUFPLHFCQUFxQiwyQkFBMkIsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLEdBQUc7aUJBQzlGLENBQUM7WUFDSixDQUFDO1lBQ0QsT0FBTyxDQUFDLElBQUksR0FBRyxPQUFrQyxDQUFDO1lBQ2xELEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQ3hFLFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsRUFBRSxDQUFDO0lBQ2pFLE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxNQUFNLFVBQVUsb0JBQW9CLENBQ2xDLE1BQTZCLEVBQzdCLFVBQW9DLEVBQUU7SUFFdEMsSUFBSSxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDO1FBQUUsT0FBTyxFQUFFLENBQUM7SUFDdEMsTUFBTSxJQUFJLEdBQUcsT0FBTyxPQUFPLENBQUMsSUFBSSxLQUFLLFFBQVEsSUFBSSxPQUFPLENBQUMsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDbEcsSUFBSSxDQUFDLElBQUk7UUFBRSxPQUFPLE1BQU0sQ0FBQztJQUN6QixPQUFPLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLEtBQUssQ0FBQyxTQUFTLEtBQUssSUFBSSxDQUFDLENBQUM7QUFDNUQsQ0FBQztBQUVELFNBQVMsT0FBTyxDQUFDLEtBQWM7SUFDN0IsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxHQUFHLENBQUM7SUFDdEQsT0FBTyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDdkIsQ0FBQztBQUVELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxNQUE2QjtJQUMvRCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsSUFBSSxNQUFNLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLDRCQUE0QixDQUFDO0lBQ3ZGLE1BQU0sTUFBTSxHQUFHO1FBQ2IsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDaEIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsUUFBUSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkIsVUFBVSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDckIsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDaEIsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDWixNQUFNLEtBQUssR0FBRyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FDakM7UUFDRSxNQUFNLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDNUIsS0FBSyxDQUFDLFNBQVMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzFCLE9BQU8sQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN0QyxLQUFLLENBQUMsV0FBVyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDNUIsS0FBSyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3pCLE9BQU8sQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztLQUM3QixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FDWixDQUFDO0lBQ0YsT0FBTyxDQUFDLE1BQU0sRUFBRSxHQUFHLEtBQUssQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUN2QyxDQUFDO0FBRUQsS0FBSyxVQUFVLGtCQUFrQixDQUMvQixPQUEyQixFQUMzQixHQUEwQztJQUUxQyxNQUFNLFVBQVUsR0FBRyxPQUFPLENBQUMsa0JBQWtCLEtBQUssU0FBUyxDQUFDO0lBQzVELE1BQU0sa0JBQWtCLEdBQ3RCLE9BQU8sQ0FBQyxrQkFBa0IsSUFBSSxDQUFDLE1BQU0sTUFBTSxDQUFDLHNCQUFzQixDQUFDLENBQUMsQ0FBQyxrQkFBa0IsQ0FBQztJQUMxRixNQUFNLGNBQWMsR0FBRyxrQkFBa0IsRUFBRSxDQUFDO0lBQzVDLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLGNBQWMsQ0FBQyxDQUFDO0lBQzdCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxVQUFVO1lBQUUsY0FBYyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3pDLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxlQUFlLENBQUMsSUFBYyxFQUFFLFVBQThCLEVBQUU7SUFDcEYsTUFBTSxNQUFNLEdBQUcscUJBQXFCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDM0MsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLE1BQU0sa0JBQWtCLENBQUMsT0FBTyxFQUFFLENBQUMsY0FBYyxFQUFFLEVBQUU7WUFDMUQsTUFBTSxNQUFNLEdBQUcsb0JBQW9CLENBQ2pDLGNBQWMsQ0FBQyxrQkFBa0IsQ0FBQztnQkFDaEMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO2FBQ2xDLENBQUMsRUFDRixFQUFFLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQ3RCLENBQUM7WUFDRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsTUFBTSxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbkQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsbUJBQW1CLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQztZQUMzQyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLGNBQWMsQ0FDbEMsVUFBOEIsRUFDOUIsSUFBYyxFQUNkLFVBQThCLEVBQUU7SUFFaEMsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sZUFBZSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNqRSxJQUFJLFVBQVUsS0FBSyxPQUFPO1FBQUUsT0FBTyxnQkFBZ0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDbkUsSUFBSSxVQUFVLEtBQUssUUFBUTtRQUFFLE9BQU8saUJBQWlCLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3JFLElBQUksVUFBVSxLQUFLLFFBQVE7UUFBRSxPQUFPLGlCQUFpQixDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNyRSxJQUFJLFVBQVUsS0FBSyxTQUFTO1FBQUUsT0FBTyxrQkFBa0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDdkUsT0FBTyxnQkFBZ0IsQ0FDckIsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUNsQixnQ0FBZ0MsVUFBVSxJQUFJLEVBQUUsTUFBTSx5QkFBeUIsRUFBRSxDQUNsRixDQUFDO0FBQ0osQ0FBQyJ9

--- a/packages/loopover-miner/lib/governor-ledger-cli.ts
+++ b/packages/loopover-miner/lib/governor-ledger-cli.ts
@@ -1,0 +1,192 @@
+import { runGovernorPause, runGovernorResume, runGovernorStatus } from "./governor-pause-cli.js";
+import type { GovernorPauseCliOptions } from "./governor-pause-cli.js";
+import { runGovernorMetrics } from "./governor-metrics-cli.js";
+
+/** Must match `GOVERNOR_LEDGER_EVENT_TYPES` in `@loopover/engine`. */
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
+
+export type GovernorLedgerEventType = "allowed" | "denied" | "throttled" | "kill_switch";
+
+const GOVERNOR_LEDGER_EVENT_TYPES: readonly GovernorLedgerEventType[] = Object.freeze([
+  "allowed",
+  "denied",
+  "throttled",
+  "kill_switch",
+]);
+
+const GOVERNOR_LIST_USAGE =
+  "Usage: loopover-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]";
+
+const GOVERNOR_SUBCOMMAND_USAGE = [
+  GOVERNOR_LIST_USAGE,
+  "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
+  "       loopover-miner governor resume [--dry-run] [--json]",
+  "       loopover-miner governor status [--json]",
+  "       loopover-miner governor metrics",
+].join("\n");
+
+export type ParsedGovernorListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+      type: GovernorLedgerEventType | null;
+    }
+  | { error: string };
+
+type ParsedRepoArg = { repoFullName: string } | { error: string };
+
+export type GovernorCliOptions = {
+  initGovernorLedger?: () => GovernorLedger;
+  nowMs?: number;
+} & GovernorPauseCliOptions;
+
+// The sole caller (the --repo branch of parseGovernorListArgs below) always checks `repoArg` is a
+// truthy, non-flag-looking string before calling this, so `value` is never empty here.
+function parseRepoArg(value: string): ParsedRepoArg {
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parseGovernorListArgs(args: string[]): ParsedGovernorListArgs {
+  const options: { json: boolean; repoFullName: string | null; type: GovernorLedgerEventType | null } = {
+    json: false,
+    repoFullName: null,
+    type: null,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
+      const repo = parseRepoArg(repoArg);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token === "--type") {
+      const type = args[index + 1];
+      if (!type || type.startsWith("-")) return { error: GOVERNOR_LIST_USAGE };
+      const trimmed = type.trim();
+      if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed as GovernorLedgerEventType)) {
+        return {
+          error: `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
+        };
+      }
+      options.type = trimmed as GovernorLedgerEventType;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length > 0) return { error: GOVERNOR_LIST_USAGE };
+  return options;
+}
+
+export function filterGovernorEvents(
+  events: GovernorLedgerEntry[],
+  options: { type?: string | null } = {},
+): GovernorLedgerEntry[] {
+  if (!Array.isArray(events)) return [];
+  const type = typeof options.type === "string" && options.type.trim() ? options.type.trim() : null;
+  if (!type) return events;
+  return events.filter((entry) => entry.eventType === type);
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderGovernorTable(events: GovernorLedgerEntry[]): string {
+  if (!Array.isArray(events) || events.length === 0) return "no governor ledger entries";
+  const header = [
+    "id".padStart(4),
+    "type".padEnd(12),
+    "repo".padEnd(24),
+    "action".padEnd(10),
+    "decision".padEnd(10),
+    "ts".padEnd(24),
+  ].join(" ");
+  const lines = events.map((entry) =>
+    [
+      String(entry.id).padStart(4),
+      entry.eventType.padEnd(12),
+      display(entry.repoFullName).padEnd(24),
+      entry.actionClass.padEnd(10),
+      entry.decision.padEnd(10),
+      display(entry.ts).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+async function withGovernorLedger<T>(
+  options: GovernorCliOptions,
+  run: (governorLedger: GovernorLedger) => T,
+): Promise<T> {
+  const ownsLedger = options.initGovernorLedger === undefined;
+  const initGovernorLedger =
+    options.initGovernorLedger ?? (await import("./governor-ledger.js")).initGovernorLedger;
+  const governorLedger = initGovernorLedger();
+  try {
+    return run(governorLedger);
+  } finally {
+    if (ownsLedger) governorLedger.close();
+  }
+}
+
+export async function runGovernorList(args: string[], options: GovernorCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return await withGovernorLedger(options, (governorLedger) => {
+      const events = filterGovernorEvents(
+        governorLedger.readGovernorEvents({
+          repoFullName: parsed.repoFullName,
+        }),
+        { type: parsed.type },
+      );
+      if (parsed.json) {
+        console.log(JSON.stringify({ events }, null, 2));
+      } else {
+        console.log(renderGovernorTable(events));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorCli(
+  subcommand: string | undefined,
+  args: string[],
+  options: GovernorCliOptions = {},
+): Promise<number> {
+  if (subcommand === "list") return runGovernorList(args, options);
+  if (subcommand === "pause") return runGovernorPause(args, options);
+  if (subcommand === "resume") return runGovernorResume(args, options);
+  if (subcommand === "status") return runGovernorStatus(args, options);
+  if (subcommand === "metrics") return runGovernorMetrics(args, options);
+  return reportCliFailure(
+    argsWantJson(args),
+    `Unknown governor subcommand: ${subcommand ?? ""}.\n${GOVERNOR_SUBCOMMAND_USAGE}`,
+  );
+}

--- a/packages/loopover-miner/lib/plan-store-cli.d.ts
+++ b/packages/loopover-miner/lib/plan-store-cli.d.ts
@@ -1,37 +1,22 @@
 import type { PlanRecord, PlanStatus, PlanStore } from "./plan-store.js";
-
-export type ParsedPlanListArgs =
-  | {
-      json: boolean;
-      status: PlanStatus | null;
-    }
-  | { error: string };
-
-export type ParsedPlanShowArgs =
-  | {
-      planId: string;
-      json: boolean;
-    }
-  | { error: string };
-
-export function parsePlanListArgs(args: string[]): ParsedPlanListArgs;
-
-export function parsePlanShowArgs(args: string[]): ParsedPlanShowArgs;
-
-export function renderPlanTable(plans: PlanRecord[]): string;
-
-export function runPlanList(
-  args: string[],
-  options?: { openPlanStore?: () => PlanStore },
-): number;
-
-export function runPlanShow(
-  args: string[],
-  options?: { openPlanStore?: () => PlanStore },
-): number;
-
-export function runPlanCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: { openPlanStore?: () => PlanStore },
-): number;
+export type ParsedPlanListArgs = {
+    json: boolean;
+    status: PlanStatus | null;
+} | {
+    error: string;
+};
+export type ParsedPlanShowArgs = {
+    planId: string;
+    json: boolean;
+} | {
+    error: string;
+};
+export type PlanCliOptions = {
+    openPlanStore?: () => PlanStore;
+};
+export declare function parsePlanListArgs(args: string[]): ParsedPlanListArgs;
+export declare function parsePlanShowArgs(args: string[]): ParsedPlanShowArgs;
+export declare function renderPlanTable(plans: PlanRecord[]): string;
+export declare function runPlanList(args: string[], options?: PlanCliOptions): number;
+export declare function runPlanShow(args: string[], options?: PlanCliOptions): number;
+export declare function runPlanCli(subcommand: string | undefined, args: string[], options?: PlanCliOptions): number;

--- a/packages/loopover-miner/lib/plan-store-cli.js
+++ b/packages/loopover-miner/lib/plan-store-cli.js
@@ -1,151 +1,147 @@
 import { PLAN_STATUSES, openPlanStore } from "./plan-store.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
-const PLAN_LIST_USAGE =
-  "Usage: loopover-miner plan list [--status pending|running|completed|failed] [--json]";
+const PLAN_LIST_USAGE = "Usage: loopover-miner plan list [--status pending|running|completed|failed] [--json]";
 const PLAN_SHOW_USAGE = "Usage: loopover-miner plan show <planId> [--json]";
-
 function parseJsonFlag(args) {
-  const options = { json: false };
-  const positional = [];
-
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false };
+    const positional = [];
+    for (const token of args) {
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  return { positional, ...options };
+    return { positional, ...options };
 }
-
 export function parsePlanListArgs(args) {
-  const options = { json: false, status: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, status: null };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--status") {
+            const status = args[index + 1];
+            if (!status || status.startsWith("-"))
+                return { error: PLAN_LIST_USAGE };
+            if (!PLAN_STATUSES.includes(status)) {
+                return { error: `Invalid status: ${status}. Expected one of ${PLAN_STATUSES.join(", ")}.` };
+            }
+            options.status = status;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    if (token === "--status") {
-      const status = args[index + 1];
-      if (!status || status.startsWith("-")) return { error: PLAN_LIST_USAGE };
-      if (!PLAN_STATUSES.includes(status)) {
-        return { error: `Invalid status: ${status}. Expected one of ${PLAN_STATUSES.join(", ")}.` };
-      }
-      options.status = status;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length > 0) return { error: PLAN_LIST_USAGE };
-  return options;
+    if (positional.length > 0)
+        return { error: PLAN_LIST_USAGE };
+    return options;
 }
-
 export function parsePlanShowArgs(args) {
-  const parsed = parseJsonFlag(args);
-  if ("error" in parsed) return parsed;
-  if (parsed.positional.length !== 1) return { error: PLAN_SHOW_USAGE };
-
-  const planId = parsed.positional[0]?.trim();
-  if (!planId) return { error: PLAN_SHOW_USAGE };
-
-  return {
-    planId,
-    json: parsed.json,
-  };
+    const parsed = parseJsonFlag(args);
+    if ("error" in parsed)
+        return parsed;
+    if (parsed.positional.length !== 1)
+        return { error: PLAN_SHOW_USAGE };
+    const planId = parsed.positional[0]?.trim();
+    if (!planId)
+        return { error: PLAN_SHOW_USAGE };
+    return {
+        planId,
+        json: parsed.json,
+    };
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderPlanTable(plans) {
-  if (!Array.isArray(plans) || plans.length === 0) return "no saved plans";
-  const header = [
-    "plan-id".padEnd(20),
-    "status".padEnd(10),
-    "steps".padStart(5),
-    "updated-at".padEnd(24),
-  ].join(" ");
-  const lines = plans.map((record) =>
-    [
-      record.planId.padEnd(20),
-      record.status.padEnd(10),
-      String(record.plan.steps.length).padStart(5),
-      display(record.updatedAt).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(plans) || plans.length === 0)
+        return "no saved plans";
+    const header = [
+        "plan-id".padEnd(20),
+        "status".padEnd(10),
+        "steps".padStart(5),
+        "updated-at".padEnd(24),
+    ].join(" ");
+    const lines = plans.map((record) => [
+        record.planId.padEnd(20),
+        record.status.padEnd(10),
+        String(record.plan.steps.length).padStart(5),
+        display(record.updatedAt).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 function withPlanStore(options, run) {
-  const ownsStore = options.openPlanStore === undefined;
-  const planStore = (options.openPlanStore ?? openPlanStore)();
-  try {
-    return run(planStore);
-  } finally {
-    if (ownsStore) planStore.close();
-  }
+    const ownsStore = options.openPlanStore === undefined;
+    const planStore = (options.openPlanStore ?? openPlanStore)();
+    try {
+        return run(planStore);
+    }
+    finally {
+        if (ownsStore)
+            planStore.close();
+    }
 }
-
 export function runPlanList(args, options = {}) {
-  const parsed = parsePlanListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withPlanStore(options, (planStore) => {
-      const plans = planStore.listPlans({ status: parsed.status });
-      if (parsed.json) {
-        console.log(JSON.stringify({ plans }, null, 2));
-      } else {
-        console.log(renderPlanTable(plans));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parsePlanListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withPlanStore(options, (planStore) => {
+            const plans = planStore.listPlans({ status: parsed.status });
+            if (parsed.json) {
+                console.log(JSON.stringify({ plans }, null, 2));
+            }
+            else {
+                console.log(renderPlanTable(plans));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runPlanShow(args, options = {}) {
-  const parsed = parsePlanShowArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withPlanStore(options, (planStore) => {
-      const plan = planStore.loadPlan(parsed.planId);
-      if (!plan) {
-        return reportCliFailure(parsed.json, "plan_not_found");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ plan }, null, 2));
-      } else {
-        console.log(`${plan.status} (${plan.plan.steps.length} steps)`);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parsePlanShowArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withPlanStore(options, (planStore) => {
+            const plan = planStore.loadPlan(parsed.planId);
+            if (!plan) {
+                return reportCliFailure(parsed.json, "plan_not_found");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ plan }, null, 2));
+            }
+            else {
+                console.log(`${plan.status} (${plan.plan.steps.length} steps)`);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runPlanCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runPlanList(args, options);
-  if (subcommand === "show") return runPlanShow(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
+    if (subcommand === "list")
+        return runPlanList(args, options);
+    if (subcommand === "show")
+        return runPlanShow(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicGxhbi1zdG9yZS1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJwbGFuLXN0b3JlLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQUUsYUFBYSxFQUFFLGFBQWEsRUFBRSxNQUFNLGlCQUFpQixDQUFDO0FBRS9ELE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUVsRixNQUFNLGVBQWUsR0FDbkIsc0ZBQXNGLENBQUM7QUFDekYsTUFBTSxlQUFlLEdBQUcsbURBQW1ELENBQUM7QUFvQjVFLFNBQVMsYUFBYSxDQUFDLElBQWM7SUFDbkMsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDaEMsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssTUFBTSxLQUFLLElBQUksSUFBSSxFQUFFLENBQUM7UUFDekIsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxPQUFPLEVBQUUsVUFBVSxFQUFFLEdBQUcsT0FBTyxFQUFFLENBQUM7QUFDcEMsQ0FBQztBQUVELE1BQU0sVUFBVSxpQkFBaUIsQ0FBQyxJQUFjO0lBQzlDLE1BQU0sT0FBTyxHQUFpRCxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDO0lBQzVGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsTUFBTSxNQUFNLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUMvQixJQUFJLENBQUMsTUFBTSxJQUFJLE1BQU0sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7WUFDekUsSUFBSSxDQUFDLGFBQWEsQ0FBQyxRQUFRLENBQUMsTUFBb0IsQ0FBQyxFQUFFLENBQUM7Z0JBQ2xELE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLE1BQU0scUJBQXFCLGFBQWEsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO1lBQzlGLENBQUM7WUFDRCxPQUFPLENBQUMsTUFBTSxHQUFHLE1BQW9CLENBQUM7WUFDdEMsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDeEUsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxHQUFHLENBQUM7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGVBQWUsRUFBRSxDQUFDO0lBQzdELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCxNQUFNLFVBQVUsaUJBQWlCLENBQUMsSUFBYztJQUM5QyxNQUFNLE1BQU0sR0FBRyxhQUFhLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDbkMsSUFBSSxPQUFPLElBQUksTUFBTTtRQUFFLE9BQU8sTUFBTSxDQUFDO0lBQ3JDLElBQUksTUFBTSxDQUFDLFVBQVUsQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7SUFFdEUsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxJQUFJLEVBQUUsQ0FBQztJQUM1QyxJQUFJLENBQUMsTUFBTTtRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7SUFFL0MsT0FBTztRQUNMLE1BQU07UUFDTixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7S0FDbEIsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLE9BQU8sQ0FBQyxLQUFjO0lBQzdCLElBQUksS0FBSyxLQUFLLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE9BQU8sR0FBRyxDQUFDO0lBQ3RELE9BQU8sTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0FBQ3ZCLENBQUM7QUFFRCxNQUFNLFVBQVUsZUFBZSxDQUFDLEtBQW1CO0lBQ2pELElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sZ0JBQWdCLENBQUM7SUFDekUsTUFBTSxNQUFNLEdBQUc7UUFDYixTQUFTLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNwQixRQUFRLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNuQixPQUFPLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUNuQixZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztLQUN4QixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNaLE1BQU0sS0FBSyxHQUFHLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUNqQztRQUNFLE1BQU0sQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN4QixNQUFNLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDeEIsTUFBTSxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDNUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQ3JDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxTQUFTLGFBQWEsQ0FBSSxPQUF1QixFQUFFLEdBQWdDO0lBQ2pGLE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxhQUFhLEtBQUssU0FBUyxDQUFDO0lBQ3RELE1BQU0sU0FBUyxHQUFHLENBQUMsT0FBTyxDQUFDLGFBQWEsSUFBSSxhQUFhLENBQUMsRUFBRSxDQUFDO0lBQzdELElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ3hCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxTQUFTO1lBQUUsU0FBUyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ25DLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFdBQVcsQ0FBQyxJQUFjLEVBQUUsVUFBMEIsRUFBRTtJQUN0RSxNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN2QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sYUFBYSxDQUFDLE9BQU8sRUFBRSxDQUFDLFNBQVMsRUFBRSxFQUFFO1lBQzFDLE1BQU0sS0FBSyxHQUFHLFNBQVMsQ0FBQyxTQUFTLENBQUMsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7WUFDN0QsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLEtBQUssRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2xELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGVBQWUsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1lBQ3RDLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsSUFBYyxFQUFFLFVBQTBCLEVBQUU7SUFDdEUsTUFBTSxNQUFNLEdBQUcsaUJBQWlCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDdkMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGFBQWEsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxTQUFTLEVBQUUsRUFBRTtZQUMxQyxNQUFNLElBQUksR0FBRyxTQUFTLENBQUMsUUFBUSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUMvQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ1YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLENBQUM7WUFDekQsQ0FBQztZQUNELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxJQUFJLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNqRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxNQUFNLEtBQUssSUFBSSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsTUFBTSxTQUFTLENBQUMsQ0FBQztZQUNsRSxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLFVBQVUsVUFBVSxDQUFDLFVBQThCLEVBQUUsSUFBYyxFQUFFLFVBQTBCLEVBQUU7SUFDckcsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sV0FBVyxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM3RCxJQUFJLFVBQVUsS0FBSyxNQUFNO1FBQUUsT0FBTyxXQUFXLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQzdELE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLDRCQUE0QixVQUFVLElBQUksRUFBRSxLQUFLLGVBQWUsRUFBRSxDQUFDLENBQUM7QUFDbEgsQ0FBQyJ9

--- a/packages/loopover-miner/lib/plan-store-cli.ts
+++ b/packages/loopover-miner/lib/plan-store-cli.ts
@@ -1,0 +1,170 @@
+import { PLAN_STATUSES, openPlanStore } from "./plan-store.js";
+import type { PlanRecord, PlanStatus, PlanStore } from "./plan-store.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+const PLAN_LIST_USAGE =
+  "Usage: loopover-miner plan list [--status pending|running|completed|failed] [--json]";
+const PLAN_SHOW_USAGE = "Usage: loopover-miner plan show <planId> [--json]";
+
+export type ParsedPlanListArgs =
+  | {
+      json: boolean;
+      status: PlanStatus | null;
+    }
+  | { error: string };
+
+export type ParsedPlanShowArgs =
+  | {
+      planId: string;
+      json: boolean;
+    }
+  | { error: string };
+
+type ParsedJsonFlag = { positional: string[]; json: boolean } | { error: string };
+
+export type PlanCliOptions = { openPlanStore?: () => PlanStore };
+
+function parseJsonFlag(args: string[]): ParsedJsonFlag {
+  const options = { json: false };
+  const positional: string[] = [];
+
+  for (const token of args) {
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  return { positional, ...options };
+}
+
+export function parsePlanListArgs(args: string[]): ParsedPlanListArgs {
+  const options: { json: boolean; status: PlanStatus | null } = { json: false, status: null };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--status") {
+      const status = args[index + 1];
+      if (!status || status.startsWith("-")) return { error: PLAN_LIST_USAGE };
+      if (!PLAN_STATUSES.includes(status as PlanStatus)) {
+        return { error: `Invalid status: ${status}. Expected one of ${PLAN_STATUSES.join(", ")}.` };
+      }
+      options.status = status as PlanStatus;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length > 0) return { error: PLAN_LIST_USAGE };
+  return options;
+}
+
+export function parsePlanShowArgs(args: string[]): ParsedPlanShowArgs {
+  const parsed = parseJsonFlag(args);
+  if ("error" in parsed) return parsed;
+  if (parsed.positional.length !== 1) return { error: PLAN_SHOW_USAGE };
+
+  const planId = parsed.positional[0]?.trim();
+  if (!planId) return { error: PLAN_SHOW_USAGE };
+
+  return {
+    planId,
+    json: parsed.json,
+  };
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderPlanTable(plans: PlanRecord[]): string {
+  if (!Array.isArray(plans) || plans.length === 0) return "no saved plans";
+  const header = [
+    "plan-id".padEnd(20),
+    "status".padEnd(10),
+    "steps".padStart(5),
+    "updated-at".padEnd(24),
+  ].join(" ");
+  const lines = plans.map((record) =>
+    [
+      record.planId.padEnd(20),
+      record.status.padEnd(10),
+      String(record.plan.steps.length).padStart(5),
+      display(record.updatedAt).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function withPlanStore<T>(options: PlanCliOptions, run: (planStore: PlanStore) => T): T {
+  const ownsStore = options.openPlanStore === undefined;
+  const planStore = (options.openPlanStore ?? openPlanStore)();
+  try {
+    return run(planStore);
+  } finally {
+    if (ownsStore) planStore.close();
+  }
+}
+
+export function runPlanList(args: string[], options: PlanCliOptions = {}): number {
+  const parsed = parsePlanListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withPlanStore(options, (planStore) => {
+      const plans = planStore.listPlans({ status: parsed.status });
+      if (parsed.json) {
+        console.log(JSON.stringify({ plans }, null, 2));
+      } else {
+        console.log(renderPlanTable(plans));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runPlanShow(args: string[], options: PlanCliOptions = {}): number {
+  const parsed = parsePlanShowArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withPlanStore(options, (planStore) => {
+      const plan = planStore.loadPlan(parsed.planId);
+      if (!plan) {
+        return reportCliFailure(parsed.json, "plan_not_found");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ plan }, null, 2));
+      } else {
+        console.log(`${plan.status} (${plan.plan.steps.length} steps)`);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runPlanCli(subcommand: string | undefined, args: string[], options: PlanCliOptions = {}): number {
+  if (subcommand === "list") return runPlanList(args, options);
+  if (subcommand === "show") return runPlanShow(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
+}

--- a/packages/loopover-miner/lib/purge-cli.d.ts
+++ b/packages/loopover-miner/lib/purge-cli.d.ts
@@ -4,45 +4,57 @@ import type { GovernorLedger } from "./governor-ledger.js";
 import type { PredictionLedger } from "./prediction-ledger.js";
 import type { PortfolioQueueStore } from "./portfolio-queue.js";
 import type { RunStateStore } from "./run-state.js";
-
-export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE: string;
-
-export type ParsedPurgeArgs = { json: boolean; dryRun: boolean; repoFullName: string } | { error: string };
-
-export function parsePurgeArgs(args: string[]): ParsedPurgeArgs;
-
-export type PurgeStoreResult = { store: string; purged: number | null; error?: string; note?: string };
-export type PurgeDryRunStoreResult = { store: string; wouldPurge: number | null; error?: string };
-
-export type PurgeDryRunResult = {
-  outcome: "dry_run";
-  repoFullName: string;
-  stores: PurgeDryRunStoreResult[];
-  attemptLogNote: string;
-  attemptLogTotalRows: number;
-};
-
-export type PurgeSummary = {
-  outcome: "purged" | "partial";
-  repoFullName: string;
-  totalPurged: number;
-  stores: PurgeStoreResult[];
-  purgedAt: string;
-};
-
+import type { ContributionProfileCache } from "./contribution-profile-cache.js";
+import type { GovernorState } from "./governor-state.js";
+import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
+export declare const ATTEMPT_LOG_NOT_PURGEABLE_NOTE = "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
 export type PurgeCliOptions = {
-  openClaimLedger?: () => ClaimLedger;
-  initEventLedger?: () => EventLedger;
-  initGovernorLedger?: () => GovernorLedger;
-  initPredictionLedger?: () => PredictionLedger;
-  initPortfolioQueueStore?: () => PortfolioQueueStore;
-  initRunStateStore?: () => RunStateStore;
-  resolveDbPaths?: Record<string, () => string>;
+    openClaimLedger?: () => ClaimLedger;
+    initEventLedger?: () => EventLedger;
+    initGovernorLedger?: () => GovernorLedger;
+    initPredictionLedger?: () => PredictionLedger;
+    initPortfolioQueueStore?: () => PortfolioQueueStore;
+    initRunStateStore?: () => RunStateStore;
+    initContributionProfileCache?: () => ContributionProfileCache;
+    openGovernorState?: () => GovernorState;
+    initPolicyVerdictCacheStore?: () => PolicyVerdictCacheStore;
+    resolveDbPaths?: Record<string, () => string>;
 };
-
-export function runPurgeDryRun(
-  parsed: { repoFullName: string; json: boolean },
-  options?: PurgeCliOptions,
-): number;
-
-export function runPurge(args: string[], options?: PurgeCliOptions): number;
+export type ParsedPurgeArgs = {
+    json: boolean;
+    dryRun: boolean;
+    repoFullName: string;
+} | {
+    error: string;
+};
+export declare function parsePurgeArgs(args: string[]): ParsedPurgeArgs;
+export type PurgeDryRunStoreResult = {
+    store: string;
+    wouldPurge: number | null;
+    error?: string;
+};
+export type PurgeDryRunResult = {
+    outcome: "dry_run";
+    repoFullName: string;
+    stores: PurgeDryRunStoreResult[];
+    attemptLogNote: string;
+    attemptLogTotalRows: number;
+};
+export declare function runPurgeDryRun(parsed: {
+    repoFullName: string;
+    json: boolean;
+}, options?: PurgeCliOptions): number;
+export type PurgeStoreResult = {
+    store: string;
+    purged: number | null;
+    error?: string;
+    note?: string;
+};
+export type PurgeSummary = {
+    outcome: "purged" | "partial";
+    repoFullName: string;
+    totalPurged: number;
+    stores: PurgeStoreResult[];
+    purgedAt: string;
+};
+export declare function runPurge(args: string[], options?: PurgeCliOptions): number;

--- a/packages/loopover-miner/lib/purge-cli.js
+++ b/packages/loopover-miner/lib/purge-cli.js
@@ -22,201 +22,183 @@ import { initContributionProfileCache, resolveContributionProfileCacheDbPath } f
 import { openGovernorState, resolveGovernorStateDbPath } from "./governor-state.js";
 import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 import { resolveAttemptLogDbPath } from "./attempt-log.js";
-import {
-  CLAIM_LEDGER_PURGE_SPEC,
-  EVENT_LEDGER_PURGE_SPEC,
-  GOVERNOR_LEDGER_PURGE_SPEC,
-  PREDICTION_LEDGER_PURGE_SPEC,
-  PORTFOLIO_QUEUE_PURGE_SPEC,
-  RUN_STATE_PURGE_SPEC,
-  CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC,
-  GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC,
-  GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC,
-  POLICY_VERDICT_CACHE_PURGE_SPEC,
-  countStoreByRepo,
-  describeError,
-} from "./store-maintenance.js";
+import { CLAIM_LEDGER_PURGE_SPEC, EVENT_LEDGER_PURGE_SPEC, GOVERNOR_LEDGER_PURGE_SPEC, PREDICTION_LEDGER_PURGE_SPEC, PORTFOLIO_QUEUE_PURGE_SPEC, RUN_STATE_PURGE_SPEC, CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC, GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC, POLICY_VERDICT_CACHE_PURGE_SPEC, countStoreByRepo, describeError, } from "./store-maintenance.js";
 import { argsWantJson, reportCliFailure } from "./cli-error.js";
-
 const PURGE_USAGE = "Usage: loopover-miner purge --repo <owner/repo> [--dry-run] [--json]";
-
-export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE =
-  "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
-
+export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE = "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
 const REAL_PURGE_TARGETS = [
-  { name: "claim-ledger", optionKey: "openClaimLedger", opener: openClaimLedger, resolveDbPath: resolveClaimLedgerDbPath, spec: CLAIM_LEDGER_PURGE_SPEC },
-  { name: "event-ledger", optionKey: "initEventLedger", opener: initEventLedger, resolveDbPath: resolveEventLedgerDbPath, spec: EVENT_LEDGER_PURGE_SPEC },
-  { name: "governor-ledger", optionKey: "initGovernorLedger", opener: initGovernorLedger, resolveDbPath: resolveGovernorLedgerDbPath, spec: GOVERNOR_LEDGER_PURGE_SPEC },
-  { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
-  { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
-  { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
-  { name: "contribution-profile-cache", optionKey: "initContributionProfileCache", opener: initContributionProfileCache, resolveDbPath: resolveContributionProfileCacheDbPath, spec: CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC },
-  // governor-state holds TWO repo-scoped tables in one DB file; its store.purgeByRepo deletes both against a
-  // single handle (never reopening the file), and its dry-run count sums both via `specs` (#7091).
-  { name: "governor-state", optionKey: "openGovernorState", opener: openGovernorState, resolveDbPath: resolveGovernorStateDbPath, specs: [GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC] },
-  { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
+    { name: "claim-ledger", optionKey: "openClaimLedger", opener: openClaimLedger, resolveDbPath: resolveClaimLedgerDbPath, spec: CLAIM_LEDGER_PURGE_SPEC },
+    { name: "event-ledger", optionKey: "initEventLedger", opener: initEventLedger, resolveDbPath: resolveEventLedgerDbPath, spec: EVENT_LEDGER_PURGE_SPEC },
+    { name: "governor-ledger", optionKey: "initGovernorLedger", opener: initGovernorLedger, resolveDbPath: resolveGovernorLedgerDbPath, spec: GOVERNOR_LEDGER_PURGE_SPEC },
+    { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
+    { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
+    { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
+    { name: "contribution-profile-cache", optionKey: "initContributionProfileCache", opener: initContributionProfileCache, resolveDbPath: resolveContributionProfileCacheDbPath, spec: CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC },
+    // governor-state holds TWO repo-scoped tables in one DB file; its store.purgeByRepo deletes both against a
+    // single handle (never reopening the file), and its dry-run count sums both via `specs` (#7091).
+    { name: "governor-state", optionKey: "openGovernorState", opener: openGovernorState, resolveDbPath: resolveGovernorStateDbPath, specs: [GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC] },
+    { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
 ];
-
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parsePurgeArgs(args) {
-  const options = { json: false, dryRun: false, repoFullName: null };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        repoFullName: null,
+    };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            // Only the flag-look-alike case is checked here ("--repo --json") -- a genuinely missing value (repoArg
+            // undefined) falls through to parseRepoArg's own `!value` guard below, the single source of truth for that.
+            if (repoArg !== undefined && repoArg.startsWith("-"))
+                return { error: PURGE_USAGE };
+            const repo = parseRepoArg(repoArg, PURGE_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        return { error: `Unknown option: ${token}` };
     }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      // Only the flag-look-alike case is checked here ("--repo --json") -- a genuinely missing value (repoArg
-      // undefined) falls through to parseRepoArg's own `!value` guard below, the single source of truth for that.
-      if (repoArg !== undefined && repoArg.startsWith("-")) return { error: PURGE_USAGE };
-      const repo = parseRepoArg(repoArg, PURGE_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
-    }
-    return { error: `Unknown option: ${token}` };
-  }
-
-  if (!options.repoFullName) return { error: PURGE_USAGE };
-  return options;
+    if (!options.repoFullName)
+        return { error: PURGE_USAGE };
+    return { json: options.json, dryRun: options.dryRun, repoFullName: options.repoFullName };
 }
-
 /** Read-only row count against an on-disk store file, for --dry-run. `{ readOnly: true }` (camelCase) is the
  *  only option node:sqlite recognizes for a driver-enforced read-only connection -- the lowercase `readonly`
  *  key is silently ignored. Never touches a store that doesn't exist yet (opening one -- even read-only --
  *  requires the file to already be there; a dry run must make zero writes). */
 function countExistingRows(dbPath, countFn) {
-  if (!existsSync(dbPath)) return 0;
-  const db = new DatabaseSync(dbPath, { readOnly: true });
-  try {
-    return countFn(db);
-  } finally {
-    db.close();
-  }
-}
-
-function renderDryRunSummary(result) {
-  const purgeableLine = result.stores
-    .map((entry) => `${entry.store}=${entry.wouldPurge}`)
-    .join(", ");
-  return [
-    `DRY RUN: would purge ${result.repoFullName} from: ${purgeableLine}. No writes were made.`,
-    `${ATTEMPT_LOG_NOT_PURGEABLE_NOTE} (${result.attemptLogTotalRows} total row(s) currently in attempt-log, all repos).`,
-  ].join("\n");
-}
-
-export function runPurgeDryRun(parsed, options = {}) {
-  const resolveDbPaths = options.resolveDbPaths ?? {};
-  const stores = REAL_PURGE_TARGETS.map((target) => {
-    const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
-    // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
-    // per-table counts against the single read-only handle so the preview matches what a real purge removes.
-    const specs = target.specs ?? [target.spec];
+    if (!existsSync(dbPath))
+        return 0;
+    const db = new DatabaseSync(dbPath, { readOnly: true });
     try {
-      const wouldPurge = countExistingRows(dbPath, (db) =>
-        specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0),
-      );
-      return { store: target.name, wouldPurge };
-    } catch (error) {
-      return { store: target.name, wouldPurge: null, error: describeError(error) };
+        return countFn(db);
     }
-  });
-
-  const attemptLogDbPath = (resolveDbPaths["attempt-log"] ?? resolveAttemptLogDbPath)();
-  const attemptLogTotalRows = countExistingRows(attemptLogDbPath, (db) =>
-    Number(db.prepare("SELECT COUNT(*) AS count FROM attempt_log_events").get().count),
-  );
-
-  const result = {
-    outcome: "dry_run",
-    repoFullName: parsed.repoFullName,
-    stores,
-    attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
-    attemptLogTotalRows,
-  };
-
-  if (parsed.json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    console.log(renderDryRunSummary(result));
-  }
-  return 0;
+    finally {
+        db.close();
+    }
 }
-
+function renderDryRunSummary(result) {
+    const purgeableLine = result.stores
+        .map((entry) => `${entry.store}=${entry.wouldPurge}`)
+        .join(", ");
+    return [
+        `DRY RUN: would purge ${result.repoFullName} from: ${purgeableLine}. No writes were made.`,
+        `${ATTEMPT_LOG_NOT_PURGEABLE_NOTE} (${result.attemptLogTotalRows} total row(s) currently in attempt-log, all repos).`,
+    ].join("\n");
+}
+export function runPurgeDryRun(parsed, options = {}) {
+    const resolveDbPaths = options.resolveDbPaths ?? {};
+    const stores = REAL_PURGE_TARGETS.map((target) => {
+        const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
+        // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
+        // per-table counts against the single read-only handle so the preview matches what a real purge removes.
+        // Every REAL_PURGE_TARGETS entry declares exactly one of the two, so `target.spec` is always set here.
+        const specs = target.specs ?? [target.spec];
+        try {
+            const wouldPurge = countExistingRows(dbPath, (db) => specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0));
+            return { store: target.name, wouldPurge };
+        }
+        catch (error) {
+            return { store: target.name, wouldPurge: null, error: describeError(error) };
+        }
+    });
+    const attemptLogDbPath = (resolveDbPaths["attempt-log"] ?? resolveAttemptLogDbPath)();
+    const attemptLogTotalRows = countExistingRows(attemptLogDbPath, (db) => Number(db.prepare("SELECT COUNT(*) AS count FROM attempt_log_events").get().count));
+    const result = {
+        outcome: "dry_run",
+        repoFullName: parsed.repoFullName,
+        stores,
+        attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+        attemptLogTotalRows,
+    };
+    if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+    }
+    else {
+        console.log(renderDryRunSummary(result));
+    }
+    return 0;
+}
 function purgeOneStore(target, options, repoFullName) {
-  const ownsStore = options[target.optionKey] === undefined;
-  let store;
-  try {
-    store = (options[target.optionKey] ?? target.opener)();
-    const purged = store.purgeByRepo(repoFullName);
-    return { store: target.name, purged };
-  } catch (error) {
-    return { store: target.name, purged: null, error: describeError(error) };
-  } finally {
-    if (ownsStore) store?.close();
-  }
+    const ownsStore = options[target.optionKey] === undefined;
+    let store;
+    try {
+        store = (options[target.optionKey] ?? target.opener)();
+        const purged = store.purgeByRepo(repoFullName);
+        return { store: target.name, purged };
+    }
+    catch (error) {
+        return { store: target.name, purged: null, error: describeError(error) };
+    }
+    finally {
+        if (ownsStore)
+            store?.close();
+    }
 }
-
 function renderPurgeSummary(summary) {
-  const perStore = summary.stores
-    .map((entry) => {
-      if ("error" in entry) return `${entry.store}=ERROR(${entry.error})`;
-      if (entry.purged === null) return `${entry.store}=skipped`;
-      return `${entry.store}=${entry.purged}`;
+    const perStore = summary.stores
+        .map((entry) => {
+        if ("error" in entry)
+            return `${entry.store}=ERROR(${entry.error})`;
+        if (entry.purged === null)
+            return `${entry.store}=skipped`;
+        return `${entry.store}=${entry.purged}`;
     })
-    .join(", ");
-  return [
-    `Purged ${summary.totalPurged} row(s) for ${summary.repoFullName} at ${summary.purgedAt}: ${perStore}.`,
-    ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
-  ].join(" ");
+        .join(", ");
+    return [
+        `Purged ${summary.totalPurged} row(s) for ${summary.repoFullName} at ${summary.purgedAt}: ${perStore}.`,
+        ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+    ].join(" ");
 }
-
 export function runPurge(args, options = {}) {
-  const parsed = parsePurgeArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    return runPurgeDryRun(parsed, options);
-  }
-
-  const perStoreResults = REAL_PURGE_TARGETS.map((target) => purgeOneStore(target, options, parsed.repoFullName));
-  perStoreResults.push({ store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE });
-
-  const totalPurged = perStoreResults.reduce((sum, entry) => sum + (entry.purged ?? 0), 0);
-  const hadError = perStoreResults.some((entry) => "error" in entry);
-  const summary = {
-    outcome: hadError ? "partial" : "purged",
-    repoFullName: parsed.repoFullName,
-    totalPurged,
-    stores: perStoreResults,
-    purgedAt: new Date().toISOString(),
-  };
-
-  // Audit-observable by design (#5564): print the summary in BOTH the success and partial-failure case, so a
-  // purge -- or a purge that only partly succeeded -- is never silent.
-  if (parsed.json) {
-    console.log(JSON.stringify(summary, null, 2));
-  } else {
-    console.log(renderPurgeSummary(summary));
-  }
-  return hadError ? 2 : 0;
+    const parsed = parsePurgeArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    if (parsed.dryRun) {
+        return runPurgeDryRun(parsed, options);
+    }
+    const perStoreResults = REAL_PURGE_TARGETS.map((target) => purgeOneStore(target, options, parsed.repoFullName));
+    perStoreResults.push({ store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE });
+    const totalPurged = perStoreResults.reduce((sum, entry) => sum + (entry.purged ?? 0), 0);
+    const hadError = perStoreResults.some((entry) => "error" in entry);
+    const summary = {
+        outcome: hadError ? "partial" : "purged",
+        repoFullName: parsed.repoFullName,
+        totalPurged,
+        stores: perStoreResults,
+        purgedAt: new Date().toISOString(),
+    };
+    // Audit-observable by design (#5564): print the summary in BOTH the success and partial-failure case, so a
+    // purge -- or a purge that only partly succeeded -- is never silent.
+    if (parsed.json) {
+        console.log(JSON.stringify(summary, null, 2));
+    }
+    else {
+        console.log(renderPurgeSummary(summary));
+    }
+    return hadError ? 2 : 0;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHVyZ2UtY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicHVyZ2UtY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLG1IQUFtSDtBQUNuSCx1R0FBdUc7QUFDdkcsZ0hBQWdIO0FBQ2hILDRHQUE0RztBQUM1RywyRUFBMkU7QUFDM0UsK0dBQStHO0FBQy9HLDhHQUE4RztBQUM5RywrR0FBK0c7QUFDL0csRUFBRTtBQUNGLDJHQUEyRztBQUMzRywrR0FBK0c7QUFDL0csMEdBQTBHO0FBQzFHLE9BQU8sRUFBRSxVQUFVLEVBQUUsTUFBTSxTQUFTLENBQUM7QUFDckMsT0FBTyxFQUFFLFlBQVksRUFBRSxNQUFNLGFBQWEsQ0FBQztBQUMzQyxPQUFPLEVBQUUsZUFBZSxFQUFFLHdCQUF3QixFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFFOUUsT0FBTyxFQUFFLGVBQWUsRUFBRSx3QkFBd0IsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRTlFLE9BQU8sRUFBRSxrQkFBa0IsRUFBRSwyQkFBMkIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBRXZGLE9BQU8sRUFBRSxvQkFBb0IsRUFBRSw2QkFBNkIsRUFBRSxNQUFNLHdCQUF3QixDQUFDO0FBRTdGLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSwyQkFBMkIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBRTVGLE9BQU8sRUFBRSxpQkFBaUIsRUFBRSxxQkFBcUIsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBRTFFLE9BQU8sRUFBRSw0QkFBNEIsRUFBRSxxQ0FBcUMsRUFBRSxNQUFNLGlDQUFpQyxDQUFDO0FBRXRILE9BQU8sRUFBRSxpQkFBaUIsRUFBRSwwQkFBMEIsRUFBRSxNQUFNLHFCQUFxQixDQUFDO0FBRXBGLE9BQU8sRUFBRSwyQkFBMkIsRUFBRSwrQkFBK0IsRUFBRSxNQUFNLDJCQUEyQixDQUFDO0FBRXpHLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQzNELE9BQU8sRUFDTCx1QkFBdUIsRUFDdkIsdUJBQXVCLEVBQ3ZCLDBCQUEwQixFQUMxQiw0QkFBNEIsRUFDNUIsMEJBQTBCLEVBQzFCLG9CQUFvQixFQUNwQixxQ0FBcUMsRUFDckMsc0NBQXNDLEVBQ3RDLG1DQUFtQyxFQUNuQywrQkFBK0IsRUFDL0IsZ0JBQWdCLEVBQ2hCLGFBQWEsR0FDZCxNQUFNLHdCQUF3QixDQUFDO0FBRWhDLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUVoRSxNQUFNLFdBQVcsR0FBRyxzRUFBc0UsQ0FBQztBQUUzRixNQUFNLENBQUMsTUFBTSw4QkFBOEIsR0FDekMsc0dBQXNHLENBQUM7QUF1Q3pHLE1BQU0sa0JBQWtCLEdBQWtCO0lBQ3hDLEVBQUUsSUFBSSxFQUFFLGNBQWMsRUFBRSxTQUFTLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxFQUFFLGVBQWUsRUFBRSxhQUFhLEVBQUUsd0JBQXdCLEVBQUUsSUFBSSxFQUFFLHVCQUF1QixFQUFFO0lBQ3ZKLEVBQUUsSUFBSSxFQUFFLGNBQWMsRUFBRSxTQUFTLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxFQUFFLGVBQWUsRUFBRSxhQUFhLEVBQUUsd0JBQXdCLEVBQUUsSUFBSSxFQUFFLHVCQUF1QixFQUFFO0lBQ3ZKLEVBQUUsSUFBSSxFQUFFLGlCQUFpQixFQUFFLFNBQVMsRUFBRSxvQkFBb0IsRUFBRSxNQUFNLEVBQUUsa0JBQWtCLEVBQUUsYUFBYSxFQUFFLDJCQUEyQixFQUFFLElBQUksRUFBRSwwQkFBMEIsRUFBRTtJQUN0SyxFQUFFLElBQUksRUFBRSxtQkFBbUIsRUFBRSxTQUFTLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSxFQUFFLG9CQUFvQixFQUFFLGFBQWEsRUFBRSw2QkFBNkIsRUFBRSxJQUFJLEVBQUUsNEJBQTRCLEVBQUU7SUFDaEwsRUFBRSxJQUFJLEVBQUUsaUJBQWlCLEVBQUUsU0FBUyxFQUFFLHlCQUF5QixFQUFFLE1BQU0sRUFBRSx1QkFBdUIsRUFBRSxhQUFhLEVBQUUsMkJBQTJCLEVBQUUsSUFBSSxFQUFFLDBCQUEwQixFQUFFO0lBQ2hMLEVBQUUsSUFBSSxFQUFFLFdBQVcsRUFBRSxTQUFTLEVBQUUsbUJBQW1CLEVBQUUsTUFBTSxFQUFFLGlCQUFpQixFQUFFLGFBQWEsRUFBRSxxQkFBcUIsRUFBRSxJQUFJLEVBQUUsb0JBQW9CLEVBQUU7SUFDbEosRUFBRSxJQUFJLEVBQUUsNEJBQTRCLEVBQUUsU0FBUyxFQUFFLDhCQUE4QixFQUFFLE1BQU0sRUFBRSw0QkFBNEIsRUFBRSxhQUFhLEVBQUUscUNBQXFDLEVBQUUsSUFBSSxFQUFFLHFDQUFxQyxFQUFFO0lBQzFOLDJHQUEyRztJQUMzRyxpR0FBaUc7SUFDakcsRUFBRSxJQUFJLEVBQUUsZ0JBQWdCLEVBQUUsU0FBUyxFQUFFLG1CQUFtQixFQUFFLE1BQU0sRUFBRSxpQkFBaUIsRUFBRSxhQUFhLEVBQUUsMEJBQTBCLEVBQUUsS0FBSyxFQUFFLENBQUMsc0NBQXNDLEVBQUUsbUNBQW1DLENBQUMsRUFBRTtJQUN0TixFQUFFLElBQUksRUFBRSxzQkFBc0IsRUFBRSxTQUFTLEVBQUUsNkJBQTZCLEVBQUUsTUFBTSxFQUFFLDJCQUEyQixFQUFFLGFBQWEsRUFBRSwrQkFBK0IsRUFBRSxJQUFJLEVBQUUsK0JBQStCLEVBQUU7Q0FDdk0sQ0FBQztBQU1GLFNBQVMsWUFBWSxDQUFDLEtBQXlCLEVBQUUsS0FBYTtJQUM1RCxJQUFJLENBQUMsS0FBSztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQzdCLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLE9BQU8sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDaEQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUyxFQUFFLENBQUM7UUFDM0MsT0FBTyxFQUFFLEtBQUssRUFBRSx3Q0FBd0MsRUFBRSxDQUFDO0lBQzdELENBQUM7SUFDRCxPQUFPLEVBQUUsWUFBWSxFQUFFLEdBQUcsS0FBSyxJQUFJLElBQUksRUFBRSxFQUFFLENBQUM7QUFDOUMsQ0FBQztBQUVELE1BQU0sVUFBVSxjQUFjLENBQUMsSUFBYztJQUMzQyxNQUFNLE9BQU8sR0FBb0U7UUFDL0UsSUFBSSxFQUFFLEtBQUs7UUFDWCxNQUFNLEVBQUUsS0FBSztRQUNiLFlBQVksRUFBRSxJQUFJO0tBQ25CLENBQUM7SUFFRixLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQ2hDLHdHQUF3RztZQUN4Ryw0R0FBNEc7WUFDNUcsSUFBSSxPQUFPLEtBQUssU0FBUyxJQUFJLE9BQU8sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsV0FBVyxFQUFFLENBQUM7WUFDcEYsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sRUFBRSxXQUFXLENBQUMsQ0FBQztZQUNoRCxJQUFJLE9BQU8sSUFBSSxJQUFJO2dCQUFFLE9BQU8sSUFBSSxDQUFDO1lBQ2pDLE9BQU8sQ0FBQyxZQUFZLEdBQUcsSUFBSSxDQUFDLFlBQVksQ0FBQztZQUN6QyxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO0lBQy9DLENBQUM7SUFFRCxJQUFJLENBQUMsT0FBTyxDQUFDLFlBQVk7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFdBQVcsRUFBRSxDQUFDO0lBQ3pELE9BQU8sRUFBRSxJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUksRUFBRSxNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU0sRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxDQUFDO0FBQzVGLENBQUM7QUFFRDs7OytFQUcrRTtBQUMvRSxTQUFTLGlCQUFpQixDQUFDLE1BQWMsRUFBRSxPQUFxQztJQUM5RSxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQztRQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ2xDLE1BQU0sRUFBRSxHQUFHLElBQUksWUFBWSxDQUFDLE1BQU0sRUFBRSxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDO0lBQ3hELElBQUksQ0FBQztRQUNILE9BQU8sT0FBTyxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ3JCLENBQUM7WUFBUyxDQUFDO1FBQ1QsRUFBRSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ2IsQ0FBQztBQUNILENBQUM7QUFZRCxTQUFTLG1CQUFtQixDQUFDLE1BQXlCO0lBQ3BELE1BQU0sYUFBYSxHQUFHLE1BQU0sQ0FBQyxNQUFNO1NBQ2hDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsR0FBRyxLQUFLLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLEVBQUUsQ0FBQztTQUNwRCxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDZCxPQUFPO1FBQ0wsd0JBQXdCLE1BQU0sQ0FBQyxZQUFZLFVBQVUsYUFBYSx3QkFBd0I7UUFDMUYsR0FBRyw4QkFBOEIsS0FBSyxNQUFNLENBQUMsbUJBQW1CLHFEQUFxRDtLQUN0SCxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUNmLENBQUM7QUFFRCxNQUFNLFVBQVUsY0FBYyxDQUM1QixNQUErQyxFQUMvQyxVQUEyQixFQUFFO0lBRTdCLE1BQU0sY0FBYyxHQUFHLE9BQU8sQ0FBQyxjQUFjLElBQUksRUFBRSxDQUFDO0lBQ3BELE1BQU0sTUFBTSxHQUE2QixrQkFBa0IsQ0FBQyxHQUFHLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRTtRQUN6RSxNQUFNLE1BQU0sR0FBRyxDQUFDLGNBQWMsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLElBQUksTUFBTSxDQUFDLGFBQWEsQ0FBQyxFQUFFLENBQUM7UUFDdkUsd0dBQXdHO1FBQ3hHLHlHQUF5RztRQUN6Ryx1R0FBdUc7UUFDdkcsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLEtBQUssSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFLLENBQUMsQ0FBQztRQUM3QyxJQUFJLENBQUM7WUFDSCxNQUFNLFVBQVUsR0FBRyxpQkFBaUIsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUNsRCxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUMsR0FBRyxFQUFFLElBQUksRUFBRSxFQUFFLENBQUMsR0FBRyxHQUFHLGdCQUFnQixDQUFDLEVBQUUsRUFBRSxJQUFJLEVBQUUsTUFBTSxDQUFDLFlBQVksQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUN0RixDQUFDO1lBQ0YsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxDQUFDO1FBQzVDLENBQUM7UUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1lBQ2YsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLGFBQWEsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQy9FLENBQUM7SUFDSCxDQUFDLENBQUMsQ0FBQztJQUVILE1BQU0sZ0JBQWdCLEdBQUcsQ0FBQyxjQUFjLENBQUMsYUFBYSxDQUFDLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQ3RGLE1BQU0sbUJBQW1CLEdBQUcsaUJBQWlCLENBQUMsZ0JBQWdCLEVBQUUsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUNyRSxNQUFNLENBQUUsRUFBRSxDQUFDLE9BQU8sQ0FBQyxrREFBa0QsQ0FBQyxDQUFDLEdBQUcsRUFBd0IsQ0FBQyxLQUFLLENBQUMsQ0FDMUcsQ0FBQztJQUVGLE1BQU0sTUFBTSxHQUFzQjtRQUNoQyxPQUFPLEVBQUUsU0FBUztRQUNsQixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7UUFDakMsTUFBTTtRQUNOLGNBQWMsRUFBRSw4QkFBOEI7UUFDOUMsbUJBQW1CO0tBQ3BCLENBQUM7SUFFRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQy9DLENBQUM7U0FBTSxDQUFDO1FBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxtQkFBbUIsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO0lBQzNDLENBQUM7SUFDRCxPQUFPLENBQUMsQ0FBQztBQUNYLENBQUM7QUFJRCxTQUFTLGFBQWEsQ0FBQyxNQUFtQixFQUFFLE9BQXdCLEVBQUUsWUFBb0I7SUFDeEYsTUFBTSxTQUFTLEdBQUcsT0FBTyxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsS0FBSyxTQUFTLENBQUM7SUFDMUQsSUFBSSxLQUFpQyxDQUFDO0lBQ3RDLElBQUksQ0FBQztRQUNILEtBQUssR0FBRyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLElBQUksTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDdkQsTUFBTSxNQUFNLEdBQUcsS0FBSyxDQUFDLFdBQVcsQ0FBQyxZQUFZLENBQUMsQ0FBQztRQUMvQyxPQUFPLEVBQUUsS0FBSyxFQUFFLE1BQU0sQ0FBQyxJQUFJLEVBQUUsTUFBTSxFQUFFLENBQUM7SUFDeEMsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLEVBQUUsS0FBSyxFQUFFLE1BQU0sQ0FBQyxJQUFJLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsYUFBYSxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUM7SUFDM0UsQ0FBQztZQUFTLENBQUM7UUFDVCxJQUFJLFNBQVM7WUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDaEMsQ0FBQztBQUNILENBQUM7QUFVRCxTQUFTLGtCQUFrQixDQUFDLE9BQXFCO0lBQy9DLE1BQU0sUUFBUSxHQUFHLE9BQU8sQ0FBQyxNQUFNO1NBQzVCLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFO1FBQ2IsSUFBSSxPQUFPLElBQUksS0FBSztZQUFFLE9BQU8sR0FBRyxLQUFLLENBQUMsS0FBSyxVQUFVLEtBQUssQ0FBQyxLQUFLLEdBQUcsQ0FBQztRQUNwRSxJQUFJLEtBQUssQ0FBQyxNQUFNLEtBQUssSUFBSTtZQUFFLE9BQU8sR0FBRyxLQUFLLENBQUMsS0FBSyxVQUFVLENBQUM7UUFDM0QsT0FBTyxHQUFHLEtBQUssQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLE1BQU0sRUFBRSxDQUFDO0lBQzFDLENBQUMsQ0FBQztTQUNELElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNkLE9BQU87UUFDTCxVQUFVLE9BQU8sQ0FBQyxXQUFXLGVBQWUsT0FBTyxDQUFDLFlBQVksT0FBTyxPQUFPLENBQUMsUUFBUSxLQUFLLFFBQVEsR0FBRztRQUN2Ryw4QkFBOEI7S0FDL0IsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7QUFDZCxDQUFDO0FBRUQsTUFBTSxVQUFVLFFBQVEsQ0FBQyxJQUFjLEVBQUUsVUFBMkIsRUFBRTtJQUNwRSxNQUFNLE1BQU0sR0FBRyxjQUFjLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDcEMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixPQUFPLGNBQWMsQ0FBQyxNQUFNLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDekMsQ0FBQztJQUVELE1BQU0sZUFBZSxHQUF1QixrQkFBa0IsQ0FBQyxHQUFHLENBQUMsQ0FBQyxNQUFNLEVBQUUsRUFBRSxDQUM1RSxhQUFhLENBQUMsTUFBTSxFQUFFLE9BQU8sRUFBRSxNQUFNLENBQUMsWUFBWSxDQUFDLENBQ3BELENBQUM7SUFDRixlQUFlLENBQUMsSUFBSSxDQUFDLEVBQUUsS0FBSyxFQUFFLGFBQWEsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSw4QkFBOEIsRUFBRSxDQUFDLENBQUM7SUFFbkcsTUFBTSxXQUFXLEdBQUcsZUFBZSxDQUFDLE1BQU0sQ0FBQyxDQUFDLEdBQUcsRUFBRSxLQUFLLEVBQUUsRUFBRSxDQUFDLEdBQUcsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLElBQUksQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7SUFDekYsTUFBTSxRQUFRLEdBQUcsZUFBZSxDQUFDLElBQUksQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsT0FBTyxJQUFJLEtBQUssQ0FBQyxDQUFDO0lBQ25FLE1BQU0sT0FBTyxHQUFpQjtRQUM1QixPQUFPLEVBQUUsUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLFFBQVE7UUFDeEMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO1FBQ2pDLFdBQVc7UUFDWCxNQUFNLEVBQUUsZUFBZTtRQUN2QixRQUFRLEVBQUUsSUFBSSxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUU7S0FDbkMsQ0FBQztJQUVGLDJHQUEyRztJQUMzRyxxRUFBcUU7SUFDckUsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLE9BQU8sRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNoRCxDQUFDO1NBQU0sQ0FBQztRQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsa0JBQWtCLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQztJQUMzQyxDQUFDO0lBQ0QsT0FBTyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQzFCLENBQUMifQ==

--- a/packages/loopover-miner/lib/purge-cli.ts
+++ b/packages/loopover-miner/lib/purge-cli.ts
@@ -1,0 +1,303 @@
+// `loopover-miner purge` (#5564, #6599): an explicit, operator-invoked right-to-be-forgotten path across the local
+// ledgers. Deletes every row for one repo from the stores that have a real `repoColumn` (claim-ledger,
+// event-ledger, governor-ledger, prediction-ledger, portfolio-queue, run-state, contribution-profile-cache, and
+// governor-state's two repo-scoped tables — #7091), via each store's own `purgeByRepo` method (which reuses
+// `store-maintenance.js`'s shared, identifier-guarded `purgeStoreByRepo`).
+// `attempt-log.js` is deliberately reported as not-purgeable rather than silently skipped or approximated: its
+// payload is a free-form `Record<string, unknown>` with no dedicated repo column, so a precise per-repo match
+// isn't possible there without risking false matches -- see store-maintenance.js's own purge-spec doc comment.
+//
+// Every purge is audit-observable by design (#5564's own acceptance criteria): the real (non-dry-run) path
+// always prints a per-store summary, even under --json, so a purge can never be silent. A failure in one store
+// does not prevent reporting what succeeded in the others -- see purgeOneStore's own per-store try/catch.
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { openClaimLedger, resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import type { ClaimLedger } from "./claim-ledger.js";
+import { initEventLedger, resolveEventLedgerDbPath } from "./event-ledger.js";
+import type { EventLedger } from "./event-ledger.js";
+import { initGovernorLedger, resolveGovernorLedgerDbPath } from "./governor-ledger.js";
+import type { GovernorLedger } from "./governor-ledger.js";
+import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
+import type { PredictionLedger } from "./prediction-ledger.js";
+import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
+import type { RunStateStore } from "./run-state.js";
+import { initContributionProfileCache, resolveContributionProfileCacheDbPath } from "./contribution-profile-cache.js";
+import type { ContributionProfileCache } from "./contribution-profile-cache.js";
+import { openGovernorState, resolveGovernorStateDbPath } from "./governor-state.js";
+import type { GovernorState } from "./governor-state.js";
+import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
+import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
+import { resolveAttemptLogDbPath } from "./attempt-log.js";
+import {
+  CLAIM_LEDGER_PURGE_SPEC,
+  EVENT_LEDGER_PURGE_SPEC,
+  GOVERNOR_LEDGER_PURGE_SPEC,
+  PREDICTION_LEDGER_PURGE_SPEC,
+  PORTFOLIO_QUEUE_PURGE_SPEC,
+  RUN_STATE_PURGE_SPEC,
+  CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC,
+  GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC,
+  GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC,
+  POLICY_VERDICT_CACHE_PURGE_SPEC,
+  countStoreByRepo,
+  describeError,
+} from "./store-maintenance.js";
+import type { LedgerPurgeSpec } from "./store-maintenance.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
+
+const PURGE_USAGE = "Usage: loopover-miner purge --repo <owner/repo> [--dry-run] [--json]";
+
+export const ATTEMPT_LOG_NOT_PURGEABLE_NOTE =
+  "attempt-log has no repoFullName column and cannot be purged by repo (#5564); its rows are unaffected";
+
+/** The shape every real purge target's opened store shares — all that `purgeOneStore`/`countExistingRows`
+ *  actually need, regardless of which concrete store type a given target opens. */
+type PurgeableStore = { purgeByRepo(repoFullName: string): number; close(): void };
+
+type PurgeOpenerKey =
+  | "openClaimLedger"
+  | "initEventLedger"
+  | "initGovernorLedger"
+  | "initPredictionLedger"
+  | "initPortfolioQueueStore"
+  | "initRunStateStore"
+  | "initContributionProfileCache"
+  | "openGovernorState"
+  | "initPolicyVerdictCacheStore";
+
+export type PurgeCliOptions = {
+  openClaimLedger?: () => ClaimLedger;
+  initEventLedger?: () => EventLedger;
+  initGovernorLedger?: () => GovernorLedger;
+  initPredictionLedger?: () => PredictionLedger;
+  initPortfolioQueueStore?: () => PortfolioQueueStore;
+  initRunStateStore?: () => RunStateStore;
+  initContributionProfileCache?: () => ContributionProfileCache;
+  openGovernorState?: () => GovernorState;
+  initPolicyVerdictCacheStore?: () => PolicyVerdictCacheStore;
+  resolveDbPaths?: Record<string, () => string>;
+};
+
+type PurgeTarget = {
+  name: string;
+  optionKey: PurgeOpenerKey;
+  opener: () => PurgeableStore;
+  resolveDbPath: () => string;
+  spec?: LedgerPurgeSpec;
+  specs?: LedgerPurgeSpec[];
+};
+
+const REAL_PURGE_TARGETS: PurgeTarget[] = [
+  { name: "claim-ledger", optionKey: "openClaimLedger", opener: openClaimLedger, resolveDbPath: resolveClaimLedgerDbPath, spec: CLAIM_LEDGER_PURGE_SPEC },
+  { name: "event-ledger", optionKey: "initEventLedger", opener: initEventLedger, resolveDbPath: resolveEventLedgerDbPath, spec: EVENT_LEDGER_PURGE_SPEC },
+  { name: "governor-ledger", optionKey: "initGovernorLedger", opener: initGovernorLedger, resolveDbPath: resolveGovernorLedgerDbPath, spec: GOVERNOR_LEDGER_PURGE_SPEC },
+  { name: "prediction-ledger", optionKey: "initPredictionLedger", opener: initPredictionLedger, resolveDbPath: resolvePredictionLedgerDbPath, spec: PREDICTION_LEDGER_PURGE_SPEC },
+  { name: "portfolio-queue", optionKey: "initPortfolioQueueStore", opener: initPortfolioQueueStore, resolveDbPath: resolvePortfolioQueueDbPath, spec: PORTFOLIO_QUEUE_PURGE_SPEC },
+  { name: "run-state", optionKey: "initRunStateStore", opener: initRunStateStore, resolveDbPath: resolveRunStateDbPath, spec: RUN_STATE_PURGE_SPEC },
+  { name: "contribution-profile-cache", optionKey: "initContributionProfileCache", opener: initContributionProfileCache, resolveDbPath: resolveContributionProfileCacheDbPath, spec: CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC },
+  // governor-state holds TWO repo-scoped tables in one DB file; its store.purgeByRepo deletes both against a
+  // single handle (never reopening the file), and its dry-run count sums both via `specs` (#7091).
+  { name: "governor-state", optionKey: "openGovernorState", opener: openGovernorState, resolveDbPath: resolveGovernorStateDbPath, specs: [GOVERNOR_REPUTATION_HISTORY_PURGE_SPEC, GOVERNOR_OWN_SUBMISSIONS_PURGE_SPEC] },
+  { name: "policy-verdict-cache", optionKey: "initPolicyVerdictCacheStore", opener: initPolicyVerdictCacheStore, resolveDbPath: resolvePolicyVerdictCacheDbPath, spec: POLICY_VERDICT_CACHE_PURGE_SPEC },
+];
+
+export type ParsedPurgeArgs = { json: boolean; dryRun: boolean; repoFullName: string } | { error: string };
+
+type ParsedRepoArg = { repoFullName: string } | { error: string };
+
+function parseRepoArg(value: string | undefined, usage: string): ParsedRepoArg {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parsePurgeArgs(args: string[]): ParsedPurgeArgs {
+  const options: { json: boolean; dryRun: boolean; repoFullName: string | null } = {
+    json: false,
+    dryRun: false,
+    repoFullName: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      // Only the flag-look-alike case is checked here ("--repo --json") -- a genuinely missing value (repoArg
+      // undefined) falls through to parseRepoArg's own `!value` guard below, the single source of truth for that.
+      if (repoArg !== undefined && repoArg.startsWith("-")) return { error: PURGE_USAGE };
+      const repo = parseRepoArg(repoArg, PURGE_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    return { error: `Unknown option: ${token}` };
+  }
+
+  if (!options.repoFullName) return { error: PURGE_USAGE };
+  return { json: options.json, dryRun: options.dryRun, repoFullName: options.repoFullName };
+}
+
+/** Read-only row count against an on-disk store file, for --dry-run. `{ readOnly: true }` (camelCase) is the
+ *  only option node:sqlite recognizes for a driver-enforced read-only connection -- the lowercase `readonly`
+ *  key is silently ignored. Never touches a store that doesn't exist yet (opening one -- even read-only --
+ *  requires the file to already be there; a dry run must make zero writes). */
+function countExistingRows(dbPath: string, countFn: (db: DatabaseSync) => number): number {
+  if (!existsSync(dbPath)) return 0;
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return countFn(db);
+  } finally {
+    db.close();
+  }
+}
+
+export type PurgeDryRunStoreResult = { store: string; wouldPurge: number | null; error?: string };
+
+export type PurgeDryRunResult = {
+  outcome: "dry_run";
+  repoFullName: string;
+  stores: PurgeDryRunStoreResult[];
+  attemptLogNote: string;
+  attemptLogTotalRows: number;
+};
+
+function renderDryRunSummary(result: PurgeDryRunResult): string {
+  const purgeableLine = result.stores
+    .map((entry) => `${entry.store}=${entry.wouldPurge}`)
+    .join(", ");
+  return [
+    `DRY RUN: would purge ${result.repoFullName} from: ${purgeableLine}. No writes were made.`,
+    `${ATTEMPT_LOG_NOT_PURGEABLE_NOTE} (${result.attemptLogTotalRows} total row(s) currently in attempt-log, all repos).`,
+  ].join("\n");
+}
+
+export function runPurgeDryRun(
+  parsed: { repoFullName: string; json: boolean },
+  options: PurgeCliOptions = {},
+): number {
+  const resolveDbPaths = options.resolveDbPaths ?? {};
+  const stores: PurgeDryRunStoreResult[] = REAL_PURGE_TARGETS.map((target) => {
+    const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
+    // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
+    // per-table counts against the single read-only handle so the preview matches what a real purge removes.
+    // Every REAL_PURGE_TARGETS entry declares exactly one of the two, so `target.spec` is always set here.
+    const specs = target.specs ?? [target.spec!];
+    try {
+      const wouldPurge = countExistingRows(dbPath, (db) =>
+        specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0),
+      );
+      return { store: target.name, wouldPurge };
+    } catch (error) {
+      return { store: target.name, wouldPurge: null, error: describeError(error) };
+    }
+  });
+
+  const attemptLogDbPath = (resolveDbPaths["attempt-log"] ?? resolveAttemptLogDbPath)();
+  const attemptLogTotalRows = countExistingRows(attemptLogDbPath, (db) =>
+    Number((db.prepare("SELECT COUNT(*) AS count FROM attempt_log_events").get() as { count: number }).count),
+  );
+
+  const result: PurgeDryRunResult = {
+    outcome: "dry_run",
+    repoFullName: parsed.repoFullName,
+    stores,
+    attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+    attemptLogTotalRows,
+  };
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(renderDryRunSummary(result));
+  }
+  return 0;
+}
+
+export type PurgeStoreResult = { store: string; purged: number | null; error?: string; note?: string };
+
+function purgeOneStore(target: PurgeTarget, options: PurgeCliOptions, repoFullName: string): PurgeStoreResult {
+  const ownsStore = options[target.optionKey] === undefined;
+  let store: PurgeableStore | undefined;
+  try {
+    store = (options[target.optionKey] ?? target.opener)();
+    const purged = store.purgeByRepo(repoFullName);
+    return { store: target.name, purged };
+  } catch (error) {
+    return { store: target.name, purged: null, error: describeError(error) };
+  } finally {
+    if (ownsStore) store?.close();
+  }
+}
+
+export type PurgeSummary = {
+  outcome: "purged" | "partial";
+  repoFullName: string;
+  totalPurged: number;
+  stores: PurgeStoreResult[];
+  purgedAt: string;
+};
+
+function renderPurgeSummary(summary: PurgeSummary): string {
+  const perStore = summary.stores
+    .map((entry) => {
+      if ("error" in entry) return `${entry.store}=ERROR(${entry.error})`;
+      if (entry.purged === null) return `${entry.store}=skipped`;
+      return `${entry.store}=${entry.purged}`;
+    })
+    .join(", ");
+  return [
+    `Purged ${summary.totalPurged} row(s) for ${summary.repoFullName} at ${summary.purgedAt}: ${perStore}.`,
+    ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
+  ].join(" ");
+}
+
+export function runPurge(args: string[], options: PurgeCliOptions = {}): number {
+  const parsed = parsePurgeArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    return runPurgeDryRun(parsed, options);
+  }
+
+  const perStoreResults: PurgeStoreResult[] = REAL_PURGE_TARGETS.map((target) =>
+    purgeOneStore(target, options, parsed.repoFullName),
+  );
+  perStoreResults.push({ store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE });
+
+  const totalPurged = perStoreResults.reduce((sum, entry) => sum + (entry.purged ?? 0), 0);
+  const hadError = perStoreResults.some((entry) => "error" in entry);
+  const summary: PurgeSummary = {
+    outcome: hadError ? "partial" : "purged",
+    repoFullName: parsed.repoFullName,
+    totalPurged,
+    stores: perStoreResults,
+    purgedAt: new Date().toISOString(),
+  };
+
+  // Audit-observable by design (#5564): print the summary in BOTH the success and partial-failure case, so a
+  // purge -- or a purge that only partly succeeded -- is never silent.
+  if (parsed.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(renderPurgeSummary(summary));
+  }
+  return hadError ? 2 : 0;
+}

--- a/packages/loopover-miner/lib/run-state-cli.d.ts
+++ b/packages/loopover-miner/lib/run-state-cli.d.ts
@@ -1,27 +1,22 @@
-export type ParsedStateGetArgs =
-  | {
-      repoFullName: string;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export type ParsedStateSetArgs =
-  | {
-      repoFullName: string;
-      state: "idle" | "discovering" | "planning" | "preparing";
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export function parseStateGetArgs(args: string[]): ParsedStateGetArgs;
-
-export function parseStateSetArgs(args: string[]): ParsedStateSetArgs;
-
-export function runStateGet(args: string[]): number;
-
-export function runStateSet(args: string[]): number;
-
-export function runStateCli(subcommand: string | undefined, args: string[]): number;
+import type { RunState } from "./run-state.js";
+export type ParsedStateGetArgs = {
+    repoFullName: string;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedStateSetArgs = {
+    repoFullName: string;
+    state: RunState;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export declare function parseStateGetArgs(args: string[]): ParsedStateGetArgs;
+export declare function parseStateSetArgs(args: string[]): ParsedStateSetArgs;
+export declare function runStateGet(args: string[]): number;
+export declare function runStateSet(args: string[]): number;
+export declare function runStateCli(subcommand: string | undefined, args: string[]): number;

--- a/packages/loopover-miner/lib/run-state-cli.js
+++ b/packages/loopover-miner/lib/run-state-cli.js
@@ -1,154 +1,148 @@
 import { RUN_STATES, getRunState, setRunState } from "./run-state.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 const STATE_GET_USAGE = "Usage: loopover-miner state get <owner/repo> [--api-base-url <url>] [--json]";
-const STATE_SET_USAGE =
-  "Usage: loopover-miner state set <owner/repo> <idle|discovering|planning|preparing> [--api-base-url <url>] [--dry-run] [--json]";
-
+const STATE_SET_USAGE = "Usage: loopover-miner state set <owner/repo> <idle|discovering|planning|preparing> [--api-base-url <url>] [--dry-run] [--json]";
 const allowedRunStates = new Set(RUN_STATES);
-
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parseStateGetArgs(args) {
-  const options = { json: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, apiBaseUrl: undefined };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #5563: scope the lookup to a non-default forge host, so it doesn't collide with (or get confused for) a
+        // same-named repo on the default github.com host.
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: STATE_GET_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #5563: scope the lookup to a non-default forge host, so it doesn't collide with (or get confused for) a
-    // same-named repo on the default github.com host.
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 1) {
         return { error: STATE_GET_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length !== 1) {
-    return { error: STATE_GET_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
-  if ("error" in repo) return repo;
-
-  return { repoFullName: repo.repoFullName, ...options };
+    const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
+    if ("error" in repo)
+        return repo;
+    return { repoFullName: repo.repoFullName, ...options };
 }
-
 export function parseStateSetArgs(args) {
-  const options = { json: false, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what a real state set would do and returns before writing to the run-state store.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: STATE_SET_USAGE };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #4847: reports what a real state set would do and returns before writing to the run-state store.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: STATE_SET_USAGE };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
+    const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
+    if ("error" in repo)
+        return repo;
+    const state = positional[1];
+    if (!allowedRunStates.has(state)) {
+        return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
     }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: STATE_SET_USAGE };
-  }
-
-  const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
-  if ("error" in repo) return repo;
-
-  const state = positional[1];
-  if (!allowedRunStates.has(state)) {
-    return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
-  }
-
-  return { repoFullName: repo.repoFullName, state, ...options };
+    return { repoFullName: repo.repoFullName, state: state, ...options };
 }
-
 export function runStateGet(args) {
-  const parsed = parseStateGetArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    const state = getRunState(parsed.repoFullName, parsed.apiBaseUrl);
-    if (parsed.json) {
-      console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
-    } else {
-      console.log(state ?? "none");
+    const parsed = parseStateGetArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    try {
+        const state = getRunState(parsed.repoFullName, parsed.apiBaseUrl);
+        if (parsed.json) {
+            console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
+        }
+        else {
+            console.log(state ?? "none");
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runStateSet(args) {
-  const parsed = parseStateSetArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, state: parsed.state };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      console.log(`DRY RUN: would set ${parsed.repoFullName}'s run state to "${parsed.state}". No run-state write was made.`);
+    const parsed = parseStateSetArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    const write = setRunState(parsed.repoFullName, parsed.state, parsed.apiBaseUrl);
-    if (parsed.json) {
-      console.log(JSON.stringify(write));
-    } else {
-      console.log(write.state);
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, state: parsed.state };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            console.log(`DRY RUN: would set ${parsed.repoFullName}'s run state to "${parsed.state}". No run-state write was made.`);
+        }
+        return 0;
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    try {
+        const write = setRunState(parsed.repoFullName, parsed.state, parsed.apiBaseUrl);
+        if (parsed.json) {
+            console.log(JSON.stringify(write));
+        }
+        else {
+            console.log(write.state);
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runStateCli(subcommand, args) {
-  if (subcommand === "get") return runStateGet(args);
-  if (subcommand === "set") return runStateSet(args);
-  return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
+    if (subcommand === "get")
+        return runStateGet(args);
+    if (subcommand === "set")
+        return runStateSet(args);
+    return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicnVuLXN0YXRlLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInJ1bi1zdGF0ZS1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLFVBQVUsRUFBRSxXQUFXLEVBQUUsV0FBVyxFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFFdEUsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBRWxGLE1BQU0sZUFBZSxHQUFHLDhFQUE4RSxDQUFDO0FBQ3ZHLE1BQU0sZUFBZSxHQUNuQixnSUFBZ0ksQ0FBQztBQUVuSSxNQUFNLGdCQUFnQixHQUFnQixJQUFJLEdBQUcsQ0FBQyxVQUFVLENBQUMsQ0FBQztBQXNCMUQsU0FBUyxZQUFZLENBQUMsS0FBeUIsRUFBRSxLQUFhO0lBQzVELElBQUksQ0FBQyxLQUFLO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUNwQyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDN0IsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztRQUMzQyxPQUFPLEVBQUUsS0FBSyxFQUFFLHdDQUF3QyxFQUFFLENBQUM7SUFDN0QsQ0FBQztJQUNELE9BQU8sRUFBRSxZQUFZLEVBQUUsR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLEVBQUUsQ0FBQztBQUM5QyxDQUFDO0FBRUQsTUFBTSxVQUFVLGlCQUFpQixDQUFDLElBQWM7SUFDOUMsTUFBTSxPQUFPLEdBQXNELEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsU0FBUyxFQUFFLENBQUM7SUFDMUcsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCwwR0FBMEc7UUFDMUcsa0RBQWtEO1FBQ2xELElBQUksS0FBSyxLQUFLLGdCQUFnQixFQUFFLENBQUM7WUFDL0IsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztnQkFDcEMsT0FBTyxFQUFFLEtBQUssRUFBRSxlQUFlLEVBQUUsQ0FBQztZQUNwQyxDQUFDO1lBQ0QsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQzVCLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7SUFDcEMsQ0FBQztJQUVELE1BQU0sSUFBSSxHQUFHLFlBQVksQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsZUFBZSxDQUFDLENBQUM7SUFDMUQsSUFBSSxPQUFPLElBQUksSUFBSTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBRWpDLE9BQU8sRUFBRSxZQUFZLEVBQUUsSUFBSSxDQUFDLFlBQVksRUFBRSxHQUFHLE9BQU8sRUFBRSxDQUFDO0FBQ3pELENBQUM7QUFFRCxNQUFNLFVBQVUsaUJBQWlCLENBQUMsSUFBYztJQUM5QyxNQUFNLE9BQU8sR0FBdUU7UUFDbEYsSUFBSSxFQUFFLEtBQUs7UUFDWCxNQUFNLEVBQUUsS0FBSztRQUNiLFVBQVUsRUFBRSxTQUFTO0tBQ3RCLENBQUM7SUFDRixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELG1HQUFtRztRQUNuRyxJQUFJLEtBQUssS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUMxQixPQUFPLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQztZQUN0QixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLGdCQUFnQixFQUFFLENBQUM7WUFDL0IsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztnQkFDcEMsT0FBTyxFQUFFLEtBQUssRUFBRSxlQUFlLEVBQUUsQ0FBQztZQUNwQyxDQUFDO1lBQ0QsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQzVCLE9BQU8sRUFBRSxLQUFLLEVBQUUsZUFBZSxFQUFFLENBQUM7SUFDcEMsQ0FBQztJQUVELE1BQU0sSUFBSSxHQUFHLFlBQVksQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsZUFBZSxDQUFDLENBQUM7SUFDMUQsSUFBSSxPQUFPLElBQUksSUFBSTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBRWpDLE1BQU0sS0FBSyxHQUFHLFVBQVUsQ0FBQyxDQUFDLENBQUUsQ0FBQztJQUM3QixJQUFJLENBQUMsZ0JBQWdCLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDakMsT0FBTyxFQUFFLEtBQUssRUFBRSxrQkFBa0IsS0FBSyxxQkFBcUIsVUFBVSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUM7SUFDekYsQ0FBQztJQUVELE9BQU8sRUFBRSxZQUFZLEVBQUUsSUFBSSxDQUFDLFlBQVksRUFBRSxLQUFLLEVBQUUsS0FBaUIsRUFBRSxHQUFHLE9BQU8sRUFBRSxDQUFDO0FBQ25GLENBQUM7QUFFRCxNQUFNLFVBQVUsV0FBVyxDQUFDLElBQWM7SUFDeEMsTUFBTSxNQUFNLEdBQUcsaUJBQWlCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDdkMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxNQUFNLEtBQUssR0FBRyxXQUFXLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUM7UUFDbEUsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQzVFLENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLElBQUksTUFBTSxDQUFDLENBQUM7UUFDL0IsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsSUFBYztJQUN4QyxNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN2QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxLQUFLLEVBQUUsTUFBTSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3BHLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDO1FBQzVDLENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxzQkFBc0IsTUFBTSxDQUFDLFlBQVksb0JBQW9CLE1BQU0sQ0FBQyxLQUFLLGlDQUFpQyxDQUFDLENBQUM7UUFDMUgsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxNQUFNLENBQUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxLQUFLLEVBQUUsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDO1FBQ2hGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1FBQ3JDLENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDM0IsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXLENBQUMsVUFBOEIsRUFBRSxJQUFjO0lBQ3hFLElBQUksVUFBVSxLQUFLLEtBQUs7UUFBRSxPQUFPLFdBQVcsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNuRCxJQUFJLFVBQVUsS0FBSyxLQUFLO1FBQUUsT0FBTyxXQUFXLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDbkQsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsNkJBQTZCLFVBQVUsSUFBSSxFQUFFLEtBQUssZUFBZSxFQUFFLENBQUMsQ0FBQztBQUNuSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/run-state-cli.ts
+++ b/packages/loopover-miner/lib/run-state-cli.ts
@@ -1,0 +1,179 @@
+import { RUN_STATES, getRunState, setRunState } from "./run-state.js";
+import type { RunState } from "./run-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+const STATE_GET_USAGE = "Usage: loopover-miner state get <owner/repo> [--api-base-url <url>] [--json]";
+const STATE_SET_USAGE =
+  "Usage: loopover-miner state set <owner/repo> <idle|discovering|planning|preparing> [--api-base-url <url>] [--dry-run] [--json]";
+
+const allowedRunStates: Set<string> = new Set(RUN_STATES);
+
+export type ParsedStateGetArgs =
+  | {
+      repoFullName: string;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedStateSetArgs =
+  | {
+      repoFullName: string;
+      state: RunState;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+type ParsedRepoArg = { repoFullName: string } | { error: string };
+
+function parseRepoArg(value: string | undefined, usage: string): ParsedRepoArg {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parseStateGetArgs(args: string[]): ParsedStateGetArgs {
+  const options: { json: boolean; apiBaseUrl: string | undefined } = { json: false, apiBaseUrl: undefined };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #5563: scope the lookup to a non-default forge host, so it doesn't collide with (or get confused for) a
+    // same-named repo on the default github.com host.
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: STATE_GET_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 1) {
+    return { error: STATE_GET_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
+  if ("error" in repo) return repo;
+
+  return { repoFullName: repo.repoFullName, ...options };
+}
+
+export function parseStateSetArgs(args: string[]): ParsedStateSetArgs {
+  const options: { json: boolean; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what a real state set would do and returns before writing to the run-state store.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: STATE_SET_USAGE };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: STATE_SET_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
+  if ("error" in repo) return repo;
+
+  const state = positional[1]!;
+  if (!allowedRunStates.has(state)) {
+    return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
+  }
+
+  return { repoFullName: repo.repoFullName, state: state as RunState, ...options };
+}
+
+export function runStateGet(args: string[]): number {
+  const parsed = parseStateGetArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    const state = getRunState(parsed.repoFullName, parsed.apiBaseUrl);
+    if (parsed.json) {
+      console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
+    } else {
+      console.log(state ?? "none");
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runStateSet(args: string[]): number {
+  const parsed = parseStateSetArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, state: parsed.state };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      console.log(`DRY RUN: would set ${parsed.repoFullName}'s run state to "${parsed.state}". No run-state write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    const write = setRunState(parsed.repoFullName, parsed.state, parsed.apiBaseUrl);
+    if (parsed.json) {
+      console.log(JSON.stringify(write));
+    } else {
+      console.log(write.state);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runStateCli(subcommand: string | undefined, args: string[]): number {
+  if (subcommand === "get") return runStateGet(args);
+  if (subcommand === "set") return runStateSet(args);
+  return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
+}

--- a/test/unit/miner-claim-ledger-cli.test.ts
+++ b/test/unit/miner-claim-ledger-cli.test.ts
@@ -403,4 +403,52 @@ describe("loopover-miner claim ledger CLI (#4290)", () => {
     ).toBe(2);
     expect(error).toHaveBeenCalledWith("list_broken");
   });
+
+  it("parseClaimClaimArgs and parseClaimReleaseArgs reject an empty repo/issue positional", () => {
+    expect(parseClaimClaimArgs(["", "42"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim claim"),
+    });
+    expect(parseClaimClaimArgs(["acme/widgets", ""])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim claim"),
+    });
+    expect(parseClaimReleaseArgs(["acme/widgets", "abc"])).toEqual({
+      error: "issue number must be a positive integer.",
+    });
+    expect(parseClaimReleaseArgs(["bad", "7"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+  });
+
+  it("parseClaimListArgs reports an invalid --repo and a missing --status value", () => {
+    expect(parseClaimListArgs(["--repo", "bad"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimListArgs(["--status"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner claim list"),
+    });
+  });
+
+  it("runClaimRelease and runClaimList report a parse-argument error", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runClaimRelease(["acme/widgets"])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Usage: loopover-miner claim release");
+    error.mockClear();
+    expect(runClaimList(["--bogus"])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Unknown option: --bogus");
+  });
+
+  it("withClaimLedger opens and closes its own default ledger when no openClaimLedger override is given", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-claim-ledger-cli-default-"));
+    roots.push(root);
+    const previousDbPath = process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB;
+    process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = join(root, "claim-ledger.sqlite3");
+    try {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(runClaimList([])).toBe(0);
+      expect(log).toHaveBeenCalledWith("no claim ledger entries");
+    } finally {
+      if (previousDbPath === undefined) delete process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB;
+      else process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = previousDbPath;
+    }
+  });
 });

--- a/test/unit/miner-cli-run-state.test.ts
+++ b/test/unit/miner-cli-run-state.test.ts
@@ -14,6 +14,7 @@ const {
   parseStateSetArgs,
   runStateGet,
   runStateSet,
+  runStateCli,
 } = await import("../../packages/loopover-miner/lib/run-state-cli.js");
 
 afterEach(() => {
@@ -145,5 +146,56 @@ describe("loopover-miner state CLI", () => {
       ok: false,
       error: "invalid_repo_full_name",
     });
+  });
+
+  it("runStateSet returns exit code 2 when the store write fails", () => {
+    setRunState.mockImplementation(() => {
+      throw new Error("invalid_state");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runStateSet(["acme/widgets", "idle"])).toBe(2);
+    expect(error).toHaveBeenCalledWith("invalid_state");
+  });
+
+  it("parseStateGetArgs and parseStateSetArgs reject an empty repo positional and unknown flags", () => {
+    expect(parseStateGetArgs(["", "--api-base-url", "https://ghe.example.com/api/v3"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner state get"),
+    });
+    expect(parseStateGetArgs(["acme/widgets", "--bogus"])).toEqual({
+      error: "Unknown option: --bogus",
+    });
+    expect(parseStateSetArgs(["acme/widgets", "planning", "--bogus"])).toEqual({
+      error: "Unknown option: --bogus",
+    });
+    expect(parseStateSetArgs(["acme/widgets"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner state set"),
+    });
+  });
+
+  it("runStateGet returns exit code 2 for malformed repositories", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runStateGet(["not-a-repo"])).toBe(2);
+    expect(error).toHaveBeenCalledWith("Repository must be in owner/repo form.");
+    expect(getRunState).not.toHaveBeenCalled();
+  });
+
+  it("runStateCli dispatches get/set and rejects unknown subcommands", () => {
+    getRunState.mockReturnValue("idle");
+    setRunState.mockReturnValue({
+      repoFullName: "acme/widgets",
+      state: "idle",
+      updatedAt: "2026-07-03T00:00:00.000Z",
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runStateCli("get", ["acme/widgets"])).toBe(0);
+    expect(runStateCli("set", ["acme/widgets", "idle"])).toBe(0);
+    expect(log).toHaveBeenCalled();
+
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runStateCli("bogus", [])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Unknown state subcommand");
+    error.mockClear();
+    expect(runStateCli(undefined, [])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Unknown state subcommand: .");
   });
 });

--- a/test/unit/miner-event-ledger-cli.test.ts
+++ b/test/unit/miner-event-ledger-cli.test.ts
@@ -7,8 +7,11 @@ import {
   initEventLedger,
 } from "../../packages/loopover-miner/lib/event-ledger.js";
 import {
+  collectEventLedgerAuditFeed,
   filterLedgerEvents,
+  normalizeAuditFeedMcpFilter,
   parseLedgerListArgs,
+  projectLedgerEventToAuditFeedEntry,
   renderEventLedgerMetrics,
   renderLedgerTable,
   runLedgerCli,
@@ -66,6 +69,22 @@ describe("loopover-miner event ledger CLI (#2290)", () => {
     });
   });
 
+  it("parseLedgerListArgs rejects missing flag values, unknown flags, and stray positionals", () => {
+    expect(parseLedgerListArgs(["--repo"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner ledger list"),
+    });
+    expect(parseLedgerListArgs(["--since"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner ledger list"),
+    });
+    expect(parseLedgerListArgs(["--type"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner ledger list"),
+    });
+    expect(parseLedgerListArgs(["--bogus"])).toEqual({ error: "Unknown option: --bogus" });
+    expect(parseLedgerListArgs(["extra"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner ledger list"),
+    });
+  });
+
   // #5831: --repo's own parser must reject the same class of malformed/unsafe identifier repo-clone.js
   // already rejects, not just "missing slash" -- for both the owner and repo segment independently.
   it("rejects an unsafe --repo value", () => {
@@ -99,9 +118,13 @@ describe("loopover-miner event ledger CLI (#2290)", () => {
     ];
     expect(filterLedgerEvents(events, { type: "discovered_issue" })).toEqual([]);
     expect(filterLedgerEvents(events, { type: "manage_pr_update" })).toEqual(events);
+    expect(filterLedgerEvents(undefined as never)).toEqual([]);
     expect(renderLedgerTable([])).toBe("no event ledger entries");
     expect(renderLedgerTable(events)).toContain("manage_pr_update");
     expect(renderLedgerTable(events)).toContain("   4");
+    expect(
+      renderLedgerTable([{ ...events[0]!, repoFullName: null, createdAt: null as unknown as string }]),
+    ).toContain("-");
   });
 
   it("runLedgerList prints table and JSON output with repo, since, and type filters", () => {
@@ -139,6 +162,21 @@ describe("loopover-miner event ledger CLI (#2290)", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(runLedgerCli("tail", [])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Unknown ledger subcommand");
+    error.mockClear();
+    expect(runLedgerCli(undefined, [])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Unknown ledger subcommand: .");
+  });
+
+  it("runLedgerList reports a failure raised by the event ledger", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      runLedgerList([], {
+        initEventLedger: () => {
+          throw new Error("event_ledger_broken");
+        },
+      }),
+    ).toBe(2);
+    expect(error).toHaveBeenCalledWith("event_ledger_broken");
   });
 
   it("surfaces invalid since cursors from argv parsing and the ledger store", () => {
@@ -286,5 +324,125 @@ describe("loopover-miner ledger metrics CLI (#4841)", () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runLedgerCli("metrics", [], { initEventLedger: () => eventLedger })).toBe(0);
     expect(String(log.mock.calls[0]?.[0])).toContain('loopover_miner_events_total{type="plan_built"} 1');
+  });
+});
+
+describe("loopover-miner event ledger MCP audit feed (#5158)", () => {
+  it("projectLedgerEventToAuditFeedEntry projects the metadata-only shape and never leaks payload_json", () => {
+    const full = projectLedgerEventToAuditFeedEntry({
+      id: 1,
+      seq: 1,
+      type: "manage_pr_update",
+      repoFullName: "acme/widgets",
+      payload: { outcome: " merged ", actor: " bot ", detail: " ok ", secret: "should-not-leak" },
+      createdAt: "2026-07-04T12:00:00.000Z",
+    });
+    expect(full).toEqual({
+      eventType: "manage_pr_update",
+      repoFullName: "acme/widgets",
+      outcome: "merged",
+      actor: "bot",
+      detail: "ok",
+      createdAt: "2026-07-04T12:00:00.000Z",
+    });
+    expect(full).not.toHaveProperty("secret");
+    expect(full).not.toHaveProperty("payload_json");
+
+    // A non-object, array, or missing payload all fall back to {} -- every metadata field is null.
+    const noPayload = projectLedgerEventToAuditFeedEntry({
+      id: 2,
+      seq: 2,
+      type: "discovered_issue",
+      repoFullName: null,
+      payload: undefined as unknown as Record<string, unknown>,
+      createdAt: "2026-07-04T12:00:00.000Z",
+    });
+    expect(noPayload).toEqual({
+      eventType: "discovered_issue",
+      repoFullName: null,
+      outcome: null,
+      actor: null,
+      detail: null,
+      createdAt: "2026-07-04T12:00:00.000Z",
+    });
+
+    const arrayPayload = projectLedgerEventToAuditFeedEntry({
+      id: 3,
+      seq: 3,
+      type: "plan_built",
+      repoFullName: null,
+      payload: [1, 2, 3] as unknown as Record<string, unknown>,
+      createdAt: "2026-07-04T12:00:00.000Z",
+    });
+    expect(arrayPayload.outcome).toBeNull();
+
+    // Non-string / blank-after-trim metadata fields also fall back to null.
+    const blankMetadata = projectLedgerEventToAuditFeedEntry({
+      id: 4,
+      seq: 4,
+      type: "plan_built",
+      repoFullName: null,
+      payload: { outcome: 42, actor: "   ", detail: null },
+      createdAt: "2026-07-04T12:00:00.000Z",
+    });
+    expect(blankMetadata.outcome).toBeNull();
+    expect(blankMetadata.actor).toBeNull();
+    expect(blankMetadata.detail).toBeNull();
+  });
+
+  it("normalizeAuditFeedMcpFilter normalizes, defaults, and validates MCP filter input", () => {
+    expect(normalizeAuditFeedMcpFilter()).toEqual({ repoFullName: null, since: null, type: null });
+    expect(normalizeAuditFeedMcpFilter({ repoFullName: null, since: null, type: null })).toEqual({
+      repoFullName: null,
+      since: null,
+      type: null,
+    });
+    expect(normalizeAuditFeedMcpFilter({ repoFullName: "acme/widgets", since: 3, type: " manage_pr_update " })).toEqual({
+      repoFullName: "acme/widgets",
+      since: 3,
+      type: "manage_pr_update",
+    });
+    expect(() => normalizeAuditFeedMcpFilter({ repoFullName: "bad" })).toThrow(
+      "Repository must be in owner/repo form.",
+    );
+    expect(() => normalizeAuditFeedMcpFilter({ repoFullName: "" })).toThrow(
+      "repoFullName must be in owner/repo form.",
+    );
+    expect(() => normalizeAuditFeedMcpFilter({ since: -1 })).toThrow(
+      "since must be a non-negative integer seq cursor.",
+    );
+    expect(() => normalizeAuditFeedMcpFilter({ type: "   " })).toThrow("type must be a non-empty string.");
+    expect(() => normalizeAuditFeedMcpFilter(null as never)).toThrow("filter must be an object");
+    expect(() => normalizeAuditFeedMcpFilter([] as never)).toThrow("filter must be an object");
+  });
+
+  it("collectEventLedgerAuditFeed returns a metadata-only, optionally repo-scoped feed", () => {
+    const eventLedger = tempLedger();
+    eventLedger.appendEvent({
+      type: "manage_pr_update",
+      repoFullName: "acme/widgets",
+      payload: { outcome: "merged", actor: "bot" },
+    });
+    eventLedger.appendEvent({
+      type: "discovered_issue",
+      repoFullName: "acme/other",
+      payload: {},
+    });
+
+    const scoped = collectEventLedgerAuditFeed(eventLedger, { repoFullName: "acme/widgets" });
+    expect(scoped.repoFullName).toBe("acme/widgets");
+    expect(scoped.events).toEqual([
+      expect.objectContaining({ eventType: "manage_pr_update", outcome: "merged", actor: "bot" }),
+    ]);
+
+    const unscoped = collectEventLedgerAuditFeed(eventLedger);
+    expect(unscoped).not.toHaveProperty("repoFullName");
+    expect(unscoped.events).toHaveLength(2);
+
+    const typed = collectEventLedgerAuditFeed(eventLedger, { type: "discovered_issue" });
+    expect(typed.events).toEqual([expect.objectContaining({ eventType: "discovered_issue" })]);
+
+    const sinced = collectEventLedgerAuditFeed(eventLedger, { since: 0 });
+    expect(sinced.events).toHaveLength(2);
   });
 });

--- a/test/unit/miner-governor-ledger-cli.test.ts
+++ b/test/unit/miner-governor-ledger-cli.test.ts
@@ -179,6 +179,10 @@ describe("loopover-miner governor ledger CLI (#2328)", () => {
     expect(await runGovernorCli("resume", ["--json"], { openGovernorState: () => governorState })).toBe(0);
     expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({ paused: false });
 
+    log.mockClear();
+    expect(await runGovernorCli("metrics", [], { openGovernorState: () => governorState })).toBe(0);
+    expect(log).toHaveBeenCalled();
+
     governorState.close();
   });
 
@@ -186,5 +190,64 @@ describe("loopover-miner governor ledger CLI (#2328)", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(await runGovernorList(["--verbose"])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Unknown option");
+  });
+
+  it("parseGovernorListArgs rejects missing flag values and stray positionals", () => {
+    expect(parseGovernorListArgs(["--repo"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner governor list"),
+    });
+    expect(parseGovernorListArgs(["--type"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner governor list"),
+    });
+    expect(parseGovernorListArgs(["extra"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner governor list"),
+    });
+  });
+
+  it("filterGovernorEvents tolerates a non-array input", () => {
+    expect(filterGovernorEvents(undefined as never)).toEqual([]);
+  });
+
+  it("renderGovernorTable displays a dash for missing repoFullName/ts", () => {
+    const events: GovernorLedgerEntry[] = [
+      {
+        id: 5,
+        ts: undefined as unknown as string,
+        eventType: "allowed",
+        repoFullName: null,
+        actionClass: "analyze",
+        decision: "allow",
+        reason: "within budget",
+        payload: {},
+      },
+    ];
+    expect(renderGovernorTable(events)).toContain("-");
+  });
+
+  it("runGovernorList reports a failure raised by the governor ledger", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      await runGovernorList([], {
+        initGovernorLedger: () => {
+          throw new Error("ledger_broken");
+        },
+      }),
+    ).toBe(2);
+    expect(error).toHaveBeenCalledWith("ledger_broken");
+  });
+
+  it("withGovernorLedger opens and closes its own default ledger when no initGovernorLedger override is given", async () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-ledger-cli-default-"));
+    roots.push(root);
+    const previousDbPath = process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB;
+    process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB = join(root, "governor-ledger.sqlite3");
+    try {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(await runGovernorList([])).toBe(0);
+      expect(log).toHaveBeenCalledWith("no governor ledger entries");
+    } finally {
+      if (previousDbPath === undefined) delete process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB;
+      else process.env.LOOPOVER_MINER_GOVERNOR_LEDGER_DB = previousDbPath;
+    }
   });
 });

--- a/test/unit/miner-plan-store-cli.test.ts
+++ b/test/unit/miner-plan-store-cli.test.ts
@@ -154,6 +154,8 @@ describe("loopover-miner plan store CLI (#2318)", () => {
   it("rejects unknown plan subcommands and options", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(runPlanCli("save", [])).toBe(2);
+    expect(runPlanCli(undefined, [])).toBe(2);
+    expect(String(error.mock.calls[1]?.[0])).toContain("Unknown plan subcommand: .");
     expect(runPlanList(["--verbose"])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Unknown plan subcommand");
     error.mockClear();
@@ -163,5 +165,66 @@ describe("loopover-miner plan store CLI (#2318)", () => {
       ok: false,
       error: expect.stringContaining("Unknown plan subcommand"),
     });
+  });
+
+  it("parsePlanListArgs and parsePlanShowArgs reject unknown flags and stray positionals", () => {
+    expect(parsePlanListArgs(["--status"])).toEqual({ error: expect.stringContaining("Usage") });
+    expect(parsePlanListArgs(["extra-positional"])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner plan list"),
+    });
+    expect(parsePlanListArgs(["--bogus"])).toEqual({ error: "Unknown option: --bogus" });
+    expect(parsePlanShowArgs(["plan-a", "--bogus"])).toEqual({ error: "Unknown option: --bogus" });
+    expect(parsePlanShowArgs(["   "])).toEqual({
+      error: expect.stringContaining("Usage: loopover-miner plan show"),
+    });
+  });
+
+  it("renderPlanTable displays a dash for a plan with no updatedAt", () => {
+    const plans: PlanRecord[] = [
+      { planId: "no-updated", status: "pending", updatedAt: undefined as unknown as string, plan: PLAN },
+    ];
+    expect(renderPlanTable(plans)).toContain("-");
+  });
+
+  it("runPlanShow reports a parse-argument error", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runPlanShow([])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Usage: loopover-miner plan show");
+  });
+
+  it("runPlanList and runPlanShow report a failure raised by the plan store", () => {
+    const failingStore = {
+      listPlans: () => {
+        throw new Error("store_read_failed");
+      },
+      loadPlan: () => {
+        throw new Error("store_read_failed");
+      },
+      savePlan: () => {
+        throw new Error("unused");
+      },
+      close: () => undefined,
+    };
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runPlanList([], { openPlanStore: () => failingStore as never })).toBe(2);
+    expect(error).toHaveBeenCalledWith("store_read_failed");
+    error.mockClear();
+    expect(runPlanShow(["plan-a"], { openPlanStore: () => failingStore as never })).toBe(2);
+    expect(error).toHaveBeenCalledWith("store_read_failed");
+  });
+
+  it("withPlanStore opens and closes its own default store when no openPlanStore override is given", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-plan-store-cli-default-"));
+    roots.push(root);
+    const previousDbPath = process.env.LOOPOVER_MINER_PLAN_STORE_DB;
+    process.env.LOOPOVER_MINER_PLAN_STORE_DB = join(root, "plan-store.sqlite3");
+    try {
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(runPlanList([])).toBe(0);
+      expect(log).toHaveBeenCalledWith("no saved plans");
+    } finally {
+      if (previousDbPath === undefined) delete process.env.LOOPOVER_MINER_PLAN_STORE_DB;
+      else process.env.LOOPOVER_MINER_PLAN_STORE_DB = previousDbPath;
+    }
   });
 });


### PR DESCRIPTION
Closes #7306

## Summary

Batch 3.2 of the #7290 migration (Phase 3, CLI command modules): converts
`plan-store-cli`, `run-state-cli`, `governor-ledger-cli`, `purge-cli`,
`event-ledger-cli`, and `claim-ledger-cli` (plus their hand-maintained
`.d.ts` siblings) from `.js` to real `.ts`, using the in-place-emit build
pipeline Phase 1 (#7299) already wired up. No `tsconfig.json` changes
needed. No behavior change; existing tests continue to pass unmodified
against the compiled output, and each converted module is driven to
100% statement/branch/function/line coverage.

## Notes

- One prior attempt on this issue ([#7358](https://github.com/JSONbored/loopover/pull/7358))
  had correct content and 100% `codecov/patch` coverage, but was closed by the
  now-fixed repo-wide `validate`/`validate-tests-merge` CI infrastructure
  outage, not a code issue — confirmed by inspecting its check runs before
  starting this attempt.
- Regenerated and committed the compiled `.js`/`.d.ts` build output alongside
  the `.ts` sources (`npm run build --workspace @loopover/miner`).
- `git diff --check` against `upstream/main` is clean (no compiled-output
  trailing-whitespace artifacts).
- Full CI parity run locally: `typecheck` (root + package), `actionlint`,
  `db:schema-drift:check`, `selfhost:env-reference:check`,
  `miner:env-reference:check`, `docs:drift-check`, `branding-drift:check`,
  `manifest:drift-check`, `engine-parity:drift-check`,
  `release-manifest:sync:check`, `command-reference:check`, `test:workers`,
  `build:mcp`, `test:mcp-pack`, `build:miner`, `test:miner-pack`,
  `test:miner-deployment-docs-audit`, `ui:openapi:check`, `ui:typecheck`,
  `ui:lint`, `npm audit` — all clean.