### PR TITLE
chore(miner): migrate batch 4.8 highest-fan-in lib modules to TypeScript

### DIFF
--- a/packages/loopover-miner/lib/cli-error.d.ts
+++ b/packages/loopover-miner/lib/cli-error.d.ts
@@ -1,3 +1,7 @@
-export function reportCliFailure(wantsJson: boolean, message: string, exitCode?: number): number;
-export function argsWantJson(args: readonly string[]): boolean;
-export function describeCliError(error: unknown): string;
+/** Shared CLI failure output (#4836): when `--json` is set, emit a parseable `{ ok: false, error }` object on
+ *  stdout (matching each command's success-path JSON stream); otherwise log plain text to stderr. */
+export declare function reportCliFailure(wantsJson: boolean, message: string, exitCode?: number): number;
+/** True when argv includes `--json` (used on parse-error paths before a full parse result exists). */
+export declare function argsWantJson(args: readonly string[]): boolean;
+/** Normalize a thrown value to a safe error string for CLI output. */
+export declare function describeCliError(error: unknown): string;

--- a/packages/loopover-miner/lib/cli-error.js
+++ b/packages/loopover-miner/lib/cli-error.js
@@ -1,27 +1,20 @@
 /** Shared CLI failure output (#4836): when `--json` is set, emit a parseable `{ ok: false, error }` object on
  *  stdout (matching each command's success-path JSON stream); otherwise log plain text to stderr. */
-
-/**
- * @param {boolean} wantsJson
- * @param {string} message
- * @param {number} [exitCode]
- * @returns {number}
- */
 export function reportCliFailure(wantsJson, message, exitCode = 2) {
-  if (wantsJson) {
-    console.log(JSON.stringify({ ok: false, error: message }, null, 2));
-  } else {
-    console.error(message);
-  }
-  return exitCode;
+    if (wantsJson) {
+        console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+    }
+    else {
+        console.error(message);
+    }
+    return exitCode;
 }
-
 /** True when argv includes `--json` (used on parse-error paths before a full parse result exists). */
 export function argsWantJson(args) {
-  return args.includes("--json");
+    return args.includes("--json");
 }
-
 /** Normalize a thrown value to a safe error string for CLI output. */
 export function describeCliError(error) {
-  return error instanceof Error ? error.message : String(error);
+    return error instanceof Error ? error.message : String(error);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2xpLWVycm9yLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiY2xpLWVycm9yLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO3FHQUNxRztBQUVyRyxNQUFNLFVBQVUsZ0JBQWdCLENBQUMsU0FBa0IsRUFBRSxPQUFlLEVBQUUsUUFBUSxHQUFHLENBQUM7SUFDaEYsSUFBSSxTQUFTLEVBQUUsQ0FBQztRQUNkLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLEVBQUUsRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLE9BQU8sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ3RFLENBQUM7U0FBTSxDQUFDO1FBQ04sT0FBTyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBQ0QsT0FBTyxRQUFRLENBQUM7QUFDbEIsQ0FBQztBQUVELHNHQUFzRztBQUN0RyxNQUFNLFVBQVUsWUFBWSxDQUFDLElBQXVCO0lBQ2xELE9BQU8sSUFBSSxDQUFDLFFBQVEsQ0FBQyxRQUFRLENBQUMsQ0FBQztBQUNqQyxDQUFDO0FBRUQsc0VBQXNFO0FBQ3RFLE1BQU0sVUFBVSxnQkFBZ0IsQ0FBQyxLQUFjO0lBQzdDLE9BQU8sS0FBSyxZQUFZLEtBQUssQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0FBQ2hFLENBQUMifQ==

--- a/packages/loopover-miner/lib/cli-error.ts
+++ b/packages/loopover-miner/lib/cli-error.ts
@@ -1,0 +1,21 @@
+/** Shared CLI failure output (#4836): when `--json` is set, emit a parseable `{ ok: false, error }` object on
+ *  stdout (matching each command's success-path JSON stream); otherwise log plain text to stderr. */
+
+export function reportCliFailure(wantsJson: boolean, message: string, exitCode = 2): number {
+  if (wantsJson) {
+    console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+  } else {
+    console.error(message);
+  }
+  return exitCode;
+}
+
+/** True when argv includes `--json` (used on parse-error paths before a full parse result exists). */
+export function argsWantJson(args: readonly string[]): boolean {
+  return args.includes("--json");
+}
+
+/** Normalize a thrown value to a safe error string for CLI output. */
+export function describeCliError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/loopover-miner/lib/event-ledger.d.ts
+++ b/packages/loopover-miner/lib/event-ledger.d.ts
@@ -1,37 +1,35 @@
 export type LedgerEntry = {
-  id: number;
-  seq: number;
-  type: string;
-  repoFullName: string | null;
-  payload: Record<string, unknown>;
-  createdAt: string;
+    id: number;
+    seq: number;
+    type: string;
+    repoFullName: string | null;
+    payload: Record<string, unknown>;
+    createdAt: string;
 };
-
 export type AppendEventInput = {
-  type: string;
-  repoFullName?: string;
-  payload: Record<string, unknown>;
+    type: string;
+    repoFullName?: string;
+    payload: Record<string, unknown>;
 };
-
 export type ReadEventsFilter = {
-  repoFullName?: string | null;
-  since?: number | null;
+    repoFullName?: string | null;
+    since?: number | null;
 };
-
 export type EventLedger = {
-  dbPath: string;
-  appendEvent(event: AppendEventInput): LedgerEntry;
-  readEvents(filter?: ReadEventsFilter): LedgerEntry[];
-  purgeByRepo(repoFullName: string): number;
-  close(): void;
+    dbPath: string;
+    appendEvent(event: AppendEventInput): LedgerEntry;
+    readEvents(filter?: ReadEventsFilter): LedgerEntry[];
+    purgeByRepo(repoFullName: string): number;
+    close(): void;
 };
-
-export function resolveEventLedgerDbPath(env?: Record<string, string | undefined>): string;
-
-export function initEventLedger(dbPath?: string): EventLedger;
-
-export function appendEvent(event: AppendEventInput): LedgerEntry;
-
-export function readEvents(filter?: ReadEventsFilter): LedgerEntry[];
-
-export function closeDefaultEventLedger(): void;
+export declare function resolveEventLedgerDbPath(env?: Record<string, string | undefined>): string;
+/**
+ * Opens the local append-only event ledger, creating the table on first use. `seq` is a monotonically increasing
+ * counter maintained by this module (next = current MAX(seq) + 1) rather than relying on `AUTOINCREMENT`'s
+ * reuse-after-vacuum behavior, so consumers get a stable ordering guarantee. Rows read back in `seq ASC` order.
+ * (#2290)
+ */
+export declare function initEventLedger(dbPath?: string): EventLedger;
+export declare function appendEvent(event: AppendEventInput): LedgerEntry;
+export declare function readEvents(filter?: ReadEventsFilter): LedgerEntry[];
+export declare function closeDefaultEventLedger(): void;

--- a/packages/loopover-miner/lib/event-ledger.js
+++ b/packages/loopover-miner/lib/event-ledger.js
@@ -1,111 +1,95 @@
 import { isDeepStrictEqual } from "node:util";
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
-import {
-  EVENT_LEDGER_PURGE_SPEC,
-  EVENT_LEDGER_RETENTION_SPEC,
-  purgeStoreByRepo,
-  pruneLedgerByRetention,
-  resolveLedgerRetentionPolicy,
-} from "./store-maintenance.js";
-
-// The miner's local, append-only event ledger (#2290): an immutable audit trail of every significant miner-loop
-// event (discovered_issue, plan_built, plan_step_completed, pr_prepared, … — a small fixed vocabulary for this
-// foundation phase that grows in later phases), each stamped with a module-maintained monotonic `seq` and a
-// timestamp. IMMUTABILITY INVARIANT: `appendEvent`/`readEvents` only ever issue INSERT and SELECT — they NEVER
-// rewrite or remove a row, so a contributor auditing the miner's history later can trust it was not retroactively
-// edited. Keep it that way: do not add mutation to the day-to-day append/read path. The two documented exceptions
-// are opt-in retention pruning (#4834, automatic, age/size-bounded) and `purgeByRepo` (#5564, always explicit and
-// operator-invoked, never automatic) — both are separate, clearly-labeled maintenance operations, not part of the
-// ledger's normal operation. The database is 100% local; this module never uploads, syncs, or phones home with
-// its contents. Mirrors the local-store pattern of run-state.js.
-
+import { EVENT_LEDGER_PURGE_SPEC, EVENT_LEDGER_RETENTION_SPEC, purgeStoreByRepo, pruneLedgerByRetention, resolveLedgerRetentionPolicy, } from "./store-maintenance.js";
 const defaultDbFileName = "event-ledger.sqlite3";
 let defaultEventLedger = null;
-
 export function resolveEventLedgerDbPath(env = process.env) {
-  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_EVENT_LEDGER_DB", env);
+    return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_EVENT_LEDGER_DB", env);
 }
-
 function normalizeDbPath(dbPath) {
-  return normalizeLocalStoreDbPath(dbPath, resolveEventLedgerDbPath(), "invalid_event_ledger_db_path");
+    return normalizeLocalStoreDbPath(dbPath, resolveEventLedgerDbPath(), "invalid_event_ledger_db_path");
 }
-
 function normalizeEventType(type) {
-  if (typeof type !== "string") throw new Error("invalid_event_type");
-  const trimmed = type.trim();
-  if (!trimmed) throw new Error("invalid_event_type");
-  return trimmed;
+    if (typeof type !== "string")
+        throw new Error("invalid_event_type");
+    const trimmed = type.trim();
+    if (!trimmed)
+        throw new Error("invalid_event_type");
+    return trimmed;
 }
-
 /** Optional repo scope: omitted/nullish → null; otherwise a validated `owner/repo`. */
 function normalizeOptionalRepoFullName(repoFullName) {
-  if (repoFullName === undefined || repoFullName === null) return null;
-  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
-  const [owner, repo, extra] = repoFullName.trim().split("/");
-  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
-  return `${owner}/${repo}`;
+    if (repoFullName === undefined || repoFullName === null)
+        return null;
+    if (typeof repoFullName !== "string")
+        throw new Error("invalid_repo_full_name");
+    const [owner, repo, extra] = repoFullName.trim().split("/");
+    if (!owner || !repo || extra !== undefined)
+        throw new Error("invalid_repo_full_name");
+    return `${owner}/${repo}`;
 }
-
 /** Optional seq cursor for polling: omitted → undefined; otherwise a non-negative integer last-seen seq. */
 function normalizeOptionalSince(since) {
-  if (since === undefined || since === null) return undefined;
-  if (typeof since !== "number" || !Number.isInteger(since) || since < 0) {
-    throw new Error("invalid_since");
-  }
-  return since;
+    if (since === undefined || since === null)
+        return undefined;
+    if (typeof since !== "number" || !Number.isInteger(since) || since < 0) {
+        throw new Error("invalid_since");
+    }
+    return since;
 }
-
 /** Read-filter repo scope: omitted/nullish → unscoped (all events); otherwise a validated `owner/repo`. */
 function normalizeReadRepoFilter(repoFullName) {
-  if (repoFullName === undefined || repoFullName === null) return undefined;
-  return normalizeOptionalRepoFullName(repoFullName);
+    if (repoFullName === undefined || repoFullName === null)
+        return undefined;
+    return normalizeOptionalRepoFullName(repoFullName);
 }
-
 // Serialize an audit payload, enforcing that it round-trips through JSON VERBATIM. A plain JSON.stringify would
 // silently drop `undefined`/function/symbol values and coerce `NaN`/`Infinity` to `null` (and throw on BigInt or a
 // cycle), so a read-back would not equal the appended event. We reject any such lossy payload outright — an audit
 // ledger must return exactly what was recorded.
 function serializePayload(payload) {
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
-    throw new Error("invalid_payload");
-  }
-  let json;
-  try {
-    json = JSON.stringify(payload);
-  } catch {
-    throw new Error("invalid_payload"); // BigInt value or circular reference
-  }
-  if (!isDeepStrictEqual(JSON.parse(json), payload)) {
-    throw new Error("invalid_payload"); // a value JSON would drop or coerce (undefined/NaN/function/symbol/Date/…)
-  }
-  return json;
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+        throw new Error("invalid_payload");
+    }
+    let json;
+    try {
+        json = JSON.stringify(payload);
+    }
+    catch {
+        throw new Error("invalid_payload"); // BigInt value or circular reference
+    }
+    if (!isDeepStrictEqual(JSON.parse(json), payload)) {
+        throw new Error("invalid_payload"); // a value JSON would drop or coerce (undefined/NaN/function/symbol/Date/…)
+    }
+    return json;
 }
-
 function rowToEntry(row) {
-  return {
-    id: row.id,
-    seq: row.seq,
-    type: row.event_type,
-    repoFullName: row.repo_full_name,
-    payload: JSON.parse(row.payload_json),
-    createdAt: row.created_at,
-  };
+    return {
+        id: row.id,
+        seq: row.seq,
+        type: row.event_type,
+        repoFullName: row.repo_full_name,
+        payload: JSON.parse(row.payload_json),
+        createdAt: row.created_at,
+    };
 }
-
+function asEventDbRow(row) {
+    return row;
+}
 // v1 -> v2 (#4939): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of this
 // same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing reads or
 // writes it yet (no consumer exists until a future hosted deployment populates it). Same defensive
 // column-presence guard as this file's sibling stores' own additive migrations (e.g. portfolio-queue.js's
 // leased_at addition).
 function addTenantIdColumn(db) {
-  const hasTenantIdColumn = db
-    .prepare("PRAGMA table_info(miner_event_ledger)")
-    .all()
-    .some((column) => column.name === "tenant_id");
-  if (!hasTenantIdColumn) db.exec("ALTER TABLE miner_event_ledger ADD COLUMN tenant_id TEXT");
+    const hasTenantIdColumn = db
+        .prepare("PRAGMA table_info(miner_event_ledger)")
+        .all()
+        .some((column) => column.name === "tenant_id");
+    if (!hasTenantIdColumn)
+        db.exec("ALTER TABLE miner_event_ledger ADD COLUMN tenant_id TEXT");
 }
-
 /**
  * Opens the local append-only event ledger, creating the table on first use. `seq` is a monotonically increasing
  * counter maintained by this module (next = current MAX(seq) + 1) rather than relying on `AUTOINCREMENT`'s
@@ -113,11 +97,11 @@ function addTenantIdColumn(db) {
  * (#2290)
  */
 export function initEventLedger(dbPath = resolveEventLedgerDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  const db = openLocalStoreDb(resolvedPath);
-  // `UNIQUE(seq)` makes the monotonic-ordering guarantee an enforced invariant: a duplicate seq can never persist,
-  // even if the append path were ever changed.
-  db.exec(`
+    const resolvedPath = normalizeDbPath(dbPath);
+    const db = openLocalStoreDb(resolvedPath);
+    // `UNIQUE(seq)` makes the monotonic-ordering guarantee an enforced invariant: a duplicate seq can never persist,
+    // even if the append path were ever changed.
+    db.exec(`
     CREATE TABLE IF NOT EXISTS miner_event_ledger (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       seq INTEGER NOT NULL UNIQUE,
@@ -127,97 +111,91 @@ export function initEventLedger(dbPath = resolveEventLedgerDbPath()) {
       created_at TEXT NOT NULL
     )
   `);
-  // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
-  applySchemaMigrations(db, [addTenantIdColumn]);
-  // Opt-in retention (#4834): prune aged/excess rows when an operator has enabled it; a no-op by default.
-  pruneLedgerByRetention(db, EVENT_LEDGER_RETENTION_SPEC, resolveLedgerRetentionPolicy(), Date.now());
-
-  const nextSeqStatement = db.prepare("SELECT COALESCE(MAX(seq), 0) + 1 AS nextSeq FROM miner_event_ledger");
-  const appendStatement = db.prepare(`
+    // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
+    applySchemaMigrations(db, [addTenantIdColumn]);
+    // Opt-in retention (#4834): prune aged/excess rows when an operator has enabled it; a no-op by default.
+    pruneLedgerByRetention(db, EVENT_LEDGER_RETENTION_SPEC, resolveLedgerRetentionPolicy(), Date.now());
+    const nextSeqStatement = db.prepare("SELECT COALESCE(MAX(seq), 0) + 1 AS nextSeq FROM miner_event_ledger");
+    const appendStatement = db.prepare(`
     INSERT INTO miner_event_ledger (seq, event_type, repo_full_name, payload_json, created_at)
     VALUES (?, ?, ?, ?, ?)
   `);
-  const getByIdStatement = db.prepare("SELECT * FROM miner_event_ledger WHERE id = ?");
-  const readAllStatement = db.prepare("SELECT * FROM miner_event_ledger ORDER BY seq ASC");
-  const readByRepoStatement = db.prepare(
-    "SELECT * FROM miner_event_ledger WHERE repo_full_name = ? ORDER BY seq ASC",
-  );
-  const readSinceStatement = db.prepare(
-    "SELECT * FROM miner_event_ledger WHERE seq > ? ORDER BY seq ASC",
-  );
-  const readByRepoSinceStatement = db.prepare(
-    "SELECT * FROM miner_event_ledger WHERE repo_full_name = ? AND seq > ? ORDER BY seq ASC",
-  );
-
-  return {
-    dbPath: resolvedPath,
-    appendEvent(event) {
-      const type = normalizeEventType(event?.type);
-      const repoFullName = normalizeOptionalRepoFullName(event?.repoFullName);
-      const payloadJson = serializePayload(event?.payload);
-      const createdAt = new Date().toISOString();
-      // Serialize the read-then-write: BEGIN IMMEDIATE takes the write lock BEFORE reading MAX(seq), so two ledger
-      // instances on the same file cannot both compute the same next seq and corrupt the ordering guarantee.
-      db.exec("BEGIN IMMEDIATE");
-      try {
-        const { nextSeq } = nextSeqStatement.get();
-        const result = appendStatement.run(nextSeq, type, repoFullName, payloadJson, createdAt);
-        const entry = rowToEntry(getByIdStatement.get(Number(result.lastInsertRowid)));
-        db.exec("COMMIT");
-        return entry;
-      } catch (error) {
-        db.exec("ROLLBACK");
-        throw error;
-      }
-    },
-    readEvents(filter = {}) {
-      const repoFullName = normalizeReadRepoFilter(filter.repoFullName);
-      // `since` returns events with a seq STRICTLY greater than it — the "give me everything after the last seq I
-      // saw" polling shape.
-      const since = normalizeOptionalSince(filter.since);
-
-      let rows;
-      if (repoFullName !== undefined && since !== undefined) {
-        rows = readByRepoSinceStatement.all(repoFullName, since);
-      } else if (repoFullName !== undefined) {
-        rows = readByRepoStatement.all(repoFullName);
-      } else if (since !== undefined) {
-        rows = readSinceStatement.all(since);
-      } else {
-        rows = readAllStatement.all();
-      }
-      return rows.map(rowToEntry);
-    },
-    // Explicit, operator-invoked right-to-be-forgotten purge (#5564) — never runs automatically. See the
-    // IMMUTABILITY INVARIANT note above: this is a deliberate, separate exception, not a normal ledger write.
-    // Requires a real repoFullName (unlike the optional filter above): a purge must never silently no-op on a
-    // missing/blank argument.
-    purgeByRepo(repoFullName) {
-      const normalized = normalizeOptionalRepoFullName(repoFullName);
-      if (normalized === null) throw new Error("invalid_repo_full_name");
-      return purgeStoreByRepo(db, EVENT_LEDGER_PURGE_SPEC, normalized);
-    },
-    close() {
-      db.close();
-    },
-  };
+    const getByIdStatement = db.prepare("SELECT * FROM miner_event_ledger WHERE id = ?");
+    const readAllStatement = db.prepare("SELECT * FROM miner_event_ledger ORDER BY seq ASC");
+    const readByRepoStatement = db.prepare("SELECT * FROM miner_event_ledger WHERE repo_full_name = ? ORDER BY seq ASC");
+    const readSinceStatement = db.prepare("SELECT * FROM miner_event_ledger WHERE seq > ? ORDER BY seq ASC");
+    const readByRepoSinceStatement = db.prepare("SELECT * FROM miner_event_ledger WHERE repo_full_name = ? AND seq > ? ORDER BY seq ASC");
+    return {
+        dbPath: resolvedPath,
+        appendEvent(event) {
+            const type = normalizeEventType(event?.type);
+            const repoFullName = normalizeOptionalRepoFullName(event?.repoFullName);
+            const payloadJson = serializePayload(event?.payload);
+            const createdAt = new Date().toISOString();
+            // Serialize the read-then-write: BEGIN IMMEDIATE takes the write lock BEFORE reading MAX(seq), so two ledger
+            // instances on the same file cannot both compute the same next seq and corrupt the ordering guarantee.
+            db.exec("BEGIN IMMEDIATE");
+            try {
+                const { nextSeq } = nextSeqStatement.get();
+                const result = appendStatement.run(nextSeq, type, repoFullName, payloadJson, createdAt);
+                const entry = rowToEntry(asEventDbRow(getByIdStatement.get(Number(result.lastInsertRowid))));
+                db.exec("COMMIT");
+                return entry;
+            }
+            catch (error) {
+                db.exec("ROLLBACK");
+                throw error;
+            }
+        },
+        readEvents(filter = {}) {
+            const repoFullName = normalizeReadRepoFilter(filter.repoFullName);
+            // `since` returns events with a seq STRICTLY greater than it — the "give me everything after the last seq I
+            // saw" polling shape.
+            const since = normalizeOptionalSince(filter.since);
+            let rows;
+            if (repoFullName !== undefined && since !== undefined) {
+                rows = readByRepoSinceStatement.all(repoFullName, since);
+            }
+            else if (repoFullName !== undefined) {
+                rows = readByRepoStatement.all(repoFullName);
+            }
+            else if (since !== undefined) {
+                rows = readSinceStatement.all(since);
+            }
+            else {
+                rows = readAllStatement.all();
+            }
+            return rows.map((row) => rowToEntry(asEventDbRow(row)));
+        },
+        // Explicit, operator-invoked right-to-be-forgotten purge (#5564) — never runs automatically. See the
+        // IMMUTABILITY INVARIANT note above: this is a deliberate, separate exception, not a normal ledger write.
+        // Requires a real repoFullName (unlike the optional filter above): a purge must never silently no-op on a
+        // missing/blank argument.
+        purgeByRepo(repoFullName) {
+            const normalized = normalizeOptionalRepoFullName(repoFullName);
+            if (normalized === null)
+                throw new Error("invalid_repo_full_name");
+            return purgeStoreByRepo(db, EVENT_LEDGER_PURGE_SPEC, normalized);
+        },
+        close() {
+            db.close();
+        },
+    };
 }
-
 function getDefaultEventLedger() {
-  defaultEventLedger ??= initEventLedger();
-  return defaultEventLedger;
+    defaultEventLedger ??= initEventLedger();
+    return defaultEventLedger;
 }
-
 export function appendEvent(event) {
-  return getDefaultEventLedger().appendEvent(event);
+    return getDefaultEventLedger().appendEvent(event);
 }
-
 export function readEvents(filter) {
-  return getDefaultEventLedger().readEvents(filter);
+    return getDefaultEventLedger().readEvents(filter);
 }
-
 export function closeDefaultEventLedger() {
-  if (!defaultEventLedger) return;
-  defaultEventLedger.close();
-  defaultEventLedger = null;
+    if (!defaultEventLedger)
+        return;
+    defaultEventLedger.close();
+    defaultEventLedger = null;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXZlbnQtbGVkZ2VyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZXZlbnQtbGVkZ2VyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUNBLE9BQU8sRUFBRSxpQkFBaUIsRUFBRSxNQUFNLFdBQVcsQ0FBQztBQUM5QyxPQUFPLEVBQUUseUJBQXlCLEVBQUUsZ0JBQWdCLEVBQUUsdUJBQXVCLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUN4RyxPQUFPLEVBQUUscUJBQXFCLEVBQUUsTUFBTSxxQkFBcUIsQ0FBQztBQUM1RCxPQUFPLEVBQ0wsdUJBQXVCLEVBQ3ZCLDJCQUEyQixFQUMzQixnQkFBZ0IsRUFDaEIsc0JBQXNCLEVBQ3RCLDRCQUE0QixHQUM3QixNQUFNLHdCQUF3QixDQUFDO0FBbURoQyxNQUFNLGlCQUFpQixHQUFHLHNCQUFzQixDQUFDO0FBQ2pELElBQUksa0JBQWtCLEdBQXVCLElBQUksQ0FBQztBQUVsRCxNQUFNLFVBQVUsd0JBQXdCLENBQUMsTUFBMEMsT0FBTyxDQUFDLEdBQUc7SUFDNUYsT0FBTyx1QkFBdUIsQ0FBQyxpQkFBaUIsRUFBRSxnQ0FBZ0MsRUFBRSxHQUFHLENBQUMsQ0FBQztBQUMzRixDQUFDO0FBRUQsU0FBUyxlQUFlLENBQUMsTUFBaUM7SUFDeEQsT0FBTyx5QkFBeUIsQ0FBQyxNQUFNLEVBQUUsd0JBQXdCLEVBQUUsRUFBRSw4QkFBOEIsQ0FBQyxDQUFDO0FBQ3ZHLENBQUM7QUFFRCxTQUFTLGtCQUFrQixDQUFDLElBQWE7SUFDdkMsSUFBSSxPQUFPLElBQUksS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxvQkFBb0IsQ0FBQyxDQUFDO0lBQ3BFLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM1QixJQUFJLENBQUMsT0FBTztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsb0JBQW9CLENBQUMsQ0FBQztJQUNwRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsdUZBQXVGO0FBQ3ZGLFNBQVMsNkJBQTZCLENBQUMsWUFBcUI7SUFDMUQsSUFBSSxZQUFZLEtBQUssU0FBUyxJQUFJLFlBQVksS0FBSyxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDckUsSUFBSSxPQUFPLFlBQVksS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDO0lBQ2hGLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLFlBQVksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDNUQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQztJQUN0RixPQUFPLEdBQUcsS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO0FBQzVCLENBQUM7QUFFRCw0R0FBNEc7QUFDNUcsU0FBUyxzQkFBc0IsQ0FBQyxLQUFjO0lBQzVDLElBQUksS0FBSyxLQUFLLFNBQVMsSUFBSSxLQUFLLEtBQUssSUFBSTtRQUFFLE9BQU8sU0FBUyxDQUFDO0lBQzVELElBQUksT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDdkUsTUFBTSxJQUFJLEtBQUssQ0FBQyxlQUFlLENBQUMsQ0FBQztJQUNuQyxDQUFDO0lBQ0QsT0FBTyxLQUFLLENBQUM7QUFDZixDQUFDO0FBRUQsMkdBQTJHO0FBQzNHLFNBQVMsdUJBQXVCLENBQUMsWUFBcUI7SUFDcEQsSUFBSSxZQUFZLEtBQUssU0FBUyxJQUFJLFlBQVksS0FBSyxJQUFJO1FBQUUsT0FBTyxTQUFTLENBQUM7SUFDMUUsT0FBTyw2QkFBNkIsQ0FBQyxZQUFZLENBQUMsQ0FBQztBQUNyRCxDQUFDO0FBRUQsZ0hBQWdIO0FBQ2hILG1IQUFtSDtBQUNuSCxrSEFBa0g7QUFDbEgsZ0RBQWdEO0FBQ2hELFNBQVMsZ0JBQWdCLENBQUMsT0FBZ0I7SUFDeEMsSUFBSSxPQUFPLEtBQUssSUFBSSxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxFQUFFLENBQUM7UUFDOUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDO0lBQ3JDLENBQUM7SUFDRCxJQUFJLElBQVksQ0FBQztJQUNqQixJQUFJLENBQUM7UUFDSCxJQUFJLEdBQUcsSUFBSSxDQUFDLFNBQVMsQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUNqQyxDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsTUFBTSxJQUFJLEtBQUssQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDLENBQUMscUNBQXFDO0lBQzNFLENBQUM7SUFDRCxJQUFJLENBQUMsaUJBQWlCLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRSxPQUFPLENBQUMsRUFBRSxDQUFDO1FBQ2xELE1BQU0sSUFBSSxLQUFLLENBQUMsaUJBQWlCLENBQUMsQ0FBQyxDQUFDLDJFQUEyRTtJQUNqSCxDQUFDO0lBQ0QsT0FBTyxJQUFJLENBQUM7QUFDZCxDQUFDO0FBRUQsU0FBUyxVQUFVLENBQUMsR0FBZTtJQUNqQyxPQUFPO1FBQ0wsRUFBRSxFQUFFLEdBQUcsQ0FBQyxFQUFFO1FBQ1YsR0FBRyxFQUFFLEdBQUcsQ0FBQyxHQUFHO1FBQ1osSUFBSSxFQUFFLEdBQUcsQ0FBQyxVQUFVO1FBQ3BCLFlBQVksRUFBRSxHQUFHLENBQUMsY0FBYztRQUNoQyxPQUFPLEVBQUUsSUFBSSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDO1FBQ3JDLFNBQVMsRUFBRSxHQUFHLENBQUMsVUFBVTtLQUMxQixDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMsWUFBWSxDQUFDLEdBQW1DO0lBQ3ZELE9BQU8sR0FBNEIsQ0FBQztBQUN0QyxDQUFDO0FBRUQsNEdBQTRHO0FBQzVHLCtHQUErRztBQUMvRyxtR0FBbUc7QUFDbkcsMEdBQTBHO0FBQzFHLHVCQUF1QjtBQUN2QixTQUFTLGlCQUFpQixDQUFDLEVBQWdCO0lBQ3pDLE1BQU0saUJBQWlCLEdBQUcsRUFBRTtTQUN6QixPQUFPLENBQUMsdUNBQXVDLENBQUM7U0FDaEQsR0FBRyxFQUFFO1NBQ0wsSUFBSSxDQUFDLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxLQUFLLFdBQVcsQ0FBQyxDQUFDO0lBQ2pELElBQUksQ0FBQyxpQkFBaUI7UUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLDBEQUEwRCxDQUFDLENBQUM7QUFDOUYsQ0FBQztBQUVEOzs7OztHQUtHO0FBQ0gsTUFBTSxVQUFVLGVBQWUsQ0FBQyxTQUFpQix3QkFBd0IsRUFBRTtJQUN6RSxNQUFNLFlBQVksR0FBRyxlQUFlLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDN0MsTUFBTSxFQUFFLEdBQUcsZ0JBQWdCLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDMUMsaUhBQWlIO0lBQ2pILDZDQUE2QztJQUM3QyxFQUFFLENBQUMsSUFBSSxDQUFDOzs7Ozs7Ozs7R0FTUCxDQUFDLENBQUM7SUFDSCw4RkFBOEY7SUFDOUYscUJBQXFCLENBQUMsRUFBRSxFQUFFLENBQUMsaUJBQWlCLENBQUMsQ0FBQyxDQUFDO0lBQy9DLHdHQUF3RztJQUN4RyxzQkFBc0IsQ0FBQyxFQUFFLEVBQUUsMkJBQTJCLEVBQUUsNEJBQTRCLEVBQUUsRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQztJQUVwRyxNQUFNLGdCQUFnQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUMscUVBQXFFLENBQUMsQ0FBQztJQUMzRyxNQUFNLGVBQWUsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDOzs7R0FHbEMsQ0FBQyxDQUFDO0lBQ0gsTUFBTSxnQkFBZ0IsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDLCtDQUErQyxDQUFDLENBQUM7SUFDckYsTUFBTSxnQkFBZ0IsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDLG1EQUFtRCxDQUFDLENBQUM7SUFDekYsTUFBTSxtQkFBbUIsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUNwQyw0RUFBNEUsQ0FDN0UsQ0FBQztJQUNGLE1BQU0sa0JBQWtCLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FDbkMsaUVBQWlFLENBQ2xFLENBQUM7SUFDRixNQUFNLHdCQUF3QixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQ3pDLHdGQUF3RixDQUN6RixDQUFDO0lBRUYsT0FBTztRQUNMLE1BQU0sRUFBRSxZQUFZO1FBQ3BCLFdBQVcsQ0FBQyxLQUFLO1lBQ2YsTUFBTSxJQUFJLEdBQUcsa0JBQWtCLENBQUMsS0FBSyxFQUFFLElBQUksQ0FBQyxDQUFDO1lBQzdDLE1BQU0sWUFBWSxHQUFHLDZCQUE2QixDQUFDLEtBQUssRUFBRSxZQUFZLENBQUMsQ0FBQztZQUN4RSxNQUFNLFdBQVcsR0FBRyxnQkFBZ0IsQ0FBQyxLQUFLLEVBQUUsT0FBTyxDQUFDLENBQUM7WUFDckQsTUFBTSxTQUFTLEdBQUcsSUFBSSxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQztZQUMzQyw2R0FBNkc7WUFDN0csdUdBQXVHO1lBQ3ZHLEVBQUUsQ0FBQyxJQUFJLENBQUMsaUJBQWlCLENBQUMsQ0FBQztZQUMzQixJQUFJLENBQUM7Z0JBQ0gsTUFBTSxFQUFFLE9BQU8sRUFBRSxHQUFHLGdCQUFnQixDQUFDLEdBQUcsRUFBb0MsQ0FBQztnQkFDN0UsTUFBTSxNQUFNLEdBQUcsZUFBZSxDQUFDLEdBQUcsQ0FBQyxPQUFPLEVBQUUsSUFBSSxFQUFFLFlBQVksRUFBRSxXQUFXLEVBQUUsU0FBUyxDQUFDLENBQUM7Z0JBQ3hGLE1BQU0sS0FBSyxHQUFHLFVBQVUsQ0FBQyxZQUFZLENBQUMsZ0JBQWdCLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsZUFBZSxDQUFDLENBQUUsQ0FBQyxDQUFDLENBQUM7Z0JBQzlGLEVBQUUsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLENBQUM7Z0JBQ2xCLE9BQU8sS0FBSyxDQUFDO1lBQ2YsQ0FBQztZQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7Z0JBQ2YsRUFBRSxDQUFDLElBQUksQ0FBQyxVQUFVLENBQUMsQ0FBQztnQkFDcEIsTUFBTSxLQUFLLENBQUM7WUFDZCxDQUFDO1FBQ0gsQ0FBQztRQUNELFVBQVUsQ0FBQyxNQUFNLEdBQUcsRUFBRTtZQUNwQixNQUFNLFlBQVksR0FBRyx1QkFBdUIsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDbEUsNEdBQTRHO1lBQzVHLHNCQUFzQjtZQUN0QixNQUFNLEtBQUssR0FBRyxzQkFBc0IsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7WUFFbkQsSUFBSSxJQUFzQyxDQUFDO1lBQzNDLElBQUksWUFBWSxLQUFLLFNBQVMsSUFBSSxLQUFLLEtBQUssU0FBUyxFQUFFLENBQUM7Z0JBQ3RELElBQUksR0FBRyx3QkFBd0IsQ0FBQyxHQUFHLENBQUMsWUFBWSxFQUFFLEtBQUssQ0FBQyxDQUFDO1lBQzNELENBQUM7aUJBQU0sSUFBSSxZQUFZLEtBQUssU0FBUyxFQUFFLENBQUM7Z0JBQ3RDLElBQUksR0FBRyxtQkFBbUIsQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDL0MsQ0FBQztpQkFBTSxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztnQkFDL0IsSUFBSSxHQUFHLGtCQUFrQixDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUN2QyxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sSUFBSSxHQUFHLGdCQUFnQixDQUFDLEdBQUcsRUFBRSxDQUFDO1lBQ2hDLENBQUM7WUFDRCxPQUFPLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLFVBQVUsQ0FBQyxZQUFZLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzFELENBQUM7UUFDRCxxR0FBcUc7UUFDckcsMEdBQTBHO1FBQzFHLDBHQUEwRztRQUMxRywwQkFBMEI7UUFDMUIsV0FBVyxDQUFDLFlBQVk7WUFDdEIsTUFBTSxVQUFVLEdBQUcsNkJBQTZCLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDL0QsSUFBSSxVQUFVLEtBQUssSUFBSTtnQkFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7WUFDbkUsT0FBTyxnQkFBZ0IsQ0FBQyxFQUFFLEVBQUUsdUJBQXVCLEVBQUUsVUFBVSxDQUFDLENBQUM7UUFDbkUsQ0FBQztRQUNELEtBQUs7WUFDSCxFQUFFLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDYixDQUFDO0tBQ0YsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLHFCQUFxQjtJQUM1QixrQkFBa0IsS0FBSyxlQUFlLEVBQUUsQ0FBQztJQUN6QyxPQUFPLGtCQUFrQixDQUFDO0FBQzVCLENBQUM7QUFFRCxNQUFNLFVBQVUsV0FBVyxDQUFDLEtBQXVCO0lBQ2pELE9BQU8scUJBQXFCLEVBQUUsQ0FBQyxXQUFXLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDcEQsQ0FBQztBQUVELE1BQU0sVUFBVSxVQUFVLENBQUMsTUFBeUI7SUFDbEQsT0FBTyxxQkFBcUIsRUFBRSxDQUFDLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQztBQUNwRCxDQUFDO0FBRUQsTUFBTSxVQUFVLHVCQUF1QjtJQUNyQyxJQUFJLENBQUMsa0JBQWtCO1FBQUUsT0FBTztJQUNoQyxrQkFBa0IsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUMzQixrQkFBa0IsR0FBRyxJQUFJLENBQUM7QUFDNUIsQ0FBQyJ9

--- a/packages/loopover-miner/lib/event-ledger.ts
+++ b/packages/loopover-miner/lib/event-ledger.ts
@@ -1,0 +1,266 @@
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
+import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { applySchemaMigrations } from "./schema-version.js";
+import {
+  EVENT_LEDGER_PURGE_SPEC,
+  EVENT_LEDGER_RETENTION_SPEC,
+  purgeStoreByRepo,
+  pruneLedgerByRetention,
+  resolveLedgerRetentionPolicy,
+} from "./store-maintenance.js";
+
+// The miner's local, append-only event ledger (#2290): an immutable audit trail of every significant miner-loop
+// event (discovered_issue, plan_built, plan_step_completed, pr_prepared, … — a small fixed vocabulary for this
+// foundation phase that grows in later phases), each stamped with a module-maintained monotonic `seq` and a
+// timestamp. IMMUTABILITY INVARIANT: `appendEvent`/`readEvents` only ever issue INSERT and SELECT — they NEVER
+// rewrite or remove a row, so a contributor auditing the miner's history later can trust it was not retroactively
+// edited. Keep it that way: do not add mutation to the day-to-day append/read path. The two documented exceptions
+// are opt-in retention pruning (#4834, automatic, age/size-bounded) and `purgeByRepo` (#5564, always explicit and
+// operator-invoked, never automatic) — both are separate, clearly-labeled maintenance operations, not part of the
+// ledger's normal operation. The database is 100% local; this module never uploads, syncs, or phones home with
+// its contents. Mirrors the local-store pattern of run-state.js.
+
+export type LedgerEntry = {
+  id: number;
+  seq: number;
+  type: string;
+  repoFullName: string | null;
+  payload: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type AppendEventInput = {
+  type: string;
+  repoFullName?: string;
+  payload: Record<string, unknown>;
+};
+
+export type ReadEventsFilter = {
+  repoFullName?: string | null;
+  since?: number | null;
+};
+
+export type EventLedger = {
+  dbPath: string;
+  appendEvent(event: AppendEventInput): LedgerEntry;
+  readEvents(filter?: ReadEventsFilter): LedgerEntry[];
+  purgeByRepo(repoFullName: string): number;
+  close(): void;
+};
+
+/** Private shape of a `miner_event_ledger` SELECT * row after casting off `Record<string, SQLOutputValue>`. */
+type EventDbRow = {
+  id: number;
+  seq: number;
+  event_type: string;
+  repo_full_name: string | null;
+  payload_json: string;
+  created_at: string;
+};
+
+const defaultDbFileName = "event-ledger.sqlite3";
+let defaultEventLedger: EventLedger | null = null;
+
+export function resolveEventLedgerDbPath(env: Record<string, string | undefined> = process.env): string {
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_EVENT_LEDGER_DB", env);
+}
+
+function normalizeDbPath(dbPath: string | null | undefined): string {
+  return normalizeLocalStoreDbPath(dbPath, resolveEventLedgerDbPath(), "invalid_event_ledger_db_path");
+}
+
+function normalizeEventType(type: unknown): string {
+  if (typeof type !== "string") throw new Error("invalid_event_type");
+  const trimmed = type.trim();
+  if (!trimmed) throw new Error("invalid_event_type");
+  return trimmed;
+}
+
+/** Optional repo scope: omitted/nullish → null; otherwise a validated `owner/repo`. */
+function normalizeOptionalRepoFullName(repoFullName: unknown): string | null {
+  if (repoFullName === undefined || repoFullName === null) return null;
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const [owner, repo, extra] = repoFullName.trim().split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  return `${owner}/${repo}`;
+}
+
+/** Optional seq cursor for polling: omitted → undefined; otherwise a non-negative integer last-seen seq. */
+function normalizeOptionalSince(since: unknown): number | undefined {
+  if (since === undefined || since === null) return undefined;
+  if (typeof since !== "number" || !Number.isInteger(since) || since < 0) {
+    throw new Error("invalid_since");
+  }
+  return since;
+}
+
+/** Read-filter repo scope: omitted/nullish → unscoped (all events); otherwise a validated `owner/repo`. */
+function normalizeReadRepoFilter(repoFullName: unknown): string | null | undefined {
+  if (repoFullName === undefined || repoFullName === null) return undefined;
+  return normalizeOptionalRepoFullName(repoFullName);
+}
+
+// Serialize an audit payload, enforcing that it round-trips through JSON VERBATIM. A plain JSON.stringify would
+// silently drop `undefined`/function/symbol values and coerce `NaN`/`Infinity` to `null` (and throw on BigInt or a
+// cycle), so a read-back would not equal the appended event. We reject any such lossy payload outright — an audit
+// ledger must return exactly what was recorded.
+function serializePayload(payload: unknown): string {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("invalid_payload");
+  }
+  let json: string;
+  try {
+    json = JSON.stringify(payload);
+  } catch {
+    throw new Error("invalid_payload"); // BigInt value or circular reference
+  }
+  if (!isDeepStrictEqual(JSON.parse(json), payload)) {
+    throw new Error("invalid_payload"); // a value JSON would drop or coerce (undefined/NaN/function/symbol/Date/…)
+  }
+  return json;
+}
+
+function rowToEntry(row: EventDbRow): LedgerEntry {
+  return {
+    id: row.id,
+    seq: row.seq,
+    type: row.event_type,
+    repoFullName: row.repo_full_name,
+    payload: JSON.parse(row.payload_json),
+    createdAt: row.created_at,
+  };
+}
+
+function asEventDbRow(row: Record<string, SQLOutputValue>): EventDbRow {
+  return row as unknown as EventDbRow;
+}
+
+// v1 -> v2 (#4939): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of this
+// same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing reads or
+// writes it yet (no consumer exists until a future hosted deployment populates it). Same defensive
+// column-presence guard as this file's sibling stores' own additive migrations (e.g. portfolio-queue.js's
+// leased_at addition).
+function addTenantIdColumn(db: DatabaseSync): void {
+  const hasTenantIdColumn = db
+    .prepare("PRAGMA table_info(miner_event_ledger)")
+    .all()
+    .some((column) => column.name === "tenant_id");
+  if (!hasTenantIdColumn) db.exec("ALTER TABLE miner_event_ledger ADD COLUMN tenant_id TEXT");
+}
+
+/**
+ * Opens the local append-only event ledger, creating the table on first use. `seq` is a monotonically increasing
+ * counter maintained by this module (next = current MAX(seq) + 1) rather than relying on `AUTOINCREMENT`'s
+ * reuse-after-vacuum behavior, so consumers get a stable ordering guarantee. Rows read back in `seq ASC` order.
+ * (#2290)
+ */
+export function initEventLedger(dbPath: string = resolveEventLedgerDbPath()): EventLedger {
+  const resolvedPath = normalizeDbPath(dbPath);
+  const db = openLocalStoreDb(resolvedPath);
+  // `UNIQUE(seq)` makes the monotonic-ordering guarantee an enforced invariant: a duplicate seq can never persist,
+  // even if the append path were ever changed.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS miner_event_ledger (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      seq INTEGER NOT NULL UNIQUE,
+      event_type TEXT NOT NULL,
+      repo_full_name TEXT,
+      payload_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+  `);
+  // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
+  applySchemaMigrations(db, [addTenantIdColumn]);
+  // Opt-in retention (#4834): prune aged/excess rows when an operator has enabled it; a no-op by default.
+  pruneLedgerByRetention(db, EVENT_LEDGER_RETENTION_SPEC, resolveLedgerRetentionPolicy(), Date.now());
+
+  const nextSeqStatement = db.prepare("SELECT COALESCE(MAX(seq), 0) + 1 AS nextSeq FROM miner_event_ledger");
+  const appendStatement = db.prepare(`
+    INSERT INTO miner_event_ledger (seq, event_type, repo_full_name, payload_json, created_at)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+  const getByIdStatement = db.prepare("SELECT * FROM miner_event_ledger WHERE id = ?");
+  const readAllStatement = db.prepare("SELECT * FROM miner_event_ledger ORDER BY seq ASC");
+  const readByRepoStatement = db.prepare(
+    "SELECT * FROM miner_event_ledger WHERE repo_full_name = ? ORDER BY seq ASC",
+  );
+  const readSinceStatement = db.prepare(
+    "SELECT * FROM miner_event_ledger WHERE seq > ? ORDER BY seq ASC",
+  );
+  const readByRepoSinceStatement = db.prepare(
+    "SELECT * FROM miner_event_ledger WHERE repo_full_name = ? AND seq > ? ORDER BY seq ASC",
+  );
+
+  return {
+    dbPath: resolvedPath,
+    appendEvent(event) {
+      const type = normalizeEventType(event?.type);
+      const repoFullName = normalizeOptionalRepoFullName(event?.repoFullName);
+      const payloadJson = serializePayload(event?.payload);
+      const createdAt = new Date().toISOString();
+      // Serialize the read-then-write: BEGIN IMMEDIATE takes the write lock BEFORE reading MAX(seq), so two ledger
+      // instances on the same file cannot both compute the same next seq and corrupt the ordering guarantee.
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const { nextSeq } = nextSeqStatement.get() as unknown as { nextSeq: number };
+        const result = appendStatement.run(nextSeq, type, repoFullName, payloadJson, createdAt);
+        const entry = rowToEntry(asEventDbRow(getByIdStatement.get(Number(result.lastInsertRowid))!));
+        db.exec("COMMIT");
+        return entry;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+    readEvents(filter = {}) {
+      const repoFullName = normalizeReadRepoFilter(filter.repoFullName);
+      // `since` returns events with a seq STRICTLY greater than it — the "give me everything after the last seq I
+      // saw" polling shape.
+      const since = normalizeOptionalSince(filter.since);
+
+      let rows: Record<string, SQLOutputValue>[];
+      if (repoFullName !== undefined && since !== undefined) {
+        rows = readByRepoSinceStatement.all(repoFullName, since);
+      } else if (repoFullName !== undefined) {
+        rows = readByRepoStatement.all(repoFullName);
+      } else if (since !== undefined) {
+        rows = readSinceStatement.all(since);
+      } else {
+        rows = readAllStatement.all();
+      }
+      return rows.map((row) => rowToEntry(asEventDbRow(row)));
+    },
+    // Explicit, operator-invoked right-to-be-forgotten purge (#5564) — never runs automatically. See the
+    // IMMUTABILITY INVARIANT note above: this is a deliberate, separate exception, not a normal ledger write.
+    // Requires a real repoFullName (unlike the optional filter above): a purge must never silently no-op on a
+    // missing/blank argument.
+    purgeByRepo(repoFullName) {
+      const normalized = normalizeOptionalRepoFullName(repoFullName);
+      if (normalized === null) throw new Error("invalid_repo_full_name");
+      return purgeStoreByRepo(db, EVENT_LEDGER_PURGE_SPEC, normalized);
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+function getDefaultEventLedger(): EventLedger {
+  defaultEventLedger ??= initEventLedger();
+  return defaultEventLedger;
+}
+
+export function appendEvent(event: AppendEventInput): LedgerEntry {
+  return getDefaultEventLedger().appendEvent(event);
+}
+
+export function readEvents(filter?: ReadEventsFilter): LedgerEntry[] {
+  return getDefaultEventLedger().readEvents(filter);
+}
+
+export function closeDefaultEventLedger(): void {
+  if (!defaultEventLedger) return;
+  defaultEventLedger.close();
+  defaultEventLedger = null;
+}

--- a/packages/loopover-miner/lib/governor-ledger.d.ts
+++ b/packages/loopover-miner/lib/governor-ledger.d.ts
@@ -1,46 +1,41 @@
 export type GovernorLedgerEntry = {
-  id: number;
-  ts: string;
-  eventType: string;
-  repoFullName: string | null;
-  actionClass: string;
-  decision: string;
-  reason: string;
-  payload: Record<string, unknown>;
+    id: number;
+    ts: string;
+    eventType: string;
+    repoFullName: string | null;
+    actionClass: string;
+    decision: string;
+    reason: string;
+    payload: Record<string, unknown>;
 };
-
 export type AppendGovernorEventInput = {
-  eventType: string;
-  repoFullName?: string | null;
-  actionClass: string;
-  decision: string;
-  reason: string;
-  payload?: Record<string, unknown>;
+    eventType: string;
+    repoFullName?: string | null;
+    actionClass: string;
+    decision: string;
+    reason: string;
+    payload?: Record<string, unknown>;
 };
-
 export type ReadGovernorEventsFilter = {
-  repoFullName?: string | null;
+    repoFullName?: string | null;
 };
-
 /** The public decision-log projection (#5159): every {@link GovernorLedgerEntry} field EXCEPT `payload`. */
 export type GovernorDecisionEntry = Omit<GovernorLedgerEntry, "payload">;
-
 export type GovernorLedger = {
-  dbPath: string;
-  appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
-  readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
-  /** Read-only decision-log projection; excludes `payload` by construction (explicit named-column SELECT). */
-  readGovernorDecisions(filter?: ReadGovernorEventsFilter): GovernorDecisionEntry[];
-  purgeByRepo(repoFullName: string): number;
-  close(): void;
+    dbPath: string;
+    appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
+    readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
+    /** Read-only decision-log projection; excludes `payload` by construction (explicit named-column SELECT). */
+    readGovernorDecisions(filter?: ReadGovernorEventsFilter): GovernorDecisionEntry[];
+    purgeByRepo(repoFullName: string): number;
+    close(): void;
 };
-
-export function resolveGovernorLedgerDbPath(env?: Record<string, string | undefined>): string;
-
-export function initGovernorLedger(dbPath?: string): GovernorLedger;
-
-export function appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
-
-export function readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
-
-export function closeDefaultGovernorLedger(): void;
+export declare function resolveGovernorLedgerDbPath(env?: Record<string, string | undefined>): string;
+/**
+ * Opens the append-only governor ledger, creating the table on first use. Rows are returned in ascending `id`
+ * order (insertion order). (#2328)
+ */
+export declare function initGovernorLedger(dbPath?: string): GovernorLedger;
+export declare function appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
+export declare function readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
+export declare function closeDefaultGovernorLedger(): void;

--- a/packages/loopover-miner/lib/governor-ledger.js
+++ b/packages/loopover-miner/lib/governor-ledger.js
@@ -1,97 +1,84 @@
 import { normalizeGovernorLedgerEvent } from "@loopover/engine";
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
-import {
-  GOVERNOR_LEDGER_PURGE_SPEC,
-  GOVERNOR_LEDGER_RETENTION_SPEC,
-  purgeStoreByRepo,
-  pruneLedgerByRetention,
-  resolveLedgerRetentionPolicy,
-} from "./store-maintenance.js";
-
-// Append-only governor decision ledger (#2328): every allowed/denied/throttled/kill-switch outcome lands in a
-// local SQLite table for contributor audit. IMMUTABILITY INVARIANT: `appendGovernorEvent`/`readGovernorEvents`
-// only ever issue INSERT and SELECT — never UPDATE/DELETE. Two documented exceptions, both separate maintenance
-// operations rather than part of normal ledger operation: opt-in retention pruning (#4834, automatic) and
-// `purgeByRepo` (#5564, always explicit and operator-invoked, never automatic).
-// This module does not enforce governor policy; it only persists structured events other phases will emit.
-
+import { GOVERNOR_LEDGER_PURGE_SPEC, GOVERNOR_LEDGER_RETENTION_SPEC, purgeStoreByRepo, pruneLedgerByRetention, resolveLedgerRetentionPolicy, } from "./store-maintenance.js";
 const defaultDbFileName = "governor-ledger.sqlite3";
 let defaultGovernorLedger = null;
-
 export function resolveGovernorLedgerDbPath(env = process.env) {
-  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_GOVERNOR_LEDGER_DB", env);
+    return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_GOVERNOR_LEDGER_DB", env);
 }
-
 function normalizeDbPath(dbPath) {
-  return normalizeLocalStoreDbPath(dbPath, resolveGovernorLedgerDbPath(), "invalid_governor_ledger_db_path");
+    return normalizeLocalStoreDbPath(dbPath, resolveGovernorLedgerDbPath(), "invalid_governor_ledger_db_path");
 }
-
 function normalizeOptionalRepoFullName(repoFullName) {
-  if (repoFullName === undefined || repoFullName === null) return undefined;
-  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
-  const [owner, repo, extra] = repoFullName.trim().split("/");
-  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
-  return `${owner}/${repo}`;
+    if (repoFullName === undefined || repoFullName === null)
+        return undefined;
+    if (typeof repoFullName !== "string")
+        throw new Error("invalid_repo_full_name");
+    const [owner, repo, extra] = repoFullName.trim().split("/");
+    if (!owner || !repo || extra !== undefined)
+        throw new Error("invalid_repo_full_name");
+    return `${owner}/${repo}`;
 }
-
 function rowToEntry(row) {
-  let payload;
-  try {
-    payload = JSON.parse(row.payload_json);
-    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
-      throw new Error("corrupted_governor_row");
+    let payload;
+    try {
+        payload = JSON.parse(row.payload_json);
+        if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+            throw new Error("corrupted_governor_row");
+        }
     }
-  } catch {
-    throw new Error("corrupted_governor_row");
-  }
-  return {
-    id: row.id,
-    ts: row.ts,
-    eventType: row.event_type,
-    repoFullName: row.repo_full_name,
-    actionClass: row.action_class,
-    decision: row.decision,
-    reason: row.reason,
-    payload,
-  };
+    catch {
+        throw new Error("corrupted_governor_row");
+    }
+    return {
+        id: row.id,
+        ts: row.ts,
+        eventType: row.event_type,
+        repoFullName: row.repo_full_name,
+        actionClass: row.action_class,
+        decision: row.decision,
+        reason: row.reason,
+        payload: payload,
+    };
 }
-
 // Decision-log projection (#5159): the public, MCP-exposed shape. Deliberately omits payload_json (which #5134
 // is expanding with reputation/self-plagiarism/budget state). Kept honest by an explicit named-column SELECT
 // below — never SELECT * — so the sensitive column cannot leak even by accident.
 function rowToDecision(row) {
-  return {
-    id: row.id,
-    ts: row.ts,
-    eventType: row.event_type,
-    repoFullName: row.repo_full_name,
-    actionClass: row.action_class,
-    decision: row.decision,
-    reason: row.reason,
-  };
+    return {
+        id: row.id,
+        ts: row.ts,
+        eventType: row.event_type,
+        repoFullName: row.repo_full_name,
+        actionClass: row.action_class,
+        decision: row.decision,
+        reason: row.reason,
+    };
 }
-
 // v1 -> v2 (#4939/#6597): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of
 // this same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing
 // reads or writes it yet. Same defensive column-presence guard as this file's sibling stores' own additive
 // migrations (e.g. event-ledger.js's addTenantIdColumn).
 function addTenantIdColumn(db) {
-  const hasTenantIdColumn = db
-    .prepare("PRAGMA table_info(governor_events)")
-    .all()
-    .some((column) => column.name === "tenant_id");
-  if (!hasTenantIdColumn) db.exec("ALTER TABLE governor_events ADD COLUMN tenant_id TEXT");
+    const hasTenantIdColumn = db
+        .prepare("PRAGMA table_info(governor_events)")
+        .all()
+        .some((column) => column.name === "tenant_id");
+    if (!hasTenantIdColumn)
+        db.exec("ALTER TABLE governor_events ADD COLUMN tenant_id TEXT");
 }
-
+function asGovernorDbRow(row) {
+    return row;
+}
 /**
  * Opens the append-only governor ledger, creating the table on first use. Rows are returned in ascending `id`
  * order (insertion order). (#2328)
  */
 export function initGovernorLedger(dbPath = resolveGovernorLedgerDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  const db = openLocalStoreDb(resolvedPath);
-  db.exec(`
+    const resolvedPath = normalizeDbPath(dbPath);
+    const db = openLocalStoreDb(resolvedPath);
+    db.exec(`
     CREATE TABLE IF NOT EXISTS governor_events (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       ts TEXT NOT NULL,
@@ -103,92 +90,73 @@ export function initGovernorLedger(dbPath = resolveGovernorLedgerDbPath()) {
       payload_json TEXT NOT NULL
     )
   `);
-  db.exec("CREATE INDEX IF NOT EXISTS idx_governor_events_repo ON governor_events (repo_full_name, id)");
-  // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
-  applySchemaMigrations(db, [addTenantIdColumn]);
-  // Opt-in retention (#4834): prune aged/excess rows when an operator has enabled it; a no-op by default.
-  pruneLedgerByRetention(db, GOVERNOR_LEDGER_RETENTION_SPEC, resolveLedgerRetentionPolicy(), Date.now());
-
-  const appendStatement = db.prepare(`
+    db.exec("CREATE INDEX IF NOT EXISTS idx_governor_events_repo ON governor_events (repo_full_name, id)");
+    // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
+    applySchemaMigrations(db, [addTenantIdColumn]);
+    // Opt-in retention (#4834): prune aged/excess rows when an operator has enabled it; a no-op by default.
+    pruneLedgerByRetention(db, GOVERNOR_LEDGER_RETENTION_SPEC, resolveLedgerRetentionPolicy(), Date.now());
+    const appendStatement = db.prepare(`
     INSERT INTO governor_events (ts, event_type, repo_full_name, action_class, decision, reason, payload_json)
     VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
-  const getByIdStatement = db.prepare("SELECT * FROM governor_events WHERE id = ?");
-  const readAllStatement = db.prepare("SELECT * FROM governor_events ORDER BY id ASC");
-  const readByRepoStatement = db.prepare(
-    "SELECT * FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC",
-  );
-  // Explicit named-column projection for the read-only decision log (#5159) — payload_json is intentionally
-  // NOT in this list, so widening it would be a deliberate edit that the redaction test guards against.
-  const decisionColumns = "id, ts, event_type, repo_full_name, action_class, decision, reason";
-  const readDecisionsAllStatement = db.prepare(
-    `SELECT ${decisionColumns} FROM governor_events ORDER BY id ASC`,
-  );
-  const readDecisionsByRepoStatement = db.prepare(
-    `SELECT ${decisionColumns} FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC`,
-  );
-
-  return {
-    dbPath: resolvedPath,
-    appendGovernorEvent(event) {
-      const normalized = normalizeGovernorLedgerEvent(event);
-      const ts = new Date().toISOString();
-      const result = appendStatement.run(
-        ts,
-        normalized.eventType,
-        normalized.repoFullName,
-        normalized.actionClass,
-        normalized.decision,
-        normalized.reason,
-        normalized.payloadJson,
-      );
-      return rowToEntry(getByIdStatement.get(Number(result.lastInsertRowid)));
-    },
-    readGovernorEvents(filter = {}) {
-      const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
-      const rows =
-        repoFullName === undefined
-          ? readAllStatement.all()
-          : readByRepoStatement.all(repoFullName);
-      return rows.map(rowToEntry);
-    },
-    readGovernorDecisions(filter = {}) {
-      const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
-      const rows =
-        repoFullName === undefined
-          ? readDecisionsAllStatement.all()
-          : readDecisionsByRepoStatement.all(repoFullName);
-      return rows.map(rowToDecision);
-    },
-    // Explicit, operator-invoked right-to-be-forgotten purge (#5564) — never runs automatically. See the
-    // IMMUTABILITY INVARIANT note above: this is a deliberate, separate exception, not a normal ledger write.
-    // Requires a real repoFullName (unlike the optional filters above): a purge must never silently no-op.
-    purgeByRepo(repoFullName) {
-      const normalized = normalizeOptionalRepoFullName(repoFullName);
-      if (normalized === undefined) throw new Error("invalid_repo_full_name");
-      return purgeStoreByRepo(db, GOVERNOR_LEDGER_PURGE_SPEC, normalized);
-    },
-    close() {
-      db.close();
-    },
-  };
+    const getByIdStatement = db.prepare("SELECT * FROM governor_events WHERE id = ?");
+    const readAllStatement = db.prepare("SELECT * FROM governor_events ORDER BY id ASC");
+    const readByRepoStatement = db.prepare("SELECT * FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC");
+    // Explicit named-column projection for the read-only decision log (#5159) — payload_json is intentionally
+    // NOT in this list, so widening it would be a deliberate edit that the redaction test guards against.
+    const decisionColumns = "id, ts, event_type, repo_full_name, action_class, decision, reason";
+    const readDecisionsAllStatement = db.prepare(`SELECT ${decisionColumns} FROM governor_events ORDER BY id ASC`);
+    const readDecisionsByRepoStatement = db.prepare(`SELECT ${decisionColumns} FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC`);
+    return {
+        dbPath: resolvedPath,
+        appendGovernorEvent(event) {
+            const normalized = normalizeGovernorLedgerEvent(event);
+            const ts = new Date().toISOString();
+            const result = appendStatement.run(ts, normalized.eventType, normalized.repoFullName, normalized.actionClass, normalized.decision, normalized.reason, normalized.payloadJson);
+            return rowToEntry(asGovernorDbRow(getByIdStatement.get(Number(result.lastInsertRowid))));
+        },
+        readGovernorEvents(filter = {}) {
+            const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
+            const rows = repoFullName === undefined
+                ? readAllStatement.all()
+                : readByRepoStatement.all(repoFullName);
+            return rows.map((row) => rowToEntry(asGovernorDbRow(row)));
+        },
+        readGovernorDecisions(filter = {}) {
+            const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
+            const rows = repoFullName === undefined
+                ? readDecisionsAllStatement.all()
+                : readDecisionsByRepoStatement.all(repoFullName);
+            return rows.map((row) => rowToDecision(asGovernorDbRow(row)));
+        },
+        // Explicit, operator-invoked right-to-be-forgotten purge (#5564) — never runs automatically. See the
+        // IMMUTABILITY INVARIANT note above: this is a deliberate, separate exception, not a normal ledger write.
+        // Requires a real repoFullName (unlike the optional filters above): a purge must never silently no-op.
+        purgeByRepo(repoFullName) {
+            const normalized = normalizeOptionalRepoFullName(repoFullName);
+            if (normalized === undefined)
+                throw new Error("invalid_repo_full_name");
+            return purgeStoreByRepo(db, GOVERNOR_LEDGER_PURGE_SPEC, normalized);
+        },
+        close() {
+            db.close();
+        },
+    };
 }
-
 function getDefaultGovernorLedger() {
-  defaultGovernorLedger ??= initGovernorLedger();
-  return defaultGovernorLedger;
+    defaultGovernorLedger ??= initGovernorLedger();
+    return defaultGovernorLedger;
 }
-
 export function appendGovernorEvent(event) {
-  return getDefaultGovernorLedger().appendGovernorEvent(event);
+    return getDefaultGovernorLedger().appendGovernorEvent(event);
 }
-
 export function readGovernorEvents(filter) {
-  return getDefaultGovernorLedger().readGovernorEvents(filter);
+    return getDefaultGovernorLedger().readGovernorEvents(filter);
 }
-
 export function closeDefaultGovernorLedger() {
-  if (!defaultGovernorLedger) return;
-  defaultGovernorLedger.close();
-  defaultGovernorLedger = null;
+    if (!defaultGovernorLedger)
+        return;
+    defaultGovernorLedger.close();
+    defaultGovernorLedger = null;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItbGVkZ2VyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZ292ZXJub3ItbGVkZ2VyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUNBLE9BQU8sRUFBRSw0QkFBNEIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQ2hFLE9BQU8sRUFBRSx5QkFBeUIsRUFBRSxnQkFBZ0IsRUFBRSx1QkFBdUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQ3hHLE9BQU8sRUFBRSxxQkFBcUIsRUFBRSxNQUFNLHFCQUFxQixDQUFDO0FBQzVELE9BQU8sRUFDTCwwQkFBMEIsRUFDMUIsOEJBQThCLEVBQzlCLGdCQUFnQixFQUNoQixzQkFBc0IsRUFDdEIsNEJBQTRCLEdBQzdCLE1BQU0sd0JBQXdCLENBQUM7QUEwRGhDLE1BQU0saUJBQWlCLEdBQUcseUJBQXlCLENBQUM7QUFDcEQsSUFBSSxxQkFBcUIsR0FBMEIsSUFBSSxDQUFDO0FBRXhELE1BQU0sVUFBVSwyQkFBMkIsQ0FBQyxNQUEwQyxPQUFPLENBQUMsR0FBRztJQUMvRixPQUFPLHVCQUF1QixDQUFDLGlCQUFpQixFQUFFLG1DQUFtQyxFQUFFLEdBQUcsQ0FBQyxDQUFDO0FBQzlGLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxNQUFjO0lBQ3JDLE9BQU8seUJBQXlCLENBQUMsTUFBTSxFQUFFLDJCQUEyQixFQUFFLEVBQUUsaUNBQWlDLENBQUMsQ0FBQztBQUM3RyxDQUFDO0FBRUQsU0FBUyw2QkFBNkIsQ0FBQyxZQUF1QztJQUM1RSxJQUFJLFlBQVksS0FBSyxTQUFTLElBQUksWUFBWSxLQUFLLElBQUk7UUFBRSxPQUFPLFNBQVMsQ0FBQztJQUMxRSxJQUFJLE9BQU8sWUFBWSxLQUFLLFFBQVE7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7SUFDaEYsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsWUFBWSxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUM1RCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDO0lBQ3RGLE9BQU8sR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLENBQUM7QUFDNUIsQ0FBQztBQUVELFNBQVMsVUFBVSxDQUFDLEdBQWtCO0lBQ3BDLElBQUksT0FBZ0IsQ0FBQztJQUNyQixJQUFJLENBQUM7UUFDSCxPQUFPLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDLENBQUM7UUFDdkMsSUFBSSxPQUFPLEtBQUssSUFBSSxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxFQUFFLENBQUM7WUFDOUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDO1FBQzVDLENBQUM7SUFDSCxDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsTUFBTSxJQUFJLEtBQUssQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDO0lBQzVDLENBQUM7SUFDRCxPQUFPO1FBQ0wsRUFBRSxFQUFFLEdBQUcsQ0FBQyxFQUFFO1FBQ1YsRUFBRSxFQUFFLEdBQUcsQ0FBQyxFQUFFO1FBQ1YsU0FBUyxFQUFFLEdBQUcsQ0FBQyxVQUFVO1FBQ3pCLFlBQVksRUFBRSxHQUFHLENBQUMsY0FBYztRQUNoQyxXQUFXLEVBQUUsR0FBRyxDQUFDLFlBQVk7UUFDN0IsUUFBUSxFQUFFLEdBQUcsQ0FBQyxRQUFRO1FBQ3RCLE1BQU0sRUFBRSxHQUFHLENBQUMsTUFBTTtRQUNsQixPQUFPLEVBQUUsT0FBa0M7S0FDNUMsQ0FBQztBQUNKLENBQUM7QUFFRCwrR0FBK0c7QUFDL0csNkdBQTZHO0FBQzdHLGlGQUFpRjtBQUNqRixTQUFTLGFBQWEsQ0FBQyxHQUFrQjtJQUN2QyxPQUFPO1FBQ0wsRUFBRSxFQUFFLEdBQUcsQ0FBQyxFQUFFO1FBQ1YsRUFBRSxFQUFFLEdBQUcsQ0FBQyxFQUFFO1FBQ1YsU0FBUyxFQUFFLEdBQUcsQ0FBQyxVQUFVO1FBQ3pCLFlBQVksRUFBRSxHQUFHLENBQUMsY0FBYztRQUNoQyxXQUFXLEVBQUUsR0FBRyxDQUFDLFlBQVk7UUFDN0IsUUFBUSxFQUFFLEdBQUcsQ0FBQyxRQUFRO1FBQ3RCLE1BQU0sRUFBRSxHQUFHLENBQUMsTUFBTTtLQUNuQixDQUFDO0FBQ0osQ0FBQztBQUVELDZHQUE2RztBQUM3RywyR0FBMkc7QUFDM0csMkdBQTJHO0FBQzNHLHlEQUF5RDtBQUN6RCxTQUFTLGlCQUFpQixDQUFDLEVBQWdCO0lBQ3pDLE1BQU0saUJBQWlCLEdBQUcsRUFBRTtTQUN6QixPQUFPLENBQUMsb0NBQW9DLENBQUM7U0FDN0MsR0FBRyxFQUFFO1NBQ0wsSUFBSSxDQUFDLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxLQUFLLFdBQVcsQ0FBQyxDQUFDO0lBQ2pELElBQUksQ0FBQyxpQkFBaUI7UUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLHVEQUF1RCxDQUFDLENBQUM7QUFDM0YsQ0FBQztBQUVELFNBQVMsZUFBZSxDQUFDLEdBQW1DO0lBQzFELE9BQU8sR0FBK0IsQ0FBQztBQUN6QyxDQUFDO0FBRUQ7OztHQUdHO0FBQ0gsTUFBTSxVQUFVLGtCQUFrQixDQUFDLFNBQWlCLDJCQUEyQixFQUFFO0lBQy9FLE1BQU0sWUFBWSxHQUFHLGVBQWUsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUM3QyxNQUFNLEVBQUUsR0FBRyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMxQyxFQUFFLENBQUMsSUFBSSxDQUFDOzs7Ozs7Ozs7OztHQVdQLENBQUMsQ0FBQztJQUNILEVBQUUsQ0FBQyxJQUFJLENBQUMsNkZBQTZGLENBQUMsQ0FBQztJQUN2Ryw4RkFBOEY7SUFDOUYscUJBQXFCLENBQUMsRUFBRSxFQUFFLENBQUMsaUJBQWlCLENBQUMsQ0FBQyxDQUFDO0lBQy9DLHdHQUF3RztJQUN4RyxzQkFBc0IsQ0FBQyxFQUFFLEVBQUUsOEJBQThCLEVBQUUsNEJBQTRCLEVBQUUsRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQztJQUV2RyxNQUFNLGVBQWUsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDOzs7R0FHbEMsQ0FBQyxDQUFDO0lBQ0gsTUFBTSxnQkFBZ0IsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDLDRDQUE0QyxDQUFDLENBQUM7SUFDbEYsTUFBTSxnQkFBZ0IsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDLCtDQUErQyxDQUFDLENBQUM7SUFDckYsTUFBTSxtQkFBbUIsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUNwQyx3RUFBd0UsQ0FDekUsQ0FBQztJQUNGLDBHQUEwRztJQUMxRyxzR0FBc0c7SUFDdEcsTUFBTSxlQUFlLEdBQUcsb0VBQW9FLENBQUM7SUFDN0YsTUFBTSx5QkFBeUIsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUMxQyxVQUFVLGVBQWUsdUNBQXVDLENBQ2pFLENBQUM7SUFDRixNQUFNLDRCQUE0QixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQzdDLFVBQVUsZUFBZSxnRUFBZ0UsQ0FDMUYsQ0FBQztJQUVGLE9BQU87UUFDTCxNQUFNLEVBQUUsWUFBWTtRQUNwQixtQkFBbUIsQ0FBQyxLQUFLO1lBQ3ZCLE1BQU0sVUFBVSxHQUFHLDRCQUE0QixDQUFDLEtBQUssQ0FBQyxDQUFDO1lBQ3ZELE1BQU0sRUFBRSxHQUFHLElBQUksSUFBSSxFQUFFLENBQUMsV0FBVyxFQUFFLENBQUM7WUFDcEMsTUFBTSxNQUFNLEdBQUcsZUFBZSxDQUFDLEdBQUcsQ0FDaEMsRUFBRSxFQUNGLFVBQVUsQ0FBQyxTQUFTLEVBQ3BCLFVBQVUsQ0FBQyxZQUFZLEVBQ3ZCLFVBQVUsQ0FBQyxXQUFXLEVBQ3RCLFVBQVUsQ0FBQyxRQUFRLEVBQ25CLFVBQVUsQ0FBQyxNQUFNLEVBQ2pCLFVBQVUsQ0FBQyxXQUFXLENBQ3ZCLENBQUM7WUFDRixPQUFPLFVBQVUsQ0FBQyxlQUFlLENBQUMsZ0JBQWdCLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsZUFBZSxDQUFDLENBQUUsQ0FBQyxDQUFDLENBQUM7UUFDNUYsQ0FBQztRQUNELGtCQUFrQixDQUFDLE1BQU0sR0FBRyxFQUFFO1lBQzVCLE1BQU0sWUFBWSxHQUFHLDZCQUE2QixDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQztZQUN4RSxNQUFNLElBQUksR0FDUixZQUFZLEtBQUssU0FBUztnQkFDeEIsQ0FBQyxDQUFDLGdCQUFnQixDQUFDLEdBQUcsRUFBRTtnQkFDeEIsQ0FBQyxDQUFDLG1CQUFtQixDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUMsQ0FBQztZQUM1QyxPQUFPLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLFVBQVUsQ0FBQyxlQUFlLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzdELENBQUM7UUFDRCxxQkFBcUIsQ0FBQyxNQUFNLEdBQUcsRUFBRTtZQUMvQixNQUFNLFlBQVksR0FBRyw2QkFBNkIsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDeEUsTUFBTSxJQUFJLEdBQ1IsWUFBWSxLQUFLLFNBQVM7Z0JBQ3hCLENBQUMsQ0FBQyx5QkFBeUIsQ0FBQyxHQUFHLEVBQUU7Z0JBQ2pDLENBQUMsQ0FBQyw0QkFBNEIsQ0FBQyxHQUFHLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDckQsT0FBTyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxFQUFFLEVBQUUsQ0FBQyxhQUFhLENBQUMsZUFBZSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNoRSxDQUFDO1FBQ0QscUdBQXFHO1FBQ3JHLDBHQUEwRztRQUMxRyx1R0FBdUc7UUFDdkcsV0FBVyxDQUFDLFlBQVk7WUFDdEIsTUFBTSxVQUFVLEdBQUcsNkJBQTZCLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDL0QsSUFBSSxVQUFVLEtBQUssU0FBUztnQkFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7WUFDeEUsT0FBTyxnQkFBZ0IsQ0FBQyxFQUFFLEVBQUUsMEJBQTBCLEVBQUUsVUFBVSxDQUFDLENBQUM7UUFDdEUsQ0FBQztRQUNELEtBQUs7WUFDSCxFQUFFLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDYixDQUFDO0tBQ0YsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLHdCQUF3QjtJQUMvQixxQkFBcUIsS0FBSyxrQkFBa0IsRUFBRSxDQUFDO0lBQy9DLE9BQU8scUJBQXFCLENBQUM7QUFDL0IsQ0FBQztBQUVELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxLQUErQjtJQUNqRSxPQUFPLHdCQUF3QixFQUFFLENBQUMsbUJBQW1CLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDL0QsQ0FBQztBQUVELE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxNQUFpQztJQUNsRSxPQUFPLHdCQUF3QixFQUFFLENBQUMsa0JBQWtCLENBQUMsTUFBTSxDQUFDLENBQUM7QUFDL0QsQ0FBQztBQUVELE1BQU0sVUFBVSwwQkFBMEI7SUFDeEMsSUFBSSxDQUFDLHFCQUFxQjtRQUFFLE9BQU87SUFDbkMscUJBQXFCLENBQUMsS0FBSyxFQUFFLENBQUM7SUFDOUIscUJBQXFCLEdBQUcsSUFBSSxDQUFDO0FBQy9CLENBQUMifQ==

--- a/packages/loopover-miner/lib/governor-ledger.ts
+++ b/packages/loopover-miner/lib/governor-ledger.ts
@@ -1,0 +1,248 @@
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+import { normalizeGovernorLedgerEvent } from "@loopover/engine";
+import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { applySchemaMigrations } from "./schema-version.js";
+import {
+  GOVERNOR_LEDGER_PURGE_SPEC,
+  GOVERNOR_LEDGER_RETENTION_SPEC,
+  purgeStoreByRepo,
+  pruneLedgerByRetention,
+  resolveLedgerRetentionPolicy,
+} from "./store-maintenance.js";
+
+// Append-only governor decision ledger (#2328): every allowed/denied/throttled/kill-switch outcome lands in a
+// local SQLite table for contributor audit. IMMUTABILITY INVARIANT: `appendGovernorEvent`/`readGovernorEvents`
+// only ever issue INSERT and SELECT — never UPDATE/DELETE. Two documented exceptions, both separate maintenance
+// operations rather than part of normal ledger operation: opt-in retention pruning (#4834, automatic) and
+// `purgeByRepo` (#5564, always explicit and operator-invoked, never automatic).
+// This module does not enforce governor policy; it only persists structured events other phases will emit.
+
+export type GovernorLedgerEntry = {
+  id: number;
+  ts: string;
+  eventType: string;
+  repoFullName: string | null;
+  actionClass: string;
+  decision: string;
+  reason: string;
+  payload: Record<string, unknown>;
+};
+
+export type AppendGovernorEventInput = {
+  eventType: string;
+  repoFullName?: string | null;
+  actionClass: string;
+  decision: string;
+  reason: string;
+  payload?: Record<string, unknown>;
+};
+
+export type ReadGovernorEventsFilter = {
+  repoFullName?: string | null;
+};
+
+/** The public decision-log projection (#5159): every {@link GovernorLedgerEntry} field EXCEPT `payload`. */
+export type GovernorDecisionEntry = Omit<GovernorLedgerEntry, "payload">;
+
+export type GovernorLedger = {
+  dbPath: string;
+  appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
+  readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
+  /** Read-only decision-log projection; excludes `payload` by construction (explicit named-column SELECT). */
+  readGovernorDecisions(filter?: ReadGovernorEventsFilter): GovernorDecisionEntry[];
+  purgeByRepo(repoFullName: string): number;
+  close(): void;
+};
+
+/** Private shape of a `governor_events` SELECT * row after casting off `Record<string, SQLOutputValue>`. */
+type GovernorDbRow = {
+  id: number;
+  ts: string;
+  event_type: string;
+  repo_full_name: string | null;
+  action_class: string;
+  decision: string;
+  reason: string;
+  payload_json: string;
+};
+
+const defaultDbFileName = "governor-ledger.sqlite3";
+let defaultGovernorLedger: GovernorLedger | null = null;
+
+export function resolveGovernorLedgerDbPath(env: Record<string, string | undefined> = process.env): string {
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_GOVERNOR_LEDGER_DB", env);
+}
+
+function normalizeDbPath(dbPath: string): string {
+  return normalizeLocalStoreDbPath(dbPath, resolveGovernorLedgerDbPath(), "invalid_governor_ledger_db_path");
+}
+
+function normalizeOptionalRepoFullName(repoFullName: string | null | undefined): string | undefined {
+  if (repoFullName === undefined || repoFullName === null) return undefined;
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const [owner, repo, extra] = repoFullName.trim().split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  return `${owner}/${repo}`;
+}
+
+function rowToEntry(row: GovernorDbRow): GovernorLedgerEntry {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(row.payload_json);
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("corrupted_governor_row");
+    }
+  } catch {
+    throw new Error("corrupted_governor_row");
+  }
+  return {
+    id: row.id,
+    ts: row.ts,
+    eventType: row.event_type,
+    repoFullName: row.repo_full_name,
+    actionClass: row.action_class,
+    decision: row.decision,
+    reason: row.reason,
+    payload: payload as Record<string, unknown>,
+  };
+}
+
+// Decision-log projection (#5159): the public, MCP-exposed shape. Deliberately omits payload_json (which #5134
+// is expanding with reputation/self-plagiarism/budget state). Kept honest by an explicit named-column SELECT
+// below — never SELECT * — so the sensitive column cannot leak even by accident.
+function rowToDecision(row: GovernorDbRow): GovernorDecisionEntry {
+  return {
+    id: row.id,
+    ts: row.ts,
+    eventType: row.event_type,
+    repoFullName: row.repo_full_name,
+    actionClass: row.action_class,
+    decision: row.decision,
+    reason: row.reason,
+  };
+}
+
+// v1 -> v2 (#4939/#6597): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of
+// this same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing
+// reads or writes it yet. Same defensive column-presence guard as this file's sibling stores' own additive
+// migrations (e.g. event-ledger.js's addTenantIdColumn).
+function addTenantIdColumn(db: DatabaseSync): void {
+  const hasTenantIdColumn = db
+    .prepare("PRAGMA table_info(governor_events)")
+    .all()
+    .some((column) => column.name === "tenant_id");
+  if (!hasTenantIdColumn) db.exec("ALTER TABLE governor_events ADD COLUMN tenant_id TEXT");
+}
+
+function asGovernorDbRow(row: Record<string, SQLOutputValue>): GovernorDbRow {
+  return row as unknown as GovernorDbRow;
+}
+
+/**
+ * Opens the append-only governor ledger, creating the table on first use. Rows are returned in ascending `id`
+ * order (insertion order). (#2328)
+ */
+export function initGovernorLedger(dbPath: string = resolveGovernorLedgerDbPath()): GovernorLedger {
+  const resolvedPath = normalizeDbPath(dbPath);
+  const db = openLocalStoreDb(resolvedPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS governor_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      repo_full_name TEXT,
+      action_class TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      payload_json TEXT NOT NULL
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_governor_events_repo ON governor_events (repo_full_name, id)");
+  // Schema-version convention (#4832): stamp the baseline and run any post-baseline migrations.
+  applySchemaMigrations(db, [addTenantIdColumn]);
+  // Opt-in retention (#4834): prune aged/excess rows when an operator has enabled it; a no-op by default.
+  pruneLedgerByRetention(db, GOVERNOR_LEDGER_RETENTION_SPEC, resolveLedgerRetentionPolicy(), Date.now());
+
+  const appendStatement = db.prepare(`
+    INSERT INTO governor_events (ts, event_type, repo_full_name, action_class, decision, reason, payload_json)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  const getByIdStatement = db.prepare("SELECT * FROM governor_events WHERE id = ?");
+  const readAllStatement = db.prepare("SELECT * FROM governor_events ORDER BY id ASC");
+  const readByRepoStatement = db.prepare(
+    "SELECT * FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC",
+  );
+  // Explicit named-column projection for the read-only decision log (#5159) — payload_json is intentionally
+  // NOT in this list, so widening it would be a deliberate edit that the redaction test guards against.
+  const decisionColumns = "id, ts, event_type, repo_full_name, action_class, decision, reason";
+  const readDecisionsAllStatement = db.prepare(
+    `SELECT ${decisionColumns} FROM governor_events ORDER BY id ASC`,
+  );
+  const readDecisionsByRepoStatement = db.prepare(
+    `SELECT ${decisionColumns} FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC`,
+  );
+
+  return {
+    dbPath: resolvedPath,
+    appendGovernorEvent(event) {
+      const normalized = normalizeGovernorLedgerEvent(event);
+      const ts = new Date().toISOString();
+      const result = appendStatement.run(
+        ts,
+        normalized.eventType,
+        normalized.repoFullName,
+        normalized.actionClass,
+        normalized.decision,
+        normalized.reason,
+        normalized.payloadJson,
+      );
+      return rowToEntry(asGovernorDbRow(getByIdStatement.get(Number(result.lastInsertRowid))!));
+    },
+    readGovernorEvents(filter = {}) {
+      const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
+      const rows =
+        repoFullName === undefined
+          ? readAllStatement.all()
+          : readByRepoStatement.all(repoFullName);
+      return rows.map((row) => rowToEntry(asGovernorDbRow(row)));
+    },
+    readGovernorDecisions(filter = {}) {
+      const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
+      const rows =
+        repoFullName === undefined
+          ? readDecisionsAllStatement.all()
+          : readDecisionsByRepoStatement.all(repoFullName);
+      return rows.map((row) => rowToDecision(asGovernorDbRow(row)));
+    },
+    // Explicit, operator-invoked right-to-be-forgotten purge (#5564) — never runs automatically. See the
+    // IMMUTABILITY INVARIANT note above: this is a deliberate, separate exception, not a normal ledger write.
+    // Requires a real repoFullName (unlike the optional filters above): a purge must never silently no-op.
+    purgeByRepo(repoFullName) {
+      const normalized = normalizeOptionalRepoFullName(repoFullName);
+      if (normalized === undefined) throw new Error("invalid_repo_full_name");
+      return purgeStoreByRepo(db, GOVERNOR_LEDGER_PURGE_SPEC, normalized);
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+function getDefaultGovernorLedger(): GovernorLedger {
+  defaultGovernorLedger ??= initGovernorLedger();
+  return defaultGovernorLedger;
+}
+
+export function appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry {
+  return getDefaultGovernorLedger().appendGovernorEvent(event);
+}
+
+export function readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[] {
+  return getDefaultGovernorLedger().readGovernorEvents(filter);
+}
+
+export function closeDefaultGovernorLedger(): void {
+  if (!defaultGovernorLedger) return;
+  defaultGovernorLedger.close();
+  defaultGovernorLedger = null;
+}

--- a/packages/loopover-miner/lib/portfolio-queue.d.ts
+++ b/packages/loopover-miner/lib/portfolio-queue.d.ts
@@ -1,75 +1,65 @@
 export type QueueStatus = "queued" | "in_progress" | "done";
-
 export type QueueEntry = {
-  apiBaseUrl: string;
-  repoFullName: string;
-  identifier: string;
-  priority: number;
-  status: QueueStatus;
-  enqueuedAt: string;
+    apiBaseUrl: string;
+    repoFullName: string;
+    identifier: string;
+    priority: number;
+    status: QueueStatus;
+    enqueuedAt: string;
 };
-
 export type EnqueueItem = {
-  repoFullName: string;
-  identifier: string;
-  priority?: number | null;
-  apiBaseUrl?: string;
+    repoFullName: string;
+    identifier: string;
+    priority?: number | null;
+    apiBaseUrl?: string;
 };
-
 /** Lease-annotated view of an in-flight row: when it was claimed, for the expiry sweep (#4827). */
 export type QueueLeaseEntry = {
-  apiBaseUrl: string;
-  repoFullName: string;
-  identifier: string;
-  status: QueueStatus;
-  leasedAt: string | null;
+    apiBaseUrl: string;
+    repoFullName: string;
+    identifier: string;
+    status: QueueStatus;
+    leasedAt: string | null;
 };
-
 /** A real per-item PortfolioConvergenceInput (non-convergence.ts, #5654), read from this store's own
  *  attempt-history counters -- see getAttemptHistory. */
 export type QueueAttemptHistory = {
-  attempts: number;
-  consecutiveFailures: number;
-  reenqueues: number;
-  reachedDone: boolean;
+    attempts: number;
+    consecutiveFailures: number;
+    reenqueues: number;
+    reachedDone: boolean;
 };
-
 export type PortfolioQueueStore = {
-  dbPath: string;
-  enqueue(item: EnqueueItem): QueueEntry;
-  dequeueNext(): QueueEntry | null;
-  listQueue(repoFullName?: string | null): QueueEntry[];
-  listInProgress(): QueueLeaseEntry[];
-  markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-  markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-  reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-  requeueItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-  batchClaim(
-    selectFn: (
-      entries: QueueEntry[],
-    ) => Array<{ repoFullName: string; identifier: string; apiBaseUrl?: string }>,
-  ): QueueEntry[];
-  getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueAttemptHistory;
-  purgeByRepo(repoFullName: string): number;
-  close(): void;
+    dbPath: string;
+    enqueue(item: EnqueueItem): QueueEntry;
+    dequeueNext(): QueueEntry | null;
+    listQueue(repoFullName?: string | null): QueueEntry[];
+    listInProgress(): QueueLeaseEntry[];
+    markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+    markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+    reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+    requeueItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+    batchClaim(selectFn: (entries: QueueEntry[]) => Array<{
+        repoFullName: string;
+        identifier: string;
+        apiBaseUrl?: string;
+    }>): QueueEntry[];
+    getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueAttemptHistory;
+    purgeByRepo(repoFullName: string): number;
+    close(): void;
 };
-
-export const QUEUE_STATUSES: readonly QueueStatus[];
-
-export function resolvePortfolioQueueDbPath(env?: Record<string, string | undefined>): string;
-
-export function initPortfolioQueueStore(dbPath?: string): PortfolioQueueStore;
-
-export function enqueue(item: EnqueueItem): QueueEntry;
-
-export function dequeueNext(): QueueEntry | null;
-
-export function listQueue(repoFullName?: string | null): QueueEntry[];
-
-export function markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-
-export function markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-
-export function getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueAttemptHistory;
-
-export function closeDefaultPortfolioQueueStore(): void;
+export declare const QUEUE_STATUSES: readonly QueueStatus[];
+export declare function resolvePortfolioQueueDbPath(env?: Record<string, string | undefined>): string;
+/**
+ * Opens the local portfolio/queue store, creating the table on first use. Rows are ordered highest-priority-first
+ * with an insertion-order tie-break: `priority DESC, enqueued_at ASC, rowid ASC` — the implicit `rowid` guarantees
+ * FIFO order even when two items share a priority AND an `enqueued_at` timestamp. (#2292)
+ */
+export declare function initPortfolioQueueStore(dbPath?: string): PortfolioQueueStore;
+export declare function enqueue(item: EnqueueItem): QueueEntry;
+export declare function dequeueNext(): QueueEntry | null;
+export declare function listQueue(repoFullName?: string | null): QueueEntry[];
+export declare function markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+export declare function markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+export declare function getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueAttemptHistory;
+export declare function closeDefaultPortfolioQueueStore(): void;

--- a/packages/loopover-miner/lib/portfolio-queue.js
+++ b/packages/loopover-miner/lib/portfolio-queue.js
@@ -2,91 +2,84 @@ import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
 import { PORTFOLIO_QUEUE_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
-
-// The miner's local portfolio/queue store (#2292): a 100% client-side, prioritized backlog of candidate work
-// items across every repo the miner has been pointed at ("what should I look at next, across everything I'm
-// tracking"). The database only lives on this machine; this module never uploads, syncs, or phones home with its
-// contents. The `priority` field is a PLACEHOLDER numeric input in this foundation phase — later phases populate
-// it from the extracted reward-risk/scoring modules in `loopover-engine`; it is not invented here.
-
 export const QUEUE_STATUSES = Object.freeze(["queued", "in_progress", "done"]);
-
 const defaultDbFileName = "portfolio-queue.sqlite3";
 let defaultPortfolioQueueStore = null;
-
 export function resolvePortfolioQueueDbPath(env = process.env) {
-  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", env);
+    return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", env);
 }
-
 function normalizeDbPath(dbPath) {
-  return normalizeLocalStoreDbPath(dbPath, resolvePortfolioQueueDbPath(), "invalid_portfolio_queue_db_path");
+    return normalizeLocalStoreDbPath(dbPath, resolvePortfolioQueueDbPath(), "invalid_portfolio_queue_db_path");
 }
-
 function normalizeRepoFullName(repoFullName) {
-  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
-  const trimmed = repoFullName.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
-  return `${owner}/${repo}`;
+    if (typeof repoFullName !== "string")
+        throw new Error("invalid_repo_full_name");
+    const trimmed = repoFullName.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        throw new Error("invalid_repo_full_name");
+    return `${owner}/${repo}`;
 }
-
 function normalizeIdentifier(identifier) {
-  if (typeof identifier !== "string") throw new Error("invalid_identifier");
-  const trimmed = identifier.trim();
-  if (!trimmed) throw new Error("invalid_identifier");
-  return trimmed;
+    if (typeof identifier !== "string")
+        throw new Error("invalid_identifier");
+    const trimmed = identifier.trim();
+    if (!trimmed)
+        throw new Error("invalid_identifier");
+    return trimmed;
 }
-
 /** Priority is a placeholder numeric input; an omitted priority defaults to 0, a non-finite or negative one is rejected. */
 function normalizePriority(priority) {
-  if (priority === undefined || priority === null) return 0;
-  if (typeof priority !== "number" || !Number.isFinite(priority) || priority < 0) {
-    throw new Error("invalid_priority");
-  }
-  return priority;
+    if (priority === undefined || priority === null)
+        return 0;
+    if (typeof priority !== "number" || !Number.isFinite(priority) || priority < 0) {
+        throw new Error("invalid_priority");
+    }
+    return priority;
 }
-
 /** Optional forge host, scoping rows so two hosts serving the same owner/repo name never collide (#5563).
  *  Omitted/nullish → the github.com default, so every pre-existing single-forge caller is unaffected. */
 function normalizeApiBaseUrl(apiBaseUrl) {
-  if (apiBaseUrl === undefined || apiBaseUrl === null) return DEFAULT_FORGE_CONFIG.apiBaseUrl;
-  if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim()) throw new Error("invalid_api_base_url");
-  return apiBaseUrl.trim();
+    if (apiBaseUrl === undefined || apiBaseUrl === null)
+        return DEFAULT_FORGE_CONFIG.apiBaseUrl;
+    if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim())
+        throw new Error("invalid_api_base_url");
+    return apiBaseUrl.trim();
 }
-
 function rowToEntry(row) {
-  return {
-    apiBaseUrl: row.api_base_url,
-    repoFullName: row.repo_full_name,
-    identifier: row.identifier,
-    priority: row.priority,
-    status: row.status,
-    enqueuedAt: row.enqueued_at,
-  };
+    return {
+        apiBaseUrl: row.api_base_url,
+        repoFullName: row.repo_full_name,
+        identifier: row.identifier,
+        priority: row.priority,
+        status: row.status,
+        enqueuedAt: row.enqueued_at,
+    };
 }
-
 /** Lease-annotated projection of an in-flight row (adds `leasedAt`), consumed by the expiry sweep. Kept separate
  *  from `rowToEntry` so the base entry shape every existing caller relies on is unchanged. */
 function rowToLeaseEntry(row) {
-  return {
-    apiBaseUrl: row.api_base_url,
-    repoFullName: row.repo_full_name,
-    identifier: row.identifier,
-    status: row.status,
-    leasedAt: row.leased_at ?? null,
-  };
+    return {
+        apiBaseUrl: row.api_base_url,
+        repoFullName: row.repo_full_name,
+        identifier: row.identifier,
+        status: row.status,
+        leasedAt: row.leased_at ?? null,
+    };
 }
-
+function asPortfolioQueueDbRow(row) {
+    return row;
+}
 /**
  * Opens the local portfolio/queue store, creating the table on first use. Rows are ordered highest-priority-first
  * with an insertion-order tie-break: `priority DESC, enqueued_at ASC, rowid ASC` — the implicit `rowid` guarantees
  * FIFO order even when two items share a priority AND an `enqueued_at` timestamp. (#2292)
  */
 export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  // openLocalStoreDb skips mkdir/chmod for the special in-memory path (':memory:'), which has no file on disk.
-  const db = openLocalStoreDb(resolvedPath);
-  db.exec(`
+    const resolvedPath = normalizeDbPath(dbPath);
+    // openLocalStoreDb skips mkdir/chmod for the special in-memory path (':memory:'), which has no file on disk.
+    const db = openLocalStoreDb(resolvedPath);
+    db.exec(`
     CREATE TABLE IF NOT EXISTS miner_portfolio_queue (
       repo_full_name TEXT NOT NULL,
       identifier TEXT NOT NULL,
@@ -97,29 +90,30 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
       PRIMARY KEY (repo_full_name, identifier)
     )
   `);
-  // `leased_at` records when an item was flipped to 'in_progress', so a crashed/killed process's stuck lease can be
-  // swept back to 'queued' by age (see portfolio-queue-expiry.js) instead of stranding the item forever — the same
-  // recovery the claim-ledger and worktree-allocator stores already provide for their own tables (#4827). Additive
-  // migration for stores created before this column: CREATE TABLE IF NOT EXISTS never adds a column to a pre-existing
-  // table, so add it idempotently. Expressed as the store's first schema migration (#4832): the baseline table is
-  // version 1; migration 1→2 adds `leased_at`. The migration stays defensive (checks table_info) so a version-0
-  // file that already ran the pre-convention ad-hoc ALTER is not re-altered into a duplicate-column error.
-  //
-  // v2 -> v3 (#5563): rebuild PRIMARY KEY (repo_full_name, identifier) into PRIMARY KEY (api_base_url,
-  // repo_full_name, identifier) -- two forge hosts serving a same-named owner/repo must not collide in this
-  // queue. SQLite cannot ALTER a PRIMARY KEY in place, so this rebuilds the table: create the new shape, copy
-  // every existing row with the pre-#4784 implicit single-forge default backfilled, drop the old table, rename
-  // the new one in.
-  applySchemaMigrations(db, [
-    (migrationDb) => {
-      const hasLeasedAtColumn = migrationDb
-        .prepare("PRAGMA table_info(miner_portfolio_queue)")
-        .all()
-        .some((column) => column.name === "leased_at");
-      if (!hasLeasedAtColumn) migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN leased_at TEXT");
-    },
-    (migrationDb) => {
-      migrationDb.exec(`
+    // `leased_at` records when an item was flipped to 'in_progress', so a crashed/killed process's stuck lease can be
+    // swept back to 'queued' by age (see portfolio-queue-expiry.js) instead of stranding the item forever — the same
+    // recovery the claim-ledger and worktree-allocator stores already provide for their own tables (#4827). Additive
+    // migration for stores created before this column: CREATE TABLE IF NOT EXISTS never adds a column to a pre-existing
+    // table, so add it idempotently. Expressed as the store's first schema migration (#4832): the baseline table is
+    // version 1; migration 1→2 adds `leased_at`. The migration stays defensive (checks table_info) so a version-0
+    // file that already ran the pre-convention ad-hoc ALTER is not re-altered into a duplicate-column error.
+    //
+    // v2 -> v3 (#5563): rebuild PRIMARY KEY (repo_full_name, identifier) into PRIMARY KEY (api_base_url,
+    // repo_full_name, identifier) -- two forge hosts serving a same-named owner/repo must not collide in this
+    // queue. SQLite cannot ALTER a PRIMARY KEY in place, so this rebuilds the table: create the new shape, copy
+    // every existing row with the pre-#4784 implicit single-forge default backfilled, drop the old table, rename
+    // the new one in.
+    applySchemaMigrations(db, [
+        (migrationDb) => {
+            const hasLeasedAtColumn = migrationDb
+                .prepare("PRAGMA table_info(miner_portfolio_queue)")
+                .all()
+                .some((column) => column.name === "leased_at");
+            if (!hasLeasedAtColumn)
+                migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN leased_at TEXT");
+        },
+        (migrationDb) => {
+            migrationDb.exec(`
         CREATE TABLE miner_portfolio_queue_v3 (
           api_base_url TEXT NOT NULL,
           repo_full_name TEXT NOT NULL,
@@ -131,63 +125,61 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
           PRIMARY KEY (api_base_url, repo_full_name, identifier)
         )
       `);
-      // ORDER BY rowid preserves the old table's FIFO insertion order in the new table's freshly-assigned rowids
-      // (the composite PRIMARY KEY above is not itself the rowid), so this rebuild doesn't reshuffle queue order.
-      // OR IGNORE: a row this store's own read path already treats as unusable garbage (an unrecognized
-      // `status`, e.g. from a hand-edited or otherwise corrupted file) would violate the CHECK constraint above
-      // and abort the whole migration. Skipping it here is consistent with that same fail-closed posture, rather
-      // than turning one bad row into a permanently unmigratable file.
-      migrationDb
-        .prepare(
-          `INSERT OR IGNORE INTO miner_portfolio_queue_v3
+            // ORDER BY rowid preserves the old table's FIFO insertion order in the new table's freshly-assigned rowids
+            // (the composite PRIMARY KEY above is not itself the rowid), so this rebuild doesn't reshuffle queue order.
+            // OR IGNORE: a row this store's own read path already treats as unusable garbage (an unrecognized
+            // `status`, e.g. from a hand-edited or otherwise corrupted file) would violate the CHECK constraint above
+            // and abort the whole migration. Skipping it here is consistent with that same fail-closed posture, rather
+            // than turning one bad row into a permanently unmigratable file.
+            migrationDb
+                .prepare(`INSERT OR IGNORE INTO miner_portfolio_queue_v3
              (api_base_url, repo_full_name, identifier, priority, status, enqueued_at, leased_at)
            SELECT ?, repo_full_name, identifier, priority, status, enqueued_at, leased_at
-           FROM miner_portfolio_queue ORDER BY rowid`,
-        )
-        .run(DEFAULT_FORGE_CONFIG.apiBaseUrl);
-      migrationDb.exec("DROP TABLE miner_portfolio_queue");
-      migrationDb.exec("ALTER TABLE miner_portfolio_queue_v3 RENAME TO miner_portfolio_queue");
-    },
-    // v3 -> v4 (#5654): three attempt-history counters feeding non-convergence.ts's real
-    // PortfolioConvergenceInput (see getAttemptHistory below) -- additive columns, same
-    // defensive column-presence guard as the leased_at migration above.
-    (migrationDb) => {
-      const existingColumns = migrationDb
-        .prepare("PRAGMA table_info(miner_portfolio_queue)")
-        .all()
-        .map((column) => column.name);
-      if (!existingColumns.includes("attempts_count")) {
-        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN attempts_count INTEGER NOT NULL DEFAULT 0");
-      }
-      if (!existingColumns.includes("consecutive_failures")) {
-        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0");
-      }
-      if (!existingColumns.includes("reenqueue_count")) {
-        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN reenqueue_count INTEGER NOT NULL DEFAULT 0");
-      }
-    },
-    // v4 -> v5 (#4939): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of this
-    // same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing reads
-    // or writes it yet (no consumer exists until a future hosted deployment populates it). Same defensive
-    // column-presence guard as the v3->v4 migration immediately above.
-    (migrationDb) => {
-      const hasTenantIdColumn = migrationDb
-        .prepare("PRAGMA table_info(miner_portfolio_queue)")
-        .all()
-        .some((column) => column.name === "tenant_id");
-      if (!hasTenantIdColumn) migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN tenant_id TEXT");
-    },
-  ]);
-
-  // `rowid` is a stable, unique key assigned once at first insert (re-enqueue updates in place, never re-inserts),
-  // so it is a deterministic total-order tie-break: two items sharing a priority AND an `enqueued_at` timestamp
-  // still order by insertion.
-  const ORDER = "ORDER BY priority DESC, enqueued_at ASC, rowid ASC";
-  // Re-enqueueing an already-tracked item re-activates it IN PLACE: refresh its (placeholder) priority and reset it
-  // to 'queued', but KEEP the original `enqueued_at` and `rowid` so it holds its existing FIFO position rather than
-  // jumping the queue. (Restamping `enqueued_at` would be inconsistent — the fixed `rowid` still pins the old
-  // position whenever timestamps collide — so position is deliberately preserved instead.)
-  const enqueueStatement = db.prepare(`
+           FROM miner_portfolio_queue ORDER BY rowid`)
+                .run(DEFAULT_FORGE_CONFIG.apiBaseUrl);
+            migrationDb.exec("DROP TABLE miner_portfolio_queue");
+            migrationDb.exec("ALTER TABLE miner_portfolio_queue_v3 RENAME TO miner_portfolio_queue");
+        },
+        // v3 -> v4 (#5654): three attempt-history counters feeding non-convergence.ts's real
+        // PortfolioConvergenceInput (see getAttemptHistory below) -- additive columns, same
+        // defensive column-presence guard as the leased_at migration above.
+        (migrationDb) => {
+            const existingColumns = migrationDb
+                .prepare("PRAGMA table_info(miner_portfolio_queue)")
+                .all()
+                .map((column) => column.name);
+            if (!existingColumns.includes("attempts_count")) {
+                migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN attempts_count INTEGER NOT NULL DEFAULT 0");
+            }
+            if (!existingColumns.includes("consecutive_failures")) {
+                migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0");
+            }
+            if (!existingColumns.includes("reenqueue_count")) {
+                migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN reenqueue_count INTEGER NOT NULL DEFAULT 0");
+            }
+        },
+        // v4 -> v5 (#4939): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of this
+        // same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing reads
+        // or writes it yet (no consumer exists until a future hosted deployment populates it). Same defensive
+        // column-presence guard as the v3->v4 migration immediately above.
+        (migrationDb) => {
+            const hasTenantIdColumn = migrationDb
+                .prepare("PRAGMA table_info(miner_portfolio_queue)")
+                .all()
+                .some((column) => column.name === "tenant_id");
+            if (!hasTenantIdColumn)
+                migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN tenant_id TEXT");
+        },
+    ]);
+    // `rowid` is a stable, unique key assigned once at first insert (re-enqueue updates in place, never re-inserts),
+    // so it is a deterministic total-order tie-break: two items sharing a priority AND an `enqueued_at` timestamp
+    // still order by insertion.
+    const ORDER = "ORDER BY priority DESC, enqueued_at ASC, rowid ASC";
+    // Re-enqueueing an already-tracked item re-activates it IN PLACE: refresh its (placeholder) priority and reset it
+    // to 'queued', but KEEP the original `enqueued_at` and `rowid` so it holds its existing FIFO position rather than
+    // jumping the queue. (Restamping `enqueued_at` would be inconsistent — the fixed `rowid` still pins the old
+    // position whenever timestamps collide — so position is deliberately preserved instead.)
+    const enqueueStatement = db.prepare(`
     INSERT INTO miner_portfolio_queue (api_base_url, repo_full_name, identifier, priority, status, enqueued_at)
     VALUES (?, ?, ?, ?, 'queued', ?)
     ON CONFLICT(api_base_url, repo_full_name, identifier) DO UPDATE SET
@@ -195,238 +187,207 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
       status = 'queued'
     WHERE miner_portfolio_queue.status <> 'in_progress'
   `);
-  const getStatement = db.prepare(
-    "SELECT * FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?",
-  );
-  // Claim the highest-priority queued item ATOMICALLY: one UPDATE selects the ordered top row in a subquery and
-  // flips it to 'in_progress', RETURNING it — so two processes sharing the file can't both claim the same row (a
-  // separate SELECT-then-UPDATE would race). Deliberately global (no api_base_url filter): the queue is a single
-  // cross-host priority ordering, not a per-host one.
-  // Claiming stamps `leased_at` with the caller-supplied claim time and increments the attempt-history
-  // `attempts_count` (#5654, non-convergence.ts's real PortfolioConvergenceInput.attempts) -- leaving
-  // 'in_progress' (done/failed/reclaim) clears leased_at back to NULL so only genuinely in-flight rows carry
-  // a lease.
-  const dequeueStatement = db.prepare(`
+    const getStatement = db.prepare("SELECT * FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?");
+    // Claim the highest-priority queued item ATOMICALLY: one UPDATE selects the ordered top row in a subquery and
+    // flips it to 'in_progress', RETURNING it — so two processes sharing the file can't both claim the same row (a
+    // separate SELECT-then-UPDATE would race). Deliberately global (no api_base_url filter): the queue is a single
+    // cross-host priority ordering, not a per-host one.
+    // Claiming stamps `leased_at` with the caller-supplied claim time and increments the attempt-history
+    // `attempts_count` (#5654, non-convergence.ts's real PortfolioConvergenceInput.attempts) -- leaving
+    // 'in_progress' (done/failed/reclaim) clears leased_at back to NULL so only genuinely in-flight rows carry
+    // a lease.
+    const dequeueStatement = db.prepare(`
     UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts_count = attempts_count + 1
     WHERE rowid = (
       SELECT rowid FROM miner_portfolio_queue WHERE status = 'queued' ${ORDER} LIMIT 1
     )
     RETURNING *
   `);
-  // RETURNING (rather than a separate post-UPDATE SELECT) makes the "nothing to mark done" case observable
-  // directly from one atomic statement. consecutive_failures resets to 0 on reaching done (#5654) -- the
-  // active failure streak breaks the moment an attempt actually succeeds; reenqueue_count is a lifetime
-  // total and deliberately untouched here (see getAttemptHistory's own doc comment).
-  const markDoneStatement = db.prepare(`
+    // RETURNING (rather than a separate post-UPDATE SELECT) makes the "nothing to mark done" case observable
+    // directly from one atomic statement. consecutive_failures resets to 0 on reaching done (#5654) -- the
+    // active failure streak breaks the moment an attempt actually succeeds; reenqueue_count is a lifetime
+    // total and deliberately untouched here (see getAttemptHistory's own doc comment).
+    const markDoneStatement = db.prepare(`
     UPDATE miner_portfolio_queue SET status = 'done', leased_at = NULL, consecutive_failures = 0
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status <> 'done'
     RETURNING *
   `);
-  // Releasing an in-flight item back to queued WITHOUT reaching done is exactly non-convergence.ts's own
-  // "cycling queued -> in_progress -> queued without ever reaching done" reenqueue trigger (#5654) -- same
-  // counters, same increment, as reclaimStuckItem below (both are this same transition, just different
-  // callers: a run-halt release here vs. a stale-lease sweep there).
-  const markFailedStatement = db.prepare(`
+    // Releasing an in-flight item back to queued WITHOUT reaching done is exactly non-convergence.ts's own
+    // "cycling queued -> in_progress -> queued without ever reaching done" reenqueue trigger (#5654) -- same
+    // counters, same increment, as reclaimStuckItem below (both are this same transition, just different
+    // callers: a run-halt release here vs. a stale-lease sweep there).
+    const markFailedStatement = db.prepare(`
     UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL,
       consecutive_failures = consecutive_failures + 1, reenqueue_count = reenqueue_count + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
     RETURNING *
   `);
-  const listAllStatement = db.prepare(`SELECT * FROM miner_portfolio_queue ${ORDER}`);
-  const listRepoStatement = db.prepare(
-    `SELECT * FROM miner_portfolio_queue WHERE repo_full_name = ? ${ORDER}`,
-  );
-  const listActiveStatement = db.prepare(
-    `SELECT * FROM miner_portfolio_queue WHERE status IN ('queued', 'in_progress') ${ORDER}`,
-  );
-  const listInProgressStatement = db.prepare(
-    `SELECT * FROM miner_portfolio_queue WHERE status = 'in_progress' ${ORDER}`,
-  );
-  // A stale-lease sweep release is the SAME "in_progress -> queued without reaching done" event as
-  // markFailedStatement above (#5654) -- same counters, same increment.
-  const reclaimStatement = db.prepare(`
+    const listAllStatement = db.prepare(`SELECT * FROM miner_portfolio_queue ${ORDER}`);
+    const listRepoStatement = db.prepare(`SELECT * FROM miner_portfolio_queue WHERE repo_full_name = ? ${ORDER}`);
+    const listActiveStatement = db.prepare(`SELECT * FROM miner_portfolio_queue WHERE status IN ('queued', 'in_progress') ${ORDER}`);
+    const listInProgressStatement = db.prepare(`SELECT * FROM miner_portfolio_queue WHERE status = 'in_progress' ${ORDER}`);
+    // A stale-lease sweep release is the SAME "in_progress -> queued without reaching done" event as
+    // markFailedStatement above (#5654) -- same counters, same increment.
+    const reclaimStatement = db.prepare(`
     UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL,
       consecutive_failures = consecutive_failures + 1, reenqueue_count = reenqueue_count + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
     RETURNING *
   `);
-  // Requeue only ever targets a COMPLETED ('done') row — an in-flight item is released via reclaimStatement, and
-  // an already-'queued' item is a no-op — so a caller's manual requeue can never disturb an active claim. The
-  // row keeps its rowid/enqueued_at, so it re-enters the queue at its original FIFO position, not the back.
-  // Deliberately leaves attempts_count/consecutive_failures/reenqueue_count untouched (#5654): this is a
-  // manual reopen of ALREADY-COMPLETED work, not the stuck queued->in_progress->queued cycle those counters
-  // track -- reachedDone (derived live from status) simply reads false again once requeued, same as any
-  // other non-done row, until the item is claimed and completed again.
-  const requeueStatement = db.prepare(`
+    // Requeue only ever targets a COMPLETED ('done') row — an in-flight item is released via reclaimStatement, and
+    // an already-'queued' item is a no-op — so a caller's manual requeue can never disturb an active claim. The
+    // row keeps its rowid/enqueued_at, so it re-enters the queue at its original FIFO position, not the back.
+    // Deliberately leaves attempts_count/consecutive_failures/reenqueue_count untouched (#5654): this is a
+    // manual reopen of ALREADY-COMPLETED work, not the stuck queued->in_progress->queued cycle those counters
+    // track -- reachedDone (derived live from status) simply reads false again once requeued, same as any
+    // other non-done row, until the item is claimed and completed again.
+    const requeueStatement = db.prepare(`
     UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'done'
     RETURNING *
   `);
-  // Same attempts_count increment as dequeueStatement (#5654) -- batchClaim's per-item claim is just as much
-  // a real attempt as the single-item dequeueNext path.
-  const claimTargetStatement = db.prepare(`
+    // Same attempts_count increment as dequeueStatement (#5654) -- batchClaim's per-item claim is just as much
+    // a real attempt as the single-item dequeueNext path.
+    const claimTargetStatement = db.prepare(`
     UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts_count = attempts_count + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'queued'
     RETURNING *
   `);
-  const attemptHistoryStatement = db.prepare(
-    "SELECT attempts_count, consecutive_failures, reenqueue_count, status FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?",
-  );
-
-  return {
-    dbPath: resolvedPath,
-    enqueue(item) {
-      const apiBaseUrl = normalizeApiBaseUrl(item?.apiBaseUrl);
-      const repoFullName = normalizeRepoFullName(item?.repoFullName);
-      const identifier = normalizeIdentifier(item?.identifier);
-      const priority = normalizePriority(item?.priority);
-      const enqueuedAt = new Date().toISOString();
-      enqueueStatement.run(apiBaseUrl, repoFullName, identifier, priority, enqueuedAt);
-      return rowToEntry(getStatement.get(apiBaseUrl, repoFullName, identifier));
-    },
-    dequeueNext() {
-      const row = dequeueStatement.get(new Date().toISOString());
-      return row ? rowToEntry(row) : null;
-    },
-    /** In-flight ('in_progress') rows with their `leasedAt` claim time, for the expiry sweep (#4827). */
-    listInProgress() {
-      return listInProgressStatement.all().map(rowToLeaseEntry);
-    },
-    /** Reclaim a single stuck in-flight item back to 'queued' (clearing its lease), returning it — or null if it is
-     *  no longer 'in_progress' (already finished/reclaimed by another sweep). The sweep target of #4827. */
-    reclaimStuckItem(repoFullName, identifier, apiBaseUrl) {
-      const row = reclaimStatement.get(
-        normalizeApiBaseUrl(apiBaseUrl),
-        normalizeRepoFullName(repoFullName),
-        normalizeIdentifier(identifier),
-      );
-      return row ? rowToEntry(row) : null;
-    },
-    /** Requeue a COMPLETED ('done') item back to 'queued' so it is picked up again, keeping its FIFO position
-     *  (rowid/enqueued_at unchanged). Returns the entry, or null when there is no 'done' item to requeue — i.e.
-     *  it is already 'queued', is currently 'in_progress' (release it via {@link reclaimStuckItem} instead), or
-     *  does not exist. The manual counterpart to {@link reclaimStuckItem} for the queue CLI's escape hatch (#4828). */
-    requeueItem(repoFullName, identifier, apiBaseUrl) {
-      const row = requeueStatement.get(
-        normalizeApiBaseUrl(apiBaseUrl),
-        normalizeRepoFullName(repoFullName),
-        normalizeIdentifier(identifier),
-      );
-      return row ? rowToEntry(row) : null;
-    },
-    listQueue(repoFullName) {
-      const rows = repoFullName === undefined || repoFullName === null
-        ? listAllStatement.all()
-        : listRepoStatement.all(normalizeRepoFullName(repoFullName));
-      return rows.map(rowToEntry);
-    },
-    markDone(repoFullName, identifier, apiBaseUrl) {
-      const row = markDoneStatement.get(
-        normalizeApiBaseUrl(apiBaseUrl),
-        normalizeRepoFullName(repoFullName),
-        normalizeIdentifier(identifier),
-      );
-      return row ? rowToEntry(row) : null;
-    },
-    /** Release an in-flight item back to `queued` when a run halts (#2347). */
-    markFailed(repoFullName, identifier, apiBaseUrl) {
-      const row = markFailedStatement.get(
-        normalizeApiBaseUrl(apiBaseUrl),
-        normalizeRepoFullName(repoFullName),
-        normalizeIdentifier(identifier),
-      );
-      return row ? rowToEntry(row) : null;
-    },
-    /**
-     * Transactional caps-aware batch claim hook used by portfolio-queue-manager.js: re-read active rows under an
-     * exclusive lock, let the caller pick targets, then atomically flip each still-queued row to `in_progress`.
-     */
-    batchClaim(selectFn) {
-      if (typeof selectFn !== "function") throw new Error("invalid_batch_claim_selector");
-      db.exec("BEGIN IMMEDIATE");
-      try {
-        const entries = listActiveStatement.all().map(rowToEntry);
-        const targets = selectFn(entries);
-        if (!Array.isArray(targets)) throw new Error("invalid_batch_claim_selection");
-        const leasedAt = new Date().toISOString();
-        const claimed = [];
-        for (const target of targets) {
-          const apiBaseUrl = normalizeApiBaseUrl(target?.apiBaseUrl);
-          const repoFullName = normalizeRepoFullName(target?.repoFullName);
-          const identifier = normalizeIdentifier(target?.identifier);
-          const row = claimTargetStatement.get(leasedAt, apiBaseUrl, repoFullName, identifier);
-          if (row) claimed.push(rowToEntry(row));
-        }
-        db.exec("COMMIT");
-        return claimed;
-      } catch (error) {
-        db.exec("ROLLBACK");
-        throw error;
-      }
-    },
-    /**
-     * A real `PortfolioConvergenceInput` (non-convergence.ts) for one queue item (#5654), replacing the
-     * first-attempt-shaped literal attempt-input-builder.js previously hardcoded. An item never enqueued here
-     * (not yet tracked at all) reads the same honest zero-state as a genuine first attempt -- absence of
-     * history is not evidence of a problem, same rule non-convergence.ts's own header documents. `reachedDone`
-     * is derived live from the row's current `status`, not a separate persisted flag (see requeueStatement's
-     * comment above for why that's the deliberate choice).
-     */
-    getAttemptHistory(repoFullName, identifier, apiBaseUrl) {
-      const row = attemptHistoryStatement.get(
-        normalizeApiBaseUrl(apiBaseUrl),
-        normalizeRepoFullName(repoFullName),
-        normalizeIdentifier(identifier),
-      );
-      if (!row) return { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false };
-      return {
-        attempts: row.attempts_count,
-        consecutiveFailures: row.consecutive_failures,
-        reenqueues: row.reenqueue_count,
-        reachedDone: row.status === "done",
-      };
-    },
-    // Explicit, operator-invoked right-to-be-forgotten purge (#5564, #6599) — never runs automatically.
-    purgeByRepo(repoFullName) {
-      return purgeStoreByRepo(db, PORTFOLIO_QUEUE_PURGE_SPEC, normalizeRepoFullName(repoFullName));
-    },
-    close() {
-      db.close();
-    },
-  };
+    const attemptHistoryStatement = db.prepare("SELECT attempts_count, consecutive_failures, reenqueue_count, status FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?");
+    return {
+        dbPath: resolvedPath,
+        enqueue(item) {
+            const apiBaseUrl = normalizeApiBaseUrl(item?.apiBaseUrl);
+            const repoFullName = normalizeRepoFullName(item?.repoFullName);
+            const identifier = normalizeIdentifier(item?.identifier);
+            const priority = normalizePriority(item?.priority);
+            const enqueuedAt = new Date().toISOString();
+            enqueueStatement.run(apiBaseUrl, repoFullName, identifier, priority, enqueuedAt);
+            return rowToEntry(asPortfolioQueueDbRow(getStatement.get(apiBaseUrl, repoFullName, identifier)));
+        },
+        dequeueNext() {
+            const row = dequeueStatement.get(new Date().toISOString());
+            return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+        },
+        /** In-flight ('in_progress') rows with their `leasedAt` claim time, for the expiry sweep (#4827). */
+        listInProgress() {
+            return listInProgressStatement.all().map((row) => rowToLeaseEntry(asPortfolioQueueDbRow(row)));
+        },
+        /** Reclaim a single stuck in-flight item back to 'queued' (clearing its lease), returning it — or null if it is
+         *  no longer 'in_progress' (already finished/reclaimed by another sweep). The sweep target of #4827. */
+        reclaimStuckItem(repoFullName, identifier, apiBaseUrl) {
+            const row = reclaimStatement.get(normalizeApiBaseUrl(apiBaseUrl), normalizeRepoFullName(repoFullName), normalizeIdentifier(identifier));
+            return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+        },
+        /** Requeue a COMPLETED ('done') item back to 'queued' so it is picked up again, keeping its FIFO position
+         *  (rowid/enqueued_at unchanged). Returns the entry, or null when there is no 'done' item to requeue — i.e.
+         *  it is already 'queued', is currently 'in_progress' (release it via {@link reclaimStuckItem} instead), or
+         *  does not exist. The manual counterpart to {@link reclaimStuckItem} for the queue CLI's escape hatch (#4828). */
+        requeueItem(repoFullName, identifier, apiBaseUrl) {
+            const row = requeueStatement.get(normalizeApiBaseUrl(apiBaseUrl), normalizeRepoFullName(repoFullName), normalizeIdentifier(identifier));
+            return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+        },
+        listQueue(repoFullName) {
+            const rows = repoFullName === undefined || repoFullName === null
+                ? listAllStatement.all()
+                : listRepoStatement.all(normalizeRepoFullName(repoFullName));
+            return rows.map((row) => rowToEntry(asPortfolioQueueDbRow(row)));
+        },
+        markDone(repoFullName, identifier, apiBaseUrl) {
+            const row = markDoneStatement.get(normalizeApiBaseUrl(apiBaseUrl), normalizeRepoFullName(repoFullName), normalizeIdentifier(identifier));
+            return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+        },
+        /** Release an in-flight item back to `queued` when a run halts (#2347). */
+        markFailed(repoFullName, identifier, apiBaseUrl) {
+            const row = markFailedStatement.get(normalizeApiBaseUrl(apiBaseUrl), normalizeRepoFullName(repoFullName), normalizeIdentifier(identifier));
+            return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+        },
+        /**
+         * Transactional caps-aware batch claim hook used by portfolio-queue-manager.js: re-read active rows under an
+         * exclusive lock, let the caller pick targets, then atomically flip each still-queued row to `in_progress`.
+         */
+        batchClaim(selectFn) {
+            if (typeof selectFn !== "function")
+                throw new Error("invalid_batch_claim_selector");
+            db.exec("BEGIN IMMEDIATE");
+            try {
+                const entries = listActiveStatement.all().map((row) => rowToEntry(asPortfolioQueueDbRow(row)));
+                const targets = selectFn(entries);
+                if (!Array.isArray(targets))
+                    throw new Error("invalid_batch_claim_selection");
+                const leasedAt = new Date().toISOString();
+                const claimed = [];
+                for (const target of targets) {
+                    const apiBaseUrl = normalizeApiBaseUrl(target?.apiBaseUrl);
+                    const repoFullName = normalizeRepoFullName(target?.repoFullName);
+                    const identifier = normalizeIdentifier(target?.identifier);
+                    const row = claimTargetStatement.get(leasedAt, apiBaseUrl, repoFullName, identifier);
+                    if (row)
+                        claimed.push(rowToEntry(asPortfolioQueueDbRow(row)));
+                }
+                db.exec("COMMIT");
+                return claimed;
+            }
+            catch (error) {
+                db.exec("ROLLBACK");
+                throw error;
+            }
+        },
+        /**
+         * A real `PortfolioConvergenceInput` (non-convergence.ts) for one queue item (#5654), replacing the
+         * first-attempt-shaped literal attempt-input-builder.js previously hardcoded. An item never enqueued here
+         * (not yet tracked at all) reads the same honest zero-state as a genuine first attempt -- absence of
+         * history is not evidence of a problem, same rule non-convergence.ts's own header documents. `reachedDone`
+         * is derived live from the row's current `status`, not a separate persisted flag (see requeueStatement's
+         * comment above for why that's the deliberate choice).
+         */
+        getAttemptHistory(repoFullName, identifier, apiBaseUrl) {
+            const row = attemptHistoryStatement.get(normalizeApiBaseUrl(apiBaseUrl), normalizeRepoFullName(repoFullName), normalizeIdentifier(identifier));
+            if (!row)
+                return { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false };
+            const historyRow = asPortfolioQueueDbRow(row);
+            return {
+                attempts: historyRow.attempts_count,
+                consecutiveFailures: historyRow.consecutive_failures,
+                reenqueues: historyRow.reenqueue_count,
+                reachedDone: historyRow.status === "done",
+            };
+        },
+        // Explicit, operator-invoked right-to-be-forgotten purge (#5564, #6599) — never runs automatically.
+        purgeByRepo(repoFullName) {
+            return purgeStoreByRepo(db, PORTFOLIO_QUEUE_PURGE_SPEC, normalizeRepoFullName(repoFullName));
+        },
+        close() {
+            db.close();
+        },
+    };
 }
-
 function getDefaultPortfolioQueueStore() {
-  defaultPortfolioQueueStore ??= initPortfolioQueueStore();
-  return defaultPortfolioQueueStore;
+    defaultPortfolioQueueStore ??= initPortfolioQueueStore();
+    return defaultPortfolioQueueStore;
 }
-
 export function enqueue(item) {
-  return getDefaultPortfolioQueueStore().enqueue(item);
+    return getDefaultPortfolioQueueStore().enqueue(item);
 }
-
 export function dequeueNext() {
-  return getDefaultPortfolioQueueStore().dequeueNext();
+    return getDefaultPortfolioQueueStore().dequeueNext();
 }
-
 export function listQueue(repoFullName) {
-  return getDefaultPortfolioQueueStore().listQueue(repoFullName);
+    return getDefaultPortfolioQueueStore().listQueue(repoFullName);
 }
-
 export function markDone(repoFullName, identifier, apiBaseUrl) {
-  return getDefaultPortfolioQueueStore().markDone(repoFullName, identifier, apiBaseUrl);
+    return getDefaultPortfolioQueueStore().markDone(repoFullName, identifier, apiBaseUrl);
 }
-
 export function markFailed(repoFullName, identifier, apiBaseUrl) {
-  return getDefaultPortfolioQueueStore().markFailed(repoFullName, identifier, apiBaseUrl);
+    return getDefaultPortfolioQueueStore().markFailed(repoFullName, identifier, apiBaseUrl);
 }
-
 export function getAttemptHistory(repoFullName, identifier, apiBaseUrl) {
-  return getDefaultPortfolioQueueStore().getAttemptHistory(repoFullName, identifier, apiBaseUrl);
+    return getDefaultPortfolioQueueStore().getAttemptHistory(repoFullName, identifier, apiBaseUrl);
 }
-
 export function closeDefaultPortfolioQueueStore() {
-  if (!defaultPortfolioQueueStore) return;
-  defaultPortfolioQueueStore.close();
-  defaultPortfolioQueueStore = null;
+    if (!defaultPortfolioQueueStore)
+        return;
+    defaultPortfolioQueueStore.close();
+    defaultPortfolioQueueStore = null;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGZvbGlvLXF1ZXVlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicG9ydGZvbGlvLXF1ZXVlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUNBLE9BQU8sRUFBRSxvQkFBb0IsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ3pELE9BQU8sRUFBRSx5QkFBeUIsRUFBRSxnQkFBZ0IsRUFBRSx1QkFBdUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQ3hHLE9BQU8sRUFBRSxxQkFBcUIsRUFBRSxNQUFNLHFCQUFxQixDQUFDO0FBQzVELE9BQU8sRUFBRSwwQkFBMEIsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLHdCQUF3QixDQUFDO0FBa0Z0RixNQUFNLENBQUMsTUFBTSxjQUFjLEdBQTJCLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxRQUFRLEVBQUUsYUFBYSxFQUFFLE1BQU0sQ0FBVSxDQUFDLENBQUM7QUFFaEgsTUFBTSxpQkFBaUIsR0FBRyx5QkFBeUIsQ0FBQztBQUNwRCxJQUFJLDBCQUEwQixHQUErQixJQUFJLENBQUM7QUFFbEUsTUFBTSxVQUFVLDJCQUEyQixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQy9GLE9BQU8sdUJBQXVCLENBQUMsaUJBQWlCLEVBQUUsbUNBQW1DLEVBQUUsR0FBRyxDQUFDLENBQUM7QUFDOUYsQ0FBQztBQUVELFNBQVMsZUFBZSxDQUFDLE1BQWM7SUFDckMsT0FBTyx5QkFBeUIsQ0FBQyxNQUFNLEVBQUUsMkJBQTJCLEVBQUUsRUFBRSxpQ0FBaUMsQ0FBQyxDQUFDO0FBQzdHLENBQUM7QUFFRCxTQUFTLHFCQUFxQixDQUFDLFlBQXFCO0lBQ2xELElBQUksT0FBTyxZQUFZLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQztJQUNoRixNQUFNLE9BQU8sR0FBRyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDcEMsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDO0lBQ3RGLE9BQU8sR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLENBQUM7QUFDNUIsQ0FBQztBQUVELFNBQVMsbUJBQW1CLENBQUMsVUFBbUI7SUFDOUMsSUFBSSxPQUFPLFVBQVUsS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxvQkFBb0IsQ0FBQyxDQUFDO0lBQzFFLE1BQU0sT0FBTyxHQUFHLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUNsQyxJQUFJLENBQUMsT0FBTztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsb0JBQW9CLENBQUMsQ0FBQztJQUNwRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsNEhBQTRIO0FBQzVILFNBQVMsaUJBQWlCLENBQUMsUUFBaUI7SUFDMUMsSUFBSSxRQUFRLEtBQUssU0FBUyxJQUFJLFFBQVEsS0FBSyxJQUFJO1FBQUUsT0FBTyxDQUFDLENBQUM7SUFDMUQsSUFBSSxPQUFPLFFBQVEsS0FBSyxRQUFRLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxJQUFJLFFBQVEsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUMvRSxNQUFNLElBQUksS0FBSyxDQUFDLGtCQUFrQixDQUFDLENBQUM7SUFDdEMsQ0FBQztJQUNELE9BQU8sUUFBUSxDQUFDO0FBQ2xCLENBQUM7QUFFRDt5R0FDeUc7QUFDekcsU0FBUyxtQkFBbUIsQ0FBQyxVQUFtQjtJQUM5QyxJQUFJLFVBQVUsS0FBSyxTQUFTLElBQUksVUFBVSxLQUFLLElBQUk7UUFBRSxPQUFPLG9CQUFvQixDQUFDLFVBQVUsQ0FBQztJQUM1RixJQUFJLE9BQU8sVUFBVSxLQUFLLFFBQVEsSUFBSSxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUU7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHNCQUFzQixDQUFDLENBQUM7SUFDbEcsT0FBTyxVQUFVLENBQUMsSUFBSSxFQUFFLENBQUM7QUFDM0IsQ0FBQztBQUVELFNBQVMsVUFBVSxDQUFDLEdBQXdCO0lBQzFDLE9BQU87UUFDTCxVQUFVLEVBQUUsR0FBRyxDQUFDLFlBQVk7UUFDNUIsWUFBWSxFQUFFLEdBQUcsQ0FBQyxjQUFjO1FBQ2hDLFVBQVUsRUFBRSxHQUFHLENBQUMsVUFBVTtRQUMxQixRQUFRLEVBQUUsR0FBRyxDQUFDLFFBQVE7UUFDdEIsTUFBTSxFQUFFLEdBQUcsQ0FBQyxNQUFNO1FBQ2xCLFVBQVUsRUFBRSxHQUFHLENBQUMsV0FBVztLQUM1QixDQUFDO0FBQ0osQ0FBQztBQUVEOzhGQUM4RjtBQUM5RixTQUFTLGVBQWUsQ0FBQyxHQUF3QjtJQUMvQyxPQUFPO1FBQ0wsVUFBVSxFQUFFLEdBQUcsQ0FBQyxZQUFZO1FBQzVCLFlBQVksRUFBRSxHQUFHLENBQUMsY0FBYztRQUNoQyxVQUFVLEVBQUUsR0FBRyxDQUFDLFVBQVU7UUFDMUIsTUFBTSxFQUFFLEdBQUcsQ0FBQyxNQUFNO1FBQ2xCLFFBQVEsRUFBRSxHQUFHLENBQUMsU0FBUyxJQUFJLElBQUk7S0FDaEMsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLHFCQUFxQixDQUFDLEdBQW1DO0lBQ2hFLE9BQU8sR0FBcUMsQ0FBQztBQUMvQyxDQUFDO0FBRUQ7Ozs7R0FJRztBQUNILE1BQU0sVUFBVSx1QkFBdUIsQ0FBQyxTQUFpQiwyQkFBMkIsRUFBRTtJQUNwRixNQUFNLFlBQVksR0FBRyxlQUFlLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDN0MsNkdBQTZHO0lBQzdHLE1BQU0sRUFBRSxHQUFHLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxDQUFDO0lBQzFDLEVBQUUsQ0FBQyxJQUFJLENBQUM7Ozs7Ozs7Ozs7R0FVUCxDQUFDLENBQUM7SUFDSCxrSEFBa0g7SUFDbEgsaUhBQWlIO0lBQ2pILGlIQUFpSDtJQUNqSCxvSEFBb0g7SUFDcEgsZ0hBQWdIO0lBQ2hILDhHQUE4RztJQUM5Ryx5R0FBeUc7SUFDekcsRUFBRTtJQUNGLHFHQUFxRztJQUNyRywwR0FBMEc7SUFDMUcsNEdBQTRHO0lBQzVHLDZHQUE2RztJQUM3RyxrQkFBa0I7SUFDbEIscUJBQXFCLENBQUMsRUFBRSxFQUFFO1FBQ3hCLENBQUMsV0FBVyxFQUFFLEVBQUU7WUFDZCxNQUFNLGlCQUFpQixHQUFHLFdBQVc7aUJBQ2xDLE9BQU8sQ0FBQywwQ0FBMEMsQ0FBQztpQkFDbkQsR0FBRyxFQUFFO2lCQUNMLElBQUksQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUUsTUFBdUIsQ0FBQyxJQUFJLEtBQUssV0FBVyxDQUFDLENBQUM7WUFDbkUsSUFBSSxDQUFDLGlCQUFpQjtnQkFBRSxXQUFXLENBQUMsSUFBSSxDQUFDLDZEQUE2RCxDQUFDLENBQUM7UUFDMUcsQ0FBQztRQUNELENBQUMsV0FBVyxFQUFFLEVBQUU7WUFDZCxXQUFXLENBQUMsSUFBSSxDQUFDOzs7Ozs7Ozs7OztPQVdoQixDQUFDLENBQUM7WUFDSCwyR0FBMkc7WUFDM0csNEdBQTRHO1lBQzVHLGtHQUFrRztZQUNsRywwR0FBMEc7WUFDMUcsMkdBQTJHO1lBQzNHLGlFQUFpRTtZQUNqRSxXQUFXO2lCQUNSLE9BQU8sQ0FDTjs7O3FEQUcyQyxDQUM1QztpQkFDQSxHQUFHLENBQUMsb0JBQW9CLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDeEMsV0FBVyxDQUFDLElBQUksQ0FBQyxrQ0FBa0MsQ0FBQyxDQUFDO1lBQ3JELFdBQVcsQ0FBQyxJQUFJLENBQUMsc0VBQXNFLENBQUMsQ0FBQztRQUMzRixDQUFDO1FBQ0QscUZBQXFGO1FBQ3JGLG9GQUFvRjtRQUNwRixvRUFBb0U7UUFDcEUsQ0FBQyxXQUFXLEVBQUUsRUFBRTtZQUNkLE1BQU0sZUFBZSxHQUFHLFdBQVc7aUJBQ2hDLE9BQU8sQ0FBQywwQ0FBMEMsQ0FBQztpQkFDbkQsR0FBRyxFQUFFO2lCQUNMLEdBQUcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUUsTUFBdUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztZQUNsRCxJQUFJLENBQUMsZUFBZSxDQUFDLFFBQVEsQ0FBQyxnQkFBZ0IsQ0FBQyxFQUFFLENBQUM7Z0JBQ2hELFdBQVcsQ0FBQyxJQUFJLENBQUMsd0ZBQXdGLENBQUMsQ0FBQztZQUM3RyxDQUFDO1lBQ0QsSUFBSSxDQUFDLGVBQWUsQ0FBQyxRQUFRLENBQUMsc0JBQXNCLENBQUMsRUFBRSxDQUFDO2dCQUN0RCxXQUFXLENBQUMsSUFBSSxDQUFDLDhGQUE4RixDQUFDLENBQUM7WUFDbkgsQ0FBQztZQUNELElBQUksQ0FBQyxlQUFlLENBQUMsUUFBUSxDQUFDLGlCQUFpQixDQUFDLEVBQUUsQ0FBQztnQkFDakQsV0FBVyxDQUFDLElBQUksQ0FBQyx5RkFBeUYsQ0FBQyxDQUFDO1lBQzlHLENBQUM7UUFDSCxDQUFDO1FBQ0QsNEdBQTRHO1FBQzVHLDRHQUE0RztRQUM1RyxzR0FBc0c7UUFDdEcsbUVBQW1FO1FBQ25FLENBQUMsV0FBVyxFQUFFLEVBQUU7WUFDZCxNQUFNLGlCQUFpQixHQUFHLFdBQVc7aUJBQ2xDLE9BQU8sQ0FBQywwQ0FBMEMsQ0FBQztpQkFDbkQsR0FBRyxFQUFFO2lCQUNMLElBQUksQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUUsTUFBdUIsQ0FBQyxJQUFJLEtBQUssV0FBVyxDQUFDLENBQUM7WUFDbkUsSUFBSSxDQUFDLGlCQUFpQjtnQkFBRSxXQUFXLENBQUMsSUFBSSxDQUFDLDZEQUE2RCxDQUFDLENBQUM7UUFDMUcsQ0FBQztLQUNGLENBQUMsQ0FBQztJQUVILGlIQUFpSDtJQUNqSCw4R0FBOEc7SUFDOUcsNEJBQTRCO0lBQzVCLE1BQU0sS0FBSyxHQUFHLG9EQUFvRCxDQUFDO0lBQ25FLGtIQUFrSDtJQUNsSCxrSEFBa0g7SUFDbEgsNEdBQTRHO0lBQzVHLHlGQUF5RjtJQUN6RixNQUFNLGdCQUFnQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUM7Ozs7Ozs7R0FPbkMsQ0FBQyxDQUFDO0lBQ0gsTUFBTSxZQUFZLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FDN0Isc0dBQXNHLENBQ3ZHLENBQUM7SUFDRiw4R0FBOEc7SUFDOUcsK0dBQStHO0lBQy9HLCtHQUErRztJQUMvRyxvREFBb0Q7SUFDcEQscUdBQXFHO0lBQ3JHLG9HQUFvRztJQUNwRywyR0FBMkc7SUFDM0csV0FBVztJQUNYLE1BQU0sZ0JBQWdCLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FBQzs7O3dFQUdrQyxLQUFLOzs7R0FHMUUsQ0FBQyxDQUFDO0lBQ0gseUdBQXlHO0lBQ3pHLHVHQUF1RztJQUN2RyxzR0FBc0c7SUFDdEcsbUZBQW1GO0lBQ25GLE1BQU0saUJBQWlCLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FBQzs7OztHQUlwQyxDQUFDLENBQUM7SUFDSCx1R0FBdUc7SUFDdkcseUdBQXlHO0lBQ3pHLHFHQUFxRztJQUNyRyxtRUFBbUU7SUFDbkUsTUFBTSxtQkFBbUIsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDOzs7OztHQUt0QyxDQUFDLENBQUM7SUFDSCxNQUFNLGdCQUFnQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUMsdUNBQXVDLEtBQUssRUFBRSxDQUFDLENBQUM7SUFDcEYsTUFBTSxpQkFBaUIsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUNsQyxnRUFBZ0UsS0FBSyxFQUFFLENBQ3hFLENBQUM7SUFDRixNQUFNLG1CQUFtQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQ3BDLGlGQUFpRixLQUFLLEVBQUUsQ0FDekYsQ0FBQztJQUNGLE1BQU0sdUJBQXVCLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FDeEMsb0VBQW9FLEtBQUssRUFBRSxDQUM1RSxDQUFDO0lBQ0YsaUdBQWlHO0lBQ2pHLHNFQUFzRTtJQUN0RSxNQUFNLGdCQUFnQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUM7Ozs7O0dBS25DLENBQUMsQ0FBQztJQUNILCtHQUErRztJQUMvRyw0R0FBNEc7SUFDNUcsMEdBQTBHO0lBQzFHLHVHQUF1RztJQUN2RywwR0FBMEc7SUFDMUcsc0dBQXNHO0lBQ3RHLHFFQUFxRTtJQUNyRSxNQUFNLGdCQUFnQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUM7Ozs7R0FJbkMsQ0FBQyxDQUFDO0lBQ0gsMkdBQTJHO0lBQzNHLHNEQUFzRDtJQUN0RCxNQUFNLG9CQUFvQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUM7Ozs7R0FJdkMsQ0FBQyxDQUFDO0lBQ0gsTUFBTSx1QkFBdUIsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUN4QyxrS0FBa0ssQ0FDbkssQ0FBQztJQUVGLE9BQU87UUFDTCxNQUFNLEVBQUUsWUFBWTtRQUNwQixPQUFPLENBQUMsSUFBSTtZQUNWLE1BQU0sVUFBVSxHQUFHLG1CQUFtQixDQUFDLElBQUksRUFBRSxVQUFVLENBQUMsQ0FBQztZQUN6RCxNQUFNLFlBQVksR0FBRyxxQkFBcUIsQ0FBQyxJQUFJLEVBQUUsWUFBWSxDQUFDLENBQUM7WUFDL0QsTUFBTSxVQUFVLEdBQUcsbUJBQW1CLENBQUMsSUFBSSxFQUFFLFVBQVUsQ0FBQyxDQUFDO1lBQ3pELE1BQU0sUUFBUSxHQUFHLGlCQUFpQixDQUFDLElBQUksRUFBRSxRQUFRLENBQUMsQ0FBQztZQUNuRCxNQUFNLFVBQVUsR0FBRyxJQUFJLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxDQUFDO1lBQzVDLGdCQUFnQixDQUFDLEdBQUcsQ0FBQyxVQUFVLEVBQUUsWUFBWSxFQUFFLFVBQVUsRUFBRSxRQUFRLEVBQUUsVUFBVSxDQUFDLENBQUM7WUFDakYsT0FBTyxVQUFVLENBQUMscUJBQXFCLENBQUMsWUFBWSxDQUFDLEdBQUcsQ0FBQyxVQUFVLEVBQUUsWUFBWSxFQUFFLFVBQVUsQ0FBRSxDQUFDLENBQUMsQ0FBQztRQUNwRyxDQUFDO1FBQ0QsV0FBVztZQUNULE1BQU0sR0FBRyxHQUFHLGdCQUFnQixDQUFDLEdBQUcsQ0FBQyxJQUFJLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxDQUFDLENBQUM7WUFDM0QsT0FBTyxHQUFHLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7UUFDN0QsQ0FBQztRQUNELHFHQUFxRztRQUNyRyxjQUFjO1lBQ1osT0FBTyx1QkFBdUIsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLGVBQWUsQ0FBQyxxQkFBcUIsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDakcsQ0FBQztRQUNEO2dIQUN3RztRQUN4RyxnQkFBZ0IsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLFVBQVU7WUFDbkQsTUFBTSxHQUFHLEdBQUcsZ0JBQWdCLENBQUMsR0FBRyxDQUM5QixtQkFBbUIsQ0FBQyxVQUFVLENBQUMsRUFDL0IscUJBQXFCLENBQUMsWUFBWSxDQUFDLEVBQ25DLG1CQUFtQixDQUFDLFVBQVUsQ0FBQyxDQUNoQyxDQUFDO1lBQ0YsT0FBTyxHQUFHLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7UUFDN0QsQ0FBQztRQUNEOzs7MkhBR21IO1FBQ25ILFdBQVcsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLFVBQVU7WUFDOUMsTUFBTSxHQUFHLEdBQUcsZ0JBQWdCLENBQUMsR0FBRyxDQUM5QixtQkFBbUIsQ0FBQyxVQUFVLENBQUMsRUFDL0IscUJBQXFCLENBQUMsWUFBWSxDQUFDLEVBQ25DLG1CQUFtQixDQUFDLFVBQVUsQ0FBQyxDQUNoQyxDQUFDO1lBQ0YsT0FBTyxHQUFHLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7UUFDN0QsQ0FBQztRQUNELFNBQVMsQ0FBQyxZQUFZO1lBQ3BCLE1BQU0sSUFBSSxHQUFHLFlBQVksS0FBSyxTQUFTLElBQUksWUFBWSxLQUFLLElBQUk7Z0JBQzlELENBQUMsQ0FBQyxnQkFBZ0IsQ0FBQyxHQUFHLEVBQUU7Z0JBQ3hCLENBQUMsQ0FBQyxpQkFBaUIsQ0FBQyxHQUFHLENBQUMscUJBQXFCLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQztZQUMvRCxPQUFPLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDbkUsQ0FBQztRQUNELFFBQVEsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLFVBQVU7WUFDM0MsTUFBTSxHQUFHLEdBQUcsaUJBQWlCLENBQUMsR0FBRyxDQUMvQixtQkFBbUIsQ0FBQyxVQUFVLENBQUMsRUFDL0IscUJBQXFCLENBQUMsWUFBWSxDQUFDLEVBQ25DLG1CQUFtQixDQUFDLFVBQVUsQ0FBQyxDQUNoQyxDQUFDO1lBQ0YsT0FBTyxHQUFHLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7UUFDN0QsQ0FBQztRQUNELDJFQUEyRTtRQUMzRSxVQUFVLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxVQUFVO1lBQzdDLE1BQU0sR0FBRyxHQUFHLG1CQUFtQixDQUFDLEdBQUcsQ0FDakMsbUJBQW1CLENBQUMsVUFBVSxDQUFDLEVBQy9CLHFCQUFxQixDQUFDLFlBQVksQ0FBQyxFQUNuQyxtQkFBbUIsQ0FBQyxVQUFVLENBQUMsQ0FDaEMsQ0FBQztZQUNGLE9BQU8sR0FBRyxDQUFDLENBQUMsQ0FBQyxVQUFVLENBQUMscUJBQXFCLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO1FBQzdELENBQUM7UUFDRDs7O1dBR0c7UUFDSCxVQUFVLENBQUMsUUFBUTtZQUNqQixJQUFJLE9BQU8sUUFBUSxLQUFLLFVBQVU7Z0JBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyw4QkFBOEIsQ0FBQyxDQUFDO1lBQ3BGLEVBQUUsQ0FBQyxJQUFJLENBQUMsaUJBQWlCLENBQUMsQ0FBQztZQUMzQixJQUFJLENBQUM7Z0JBQ0gsTUFBTSxPQUFPLEdBQUcsbUJBQW1CLENBQUMsR0FBRyxFQUFFLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxFQUFFLEVBQUUsQ0FBQyxVQUFVLENBQUMscUJBQXFCLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUMvRixNQUFNLE9BQU8sR0FBRyxRQUFRLENBQUMsT0FBTyxDQUFDLENBQUM7Z0JBQ2xDLElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQztvQkFBRSxNQUFNLElBQUksS0FBSyxDQUFDLCtCQUErQixDQUFDLENBQUM7Z0JBQzlFLE1BQU0sUUFBUSxHQUFHLElBQUksSUFBSSxFQUFFLENBQUMsV0FBVyxFQUFFLENBQUM7Z0JBQzFDLE1BQU0sT0FBTyxHQUFpQixFQUFFLENBQUM7Z0JBQ2pDLEtBQUssTUFBTSxNQUFNLElBQUksT0FBTyxFQUFFLENBQUM7b0JBQzdCLE1BQU0sVUFBVSxHQUFHLG1CQUFtQixDQUFDLE1BQU0sRUFBRSxVQUFVLENBQUMsQ0FBQztvQkFDM0QsTUFBTSxZQUFZLEdBQUcscUJBQXFCLENBQUMsTUFBTSxFQUFFLFlBQVksQ0FBQyxDQUFDO29CQUNqRSxNQUFNLFVBQVUsR0FBRyxtQkFBbUIsQ0FBQyxNQUFNLEVBQUUsVUFBVSxDQUFDLENBQUM7b0JBQzNELE1BQU0sR0FBRyxHQUFHLG9CQUFvQixDQUFDLEdBQUcsQ0FBQyxRQUFRLEVBQUUsVUFBVSxFQUFFLFlBQVksRUFBRSxVQUFVLENBQUMsQ0FBQztvQkFDckYsSUFBSSxHQUFHO3dCQUFFLE9BQU8sQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLHFCQUFxQixDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDaEUsQ0FBQztnQkFDRCxFQUFFLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDO2dCQUNsQixPQUFPLE9BQU8sQ0FBQztZQUNqQixDQUFDO1lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztnQkFDZixFQUFFLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDO2dCQUNwQixNQUFNLEtBQUssQ0FBQztZQUNkLENBQUM7UUFDSCxDQUFDO1FBQ0Q7Ozs7Ozs7V0FPRztRQUNILGlCQUFpQixDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsVUFBVTtZQUNwRCxNQUFNLEdBQUcsR0FBRyx1QkFBdUIsQ0FBQyxHQUFHLENBQ3JDLG1CQUFtQixDQUFDLFVBQVUsQ0FBQyxFQUMvQixxQkFBcUIsQ0FBQyxZQUFZLENBQUMsRUFDbkMsbUJBQW1CLENBQUMsVUFBVSxDQUFDLENBQ2hDLENBQUM7WUFDRixJQUFJLENBQUMsR0FBRztnQkFBRSxPQUFPLEVBQUUsUUFBUSxFQUFFLENBQUMsRUFBRSxtQkFBbUIsRUFBRSxDQUFDLEVBQUUsVUFBVSxFQUFFLENBQUMsRUFBRSxXQUFXLEVBQUUsS0FBSyxFQUFFLENBQUM7WUFDNUYsTUFBTSxVQUFVLEdBQUcscUJBQXFCLENBQUMsR0FBRyxDQUFDLENBQUM7WUFDOUMsT0FBTztnQkFDTCxRQUFRLEVBQUUsVUFBVSxDQUFDLGNBQWM7Z0JBQ25DLG1CQUFtQixFQUFFLFVBQVUsQ0FBQyxvQkFBb0I7Z0JBQ3BELFVBQVUsRUFBRSxVQUFVLENBQUMsZUFBZTtnQkFDdEMsV0FBVyxFQUFFLFVBQVUsQ0FBQyxNQUFNLEtBQUssTUFBTTthQUMxQyxDQUFDO1FBQ0osQ0FBQztRQUNELG9HQUFvRztRQUNwRyxXQUFXLENBQUMsWUFBWTtZQUN0QixPQUFPLGdCQUFnQixDQUFDLEVBQUUsRUFBRSwwQkFBMEIsRUFBRSxxQkFBcUIsQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDO1FBQy9GLENBQUM7UUFDRCxLQUFLO1lBQ0gsRUFBRSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ2IsQ0FBQztLQUNGLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyw2QkFBNkI7SUFDcEMsMEJBQTBCLEtBQUssdUJBQXVCLEVBQUUsQ0FBQztJQUN6RCxPQUFPLDBCQUEwQixDQUFDO0FBQ3BDLENBQUM7QUFFRCxNQUFNLFVBQVUsT0FBTyxDQUFDLElBQWlCO0lBQ3ZDLE9BQU8sNkJBQTZCLEVBQUUsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDdkQsQ0FBQztBQUVELE1BQU0sVUFBVSxXQUFXO0lBQ3pCLE9BQU8sNkJBQTZCLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQztBQUN2RCxDQUFDO0FBRUQsTUFBTSxVQUFVLFNBQVMsQ0FBQyxZQUE0QjtJQUNwRCxPQUFPLDZCQUE2QixFQUFFLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxDQUFDO0FBQ2pFLENBQUM7QUFFRCxNQUFNLFVBQVUsUUFBUSxDQUFDLFlBQW9CLEVBQUUsVUFBa0IsRUFBRSxVQUFtQjtJQUNwRixPQUFPLDZCQUE2QixFQUFFLENBQUMsUUFBUSxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsVUFBVSxDQUFDLENBQUM7QUFDeEYsQ0FBQztBQUVELE1BQU0sVUFBVSxVQUFVLENBQUMsWUFBb0IsRUFBRSxVQUFrQixFQUFFLFVBQW1CO0lBQ3RGLE9BQU8sNkJBQTZCLEVBQUUsQ0FBQyxVQUFVLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxVQUFVLENBQUMsQ0FBQztBQUMxRixDQUFDO0FBRUQsTUFBTSxVQUFVLGlCQUFpQixDQUFDLFlBQW9CLEVBQUUsVUFBa0IsRUFBRSxVQUFtQjtJQUM3RixPQUFPLDZCQUE2QixFQUFFLENBQUMsaUJBQWlCLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxVQUFVLENBQUMsQ0FBQztBQUNqRyxDQUFDO0FBRUQsTUFBTSxVQUFVLCtCQUErQjtJQUM3QyxJQUFJLENBQUMsMEJBQTBCO1FBQUUsT0FBTztJQUN4QywwQkFBMEIsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNuQywwQkFBMEIsR0FBRyxJQUFJLENBQUM7QUFDcEMsQ0FBQyJ9

--- a/packages/loopover-miner/lib/portfolio-queue.ts
+++ b/packages/loopover-miner/lib/portfolio-queue.ts
@@ -1,0 +1,512 @@
+import type { SQLOutputValue } from "node:sqlite";
+import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
+import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { applySchemaMigrations } from "./schema-version.js";
+import { PORTFOLIO_QUEUE_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
+
+// The miner's local portfolio/queue store (#2292): a 100% client-side, prioritized backlog of candidate work
+// items across every repo the miner has been pointed at ("what should I look at next, across everything I'm
+// tracking"). The database only lives on this machine; this module never uploads, syncs, or phones home with its
+// contents. The `priority` field is a PLACEHOLDER numeric input in this foundation phase — later phases populate
+// it from the extracted reward-risk/scoring modules in `loopover-engine`; it is not invented here.
+
+export type QueueStatus = "queued" | "in_progress" | "done";
+
+export type QueueEntry = {
+  apiBaseUrl: string;
+  repoFullName: string;
+  identifier: string;
+  priority: number;
+  status: QueueStatus;
+  enqueuedAt: string;
+};
+
+export type EnqueueItem = {
+  repoFullName: string;
+  identifier: string;
+  priority?: number | null;
+  apiBaseUrl?: string;
+};
+
+/** Lease-annotated view of an in-flight row: when it was claimed, for the expiry sweep (#4827). */
+export type QueueLeaseEntry = {
+  apiBaseUrl: string;
+  repoFullName: string;
+  identifier: string;
+  status: QueueStatus;
+  leasedAt: string | null;
+};
+
+/** A real per-item PortfolioConvergenceInput (non-convergence.ts, #5654), read from this store's own
+ *  attempt-history counters -- see getAttemptHistory. */
+export type QueueAttemptHistory = {
+  attempts: number;
+  consecutiveFailures: number;
+  reenqueues: number;
+  reachedDone: boolean;
+};
+
+export type PortfolioQueueStore = {
+  dbPath: string;
+  enqueue(item: EnqueueItem): QueueEntry;
+  dequeueNext(): QueueEntry | null;
+  listQueue(repoFullName?: string | null): QueueEntry[];
+  listInProgress(): QueueLeaseEntry[];
+  markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  requeueItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  batchClaim(
+    selectFn: (
+      entries: QueueEntry[],
+    ) => Array<{ repoFullName: string; identifier: string; apiBaseUrl?: string }>,
+  ): QueueEntry[];
+  getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueAttemptHistory;
+  purgeByRepo(repoFullName: string): number;
+  close(): void;
+};
+
+/** Private shape of a `miner_portfolio_queue` SELECT * row after casting off `Record<string, SQLOutputValue>`. */
+type PortfolioQueueDbRow = {
+  api_base_url: string;
+  repo_full_name: string;
+  identifier: string;
+  priority: number;
+  status: QueueStatus;
+  enqueued_at: string;
+  leased_at: string | null;
+  attempts_count: number;
+  consecutive_failures: number;
+  reenqueue_count: number;
+  tenant_id: string | null;
+};
+
+/** `PRAGMA table_info(...)` row projection used by the additive-column migration guards. */
+type TableInfoRow = { name: string };
+
+export const QUEUE_STATUSES: readonly QueueStatus[] = Object.freeze(["queued", "in_progress", "done"] as const);
+
+const defaultDbFileName = "portfolio-queue.sqlite3";
+let defaultPortfolioQueueStore: PortfolioQueueStore | null = null;
+
+export function resolvePortfolioQueueDbPath(env: Record<string, string | undefined> = process.env): string {
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", env);
+}
+
+function normalizeDbPath(dbPath: string): string {
+  return normalizeLocalStoreDbPath(dbPath, resolvePortfolioQueueDbPath(), "invalid_portfolio_queue_db_path");
+}
+
+function normalizeRepoFullName(repoFullName: unknown): string {
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const trimmed = repoFullName.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  return `${owner}/${repo}`;
+}
+
+function normalizeIdentifier(identifier: unknown): string {
+  if (typeof identifier !== "string") throw new Error("invalid_identifier");
+  const trimmed = identifier.trim();
+  if (!trimmed) throw new Error("invalid_identifier");
+  return trimmed;
+}
+
+/** Priority is a placeholder numeric input; an omitted priority defaults to 0, a non-finite or negative one is rejected. */
+function normalizePriority(priority: unknown): number {
+  if (priority === undefined || priority === null) return 0;
+  if (typeof priority !== "number" || !Number.isFinite(priority) || priority < 0) {
+    throw new Error("invalid_priority");
+  }
+  return priority;
+}
+
+/** Optional forge host, scoping rows so two hosts serving the same owner/repo name never collide (#5563).
+ *  Omitted/nullish → the github.com default, so every pre-existing single-forge caller is unaffected. */
+function normalizeApiBaseUrl(apiBaseUrl: unknown): string {
+  if (apiBaseUrl === undefined || apiBaseUrl === null) return DEFAULT_FORGE_CONFIG.apiBaseUrl;
+  if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim()) throw new Error("invalid_api_base_url");
+  return apiBaseUrl.trim();
+}
+
+function rowToEntry(row: PortfolioQueueDbRow): QueueEntry {
+  return {
+    apiBaseUrl: row.api_base_url,
+    repoFullName: row.repo_full_name,
+    identifier: row.identifier,
+    priority: row.priority,
+    status: row.status,
+    enqueuedAt: row.enqueued_at,
+  };
+}
+
+/** Lease-annotated projection of an in-flight row (adds `leasedAt`), consumed by the expiry sweep. Kept separate
+ *  from `rowToEntry` so the base entry shape every existing caller relies on is unchanged. */
+function rowToLeaseEntry(row: PortfolioQueueDbRow): QueueLeaseEntry {
+  return {
+    apiBaseUrl: row.api_base_url,
+    repoFullName: row.repo_full_name,
+    identifier: row.identifier,
+    status: row.status,
+    leasedAt: row.leased_at ?? null,
+  };
+}
+
+function asPortfolioQueueDbRow(row: Record<string, SQLOutputValue>): PortfolioQueueDbRow {
+  return row as unknown as PortfolioQueueDbRow;
+}
+
+/**
+ * Opens the local portfolio/queue store, creating the table on first use. Rows are ordered highest-priority-first
+ * with an insertion-order tie-break: `priority DESC, enqueued_at ASC, rowid ASC` — the implicit `rowid` guarantees
+ * FIFO order even when two items share a priority AND an `enqueued_at` timestamp. (#2292)
+ */
+export function initPortfolioQueueStore(dbPath: string = resolvePortfolioQueueDbPath()): PortfolioQueueStore {
+  const resolvedPath = normalizeDbPath(dbPath);
+  // openLocalStoreDb skips mkdir/chmod for the special in-memory path (':memory:'), which has no file on disk.
+  const db = openLocalStoreDb(resolvedPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS miner_portfolio_queue (
+      repo_full_name TEXT NOT NULL,
+      identifier TEXT NOT NULL,
+      priority REAL NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+      enqueued_at TEXT NOT NULL,
+      leased_at TEXT,
+      PRIMARY KEY (repo_full_name, identifier)
+    )
+  `);
+  // `leased_at` records when an item was flipped to 'in_progress', so a crashed/killed process's stuck lease can be
+  // swept back to 'queued' by age (see portfolio-queue-expiry.js) instead of stranding the item forever — the same
+  // recovery the claim-ledger and worktree-allocator stores already provide for their own tables (#4827). Additive
+  // migration for stores created before this column: CREATE TABLE IF NOT EXISTS never adds a column to a pre-existing
+  // table, so add it idempotently. Expressed as the store's first schema migration (#4832): the baseline table is
+  // version 1; migration 1→2 adds `leased_at`. The migration stays defensive (checks table_info) so a version-0
+  // file that already ran the pre-convention ad-hoc ALTER is not re-altered into a duplicate-column error.
+  //
+  // v2 -> v3 (#5563): rebuild PRIMARY KEY (repo_full_name, identifier) into PRIMARY KEY (api_base_url,
+  // repo_full_name, identifier) -- two forge hosts serving a same-named owner/repo must not collide in this
+  // queue. SQLite cannot ALTER a PRIMARY KEY in place, so this rebuilds the table: create the new shape, copy
+  // every existing row with the pre-#4784 implicit single-forge default backfilled, drop the old table, rename
+  // the new one in.
+  applySchemaMigrations(db, [
+    (migrationDb) => {
+      const hasLeasedAtColumn = migrationDb
+        .prepare("PRAGMA table_info(miner_portfolio_queue)")
+        .all()
+        .some((column) => (column as TableInfoRow).name === "leased_at");
+      if (!hasLeasedAtColumn) migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN leased_at TEXT");
+    },
+    (migrationDb) => {
+      migrationDb.exec(`
+        CREATE TABLE miner_portfolio_queue_v3 (
+          api_base_url TEXT NOT NULL,
+          repo_full_name TEXT NOT NULL,
+          identifier TEXT NOT NULL,
+          priority REAL NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+          enqueued_at TEXT NOT NULL,
+          leased_at TEXT,
+          PRIMARY KEY (api_base_url, repo_full_name, identifier)
+        )
+      `);
+      // ORDER BY rowid preserves the old table's FIFO insertion order in the new table's freshly-assigned rowids
+      // (the composite PRIMARY KEY above is not itself the rowid), so this rebuild doesn't reshuffle queue order.
+      // OR IGNORE: a row this store's own read path already treats as unusable garbage (an unrecognized
+      // `status`, e.g. from a hand-edited or otherwise corrupted file) would violate the CHECK constraint above
+      // and abort the whole migration. Skipping it here is consistent with that same fail-closed posture, rather
+      // than turning one bad row into a permanently unmigratable file.
+      migrationDb
+        .prepare(
+          `INSERT OR IGNORE INTO miner_portfolio_queue_v3
+             (api_base_url, repo_full_name, identifier, priority, status, enqueued_at, leased_at)
+           SELECT ?, repo_full_name, identifier, priority, status, enqueued_at, leased_at
+           FROM miner_portfolio_queue ORDER BY rowid`,
+        )
+        .run(DEFAULT_FORGE_CONFIG.apiBaseUrl);
+      migrationDb.exec("DROP TABLE miner_portfolio_queue");
+      migrationDb.exec("ALTER TABLE miner_portfolio_queue_v3 RENAME TO miner_portfolio_queue");
+    },
+    // v3 -> v4 (#5654): three attempt-history counters feeding non-convergence.ts's real
+    // PortfolioConvergenceInput (see getAttemptHistory below) -- additive columns, same
+    // defensive column-presence guard as the leased_at migration above.
+    (migrationDb) => {
+      const existingColumns = migrationDb
+        .prepare("PRAGMA table_info(miner_portfolio_queue)")
+        .all()
+        .map((column) => (column as TableInfoRow).name);
+      if (!existingColumns.includes("attempts_count")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN attempts_count INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!existingColumns.includes("consecutive_failures")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!existingColumns.includes("reenqueue_count")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN reenqueue_count INTEGER NOT NULL DEFAULT 0");
+      }
+    },
+    // v4 -> v5 (#4939): additive tenant-scoping column, a prerequisite for any hosted, multi-tenant use of this
+    // same store's logic. NULL for every row today -- self-host behavior is byte-identical, since nothing reads
+    // or writes it yet (no consumer exists until a future hosted deployment populates it). Same defensive
+    // column-presence guard as the v3->v4 migration immediately above.
+    (migrationDb) => {
+      const hasTenantIdColumn = migrationDb
+        .prepare("PRAGMA table_info(miner_portfolio_queue)")
+        .all()
+        .some((column) => (column as TableInfoRow).name === "tenant_id");
+      if (!hasTenantIdColumn) migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN tenant_id TEXT");
+    },
+  ]);
+
+  // `rowid` is a stable, unique key assigned once at first insert (re-enqueue updates in place, never re-inserts),
+  // so it is a deterministic total-order tie-break: two items sharing a priority AND an `enqueued_at` timestamp
+  // still order by insertion.
+  const ORDER = "ORDER BY priority DESC, enqueued_at ASC, rowid ASC";
+  // Re-enqueueing an already-tracked item re-activates it IN PLACE: refresh its (placeholder) priority and reset it
+  // to 'queued', but KEEP the original `enqueued_at` and `rowid` so it holds its existing FIFO position rather than
+  // jumping the queue. (Restamping `enqueued_at` would be inconsistent — the fixed `rowid` still pins the old
+  // position whenever timestamps collide — so position is deliberately preserved instead.)
+  const enqueueStatement = db.prepare(`
+    INSERT INTO miner_portfolio_queue (api_base_url, repo_full_name, identifier, priority, status, enqueued_at)
+    VALUES (?, ?, ?, ?, 'queued', ?)
+    ON CONFLICT(api_base_url, repo_full_name, identifier) DO UPDATE SET
+      priority = excluded.priority,
+      status = 'queued'
+    WHERE miner_portfolio_queue.status <> 'in_progress'
+  `);
+  const getStatement = db.prepare(
+    "SELECT * FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?",
+  );
+  // Claim the highest-priority queued item ATOMICALLY: one UPDATE selects the ordered top row in a subquery and
+  // flips it to 'in_progress', RETURNING it — so two processes sharing the file can't both claim the same row (a
+  // separate SELECT-then-UPDATE would race). Deliberately global (no api_base_url filter): the queue is a single
+  // cross-host priority ordering, not a per-host one.
+  // Claiming stamps `leased_at` with the caller-supplied claim time and increments the attempt-history
+  // `attempts_count` (#5654, non-convergence.ts's real PortfolioConvergenceInput.attempts) -- leaving
+  // 'in_progress' (done/failed/reclaim) clears leased_at back to NULL so only genuinely in-flight rows carry
+  // a lease.
+  const dequeueStatement = db.prepare(`
+    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts_count = attempts_count + 1
+    WHERE rowid = (
+      SELECT rowid FROM miner_portfolio_queue WHERE status = 'queued' ${ORDER} LIMIT 1
+    )
+    RETURNING *
+  `);
+  // RETURNING (rather than a separate post-UPDATE SELECT) makes the "nothing to mark done" case observable
+  // directly from one atomic statement. consecutive_failures resets to 0 on reaching done (#5654) -- the
+  // active failure streak breaks the moment an attempt actually succeeds; reenqueue_count is a lifetime
+  // total and deliberately untouched here (see getAttemptHistory's own doc comment).
+  const markDoneStatement = db.prepare(`
+    UPDATE miner_portfolio_queue SET status = 'done', leased_at = NULL, consecutive_failures = 0
+    WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status <> 'done'
+    RETURNING *
+  `);
+  // Releasing an in-flight item back to queued WITHOUT reaching done is exactly non-convergence.ts's own
+  // "cycling queued -> in_progress -> queued without ever reaching done" reenqueue trigger (#5654) -- same
+  // counters, same increment, as reclaimStuckItem below (both are this same transition, just different
+  // callers: a run-halt release here vs. a stale-lease sweep there).
+  const markFailedStatement = db.prepare(`
+    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL,
+      consecutive_failures = consecutive_failures + 1, reenqueue_count = reenqueue_count + 1
+    WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
+    RETURNING *
+  `);
+  const listAllStatement = db.prepare(`SELECT * FROM miner_portfolio_queue ${ORDER}`);
+  const listRepoStatement = db.prepare(
+    `SELECT * FROM miner_portfolio_queue WHERE repo_full_name = ? ${ORDER}`,
+  );
+  const listActiveStatement = db.prepare(
+    `SELECT * FROM miner_portfolio_queue WHERE status IN ('queued', 'in_progress') ${ORDER}`,
+  );
+  const listInProgressStatement = db.prepare(
+    `SELECT * FROM miner_portfolio_queue WHERE status = 'in_progress' ${ORDER}`,
+  );
+  // A stale-lease sweep release is the SAME "in_progress -> queued without reaching done" event as
+  // markFailedStatement above (#5654) -- same counters, same increment.
+  const reclaimStatement = db.prepare(`
+    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL,
+      consecutive_failures = consecutive_failures + 1, reenqueue_count = reenqueue_count + 1
+    WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
+    RETURNING *
+  `);
+  // Requeue only ever targets a COMPLETED ('done') row — an in-flight item is released via reclaimStatement, and
+  // an already-'queued' item is a no-op — so a caller's manual requeue can never disturb an active claim. The
+  // row keeps its rowid/enqueued_at, so it re-enters the queue at its original FIFO position, not the back.
+  // Deliberately leaves attempts_count/consecutive_failures/reenqueue_count untouched (#5654): this is a
+  // manual reopen of ALREADY-COMPLETED work, not the stuck queued->in_progress->queued cycle those counters
+  // track -- reachedDone (derived live from status) simply reads false again once requeued, same as any
+  // other non-done row, until the item is claimed and completed again.
+  const requeueStatement = db.prepare(`
+    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
+    WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'done'
+    RETURNING *
+  `);
+  // Same attempts_count increment as dequeueStatement (#5654) -- batchClaim's per-item claim is just as much
+  // a real attempt as the single-item dequeueNext path.
+  const claimTargetStatement = db.prepare(`
+    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts_count = attempts_count + 1
+    WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'queued'
+    RETURNING *
+  `);
+  const attemptHistoryStatement = db.prepare(
+    "SELECT attempts_count, consecutive_failures, reenqueue_count, status FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?",
+  );
+
+  return {
+    dbPath: resolvedPath,
+    enqueue(item) {
+      const apiBaseUrl = normalizeApiBaseUrl(item?.apiBaseUrl);
+      const repoFullName = normalizeRepoFullName(item?.repoFullName);
+      const identifier = normalizeIdentifier(item?.identifier);
+      const priority = normalizePriority(item?.priority);
+      const enqueuedAt = new Date().toISOString();
+      enqueueStatement.run(apiBaseUrl, repoFullName, identifier, priority, enqueuedAt);
+      return rowToEntry(asPortfolioQueueDbRow(getStatement.get(apiBaseUrl, repoFullName, identifier)!));
+    },
+    dequeueNext() {
+      const row = dequeueStatement.get(new Date().toISOString());
+      return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+    },
+    /** In-flight ('in_progress') rows with their `leasedAt` claim time, for the expiry sweep (#4827). */
+    listInProgress() {
+      return listInProgressStatement.all().map((row) => rowToLeaseEntry(asPortfolioQueueDbRow(row)));
+    },
+    /** Reclaim a single stuck in-flight item back to 'queued' (clearing its lease), returning it — or null if it is
+     *  no longer 'in_progress' (already finished/reclaimed by another sweep). The sweep target of #4827. */
+    reclaimStuckItem(repoFullName, identifier, apiBaseUrl) {
+      const row = reclaimStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+    },
+    /** Requeue a COMPLETED ('done') item back to 'queued' so it is picked up again, keeping its FIFO position
+     *  (rowid/enqueued_at unchanged). Returns the entry, or null when there is no 'done' item to requeue — i.e.
+     *  it is already 'queued', is currently 'in_progress' (release it via {@link reclaimStuckItem} instead), or
+     *  does not exist. The manual counterpart to {@link reclaimStuckItem} for the queue CLI's escape hatch (#4828). */
+    requeueItem(repoFullName, identifier, apiBaseUrl) {
+      const row = requeueStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+    },
+    listQueue(repoFullName) {
+      const rows = repoFullName === undefined || repoFullName === null
+        ? listAllStatement.all()
+        : listRepoStatement.all(normalizeRepoFullName(repoFullName));
+      return rows.map((row) => rowToEntry(asPortfolioQueueDbRow(row)));
+    },
+    markDone(repoFullName, identifier, apiBaseUrl) {
+      const row = markDoneStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+    },
+    /** Release an in-flight item back to `queued` when a run halts (#2347). */
+    markFailed(repoFullName, identifier, apiBaseUrl) {
+      const row = markFailedStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      return row ? rowToEntry(asPortfolioQueueDbRow(row)) : null;
+    },
+    /**
+     * Transactional caps-aware batch claim hook used by portfolio-queue-manager.js: re-read active rows under an
+     * exclusive lock, let the caller pick targets, then atomically flip each still-queued row to `in_progress`.
+     */
+    batchClaim(selectFn) {
+      if (typeof selectFn !== "function") throw new Error("invalid_batch_claim_selector");
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const entries = listActiveStatement.all().map((row) => rowToEntry(asPortfolioQueueDbRow(row)));
+        const targets = selectFn(entries);
+        if (!Array.isArray(targets)) throw new Error("invalid_batch_claim_selection");
+        const leasedAt = new Date().toISOString();
+        const claimed: QueueEntry[] = [];
+        for (const target of targets) {
+          const apiBaseUrl = normalizeApiBaseUrl(target?.apiBaseUrl);
+          const repoFullName = normalizeRepoFullName(target?.repoFullName);
+          const identifier = normalizeIdentifier(target?.identifier);
+          const row = claimTargetStatement.get(leasedAt, apiBaseUrl, repoFullName, identifier);
+          if (row) claimed.push(rowToEntry(asPortfolioQueueDbRow(row)));
+        }
+        db.exec("COMMIT");
+        return claimed;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+    /**
+     * A real `PortfolioConvergenceInput` (non-convergence.ts) for one queue item (#5654), replacing the
+     * first-attempt-shaped literal attempt-input-builder.js previously hardcoded. An item never enqueued here
+     * (not yet tracked at all) reads the same honest zero-state as a genuine first attempt -- absence of
+     * history is not evidence of a problem, same rule non-convergence.ts's own header documents. `reachedDone`
+     * is derived live from the row's current `status`, not a separate persisted flag (see requeueStatement's
+     * comment above for why that's the deliberate choice).
+     */
+    getAttemptHistory(repoFullName, identifier, apiBaseUrl) {
+      const row = attemptHistoryStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      if (!row) return { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false };
+      const historyRow = asPortfolioQueueDbRow(row);
+      return {
+        attempts: historyRow.attempts_count,
+        consecutiveFailures: historyRow.consecutive_failures,
+        reenqueues: historyRow.reenqueue_count,
+        reachedDone: historyRow.status === "done",
+      };
+    },
+    // Explicit, operator-invoked right-to-be-forgotten purge (#5564, #6599) — never runs automatically.
+    purgeByRepo(repoFullName) {
+      return purgeStoreByRepo(db, PORTFOLIO_QUEUE_PURGE_SPEC, normalizeRepoFullName(repoFullName));
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+function getDefaultPortfolioQueueStore(): PortfolioQueueStore {
+  defaultPortfolioQueueStore ??= initPortfolioQueueStore();
+  return defaultPortfolioQueueStore;
+}
+
+export function enqueue(item: EnqueueItem): QueueEntry {
+  return getDefaultPortfolioQueueStore().enqueue(item);
+}
+
+export function dequeueNext(): QueueEntry | null {
+  return getDefaultPortfolioQueueStore().dequeueNext();
+}
+
+export function listQueue(repoFullName?: string | null): QueueEntry[] {
+  return getDefaultPortfolioQueueStore().listQueue(repoFullName);
+}
+
+export function markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null {
+  return getDefaultPortfolioQueueStore().markDone(repoFullName, identifier, apiBaseUrl);
+}
+
+export function markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null {
+  return getDefaultPortfolioQueueStore().markFailed(repoFullName, identifier, apiBaseUrl);
+}
+
+export function getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueAttemptHistory {
+  return getDefaultPortfolioQueueStore().getAttemptHistory(repoFullName, identifier, apiBaseUrl);
+}
+
+export function closeDefaultPortfolioQueueStore(): void {
+  if (!defaultPortfolioQueueStore) return;
+  defaultPortfolioQueueStore.close();
+  defaultPortfolioQueueStore = null;
+}

--- a/test/unit/miner-event-ledger.test.ts
+++ b/test/unit/miner-event-ledger.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  appendEvent,
   closeDefaultEventLedger,
   initEventLedger,
+  readEvents,
   resolveEventLedgerDbPath,
 } from "../../packages/loopover-miner/lib/event-ledger.js";
 
@@ -136,7 +138,13 @@ describe("loopover-miner event ledger (#2290)", () => {
     // @ts-expect-error — payload must be an object
     expect(() => ledger.appendEvent({ type: "x", payload: "nope" })).toThrow("invalid_payload");
     expect(() => ledger.appendEvent({ type: "  ", payload: {} })).toThrow("invalid_event_type");
+    // A non-string event type is rejected the same as an empty one, before any SQL runs.
+    expect(() => ledger.appendEvent({ type: 42 as unknown as string, payload: {} })).toThrow("invalid_event_type");
     expect(() => ledger.appendEvent({ type: "x", repoFullName: "no-slash", payload: {} })).toThrow(
+      "invalid_repo_full_name",
+    );
+    // A non-string (but non-nullish) repo scope is rejected too — distinct from the omitted/null "unscoped" case.
+    expect(() => ledger.appendEvent({ type: "x", repoFullName: 42 as unknown as string, payload: {} })).toThrow(
       "invalid_repo_full_name",
     );
   });
@@ -148,9 +156,44 @@ describe("loopover-miner event ledger (#2290)", () => {
     expect(() => ledger.appendEvent({ type: "x", payload: { a: Number.NaN } })).toThrow("invalid_payload");
     expect(() => ledger.appendEvent({ type: "x", payload: { a: () => 1 } })).toThrow("invalid_payload");
     expect(() => ledger.appendEvent({ type: "x", payload: { a: [1, undefined] } })).toThrow("invalid_payload");
+    // A payload JSON.stringify cannot even serialize (BigInt / a circular reference) fails closed the same way,
+    // via the stringify try/catch rather than the round-trip equality check.
+    expect(() => ledger.appendEvent({ type: "x", payload: { a: 1n } })).toThrow("invalid_payload");
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => ledger.appendEvent({ type: "x", payload: circular })).toThrow("invalid_payload");
     // A fully JSON-safe nested payload is accepted and reads back identically.
     const entry = ledger.appendEvent({ type: "x", payload: { a: { b: [1, "two", true, null] } } });
     expect(ledger.readEvents()).toContainEqual(entry);
+  });
+
+  it("rolls back and rethrows when the append transaction hits a database error mid-flight", () => {
+    const ledger = tempLedger();
+    // Force a deterministic mid-transaction failure: drop the table out from under the open ledger via a separate
+    // connection, so the in-transaction `MAX(seq)` read fails. appendEvent takes BEGIN IMMEDIATE before the try,
+    // so the failure must ROLLBACK (never leave a dangling write transaction) and rethrow the underlying error.
+    const raw = new DatabaseSync(ledger.dbPath);
+    raw.exec("DROP TABLE miner_event_ledger");
+    raw.close();
+    expect(() => ledger.appendEvent({ type: "discovered_issue", payload: {} })).toThrow(/no such table/i);
+    // afterEach then closes the handle cleanly, proving the failed append left no dangling write transaction.
+  });
+
+  it("uses the default singleton ledger helpers and closes cleanly", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-event-default-"));
+    roots.push(root);
+    const previousConfigDir = process.env.LOOPOVER_MINER_CONFIG_DIR;
+    process.env.LOOPOVER_MINER_CONFIG_DIR = root;
+    try {
+      const entry = appendEvent({ type: "discovered_issue", repoFullName: "acme/widgets", payload: { issueNumber: 1 } });
+      expect(readEvents()).toEqual([entry]);
+      // First close releases the real singleton; the second hits the already-closed no-op early return.
+      closeDefaultEventLedger();
+      closeDefaultEventLedger();
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.LOOPOVER_MINER_CONFIG_DIR;
+      else process.env.LOOPOVER_MINER_CONFIG_DIR = previousConfigDir;
+    }
   });
 
   it("is append-only: the module's own source issues no inline UPDATE or DELETE against the ledger (#5564: the sole exception, purgeByRepo, delegates its DELETE to store-maintenance.js's shared helper, never inline SQL here)", () => {

--- a/test/unit/miner-governor-ledger.test.ts
+++ b/test/unit/miner-governor-ledger.test.ts
@@ -118,6 +118,17 @@ describe("loopover-miner governor ledger (#2328)", () => {
     expect(() => ledger.readGovernorEvents()).toThrow("corrupted_governor_row");
   });
 
+  it("rejects a payload blob that is valid JSON but not an object (null/array/scalar) on read", () => {
+    const ledger = tempLedger();
+    ledger.appendGovernorEvent({ eventType: "allowed", actionClass: "analyze", decision: "allow", reason: "ok" });
+    const raw = new DatabaseSync(ledger.dbPath);
+    // Valid JSON, but a scalar rather than an object -- the explicit shape guard rejects it distinctly from a
+    // JSON.parse failure, so a widened-but-malformed row can never read back as a governor entry.
+    raw.prepare("UPDATE governor_events SET payload_json = ? WHERE id = 1").run("123");
+    raw.close();
+    expect(() => ledger.readGovernorEvents()).toThrow("corrupted_governor_row");
+  });
+
   it("records throttled and kill_switch outcomes for later audit", () => {
     const ledger = tempLedger();
     const throttled = ledger.appendGovernorEvent({
@@ -137,6 +148,36 @@ describe("loopover-miner governor ledger (#2328)", () => {
     expect(ledger.readGovernorEvents().map((row) => row.eventType)).toEqual(["throttled", "kill_switch"]);
     expect(throttled.payload).toEqual({ retryAfterMs: 5000 });
     expect(killSwitch.repoFullName).toBeNull();
+  });
+
+  it("readGovernorDecisions returns the redacted decision-log projection (no payload), filterable by repo (#5159)", () => {
+    const ledger = tempLedger();
+    ledger.appendGovernorEvent({
+      eventType: "denied",
+      repoFullName: "acme/widgets",
+      actionClass: "write",
+      decision: "block",
+      reason: "kill switch active",
+      payload: { rule: "global_kill_switch", sensitive: true },
+    });
+    ledger.appendGovernorEvent({
+      eventType: "allowed",
+      repoFullName: "acme/other",
+      actionClass: "analyze",
+      decision: "allow",
+      reason: "within budget",
+    });
+
+    const all = ledger.readGovernorDecisions();
+    expect(all).toHaveLength(2);
+    // The projection omits payload by construction — the sensitive column never leaves the store.
+    for (const decision of all) expect("payload" in decision).toBe(false);
+    expect(all.map((decision) => decision.eventType)).toEqual(["denied", "allowed"]);
+
+    const scoped = ledger.readGovernorDecisions({ repoFullName: "acme/widgets" });
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0]).toMatchObject({ eventType: "denied", decision: "block", reason: "kill switch active" });
+    expect("payload" in scoped[0]!).toBe(false);
   });
 
   describe("purgeByRepo (#5564)", () => {

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -10,6 +10,7 @@ import {
   enqueue,
   getAttemptHistory,
   initPortfolioQueueStore,
+  listQueue,
   markDone,
   markFailed,
   resolvePortfolioQueueDbPath,
@@ -197,6 +198,8 @@ describe("loopover-miner portfolio/queue store (#2292)", () => {
     const store = tempStore();
     expect(() => store.enqueue({ repoFullName: "no-slash", identifier: "1" })).toThrow("invalid_repo_full_name");
     expect(() => store.enqueue({ repoFullName: "o/a", identifier: "  " })).toThrow("invalid_identifier");
+    // A non-string identifier is rejected before any trim, distinct from the empty-string case above.
+    expect(() => store.enqueue({ repoFullName: "o/a", identifier: 42 as unknown as string })).toThrow("invalid_identifier");
     expect(() => store.enqueue({ repoFullName: "o/a", identifier: "1", priority: Number.NaN })).toThrow(
       "invalid_priority",
     );
@@ -216,6 +219,31 @@ describe("loopover-miner portfolio/queue store (#2292)", () => {
     enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
     expect(markDone("o/a", "work")?.status).toBe("done");
     expect(markDone("o/a", "work")).toBeNull();
+  });
+
+  it("module-level listQueue delegates to the default portfolio-queue store", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-default-"));
+    roots.push(root);
+    vi.stubEnv("LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
+    enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
+    expect(listQueue().map((entry) => entry.identifier)).toEqual(["work"]);
+    expect(listQueue("o/a").map((entry) => entry.identifier)).toEqual(["work"]);
+  });
+
+  it("batchClaim rejects a non-function selector and a non-array selection, and rolls back (never partially claims) when the selector throws", () => {
+    const store = tempStore();
+    store.enqueue({ repoFullName: "o/a", identifier: "1", priority: 1 });
+    expect(() => store.batchClaim(undefined as never)).toThrow("invalid_batch_claim_selector");
+    // A selector that returns a non-array is rejected inside the transaction, which then rolls back.
+    expect(() => store.batchClaim(() => ({}) as never)).toThrow("invalid_batch_claim_selection");
+    // A selector that throws propagates after the transaction rolls back — the row stays claimable, unchanged.
+    expect(() =>
+      store.batchClaim(() => {
+        throw new Error("selector boom");
+      }),
+    ).toThrow("selector boom");
+    // No partial claim survived either failure: the item is still queued and dequeues normally.
+    expect(store.dequeueNext()?.identifier).toBe("1");
   });
 
   describe("forge-scoping (#5563)", () => {
@@ -326,6 +354,44 @@ describe("loopover-miner portfolio/queue store (#2292)", () => {
       const geEntry = store.enqueue({ repoFullName: "acme/widgets", identifier: "issue:5", apiBaseUrl: "https://ghe.example.com/api/v3" });
       expect(store.listQueue("acme/widgets")).toHaveLength(2);
       expect(geEntry.apiBaseUrl).toBe("https://ghe.example.com/api/v3");
+    });
+
+    it("migrates a pre-leased_at v1 file: adds the leased_at column before the v3 rebuild, and a pre-existing in-progress row keeps a null lease", () => {
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-legacy-v1-"));
+      roots.push(root);
+      const dbPath = join(root, "legacy-v1.sqlite3");
+      const legacy = new DatabaseSync(dbPath);
+      // The original v1 shape predates leased_at (#4827) entirely, so opening it must run the additive ALTER
+      // migration (1->2) before the (2->3) primary-key rebuild.
+      legacy.exec(`
+        CREATE TABLE miner_portfolio_queue (
+          repo_full_name TEXT NOT NULL,
+          identifier TEXT NOT NULL,
+          priority REAL NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+          enqueued_at TEXT NOT NULL,
+          PRIMARY KEY (repo_full_name, identifier)
+        )
+      `);
+      legacy.exec("PRAGMA user_version = 1");
+      legacy.exec(
+        "INSERT INTO miner_portfolio_queue (repo_full_name, identifier, priority, status, enqueued_at) VALUES ('acme/widgets', 'issue:9', 2, 'in_progress', '2026-01-01T00:00:00.000Z')",
+      );
+      legacy.close();
+
+      const store = initPortfolioQueueStore(dbPath);
+      stores.push(store);
+      // The newly-added leased_at column is NULL for the pre-existing in-progress row; listInProgress surfaces it
+      // as a null lease (which the expiry sweep treats as immediately reclaimable).
+      expect(store.listInProgress()).toEqual([
+        {
+          apiBaseUrl: "https://api.github.com",
+          repoFullName: "acme/widgets",
+          identifier: "issue:9",
+          status: "in_progress",
+          leasedAt: null,
+        },
+      ]);
     });
 
     it("REGRESSION: a legacy row violating the rebuilt table's status CHECK constraint is dropped, not a migration-aborting crash", () => {


### PR DESCRIPTION
## Summary

Phase-4 **batch 4.8** (the final batch) of the #7290 TypeScript migration: convert the 4 highest-fan-in `packages/loopover-miner/lib` modules from hand-maintained `.js` + `.d.ts` to real TypeScript, compiled in place via the package's existing `tsc` pipeline.

Files: `governor-ledger`, `event-ledger`, `portfolio-queue`, `cli-error`.

These are the most-depended-on modules in the package (event-ledger is imported by 23 test files, portfolio-queue by 22), so the public API is preserved **exactly** — every exported name and signature matches the removed hand-written `.d.ts` — and the compiled `.js` output is **behavior-identical** to the original: only type annotations, identity row-cast helpers (`asXDbRow(row) => row`), and tsc formatting differ. No `tsconfig.json` change is needed; its `lib/**/*.ts` include glob picks the files up automatically.

Verified byte-identical by diffing the freshly-compiled `.js` against the original hand-written `.js` with comments/whitespace normalized away — every remaining difference is either tsc reformatting or an identity cast that returns its argument unchanged.

## Coverage

All 4 converted files are at **100% line + branch + function** coverage (`292/292` statements, `153/153` branches, `84/84` functions, `256/256` lines across the four). The migration surfaces several pre-existing `.js` branches as newly-tracked lines, so this PR adds targeted tests for: non-string `type`/`repoFullName`/`identifier` validation arms; BigInt/circular `serializePayload` rejection; the `readGovernorDecisions` redacted projection and the valid-JSON-but-non-object corrupted-row guard; the default-singleton module wrappers; the `batchClaim` non-function/non-array/rollback error paths; a pre-`leased_at` v1→v3 legacy migration (with a null-lease in-progress row); and the `appendEvent` transaction ROLLBACK path (triggered deterministically by dropping the table mid-flight).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root `tsc --noEmit`) and the `@loopover/miner` package `tsc` build both green
- [x] Converted files at **100% line + branch + function** (verified via `--coverage` over the modules' dedicated + CLI + importer tests)
- [x] `npm run build:miner` regenerates the committed `.js`/`.d.ts` with **zero drift**; `npm run test:miner-pack` confirms **0 `.ts` files leak** into the published package; `npm run miner:env-reference:check` clean
- [x] All existing tests for the four modules pass unmodified; new tests added only for the branches the migration newly tracks
- [x] Rebased onto the current `main` tip

Not run here (out of scope for a `packages/loopover-miner/lib/**`-only, behavior-identical migration; no such surface changed): `ui:*`, `build:mcp`/`test:mcp-pack`, `ui:openapi:check`. No API/OpenAPI/MCP/UI/DB/wrangler surface is touched.

## Safety

- [x] No secrets, wallets, hotkeys/coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence anywhere.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/GitHub App/Cloudflare/session: N/A — none changed.
- [x] API/OpenAPI/MCP: N/A — none changed.
- [x] UI: N/A — no UI change.
- [x] No changelog edit; no `site/`/`CNAME`/`lovable` changes.

Closes #7316
