### PR TITLE
chore(miner): migrate CLI command packages/loopover-miner/lib modules to TypeScript (#7307)

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.d.ts
+++ b/packages/loopover-miner/lib/attempt-cli.d.ts
@@ -1,108 +1,128 @@
 import type { CodingAgentExecutionMode, FeasibilityVerdict, LocalWriteActionSpec } from "@loopover/engine";
-import type { AttemptDeps, AttemptResult as RunMinerAttemptResult, runMinerAttempt } from "./attempt-runner.js";
 import type { ClaimLedger } from "./claim-ledger.js";
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
+import { resolveClaimConflict } from "./claim-conflict-resolver.js";
+import type { ClaimConflictResult } from "./claim-conflict-resolver.js";
 import type { EventLedger } from "./event-ledger.js";
 import type { AttemptLog } from "./attempt-log.js";
 import type { GovernorLedger } from "./governor-ledger.js";
 import type { WorktreeAllocator } from "./worktree-allocator.js";
-import type { resolveRejectionSignaled } from "./rejection-signal.js";
-import type { SelfReviewContextFetch, fetchSelfReviewContext } from "./self-review-context.js";
-import type { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
-import type { buildCodingTaskSpec } from "./coding-task-spec.js";
-import type { resolveAmsPolicy } from "./ams-policy.js";
-import type { checkMinerKillSwitch } from "./governor-kill-switch.js";
-import type { resolveMinerGoalSpec } from "./miner-goal-spec.js";
-import type { ClaimConflictResult, resolveClaimConflict } from "./claim-conflict-resolver.js";
-import type { recordOwnSubmission } from "./governor-state.js";
-import type { getAttemptHistory } from "./portfolio-queue.js";
-import type { submitSoftClaim } from "./discovery-index-client.js";
-
+import { resolveRejectionSignaled } from "./rejection-signal.js";
+import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
+import { fetchSelfReviewContext } from "./self-review-context.js";
+import type { SelfReviewContextFetch } from "./self-review-context.js";
+import { buildCodingTaskSpec } from "./coding-task-spec.js";
+import { resolveAmsPolicy } from "./ams-policy.js";
+import { checkMinerKillSwitch } from "./governor-kill-switch.js";
+import { getAttemptHistory } from "./portfolio-queue.js";
+import { recordOwnSubmission } from "./governor-state.js";
+import { runMinerAttempt } from "./attempt-runner.js";
+import type { AttemptDeps, AttemptResult as RunMinerAttemptResult } from "./attempt-runner.js";
+import { submitSoftClaim } from "./discovery-index-client.js";
 type CommonAttemptResultFields = {
-  repoFullName: string;
-  issueNumber: number;
-  minerLogin: string;
-  base: string;
-  mode: CodingAgentExecutionMode;
-  attemptId: string;
+    repoFullName: string;
+    issueNumber: number;
+    minerLogin: string;
+    base: string;
+    mode: CodingAgentExecutionMode;
+    attemptId: string;
 };
-
 /** The result runAttempt reports at every real return point, threaded to `options.onResult` (in addition to
  *  the plain exit-code return runAttempt itself still returns, unchanged, so bin/loopover-miner.js's own
  *  `process.exit(exitCode)` usage never breaks) -- the loop orchestrator's real caller for this data. */
-export type AttemptCliResult =
-  | (CommonAttemptResultFields & { outcome: "dry_run" })
-  | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
-  | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
-  | (CommonAttemptResultFields & {
-      outcome: "blocked_infeasible";
-      reason: string;
-      verdict: FeasibilityVerdict;
-      avoidReasons: string[];
-      raiseReasons: string[];
-    })
-  | (CommonAttemptResultFields & {
-      outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
-      submissionMode: "observe" | "enforce";
-      totalTurnsUsed: number;
-      totalCostUsd: number;
-      totalTokensUsed: number;
-      iterationsUsed: number;
-      reason?: string;
-      decision?: unknown;
-      spec?: LocalWriteActionSpec;
-      execResult?: unknown;
-      claimConflict?: ClaimConflictResult;
-    });
-
-export type ParsedAttemptArgs =
-  | { error: string }
-  | {
-      repoFullName: string;
-      issueNumber: number;
-      minerLogin: string;
-      base: string;
-      live: boolean;
-      dryRun: boolean;
-      json: boolean;
-    };
-
-export function parseAttemptArgs(args: string[]): ParsedAttemptArgs;
-
-export function buildAttemptDeps(
-  env: Record<string, string | undefined>,
-  ledgers: { claimLedger: ClaimLedger; eventLedger: EventLedger; attemptLog: AttemptLog; governorLedger: GovernorLedger; nowMs: number },
-): AttemptDeps;
-
-export type RunAttemptOptions = {
-  env?: Record<string, string | undefined>;
-  nowMs?: number;
-  attemptId?: string;
-  resolveCodingAgentModeFromConfig?: (config: { env?: Record<string, string | undefined> }) => CodingAgentExecutionMode;
-  openWorktreeAllocator?: () => WorktreeAllocator;
-  openClaimLedger?: () => ClaimLedger;
-  initEventLedger?: () => EventLedger;
-  initAttemptLog?: () => AttemptLog;
-  initGovernorLedger?: () => GovernorLedger;
-  buildAttemptDeps?: typeof buildAttemptDeps;
-  resolveRejectionSignaled?: typeof resolveRejectionSignaled;
-  fetchImpl?: SelfReviewContextFetch;
-  prepareAttemptWorktree?: typeof prepareAttemptWorktree;
-  cleanupAttemptWorktree?: typeof cleanupAttemptWorktree;
-  fetchSelfReviewContext?: typeof fetchSelfReviewContext;
-  buildCodingTaskSpec?: typeof buildCodingTaskSpec;
-  resolveAmsPolicy?: typeof resolveAmsPolicy;
-  checkMinerKillSwitch?: typeof checkMinerKillSwitch;
-  resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
-  runMinerAttempt?: typeof runMinerAttempt;
-  resolveClaimConflict?: typeof resolveClaimConflict;
-  recordOwnSubmission?: typeof recordOwnSubmission;
-  getAttemptHistory?: typeof getAttemptHistory;
-  /** Hosted soft-claim coordination at work-start/work-end, when the plane is enabled (#7168). Defaults to
-   *  discovery-index-client.js's own submitSoftClaim. */
-  submitSoftClaim?: typeof submitSoftClaim;
-  /** Invoked with the real structured result at every return point, in addition to (never instead of) the
-   *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
-  onResult?: (result: AttemptCliResult) => void;
+export type AttemptCliResult = (CommonAttemptResultFields & {
+    outcome: "dry_run";
+}) | (CommonAttemptResultFields & {
+    outcome: "blocked_rejection_signaled";
+    reason: string;
+}) | (CommonAttemptResultFields & {
+    outcome: "blocked_worktree_preparation_failed";
+    reason: string;
+}) | (CommonAttemptResultFields & {
+    outcome: "blocked_infeasible";
+    reason: string;
+    verdict: FeasibilityVerdict;
+    avoidReasons: string[];
+    raiseReasons: string[];
+}) | (CommonAttemptResultFields & {
+    outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
+    submissionMode: "observe" | "enforce";
+    totalTurnsUsed: number;
+    totalCostUsd: number;
+    totalTokensUsed: number;
+    iterationsUsed: number;
+    reason?: string;
+    decision?: unknown;
+    spec?: LocalWriteActionSpec;
+    execResult?: unknown;
+    claimConflict?: ClaimConflictResult;
+});
+export type ParsedAttemptArgs = {
+    error: string;
+} | {
+    repoFullName: string;
+    issueNumber: number;
+    minerLogin: string;
+    base: string;
+    live: boolean;
+    dryRun: boolean;
+    json: boolean;
 };
-
-export function runAttempt(args: string[], options?: RunAttemptOptions): Promise<number>;
+export declare function parseAttemptArgs(args: string[]): ParsedAttemptArgs;
+/**
+ * Assemble a real AttemptDeps object: every field wired to a genuine implementation (the #5131 driver, the
+ * #5133 slop assessor, the four real ledgers passed in, and the fetchLiveIssueSnapshot/executeLocalWrite
+ * built alongside this file). Throws if the coding-agent driver is unconfigured (fails closed, matching
+ * constructProductionCodingAgentDriver's own contract) -- callers should report that clearly rather than
+ * silently falling back to a driver that could never run.
+ */
+export declare function buildAttemptDeps(env: Record<string, string | undefined>, ledgers: {
+    claimLedger: ClaimLedger;
+    eventLedger: EventLedger;
+    attemptLog: AttemptLog;
+    governorLedger: GovernorLedger;
+    nowMs: number;
+}): AttemptDeps;
+export type RunAttemptOptions = {
+    env?: Record<string, string | undefined>;
+    nowMs?: number;
+    attemptId?: string;
+    resolveCodingAgentModeFromConfig?: (config: {
+        env?: Record<string, string | undefined>;
+    }) => CodingAgentExecutionMode;
+    openWorktreeAllocator?: () => WorktreeAllocator;
+    openClaimLedger?: () => ClaimLedger;
+    initEventLedger?: () => EventLedger;
+    initAttemptLog?: () => AttemptLog;
+    initGovernorLedger?: () => GovernorLedger;
+    buildAttemptDeps?: typeof buildAttemptDeps;
+    resolveRejectionSignaled?: typeof resolveRejectionSignaled;
+    fetchImpl?: SelfReviewContextFetch;
+    prepareAttemptWorktree?: typeof prepareAttemptWorktree;
+    cleanupAttemptWorktree?: typeof cleanupAttemptWorktree;
+    fetchSelfReviewContext?: typeof fetchSelfReviewContext;
+    buildCodingTaskSpec?: typeof buildCodingTaskSpec;
+    resolveAmsPolicy?: typeof resolveAmsPolicy;
+    checkMinerKillSwitch?: typeof checkMinerKillSwitch;
+    resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
+    runMinerAttempt?: typeof runMinerAttempt;
+    resolveClaimConflict?: typeof resolveClaimConflict;
+    recordOwnSubmission?: typeof recordOwnSubmission;
+    getAttemptHistory?: typeof getAttemptHistory;
+    /** Hosted soft-claim coordination at work-start/work-end, when the plane is enabled (#7168). Defaults to
+     *  discovery-index-client.js's own submitSoftClaim. */
+    submitSoftClaim?: typeof submitSoftClaim;
+    /** Invoked with the real structured result at every return point, in addition to (never instead of) the
+     *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
+    onResult?: (result: AttemptCliResult) => void;
+};
+/**
+ * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
+ * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
+ * SelfReviewContext -> build a real coding-task spec (blocks on an infeasible verdict) -> resolve the real
+ * AmsPolicySpec execution policy -> assemble the real IterateLoopInput + Governor context -> call
+ * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) in `finally`.
+ * See this file's header for the documented gaps (real convergence history).
+ */
+export declare function runAttempt(args: string[], options?: RunAttemptOptions): Promise<number>;
+export {};

--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -12,7 +12,6 @@
 // governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted (chokepoint.ts's own design treats
 // that as "skip that stage entirely"). governor.convergenceInput is now a real per-issue portfolio-queue.js read
 // (#5654) and governor.reputationHistory a real per-repo governor-state.js read (#5675), not placeholders.
-
 import { fingerprintFromChangedFiles, resolveCodingAgentModeFromConfig, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { constructProductionCodingAgentDriver } from "./coding-agent-construction.js";
@@ -41,115 +40,104 @@ import { loadReputationHistory, recordOwnSubmission } from "./governor-state.js"
 import { runMinerAttempt } from "./attempt-runner.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
 import { isDiscoveryPlaneEnabled, submitSoftClaim } from "./discovery-index-client.js";
-
-const ATTEMPT_USAGE =
-  "Usage: loopover-miner attempt <owner/repo> <issue#> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--json]";
-
+const ATTEMPT_USAGE = "Usage: loopover-miner attempt <owner/repo> <issue#> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--json]";
 function parseRepoTarget(value) {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
-  return `${owner}/${repo}`;
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo))
+        return null;
+    return `${owner}/${repo}`;
 }
-
 export function parseAttemptArgs(args) {
-  const options = { json: false, minerLogin: null, base: "main", live: false, dryRun: false };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, minerLogin: null, base: "main", live: false, dryRun: false };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // Opt-in only: resolveCodingAgentModeFromConfig's own default (no agentDryRun override) is "live", not
+        // "dry_run" -- so #5132's "dry-run is default" acceptance criteria (#2342) has to be enforced HERE, by
+        // requiring an explicit --live flag before this command will ever request live mode.
+        if (token === "--live") {
+            options.live = true;
+            continue;
+        }
+        // #4847: distinct from --live's absence above -- --live only ever gated the coding-agent DRIVER's mode,
+        // but a non---live run still opened every store and made real worktree/claim/ledger writes. --dry-run
+        // short-circuits BEFORE any of that infrastructure is even opened, guaranteeing zero writes rather than
+        // merely skipping the driver.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--miner-login") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: ATTEMPT_USAGE };
+            options.minerLogin = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--base") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: ATTEMPT_USAGE };
+            options.base = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    // Opt-in only: resolveCodingAgentModeFromConfig's own default (no agentDryRun override) is "live", not
-    // "dry_run" -- so #5132's "dry-run is default" acceptance criteria (#2342) has to be enforced HERE, by
-    // requiring an explicit --live flag before this command will ever request live mode.
-    if (token === "--live") {
-      options.live = true;
-      continue;
+    if (positional.length !== 2)
+        return { error: ATTEMPT_USAGE };
+    const repoFullName = parseRepoTarget(positional[0]);
+    if (!repoFullName)
+        return { error: `Repository must be in owner/repo form: ${positional[0]}` };
+    const issueNumber = Number(positional[1]);
+    if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+        return { error: `Issue number must be a positive integer: ${positional[1]}` };
     }
-    // #4847: distinct from --live's absence above -- --live only ever gated the coding-agent DRIVER's mode,
-    // but a non---live run still opened every store and made real worktree/claim/ledger writes. --dry-run
-    // short-circuits BEFORE any of that infrastructure is even opened, guaranteeing zero writes rather than
-    // merely skipping the driver.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--miner-login") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
-      options.minerLogin = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--base") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
-      options.base = value;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) return { error: ATTEMPT_USAGE };
-  const repoFullName = parseRepoTarget(positional[0]);
-  if (!repoFullName) return { error: `Repository must be in owner/repo form: ${positional[0]}` };
-  const issueNumber = Number(positional[1]);
-  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
-    return { error: `Issue number must be a positive integer: ${positional[1]}` };
-  }
-  if (!options.minerLogin) return { error: `--miner-login is required. ${ATTEMPT_USAGE}` };
-
-  return {
-    repoFullName,
-    issueNumber,
-    minerLogin: options.minerLogin,
-    base: options.base,
-    live: options.live,
-    dryRun: options.dryRun,
-    json: options.json,
-  };
+    if (!options.minerLogin)
+        return { error: `--miner-login is required. ${ATTEMPT_USAGE}` };
+    return {
+        repoFullName,
+        issueNumber,
+        minerLogin: options.minerLogin,
+        base: options.base,
+        live: options.live,
+        dryRun: options.dryRun,
+        json: options.json,
+    };
 }
-
 /**
  * Assemble a real AttemptDeps object: every field wired to a genuine implementation (the #5131 driver, the
  * #5133 slop assessor, the four real ledgers passed in, and the fetchLiveIssueSnapshot/executeLocalWrite
  * built alongside this file). Throws if the coding-agent driver is unconfigured (fails closed, matching
  * constructProductionCodingAgentDriver's own contract) -- callers should report that clearly rather than
  * silently falling back to a driver that could never run.
- *
- * @param {Record<string, string | undefined>} env
- * @param {{
- *   claimLedger: import("./claim-ledger.js").ClaimLedger,
- *   eventLedger: import("./event-ledger.js").EventLedger,
- *   attemptLog: import("./attempt-log.js").AttemptLog,
- *   governorLedger: import("./governor-ledger.js").GovernorLedger,
- *   nowMs: number,
- * }} ledgers
- * @returns {import("./attempt-runner.js").AttemptDeps}
  */
 export function buildAttemptDeps(env, ledgers) {
-  return {
-    driver: constructProductionCodingAgentDriver(env),
-    runSlopAssessment: (input) => runSlopAssessment(input),
-    appendAttemptLogEvent: (event) => ledgers.attemptLog.appendAttemptLogEvent(event),
-    claimLedger: ledgers.claimLedger,
-    // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
-    // authenticated `loopover-mcp login` session -- cached in memory, so repeat calls within this process
-    // don't repeatedly hit the session-fetch endpoint after the first successful resolution.
-    fetchLiveIssueSnapshot: async (repoFullName, issueNumber) => fetchLiveIssueSnapshot(repoFullName, issueNumber, { githubToken: await resolveGitHubToken(env) }),
-    eventLedger: ledgers.eventLedger,
-    governorLedgerAppend: (event) => ledgers.governorLedger.appendGovernorEvent(event),
-    nowMs: ledgers.nowMs,
-    executeLocalWrite: (spec) => executeLocalWrite(spec),
-  };
+    return {
+        driver: constructProductionCodingAgentDriver(env),
+        runSlopAssessment: (input) => runSlopAssessment(input),
+        appendAttemptLogEvent: (event) => ledgers.attemptLog.appendAttemptLogEvent(event),
+        claimLedger: ledgers.claimLedger,
+        // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+        // authenticated `loopover-mcp login` session -- cached in memory, so repeat calls within this process
+        // don't repeatedly hit the session-fetch endpoint after the first successful resolution.
+        fetchLiveIssueSnapshot: async (repoFullName, issueNumber) => fetchLiveIssueSnapshot(repoFullName, issueNumber, { githubToken: await resolveGitHubToken(env) }),
+        eventLedger: ledgers.eventLedger,
+        governorLedgerAppend: (event) => ledgers.governorLedger.appendGovernorEvent(event),
+        nowMs: ledgers.nowMs,
+        executeLocalWrite: (spec) => executeLocalWrite(spec),
+    };
 }
-
 /**
  * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
  * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
@@ -159,573 +147,534 @@ export function buildAttemptDeps(env, ledgers) {
  * See this file's header for the documented gaps (real convergence history).
  */
 export async function runAttempt(args, options = {}) {
-  const parsed = parseAttemptArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const env = options.env ?? process.env;
-  const nowMs = options.nowMs ?? Date.now();
-  const resolveMode = options.resolveCodingAgentModeFromConfig ?? resolveCodingAgentModeFromConfig;
-  const mode = resolveMode({ env, agentDryRun: !parsed.live });
-
-  if (mode === "paused") {
-    return reportCliFailure(
-      parsed.json,
-      `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`,
-      3,
-    );
-  }
-
-  const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
-
-  // #4847: reports what a real run would do and returns BEFORE any store (allocator/claim/event/attempt-log/
-  // governor ledger) is even opened, so this is a provable zero-write path -- not just "opened but didn't
-  // write to" the local stores, and nowhere near the real worktree clone, claim, or coding-agent driver.
-  if (parsed.dryRun) {
-    const dryRunResult = {
-      outcome: "dry_run",
-      repoFullName: parsed.repoFullName,
-      issueNumber: parsed.issueNumber,
-      minerLogin: parsed.minerLogin,
-      base: parsed.base,
-      mode,
-      attemptId,
-    };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(
-        `DRY RUN: would attempt ${parsed.repoFullName}#${parsed.issueNumber} for ${parsed.minerLogin} (mode: ${mode}, base: ${parsed.base}). No worktree, claim, or ledger writes were made.`,
-      );
+    const parsed = parseAttemptArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    options.onResult?.(dryRunResult);
-    return 0;
-  }
-
-  let allocator = null;
-  let claimLedger = null;
-  let eventLedger = null;
-  let attemptLog = null;
-  let governorLedger = null;
-  let allocation = null;
-  let worktreeResult = null;
-  let claimedIssue = false;
-  let claimRecord = null;
-
-  try {
-    allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
-    claimLedger = (options.openClaimLedger ?? openClaimLedger)();
-    eventLedger = (options.initEventLedger ?? initEventLedger)();
-    attemptLog = (options.initAttemptLog ?? initAttemptLog)();
-    governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
-
-    // Checked before acquiring a worktree slot: a rejection-signaled repo should never consume one.
-    // resolveRejectionSignaled resolves both documented triggers (#5132 policy ban, #5655 own-rejection
-    // history) and returns a trigger-specific reason string for accurate audit-trail labeling.
-    const resolveRejection = options.resolveRejectionSignaled ?? resolveRejectionSignaled;
-    const rejectionSignal = await resolveRejection(parsed.repoFullName, { fetchImpl: options.fetchImpl });
-    if (rejectionSignal) {
-      const reason =
-        rejectionSignal === true ? REJECTION_REASON_AI_USAGE_POLICY_BAN : rejectionSignal;
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const rejectedResult = {
-        outcome: "blocked_rejection_signaled",
-        reason,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(rejectedResult, null, 2));
-      } else {
-        console.error(
-          reason === REJECTION_REASON_OWN_SUBMISSION_REJECTED
-            ? `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this miner was previously rejected on this repo.`
-            : `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's AI-usage policy bans automated/AI-authored contributions.`,
-        );
-      }
-      options.onResult?.(rejectedResult);
-      return 5;
+    const env = options.env ?? process.env;
+    const nowMs = options.nowMs ?? Date.now();
+    const resolveMode = options.resolveCodingAgentModeFromConfig ?? resolveCodingAgentModeFromConfig;
+    const mode = resolveMode({ env, agentDryRun: !parsed.live });
+    if (mode === "paused") {
+        return reportCliFailure(parsed.json, `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`, 3);
     }
-
-    allocation = allocator.acquire(attemptId, parsed.repoFullName);
-
-    let deps;
-    try {
-      const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
-      deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
-    } catch (error) {
-      const reason = describeCliError(error);
-      return reportCliFailure(
-        parsed.json,
-        `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`,
-        3,
-      );
-    }
-
-    // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
-    // reserves a concurrency SLOT (worktree-allocator.js's own `slot-N` placeholder dirs never receive real
-    // git content) -- this is the step that actually clones/fetches the target repo and creates a real
-    // `git worktree` for this attempt. Its own path, NOT the allocator's slot path, is the real
-    // workingDirectory a future runMinerAttempt call must use.
-    const prepareWorktree = options.prepareAttemptWorktree ?? prepareAttemptWorktree;
-    worktreeResult = await prepareWorktree(parsed.repoFullName, attemptId, { baseBranch: parsed.base, env });
-    if (!worktreeResult.ok) {
-      const reason = worktreeResult.error;
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const worktreeFailureResult = {
-        outcome: "blocked_worktree_preparation_failed",
-        reason,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(worktreeFailureResult, null, 2));
-      } else {
-        console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: real worktree preparation failed: ${reason}`);
-      }
-      options.onResult?.(worktreeFailureResult);
-      return 6;
-    }
-
-    // Real SelfReviewContext (#5145): issue/PR/manifest data at live-gate fidelity for the target repo.
-    const fetchReviewContext = options.fetchSelfReviewContext ?? fetchSelfReviewContext;
-    const reviewContext = await fetchReviewContext(parsed.repoFullName, {
-      githubToken: await resolveGitHubToken(env),
-      contributorLogin: parsed.minerLogin,
-      linkedIssues: [parsed.issueNumber],
-    });
-
-    // The target issue's own real record, when present in the fetched context. When absent (e.g. already
-    // closed, or genuinely not found), buildCodingTaskSpec's own feasibility check reports target_not_found
-    // and this placeholder's empty title/body are never surfaced anywhere -- not fabricated content, just an
-    // inert shape for a verdict that immediately blocks.
-    const targetIssue = reviewContext.issues.find((candidate) => candidate.number === parsed.issueNumber) ?? {
-      number: parsed.issueNumber,
-      title: "",
-      body: null,
-      labels: [],
-    };
-
-    const buildTaskSpec = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
-    const codingTaskSpec = buildTaskSpec({
-      repoFullName: parsed.repoFullName,
-      issue: targetIssue,
-      context: { issues: reviewContext.issues, pullRequests: reviewContext.pullRequests },
-      claimLedger,
-      workingDirectory: worktreeResult.worktreePath,
-    });
-
-    if (!codingTaskSpec.ready) {
-      const reason = `infeasible_${codingTaskSpec.verdict}`;
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, feasibility: codingTaskSpec.feasibility },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const infeasibleResult = {
-        outcome: "blocked_infeasible",
-        reason,
-        verdict: codingTaskSpec.verdict,
-        avoidReasons: codingTaskSpec.feasibility.avoidReasons,
-        raiseReasons: codingTaskSpec.feasibility.raiseReasons,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(infeasibleResult, null, 2));
-      } else {
-        console.error(
-          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: feasibility verdict "${codingTaskSpec.verdict}" (${[...codingTaskSpec.feasibility.avoidReasons, ...codingTaskSpec.feasibility.raiseReasons].join(", ")}).`,
-        );
-      }
-      options.onResult?.(infeasibleResult);
-      return 4;
-    }
-
-    const amsPolicy = await (options.resolveAmsPolicy ?? resolveAmsPolicy)(parsed.repoFullName, { env });
-
-    // Real per-repo pause (#5392): read straight from the already-cloned worktree's own .loopover-miner.yml
-    // (resolveMinerGoalSpec never throws -- a missing/malformed file degrades to killSwitch.paused: false, so
-    // this can't fail this attempt on its own). Threaded into BOTH checkMinerKillSwitch (killSwitchScope, used
-    // by the freshness/submission gate) and the governor context (killSwitchRepoPaused, used by the Governor
-    // chokepoint) -- the same two places the GLOBAL kill switch already reaches.
-    const resolveGoalSpec = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
-    const minerGoalSpec = resolveGoalSpec(worktreeResult.repoPath);
-    const repoPaused = minerGoalSpec.spec.killSwitch.paused;
-
-    const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
-    const recordKillTransition = options.recordMinerKillSwitchTransition ?? recordMinerKillSwitchTransition;
-    let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
-    let previousKillSwitchScope = killSwitchScope;
-
-    const resolveLiveKillSwitch = () => {
-      // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
-      const liveRepoPaused = resolveGoalSpec(worktreeResult.repoPath).spec.killSwitch.paused;
-      const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
-      if (live.scope !== previousKillSwitchScope) {
-        try {
-          recordKillTransition({
-            repoFullName: parsed.repoFullName,
-            actionClass: "attempt",
-            previousScope: previousKillSwitchScope,
-            scope: live.scope,
-          });
-        } catch (error) {
-          // Ledger append must never crash an aborting attempt (kept), but was previously silent -- a
-          // kill-switch flip mid-attempt (a compliance-relevant event) could vanish with no record (#6011).
-          captureMinerError(error, { kind: "kill_switch_transition_record_failed", repoFullName: parsed.repoFullName, scope: live.scope });
-        }
-        previousKillSwitchScope = live.scope;
-      }
-      killSwitchScope = live.scope;
-      return live;
-    };
-
-    const shouldAbort = () => {
-      const live = resolveLiveKillSwitch();
-      if (!live.active) return false;
-      return {
-        abort: true,
-        reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
-      };
-    };
-
-    const loopInput = buildAttemptLoopInput({
-      codingTaskSpec,
-      reviewContext,
-      worktreePath: worktreeResult.worktreePath,
-      attemptId,
-      mode,
-      repoFullName: parsed.repoFullName,
-      minerLogin: parsed.minerLogin,
-      rejectionSignaled: false,
-      amsPolicySpec: amsPolicy.spec,
-      branchRef: worktreeResult.branchName,
-    });
-
-    // Real per-issue attempt history (#5654): portfolio-queue.js's own claim/reclaim/requeue/done counters,
-    // keyed the same way opportunity-fanout.js enqueues issue-shaped candidates (`issue:<number>`). No
-    // apiBaseUrl: this file has no multi-forge host context of its own today, so this reads (and every
-    // pre-#5563 single-forge caller already reads) the github.com default.
-    const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
-    const convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
-    // Real per-repo reputation history (#5675): the miner's own decided/unfavorable outcome streak for this repo,
-    // read from governor-state.js so the chokepoint's self-reputation throttle sees real data instead of nothing.
-    const readReputationHistory = options.loadReputationHistory ?? loadReputationHistory;
-    const reputationHistory = readReputationHistory(parsed.repoFullName);
-    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
-
-    // Real maxConcurrentClaims enforcement (#6758): the repo's .loopover-miner.yml cap is honored ATOMICALLY by
-    // the ledger's count-and-claim, not by a listActiveClaims pre-check here. The old check-then-act split -- read
-    // the count in this file, then record the claim in a separate claimLedger call -- let two sibling miner
-    // processes racing the same repo both pass a stale sub-cap count and both claim, exceeding the cap.
-    // claimIssueWithinCap fuses the count and the insert into one transaction; the loser gets `claimed: false`
-    // and is reported below rather than silently dropped. This is also the real soft-claim (#5393): once it
-    // returns claimed, a sibling process sees it via claimLedger.listActiveClaims while this attempt is in
-    // flight, it is released in `finally` on every terminal outcome (mirroring the worktree allocation slot's
-    // acquire-then-always-release), and its claimedAt feeds the post-submission conflict check further down (#4848).
-    const claimResult = claimLedger.claimIssueWithinCap(
-      parsed.repoFullName,
-      parsed.issueNumber,
-      `attempt:${attemptId}`,
-      undefined,
-      minerGoalSpec.spec.maxConcurrentClaims,
-    );
-    if (!claimResult.claimed) {
-      const reason = "max_concurrent_claims_exceeded";
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: {
-          repoFullName: parsed.repoFullName,
-          issueNumber: parsed.issueNumber,
-          maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
-          activeClaimCount: claimResult.activeClaimCount,
-        },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const blockedResult = {
-        outcome: "blocked_max_concurrent_claims",
-        reason,
-        maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
-        activeClaimCount: claimResult.activeClaimCount,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(blockedResult, null, 2));
-      } else {
-        console.error(
-          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${claimResult.activeClaimCount} active claim(s)).`,
-        );
-      }
-      options.onResult?.(blockedResult);
-      return 11;
-    }
-
-    claimRecord = claimResult.claim;
-    claimedIssue = true;
-    // Hosted soft-claim coordination (#7168), opt-in via LOOPOVER_MINER_DISCOVERY_PLANE -- gated HERE at the
-    // call site (not left to submitSoftClaim's own internal check alone) so a disabled plane costs zero calls,
-    // matching discover-cli.js's supplementWithDiscoveryIndex gating; a caller-injected options.submitSoftClaim
-    // (tests, or a future programmatic caller) can't accidentally bypass the opt-in this way either. Awaited
-    // (not fire-and-forget) so a sibling instance racing the same issue is genuinely less likely to start
-    // duplicate work in the window before this attempt's claim reaches the shared index -- the whole point of
-    // coordinating BEFORE work begins, not after.
-    if (isDiscoveryPlaneEnabled(env)) {
-      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
-      await submitClaim(claimRecord, { env });
-    }
-
-    const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
-    let result;
-    try {
-      result = await runAttemptPipeline(
-        {
-          loopInput,
-          issueNumber: parsed.issueNumber,
-          minerLogin: parsed.minerLogin,
-          base: parsed.base,
-          killSwitchScope,
-          slopThreshold: amsPolicy.spec.slopThreshold,
-          submissionMode: amsPolicy.spec.submissionMode,
-          governor,
-        },
-        {
-          ...deps,
-          shouldAbort,
-          resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
-        },
-      );
-    } catch (error) {
-      // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
-      // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
-      // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
-      // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
-      worktreeResult.attemptOk = false;
-      throw error;
-    }
-
-    worktreeResult.attemptOk = result.outcome === "submitted";
-
-    // Real claim-conflict resolution (#4848): only meaningful once a real PR exists, so this only ever runs
-    // on a real "submitted" outcome. checkSubmissionFreshness (inside runMinerAttempt) already caught the
-    // common pre-submission case; this closes the narrower TOCTOU window where two miners raced past that
-    // check almost simultaneously -- see claim-conflict-resolver.js's own header for why the adjudicator
-    // can only run POST-submission (it needs a real PR number on both sides of the election).
-    let claimConflict;
-    if (result.outcome === "submitted") {
-      const selfPrNumber = parsePrNumberFromExecResult(result.execResult, parsed.repoFullName);
-      if (selfPrNumber !== null) {
-        const resolveConflict = options.resolveClaimConflict ?? resolveClaimConflict;
-        claimConflict = await resolveConflict(
-          {
+    const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
+    // #4847: reports what a real run would do and returns BEFORE any store (allocator/claim/event/attempt-log/
+    // governor ledger) is even opened, so this is a provable zero-write path -- not just "opened but didn't
+    // write to" the local stores, and nowhere near the real worktree clone, claim, or coding-agent driver.
+    if (parsed.dryRun) {
+        const dryRunResult = {
+            outcome: "dry_run",
             repoFullName: parsed.repoFullName,
             issueNumber: parsed.issueNumber,
-            selfPrNumber,
-            selfClaimedAt: claimRecord.claimedAt,
             minerLogin: parsed.minerLogin,
-          },
-          { fetchLiveIssueSnapshot: deps.fetchLiveIssueSnapshot, executeLocalWrite: deps.executeLocalWrite },
-        );
-      }
-
-      // Real own-submission history (#5655 follow-up): governor-state.js's recordOwnSubmission/
-      // listRecentOwnSubmissions store (#5134) existed and was already READ by resolveOwnRejectionHistory
-      // (#5655), but nothing ever WROTE to it -- attempt-runner.js's own header names this exact gap
-      // ("real persistence primitives... but isn't auto-loaded here yet"). Left unfixed, that trigger is a
-      // silent no-op in every real deployment: an empty table always resolves "no prior submissions found."
-      // The fingerprint is the real changed-files set from the loop's own handoff packet (never fabricated) --
-      // omitted (not recorded as an empty placeholder) when the packet reports no changed files at all. A
-      // logging failure must never fail an otherwise-successful attempt, matching the summary-event write below.
-      const changedFiles = result.loopResult.handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
-      const fingerprint = fingerprintFromChangedFiles(changedFiles);
-      if (fingerprint) {
-        try {
-          const record = options.recordOwnSubmission ?? recordOwnSubmission;
-          record({
-            repoFullName: parsed.repoFullName,
-            fingerprint,
-            submittedAt: new Date(nowMs).toISOString(),
-            pullRequestNumber: selfPrNumber,
-            issueNumber: parsed.issueNumber,
-          });
-        } catch (error) {
-          // A logging failure must never fail an otherwise-successful attempt (kept), but was previously
-          // silent -- if this write fails AFTER a real PR has already opened, future self-plagiarism checks go
-          // permanently blind to this exact submission with nobody told (#6011).
-          captureMinerError(error, { kind: "record_own_submission_failed", repoFullName: parsed.repoFullName, pullRequestNumber: selfPrNumber });
+            base: parsed.base,
+            mode,
+            attemptId,
+        };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
         }
-      }
-    }
-
-    const finalResult = {
-      outcome: `attempt_${result.outcome}`,
-      repoFullName: parsed.repoFullName,
-      issueNumber: parsed.issueNumber,
-      minerLogin: parsed.minerLogin,
-      base: parsed.base,
-      mode,
-      attemptId,
-      submissionMode: amsPolicy.spec.submissionMode,
-      // Every runMinerAttempt outcome carries a real loopResult (#5135's loop needs its genuine turn-usage and
-      // cost to save real GovernorCapUsage via governor-state.js's saveCapUsage -- nothing else in the codebase
-      // calls it yet). Surfaced flat rather than the whole loopResult object, matching this result's own
-      // shallow shape. costUsd is real only for the agent-sdk provider (its own SDK result message reports
-      // total_cost_usd); CLI-subprocess providers (claude-cli/codex-cli) report no cost signal today, so this
-      // is 0 for those -- an honest absence, not a fabricated number.
-      totalTurnsUsed: result.loopResult.totalTurnsUsed,
-      totalCostUsd: result.loopResult.totalCostUsd,
-      // Real accumulated tokens (#5653) -- read from finalMeterTotals rather than a flat totalTokensUsed field
-      // (IterateLoopResult has no such flat field, unlike turns/cost). 0 when no driver reported a token signal
-      // on any iteration this attempt ran, never fabricated.
-      totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
-      iterationsUsed: result.loopResult.iterationsUsed,
-      ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
-        ? { abandonReason: result.loopResult.finalDecision.abandonReason }
-        : {}),
-      ...("reason" in result ? { reason: result.reason } : {}),
-      ...("decision" in result ? { decision: result.decision } : {}),
-      ...("spec" in result ? { spec: result.spec } : {}),
-      ...("execResult" in result ? { execResult: result.execResult } : {}),
-      // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
-      // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
-      // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).
-      ...(claimConflict !== undefined ? { claimConflict } : {}),
-    };
-
-    // One summary row per completed attempt (#5185), for the Grafana per-provider usage dashboard the redacted
-    // AMS reporting export exposes -- distinct from the per-iteration attempt_started/attempt_tool_edit/... trail
-    // iterate-loop.ts already writes. No fallback for an unconfigured provider: buildAttemptDeps already fails
-    // closed (throws) on the same env before a worktree is even allocated, so reaching this point guarantees
-    // resolveFirstConfiguredCodingAgentDriverName(env) resolves a real name. costUsd/tokensUsed are both real,
-    // driver-reported accumulated totals (#5653) -- 0 when no iteration's driver reported a signal, never
-    // fabricated. A logging failure must never fail an otherwise-successful attempt -- mirrors iterate-loop.ts's
-    // own safeAppendAttemptLogEvent non-fatal handling.
-    try {
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_outcome_summary",
-        attemptId,
-        actionClass: finalResult.outcome,
-        mode,
-        reason: `attempt finished with outcome: ${result.outcome}`,
-        provider: resolveFirstConfiguredCodingAgentDriverName(env),
-        costUsd: finalResult.totalCostUsd,
-        tokensUsed: finalResult.totalTokensUsed,
-      });
-    } catch (error) {
-      // A logging failure must never fail an otherwise-successful attempt (kept), but was previously silent --
-      // per docs/observability.md this row feeds the Grafana per-provider cost/usage dashboard, so a failure
-      // here silently drops the attempt from operator-facing metrics with nobody told (#6011).
-      captureMinerError(error, { kind: "attempt_outcome_summary_append_failed", attemptId, repoFullName: parsed.repoFullName });
-    }
-
-    if (parsed.json) {
-      console.log(JSON.stringify(finalResult, null, 2));
-    } else {
-      console.log(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} finished with outcome: ${result.outcome}.`);
-    }
-    options.onResult?.(finalResult);
-
-    switch (result.outcome) {
-      case "submitted":
+        else {
+            console.log(`DRY RUN: would attempt ${parsed.repoFullName}#${parsed.issueNumber} for ${parsed.minerLogin} (mode: ${mode}, base: ${parsed.base}). No worktree, claim, or ledger writes were made.`);
+        }
+        options.onResult?.(dryRunResult);
         return 0;
-      case "abandon":
-        return 7;
-      case "stale":
-        return 8;
-      case "blocked":
-        return 9;
-      case "governed":
-        return 10;
-      default:
-        return 2;
     }
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
-    // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
-    // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
-    // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
-    // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
-    // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
-    if (worktreeResult?.ok) {
-      const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;
-      await cleanupWorktree(worktreeResult.repoPath, worktreeResult.worktreePath, worktreeResult.attemptOk ?? true);
+    let allocator = null;
+    let claimLedger = null;
+    let eventLedger = null;
+    let attemptLog = null;
+    let governorLedger = null;
+    let allocation = null;
+    // `attemptOk` is stamped onto the ok-result at runtime (set to the real runMinerAttempt outcome, or `false`
+    // when it throws) and read back in `finally` -- the declared PrepareAttemptWorktreeResult carries no such
+    // field, so widen the local accumulator to allow the mutation without changing any runtime behavior.
+    let worktreeResult = null;
+    let claimedIssue = false;
+    let claimRecord = null;
+    try {
+        allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
+        claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+        eventLedger = (options.initEventLedger ?? initEventLedger)();
+        attemptLog = (options.initAttemptLog ?? initAttemptLog)();
+        governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+        // Checked before acquiring a worktree slot: a rejection-signaled repo should never consume one.
+        // resolveRejectionSignaled resolves both documented triggers (#5132 policy ban, #5655 own-rejection
+        // history) and returns a trigger-specific reason string for accurate audit-trail labeling.
+        const resolveRejection = options.resolveRejectionSignaled ?? resolveRejectionSignaled;
+        const rejectionSignal = await resolveRejection(parsed.repoFullName, { fetchImpl: options.fetchImpl });
+        if (rejectionSignal) {
+            const reason = rejectionSignal === true ? REJECTION_REASON_AI_USAGE_POLICY_BAN : rejectionSignal;
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const rejectedResult = {
+                outcome: "blocked_rejection_signaled",
+                reason,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(rejectedResult, null, 2));
+            }
+            else {
+                console.error(reason === REJECTION_REASON_OWN_SUBMISSION_REJECTED
+                    ? `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this miner was previously rejected on this repo.`
+                    : `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's AI-usage policy bans automated/AI-authored contributions.`);
+            }
+            options.onResult?.(rejectedResult);
+            return 5;
+        }
+        allocation = allocator.acquire(attemptId, parsed.repoFullName);
+        let deps;
+        try {
+            const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
+            deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
+        }
+        catch (error) {
+            const reason = describeCliError(error);
+            return reportCliFailure(parsed.json, `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`, 3);
+        }
+        // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
+        // reserves a concurrency SLOT (worktree-allocator.js's own `slot-N` placeholder dirs never receive real
+        // git content) -- this is the step that actually clones/fetches the target repo and creates a real
+        // `git worktree` for this attempt. Its own path, NOT the allocator's slot path, is the real
+        // workingDirectory a future runMinerAttempt call must use.
+        const prepareWorktree = options.prepareAttemptWorktree ?? prepareAttemptWorktree;
+        worktreeResult = await prepareWorktree(parsed.repoFullName, attemptId, { baseBranch: parsed.base, env });
+        if (!worktreeResult.ok) {
+            const reason = worktreeResult.error;
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const worktreeFailureResult = {
+                outcome: "blocked_worktree_preparation_failed",
+                reason,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(worktreeFailureResult, null, 2));
+            }
+            else {
+                console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: real worktree preparation failed: ${reason}`);
+            }
+            options.onResult?.(worktreeFailureResult);
+            return 6;
+        }
+        // Real SelfReviewContext (#5145): issue/PR/manifest data at live-gate fidelity for the target repo.
+        const fetchReviewContext = options.fetchSelfReviewContext ?? fetchSelfReviewContext;
+        const reviewContext = await fetchReviewContext(parsed.repoFullName, {
+            githubToken: await resolveGitHubToken(env),
+            contributorLogin: parsed.minerLogin,
+            linkedIssues: [parsed.issueNumber],
+        });
+        // The target issue's own real record, when present in the fetched context. When absent (e.g. already
+        // closed, or genuinely not found), buildCodingTaskSpec's own feasibility check reports target_not_found
+        // and this placeholder's empty title/body are never surfaced anywhere -- not fabricated content, just an
+        // inert shape for a verdict that immediately blocks.
+        const targetIssue = reviewContext.issues.find((candidate) => candidate.number === parsed.issueNumber) ?? {
+            number: parsed.issueNumber,
+            title: "",
+            body: null,
+            labels: [],
+        };
+        const buildTaskSpec = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
+        const codingTaskSpec = buildTaskSpec({
+            repoFullName: parsed.repoFullName,
+            issue: targetIssue,
+            context: { issues: reviewContext.issues, pullRequests: reviewContext.pullRequests },
+            claimLedger,
+            workingDirectory: worktreeResult.worktreePath,
+        });
+        if (!codingTaskSpec.ready) {
+            const reason = `infeasible_${codingTaskSpec.verdict}`;
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, feasibility: codingTaskSpec.feasibility },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const infeasibleResult = {
+                outcome: "blocked_infeasible",
+                reason,
+                verdict: codingTaskSpec.verdict,
+                avoidReasons: codingTaskSpec.feasibility.avoidReasons,
+                raiseReasons: codingTaskSpec.feasibility.raiseReasons,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(infeasibleResult, null, 2));
+            }
+            else {
+                console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: feasibility verdict "${codingTaskSpec.verdict}" (${[...codingTaskSpec.feasibility.avoidReasons, ...codingTaskSpec.feasibility.raiseReasons].join(", ")}).`);
+            }
+            options.onResult?.(infeasibleResult);
+            return 4;
+        }
+        const amsPolicy = await (options.resolveAmsPolicy ?? resolveAmsPolicy)(parsed.repoFullName, { env });
+        // Real per-repo pause (#5392): read straight from the already-cloned worktree's own .loopover-miner.yml
+        // (resolveMinerGoalSpec never throws -- a missing/malformed file degrades to killSwitch.paused: false, so
+        // this can't fail this attempt on its own). Threaded into BOTH checkMinerKillSwitch (killSwitchScope, used
+        // by the freshness/submission gate) and the governor context (killSwitchRepoPaused, used by the Governor
+        // chokepoint) -- the same two places the GLOBAL kill switch already reaches.
+        const resolveGoalSpec = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+        const minerGoalSpec = resolveGoalSpec(worktreeResult.repoPath);
+        const repoPaused = minerGoalSpec.spec.killSwitch.paused;
+        const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
+        const recordKillTransition = options.recordMinerKillSwitchTransition ??
+            recordMinerKillSwitchTransition;
+        let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
+        let previousKillSwitchScope = killSwitchScope;
+        const resolveLiveKillSwitch = () => {
+            // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
+            const liveRepoPaused = resolveGoalSpec(worktreeResult.repoPath).spec.killSwitch.paused;
+            const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
+            if (live.scope !== previousKillSwitchScope) {
+                try {
+                    recordKillTransition({
+                        repoFullName: parsed.repoFullName,
+                        actionClass: "attempt",
+                        previousScope: previousKillSwitchScope,
+                        scope: live.scope,
+                    });
+                }
+                catch (error) {
+                    // Ledger append must never crash an aborting attempt (kept), but was previously silent -- a
+                    // kill-switch flip mid-attempt (a compliance-relevant event) could vanish with no record (#6011).
+                    captureMinerError(error, { kind: "kill_switch_transition_record_failed", repoFullName: parsed.repoFullName, scope: live.scope });
+                }
+                previousKillSwitchScope = live.scope;
+            }
+            killSwitchScope = live.scope;
+            return live;
+        };
+        const shouldAbort = () => {
+            const live = resolveLiveKillSwitch();
+            if (!live.active)
+                return false;
+            return {
+                abort: true,
+                reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
+            };
+        };
+        const loopInput = buildAttemptLoopInput({
+            codingTaskSpec,
+            reviewContext,
+            worktreePath: worktreeResult.worktreePath,
+            attemptId,
+            mode,
+            repoFullName: parsed.repoFullName,
+            minerLogin: parsed.minerLogin,
+            rejectionSignaled: false,
+            amsPolicySpec: amsPolicy.spec,
+            branchRef: worktreeResult.branchName,
+        });
+        // Real per-issue attempt history (#5654): portfolio-queue.js's own claim/reclaim/requeue/done counters,
+        // keyed the same way opportunity-fanout.js enqueues issue-shaped candidates (`issue:<number>`). No
+        // apiBaseUrl: this file has no multi-forge host context of its own today, so this reads (and every
+        // pre-#5563 single-forge caller already reads) the github.com default.
+        const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
+        const convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
+        // Real per-repo reputation history (#5675): the miner's own decided/unfavorable outcome streak for this repo,
+        // read from governor-state.js so the chokepoint's self-reputation throttle sees real data instead of nothing.
+        const readReputationHistory = options.loadReputationHistory ?? loadReputationHistory;
+        const reputationHistory = readReputationHistory(parsed.repoFullName);
+        const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
+        // Real maxConcurrentClaims enforcement (#6758): the repo's .loopover-miner.yml cap is honored ATOMICALLY by
+        // the ledger's count-and-claim, not by a listActiveClaims pre-check here. The old check-then-act split -- read
+        // the count in this file, then record the claim in a separate claimLedger call -- let two sibling miner
+        // processes racing the same repo both pass a stale sub-cap count and both claim, exceeding the cap.
+        // claimIssueWithinCap fuses the count and the insert into one transaction; the loser gets `claimed: false`
+        // and is reported below rather than silently dropped. This is also the real soft-claim (#5393): once it
+        // returns claimed, a sibling process sees it via claimLedger.listActiveClaims while this attempt is in
+        // flight, it is released in `finally` on every terminal outcome (mirroring the worktree allocation slot's
+        // acquire-then-always-release), and its claimedAt feeds the post-submission conflict check further down (#4848).
+        const claimResult = claimLedger.claimIssueWithinCap(parsed.repoFullName, parsed.issueNumber, `attempt:${attemptId}`, undefined, minerGoalSpec.spec.maxConcurrentClaims);
+        if (!claimResult.claimed) {
+            const reason = "max_concurrent_claims_exceeded";
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: {
+                    repoFullName: parsed.repoFullName,
+                    issueNumber: parsed.issueNumber,
+                    maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+                    activeClaimCount: claimResult.activeClaimCount,
+                },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const blockedResult = {
+                outcome: "blocked_max_concurrent_claims",
+                reason,
+                maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+                activeClaimCount: claimResult.activeClaimCount,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(blockedResult, null, 2));
+            }
+            else {
+                console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${claimResult.activeClaimCount} active claim(s)).`);
+            }
+            options.onResult?.(blockedResult);
+            return 11;
+        }
+        claimRecord = claimResult.claim;
+        claimedIssue = true;
+        // Hosted soft-claim coordination (#7168), opt-in via LOOPOVER_MINER_DISCOVERY_PLANE -- gated HERE at the
+        // call site (not left to submitSoftClaim's own internal check alone) so a disabled plane costs zero calls,
+        // matching discover-cli.js's supplementWithDiscoveryIndex gating; a caller-injected options.submitSoftClaim
+        // (tests, or a future programmatic caller) can't accidentally bypass the opt-in this way either. Awaited
+        // (not fire-and-forget) so a sibling instance racing the same issue is genuinely less likely to start
+        // duplicate work in the window before this attempt's claim reaches the shared index -- the whole point of
+        // coordinating BEFORE work begins, not after.
+        if (isDiscoveryPlaneEnabled(env)) {
+            const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+            await submitClaim(claimRecord, { env });
+        }
+        const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
+        let result;
+        try {
+            result = await runAttemptPipeline({
+                loopInput,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                killSwitchScope,
+                slopThreshold: amsPolicy.spec.slopThreshold,
+                submissionMode: amsPolicy.spec.submissionMode,
+                governor,
+            }, {
+                ...deps,
+                shouldAbort,
+                resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
+            });
+        }
+        catch (error) {
+            // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
+            // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
+            // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
+            // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
+            worktreeResult.attemptOk = false;
+            throw error;
+        }
+        worktreeResult.attemptOk = result.outcome === "submitted";
+        // Real claim-conflict resolution (#4848): only meaningful once a real PR exists, so this only ever runs
+        // on a real "submitted" outcome. checkSubmissionFreshness (inside runMinerAttempt) already caught the
+        // common pre-submission case; this closes the narrower TOCTOU window where two miners raced past that
+        // check almost simultaneously -- see claim-conflict-resolver.js's own header for why the adjudicator
+        // can only run POST-submission (it needs a real PR number on both sides of the election).
+        let claimConflict;
+        if (result.outcome === "submitted") {
+            const selfPrNumber = parsePrNumberFromExecResult(result.execResult, parsed.repoFullName);
+            if (selfPrNumber !== null) {
+                const resolveConflict = options.resolveClaimConflict ?? resolveClaimConflict;
+                claimConflict = await resolveConflict({
+                    repoFullName: parsed.repoFullName,
+                    issueNumber: parsed.issueNumber,
+                    selfPrNumber,
+                    selfClaimedAt: claimRecord.claimedAt,
+                    minerLogin: parsed.minerLogin,
+                }, { fetchLiveIssueSnapshot: deps.fetchLiveIssueSnapshot, executeLocalWrite: deps.executeLocalWrite });
+            }
+            // Real own-submission history (#5655 follow-up): governor-state.js's recordOwnSubmission/
+            // listRecentOwnSubmissions store (#5134) existed and was already READ by resolveOwnRejectionHistory
+            // (#5655), but nothing ever WROTE to it -- attempt-runner.js's own header names this exact gap
+            // ("real persistence primitives... but isn't auto-loaded here yet"). Left unfixed, that trigger is a
+            // silent no-op in every real deployment: an empty table always resolves "no prior submissions found."
+            // The fingerprint is the real changed-files set from the loop's own handoff packet (never fabricated) --
+            // omitted (not recorded as an empty placeholder) when the packet reports no changed files at all. A
+            // logging failure must never fail an otherwise-successful attempt, matching the summary-event write below.
+            const changedFiles = result.loopResult.handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
+            const fingerprint = fingerprintFromChangedFiles(changedFiles);
+            if (fingerprint) {
+                try {
+                    const record = options.recordOwnSubmission ?? recordOwnSubmission;
+                    record({
+                        repoFullName: parsed.repoFullName,
+                        fingerprint,
+                        submittedAt: new Date(nowMs).toISOString(),
+                        pullRequestNumber: selfPrNumber,
+                        issueNumber: parsed.issueNumber,
+                    });
+                }
+                catch (error) {
+                    // A logging failure must never fail an otherwise-successful attempt (kept), but was previously
+                    // silent -- if this write fails AFTER a real PR has already opened, future self-plagiarism checks go
+                    // permanently blind to this exact submission with nobody told (#6011).
+                    captureMinerError(error, { kind: "record_own_submission_failed", repoFullName: parsed.repoFullName, pullRequestNumber: selfPrNumber });
+                }
+            }
+        }
+        const finalResult = {
+            outcome: `attempt_${result.outcome}`,
+            repoFullName: parsed.repoFullName,
+            issueNumber: parsed.issueNumber,
+            minerLogin: parsed.minerLogin,
+            base: parsed.base,
+            mode,
+            attemptId,
+            submissionMode: amsPolicy.spec.submissionMode,
+            // Every runMinerAttempt outcome carries a real loopResult (#5135's loop needs its genuine turn-usage and
+            // cost to save real GovernorCapUsage via governor-state.js's saveCapUsage -- nothing else in the codebase
+            // calls it yet). Surfaced flat rather than the whole loopResult object, matching this result's own
+            // shallow shape. costUsd is real only for the agent-sdk provider (its own SDK result message reports
+            // total_cost_usd); CLI-subprocess providers (claude-cli/codex-cli) report no cost signal today, so this
+            // is 0 for those -- an honest absence, not a fabricated number.
+            totalTurnsUsed: result.loopResult.totalTurnsUsed,
+            totalCostUsd: result.loopResult.totalCostUsd,
+            // Real accumulated tokens (#5653) -- read from finalMeterTotals rather than a flat totalTokensUsed field
+            // (IterateLoopResult has no such flat field, unlike turns/cost). 0 when no driver reported a token signal
+            // on any iteration this attempt ran, never fabricated.
+            totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
+            iterationsUsed: result.loopResult.iterationsUsed,
+            ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
+                ? { abandonReason: result.loopResult.finalDecision.abandonReason }
+                : {}),
+            ...("reason" in result ? { reason: result.reason } : {}),
+            ...("decision" in result ? { decision: result.decision } : {}),
+            ...("spec" in result ? { spec: result.spec } : {}),
+            ...("execResult" in result ? { execResult: result.execResult } : {}),
+            // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
+            // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
+            // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).
+            ...(claimConflict !== undefined ? { claimConflict } : {}),
+        };
+        // One summary row per completed attempt (#5185), for the Grafana per-provider usage dashboard the redacted
+        // AMS reporting export exposes -- distinct from the per-iteration attempt_started/attempt_tool_edit/... trail
+        // iterate-loop.ts already writes. No fallback for an unconfigured provider: buildAttemptDeps already fails
+        // closed (throws) on the same env before a worktree is even allocated, so reaching this point guarantees
+        // resolveFirstConfiguredCodingAgentDriverName(env) resolves a real name. costUsd/tokensUsed are both real,
+        // driver-reported accumulated totals (#5653) -- 0 when no iteration's driver reported a signal, never
+        // fabricated. A logging failure must never fail an otherwise-successful attempt -- mirrors iterate-loop.ts's
+        // own safeAppendAttemptLogEvent non-fatal handling.
+        try {
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_outcome_summary",
+                attemptId,
+                actionClass: finalResult.outcome,
+                mode,
+                reason: `attempt finished with outcome: ${result.outcome}`,
+                provider: resolveFirstConfiguredCodingAgentDriverName(env),
+                costUsd: finalResult.totalCostUsd,
+                tokensUsed: finalResult.totalTokensUsed,
+            });
+        }
+        catch (error) {
+            // A logging failure must never fail an otherwise-successful attempt (kept), but was previously silent --
+            // per docs/observability.md this row feeds the Grafana per-provider cost/usage dashboard, so a failure
+            // here silently drops the attempt from operator-facing metrics with nobody told (#6011).
+            captureMinerError(error, { kind: "attempt_outcome_summary_append_failed", attemptId, repoFullName: parsed.repoFullName });
+        }
+        if (parsed.json) {
+            console.log(JSON.stringify(finalResult, null, 2));
+        }
+        else {
+            console.log(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} finished with outcome: ${result.outcome}.`);
+        }
+        options.onResult?.(finalResult);
+        switch (result.outcome) {
+            case "submitted":
+                return 0;
+            case "abandon":
+                return 7;
+            case "stale":
+                return 8;
+            case "blocked":
+                return 9;
+            case "governed":
+                return 10;
+            default:
+                return 2;
+        }
     }
-    // Every terminal outcome past the claim point (submitted/abandon/stale/blocked/governed, or an
-    // unexpected throw) releases the soft-claim -- a claim that outlives its own attempt process would
-    // wrongly tell a sibling miner this issue is still in flight.
-    if (claimedIssue && claimLedger) claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
-    // Paired hosted release (#7168): same call-site opt-in gate as the claim submission above. Only fires when
-    // the initial claim submission actually ran (claimRecord is only set once claimedIssue is), so a run that
-    // never reached the claim point (e.g. blocked_max_concurrent_claims) has nothing to release remotely.
-    if (claimedIssue && claimRecord && isDiscoveryPlaneEnabled(env)) {
-      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
-      await submitClaim({ ...claimRecord, status: "released" }, { env });
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
     }
-    if (allocation && allocator) allocator.release(attemptId);
-    allocator?.close();
-    claimLedger?.close();
-    eventLedger?.close();
-    attemptLog?.close();
-    governorLedger?.close();
-  }
+    finally {
+        // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
+        // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
+        // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
+        // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
+        // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
+        // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
+        if (worktreeResult?.ok) {
+            const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;
+            await cleanupWorktree(worktreeResult.repoPath, worktreeResult.worktreePath, worktreeResult.attemptOk ?? true);
+        }
+        // Every terminal outcome past the claim point (submitted/abandon/stale/blocked/governed, or an
+        // unexpected throw) releases the soft-claim -- a claim that outlives its own attempt process would
+        // wrongly tell a sibling miner this issue is still in flight.
+        if (claimedIssue && claimLedger)
+            claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
+        // Paired hosted release (#7168): same call-site opt-in gate as the claim submission above. Only fires when
+        // the initial claim submission actually ran (claimRecord is only set once claimedIssue is), so a run that
+        // never reached the claim point (e.g. blocked_max_concurrent_claims) has nothing to release remotely.
+        if (claimedIssue && claimRecord && isDiscoveryPlaneEnabled(env)) {
+            const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+            await submitClaim({ ...claimRecord, status: "released" }, { env });
+        }
+        if (allocation && allocator)
+            allocator.release(attemptId);
+        allocator?.close();
+        claimLedger?.close();
+        eventLedger?.close();
+        attemptLog?.close();
+        governorLedger?.close();
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYXR0ZW1wdC1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJhdHRlbXB0LWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxvSEFBb0g7QUFDcEgscUdBQXFHO0FBQ3JHLDBHQUEwRztBQUMxRyw2R0FBNkc7QUFDN0csOEdBQThHO0FBQzlHLDJHQUEyRztBQUMzRyxxR0FBcUc7QUFDckcsMkZBQTJGO0FBQzNGLHFGQUFxRjtBQUNyRixFQUFFO0FBQ0YsMEdBQTBHO0FBQzFHLGtIQUFrSDtBQUNsSCxpSEFBaUg7QUFDakgsMkdBQTJHO0FBRzNHLE9BQU8sRUFBRSwyQkFBMkIsRUFBRSxnQ0FBZ0MsRUFBRSwyQ0FBMkMsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQzlJLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsb0NBQW9DLEVBQUUsTUFBTSxnQ0FBZ0MsQ0FBQztBQUN0RixPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUN6RCxPQUFPLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSwwQkFBMEIsQ0FBQztBQUNsRSxPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSwwQkFBMEIsQ0FBQztBQUM3RCxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFFcEQsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDNUQsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sOEJBQThCLENBQUM7QUFFcEUsT0FBTyxFQUFFLDJCQUEyQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDbkUsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRXBELE9BQU8sRUFBRSxjQUFjLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUVsRCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUUxRCxPQUFPLEVBQUUscUJBQXFCLEVBQUUsTUFBTSx5QkFBeUIsQ0FBQztBQUVoRSxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUNyRCxPQUFPLEVBQUUsb0NBQW9DLEVBQUUsd0NBQXdDLEVBQUUsd0JBQXdCLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUNqSixPQUFPLEVBQUUsc0JBQXNCLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUN2RixPQUFPLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSwwQkFBMEIsQ0FBQztBQUVsRSxPQUFPLEVBQUUsbUJBQW1CLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUM1RCxPQUFPLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUNuRCxPQUFPLEVBQUUsb0JBQW9CLEVBQUUsK0JBQStCLEVBQUUsTUFBTSwyQkFBMkIsQ0FBQztBQUNsRyxPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxhQUFhLENBQUM7QUFDaEQsT0FBTyxFQUFFLDJCQUEyQixFQUFFLHFCQUFxQixFQUFFLE1BQU0sNEJBQTRCLENBQUM7QUFDaEcsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDekQsT0FBTyxFQUFFLHFCQUFxQixFQUFFLG1CQUFtQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFDakYsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLHFCQUFxQixDQUFDO0FBRXRELE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBQ2xFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxlQUFlLEVBQUUsTUFBTSw2QkFBNkIsQ0FBQztBQW1EdkYsTUFBTSxhQUFhLEdBQ2pCLDJIQUEySCxDQUFDO0FBRTlILFNBQVMsZUFBZSxDQUFDLEtBQWM7SUFDckMsTUFBTSxPQUFPLEdBQUcsT0FBTyxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUM5RCxNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2hELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN4RCxJQUFJLENBQUMsa0JBQWtCLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxJQUFJLENBQUM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN6RSxPQUFPLEdBQUcsS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO0FBQzVCLENBQUM7QUFFRCxNQUFNLFVBQVUsZ0JBQWdCLENBQUMsSUFBYztJQUM3QyxNQUFNLE9BQU8sR0FBRyxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFFLElBQXFCLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUM3RyxNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELHVHQUF1RztRQUN2Ryx1R0FBdUc7UUFDdkcscUZBQXFGO1FBQ3JGLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0Qsd0dBQXdHO1FBQ3hHLHNHQUFzRztRQUN0Ryx3R0FBd0c7UUFDeEcsOEJBQThCO1FBQzlCLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssZUFBZSxFQUFFLENBQUM7WUFDOUIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsYUFBYSxFQUFFLENBQUM7WUFDckUsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsYUFBYSxFQUFFLENBQUM7WUFDckUsT0FBTyxDQUFDLElBQUksR0FBRyxLQUFLLENBQUM7WUFDckIsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDeEUsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGFBQWEsRUFBRSxDQUFDO0lBQzdELE1BQU0sWUFBWSxHQUFHLGVBQWUsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNwRCxJQUFJLENBQUMsWUFBWTtRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsMENBQTBDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUM7SUFDL0YsTUFBTSxXQUFXLEdBQUcsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQzFDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLFdBQVcsQ0FBQyxJQUFJLFdBQVcsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUN0RCxPQUFPLEVBQUUsS0FBSyxFQUFFLDRDQUE0QyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDO0lBQ2hGLENBQUM7SUFDRCxJQUFJLENBQUMsT0FBTyxDQUFDLFVBQVU7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLDhCQUE4QixhQUFhLEVBQUUsRUFBRSxDQUFDO0lBRXpGLE9BQU87UUFDTCxZQUFZO1FBQ1osV0FBVztRQUNYLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtRQUM5QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7UUFDbEIsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO1FBQ2xCLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTTtRQUN0QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7S0FDbkIsQ0FBQztBQUNKLENBQUM7QUFFRDs7Ozs7O0dBTUc7QUFDSCxNQUFNLFVBQVUsZ0JBQWdCLENBQzlCLEdBQXVDLEVBQ3ZDLE9BQXNJO0lBRXRJLE9BQU87UUFDTCxNQUFNLEVBQUUsb0NBQW9DLENBQUMsR0FBRyxDQUFDO1FBQ2pELGlCQUFpQixFQUFFLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxpQkFBaUIsQ0FBQyxLQUFnRCxDQUFDO1FBQ2pHLHFCQUFxQixFQUFFLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLHFCQUFxQixDQUFDLEtBQXVFLENBQUM7UUFDbkosV0FBVyxFQUFFLE9BQU8sQ0FBQyxXQUFXO1FBQ2hDLGtHQUFrRztRQUNsRyxzR0FBc0c7UUFDdEcseUZBQXlGO1FBQ3pGLHNCQUFzQixFQUFFLEtBQUssRUFBRSxZQUFZLEVBQUUsV0FBVyxFQUFFLEVBQUUsQ0FBQyxzQkFBc0IsQ0FBQyxZQUFZLEVBQUUsV0FBVyxFQUFFLEVBQUUsV0FBVyxFQUFFLE1BQU0sa0JBQWtCLENBQUMsR0FBd0IsQ0FBQyxFQUFrRCxDQUFDO1FBQ25PLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVztRQUNoQyxvQkFBb0IsRUFBRSxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsT0FBTyxDQUFDLGNBQWMsQ0FBQyxtQkFBbUIsQ0FBQyxLQUF5RSxDQUFDO1FBQ3RKLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSztRQUNwQixpQkFBaUIsRUFBRSxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsaUJBQWlCLENBQUMsSUFBSSxDQUFDO0tBQ3RDLENBQUM7QUFDbkIsQ0FBQztBQWtDRDs7Ozs7OztHQU9HO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSxVQUFVLENBQUMsSUFBYyxFQUFFLFVBQTZCLEVBQUU7SUFDOUUsTUFBTSxNQUFNLEdBQUcsZ0JBQWdCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDdEMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxNQUFNLEdBQUcsR0FBRyxPQUFPLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUM7SUFDdkMsTUFBTSxLQUFLLEdBQUcsT0FBTyxDQUFDLEtBQUssSUFBSSxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUM7SUFDMUMsTUFBTSxXQUFXLEdBQUcsT0FBTyxDQUFDLGdDQUFnQyxJQUFJLGdDQUFnQyxDQUFDO0lBQ2pHLE1BQU0sSUFBSSxHQUFHLFdBQVcsQ0FBQyxFQUFFLEdBQUcsRUFBRSxXQUFXLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQztJQUU3RCxJQUFJLElBQUksS0FBSyxRQUFRLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUNyQixNQUFNLENBQUMsSUFBSSxFQUNYLGtHQUFrRyxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLEdBQUcsRUFDOUksQ0FBQyxDQUNGLENBQUM7SUFDSixDQUFDO0lBRUQsTUFBTSxTQUFTLEdBQUcsT0FBTyxDQUFDLFNBQVMsSUFBSSxHQUFHLE1BQU0sQ0FBQyxZQUFZLENBQUMsT0FBTyxDQUFDLEdBQUcsRUFBRSxHQUFHLENBQUMsSUFBSSxNQUFNLENBQUMsV0FBVyxJQUFJLEtBQUssRUFBRSxDQUFDO0lBRWpILDJHQUEyRztJQUMzRyx3R0FBd0c7SUFDeEcsdUdBQXVHO0lBQ3ZHLElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFxQjtZQUNyQyxPQUFPLEVBQUUsU0FBUztZQUNsQixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7WUFDakMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO1lBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtZQUM3QixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7WUFDakIsSUFBSTtZQUNKLFNBQVM7U0FDVixDQUFDO1FBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQ1QsMEJBQTBCLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFdBQVcsUUFBUSxNQUFNLENBQUMsVUFBVSxXQUFXLElBQUksV0FBVyxNQUFNLENBQUMsSUFBSSxvREFBb0QsQ0FDdEwsQ0FBQztRQUNKLENBQUM7UUFDRCxPQUFPLENBQUMsUUFBUSxFQUFFLENBQUMsWUFBWSxDQUFDLENBQUM7UUFDakMsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxTQUFTLEdBQTZCLElBQUksQ0FBQztJQUMvQyxJQUFJLFdBQVcsR0FBdUIsSUFBSSxDQUFDO0lBQzNDLElBQUksV0FBVyxHQUF1QixJQUFJLENBQUM7SUFDM0MsSUFBSSxVQUFVLEdBQXNCLElBQUksQ0FBQztJQUN6QyxJQUFJLGNBQWMsR0FBMEIsSUFBSSxDQUFDO0lBQ2pELElBQUksVUFBVSxHQUFvRCxJQUFJLENBQUM7SUFDdkUsNEdBQTRHO0lBQzVHLDBHQUEwRztJQUMxRyxxR0FBcUc7SUFDckcsSUFBSSxjQUFjLEdBRVAsSUFBSSxDQUFDO0lBQ2hCLElBQUksWUFBWSxHQUFHLEtBQUssQ0FBQztJQUN6QixJQUFJLFdBQVcsR0FBc0IsSUFBSSxDQUFDO0lBRTFDLElBQUksQ0FBQztRQUNILFNBQVMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxxQkFBcUIsSUFBSSxxQkFBcUIsQ0FBQyxFQUFFLENBQUM7UUFDdkUsV0FBVyxHQUFHLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUMsRUFBRSxDQUFDO1FBQzdELFdBQVcsR0FBRyxDQUFDLE9BQU8sQ0FBQyxlQUFlLElBQUksZUFBZSxDQUFDLEVBQUUsQ0FBQztRQUM3RCxVQUFVLEdBQUcsQ0FBQyxPQUFPLENBQUMsY0FBYyxJQUFJLGNBQWMsQ0FBQyxFQUFFLENBQUM7UUFDMUQsY0FBYyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLGtCQUFrQixDQUFDLEVBQUUsQ0FBQztRQUV0RSxnR0FBZ0c7UUFDaEcsb0dBQW9HO1FBQ3BHLDJGQUEyRjtRQUMzRixNQUFNLGdCQUFnQixHQUFHLE9BQU8sQ0FBQyx3QkFBd0IsSUFBSSx3QkFBd0IsQ0FBQztRQUN0RixNQUFNLGVBQWUsR0FBRyxNQUFNLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsRUFBRSxTQUFTLEVBQUUsT0FBTyxDQUFDLFNBQVMsRUFBNEMsQ0FBQyxDQUFDO1FBQ2hKLElBQUksZUFBZSxFQUFFLENBQUM7WUFDcEIsTUFBTSxNQUFNLEdBQ1YsZUFBZSxLQUFLLElBQUksQ0FBQyxDQUFDLENBQUMsb0NBQW9DLENBQUMsQ0FBQyxDQUFDLGVBQWUsQ0FBQztZQUNwRixVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSxpQkFBaUI7Z0JBQzVCLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFNBQVM7Z0JBQ3RCLElBQUk7Z0JBQ0osTUFBTTtnQkFDTixPQUFPLEVBQUUsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRTthQUNoRixDQUFDLENBQUM7WUFDSCxXQUFXLENBQUMsV0FBVyxDQUFDO2dCQUN0QixJQUFJLEVBQUUsaUJBQWlCO2dCQUN2QixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLE9BQU8sRUFBRSxFQUFFLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sRUFBRTthQUNyRCxDQUFDLENBQUM7WUFDSCxNQUFNLGNBQWMsR0FBcUI7Z0JBQ3ZDLE9BQU8sRUFBRSw0QkFBNEI7Z0JBQ3JDLE1BQU07Z0JBQ04sWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO2dCQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7Z0JBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtnQkFDN0IsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJO2dCQUNqQixJQUFJO2dCQUNKLFNBQVM7YUFDVixDQUFDO1lBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxjQUFjLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDdkQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxLQUFLLENBQ1gsTUFBTSxLQUFLLHdDQUF3QztvQkFDakQsQ0FBQyxDQUFDLGVBQWUsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVywrREFBK0Q7b0JBQ3pILENBQUMsQ0FBQyxlQUFlLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFdBQVcsb0ZBQW9GLENBQ2pKLENBQUM7WUFDSixDQUFDO1lBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLGNBQWMsQ0FBQyxDQUFDO1lBQ25DLE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQztRQUVELFVBQVUsR0FBRyxTQUFTLENBQUMsT0FBTyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7UUFFL0QsSUFBSSxJQUFpQixDQUFDO1FBQ3RCLElBQUksQ0FBQztZQUNILE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxnQkFBZ0IsSUFBSSxnQkFBZ0IsQ0FBQztZQUMvRCxJQUFJLEdBQUcsU0FBUyxDQUFDLEdBQUcsRUFBRSxFQUFFLFdBQVcsRUFBRSxXQUFXLEVBQUUsVUFBVSxFQUFFLGNBQWMsRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO1FBQ3pGLENBQUM7UUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1lBQ2YsTUFBTSxNQUFNLEdBQUcsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUM7WUFDdkMsT0FBTyxnQkFBZ0IsQ0FDckIsTUFBTSxDQUFDLElBQUksRUFDWCxlQUFlLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFdBQVcsZ0JBQWdCLE1BQU0sRUFBRSxFQUNoRixDQUFDLENBQ0YsQ0FBQztRQUNKLENBQUM7UUFFRCxtR0FBbUc7UUFDbkcsd0dBQXdHO1FBQ3hHLG1HQUFtRztRQUNuRyw0RkFBNEY7UUFDNUYsMkRBQTJEO1FBQzNELE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsSUFBSSxzQkFBc0IsQ0FBQztRQUNqRixjQUFjLEdBQUcsTUFBTSxlQUFlLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxTQUFTLEVBQUUsRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLElBQUksRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQ3pHLElBQUksQ0FBQyxjQUFjLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDdkIsTUFBTSxNQUFNLEdBQUcsY0FBYyxDQUFDLEtBQUssQ0FBQztZQUNwQyxVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSxpQkFBaUI7Z0JBQzVCLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFNBQVM7Z0JBQ3RCLElBQUk7Z0JBQ0osTUFBTTtnQkFDTixPQUFPLEVBQUUsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRTthQUNoRixDQUFDLENBQUM7WUFDSCxXQUFXLENBQUMsV0FBVyxDQUFDO2dCQUN0QixJQUFJLEVBQUUsaUJBQWlCO2dCQUN2QixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLE9BQU8sRUFBRSxFQUFFLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sRUFBRTthQUNyRCxDQUFDLENBQUM7WUFDSCxNQUFNLHFCQUFxQixHQUFxQjtnQkFDOUMsT0FBTyxFQUFFLHFDQUFxQztnQkFDOUMsTUFBTTtnQkFDTixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVztnQkFDL0IsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVO2dCQUM3QixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7Z0JBQ2pCLElBQUk7Z0JBQ0osU0FBUzthQUNWLENBQUM7WUFDRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLHFCQUFxQixFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQzlELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsS0FBSyxDQUFDLGVBQWUsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVyxrREFBa0QsTUFBTSxFQUFFLENBQUMsQ0FBQztZQUNwSSxDQUFDO1lBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLHFCQUFxQixDQUFDLENBQUM7WUFDMUMsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDO1FBRUQsb0dBQW9HO1FBQ3BHLE1BQU0sa0JBQWtCLEdBQUcsT0FBTyxDQUFDLHNCQUFzQixJQUFJLHNCQUFzQixDQUFDO1FBQ3BGLE1BQU0sYUFBYSxHQUFHLE1BQU0sa0JBQWtCLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRTtZQUNsRSxXQUFXLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQyxHQUF3QixDQUFDO1lBQy9ELGdCQUFnQixFQUFFLE1BQU0sQ0FBQyxVQUFVO1lBQ25DLFlBQVksRUFBRSxDQUFDLE1BQU0sQ0FBQyxXQUFXLENBQUM7U0FDUyxDQUFDLENBQUM7UUFFL0MscUdBQXFHO1FBQ3JHLHdHQUF3RztRQUN4Ryx5R0FBeUc7UUFDekcscURBQXFEO1FBQ3JELE1BQU0sV0FBVyxHQUFHLGFBQWEsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsU0FBUyxFQUFFLEVBQUUsQ0FBQyxTQUFTLENBQUMsTUFBTSxLQUFLLE1BQU0sQ0FBQyxXQUFXLENBQUMsSUFBSTtZQUN2RyxNQUFNLEVBQUUsTUFBTSxDQUFDLFdBQVc7WUFDMUIsS0FBSyxFQUFFLEVBQUU7WUFDVCxJQUFJLEVBQUUsSUFBSTtZQUNWLE1BQU0sRUFBRSxFQUFFO1NBQ1gsQ0FBQztRQUVGLE1BQU0sYUFBYSxHQUFHLE9BQU8sQ0FBQyxtQkFBbUIsSUFBSSxtQkFBbUIsQ0FBQztRQUN6RSxNQUFNLGNBQWMsR0FBRyxhQUFhLENBQUM7WUFDbkMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO1lBQ2pDLEtBQUssRUFBRSxXQUFXO1lBQ2xCLE9BQU8sRUFBRSxFQUFFLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTSxFQUFFLFlBQVksRUFBRSxhQUFhLENBQUMsWUFBWSxFQUFFO1lBQ25GLFdBQVc7WUFDWCxnQkFBZ0IsRUFBRSxjQUFjLENBQUMsWUFBWTtTQUNQLENBQUMsQ0FBQztRQUUxQyxJQUFJLENBQUMsY0FBYyxDQUFDLEtBQUssRUFBRSxDQUFDO1lBQzFCLE1BQU0sTUFBTSxHQUFHLGNBQWMsY0FBYyxDQUFDLE9BQU8sRUFBRSxDQUFDO1lBQ3RELFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQztnQkFDL0IsU0FBUyxFQUFFLGlCQUFpQjtnQkFDNUIsU0FBUztnQkFDVCxXQUFXLEVBQUUsU0FBUztnQkFDdEIsSUFBSTtnQkFDSixNQUFNO2dCQUNOLE9BQU8sRUFBRSxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLFdBQVcsRUFBRSxjQUFjLENBQUMsV0FBVyxFQUFFO2FBQ3pILENBQUMsQ0FBQztZQUNILFdBQVcsQ0FBQyxXQUFXLENBQUM7Z0JBQ3RCLElBQUksRUFBRSxpQkFBaUI7Z0JBQ3ZCLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtnQkFDakMsT0FBTyxFQUFFLEVBQUUsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXLEVBQUUsTUFBTSxFQUFFO2FBQ3JELENBQUMsQ0FBQztZQUNILE1BQU0sZ0JBQWdCLEdBQXFCO2dCQUN6QyxPQUFPLEVBQUUsb0JBQW9CO2dCQUM3QixNQUFNO2dCQUNOLE9BQU8sRUFBRSxjQUFjLENBQUMsT0FBTztnQkFDL0IsWUFBWSxFQUFFLGNBQWMsQ0FBQyxXQUFXLENBQUMsWUFBd0I7Z0JBQ2pFLFlBQVksRUFBRSxjQUFjLENBQUMsV0FBVyxDQUFDLFlBQXdCO2dCQUNqRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVztnQkFDL0IsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVO2dCQUM3QixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7Z0JBQ2pCLElBQUk7Z0JBQ0osU0FBUzthQUNWLENBQUM7WUFDRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLGdCQUFnQixFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3pELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsS0FBSyxDQUNYLGVBQWUsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVyxxQ0FBcUMsY0FBYyxDQUFDLE9BQU8sTUFBTSxDQUFDLEdBQUcsY0FBYyxDQUFDLFdBQVcsQ0FBQyxZQUFZLEVBQUUsR0FBRyxjQUFjLENBQUMsV0FBVyxDQUFDLFlBQVksQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUNqTyxDQUFDO1lBQ0osQ0FBQztZQUNELE9BQU8sQ0FBQyxRQUFRLEVBQUUsQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDO1lBQ3JDLE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQztRQUVELE1BQU0sU0FBUyxHQUFHLE1BQU0sQ0FBQyxPQUFPLENBQUMsZ0JBQWdCLElBQUksZ0JBQWdCLENBQUMsQ0FBQyxNQUFNLENBQUMsWUFBWSxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztRQUVyRyx3R0FBd0c7UUFDeEcsMEdBQTBHO1FBQzFHLDJHQUEyRztRQUMzRyx5R0FBeUc7UUFDekcsNkVBQTZFO1FBQzdFLE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQyxvQkFBb0IsSUFBSSxvQkFBb0IsQ0FBQztRQUM3RSxNQUFNLGFBQWEsR0FBRyxlQUFlLENBQUMsY0FBYyxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBQy9ELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQztRQUV4RCxNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsb0JBQW9CLElBQUksb0JBQW9CLENBQUM7UUFDN0UsTUFBTSxvQkFBb0IsR0FDdkIsT0FBd0YsQ0FBQywrQkFBK0I7WUFDekgsK0JBQStCLENBQUM7UUFDbEMsSUFBSSxlQUFlLEdBQUcsZUFBZSxDQUFDLEVBQUUsR0FBRyxFQUFFLFVBQVUsRUFBRSxDQUFDLENBQUMsS0FBSyxDQUFDO1FBQ2pFLElBQUksdUJBQXVCLEdBQUcsZUFBZSxDQUFDO1FBRTlDLE1BQU0scUJBQXFCLEdBQUcsR0FBRyxFQUFFO1lBQ2pDLGlHQUFpRztZQUNqRyxNQUFNLGNBQWMsR0FBRyxlQUFlLENBQUUsY0FBdUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQztZQUNqSCxNQUFNLElBQUksR0FBRyxlQUFlLENBQUMsRUFBRSxHQUFHLEVBQUUsVUFBVSxFQUFFLGNBQWMsRUFBRSxDQUFDLENBQUM7WUFDbEUsSUFBSSxJQUFJLENBQUMsS0FBSyxLQUFLLHVCQUF1QixFQUFFLENBQUM7Z0JBQzNDLElBQUksQ0FBQztvQkFDSCxvQkFBb0IsQ0FBQzt3QkFDbkIsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO3dCQUNqQyxXQUFXLEVBQUUsU0FBUzt3QkFDdEIsYUFBYSxFQUFFLHVCQUF1Qjt3QkFDdEMsS0FBSyxFQUFFLElBQUksQ0FBQyxLQUFLO3FCQUNsQixDQUFDLENBQUM7Z0JBQ0wsQ0FBQztnQkFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO29CQUNmLDRGQUE0RjtvQkFDNUYsa0dBQWtHO29CQUNsRyxpQkFBaUIsQ0FBQyxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsc0NBQXNDLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsS0FBSyxFQUFFLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDO2dCQUNuSSxDQUFDO2dCQUNELHVCQUF1QixHQUFHLElBQUksQ0FBQyxLQUFLLENBQUM7WUFDdkMsQ0FBQztZQUNELGVBQWUsR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDO1lBQzdCLE9BQU8sSUFBSSxDQUFDO1FBQ2QsQ0FBQyxDQUFDO1FBRUYsTUFBTSxXQUFXLEdBQUcsR0FBRyxFQUFFO1lBQ3ZCLE1BQU0sSUFBSSxHQUFHLHFCQUFxQixFQUFFLENBQUM7WUFDckMsSUFBSSxDQUFDLElBQUksQ0FBQyxNQUFNO2dCQUFFLE9BQU8sS0FBSyxDQUFDO1lBQy9CLE9BQU87Z0JBQ0wsS0FBSyxFQUFFLElBQUk7Z0JBQ1gsTUFBTSxFQUFFLGdCQUFnQixJQUFJLENBQUMsS0FBSyw4RUFBOEU7YUFDakgsQ0FBQztRQUNKLENBQUMsQ0FBQztRQUVGLE1BQU0sU0FBUyxHQUFHLHFCQUFxQixDQUFDO1lBQ3RDLGNBQWM7WUFDZCxhQUFhO1lBQ2IsWUFBWSxFQUFFLGNBQWMsQ0FBQyxZQUFZO1lBQ3pDLFNBQVM7WUFDVCxJQUFJO1lBQ0osWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO1lBQ2pDLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtZQUM3QixpQkFBaUIsRUFBRSxLQUFLO1lBQ3hCLGFBQWEsRUFBRSxTQUFTLENBQUMsSUFBSTtZQUM3QixTQUFTLEVBQUUsY0FBYyxDQUFDLFVBQVU7U0FDckMsQ0FBQyxDQUFDO1FBRUgsd0dBQXdHO1FBQ3hHLG1HQUFtRztRQUNuRyxtR0FBbUc7UUFDbkcsdUVBQXVFO1FBQ3ZFLE1BQU0sa0JBQWtCLEdBQUcsT0FBTyxDQUFDLGlCQUFpQixJQUFJLGlCQUFpQixDQUFDO1FBQzFFLE1BQU0sZ0JBQWdCLEdBQUcsa0JBQWtCLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxTQUFTLE1BQU0sQ0FBQyxXQUFXLEVBQUUsQ0FBQyxDQUFDO1FBQ2hHLDhHQUE4RztRQUM5Ryw4R0FBOEc7UUFDOUcsTUFBTSxxQkFBcUIsR0FDeEIsT0FBb0UsQ0FBQyxxQkFBcUIsSUFBSSxxQkFBcUIsQ0FBQztRQUN2SCxNQUFNLGlCQUFpQixHQUFHLHFCQUFxQixDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQztRQUNyRSxNQUFNLFFBQVEsR0FBRywyQkFBMkIsQ0FBQyxHQUFHLEVBQUUsU0FBUyxDQUFDLElBQUksRUFBRSxVQUFVLEVBQUUsZ0JBQWdCLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztRQUVuSCw0R0FBNEc7UUFDNUcsK0dBQStHO1FBQy9HLHdHQUF3RztRQUN4RyxvR0FBb0c7UUFDcEcsMkdBQTJHO1FBQzNHLHdHQUF3RztRQUN4Ryx1R0FBdUc7UUFDdkcsMEdBQTBHO1FBQzFHLGlIQUFpSDtRQUNqSCxNQUFNLFdBQVcsR0FBRyxXQUFXLENBQUMsbUJBQW1CLENBQ2pELE1BQU0sQ0FBQyxZQUFZLEVBQ25CLE1BQU0sQ0FBQyxXQUFXLEVBQ2xCLFdBQVcsU0FBUyxFQUFFLEVBQ3RCLFNBQVMsRUFDVCxhQUFhLENBQUMsSUFBSSxDQUFDLG1CQUFtQixDQUN2QyxDQUFDO1FBQ0YsSUFBSSxDQUFDLFdBQVcsQ0FBQyxPQUFPLEVBQUUsQ0FBQztZQUN6QixNQUFNLE1BQU0sR0FBRyxnQ0FBZ0MsQ0FBQztZQUNoRCxVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSxpQkFBaUI7Z0JBQzVCLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFNBQVM7Z0JBQ3RCLElBQUk7Z0JBQ0osTUFBTTtnQkFDTixPQUFPLEVBQUU7b0JBQ1AsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO29CQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7b0JBQy9CLG1CQUFtQixFQUFFLGFBQWEsQ0FBQyxJQUFJLENBQUMsbUJBQW1CO29CQUMzRCxnQkFBZ0IsRUFBRSxXQUFXLENBQUMsZ0JBQWdCO2lCQUMvQzthQUNGLENBQUMsQ0FBQztZQUNILFdBQVcsQ0FBQyxXQUFXLENBQUM7Z0JBQ3RCLElBQUksRUFBRSxpQkFBaUI7Z0JBQ3ZCLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtnQkFDakMsT0FBTyxFQUFFLEVBQUUsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXLEVBQUUsTUFBTSxFQUFFO2FBQ3JELENBQUMsQ0FBQztZQUNILE1BQU0sYUFBYSxHQUFxQjtnQkFDdEMsT0FBTyxFQUFFLCtCQUErQjtnQkFDeEMsTUFBTTtnQkFDTixtQkFBbUIsRUFBRSxhQUFhLENBQUMsSUFBSSxDQUFDLG1CQUFtQjtnQkFDM0QsZ0JBQWdCLEVBQUUsV0FBVyxDQUFDLGdCQUFnQjtnQkFDOUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO2dCQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7Z0JBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtnQkFDN0IsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJO2dCQUNqQixJQUFJO2dCQUNKLFNBQVM7YUFDcUIsQ0FBQztZQUNqQyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLGFBQWEsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUN0RCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEtBQUssQ0FDWCxlQUFlLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFdBQVcscURBQXFELGFBQWEsQ0FBQyxJQUFJLENBQUMsbUJBQW1CLHFCQUFxQixXQUFXLENBQUMsZ0JBQWdCLG9CQUFvQixDQUN6TixDQUFDO1lBQ0osQ0FBQztZQUNELE9BQU8sQ0FBQyxRQUFRLEVBQUUsQ0FBQyxhQUFhLENBQUMsQ0FBQztZQUNsQyxPQUFPLEVBQUUsQ0FBQztRQUNaLENBQUM7UUFFRCxXQUFXLEdBQUcsV0FBVyxDQUFDLEtBQUssQ0FBQztRQUNoQyxZQUFZLEdBQUcsSUFBSSxDQUFDO1FBQ3BCLHlHQUF5RztRQUN6RywyR0FBMkc7UUFDM0csNEdBQTRHO1FBQzVHLHlHQUF5RztRQUN6RyxzR0FBc0c7UUFDdEcsMEdBQTBHO1FBQzFHLDhDQUE4QztRQUM5QyxJQUFJLHVCQUF1QixDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDakMsTUFBTSxXQUFXLEdBQUcsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUM7WUFDL0QsTUFBTSxXQUFXLENBQUMsV0FBVyxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztRQUMxQyxDQUFDO1FBRUQsTUFBTSxrQkFBa0IsR0FBRyxPQUFPLENBQUMsZUFBZSxJQUFJLGVBQWUsQ0FBQztRQUN0RSxJQUFJLE1BQTZCLENBQUM7UUFDbEMsSUFBSSxDQUFDO1lBQ0gsTUFBTSxHQUFHLE1BQU0sa0JBQWtCLENBQy9CO2dCQUNFLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO2dCQUMvQixVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7Z0JBQzdCLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSTtnQkFDakIsZUFBZTtnQkFDZixhQUFhLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxhQUFhO2dCQUMzQyxjQUFjLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxjQUFjO2dCQUM3QyxRQUFRO2FBQ1QsRUFDRDtnQkFDRSxHQUFHLElBQUk7Z0JBQ1AsV0FBVztnQkFDWCxzQkFBc0IsRUFBRSxHQUFHLEVBQUUsQ0FBQyxxQkFBcUIsRUFBRSxDQUFDLEtBQUs7YUFDNUQsQ0FDRixDQUFDO1FBQ0osQ0FBQztRQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7WUFDZixvR0FBb0c7WUFDcEcsa0dBQWtHO1lBQ2xHLHdHQUF3RztZQUN4RyxrR0FBa0c7WUFDbEcsY0FBYyxDQUFDLFNBQVMsR0FBRyxLQUFLLENBQUM7WUFDakMsTUFBTSxLQUFLLENBQUM7UUFDZCxDQUFDO1FBRUQsY0FBYyxDQUFDLFNBQVMsR0FBRyxNQUFNLENBQUMsT0FBTyxLQUFLLFdBQVcsQ0FBQztRQUUxRCx3R0FBd0c7UUFDeEcsc0dBQXNHO1FBQ3RHLHNHQUFzRztRQUN0RyxxR0FBcUc7UUFDckcsMEZBQTBGO1FBQzFGLElBQUksYUFBOEMsQ0FBQztRQUNuRCxJQUFJLE1BQU0sQ0FBQyxPQUFPLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDbkMsTUFBTSxZQUFZLEdBQUcsMkJBQTJCLENBQUMsTUFBTSxDQUFDLFVBQStELEVBQUUsTUFBTSxDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQzlJLElBQUksWUFBWSxLQUFLLElBQUksRUFBRSxDQUFDO2dCQUMxQixNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsb0JBQW9CLElBQUksb0JBQW9CLENBQUM7Z0JBQzdFLGFBQWEsR0FBRyxNQUFNLGVBQWUsQ0FDbkM7b0JBQ0UsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO29CQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7b0JBQy9CLFlBQVk7b0JBQ1osYUFBYSxFQUFFLFdBQVcsQ0FBQyxTQUFTO29CQUNwQyxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7aUJBQzlCLEVBQ0QsRUFBRSxzQkFBc0IsRUFBRSxJQUFJLENBQUMsc0JBQXNCLEVBQUUsaUJBQWlCLEVBQUUsSUFBSSxDQUFDLGlCQUFpQixFQUFFLENBQ25HLENBQUM7WUFDSixDQUFDO1lBRUQsMEZBQTBGO1lBQzFGLG9HQUFvRztZQUNwRywrRkFBK0Y7WUFDL0YscUdBQXFHO1lBQ3JHLHNHQUFzRztZQUN0Ryx5R0FBeUc7WUFDekcsb0dBQW9HO1lBQ3BHLDJHQUEyRztZQUMzRyxNQUFNLFlBQVksR0FBRyxNQUFNLENBQUMsVUFBVSxDQUFDLGFBQWEsRUFBRSxZQUFZLEVBQUUsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ25HLE1BQU0sV0FBVyxHQUFHLDJCQUEyQixDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQzlELElBQUksV0FBVyxFQUFFLENBQUM7Z0JBQ2hCLElBQUksQ0FBQztvQkFDSCxNQUFNLE1BQU0sR0FBRyxPQUFPLENBQUMsbUJBQW1CLElBQUksbUJBQW1CLENBQUM7b0JBQ2xFLE1BQU0sQ0FBQzt3QkFDTCxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7d0JBQ2pDLFdBQVc7d0JBQ1gsV0FBVyxFQUFFLElBQUksSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLFdBQVcsRUFBRTt3QkFDMUMsaUJBQWlCLEVBQUUsWUFBWTt3QkFDL0IsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO3FCQUNoQyxDQUFDLENBQUM7Z0JBQ0wsQ0FBQztnQkFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO29CQUNmLCtGQUErRjtvQkFDL0YscUdBQXFHO29CQUNyRyx1RUFBdUU7b0JBQ3ZFLGlCQUFpQixDQUFDLEtBQUssRUFBRSxFQUFFLElBQUksRUFBRSw4QkFBOEIsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxpQkFBaUIsRUFBRSxZQUFZLEVBQUUsQ0FBQyxDQUFDO2dCQUN6SSxDQUFDO1lBQ0gsQ0FBQztRQUNILENBQUM7UUFFRCxNQUFNLFdBQVcsR0FBZ0U7WUFDL0UsT0FBTyxFQUFFLFdBQVcsTUFBTSxDQUFDLE9BQU8sRUFBRTtZQUNwQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7WUFDakMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO1lBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtZQUM3QixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7WUFDakIsSUFBSTtZQUNKLFNBQVM7WUFDVCxjQUFjLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxjQUFjO1lBQzdDLHlHQUF5RztZQUN6RywwR0FBMEc7WUFDMUcsbUdBQW1HO1lBQ25HLHFHQUFxRztZQUNyRyx3R0FBd0c7WUFDeEcsZ0VBQWdFO1lBQ2hFLGNBQWMsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLGNBQWM7WUFDaEQsWUFBWSxFQUFFLE1BQU0sQ0FBQyxVQUFVLENBQUMsWUFBWTtZQUM1Qyx5R0FBeUc7WUFDekcsMEdBQTBHO1lBQzFHLHVEQUF1RDtZQUN2RCxlQUFlLEVBQUUsTUFBTSxDQUFDLFVBQVUsQ0FBQyxnQkFBZ0IsQ0FBQyxNQUFNO1lBQzFELGNBQWMsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLGNBQWM7WUFDaEQsR0FBRyxDQUFDLE1BQU0sQ0FBQyxPQUFPLEtBQUssU0FBUyxJQUFJLE1BQU0sQ0FBQyxVQUFVLENBQUMsYUFBYSxFQUFFLGFBQWE7Z0JBQ2hGLENBQUMsQ0FBQyxFQUFFLGFBQWEsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLGFBQWEsQ0FBQyxhQUFhLEVBQUU7Z0JBQ2xFLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDUCxHQUFHLENBQUMsUUFBUSxJQUFJLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDeEQsR0FBRyxDQUFDLFVBQVUsSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUUsUUFBUSxFQUFFLE1BQU0sQ0FBQyxRQUFRLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQzlELEdBQUcsQ0FBQyxNQUFNLElBQUksTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUNsRCxHQUFHLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDcEUsd0dBQXdHO1lBQ3hHLHdHQUF3RztZQUN4RyxvRkFBb0Y7WUFDcEYsR0FBRyxDQUFDLGFBQWEsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsYUFBYSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztTQUNLLENBQUM7UUFFakUsMkdBQTJHO1FBQzNHLDhHQUE4RztRQUM5RywyR0FBMkc7UUFDM0cseUdBQXlHO1FBQ3pHLDJHQUEyRztRQUMzRyxzR0FBc0c7UUFDdEcsNkdBQTZHO1FBQzdHLG9EQUFvRDtRQUNwRCxJQUFJLENBQUM7WUFDSCxVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSx5QkFBeUI7Z0JBQ3BDLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFdBQVcsQ0FBQyxPQUFPO2dCQUNoQyxJQUFJO2dCQUNKLE1BQU0sRUFBRSxrQ0FBa0MsTUFBTSxDQUFDLE9BQU8sRUFBRTtnQkFDMUQsUUFBUSxFQUFFLDJDQUEyQyxDQUFDLEdBQUcsQ0FBQztnQkFDMUQsT0FBTyxFQUFFLFdBQVcsQ0FBQyxZQUFZO2dCQUNqQyxVQUFVLEVBQUUsV0FBVyxDQUFDLGVBQWU7YUFDeEMsQ0FBQyxDQUFDO1FBQ0wsQ0FBQztRQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7WUFDZix5R0FBeUc7WUFDekcsdUdBQXVHO1lBQ3ZHLHlGQUF5RjtZQUN6RixpQkFBaUIsQ0FBQyxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsdUNBQXVDLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLENBQUMsQ0FBQztRQUM1SCxDQUFDO1FBRUQsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFdBQVcsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNwRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZUFBZSxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLDJCQUEyQixNQUFNLENBQUMsT0FBTyxHQUFHLENBQUMsQ0FBQztRQUNwSCxDQUFDO1FBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLFdBQVcsQ0FBQyxDQUFDO1FBRWhDLFFBQVEsTUFBTSxDQUFDLE9BQU8sRUFBRSxDQUFDO1lBQ3ZCLEtBQUssV0FBVztnQkFDZCxPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssU0FBUztnQkFDWixPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssT0FBTztnQkFDVixPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssU0FBUztnQkFDWixPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssVUFBVTtnQkFDYixPQUFPLEVBQUUsQ0FBQztZQUNaO2dCQUNFLE9BQU8sQ0FBQyxDQUFDO1FBQ2IsQ0FBQztJQUNILENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztZQUFTLENBQUM7UUFDVCx3R0FBd0c7UUFDeEcsMEdBQTBHO1FBQzFHLHVHQUF1RztRQUN2Ryx3R0FBd0c7UUFDeEcseUdBQXlHO1FBQ3pHLCtGQUErRjtRQUMvRixJQUFJLGNBQWMsRUFBRSxFQUFFLEVBQUUsQ0FBQztZQUN2QixNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsc0JBQXNCLElBQUksc0JBQXNCLENBQUM7WUFDakYsTUFBTSxlQUFlLENBQUMsY0FBYyxDQUFDLFFBQVEsRUFBRSxjQUFjLENBQUMsWUFBWSxFQUFFLGNBQWMsQ0FBQyxTQUFTLElBQUksSUFBSSxDQUFDLENBQUM7UUFDaEgsQ0FBQztRQUNELCtGQUErRjtRQUMvRixtR0FBbUc7UUFDbkcsOERBQThEO1FBQzlELElBQUksWUFBWSxJQUFJLFdBQVc7WUFBRSxXQUFXLENBQUMsWUFBWSxDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFdBQVcsQ0FBQyxDQUFDO1FBQ25HLDJHQUEyRztRQUMzRywwR0FBMEc7UUFDMUcsc0dBQXNHO1FBQ3RHLElBQUksWUFBWSxJQUFJLFdBQVcsSUFBSSx1QkFBdUIsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQ2hFLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxlQUFlLElBQUksZUFBZSxDQUFDO1lBQy9ELE1BQU0sV0FBVyxDQUFDLEVBQUUsR0FBRyxXQUFXLEVBQUUsTUFBTSxFQUFFLFVBQVUsRUFBRSxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztRQUNyRSxDQUFDO1FBQ0QsSUFBSSxVQUFVLElBQUksU0FBUztZQUFFLFNBQVMsQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLENBQUM7UUFDMUQsU0FBUyxFQUFFLEtBQUssRUFBRSxDQUFDO1FBQ25CLFdBQVcsRUFBRSxLQUFLLEVBQUUsQ0FBQztRQUNyQixXQUFXLEVBQUUsS0FBSyxFQUFFLENBQUM7UUFDckIsVUFBVSxFQUFFLEtBQUssRUFBRSxDQUFDO1FBQ3BCLGNBQWMsRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUMxQixDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -1,0 +1,822 @@
+// CLI dispatch for the real attempt pipeline (#5132, Wave 3.5 -- the final assembly). Wires bin/loopover-miner.js's
+// `attempt` subcommand to real infrastructure end to end: worktree allocation + real git preparation
+// (worktree-allocator.js + attempt-worktree.js), the four ledgers (claim/event/attempt-log/governor), the
+// real coding-agent driver (#5131) and slop assessor (#5133), a live SelfReviewContext fetch (#5145), a real
+// coding-task spec (#5239), the operator's AmsPolicySpec execution policy (#5249), rejectionSignaled (#5241),
+// a real runMinerAttempt call -- the first point in this epic where a real coding agent actually runs, not
+// just checks-and-reports-blocked -- and, only on a real "submitted" outcome, a real post-submission
+// claim-conflict resolution (#4848, claim-conflict-resolver.js) for the narrow race window
+// checkSubmissionFreshness cannot see (two miners submitting almost simultaneously).
+//
+// KNOWN, DOCUMENTED GAPS (not fabricated -- see attempt-input-builder.js's own header for the full list):
+// governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted (chokepoint.ts's own design treats
+// that as "skip that stage entirely"). governor.convergenceInput is now a real per-issue portfolio-queue.js read
+// (#5654) and governor.reputationHistory a real per-repo governor-state.js read (#5675), not placeholders.
+
+import type { CodingAgentExecutionMode, FeasibilityVerdict, LocalWriteActionSpec } from "@loopover/engine";
+import { fingerprintFromChangedFiles, resolveCodingAgentModeFromConfig, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { constructProductionCodingAgentDriver } from "./coding-agent-construction.js";
+import { runSlopAssessment } from "./slop-assessment.js";
+import { fetchLiveIssueSnapshot } from "./live-issue-snapshot.js";
+import { executeLocalWrite } from "./execute-local-write.js";
+import { openClaimLedger } from "./claim-ledger.js";
+import type { ClaimEntry, ClaimLedger } from "./claim-ledger.js";
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
+import { resolveClaimConflict } from "./claim-conflict-resolver.js";
+import type { ClaimConflictResult } from "./claim-conflict-resolver.js";
+import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
+import { initEventLedger } from "./event-ledger.js";
+import type { EventLedger } from "./event-ledger.js";
+import { initAttemptLog } from "./attempt-log.js";
+import type { AttemptLog } from "./attempt-log.js";
+import { initGovernorLedger } from "./governor-ledger.js";
+import type { GovernorLedger } from "./governor-ledger.js";
+import { openWorktreeAllocator } from "./worktree-allocator.js";
+import type { WorktreeAllocator } from "./worktree-allocator.js";
+import { isValidRepoSegment } from "./repo-clone.js";
+import { REJECTION_REASON_AI_USAGE_POLICY_BAN, REJECTION_REASON_OWN_SUBMISSION_REJECTED, resolveRejectionSignaled } from "./rejection-signal.js";
+import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
+import { fetchSelfReviewContext } from "./self-review-context.js";
+import type { SelfReviewContextFetch } from "./self-review-context.js";
+import { buildCodingTaskSpec } from "./coding-task-spec.js";
+import { resolveAmsPolicy } from "./ams-policy.js";
+import { checkMinerKillSwitch, recordMinerKillSwitchTransition } from "./governor-kill-switch.js";
+import { captureMinerError } from "./sentry.js";
+import { buildAttemptGovernorContext, buildAttemptLoopInput } from "./attempt-input-builder.js";
+import { getAttemptHistory } from "./portfolio-queue.js";
+import { loadReputationHistory, recordOwnSubmission } from "./governor-state.js";
+import { runMinerAttempt } from "./attempt-runner.js";
+import type { AttemptDeps, AttemptResult as RunMinerAttemptResult } from "./attempt-runner.js";
+import { resolveGitHubToken } from "./github-token-resolution.js";
+import { isDiscoveryPlaneEnabled, submitSoftClaim } from "./discovery-index-client.js";
+
+type CommonAttemptResultFields = {
+  repoFullName: string;
+  issueNumber: number;
+  minerLogin: string;
+  base: string;
+  mode: CodingAgentExecutionMode;
+  attemptId: string;
+};
+
+/** The result runAttempt reports at every real return point, threaded to `options.onResult` (in addition to
+ *  the plain exit-code return runAttempt itself still returns, unchanged, so bin/loopover-miner.js's own
+ *  `process.exit(exitCode)` usage never breaks) -- the loop orchestrator's real caller for this data. */
+export type AttemptCliResult =
+  | (CommonAttemptResultFields & { outcome: "dry_run" })
+  | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
+  | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
+  | (CommonAttemptResultFields & {
+      outcome: "blocked_infeasible";
+      reason: string;
+      verdict: FeasibilityVerdict;
+      avoidReasons: string[];
+      raiseReasons: string[];
+    })
+  | (CommonAttemptResultFields & {
+      outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
+      submissionMode: "observe" | "enforce";
+      totalTurnsUsed: number;
+      totalCostUsd: number;
+      totalTokensUsed: number;
+      iterationsUsed: number;
+      reason?: string;
+      decision?: unknown;
+      spec?: LocalWriteActionSpec;
+      execResult?: unknown;
+      claimConflict?: ClaimConflictResult;
+    });
+
+export type ParsedAttemptArgs =
+  | { error: string }
+  | {
+      repoFullName: string;
+      issueNumber: number;
+      minerLogin: string;
+      base: string;
+      live: boolean;
+      dryRun: boolean;
+      json: boolean;
+    };
+
+const ATTEMPT_USAGE =
+  "Usage: loopover-miner attempt <owner/repo> <issue#> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--json]";
+
+function parseRepoTarget(value: unknown): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
+  return `${owner}/${repo}`;
+}
+
+export function parseAttemptArgs(args: string[]): ParsedAttemptArgs {
+  const options = { json: false, minerLogin: null as string | null, base: "main", live: false, dryRun: false };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // Opt-in only: resolveCodingAgentModeFromConfig's own default (no agentDryRun override) is "live", not
+    // "dry_run" -- so #5132's "dry-run is default" acceptance criteria (#2342) has to be enforced HERE, by
+    // requiring an explicit --live flag before this command will ever request live mode.
+    if (token === "--live") {
+      options.live = true;
+      continue;
+    }
+    // #4847: distinct from --live's absence above -- --live only ever gated the coding-agent DRIVER's mode,
+    // but a non---live run still opened every store and made real worktree/claim/ledger writes. --dry-run
+    // short-circuits BEFORE any of that infrastructure is even opened, guaranteeing zero writes rather than
+    // merely skipping the driver.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--miner-login") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
+      options.minerLogin = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--base") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
+      options.base = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) return { error: ATTEMPT_USAGE };
+  const repoFullName = parseRepoTarget(positional[0]);
+  if (!repoFullName) return { error: `Repository must be in owner/repo form: ${positional[0]}` };
+  const issueNumber = Number(positional[1]);
+  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+    return { error: `Issue number must be a positive integer: ${positional[1]}` };
+  }
+  if (!options.minerLogin) return { error: `--miner-login is required. ${ATTEMPT_USAGE}` };
+
+  return {
+    repoFullName,
+    issueNumber,
+    minerLogin: options.minerLogin,
+    base: options.base,
+    live: options.live,
+    dryRun: options.dryRun,
+    json: options.json,
+  };
+}
+
+/**
+ * Assemble a real AttemptDeps object: every field wired to a genuine implementation (the #5131 driver, the
+ * #5133 slop assessor, the four real ledgers passed in, and the fetchLiveIssueSnapshot/executeLocalWrite
+ * built alongside this file). Throws if the coding-agent driver is unconfigured (fails closed, matching
+ * constructProductionCodingAgentDriver's own contract) -- callers should report that clearly rather than
+ * silently falling back to a driver that could never run.
+ */
+export function buildAttemptDeps(
+  env: Record<string, string | undefined>,
+  ledgers: { claimLedger: ClaimLedger; eventLedger: EventLedger; attemptLog: AttemptLog; governorLedger: GovernorLedger; nowMs: number },
+): AttemptDeps {
+  return {
+    driver: constructProductionCodingAgentDriver(env),
+    runSlopAssessment: (input) => runSlopAssessment(input as Parameters<typeof runSlopAssessment>[0]),
+    appendAttemptLogEvent: (event) => ledgers.attemptLog.appendAttemptLogEvent(event as Parameters<typeof ledgers.attemptLog.appendAttemptLogEvent>[0]),
+    claimLedger: ledgers.claimLedger,
+    // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+    // authenticated `loopover-mcp login` session -- cached in memory, so repeat calls within this process
+    // don't repeatedly hit the session-fetch endpoint after the first successful resolution.
+    fetchLiveIssueSnapshot: async (repoFullName, issueNumber) => fetchLiveIssueSnapshot(repoFullName, issueNumber, { githubToken: await resolveGitHubToken(env as NodeJS.ProcessEnv) } as Parameters<typeof fetchLiveIssueSnapshot>[2]),
+    eventLedger: ledgers.eventLedger,
+    governorLedgerAppend: (event) => ledgers.governorLedger.appendGovernorEvent(event as Parameters<typeof ledgers.governorLedger.appendGovernorEvent>[0]),
+    nowMs: ledgers.nowMs,
+    executeLocalWrite: (spec) => executeLocalWrite(spec),
+  } as AttemptDeps;
+}
+
+export type RunAttemptOptions = {
+  env?: Record<string, string | undefined>;
+  nowMs?: number;
+  attemptId?: string;
+  resolveCodingAgentModeFromConfig?: (config: { env?: Record<string, string | undefined> }) => CodingAgentExecutionMode;
+  openWorktreeAllocator?: () => WorktreeAllocator;
+  openClaimLedger?: () => ClaimLedger;
+  initEventLedger?: () => EventLedger;
+  initAttemptLog?: () => AttemptLog;
+  initGovernorLedger?: () => GovernorLedger;
+  buildAttemptDeps?: typeof buildAttemptDeps;
+  resolveRejectionSignaled?: typeof resolveRejectionSignaled;
+  fetchImpl?: SelfReviewContextFetch;
+  prepareAttemptWorktree?: typeof prepareAttemptWorktree;
+  cleanupAttemptWorktree?: typeof cleanupAttemptWorktree;
+  fetchSelfReviewContext?: typeof fetchSelfReviewContext;
+  buildCodingTaskSpec?: typeof buildCodingTaskSpec;
+  resolveAmsPolicy?: typeof resolveAmsPolicy;
+  checkMinerKillSwitch?: typeof checkMinerKillSwitch;
+  resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
+  runMinerAttempt?: typeof runMinerAttempt;
+  resolveClaimConflict?: typeof resolveClaimConflict;
+  recordOwnSubmission?: typeof recordOwnSubmission;
+  getAttemptHistory?: typeof getAttemptHistory;
+  /** Hosted soft-claim coordination at work-start/work-end, when the plane is enabled (#7168). Defaults to
+   *  discovery-index-client.js's own submitSoftClaim. */
+  submitSoftClaim?: typeof submitSoftClaim;
+  /** Invoked with the real structured result at every return point, in addition to (never instead of) the
+   *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
+  onResult?: (result: AttemptCliResult) => void;
+};
+
+/**
+ * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
+ * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
+ * SelfReviewContext -> build a real coding-task spec (blocks on an infeasible verdict) -> resolve the real
+ * AmsPolicySpec execution policy -> assemble the real IterateLoopInput + Governor context -> call
+ * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) in `finally`.
+ * See this file's header for the documented gaps (real convergence history).
+ */
+export async function runAttempt(args: string[], options: RunAttemptOptions = {}): Promise<number> {
+  const parsed = parseAttemptArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  const env = options.env ?? process.env;
+  const nowMs = options.nowMs ?? Date.now();
+  const resolveMode = options.resolveCodingAgentModeFromConfig ?? resolveCodingAgentModeFromConfig;
+  const mode = resolveMode({ env, agentDryRun: !parsed.live });
+
+  if (mode === "paused") {
+    return reportCliFailure(
+      parsed.json,
+      `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`,
+      3,
+    );
+  }
+
+  const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
+
+  // #4847: reports what a real run would do and returns BEFORE any store (allocator/claim/event/attempt-log/
+  // governor ledger) is even opened, so this is a provable zero-write path -- not just "opened but didn't
+  // write to" the local stores, and nowhere near the real worktree clone, claim, or coding-agent driver.
+  if (parsed.dryRun) {
+    const dryRunResult: AttemptCliResult = {
+      outcome: "dry_run",
+      repoFullName: parsed.repoFullName,
+      issueNumber: parsed.issueNumber,
+      minerLogin: parsed.minerLogin,
+      base: parsed.base,
+      mode,
+      attemptId,
+    };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(
+        `DRY RUN: would attempt ${parsed.repoFullName}#${parsed.issueNumber} for ${parsed.minerLogin} (mode: ${mode}, base: ${parsed.base}). No worktree, claim, or ledger writes were made.`,
+      );
+    }
+    options.onResult?.(dryRunResult);
+    return 0;
+  }
+
+  let allocator: WorktreeAllocator | null = null;
+  let claimLedger: ClaimLedger | null = null;
+  let eventLedger: EventLedger | null = null;
+  let attemptLog: AttemptLog | null = null;
+  let governorLedger: GovernorLedger | null = null;
+  let allocation: ReturnType<WorktreeAllocator["acquire"]> | null = null;
+  // `attemptOk` is stamped onto the ok-result at runtime (set to the real runMinerAttempt outcome, or `false`
+  // when it throws) and read back in `finally` -- the declared PrepareAttemptWorktreeResult carries no such
+  // field, so widen the local accumulator to allow the mutation without changing any runtime behavior.
+  let worktreeResult:
+    | (Awaited<ReturnType<typeof prepareAttemptWorktree>> & { attemptOk?: boolean })
+    | null = null;
+  let claimedIssue = false;
+  let claimRecord: ClaimEntry | null = null;
+
+  try {
+    allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
+    claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+    eventLedger = (options.initEventLedger ?? initEventLedger)();
+    attemptLog = (options.initAttemptLog ?? initAttemptLog)();
+    governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+
+    // Checked before acquiring a worktree slot: a rejection-signaled repo should never consume one.
+    // resolveRejectionSignaled resolves both documented triggers (#5132 policy ban, #5655 own-rejection
+    // history) and returns a trigger-specific reason string for accurate audit-trail labeling.
+    const resolveRejection = options.resolveRejectionSignaled ?? resolveRejectionSignaled;
+    const rejectionSignal = await resolveRejection(parsed.repoFullName, { fetchImpl: options.fetchImpl } as Parameters<typeof resolveRejection>[1]);
+    if (rejectionSignal) {
+      const reason =
+        rejectionSignal === true ? REJECTION_REASON_AI_USAGE_POLICY_BAN : rejectionSignal;
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const rejectedResult: AttemptCliResult = {
+        outcome: "blocked_rejection_signaled",
+        reason,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(rejectedResult, null, 2));
+      } else {
+        console.error(
+          reason === REJECTION_REASON_OWN_SUBMISSION_REJECTED
+            ? `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this miner was previously rejected on this repo.`
+            : `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's AI-usage policy bans automated/AI-authored contributions.`,
+        );
+      }
+      options.onResult?.(rejectedResult);
+      return 5;
+    }
+
+    allocation = allocator.acquire(attemptId, parsed.repoFullName);
+
+    let deps: AttemptDeps;
+    try {
+      const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
+      deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
+    } catch (error) {
+      const reason = describeCliError(error);
+      return reportCliFailure(
+        parsed.json,
+        `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`,
+        3,
+      );
+    }
+
+    // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
+    // reserves a concurrency SLOT (worktree-allocator.js's own `slot-N` placeholder dirs never receive real
+    // git content) -- this is the step that actually clones/fetches the target repo and creates a real
+    // `git worktree` for this attempt. Its own path, NOT the allocator's slot path, is the real
+    // workingDirectory a future runMinerAttempt call must use.
+    const prepareWorktree = options.prepareAttemptWorktree ?? prepareAttemptWorktree;
+    worktreeResult = await prepareWorktree(parsed.repoFullName, attemptId, { baseBranch: parsed.base, env });
+    if (!worktreeResult.ok) {
+      const reason = worktreeResult.error;
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const worktreeFailureResult: AttemptCliResult = {
+        outcome: "blocked_worktree_preparation_failed",
+        reason,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(worktreeFailureResult, null, 2));
+      } else {
+        console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: real worktree preparation failed: ${reason}`);
+      }
+      options.onResult?.(worktreeFailureResult);
+      return 6;
+    }
+
+    // Real SelfReviewContext (#5145): issue/PR/manifest data at live-gate fidelity for the target repo.
+    const fetchReviewContext = options.fetchSelfReviewContext ?? fetchSelfReviewContext;
+    const reviewContext = await fetchReviewContext(parsed.repoFullName, {
+      githubToken: await resolveGitHubToken(env as NodeJS.ProcessEnv),
+      contributorLogin: parsed.minerLogin,
+      linkedIssues: [parsed.issueNumber],
+    } as Parameters<typeof fetchReviewContext>[1]);
+
+    // The target issue's own real record, when present in the fetched context. When absent (e.g. already
+    // closed, or genuinely not found), buildCodingTaskSpec's own feasibility check reports target_not_found
+    // and this placeholder's empty title/body are never surfaced anywhere -- not fabricated content, just an
+    // inert shape for a verdict that immediately blocks.
+    const targetIssue = reviewContext.issues.find((candidate) => candidate.number === parsed.issueNumber) ?? {
+      number: parsed.issueNumber,
+      title: "",
+      body: null,
+      labels: [],
+    };
+
+    const buildTaskSpec = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
+    const codingTaskSpec = buildTaskSpec({
+      repoFullName: parsed.repoFullName,
+      issue: targetIssue,
+      context: { issues: reviewContext.issues, pullRequests: reviewContext.pullRequests },
+      claimLedger,
+      workingDirectory: worktreeResult.worktreePath,
+    } as Parameters<typeof buildTaskSpec>[0]);
+
+    if (!codingTaskSpec.ready) {
+      const reason = `infeasible_${codingTaskSpec.verdict}`;
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, feasibility: codingTaskSpec.feasibility },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const infeasibleResult: AttemptCliResult = {
+        outcome: "blocked_infeasible",
+        reason,
+        verdict: codingTaskSpec.verdict,
+        avoidReasons: codingTaskSpec.feasibility.avoidReasons as string[],
+        raiseReasons: codingTaskSpec.feasibility.raiseReasons as string[],
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(infeasibleResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: feasibility verdict "${codingTaskSpec.verdict}" (${[...codingTaskSpec.feasibility.avoidReasons, ...codingTaskSpec.feasibility.raiseReasons].join(", ")}).`,
+        );
+      }
+      options.onResult?.(infeasibleResult);
+      return 4;
+    }
+
+    const amsPolicy = await (options.resolveAmsPolicy ?? resolveAmsPolicy)(parsed.repoFullName, { env });
+
+    // Real per-repo pause (#5392): read straight from the already-cloned worktree's own .loopover-miner.yml
+    // (resolveMinerGoalSpec never throws -- a missing/malformed file degrades to killSwitch.paused: false, so
+    // this can't fail this attempt on its own). Threaded into BOTH checkMinerKillSwitch (killSwitchScope, used
+    // by the freshness/submission gate) and the governor context (killSwitchRepoPaused, used by the Governor
+    // chokepoint) -- the same two places the GLOBAL kill switch already reaches.
+    const resolveGoalSpec = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+    const minerGoalSpec = resolveGoalSpec(worktreeResult.repoPath);
+    const repoPaused = minerGoalSpec.spec.killSwitch.paused;
+
+    const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
+    const recordKillTransition =
+      (options as { recordMinerKillSwitchTransition?: typeof recordMinerKillSwitchTransition }).recordMinerKillSwitchTransition ??
+      recordMinerKillSwitchTransition;
+    let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
+    let previousKillSwitchScope = killSwitchScope;
+
+    const resolveLiveKillSwitch = () => {
+      // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
+      const liveRepoPaused = resolveGoalSpec((worktreeResult as { repoPath: string }).repoPath).spec.killSwitch.paused;
+      const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
+      if (live.scope !== previousKillSwitchScope) {
+        try {
+          recordKillTransition({
+            repoFullName: parsed.repoFullName,
+            actionClass: "attempt",
+            previousScope: previousKillSwitchScope,
+            scope: live.scope,
+          });
+        } catch (error) {
+          // Ledger append must never crash an aborting attempt (kept), but was previously silent -- a
+          // kill-switch flip mid-attempt (a compliance-relevant event) could vanish with no record (#6011).
+          captureMinerError(error, { kind: "kill_switch_transition_record_failed", repoFullName: parsed.repoFullName, scope: live.scope });
+        }
+        previousKillSwitchScope = live.scope;
+      }
+      killSwitchScope = live.scope;
+      return live;
+    };
+
+    const shouldAbort = () => {
+      const live = resolveLiveKillSwitch();
+      if (!live.active) return false;
+      return {
+        abort: true,
+        reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
+      };
+    };
+
+    const loopInput = buildAttemptLoopInput({
+      codingTaskSpec,
+      reviewContext,
+      worktreePath: worktreeResult.worktreePath,
+      attemptId,
+      mode,
+      repoFullName: parsed.repoFullName,
+      minerLogin: parsed.minerLogin,
+      rejectionSignaled: false,
+      amsPolicySpec: amsPolicy.spec,
+      branchRef: worktreeResult.branchName,
+    });
+
+    // Real per-issue attempt history (#5654): portfolio-queue.js's own claim/reclaim/requeue/done counters,
+    // keyed the same way opportunity-fanout.js enqueues issue-shaped candidates (`issue:<number>`). No
+    // apiBaseUrl: this file has no multi-forge host context of its own today, so this reads (and every
+    // pre-#5563 single-forge caller already reads) the github.com default.
+    const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
+    const convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
+    // Real per-repo reputation history (#5675): the miner's own decided/unfavorable outcome streak for this repo,
+    // read from governor-state.js so the chokepoint's self-reputation throttle sees real data instead of nothing.
+    const readReputationHistory =
+      (options as { loadReputationHistory?: typeof loadReputationHistory }).loadReputationHistory ?? loadReputationHistory;
+    const reputationHistory = readReputationHistory(parsed.repoFullName);
+    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
+
+    // Real maxConcurrentClaims enforcement (#6758): the repo's .loopover-miner.yml cap is honored ATOMICALLY by
+    // the ledger's count-and-claim, not by a listActiveClaims pre-check here. The old check-then-act split -- read
+    // the count in this file, then record the claim in a separate claimLedger call -- let two sibling miner
+    // processes racing the same repo both pass a stale sub-cap count and both claim, exceeding the cap.
+    // claimIssueWithinCap fuses the count and the insert into one transaction; the loser gets `claimed: false`
+    // and is reported below rather than silently dropped. This is also the real soft-claim (#5393): once it
+    // returns claimed, a sibling process sees it via claimLedger.listActiveClaims while this attempt is in
+    // flight, it is released in `finally` on every terminal outcome (mirroring the worktree allocation slot's
+    // acquire-then-always-release), and its claimedAt feeds the post-submission conflict check further down (#4848).
+    const claimResult = claimLedger.claimIssueWithinCap(
+      parsed.repoFullName,
+      parsed.issueNumber,
+      `attempt:${attemptId}`,
+      undefined,
+      minerGoalSpec.spec.maxConcurrentClaims,
+    );
+    if (!claimResult.claimed) {
+      const reason = "max_concurrent_claims_exceeded";
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: {
+          repoFullName: parsed.repoFullName,
+          issueNumber: parsed.issueNumber,
+          maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+          activeClaimCount: claimResult.activeClaimCount,
+        },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const blockedResult: AttemptCliResult = {
+        outcome: "blocked_max_concurrent_claims",
+        reason,
+        maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+        activeClaimCount: claimResult.activeClaimCount,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      } as unknown as AttemptCliResult;
+      if (parsed.json) {
+        console.log(JSON.stringify(blockedResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${claimResult.activeClaimCount} active claim(s)).`,
+        );
+      }
+      options.onResult?.(blockedResult);
+      return 11;
+    }
+
+    claimRecord = claimResult.claim;
+    claimedIssue = true;
+    // Hosted soft-claim coordination (#7168), opt-in via LOOPOVER_MINER_DISCOVERY_PLANE -- gated HERE at the
+    // call site (not left to submitSoftClaim's own internal check alone) so a disabled plane costs zero calls,
+    // matching discover-cli.js's supplementWithDiscoveryIndex gating; a caller-injected options.submitSoftClaim
+    // (tests, or a future programmatic caller) can't accidentally bypass the opt-in this way either. Awaited
+    // (not fire-and-forget) so a sibling instance racing the same issue is genuinely less likely to start
+    // duplicate work in the window before this attempt's claim reaches the shared index -- the whole point of
+    // coordinating BEFORE work begins, not after.
+    if (isDiscoveryPlaneEnabled(env)) {
+      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+      await submitClaim(claimRecord, { env });
+    }
+
+    const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
+    let result: RunMinerAttemptResult;
+    try {
+      result = await runAttemptPipeline(
+        {
+          loopInput,
+          issueNumber: parsed.issueNumber,
+          minerLogin: parsed.minerLogin,
+          base: parsed.base,
+          killSwitchScope,
+          slopThreshold: amsPolicy.spec.slopThreshold,
+          submissionMode: amsPolicy.spec.submissionMode,
+          governor,
+        },
+        {
+          ...deps,
+          shouldAbort,
+          resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
+        },
+      );
+    } catch (error) {
+      // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
+      // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
+      // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
+      // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
+      worktreeResult.attemptOk = false;
+      throw error;
+    }
+
+    worktreeResult.attemptOk = result.outcome === "submitted";
+
+    // Real claim-conflict resolution (#4848): only meaningful once a real PR exists, so this only ever runs
+    // on a real "submitted" outcome. checkSubmissionFreshness (inside runMinerAttempt) already caught the
+    // common pre-submission case; this closes the narrower TOCTOU window where two miners raced past that
+    // check almost simultaneously -- see claim-conflict-resolver.js's own header for why the adjudicator
+    // can only run POST-submission (it needs a real PR number on both sides of the election).
+    let claimConflict: ClaimConflictResult | undefined;
+    if (result.outcome === "submitted") {
+      const selfPrNumber = parsePrNumberFromExecResult(result.execResult as Parameters<typeof parsePrNumberFromExecResult>[0], parsed.repoFullName);
+      if (selfPrNumber !== null) {
+        const resolveConflict = options.resolveClaimConflict ?? resolveClaimConflict;
+        claimConflict = await resolveConflict(
+          {
+            repoFullName: parsed.repoFullName,
+            issueNumber: parsed.issueNumber,
+            selfPrNumber,
+            selfClaimedAt: claimRecord.claimedAt,
+            minerLogin: parsed.minerLogin,
+          },
+          { fetchLiveIssueSnapshot: deps.fetchLiveIssueSnapshot, executeLocalWrite: deps.executeLocalWrite },
+        );
+      }
+
+      // Real own-submission history (#5655 follow-up): governor-state.js's recordOwnSubmission/
+      // listRecentOwnSubmissions store (#5134) existed and was already READ by resolveOwnRejectionHistory
+      // (#5655), but nothing ever WROTE to it -- attempt-runner.js's own header names this exact gap
+      // ("real persistence primitives... but isn't auto-loaded here yet"). Left unfixed, that trigger is a
+      // silent no-op in every real deployment: an empty table always resolves "no prior submissions found."
+      // The fingerprint is the real changed-files set from the loop's own handoff packet (never fabricated) --
+      // omitted (not recorded as an empty placeholder) when the packet reports no changed files at all. A
+      // logging failure must never fail an otherwise-successful attempt, matching the summary-event write below.
+      const changedFiles = result.loopResult.handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
+      const fingerprint = fingerprintFromChangedFiles(changedFiles);
+      if (fingerprint) {
+        try {
+          const record = options.recordOwnSubmission ?? recordOwnSubmission;
+          record({
+            repoFullName: parsed.repoFullName,
+            fingerprint,
+            submittedAt: new Date(nowMs).toISOString(),
+            pullRequestNumber: selfPrNumber,
+            issueNumber: parsed.issueNumber,
+          });
+        } catch (error) {
+          // A logging failure must never fail an otherwise-successful attempt (kept), but was previously
+          // silent -- if this write fails AFTER a real PR has already opened, future self-plagiarism checks go
+          // permanently blind to this exact submission with nobody told (#6011).
+          captureMinerError(error, { kind: "record_own_submission_failed", repoFullName: parsed.repoFullName, pullRequestNumber: selfPrNumber });
+        }
+      }
+    }
+
+    const finalResult: Extract<AttemptCliResult, { outcome: `attempt_${string}` }> = {
+      outcome: `attempt_${result.outcome}`,
+      repoFullName: parsed.repoFullName,
+      issueNumber: parsed.issueNumber,
+      minerLogin: parsed.minerLogin,
+      base: parsed.base,
+      mode,
+      attemptId,
+      submissionMode: amsPolicy.spec.submissionMode,
+      // Every runMinerAttempt outcome carries a real loopResult (#5135's loop needs its genuine turn-usage and
+      // cost to save real GovernorCapUsage via governor-state.js's saveCapUsage -- nothing else in the codebase
+      // calls it yet). Surfaced flat rather than the whole loopResult object, matching this result's own
+      // shallow shape. costUsd is real only for the agent-sdk provider (its own SDK result message reports
+      // total_cost_usd); CLI-subprocess providers (claude-cli/codex-cli) report no cost signal today, so this
+      // is 0 for those -- an honest absence, not a fabricated number.
+      totalTurnsUsed: result.loopResult.totalTurnsUsed,
+      totalCostUsd: result.loopResult.totalCostUsd,
+      // Real accumulated tokens (#5653) -- read from finalMeterTotals rather than a flat totalTokensUsed field
+      // (IterateLoopResult has no such flat field, unlike turns/cost). 0 when no driver reported a token signal
+      // on any iteration this attempt ran, never fabricated.
+      totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
+      iterationsUsed: result.loopResult.iterationsUsed,
+      ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
+        ? { abandonReason: result.loopResult.finalDecision.abandonReason }
+        : {}),
+      ...("reason" in result ? { reason: result.reason } : {}),
+      ...("decision" in result ? { decision: result.decision } : {}),
+      ...("spec" in result ? { spec: result.spec } : {}),
+      ...("execResult" in result ? { execResult: result.execResult } : {}),
+      // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
+      // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
+      // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).
+      ...(claimConflict !== undefined ? { claimConflict } : {}),
+    } as Extract<AttemptCliResult, { outcome: `attempt_${string}` }>;
+
+    // One summary row per completed attempt (#5185), for the Grafana per-provider usage dashboard the redacted
+    // AMS reporting export exposes -- distinct from the per-iteration attempt_started/attempt_tool_edit/... trail
+    // iterate-loop.ts already writes. No fallback for an unconfigured provider: buildAttemptDeps already fails
+    // closed (throws) on the same env before a worktree is even allocated, so reaching this point guarantees
+    // resolveFirstConfiguredCodingAgentDriverName(env) resolves a real name. costUsd/tokensUsed are both real,
+    // driver-reported accumulated totals (#5653) -- 0 when no iteration's driver reported a signal, never
+    // fabricated. A logging failure must never fail an otherwise-successful attempt -- mirrors iterate-loop.ts's
+    // own safeAppendAttemptLogEvent non-fatal handling.
+    try {
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_outcome_summary",
+        attemptId,
+        actionClass: finalResult.outcome,
+        mode,
+        reason: `attempt finished with outcome: ${result.outcome}`,
+        provider: resolveFirstConfiguredCodingAgentDriverName(env),
+        costUsd: finalResult.totalCostUsd,
+        tokensUsed: finalResult.totalTokensUsed,
+      });
+    } catch (error) {
+      // A logging failure must never fail an otherwise-successful attempt (kept), but was previously silent --
+      // per docs/observability.md this row feeds the Grafana per-provider cost/usage dashboard, so a failure
+      // here silently drops the attempt from operator-facing metrics with nobody told (#6011).
+      captureMinerError(error, { kind: "attempt_outcome_summary_append_failed", attemptId, repoFullName: parsed.repoFullName });
+    }
+
+    if (parsed.json) {
+      console.log(JSON.stringify(finalResult, null, 2));
+    } else {
+      console.log(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} finished with outcome: ${result.outcome}.`);
+    }
+    options.onResult?.(finalResult);
+
+    switch (result.outcome) {
+      case "submitted":
+        return 0;
+      case "abandon":
+        return 7;
+      case "stale":
+        return 8;
+      case "blocked":
+        return 9;
+      case "governed":
+        return 10;
+      default:
+        return 2;
+    }
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
+    // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
+    // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
+    // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
+    // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
+    // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
+    if (worktreeResult?.ok) {
+      const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;
+      await cleanupWorktree(worktreeResult.repoPath, worktreeResult.worktreePath, worktreeResult.attemptOk ?? true);
+    }
+    // Every terminal outcome past the claim point (submitted/abandon/stale/blocked/governed, or an
+    // unexpected throw) releases the soft-claim -- a claim that outlives its own attempt process would
+    // wrongly tell a sibling miner this issue is still in flight.
+    if (claimedIssue && claimLedger) claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
+    // Paired hosted release (#7168): same call-site opt-in gate as the claim submission above. Only fires when
+    // the initial claim submission actually ran (claimRecord is only set once claimedIssue is), so a run that
+    // never reached the claim point (e.g. blocked_max_concurrent_claims) has nothing to release remotely.
+    if (claimedIssue && claimRecord && isDiscoveryPlaneEnabled(env)) {
+      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+      await submitClaim({ ...claimRecord, status: "released" }, { env });
+    }
+    if (allocation && allocator) allocator.release(attemptId);
+    allocator?.close();
+    claimLedger?.close();
+    eventLedger?.close();
+    attemptLog?.close();
+    governorLedger?.close();
+  }
+}

--- a/packages/loopover-miner/lib/discover-cli.d.ts
+++ b/packages/loopover-miner/lib/discover-cli.d.ts
@@ -1,135 +1,110 @@
-import type { ForgeConfig } from "./forge-config.js";
-import type {
-  CandidateIssueWarning,
-  FanoutOptions,
-  FanoutTarget,
-  RawCandidateIssue,
-} from "./opportunity-fanout.js";
-import type {
-  RankCandidateIssuesOptions,
-  RankedCandidateIssue,
-  RankedCandidateSummary,
-} from "./opportunity-ranker.js";
+import type { CandidateIssueWarning, FanoutOptions, FanoutTarget, RawCandidateIssue } from "./opportunity-fanout.js";
+import type { RankCandidateIssuesOptions, RankedCandidateIssue, RankedCandidateSummary } from "./opportunity-ranker.js";
 import type { PolicyDocCacheStore } from "./policy-doc-cache.js";
 import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
 import type { EnqueueRankedDiscoverySummary } from "./portfolio-discovery.js";
 import type { PortfolioQueueStore } from "./portfolio-queue.js";
 import type { RankedCandidatesStore } from "./ranked-candidates.js";
-import type { queryDiscoveryIndex } from "./discovery-index-client.js";
-
-export type ParsedDiscoverArgs =
-  | {
-      targets: FanoutTarget[];
-      search: string | null;
-      dryRun: boolean;
-      json: boolean;
-      /** Present only when `--api-base-url` is supplied (#4784); threads the tenant's forge host to the fan-out. */
-      apiBaseUrl?: string;
-      /** Present only when `--token-env` is supplied (#4784); names the credential env var to read. */
-      tokenEnv?: string;
-    }
-  | { error: string };
-
+import { extractContributionProfile } from "./contribution-profile-extract.js";
+import { initContributionProfileCache } from "./contribution-profile-cache.js";
+import { queryDiscoveryIndex } from "./discovery-index-client.js";
+import type { ForgeConfig } from "./forge-config.js";
+export type ParsedDiscoverArgs = {
+    targets: FanoutTarget[];
+    search: string | null;
+    dryRun: boolean;
+    json: boolean;
+    /** Present only when `--api-base-url` is supplied (#4784); threads the tenant's forge host to the fan-out. */
+    apiBaseUrl?: string;
+    /** Present only when `--token-env` is supplied (#4784); names the credential env var to read. */
+    tokenEnv?: string;
+} | {
+    error: string;
+};
 /** The subset of `CandidateIssueSummary` runDiscover actually reads. It surfaces the rate-limit telemetry (#4837),
  * so a fake must supply it. A real `fetchCandidateIssuesWithSummary` result satisfies this, since it is a superset. */
 export type DiscoverFanOutSummary = {
-  issues: RawCandidateIssue[];
-  warnings: CandidateIssueWarning[];
-  rateLimitRemaining: number | null;
-  rateLimitResetAt: string | null;
+    issues: RawCandidateIssue[];
+    warnings: CandidateIssueWarning[];
+    rateLimitRemaining: number | null;
+    rateLimitResetAt: string | null;
 };
-
 /** The subset of a ranked entry that `renderDiscoverSummary` reads for its top-candidates listing. */
-export type DiscoverRankedEntry = Pick<
-  RankedCandidateIssue,
-  "repoFullName" | "issueNumber" | "title" | "rankScore"
->;
-
+export type DiscoverRankedEntry = Pick<RankedCandidateIssue, "repoFullName" | "issueNumber" | "title" | "rankScore">;
 export type DiscoverResult = {
-  fanOutCount: number;
-  warnings: CandidateIssueWarning[];
-  rateLimitRemaining: number | null;
-  rateLimitResetAt: string | null;
-  ranked: DiscoverRankedEntry[];
-  /** Candidates the eligibility filter dropped, each with the repo/issue and the reason (#6798). */
-  excluded?: Array<{
-    repoFullName: string;
-    issueNumber: number;
-    reason: string;
-  }>;
-  /** True when ranking fell back to the built-in default goal spec because no per-tenant spec was supplied (#4784). */
-  usedDefaultGoalSpec?: boolean;
-  enqueueSummary: EnqueueRankedDiscoverySummary;
+    fanOutCount: number;
+    warnings: CandidateIssueWarning[];
+    rateLimitRemaining: number | null;
+    rateLimitResetAt: string | null;
+    ranked: DiscoverRankedEntry[];
+    /** Candidates the eligibility filter dropped, each with the repo/issue and the reason (#6798). */
+    excluded?: Array<{
+        repoFullName: string;
+        issueNumber: number;
+        reason: string;
+    }>;
+    /** True when ranking fell back to the built-in default goal spec because no per-tenant spec was supplied (#4784). */
+    usedDefaultGoalSpec?: boolean;
+    enqueueSummary: EnqueueRankedDiscoverySummary;
 };
-
 export type RunDiscoverOptions = {
-  /** Read for the discovery-index opt-in gate (#7168) -- defaults to `process.env`. */
-  env?: Record<string, string | undefined>;
-  githubToken?: string;
-  apiBaseUrl?: string;
-  /** Per-tenant credential env var name (#4784); defaults to GITHUB_TOKEN. Overridden by a `--token-env` flag. */
-  tokenEnv?: string;
-  /** Per-tenant forge knobs beyond the host (#4784), forwarded to the fan-out. */
-  forge?: Partial<ForgeConfig>;
-  nowMs?: number;
-  /** Per-tenant goal specs threaded to the ranker so lane fit uses the tenant's conventions, not the defaults (#4784). */
-  goalSpecsByRepo?: RankCandidateIssuesOptions["goalSpecsByRepo"];
-  goalSpecContentByRepo?: RankCandidateIssuesOptions["goalSpecContentByRepo"];
-  initPortfolioQueue?: () => PortfolioQueueStore;
-  initPolicyDocCache?: () => PolicyDocCacheStore;
-  initPolicyVerdictCache?: () => PolicyVerdictCacheStore;
-  initRankedCandidatesStore?: () => RankedCandidatesStore;
-  fetchCandidateIssuesWithSummary?: (
-    targets: FanoutTarget[],
-    githubToken: string,
-    options?: FanoutOptions,
-  ) => Promise<DiscoverFanOutSummary>;
-  searchCandidateIssuesWithSummary?: (
-    searchQuery: string,
-    githubToken: string,
-    options?: FanoutOptions,
-  ) => Promise<DiscoverFanOutSummary>;
-  rankCandidateIssuesWithSummary?: (
-    candidates: RawCandidateIssue[],
-    options?: RankCandidateIssuesOptions,
-  ) => RankedCandidateSummary;
-  enqueueRankedDiscovery?: (
-    rankedIssues: RankedCandidateIssue[],
-    options: { queueStore: PortfolioQueueStore },
-  ) => EnqueueRankedDiscoverySummary;
-  /** Supplements the local fan-out with hosted discovery-index results for the same scope, when the plane is
-   *  enabled (#7168). Defaults to discovery-index-client.js's own queryDiscoveryIndex. */
-  queryDiscoveryIndex?: typeof queryDiscoveryIndex;
-  /** Invoked with the real structured result at each success return point (dry-run and full-run), in addition
-   *  to (never instead of) the plain exit-code return -- mirrors `RunAttemptOptions.onResult`. Never fires on a
-   *  parse-error/unexpected-error `reportCliFailure` branch, matching runAttempt's own asymmetry (#6522). */
-  onResult?: (result: DiscoverResult) => void;
-  /** Resolve each candidate repo's ContributionProfile for eligibility filtering (#6798). Defaults to
-   *  resolveContributionProfilesForDiscover; injectable so tests avoid the network. */
-  resolveContributionProfiles?: (
-    repoFullNames: string[],
-    ctx: { githubToken?: string; apiBaseUrl?: string; nowMs?: number },
-  ) => Promise<Map<string, unknown>>;
+    /** Read for the discovery-index opt-in gate (#7168) -- defaults to `process.env`. */
+    env?: Record<string, string | undefined>;
+    githubToken?: string;
+    apiBaseUrl?: string;
+    /** Per-tenant credential env var name (#4784); defaults to GITHUB_TOKEN. Overridden by a `--token-env` flag. */
+    tokenEnv?: string;
+    /** Per-tenant forge knobs beyond the host (#4784), forwarded to the fan-out. */
+    forge?: Partial<ForgeConfig>;
+    nowMs?: number;
+    /** Per-tenant goal specs threaded to the ranker so lane fit uses the tenant's conventions, not the defaults (#4784). */
+    goalSpecsByRepo?: RankCandidateIssuesOptions["goalSpecsByRepo"];
+    goalSpecContentByRepo?: RankCandidateIssuesOptions["goalSpecContentByRepo"];
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initPolicyDocCache?: () => PolicyDocCacheStore;
+    initPolicyVerdictCache?: () => PolicyVerdictCacheStore;
+    initRankedCandidatesStore?: () => RankedCandidatesStore;
+    fetchCandidateIssuesWithSummary?: (targets: FanoutTarget[], githubToken: string, options?: FanoutOptions) => Promise<DiscoverFanOutSummary>;
+    searchCandidateIssuesWithSummary?: (searchQuery: string, githubToken: string, options?: FanoutOptions) => Promise<DiscoverFanOutSummary>;
+    rankCandidateIssuesWithSummary?: (candidates: RawCandidateIssue[], options?: RankCandidateIssuesOptions) => RankedCandidateSummary;
+    enqueueRankedDiscovery?: (rankedIssues: RankedCandidateIssue[], options: {
+        queueStore: PortfolioQueueStore;
+    }) => EnqueueRankedDiscoverySummary;
+    /** Supplements the local fan-out with hosted discovery-index results for the same scope, when the plane is
+     *  enabled (#7168). Defaults to discovery-index-client.js's own queryDiscoveryIndex. */
+    queryDiscoveryIndex?: typeof queryDiscoveryIndex;
+    /** Invoked with the real structured result at each success return point (dry-run and full-run), in addition
+     *  to (never instead of) the plain exit-code return -- mirrors `RunAttemptOptions.onResult`. Never fires on a
+     *  parse-error/unexpected-error `reportCliFailure` branch, matching runAttempt's own asymmetry (#6522). */
+    onResult?: (result: DiscoverResult) => void;
+    /** Resolve each candidate repo's ContributionProfile for eligibility filtering (#6798). Defaults to
+     *  resolveContributionProfilesForDiscover; injectable so tests avoid the network. */
+    resolveContributionProfiles?: (repoFullNames: string[], ctx: {
+        githubToken?: string;
+        apiBaseUrl?: string;
+        nowMs?: number;
+    }) => Promise<Map<string, unknown>>;
 };
-
-export function resolveContributionProfilesForDiscover(
-  repoFullNames: string[],
-  ctx?: {
+export declare function sanitizeDiscoverDisplayText(value: unknown): string;
+export declare function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs;
+export declare function renderDiscoverSummary(result: DiscoverResult): string;
+/**
+ * Default per-repo ContributionProfile resolver (#6798): reads the local cache and, on a miss/stale entry,
+ * extracts a fresh profile and caches it. Returns a Map keyed by repoFullName.
+ *
+ * WITHOUT a github token this returns an empty map and does no network work at all — AMS can't reliably read a
+ * repo's label taxonomy/docs unauthenticated (rate limits), so it safe-defaults to no eligibility filtering.
+ * That also keeps callers that don't supply a token (the common CLI path, and every test) hermetic.
+ *
+ * @param {string[]} repoFullNames unique repos among the fanned-out candidates
+ * @param {{ githubToken?: string, apiBaseUrl?: string, nowMs?: number, initCache?: typeof initContributionProfileCache, extract?: typeof extractContributionProfile }} ctx
+ * @returns {Promise<Map<string, object>>}
+ */
+export declare function resolveContributionProfilesForDiscover(repoFullNames: string[], ctx?: {
     githubToken?: string;
     apiBaseUrl?: string;
     nowMs?: number;
-    initCache?: unknown;
-    extract?: unknown;
-  },
-): Promise<Map<string, unknown>>;
-
-export function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs;
-
-export function sanitizeDiscoverDisplayText(value: unknown): string;
-
-export function renderDiscoverSummary(result: DiscoverResult): string;
-
-export function runDiscover(
-  args: string[],
-  options?: RunDiscoverOptions,
-): Promise<number>;
+    initCache?: typeof initContributionProfileCache;
+    extract?: typeof extractContributionProfile;
+}): Promise<Map<string, unknown>>;
+export declare function runDiscover(args: string[], options?: RunDiscoverOptions): Promise<number>;

--- a/packages/loopover-miner/lib/discover-cli.js
+++ b/packages/loopover-miner/lib/discover-cli.js
@@ -1,10 +1,7 @@
 /** `discover` CLI command (#4247): wires the existing fanout -> rank -> enqueue pipeline together so a miner
  * can actually run it. Every piece already exists and is independently tested; this module only composes them. */
 import { resolveForgeConfig } from "./forge-config.js";
-import {
-  fetchCandidateIssuesWithSummary,
-  searchCandidateIssuesWithSummary,
-} from "./opportunity-fanout.js";
+import { fetchCandidateIssuesWithSummary, searchCandidateIssuesWithSummary, } from "./opportunity-fanout.js";
 import { rankCandidateIssuesWithSummary } from "./opportunity-ranker.js";
 import { initPolicyDocCacheStore } from "./policy-doc-cache.js";
 import { initPolicyVerdictCacheStore } from "./policy-verdict-cache.js";
@@ -16,31 +13,25 @@ import { initContributionProfileCache } from "./contribution-profile-cache.js";
 import { filterCandidatesByProfiles } from "./contribution-profile-filter.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { isDiscoveryPlaneEnabled, queryDiscoveryIndex, recordDiscoveryTelemetry } from "./discovery-index-client.js";
-
-const DISCOVER_USAGE =
-  "Usage: loopover-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--dry-run] [--json] [--api-base-url <url>] [--token-env <VAR>]";
-
+const DISCOVER_USAGE = "Usage: loopover-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--dry-run] [--json] [--api-base-url <url>] [--token-env <VAR>]";
 const MAX_DISCOVER_TITLE_DISPLAY_LENGTH = 240;
 const OSC_SEQUENCE_PATTERN = /\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g;
 const ANSI_ESCAPE_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|[@-_])/g;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/g;
 const BIDI_CONTROL_PATTERN = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
-
 export function sanitizeDiscoverDisplayText(value) {
-  return String(value ?? "")
-    .replace(OSC_SEQUENCE_PATTERN, "")
-    .replace(ANSI_ESCAPE_PATTERN, "")
-    .replace(CONTROL_CHARACTER_PATTERN, " ")
-    .replace(BIDI_CONTROL_PATTERN, "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, MAX_DISCOVER_TITLE_DISPLAY_LENGTH);
+    return String(value ?? "")
+        .replace(OSC_SEQUENCE_PATTERN, "")
+        .replace(ANSI_ESCAPE_PATTERN, "")
+        .replace(CONTROL_CHARACTER_PATTERN, " ")
+        .replace(BIDI_CONTROL_PATTERN, "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, MAX_DISCOVER_TITLE_DISPLAY_LENGTH);
 }
-
 function dedupeKey(repoFullName, issueNumber) {
-  return `${repoFullName.toLowerCase()}#${issueNumber}`;
+    return `${repoFullName.toLowerCase()}#${issueNumber}`;
 }
-
 /**
  * Supplements `fanOut.issues` with hosted discovery-index results for the same scope (#7168) -- a complete
  * no-op (returns `fanOut` unchanged) unless the plane is enabled, so a run with the flag unset behaves exactly
@@ -51,139 +42,136 @@ function dedupeKey(repoFullName, issueNumber) {
  * filter.js's assignee-exclusion rule treats that identically to "no assignees on this issue".
  */
 async function supplementWithDiscoveryIndex(fanOut, queryScope, options) {
-  const env = options.env ?? process.env;
-  if (!isDiscoveryPlaneEnabled(env)) return fanOut;
-  const queryIndex = options.queryDiscoveryIndex ?? queryDiscoveryIndex;
-  const response = await queryIndex(queryScope, { env });
-  recordDiscoveryTelemetry("discover_query", response.candidates.length > 0 ? "supplemented" : "empty", { env });
-  if (response.candidates.length === 0) return fanOut;
-
-  const seen = new Set(fanOut.issues.map((issue) => dedupeKey(issue.repoFullName, issue.issueNumber)));
-  const supplemented = response.candidates
-    .filter((candidate) => !seen.has(dedupeKey(candidate.repoFullName, candidate.issueNumber)))
-    .map((candidate) => ({ ...candidate, assignees: [] }));
-  if (supplemented.length === 0) return fanOut;
-  return { ...fanOut, issues: [...fanOut.issues, ...supplemented] };
+    const env = options.env ?? process.env;
+    if (!isDiscoveryPlaneEnabled(env))
+        return fanOut;
+    const queryIndex = options.queryDiscoveryIndex ?? queryDiscoveryIndex;
+    const response = await queryIndex(queryScope, { env });
+    recordDiscoveryTelemetry("discover_query", response.candidates.length > 0 ? "supplemented" : "empty", { env });
+    if (response.candidates.length === 0)
+        return fanOut;
+    const seen = new Set(fanOut.issues.map((issue) => dedupeKey(issue.repoFullName, issue.issueNumber)));
+    const supplemented = response.candidates
+        .filter((candidate) => !seen.has(dedupeKey(candidate.repoFullName, candidate.issueNumber)))
+        .map((candidate) => ({ ...candidate, assignees: [] }));
+    if (supplemented.length === 0)
+        return fanOut;
+    return { ...fanOut, issues: [...fanOut.issues, ...supplemented] };
 }
-
 function parseRepoTarget(value) {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  return { owner, repo };
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    return { owner, repo };
 }
-
 export function parseDiscoverArgs(args) {
-  // `--api-base-url` and `--token-env` (#4784) thread the tenant's forge host and credential env var into the
-  // fan-out; they are kept off the parsed result unless supplied, so callers that pass neither see the exact
-  // pre-#4784 `{ targets, search, json }` shape.
-  const options = { json: false, dryRun: false, search: null, apiBaseUrl: null, tokenEnv: null };
-  const targets = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    // `--api-base-url` and `--token-env` (#4784) thread the tenant's forge host and credential env var into the
+    // fan-out; they are kept off the parsed result unless supplied, so callers that pass neither see the exact
+    // pre-#4784 `{ targets, search, json }` shape.
+    const options = { json: false, dryRun: false, search: null, apiBaseUrl: null, tokenEnv: null };
+    const targets = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: fetches + ranks exactly as a real run, but skips opening any local store and makes zero writes.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--search") {
+            const query = args[index + 1];
+            if (!query || query.startsWith("-"))
+                return { error: DISCOVER_USAGE };
+            options.search = query;
+            index += 1;
+            continue;
+        }
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: DISCOVER_USAGE };
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--token-env") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: DISCOVER_USAGE };
+            options.tokenEnv = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        const target = parseRepoTarget(token);
+        if (!target)
+            return { error: `Repository must be in owner/repo form: ${token}` };
+        targets.push(target);
     }
-    // #4847: fetches + ranks exactly as a real run, but skips opening any local store and makes zero writes.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
+    if (options.search === null && targets.length === 0) {
+        return { error: DISCOVER_USAGE };
     }
-    if (token === "--search") {
-      const query = args[index + 1];
-      if (!query || query.startsWith("-")) return { error: DISCOVER_USAGE };
-      options.search = query;
-      index += 1;
-      continue;
+    if (options.search !== null && targets.length > 0) {
+        return { error: "Pass either repository targets or --search, not both." };
     }
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--token-env") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
-      options.tokenEnv = value;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    const target = parseRepoTarget(token);
-    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
-    targets.push(target);
-  }
-
-  if (options.search === null && targets.length === 0) {
-    return { error: DISCOVER_USAGE };
-  }
-  if (options.search !== null && targets.length > 0) {
-    return { error: "Pass either repository targets or --search, not both." };
-  }
-
-  return {
-    targets,
-    search: options.search,
-    dryRun: options.dryRun,
-    json: options.json,
-    ...(options.apiBaseUrl !== null ? { apiBaseUrl: options.apiBaseUrl } : {}),
-    ...(options.tokenEnv !== null ? { tokenEnv: options.tokenEnv } : {}),
-  };
+    return {
+        targets,
+        search: options.search,
+        dryRun: options.dryRun,
+        json: options.json,
+        ...(options.apiBaseUrl !== null ? { apiBaseUrl: options.apiBaseUrl } : {}),
+        ...(options.tokenEnv !== null ? { tokenEnv: options.tokenEnv } : {}),
+    };
 }
-
 // The rate-limit line surfaces the telemetry the fanout already records (#4837) so an operator sees how close a
 // `discover` run is to being throttled without running a separate command. `unknown` covers the no-fetch/no-header
 // case where the fanout captured no remaining count.
 function renderRateLimitLine(result) {
-  const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
-  const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
-  return `rate-limit remaining: ${remaining}${resetSuffix}`;
+    const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
+    const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
+    return `rate-limit remaining: ${remaining}${resetSuffix}`;
 }
-
 export function renderDiscoverSummary(result) {
-  const lines = [
-    `fanned out: ${result.fanOutCount} candidate issue(s)`,
-    `ai-policy warnings: ${result.warnings.length}`,
-    `ranked: ${result.ranked.length}`,
-    `enqueued: ${result.enqueueSummary.enqueued}`,
-    renderRateLimitLine(result),
-  ];
-  if (result.enqueueSummary.skippedBelowMinRank > 0) {
-    lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
-  }
-  // #6798: surface what the eligibility filter dropped and why, so a human sees AMS's inference.
-  const excluded = result.excluded ?? [];
-  if (excluded.length > 0) {
-    lines.push(`excluded (eligibility): ${excluded.length}`);
-    for (const entry of excluded.slice(0, 10)) {
-      lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  ${entry.reason}`);
+    const lines = [
+        `fanned out: ${result.fanOutCount} candidate issue(s)`,
+        `ai-policy warnings: ${result.warnings.length}`,
+        `ranked: ${result.ranked.length}`,
+        `enqueued: ${result.enqueueSummary.enqueued}`,
+        renderRateLimitLine(result),
+    ];
+    if (result.enqueueSummary.skippedBelowMinRank > 0) {
+        lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
     }
-  }
-  // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
-  // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
-  if (result.usedDefaultGoalSpec) {
-    lines.push(
-      "note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)",
-    );
-  }
-  if (result.ranked.length === 0) {
-    lines.push("", "no candidates found.");
+    // #6798: surface what the eligibility filter dropped and why, so a human sees AMS's inference.
+    const excluded = result.excluded ?? [];
+    if (excluded.length > 0) {
+        lines.push(`excluded (eligibility): ${excluded.length}`);
+        for (const entry of excluded.slice(0, 10)) {
+            lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  ${entry.reason}`);
+        }
+    }
+    // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
+    // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
+    if (result.usedDefaultGoalSpec) {
+        lines.push("note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)");
+    }
+    if (result.ranked.length === 0) {
+        lines.push("", "no candidates found.");
+        return lines.join("\n");
+    }
+    lines.push("", "top candidates:");
+    for (const entry of result.ranked.slice(0, 10)) {
+        const title = sanitizeDiscoverDisplayText(entry.title);
+        lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${title}`);
+    }
     return lines.join("\n");
-  }
-  lines.push("", "top candidates:");
-  for (const entry of result.ranked.slice(0, 10)) {
-    const title = sanitizeDiscoverDisplayText(entry.title);
-    lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${title}`);
-  }
-  return lines.join("\n");
 }
-
 /**
  * Default per-repo ContributionProfile resolver (#6798): reads the local cache and, on a miss/stale entry,
  * extracts a fresh profile and caches it. Returns a Map keyed by repoFullName.
@@ -197,233 +185,234 @@ export function renderDiscoverSummary(result) {
  * @returns {Promise<Map<string, object>>}
  */
 export async function resolveContributionProfilesForDiscover(repoFullNames, ctx = {}) {
-  const profiles = new Map();
-  if (!ctx.githubToken) return profiles;
-  const initCache = ctx.initCache ?? initContributionProfileCache;
-  const extract = ctx.extract ?? extractContributionProfile;
-  const cache = initCache();
-  try {
-    for (const repoFullName of repoFullNames) {
-      const cached = cache.get(repoFullName, ctx.nowMs);
-      if (cached && !cached.stale) {
-        profiles.set(repoFullName, cached.profile);
-        continue;
-      }
-      const profile = await extract(repoFullName, { githubToken: ctx.githubToken, apiBaseUrl: ctx.apiBaseUrl });
-      cache.put(profile, ctx.nowMs);
-      profiles.set(repoFullName, profile);
+    const profiles = new Map();
+    if (!ctx.githubToken)
+        return profiles;
+    const initCache = ctx.initCache ?? initContributionProfileCache;
+    const extract = ctx.extract ?? extractContributionProfile;
+    const cache = initCache();
+    try {
+        for (const repoFullName of repoFullNames) {
+            const cached = cache.get(repoFullName, ctx.nowMs);
+            if (cached && !cached.stale) {
+                profiles.set(repoFullName, cached.profile);
+                continue;
+            }
+            const profile = await extract(repoFullName, { githubToken: ctx.githubToken, apiBaseUrl: ctx.apiBaseUrl });
+            cache.put(profile, ctx.nowMs);
+            profiles.set(repoFullName, profile);
+        }
     }
-  } finally {
-    cache.close();
-  }
-  return profiles;
+    finally {
+        cache.close();
+    }
+    return profiles;
 }
-
 export async function runDiscover(args, options = {}) {
-  const parsed = parseDiscoverArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
-  // non-`GITHUB_TOKEN` variable so a non-github.com forge's token is reachable. The default falls through to the
-  // forge adapter's own `tokenEnvVar` (github.com's `GITHUB_TOKEN`), so there's a single source of truth for the
-  // default credential env instead of a second hardcoded literal that could drift from `DEFAULT_FORGE_CONFIG`.
-  const tokenEnv = parsed.tokenEnv ?? options.tokenEnv ?? resolveForgeConfig(options.forge).tokenEnvVar;
-  const githubToken = options.githubToken ?? process.env[tokenEnv] ?? "";
-  // A `--api-base-url` flag (or `options.apiBaseUrl`) surfaces the fan-out's existing forge-host override at the CLI
-  // (#4784); `options.forge` carries any remaining per-tenant forge knobs for a programmatic caller.
-  const apiBaseUrl = parsed.apiBaseUrl ?? options.apiBaseUrl;
-  const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
-  const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
-  const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
-  const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
-  // Eligibility filtering (#6798): resolve each candidate repo's ContributionProfile and drop candidates the
-  // repo's own conventions would reject, BEFORE ranking. Safe by default -- see resolveContributionProfilesForDiscover.
-  const resolveProfiles = options.resolveContributionProfiles ?? resolveContributionProfilesForDiscover;
-  // Same scope this run already asks GitHub about (#7168) -- the discovery-index supplement, when enabled,
-  // asks the shared hosted index about the identical targets/search rather than a different query entirely.
-  const discoveryQueryScope =
-    parsed.search !== null
-      ? { repos: [], orgs: [], searchTerms: [parsed.search] }
-      : { repos: parsed.targets.map((target) => `${target.owner}/${target.repo}`), orgs: [], searchTerms: [] };
-
-  // #4847: fetch + rank are read-only GitHub GETs and pure local computation, so a dry run still does them for
-  // real (that's the useful "what would this discover?" output) -- but it never opens any local store (portfolio
-  // queue, policy-doc cache, policy-verdict cache), since opening a not-yet-existing SQLite store file is itself
-  // a write. The ranked issues are fed through a no-op queue stub so enqueueRankedDiscovery's own classification
-  // logic (valid/invalid, below-min-rank) still runs for real, just without ever touching the real queue.
-  if (parsed.dryRun) {
-    const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache: null, policyVerdictCache: null };
+    const parsed = parseDiscoverArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
+    // non-`GITHUB_TOKEN` variable so a non-github.com forge's token is reachable. The default falls through to the
+    // forge adapter's own `tokenEnvVar` (github.com's `GITHUB_TOKEN`), so there's a single source of truth for the
+    // default credential env instead of a second hardcoded literal that could drift from `DEFAULT_FORGE_CONFIG`.
+    const tokenEnv = parsed.tokenEnv ?? options.tokenEnv ?? resolveForgeConfig(options.forge).tokenEnvVar;
+    const githubToken = options.githubToken ?? process.env[tokenEnv] ?? "";
+    // A `--api-base-url` flag (or `options.apiBaseUrl`) surfaces the fan-out's existing forge-host override at the CLI
+    // (#4784); `options.forge` carries any remaining per-tenant forge knobs for a programmatic caller.
+    const apiBaseUrl = parsed.apiBaseUrl ?? options.apiBaseUrl;
+    const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
+    const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
+    const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
+    const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
+    // Eligibility filtering (#6798): resolve each candidate repo's ContributionProfile and drop candidates the
+    // repo's own conventions would reject, BEFORE ranking. Safe by default -- see resolveContributionProfilesForDiscover.
+    const resolveProfiles = options.resolveContributionProfiles ?? resolveContributionProfilesForDiscover;
+    // Same scope this run already asks GitHub about (#7168) -- the discovery-index supplement, when enabled,
+    // asks the shared hosted index about the identical targets/search rather than a different query entirely.
+    const discoveryQueryScope = parsed.search !== null
+        ? { repos: [], orgs: [], searchTerms: [parsed.search] }
+        : { repos: parsed.targets.map((target) => `${target.owner}/${target.repo}`), orgs: [], searchTerms: [] };
+    // #4847: fetch + rank are read-only GitHub GETs and pure local computation, so a dry run still does them for
+    // real (that's the useful "what would this discover?" output) -- but it never opens any local store (portfolio
+    // queue, policy-doc cache, policy-verdict cache), since opening a not-yet-existing SQLite store file is itself
+    // a write. The ranked issues are fed through a no-op queue stub so enqueueRankedDiscovery's own classification
+    // logic (valid/invalid, below-min-rank) still runs for real, just without ever touching the real queue.
+    if (parsed.dryRun) {
+        const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache: null, policyVerdictCache: null };
+        try {
+            let fanOut = parsed.search !== null
+                ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+                : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+            fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+            // #6798: same eligibility filter as the real path, so a dry run shows the exact candidate set a real run
+            // would enqueue (and the same excluded set), rather than an unfiltered preview.
+            const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+            const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
+            const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
+            const rankedSummary = rankIssues(kept, {
+                nowMs: options.nowMs,
+                goalSpecsByRepo: options.goalSpecsByRepo,
+                goalSpecContentByRepo: options.goalSpecContentByRepo,
+            });
+            const noopQueueStore = { enqueue: () => { } };
+            const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: noopQueueStore });
+            const result = {
+                outcome: "dry_run",
+                fanOutCount: fanOut.issues.length,
+                warnings: fanOut.warnings,
+                rateLimitRemaining: fanOut.rateLimitRemaining,
+                rateLimitResetAt: fanOut.rateLimitResetAt,
+                ranked: rankedSummary.issues,
+                excluded: excluded.map((entry) => ({
+                    repoFullName: entry.candidate.repoFullName,
+                    issueNumber: entry.candidate.issueNumber,
+                    reason: entry.reason,
+                })),
+                usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+                enqueueSummary,
+            };
+            // Structured-outcome hook (#6522), mirroring runAttempt's onResult convention: fires only at a real
+            // structured success point (never the reportCliFailure branches), in addition to -- never instead of --
+            // the plain exit-code return, so a non-CLI caller (the /api/discover route) can read the result.
+            options.onResult?.(result);
+            if (parsed.json) {
+                console.log(JSON.stringify(result, null, 2));
+            }
+            else {
+                console.log(renderDiscoverSummary(result));
+                console.log("\nDRY RUN: no portfolio-queue write was made.");
+            }
+            return 0;
+        }
+        catch (error) {
+            return reportCliFailure(parsed.json, describeCliError(error));
+        }
+    }
+    const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+    let portfolioQueue;
     try {
-      let fanOut =
-        parsed.search !== null
-          ? await searchTargets(parsed.search, githubToken, fanOutOptions)
-          : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
-      fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
-      // #6798: same eligibility filter as the real path, so a dry run shows the exact candidate set a real run
-      // would enqueue (and the same excluded set), rather than an unfiltered preview.
-      const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
-      const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
-      const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
-      const rankedSummary = rankIssues(kept, {
-        nowMs: options.nowMs,
-        goalSpecsByRepo: options.goalSpecsByRepo,
-        goalSpecContentByRepo: options.goalSpecContentByRepo,
-      });
-      const noopQueueStore = { enqueue: () => {} };
-      const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: noopQueueStore });
-      const result = {
-        outcome: "dry_run",
-        fanOutCount: fanOut.issues.length,
-        warnings: fanOut.warnings,
-        rateLimitRemaining: fanOut.rateLimitRemaining,
-        rateLimitResetAt: fanOut.rateLimitResetAt,
-        ranked: rankedSummary.issues,
-        excluded: excluded.map((entry) => ({
-          repoFullName: entry.candidate.repoFullName,
-          issueNumber: entry.candidate.issueNumber,
-          reason: entry.reason,
-        })),
-        usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
-        enqueueSummary,
-      };
-      // Structured-outcome hook (#6522), mirroring runAttempt's onResult convention: fires only at a real
-      // structured success point (never the reportCliFailure branches), in addition to -- never instead of --
-      // the plain exit-code return, so a non-CLI caller (the /api/discover route) can read the result.
-      options.onResult?.(result);
-      if (parsed.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(renderDiscoverSummary(result));
-        console.log("\nDRY RUN: no portfolio-queue write was made.");
-      }
-      return 0;
-    } catch (error) {
-      return reportCliFailure(parsed.json, describeCliError(error));
+        portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
     }
-  }
-
-  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
-  let portfolioQueue;
-  try {
-    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
-
-  // Local ETag cache so a repeated discover revalidates each repo's policy docs with a conditional GET instead of
-  // re-downloading them (#4842). Opened inside its OWN try/catch, separate from the portfolio queue above: the
-  // queue is required infrastructure (discovery genuinely cannot enqueue anything without it, so a real open
-  // failure should abort the run), but the policy-doc cache is a pure performance optimization -- a corrupt or
-  // unwritable cache DB must degrade to "no cache" (every doc fetched in full, exactly as before #4842) rather
-  // than fail discovery outright.
-  let policyDocCache = null;
-  let ownsPolicyDocCache = false;
-  try {
-    ownsPolicyDocCache = options.initPolicyDocCache === undefined;
-    policyDocCache = (options.initPolicyDocCache ?? initPolicyDocCacheStore)();
-  } catch {
-    policyDocCache = null;
-    ownsPolicyDocCache = false;
-  }
-
-  // Persisted cache of resolved policy verdicts (#4843), same "own try/catch, degrade to null" discipline as the
-  // doc cache above and for the same reason: purely a performance optimization the feature is inert without, so a
-  // corrupt/unwritable cache DB must never abort a run.
-  let policyVerdictCache = null;
-  let ownsPolicyVerdictCache = false;
-  try {
-    ownsPolicyVerdictCache = options.initPolicyVerdictCache === undefined;
-    policyVerdictCache = (options.initPolicyVerdictCache ?? initPolicyVerdictCacheStore)();
-  } catch {
-    policyVerdictCache = null;
-    ownsPolicyVerdictCache = false;
-  }
-
-  // Snapshot of this run's full ranked output (#4859 prerequisite), so a local HTTP endpoint (and eventually the
-  // miner-ui/browser-extension live-fetch it's meant for) can serve the same per-issue breakdown `--json` prints,
-  // without the operator re-running discover or hand-pasting its output. Same "own try/catch, degrade to null"
-  // discipline as the two caches above: a corrupt/unwritable snapshot store must never abort discovery's actual
-  // job (fan out, rank, enqueue). Unlike the caches, this store is a WRITE target, not a read optimization -- the
-  // save call itself gets its own try/catch below for the same reason.
-  let rankedCandidatesStore = null;
-  let ownsRankedCandidatesStore = false;
-  try {
-    ownsRankedCandidatesStore = options.initRankedCandidatesStore === undefined;
-    rankedCandidatesStore = (options.initRankedCandidatesStore ?? initRankedCandidatesStore)();
-  } catch {
-    rankedCandidatesStore = null;
-    ownsRankedCandidatesStore = false;
-  }
-  const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache, policyVerdictCache };
-
-  try {
-    let fanOut =
-      parsed.search !== null
-        ? await searchTargets(parsed.search, githubToken, fanOutOptions)
-        : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
-    fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
-
-    // Eligibility filter (#6798): drop candidates a target repo's own conventions would reject, before ranking.
-    // A repo with no trustworthy eligibility profile keeps every candidate (filterCandidatesByProfiles' safe
-    // default), so this never silently skips real work on a repo whose conventions AMS couldn't read.
-    const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
-    const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
-    const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
-
-    // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
-    // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
-    // `usedDefaultGoalSpec` below rather than hidden.
-    const rankedSummary = rankIssues(kept, {
-      nowMs: options.nowMs,
-      goalSpecsByRepo: options.goalSpecsByRepo,
-      goalSpecContentByRepo: options.goalSpecContentByRepo,
-    });
-    const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue, apiBaseUrl });
-
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    // Local ETag cache so a repeated discover revalidates each repo's policy docs with a conditional GET instead of
+    // re-downloading them (#4842). Opened inside its OWN try/catch, separate from the portfolio queue above: the
+    // queue is required infrastructure (discovery genuinely cannot enqueue anything without it, so a real open
+    // failure should abort the run), but the policy-doc cache is a pure performance optimization -- a corrupt or
+    // unwritable cache DB must degrade to "no cache" (every doc fetched in full, exactly as before #4842) rather
+    // than fail discovery outright.
+    let policyDocCache = null;
+    let ownsPolicyDocCache = false;
     try {
-      // Optional chaining rather than an `if (rankedCandidatesStore)` guard: a null store (open failed above)
-      // short-circuits to a no-op read, so the same try/catch below also covers the open-failed case without a
-      // second explicit branch.
-      rankedCandidatesStore?.saveRankedCandidates(rankedSummary.issues, options.nowMs);
-    } catch {
-      // Non-fatal: the ranked-candidates snapshot is a nice-to-have for the local HTTP endpoint, not a
-      // requirement for discover's own job (fan out, rank, enqueue), which already succeeded above.
+        ownsPolicyDocCache = options.initPolicyDocCache === undefined;
+        policyDocCache = (options.initPolicyDocCache ?? initPolicyDocCacheStore)();
     }
-
-    const result = {
-      fanOutCount: fanOut.issues.length,
-      warnings: fanOut.warnings,
-      rateLimitRemaining: fanOut.rateLimitRemaining,
-      rateLimitResetAt: fanOut.rateLimitResetAt,
-      ranked: rankedSummary.issues,
-      // #6798: candidates the eligibility filter dropped, each with the repo + issue + reason, so a human sees
-      // what AMS inferred and why a candidate was skipped. Empty when no profile was trustworthy enough to filter.
-      excluded: excluded.map((entry) => ({
-        repoFullName: entry.candidate.repoFullName,
-        issueNumber: entry.candidate.issueNumber,
-        reason: entry.reason,
-      })),
-      usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
-      enqueueSummary,
-    };
-
-    // Structured-outcome hook (#6522) for the full-run success point -- same convention as the dry-run branch
-    // above and as runAttempt's onResult: real result only, additive to the unchanged exit-code return.
-    options.onResult?.(result);
-    if (parsed.json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      console.log(renderDiscoverSummary(result));
+    catch {
+        policyDocCache = null;
+        ownsPolicyDocCache = false;
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsPortfolioQueue && portfolioQueue) portfolioQueue.close();
-    if (ownsPolicyDocCache && policyDocCache) policyDocCache.close();
-    if (ownsPolicyVerdictCache && policyVerdictCache) policyVerdictCache.close();
-    if (ownsRankedCandidatesStore && rankedCandidatesStore) rankedCandidatesStore.close();
-  }
+    // Persisted cache of resolved policy verdicts (#4843), same "own try/catch, degrade to null" discipline as the
+    // doc cache above and for the same reason: purely a performance optimization the feature is inert without, so a
+    // corrupt/unwritable cache DB must never abort a run.
+    let policyVerdictCache = null;
+    let ownsPolicyVerdictCache = false;
+    try {
+        ownsPolicyVerdictCache = options.initPolicyVerdictCache === undefined;
+        policyVerdictCache = (options.initPolicyVerdictCache ?? initPolicyVerdictCacheStore)();
+    }
+    catch {
+        policyVerdictCache = null;
+        ownsPolicyVerdictCache = false;
+    }
+    // Snapshot of this run's full ranked output (#4859 prerequisite), so a local HTTP endpoint (and eventually the
+    // miner-ui/browser-extension live-fetch it's meant for) can serve the same per-issue breakdown `--json` prints,
+    // without the operator re-running discover or hand-pasting its output. Same "own try/catch, degrade to null"
+    // discipline as the two caches above: a corrupt/unwritable snapshot store must never abort discovery's actual
+    // job (fan out, rank, enqueue). Unlike the caches, this store is a WRITE target, not a read optimization -- the
+    // save call itself gets its own try/catch below for the same reason.
+    let rankedCandidatesStore = null;
+    let ownsRankedCandidatesStore = false;
+    try {
+        ownsRankedCandidatesStore = options.initRankedCandidatesStore === undefined;
+        rankedCandidatesStore = (options.initRankedCandidatesStore ?? initRankedCandidatesStore)();
+    }
+    catch {
+        rankedCandidatesStore = null;
+        ownsRankedCandidatesStore = false;
+    }
+    const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache, policyVerdictCache };
+    try {
+        let fanOut = parsed.search !== null
+            ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+            : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+        fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+        // Eligibility filter (#6798): drop candidates a target repo's own conventions would reject, before ranking.
+        // A repo with no trustworthy eligibility profile keeps every candidate (filterCandidatesByProfiles' safe
+        // default), so this never silently skips real work on a repo whose conventions AMS couldn't read.
+        const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+        const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
+        const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
+        // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
+        // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
+        // `usedDefaultGoalSpec` below rather than hidden.
+        const rankedSummary = rankIssues(kept, {
+            nowMs: options.nowMs,
+            goalSpecsByRepo: options.goalSpecsByRepo,
+            goalSpecContentByRepo: options.goalSpecContentByRepo,
+        });
+        const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue, apiBaseUrl });
+        try {
+            // Optional chaining rather than an `if (rankedCandidatesStore)` guard: a null store (open failed above)
+            // short-circuits to a no-op read, so the same try/catch below also covers the open-failed case without a
+            // second explicit branch.
+            rankedCandidatesStore?.saveRankedCandidates(rankedSummary.issues, options.nowMs);
+        }
+        catch {
+            // Non-fatal: the ranked-candidates snapshot is a nice-to-have for the local HTTP endpoint, not a
+            // requirement for discover's own job (fan out, rank, enqueue), which already succeeded above.
+        }
+        const result = {
+            fanOutCount: fanOut.issues.length,
+            warnings: fanOut.warnings,
+            rateLimitRemaining: fanOut.rateLimitRemaining,
+            rateLimitResetAt: fanOut.rateLimitResetAt,
+            ranked: rankedSummary.issues,
+            // #6798: candidates the eligibility filter dropped, each with the repo + issue + reason, so a human sees
+            // what AMS inferred and why a candidate was skipped. Empty when no profile was trustworthy enough to filter.
+            excluded: excluded.map((entry) => ({
+                repoFullName: entry.candidate.repoFullName,
+                issueNumber: entry.candidate.issueNumber,
+                reason: entry.reason,
+            })),
+            usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+            enqueueSummary,
+        };
+        // Structured-outcome hook (#6522) for the full-run success point -- same convention as the dry-run branch
+        // above and as runAttempt's onResult: real result only, additive to the unchanged exit-code return.
+        options.onResult?.(result);
+        if (parsed.json) {
+            console.log(JSON.stringify(result, null, 2));
+        }
+        else {
+            console.log(renderDiscoverSummary(result));
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    finally {
+        if (ownsPortfolioQueue && portfolioQueue)
+            portfolioQueue.close();
+        if (ownsPolicyDocCache && policyDocCache)
+            policyDocCache.close();
+        if (ownsPolicyVerdictCache && policyVerdictCache)
+            policyVerdictCache.close();
+        if (ownsRankedCandidatesStore && rankedCandidatesStore)
+            rankedCandidatesStore.close();
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGlzY292ZXItY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZGlzY292ZXItY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO2tIQUNrSDtBQUNsSCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxtQkFBbUIsQ0FBQztBQUN2RCxPQUFPLEVBQ0wsK0JBQStCLEVBQy9CLGdDQUFnQyxHQUNqQyxNQUFNLHlCQUF5QixDQUFDO0FBT2pDLE9BQU8sRUFBRSw4QkFBOEIsRUFBRSxNQUFNLHlCQUF5QixDQUFDO0FBTXpFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLHVCQUF1QixDQUFDO0FBRWhFLE9BQU8sRUFBRSwyQkFBMkIsRUFBRSxNQUFNLDJCQUEyQixDQUFDO0FBRXhFLE9BQU8sRUFBRSxzQkFBc0IsRUFBRSxNQUFNLDBCQUEwQixDQUFDO0FBRWxFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBRS9ELE9BQU8sRUFBRSx5QkFBeUIsRUFBRSxNQUFNLHdCQUF3QixDQUFDO0FBRW5FLE9BQU8sRUFBRSwwQkFBMEIsRUFBRSxNQUFNLG1DQUFtQyxDQUFDO0FBQy9FLE9BQU8sRUFBRSw0QkFBNEIsRUFBRSxNQUFNLGlDQUFpQyxDQUFDO0FBQy9FLE9BQU8sRUFBRSwwQkFBMEIsRUFBRSxNQUFNLGtDQUFrQyxDQUFDO0FBQzlFLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsdUJBQXVCLEVBQUUsbUJBQW1CLEVBQUUsd0JBQXdCLEVBQUUsTUFBTSw2QkFBNkIsQ0FBQztBQWtHckgsTUFBTSxjQUFjLEdBQ2xCLGtKQUFrSixDQUFDO0FBRXJKLE1BQU0saUNBQWlDLEdBQUcsR0FBRyxDQUFDO0FBQzlDLE1BQU0sb0JBQW9CLEdBQUcsc0NBQXNDLENBQUM7QUFDcEUsTUFBTSxtQkFBbUIsR0FBRyxzQ0FBc0MsQ0FBQztBQUNuRSxNQUFNLHlCQUF5QixHQUFHLCtCQUErQixDQUFDO0FBQ2xFLE1BQU0sb0JBQW9CLEdBQUcsMkNBQTJDLENBQUM7QUFFekUsTUFBTSxVQUFVLDJCQUEyQixDQUFDLEtBQWM7SUFDeEQsT0FBTyxNQUFNLENBQUMsS0FBSyxJQUFJLEVBQUUsQ0FBQztTQUN2QixPQUFPLENBQUMsb0JBQW9CLEVBQUUsRUFBRSxDQUFDO1NBQ2pDLE9BQU8sQ0FBQyxtQkFBbUIsRUFBRSxFQUFFLENBQUM7U0FDaEMsT0FBTyxDQUFDLHlCQUF5QixFQUFFLEdBQUcsQ0FBQztTQUN2QyxPQUFPLENBQUMsb0JBQW9CLEVBQUUsRUFBRSxDQUFDO1NBQ2pDLE9BQU8sQ0FBQyxNQUFNLEVBQUUsR0FBRyxDQUFDO1NBQ3BCLElBQUksRUFBRTtTQUNOLEtBQUssQ0FBQyxDQUFDLEVBQUUsaUNBQWlDLENBQUMsQ0FBQztBQUNqRCxDQUFDO0FBRUQsU0FBUyxTQUFTLENBQUMsWUFBb0IsRUFBRSxXQUFtQjtJQUMxRCxPQUFPLEdBQUcsWUFBWSxDQUFDLFdBQVcsRUFBRSxJQUFJLFdBQVcsRUFBRSxDQUFDO0FBQ3hELENBQUM7QUFFRDs7Ozs7Ozs7R0FRRztBQUNILEtBQUssVUFBVSw0QkFBNEIsQ0FDekMsTUFBNkIsRUFDN0IsVUFBcUQsRUFDckQsT0FBMkI7SUFFM0IsTUFBTSxHQUFHLEdBQUcsT0FBTyxDQUFDLEdBQUcsSUFBSSxPQUFPLENBQUMsR0FBRyxDQUFDO0lBQ3ZDLElBQUksQ0FBQyx1QkFBdUIsQ0FBQyxHQUFHLENBQUM7UUFBRSxPQUFPLE1BQU0sQ0FBQztJQUNqRCxNQUFNLFVBQVUsR0FBRyxPQUFPLENBQUMsbUJBQW1CLElBQUksbUJBQW1CLENBQUM7SUFDdEUsTUFBTSxRQUFRLEdBQUcsTUFBTSxVQUFVLENBQUMsVUFBVSxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztJQUN2RCx3QkFBd0IsQ0FBQyxnQkFBZ0IsRUFBRSxRQUFRLENBQUMsVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLGNBQWMsQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztJQUMvRyxJQUFJLFFBQVEsQ0FBQyxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLE1BQU0sQ0FBQztJQUVwRCxNQUFNLElBQUksR0FBRyxJQUFJLEdBQUcsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNyRyxNQUFNLFlBQVksR0FBRyxRQUFRLENBQUMsVUFBVTtTQUNyQyxNQUFNLENBQUMsQ0FBQyxTQUFTLEVBQUUsRUFBRSxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxTQUFTLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxTQUFTLENBQUMsV0FBVyxDQUFDLENBQUMsQ0FBQztTQUMxRixHQUFHLENBQUMsQ0FBQyxTQUFTLEVBQUUsRUFBRSxDQUFDLENBQUMsRUFBRSxHQUFHLFNBQVMsRUFBRSxTQUFTLEVBQUUsRUFBRSxFQUFFLENBQWlDLENBQUMsQ0FBQztJQUN6RixJQUFJLFlBQVksQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sTUFBTSxDQUFDO0lBQzdDLE9BQU8sRUFBRSxHQUFHLE1BQU0sRUFBRSxNQUFNLEVBQUUsQ0FBQyxHQUFHLE1BQU0sQ0FBQyxNQUFNLEVBQUUsR0FBRyxZQUFZLENBQUMsRUFBRSxDQUFDO0FBQ3BFLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxLQUFjO0lBQ3JDLE1BQU0sT0FBTyxHQUFHLE9BQU8sS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDOUQsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDeEQsT0FBTyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsQ0FBQztBQUN6QixDQUFDO0FBRUQsTUFBTSxVQUFVLGlCQUFpQixDQUFDLElBQWM7SUFDOUMsNEdBQTRHO0lBQzVHLDJHQUEyRztJQUMzRywrQ0FBK0M7SUFDL0MsTUFBTSxPQUFPLEdBTVQsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxVQUFVLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsQ0FBQztJQUNuRixNQUFNLE9BQU8sR0FBbUIsRUFBRSxDQUFDO0lBRW5DLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCx5R0FBeUc7UUFDekcsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxVQUFVLEVBQUUsQ0FBQztZQUN6QixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxjQUFjLEVBQUUsQ0FBQztZQUN0RSxPQUFPLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQztZQUN2QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxnQkFBZ0IsRUFBRSxDQUFDO1lBQy9CLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGNBQWMsRUFBRSxDQUFDO1lBQ3RFLE9BQU8sQ0FBQyxVQUFVLEdBQUcsS0FBSyxDQUFDO1lBQzNCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLGFBQWEsRUFBRSxDQUFDO1lBQzVCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGNBQWMsRUFBRSxDQUFDO1lBQ3RFLE9BQU8sQ0FBQyxRQUFRLEdBQUcsS0FBSyxDQUFDO1lBQ3pCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDL0MsQ0FBQztRQUNELE1BQU0sTUFBTSxHQUFHLGVBQWUsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUN0QyxJQUFJLENBQUMsTUFBTTtZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsMENBQTBDLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDakYsT0FBTyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUN2QixDQUFDO0lBRUQsSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLElBQUksSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQ3BELE9BQU8sRUFBRSxLQUFLLEVBQUUsY0FBYyxFQUFFLENBQUM7SUFDbkMsQ0FBQztJQUNELElBQUksT0FBTyxDQUFDLE1BQU0sS0FBSyxJQUFJLElBQUksT0FBTyxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNsRCxPQUFPLEVBQUUsS0FBSyxFQUFFLHVEQUF1RCxFQUFFLENBQUM7SUFDNUUsQ0FBQztJQUVELE9BQU87UUFDTCxPQUFPO1FBQ1AsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNO1FBQ3RCLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTTtRQUN0QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7UUFDbEIsR0FBRyxDQUFDLE9BQU8sQ0FBQyxVQUFVLEtBQUssSUFBSSxDQUFDLENBQUMsQ0FBQyxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUMxRSxHQUFHLENBQUMsT0FBTyxDQUFDLFFBQVEsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsUUFBUSxFQUFFLE9BQU8sQ0FBQyxRQUFRLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0tBQ3JFLENBQUM7QUFDSixDQUFDO0FBRUQsZ0hBQWdIO0FBQ2hILG1IQUFtSDtBQUNuSCxxREFBcUQ7QUFDckQsU0FBUyxtQkFBbUIsQ0FBQyxNQUF1RTtJQUNsRyxNQUFNLFNBQVMsR0FBRyxNQUFNLENBQUMsa0JBQWtCLEtBQUssSUFBSSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsa0JBQWtCLENBQUMsQ0FBQztJQUNyRyxNQUFNLFdBQVcsR0FBRyxNQUFNLENBQUMsZ0JBQWdCLEtBQUssSUFBSSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLFlBQVksTUFBTSxDQUFDLGdCQUFnQixHQUFHLENBQUM7SUFDbkcsT0FBTyx5QkFBeUIsU0FBUyxHQUFHLFdBQVcsRUFBRSxDQUFDO0FBQzVELENBQUM7QUFFRCxNQUFNLFVBQVUscUJBQXFCLENBQUMsTUFBc0I7SUFDMUQsTUFBTSxLQUFLLEdBQUc7UUFDWixlQUFlLE1BQU0sQ0FBQyxXQUFXLHFCQUFxQjtRQUN0RCx1QkFBdUIsTUFBTSxDQUFDLFFBQVEsQ0FBQyxNQUFNLEVBQUU7UUFDL0MsV0FBVyxNQUFNLENBQUMsTUFBTSxDQUFDLE1BQU0sRUFBRTtRQUNqQyxhQUFhLE1BQU0sQ0FBQyxjQUFjLENBQUMsUUFBUSxFQUFFO1FBQzdDLG1CQUFtQixDQUFDLE1BQU0sQ0FBQztLQUM1QixDQUFDO0lBQ0YsSUFBSSxNQUFNLENBQUMsY0FBYyxDQUFDLG1CQUFtQixHQUFHLENBQUMsRUFBRSxDQUFDO1FBQ2xELEtBQUssQ0FBQyxJQUFJLENBQUMsNkJBQTZCLE1BQU0sQ0FBQyxjQUFjLENBQUMsbUJBQW1CLEVBQUUsQ0FBQyxDQUFDO0lBQ3ZGLENBQUM7SUFDRCwrRkFBK0Y7SUFDL0YsTUFBTSxRQUFRLEdBQUcsTUFBTSxDQUFDLFFBQVEsSUFBSSxFQUFFLENBQUM7SUFDdkMsSUFBSSxRQUFRLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxDQUFDO1FBQ3hCLEtBQUssQ0FBQyxJQUFJLENBQUMsMkJBQTJCLFFBQVEsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDO1FBQ3pELEtBQUssTUFBTSxLQUFLLElBQUksUUFBUSxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDLEVBQUUsQ0FBQztZQUMxQyxLQUFLLENBQUMsSUFBSSxDQUFDLEtBQUssS0FBSyxDQUFDLFlBQVksSUFBSSxLQUFLLENBQUMsV0FBVyxLQUFLLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDO1FBQzlFLENBQUM7SUFDSCxDQUFDO0lBQ0QsK0dBQStHO0lBQy9HLGtHQUFrRztJQUNsRyxJQUFJLE1BQU0sQ0FBQyxtQkFBbUIsRUFBRSxDQUFDO1FBQy9CLEtBQUssQ0FBQyxJQUFJLENBQ1IsK0ZBQStGLENBQ2hHLENBQUM7SUFDSixDQUFDO0lBQ0QsSUFBSSxNQUFNLENBQUMsTUFBTSxDQUFDLE1BQU0sS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUMvQixLQUFLLENBQUMsSUFBSSxDQUFDLEVBQUUsRUFBRSxzQkFBc0IsQ0FBQyxDQUFDO1FBQ3ZDLE9BQU8sS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUMxQixDQUFDO0lBQ0QsS0FBSyxDQUFDLElBQUksQ0FBQyxFQUFFLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztJQUNsQyxLQUFLLE1BQU0sS0FBSyxJQUFJLE1BQU0sQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUMsRUFBRSxDQUFDO1FBQy9DLE1BQU0sS0FBSyxHQUFHLDJCQUEyQixDQUFDLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUN2RCxLQUFLLENBQUMsSUFBSSxDQUFDLEtBQUssS0FBSyxDQUFDLFlBQVksSUFBSSxLQUFLLENBQUMsV0FBVyxXQUFXLEtBQUssQ0FBQyxTQUFTLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxLQUFLLEtBQUssRUFBRSxDQUFDLENBQUM7SUFDNUcsQ0FBQztJQUNELE9BQU8sS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztBQUMxQixDQUFDO0FBRUQ7Ozs7Ozs7Ozs7O0dBV0c7QUFDSCxNQUFNLENBQUMsS0FBSyxVQUFVLHNDQUFzQyxDQUMxRCxhQUF1QixFQUN2QixNQU1JLEVBQUU7SUFFTixNQUFNLFFBQVEsR0FBRyxJQUFJLEdBQUcsRUFBbUIsQ0FBQztJQUM1QyxJQUFJLENBQUMsR0FBRyxDQUFDLFdBQVc7UUFBRSxPQUFPLFFBQVEsQ0FBQztJQUN0QyxNQUFNLFNBQVMsR0FBRyxHQUFHLENBQUMsU0FBUyxJQUFJLDRCQUE0QixDQUFDO0lBQ2hFLE1BQU0sT0FBTyxHQUFHLEdBQUcsQ0FBQyxPQUFPLElBQUksMEJBQTBCLENBQUM7SUFDMUQsTUFBTSxLQUFLLEdBQUcsU0FBUyxFQUFFLENBQUM7SUFDMUIsSUFBSSxDQUFDO1FBQ0gsS0FBSyxNQUFNLFlBQVksSUFBSSxhQUFhLEVBQUUsQ0FBQztZQUN6QyxNQUFNLE1BQU0sR0FBRyxLQUFLLENBQUMsR0FBRyxDQUFDLFlBQVksRUFBRSxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUM7WUFDbEQsSUFBSSxNQUFNLElBQUksQ0FBQyxNQUFNLENBQUMsS0FBSyxFQUFFLENBQUM7Z0JBQzVCLFFBQVEsQ0FBQyxHQUFHLENBQUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxPQUFPLENBQUMsQ0FBQztnQkFDM0MsU0FBUztZQUNYLENBQUM7WUFDRCxNQUFNLE9BQU8sR0FBRyxNQUFNLE9BQU8sQ0FBQyxZQUFZLEVBQUUsRUFBRSxXQUFXLEVBQUUsR0FBRyxDQUFDLFdBQVcsRUFBRSxVQUFVLEVBQUUsR0FBRyxDQUFDLFVBQVUsRUFBc0QsQ0FBQyxDQUFDO1lBQzlKLEtBQUssQ0FBQyxHQUFHLENBQUMsT0FBTyxFQUFFLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUM5QixRQUFRLENBQUMsR0FBRyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsQ0FBQztRQUN0QyxDQUFDO0lBQ0gsQ0FBQztZQUFTLENBQUM7UUFDVCxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUM7SUFDaEIsQ0FBQztJQUNELE9BQU8sUUFBUSxDQUFDO0FBQ2xCLENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLFdBQVcsQ0FBQyxJQUFjLEVBQUUsVUFBOEIsRUFBRTtJQUNoRixNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN2QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELDJHQUEyRztJQUMzRywrR0FBK0c7SUFDL0csK0dBQStHO0lBQy9HLDZHQUE2RztJQUM3RyxNQUFNLFFBQVEsR0FBRyxNQUFNLENBQUMsUUFBUSxJQUFJLE9BQU8sQ0FBQyxRQUFRLElBQUksa0JBQWtCLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxDQUFDLFdBQVcsQ0FBQztJQUN0RyxNQUFNLFdBQVcsR0FBRyxPQUFPLENBQUMsV0FBVyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUMsUUFBUSxDQUFDLElBQUksRUFBRSxDQUFDO0lBQ3ZFLG1IQUFtSDtJQUNuSCxtR0FBbUc7SUFDbkcsTUFBTSxVQUFVLEdBQUcsTUFBTSxDQUFDLFVBQVUsSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDO0lBQzNELE1BQU0sWUFBWSxHQUFHLE9BQU8sQ0FBQywrQkFBK0IsSUFBSSwrQkFBK0IsQ0FBQztJQUNoRyxNQUFNLGFBQWEsR0FBRyxPQUFPLENBQUMsZ0NBQWdDLElBQUksZ0NBQWdDLENBQUM7SUFDbkcsTUFBTSxVQUFVLEdBQUcsT0FBTyxDQUFDLDhCQUE4QixJQUFJLDhCQUE4QixDQUFDO0lBQzVGLE1BQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsSUFBSSxzQkFBc0IsQ0FBQztJQUN6RSwyR0FBMkc7SUFDM0csc0hBQXNIO0lBQ3RILE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQywyQkFBMkIsSUFBSSxzQ0FBc0MsQ0FBQztJQUN0Ryx5R0FBeUc7SUFDekcsMEdBQTBHO0lBQzFHLE1BQU0sbUJBQW1CLEdBQ3ZCLE1BQU0sQ0FBQyxNQUFNLEtBQUssSUFBSTtRQUNwQixDQUFDLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxFQUFFLElBQUksRUFBRSxFQUFFLEVBQUUsV0FBVyxFQUFFLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFO1FBQ3ZELENBQUMsQ0FBQyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUMsR0FBRyxNQUFNLENBQUMsS0FBSyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQyxFQUFFLElBQUksRUFBRSxFQUFFLEVBQUUsV0FBVyxFQUFFLEVBQUUsRUFBRSxDQUFDO0lBRTdHLDZHQUE2RztJQUM3RywrR0FBK0c7SUFDL0csK0dBQStHO0lBQy9HLCtHQUErRztJQUMvRyx3R0FBd0c7SUFDeEcsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxhQUFhLEdBQUcsRUFBRSxVQUFVLEVBQUUsS0FBSyxFQUFFLE9BQU8sQ0FBQyxLQUFLLEVBQUUsY0FBYyxFQUFFLElBQUksRUFBRSxrQkFBa0IsRUFBRSxJQUFJLEVBQW1CLENBQUM7UUFDNUgsSUFBSSxDQUFDO1lBQ0gsSUFBSSxNQUFNLEdBQ1IsTUFBTSxDQUFDLE1BQU0sS0FBSyxJQUFJO2dCQUNwQixDQUFDLENBQUMsTUFBTSxhQUFhLENBQUMsTUFBTSxDQUFDLE1BQU0sRUFBRSxXQUFXLEVBQUUsYUFBYSxDQUFDO2dCQUNoRSxDQUFDLENBQUMsTUFBTSxZQUFZLENBQUMsTUFBTSxDQUFDLE9BQU8sRUFBRSxXQUFXLEVBQUUsYUFBYSxDQUFDLENBQUM7WUFDckUsTUFBTSxHQUFHLE1BQU0sNEJBQTRCLENBQUMsTUFBTSxFQUFFLG1CQUFtQixFQUFFLE9BQU8sQ0FBQyxDQUFDO1lBQ2xGLHlHQUF5RztZQUN6RyxnRkFBZ0Y7WUFDaEYsTUFBTSxhQUFhLEdBQUcsQ0FBQyxHQUFHLElBQUksR0FBRyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3JGLE1BQU0sY0FBYyxHQUFHLE1BQU0sZUFBZSxDQUFDLGFBQWEsRUFBRSxFQUFFLFdBQVcsRUFBRSxVQUFVLEVBQUUsS0FBSyxFQUFFLE9BQU8sQ0FBQyxLQUFLLEVBQW1FLENBQUMsQ0FBQztZQUNoTCxNQUFNLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxHQUFHLDBCQUEwQixDQUFDLE1BQU0sQ0FBQyxNQUFNLEVBQUUsY0FBb0MsQ0FBQyxDQUFDO1lBQzNHLE1BQU0sYUFBYSxHQUFHLFVBQVUsQ0FBQyxJQUFJLEVBQUU7Z0JBQ3JDLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSztnQkFDcEIsZUFBZSxFQUFFLE9BQU8sQ0FBQyxlQUFlO2dCQUN4QyxxQkFBcUIsRUFBRSxPQUFPLENBQUMscUJBQXFCO2FBQ3ZCLENBQUMsQ0FBQztZQUNqQyxNQUFNLGNBQWMsR0FBRyxFQUFFLE9BQU8sRUFBRSxHQUFHLEVBQUUsR0FBRSxDQUFDLEVBQW9DLENBQUM7WUFDL0UsTUFBTSxjQUFjLEdBQUcsT0FBTyxDQUFDLGFBQWEsQ0FBQyxNQUFNLEVBQUUsRUFBRSxVQUFVLEVBQUUsY0FBYyxFQUFFLENBQUMsQ0FBQztZQUNyRixNQUFNLE1BQU0sR0FBeUM7Z0JBQ25ELE9BQU8sRUFBRSxTQUFTO2dCQUNsQixXQUFXLEVBQUUsTUFBTSxDQUFDLE1BQU0sQ0FBQyxNQUFNO2dCQUNqQyxRQUFRLEVBQUUsTUFBTSxDQUFDLFFBQVE7Z0JBQ3pCLGtCQUFrQixFQUFFLE1BQU0sQ0FBQyxrQkFBa0I7Z0JBQzdDLGdCQUFnQixFQUFFLE1BQU0sQ0FBQyxnQkFBZ0I7Z0JBQ3pDLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTTtnQkFDNUIsUUFBUSxFQUFFLFFBQVEsQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLENBQUM7b0JBQ2pDLFlBQVksRUFBRSxLQUFLLENBQUMsU0FBUyxDQUFDLFlBQVk7b0JBQzFDLFdBQVcsRUFBRSxLQUFLLENBQUMsU0FBUyxDQUFDLFdBQVc7b0JBQ3hDLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTTtpQkFDckIsQ0FBQyxDQUFDO2dCQUNILG1CQUFtQixFQUFFLGFBQWEsQ0FBQyxtQkFBbUI7Z0JBQ3RELGNBQWM7YUFDZixDQUFDO1lBQ0Ysb0dBQW9HO1lBQ3BHLHdHQUF3RztZQUN4RyxpR0FBaUc7WUFDakcsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzNCLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQy9DLENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHFCQUFxQixDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7Z0JBQzNDLE9BQU8sQ0FBQyxHQUFHLENBQUMsK0NBQStDLENBQUMsQ0FBQztZQUMvRCxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDO1FBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztZQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1FBQ2hFLENBQUM7SUFDSCxDQUFDO0lBRUQsTUFBTSxrQkFBa0IsR0FBRyxPQUFPLENBQUMsa0JBQWtCLEtBQUssU0FBUyxDQUFDO0lBQ3BFLElBQUksY0FBbUMsQ0FBQztJQUN4QyxJQUFJLENBQUM7UUFDSCxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQzdFLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztJQUVELGdIQUFnSDtJQUNoSCw2R0FBNkc7SUFDN0csMkdBQTJHO0lBQzNHLDZHQUE2RztJQUM3Ryw2R0FBNkc7SUFDN0csZ0NBQWdDO0lBQ2hDLElBQUksY0FBYyxHQUErQixJQUFJLENBQUM7SUFDdEQsSUFBSSxrQkFBa0IsR0FBRyxLQUFLLENBQUM7SUFDL0IsSUFBSSxDQUFDO1FBQ0gsa0JBQWtCLEdBQUcsT0FBTyxDQUFDLGtCQUFrQixLQUFLLFNBQVMsQ0FBQztRQUM5RCxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQzdFLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxjQUFjLEdBQUcsSUFBSSxDQUFDO1FBQ3RCLGtCQUFrQixHQUFHLEtBQUssQ0FBQztJQUM3QixDQUFDO0lBRUQsK0dBQStHO0lBQy9HLGdIQUFnSDtJQUNoSCxzREFBc0Q7SUFDdEQsSUFBSSxrQkFBa0IsR0FBbUMsSUFBSSxDQUFDO0lBQzlELElBQUksc0JBQXNCLEdBQUcsS0FBSyxDQUFDO0lBQ25DLElBQUksQ0FBQztRQUNILHNCQUFzQixHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsS0FBSyxTQUFTLENBQUM7UUFDdEUsa0JBQWtCLEdBQUcsQ0FBQyxPQUFPLENBQUMsc0JBQXNCLElBQUksMkJBQTJCLENBQUMsRUFBRSxDQUFDO0lBQ3pGLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxrQkFBa0IsR0FBRyxJQUFJLENBQUM7UUFDMUIsc0JBQXNCLEdBQUcsS0FBSyxDQUFDO0lBQ2pDLENBQUM7SUFFRCwrR0FBK0c7SUFDL0csZ0hBQWdIO0lBQ2hILDZHQUE2RztJQUM3Ryw4R0FBOEc7SUFDOUcsZ0hBQWdIO0lBQ2hILHFFQUFxRTtJQUNyRSxJQUFJLHFCQUFxQixHQUFpQyxJQUFJLENBQUM7SUFDL0QsSUFBSSx5QkFBeUIsR0FBRyxLQUFLLENBQUM7SUFDdEMsSUFBSSxDQUFDO1FBQ0gseUJBQXlCLEdBQUcsT0FBTyxDQUFDLHlCQUF5QixLQUFLLFNBQVMsQ0FBQztRQUM1RSxxQkFBcUIsR0FBRyxDQUFDLE9BQU8sQ0FBQyx5QkFBeUIsSUFBSSx5QkFBeUIsQ0FBQyxFQUFFLENBQUM7SUFDN0YsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLHFCQUFxQixHQUFHLElBQUksQ0FBQztRQUM3Qix5QkFBeUIsR0FBRyxLQUFLLENBQUM7SUFDcEMsQ0FBQztJQUNELE1BQU0sYUFBYSxHQUFHLEVBQUUsVUFBVSxFQUFFLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSyxFQUFFLGNBQWMsRUFBRSxrQkFBa0IsRUFBbUIsQ0FBQztJQUVoSCxJQUFJLENBQUM7UUFDSCxJQUFJLE1BQU0sR0FDUixNQUFNLENBQUMsTUFBTSxLQUFLLElBQUk7WUFDcEIsQ0FBQyxDQUFDLE1BQU0sYUFBYSxDQUFDLE1BQU0sQ0FBQyxNQUFNLEVBQUUsV0FBVyxFQUFFLGFBQWEsQ0FBQztZQUNoRSxDQUFDLENBQUMsTUFBTSxZQUFZLENBQUMsTUFBTSxDQUFDLE9BQU8sRUFBRSxXQUFXLEVBQUUsYUFBYSxDQUFDLENBQUM7UUFDckUsTUFBTSxHQUFHLE1BQU0sNEJBQTRCLENBQUMsTUFBTSxFQUFFLG1CQUFtQixFQUFFLE9BQU8sQ0FBQyxDQUFDO1FBRWxGLDRHQUE0RztRQUM1Ryx5R0FBeUc7UUFDekcsa0dBQWtHO1FBQ2xHLE1BQU0sYUFBYSxHQUFHLENBQUMsR0FBRyxJQUFJLEdBQUcsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRixNQUFNLGNBQWMsR0FBRyxNQUFNLGVBQWUsQ0FBQyxhQUFhLEVBQUUsRUFBRSxXQUFXLEVBQUUsVUFBVSxFQUFFLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSyxFQUFtRSxDQUFDLENBQUM7UUFDaEwsTUFBTSxFQUFFLElBQUksRUFBRSxRQUFRLEVBQUUsR0FBRywwQkFBMEIsQ0FBQyxNQUFNLENBQUMsTUFBTSxFQUFFLGNBQW9DLENBQUMsQ0FBQztRQUUzRyxxR0FBcUc7UUFDckcsNEdBQTRHO1FBQzVHLGtEQUFrRDtRQUNsRCxNQUFNLGFBQWEsR0FBRyxVQUFVLENBQUMsSUFBSSxFQUFFO1lBQ3JDLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSztZQUNwQixlQUFlLEVBQUUsT0FBTyxDQUFDLGVBQWU7WUFDeEMscUJBQXFCLEVBQUUsT0FBTyxDQUFDLHFCQUFxQjtTQUN2QixDQUFDLENBQUM7UUFDakMsTUFBTSxjQUFjLEdBQUcsT0FBTyxDQUFDLGFBQWEsQ0FBQyxNQUFNLEVBQUUsRUFBRSxVQUFVLEVBQUUsY0FBYyxFQUFFLFVBQVUsRUFBbUMsQ0FBQyxDQUFDO1FBRWxJLElBQUksQ0FBQztZQUNILHdHQUF3RztZQUN4Ryx5R0FBeUc7WUFDekcsMEJBQTBCO1lBQzFCLHFCQUFxQixFQUFFLG9CQUFvQixDQUFDLGFBQWEsQ0FBQyxNQUFNLEVBQUUsT0FBTyxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQ25GLENBQUM7UUFBQyxNQUFNLENBQUM7WUFDUCxpR0FBaUc7WUFDakcsOEZBQThGO1FBQ2hHLENBQUM7UUFFRCxNQUFNLE1BQU0sR0FBbUI7WUFDN0IsV0FBVyxFQUFFLE1BQU0sQ0FBQyxNQUFNLENBQUMsTUFBTTtZQUNqQyxRQUFRLEVBQUUsTUFBTSxDQUFDLFFBQVE7WUFDekIsa0JBQWtCLEVBQUUsTUFBTSxDQUFDLGtCQUFrQjtZQUM3QyxnQkFBZ0IsRUFBRSxNQUFNLENBQUMsZ0JBQWdCO1lBQ3pDLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTTtZQUM1Qix5R0FBeUc7WUFDekcsNkdBQTZHO1lBQzdHLFFBQVEsRUFBRSxRQUFRLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxDQUFDO2dCQUNqQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFNBQVMsQ0FBQyxZQUFZO2dCQUMxQyxXQUFXLEVBQUUsS0FBSyxDQUFDLFNBQVMsQ0FBQyxXQUFXO2dCQUN4QyxNQUFNLEVBQUUsS0FBSyxDQUFDLE1BQU07YUFDckIsQ0FBQyxDQUFDO1lBQ0gsbUJBQW1CLEVBQUUsYUFBYSxDQUFDLG1CQUFtQjtZQUN0RCxjQUFjO1NBQ2YsQ0FBQztRQUVGLDBHQUEwRztRQUMxRyxvR0FBb0c7UUFDcEcsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQzNCLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxNQUFNLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDL0MsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHFCQUFxQixDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7UUFDN0MsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksa0JBQWtCLElBQUksY0FBYztZQUFFLGNBQWMsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNqRSxJQUFJLGtCQUFrQixJQUFJLGNBQWM7WUFBRSxjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDakUsSUFBSSxzQkFBc0IsSUFBSSxrQkFBa0I7WUFBRSxrQkFBa0IsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUM3RSxJQUFJLHlCQUF5QixJQUFJLHFCQUFxQjtZQUFFLHFCQUFxQixDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3hGLENBQUM7QUFDSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/discover-cli.ts
+++ b/packages/loopover-miner/lib/discover-cli.ts
@@ -1,0 +1,560 @@
+/** `discover` CLI command (#4247): wires the existing fanout -> rank -> enqueue pipeline together so a miner
+ * can actually run it. Every piece already exists and is independently tested; this module only composes them. */
+import { resolveForgeConfig } from "./forge-config.js";
+import {
+  fetchCandidateIssuesWithSummary,
+  searchCandidateIssuesWithSummary,
+} from "./opportunity-fanout.js";
+import type {
+  CandidateIssueWarning,
+  FanoutOptions,
+  FanoutTarget,
+  RawCandidateIssue,
+} from "./opportunity-fanout.js";
+import { rankCandidateIssuesWithSummary } from "./opportunity-ranker.js";
+import type {
+  RankCandidateIssuesOptions,
+  RankedCandidateIssue,
+  RankedCandidateSummary,
+} from "./opportunity-ranker.js";
+import { initPolicyDocCacheStore } from "./policy-doc-cache.js";
+import type { PolicyDocCacheStore } from "./policy-doc-cache.js";
+import { initPolicyVerdictCacheStore } from "./policy-verdict-cache.js";
+import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
+import { enqueueRankedDiscovery } from "./portfolio-discovery.js";
+import type { EnqueueRankedDiscoverySummary } from "./portfolio-discovery.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+import { initRankedCandidatesStore } from "./ranked-candidates.js";
+import type { RankedCandidatesStore } from "./ranked-candidates.js";
+import { extractContributionProfile } from "./contribution-profile-extract.js";
+import { initContributionProfileCache } from "./contribution-profile-cache.js";
+import { filterCandidatesByProfiles } from "./contribution-profile-filter.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isDiscoveryPlaneEnabled, queryDiscoveryIndex, recordDiscoveryTelemetry } from "./discovery-index-client.js";
+import type { ForgeConfig } from "./forge-config.js";
+
+export type ParsedDiscoverArgs =
+  | {
+      targets: FanoutTarget[];
+      search: string | null;
+      dryRun: boolean;
+      json: boolean;
+      /** Present only when `--api-base-url` is supplied (#4784); threads the tenant's forge host to the fan-out. */
+      apiBaseUrl?: string;
+      /** Present only when `--token-env` is supplied (#4784); names the credential env var to read. */
+      tokenEnv?: string;
+    }
+  | { error: string };
+
+/** The subset of `CandidateIssueSummary` runDiscover actually reads. It surfaces the rate-limit telemetry (#4837),
+ * so a fake must supply it. A real `fetchCandidateIssuesWithSummary` result satisfies this, since it is a superset. */
+export type DiscoverFanOutSummary = {
+  issues: RawCandidateIssue[];
+  warnings: CandidateIssueWarning[];
+  rateLimitRemaining: number | null;
+  rateLimitResetAt: string | null;
+};
+
+/** The subset of a ranked entry that `renderDiscoverSummary` reads for its top-candidates listing. */
+export type DiscoverRankedEntry = Pick<
+  RankedCandidateIssue,
+  "repoFullName" | "issueNumber" | "title" | "rankScore"
+>;
+
+export type DiscoverResult = {
+  fanOutCount: number;
+  warnings: CandidateIssueWarning[];
+  rateLimitRemaining: number | null;
+  rateLimitResetAt: string | null;
+  ranked: DiscoverRankedEntry[];
+  /** Candidates the eligibility filter dropped, each with the repo/issue and the reason (#6798). */
+  excluded?: Array<{
+    repoFullName: string;
+    issueNumber: number;
+    reason: string;
+  }>;
+  /** True when ranking fell back to the built-in default goal spec because no per-tenant spec was supplied (#4784). */
+  usedDefaultGoalSpec?: boolean;
+  enqueueSummary: EnqueueRankedDiscoverySummary;
+};
+
+export type RunDiscoverOptions = {
+  /** Read for the discovery-index opt-in gate (#7168) -- defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+  githubToken?: string;
+  apiBaseUrl?: string;
+  /** Per-tenant credential env var name (#4784); defaults to GITHUB_TOKEN. Overridden by a `--token-env` flag. */
+  tokenEnv?: string;
+  /** Per-tenant forge knobs beyond the host (#4784), forwarded to the fan-out. */
+  forge?: Partial<ForgeConfig>;
+  nowMs?: number;
+  /** Per-tenant goal specs threaded to the ranker so lane fit uses the tenant's conventions, not the defaults (#4784). */
+  goalSpecsByRepo?: RankCandidateIssuesOptions["goalSpecsByRepo"];
+  goalSpecContentByRepo?: RankCandidateIssuesOptions["goalSpecContentByRepo"];
+  initPortfolioQueue?: () => PortfolioQueueStore;
+  initPolicyDocCache?: () => PolicyDocCacheStore;
+  initPolicyVerdictCache?: () => PolicyVerdictCacheStore;
+  initRankedCandidatesStore?: () => RankedCandidatesStore;
+  fetchCandidateIssuesWithSummary?: (
+    targets: FanoutTarget[],
+    githubToken: string,
+    options?: FanoutOptions,
+  ) => Promise<DiscoverFanOutSummary>;
+  searchCandidateIssuesWithSummary?: (
+    searchQuery: string,
+    githubToken: string,
+    options?: FanoutOptions,
+  ) => Promise<DiscoverFanOutSummary>;
+  rankCandidateIssuesWithSummary?: (
+    candidates: RawCandidateIssue[],
+    options?: RankCandidateIssuesOptions,
+  ) => RankedCandidateSummary;
+  enqueueRankedDiscovery?: (
+    rankedIssues: RankedCandidateIssue[],
+    options: { queueStore: PortfolioQueueStore },
+  ) => EnqueueRankedDiscoverySummary;
+  /** Supplements the local fan-out with hosted discovery-index results for the same scope, when the plane is
+   *  enabled (#7168). Defaults to discovery-index-client.js's own queryDiscoveryIndex. */
+  queryDiscoveryIndex?: typeof queryDiscoveryIndex;
+  /** Invoked with the real structured result at each success return point (dry-run and full-run), in addition
+   *  to (never instead of) the plain exit-code return -- mirrors `RunAttemptOptions.onResult`. Never fires on a
+   *  parse-error/unexpected-error `reportCliFailure` branch, matching runAttempt's own asymmetry (#6522). */
+  onResult?: (result: DiscoverResult) => void;
+  /** Resolve each candidate repo's ContributionProfile for eligibility filtering (#6798). Defaults to
+   *  resolveContributionProfilesForDiscover; injectable so tests avoid the network. */
+  resolveContributionProfiles?: (
+    repoFullNames: string[],
+    ctx: { githubToken?: string; apiBaseUrl?: string; nowMs?: number },
+  ) => Promise<Map<string, unknown>>;
+};
+
+const DISCOVER_USAGE =
+  "Usage: loopover-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--dry-run] [--json] [--api-base-url <url>] [--token-env <VAR>]";
+
+const MAX_DISCOVER_TITLE_DISPLAY_LENGTH = 240;
+const OSC_SEQUENCE_PATTERN = /\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g;
+const ANSI_ESCAPE_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|[@-_])/g;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/g;
+const BIDI_CONTROL_PATTERN = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
+
+export function sanitizeDiscoverDisplayText(value: unknown): string {
+  return String(value ?? "")
+    .replace(OSC_SEQUENCE_PATTERN, "")
+    .replace(ANSI_ESCAPE_PATTERN, "")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(BIDI_CONTROL_PATTERN, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_DISCOVER_TITLE_DISPLAY_LENGTH);
+}
+
+function dedupeKey(repoFullName: string, issueNumber: number): string {
+  return `${repoFullName.toLowerCase()}#${issueNumber}`;
+}
+
+/**
+ * Supplements `fanOut.issues` with hosted discovery-index results for the same scope (#7168) -- a complete
+ * no-op (returns `fanOut` unchanged) unless the plane is enabled, so a run with the flag unset behaves exactly
+ * as before this feature existed. Local results always win on a duplicate issue (the discovery-index candidate
+ * is dropped, not merged over it) -- this instance's own live fan-out is more current than a cached shared
+ * index entry. Discovery-index candidates lack `assignees` (not part of the public contract), so they're
+ * annotated with an empty array to match opportunity-fanout.js's own candidate shape; contribution-profile-
+ * filter.js's assignee-exclusion rule treats that identically to "no assignees on this issue".
+ */
+async function supplementWithDiscoveryIndex(
+  fanOut: DiscoverFanOutSummary,
+  queryScope: Parameters<typeof queryDiscoveryIndex>[0],
+  options: RunDiscoverOptions,
+): Promise<DiscoverFanOutSummary> {
+  const env = options.env ?? process.env;
+  if (!isDiscoveryPlaneEnabled(env)) return fanOut;
+  const queryIndex = options.queryDiscoveryIndex ?? queryDiscoveryIndex;
+  const response = await queryIndex(queryScope, { env });
+  recordDiscoveryTelemetry("discover_query", response.candidates.length > 0 ? "supplemented" : "empty", { env });
+  if (response.candidates.length === 0) return fanOut;
+
+  const seen = new Set(fanOut.issues.map((issue) => dedupeKey(issue.repoFullName, issue.issueNumber)));
+  const supplemented = response.candidates
+    .filter((candidate) => !seen.has(dedupeKey(candidate.repoFullName, candidate.issueNumber)))
+    .map((candidate) => ({ ...candidate, assignees: [] }) as unknown as RawCandidateIssue);
+  if (supplemented.length === 0) return fanOut;
+  return { ...fanOut, issues: [...fanOut.issues, ...supplemented] };
+}
+
+function parseRepoTarget(value: unknown): FanoutTarget | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return { owner, repo };
+}
+
+export function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs {
+  // `--api-base-url` and `--token-env` (#4784) thread the tenant's forge host and credential env var into the
+  // fan-out; they are kept off the parsed result unless supplied, so callers that pass neither see the exact
+  // pre-#4784 `{ targets, search, json }` shape.
+  const options: {
+    json: boolean;
+    dryRun: boolean;
+    search: string | null;
+    apiBaseUrl: string | null;
+    tokenEnv: string | null;
+  } = { json: false, dryRun: false, search: null, apiBaseUrl: null, tokenEnv: null };
+  const targets: FanoutTarget[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: fetches + ranks exactly as a real run, but skips opening any local store and makes zero writes.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--search") {
+      const query = args[index + 1];
+      if (!query || query.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.search = query;
+      index += 1;
+      continue;
+    }
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--token-env") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.tokenEnv = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    const target = parseRepoTarget(token);
+    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
+    targets.push(target);
+  }
+
+  if (options.search === null && targets.length === 0) {
+    return { error: DISCOVER_USAGE };
+  }
+  if (options.search !== null && targets.length > 0) {
+    return { error: "Pass either repository targets or --search, not both." };
+  }
+
+  return {
+    targets,
+    search: options.search,
+    dryRun: options.dryRun,
+    json: options.json,
+    ...(options.apiBaseUrl !== null ? { apiBaseUrl: options.apiBaseUrl } : {}),
+    ...(options.tokenEnv !== null ? { tokenEnv: options.tokenEnv } : {}),
+  };
+}
+
+// The rate-limit line surfaces the telemetry the fanout already records (#4837) so an operator sees how close a
+// `discover` run is to being throttled without running a separate command. `unknown` covers the no-fetch/no-header
+// case where the fanout captured no remaining count.
+function renderRateLimitLine(result: Pick<DiscoverResult, "rateLimitRemaining" | "rateLimitResetAt">): string {
+  const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
+  const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
+  return `rate-limit remaining: ${remaining}${resetSuffix}`;
+}
+
+export function renderDiscoverSummary(result: DiscoverResult): string {
+  const lines = [
+    `fanned out: ${result.fanOutCount} candidate issue(s)`,
+    `ai-policy warnings: ${result.warnings.length}`,
+    `ranked: ${result.ranked.length}`,
+    `enqueued: ${result.enqueueSummary.enqueued}`,
+    renderRateLimitLine(result),
+  ];
+  if (result.enqueueSummary.skippedBelowMinRank > 0) {
+    lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
+  }
+  // #6798: surface what the eligibility filter dropped and why, so a human sees AMS's inference.
+  const excluded = result.excluded ?? [];
+  if (excluded.length > 0) {
+    lines.push(`excluded (eligibility): ${excluded.length}`);
+    for (const entry of excluded.slice(0, 10)) {
+      lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  ${entry.reason}`);
+    }
+  }
+  // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
+  // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
+  if (result.usedDefaultGoalSpec) {
+    lines.push(
+      "note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)",
+    );
+  }
+  if (result.ranked.length === 0) {
+    lines.push("", "no candidates found.");
+    return lines.join("\n");
+  }
+  lines.push("", "top candidates:");
+  for (const entry of result.ranked.slice(0, 10)) {
+    const title = sanitizeDiscoverDisplayText(entry.title);
+    lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${title}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Default per-repo ContributionProfile resolver (#6798): reads the local cache and, on a miss/stale entry,
+ * extracts a fresh profile and caches it. Returns a Map keyed by repoFullName.
+ *
+ * WITHOUT a github token this returns an empty map and does no network work at all — AMS can't reliably read a
+ * repo's label taxonomy/docs unauthenticated (rate limits), so it safe-defaults to no eligibility filtering.
+ * That also keeps callers that don't supply a token (the common CLI path, and every test) hermetic.
+ *
+ * @param {string[]} repoFullNames unique repos among the fanned-out candidates
+ * @param {{ githubToken?: string, apiBaseUrl?: string, nowMs?: number, initCache?: typeof initContributionProfileCache, extract?: typeof extractContributionProfile }} ctx
+ * @returns {Promise<Map<string, object>>}
+ */
+export async function resolveContributionProfilesForDiscover(
+  repoFullNames: string[],
+  ctx: {
+    githubToken?: string;
+    apiBaseUrl?: string;
+    nowMs?: number;
+    initCache?: typeof initContributionProfileCache;
+    extract?: typeof extractContributionProfile;
+  } = {},
+): Promise<Map<string, unknown>> {
+  const profiles = new Map<string, unknown>();
+  if (!ctx.githubToken) return profiles;
+  const initCache = ctx.initCache ?? initContributionProfileCache;
+  const extract = ctx.extract ?? extractContributionProfile;
+  const cache = initCache();
+  try {
+    for (const repoFullName of repoFullNames) {
+      const cached = cache.get(repoFullName, ctx.nowMs);
+      if (cached && !cached.stale) {
+        profiles.set(repoFullName, cached.profile);
+        continue;
+      }
+      const profile = await extract(repoFullName, { githubToken: ctx.githubToken, apiBaseUrl: ctx.apiBaseUrl } as Parameters<typeof extractContributionProfile>[1]);
+      cache.put(profile, ctx.nowMs);
+      profiles.set(repoFullName, profile);
+    }
+  } finally {
+    cache.close();
+  }
+  return profiles;
+}
+
+export async function runDiscover(args: string[], options: RunDiscoverOptions = {}): Promise<number> {
+  const parsed = parseDiscoverArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
+  // non-`GITHUB_TOKEN` variable so a non-github.com forge's token is reachable. The default falls through to the
+  // forge adapter's own `tokenEnvVar` (github.com's `GITHUB_TOKEN`), so there's a single source of truth for the
+  // default credential env instead of a second hardcoded literal that could drift from `DEFAULT_FORGE_CONFIG`.
+  const tokenEnv = parsed.tokenEnv ?? options.tokenEnv ?? resolveForgeConfig(options.forge).tokenEnvVar;
+  const githubToken = options.githubToken ?? process.env[tokenEnv] ?? "";
+  // A `--api-base-url` flag (or `options.apiBaseUrl`) surfaces the fan-out's existing forge-host override at the CLI
+  // (#4784); `options.forge` carries any remaining per-tenant forge knobs for a programmatic caller.
+  const apiBaseUrl = parsed.apiBaseUrl ?? options.apiBaseUrl;
+  const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
+  const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
+  const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
+  const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
+  // Eligibility filtering (#6798): resolve each candidate repo's ContributionProfile and drop candidates the
+  // repo's own conventions would reject, BEFORE ranking. Safe by default -- see resolveContributionProfilesForDiscover.
+  const resolveProfiles = options.resolveContributionProfiles ?? resolveContributionProfilesForDiscover;
+  // Same scope this run already asks GitHub about (#7168) -- the discovery-index supplement, when enabled,
+  // asks the shared hosted index about the identical targets/search rather than a different query entirely.
+  const discoveryQueryScope =
+    parsed.search !== null
+      ? { repos: [], orgs: [], searchTerms: [parsed.search] }
+      : { repos: parsed.targets.map((target) => `${target.owner}/${target.repo}`), orgs: [], searchTerms: [] };
+
+  // #4847: fetch + rank are read-only GitHub GETs and pure local computation, so a dry run still does them for
+  // real (that's the useful "what would this discover?" output) -- but it never opens any local store (portfolio
+  // queue, policy-doc cache, policy-verdict cache), since opening a not-yet-existing SQLite store file is itself
+  // a write. The ranked issues are fed through a no-op queue stub so enqueueRankedDiscovery's own classification
+  // logic (valid/invalid, below-min-rank) still runs for real, just without ever touching the real queue.
+  if (parsed.dryRun) {
+    const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache: null, policyVerdictCache: null } as FanoutOptions;
+    try {
+      let fanOut =
+        parsed.search !== null
+          ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+          : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+      fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+      // #6798: same eligibility filter as the real path, so a dry run shows the exact candidate set a real run
+      // would enqueue (and the same excluded set), rather than an unfiltered preview.
+      const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+      const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs } as { githubToken?: string; apiBaseUrl?: string; nowMs?: number });
+      const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo as Map<string, never>);
+      const rankedSummary = rankIssues(kept, {
+        nowMs: options.nowMs,
+        goalSpecsByRepo: options.goalSpecsByRepo,
+        goalSpecContentByRepo: options.goalSpecContentByRepo,
+      } as RankCandidateIssuesOptions);
+      const noopQueueStore = { enqueue: () => {} } as unknown as PortfolioQueueStore;
+      const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: noopQueueStore });
+      const result: DiscoverResult & { outcome: string } = {
+        outcome: "dry_run",
+        fanOutCount: fanOut.issues.length,
+        warnings: fanOut.warnings,
+        rateLimitRemaining: fanOut.rateLimitRemaining,
+        rateLimitResetAt: fanOut.rateLimitResetAt,
+        ranked: rankedSummary.issues,
+        excluded: excluded.map((entry) => ({
+          repoFullName: entry.candidate.repoFullName,
+          issueNumber: entry.candidate.issueNumber,
+          reason: entry.reason,
+        })),
+        usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+        enqueueSummary,
+      };
+      // Structured-outcome hook (#6522), mirroring runAttempt's onResult convention: fires only at a real
+      // structured success point (never the reportCliFailure branches), in addition to -- never instead of --
+      // the plain exit-code return, so a non-CLI caller (the /api/discover route) can read the result.
+      options.onResult?.(result);
+      if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(renderDiscoverSummary(result));
+        console.log("\nDRY RUN: no portfolio-queue write was made.");
+      }
+      return 0;
+    } catch (error) {
+      return reportCliFailure(parsed.json, describeCliError(error));
+    }
+  }
+
+  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+  let portfolioQueue: PortfolioQueueStore;
+  try {
+    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+
+  // Local ETag cache so a repeated discover revalidates each repo's policy docs with a conditional GET instead of
+  // re-downloading them (#4842). Opened inside its OWN try/catch, separate from the portfolio queue above: the
+  // queue is required infrastructure (discovery genuinely cannot enqueue anything without it, so a real open
+  // failure should abort the run), but the policy-doc cache is a pure performance optimization -- a corrupt or
+  // unwritable cache DB must degrade to "no cache" (every doc fetched in full, exactly as before #4842) rather
+  // than fail discovery outright.
+  let policyDocCache: PolicyDocCacheStore | null = null;
+  let ownsPolicyDocCache = false;
+  try {
+    ownsPolicyDocCache = options.initPolicyDocCache === undefined;
+    policyDocCache = (options.initPolicyDocCache ?? initPolicyDocCacheStore)();
+  } catch {
+    policyDocCache = null;
+    ownsPolicyDocCache = false;
+  }
+
+  // Persisted cache of resolved policy verdicts (#4843), same "own try/catch, degrade to null" discipline as the
+  // doc cache above and for the same reason: purely a performance optimization the feature is inert without, so a
+  // corrupt/unwritable cache DB must never abort a run.
+  let policyVerdictCache: PolicyVerdictCacheStore | null = null;
+  let ownsPolicyVerdictCache = false;
+  try {
+    ownsPolicyVerdictCache = options.initPolicyVerdictCache === undefined;
+    policyVerdictCache = (options.initPolicyVerdictCache ?? initPolicyVerdictCacheStore)();
+  } catch {
+    policyVerdictCache = null;
+    ownsPolicyVerdictCache = false;
+  }
+
+  // Snapshot of this run's full ranked output (#4859 prerequisite), so a local HTTP endpoint (and eventually the
+  // miner-ui/browser-extension live-fetch it's meant for) can serve the same per-issue breakdown `--json` prints,
+  // without the operator re-running discover or hand-pasting its output. Same "own try/catch, degrade to null"
+  // discipline as the two caches above: a corrupt/unwritable snapshot store must never abort discovery's actual
+  // job (fan out, rank, enqueue). Unlike the caches, this store is a WRITE target, not a read optimization -- the
+  // save call itself gets its own try/catch below for the same reason.
+  let rankedCandidatesStore: RankedCandidatesStore | null = null;
+  let ownsRankedCandidatesStore = false;
+  try {
+    ownsRankedCandidatesStore = options.initRankedCandidatesStore === undefined;
+    rankedCandidatesStore = (options.initRankedCandidatesStore ?? initRankedCandidatesStore)();
+  } catch {
+    rankedCandidatesStore = null;
+    ownsRankedCandidatesStore = false;
+  }
+  const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache, policyVerdictCache } as FanoutOptions;
+
+  try {
+    let fanOut =
+      parsed.search !== null
+        ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+        : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+    fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+
+    // Eligibility filter (#6798): drop candidates a target repo's own conventions would reject, before ranking.
+    // A repo with no trustworthy eligibility profile keeps every candidate (filterCandidatesByProfiles' safe
+    // default), so this never silently skips real work on a repo whose conventions AMS couldn't read.
+    const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+    const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs } as { githubToken?: string; apiBaseUrl?: string; nowMs?: number });
+    const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo as Map<string, never>);
+
+    // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
+    // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
+    // `usedDefaultGoalSpec` below rather than hidden.
+    const rankedSummary = rankIssues(kept, {
+      nowMs: options.nowMs,
+      goalSpecsByRepo: options.goalSpecsByRepo,
+      goalSpecContentByRepo: options.goalSpecContentByRepo,
+    } as RankCandidateIssuesOptions);
+    const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue, apiBaseUrl } as Parameters<typeof enqueue>[1]);
+
+    try {
+      // Optional chaining rather than an `if (rankedCandidatesStore)` guard: a null store (open failed above)
+      // short-circuits to a no-op read, so the same try/catch below also covers the open-failed case without a
+      // second explicit branch.
+      rankedCandidatesStore?.saveRankedCandidates(rankedSummary.issues, options.nowMs);
+    } catch {
+      // Non-fatal: the ranked-candidates snapshot is a nice-to-have for the local HTTP endpoint, not a
+      // requirement for discover's own job (fan out, rank, enqueue), which already succeeded above.
+    }
+
+    const result: DiscoverResult = {
+      fanOutCount: fanOut.issues.length,
+      warnings: fanOut.warnings,
+      rateLimitRemaining: fanOut.rateLimitRemaining,
+      rateLimitResetAt: fanOut.rateLimitResetAt,
+      ranked: rankedSummary.issues,
+      // #6798: candidates the eligibility filter dropped, each with the repo + issue + reason, so a human sees
+      // what AMS inferred and why a candidate was skipped. Empty when no profile was trustworthy enough to filter.
+      excluded: excluded.map((entry) => ({
+        repoFullName: entry.candidate.repoFullName,
+        issueNumber: entry.candidate.issueNumber,
+        reason: entry.reason,
+      })),
+      usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+      enqueueSummary,
+    };
+
+    // Structured-outcome hook (#6522) for the full-run success point -- same convention as the dry-run branch
+    // above and as runAttempt's onResult: real result only, additive to the unchanged exit-code return.
+    options.onResult?.(result);
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(renderDiscoverSummary(result));
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsPortfolioQueue && portfolioQueue) portfolioQueue.close();
+    if (ownsPolicyDocCache && policyDocCache) policyDocCache.close();
+    if (ownsPolicyVerdictCache && policyVerdictCache) policyVerdictCache.close();
+    if (ownsRankedCandidatesStore && rankedCandidatesStore) rankedCandidatesStore.close();
+  }
+}

--- a/packages/loopover-miner/lib/governor-metrics-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-metrics-cli.d.ts
@@ -1,16 +1,9 @@
 import type { GovernorCapUsage } from "@loopover/engine";
 import type { GovernorRateLimitState, GovernorState } from "./governor-state.js";
-
-export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO: string;
-export const GOVERNOR_CAP_USAGE_RATIO: string;
-
-export function renderGovernorMetrics(
-  rateLimitState: GovernorRateLimitState,
-  capUsage: GovernorCapUsage,
-  nowMs: number,
-): string;
-
-export function runGovernorMetrics(
-  args: string[],
-  options?: { openGovernorState?: () => GovernorState; nowMs?: number },
-): Promise<number>;
+export declare const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
+export declare const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
+export declare function renderGovernorMetrics(rateLimitState: GovernorRateLimitState, capUsage: GovernorCapUsage, nowMs: number): string;
+export declare function runGovernorMetrics(args: string[], options?: {
+    openGovernorState?: () => GovernorState;
+    nowMs?: number;
+}): Promise<number>;

--- a/packages/loopover-miner/lib/governor-metrics-cli.js
+++ b/packages/loopover-miner/lib/governor-metrics-cli.js
@@ -1,12 +1,6 @@
-import {
-  DEFAULT_AMS_POLICY_SPEC,
-  DEFAULT_WRITE_RATE_LIMIT_POLICIES,
-  evaluateGovernorCaps,
-  evaluateLocalRateLimit,
-} from "@loopover/engine";
+import { DEFAULT_AMS_POLICY_SPEC, DEFAULT_WRITE_RATE_LIMIT_POLICIES, evaluateGovernorCaps, evaluateLocalRateLimit, } from "@loopover/engine";
 import { openGovernorState } from "./governor-state.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 // `governor metrics` (#5187): render the governor's persisted rate-limit + cap-usage state (#5134,
 // governor-state.js) as Prometheus text-exposition, so an operator's Alertmanager can page on rate-limit/
 // budget pressure without hand-rolling a scrape. Strictly read-only, mirroring queue-cli.js's `queue metrics`
@@ -23,32 +17,27 @@ import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js
 // per-repo capLimits override from a resolved `.loopover-miner.yml` has no matching per-repo usage row to
 // pair it with here. Using the fleet-wide DEFAULT_AMS_POLICY_SPEC.capLimits is the same approximation
 // loop-cli.js itself already makes for any repo without its own override.
-
 const GOVERNOR_METRICS_USAGE = "Usage: loopover-miner governor metrics";
-
 export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
 export const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeMetricsHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /** Prometheus label-value escaping — backslash, double-quote, newline (mirrors event-ledger-cli.js's
  *  escapeLabelValue). */
 function escapeLabelValue(value) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
-
 /** buckets.perRepo is keyed by writeRateLimitRepoKey(actionClass, repoFullName) = "actionClass:repoFullName"
  *  (write-rate-limit.ts). actionClass is a fixed identifier (never contains ":"), so splitting on the FIRST
  *  colon recovers both parts even though repoFullName itself contains a "/". */
 function splitPerRepoKey(key) {
-  const separatorIndex = key.indexOf(":");
-  if (separatorIndex === -1) return { actionClass: key, repoFullName: "" };
-  return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
+    const separatorIndex = key.indexOf(":");
+    if (separatorIndex === -1)
+        return { actionClass: key, repoFullName: "" };
+    return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
 }
-
 // evaluateLocalRateLimit's own `remaining` field answers "how many MORE writes are allowed AFTER one more write
 // right now" (rate-limit.ts: `remaining = allowed ? limit - effectiveCount - 1 : 0`) -- it is NOT current
 // headroom. At count=2/limit=3 that field is already 0, identical to a fully exhausted count=3/limit=3 bucket,
@@ -58,114 +47,100 @@ function splitPerRepoKey(key) {
 // has already passed the DEFAULT_WRITE_RATE_LIMIT_POLICIES lookup above, so decision.limit is always one of the
 // frozen, non-zero policy limits -- no zero-limit guard needed.
 function remainingRatio(decision) {
-  const headroom = decision.allowed ? decision.remaining + 1 : 0;
-  return headroom / decision.limit;
+    const headroom = decision.allowed ? decision.remaining + 1 : 0;
+    return headroom / decision.limit;
 }
-
 function collectRateLimitRows(buckets, nowMs) {
-  const rows = [];
-  for (const [actionClass, bucket] of Object.entries(buckets.global)) {
-    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
-    if (!config) continue;
-    rows.push({
-      scope: "global",
-      actionClass,
-      repoFullName: "",
-      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    const rows = [];
+    for (const [actionClass, bucket] of Object.entries(buckets.global)) {
+        const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
+        if (!config)
+            continue;
+        rows.push({
+            scope: "global",
+            actionClass,
+            repoFullName: "",
+            ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+        });
+    }
+    for (const [key, bucket] of Object.entries(buckets.perRepo)) {
+        const { actionClass, repoFullName } = splitPerRepoKey(key);
+        const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
+        if (!config)
+            continue;
+        rows.push({
+            scope: "per_repo",
+            actionClass,
+            repoFullName,
+            ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+        });
+    }
+    rows.sort((a, b) => {
+        if (a.scope !== b.scope)
+            return a.scope.localeCompare(b.scope);
+        if (a.actionClass !== b.actionClass)
+            return a.actionClass.localeCompare(b.actionClass);
+        return a.repoFullName.localeCompare(b.repoFullName);
     });
-  }
-  for (const [key, bucket] of Object.entries(buckets.perRepo)) {
-    const { actionClass, repoFullName } = splitPerRepoKey(key);
-    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
-    if (!config) continue;
-    rows.push({
-      scope: "per_repo",
-      actionClass,
-      repoFullName,
-      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
-    });
-  }
-  rows.sort((a, b) => {
-    if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
-    if (a.actionClass !== b.actionClass) return a.actionClass.localeCompare(b.actionClass);
-    return a.repoFullName.localeCompare(b.repoFullName);
-  });
-  return rows;
+    return rows;
 }
-
 // DEFAULT_AMS_POLICY_SPEC.capLimits is a frozen, non-zero constant for every dimension -- no zero-limit guard
 // needed, mirroring remainingRatio()'s reasoning above.
 function collectCapUsageRows(capUsage) {
-  const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
-  return [
-    { dimension: "budget", dimensionReport: report.budget },
-    { dimension: "turns", dimensionReport: report.turns },
-    { dimension: "elapsed_ms", dimensionReport: report.termination },
-  ].map(({ dimension, dimensionReport }) => ({
-    dimension,
-    ratio: dimensionReport.used / dimensionReport.limit,
-  }));
+    const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
+    return [
+        { dimension: "budget", dimensionReport: report.budget },
+        { dimension: "turns", dimensionReport: report.turns },
+        { dimension: "elapsed_ms", dimensionReport: report.termination },
+    ].map(({ dimension, dimensionReport }) => ({
+        dimension,
+        ratio: dimensionReport.used / dimensionReport.limit,
+    }));
 }
-
-/**
- * @param {import("./governor-state.js").GovernorRateLimitState} rateLimitState
- * @param {import("@loopover/engine").GovernorCapUsage} capUsage
- * @param {number} nowMs
- */
 export function renderGovernorMetrics(rateLimitState, capUsage, nowMs) {
-  const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
-  const capRows = collectCapUsageRows(capUsage);
-
-  const lines = [
-    `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText(
-      "Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.",
-    )}`,
-    `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
-  ];
-  for (const row of rateLimitRows) {
-    const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
-    lines.push(
-      `${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`,
-    );
-  }
-
-  lines.push(
-    `# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText(
-      "The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.",
-    )}`,
-  );
-  lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
-  for (const row of capRows) {
-    lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
-  }
-
-  return `${lines.join("\n")}\n`;
+    const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
+    const capRows = collectCapUsageRows(capUsage);
+    const lines = [
+        `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText("Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.")}`,
+        `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
+    ];
+    for (const row of rateLimitRows) {
+        const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
+        lines.push(`${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`);
+    }
+    lines.push(`# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText("The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.")}`);
+    lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
+    for (const row of capRows) {
+        lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
+    }
+    return `${lines.join("\n")}\n`;
 }
-
 async function withGovernorState(options, run) {
-  const ownsGovernorState = options.openGovernorState === undefined;
-  const governorState = (options.openGovernorState ?? openGovernorState)();
-  try {
-    return run(governorState);
-  } finally {
-    if (ownsGovernorState) governorState.close();
-  }
+    const ownsGovernorState = options.openGovernorState === undefined;
+    const governorState = (options.openGovernorState ?? openGovernorState)();
+    try {
+        return run(governorState);
+    }
+    finally {
+        if (ownsGovernorState)
+            governorState.close();
+    }
 }
-
 export async function runGovernorMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
-      const rateLimitState = governorState.loadRateLimitState();
-      const capUsage = governorState.loadCapUsage();
-      console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+            const rateLimitState = governorState.loadRateLimitState();
+            const capUsage = governorState.loadCapUsage();
+            console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItbWV0cmljcy1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJnb3Zlcm5vci1tZXRyaWNzLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQ0wsdUJBQXVCLEVBQ3ZCLGlDQUFpQyxFQUNqQyxvQkFBb0IsRUFDcEIsc0JBQXNCLEdBQ3ZCLE1BQU0sa0JBQWtCLENBQUM7QUFNMUIsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFFeEQsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBRWxGLG1HQUFtRztBQUNuRywwR0FBMEc7QUFDMUcsOEdBQThHO0FBQzlHLDZHQUE2RztBQUM3Ryx1R0FBdUc7QUFDdkcsNkdBQTZHO0FBQzdHLCtHQUErRztBQUMvRyw4R0FBOEc7QUFDOUcsOEdBQThHO0FBQzlHLDBDQUEwQztBQUMxQyxFQUFFO0FBQ0YsOEdBQThHO0FBQzlHLDBHQUEwRztBQUMxRywwR0FBMEc7QUFDMUcsc0dBQXNHO0FBQ3RHLDBFQUEwRTtBQUUxRSxNQUFNLHNCQUFzQixHQUFHLHdDQUF3QyxDQUFDO0FBRXhFLE1BQU0sQ0FBQyxNQUFNLG1DQUFtQyxHQUFHLG9EQUFvRCxDQUFDO0FBQ3hHLE1BQU0sQ0FBQyxNQUFNLHdCQUF3QixHQUFHLHlDQUF5QyxDQUFDO0FBY2xGLHVHQUF1RztBQUN2RyxTQUFTLHFCQUFxQixDQUFDLElBQVk7SUFDekMsT0FBTyxJQUFJLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxNQUFNLENBQUMsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO0FBQzNELENBQUM7QUFFRDt5QkFDeUI7QUFDekIsU0FBUyxnQkFBZ0IsQ0FBQyxLQUFhO0lBQ3JDLE9BQU8sS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsTUFBTSxDQUFDLENBQUMsT0FBTyxDQUFDLElBQUksRUFBRSxLQUFLLENBQUMsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO0FBQ2pGLENBQUM7QUFFRDs7Z0ZBRWdGO0FBQ2hGLFNBQVMsZUFBZSxDQUFDLEdBQVc7SUFDbEMsTUFBTSxjQUFjLEdBQUcsR0FBRyxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUN4QyxJQUFJLGNBQWMsS0FBSyxDQUFDLENBQUM7UUFBRSxPQUFPLEVBQUUsV0FBVyxFQUFFLEdBQUcsRUFBRSxZQUFZLEVBQUUsRUFBRSxFQUFFLENBQUM7SUFDekUsT0FBTyxFQUFFLFdBQVcsRUFBRSxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxjQUFjLENBQUMsRUFBRSxZQUFZLEVBQUUsR0FBRyxDQUFDLEtBQUssQ0FBQyxjQUFjLEdBQUcsQ0FBQyxDQUFDLEVBQUUsQ0FBQztBQUNwRyxDQUFDO0FBRUQsZ0hBQWdIO0FBQ2hILDBHQUEwRztBQUMxRywrR0FBK0c7QUFDL0csNEdBQTRHO0FBQzVHLDhHQUE4RztBQUM5Ryw2R0FBNkc7QUFDN0csZ0hBQWdIO0FBQ2hILGdFQUFnRTtBQUNoRSxTQUFTLGNBQWMsQ0FBQyxRQUFnQztJQUN0RCxNQUFNLFFBQVEsR0FBRyxRQUFRLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsU0FBUyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQy9ELE9BQU8sUUFBUSxHQUFHLFFBQVEsQ0FBQyxLQUFLLENBQUM7QUFDbkMsQ0FBQztBQUVELFNBQVMsb0JBQW9CLENBQUMsT0FBa0MsRUFBRSxLQUFhO0lBQzdFLE1BQU0sSUFBSSxHQUFtQixFQUFFLENBQUM7SUFDaEMsS0FBSyxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDbkUsTUFBTSxNQUFNLEdBQUcsaUNBQWlDLENBQUMsTUFBTSxDQUFDLFdBQVcsQ0FBQyxDQUFDO1FBQ3JFLElBQUksQ0FBQyxNQUFNO1lBQUUsU0FBUztRQUN0QixJQUFJLENBQUMsSUFBSSxDQUFDO1lBQ1IsS0FBSyxFQUFFLFFBQVE7WUFDZixXQUFXO1lBQ1gsWUFBWSxFQUFFLEVBQUU7WUFDaEIsS0FBSyxFQUFFLGNBQWMsQ0FBQyxzQkFBc0IsQ0FBQyxNQUFNLEVBQUUsTUFBTSxFQUFFLEtBQUssQ0FBQyxDQUFDO1NBQ3JFLENBQUMsQ0FBQztJQUNMLENBQUM7SUFDRCxLQUFLLE1BQU0sQ0FBQyxHQUFHLEVBQUUsTUFBTSxDQUFDLElBQUksTUFBTSxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDLEVBQUUsQ0FBQztRQUM1RCxNQUFNLEVBQUUsV0FBVyxFQUFFLFlBQVksRUFBRSxHQUFHLGVBQWUsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUMzRCxNQUFNLE1BQU0sR0FBRyxpQ0FBaUMsQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDLENBQUM7UUFDdEUsSUFBSSxDQUFDLE1BQU07WUFBRSxTQUFTO1FBQ3RCLElBQUksQ0FBQyxJQUFJLENBQUM7WUFDUixLQUFLLEVBQUUsVUFBVTtZQUNqQixXQUFXO1lBQ1gsWUFBWTtZQUNaLEtBQUssRUFBRSxjQUFjLENBQUMsc0JBQXNCLENBQUMsTUFBTSxFQUFFLE1BQU0sRUFBRSxLQUFLLENBQUMsQ0FBQztTQUNyRSxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQ0QsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsRUFBRTtRQUNqQixJQUFJLENBQUMsQ0FBQyxLQUFLLEtBQUssQ0FBQyxDQUFDLEtBQUs7WUFBRSxPQUFPLENBQUMsQ0FBQyxLQUFLLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMvRCxJQUFJLENBQUMsQ0FBQyxXQUFXLEtBQUssQ0FBQyxDQUFDLFdBQVc7WUFBRSxPQUFPLENBQUMsQ0FBQyxXQUFXLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxXQUFXLENBQUMsQ0FBQztRQUN2RixPQUFPLENBQUMsQ0FBQyxZQUFZLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUN0RCxDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sSUFBSSxDQUFDO0FBQ2QsQ0FBQztBQUVELDhHQUE4RztBQUM5Ryx3REFBd0Q7QUFDeEQsU0FBUyxtQkFBbUIsQ0FBQyxRQUEwQjtJQUNyRCxNQUFNLE1BQU0sR0FBRyxvQkFBb0IsQ0FBQyxRQUFRLEVBQUUsdUJBQXVCLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDakYsT0FBTztRQUNMLEVBQUUsU0FBUyxFQUFFLFFBQVEsRUFBRSxlQUFlLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRTtRQUN2RCxFQUFFLFNBQVMsRUFBRSxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sQ0FBQyxLQUFLLEVBQUU7UUFDckQsRUFBRSxTQUFTLEVBQUUsWUFBWSxFQUFFLGVBQWUsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFO0tBQ2pFLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxTQUFTLEVBQUUsZUFBZSxFQUFFLEVBQUUsRUFBRSxDQUFDLENBQUM7UUFDekMsU0FBUztRQUNULEtBQUssRUFBRSxlQUFlLENBQUMsSUFBSSxHQUFHLGVBQWUsQ0FBQyxLQUFLO0tBQ3BELENBQUMsQ0FBQyxDQUFDO0FBQ04sQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FDbkMsY0FBc0MsRUFDdEMsUUFBMEIsRUFDMUIsS0FBYTtJQUViLE1BQU0sYUFBYSxHQUFHLG9CQUFvQixDQUFDLGNBQWMsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLENBQUM7SUFDMUUsTUFBTSxPQUFPLEdBQUcsbUJBQW1CLENBQUMsUUFBUSxDQUFDLENBQUM7SUFFOUMsTUFBTSxLQUFLLEdBQUc7UUFDWixVQUFVLG1DQUFtQyxJQUFJLHFCQUFxQixDQUNwRSxxTUFBcU0sQ0FDdE0sRUFBRTtRQUNILFVBQVUsbUNBQW1DLFFBQVE7S0FDdEQsQ0FBQztJQUNGLEtBQUssTUFBTSxHQUFHLElBQUksYUFBYSxFQUFFLENBQUM7UUFDaEMsTUFBTSxTQUFTLEdBQUcsR0FBRyxDQUFDLEtBQUssS0FBSyxVQUFVLENBQUMsQ0FBQyxDQUFDLFVBQVUsZ0JBQWdCLENBQUMsR0FBRyxDQUFDLFlBQVksQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUNsRyxLQUFLLENBQUMsSUFBSSxDQUNSLEdBQUcsbUNBQW1DLFdBQVcsR0FBRyxDQUFDLEtBQUssbUJBQW1CLGdCQUFnQixDQUFDLEdBQUcsQ0FBQyxXQUFXLENBQUMsSUFBSSxTQUFTLEtBQUssR0FBRyxDQUFDLEtBQUssRUFBRSxDQUM1SSxDQUFDO0lBQ0osQ0FBQztJQUVELEtBQUssQ0FBQyxJQUFJLENBQ1IsVUFBVSx3QkFBd0IsSUFBSSxxQkFBcUIsQ0FDekQsc0tBQXNLLENBQ3ZLLEVBQUUsQ0FDSixDQUFDO0lBQ0YsS0FBSyxDQUFDLElBQUksQ0FBQyxVQUFVLHdCQUF3QixRQUFRLENBQUMsQ0FBQztJQUN2RCxLQUFLLE1BQU0sR0FBRyxJQUFJLE9BQU8sRUFBRSxDQUFDO1FBQzFCLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyx3QkFBd0IsZUFBZSxHQUFHLENBQUMsU0FBUyxNQUFNLEdBQUcsQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQ3ZGLENBQUM7SUFFRCxPQUFPLEdBQUcsS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDO0FBQ2pDLENBQUM7QUFFRCxLQUFLLFVBQVUsaUJBQWlCLENBQzlCLE9BQW9FLEVBQ3BFLEdBQXdDO0lBRXhDLE1BQU0saUJBQWlCLEdBQUcsT0FBTyxDQUFDLGlCQUFpQixLQUFLLFNBQVMsQ0FBQztJQUNsRSxNQUFNLGFBQWEsR0FBRyxDQUFDLE9BQU8sQ0FBQyxpQkFBaUIsSUFBSSxpQkFBaUIsQ0FBQyxFQUFFLENBQUM7SUFDekUsSUFBSSxDQUFDO1FBQ0gsT0FBTyxHQUFHLENBQUMsYUFBYSxDQUFDLENBQUM7SUFDNUIsQ0FBQztZQUFTLENBQUM7UUFDVCxJQUFJLGlCQUFpQjtZQUFFLGFBQWEsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUMvQyxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sQ0FBQyxLQUFLLFVBQVUsa0JBQWtCLENBQ3RDLElBQWMsRUFDZCxVQUF1RSxFQUFFO0lBRXpFLElBQUksSUFBSSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNwQixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxzQkFBc0IsQ0FBQyxDQUFDO0lBQ3RFLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLE1BQU0saUJBQWlCLENBQUMsT0FBTyxFQUFFLENBQUMsYUFBYSxFQUFFLEVBQUU7WUFDeEQsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxLQUFNLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQztZQUMzRSxNQUFNLGNBQWMsR0FBRyxhQUFhLENBQUMsa0JBQWtCLEVBQUUsQ0FBQztZQUMxRCxNQUFNLFFBQVEsR0FBRyxhQUFhLENBQUMsWUFBWSxFQUFFLENBQUM7WUFDOUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxxQkFBcUIsQ0FBQyxjQUFjLEVBQUUsUUFBUSxFQUFFLEtBQUssQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUM7WUFDOUUsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUN2RSxDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/governor-metrics-cli.ts
+++ b/packages/loopover-miner/lib/governor-metrics-cli.ts
@@ -1,0 +1,194 @@
+import {
+  DEFAULT_AMS_POLICY_SPEC,
+  DEFAULT_WRITE_RATE_LIMIT_POLICIES,
+  evaluateGovernorCaps,
+  evaluateLocalRateLimit,
+} from "@loopover/engine";
+import type {
+  GovernorCapUsage,
+  LocalRateLimitDecision,
+  WriteRateLimitBucketStore,
+} from "@loopover/engine";
+import { openGovernorState } from "./governor-state.js";
+import type { GovernorRateLimitState, GovernorState } from "./governor-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+// `governor metrics` (#5187): render the governor's persisted rate-limit + cap-usage state (#5134,
+// governor-state.js) as Prometheus text-exposition, so an operator's Alertmanager can page on rate-limit/
+// budget pressure without hand-rolling a scrape. Strictly read-only, mirroring queue-cli.js's `queue metrics`
+// (#5186) and event-ledger-cli.js's `ledger metrics` (#4841): opens the local governor-state store, composes
+// its EXISTING loadRateLimitState()/loadCapUsage() with the engine's already-exported PURE calculators
+// (evaluateLocalRateLimit, evaluateGovernorCaps) against the SAME defaults the production loop (loop-cli.js)
+// already falls back to when no `.loopover-ams.yml` override is configured (DEFAULT_WRITE_RATE_LIMIT_POLICIES,
+// DEFAULT_AMS_POLICY_SPEC.capLimits) -- it never invents a threshold of its own, and it does not gate, retry,
+// mutate, or otherwise touch governor decision logic (governor-chokepoint.js/governor-chokepoint-persisted.js
+// are completely untouched by this file).
+//
+// capLimits is intentionally NOT read per-repo: governor-state.js's capUsage row is a single global scalar (a
+// run-scoped cumulative counter, not indexed by repo -- see governor-state.js's own header comment), so a
+// per-repo capLimits override from a resolved `.loopover-miner.yml` has no matching per-repo usage row to
+// pair it with here. Using the fleet-wide DEFAULT_AMS_POLICY_SPEC.capLimits is the same approximation
+// loop-cli.js itself already makes for any repo without its own override.
+
+const GOVERNOR_METRICS_USAGE = "Usage: loopover-miner governor metrics";
+
+export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
+export const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
+
+type RateLimitRow = {
+  scope: "global" | "per_repo";
+  actionClass: string;
+  repoFullName: string;
+  ratio: number;
+};
+
+type CapUsageRow = {
+  dimension: string;
+  ratio: number;
+};
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeMetricsHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping — backslash, double-quote, newline (mirrors event-ledger-cli.js's
+ *  escapeLabelValue). */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/** buckets.perRepo is keyed by writeRateLimitRepoKey(actionClass, repoFullName) = "actionClass:repoFullName"
+ *  (write-rate-limit.ts). actionClass is a fixed identifier (never contains ":"), so splitting on the FIRST
+ *  colon recovers both parts even though repoFullName itself contains a "/". */
+function splitPerRepoKey(key: string): { actionClass: string; repoFullName: string } {
+  const separatorIndex = key.indexOf(":");
+  if (separatorIndex === -1) return { actionClass: key, repoFullName: "" };
+  return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
+}
+
+// evaluateLocalRateLimit's own `remaining` field answers "how many MORE writes are allowed AFTER one more write
+// right now" (rate-limit.ts: `remaining = allowed ? limit - effectiveCount - 1 : 0`) -- it is NOT current
+// headroom. At count=2/limit=3 that field is already 0, identical to a fully exhausted count=3/limit=3 bucket,
+// even though the count=2 bucket still has one write available. Recover true current headroom algebraically
+// instead: when allowed, decision.remaining + 1 is exactly limit - effectiveCount (undo the "-1 for this next
+// write" the decision already applied); when not allowed, headroom is 0. Every actionClass this loop reaches
+// has already passed the DEFAULT_WRITE_RATE_LIMIT_POLICIES lookup above, so decision.limit is always one of the
+// frozen, non-zero policy limits -- no zero-limit guard needed.
+function remainingRatio(decision: LocalRateLimitDecision): number {
+  const headroom = decision.allowed ? decision.remaining + 1 : 0;
+  return headroom / decision.limit;
+}
+
+function collectRateLimitRows(buckets: WriteRateLimitBucketStore, nowMs: number): RateLimitRow[] {
+  const rows: RateLimitRow[] = [];
+  for (const [actionClass, bucket] of Object.entries(buckets.global)) {
+    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
+    if (!config) continue;
+    rows.push({
+      scope: "global",
+      actionClass,
+      repoFullName: "",
+      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    });
+  }
+  for (const [key, bucket] of Object.entries(buckets.perRepo)) {
+    const { actionClass, repoFullName } = splitPerRepoKey(key);
+    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
+    if (!config) continue;
+    rows.push({
+      scope: "per_repo",
+      actionClass,
+      repoFullName,
+      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    });
+  }
+  rows.sort((a, b) => {
+    if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
+    if (a.actionClass !== b.actionClass) return a.actionClass.localeCompare(b.actionClass);
+    return a.repoFullName.localeCompare(b.repoFullName);
+  });
+  return rows;
+}
+
+// DEFAULT_AMS_POLICY_SPEC.capLimits is a frozen, non-zero constant for every dimension -- no zero-limit guard
+// needed, mirroring remainingRatio()'s reasoning above.
+function collectCapUsageRows(capUsage: GovernorCapUsage): CapUsageRow[] {
+  const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  return [
+    { dimension: "budget", dimensionReport: report.budget },
+    { dimension: "turns", dimensionReport: report.turns },
+    { dimension: "elapsed_ms", dimensionReport: report.termination },
+  ].map(({ dimension, dimensionReport }) => ({
+    dimension,
+    ratio: dimensionReport.used / dimensionReport.limit,
+  }));
+}
+
+export function renderGovernorMetrics(
+  rateLimitState: GovernorRateLimitState,
+  capUsage: GovernorCapUsage,
+  nowMs: number,
+): string {
+  const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
+  const capRows = collectCapUsageRows(capUsage);
+
+  const lines = [
+    `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText(
+      "Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.",
+    )}`,
+    `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
+  ];
+  for (const row of rateLimitRows) {
+    const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
+    lines.push(
+      `${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`,
+    );
+  }
+
+  lines.push(
+    `# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText(
+      "The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.",
+    )}`,
+  );
+  lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
+  for (const row of capRows) {
+    lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function withGovernorState<T>(
+  options: { openGovernorState?: () => GovernorState; nowMs?: number },
+  run: (governorState: GovernorState) => T,
+): Promise<T> {
+  const ownsGovernorState = options.openGovernorState === undefined;
+  const governorState = (options.openGovernorState ?? openGovernorState)();
+  try {
+    return run(governorState);
+  } finally {
+    if (ownsGovernorState) governorState.close();
+  }
+}
+
+export async function runGovernorMetrics(
+  args: string[],
+  options: { openGovernorState?: () => GovernorState; nowMs?: number } = {},
+): Promise<number> {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const nowMs = Number.isFinite(options.nowMs) ? options.nowMs! : Date.now();
+      const rateLimitState = governorState.loadRateLimitState();
+      const capUsage = governorState.loadCapUsage();
+      console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}

--- a/packages/loopover-miner/lib/governor-pause-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-pause-cli.d.ts
@@ -1,23 +1,27 @@
 import type { GovernorState } from "./governor-state.js";
-
-export type ParsedGovernorPauseArgs =
-  | { json: boolean; dryRun: boolean; reason: string | null }
-  | { error: string };
-
-export type ParsedGovernorResumeArgs = { json: boolean; dryRun: boolean } | { error: string };
-
-export type ParsedGovernorNoArgsSubcommand = { json: boolean } | { error: string };
-
-export type GovernorPauseCliOptions = {
-  openGovernorState?: () => GovernorState;
+export type ParsedGovernorPauseArgs = {
+    json: boolean;
+    dryRun: boolean;
+    reason: string | null;
+} | {
+    error: string;
 };
-
-export function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs;
-
-export function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs;
-
-export function runGovernorPause(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
-
-export function runGovernorResume(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
-
-export function runGovernorStatus(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export type ParsedGovernorResumeArgs = {
+    json: boolean;
+    dryRun: boolean;
+} | {
+    error: string;
+};
+export type ParsedGovernorNoArgsSubcommand = {
+    json: boolean;
+} | {
+    error: string;
+};
+export type GovernorPauseCliOptions = {
+    openGovernorState?: () => GovernorState;
+};
+export declare function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs;
+export declare function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs;
+export declare function runGovernorPause(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export declare function runGovernorResume(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export declare function runGovernorStatus(args: string[], options?: GovernorPauseCliOptions): Promise<number>;

--- a/packages/loopover-miner/lib/governor-pause-cli.js
+++ b/packages/loopover-miner/lib/governor-pause-cli.js
@@ -5,162 +5,158 @@
 // path) -- this is the first genuinely operator/governor-writable stop/go control. Persisted on governor-state.js's
 // existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
 // same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
-
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { openGovernorState } from "./governor-state.js";
-
 const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
 const GOVERNOR_RESUME_USAGE = "Usage: loopover-miner governor resume [--dry-run] [--json]";
 const GOVERNOR_STATUS_USAGE = "Usage: loopover-miner governor status [--json]";
-
 export function parseGovernorPauseArgs(args) {
-  const options = { json: false, dryRun: false, reason: null };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false, reason: null };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what pausing would do and returns before writing to governor-state.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--reason") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: GOVERNOR_PAUSE_USAGE };
+            options.reason = value;
+            index += 1;
+            continue;
+        }
+        return { error: `Unknown option: ${token}` };
     }
-    // #4847: reports what pausing would do and returns before writing to governor-state.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--reason") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: GOVERNOR_PAUSE_USAGE };
-      options.reason = value;
-      index += 1;
-      continue;
-    }
-    return { error: `Unknown option: ${token}` };
-  }
-
-  return options;
+    return options;
 }
-
 export function parseGovernorResumeArgs(args) {
-  const options = { json: false, dryRun: false };
-
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false };
+    for (const token of args) {
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what resuming would do and returns before writing to governor-state.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        return { error: GOVERNOR_RESUME_USAGE };
     }
-    // #4847: reports what resuming would do and returns before writing to governor-state.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    return { error: GOVERNOR_RESUME_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 function parseNoArgsSubcommand(args, usage) {
-  if (args.length === 0) return { json: false };
-  if (args.length === 1 && args[0] === "--json") return { json: true };
-  return { error: usage };
+    if (args.length === 0)
+        return { json: false };
+    if (args.length === 1 && args[0] === "--json")
+        return { json: true };
+    return { error: usage };
 }
-
 async function withGovernorState(options, run) {
-  const ownsGovernorState = options.openGovernorState === undefined;
-  const governorState = (options.openGovernorState ?? openGovernorState)();
-  try {
-    return run(governorState);
-  } finally {
-    if (ownsGovernorState) governorState.close();
-  }
+    const ownsGovernorState = options.openGovernorState === undefined;
+    const governorState = (options.openGovernorState ?? openGovernorState)();
+    try {
+        return run(governorState);
+    }
+    finally {
+        if (ownsGovernorState)
+            governorState.close();
+    }
 }
-
 function renderPauseState(pauseState) {
-  if (!pauseState.paused) return "governor is not paused";
-  const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
-  return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
+    if (!pauseState.paused)
+        return "governor is not paused";
+    const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
+    return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
 }
-
 export async function runGovernorPause(args, options = {}) {
-  const parsed = parseGovernorPauseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      const reason = parsed.reason ? ` (${parsed.reason})` : "";
-      console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+    const parsed = parseGovernorPauseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            const reason = parsed.reason ? ` (${parsed.reason})` : "";
+            console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorResume(args, options = {}) {
-  const parsed = parseGovernorResumeArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", paused: false };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+    const parsed = parseGovernorResumeArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.savePauseState({ paused: false });
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", paused: false };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+        }
+        return 0;
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.savePauseState({ paused: false });
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorStatus(args, options = {}) {
-  const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.loadPauseState();
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.loadPauseState();
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItcGF1c2UtY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZ292ZXJub3ItcGF1c2UtY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtHQUErRztBQUMvRywrR0FBK0c7QUFDL0csaUhBQWlIO0FBQ2pILCtHQUErRztBQUMvRyxvSEFBb0g7QUFDcEgsOEdBQThHO0FBQzlHLG1HQUFtRztBQUVuRyxPQUFPLEVBQUUsWUFBWSxFQUFFLGdCQUFnQixFQUFFLGdCQUFnQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbEYsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFleEQsTUFBTSxvQkFBb0IsR0FBRyw2RUFBNkUsQ0FBQztBQUMzRyxNQUFNLHFCQUFxQixHQUFHLDREQUE0RCxDQUFDO0FBQzNGLE1BQU0scUJBQXFCLEdBQUcsZ0RBQWdELENBQUM7QUFFL0UsTUFBTSxVQUFVLHNCQUFzQixDQUFDLElBQWM7SUFDbkQsTUFBTSxPQUFPLEdBQThELEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsQ0FBQztJQUV4SCxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QscUZBQXFGO1FBQ3JGLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsb0JBQW9CLEVBQUUsQ0FBQztZQUM1RSxPQUFPLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQztZQUN2QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO0lBQy9DLENBQUM7SUFFRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsTUFBTSxVQUFVLHVCQUF1QixDQUFDLElBQWM7SUFDcEQsTUFBTSxPQUFPLEdBQXVDLEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFFbkYsS0FBSyxNQUFNLEtBQUssSUFBSSxJQUFJLEVBQUUsQ0FBQztRQUN6QixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELHNGQUFzRjtRQUN0RixJQUFJLEtBQUssS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUMxQixPQUFPLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQztZQUN0QixTQUFTO1FBQ1gsQ0FBQztRQUNELE9BQU8sRUFBRSxLQUFLLEVBQUUscUJBQXFCLEVBQUUsQ0FBQztJQUMxQyxDQUFDO0lBRUQsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVELFNBQVMscUJBQXFCLENBQUMsSUFBYyxFQUFFLEtBQWE7SUFDMUQsSUFBSSxJQUFJLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxDQUFDO0lBQzlDLElBQUksSUFBSSxDQUFDLE1BQU0sS0FBSyxDQUFDLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxLQUFLLFFBQVE7UUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxDQUFDO0lBQ3JFLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7QUFDMUIsQ0FBQztBQUVELEtBQUssVUFBVSxpQkFBaUIsQ0FDOUIsT0FBZ0MsRUFDaEMsR0FBd0M7SUFFeEMsTUFBTSxpQkFBaUIsR0FBRyxPQUFPLENBQUMsaUJBQWlCLEtBQUssU0FBUyxDQUFDO0lBQ2xFLE1BQU0sYUFBYSxHQUFHLENBQUMsT0FBTyxDQUFDLGlCQUFpQixJQUFJLGlCQUFpQixDQUFDLEVBQUUsQ0FBQztJQUN6RSxJQUFJLENBQUM7UUFDSCxPQUFPLEdBQUcsQ0FBQyxhQUFhLENBQUMsQ0FBQztJQUM1QixDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksaUJBQWlCO1lBQUUsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQy9DLENBQUM7QUFDSCxDQUFDO0FBRUQsU0FBUyxnQkFBZ0IsQ0FBQyxVQUE4QjtJQUN0RCxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU07UUFBRSxPQUFPLHdCQUF3QixDQUFDO0lBQ3hELE1BQU0sTUFBTSxHQUFHLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEtBQUssVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDbEUsT0FBTyw0QkFBNEIsVUFBVSxDQUFDLFFBQVEsR0FBRyxNQUFNLEVBQUUsQ0FBQztBQUNwRSxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxnQkFBZ0IsQ0FBQyxJQUFjLEVBQUUsVUFBbUMsRUFBRTtJQUMxRixNQUFNLE1BQU0sR0FBRyxzQkFBc0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUM1QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDakYsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUM7UUFDNUMsQ0FBQzthQUFNLENBQUM7WUFDTixNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxLQUFLLE1BQU0sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQzFELE9BQU8sQ0FBQyxHQUFHLENBQUMsb0NBQW9DLE1BQU0scUNBQXFDLENBQUMsQ0FBQztRQUMvRixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLENBQUMsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQztZQUN6RixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDMUMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLGlCQUFpQixDQUFDLElBQWMsRUFBRSxVQUFtQyxFQUFFO0lBQzNGLE1BQU0sTUFBTSxHQUFHLHVCQUF1QixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQzdDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztRQUMzRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQztRQUM1QyxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsdUVBQXVFLENBQUMsQ0FBQztRQUN2RixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLENBQUMsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztZQUNuRSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDMUMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLGlCQUFpQixDQUFDLElBQWMsRUFBRSxVQUFtQyxFQUFFO0lBQzNGLE1BQU0sTUFBTSxHQUFHLHFCQUFxQixDQUFDLElBQUksRUFBRSxxQkFBcUIsQ0FBQyxDQUFDO0lBQ2xFLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLEVBQUUsQ0FBQztZQUNsRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDMUMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUMifQ==

--- a/packages/loopover-miner/lib/governor-pause-cli.ts
+++ b/packages/loopover-miner/lib/governor-pause-cli.ts
@@ -1,0 +1,182 @@
+// The governor pause/resume control surface (#4851): a real, persisted pause flag an operator (or, in a future
+// wave, the governor itself) can toggle via this CLI, that loop-cli.js's iteration loop actually checks before
+// each cycle. Distinct from governor-kill-switch.js (a read-only resolver over pre-existing env/YAML inputs this
+// package never itself writes) and governor-run-halt.js (a one-way, run-scoped terminal breaker with no resume
+// path) -- this is the first genuinely operator/governor-writable stop/go control. Persisted on governor-state.js's
+// existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
+// same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
+
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { openGovernorState } from "./governor-state.js";
+import type { GovernorPauseState, GovernorState } from "./governor-state.js";
+
+export type ParsedGovernorPauseArgs =
+  | { json: boolean; dryRun: boolean; reason: string | null }
+  | { error: string };
+
+export type ParsedGovernorResumeArgs = { json: boolean; dryRun: boolean } | { error: string };
+
+export type ParsedGovernorNoArgsSubcommand = { json: boolean } | { error: string };
+
+export type GovernorPauseCliOptions = {
+  openGovernorState?: () => GovernorState;
+};
+
+const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
+const GOVERNOR_RESUME_USAGE = "Usage: loopover-miner governor resume [--dry-run] [--json]";
+const GOVERNOR_STATUS_USAGE = "Usage: loopover-miner governor status [--json]";
+
+export function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs {
+  const options: { json: boolean; dryRun: boolean; reason: string | null } = { json: false, dryRun: false, reason: null };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what pausing would do and returns before writing to governor-state.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--reason") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: GOVERNOR_PAUSE_USAGE };
+      options.reason = value;
+      index += 1;
+      continue;
+    }
+    return { error: `Unknown option: ${token}` };
+  }
+
+  return options;
+}
+
+export function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs {
+  const options: { json: boolean; dryRun: boolean } = { json: false, dryRun: false };
+
+  for (const token of args) {
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what resuming would do and returns before writing to governor-state.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    return { error: GOVERNOR_RESUME_USAGE };
+  }
+
+  return options;
+}
+
+function parseNoArgsSubcommand(args: string[], usage: string): ParsedGovernorNoArgsSubcommand {
+  if (args.length === 0) return { json: false };
+  if (args.length === 1 && args[0] === "--json") return { json: true };
+  return { error: usage };
+}
+
+async function withGovernorState<T>(
+  options: GovernorPauseCliOptions,
+  run: (governorState: GovernorState) => T,
+): Promise<T> {
+  const ownsGovernorState = options.openGovernorState === undefined;
+  const governorState = (options.openGovernorState ?? openGovernorState)();
+  try {
+    return run(governorState);
+  } finally {
+    if (ownsGovernorState) governorState.close();
+  }
+}
+
+function renderPauseState(pauseState: GovernorPauseState): string {
+  if (!pauseState.paused) return "governor is not paused";
+  const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
+  return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
+}
+
+export async function runGovernorPause(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorPauseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      const reason = parsed.reason ? ` (${parsed.reason})` : "";
+      console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorResume(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorResumeArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", paused: false };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+    }
+    return 0;
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.savePauseState({ paused: false });
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorStatus(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.loadPauseState();
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}

--- a/packages/loopover-miner/lib/loop-cli.d.ts
+++ b/packages/loopover-miner/lib/loop-cli.d.ts
@@ -6,61 +6,129 @@ import type { GovernorLedger } from "./governor-ledger.js";
 import type { RunStateStore } from "./run-state.js";
 import type { PollPrDispositionOptions } from "./pr-disposition-poller.js";
 import type { CheckRunConclusion, PollCheckRunsOptions } from "./ci-poller.js";
-
-export type ParsedLoopArgs =
-  | { error: string }
-  | {
-      targets: string[];
-      search: string | null;
-      minerLogin: string;
-      base: string;
-      live: boolean;
-      dryRun: boolean;
-      maxCycles: number | undefined;
-      cycleDelayMs: number;
-      json: boolean;
-    };
-
-export function parseLoopArgs(args: string[]): ParsedLoopArgs;
-
+export type ParsedLoopArgs = {
+    error: string;
+} | {
+    targets: string[];
+    search: string | null;
+    minerLogin: string;
+    base: string;
+    live: boolean;
+    dryRun: boolean;
+    maxCycles: number | undefined;
+    cycleDelayMs: number;
+    json: boolean;
+};
 export type LoopCycleSummary = {
-  cycle: number;
-  outcome: "idle_queue_empty" | "halted" | "attempted" | "skipped_malformed_identifier";
-  reason?: string;
-  repoFullName?: string;
-  identifier?: string;
-  attemptOutcome?: AttemptCliResult["outcome"] | "attempt_error";
-  reentryOutcome?: "merged" | "disengaged" | "other";
-  prNumber?: number | null;
-  ciConclusion?: CheckRunConclusion | null;
-  reentered?: boolean;
-  reasons?: string[];
+    cycle: number;
+    outcome: "idle_queue_empty" | "halted" | "attempted" | "skipped_malformed_identifier";
+    reason?: string;
+    repoFullName?: string;
+    identifier?: string;
+    attemptOutcome?: AttemptCliResult["outcome"] | "attempt_error";
+    reentryOutcome?: "merged" | "disengaged" | "other";
+    prNumber?: number | null;
+    ciConclusion?: CheckRunConclusion | null;
+    reentered?: boolean;
+    reasons?: string[];
 };
-
 export type RunLoopOptions = {
-  env?: Record<string, string | undefined>;
-  nowMs?: number;
-  githubToken?: string;
-  apiBaseUrl?: string;
-  sleepFn?: (delayMs: number) => Promise<void>;
-  openGovernorState?: () => GovernorState;
-  initEventLedger?: () => EventLedger;
-  initGovernorLedger?: () => GovernorLedger;
-  initPortfolioQueue?: () => PortfolioQueueStore;
-  initRunStateStore?: () => RunStateStore;
-  runDiscover?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
-  runAttempt?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
-  resolveAmsPolicy?: (repoFullName: string, options?: Record<string, unknown>) => Promise<{ spec: Record<string, unknown>; source: string; warnings: string[] }>;
-  checkMinerKillSwitch?: (input?: { env?: Record<string, string | undefined>; repoPaused?: boolean }) => { scope: "global" | "repo" | "none"; active: boolean };
-  evaluateRunLoopBoundaryGate?: (input: unknown, options?: unknown) => { verdict: { reason: string }; canClaimNext: boolean };
-  pollPrDisposition?: (repoFullName: string, prNumber: number, options?: PollPrDispositionOptions) => Promise<{ state: "open" | "closed"; merged: boolean; closedAt: string | null; attempts: number }>;
-  pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<{ conclusion: CheckRunConclusion; checks: unknown[]; headSha: string; attempts: number }>;
-  recordPrOutcomeSnapshot?: (input: unknown, options?: unknown) => unknown;
-  buildLoopClosureSummary?: (sources: unknown, options?: unknown) => { sinceSeq: number | null; lastSeq: number };
-  attemptLoopReentry?: (candidate: unknown, deps: unknown) => { decision: { reenter: boolean; reasons: string[] }; dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null };
-  attemptOptions?: Record<string, unknown>;
-  prDispositionOptions?: PollPrDispositionOptions;
-  ciPollOptions?: PollCheckRunsOptions;
+    env?: Record<string, string | undefined>;
+    nowMs?: number;
+    githubToken?: string;
+    apiBaseUrl?: string;
+    sleepFn?: (delayMs: number) => Promise<void>;
+    openGovernorState?: () => GovernorState;
+    initEventLedger?: () => EventLedger;
+    initGovernorLedger?: () => GovernorLedger;
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initRunStateStore?: () => RunStateStore;
+    runDiscover?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+    runAttempt?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+    resolveAmsPolicy?: (repoFullName: string, options?: Record<string, unknown>) => Promise<{
+        spec: Record<string, unknown>;
+        source: string;
+        warnings: string[];
+    }>;
+    checkMinerKillSwitch?: (input?: {
+        env?: Record<string, string | undefined>;
+        repoPaused?: boolean;
+    }) => {
+        scope: "global" | "repo" | "none";
+        active: boolean;
+    };
+    evaluateRunLoopBoundaryGate?: (input: unknown, options?: unknown) => {
+        verdict: {
+            reason: string;
+        };
+        canClaimNext: boolean;
+    };
+    pollPrDisposition?: (repoFullName: string, prNumber: number, options?: PollPrDispositionOptions) => Promise<{
+        state: "open" | "closed";
+        merged: boolean;
+        closedAt: string | null;
+        attempts: number;
+    }>;
+    pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<{
+        conclusion: CheckRunConclusion;
+        checks: unknown[];
+        headSha: string;
+        attempts: number;
+    }>;
+    recordPrOutcomeSnapshot?: (input: unknown, options?: unknown) => unknown;
+    buildLoopClosureSummary?: (sources: unknown, options?: unknown) => {
+        sinceSeq: number | null;
+        lastSeq: number;
+    };
+    attemptLoopReentry?: (candidate: unknown, deps: unknown) => {
+        decision: {
+            reenter: boolean;
+            reasons: string[];
+        };
+        dequeued: {
+            repoFullName: string;
+            identifier: string;
+            priority: number;
+            status: string;
+            enqueuedAt: string;
+        } | null;
+    };
+    attemptOptions?: Record<string, unknown>;
+    prDispositionOptions?: PollPrDispositionOptions;
+    ciPollOptions?: PollCheckRunsOptions;
 };
-
-export function runLoop(args: string[], options?: RunLoopOptions): Promise<number>;
+export declare function parseLoopArgs(args: string[]): ParsedLoopArgs;
+/**
+ * Run one full discover -> claim -> attempt -> observe -> reenter cycle repeatedly until a kill-switch trips,
+ * the run-loop boundary gate halts (non-convergence or a real budget/turn/elapsed cap), re-entry is declined,
+ * or `--max-cycles` is reached. Fails closed: refuses to start at all if governor state cannot be loaded.
+ *
+ * @param {string[]} args
+ * @param {{
+ *   env?: Record<string, string | undefined>,
+ *   nowMs?: number,
+ *   githubToken?: string,
+ *   apiBaseUrl?: string,
+ *   sleepFn?: (delayMs: number) => Promise<void>,
+ *   openGovernorState?: typeof openGovernorState,
+ *   initEventLedger?: typeof initEventLedger,
+ *   initGovernorLedger?: typeof initGovernorLedger,
+ *   initPortfolioQueue?: () => import("./portfolio-queue.js").PortfolioQueueStore,
+ *   initRunStateStore?: typeof initRunStateStore,
+ *   runDiscover?: typeof runDiscover,
+ *   runAttempt?: typeof runAttempt,
+ *   resolveAmsPolicy?: typeof resolveAmsPolicy,
+ *   checkMinerKillSwitch?: typeof checkMinerKillSwitch,
+ *   evaluateRunLoopBoundaryGate?: typeof evaluateRunLoopBoundaryGate,
+ *   pollPrDisposition?: typeof pollPrDisposition,
+ *   pollCheckRuns?: typeof pollCheckRuns,
+ *   recordPrOutcomeSnapshot?: typeof recordPrOutcomeSnapshot,
+ *   buildLoopClosureSummary?: typeof buildLoopClosureSummary,
+ *   attemptLoopReentry?: typeof attemptLoopReentry,
+ *   attemptOptions?: Record<string, unknown>,
+ *   prDispositionOptions?: Record<string, unknown>,
+ *   ciPollOptions?: Record<string, unknown>,
+ * }} [options]
+ * @returns {Promise<number>}
+ */
+export declare function runLoop(args: string[], options?: RunLoopOptions): Promise<number>;

--- a/packages/loopover-miner/lib/loop-cli.js
+++ b/packages/loopover-miner/lib/loop-cli.js
@@ -21,7 +21,6 @@
 // dequeueNext claim + markDone/markFailed calls below already maintain -- the same source a one-shot `attempt`
 // invocation reads (#5654), so both share one source of truth and the counters survive a loop-daemon restart
 // (crash/deploy/systemd bounce) instead of resetting with the process (#5677).
-
 import { checkMinerKillSwitch } from "./governor-kill-switch.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { evaluateRunLoopBoundaryGate } from "./governor-run-halt.js";
@@ -42,131 +41,133 @@ import { attemptLoopReentry } from "./loop-reentry.js";
 import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
 import { DEFAULT_AMS_POLICY_SPEC } from "@loopover/engine";
-
-const LOOP_USAGE =
-  "Usage: loopover-miner loop <owner/repo> [<owner/repo>...] | --search <query> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]";
+const LOOP_USAGE = "Usage: loopover-miner loop <owner/repo> [<owner/repo>...] | --search <query> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]";
 const DEFAULT_CYCLE_DELAY_MS = 60_000;
 const ISSUE_IDENTIFIER_PATTERN = /^issue:(\d+)$/;
-
 function parseRepoTarget(value) {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  return `${owner}/${repo}`;
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    return `${owner}/${repo}`;
 }
-
 function normalizeOptionalPositiveInt(value, label) {
-  const parsedValue = Number(value);
-  if (!Number.isFinite(parsedValue) || !Number.isInteger(parsedValue) || parsedValue < 0) {
-    throw new Error(`${label} must be a non-negative integer: ${value}`);
-  }
-  return parsedValue;
+    const parsedValue = Number(value);
+    if (!Number.isFinite(parsedValue) || !Number.isInteger(parsedValue) || parsedValue < 0) {
+        throw new Error(`${label} must be a non-negative integer: ${value}`);
+    }
+    return parsedValue;
 }
-
 export function parseLoopArgs(args) {
-  const options = {
-    json: false,
-    minerLogin: null,
-    base: "main",
-    live: false,
-    dryRun: false,
-    search: null,
-    maxCycles: undefined,
-    cycleDelayMs: DEFAULT_CYCLE_DELAY_MS,
-  };
-  const targets = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        minerLogin: null,
+        base: "main",
+        live: false,
+        dryRun: false,
+        search: null,
+        maxCycles: undefined,
+        cycleDelayMs: DEFAULT_CYCLE_DELAY_MS,
+    };
+    const targets = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--live") {
+            options.live = true;
+            continue;
+        }
+        // #4847: see attempt-cli.js's own --dry-run comment -- distinct from --live's absence, this short-circuits
+        // BEFORE governor state or any other store is opened, guaranteeing zero discovery/queue/ledger writes.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--search") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            options.search = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--miner-login") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            options.minerLogin = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--base") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            options.base = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--max-cycles") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            try {
+                options.maxCycles = normalizeOptionalPositiveInt(value, "--max-cycles");
+            }
+            catch (error) {
+                return { error: error instanceof Error ? error.message : String(error) };
+            }
+            index += 1;
+            continue;
+        }
+        if (token === "--cycle-delay-ms") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            try {
+                options.cycleDelayMs = normalizeOptionalPositiveInt(value, "--cycle-delay-ms");
+            }
+            catch (error) {
+                return { error: error instanceof Error ? error.message : String(error) };
+            }
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        const target = parseRepoTarget(token);
+        if (!target)
+            return { error: `Repository must be in owner/repo form: ${token}` };
+        targets.push(target);
     }
-    if (token === "--live") {
-      options.live = true;
-      continue;
-    }
-    // #4847: see attempt-cli.js's own --dry-run comment -- distinct from --live's absence, this short-circuits
-    // BEFORE governor state or any other store is opened, guaranteeing zero discovery/queue/ledger writes.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--search") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      options.search = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--miner-login") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      options.minerLogin = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--base") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      options.base = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--max-cycles") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      try {
-        options.maxCycles = normalizeOptionalPositiveInt(value, "--max-cycles");
-      } catch (error) {
-        return { error: error instanceof Error ? error.message : String(error) };
-      }
-      index += 1;
-      continue;
-    }
-    if (token === "--cycle-delay-ms") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      try {
-        options.cycleDelayMs = normalizeOptionalPositiveInt(value, "--cycle-delay-ms");
-      } catch (error) {
-        return { error: error instanceof Error ? error.message : String(error) };
-      }
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    const target = parseRepoTarget(token);
-    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
-    targets.push(target);
-  }
-
-  if (options.search === null && targets.length === 0) return { error: LOOP_USAGE };
-  if (options.search !== null && targets.length > 0) return { error: "Pass either repository targets or --search, not both." };
-  if (!options.minerLogin) return { error: `--miner-login is required. ${LOOP_USAGE}` };
-
-  return {
-    targets,
-    search: options.search,
-    minerLogin: options.minerLogin,
-    base: options.base,
-    live: options.live,
-    dryRun: options.dryRun,
-    maxCycles: options.maxCycles,
-    cycleDelayMs: options.cycleDelayMs,
-    json: options.json,
-  };
+    if (options.search === null && targets.length === 0)
+        return { error: LOOP_USAGE };
+    if (options.search !== null && targets.length > 0)
+        return { error: "Pass either repository targets or --search, not both." };
+    if (!options.minerLogin)
+        return { error: `--miner-login is required. ${LOOP_USAGE}` };
+    return {
+        targets,
+        search: options.search,
+        minerLogin: options.minerLogin,
+        base: options.base,
+        live: options.live,
+        dryRun: options.dryRun,
+        maxCycles: options.maxCycles,
+        cycleDelayMs: options.cycleDelayMs,
+        json: options.json,
+    };
 }
-
 function discoverArgv(parsed) {
-  return parsed.search !== null ? ["--search", parsed.search] : [...parsed.targets];
+    return parsed.search !== null ? ["--search", parsed.search] : [...parsed.targets];
 }
-
 function parseIssueNumberFromIdentifier(identifier) {
-  const match = typeof identifier === "string" ? identifier.match(ISSUE_IDENTIFIER_PATTERN) : null;
-  return match ? Number(match[1]) : null;
+    const match = typeof identifier === "string" ? identifier.match(ISSUE_IDENTIFIER_PATTERN) : null;
+    return match ? Number(match[1]) : null;
 }
-
 /**
  * Run one full discover -> claim -> attempt -> observe -> reenter cycle repeatedly until a kill-switch trips,
  * the run-loop boundary gate halts (non-convergence or a real budget/turn/elapsed cap), re-entry is declined,
@@ -201,390 +202,343 @@ function parseIssueNumberFromIdentifier(identifier) {
  * @returns {Promise<number>}
  */
 export async function runLoop(args, options = {}) {
-  const parsed = parseLoopArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const env = options.env ?? process.env;
-  const sleepFn = options.sleepFn ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
-  const nowMsFn = () => options.nowMs ?? Date.now();
-  const sessionStartMs = nowMsFn();
-
-  // #4847: reports what a real loop invocation would target and returns BEFORE governor state or any other
-  // store (event/governor ledger, portfolio queue, run state) is opened -- a provable zero-write path, not just
-  // "opened but didn't write." The loop's own discovery call enqueues newly-found candidates into the LOCAL
-  // portfolio queue even before any attempt happens, so a faithful dry run cannot call it either.
-  if (parsed.dryRun) {
-    const dryRunResult = {
-      outcome: "dry_run",
-      targets: parsed.targets,
-      search: parsed.search,
-      minerLogin: parsed.minerLogin,
-      base: parsed.base,
-      live: parsed.live,
-      maxCycles: parsed.maxCycles ?? null,
-    };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      const target = parsed.search !== null ? `--search ${parsed.search}` : parsed.targets.join(", ");
-      console.log(
-        `DRY RUN: would run an autonomous loop against ${target} for ${parsed.minerLogin} (base: ${parsed.base}, live: ${parsed.live}). No discovery, queue, or ledger writes were made.`,
-      );
+    const parsed = parseLoopArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  let governorState;
-  try {
-    governorState = (options.openGovernorState ?? openGovernorState)();
-  } catch (error) {
-    return reportCliFailure(
-      parsed.json,
-      `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`,
-      3,
-    );
-  }
-
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  const runState = (options.initRunStateStore ?? initRunStateStore)();
-
-  const runDiscoverFn = options.runDiscover ?? runDiscover;
-  const runAttemptFn = options.runAttempt ?? runAttempt;
-  const resolveAmsPolicyFn = options.resolveAmsPolicy ?? resolveAmsPolicy;
-  const checkKillSwitchFn = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
-  const evaluateBoundaryGateFn = options.evaluateRunLoopBoundaryGate ?? evaluateRunLoopBoundaryGate;
-  const pollPrDispositionFn = options.pollPrDisposition ?? pollPrDisposition;
-  const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
-  const recordPrOutcomeSnapshotFn = options.recordPrOutcomeSnapshot ?? recordPrOutcomeSnapshot;
-  const buildLoopClosureSummaryFn = options.buildLoopClosureSummary ?? buildLoopClosureSummary;
-  const attemptLoopReentryFn = options.attemptLoopReentry ?? attemptLoopReentry;
-
-  // Resolved ONCE, at the CLI-entrypoint layer, mirroring manage-poll.js's own runManagePoll (its
-  // recordManagePollSnapshot callee has no env fallback of its own either -- the top-level CLI function is
-  // where the GitHub token gets resolved, then threaded down explicitly to every real GitHub caller).
-  // pollPrDisposition (unlike runDiscover, which falls back to process.env.GITHUB_TOKEN internally) has NO
-  // such fallback -- an unresolved githubToken here would silently poll unauthenticated.
-  // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
-  // authenticated `loopover-mcp login` session -- cached in memory for this process's lifetime.
-  const githubToken = options.githubToken ?? (await resolveGitHubToken(env)) ?? "";
-
-  async function runDiscoveryOnce() {
-    await runDiscoverFn(discoverArgv(parsed), {
-      initPortfolioQueue: () => portfolioQueue,
-      githubToken,
-      apiBaseUrl: options.apiBaseUrl,
-      nowMs: nowMsFn(),
-    });
-  }
-
-  let usage = governorState.loadCapUsage();
-  const cycles = [];
-  let sinceSeq = eventLedger.readEvents({}).at(-1)?.seq ?? 0;
-  let haltReason = null;
-
-  try {
-    // Checked BEFORE any work at all -- including the very first discovery call -- so an already-active kill
-    // switch OR an already-active pause (#4851) halts the loop without ever touching GitHub or the queue. The
-    // pause flag is real, persisted, operator/governor-writable state on governorState (toggled via
-    // `loopover-miner governor pause`/`resume`) -- unlike the kill switch, a paused run resumes simply by being
-    // re-invoked: every piece of per-cycle state this loop reads (portfolioQueue, runState, governorState's own
-    // cap usage) is already durable, so clearing the flag and restarting continues exactly where it left off.
-    const initialKillSwitch = checkKillSwitchFn({ env });
-    const initialPauseState = governorState.loadPauseState();
-    let claimed = null;
-    if (initialKillSwitch.active) {
-      haltReason = `kill_switch_${initialKillSwitch.scope}`;
-      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
-    } else if (initialPauseState.paused) {
-      haltReason = "paused";
-      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
-    } else {
-      await runDiscoveryOnce();
-      claimed = portfolioQueue.dequeueNext();
+    const env = options.env ?? process.env;
+    const sleepFn = options.sleepFn ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+    const nowMsFn = () => options.nowMs ?? Date.now();
+    const sessionStartMs = nowMsFn();
+    // #4847: reports what a real loop invocation would target and returns BEFORE governor state or any other
+    // store (event/governor ledger, portfolio queue, run state) is opened -- a provable zero-write path, not just
+    // "opened but didn't write." The loop's own discovery call enqueues newly-found candidates into the LOCAL
+    // portfolio queue even before any attempt happens, so a faithful dry run cannot call it either.
+    if (parsed.dryRun) {
+        const dryRunResult = {
+            outcome: "dry_run",
+            targets: parsed.targets,
+            search: parsed.search,
+            minerLogin: parsed.minerLogin,
+            base: parsed.base,
+            live: parsed.live,
+            maxCycles: parsed.maxCycles ?? null,
+        };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            const target = parsed.search !== null ? `--search ${parsed.search}` : parsed.targets.join(", ");
+            console.log(`DRY RUN: would run an autonomous loop against ${target} for ${parsed.minerLogin} (base: ${parsed.base}, live: ${parsed.live}). No discovery, queue, or ledger writes were made.`);
+        }
+        return 0;
     }
-
-    let cycleIndex = haltReason !== null ? 1 : 0;
-    while (haltReason === null && (parsed.maxCycles === undefined || cycleIndex < parsed.maxCycles)) {
-      cycleIndex += 1;
-
-      const killSwitch = checkKillSwitchFn({ env });
-      if (killSwitch.active) {
-        haltReason = `kill_switch_${killSwitch.scope}`;
-        // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
-        if (claimed) {
-          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-        }
-        cycles.push({
-          cycle: cycleIndex,
-          outcome: "halted",
-          reason: haltReason,
-          ...(claimed
-            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
-            : {}),
-        });
-        break;
-      }
-
-      const pauseState = governorState.loadPauseState();
-      if (pauseState.paused) {
-        haltReason = "paused";
-        if (claimed) {
-          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-        }
-        cycles.push({
-          cycle: cycleIndex,
-          outcome: "halted",
-          reason: haltReason,
-          ...(claimed
-            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
-            : {}),
-        });
-        break;
-      }
-
-      if (!claimed) {
-        cycles.push({ cycle: cycleIndex, outcome: "idle_queue_empty" });
-        await sleepFn(parsed.cycleDelayMs);
-        await runDiscoveryOnce();
-        claimed = portfolioQueue.dequeueNext();
-        continue;
-      }
-
-      const issueNumber = parseIssueNumberFromIdentifier(claimed.identifier);
-      if (issueNumber === null) {
-        // Never produced by enqueueRankedDiscovery in practice (always "issue:N") -- fail soft rather than
-        // crash the whole run: this exact item can never be attempted, so it will never resolve on retry.
-        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-        cycles.push({ cycle: cycleIndex, outcome: "skipped_malformed_identifier", identifier: claimed.identifier });
-        claimed = portfolioQueue.dequeueNext();
-        continue;
-      }
-
-      const amsPolicy = await resolveAmsPolicyFn(claimed.repoFullName, { env });
-      // Real, SQLite-persisted per-item convergence history (#5677): the dequeueNext claim above already recorded
-      // this attempt and the markDone/markFailed calls below record the outcome, so reading it back here shares one
-      // source of truth with attempt-cli.js (#5654) and survives a loop-daemon restart instead of resetting.
-      const convergenceInput = portfolioQueue.getAttemptHistory(
-        claimed.repoFullName,
-        claimed.identifier,
-        claimed.apiBaseUrl,
-      );
-
-      const boundary = evaluateBoundaryGateFn(
-        {
-          runHalted: false,
-          usage,
-          limits: amsPolicy.spec.capLimits ?? DEFAULT_AMS_POLICY_SPEC.capLimits,
-          convergence: convergenceInput,
-          convergenceThresholds: amsPolicy.spec.convergenceThresholds ?? DEFAULT_AMS_POLICY_SPEC.convergenceThresholds,
-          inFlightItem: { repoFullName: claimed.repoFullName, identifier: claimed.identifier },
-          // Echoes claimed.apiBaseUrl (#5563), NOT the callback's own repoFullName/identifier alone -- two forge
-          // hosts can share an in-flight item with the same repo name+identifier.
-          markFailed: (repoFullName, identifier) => portfolioQueue.markFailed(repoFullName, identifier, claimed.apiBaseUrl),
-        },
-        { append: (event) => governorLedger.appendGovernorEvent(event) },
-      );
-
-      if (!boundary.canClaimNext) {
-        haltReason = `boundary_${boundary.verdict.reason}`;
-        cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason, repoFullName: claimed.repoFullName, identifier: claimed.identifier });
-        break;
-      }
-
-      const cycleStartMs = nowMsFn();
-      let lastResult = null;
-      const attemptArgv = [
-        claimed.repoFullName,
-        String(issueNumber),
-        "--miner-login",
-        parsed.minerLogin,
-        "--base",
-        parsed.base,
-        ...(parsed.live ? ["--live"] : []),
-      ];
-      await runAttemptFn(attemptArgv, {
-        ...(options.attemptOptions ?? {}),
-        env,
-        onResult: (result) => {
-          lastResult = result;
-        },
-      });
-      const cycleElapsedMs = nowMsFn() - cycleStartMs;
-
-      usage = {
-        // Real for the agent-sdk provider (its own SDK result message reports total_cost_usd, wired through
-        // runMinerAttempt's real loopResult.totalCostUsd); the CLI-subprocess providers (claude-cli/codex-cli)
-        // report no cost signal today, so this contributes 0 for those runs -- an honest absence, not a
-        // fabricated number. A capLimits.budget dimension only ever meaningfully trips against agent-sdk spend.
-        budgetSpent: usage.budgetSpent + (lastResult?.totalCostUsd ?? 0),
-        turnsTaken: usage.turnsTaken + (lastResult?.totalTurnsUsed ?? 0),
-        elapsedMs: usage.elapsedMs + cycleElapsedMs,
-      };
-      governorState.saveCapUsage(usage);
-
-      const attemptOutcome = lastResult?.outcome ?? "attempt_error";
-      const submitted = attemptOutcome === "attempt_submitted";
-      // A repo-wide AI-usage-policy ban will never resolve on retry -- stop re-queuing it (matches
-      // rejection-signal.js's own "this repo bans automated contributions" semantics). Every other blocked/
-      // abandoned/stale/governed outcome MAY resolve on a later retry (transient infra, contention, a
-      // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
-      // (reenqueues threshold) rather than silently retried forever.
-      const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
-      // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
-      // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
-      const killSwitchAbandon = lastResult?.abandonReason === "kill_switch_engaged";
-
-      if (submitted || permanentBlock) {
-        // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
-        // so neither is re-queued. markDone also clears the persisted consecutive-failure streak.
-        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-      } else {
-        // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
-        // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
-        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-      }
-
-      if (killSwitchAbandon) {
-        const liveKill = checkKillSwitchFn({ env });
-        haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
-        cycles.push({
-          cycle: cycleIndex,
-          outcome: "halted",
-          reason: haltReason,
-          repoFullName: claimed.repoFullName,
-          identifier: claimed.identifier,
-          attemptOutcome,
-        });
-        break;
-      }
-
-      let reentryOutcome = "other";
-      let prNumber = null;
-      let prDisposition = null;
-      let ciConclusion = null;
-      if (submitted) {
-        prNumber = parsePrNumberFromExecResult(lastResult?.execResult, claimed.repoFullName);
-        if (prNumber !== null) {
-          // Real CI-status observation (#5394): recorded BEFORE the disposition poll below, so a submitted
-          // PR's check-run state is captured even while it's still open, not just at its eventual merge/close.
-          // ci-poller.js's real GitHub check-run polling is a heuristic proxy for the gate verdict; the
-          // authoritative terminal merge/close outcome comes from pollPrDispositionFn below, sourced directly
-          // from GitHub's own PR state rather than a server-internal endpoint (#5450).
-          const ciStatus = await pollCheckRunsFn(claimed.repoFullName, prNumber, {
+    let governorState;
+    try {
+        governorState = (options.openGovernorState ?? openGovernorState)();
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`, 3);
+    }
+    const eventLedger = (options.initEventLedger ?? initEventLedger)();
+    const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    const runState = (options.initRunStateStore ?? initRunStateStore)();
+    const runDiscoverFn = (options.runDiscover ?? runDiscover);
+    const runAttemptFn = (options.runAttempt ?? runAttempt);
+    const resolveAmsPolicyFn = (options.resolveAmsPolicy ?? resolveAmsPolicy);
+    const checkKillSwitchFn = (options.checkMinerKillSwitch ?? checkMinerKillSwitch);
+    const evaluateBoundaryGateFn = (options.evaluateRunLoopBoundaryGate ?? evaluateRunLoopBoundaryGate);
+    const pollPrDispositionFn = (options.pollPrDisposition ?? pollPrDisposition);
+    const pollCheckRunsFn = (options.pollCheckRuns ?? pollCheckRuns);
+    const recordPrOutcomeSnapshotFn = (options.recordPrOutcomeSnapshot ?? recordPrOutcomeSnapshot);
+    const buildLoopClosureSummaryFn = (options.buildLoopClosureSummary ?? buildLoopClosureSummary);
+    const attemptLoopReentryFn = (options.attemptLoopReentry ?? attemptLoopReentry);
+    // Resolved ONCE, at the CLI-entrypoint layer, mirroring manage-poll.js's own runManagePoll (its
+    // recordManagePollSnapshot callee has no env fallback of its own either -- the top-level CLI function is
+    // where the GitHub token gets resolved, then threaded down explicitly to every real GitHub caller).
+    // pollPrDisposition (unlike runDiscover, which falls back to process.env.GITHUB_TOKEN internally) has NO
+    // such fallback -- an unresolved githubToken here would silently poll unauthenticated.
+    // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+    // authenticated `loopover-mcp login` session -- cached in memory for this process's lifetime.
+    const githubToken = options.githubToken ?? (await resolveGitHubToken(env)) ?? "";
+    async function runDiscoveryOnce() {
+        await runDiscoverFn(discoverArgv(parsed), {
+            initPortfolioQueue: () => portfolioQueue,
             githubToken,
             apiBaseUrl: options.apiBaseUrl,
-            ...(options.ciPollOptions ?? {}),
-          });
-          ciConclusion = ciStatus.conclusion;
-          eventLedger.appendEvent({
-            type: "ci_status_observed",
-            repoFullName: claimed.repoFullName,
-            payload: { prNumber, conclusion: ciStatus.conclusion, checkCount: ciStatus.checks.length, source: "ci-poller" },
-          });
-
-          prDisposition = await pollPrDispositionFn(claimed.repoFullName, prNumber, {
-            githubToken,
-            apiBaseUrl: options.apiBaseUrl,
-            ...(options.prDispositionOptions ?? {}),
-          });
-          if (prDisposition.state === "closed") {
-            recordPrOutcomeSnapshotFn(
-              {
+            nowMs: nowMsFn(),
+        });
+    }
+    let usage = governorState.loadCapUsage();
+    const cycles = [];
+    let sinceSeq = eventLedger.readEvents({}).at(-1)?.seq ?? 0;
+    let haltReason = null;
+    try {
+        // Checked BEFORE any work at all -- including the very first discovery call -- so an already-active kill
+        // switch OR an already-active pause (#4851) halts the loop without ever touching GitHub or the queue. The
+        // pause flag is real, persisted, operator/governor-writable state on governorState (toggled via
+        // `loopover-miner governor pause`/`resume`) -- unlike the kill switch, a paused run resumes simply by being
+        // re-invoked: every piece of per-cycle state this loop reads (portfolioQueue, runState, governorState's own
+        // cap usage) is already durable, so clearing the flag and restarting continues exactly where it left off.
+        const initialKillSwitch = checkKillSwitchFn({ env });
+        const initialPauseState = governorState.loadPauseState();
+        let claimed = null;
+        if (initialKillSwitch.active) {
+            haltReason = `kill_switch_${initialKillSwitch.scope}`;
+            cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+        }
+        else if (initialPauseState.paused) {
+            haltReason = "paused";
+            cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+        }
+        else {
+            await runDiscoveryOnce();
+            claimed = portfolioQueue.dequeueNext();
+        }
+        let cycleIndex = haltReason !== null ? 1 : 0;
+        while (haltReason === null && (parsed.maxCycles === undefined || cycleIndex < parsed.maxCycles)) {
+            cycleIndex += 1;
+            const killSwitch = checkKillSwitchFn({ env });
+            if (killSwitch.active) {
+                haltReason = `kill_switch_${killSwitch.scope}`;
+                // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
+                if (claimed) {
+                    portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+                }
+                cycles.push({
+                    cycle: cycleIndex,
+                    outcome: "halted",
+                    reason: haltReason,
+                    ...(claimed
+                        ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+                        : {}),
+                });
+                break;
+            }
+            const pauseState = governorState.loadPauseState();
+            if (pauseState.paused) {
+                haltReason = "paused";
+                if (claimed) {
+                    portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+                }
+                cycles.push({
+                    cycle: cycleIndex,
+                    outcome: "halted",
+                    reason: haltReason,
+                    ...(claimed
+                        ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+                        : {}),
+                });
+                break;
+            }
+            if (!claimed) {
+                cycles.push({ cycle: cycleIndex, outcome: "idle_queue_empty" });
+                await sleepFn(parsed.cycleDelayMs);
+                await runDiscoveryOnce();
+                claimed = portfolioQueue.dequeueNext();
+                continue;
+            }
+            const issueNumber = parseIssueNumberFromIdentifier(claimed.identifier);
+            if (issueNumber === null) {
+                // Never produced by enqueueRankedDiscovery in practice (always "issue:N") -- fail soft rather than
+                // crash the whole run: this exact item can never be attempted, so it will never resolve on retry.
+                portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+                cycles.push({ cycle: cycleIndex, outcome: "skipped_malformed_identifier", identifier: claimed.identifier });
+                claimed = portfolioQueue.dequeueNext();
+                continue;
+            }
+            const amsPolicy = await resolveAmsPolicyFn(claimed.repoFullName, { env });
+            // Real, SQLite-persisted per-item convergence history (#5677): the dequeueNext claim above already recorded
+            // this attempt and the markDone/markFailed calls below record the outcome, so reading it back here shares one
+            // source of truth with attempt-cli.js (#5654) and survives a loop-daemon restart instead of resetting.
+            const convergenceInput = portfolioQueue.getAttemptHistory(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            const boundary = evaluateBoundaryGateFn({
+                runHalted: false,
+                usage,
+                limits: amsPolicy.spec.capLimits ?? DEFAULT_AMS_POLICY_SPEC.capLimits,
+                convergence: convergenceInput,
+                convergenceThresholds: amsPolicy.spec.convergenceThresholds ?? DEFAULT_AMS_POLICY_SPEC.convergenceThresholds,
+                inFlightItem: { repoFullName: claimed.repoFullName, identifier: claimed.identifier },
+                // Echoes claimed.apiBaseUrl (#5563), NOT the callback's own repoFullName/identifier alone -- two forge
+                // hosts can share an in-flight item with the same repo name+identifier.
+                markFailed: (repoFullName, identifier) => portfolioQueue.markFailed(repoFullName, identifier, claimed.apiBaseUrl),
+            }, { append: (event) => governorLedger.appendGovernorEvent(event) });
+            if (!boundary.canClaimNext) {
+                haltReason = `boundary_${boundary.verdict.reason}`;
+                cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason, repoFullName: claimed.repoFullName, identifier: claimed.identifier });
+                break;
+            }
+            const cycleStartMs = nowMsFn();
+            let lastResult = null;
+            const attemptArgv = [
+                claimed.repoFullName,
+                String(issueNumber),
+                "--miner-login",
+                parsed.minerLogin,
+                "--base",
+                parsed.base,
+                ...(parsed.live ? ["--live"] : []),
+            ];
+            await runAttemptFn(attemptArgv, {
+                ...(options.attemptOptions ?? {}),
+                env,
+                onResult: (result) => {
+                    lastResult = result;
+                },
+            });
+            const cycleElapsedMs = nowMsFn() - cycleStartMs;
+            usage = {
+                // Real for the agent-sdk provider (its own SDK result message reports total_cost_usd, wired through
+                // runMinerAttempt's real loopResult.totalCostUsd); the CLI-subprocess providers (claude-cli/codex-cli)
+                // report no cost signal today, so this contributes 0 for those runs -- an honest absence, not a
+                // fabricated number. A capLimits.budget dimension only ever meaningfully trips against agent-sdk spend.
+                budgetSpent: usage.budgetSpent + (lastResult?.totalCostUsd ?? 0),
+                turnsTaken: usage.turnsTaken + (lastResult?.totalTurnsUsed ?? 0),
+                elapsedMs: usage.elapsedMs + cycleElapsedMs,
+            };
+            governorState.saveCapUsage(usage);
+            const attemptOutcome = lastResult?.outcome ?? "attempt_error";
+            const submitted = attemptOutcome === "attempt_submitted";
+            // A repo-wide AI-usage-policy ban will never resolve on retry -- stop re-queuing it (matches
+            // rejection-signal.js's own "this repo bans automated contributions" semantics). Every other blocked/
+            // abandoned/stale/governed outcome MAY resolve on a later retry (transient infra, contention, a
+            // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
+            // (reenqueues threshold) rather than silently retried forever.
+            const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
+            // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
+            // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
+            const killSwitchAbandon = lastResult?.abandonReason === "kill_switch_engaged";
+            if (submitted || permanentBlock) {
+                // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
+                // so neither is re-queued. markDone also clears the persisted consecutive-failure streak.
+                portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            }
+            else {
+                // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
+                // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
+                portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            }
+            if (killSwitchAbandon) {
+                const liveKill = checkKillSwitchFn({ env });
+                haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
+                cycles.push({
+                    cycle: cycleIndex,
+                    outcome: "halted",
+                    reason: haltReason,
+                    repoFullName: claimed.repoFullName,
+                    identifier: claimed.identifier,
+                    attemptOutcome,
+                });
+                break;
+            }
+            let reentryOutcome = "other";
+            let prNumber = null;
+            let prDisposition = null;
+            let ciConclusion = null;
+            if (submitted) {
+                prNumber = parsePrNumberFromExecResult(lastResult?.execResult, claimed.repoFullName);
+                if (prNumber !== null) {
+                    // Real CI-status observation (#5394): recorded BEFORE the disposition poll below, so a submitted
+                    // PR's check-run state is captured even while it's still open, not just at its eventual merge/close.
+                    // ci-poller.js's real GitHub check-run polling is a heuristic proxy for the gate verdict; the
+                    // authoritative terminal merge/close outcome comes from pollPrDispositionFn below, sourced directly
+                    // from GitHub's own PR state rather than a server-internal endpoint (#5450).
+                    const ciStatus = await pollCheckRunsFn(claimed.repoFullName, prNumber, {
+                        githubToken,
+                        apiBaseUrl: options.apiBaseUrl,
+                        ...(options.ciPollOptions ?? {}),
+                    });
+                    ciConclusion = ciStatus.conclusion;
+                    eventLedger.appendEvent({
+                        type: "ci_status_observed",
+                        repoFullName: claimed.repoFullName,
+                        payload: { prNumber, conclusion: ciStatus.conclusion, checkCount: ciStatus.checks.length, source: "ci-poller" },
+                    });
+                    prDisposition = await pollPrDispositionFn(claimed.repoFullName, prNumber, {
+                        githubToken,
+                        apiBaseUrl: options.apiBaseUrl,
+                        ...(options.prDispositionOptions ?? {}),
+                    });
+                    if (prDisposition.state === "closed") {
+                        recordPrOutcomeSnapshotFn({
+                            repoFullName: claimed.repoFullName,
+                            prNumber,
+                            decision: prDisposition.merged ? "merged" : "closed",
+                            closedAt: prDisposition.closedAt,
+                        }, { eventLedger });
+                        // Real per-repo reputation history (#5675): a resolved terminal outcome updates the decided/unfavorable
+                        // counts the Governor's self-reputation throttle reads on this repo's next attempt. `decided` always;
+                        // `unfavorable` only on a closed-without-merge (rejection-state-machine.js's isRejectedPr, matching
+                        // #5655's own-rejection classification). Forge-scoped by claimed.apiBaseUrl (#5563), like every other
+                        // governor-state write here.
+                        const priorReputation = governorState.loadReputationHistory(claimed.repoFullName, claimed.apiBaseUrl);
+                        governorState.saveReputationHistory(claimed.repoFullName, {
+                            decided: priorReputation.decided + 1,
+                            unfavorable: priorReputation.unfavorable + (isRejectedPr(prDisposition) ? 1 : 0),
+                        }, claimed.apiBaseUrl);
+                        reentryOutcome = classifyPrDisposition(prDisposition);
+                    }
+                }
+            }
+            const loopSummary = buildLoopClosureSummaryFn({ eventLedger, portfolioQueue, runState }, { sinceSeq, repoFullName: claimed.repoFullName });
+            sinceSeq = loopSummary.lastSeq;
+            const reentry = attemptLoopReentryFn({ killSwitchScope: killSwitch.scope, repoFullName: claimed.repoFullName, outcome: reentryOutcome }, { eventLedger, portfolioQueue, runState, nowMs: nowMsFn(), sessionStartMs, loopSummary });
+            cycles.push({
+                cycle: cycleIndex,
+                outcome: "attempted",
                 repoFullName: claimed.repoFullName,
+                identifier: claimed.identifier,
+                attemptOutcome,
+                reentryOutcome,
                 prNumber,
-                decision: prDisposition.merged ? "merged" : "closed",
-                closedAt: prDisposition.closedAt,
-              },
-              { eventLedger },
-            );
-            // Real per-repo reputation history (#5675): a resolved terminal outcome updates the decided/unfavorable
-            // counts the Governor's self-reputation throttle reads on this repo's next attempt. `decided` always;
-            // `unfavorable` only on a closed-without-merge (rejection-state-machine.js's isRejectedPr, matching
-            // #5655's own-rejection classification). Forge-scoped by claimed.apiBaseUrl (#5563), like every other
-            // governor-state write here.
-            const priorReputation = governorState.loadReputationHistory(claimed.repoFullName, claimed.apiBaseUrl);
-            governorState.saveReputationHistory(
-              claimed.repoFullName,
-              {
-                decided: priorReputation.decided + 1,
-                unfavorable: priorReputation.unfavorable + (isRejectedPr(prDisposition) ? 1 : 0),
-              },
-              claimed.apiBaseUrl,
-            );
-            reentryOutcome = classifyPrDisposition(prDisposition);
-          }
+                ciConclusion,
+                reentered: reentry.decision.reenter,
+                reasons: reentry.decision.reasons,
+            });
+            if (!reentry.decision.reenter) {
+                haltReason = `reentry_declined:${reentry.decision.reasons.join(",")}`;
+                break;
+            }
+            if (reentry.dequeued) {
+                claimed = reentry.dequeued;
+                await sleepFn(parsed.cycleDelayMs);
+            }
+            else {
+                await sleepFn(parsed.cycleDelayMs);
+                await runDiscoveryOnce();
+                claimed = portfolioQueue.dequeueNext();
+            }
         }
-      }
-
-      const loopSummary = buildLoopClosureSummaryFn(
-        { eventLedger, portfolioQueue, runState },
-        { sinceSeq, repoFullName: claimed.repoFullName },
-      );
-      sinceSeq = loopSummary.lastSeq;
-
-      const reentry = attemptLoopReentryFn(
-        { killSwitchScope: killSwitch.scope, repoFullName: claimed.repoFullName, outcome: reentryOutcome },
-        { eventLedger, portfolioQueue, runState, nowMs: nowMsFn(), sessionStartMs, loopSummary },
-      );
-
-      cycles.push({
-        cycle: cycleIndex,
-        outcome: "attempted",
-        repoFullName: claimed.repoFullName,
-        identifier: claimed.identifier,
-        attemptOutcome,
-        reentryOutcome,
-        prNumber,
-        ciConclusion,
-        reentered: reentry.decision.reenter,
-        reasons: reentry.decision.reasons,
-      });
-
-      if (!reentry.decision.reenter) {
-        haltReason = `reentry_declined:${reentry.decision.reasons.join(",")}`;
-        break;
-      }
-
-      if (reentry.dequeued) {
-        claimed = reentry.dequeued;
-        await sleepFn(parsed.cycleDelayMs);
-      } else {
-        await sleepFn(parsed.cycleDelayMs);
-        await runDiscoveryOnce();
-        claimed = portfolioQueue.dequeueNext();
-      }
+        if (haltReason === null && parsed.maxCycles !== undefined) {
+            haltReason = "max_cycles_reached";
+            // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
+            // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
+            // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
+            // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
+            // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
+            if (claimed) {
+                portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            }
+        }
+        const summary = { haltReason, cyclesRun: cycles.length, cycles };
+        if (parsed.json) {
+            console.log(JSON.stringify(summary, null, 2));
+        }
+        else {
+            console.log(`Loop finished after ${cycles.length} cycle(s): ${haltReason ?? "unknown"}.`);
+        }
+        return 0;
     }
-
-    if (haltReason === null && parsed.maxCycles !== undefined) {
-      haltReason = "max_cycles_reached";
-      // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
-      // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
-      // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
-      // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
-      // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
-      if (claimed) {
-        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-      }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
     }
-
-    const summary = { haltReason, cyclesRun: cycles.length, cycles };
-    if (parsed.json) {
-      console.log(JSON.stringify(summary, null, 2));
-    } else {
-      console.log(`Loop finished after ${cycles.length} cycle(s): ${haltReason ?? "unknown"}.`);
+    finally {
+        governorState.close();
+        eventLedger.close();
+        governorLedger.close();
+        portfolioQueue.close();
+        runState.close();
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    governorState.close();
-    eventLedger.close();
-    governorLedger.close();
-    portfolioQueue.close();
-    runState.close();
-  }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9vcC1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJsb29wLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxzR0FBc0c7QUFDdEcsaUdBQWlHO0FBQ2pHLHlHQUF5RztBQUN6RyxtR0FBbUc7QUFDbkcsRUFBRTtBQUNGLHFHQUFxRztBQUNyRyx5R0FBeUc7QUFDekcscUZBQXFGO0FBQ3JGLDZHQUE2RztBQUM3RyxzREFBc0Q7QUFDdEQscUdBQXFHO0FBQ3JHLDBHQUEwRztBQUMxRyw4R0FBOEc7QUFDOUcsNkdBQTZHO0FBQzdHLDJEQUEyRDtBQUMzRCxFQUFFO0FBQ0YsdUdBQXVHO0FBQ3ZHLDBHQUEwRztBQUMxRyw4R0FBOEc7QUFDOUcsNEdBQTRHO0FBQzVHLCtHQUErRztBQUMvRyw2R0FBNkc7QUFDN0csK0VBQStFO0FBRS9FLE9BQU8sRUFBRSxvQkFBb0IsRUFBRSxNQUFNLDJCQUEyQixDQUFDO0FBQ2pFLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsMkJBQTJCLEVBQUUsTUFBTSx3QkFBd0IsQ0FBQztBQUNyRSxPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxxQkFBcUIsQ0FBQztBQUN4RCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUMxRCxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFDcEQsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDL0QsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbkQsT0FBTyxFQUFFLFdBQVcsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ2hELE9BQU8sRUFBRSxVQUFVLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUM5QyxPQUFPLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUNuRCxPQUFPLEVBQUUsaUJBQWlCLEVBQUUscUJBQXFCLEVBQUUsTUFBTSw0QkFBNEIsQ0FBQztBQUN0RixPQUFPLEVBQUUsYUFBYSxFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDL0MsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0saUJBQWlCLENBQUM7QUFDMUQsT0FBTyxFQUFFLFlBQVksRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBQzVELE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQzVELE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ3ZELE9BQU8sRUFBRSwyQkFBMkIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBQ25FLE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBQ2xFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBZ0UzRCxNQUFNLFVBQVUsR0FDZCwrTEFBK0wsQ0FBQztBQUNsTSxNQUFNLHNCQUFzQixHQUFHLE1BQU0sQ0FBQztBQUN0QyxNQUFNLHdCQUF3QixHQUFHLGVBQWUsQ0FBQztBQUVqRCxTQUFTLGVBQWUsQ0FBQyxLQUFhO0lBQ3BDLE1BQU0sT0FBTyxHQUFHLE9BQU8sS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDOUQsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDeEQsT0FBTyxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsQ0FBQztBQUM1QixDQUFDO0FBRUQsU0FBUyw0QkFBNEIsQ0FBQyxLQUFhLEVBQUUsS0FBYTtJQUNoRSxNQUFNLFdBQVcsR0FBRyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDbEMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsV0FBVyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLFdBQVcsQ0FBQyxJQUFJLFdBQVcsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUN2RixNQUFNLElBQUksS0FBSyxDQUFDLEdBQUcsS0FBSyxvQ0FBb0MsS0FBSyxFQUFFLENBQUMsQ0FBQztJQUN2RSxDQUFDO0lBQ0QsT0FBTyxXQUFXLENBQUM7QUFDckIsQ0FBQztBQUVELE1BQU0sVUFBVSxhQUFhLENBQUMsSUFBYztJQUMxQyxNQUFNLE9BQU8sR0FTVDtRQUNGLElBQUksRUFBRSxLQUFLO1FBQ1gsVUFBVSxFQUFFLElBQUk7UUFDaEIsSUFBSSxFQUFFLE1BQU07UUFDWixJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsTUFBTSxFQUFFLElBQUk7UUFDWixTQUFTLEVBQUUsU0FBUztRQUNwQixZQUFZLEVBQUUsc0JBQXNCO0tBQ3JDLENBQUM7SUFDRixNQUFNLE9BQU8sR0FBYSxFQUFFLENBQUM7SUFFN0IsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsMkdBQTJHO1FBQzNHLHVHQUF1RztRQUN2RyxJQUFJLEtBQUssS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUMxQixPQUFPLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQztZQUN0QixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFVBQVUsRUFBRSxDQUFDO1lBQ3pCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxDQUFDO1lBQ2xFLE9BQU8sQ0FBQyxNQUFNLEdBQUcsS0FBSyxDQUFDO1lBQ3ZCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLGVBQWUsRUFBRSxDQUFDO1lBQzlCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxDQUFDO1lBQ2xFLE9BQU8sQ0FBQyxVQUFVLEdBQUcsS0FBSyxDQUFDO1lBQzNCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxDQUFDO1lBQ2xFLE9BQU8sQ0FBQyxJQUFJLEdBQUcsS0FBSyxDQUFDO1lBQ3JCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLGNBQWMsRUFBRSxDQUFDO1lBQzdCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxDQUFDO1lBQ2xFLElBQUksQ0FBQztnQkFDSCxPQUFPLENBQUMsU0FBUyxHQUFHLDRCQUE0QixDQUFDLEtBQUssRUFBRSxjQUFjLENBQUMsQ0FBQztZQUMxRSxDQUFDO1lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztnQkFDZixPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssWUFBWSxLQUFLLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1lBQzNFLENBQUM7WUFDRCxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxrQkFBa0IsRUFBRSxDQUFDO1lBQ2pDLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxDQUFDO1lBQ2xFLElBQUksQ0FBQztnQkFDSCxPQUFPLENBQUMsWUFBWSxHQUFHLDRCQUE0QixDQUFDLEtBQUssRUFBRSxrQkFBa0IsQ0FBQyxDQUFDO1lBQ2pGLENBQUM7WUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO2dCQUNmLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxZQUFZLEtBQUssQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUM7WUFDM0UsQ0FBQztZQUNELEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQ3hFLE1BQU0sTUFBTSxHQUFHLGVBQWUsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUN0QyxJQUFJLENBQUMsTUFBTTtZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsMENBQTBDLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDakYsT0FBTyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUN2QixDQUFDO0lBRUQsSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLElBQUksSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxDQUFDO0lBQ2xGLElBQUksT0FBTyxDQUFDLE1BQU0sS0FBSyxJQUFJLElBQUksT0FBTyxDQUFDLE1BQU0sR0FBRyxDQUFDO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSx1REFBdUQsRUFBRSxDQUFDO0lBQzdILElBQUksQ0FBQyxPQUFPLENBQUMsVUFBVTtRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsOEJBQThCLFVBQVUsRUFBRSxFQUFFLENBQUM7SUFFdEYsT0FBTztRQUNMLE9BQU87UUFDUCxNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU07UUFDdEIsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVO1FBQzlCLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtRQUNsQixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7UUFDbEIsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNO1FBQ3RCLFNBQVMsRUFBRSxPQUFPLENBQUMsU0FBUztRQUM1QixZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVk7UUFDbEMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO0tBQ25CLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxZQUFZLENBQUMsTUFBa0Q7SUFDdEUsT0FBTyxNQUFNLENBQUMsTUFBTSxLQUFLLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxVQUFVLEVBQUUsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0FBQ3BGLENBQUM7QUFFRCxTQUFTLDhCQUE4QixDQUFDLFVBQWtCO0lBQ3hELE1BQU0sS0FBSyxHQUFHLE9BQU8sVUFBVSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsVUFBVSxDQUFDLEtBQUssQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUM7SUFDakcsT0FBTyxLQUFLLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0FBQ3pDLENBQUM7QUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FnQ0c7QUFDSCxNQUFNLENBQUMsS0FBSyxVQUFVLE9BQU8sQ0FBQyxJQUFjLEVBQUUsVUFBMEIsRUFBRTtJQUN4RSxNQUFNLE1BQU0sR0FBRyxhQUFhLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDbkMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxNQUFNLEdBQUcsR0FBRyxPQUFPLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUM7SUFDdkMsTUFBTSxPQUFPLEdBQUcsT0FBTyxDQUFDLE9BQU8sSUFBSSxDQUFDLENBQUMsT0FBZSxFQUFFLEVBQUUsQ0FBQyxJQUFJLE9BQU8sQ0FBTyxDQUFDLE9BQU8sRUFBRSxFQUFFLENBQUMsVUFBVSxDQUFDLE9BQU8sRUFBRSxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDdkgsTUFBTSxPQUFPLEdBQUcsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDLEtBQUssSUFBSSxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUM7SUFDbEQsTUFBTSxjQUFjLEdBQUcsT0FBTyxFQUFFLENBQUM7SUFFakMseUdBQXlHO0lBQ3pHLDhHQUE4RztJQUM5RywwR0FBMEc7SUFDMUcsZ0dBQWdHO0lBQ2hHLElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHO1lBQ25CLE9BQU8sRUFBRSxTQUFTO1lBQ2xCLE9BQU8sRUFBRSxNQUFNLENBQUMsT0FBTztZQUN2QixNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU07WUFDckIsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVO1lBQzdCLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSTtZQUNqQixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7WUFDakIsU0FBUyxFQUFFLE1BQU0sQ0FBQyxTQUFTLElBQUksSUFBSTtTQUNwQyxDQUFDO1FBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE1BQU0sTUFBTSxHQUFHLE1BQU0sQ0FBQyxNQUFNLEtBQUssSUFBSSxDQUFDLENBQUMsQ0FBQyxZQUFZLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7WUFDaEcsT0FBTyxDQUFDLEdBQUcsQ0FDVCxpREFBaUQsTUFBTSxRQUFRLE1BQU0sQ0FBQyxVQUFVLFdBQVcsTUFBTSxDQUFDLElBQUksV0FBVyxNQUFNLENBQUMsSUFBSSxxREFBcUQsQ0FDbEwsQ0FBQztRQUNKLENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFFRCxJQUFJLGFBQTRCLENBQUM7SUFDakMsSUFBSSxDQUFDO1FBQ0gsYUFBYSxHQUFHLENBQUMsT0FBTyxDQUFDLGlCQUFpQixJQUFJLGlCQUFpQixDQUFDLEVBQUUsQ0FBQztJQUNyRSxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQ3JCLE1BQU0sQ0FBQyxJQUFJLEVBQ1gsMkRBQTJELGdCQUFnQixDQUFDLEtBQUssQ0FBQyxFQUFFLEVBQ3BGLENBQUMsQ0FDRixDQUFDO0lBQ0osQ0FBQztJQUVELE1BQU0sV0FBVyxHQUFHLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxlQUFlLENBQUMsRUFBRSxDQUFDO0lBQ25FLE1BQU0sY0FBYyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLGtCQUFrQixDQUFDLEVBQUUsQ0FBQztJQUM1RSxNQUFNLGNBQWMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxrQkFBa0IsSUFBSSx1QkFBdUIsQ0FBQyxFQUFFLENBQUM7SUFDakYsTUFBTSxRQUFRLEdBQUcsQ0FBQyxPQUFPLENBQUMsaUJBQWlCLElBQUksaUJBQWlCLENBQUMsRUFBRSxDQUFDO0lBRXBFLE1BQU0sYUFBYSxHQUFHLENBQUMsT0FBTyxDQUFDLFdBQVcsSUFBSSxXQUFXLENBQStDLENBQUM7SUFDekcsTUFBTSxZQUFZLEdBQUcsQ0FBQyxPQUFPLENBQUMsVUFBVSxJQUFJLFVBQVUsQ0FBOEMsQ0FBQztJQUNyRyxNQUFNLGtCQUFrQixHQUFHLENBQUMsT0FBTyxDQUFDLGdCQUFnQixJQUFJLGdCQUFnQixDQUFvRCxDQUFDO0lBQzdILE1BQU0saUJBQWlCLEdBQUcsQ0FBQyxPQUFPLENBQUMsb0JBQW9CLElBQUksb0JBQW9CLENBQXdELENBQUM7SUFDeEksTUFBTSxzQkFBc0IsR0FBRyxDQUFDLE9BQU8sQ0FBQywyQkFBMkIsSUFBSSwyQkFBMkIsQ0FBK0QsQ0FBQztJQUNsSyxNQUFNLG1CQUFtQixHQUFHLENBQUMsT0FBTyxDQUFDLGlCQUFpQixJQUFJLGlCQUFpQixDQUFxRCxDQUFDO0lBQ2pJLE1BQU0sZUFBZSxHQUFHLENBQUMsT0FBTyxDQUFDLGFBQWEsSUFBSSxhQUFhLENBQWlELENBQUM7SUFDakgsTUFBTSx5QkFBeUIsR0FBRyxDQUFDLE9BQU8sQ0FBQyx1QkFBdUIsSUFBSSx1QkFBdUIsQ0FBMkQsQ0FBQztJQUN6SixNQUFNLHlCQUF5QixHQUFHLENBQUMsT0FBTyxDQUFDLHVCQUF1QixJQUFJLHVCQUF1QixDQUEyRCxDQUFDO0lBQ3pKLE1BQU0sb0JBQW9CLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksa0JBQWtCLENBQXNELENBQUM7SUFFckksZ0dBQWdHO0lBQ2hHLHlHQUF5RztJQUN6RyxvR0FBb0c7SUFDcEcseUdBQXlHO0lBQ3pHLHVGQUF1RjtJQUN2RixrR0FBa0c7SUFDbEcsOEZBQThGO0lBQzlGLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxXQUFXLElBQUksQ0FBQyxNQUFNLGtCQUFrQixDQUFDLEdBQXdCLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUV0RyxLQUFLLFVBQVUsZ0JBQWdCO1FBQzdCLE1BQU0sYUFBYSxDQUFDLFlBQVksQ0FBQyxNQUFvRCxDQUFDLEVBQUU7WUFDdEYsa0JBQWtCLEVBQUUsR0FBRyxFQUFFLENBQUMsY0FBYztZQUN4QyxXQUFXO1lBQ1gsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVO1lBQzlCLEtBQUssRUFBRSxPQUFPLEVBQUU7U0FDakIsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUVELElBQUksS0FBSyxHQUFHLGFBQWEsQ0FBQyxZQUFZLEVBQUUsQ0FBQztJQUN6QyxNQUFNLE1BQU0sR0FBdUIsRUFBRSxDQUFDO0lBQ3RDLElBQUksUUFBUSxHQUFHLFdBQVcsQ0FBQyxVQUFVLENBQUMsRUFBRSxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsR0FBRyxJQUFJLENBQUMsQ0FBQztJQUMzRCxJQUFJLFVBQVUsR0FBa0IsSUFBSSxDQUFDO0lBRXJDLElBQUksQ0FBQztRQUNILHlHQUF5RztRQUN6RywwR0FBMEc7UUFDMUcsZ0dBQWdHO1FBQ2hHLDRHQUE0RztRQUM1Ryw0R0FBNEc7UUFDNUcsMEdBQTBHO1FBQzFHLE1BQU0saUJBQWlCLEdBQUcsaUJBQWlCLENBQUMsRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQ3JELE1BQU0saUJBQWlCLEdBQUcsYUFBYSxDQUFDLGNBQWMsRUFBRSxDQUFDO1FBQ3pELElBQUksT0FBTyxHQUFzQixJQUFJLENBQUM7UUFDdEMsSUFBSSxpQkFBaUIsQ0FBQyxNQUFNLEVBQUUsQ0FBQztZQUM3QixVQUFVLEdBQUcsZUFBZSxpQkFBaUIsQ0FBQyxLQUFLLEVBQUUsQ0FBQztZQUN0RCxNQUFNLENBQUMsSUFBSSxDQUFDLEVBQUUsS0FBSyxFQUFFLENBQUMsRUFBRSxPQUFPLEVBQUUsUUFBUSxFQUFFLE1BQU0sRUFBRSxVQUFVLEVBQUUsQ0FBQyxDQUFDO1FBQ25FLENBQUM7YUFBTSxJQUFJLGlCQUFpQixDQUFDLE1BQU0sRUFBRSxDQUFDO1lBQ3BDLFVBQVUsR0FBRyxRQUFRLENBQUM7WUFDdEIsTUFBTSxDQUFDLElBQUksQ0FBQyxFQUFFLEtBQUssRUFBRSxDQUFDLEVBQUUsT0FBTyxFQUFFLFFBQVEsRUFBRSxNQUFNLEVBQUUsVUFBVSxFQUFFLENBQUMsQ0FBQztRQUNuRSxDQUFDO2FBQU0sQ0FBQztZQUNOLE1BQU0sZ0JBQWdCLEVBQUUsQ0FBQztZQUN6QixPQUFPLEdBQUcsY0FBYyxDQUFDLFdBQVcsRUFBRSxDQUFDO1FBQ3pDLENBQUM7UUFFRCxJQUFJLFVBQVUsR0FBRyxVQUFVLEtBQUssSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUM3QyxPQUFPLFVBQVUsS0FBSyxJQUFJLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxLQUFLLFNBQVMsSUFBSSxVQUFVLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQyxFQUFFLENBQUM7WUFDaEcsVUFBVSxJQUFJLENBQUMsQ0FBQztZQUVoQixNQUFNLFVBQVUsR0FBRyxpQkFBaUIsQ0FBQyxFQUFFLEdBQUcsRUFBRSxDQUFDLENBQUM7WUFDOUMsSUFBSSxVQUFVLENBQUMsTUFBTSxFQUFFLENBQUM7Z0JBQ3RCLFVBQVUsR0FBRyxlQUFlLFVBQVUsQ0FBQyxLQUFLLEVBQUUsQ0FBQztnQkFDL0MsZ0dBQWdHO2dCQUNoRyxJQUFJLE9BQU8sRUFBRSxDQUFDO29CQUNaLGNBQWMsQ0FBQyxVQUFVLENBQUMsT0FBTyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQztnQkFDMUYsQ0FBQztnQkFDRCxNQUFNLENBQUMsSUFBSSxDQUFDO29CQUNWLEtBQUssRUFBRSxVQUFVO29CQUNqQixPQUFPLEVBQUUsUUFBUTtvQkFDakIsTUFBTSxFQUFFLFVBQVU7b0JBQ2xCLEdBQUcsQ0FBQyxPQUFPO3dCQUNULENBQUMsQ0FBQyxFQUFFLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFO3dCQUN4RSxDQUFDLENBQUMsRUFBRSxDQUFDO2lCQUNSLENBQUMsQ0FBQztnQkFDSCxNQUFNO1lBQ1IsQ0FBQztZQUVELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLEVBQUUsQ0FBQztZQUNsRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEVBQUUsQ0FBQztnQkFDdEIsVUFBVSxHQUFHLFFBQVEsQ0FBQztnQkFDdEIsSUFBSSxPQUFPLEVBQUUsQ0FBQztvQkFDWixjQUFjLENBQUMsVUFBVSxDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7Z0JBQzFGLENBQUM7Z0JBQ0QsTUFBTSxDQUFDLElBQUksQ0FBQztvQkFDVixLQUFLLEVBQUUsVUFBVTtvQkFDakIsT0FBTyxFQUFFLFFBQVE7b0JBQ2pCLE1BQU0sRUFBRSxVQUFVO29CQUNsQixHQUFHLENBQUMsT0FBTzt3QkFDVCxDQUFDLENBQUMsRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRTt3QkFDeEUsQ0FBQyxDQUFDLEVBQUUsQ0FBQztpQkFDUixDQUFDLENBQUM7Z0JBQ0gsTUFBTTtZQUNSLENBQUM7WUFFRCxJQUFJLENBQUMsT0FBTyxFQUFFLENBQUM7Z0JBQ2IsTUFBTSxDQUFDLElBQUksQ0FBQyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsT0FBTyxFQUFFLGtCQUFrQixFQUFFLENBQUMsQ0FBQztnQkFDaEUsTUFBTSxPQUFPLENBQUMsTUFBTSxDQUFDLFlBQVksQ0FBQyxDQUFDO2dCQUNuQyxNQUFNLGdCQUFnQixFQUFFLENBQUM7Z0JBQ3pCLE9BQU8sR0FBRyxjQUFjLENBQUMsV0FBVyxFQUFFLENBQUM7Z0JBQ3ZDLFNBQVM7WUFDWCxDQUFDO1lBRUQsTUFBTSxXQUFXLEdBQUcsOEJBQThCLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ3ZFLElBQUksV0FBVyxLQUFLLElBQUksRUFBRSxDQUFDO2dCQUN6QixtR0FBbUc7Z0JBQ25HLGtHQUFrRztnQkFDbEcsY0FBYyxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO2dCQUN0RixNQUFNLENBQUMsSUFBSSxDQUFDLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxPQUFPLEVBQUUsOEJBQThCLEVBQUUsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUUsQ0FBQyxDQUFDO2dCQUM1RyxPQUFPLEdBQUcsY0FBYyxDQUFDLFdBQVcsRUFBRSxDQUFDO2dCQUN2QyxTQUFTO1lBQ1gsQ0FBQztZQUVELE1BQU0sU0FBUyxHQUFHLE1BQU0sa0JBQWtCLENBQUMsT0FBTyxDQUFDLFlBQVksRUFBRSxFQUFFLEdBQUcsRUFBRSxDQUFDLENBQUM7WUFDMUUsNEdBQTRHO1lBQzVHLDhHQUE4RztZQUM5Ryx1R0FBdUc7WUFDdkcsTUFBTSxnQkFBZ0IsR0FBRyxjQUFjLENBQUMsaUJBQWlCLENBQ3ZELE9BQU8sQ0FBQyxZQUFZLEVBQ3BCLE9BQU8sQ0FBQyxVQUFVLEVBQ2xCLE9BQU8sQ0FBQyxVQUFVLENBQ25CLENBQUM7WUFFRixNQUFNLFFBQVEsR0FBRyxzQkFBc0IsQ0FDckM7Z0JBQ0UsU0FBUyxFQUFFLEtBQUs7Z0JBQ2hCLEtBQUs7Z0JBQ0wsTUFBTSxFQUFFLFNBQVMsQ0FBQyxJQUFJLENBQUMsU0FBUyxJQUFJLHVCQUF1QixDQUFDLFNBQVM7Z0JBQ3JFLFdBQVcsRUFBRSxnQkFBZ0I7Z0JBQzdCLHFCQUFxQixFQUFFLFNBQVMsQ0FBQyxJQUFJLENBQUMscUJBQXFCLElBQUksdUJBQXVCLENBQUMscUJBQXFCO2dCQUM1RyxZQUFZLEVBQUUsRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRTtnQkFDcEYsdUdBQXVHO2dCQUN2Ryx3RUFBd0U7Z0JBQ3hFLFVBQVUsRUFBRSxDQUFDLFlBQW9CLEVBQUUsVUFBa0IsRUFBRSxFQUFFLENBQUMsY0FBYyxDQUFDLFVBQVUsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLE9BQVEsQ0FBQyxVQUFVLENBQUM7YUFDbkksRUFDRCxFQUFFLE1BQU0sRUFBRSxDQUFDLEtBQStELEVBQUUsRUFBRSxDQUFDLGNBQWMsQ0FBQyxtQkFBbUIsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUMzSCxDQUFDO1lBRUYsSUFBSSxDQUFDLFFBQVEsQ0FBQyxZQUFZLEVBQUUsQ0FBQztnQkFDM0IsVUFBVSxHQUFHLFlBQVksUUFBUSxDQUFDLE9BQU8sQ0FBQyxNQUFNLEVBQUUsQ0FBQztnQkFDbkQsTUFBTSxDQUFDLElBQUksQ0FBQyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsT0FBTyxFQUFFLFFBQVEsRUFBRSxNQUFNLEVBQUUsVUFBVSxFQUFFLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQztnQkFDOUksTUFBTTtZQUNSLENBQUM7WUFFRCxNQUFNLFlBQVksR0FBRyxPQUFPLEVBQUUsQ0FBQztZQUMvQixJQUFJLFVBQVUsR0FBUSxJQUFJLENBQUM7WUFDM0IsTUFBTSxXQUFXLEdBQUc7Z0JBQ2xCLE9BQU8sQ0FBQyxZQUFZO2dCQUNwQixNQUFNLENBQUMsV0FBVyxDQUFDO2dCQUNuQixlQUFlO2dCQUNmLE1BQU0sQ0FBQyxVQUFVO2dCQUNqQixRQUFRO2dCQUNSLE1BQU0sQ0FBQyxJQUFJO2dCQUNYLEdBQUcsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7YUFDbkMsQ0FBQztZQUNGLE1BQU0sWUFBWSxDQUFDLFdBQVcsRUFBRTtnQkFDOUIsR0FBRyxDQUFDLE9BQU8sQ0FBQyxjQUFjLElBQUksRUFBRSxDQUFDO2dCQUNqQyxHQUFHO2dCQUNILFFBQVEsRUFBRSxDQUFDLE1BQXdCLEVBQUUsRUFBRTtvQkFDckMsVUFBVSxHQUFHLE1BQU0sQ0FBQztnQkFDdEIsQ0FBQzthQUNGLENBQUMsQ0FBQztZQUNILE1BQU0sY0FBYyxHQUFHLE9BQU8sRUFBRSxHQUFHLFlBQVksQ0FBQztZQUVoRCxLQUFLLEdBQUc7Z0JBQ04sb0dBQW9HO2dCQUNwRyx1R0FBdUc7Z0JBQ3ZHLGdHQUFnRztnQkFDaEcsd0dBQXdHO2dCQUN4RyxXQUFXLEVBQUUsS0FBSyxDQUFDLFdBQVcsR0FBRyxDQUFDLFVBQVUsRUFBRSxZQUFZLElBQUksQ0FBQyxDQUFDO2dCQUNoRSxVQUFVLEVBQUUsS0FBSyxDQUFDLFVBQVUsR0FBRyxDQUFDLFVBQVUsRUFBRSxjQUFjLElBQUksQ0FBQyxDQUFDO2dCQUNoRSxTQUFTLEVBQUUsS0FBSyxDQUFDLFNBQVMsR0FBRyxjQUFjO2FBQzVDLENBQUM7WUFDRixhQUFhLENBQUMsWUFBWSxDQUFDLEtBQUssQ0FBQyxDQUFDO1lBRWxDLE1BQU0sY0FBYyxHQUFHLFVBQVUsRUFBRSxPQUFPLElBQUksZUFBZSxDQUFDO1lBQzlELE1BQU0sU0FBUyxHQUFHLGNBQWMsS0FBSyxtQkFBbUIsQ0FBQztZQUN6RCw2RkFBNkY7WUFDN0Ysc0dBQXNHO1lBQ3RHLGdHQUFnRztZQUNoRyxxR0FBcUc7WUFDckcsK0RBQStEO1lBQy9ELE1BQU0sY0FBYyxHQUFHLGNBQWMsS0FBSyw0QkFBNEIsQ0FBQztZQUN2RSxzR0FBc0c7WUFDdEcsc0dBQXNHO1lBQ3RHLE1BQU0saUJBQWlCLEdBQUcsVUFBVSxFQUFFLGFBQWEsS0FBSyxxQkFBcUIsQ0FBQztZQUU5RSxJQUFJLFNBQVMsSUFBSSxjQUFjLEVBQUUsQ0FBQztnQkFDaEMsMEdBQTBHO2dCQUMxRywwRkFBMEY7Z0JBQzFGLGNBQWMsQ0FBQyxRQUFRLENBQUMsT0FBTyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQztZQUN4RixDQUFDO2lCQUFNLENBQUM7Z0JBQ04sNkdBQTZHO2dCQUM3RyxxR0FBcUc7Z0JBQ3JHLGNBQWMsQ0FBQyxVQUFVLENBQUMsT0FBTyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQztZQUMxRixDQUFDO1lBRUQsSUFBSSxpQkFBaUIsRUFBRSxDQUFDO2dCQUN0QixNQUFNLFFBQVEsR0FBRyxpQkFBaUIsQ0FBQyxFQUFFLEdBQUcsRUFBRSxDQUFDLENBQUM7Z0JBQzVDLFVBQVUsR0FBRyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxlQUFlLFFBQVEsQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMscUJBQXFCLENBQUM7Z0JBQ3ZGLE1BQU0sQ0FBQyxJQUFJLENBQUM7b0JBQ1YsS0FBSyxFQUFFLFVBQVU7b0JBQ2pCLE9BQU8sRUFBRSxRQUFRO29CQUNqQixNQUFNLEVBQUUsVUFBVTtvQkFDbEIsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZO29CQUNsQyxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVU7b0JBQzlCLGNBQWM7aUJBQ2YsQ0FBQyxDQUFDO2dCQUNILE1BQU07WUFDUixDQUFDO1lBRUQsSUFBSSxjQUFjLEdBQXNDLE9BQU8sQ0FBQztZQUNoRSxJQUFJLFFBQVEsR0FBa0IsSUFBSSxDQUFDO1lBQ25DLElBQUksYUFBYSxHQUEyRCxJQUFJLENBQUM7WUFDakYsSUFBSSxZQUFZLEdBQThCLElBQUksQ0FBQztZQUNuRCxJQUFJLFNBQVMsRUFBRSxDQUFDO2dCQUNkLFFBQVEsR0FBRywyQkFBMkIsQ0FBQyxVQUFVLEVBQUUsVUFBVSxFQUFFLE9BQU8sQ0FBQyxZQUFZLENBQUMsQ0FBQztnQkFDckYsSUFBSSxRQUFRLEtBQUssSUFBSSxFQUFFLENBQUM7b0JBQ3RCLGlHQUFpRztvQkFDakcscUdBQXFHO29CQUNyRyw4RkFBOEY7b0JBQzlGLG9HQUFvRztvQkFDcEcsNkVBQTZFO29CQUM3RSxNQUFNLFFBQVEsR0FBRyxNQUFNLGVBQWUsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLFFBQVEsRUFBRTt3QkFDckUsV0FBVzt3QkFDWCxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVU7d0JBQzlCLEdBQUcsQ0FBQyxPQUFPLENBQUMsYUFBYSxJQUFJLEVBQUUsQ0FBQztxQkFDVCxDQUFDLENBQUM7b0JBQzNCLFlBQVksR0FBRyxRQUFRLENBQUMsVUFBVSxDQUFDO29CQUNuQyxXQUFXLENBQUMsV0FBVyxDQUFDO3dCQUN0QixJQUFJLEVBQUUsb0JBQW9CO3dCQUMxQixZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVk7d0JBQ2xDLE9BQU8sRUFBRSxFQUFFLFFBQVEsRUFBRSxVQUFVLEVBQUUsUUFBUSxDQUFDLFVBQVUsRUFBRSxVQUFVLEVBQUUsUUFBUSxDQUFDLE1BQU0sQ0FBQyxNQUFNLEVBQUUsTUFBTSxFQUFFLFdBQVcsRUFBRTtxQkFDaEgsQ0FBQyxDQUFDO29CQUVILGFBQWEsR0FBRyxNQUFNLG1CQUFtQixDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsUUFBUSxFQUFFO3dCQUN4RSxXQUFXO3dCQUNYLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTt3QkFDOUIsR0FBRyxDQUFDLE9BQU8sQ0FBQyxvQkFBb0IsSUFBSSxFQUFFLENBQUM7cUJBQ1osQ0FBQyxDQUFDO29CQUMvQixJQUFJLGFBQWEsQ0FBQyxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7d0JBQ3JDLHlCQUF5QixDQUN2Qjs0QkFDRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVk7NEJBQ2xDLFFBQVE7NEJBQ1IsUUFBUSxFQUFFLGFBQWEsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsUUFBUTs0QkFDcEQsUUFBUSxFQUFFLGFBQWEsQ0FBQyxRQUFRO3lCQUNqQyxFQUNELEVBQUUsV0FBVyxFQUFFLENBQ2hCLENBQUM7d0JBQ0Ysd0dBQXdHO3dCQUN4RyxzR0FBc0c7d0JBQ3RHLG9HQUFvRzt3QkFDcEcsc0dBQXNHO3dCQUN0Ryw2QkFBNkI7d0JBQzdCLE1BQU0sZUFBZSxHQUFHLGFBQWEsQ0FBQyxxQkFBcUIsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQzt3QkFDdEcsYUFBYSxDQUFDLHFCQUFxQixDQUNqQyxPQUFPLENBQUMsWUFBWSxFQUNwQjs0QkFDRSxPQUFPLEVBQUUsZUFBZSxDQUFDLE9BQU8sR0FBRyxDQUFDOzRCQUNwQyxXQUFXLEVBQUUsZUFBZSxDQUFDLFdBQVcsR0FBRyxDQUFDLFlBQVksQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7eUJBQ2pGLEVBQ0QsT0FBTyxDQUFDLFVBQVUsQ0FDbkIsQ0FBQzt3QkFDRixjQUFjLEdBQUcscUJBQXFCLENBQUMsYUFBYSxDQUFDLENBQUM7b0JBQ3hELENBQUM7Z0JBQ0gsQ0FBQztZQUNILENBQUM7WUFFRCxNQUFNLFdBQVcsR0FBRyx5QkFBeUIsQ0FDM0MsRUFBRSxXQUFXLEVBQUUsY0FBYyxFQUFFLFFBQVEsRUFBRSxFQUN6QyxFQUFFLFFBQVEsRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxDQUNqRCxDQUFDO1lBQ0YsUUFBUSxHQUFHLFdBQVcsQ0FBQyxPQUFPLENBQUM7WUFFL0IsTUFBTSxPQUFPLEdBQUcsb0JBQW9CLENBQ2xDLEVBQUUsZUFBZSxFQUFFLFVBQVUsQ0FBQyxLQUFLLEVBQUUsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZLEVBQUUsT0FBTyxFQUFFLGNBQWMsRUFBRSxFQUNsRyxFQUFFLFdBQVcsRUFBRSxjQUFjLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxPQUFPLEVBQUUsRUFBRSxjQUFjLEVBQUUsV0FBVyxFQUFFLENBQ3pGLENBQUM7WUFFRixNQUFNLENBQUMsSUFBSSxDQUFDO2dCQUNWLEtBQUssRUFBRSxVQUFVO2dCQUNqQixPQUFPLEVBQUUsV0FBVztnQkFDcEIsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZO2dCQUNsQyxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVU7Z0JBQzlCLGNBQWM7Z0JBQ2QsY0FBYztnQkFDZCxRQUFRO2dCQUNSLFlBQVk7Z0JBQ1osU0FBUyxFQUFFLE9BQU8sQ0FBQyxRQUFRLENBQUMsT0FBTztnQkFDbkMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxRQUFRLENBQUMsT0FBTzthQUNsQyxDQUFDLENBQUM7WUFFSCxJQUFJLENBQUMsT0FBTyxDQUFDLFFBQVEsQ0FBQyxPQUFPLEVBQUUsQ0FBQztnQkFDOUIsVUFBVSxHQUFHLG9CQUFvQixPQUFPLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztnQkFDdEUsTUFBTTtZQUNSLENBQUM7WUFFRCxJQUFJLE9BQU8sQ0FBQyxRQUFRLEVBQUUsQ0FBQztnQkFDckIsT0FBTyxHQUFHLE9BQU8sQ0FBQyxRQUFzQixDQUFDO2dCQUN6QyxNQUFNLE9BQU8sQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDckMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE1BQU0sT0FBTyxDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQztnQkFDbkMsTUFBTSxnQkFBZ0IsRUFBRSxDQUFDO2dCQUN6QixPQUFPLEdBQUcsY0FBYyxDQUFDLFdBQVcsRUFBRSxDQUFDO1lBQ3pDLENBQUM7UUFDSCxDQUFDO1FBRUQsSUFBSSxVQUFVLEtBQUssSUFBSSxJQUFJLE1BQU0sQ0FBQyxTQUFTLEtBQUssU0FBUyxFQUFFLENBQUM7WUFDMUQsVUFBVSxHQUFHLG9CQUFvQixDQUFDO1lBQ2xDLGtHQUFrRztZQUNsRyxxR0FBcUc7WUFDckcsb0dBQW9HO1lBQ3BHLHNHQUFzRztZQUN0Ryw4RUFBOEU7WUFDOUUsSUFBSSxPQUFPLEVBQUUsQ0FBQztnQkFDWixjQUFjLENBQUMsVUFBVSxDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDMUYsQ0FBQztRQUNILENBQUM7UUFFRCxNQUFNLE9BQU8sR0FBRyxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsQ0FBQztRQUNqRSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsT0FBTyxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ2hELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyx1QkFBdUIsTUFBTSxDQUFDLE1BQU0sY0FBYyxVQUFVLElBQUksU0FBUyxHQUFHLENBQUMsQ0FBQztRQUM1RixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7WUFBUyxDQUFDO1FBQ1QsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3RCLFdBQVcsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNwQixjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDdkIsY0FBYyxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3ZCLFFBQVEsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNuQixDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/loop-cli.ts
+++ b/packages/loopover-miner/lib/loop-cli.ts
@@ -1,0 +1,661 @@
+// The autonomous supervising loop (#5135, Wave 3.5): the missing daemon/watch layer over the one-shot
+// `discover`/`attempt` subcommands. Every existing piece it composes -- runDiscover, runAttempt,
+// evaluateRunLoopBoundaryGate, attemptLoopReentry, buildLoopClosureSummary, governor-state.js -- already
+// existed; this is the first caller that actually chains them into a real repeat-until-halted run.
+//
+// STRUCTURE (one cycle): kill-switch check -> pause-flag check (#4851, governor-state.js's persisted
+// paused/reason/pausedAt) -> real-per-repo-policy-aware run-loop boundary gate (before claiming) -> real
+// runAttempt -> real CI-status poll (ci-poller.js, #5394) + real PR-disposition poll
+// (pr-disposition-poller.js, on a submitted outcome) -> real loop-closure summary -> real attemptLoopReentry
+// decision. `attemptLoopReentry`'s own dequeue is the
+// AUTHORITATIVE claim for every cycle after the first (its own doc: "if allowed -- dequeues the next
+// candidate") -- this loop does not ALSO call portfolioQueue.dequeueNext() on a successful reentry, which
+// would silently double-claim (the reentry's own claim would then leak as a permanently 'in_progress', never-
+// attempted row). A manual dequeueNext() is used only to prime the very first cycle (no prior outcome exists
+// yet to reenter from) and to refill after an empty queue.
+//
+// REAL, NOT FABRICATED: this loop is the first production caller of governor-state.js's `saveCapUsage`
+// (turnsTaken from runMinerAttempt's own real `loopResult.totalTurnsUsed`, elapsedMs from real wall-clock
+// measurement). Its per-identifier convergence history (attempts/consecutiveFailures/reenqueues) is the real,
+// SQLite-persisted portfolio-queue attempt-history (portfolio-queue.js's getAttemptHistory, #5654) that the
+// dequeueNext claim + markDone/markFailed calls below already maintain -- the same source a one-shot `attempt`
+// invocation reads (#5654), so both share one source of truth and the counters survive a loop-daemon restart
+// (crash/deploy/systemd bounce) instead of resetting with the process (#5677).
+
+import { checkMinerKillSwitch } from "./governor-kill-switch.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { evaluateRunLoopBoundaryGate } from "./governor-run-halt.js";
+import { openGovernorState } from "./governor-state.js";
+import { initGovernorLedger } from "./governor-ledger.js";
+import { initEventLedger } from "./event-ledger.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { initRunStateStore } from "./run-state.js";
+import { runDiscover } from "./discover-cli.js";
+import { runAttempt } from "./attempt-cli.js";
+import { resolveAmsPolicy } from "./ams-policy.js";
+import { pollPrDisposition, classifyPrDisposition } from "./pr-disposition-poller.js";
+import { pollCheckRuns } from "./ci-poller.js";
+import { recordPrOutcomeSnapshot } from "./pr-outcome.js";
+import { isRejectedPr } from "./rejection-state-machine.js";
+import { buildLoopClosureSummary } from "./loop-closure.js";
+import { attemptLoopReentry } from "./loop-reentry.js";
+import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
+import { resolveGitHubToken } from "./github-token-resolution.js";
+import { DEFAULT_AMS_POLICY_SPEC } from "@loopover/engine";
+import type { AttemptCliResult } from "./attempt-cli.js";
+import type { PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
+import type { GovernorState } from "./governor-state.js";
+import type { EventLedger } from "./event-ledger.js";
+import type { GovernorLedger } from "./governor-ledger.js";
+import type { RunStateStore } from "./run-state.js";
+import type { PollPrDispositionOptions } from "./pr-disposition-poller.js";
+import type { CheckRunConclusion, PollCheckRunsOptions } from "./ci-poller.js";
+
+export type ParsedLoopArgs =
+  | { error: string }
+  | {
+      targets: string[];
+      search: string | null;
+      minerLogin: string;
+      base: string;
+      live: boolean;
+      dryRun: boolean;
+      maxCycles: number | undefined;
+      cycleDelayMs: number;
+      json: boolean;
+    };
+
+export type LoopCycleSummary = {
+  cycle: number;
+  outcome: "idle_queue_empty" | "halted" | "attempted" | "skipped_malformed_identifier";
+  reason?: string;
+  repoFullName?: string;
+  identifier?: string;
+  attemptOutcome?: AttemptCliResult["outcome"] | "attempt_error";
+  reentryOutcome?: "merged" | "disengaged" | "other";
+  prNumber?: number | null;
+  ciConclusion?: CheckRunConclusion | null;
+  reentered?: boolean;
+  reasons?: string[];
+};
+
+export type RunLoopOptions = {
+  env?: Record<string, string | undefined>;
+  nowMs?: number;
+  githubToken?: string;
+  apiBaseUrl?: string;
+  sleepFn?: (delayMs: number) => Promise<void>;
+  openGovernorState?: () => GovernorState;
+  initEventLedger?: () => EventLedger;
+  initGovernorLedger?: () => GovernorLedger;
+  initPortfolioQueue?: () => PortfolioQueueStore;
+  initRunStateStore?: () => RunStateStore;
+  runDiscover?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+  runAttempt?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+  resolveAmsPolicy?: (repoFullName: string, options?: Record<string, unknown>) => Promise<{ spec: Record<string, unknown>; source: string; warnings: string[] }>;
+  checkMinerKillSwitch?: (input?: { env?: Record<string, string | undefined>; repoPaused?: boolean }) => { scope: "global" | "repo" | "none"; active: boolean };
+  evaluateRunLoopBoundaryGate?: (input: unknown, options?: unknown) => { verdict: { reason: string }; canClaimNext: boolean };
+  pollPrDisposition?: (repoFullName: string, prNumber: number, options?: PollPrDispositionOptions) => Promise<{ state: "open" | "closed"; merged: boolean; closedAt: string | null; attempts: number }>;
+  pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<{ conclusion: CheckRunConclusion; checks: unknown[]; headSha: string; attempts: number }>;
+  recordPrOutcomeSnapshot?: (input: unknown, options?: unknown) => unknown;
+  buildLoopClosureSummary?: (sources: unknown, options?: unknown) => { sinceSeq: number | null; lastSeq: number };
+  attemptLoopReentry?: (candidate: unknown, deps: unknown) => { decision: { reenter: boolean; reasons: string[] }; dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null };
+  attemptOptions?: Record<string, unknown>;
+  prDispositionOptions?: PollPrDispositionOptions;
+  ciPollOptions?: PollCheckRunsOptions;
+};
+
+const LOOP_USAGE =
+  "Usage: loopover-miner loop <owner/repo> [<owner/repo>...] | --search <query> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]";
+const DEFAULT_CYCLE_DELAY_MS = 60_000;
+const ISSUE_IDENTIFIER_PATTERN = /^issue:(\d+)$/;
+
+function parseRepoTarget(value: string): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return `${owner}/${repo}`;
+}
+
+function normalizeOptionalPositiveInt(value: string, label: string): number {
+  const parsedValue = Number(value);
+  if (!Number.isFinite(parsedValue) || !Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`${label} must be a non-negative integer: ${value}`);
+  }
+  return parsedValue;
+}
+
+export function parseLoopArgs(args: string[]): ParsedLoopArgs {
+  const options: {
+    json: boolean;
+    minerLogin: string | null;
+    base: string;
+    live: boolean;
+    dryRun: boolean;
+    search: string | null;
+    maxCycles: number | undefined;
+    cycleDelayMs: number;
+  } = {
+    json: false,
+    minerLogin: null,
+    base: "main",
+    live: false,
+    dryRun: false,
+    search: null,
+    maxCycles: undefined,
+    cycleDelayMs: DEFAULT_CYCLE_DELAY_MS,
+  };
+  const targets: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--live") {
+      options.live = true;
+      continue;
+    }
+    // #4847: see attempt-cli.js's own --dry-run comment -- distinct from --live's absence, this short-circuits
+    // BEFORE governor state or any other store is opened, guaranteeing zero discovery/queue/ledger writes.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--search") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      options.search = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--miner-login") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      options.minerLogin = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--base") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      options.base = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--max-cycles") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      try {
+        options.maxCycles = normalizeOptionalPositiveInt(value, "--max-cycles");
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+      index += 1;
+      continue;
+    }
+    if (token === "--cycle-delay-ms") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      try {
+        options.cycleDelayMs = normalizeOptionalPositiveInt(value, "--cycle-delay-ms");
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    const target = parseRepoTarget(token);
+    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
+    targets.push(target);
+  }
+
+  if (options.search === null && targets.length === 0) return { error: LOOP_USAGE };
+  if (options.search !== null && targets.length > 0) return { error: "Pass either repository targets or --search, not both." };
+  if (!options.minerLogin) return { error: `--miner-login is required. ${LOOP_USAGE}` };
+
+  return {
+    targets,
+    search: options.search,
+    minerLogin: options.minerLogin,
+    base: options.base,
+    live: options.live,
+    dryRun: options.dryRun,
+    maxCycles: options.maxCycles,
+    cycleDelayMs: options.cycleDelayMs,
+    json: options.json,
+  };
+}
+
+function discoverArgv(parsed: Exclude<ParsedLoopArgs, { error: string }>): string[] {
+  return parsed.search !== null ? ["--search", parsed.search] : [...parsed.targets];
+}
+
+function parseIssueNumberFromIdentifier(identifier: string): number | null {
+  const match = typeof identifier === "string" ? identifier.match(ISSUE_IDENTIFIER_PATTERN) : null;
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Run one full discover -> claim -> attempt -> observe -> reenter cycle repeatedly until a kill-switch trips,
+ * the run-loop boundary gate halts (non-convergence or a real budget/turn/elapsed cap), re-entry is declined,
+ * or `--max-cycles` is reached. Fails closed: refuses to start at all if governor state cannot be loaded.
+ *
+ * @param {string[]} args
+ * @param {{
+ *   env?: Record<string, string | undefined>,
+ *   nowMs?: number,
+ *   githubToken?: string,
+ *   apiBaseUrl?: string,
+ *   sleepFn?: (delayMs: number) => Promise<void>,
+ *   openGovernorState?: typeof openGovernorState,
+ *   initEventLedger?: typeof initEventLedger,
+ *   initGovernorLedger?: typeof initGovernorLedger,
+ *   initPortfolioQueue?: () => import("./portfolio-queue.js").PortfolioQueueStore,
+ *   initRunStateStore?: typeof initRunStateStore,
+ *   runDiscover?: typeof runDiscover,
+ *   runAttempt?: typeof runAttempt,
+ *   resolveAmsPolicy?: typeof resolveAmsPolicy,
+ *   checkMinerKillSwitch?: typeof checkMinerKillSwitch,
+ *   evaluateRunLoopBoundaryGate?: typeof evaluateRunLoopBoundaryGate,
+ *   pollPrDisposition?: typeof pollPrDisposition,
+ *   pollCheckRuns?: typeof pollCheckRuns,
+ *   recordPrOutcomeSnapshot?: typeof recordPrOutcomeSnapshot,
+ *   buildLoopClosureSummary?: typeof buildLoopClosureSummary,
+ *   attemptLoopReentry?: typeof attemptLoopReentry,
+ *   attemptOptions?: Record<string, unknown>,
+ *   prDispositionOptions?: Record<string, unknown>,
+ *   ciPollOptions?: Record<string, unknown>,
+ * }} [options]
+ * @returns {Promise<number>}
+ */
+export async function runLoop(args: string[], options: RunLoopOptions = {}): Promise<number> {
+  const parsed = parseLoopArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  const env = options.env ?? process.env;
+  const sleepFn = options.sleepFn ?? ((delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
+  const nowMsFn = () => options.nowMs ?? Date.now();
+  const sessionStartMs = nowMsFn();
+
+  // #4847: reports what a real loop invocation would target and returns BEFORE governor state or any other
+  // store (event/governor ledger, portfolio queue, run state) is opened -- a provable zero-write path, not just
+  // "opened but didn't write." The loop's own discovery call enqueues newly-found candidates into the LOCAL
+  // portfolio queue even before any attempt happens, so a faithful dry run cannot call it either.
+  if (parsed.dryRun) {
+    const dryRunResult = {
+      outcome: "dry_run",
+      targets: parsed.targets,
+      search: parsed.search,
+      minerLogin: parsed.minerLogin,
+      base: parsed.base,
+      live: parsed.live,
+      maxCycles: parsed.maxCycles ?? null,
+    };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      const target = parsed.search !== null ? `--search ${parsed.search}` : parsed.targets.join(", ");
+      console.log(
+        `DRY RUN: would run an autonomous loop against ${target} for ${parsed.minerLogin} (base: ${parsed.base}, live: ${parsed.live}). No discovery, queue, or ledger writes were made.`,
+      );
+    }
+    return 0;
+  }
+
+  let governorState: GovernorState;
+  try {
+    governorState = (options.openGovernorState ?? openGovernorState)();
+  } catch (error) {
+    return reportCliFailure(
+      parsed.json,
+      `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`,
+      3,
+    );
+  }
+
+  const eventLedger = (options.initEventLedger ?? initEventLedger)();
+  const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  const runState = (options.initRunStateStore ?? initRunStateStore)();
+
+  const runDiscoverFn = (options.runDiscover ?? runDiscover) as NonNullable<RunLoopOptions["runDiscover"]>;
+  const runAttemptFn = (options.runAttempt ?? runAttempt) as NonNullable<RunLoopOptions["runAttempt"]>;
+  const resolveAmsPolicyFn = (options.resolveAmsPolicy ?? resolveAmsPolicy) as NonNullable<RunLoopOptions["resolveAmsPolicy"]>;
+  const checkKillSwitchFn = (options.checkMinerKillSwitch ?? checkMinerKillSwitch) as NonNullable<RunLoopOptions["checkMinerKillSwitch"]>;
+  const evaluateBoundaryGateFn = (options.evaluateRunLoopBoundaryGate ?? evaluateRunLoopBoundaryGate) as NonNullable<RunLoopOptions["evaluateRunLoopBoundaryGate"]>;
+  const pollPrDispositionFn = (options.pollPrDisposition ?? pollPrDisposition) as NonNullable<RunLoopOptions["pollPrDisposition"]>;
+  const pollCheckRunsFn = (options.pollCheckRuns ?? pollCheckRuns) as NonNullable<RunLoopOptions["pollCheckRuns"]>;
+  const recordPrOutcomeSnapshotFn = (options.recordPrOutcomeSnapshot ?? recordPrOutcomeSnapshot) as NonNullable<RunLoopOptions["recordPrOutcomeSnapshot"]>;
+  const buildLoopClosureSummaryFn = (options.buildLoopClosureSummary ?? buildLoopClosureSummary) as NonNullable<RunLoopOptions["buildLoopClosureSummary"]>;
+  const attemptLoopReentryFn = (options.attemptLoopReentry ?? attemptLoopReentry) as NonNullable<RunLoopOptions["attemptLoopReentry"]>;
+
+  // Resolved ONCE, at the CLI-entrypoint layer, mirroring manage-poll.js's own runManagePoll (its
+  // recordManagePollSnapshot callee has no env fallback of its own either -- the top-level CLI function is
+  // where the GitHub token gets resolved, then threaded down explicitly to every real GitHub caller).
+  // pollPrDisposition (unlike runDiscover, which falls back to process.env.GITHUB_TOKEN internally) has NO
+  // such fallback -- an unresolved githubToken here would silently poll unauthenticated.
+  // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+  // authenticated `loopover-mcp login` session -- cached in memory for this process's lifetime.
+  const githubToken = options.githubToken ?? (await resolveGitHubToken(env as NodeJS.ProcessEnv)) ?? "";
+
+  async function runDiscoveryOnce(): Promise<void> {
+    await runDiscoverFn(discoverArgv(parsed as Exclude<ParsedLoopArgs, { error: string }>), {
+      initPortfolioQueue: () => portfolioQueue,
+      githubToken,
+      apiBaseUrl: options.apiBaseUrl,
+      nowMs: nowMsFn(),
+    });
+  }
+
+  let usage = governorState.loadCapUsage();
+  const cycles: LoopCycleSummary[] = [];
+  let sinceSeq = eventLedger.readEvents({}).at(-1)?.seq ?? 0;
+  let haltReason: string | null = null;
+
+  try {
+    // Checked BEFORE any work at all -- including the very first discovery call -- so an already-active kill
+    // switch OR an already-active pause (#4851) halts the loop without ever touching GitHub or the queue. The
+    // pause flag is real, persisted, operator/governor-writable state on governorState (toggled via
+    // `loopover-miner governor pause`/`resume`) -- unlike the kill switch, a paused run resumes simply by being
+    // re-invoked: every piece of per-cycle state this loop reads (portfolioQueue, runState, governorState's own
+    // cap usage) is already durable, so clearing the flag and restarting continues exactly where it left off.
+    const initialKillSwitch = checkKillSwitchFn({ env });
+    const initialPauseState = governorState.loadPauseState();
+    let claimed: QueueEntry | null = null;
+    if (initialKillSwitch.active) {
+      haltReason = `kill_switch_${initialKillSwitch.scope}`;
+      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+    } else if (initialPauseState.paused) {
+      haltReason = "paused";
+      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+    } else {
+      await runDiscoveryOnce();
+      claimed = portfolioQueue.dequeueNext();
+    }
+
+    let cycleIndex = haltReason !== null ? 1 : 0;
+    while (haltReason === null && (parsed.maxCycles === undefined || cycleIndex < parsed.maxCycles)) {
+      cycleIndex += 1;
+
+      const killSwitch = checkKillSwitchFn({ env });
+      if (killSwitch.active) {
+        haltReason = `kill_switch_${killSwitch.scope}`;
+        // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
+        if (claimed) {
+          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        }
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          ...(claimed
+            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+            : {}),
+        });
+        break;
+      }
+
+      const pauseState = governorState.loadPauseState();
+      if (pauseState.paused) {
+        haltReason = "paused";
+        if (claimed) {
+          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        }
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          ...(claimed
+            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+            : {}),
+        });
+        break;
+      }
+
+      if (!claimed) {
+        cycles.push({ cycle: cycleIndex, outcome: "idle_queue_empty" });
+        await sleepFn(parsed.cycleDelayMs);
+        await runDiscoveryOnce();
+        claimed = portfolioQueue.dequeueNext();
+        continue;
+      }
+
+      const issueNumber = parseIssueNumberFromIdentifier(claimed.identifier);
+      if (issueNumber === null) {
+        // Never produced by enqueueRankedDiscovery in practice (always "issue:N") -- fail soft rather than
+        // crash the whole run: this exact item can never be attempted, so it will never resolve on retry.
+        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        cycles.push({ cycle: cycleIndex, outcome: "skipped_malformed_identifier", identifier: claimed.identifier });
+        claimed = portfolioQueue.dequeueNext();
+        continue;
+      }
+
+      const amsPolicy = await resolveAmsPolicyFn(claimed.repoFullName, { env });
+      // Real, SQLite-persisted per-item convergence history (#5677): the dequeueNext claim above already recorded
+      // this attempt and the markDone/markFailed calls below record the outcome, so reading it back here shares one
+      // source of truth with attempt-cli.js (#5654) and survives a loop-daemon restart instead of resetting.
+      const convergenceInput = portfolioQueue.getAttemptHistory(
+        claimed.repoFullName,
+        claimed.identifier,
+        claimed.apiBaseUrl,
+      );
+
+      const boundary = evaluateBoundaryGateFn(
+        {
+          runHalted: false,
+          usage,
+          limits: amsPolicy.spec.capLimits ?? DEFAULT_AMS_POLICY_SPEC.capLimits,
+          convergence: convergenceInput,
+          convergenceThresholds: amsPolicy.spec.convergenceThresholds ?? DEFAULT_AMS_POLICY_SPEC.convergenceThresholds,
+          inFlightItem: { repoFullName: claimed.repoFullName, identifier: claimed.identifier },
+          // Echoes claimed.apiBaseUrl (#5563), NOT the callback's own repoFullName/identifier alone -- two forge
+          // hosts can share an in-flight item with the same repo name+identifier.
+          markFailed: (repoFullName: string, identifier: string) => portfolioQueue.markFailed(repoFullName, identifier, claimed!.apiBaseUrl),
+        },
+        { append: (event: Parameters<typeof governorLedger.appendGovernorEvent>[0]) => governorLedger.appendGovernorEvent(event) },
+      );
+
+      if (!boundary.canClaimNext) {
+        haltReason = `boundary_${boundary.verdict.reason}`;
+        cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason, repoFullName: claimed.repoFullName, identifier: claimed.identifier });
+        break;
+      }
+
+      const cycleStartMs = nowMsFn();
+      let lastResult: any = null;
+      const attemptArgv = [
+        claimed.repoFullName,
+        String(issueNumber),
+        "--miner-login",
+        parsed.minerLogin,
+        "--base",
+        parsed.base,
+        ...(parsed.live ? ["--live"] : []),
+      ];
+      await runAttemptFn(attemptArgv, {
+        ...(options.attemptOptions ?? {}),
+        env,
+        onResult: (result: AttemptCliResult) => {
+          lastResult = result;
+        },
+      });
+      const cycleElapsedMs = nowMsFn() - cycleStartMs;
+
+      usage = {
+        // Real for the agent-sdk provider (its own SDK result message reports total_cost_usd, wired through
+        // runMinerAttempt's real loopResult.totalCostUsd); the CLI-subprocess providers (claude-cli/codex-cli)
+        // report no cost signal today, so this contributes 0 for those runs -- an honest absence, not a
+        // fabricated number. A capLimits.budget dimension only ever meaningfully trips against agent-sdk spend.
+        budgetSpent: usage.budgetSpent + (lastResult?.totalCostUsd ?? 0),
+        turnsTaken: usage.turnsTaken + (lastResult?.totalTurnsUsed ?? 0),
+        elapsedMs: usage.elapsedMs + cycleElapsedMs,
+      };
+      governorState.saveCapUsage(usage);
+
+      const attemptOutcome = lastResult?.outcome ?? "attempt_error";
+      const submitted = attemptOutcome === "attempt_submitted";
+      // A repo-wide AI-usage-policy ban will never resolve on retry -- stop re-queuing it (matches
+      // rejection-signal.js's own "this repo bans automated contributions" semantics). Every other blocked/
+      // abandoned/stale/governed outcome MAY resolve on a later retry (transient infra, contention, a
+      // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
+      // (reenqueues threshold) rather than silently retried forever.
+      const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
+      // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
+      // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
+      const killSwitchAbandon = lastResult?.abandonReason === "kill_switch_engaged";
+
+      if (submitted || permanentBlock) {
+        // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
+        // so neither is re-queued. markDone also clears the persisted consecutive-failure streak.
+        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      } else {
+        // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
+        // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
+        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      }
+
+      if (killSwitchAbandon) {
+        const liveKill = checkKillSwitchFn({ env });
+        haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          repoFullName: claimed.repoFullName,
+          identifier: claimed.identifier,
+          attemptOutcome,
+        });
+        break;
+      }
+
+      let reentryOutcome: "merged" | "disengaged" | "other" = "other";
+      let prNumber: number | null = null;
+      let prDisposition: Awaited<ReturnType<typeof pollPrDispositionFn>> | null = null;
+      let ciConclusion: CheckRunConclusion | null = null;
+      if (submitted) {
+        prNumber = parsePrNumberFromExecResult(lastResult?.execResult, claimed.repoFullName);
+        if (prNumber !== null) {
+          // Real CI-status observation (#5394): recorded BEFORE the disposition poll below, so a submitted
+          // PR's check-run state is captured even while it's still open, not just at its eventual merge/close.
+          // ci-poller.js's real GitHub check-run polling is a heuristic proxy for the gate verdict; the
+          // authoritative terminal merge/close outcome comes from pollPrDispositionFn below, sourced directly
+          // from GitHub's own PR state rather than a server-internal endpoint (#5450).
+          const ciStatus = await pollCheckRunsFn(claimed.repoFullName, prNumber, {
+            githubToken,
+            apiBaseUrl: options.apiBaseUrl,
+            ...(options.ciPollOptions ?? {}),
+          } as PollCheckRunsOptions);
+          ciConclusion = ciStatus.conclusion;
+          eventLedger.appendEvent({
+            type: "ci_status_observed",
+            repoFullName: claimed.repoFullName,
+            payload: { prNumber, conclusion: ciStatus.conclusion, checkCount: ciStatus.checks.length, source: "ci-poller" },
+          });
+
+          prDisposition = await pollPrDispositionFn(claimed.repoFullName, prNumber, {
+            githubToken,
+            apiBaseUrl: options.apiBaseUrl,
+            ...(options.prDispositionOptions ?? {}),
+          } as PollPrDispositionOptions);
+          if (prDisposition.state === "closed") {
+            recordPrOutcomeSnapshotFn(
+              {
+                repoFullName: claimed.repoFullName,
+                prNumber,
+                decision: prDisposition.merged ? "merged" : "closed",
+                closedAt: prDisposition.closedAt,
+              },
+              { eventLedger },
+            );
+            // Real per-repo reputation history (#5675): a resolved terminal outcome updates the decided/unfavorable
+            // counts the Governor's self-reputation throttle reads on this repo's next attempt. `decided` always;
+            // `unfavorable` only on a closed-without-merge (rejection-state-machine.js's isRejectedPr, matching
+            // #5655's own-rejection classification). Forge-scoped by claimed.apiBaseUrl (#5563), like every other
+            // governor-state write here.
+            const priorReputation = governorState.loadReputationHistory(claimed.repoFullName, claimed.apiBaseUrl);
+            governorState.saveReputationHistory(
+              claimed.repoFullName,
+              {
+                decided: priorReputation.decided + 1,
+                unfavorable: priorReputation.unfavorable + (isRejectedPr(prDisposition) ? 1 : 0),
+              },
+              claimed.apiBaseUrl,
+            );
+            reentryOutcome = classifyPrDisposition(prDisposition);
+          }
+        }
+      }
+
+      const loopSummary = buildLoopClosureSummaryFn(
+        { eventLedger, portfolioQueue, runState },
+        { sinceSeq, repoFullName: claimed.repoFullName },
+      );
+      sinceSeq = loopSummary.lastSeq;
+
+      const reentry = attemptLoopReentryFn(
+        { killSwitchScope: killSwitch.scope, repoFullName: claimed.repoFullName, outcome: reentryOutcome },
+        { eventLedger, portfolioQueue, runState, nowMs: nowMsFn(), sessionStartMs, loopSummary },
+      );
+
+      cycles.push({
+        cycle: cycleIndex,
+        outcome: "attempted",
+        repoFullName: claimed.repoFullName,
+        identifier: claimed.identifier,
+        attemptOutcome,
+        reentryOutcome,
+        prNumber,
+        ciConclusion,
+        reentered: reentry.decision.reenter,
+        reasons: reentry.decision.reasons,
+      });
+
+      if (!reentry.decision.reenter) {
+        haltReason = `reentry_declined:${reentry.decision.reasons.join(",")}`;
+        break;
+      }
+
+      if (reentry.dequeued) {
+        claimed = reentry.dequeued as QueueEntry;
+        await sleepFn(parsed.cycleDelayMs);
+      } else {
+        await sleepFn(parsed.cycleDelayMs);
+        await runDiscoveryOnce();
+        claimed = portfolioQueue.dequeueNext();
+      }
+    }
+
+    if (haltReason === null && parsed.maxCycles !== undefined) {
+      haltReason = "max_cycles_reached";
+      // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
+      // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
+      // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
+      // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
+      // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
+      if (claimed) {
+        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      }
+    }
+
+    const summary = { haltReason, cyclesRun: cycles.length, cycles };
+    if (parsed.json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      console.log(`Loop finished after ${cycles.length} cycle(s): ${haltReason ?? "unknown"}.`);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    governorState.close();
+    eventLedger.close();
+    governorLedger.close();
+    portfolioQueue.close();
+    runState.close();
+  }
+}

--- a/packages/loopover-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.d.ts
@@ -1,101 +1,116 @@
 import type { PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
 import type { PortfolioQueueManager } from "./portfolio-queue-manager.js";
-
-export type ParsedQueueListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-    }
-  | { error: string };
-
-export type ParsedQueueNextArgs =
-  | { json: boolean; dryRun: boolean; globalWipCap: number | undefined; perRepoWipCap: number | undefined }
-  | { error: string };
-
-export type QueueClaimTarget = { repoFullName: string; identifier: string; apiBaseUrl: string };
-
-export function selectNextEligibleTarget(
-  entries: Array<{ repoFullName: string; identifier: string; apiBaseUrl: string; status: string }>,
-  caps: { globalWipCap: number; perRepoWipCap: number } | null,
-): QueueClaimTarget[];
-
-export type ParsedQueueDoneArgs =
-  | {
-      repoFullName: string;
-      identifier: string;
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export function parseQueueListArgs(args: string[]): ParsedQueueListArgs;
-
-export function parseQueueNextArgs(args: string[]): ParsedQueueNextArgs;
-
-export function parseQueueDoneArgs(args: string[]): ParsedQueueDoneArgs;
-
-export function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs;
-
-export function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs;
-
-export type ParsedQueueClaimBatchArgs =
-  | { json: boolean; dryRun: boolean; globalWipCap: number; perRepoWipCap: number }
-  | { error: string };
-
-export function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs;
-
-export function renderQueueTable(entries: QueueEntry[]): string;
-
-export function runQueueList(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueNext(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueDone(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueRelease(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueRequeue(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueClaimBatch(
-  args: string[],
-  options?: { initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager },
-): number;
-
-export const QUEUE_ITEMS: string;
-export const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS: string;
-
-export function renderPortfolioQueueMetrics(
-  queueEntries: Array<{ status: string }>,
-  leaseEntries: Array<{ leasedAt: string | null }>,
-  nowMs: number,
-): string;
-
-export function runQueueMetrics(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore; nowMs?: number },
-): number;
-
-export function runQueueCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: {
+export type ParsedQueueListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+} | {
+    error: string;
+};
+export type ParsedQueueNextArgs = {
+    json: boolean;
+    dryRun: boolean;
+    globalWipCap: number | undefined;
+    perRepoWipCap: number | undefined;
+} | {
+    error: string;
+};
+export type QueueClaimTarget = {
+    repoFullName: string;
+    identifier: string;
+    apiBaseUrl: string;
+};
+export type ParsedQueueDoneArgs = {
+    repoFullName: string;
+    identifier: string;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export type ParsedQueueClaimBatchArgs = {
+    json: boolean;
+    dryRun: boolean;
+    globalWipCap: number;
+    perRepoWipCap: number;
+} | {
+    error: string;
+};
+export declare function parseQueueListArgs(args: string[]): ParsedQueueListArgs;
+export declare function parseQueueNextArgs(args: string[]): ParsedQueueNextArgs;
+/**
+ * Pick at most one atomically-claimable target from the store's already-priority-ordered active rows (queued
+ * AND in_progress interleaved, exactly `batchClaim`'s own `entries` shape). `caps` of `null` replicates the
+ * pre-#4850 behavior: the single highest-priority queued row, unconditionally. When caps are set, refuses to
+ * select anything once the global or the target row's own per-repo in-progress count has reached its cap --
+ * "stops claiming once the cap is reached" (#4850), not a diversifying batch selection (that remains
+ * claim-batch's job via the engine's own `nextEligibleItems`).
+ * @param {Array<{ repoFullName: string, identifier: string, apiBaseUrl: string, status: string }>} entries
+ * @param {{ globalWipCap: number, perRepoWipCap: number } | null} caps
+ */
+export declare function selectNextEligibleTarget(entries: Array<{
+    repoFullName: string;
+    identifier: string;
+    apiBaseUrl: string;
+    status: string;
+}>, caps: {
+    globalWipCap: number;
+    perRepoWipCap: number;
+} | null): QueueClaimTarget[];
+export declare function parseQueueDoneArgs(args: string[]): ParsedQueueDoneArgs;
+export declare function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs;
+export declare function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs;
+export declare function renderQueueTable(entries: QueueEntry[]): string;
+export declare function runQueueList(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+export declare function runQueueNext(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+export declare function runQueueDone(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+/** `release <owner/repo> <identifier>`: manually give up a CLAIMED (in_progress) item, returning it to the queue
+ *  (the manual counterpart to the automated stuck-lease sweep). Exit 2 when there is no in-flight item to release. */
+export declare function runQueueRelease(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+/** `requeue <owner/repo> <identifier>`: manually put a COMPLETED (done) item back on the queue so it is picked up
+ *  again, keeping its original FIFO position. Exit 2 when there is no done item to requeue (already queued,
+ *  in-flight — release it instead — or absent). */
+export declare function runQueueRequeue(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+export declare function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs;
+/** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
+ *  reclaims any leases orphaned by a crashed process first (#4833 wires the previously caller-less claimer). */
+export declare function runQueueClaimBatch(args: string[], options?: {
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+}): number;
+export declare const QUEUE_ITEMS = "loopover_miner_portfolio_queue_items";
+export declare const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS = "loopover_miner_portfolio_queue_oldest_in_progress_lease_age_seconds";
+/**
+ * Render portfolio-queue backlog health as Prometheus text-exposition gauges: current item count per status, and
+ * the age of the OLDEST still-in-flight lease -- the concrete "is anything stuck" signal a
+ * `loopover_queue_oldest_maintenance_pending_age_seconds`-style alert rule can threshold on (#5186). Pure and
+ * side-effect-free: the caller supplies the rows and `nowMs` (no internal clock read, matching
+ * store-maintenance.js's pruneLedgerByRetention convention) and prints the result. Deterministic (status series
+ * sorted); always emits HELP/TYPE so an empty queue is still a well-formed exposition document, and the lease-age
+ * gauge reads 0 (never stuck) rather than being omitted when nothing is in-flight.
+ * @param {Array<{ status: string }>} queueEntries - every row, any status (e.g. store.listQueue()'s output).
+ * @param {Array<{ leasedAt: string | null }>} leaseEntries - in-flight rows only (store.listInProgress()'s output).
+ * @param {number} nowMs
+ */
+export declare function renderPortfolioQueueMetrics(queueEntries: Array<{
+    status: string;
+}>, leaseEntries: Array<{
+    leasedAt: string | null;
+}>, nowMs: number): string;
+export declare function runQueueMetrics(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    nowMs?: number;
+}): number;
+export declare function runQueueCli(subcommand: string | undefined, args: string[], options?: {
     initPortfolioQueue?: () => PortfolioQueueStore;
     initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
-  },
-): number;
+}): number;

--- a/packages/loopover-miner/lib/portfolio-queue-cli.js
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.js
@@ -2,104 +2,98 @@ import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 const QUEUE_LIST_USAGE = "Usage: loopover-miner queue list [--repo <owner/repo>] [--json]";
-const QUEUE_NEXT_USAGE =
-  "Usage: loopover-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
-const QUEUE_DONE_USAGE =
-  "Usage: loopover-miner queue done <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
-const QUEUE_RELEASE_USAGE =
-  "Usage: loopover-miner queue release <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
-const QUEUE_REQUEUE_USAGE =
-  "Usage: loopover-miner queue requeue <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
-const QUEUE_CLAIM_BATCH_USAGE =
-  "Usage: loopover-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
-
+const QUEUE_NEXT_USAGE = "Usage: loopover-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
+const QUEUE_DONE_USAGE = "Usage: loopover-miner queue done <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_RELEASE_USAGE = "Usage: loopover-miner queue release <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_REQUEUE_USAGE = "Usage: loopover-miner queue requeue <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_CLAIM_BATCH_USAGE = "Usage: loopover-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parseQueueListArgs(args) {
-  const options = { json: false, repoFullName: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, repoFullName: null };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-")) {
+                return { error: QUEUE_LIST_USAGE };
+            }
+            const repo = parseRepoArg(repoArg, QUEUE_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) {
+    if (positional.length > 0) {
         return { error: QUEUE_LIST_USAGE };
-      }
-      const repo = parseRepoArg(repoArg, QUEUE_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length > 0) {
-    return { error: QUEUE_LIST_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 // #4850: --global-wip/--per-repo-wip are OMITTED (undefined) by default -- queue next stays uncapped, byte-
 // identical to its pre-#4850 behavior, unless an operator explicitly opts in. Mirrors queue claim-batch's own
 // flag names (portfolio-queue-manager.js's WIP-cap-aware claimer), but claim-batch's OWN default of 1/1 is not
 // reused here: claim-batch's whole purpose is cap enforcement, while queue next has always been a plain
 // highest-priority dequeue and must not silently start capping existing callers that never asked for it.
 export function parseQueueNextArgs(args) {
-  const options = { json: false, dryRun: false, globalWipCap: undefined, perRepoWipCap: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        globalWipCap: undefined,
+        perRepoWipCap: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--global-wip" || token === "--per-repo-wip") {
+            const value = Number(args[index + 1]);
+            if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+                return { error: QUEUE_NEXT_USAGE };
+            }
+            if (token === "--global-wip")
+                options.globalWipCap = value;
+            else
+                options.perRepoWipCap = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--global-wip" || token === "--per-repo-wip") {
-      const value = Number(args[index + 1]);
-      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+    if (positional.length > 0) {
         return { error: QUEUE_NEXT_USAGE };
-      }
-      if (token === "--global-wip") options.globalWipCap = value;
-      else options.perRepoWipCap = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length > 0) {
-    return { error: QUEUE_NEXT_USAGE };
-  }
-  return options;
+    return options;
 }
-
 /**
  * Pick at most one atomically-claimable target from the store's already-priority-ordered active rows (queued
  * AND in_progress interleaved, exactly `batchClaim`'s own `entries` shape). `caps` of `null` replicates the
@@ -111,392 +105,389 @@ export function parseQueueNextArgs(args) {
  * @param {{ globalWipCap: number, perRepoWipCap: number } | null} caps
  */
 export function selectNextEligibleTarget(entries, caps) {
-  const topQueued = entries.find((entry) => entry.status === "queued");
-  if (!topQueued) return [];
-  if (!caps) {
+    const topQueued = entries.find((entry) => entry.status === "queued");
+    if (!topQueued)
+        return [];
+    if (!caps) {
+        return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
+    }
+    const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
+    if (globalActiveCount >= caps.globalWipCap)
+        return [];
+    // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
+    // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
+    // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
+    const repoActiveCount = entries.filter((entry) => entry.status === "in_progress" &&
+        entry.repoFullName === topQueued.repoFullName &&
+        entry.apiBaseUrl === topQueued.apiBaseUrl).length;
+    if (repoActiveCount >= caps.perRepoWipCap)
+        return [];
     return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
-  }
-  const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
-  if (globalActiveCount >= caps.globalWipCap) return [];
-  // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
-  // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
-  // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
-  const repoActiveCount = entries.filter(
-    (entry) =>
-      entry.status === "in_progress" &&
-      entry.repoFullName === topQueued.repoFullName &&
-      entry.apiBaseUrl === topQueued.apiBaseUrl,
-  ).length;
-  if (repoActiveCount >= caps.perRepoWipCap) return [];
-  return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
 }
-
 /** Shared `<owner/repo> <identifier> [--api-base-url <url>] [--json]` parse for the item-targeting subcommands
  *  (done/release/requeue). `usage` is the command-specific message surfaced on a malformed argv. */
 function parseRepoIdentifierArgs(args, usage) {
-  const options = { json: false, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        apiBaseUrl: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        // #5563: scope the target to a non-default forge host, so it doesn't collide with (or get confused for) a
+        // same-named repo on the default github.com host.
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: usage };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    // #5563: scope the target to a non-default forge host, so it doesn't collide with (or get confused for) a
-    // same-named repo on the default github.com host.
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: usage };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
+    const repo = parseRepoArg(positional[0], usage);
+    if ("error" in repo)
+        return repo;
+    const identifier = positional[1]?.trim();
+    if (!identifier) {
+        return { error: usage };
     }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: usage };
-  }
-
-  const repo = parseRepoArg(positional[0], usage);
-  if ("error" in repo) return repo;
-
-  const identifier = positional[1]?.trim();
-  if (!identifier) {
-    return { error: usage };
-  }
-
-  return {
-    repoFullName: repo.repoFullName,
-    identifier,
-    dryRun: options.dryRun,
-    json: options.json,
-    apiBaseUrl: options.apiBaseUrl,
-  };
+    return {
+        repoFullName: repo.repoFullName,
+        identifier,
+        dryRun: options.dryRun,
+        json: options.json,
+        apiBaseUrl: options.apiBaseUrl,
+    };
 }
-
 export function parseQueueDoneArgs(args) {
-  return parseRepoIdentifierArgs(args, QUEUE_DONE_USAGE);
+    return parseRepoIdentifierArgs(args, QUEUE_DONE_USAGE);
 }
-
 export function parseQueueReleaseArgs(args) {
-  return parseRepoIdentifierArgs(args, QUEUE_RELEASE_USAGE);
+    return parseRepoIdentifierArgs(args, QUEUE_RELEASE_USAGE);
 }
-
 export function parseQueueRequeueArgs(args) {
-  return parseRepoIdentifierArgs(args, QUEUE_REQUEUE_USAGE);
+    return parseRepoIdentifierArgs(args, QUEUE_REQUEUE_USAGE);
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderQueueTable(entries) {
-  if (!Array.isArray(entries) || entries.length === 0) return "no portfolio queue entries";
-  const header = [
-    "repo".padEnd(24),
-    "identifier".padEnd(16),
-    // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
-    // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
-    "host".padEnd(30),
-    "status".padEnd(12),
-    "pri".padStart(4),
-    "enqueued-at".padEnd(24),
-  ].join(" ");
-  const lines = entries.map((entry) =>
-    [
-      entry.repoFullName.padEnd(24),
-      entry.identifier.padEnd(16),
-      display(entry.apiBaseUrl).padEnd(30),
-      entry.status.padEnd(12),
-      display(entry.priority).padStart(4),
-      display(entry.enqueuedAt).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(entries) || entries.length === 0)
+        return "no portfolio queue entries";
+    const header = [
+        "repo".padEnd(24),
+        "identifier".padEnd(16),
+        // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
+        // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
+        "host".padEnd(30),
+        "status".padEnd(12),
+        "pri".padStart(4),
+        "enqueued-at".padEnd(24),
+    ].join(" ");
+    const lines = entries.map((entry) => [
+        entry.repoFullName.padEnd(24),
+        entry.identifier.padEnd(16),
+        display(entry.apiBaseUrl).padEnd(30),
+        entry.status.padEnd(12),
+        display(entry.priority).padStart(4),
+        display(entry.enqueuedAt).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 function withPortfolioQueue(options, run) {
-  const ownsStore = options.initPortfolioQueue === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  try {
-    return run(portfolioQueue);
-  } finally {
-    if (ownsStore) portfolioQueue.close();
-  }
+    const ownsStore = options.initPortfolioQueue === undefined;
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    try {
+        return run(portfolioQueue);
+    }
+    finally {
+        if (ownsStore)
+            portfolioQueue.close();
+    }
 }
-
 export function runQueueList(args, options = {}) {
-  const parsed = parseQueueListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entries = portfolioQueue.listQueue(parsed.repoFullName);
-      if (parsed.json) {
-        console.log(JSON.stringify({ entries }, null, 2));
-      } else {
-        console.log(renderQueueTable(entries));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseQueueListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entries = portfolioQueue.listQueue(parsed.repoFullName);
+            if (parsed.json) {
+                console.log(JSON.stringify({ entries }, null, 2));
+            }
+            else {
+                console.log(renderQueueTable(entries));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runQueueNext(args, options = {}) {
-  const parsed = parseQueueNextArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const capsRequested = parsed.globalWipCap !== undefined || parsed.perRepoWipCap !== undefined;
-  if (parsed.dryRun) {
-    const dryRunResult = capsRequested
-      ? { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap }
-      : { outcome: "dry_run" };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else if (capsRequested) {
-      console.log(
-        `DRY RUN: would dequeue the highest-priority queued item within WIP caps (global-wip: ${parsed.globalWipCap ?? "unset"}, per-repo-wip: ${parsed.perRepoWipCap ?? "unset"}). No portfolio-queue write was made.`,
-      );
-    } else {
-      console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+    const parsed = parseQueueNextArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      let entry;
-      if (capsRequested) {
-        // Unset dimensions stay genuinely uncapped (Infinity), not silently defaulted to 1 like claim-batch.
-        const caps = {
-          globalWipCap: parsed.globalWipCap ?? Number.POSITIVE_INFINITY,
-          perRepoWipCap: parsed.perRepoWipCap ?? Number.POSITIVE_INFINITY,
-        };
-        const claimed = portfolioQueue.batchClaim((entries) => selectNextEligibleTarget(entries, caps));
-        entry = claimed[0] ?? null;
-      } else {
-        entry = portfolioQueue.dequeueNext();
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry ? entry.identifier : "none");
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const capsRequested = parsed.globalWipCap !== undefined || parsed.perRepoWipCap !== undefined;
+    if (parsed.dryRun) {
+        const dryRunResult = capsRequested
+            ? { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap }
+            : { outcome: "dry_run" };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else if (capsRequested) {
+            console.log(`DRY RUN: would dequeue the highest-priority queued item within WIP caps (global-wip: ${parsed.globalWipCap ?? "unset"}, per-repo-wip: ${parsed.perRepoWipCap ?? "unset"}). No portfolio-queue write was made.`);
+        }
+        else {
+            console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            let entry;
+            if (capsRequested) {
+                // Unset dimensions stay genuinely uncapped (Infinity), not silently defaulted to 1 like claim-batch.
+                const caps = {
+                    globalWipCap: parsed.globalWipCap ?? Number.POSITIVE_INFINITY,
+                    perRepoWipCap: parsed.perRepoWipCap ?? Number.POSITIVE_INFINITY,
+                };
+                const claimed = portfolioQueue.batchClaim((entries) => selectNextEligibleTarget(entries, caps));
+                entry = claimed[0] ?? null;
+            }
+            else {
+                entry = portfolioQueue.dequeueNext();
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry ? entry.identifier : "none");
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runQueueDone(args, options = {}) {
-  const parsed = parseQueueDoneArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would mark ${parsed.repoFullName} ${parsed.identifier} done. No portfolio-queue write was made.`);
+    const parsed = parseQueueDoneArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
-      if (!entry) {
-        return reportCliFailure(parsed.json, "queue_entry_not_found");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would mark ${parsed.repoFullName} ${parsed.identifier} done. No portfolio-queue write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+            if (!entry) {
+                return reportCliFailure(parsed.json, "queue_entry_not_found");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 /** `release <owner/repo> <identifier>`: manually give up a CLAIMED (in_progress) item, returning it to the queue
  *  (the manual counterpart to the automated stuck-lease sweep). Exit 2 when there is no in-flight item to release. */
 export function runQueueRelease(args, options = {}) {
-  const parsed = parseQueueReleaseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would release ${parsed.repoFullName} ${parsed.identifier} back to the queue. No portfolio-queue write was made.`);
+    const parsed = parseQueueReleaseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
-      if (!entry) {
-        return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would release ${parsed.repoFullName} ${parsed.identifier} back to the queue. No portfolio-queue write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+            if (!entry) {
+                return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 /** `requeue <owner/repo> <identifier>`: manually put a COMPLETED (done) item back on the queue so it is picked up
  *  again, keeping its original FIFO position. Exit 2 when there is no done item to requeue (already queued,
  *  in-flight — release it instead — or absent). */
 export function runQueueRequeue(args, options = {}) {
-  const parsed = parseQueueRequeueArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would requeue ${parsed.repoFullName} ${parsed.identifier}. No portfolio-queue write was made.`);
+    const parsed = parseQueueRequeueArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
-      if (!entry) {
-        return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would requeue ${parsed.repoFullName} ${parsed.identifier}. No portfolio-queue write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+            if (!entry) {
+                return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function parseQueueClaimBatchArgs(args) {
-  const options = { json: false, dryRun: false, globalWipCap: 1, perRepoWipCap: 1 };
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
-    }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--global-wip" || token === "--per-repo-wip") {
-      const value = Number(args[index + 1]);
-      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+    const options = {
+        json: false,
+        dryRun: false,
+        globalWipCap: 1,
+        perRepoWipCap: 1,
+    };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--global-wip" || token === "--per-repo-wip") {
+            const value = Number(args[index + 1]);
+            if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+                return { error: QUEUE_CLAIM_BATCH_USAGE };
+            }
+            if (token === "--global-wip")
+                options.globalWipCap = value;
+            else
+                options.perRepoWipCap = value;
+            index += 1;
+            continue;
+        }
         return { error: QUEUE_CLAIM_BATCH_USAGE };
-      }
-      if (token === "--global-wip") options.globalWipCap = value;
-      else options.perRepoWipCap = value;
-      index += 1;
-      continue;
     }
-    return { error: QUEUE_CLAIM_BATCH_USAGE };
-  }
-  return options;
+    return options;
 }
-
 /** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
  *  reclaims any leases orphaned by a crashed process first (#4833 wires the previously caller-less claimer). */
 export function runQueueClaimBatch(args, options = {}) {
-  const parsed = parseQueueClaimBatchArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(
-        `DRY RUN: would claim a batch (global-wip: ${parsed.globalWipCap}, per-repo-wip: ${parsed.perRepoWipCap}). No portfolio-queue write was made.`,
-      );
+    const parsed = parseQueueClaimBatchArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
-  // close with `?.` since the initializer may have thrown before assigning.
-  const ownsManager = options.initPortfolioQueueManager === undefined;
-  let manager;
-  try {
-    manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
-      caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
-    });
-    const claimed = manager.claimNextBatch();
-    if (parsed.json) {
-      console.log(JSON.stringify({ claimed }, null, 2));
-    } else {
-      console.log(claimed.length === 0 ? "none" : claimed.map((entry) => entry.identifier).join("\n"));
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would claim a batch (global-wip: ${parsed.globalWipCap}, per-repo-wip: ${parsed.perRepoWipCap}). No portfolio-queue write was made.`);
+        }
+        return 0;
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsManager) manager?.close();
-  }
+    // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
+    // close with `?.` since the initializer may have thrown before assigning.
+    const ownsManager = options.initPortfolioQueueManager === undefined;
+    let manager;
+    try {
+        manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+            caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+        });
+        const claimed = manager.claimNextBatch();
+        if (parsed.json) {
+            console.log(JSON.stringify({ claimed }, null, 2));
+        }
+        else {
+            console.log(claimed.length === 0 ? "none" : claimed.map((entry) => entry.identifier).join("\n"));
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    finally {
+        if (ownsManager)
+            manager?.close();
+    }
 }
-
 const QUEUE_METRICS_USAGE = "Usage: loopover-miner queue metrics";
-
 // Prometheus metric names for the portfolio-queue gauges (#5186). Mirrors the `loopover_miner_*` naming and
 // HELP/TYPE/label conventions of event-ledger-cli.js's renderEventLedgerMetrics / the engine's
 // renderMinerPredictionMetrics, rather than importing across the package boundary.
 export const QUEUE_ITEMS = "loopover_miner_portfolio_queue_items";
 export const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS = "loopover_miner_portfolio_queue_oldest_in_progress_lease_age_seconds";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeMetricsHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /**
  * Render portfolio-queue backlog health as Prometheus text-exposition gauges: current item count per status, and
  * the age of the OLDEST still-in-flight lease -- the concrete "is anything stuck" signal a
@@ -510,64 +501,65 @@ function escapeMetricsHelpText(help) {
  * @param {number} nowMs
  */
 export function renderPortfolioQueueMetrics(queueEntries, leaseEntries, nowMs) {
-  const countByStatus = new Map();
-  for (const entry of queueEntries) {
-    countByStatus.set(entry.status, (countByStatus.get(entry.status) ?? 0) + 1);
-  }
-
-  let oldestLeaseAgeSeconds = 0;
-  for (const lease of leaseEntries) {
-    const leasedAtMs = Date.parse(lease.leasedAt ?? "");
-    if (!Number.isFinite(leasedAtMs)) continue;
-    const ageSeconds = Math.max(0, (nowMs - leasedAtMs) / 1000);
-    if (ageSeconds > oldestLeaseAgeSeconds) oldestLeaseAgeSeconds = ageSeconds;
-  }
-
-  const lines = [
-    `# HELP ${QUEUE_ITEMS} ${escapeMetricsHelpText("Current portfolio-queue item count, by status.")}`,
-    `# TYPE ${QUEUE_ITEMS} gauge`,
-  ];
-  for (const [status, count] of [...countByStatus.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-    lines.push(`${QUEUE_ITEMS}{status="${status}"} ${count}`);
-  }
-
-  lines.push(
-    `# HELP ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${escapeMetricsHelpText("Age in seconds of the oldest still-in-flight (in_progress) claim lease. 0 when nothing is in-flight.")}`,
-  );
-  lines.push(`# TYPE ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} gauge`);
-  lines.push(`${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${oldestLeaseAgeSeconds}`);
-
-  return `${lines.join("\n")}\n`;
+    const countByStatus = new Map();
+    for (const entry of queueEntries) {
+        countByStatus.set(entry.status, (countByStatus.get(entry.status) ?? 0) + 1);
+    }
+    let oldestLeaseAgeSeconds = 0;
+    for (const lease of leaseEntries) {
+        const leasedAtMs = Date.parse(lease.leasedAt ?? "");
+        if (!Number.isFinite(leasedAtMs))
+            continue;
+        const ageSeconds = Math.max(0, (nowMs - leasedAtMs) / 1000);
+        if (ageSeconds > oldestLeaseAgeSeconds)
+            oldestLeaseAgeSeconds = ageSeconds;
+    }
+    const lines = [
+        `# HELP ${QUEUE_ITEMS} ${escapeMetricsHelpText("Current portfolio-queue item count, by status.")}`,
+        `# TYPE ${QUEUE_ITEMS} gauge`,
+    ];
+    for (const [status, count] of [...countByStatus.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+        lines.push(`${QUEUE_ITEMS}{status="${status}"} ${count}`);
+    }
+    lines.push(`# HELP ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${escapeMetricsHelpText("Age in seconds of the oldest still-in-flight (in_progress) claim lease. 0 when nothing is in-flight.")}`);
+    lines.push(`# TYPE ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} gauge`);
+    lines.push(`${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${oldestLeaseAgeSeconds}`);
+    return `${lines.join("\n")}\n`;
 }
-
 export function runQueueMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), QUEUE_METRICS_USAGE);
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
-      // renderPortfolioQueueMetrics returns a newline-terminated document; console.log re-adds the terminator, so
-      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
-      console.log(
-        renderPortfolioQueueMetrics(portfolioQueue.listQueue(), portfolioQueue.listInProgress(), nowMs).trimEnd(),
-      );
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), QUEUE_METRICS_USAGE);
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+            // renderPortfolioQueueMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+            // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+            console.log(renderPortfolioQueueMetrics(portfolioQueue.listQueue(), portfolioQueue.listInProgress(), nowMs).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
-
 export function runQueueCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runQueueList(args, options);
-  if (subcommand === "next") return runQueueNext(args, options);
-  if (subcommand === "done") return runQueueDone(args, options);
-  if (subcommand === "release") return runQueueRelease(args, options);
-  if (subcommand === "requeue") return runQueueRequeue(args, options);
-  if (subcommand === "claim-batch") return runQueueClaimBatch(args, options);
-  if (subcommand === "metrics") return runQueueMetrics(args, options);
-  if (subcommand === "dashboard") return runPortfolioDashboard(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
+    if (subcommand === "list")
+        return runQueueList(args, options);
+    if (subcommand === "next")
+        return runQueueNext(args, options);
+    if (subcommand === "done")
+        return runQueueDone(args, options);
+    if (subcommand === "release")
+        return runQueueRelease(args, options);
+    if (subcommand === "requeue")
+        return runQueueRequeue(args, options);
+    if (subcommand === "claim-batch")
+        return runQueueClaimBatch(args, options);
+    if (subcommand === "metrics")
+        return runQueueMetrics(args, options);
+    if (subcommand === "dashboard")
+        return runPortfolioDashboard(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGZvbGlvLXF1ZXVlLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInBvcnRmb2xpby1xdWV1ZS1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFFL0QsT0FBTyxFQUFFLHlCQUF5QixFQUFFLE1BQU0sOEJBQThCLENBQUM7QUFFekUsT0FBTyxFQUFFLHFCQUFxQixFQUFFLE1BQU0sMEJBQTBCLENBQUM7QUFDakUsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBNkJsRixNQUFNLGdCQUFnQixHQUFHLGlFQUFpRSxDQUFDO0FBQzNGLE1BQU0sZ0JBQWdCLEdBQ3BCLCtGQUErRixDQUFDO0FBQ2xHLE1BQU0sZ0JBQWdCLEdBQ3BCLHdHQUF3RyxDQUFDO0FBQzNHLE1BQU0sbUJBQW1CLEdBQ3ZCLDJHQUEyRyxDQUFDO0FBQzlHLE1BQU0sbUJBQW1CLEdBQ3ZCLDJHQUEyRyxDQUFDO0FBQzlHLE1BQU0sdUJBQXVCLEdBQzNCLHNHQUFzRyxDQUFDO0FBRXpHLFNBQVMsWUFBWSxDQUNuQixLQUF5QixFQUN6QixLQUFhO0lBRWIsSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO0lBQ3BDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM3QixNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2hELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVMsRUFBRSxDQUFDO1FBQzNDLE9BQU8sRUFBRSxLQUFLLEVBQUUsd0NBQXdDLEVBQUUsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxFQUFFLFlBQVksRUFBRSxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsRUFBRSxDQUFDO0FBQzlDLENBQUM7QUFFRCxNQUFNLFVBQVUsa0JBQWtCLENBQUMsSUFBYztJQUMvQyxNQUFNLE9BQU8sR0FBbUQsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQztJQUNwRyxNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE1BQU0sT0FBTyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDaEMsSUFBSSxDQUFDLE9BQU8sSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3hDLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztZQUNyQyxDQUFDO1lBQ0QsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLE9BQU8sRUFBRSxnQkFBZ0IsQ0FBQyxDQUFDO1lBQ3JELElBQUksT0FBTyxJQUFJLElBQUk7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFDakMsT0FBTyxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsWUFBWSxDQUFDO1lBQ3pDLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDL0MsQ0FBQztRQUNELFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLGdCQUFnQixFQUFFLENBQUM7SUFDckMsQ0FBQztJQUVELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRCw0R0FBNEc7QUFDNUcsOEdBQThHO0FBQzlHLCtHQUErRztBQUMvRyx3R0FBd0c7QUFDeEcseUdBQXlHO0FBQ3pHLE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxJQUFjO0lBQy9DLE1BQU0sT0FBTyxHQUE0RztRQUN2SCxJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsWUFBWSxFQUFFLFNBQVM7UUFDdkIsYUFBYSxFQUFFLFNBQVM7S0FDekIsQ0FBQztJQUNGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxjQUFjLElBQUksS0FBSyxLQUFLLGdCQUFnQixFQUFFLENBQUM7WUFDM0QsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUN0QyxJQUFJLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLEtBQUssU0FBUyxJQUFJLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQzFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsZ0JBQWdCLEVBQUUsQ0FBQztZQUNyQyxDQUFDO1lBQ0QsSUFBSSxLQUFLLEtBQUssY0FBYztnQkFBRSxPQUFPLENBQUMsWUFBWSxHQUFHLEtBQUssQ0FBQzs7Z0JBQ3RELE9BQU8sQ0FBQyxhQUFhLEdBQUcsS0FBSyxDQUFDO1lBQ25DLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDL0MsQ0FBQztRQUNELFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLGdCQUFnQixFQUFFLENBQUM7SUFDckMsQ0FBQztJQUNELE9BQU8sT0FBTyxDQUFDO0FBQ2pCLENBQUM7QUFFRDs7Ozs7Ozs7O0dBU0c7QUFDSCxNQUFNLFVBQVUsd0JBQXdCLENBQ3RDLE9BQWdHLEVBQ2hHLElBQTREO0lBRTVELE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxJQUFJLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLEtBQUssQ0FBQyxNQUFNLEtBQUssUUFBUSxDQUFDLENBQUM7SUFDckUsSUFBSSxDQUFDLFNBQVM7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUMxQixJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDVixPQUFPLENBQUMsRUFBRSxZQUFZLEVBQUUsU0FBUyxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsU0FBUyxDQUFDLFVBQVUsRUFBRSxVQUFVLEVBQUUsU0FBUyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUM7SUFDeEgsQ0FBQztJQUNELE1BQU0saUJBQWlCLEdBQUcsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLE1BQU0sS0FBSyxhQUFhLENBQUMsQ0FBQyxNQUFNLENBQUM7SUFDM0YsSUFBSSxpQkFBaUIsSUFBSSxJQUFJLENBQUMsWUFBWTtRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQ3RELGtIQUFrSDtJQUNsSCw2R0FBNkc7SUFDN0csdUhBQXVIO0lBQ3ZILE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQyxNQUFNLENBQ3BDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FDUixLQUFLLENBQUMsTUFBTSxLQUFLLGFBQWE7UUFDOUIsS0FBSyxDQUFDLFlBQVksS0FBSyxTQUFTLENBQUMsWUFBWTtRQUM3QyxLQUFLLENBQUMsVUFBVSxLQUFLLFNBQVMsQ0FBQyxVQUFVLENBQzVDLENBQUMsTUFBTSxDQUFDO0lBQ1QsSUFBSSxlQUFlLElBQUksSUFBSSxDQUFDLGFBQWE7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUNyRCxPQUFPLENBQUMsRUFBRSxZQUFZLEVBQUUsU0FBUyxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsU0FBUyxDQUFDLFVBQVUsRUFBRSxVQUFVLEVBQUUsU0FBUyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUM7QUFDeEgsQ0FBQztBQUVEO29HQUNvRztBQUNwRyxTQUFTLHVCQUF1QixDQUFDLElBQWMsRUFBRSxLQUFhO0lBQzVELE1BQU0sT0FBTyxHQUF1RTtRQUNsRixJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsVUFBVSxFQUFFLFNBQVM7S0FDdEIsQ0FBQztJQUNGLE1BQU0sVUFBVSxHQUFhLEVBQUUsQ0FBQztJQUVoQyxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0Qsc0dBQXNHO1FBQ3RHLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsMEdBQTBHO1FBQzFHLGtEQUFrRDtRQUNsRCxJQUFJLEtBQUssS0FBSyxnQkFBZ0IsRUFBRSxDQUFDO1lBQy9CLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3BDLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7WUFDMUIsQ0FBQztZQUNELE9BQU8sQ0FBQyxVQUFVLEdBQUcsS0FBSyxDQUFDO1lBQzNCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQzFCLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDL0MsQ0FBQztRQUNELFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVELElBQUksVUFBVSxDQUFDLE1BQU0sS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUM1QixPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO0lBQzFCLENBQUM7SUFFRCxNQUFNLElBQUksR0FBRyxZQUFZLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLEtBQUssQ0FBQyxDQUFDO0lBQ2hELElBQUksT0FBTyxJQUFJLElBQUk7UUFBRSxPQUFPLElBQUksQ0FBQztJQUVqQyxNQUFNLFVBQVUsR0FBRyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsSUFBSSxFQUFFLENBQUM7SUFDekMsSUFBSSxDQUFDLFVBQVUsRUFBRSxDQUFDO1FBQ2hCLE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDMUIsQ0FBQztJQUVELE9BQU87UUFDTCxZQUFZLEVBQUUsSUFBSSxDQUFDLFlBQVk7UUFDL0IsVUFBVTtRQUNWLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTTtRQUN0QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7UUFDbEIsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVO0tBQy9CLENBQUM7QUFDSixDQUFDO0FBRUQsTUFBTSxVQUFVLGtCQUFrQixDQUFDLElBQWM7SUFDL0MsT0FBTyx1QkFBdUIsQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsQ0FBQztBQUN6RCxDQUFDO0FBRUQsTUFBTSxVQUFVLHFCQUFxQixDQUFDLElBQWM7SUFDbEQsT0FBTyx1QkFBdUIsQ0FBQyxJQUFJLEVBQUUsbUJBQW1CLENBQUMsQ0FBQztBQUM1RCxDQUFDO0FBRUQsTUFBTSxVQUFVLHFCQUFxQixDQUFDLElBQWM7SUFDbEQsT0FBTyx1QkFBdUIsQ0FBQyxJQUFJLEVBQUUsbUJBQW1CLENBQUMsQ0FBQztBQUM1RCxDQUFDO0FBRUQsU0FBUyxPQUFPLENBQUMsS0FBYztJQUM3QixJQUFJLEtBQUssS0FBSyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLEdBQUcsQ0FBQztJQUN0RCxPQUFPLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztBQUN2QixDQUFDO0FBRUQsTUFBTSxVQUFVLGdCQUFnQixDQUFDLE9BQXFCO0lBQ3BELElBQUksQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxJQUFJLE9BQU8sQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sNEJBQTRCLENBQUM7SUFDekYsTUFBTSxNQUFNLEdBQUc7UUFDYixNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNqQixZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN2QiwwR0FBMEc7UUFDMUcsb0dBQW9HO1FBQ3BHLE1BQU0sQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ2pCLFFBQVEsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ25CLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQ2pCLGFBQWEsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQ3pCLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ1osTUFBTSxLQUFLLEdBQUcsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQ2xDO1FBQ0UsS0FBSyxDQUFDLFlBQVksQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzdCLEtBQUssQ0FBQyxVQUFVLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUMzQixPQUFPLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDcEMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3ZCLE9BQU8sQ0FBQyxLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUNuQyxPQUFPLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7S0FDckMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQ1osQ0FBQztJQUNGLE9BQU8sQ0FBQyxNQUFNLEVBQUUsR0FBRyxLQUFLLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7QUFDdkMsQ0FBQztBQUVELFNBQVMsa0JBQWtCLENBQ3pCLE9BQTJELEVBQzNELEdBQStDO0lBRS9DLE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxrQkFBa0IsS0FBSyxTQUFTLENBQUM7SUFDM0QsTUFBTSxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQ2pGLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLGNBQWMsQ0FBQyxDQUFDO0lBQzdCLENBQUM7WUFBUyxDQUFDO1FBQ1QsSUFBSSxTQUFTO1lBQUUsY0FBYyxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3hDLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFlBQVksQ0FDMUIsSUFBYyxFQUNkLFVBQThELEVBQUU7SUFFaEUsTUFBTSxNQUFNLEdBQUcsa0JBQWtCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDeEMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGtCQUFrQixDQUFDLE9BQU8sRUFBRSxDQUFDLGNBQWMsRUFBRSxFQUFFO1lBQ3BELE1BQU0sT0FBTyxHQUFHLGNBQWMsQ0FBQyxTQUFTLENBQUMsTUFBTSxDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQzlELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxPQUFPLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNwRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxnQkFBZ0IsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1lBQ3pDLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxZQUFZLENBQzFCLElBQWMsRUFDZCxVQUE4RCxFQUFFO0lBRWhFLE1BQU0sTUFBTSxHQUFHLGtCQUFrQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3hDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsTUFBTSxhQUFhLEdBQUcsTUFBTSxDQUFDLFlBQVksS0FBSyxTQUFTLElBQUksTUFBTSxDQUFDLGFBQWEsS0FBSyxTQUFTLENBQUM7SUFDOUYsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsYUFBYTtZQUNoQyxDQUFDLENBQUMsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLGFBQWEsRUFBRSxNQUFNLENBQUMsYUFBYSxFQUFFO1lBQ2hHLENBQUMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsQ0FBQztRQUMzQixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxJQUFJLGFBQWEsRUFBRSxDQUFDO1lBQ3pCLE9BQU8sQ0FBQyxHQUFHLENBQ1Qsd0ZBQXdGLE1BQU0sQ0FBQyxZQUFZLElBQUksT0FBTyxtQkFBbUIsTUFBTSxDQUFDLGFBQWEsSUFBSSxPQUFPLHVDQUF1QyxDQUNoTixDQUFDO1FBQ0osQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLDZGQUE2RixDQUFDLENBQUM7UUFDN0csQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sa0JBQWtCLENBQUMsT0FBTyxFQUFFLENBQUMsY0FBYyxFQUFFLEVBQUU7WUFDcEQsSUFBSSxLQUF3QixDQUFDO1lBQzdCLElBQUksYUFBYSxFQUFFLENBQUM7Z0JBQ2xCLHFHQUFxRztnQkFDckcsTUFBTSxJQUFJLEdBQUc7b0JBQ1gsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLGlCQUFpQjtvQkFDN0QsYUFBYSxFQUFFLE1BQU0sQ0FBQyxhQUFhLElBQUksTUFBTSxDQUFDLGlCQUFpQjtpQkFDaEUsQ0FBQztnQkFDRixNQUFNLE9BQU8sR0FBRyxjQUFjLENBQUMsVUFBVSxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUUsQ0FBQyx3QkFBd0IsQ0FBQyxPQUFPLEVBQUUsSUFBSSxDQUFDLENBQUMsQ0FBQztnQkFDaEcsS0FBSyxHQUFHLE9BQU8sQ0FBQyxDQUFDLENBQUMsSUFBSSxJQUFJLENBQUM7WUFDN0IsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLEtBQUssR0FBRyxjQUFjLENBQUMsV0FBVyxFQUFFLENBQUM7WUFDdkMsQ0FBQztZQUNELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNsRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQ2pELENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxZQUFZLENBQzFCLElBQWMsRUFDZCxVQUE4RCxFQUFFO0lBRWhFLE1BQU0sTUFBTSxHQUFHLGtCQUFrQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3hDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVSxFQUFFLENBQUM7UUFDOUcsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsdUJBQXVCLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFVBQVUsMkNBQTJDLENBQUMsQ0FBQztRQUMxSCxDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxrQkFBa0IsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxjQUFjLEVBQUUsRUFBRTtZQUNwRCxNQUFNLEtBQUssR0FBRyxjQUFjLENBQUMsUUFBUSxDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDakcsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDO2dCQUNYLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSx1QkFBdUIsQ0FBQyxDQUFDO1lBQ2hFLENBQUM7WUFDRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsS0FBSyxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbEQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzVCLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVEO3NIQUNzSDtBQUN0SCxNQUFNLFVBQVUsZUFBZSxDQUM3QixJQUFjLEVBQ2QsVUFBOEQsRUFBRTtJQUVoRSxNQUFNLE1BQU0sR0FBRyxxQkFBcUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUMzQyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxDQUFDO1FBQzlHLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDckQsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLDBCQUEwQixNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxVQUFVLHdEQUF3RCxDQUFDLENBQUM7UUFDMUksQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sa0JBQWtCLENBQUMsT0FBTyxFQUFFLENBQUMsY0FBYyxFQUFFLEVBQUU7WUFDcEQsTUFBTSxLQUFLLEdBQUcsY0FBYyxDQUFDLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDekcsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDO2dCQUNYLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSw2QkFBNkIsQ0FBQyxDQUFDO1lBQ3RFLENBQUM7WUFDRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsS0FBSyxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbEQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzVCLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQUVEOzttREFFbUQ7QUFDbkQsTUFBTSxVQUFVLGVBQWUsQ0FDN0IsSUFBYyxFQUNkLFVBQThELEVBQUU7SUFFaEUsTUFBTSxNQUFNLEdBQUcscUJBQXFCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDM0MsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixNQUFNLFlBQVksR0FBRyxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVLEVBQUUsQ0FBQztRQUM5RyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQywwQkFBMEIsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsVUFBVSxzQ0FBc0MsQ0FBQyxDQUFDO1FBQ3hILENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGtCQUFrQixDQUFDLE9BQU8sRUFBRSxDQUFDLGNBQWMsRUFBRSxFQUFFO1lBQ3BELE1BQU0sS0FBSyxHQUFHLGNBQWMsQ0FBQyxXQUFXLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxNQUFNLENBQUMsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQztZQUNwRyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUM7Z0JBQ1gsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLDRCQUE0QixDQUFDLENBQUM7WUFDckUsQ0FBQztZQUNELElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNsRCxDQUFDO2lCQUFNLENBQUM7Z0JBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLENBQUM7WUFDNUIsQ0FBQztZQUNELE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLHdCQUF3QixDQUFDLElBQWM7SUFDckQsTUFBTSxPQUFPLEdBQW9GO1FBQy9GLElBQUksRUFBRSxLQUFLO1FBQ1gsTUFBTSxFQUFFLEtBQUs7UUFDYixZQUFZLEVBQUUsQ0FBQztRQUNmLGFBQWEsRUFBRSxDQUFDO0tBQ2pCLENBQUM7SUFDRixLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBRSxDQUFDO1FBQzNCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxjQUFjLElBQUksS0FBSyxLQUFLLGdCQUFnQixFQUFFLENBQUM7WUFDM0QsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUN0QyxJQUFJLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLEtBQUssU0FBUyxJQUFJLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQzFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsdUJBQXVCLEVBQUUsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsSUFBSSxLQUFLLEtBQUssY0FBYztnQkFBRSxPQUFPLENBQUMsWUFBWSxHQUFHLEtBQUssQ0FBQzs7Z0JBQ3RELE9BQU8sQ0FBQyxhQUFhLEdBQUcsS0FBSyxDQUFDO1lBQ25DLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELE9BQU8sRUFBRSxLQUFLLEVBQUUsdUJBQXVCLEVBQUUsQ0FBQztJQUM1QyxDQUFDO0lBQ0QsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVEO2dIQUNnSDtBQUNoSCxNQUFNLFVBQVUsa0JBQWtCLENBQ2hDLElBQWMsRUFDZCxVQUFvRixFQUFFO0lBRXRGLE1BQU0sTUFBTSxHQUFHLHdCQUF3QixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQzlDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLGFBQWEsRUFBRSxNQUFNLENBQUMsYUFBYSxFQUFFLENBQUM7UUFDcEgsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQ1QsNkNBQTZDLE1BQU0sQ0FBQyxZQUFZLG1CQUFtQixNQUFNLENBQUMsYUFBYSx1Q0FBdUMsQ0FDL0ksQ0FBQztRQUNKLENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFFRCxnSEFBZ0g7SUFDaEgsMEVBQTBFO0lBQzFFLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyx5QkFBeUIsS0FBSyxTQUFTLENBQUM7SUFDcEUsSUFBSSxPQUEwQyxDQUFDO0lBQy9DLElBQUksQ0FBQztRQUNILE9BQU8sR0FBRyxDQUFDLE9BQU8sQ0FBQyx5QkFBeUIsSUFBSSx5QkFBeUIsQ0FBQyxDQUFDO1lBQ3pFLElBQUksRUFBRSxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLGFBQWEsRUFBRSxNQUFNLENBQUMsYUFBYSxFQUFFO1NBQ2pGLENBQUMsQ0FBQztRQUNILE1BQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyxjQUFjLEVBQUUsQ0FBQztRQUN6QyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsRUFBRSxPQUFPLEVBQUUsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNwRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsT0FBTyxDQUFDLE1BQU0sS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO1FBQ25HLENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztZQUFTLENBQUM7UUFDVCxJQUFJLFdBQVc7WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDcEMsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLG1CQUFtQixHQUFHLHFDQUFxQyxDQUFDO0FBRWxFLDRHQUE0RztBQUM1RywrRkFBK0Y7QUFDL0YsbUZBQW1GO0FBQ25GLE1BQU0sQ0FBQyxNQUFNLFdBQVcsR0FBRyxzQ0FBc0MsQ0FBQztBQUNsRSxNQUFNLENBQUMsTUFBTSwwQ0FBMEMsR0FBRyxxRUFBcUUsQ0FBQztBQUVoSSx1R0FBdUc7QUFDdkcsU0FBUyxxQkFBcUIsQ0FBQyxJQUFZO0lBQ3pDLE9BQU8sSUFBSSxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsTUFBTSxDQUFDLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsQ0FBQztBQUMzRCxDQUFDO0FBRUQ7Ozs7Ozs7Ozs7O0dBV0c7QUFDSCxNQUFNLFVBQVUsMkJBQTJCLENBQ3pDLFlBQXVDLEVBQ3ZDLFlBQWdELEVBQ2hELEtBQWE7SUFFYixNQUFNLGFBQWEsR0FBRyxJQUFJLEdBQUcsRUFBa0IsQ0FBQztJQUNoRCxLQUFLLE1BQU0sS0FBSyxJQUFJLFlBQVksRUFBRSxDQUFDO1FBQ2pDLGFBQWEsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sRUFBRSxDQUFDLGFBQWEsQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDO0lBQzlFLENBQUM7SUFFRCxJQUFJLHFCQUFxQixHQUFHLENBQUMsQ0FBQztJQUM5QixLQUFLLE1BQU0sS0FBSyxJQUFJLFlBQVksRUFBRSxDQUFDO1FBQ2pDLE1BQU0sVUFBVSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsS0FBSyxDQUFDLFFBQVEsSUFBSSxFQUFFLENBQUMsQ0FBQztRQUNwRCxJQUFJLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxVQUFVLENBQUM7WUFBRSxTQUFTO1FBQzNDLE1BQU0sVUFBVSxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLENBQUMsS0FBSyxHQUFHLFVBQVUsQ0FBQyxHQUFHLElBQUksQ0FBQyxDQUFDO1FBQzVELElBQUksVUFBVSxHQUFHLHFCQUFxQjtZQUFFLHFCQUFxQixHQUFHLFVBQVUsQ0FBQztJQUM3RSxDQUFDO0lBRUQsTUFBTSxLQUFLLEdBQUc7UUFDWixVQUFVLFdBQVcsSUFBSSxxQkFBcUIsQ0FBQyxnREFBZ0QsQ0FBQyxFQUFFO1FBQ2xHLFVBQVUsV0FBVyxRQUFRO0tBQzlCLENBQUM7SUFDRixLQUFLLE1BQU0sQ0FBQyxNQUFNLEVBQUUsS0FBSyxDQUFDLElBQUksQ0FBQyxHQUFHLGFBQWEsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3BHLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxXQUFXLFlBQVksTUFBTSxNQUFNLEtBQUssRUFBRSxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELEtBQUssQ0FBQyxJQUFJLENBQ1IsVUFBVSwwQ0FBMEMsSUFBSSxxQkFBcUIsQ0FBQyxzR0FBc0csQ0FBQyxFQUFFLENBQ3hMLENBQUM7SUFDRixLQUFLLENBQUMsSUFBSSxDQUFDLFVBQVUsMENBQTBDLFFBQVEsQ0FBQyxDQUFDO0lBQ3pFLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRywwQ0FBMEMsSUFBSSxxQkFBcUIsRUFBRSxDQUFDLENBQUM7SUFFckYsT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQztBQUNqQyxDQUFDO0FBRUQsTUFBTSxVQUFVLGVBQWUsQ0FDN0IsSUFBYyxFQUNkLFVBQThFLEVBQUU7SUFFaEYsSUFBSSxJQUFJLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxDQUFDO1FBQ3BCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLG1CQUFtQixDQUFDLENBQUM7SUFDbkUsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sa0JBQWtCLENBQUMsT0FBTyxFQUFFLENBQUMsY0FBYyxFQUFFLEVBQUU7WUFDcEQsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFFLE9BQU8sQ0FBQyxLQUFnQixDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUM7WUFDdEYsNEdBQTRHO1lBQzVHLHNGQUFzRjtZQUN0RixPQUFPLENBQUMsR0FBRyxDQUNULDJCQUEyQixDQUFDLGNBQWMsQ0FBQyxTQUFTLEVBQUUsRUFBRSxjQUFjLENBQUMsY0FBYyxFQUFFLEVBQUUsS0FBSyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQzFHLENBQUM7WUFDRixPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ3ZFLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLFdBQVcsQ0FDekIsVUFBOEIsRUFDOUIsSUFBYyxFQUNkLFVBR0ksRUFBRTtJQUVOLElBQUksVUFBVSxLQUFLLE1BQU07UUFBRSxPQUFPLFlBQVksQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDOUQsSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sWUFBWSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM5RCxJQUFJLFVBQVUsS0FBSyxNQUFNO1FBQUUsT0FBTyxZQUFZLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQzlELElBQUksVUFBVSxLQUFLLFNBQVM7UUFBRSxPQUFPLGVBQWUsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDcEUsSUFBSSxVQUFVLEtBQUssU0FBUztRQUFFLE9BQU8sZUFBZSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNwRSxJQUFJLFVBQVUsS0FBSyxhQUFhO1FBQUUsT0FBTyxrQkFBa0IsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDM0UsSUFBSSxVQUFVLEtBQUssU0FBUztRQUFFLE9BQU8sZUFBZSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNwRSxJQUFJLFVBQVUsS0FBSyxXQUFXO1FBQUUsT0FBTyxxQkFBcUIsQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDNUUsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsNkJBQTZCLFVBQVUsSUFBSSxFQUFFLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQyxDQUFDO0FBQ3BILENBQUMifQ==

--- a/packages/loopover-miner/lib/portfolio-queue-cli.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.ts
@@ -1,0 +1,657 @@
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import type { PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
+import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
+import type { PortfolioQueueManager } from "./portfolio-queue-manager.js";
+import { runPortfolioDashboard } from "./portfolio-dashboard.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+export type ParsedQueueListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+    }
+  | { error: string };
+
+export type ParsedQueueNextArgs =
+  | { json: boolean; dryRun: boolean; globalWipCap: number | undefined; perRepoWipCap: number | undefined }
+  | { error: string };
+
+export type QueueClaimTarget = { repoFullName: string; identifier: string; apiBaseUrl: string };
+
+export type ParsedQueueDoneArgs =
+  | {
+      repoFullName: string;
+      identifier: string;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+export type ParsedQueueClaimBatchArgs =
+  | { json: boolean; dryRun: boolean; globalWipCap: number; perRepoWipCap: number }
+  | { error: string };
+
+const QUEUE_LIST_USAGE = "Usage: loopover-miner queue list [--repo <owner/repo>] [--json]";
+const QUEUE_NEXT_USAGE =
+  "Usage: loopover-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
+const QUEUE_DONE_USAGE =
+  "Usage: loopover-miner queue done <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_RELEASE_USAGE =
+  "Usage: loopover-miner queue release <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_REQUEUE_USAGE =
+  "Usage: loopover-miner queue requeue <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_CLAIM_BATCH_USAGE =
+  "Usage: loopover-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
+
+function parseRepoArg(
+  value: string | undefined,
+  usage: string,
+): { repoFullName: string } | { error: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parseQueueListArgs(args: string[]): ParsedQueueListArgs {
+  const options: { json: boolean; repoFullName: string | null } = { json: false, repoFullName: null };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) {
+        return { error: QUEUE_LIST_USAGE };
+      }
+      const repo = parseRepoArg(repoArg, QUEUE_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    return { error: QUEUE_LIST_USAGE };
+  }
+
+  return options;
+}
+
+// #4850: --global-wip/--per-repo-wip are OMITTED (undefined) by default -- queue next stays uncapped, byte-
+// identical to its pre-#4850 behavior, unless an operator explicitly opts in. Mirrors queue claim-batch's own
+// flag names (portfolio-queue-manager.js's WIP-cap-aware claimer), but claim-batch's OWN default of 1/1 is not
+// reused here: claim-batch's whole purpose is cap enforcement, while queue next has always been a plain
+// highest-priority dequeue and must not silently start capping existing callers that never asked for it.
+export function parseQueueNextArgs(args: string[]): ParsedQueueNextArgs {
+  const options: { json: boolean; dryRun: boolean; globalWipCap: number | undefined; perRepoWipCap: number | undefined } = {
+    json: false,
+    dryRun: false,
+    globalWipCap: undefined,
+    perRepoWipCap: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--global-wip" || token === "--per-repo-wip") {
+      const value = Number(args[index + 1]);
+      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+        return { error: QUEUE_NEXT_USAGE };
+      }
+      if (token === "--global-wip") options.globalWipCap = value;
+      else options.perRepoWipCap = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    return { error: QUEUE_NEXT_USAGE };
+  }
+  return options;
+}
+
+/**
+ * Pick at most one atomically-claimable target from the store's already-priority-ordered active rows (queued
+ * AND in_progress interleaved, exactly `batchClaim`'s own `entries` shape). `caps` of `null` replicates the
+ * pre-#4850 behavior: the single highest-priority queued row, unconditionally. When caps are set, refuses to
+ * select anything once the global or the target row's own per-repo in-progress count has reached its cap --
+ * "stops claiming once the cap is reached" (#4850), not a diversifying batch selection (that remains
+ * claim-batch's job via the engine's own `nextEligibleItems`).
+ * @param {Array<{ repoFullName: string, identifier: string, apiBaseUrl: string, status: string }>} entries
+ * @param {{ globalWipCap: number, perRepoWipCap: number } | null} caps
+ */
+export function selectNextEligibleTarget(
+  entries: Array<{ repoFullName: string; identifier: string; apiBaseUrl: string; status: string }>,
+  caps: { globalWipCap: number; perRepoWipCap: number } | null,
+): QueueClaimTarget[] {
+  const topQueued = entries.find((entry) => entry.status === "queued");
+  if (!topQueued) return [];
+  if (!caps) {
+    return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
+  }
+  const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
+  if (globalActiveCount >= caps.globalWipCap) return [];
+  // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
+  // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
+  // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
+  const repoActiveCount = entries.filter(
+    (entry) =>
+      entry.status === "in_progress" &&
+      entry.repoFullName === topQueued.repoFullName &&
+      entry.apiBaseUrl === topQueued.apiBaseUrl,
+  ).length;
+  if (repoActiveCount >= caps.perRepoWipCap) return [];
+  return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
+}
+
+/** Shared `<owner/repo> <identifier> [--api-base-url <url>] [--json]` parse for the item-targeting subcommands
+ *  (done/release/requeue). `usage` is the command-specific message surfaced on a malformed argv. */
+function parseRepoIdentifierArgs(args: string[], usage: string): ParsedQueueDoneArgs {
+  const options: { json: boolean; dryRun: boolean; apiBaseUrl: string | undefined } = {
+    json: false,
+    dryRun: false,
+    apiBaseUrl: undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    // #5563: scope the target to a non-default forge host, so it doesn't collide with (or get confused for) a
+    // same-named repo on the default github.com host.
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: usage };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: usage };
+  }
+
+  const repo = parseRepoArg(positional[0], usage);
+  if ("error" in repo) return repo;
+
+  const identifier = positional[1]?.trim();
+  if (!identifier) {
+    return { error: usage };
+  }
+
+  return {
+    repoFullName: repo.repoFullName,
+    identifier,
+    dryRun: options.dryRun,
+    json: options.json,
+    apiBaseUrl: options.apiBaseUrl,
+  };
+}
+
+export function parseQueueDoneArgs(args: string[]): ParsedQueueDoneArgs {
+  return parseRepoIdentifierArgs(args, QUEUE_DONE_USAGE);
+}
+
+export function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs {
+  return parseRepoIdentifierArgs(args, QUEUE_RELEASE_USAGE);
+}
+
+export function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs {
+  return parseRepoIdentifierArgs(args, QUEUE_REQUEUE_USAGE);
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderQueueTable(entries: QueueEntry[]): string {
+  if (!Array.isArray(entries) || entries.length === 0) return "no portfolio queue entries";
+  const header = [
+    "repo".padEnd(24),
+    "identifier".padEnd(16),
+    // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
+    // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
+    "host".padEnd(30),
+    "status".padEnd(12),
+    "pri".padStart(4),
+    "enqueued-at".padEnd(24),
+  ].join(" ");
+  const lines = entries.map((entry) =>
+    [
+      entry.repoFullName.padEnd(24),
+      entry.identifier.padEnd(16),
+      display(entry.apiBaseUrl).padEnd(30),
+      entry.status.padEnd(12),
+      display(entry.priority).padStart(4),
+      display(entry.enqueuedAt).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function withPortfolioQueue<T>(
+  options: { initPortfolioQueue?: () => PortfolioQueueStore },
+  run: (portfolioQueue: PortfolioQueueStore) => T,
+): T {
+  const ownsStore = options.initPortfolioQueue === undefined;
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  try {
+    return run(portfolioQueue);
+  } finally {
+    if (ownsStore) portfolioQueue.close();
+  }
+}
+
+export function runQueueList(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entries = portfolioQueue.listQueue(parsed.repoFullName);
+      if (parsed.json) {
+        console.log(JSON.stringify({ entries }, null, 2));
+      } else {
+        console.log(renderQueueTable(entries));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runQueueNext(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueNextArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  const capsRequested = parsed.globalWipCap !== undefined || parsed.perRepoWipCap !== undefined;
+  if (parsed.dryRun) {
+    const dryRunResult = capsRequested
+      ? { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap }
+      : { outcome: "dry_run" };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else if (capsRequested) {
+      console.log(
+        `DRY RUN: would dequeue the highest-priority queued item within WIP caps (global-wip: ${parsed.globalWipCap ?? "unset"}, per-repo-wip: ${parsed.perRepoWipCap ?? "unset"}). No portfolio-queue write was made.`,
+      );
+    } else {
+      console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      let entry: QueueEntry | null;
+      if (capsRequested) {
+        // Unset dimensions stay genuinely uncapped (Infinity), not silently defaulted to 1 like claim-batch.
+        const caps = {
+          globalWipCap: parsed.globalWipCap ?? Number.POSITIVE_INFINITY,
+          perRepoWipCap: parsed.perRepoWipCap ?? Number.POSITIVE_INFINITY,
+        };
+        const claimed = portfolioQueue.batchClaim((entries) => selectNextEligibleTarget(entries, caps));
+        entry = claimed[0] ?? null;
+      } else {
+        entry = portfolioQueue.dequeueNext();
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry ? entry.identifier : "none");
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runQueueDone(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueDoneArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would mark ${parsed.repoFullName} ${parsed.identifier} done. No portfolio-queue write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+      if (!entry) {
+        return reportCliFailure(parsed.json, "queue_entry_not_found");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+/** `release <owner/repo> <identifier>`: manually give up a CLAIMED (in_progress) item, returning it to the queue
+ *  (the manual counterpart to the automated stuck-lease sweep). Exit 2 when there is no in-flight item to release. */
+export function runQueueRelease(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueReleaseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would release ${parsed.repoFullName} ${parsed.identifier} back to the queue. No portfolio-queue write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+      if (!entry) {
+        return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+/** `requeue <owner/repo> <identifier>`: manually put a COMPLETED (done) item back on the queue so it is picked up
+ *  again, keeping its original FIFO position. Exit 2 when there is no done item to requeue (already queued,
+ *  in-flight — release it instead — or absent). */
+export function runQueueRequeue(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueRequeueArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would requeue ${parsed.repoFullName} ${parsed.identifier}. No portfolio-queue write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+      if (!entry) {
+        return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs {
+  const options: { json: boolean; dryRun: boolean; globalWipCap: number; perRepoWipCap: number } = {
+    json: false,
+    dryRun: false,
+    globalWipCap: 1,
+    perRepoWipCap: 1,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--global-wip" || token === "--per-repo-wip") {
+      const value = Number(args[index + 1]);
+      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+        return { error: QUEUE_CLAIM_BATCH_USAGE };
+      }
+      if (token === "--global-wip") options.globalWipCap = value;
+      else options.perRepoWipCap = value;
+      index += 1;
+      continue;
+    }
+    return { error: QUEUE_CLAIM_BATCH_USAGE };
+  }
+  return options;
+}
+
+/** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
+ *  reclaims any leases orphaned by a crashed process first (#4833 wires the previously caller-less claimer). */
+export function runQueueClaimBatch(
+  args: string[],
+  options: { initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager } = {},
+): number {
+  const parsed = parseQueueClaimBatchArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(
+        `DRY RUN: would claim a batch (global-wip: ${parsed.globalWipCap}, per-repo-wip: ${parsed.perRepoWipCap}). No portfolio-queue write was made.`,
+      );
+    }
+    return 0;
+  }
+
+  // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
+  // close with `?.` since the initializer may have thrown before assigning.
+  const ownsManager = options.initPortfolioQueueManager === undefined;
+  let manager: PortfolioQueueManager | undefined;
+  try {
+    manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+      caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+    });
+    const claimed = manager.claimNextBatch();
+    if (parsed.json) {
+      console.log(JSON.stringify({ claimed }, null, 2));
+    } else {
+      console.log(claimed.length === 0 ? "none" : claimed.map((entry) => entry.identifier).join("\n"));
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsManager) manager?.close();
+  }
+}
+
+const QUEUE_METRICS_USAGE = "Usage: loopover-miner queue metrics";
+
+// Prometheus metric names for the portfolio-queue gauges (#5186). Mirrors the `loopover_miner_*` naming and
+// HELP/TYPE/label conventions of event-ledger-cli.js's renderEventLedgerMetrics / the engine's
+// renderMinerPredictionMetrics, rather than importing across the package boundary.
+export const QUEUE_ITEMS = "loopover_miner_portfolio_queue_items";
+export const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS = "loopover_miner_portfolio_queue_oldest_in_progress_lease_age_seconds";
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeMetricsHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/**
+ * Render portfolio-queue backlog health as Prometheus text-exposition gauges: current item count per status, and
+ * the age of the OLDEST still-in-flight lease -- the concrete "is anything stuck" signal a
+ * `loopover_queue_oldest_maintenance_pending_age_seconds`-style alert rule can threshold on (#5186). Pure and
+ * side-effect-free: the caller supplies the rows and `nowMs` (no internal clock read, matching
+ * store-maintenance.js's pruneLedgerByRetention convention) and prints the result. Deterministic (status series
+ * sorted); always emits HELP/TYPE so an empty queue is still a well-formed exposition document, and the lease-age
+ * gauge reads 0 (never stuck) rather than being omitted when nothing is in-flight.
+ * @param {Array<{ status: string }>} queueEntries - every row, any status (e.g. store.listQueue()'s output).
+ * @param {Array<{ leasedAt: string | null }>} leaseEntries - in-flight rows only (store.listInProgress()'s output).
+ * @param {number} nowMs
+ */
+export function renderPortfolioQueueMetrics(
+  queueEntries: Array<{ status: string }>,
+  leaseEntries: Array<{ leasedAt: string | null }>,
+  nowMs: number,
+): string {
+  const countByStatus = new Map<string, number>();
+  for (const entry of queueEntries) {
+    countByStatus.set(entry.status, (countByStatus.get(entry.status) ?? 0) + 1);
+  }
+
+  let oldestLeaseAgeSeconds = 0;
+  for (const lease of leaseEntries) {
+    const leasedAtMs = Date.parse(lease.leasedAt ?? "");
+    if (!Number.isFinite(leasedAtMs)) continue;
+    const ageSeconds = Math.max(0, (nowMs - leasedAtMs) / 1000);
+    if (ageSeconds > oldestLeaseAgeSeconds) oldestLeaseAgeSeconds = ageSeconds;
+  }
+
+  const lines = [
+    `# HELP ${QUEUE_ITEMS} ${escapeMetricsHelpText("Current portfolio-queue item count, by status.")}`,
+    `# TYPE ${QUEUE_ITEMS} gauge`,
+  ];
+  for (const [status, count] of [...countByStatus.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`${QUEUE_ITEMS}{status="${status}"} ${count}`);
+  }
+
+  lines.push(
+    `# HELP ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${escapeMetricsHelpText("Age in seconds of the oldest still-in-flight (in_progress) claim lease. 0 when nothing is in-flight.")}`,
+  );
+  lines.push(`# TYPE ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} gauge`);
+  lines.push(`${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${oldestLeaseAgeSeconds}`);
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function runQueueMetrics(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore; nowMs?: number } = {},
+): number {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), QUEUE_METRICS_USAGE);
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const nowMs = Number.isFinite(options.nowMs) ? (options.nowMs as number) : Date.now();
+      // renderPortfolioQueueMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+      console.log(
+        renderPortfolioQueueMetrics(portfolioQueue.listQueue(), portfolioQueue.listInProgress(), nowMs).trimEnd(),
+      );
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}
+
+export function runQueueCli(
+  subcommand: string | undefined,
+  args: string[],
+  options: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+  } = {},
+): number {
+  if (subcommand === "list") return runQueueList(args, options);
+  if (subcommand === "next") return runQueueNext(args, options);
+  if (subcommand === "done") return runQueueDone(args, options);
+  if (subcommand === "release") return runQueueRelease(args, options);
+  if (subcommand === "requeue") return runQueueRequeue(args, options);
+  if (subcommand === "claim-batch") return runQueueClaimBatch(args, options);
+  if (subcommand === "metrics") return runQueueMetrics(args, options);
+  if (subcommand === "dashboard") return runPortfolioDashboard(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
+}


### PR DESCRIPTION
## What

Batch 3.3 of 4 (Phase 3) of the `packages/loopover-miner` TypeScript migration (#7290): converts this batch's six CLI-command modules from hand-maintained `.js` + `.d.ts` pairs into real `.ts` sources, using the in-place-emit `tsc` build pipeline Phase 1 (#7299) established and batches 3.1 (#7305) and 3.2 followed.

Converted:

- `lib/portfolio-queue-cli.ts`
- `lib/loop-cli.ts`
- `lib/governor-metrics-cli.ts`
- `lib/discover-cli.ts`
- `lib/governor-pause-cli.ts`
- `lib/attempt-cli.ts`

For each file, the hand-maintained `.d.ts` sibling is removed and `tsc` regenerates it (plus the compiled `.js` with an inline sourcemap) in place. No `tsconfig.json` change is needed — its existing `lib/**/*.ts` include glob picks the new sources up automatically.

## Why

Mechanical continuation of the package's `.js`→`.ts` migration so these command modules gain real compile-time type checking (`exactOptionalPropertyTypes` included) instead of drift-prone hand-maintained `.d.ts` contracts.

## No behavior change — strictly a type-annotation migration

This is a pure migration: **no runtime logic, guard, try/catch, side effect, or string literal is added, removed, or altered.** The `tsc`-emitted `.js` for each file is token-for-token identical to the original hand-written `.js` apart from cosmetic emitter formatting (multi-line string constants reflowed onto one line, `if (c) return x;` split across two lines, ES6 property shorthand expanded, and trailing commas in multi-line literals) and any `exactOptionalPropertyTypes`-driven `?? null` normalization at a call site (behavior-identical, since the callee already treats a missing / `null` / `undefined` field the same). Every converted module's regenerated `.d.ts` exports the exact same names and signatures as the hand-maintained one it replaces.

In particular, `attempt-cli.ts` preserves its existing behavior verbatim, including the pre-existing `#6011` kill-switch-transition / own-submission failure-capture guards and worktree-retention handling already present in mainline `attempt-cli.js` — none of that logic is touched, only annotated.

## Tests

Existing suites for all six CLIs pass unchanged against the compiled output.

Closes #7307
