### PR TITLE
chore(miner): migrate batch 4.2 foundational lib modules to TypeScript

### DIFF
--- a/packages/loopover-miner/lib/claim-conflict-resolver.d.ts
+++ b/packages/loopover-miner/lib/claim-conflict-resolver.d.ts
@@ -1,39 +1,73 @@
 import type { LiveIssueSnapshot } from "./submission-freshness-check.js";
 import type { ObservedClaim } from "./claim-adjudication.js";
 import type { LocalWriteActionSpec } from "@loopover/engine";
-
-export function assembleCompetingClaims(
-  snapshot: LiveIssueSnapshot | null | undefined,
-  selfPrNumber: number,
-  minerLogin: string,
-): ObservedClaim[];
-
+/**
+ * Assemble the real competing-claims set from a fetched LiveIssueSnapshot: every OTHER open PR referencing
+ * the issue, excluding `selfPrNumber` and any PR authored by `minerLogin` itself (case-insensitive, mirrors
+ * checkSubmissionFreshness's own author comparison -- a login can be echoed back with different casing).
+ * Excluding same-author PRs is deliberate, not an edge case slipping through: a miner never competes against
+ * its own work, so if this login somehow has ANOTHER open PR on the same issue (e.g. a retry after a crash
+ * left a stale one behind), that PR is never treated as a competing claim to lose against -- only a genuinely
+ * different claimant's PR can trigger a real close.
+ * Pure given its inputs.
+ *
+ * @param {import("./submission-freshness-check.js").LiveIssueSnapshot | null | undefined} snapshot
+ * @param {number} selfPrNumber
+ * @param {string} minerLogin
+ * @returns {import("./claim-adjudication.js").ObservedClaim[]}
+ */
+export declare function assembleCompetingClaims(snapshot: LiveIssueSnapshot | null | undefined, selfPrNumber: number, minerLogin: string): ObservedClaim[];
 export type ClaimConflictInput = {
-  repoFullName: string;
-  issueNumber: number;
-  selfPrNumber: number;
-  selfClaimedAt: string | null;
-  minerLogin: string;
+    repoFullName: string;
+    issueNumber: number;
+    selfPrNumber: number;
+    selfClaimedAt: string | null;
+    minerLogin: string;
 };
-
 export type ClaimConflictDeps = {
-  fetchLiveIssueSnapshot: (repoFullName: string, issueNumber: number) => Promise<LiveIssueSnapshot | null>;
-  executeLocalWrite: (spec: LocalWriteActionSpec) => Promise<unknown>;
+    fetchLiveIssueSnapshot: (repoFullName: string, issueNumber: number) => Promise<LiveIssueSnapshot | null>;
+    executeLocalWrite: (spec: LocalWriteActionSpec) => Promise<unknown>;
 };
-
-export type ClaimConflictResult =
-  | { checked: false; reason: "live_state_unavailable" }
-  | { checked: true; isWinner: true; winnerNumber: number | null; competingCount: number }
-  | { checked: true; isWinner: false; winnerNumber: number | null; competingCount: number; closeResult: unknown };
-
+export type ClaimConflictResult = {
+    checked: false;
+    reason: "live_state_unavailable";
+} | {
+    checked: true;
+    isWinner: true;
+    winnerNumber: number | null;
+    competingCount: number;
+} | {
+    checked: true;
+    isWinner: false;
+    winnerNumber: number | null;
+    competingCount: number;
+    closeResult: unknown;
+};
 export type ClaimConflictRetryOptions = {
-  maxAttempts?: number;
-  sleepFn?: (ms: number) => Promise<unknown>;
-  backoffMs?: (attempt: number) => number;
+    maxAttempts?: number;
+    sleepFn?: (ms: number) => Promise<unknown>;
+    backoffMs?: (attempt: number) => number;
 };
-
-export function resolveClaimConflict(
-  input: ClaimConflictInput,
-  deps: ClaimConflictDeps,
-  options?: ClaimConflictRetryOptions,
-): Promise<ClaimConflictResult>;
+/**
+ * Resolve a real claim conflict for an already-submitted PR. Fails OPEN (never closes anything) when the live
+ * snapshot can't be fetched -- an unavailable check is not evidence of a lost claim.
+ *
+ * @param {{ repoFullName: string, issueNumber: number, selfPrNumber: number, selfClaimedAt: string | null, minerLogin: string }} input
+ * @param {{
+ *   fetchLiveIssueSnapshot: (repoFullName: string, issueNumber: number) => Promise<import("./submission-freshness-check.js").LiveIssueSnapshot | null>,
+ *   executeLocalWrite: (spec: import("@loopover/engine").LocalWriteActionSpec) => Promise<unknown>,
+ * }} deps
+ * @param {{ maxAttempts?: number, sleepFn?: (ms: number) => Promise<unknown>, backoffMs?: (attempt: number) => number }} [options]
+ *   Bounded retry for the live-state snapshot fetch (#6058): up to `maxAttempts` (default 3) attempts with
+ *   `backoffMs(attempt)` backoff between them, returning as soon as a competing claim is observed. Pure over
+ *   the injected `sleepFn`/`backoffMs` -- no real timers in tests.
+ * @returns {Promise<{
+ *   checked: boolean,
+ *   reason?: "live_state_unavailable",
+ *   isWinner?: boolean,
+ *   winnerNumber?: number | null,
+ *   competingCount?: number,
+ *   closeResult?: unknown,
+ * }>}
+ */
+export declare function resolveClaimConflict(input: ClaimConflictInput, deps: ClaimConflictDeps, options?: ClaimConflictRetryOptions): Promise<ClaimConflictResult>;

--- a/packages/loopover-miner/lib/claim-conflict-resolver.js
+++ b/packages/loopover-miner/lib/claim-conflict-resolver.js
@@ -24,16 +24,13 @@
 // a few attempts with exponential backoff (following http-retry.js's convention), returning as soon as a
 // competing claim is observed, and otherwise giving a late-propagating competitor time to surface before
 // this miner is declared the winner. The write-authorization boundary (#4833) is unchanged.
-
 import { adjudicateSoftClaim } from "./claim-adjudication.js";
 import { buildClosePrSpec } from "@loopover/engine";
 import { defaultRetryBackoffMs } from "./http-retry.js";
-
 // Bounded retry for the post-submission live-state check (#6058): a few attempts give a competing PR that
 // hasn't propagated through GitHub's search/GraphQL index yet time to surface, without an unbounded loop.
 const DEFAULT_SNAPSHOT_MAX_ATTEMPTS = 3;
 const defaultSnapshotSleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs));
-
 /**
  * Assemble the real competing-claims set from a fetched LiveIssueSnapshot: every OTHER open PR referencing
  * the issue, excluding `selfPrNumber` and any PR authored by `minerLogin` itself (case-insensitive, mirrors
@@ -50,14 +47,13 @@ const defaultSnapshotSleep = (delayMs) => new Promise((resolve) => setTimeout(re
  * @returns {import("./claim-adjudication.js").ObservedClaim[]}
  */
 export function assembleCompetingClaims(snapshot, selfPrNumber, minerLogin) {
-  const minerLoginKey = minerLogin.trim().toLowerCase();
-  const referencingPrs = Array.isArray(snapshot?.referencingPrs) ? snapshot.referencingPrs : [];
-  return referencingPrs
-    .filter((pr) => pr.state === "open" && pr.number !== selfPrNumber)
-    .filter((pr) => typeof pr.authorLogin !== "string" || pr.authorLogin.trim().toLowerCase() !== minerLoginKey)
-    .map((pr) => ({ number: pr.number, claimedAt: pr.createdAt ?? null }));
+    const minerLoginKey = minerLogin.trim().toLowerCase();
+    const referencingPrs = Array.isArray(snapshot?.referencingPrs) ? snapshot.referencingPrs : [];
+    return referencingPrs
+        .filter((pr) => pr.state === "open" && pr.number !== selfPrNumber)
+        .filter((pr) => typeof pr.authorLogin !== "string" || pr.authorLogin.trim().toLowerCase() !== minerLoginKey)
+        .map((pr) => ({ number: pr.number, claimedAt: pr.createdAt ?? null }));
 }
-
 /**
  * Resolve a real claim conflict for an already-submitted PR. Fails OPEN (never closes anything) when the live
  * snapshot can't be fetched -- an unavailable check is not evidence of a lost claim.
@@ -81,50 +77,50 @@ export function assembleCompetingClaims(snapshot, selfPrNumber, minerLogin) {
  * }>}
  */
 export async function resolveClaimConflict(input, deps, options = {}) {
-  const maxAttempts =
-    Number.isFinite(options.maxAttempts) && options.maxAttempts >= 1 ? Math.floor(options.maxAttempts) : DEFAULT_SNAPSHOT_MAX_ATTEMPTS;
-  const sleepFn = typeof options.sleepFn === "function" ? options.sleepFn : defaultSnapshotSleep;
-  const backoffMs = typeof options.backoffMs === "function" ? options.backoffMs : defaultRetryBackoffMs;
-
-  let snapshot = null;
-  let competing = [];
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    let current;
-    try {
-      current = await deps.fetchLiveIssueSnapshot(input.repoFullName, input.issueNumber);
-    } catch {
-      current = null;
+    const maxAttempts = Number.isFinite(options.maxAttempts) && options.maxAttempts >= 1
+        ? Math.floor(options.maxAttempts)
+        : DEFAULT_SNAPSHOT_MAX_ATTEMPTS;
+    const sleepFn = typeof options.sleepFn === "function" ? options.sleepFn : defaultSnapshotSleep;
+    const backoffMs = typeof options.backoffMs === "function" ? options.backoffMs : defaultRetryBackoffMs;
+    let snapshot = null;
+    let competing = [];
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        let current;
+        try {
+            current = await deps.fetchLiveIssueSnapshot(input.repoFullName, input.issueNumber);
+        }
+        catch {
+            current = null;
+        }
+        if (current && typeof current === "object") {
+            snapshot = current;
+            competing = assembleCompetingClaims(current, input.selfPrNumber, input.minerLogin);
+            // A competing claim observed = GitHub's index has propagated it; stop retrying and act on it now.
+            if (competing.length > 0)
+                break;
+        }
+        // Back off before the next attempt (index-propagation lag / a transient fetch failure); never after the last.
+        if (attempt < maxAttempts)
+            await sleepFn(backoffMs(attempt));
     }
-    if (current && typeof current === "object") {
-      snapshot = current;
-      competing = assembleCompetingClaims(current, input.selfPrNumber, input.minerLogin);
-      // A competing claim observed = GitHub's index has propagated it; stop retrying and act on it now.
-      if (competing.length > 0) break;
+    if (!snapshot) {
+        return { checked: false, reason: "live_state_unavailable" };
     }
-    // Back off before the next attempt (index-propagation lag / a transient fetch failure); never after the last.
-    if (attempt < maxAttempts) await sleepFn(backoffMs(attempt));
-  }
-  if (!snapshot) {
-    return { checked: false, reason: "live_state_unavailable" };
-  }
-
-  const adjudication = adjudicateSoftClaim({ number: input.selfPrNumber, claimedAt: input.selfClaimedAt }, competing);
-
-  if (adjudication.isWinner) {
-    return { checked: true, isWinner: true, winnerNumber: adjudication.winnerNumber, competingCount: competing.length };
-  }
-
-  const comment = adjudication.winnerNumber
-    ? `Closing this PR: pull request #${adjudication.winnerNumber} claimed this issue first. This is an automated soft-claim conflict resolution -- no action needed from you.`
-    : `Closing this PR: another open pull request already claims this issue. This is an automated soft-claim conflict resolution -- no action needed from you.`;
-  const spec = buildClosePrSpec({ repoFullName: input.repoFullName, number: input.selfPrNumber, comment });
-  const closeResult = await deps.executeLocalWrite(spec);
-
-  return {
-    checked: true,
-    isWinner: false,
-    winnerNumber: adjudication.winnerNumber,
-    competingCount: competing.length,
-    closeResult,
-  };
+    const adjudication = adjudicateSoftClaim({ number: input.selfPrNumber, claimedAt: input.selfClaimedAt }, competing);
+    if (adjudication.isWinner) {
+        return { checked: true, isWinner: true, winnerNumber: adjudication.winnerNumber, competingCount: competing.length };
+    }
+    const comment = adjudication.winnerNumber
+        ? `Closing this PR: pull request #${adjudication.winnerNumber} claimed this issue first. This is an automated soft-claim conflict resolution -- no action needed from you.`
+        : `Closing this PR: another open pull request already claims this issue. This is an automated soft-claim conflict resolution -- no action needed from you.`;
+    const spec = buildClosePrSpec({ repoFullName: input.repoFullName, number: input.selfPrNumber, comment });
+    const closeResult = await deps.executeLocalWrite(spec);
+    return {
+        checked: true,
+        isWinner: false,
+        winnerNumber: adjudication.winnerNumber,
+        competingCount: competing.length,
+        closeResult,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2xhaW0tY29uZmxpY3QtcmVzb2x2ZXIuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJjbGFpbS1jb25mbGljdC1yZXNvbHZlci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSwwR0FBMEc7QUFDMUcsOEdBQThHO0FBQzlHLDZHQUE2RztBQUM3Ryw2R0FBNkc7QUFDN0csMkdBQTJHO0FBQzNHLDRHQUE0RztBQUM1Ryx5R0FBeUc7QUFDekcsOEdBQThHO0FBQzlHLDhHQUE4RztBQUM5RywrR0FBK0c7QUFDL0csaUNBQWlDO0FBQ2pDLEVBQUU7QUFDRixzR0FBc0c7QUFDdEcsK0dBQStHO0FBQy9HLDJHQUEyRztBQUMzRyw2R0FBNkc7QUFDN0csNEdBQTRHO0FBQzVHLDJHQUEyRztBQUMzRyx1REFBdUQ7QUFDdkQsRUFBRTtBQUNGLHlHQUF5RztBQUN6Ryw2R0FBNkc7QUFDN0csMEdBQTBHO0FBQzFHLHlHQUF5RztBQUN6Ryx5R0FBeUc7QUFDekcsNEZBQTRGO0FBRTVGLE9BQU8sRUFBRSxtQkFBbUIsRUFBRSxNQUFNLHlCQUF5QixDQUFDO0FBQzlELE9BQU8sRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQ3BELE9BQU8sRUFBRSxxQkFBcUIsRUFBRSxNQUFNLGlCQUFpQixDQUFDO0FBS3hELDBHQUEwRztBQUMxRywwR0FBMEc7QUFDMUcsTUFBTSw2QkFBNkIsR0FBRyxDQUFDLENBQUM7QUFDeEMsTUFBTSxvQkFBb0IsR0FBRyxDQUFDLE9BQWUsRUFBaUIsRUFBRSxDQUFDLElBQUksT0FBTyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUUsQ0FBQyxVQUFVLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUM7QUFFeEg7Ozs7Ozs7Ozs7Ozs7O0dBY0c7QUFDSCxNQUFNLFVBQVUsdUJBQXVCLENBQ3JDLFFBQThDLEVBQzlDLFlBQW9CLEVBQ3BCLFVBQWtCO0lBRWxCLE1BQU0sYUFBYSxHQUFHLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQztJQUN0RCxNQUFNLGNBQWMsR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLFFBQVEsRUFBRSxjQUFjLENBQUMsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLGNBQWMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzlGLE9BQU8sY0FBYztTQUNsQixNQUFNLENBQUMsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUFDLEVBQUUsQ0FBQyxLQUFLLEtBQUssTUFBTSxJQUFJLEVBQUUsQ0FBQyxNQUFNLEtBQUssWUFBWSxDQUFDO1NBQ2pFLE1BQU0sQ0FBQyxDQUFDLEVBQUUsRUFBRSxFQUFFLENBQUMsT0FBTyxFQUFFLENBQUMsV0FBVyxLQUFLLFFBQVEsSUFBSSxFQUFFLENBQUMsV0FBVyxDQUFDLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxLQUFLLGFBQWEsQ0FBQztTQUMzRyxHQUFHLENBQUMsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUFDLENBQUMsRUFBRSxNQUFNLEVBQUUsRUFBRSxDQUFDLE1BQU0sRUFBRSxTQUFTLEVBQUUsRUFBRSxDQUFDLFNBQVMsSUFBSSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUM7QUFDM0UsQ0FBQztBQTBCRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0dBcUJHO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSxvQkFBb0IsQ0FDeEMsS0FBeUIsRUFDekIsSUFBdUIsRUFDdkIsVUFBcUMsRUFBRTtJQUV2QyxNQUFNLFdBQVcsR0FDZixNQUFNLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxXQUFXLENBQUMsSUFBSyxPQUFPLENBQUMsV0FBc0IsSUFBSSxDQUFDO1FBQzFFLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxXQUFxQixDQUFDO1FBQzNDLENBQUMsQ0FBQyw2QkFBNkIsQ0FBQztJQUNwQyxNQUFNLE9BQU8sR0FBRyxPQUFPLE9BQU8sQ0FBQyxPQUFPLEtBQUssVUFBVSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxvQkFBb0IsQ0FBQztJQUMvRixNQUFNLFNBQVMsR0FBRyxPQUFPLE9BQU8sQ0FBQyxTQUFTLEtBQUssVUFBVSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxxQkFBcUIsQ0FBQztJQUV0RyxJQUFJLFFBQVEsR0FBNkIsSUFBSSxDQUFDO0lBQzlDLElBQUksU0FBUyxHQUFvQixFQUFFLENBQUM7SUFDcEMsS0FBSyxJQUFJLE9BQU8sR0FBRyxDQUFDLEVBQUUsT0FBTyxJQUFJLFdBQVcsRUFBRSxPQUFPLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDM0QsSUFBSSxPQUFpQyxDQUFDO1FBQ3RDLElBQUksQ0FBQztZQUNILE9BQU8sR0FBRyxNQUFNLElBQUksQ0FBQyxzQkFBc0IsQ0FBQyxLQUFLLENBQUMsWUFBWSxFQUFFLEtBQUssQ0FBQyxXQUFXLENBQUMsQ0FBQztRQUNyRixDQUFDO1FBQUMsTUFBTSxDQUFDO1lBQ1AsT0FBTyxHQUFHLElBQUksQ0FBQztRQUNqQixDQUFDO1FBQ0QsSUFBSSxPQUFPLElBQUksT0FBTyxPQUFPLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDM0MsUUFBUSxHQUFHLE9BQU8sQ0FBQztZQUNuQixTQUFTLEdBQUcsdUJBQXVCLENBQUMsT0FBTyxFQUFFLEtBQUssQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ25GLGtHQUFrRztZQUNsRyxJQUFJLFNBQVMsQ0FBQyxNQUFNLEdBQUcsQ0FBQztnQkFBRSxNQUFNO1FBQ2xDLENBQUM7UUFDRCw4R0FBOEc7UUFDOUcsSUFBSSxPQUFPLEdBQUcsV0FBVztZQUFFLE1BQU0sT0FBTyxDQUFDLFNBQVMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO0lBQy9ELENBQUM7SUFDRCxJQUFJLENBQUMsUUFBUSxFQUFFLENBQUM7UUFDZCxPQUFPLEVBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsd0JBQXdCLEVBQUUsQ0FBQztJQUM5RCxDQUFDO0lBRUQsTUFBTSxZQUFZLEdBQUcsbUJBQW1CLENBQUMsRUFBRSxNQUFNLEVBQUUsS0FBSyxDQUFDLFlBQVksRUFBRSxTQUFTLEVBQUUsS0FBSyxDQUFDLGFBQWEsRUFBRSxFQUFFLFNBQVMsQ0FBQyxDQUFDO0lBRXBILElBQUksWUFBWSxDQUFDLFFBQVEsRUFBRSxDQUFDO1FBQzFCLE9BQU8sRUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsWUFBWSxFQUFFLFlBQVksQ0FBQyxZQUFZLEVBQUUsY0FBYyxFQUFFLFNBQVMsQ0FBQyxNQUFNLEVBQUUsQ0FBQztJQUN0SCxDQUFDO0lBRUQsTUFBTSxPQUFPLEdBQUcsWUFBWSxDQUFDLFlBQVk7UUFDdkMsQ0FBQyxDQUFDLGtDQUFrQyxZQUFZLENBQUMsWUFBWSw4R0FBOEc7UUFDM0ssQ0FBQyxDQUFDLHlKQUF5SixDQUFDO0lBQzlKLE1BQU0sSUFBSSxHQUFHLGdCQUFnQixDQUFDLEVBQUUsWUFBWSxFQUFFLEtBQUssQ0FBQyxZQUFZLEVBQUUsTUFBTSxFQUFFLEtBQUssQ0FBQyxZQUFZLEVBQUUsT0FBTyxFQUFFLENBQUMsQ0FBQztJQUN6RyxNQUFNLFdBQVcsR0FBRyxNQUFNLElBQUksQ0FBQyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUV2RCxPQUFPO1FBQ0wsT0FBTyxFQUFFLElBQUk7UUFDYixRQUFRLEVBQUUsS0FBSztRQUNmLFlBQVksRUFBRSxZQUFZLENBQUMsWUFBWTtRQUN2QyxjQUFjLEVBQUUsU0FBUyxDQUFDLE1BQU07UUFDaEMsV0FBVztLQUNaLENBQUM7QUFDSixDQUFDIn0=

--- a/packages/loopover-miner/lib/claim-conflict-resolver.ts
+++ b/packages/loopover-miner/lib/claim-conflict-resolver.ts
@@ -1,0 +1,167 @@
+// Real claim-conflict resolution (#4848): the missing piece over claim-adjudication.js's own adjudicator,
+// which is correct and well-tested in isolation but has no caller that assembles a REAL competing-claims set.
+// checkSubmissionFreshness (submission-freshness-check.js) already catches the common case pre-submission --
+// aborting before open_pr if another author's PR already references the issue -- but that check can only see
+// what's PUBLIC at the moment it runs. Two miners racing closely enough that BOTH pass their own freshness
+// check before either's PR exists yet is a genuine TOCTOU window freshness cannot close. This module is the
+// POST-submission reconciliation for exactly that window: once THIS miner's PR is real and public, check
+// whether ANOTHER open PR also claims the same issue and, if this miner's claim loses the election, close its
+// own just-opened PR (never anyone else's) -- the write action the contributor-vs-maintainer safety framework
+// keeps maintainer-only (#4833's own scope note), since it means the autonomous loop acts on a race-resolution
+// decision with no human review.
+//
+// CLAIM-TIME ASYMMETRY (documented, not accidental): `self`'s claimedAt is the miner's OWN real local
+// claim-ledger timestamp (claim-ledger.js, recorded before work even started). A competing PR's claimedAt uses
+// its real GitHub `createdAt` instead -- the maintainer gate's own duplicate-winner election uses loopover
+// server's "first observed this PR's linked-issue set" timestamp, but that requires a continuous, persistent
+// observation history this stateless client-side tool does not have for a PR it doesn't own. `createdAt` is
+// the best real, publicly-observable proxy available for someone else's PR -- live-issue-snapshot.js's own
+// comment on `createdAt` explains this in more detail.
+//
+// EVENTUAL CONSISTENCY: this checks GitHub's live state after submission. A competing PR that exists but
+// hasn't yet propagated through GitHub's own search/GraphQL indexing in the first instant would be invisible
+// to a single check, so the live-state snapshot fetch is wrapped in a bounded retry-with-backoff (#6058):
+// a few attempts with exponential backoff (following http-retry.js's convention), returning as soon as a
+// competing claim is observed, and otherwise giving a late-propagating competitor time to surface before
+// this miner is declared the winner. The write-authorization boundary (#4833) is unchanged.
+
+import { adjudicateSoftClaim } from "./claim-adjudication.js";
+import { buildClosePrSpec } from "@loopover/engine";
+import { defaultRetryBackoffMs } from "./http-retry.js";
+import type { LiveIssueSnapshot } from "./submission-freshness-check.js";
+import type { ObservedClaim } from "./claim-adjudication.js";
+import type { LocalWriteActionSpec } from "@loopover/engine";
+
+// Bounded retry for the post-submission live-state check (#6058): a few attempts give a competing PR that
+// hasn't propagated through GitHub's search/GraphQL index yet time to surface, without an unbounded loop.
+const DEFAULT_SNAPSHOT_MAX_ATTEMPTS = 3;
+const defaultSnapshotSleep = (delayMs: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, delayMs));
+
+/**
+ * Assemble the real competing-claims set from a fetched LiveIssueSnapshot: every OTHER open PR referencing
+ * the issue, excluding `selfPrNumber` and any PR authored by `minerLogin` itself (case-insensitive, mirrors
+ * checkSubmissionFreshness's own author comparison -- a login can be echoed back with different casing).
+ * Excluding same-author PRs is deliberate, not an edge case slipping through: a miner never competes against
+ * its own work, so if this login somehow has ANOTHER open PR on the same issue (e.g. a retry after a crash
+ * left a stale one behind), that PR is never treated as a competing claim to lose against -- only a genuinely
+ * different claimant's PR can trigger a real close.
+ * Pure given its inputs.
+ *
+ * @param {import("./submission-freshness-check.js").LiveIssueSnapshot | null | undefined} snapshot
+ * @param {number} selfPrNumber
+ * @param {string} minerLogin
+ * @returns {import("./claim-adjudication.js").ObservedClaim[]}
+ */
+export function assembleCompetingClaims(
+  snapshot: LiveIssueSnapshot | null | undefined,
+  selfPrNumber: number,
+  minerLogin: string,
+): ObservedClaim[] {
+  const minerLoginKey = minerLogin.trim().toLowerCase();
+  const referencingPrs = Array.isArray(snapshot?.referencingPrs) ? snapshot.referencingPrs : [];
+  return referencingPrs
+    .filter((pr) => pr.state === "open" && pr.number !== selfPrNumber)
+    .filter((pr) => typeof pr.authorLogin !== "string" || pr.authorLogin.trim().toLowerCase() !== minerLoginKey)
+    .map((pr) => ({ number: pr.number, claimedAt: pr.createdAt ?? null }));
+}
+
+export type ClaimConflictInput = {
+  repoFullName: string;
+  issueNumber: number;
+  selfPrNumber: number;
+  selfClaimedAt: string | null;
+  minerLogin: string;
+};
+
+export type ClaimConflictDeps = {
+  fetchLiveIssueSnapshot: (repoFullName: string, issueNumber: number) => Promise<LiveIssueSnapshot | null>;
+  executeLocalWrite: (spec: LocalWriteActionSpec) => Promise<unknown>;
+};
+
+export type ClaimConflictResult =
+  | { checked: false; reason: "live_state_unavailable" }
+  | { checked: true; isWinner: true; winnerNumber: number | null; competingCount: number }
+  | { checked: true; isWinner: false; winnerNumber: number | null; competingCount: number; closeResult: unknown };
+
+export type ClaimConflictRetryOptions = {
+  maxAttempts?: number;
+  sleepFn?: (ms: number) => Promise<unknown>;
+  backoffMs?: (attempt: number) => number;
+};
+
+/**
+ * Resolve a real claim conflict for an already-submitted PR. Fails OPEN (never closes anything) when the live
+ * snapshot can't be fetched -- an unavailable check is not evidence of a lost claim.
+ *
+ * @param {{ repoFullName: string, issueNumber: number, selfPrNumber: number, selfClaimedAt: string | null, minerLogin: string }} input
+ * @param {{
+ *   fetchLiveIssueSnapshot: (repoFullName: string, issueNumber: number) => Promise<import("./submission-freshness-check.js").LiveIssueSnapshot | null>,
+ *   executeLocalWrite: (spec: import("@loopover/engine").LocalWriteActionSpec) => Promise<unknown>,
+ * }} deps
+ * @param {{ maxAttempts?: number, sleepFn?: (ms: number) => Promise<unknown>, backoffMs?: (attempt: number) => number }} [options]
+ *   Bounded retry for the live-state snapshot fetch (#6058): up to `maxAttempts` (default 3) attempts with
+ *   `backoffMs(attempt)` backoff between them, returning as soon as a competing claim is observed. Pure over
+ *   the injected `sleepFn`/`backoffMs` -- no real timers in tests.
+ * @returns {Promise<{
+ *   checked: boolean,
+ *   reason?: "live_state_unavailable",
+ *   isWinner?: boolean,
+ *   winnerNumber?: number | null,
+ *   competingCount?: number,
+ *   closeResult?: unknown,
+ * }>}
+ */
+export async function resolveClaimConflict(
+  input: ClaimConflictInput,
+  deps: ClaimConflictDeps,
+  options: ClaimConflictRetryOptions = {},
+): Promise<ClaimConflictResult> {
+  const maxAttempts =
+    Number.isFinite(options.maxAttempts) && (options.maxAttempts as number) >= 1
+      ? Math.floor(options.maxAttempts as number)
+      : DEFAULT_SNAPSHOT_MAX_ATTEMPTS;
+  const sleepFn = typeof options.sleepFn === "function" ? options.sleepFn : defaultSnapshotSleep;
+  const backoffMs = typeof options.backoffMs === "function" ? options.backoffMs : defaultRetryBackoffMs;
+
+  let snapshot: LiveIssueSnapshot | null = null;
+  let competing: ObservedClaim[] = [];
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let current: LiveIssueSnapshot | null;
+    try {
+      current = await deps.fetchLiveIssueSnapshot(input.repoFullName, input.issueNumber);
+    } catch {
+      current = null;
+    }
+    if (current && typeof current === "object") {
+      snapshot = current;
+      competing = assembleCompetingClaims(current, input.selfPrNumber, input.minerLogin);
+      // A competing claim observed = GitHub's index has propagated it; stop retrying and act on it now.
+      if (competing.length > 0) break;
+    }
+    // Back off before the next attempt (index-propagation lag / a transient fetch failure); never after the last.
+    if (attempt < maxAttempts) await sleepFn(backoffMs(attempt));
+  }
+  if (!snapshot) {
+    return { checked: false, reason: "live_state_unavailable" };
+  }
+
+  const adjudication = adjudicateSoftClaim({ number: input.selfPrNumber, claimedAt: input.selfClaimedAt }, competing);
+
+  if (adjudication.isWinner) {
+    return { checked: true, isWinner: true, winnerNumber: adjudication.winnerNumber, competingCount: competing.length };
+  }
+
+  const comment = adjudication.winnerNumber
+    ? `Closing this PR: pull request #${adjudication.winnerNumber} claimed this issue first. This is an automated soft-claim conflict resolution -- no action needed from you.`
+    : `Closing this PR: another open pull request already claims this issue. This is an automated soft-claim conflict resolution -- no action needed from you.`;
+  const spec = buildClosePrSpec({ repoFullName: input.repoFullName, number: input.selfPrNumber, comment });
+  const closeResult = await deps.executeLocalWrite(spec);
+
+  return {
+    checked: true,
+    isWinner: false,
+    winnerNumber: adjudication.winnerNumber,
+    competingCount: competing.length,
+    closeResult,
+  };
+}

--- a/packages/loopover-miner/lib/harness-submission-trigger.d.ts
+++ b/packages/loopover-miner/lib/harness-submission-trigger.d.ts
@@ -1,69 +1,121 @@
-export const HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT: "harness_submission_trigger_decision";
-
+export declare const HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT: "harness_submission_trigger_decision";
 export type HarnessSubmissionSlopBand = "clean" | "low" | "elevated" | "high";
 export type HarnessSubmissionMode = "observe" | "enforce";
 export type HarnessSubmissionKillSwitchScope = "global" | "repo" | "none";
-
 export type HarnessSubmissionCandidateInput = {
-  /** Forwarded to shouldSubmit's own kill-switch check (#2339). */
-  killSwitchScope: HarnessSubmissionKillSwitchScope;
-  repoFullName: string;
-  handoffPacket: {
-    worktreePath: string;
-    branchRef?: string;
-    diffSummary: string;
-    selfReviewVerdict: unknown;
-    attemptLogReference: string;
-  };
-  slopThreshold: HarnessSubmissionSlopBand;
-  mode: HarnessSubmissionMode;
-  maxConsecutiveGateBlocks?: number;
+    /** Forwarded to shouldSubmit's own kill-switch check (#2339). */
+    killSwitchScope: HarnessSubmissionKillSwitchScope;
+    repoFullName: string;
+    handoffPacket: {
+        worktreePath: string;
+        branchRef?: string;
+        diffSummary: string;
+        selfReviewVerdict: unknown;
+        attemptLogReference: string;
+    };
+    slopThreshold: HarnessSubmissionSlopBand;
+    mode: HarnessSubmissionMode;
+    maxConsecutiveGateBlocks?: number;
 };
-
 export interface HarnessSubmissionEventLedger {
-  appendEvent(event: { type: string; repoFullName?: string; payload: Record<string, unknown> }): { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
-  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ type: string; repoFullName?: string | null; payload?: Record<string, unknown>; createdAt: string }>;
+    appendEvent(event: {
+        type: string;
+        repoFullName?: string;
+        payload: Record<string, unknown>;
+    }): {
+        id: number;
+        seq: number;
+        type: string;
+        repoFullName: string | null;
+        payload: Record<string, unknown>;
+        createdAt: string;
+    };
+    readEvents(filter?: {
+        since?: number;
+        repoFullName?: string;
+    }): Array<{
+        type: string;
+        repoFullName?: string | null;
+        payload?: Record<string, unknown>;
+        createdAt: string;
+    }>;
 }
-
 export type HarnessSubmissionDeps = {
-  eventLedger: HarnessSubmissionEventLedger;
-  sessionStartMs?: number;
+    eventLedger: HarnessSubmissionEventLedger;
+    sessionStartMs?: number;
 };
-
 export type HarnessSubmissionDecision = {
-  allow: boolean;
-  reasons: string[];
-  circuitBreakerTripped: boolean;
+    allow: boolean;
+    reasons: string[];
+    circuitBreakerTripped: boolean;
 };
-
 export type HarnessSubmissionResult = {
-  decision: HarnessSubmissionDecision;
-  event: { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
+    decision: HarnessSubmissionDecision;
+    event: {
+        id: number;
+        seq: number;
+        type: string;
+        repoFullName: string | null;
+        payload: Record<string, unknown>;
+        createdAt: string;
+    };
 };
-
-export function countConsecutiveGateBlocks(eventLedger: HarnessSubmissionEventLedger, sinceMs: number): number;
-
-export function evaluateAndRecordHarnessSubmissionTrigger(candidate: HarnessSubmissionCandidateInput, deps: HarnessSubmissionDeps): HarnessSubmissionResult;
-
+/** Count consecutive `allow: false` decisions recorded at or after `sinceMs`, walking backward from the most
+ *  recent decision until an `allow: true` breaks the streak (or history runs out). Session-scoped (not
+ *  filtered by repo) to match the circuit breaker's own "pauses the run entirely" semantics. */
+export declare function countConsecutiveGateBlocks(eventLedger: HarnessSubmissionEventLedger, sinceMs: number): number;
+/**
+ * Evaluate the harness submission trigger for one candidate handoff, reading real session history to compute
+ * the circuit-breaker tally, and always appending exactly one audit event. Fails closed (throws) on a
+ * malformed candidate or missing required dependency.
+ *
+ * @param {{ killSwitchScope: "global"|"repo"|"none", repoFullName: string, handoffPacket: object, slopThreshold: "clean"|"low"|"elevated"|"high", mode: "observe"|"enforce", maxConsecutiveGateBlocks?: number }} candidate
+ * @param {{ eventLedger: object, sessionStartMs?: number }} deps
+ */
+export declare function evaluateAndRecordHarnessSubmissionTrigger(candidate: HarnessSubmissionCandidateInput, deps: HarnessSubmissionDeps): HarnessSubmissionResult;
 /** The exact input shape buildOpenPrSpec (`@loopover/engine`) expects. */
 export type OpenPrInput = {
-  repoFullName: string;
-  base: string;
-  head: string;
-  title: string;
-  body: string;
-  draft: boolean;
+    repoFullName: string;
+    base: string;
+    head: string;
+    title: string;
+    body: string;
+    draft: boolean;
 };
-
 export type PrepareOpenPrSubmissionCandidate = HarnessSubmissionCandidateInput & {
-  base: string;
-  title: string;
-  body?: string;
-  draft?: boolean;
+    base: string;
+    title: string;
+    body?: string;
+    draft?: boolean;
 };
-
-export type PrepareOpenPrSubmissionResult =
-  | { ready: true; decision: HarnessSubmissionDecision; event: HarnessSubmissionResult["event"]; openPrInput: OpenPrInput }
-  | { ready: false; decision: HarnessSubmissionDecision; event: HarnessSubmissionResult["event"] };
-
-export function prepareOpenPrSubmission(candidate: PrepareOpenPrSubmissionCandidate, deps: HarnessSubmissionDeps): PrepareOpenPrSubmissionResult;
+export type PrepareOpenPrSubmissionResult = {
+    ready: true;
+    decision: HarnessSubmissionDecision;
+    event: HarnessSubmissionResult["event"];
+    openPrInput: OpenPrInput;
+} | {
+    ready: false;
+    decision: HarnessSubmissionDecision;
+    event: HarnessSubmissionResult["event"];
+};
+/**
+ * Bridge one completed handoff through the submission gate to a submission-READY payload -- the exact input
+ * shape `buildOpenPrSpec` (`@loopover/engine`) expects (repoFullName/base/head/title/body/draft). On `allow:
+ * true` returns `{ ready: true, decision, event, openPrInput }`; otherwise `{ ready: false, decision, event }`
+ * -- the block reasons are on `decision.reasons` and already on the ledger via the wrapped call either way.
+ * Does NOT call `buildOpenPrSpec` itself: this stays a gate→payload bridge; `attempt-runner.js` (and MCP
+ * `loopover_open_pr` equivalents) take `openPrInput` from a `ready: true` result and call
+ * `buildOpenPrSpec`. The cross-package "unreachable from root src/" reason no longer applies (#5131/#5132
+ * moved the builder into `@loopover/engine`), but the deliberate non-call layering is still necessary.
+ *
+ * Fails closed (throws) on a malformed candidate, mirroring evaluateAndRecordHarnessSubmissionTrigger's own
+ * validation -- a missing PR title/base is a caller bug that must never silently degrade into a garbage spec.
+ * The one field evaluateAndRecordHarnessSubmissionTrigger does NOT itself require -- handoffPacket.branchRef,
+ * optional there because iterate-loop.ts deliberately does not manage worktrees/branches -- IS required here,
+ * but only once the decision is known to be `allow: true`: a PR cannot be opened without a source branch, but a
+ * blocked candidate needs no branch at all, and must not throw for a reason unrelated to why it was blocked.
+ *
+ * @param {{ killSwitchScope: "global"|"repo"|"none", repoFullName: string, handoffPacket: { branchRef?: string, [key: string]: unknown }, slopThreshold: "clean"|"low"|"elevated"|"high", mode: "observe"|"enforce", maxConsecutiveGateBlocks?: number, base: string, title: string, body?: string, draft?: boolean }} candidate
+ * @param {{ eventLedger: object, sessionStartMs?: number }} deps
+ */
+export declare function prepareOpenPrSubmission(candidate: PrepareOpenPrSubmissionCandidate, deps: HarnessSubmissionDeps): PrepareOpenPrSubmissionResult;

--- a/packages/loopover-miner/lib/harness-submission-trigger.js
+++ b/packages/loopover-miner/lib/harness-submission-trigger.js
@@ -1,5 +1,4 @@
 import { evaluateHarnessSubmissionTrigger } from "@loopover/engine";
-
 // Harness submission-gate wiring orchestrator (#2337): the real-IO half of connecting the gated-submission
 // decision (`shouldSubmit`, wrapped by `evaluateHarnessSubmissionTrigger`, @loopover/engine) to a
 // real driving loop's own handoff signal. Reads the session's recent decision history to compute the
@@ -21,24 +20,22 @@ import { evaluateHarnessSubmissionTrigger } from "@loopover/engine";
 // counted across EVERY repo's decisions this session, not scoped to one repo -- distinct from #2338's loop-
 // reentry circuit breaker, which is deliberately per-repo (a rejection streak on one repo must not pause
 // unrelated repos).
-
 export const HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT = "harness_submission_trigger_decision";
-
 /** Count consecutive `allow: false` decisions recorded at or after `sinceMs`, walking backward from the most
  *  recent decision until an `allow: true` breaks the streak (or history runs out). Session-scoped (not
  *  filtered by repo) to match the circuit breaker's own "pauses the run entirely" semantics. */
 export function countConsecutiveGateBlocks(eventLedger, sinceMs) {
-  const decisions = eventLedger
-    .readEvents({})
-    .filter((event) => event.type === HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT && Date.parse(event.createdAt) >= sinceMs);
-  let count = 0;
-  for (let i = decisions.length - 1; i >= 0; i -= 1) {
-    if (decisions[i].payload?.allow === true) break;
-    count += 1;
-  }
-  return count;
+    const decisions = eventLedger
+        .readEvents({})
+        .filter((event) => event.type === HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT && Date.parse(event.createdAt) >= sinceMs);
+    let count = 0;
+    for (let i = decisions.length - 1; i >= 0; i -= 1) {
+        if (decisions[i].payload?.allow === true)
+            break;
+        count += 1;
+    }
+    return count;
 }
-
 /**
  * Evaluate the harness submission trigger for one candidate handoff, reading real session history to compute
  * the circuit-breaker tally, and always appending exactly one audit event. Fails closed (throws) on a
@@ -48,45 +45,44 @@ export function countConsecutiveGateBlocks(eventLedger, sinceMs) {
  * @param {{ eventLedger: object, sessionStartMs?: number }} deps
  */
 export function evaluateAndRecordHarnessSubmissionTrigger(candidate, deps) {
-  if (!candidate || typeof candidate !== "object") throw new Error("invalid_harness_submission_candidate");
-  if (!["global", "repo", "none"].includes(candidate.killSwitchScope)) throw new Error("invalid_kill_switch_scope");
-  const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
-  if (!repoFullName) throw new Error("invalid_repo_full_name");
-  if (!candidate.handoffPacket || typeof candidate.handoffPacket !== "object") throw new Error("invalid_handoff_packet");
-
-  if (!deps || typeof deps !== "object") throw new Error("invalid_harness_submission_deps");
-  const { eventLedger, sessionStartMs = 0 } = deps;
-  if (!eventLedger || typeof eventLedger.appendEvent !== "function" || typeof eventLedger.readEvents !== "function") {
-    throw new Error("invalid_event_ledger");
-  }
-
-  const consecutiveGateBlocks = countConsecutiveGateBlocks(eventLedger, sessionStartMs);
-
-  const decision = evaluateHarnessSubmissionTrigger({
-    killSwitchScope: candidate.killSwitchScope,
-    handoffPacket: candidate.handoffPacket,
-    slopThreshold: candidate.slopThreshold,
-    mode: candidate.mode,
-    consecutiveGateBlocks,
-    maxConsecutiveGateBlocks: candidate.maxConsecutiveGateBlocks,
-  });
-
-  const event = eventLedger.appendEvent({
-    type: HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT,
-    repoFullName,
-    payload: {
-      killSwitchScope: candidate.killSwitchScope,
-      allow: decision.allow,
-      reasons: decision.reasons,
-      circuitBreakerTripped: decision.circuitBreakerTripped,
-      consecutiveGateBlocks,
-      attemptLogReference: candidate.handoffPacket.attemptLogReference ?? null,
-    },
-  });
-
-  return { decision, event };
+    if (!candidate || typeof candidate !== "object")
+        throw new Error("invalid_harness_submission_candidate");
+    if (!["global", "repo", "none"].includes(candidate.killSwitchScope))
+        throw new Error("invalid_kill_switch_scope");
+    const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+    if (!repoFullName)
+        throw new Error("invalid_repo_full_name");
+    if (!candidate.handoffPacket || typeof candidate.handoffPacket !== "object")
+        throw new Error("invalid_handoff_packet");
+    if (!deps || typeof deps !== "object")
+        throw new Error("invalid_harness_submission_deps");
+    const { eventLedger, sessionStartMs = 0 } = deps;
+    if (!eventLedger || typeof eventLedger.appendEvent !== "function" || typeof eventLedger.readEvents !== "function") {
+        throw new Error("invalid_event_ledger");
+    }
+    const consecutiveGateBlocks = countConsecutiveGateBlocks(eventLedger, sessionStartMs);
+    const decision = evaluateHarnessSubmissionTrigger({
+        killSwitchScope: candidate.killSwitchScope,
+        handoffPacket: candidate.handoffPacket,
+        slopThreshold: candidate.slopThreshold,
+        mode: candidate.mode,
+        consecutiveGateBlocks,
+        maxConsecutiveGateBlocks: candidate.maxConsecutiveGateBlocks,
+    });
+    const event = eventLedger.appendEvent({
+        type: HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT,
+        repoFullName,
+        payload: {
+            killSwitchScope: candidate.killSwitchScope,
+            allow: decision.allow,
+            reasons: decision.reasons,
+            circuitBreakerTripped: decision.circuitBreakerTripped,
+            consecutiveGateBlocks,
+            attemptLogReference: candidate.handoffPacket.attemptLogReference ?? null,
+        },
+    });
+    return { decision, event };
 }
-
 /**
  * Bridge one completed handoff through the submission gate to a submission-READY payload -- the exact input
  * shape `buildOpenPrSpec` (`@loopover/engine`) expects (repoFullName/base/head/title/body/draft). On `allow:
@@ -108,31 +104,34 @@ export function evaluateAndRecordHarnessSubmissionTrigger(candidate, deps) {
  * @param {{ eventLedger: object, sessionStartMs?: number }} deps
  */
 export function prepareOpenPrSubmission(candidate, deps) {
-  if (!candidate || typeof candidate !== "object") throw new Error("invalid_harness_submission_candidate");
-  const base = typeof candidate.base === "string" ? candidate.base.trim() : "";
-  if (!base) throw new Error("invalid_pr_base");
-  const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
-  if (!title) throw new Error("invalid_pr_title");
-
-  const { decision, event } = evaluateAndRecordHarnessSubmissionTrigger(candidate, deps);
-  if (!decision.allow) return { ready: false, decision, event };
-
-  // Only reached once evaluateAndRecordHarnessSubmissionTrigger has already validated handoffPacket is a
-  // well-formed object -- safe to read .branchRef directly.
-  const head = typeof candidate.handoffPacket.branchRef === "string" ? candidate.handoffPacket.branchRef.trim() : "";
-  if (!head) throw new Error("invalid_pr_head_branch");
-
-  return {
-    ready: true,
-    decision,
-    event,
-    openPrInput: {
-      repoFullName: candidate.repoFullName.trim(),
-      base,
-      head,
-      title,
-      body: typeof candidate.body === "string" ? candidate.body : "",
-      draft: candidate.draft === true,
-    },
-  };
+    if (!candidate || typeof candidate !== "object")
+        throw new Error("invalid_harness_submission_candidate");
+    const base = typeof candidate.base === "string" ? candidate.base.trim() : "";
+    if (!base)
+        throw new Error("invalid_pr_base");
+    const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
+    if (!title)
+        throw new Error("invalid_pr_title");
+    const { decision, event } = evaluateAndRecordHarnessSubmissionTrigger(candidate, deps);
+    if (!decision.allow)
+        return { ready: false, decision, event };
+    // Only reached once evaluateAndRecordHarnessSubmissionTrigger has already validated handoffPacket is a
+    // well-formed object -- safe to read .branchRef directly.
+    const head = typeof candidate.handoffPacket.branchRef === "string" ? candidate.handoffPacket.branchRef.trim() : "";
+    if (!head)
+        throw new Error("invalid_pr_head_branch");
+    return {
+        ready: true,
+        decision,
+        event,
+        openPrInput: {
+            repoFullName: candidate.repoFullName.trim(),
+            base,
+            head,
+            title,
+            body: typeof candidate.body === "string" ? candidate.body : "",
+            draft: candidate.draft === true,
+        },
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaGFybmVzcy1zdWJtaXNzaW9uLXRyaWdnZXIuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJoYXJuZXNzLXN1Ym1pc3Npb24tdHJpZ2dlci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQUUsZ0NBQWdDLEVBQXNCLE1BQU0sa0JBQWtCLENBQUM7QUFFeEYsMkdBQTJHO0FBQzNHLGtHQUFrRztBQUNsRyxxR0FBcUc7QUFDckcsNEdBQTRHO0FBQzVHLHVHQUF1RztBQUN2RyxFQUFFO0FBQ0YsK0dBQStHO0FBQy9HLDRHQUE0RztBQUM1RyxvRkFBb0Y7QUFDcEYsZ0hBQWdIO0FBQ2hILDZHQUE2RztBQUM3Ryw4R0FBOEc7QUFDOUcsMEdBQTBHO0FBQzFHLDhHQUE4RztBQUM5Ryx5R0FBeUc7QUFDekcseUZBQXlGO0FBQ3pGLEVBQUU7QUFDRiwrR0FBK0c7QUFDL0csNEdBQTRHO0FBQzVHLHlHQUF5RztBQUN6RyxvQkFBb0I7QUFFcEIsTUFBTSxDQUFDLE1BQU0seUNBQXlDLEdBQUcscUNBQThDLENBQUM7QUEyQ3hHOztnR0FFZ0c7QUFDaEcsTUFBTSxVQUFVLDBCQUEwQixDQUFDLFdBQXlDLEVBQUUsT0FBZTtJQUNuRyxNQUFNLFNBQVMsR0FBRyxXQUFXO1NBQzFCLFVBQVUsQ0FBQyxFQUFFLENBQUM7U0FDZCxNQUFNLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUsseUNBQXlDLElBQUksSUFBSSxDQUFDLEtBQUssQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDLElBQUksT0FBTyxDQUFDLENBQUM7SUFDekgsSUFBSSxLQUFLLEdBQUcsQ0FBQyxDQUFDO0lBQ2QsS0FBSyxJQUFJLENBQUMsR0FBRyxTQUFTLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNsRCxJQUFJLFNBQVMsQ0FBQyxDQUFDLENBQUUsQ0FBQyxPQUFPLEVBQUUsS0FBSyxLQUFLLElBQUk7WUFBRSxNQUFNO1FBQ2pELEtBQUssSUFBSSxDQUFDLENBQUM7SUFDYixDQUFDO0lBQ0QsT0FBTyxLQUFLLENBQUM7QUFDZixDQUFDO0FBRUQ7Ozs7Ozs7R0FPRztBQUNILE1BQU0sVUFBVSx5Q0FBeUMsQ0FBQyxTQUEwQyxFQUFFLElBQTJCO0lBQy9ILElBQUksQ0FBQyxTQUFTLElBQUksT0FBTyxTQUFTLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsc0NBQXNDLENBQUMsQ0FBQztJQUN6RyxJQUFJLENBQUMsQ0FBQyxRQUFRLEVBQUUsTUFBTSxFQUFFLE1BQU0sQ0FBQyxDQUFDLFFBQVEsQ0FBQyxTQUFTLENBQUMsZUFBZSxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywyQkFBMkIsQ0FBQyxDQUFDO0lBQ2xILE1BQU0sWUFBWSxHQUFHLE9BQU8sU0FBUyxDQUFDLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNyRyxJQUFJLENBQUMsWUFBWTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQztJQUM3RCxJQUFJLENBQUMsU0FBUyxDQUFDLGFBQWEsSUFBSSxPQUFPLFNBQVMsQ0FBQyxhQUFhLEtBQUssUUFBUTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQztJQUV2SCxJQUFJLENBQUMsSUFBSSxJQUFJLE9BQU8sSUFBSSxLQUFLLFFBQVE7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLGlDQUFpQyxDQUFDLENBQUM7SUFDMUYsTUFBTSxFQUFFLFdBQVcsRUFBRSxjQUFjLEdBQUcsQ0FBQyxFQUFFLEdBQUcsSUFBSSxDQUFDO0lBQ2pELElBQUksQ0FBQyxXQUFXLElBQUksT0FBTyxXQUFXLENBQUMsV0FBVyxLQUFLLFVBQVUsSUFBSSxPQUFPLFdBQVcsQ0FBQyxVQUFVLEtBQUssVUFBVSxFQUFFLENBQUM7UUFDbEgsTUFBTSxJQUFJLEtBQUssQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFFRCxNQUFNLHFCQUFxQixHQUFHLDBCQUEwQixDQUFDLFdBQVcsRUFBRSxjQUFjLENBQUMsQ0FBQztJQUV0RixNQUFNLFFBQVEsR0FBRyxnQ0FBZ0MsQ0FBQztRQUNoRCxlQUFlLEVBQUUsU0FBUyxDQUFDLGVBQWU7UUFDMUMsYUFBYSxFQUFFLFNBQVMsQ0FBQyxhQUE4QjtRQUN2RCxhQUFhLEVBQUUsU0FBUyxDQUFDLGFBQWE7UUFDdEMsSUFBSSxFQUFFLFNBQVMsQ0FBQyxJQUFJO1FBQ3BCLHFCQUFxQjtRQUNyQix3QkFBd0IsRUFBRSxTQUFTLENBQUMsd0JBQXdCO0tBQzdELENBQUMsQ0FBQztJQUVILE1BQU0sS0FBSyxHQUFHLFdBQVcsQ0FBQyxXQUFXLENBQUM7UUFDcEMsSUFBSSxFQUFFLHlDQUF5QztRQUMvQyxZQUFZO1FBQ1osT0FBTyxFQUFFO1lBQ1AsZUFBZSxFQUFFLFNBQVMsQ0FBQyxlQUFlO1lBQzFDLEtBQUssRUFBRSxRQUFRLENBQUMsS0FBSztZQUNyQixPQUFPLEVBQUUsUUFBUSxDQUFDLE9BQU87WUFDekIscUJBQXFCLEVBQUUsUUFBUSxDQUFDLHFCQUFxQjtZQUNyRCxxQkFBcUI7WUFDckIsbUJBQW1CLEVBQUUsU0FBUyxDQUFDLGFBQWEsQ0FBQyxtQkFBbUIsSUFBSSxJQUFJO1NBQ3pFO0tBQ0YsQ0FBQyxDQUFDO0lBRUgsT0FBTyxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUM3QixDQUFDO0FBdUJEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0dBbUJHO0FBQ0gsTUFBTSxVQUFVLHVCQUF1QixDQUFDLFNBQTJDLEVBQUUsSUFBMkI7SUFDOUcsSUFBSSxDQUFDLFNBQVMsSUFBSSxPQUFPLFNBQVMsS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxzQ0FBc0MsQ0FBQyxDQUFDO0lBQ3pHLE1BQU0sSUFBSSxHQUFHLE9BQU8sU0FBUyxDQUFDLElBQUksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUM3RSxJQUFJLENBQUMsSUFBSTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsaUJBQWlCLENBQUMsQ0FBQztJQUM5QyxNQUFNLEtBQUssR0FBRyxPQUFPLFNBQVMsQ0FBQyxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDaEYsSUFBSSxDQUFDLEtBQUs7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLGtCQUFrQixDQUFDLENBQUM7SUFFaEQsTUFBTSxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsR0FBRyx5Q0FBeUMsQ0FBQyxTQUFTLEVBQUUsSUFBSSxDQUFDLENBQUM7SUFDdkYsSUFBSSxDQUFDLFFBQVEsQ0FBQyxLQUFLO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxDQUFDO0lBRTlELHVHQUF1RztJQUN2RywwREFBMEQ7SUFDMUQsTUFBTSxJQUFJLEdBQUcsT0FBTyxTQUFTLENBQUMsYUFBYSxDQUFDLFNBQVMsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxhQUFhLENBQUMsU0FBUyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDbkgsSUFBSSxDQUFDLElBQUk7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7SUFFckQsT0FBTztRQUNMLEtBQUssRUFBRSxJQUFJO1FBQ1gsUUFBUTtRQUNSLEtBQUs7UUFDTCxXQUFXLEVBQUU7WUFDWCxZQUFZLEVBQUUsU0FBUyxDQUFDLFlBQVksQ0FBQyxJQUFJLEVBQUU7WUFDM0MsSUFBSTtZQUNKLElBQUk7WUFDSixLQUFLO1lBQ0wsSUFBSSxFQUFFLE9BQU8sU0FBUyxDQUFDLElBQUksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUU7WUFDOUQsS0FBSyxFQUFFLFNBQVMsQ0FBQyxLQUFLLEtBQUssSUFBSTtTQUNoQztLQUNGLENBQUM7QUFDSixDQUFDIn0=

--- a/packages/loopover-miner/lib/harness-submission-trigger.ts
+++ b/packages/loopover-miner/lib/harness-submission-trigger.ts
@@ -1,0 +1,200 @@
+import { evaluateHarnessSubmissionTrigger, type HandoffPacket } from "@loopover/engine";
+
+// Harness submission-gate wiring orchestrator (#2337): the real-IO half of connecting the gated-submission
+// decision (`shouldSubmit`, wrapped by `evaluateHarnessSubmissionTrigger`, @loopover/engine) to a
+// real driving loop's own handoff signal. Reads the session's recent decision history to compute the
+// consecutive-block circuit-breaker tally, consults the pure decision, and always records exactly one audit
+// event -- regardless of outcome, so a paused-pending-human-review session leaves a full trail of why.
+//
+// NOT WIRED INTO ANY AUTOMATIC SCHEDULE: per this issue's own "manual owner sign-off on the wiring before this
+// ships to any default-on profile" deliverable. `prepareOpenPrSubmission` below is the gate→payload bridge:
+// on `allow: true` it shapes the exact input `buildOpenPrSpec` (`@loopover/engine`,
+// `packages/loopover-engine/src/miner/local-write-tools.ts`, re-exported from the engine public barrel) expects
+// as `openPrInput`. It deliberately does NOT call `buildOpenPrSpec` itself -- that stays the caller's job so
+// this module stays a decision-to-payload bridge. The in-package caller is `attempt-runner.js`, which imports
+// `buildOpenPrSpec` from `@loopover/engine` and runs it after a `ready: true` result (the pre-#5131/#5132
+// "unreachable from root `src/mcp/`" boundary no longer applies, but the layering still does: gate evaluate →
+// shape openPrInput here → build the runnable local-write spec in the driver). Equivalent MCP call sites
+// (e.g. `loopover_open_pr`) can likewise take `openPrInput` from a `ready: true` result.
+//
+// SESSION-SCOPED, NOT PER-REPO: the circuit breaker's own "pauses the run entirely" wording means the tally is
+// counted across EVERY repo's decisions this session, not scoped to one repo -- distinct from #2338's loop-
+// reentry circuit breaker, which is deliberately per-repo (a rejection streak on one repo must not pause
+// unrelated repos).
+
+export const HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT = "harness_submission_trigger_decision" as const;
+
+export type HarnessSubmissionSlopBand = "clean" | "low" | "elevated" | "high";
+export type HarnessSubmissionMode = "observe" | "enforce";
+export type HarnessSubmissionKillSwitchScope = "global" | "repo" | "none";
+
+export type HarnessSubmissionCandidateInput = {
+  /** Forwarded to shouldSubmit's own kill-switch check (#2339). */
+  killSwitchScope: HarnessSubmissionKillSwitchScope;
+  repoFullName: string;
+  handoffPacket: {
+    worktreePath: string;
+    branchRef?: string;
+    diffSummary: string;
+    selfReviewVerdict: unknown;
+    attemptLogReference: string;
+  };
+  slopThreshold: HarnessSubmissionSlopBand;
+  mode: HarnessSubmissionMode;
+  maxConsecutiveGateBlocks?: number;
+};
+
+export interface HarnessSubmissionEventLedger {
+  appendEvent(event: { type: string; repoFullName?: string; payload: Record<string, unknown> }): { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
+  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ type: string; repoFullName?: string | null; payload?: Record<string, unknown>; createdAt: string }>;
+}
+
+export type HarnessSubmissionDeps = {
+  eventLedger: HarnessSubmissionEventLedger;
+  sessionStartMs?: number;
+};
+
+export type HarnessSubmissionDecision = {
+  allow: boolean;
+  reasons: string[];
+  circuitBreakerTripped: boolean;
+};
+
+export type HarnessSubmissionResult = {
+  decision: HarnessSubmissionDecision;
+  event: { id: number; seq: number; type: string; repoFullName: string | null; payload: Record<string, unknown>; createdAt: string };
+};
+
+/** Count consecutive `allow: false` decisions recorded at or after `sinceMs`, walking backward from the most
+ *  recent decision until an `allow: true` breaks the streak (or history runs out). Session-scoped (not
+ *  filtered by repo) to match the circuit breaker's own "pauses the run entirely" semantics. */
+export function countConsecutiveGateBlocks(eventLedger: HarnessSubmissionEventLedger, sinceMs: number): number {
+  const decisions = eventLedger
+    .readEvents({})
+    .filter((event) => event.type === HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT && Date.parse(event.createdAt) >= sinceMs);
+  let count = 0;
+  for (let i = decisions.length - 1; i >= 0; i -= 1) {
+    if (decisions[i]!.payload?.allow === true) break;
+    count += 1;
+  }
+  return count;
+}
+
+/**
+ * Evaluate the harness submission trigger for one candidate handoff, reading real session history to compute
+ * the circuit-breaker tally, and always appending exactly one audit event. Fails closed (throws) on a
+ * malformed candidate or missing required dependency.
+ *
+ * @param {{ killSwitchScope: "global"|"repo"|"none", repoFullName: string, handoffPacket: object, slopThreshold: "clean"|"low"|"elevated"|"high", mode: "observe"|"enforce", maxConsecutiveGateBlocks?: number }} candidate
+ * @param {{ eventLedger: object, sessionStartMs?: number }} deps
+ */
+export function evaluateAndRecordHarnessSubmissionTrigger(candidate: HarnessSubmissionCandidateInput, deps: HarnessSubmissionDeps): HarnessSubmissionResult {
+  if (!candidate || typeof candidate !== "object") throw new Error("invalid_harness_submission_candidate");
+  if (!["global", "repo", "none"].includes(candidate.killSwitchScope)) throw new Error("invalid_kill_switch_scope");
+  const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+  if (!repoFullName) throw new Error("invalid_repo_full_name");
+  if (!candidate.handoffPacket || typeof candidate.handoffPacket !== "object") throw new Error("invalid_handoff_packet");
+
+  if (!deps || typeof deps !== "object") throw new Error("invalid_harness_submission_deps");
+  const { eventLedger, sessionStartMs = 0 } = deps;
+  if (!eventLedger || typeof eventLedger.appendEvent !== "function" || typeof eventLedger.readEvents !== "function") {
+    throw new Error("invalid_event_ledger");
+  }
+
+  const consecutiveGateBlocks = countConsecutiveGateBlocks(eventLedger, sessionStartMs);
+
+  const decision = evaluateHarnessSubmissionTrigger({
+    killSwitchScope: candidate.killSwitchScope,
+    handoffPacket: candidate.handoffPacket as HandoffPacket,
+    slopThreshold: candidate.slopThreshold,
+    mode: candidate.mode,
+    consecutiveGateBlocks,
+    maxConsecutiveGateBlocks: candidate.maxConsecutiveGateBlocks,
+  });
+
+  const event = eventLedger.appendEvent({
+    type: HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT,
+    repoFullName,
+    payload: {
+      killSwitchScope: candidate.killSwitchScope,
+      allow: decision.allow,
+      reasons: decision.reasons,
+      circuitBreakerTripped: decision.circuitBreakerTripped,
+      consecutiveGateBlocks,
+      attemptLogReference: candidate.handoffPacket.attemptLogReference ?? null,
+    },
+  });
+
+  return { decision, event };
+}
+
+/** The exact input shape buildOpenPrSpec (`@loopover/engine`) expects. */
+export type OpenPrInput = {
+  repoFullName: string;
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  draft: boolean;
+};
+
+export type PrepareOpenPrSubmissionCandidate = HarnessSubmissionCandidateInput & {
+  base: string;
+  title: string;
+  body?: string;
+  draft?: boolean;
+};
+
+export type PrepareOpenPrSubmissionResult =
+  | { ready: true; decision: HarnessSubmissionDecision; event: HarnessSubmissionResult["event"]; openPrInput: OpenPrInput }
+  | { ready: false; decision: HarnessSubmissionDecision; event: HarnessSubmissionResult["event"] };
+
+/**
+ * Bridge one completed handoff through the submission gate to a submission-READY payload -- the exact input
+ * shape `buildOpenPrSpec` (`@loopover/engine`) expects (repoFullName/base/head/title/body/draft). On `allow:
+ * true` returns `{ ready: true, decision, event, openPrInput }`; otherwise `{ ready: false, decision, event }`
+ * -- the block reasons are on `decision.reasons` and already on the ledger via the wrapped call either way.
+ * Does NOT call `buildOpenPrSpec` itself: this stays a gate→payload bridge; `attempt-runner.js` (and MCP
+ * `loopover_open_pr` equivalents) take `openPrInput` from a `ready: true` result and call
+ * `buildOpenPrSpec`. The cross-package "unreachable from root src/" reason no longer applies (#5131/#5132
+ * moved the builder into `@loopover/engine`), but the deliberate non-call layering is still necessary.
+ *
+ * Fails closed (throws) on a malformed candidate, mirroring evaluateAndRecordHarnessSubmissionTrigger's own
+ * validation -- a missing PR title/base is a caller bug that must never silently degrade into a garbage spec.
+ * The one field evaluateAndRecordHarnessSubmissionTrigger does NOT itself require -- handoffPacket.branchRef,
+ * optional there because iterate-loop.ts deliberately does not manage worktrees/branches -- IS required here,
+ * but only once the decision is known to be `allow: true`: a PR cannot be opened without a source branch, but a
+ * blocked candidate needs no branch at all, and must not throw for a reason unrelated to why it was blocked.
+ *
+ * @param {{ killSwitchScope: "global"|"repo"|"none", repoFullName: string, handoffPacket: { branchRef?: string, [key: string]: unknown }, slopThreshold: "clean"|"low"|"elevated"|"high", mode: "observe"|"enforce", maxConsecutiveGateBlocks?: number, base: string, title: string, body?: string, draft?: boolean }} candidate
+ * @param {{ eventLedger: object, sessionStartMs?: number }} deps
+ */
+export function prepareOpenPrSubmission(candidate: PrepareOpenPrSubmissionCandidate, deps: HarnessSubmissionDeps): PrepareOpenPrSubmissionResult {
+  if (!candidate || typeof candidate !== "object") throw new Error("invalid_harness_submission_candidate");
+  const base = typeof candidate.base === "string" ? candidate.base.trim() : "";
+  if (!base) throw new Error("invalid_pr_base");
+  const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
+  if (!title) throw new Error("invalid_pr_title");
+
+  const { decision, event } = evaluateAndRecordHarnessSubmissionTrigger(candidate, deps);
+  if (!decision.allow) return { ready: false, decision, event };
+
+  // Only reached once evaluateAndRecordHarnessSubmissionTrigger has already validated handoffPacket is a
+  // well-formed object -- safe to read .branchRef directly.
+  const head = typeof candidate.handoffPacket.branchRef === "string" ? candidate.handoffPacket.branchRef.trim() : "";
+  if (!head) throw new Error("invalid_pr_head_branch");
+
+  return {
+    ready: true,
+    decision,
+    event,
+    openPrInput: {
+      repoFullName: candidate.repoFullName.trim(),
+      base,
+      head,
+      title,
+      body: typeof candidate.body === "string" ? candidate.body : "",
+      draft: candidate.draft === true,
+    },
+  };
+}

--- a/packages/loopover-miner/lib/opportunity-ranker.d.ts
+++ b/packages/loopover-miner/lib/opportunity-ranker.d.ts
@@ -1,36 +1,29 @@
 import type { MinerGoalSpec } from "@loopover/engine";
 import type { RawCandidateIssue } from "./opportunity-fanout.js";
-
 export type RankedCandidateIssue = RawCandidateIssue & {
-  potential: number;
-  feasibility: number;
-  laneFit: number;
-  freshness: number;
-  dupRisk: number;
-  rankScore: number;
+    potential: number;
+    feasibility: number;
+    laneFit: number;
+    freshness: number;
+    dupRisk: number;
+    rankScore: number;
 };
-
 export type RankCandidateIssuesOptions = {
-  nowMs?: number;
-  highRiskDuplicateClusters?: number;
-  openPullRequests?: number;
-  goalSpecsByRepo?: Record<string, MinerGoalSpec>;
-  goalSpecContentByRepo?: Record<string, string>;
+    nowMs?: number;
+    highRiskDuplicateClusters?: number;
+    openPullRequests?: number;
+    goalSpecsByRepo?: Record<string, MinerGoalSpec>;
+    goalSpecContentByRepo?: Record<string, string>;
 };
-
 export type RankedCandidateSummary = {
-  issues: RankedCandidateIssue[];
-  skippedInvalid: number;
-  usedDefaultGoalSpec: boolean;
-  defaultGoalSpec: MinerGoalSpec;
+    issues: RankedCandidateIssue[];
+    skippedInvalid: number;
+    usedDefaultGoalSpec: boolean;
+    defaultGoalSpec: MinerGoalSpec;
 };
-
-export function rankCandidateIssues(
-  candidates: RawCandidateIssue[],
-  options?: RankCandidateIssuesOptions,
-): RankedCandidateIssue[];
-
-export function rankCandidateIssuesWithSummary(
-  candidates: RawCandidateIssue[],
-  options?: RankCandidateIssuesOptions,
-): RankedCandidateSummary;
+/**
+ * Rank metadata-only fan-out candidates locally. Never clones source, never uploads metadata, and never writes to
+ * GitHub — it only composes deterministic engine signals and returns the sorted list.
+ */
+export declare function rankCandidateIssues(candidates: RawCandidateIssue[], options?: RankCandidateIssuesOptions): RankedCandidateIssue[];
+export declare function rankCandidateIssuesWithSummary(candidates: RawCandidateIssue[], options?: RankCandidateIssuesOptions): RankedCandidateSummary;

--- a/packages/loopover-miner/lib/opportunity-ranker.js
+++ b/packages/loopover-miner/lib/opportunity-ranker.js
@@ -1,122 +1,115 @@
-import {
-  DEFAULT_MINER_GOAL_SPEC,
-  parseMinerGoalSpecContent,
-  rankMetadataOpportunities,
-} from "@loopover/engine";
-
+import { DEFAULT_MINER_GOAL_SPEC, parseMinerGoalSpecContent, rankMetadataOpportunities, } from "@loopover/engine";
 function finiteEpochMs(value) {
-  return Number.isFinite(value) ? value : Date.now();
+    return Number.isFinite(value) ? value : Date.now();
 }
-
 function finiteNonNegativeInt(value) {
-  if (!Number.isFinite(value)) return 0;
-  return Math.max(0, Math.floor(value));
+    if (!Number.isFinite(value))
+        return 0;
+    return Math.max(0, Math.floor(value));
 }
-
 function normalizeCandidate(candidate) {
-  if (!candidate || typeof candidate !== "object") return null;
-  const repoFullName =
-    typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
-  const issueNumber = candidate.issueNumber;
-  const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !title) return null;
-  const canonicalRepoFullName = `${owner}/${repo}`;
-  const labels = Array.isArray(candidate.labels)
-    ? candidate.labels
-        .filter((label) => typeof label === "string" && label.trim())
-        .map((label) => label.trim())
-    : [];
-  return {
-    owner,
-    repo,
-    repoFullName: canonicalRepoFullName,
-    issueNumber,
-    title,
-    labels,
-    commentsCount: Number.isFinite(candidate.commentsCount) ? candidate.commentsCount : 0,
-    createdAt: typeof candidate.createdAt === "string" ? candidate.createdAt : null,
-    updatedAt: typeof candidate.updatedAt === "string" ? candidate.updatedAt : null,
-    htmlUrl: typeof candidate.htmlUrl === "string" ? candidate.htmlUrl : null,
-    aiPolicyAllowed: candidate.aiPolicyAllowed !== false,
-    aiPolicySource:
-      candidate.aiPolicySource === "AI-USAGE.md" ||
-      candidate.aiPolicySource === "CONTRIBUTING.md" ||
-      candidate.aiPolicySource === "none"
-        ? candidate.aiPolicySource
-        : "none",
-  };
+    if (!candidate || typeof candidate !== "object")
+        return null;
+    const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+    const issueNumber = candidate.issueNumber;
+    const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !title)
+        return null;
+    const canonicalRepoFullName = `${owner}/${repo}`;
+    const labels = Array.isArray(candidate.labels)
+        ? candidate.labels
+            .filter((label) => typeof label === "string" && label.trim())
+            .map((label) => label.trim())
+        : [];
+    return {
+        owner,
+        repo,
+        repoFullName: canonicalRepoFullName,
+        issueNumber,
+        title,
+        labels,
+        commentsCount: Number.isFinite(candidate.commentsCount) ? candidate.commentsCount : 0,
+        createdAt: typeof candidate.createdAt === "string" ? candidate.createdAt : null,
+        updatedAt: typeof candidate.updatedAt === "string" ? candidate.updatedAt : null,
+        htmlUrl: typeof candidate.htmlUrl === "string" ? candidate.htmlUrl : null,
+        aiPolicyAllowed: candidate.aiPolicyAllowed !== false,
+        aiPolicySource: candidate.aiPolicySource === "AI-USAGE.md" ||
+            candidate.aiPolicySource === "CONTRIBUTING.md" ||
+            candidate.aiPolicySource === "none"
+            ? candidate.aiPolicySource
+            : "none",
+    };
 }
-
 function buildGoalSpecsByRepo(options = {}) {
-  const goalSpecsByRepo = { ...(options.goalSpecsByRepo ?? {}) };
-  const rawContentByRepo = options.goalSpecContentByRepo ?? {};
-  for (const [repoFullName, content] of Object.entries(rawContentByRepo)) {
-    if (typeof content !== "string" || !content.trim()) continue;
-    goalSpecsByRepo[repoFullName] = parseMinerGoalSpecContent(content).spec;
-  }
-  return goalSpecsByRepo;
-}
-
-function buildRankContext(options = {}) {
-  return {
-    nowMs: finiteEpochMs(options.nowMs),
-    highRiskDuplicateClusters: finiteNonNegativeInt(options.highRiskDuplicateClusters),
-    openPullRequests: finiteNonNegativeInt(options.openPullRequests),
-    goalSpecsByRepo: buildGoalSpecsByRepo(options),
-  };
-}
-
-function collectCandidates(candidates) {
-  const input = Array.isArray(candidates) ? candidates : [];
-  let skippedInvalid = 0;
-  const normalized = [];
-  const seen = new Set();
-  for (const candidate of input) {
-    const entry = normalizeCandidate(candidate);
-    if (!entry) {
-      skippedInvalid += 1;
-      continue;
+    const goalSpecsByRepo = { ...(options.goalSpecsByRepo ?? {}) };
+    const rawContentByRepo = options.goalSpecContentByRepo ?? {};
+    for (const [repoFullName, content] of Object.entries(rawContentByRepo)) {
+        if (typeof content !== "string" || !content.trim())
+            continue;
+        goalSpecsByRepo[repoFullName] = parseMinerGoalSpecContent(content).spec;
     }
-    const key = `${entry.repoFullName.toLowerCase()}#${entry.issueNumber}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    normalized.push(entry);
-  }
-  return { normalized, skippedInvalid };
+    return goalSpecsByRepo;
 }
-
+function buildRankContext(options = {}) {
+    return {
+        nowMs: finiteEpochMs(options.nowMs),
+        highRiskDuplicateClusters: finiteNonNegativeInt(options.highRiskDuplicateClusters),
+        openPullRequests: finiteNonNegativeInt(options.openPullRequests),
+        goalSpecsByRepo: buildGoalSpecsByRepo(options),
+    };
+}
+function collectCandidates(candidates) {
+    const input = Array.isArray(candidates) ? candidates : [];
+    let skippedInvalid = 0;
+    const normalized = [];
+    const seen = new Set();
+    for (const candidate of input) {
+        const entry = normalizeCandidate(candidate);
+        if (!entry) {
+            skippedInvalid += 1;
+            continue;
+        }
+        const key = `${entry.repoFullName.toLowerCase()}#${entry.issueNumber}`;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        normalized.push(entry);
+    }
+    return { normalized, skippedInvalid };
+}
 function rankedUsesDefaultGoalSpec(ranked, options = {}) {
-  const goalSpecsByRepo = buildGoalSpecsByRepo(options);
-  const specRepos = Object.keys(goalSpecsByRepo);
-  if (ranked.length === 0) return specRepos.length === 0;
-  // The "ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)" note is only
-  // truthful when the WHOLE batch fell back to the default -- so require EVERY ranked repo to lack a supplied spec,
-  // not just any one of them (#7226). With `.some`, a single spec-less repo made a mixed batch (where other repos
-  // genuinely had a spec supplied and applied) print the blanket note as if none did.
-  return ranked.every((issue) => {
-    const target = issue.repoFullName.trim().toLowerCase();
-    return !specRepos.some((repo) => repo.trim().toLowerCase() === target);
-  });
+    const goalSpecsByRepo = buildGoalSpecsByRepo(options);
+    const specRepos = Object.keys(goalSpecsByRepo);
+    if (ranked.length === 0)
+        return specRepos.length === 0;
+    // The "ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)" note is only
+    // truthful when the WHOLE batch fell back to the default -- so require EVERY ranked repo to lack a supplied spec,
+    // not just any one of them (#7226). With `.some`, a single spec-less repo made a mixed batch (where other repos
+    // genuinely had a spec supplied and applied) print the blanket note as if none did.
+    return ranked.every((issue) => {
+        const target = issue.repoFullName.trim().toLowerCase();
+        return !specRepos.some((repo) => repo.trim().toLowerCase() === target);
+    });
 }
-
 /**
  * Rank metadata-only fan-out candidates locally. Never clones source, never uploads metadata, and never writes to
  * GitHub — it only composes deterministic engine signals and returns the sorted list.
  */
 export function rankCandidateIssues(candidates, options = {}) {
-  const { normalized } = collectCandidates(candidates);
-  return rankMetadataOpportunities(normalized, buildRankContext(options));
+    const { normalized } = collectCandidates(candidates);
+    return rankMetadataOpportunities(normalized, buildRankContext(options));
 }
-
 export function rankCandidateIssuesWithSummary(candidates, options = {}) {
-  const { normalized, skippedInvalid } = collectCandidates(candidates);
-  const ranked = rankMetadataOpportunities(normalized, buildRankContext(options));
-  return {
-    issues: ranked,
-    skippedInvalid,
-    usedDefaultGoalSpec: rankedUsesDefaultGoalSpec(ranked, options),
-    defaultGoalSpec: DEFAULT_MINER_GOAL_SPEC,
-  };
+    const { normalized, skippedInvalid } = collectCandidates(candidates);
+    const ranked = rankMetadataOpportunities(normalized, buildRankContext(options));
+    return {
+        issues: ranked,
+        skippedInvalid,
+        usedDefaultGoalSpec: rankedUsesDefaultGoalSpec(ranked, options),
+        defaultGoalSpec: DEFAULT_MINER_GOAL_SPEC,
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3Bwb3J0dW5pdHktcmFua2VyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsib3Bwb3J0dW5pdHktcmFua2VyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFDTCx1QkFBdUIsRUFDdkIseUJBQXlCLEVBQ3pCLHlCQUF5QixHQUMxQixNQUFNLGtCQUFrQixDQUFDO0FBNEIxQixTQUFTLGFBQWEsQ0FBQyxLQUFjO0lBQ25DLE9BQU8sTUFBTSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUUsS0FBZ0IsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO0FBQ2pFLENBQUM7QUFFRCxTQUFTLG9CQUFvQixDQUFDLEtBQWM7SUFDMUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDO1FBQUUsT0FBTyxDQUFDLENBQUM7SUFDdEMsT0FBTyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxJQUFJLENBQUMsS0FBSyxDQUFDLEtBQWUsQ0FBQyxDQUFDLENBQUM7QUFDbEQsQ0FBQztBQUVELFNBQVMsa0JBQWtCLENBQUMsU0FBa0M7SUFDNUQsSUFBSSxDQUFDLFNBQVMsSUFBSSxPQUFPLFNBQVMsS0FBSyxRQUFRO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDN0QsTUFBTSxZQUFZLEdBQ2hCLE9BQU8sU0FBUyxDQUFDLFlBQVksS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNsRixNQUFNLFdBQVcsR0FBRyxTQUFTLENBQUMsV0FBcUIsQ0FBQztJQUNwRCxNQUFNLEtBQUssR0FBRyxPQUFPLFNBQVMsQ0FBQyxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDaEYsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsWUFBWSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNyRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDeEQsSUFBSSxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsV0FBVyxDQUFDLElBQUksV0FBVyxJQUFJLENBQUMsSUFBSSxDQUFDLEtBQUs7UUFBRSxPQUFPLElBQUksQ0FBQztJQUM5RSxNQUFNLHFCQUFxQixHQUFHLEdBQUcsS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO0lBQ2pELE1BQU0sTUFBTSxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLE1BQU0sQ0FBQztRQUM1QyxDQUFDLENBQUMsU0FBUyxDQUFDLE1BQU07YUFDYixNQUFNLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLE9BQU8sS0FBSyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7YUFDNUQsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDakMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUNQLE9BQU87UUFDTCxLQUFLO1FBQ0wsSUFBSTtRQUNKLFlBQVksRUFBRSxxQkFBcUI7UUFDbkMsV0FBVztRQUNYLEtBQUs7UUFDTCxNQUFNO1FBQ04sYUFBYSxFQUFFLE1BQU0sQ0FBQyxRQUFRLENBQUMsU0FBUyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsQ0FBRSxTQUFTLENBQUMsYUFBd0IsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNqRyxTQUFTLEVBQUUsT0FBTyxTQUFTLENBQUMsU0FBUyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsSUFBSTtRQUMvRSxTQUFTLEVBQUUsT0FBTyxTQUFTLENBQUMsU0FBUyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsSUFBSTtRQUMvRSxPQUFPLEVBQUUsT0FBTyxTQUFTLENBQUMsT0FBTyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsSUFBSTtRQUN6RSxlQUFlLEVBQUUsU0FBUyxDQUFDLGVBQWUsS0FBSyxLQUFLO1FBQ3BELGNBQWMsRUFDWixTQUFTLENBQUMsY0FBYyxLQUFLLGFBQWE7WUFDMUMsU0FBUyxDQUFDLGNBQWMsS0FBSyxpQkFBaUI7WUFDOUMsU0FBUyxDQUFDLGNBQWMsS0FBSyxNQUFNO1lBQ2pDLENBQUMsQ0FBQyxTQUFTLENBQUMsY0FBYztZQUMxQixDQUFDLENBQUMsTUFBTTtLQUNiLENBQUM7QUFDSixDQUFDO0FBSUQsU0FBUyxvQkFBb0IsQ0FBQyxVQUFzQyxFQUFFO0lBQ3BFLE1BQU0sZUFBZSxHQUFrQyxFQUFFLEdBQUcsQ0FBQyxPQUFPLENBQUMsZUFBZSxJQUFJLEVBQUUsQ0FBQyxFQUFFLENBQUM7SUFDOUYsTUFBTSxnQkFBZ0IsR0FBMkIsT0FBTyxDQUFDLHFCQUFxQixJQUFJLEVBQUUsQ0FBQztJQUNyRixLQUFLLE1BQU0sQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLElBQUksTUFBTSxDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQyxFQUFFLENBQUM7UUFDdkUsSUFBSSxPQUFPLE9BQU8sS0FBSyxRQUFRLElBQUksQ0FBQyxPQUFPLENBQUMsSUFBSSxFQUFFO1lBQUUsU0FBUztRQUM3RCxlQUFlLENBQUMsWUFBWSxDQUFDLEdBQUcseUJBQXlCLENBQUMsT0FBTyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQzFFLENBQUM7SUFDRCxPQUFPLGVBQWUsQ0FBQztBQUN6QixDQUFDO0FBRUQsU0FBUyxnQkFBZ0IsQ0FBQyxVQUFzQyxFQUFFO0lBQ2hFLE9BQU87UUFDTCxLQUFLLEVBQUUsYUFBYSxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUM7UUFDbkMseUJBQXlCLEVBQUUsb0JBQW9CLENBQUMsT0FBTyxDQUFDLHlCQUF5QixDQUFDO1FBQ2xGLGdCQUFnQixFQUFFLG9CQUFvQixDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQztRQUNoRSxlQUFlLEVBQUUsb0JBQW9CLENBQUMsT0FBTyxDQUFDO0tBQy9DLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxpQkFBaUIsQ0FBQyxVQUErQjtJQUN4RCxNQUFNLEtBQUssR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUMxRCxJQUFJLGNBQWMsR0FBRyxDQUFDLENBQUM7SUFDdkIsTUFBTSxVQUFVLEdBQTBCLEVBQUUsQ0FBQztJQUM3QyxNQUFNLElBQUksR0FBRyxJQUFJLEdBQUcsRUFBRSxDQUFDO0lBQ3ZCLEtBQUssTUFBTSxTQUFTLElBQUksS0FBSyxFQUFFLENBQUM7UUFDOUIsTUFBTSxLQUFLLEdBQUcsa0JBQWtCLENBQUMsU0FBUyxDQUFDLENBQUM7UUFDNUMsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDO1lBQ1gsY0FBYyxJQUFJLENBQUMsQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELE1BQU0sR0FBRyxHQUFHLEdBQUcsS0FBSyxDQUFDLFlBQVksQ0FBQyxXQUFXLEVBQUUsSUFBSSxLQUFLLENBQUMsV0FBVyxFQUFFLENBQUM7UUFDdkUsSUFBSSxJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQztZQUFFLFNBQVM7UUFDNUIsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUNkLFVBQVUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUNELE9BQU8sRUFBRSxVQUFVLEVBQUUsY0FBYyxFQUFFLENBQUM7QUFDeEMsQ0FBQztBQUVELFNBQVMseUJBQXlCLENBQUMsTUFBOEIsRUFBRSxVQUFzQyxFQUFFO0lBQ3pHLE1BQU0sZUFBZSxHQUFHLG9CQUFvQixDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ3RELE1BQU0sU0FBUyxHQUFHLE1BQU0sQ0FBQyxJQUFJLENBQUMsZUFBZSxDQUFDLENBQUM7SUFDL0MsSUFBSSxNQUFNLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLFNBQVMsQ0FBQyxNQUFNLEtBQUssQ0FBQyxDQUFDO0lBQ3ZELDZHQUE2RztJQUM3RyxrSEFBa0g7SUFDbEgsZ0hBQWdIO0lBQ2hILG9GQUFvRjtJQUNwRixPQUFPLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRTtRQUM1QixNQUFNLE1BQU0sR0FBRyxLQUFLLENBQUMsWUFBWSxDQUFDLElBQUksRUFBRSxDQUFDLFdBQVcsRUFBRSxDQUFDO1FBQ3ZELE9BQU8sQ0FBQyxTQUFTLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUMsV0FBVyxFQUFFLEtBQUssTUFBTSxDQUFDLENBQUM7SUFDekUsQ0FBQyxDQUFDLENBQUM7QUFDTCxDQUFDO0FBRUQ7OztHQUdHO0FBQ0gsTUFBTSxVQUFVLG1CQUFtQixDQUNqQyxVQUErQixFQUMvQixVQUFzQyxFQUFFO0lBRXhDLE1BQU0sRUFBRSxVQUFVLEVBQUUsR0FBRyxpQkFBaUIsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUNyRCxPQUFPLHlCQUF5QixDQUFDLFVBQVUsRUFBRSxnQkFBZ0IsQ0FBQyxPQUFPLENBQUMsQ0FBMkIsQ0FBQztBQUNwRyxDQUFDO0FBRUQsTUFBTSxVQUFVLDhCQUE4QixDQUM1QyxVQUErQixFQUMvQixVQUFzQyxFQUFFO0lBRXhDLE1BQU0sRUFBRSxVQUFVLEVBQUUsY0FBYyxFQUFFLEdBQUcsaUJBQWlCLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDckUsTUFBTSxNQUFNLEdBQUcseUJBQXlCLENBQUMsVUFBVSxFQUFFLGdCQUFnQixDQUFDLE9BQU8sQ0FBQyxDQUEyQixDQUFDO0lBQzFHLE9BQU87UUFDTCxNQUFNLEVBQUUsTUFBTTtRQUNkLGNBQWM7UUFDZCxtQkFBbUIsRUFBRSx5QkFBeUIsQ0FBQyxNQUFNLEVBQUUsT0FBTyxDQUFDO1FBQy9ELGVBQWUsRUFBRSx1QkFBdUI7S0FDekMsQ0FBQztBQUNKLENBQUMifQ==

--- a/packages/loopover-miner/lib/opportunity-ranker.ts
+++ b/packages/loopover-miner/lib/opportunity-ranker.ts
@@ -1,0 +1,156 @@
+import {
+  DEFAULT_MINER_GOAL_SPEC,
+  parseMinerGoalSpecContent,
+  rankMetadataOpportunities,
+} from "@loopover/engine";
+import type { MinerGoalSpec } from "@loopover/engine";
+import type { RawCandidateIssue } from "./opportunity-fanout.js";
+
+export type RankedCandidateIssue = RawCandidateIssue & {
+  potential: number;
+  feasibility: number;
+  laneFit: number;
+  freshness: number;
+  dupRisk: number;
+  rankScore: number;
+};
+
+export type RankCandidateIssuesOptions = {
+  nowMs?: number;
+  highRiskDuplicateClusters?: number;
+  openPullRequests?: number;
+  goalSpecsByRepo?: Record<string, MinerGoalSpec>;
+  goalSpecContentByRepo?: Record<string, string>;
+};
+
+export type RankedCandidateSummary = {
+  issues: RankedCandidateIssue[];
+  skippedInvalid: number;
+  usedDefaultGoalSpec: boolean;
+  defaultGoalSpec: MinerGoalSpec;
+};
+
+function finiteEpochMs(value: unknown): number {
+  return Number.isFinite(value) ? (value as number) : Date.now();
+}
+
+function finiteNonNegativeInt(value: unknown): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value as number));
+}
+
+function normalizeCandidate(candidate: Record<string, unknown>) {
+  if (!candidate || typeof candidate !== "object") return null;
+  const repoFullName =
+    typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+  const issueNumber = candidate.issueNumber as number;
+  const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !title) return null;
+  const canonicalRepoFullName = `${owner}/${repo}`;
+  const labels = Array.isArray(candidate.labels)
+    ? candidate.labels
+        .filter((label) => typeof label === "string" && label.trim())
+        .map((label) => label.trim())
+    : [];
+  return {
+    owner,
+    repo,
+    repoFullName: canonicalRepoFullName,
+    issueNumber,
+    title,
+    labels,
+    commentsCount: Number.isFinite(candidate.commentsCount) ? (candidate.commentsCount as number) : 0,
+    createdAt: typeof candidate.createdAt === "string" ? candidate.createdAt : null,
+    updatedAt: typeof candidate.updatedAt === "string" ? candidate.updatedAt : null,
+    htmlUrl: typeof candidate.htmlUrl === "string" ? candidate.htmlUrl : null,
+    aiPolicyAllowed: candidate.aiPolicyAllowed !== false,
+    aiPolicySource:
+      candidate.aiPolicySource === "AI-USAGE.md" ||
+      candidate.aiPolicySource === "CONTRIBUTING.md" ||
+      candidate.aiPolicySource === "none"
+        ? candidate.aiPolicySource
+        : "none",
+  };
+}
+
+type NormalizedCandidate = NonNullable<ReturnType<typeof normalizeCandidate>>;
+
+function buildGoalSpecsByRepo(options: RankCandidateIssuesOptions = {}) {
+  const goalSpecsByRepo: Record<string, MinerGoalSpec> = { ...(options.goalSpecsByRepo ?? {}) };
+  const rawContentByRepo: Record<string, string> = options.goalSpecContentByRepo ?? {};
+  for (const [repoFullName, content] of Object.entries(rawContentByRepo)) {
+    if (typeof content !== "string" || !content.trim()) continue;
+    goalSpecsByRepo[repoFullName] = parseMinerGoalSpecContent(content).spec;
+  }
+  return goalSpecsByRepo;
+}
+
+function buildRankContext(options: RankCandidateIssuesOptions = {}) {
+  return {
+    nowMs: finiteEpochMs(options.nowMs),
+    highRiskDuplicateClusters: finiteNonNegativeInt(options.highRiskDuplicateClusters),
+    openPullRequests: finiteNonNegativeInt(options.openPullRequests),
+    goalSpecsByRepo: buildGoalSpecsByRepo(options),
+  };
+}
+
+function collectCandidates(candidates: RawCandidateIssue[]) {
+  const input = Array.isArray(candidates) ? candidates : [];
+  let skippedInvalid = 0;
+  const normalized: NormalizedCandidate[] = [];
+  const seen = new Set();
+  for (const candidate of input) {
+    const entry = normalizeCandidate(candidate);
+    if (!entry) {
+      skippedInvalid += 1;
+      continue;
+    }
+    const key = `${entry.repoFullName.toLowerCase()}#${entry.issueNumber}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(entry);
+  }
+  return { normalized, skippedInvalid };
+}
+
+function rankedUsesDefaultGoalSpec(ranked: RankedCandidateIssue[], options: RankCandidateIssuesOptions = {}) {
+  const goalSpecsByRepo = buildGoalSpecsByRepo(options);
+  const specRepos = Object.keys(goalSpecsByRepo);
+  if (ranked.length === 0) return specRepos.length === 0;
+  // The "ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)" note is only
+  // truthful when the WHOLE batch fell back to the default -- so require EVERY ranked repo to lack a supplied spec,
+  // not just any one of them (#7226). With `.some`, a single spec-less repo made a mixed batch (where other repos
+  // genuinely had a spec supplied and applied) print the blanket note as if none did.
+  return ranked.every((issue) => {
+    const target = issue.repoFullName.trim().toLowerCase();
+    return !specRepos.some((repo) => repo.trim().toLowerCase() === target);
+  });
+}
+
+/**
+ * Rank metadata-only fan-out candidates locally. Never clones source, never uploads metadata, and never writes to
+ * GitHub — it only composes deterministic engine signals and returns the sorted list.
+ */
+export function rankCandidateIssues(
+  candidates: RawCandidateIssue[],
+  options: RankCandidateIssuesOptions = {},
+): RankedCandidateIssue[] {
+  const { normalized } = collectCandidates(candidates);
+  return rankMetadataOpportunities(normalized, buildRankContext(options)) as RankedCandidateIssue[];
+}
+
+export function rankCandidateIssuesWithSummary(
+  candidates: RawCandidateIssue[],
+  options: RankCandidateIssuesOptions = {},
+): RankedCandidateSummary {
+  const { normalized, skippedInvalid } = collectCandidates(candidates);
+  const ranked = rankMetadataOpportunities(normalized, buildRankContext(options)) as RankedCandidateIssue[];
+  return {
+    issues: ranked,
+    skippedInvalid,
+    usedDefaultGoalSpec: rankedUsesDefaultGoalSpec(ranked, options),
+    defaultGoalSpec: DEFAULT_MINER_GOAL_SPEC,
+  };
+}

--- a/packages/loopover-miner/lib/portfolio-queue-manager.d.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-manager.d.ts
@@ -1,50 +1,56 @@
 import type { PortfolioCaps } from "@loopover/engine";
 import type { EnqueueItem, PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
-
 export type PortfolioQueueClaimTarget = {
-  apiBaseUrl: string;
-  repoFullName: string;
-  identifier: string;
-};
-
-export function queueItemId(apiBaseUrl: string, repoFullName: string, identifier: string): string;
-
-export function parseQueueItemId(id: string): PortfolioQueueClaimTarget;
-
-export function normalizePortfolioCaps(caps?: Partial<PortfolioCaps>): PortfolioCaps;
-
-export function entriesToPortfolioQueue(entries: QueueEntry[]): {
-  buckets: Array<{
+    apiBaseUrl: string;
     repoFullName: string;
-    items: Array<{ id: string; repoFullName: string; state: "queued" | "in_progress" }>;
-  }>;
+    identifier: string;
 };
-
-export function selectEligibleBatch(
-  entries: QueueEntry[],
-  caps: PortfolioCaps,
-): PortfolioQueueClaimTarget[];
-
+/**
+ * Stable composite id for projecting SQLite rows into the engine's PortfolioQueueItem shape. Encodes apiBaseUrl
+ * too (#5563) — the engine's own selection logic has no forge dimension, but two hosts can now enqueue an item
+ * under the same repoFullName+identifier (post-#5563 scoping), and the id is the ONLY thing selectEligibleBatch's
+ * output threads back to batchClaim; without the host baked in here, a selected item's host would be lost and
+ * batchClaim would default to github.com, potentially claiming a DIFFERENT row than the one the engine selected.
+ */
+export declare function queueItemId(apiBaseUrl: string, repoFullName: string, identifier: string): string;
+/** Reverse {@link queueItemId} after engine selection so claims can target SQLite primary keys. */
+export declare function parseQueueItemId(id: unknown): PortfolioQueueClaimTarget;
+/** Coerce caps to finite non-negative integers (mirrors the engine's normalizeCaps posture). */
+export declare function normalizePortfolioCaps(caps?: Partial<PortfolioCaps>): PortfolioCaps;
+/** Project persisted queue rows into the engine's in-memory PortfolioQueue (done rows omitted). Pure. */
+export declare function entriesToPortfolioQueue(entries: QueueEntry[]): {
+    buckets: Array<{
+        repoFullName: string;
+        items: Array<{
+            id: string;
+            repoFullName: string;
+            state: "queued" | "in_progress";
+        }>;
+    }>;
+};
+/** Select the next eligible batch from active rows using the engine primitive. Pure. */
+export declare function selectEligibleBatch(entries: QueueEntry[], caps: PortfolioCaps): PortfolioQueueClaimTarget[];
 export type PortfolioQueueManager = {
-  caps: PortfolioCaps;
-  store: PortfolioQueueStore;
-  dbPath: string;
-  enqueue(item: EnqueueItem): QueueEntry;
-  listQueue(repoFullName?: string | null): QueueEntry[];
-  markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-  markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
-  reclaimStuckItems(maxLeaseMs?: number): QueueEntry[];
-  claimNextBatch(): QueueEntry[];
-  close(): void;
+    caps: PortfolioCaps;
+    store: PortfolioQueueStore;
+    dbPath: string;
+    enqueue(item: EnqueueItem): QueueEntry;
+    listQueue(repoFullName?: string | null): QueueEntry[];
+    markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+    markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+    reclaimStuckItems(maxLeaseMs?: number): QueueEntry[];
+    claimNextBatch(): QueueEntry[];
+    close(): void;
 };
-
 export type InitPortfolioQueueManagerOptions = {
-  caps?: Partial<PortfolioCaps>;
-  store?: PortfolioQueueStore;
-  dbPath?: string;
-  staleLeaseMs?: number;
+    caps?: Partial<PortfolioCaps>;
+    store?: PortfolioQueueStore;
+    dbPath?: string;
+    staleLeaseMs?: number;
 };
-
-export function initPortfolioQueueManager(options?: InitPortfolioQueueManagerOptions): PortfolioQueueManager;
-
-export function closeDefaultPortfolioQueueManager(): void;
+/**
+ * Open a caps-aware portfolio queue manager backed by the local SQLite store. The existing single-row
+ * `dequeueNext()` CLI surface is untouched — this adds `claimNextBatch()` for fleet-style batch claiming.
+ */
+export declare function initPortfolioQueueManager(options?: InitPortfolioQueueManagerOptions): PortfolioQueueManager;
+export declare function closeDefaultPortfolioQueueManager(): void;

--- a/packages/loopover-miner/lib/portfolio-queue-manager.js
+++ b/packages/loopover-miner/lib/portfolio-queue-manager.js
@@ -6,9 +6,7 @@ import { nextEligibleItems } from "@loopover/engine";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { DEFAULT_MAX_LEASE_MS, sweepStuckItems } from "./portfolio-queue-expiry.js";
-
 const ITEM_ID_SEPARATOR = "::";
-
 /**
  * Stable composite id for projecting SQLite rows into the engine's PortfolioQueueItem shape. Encodes apiBaseUrl
  * too (#5563) — the engine's own selection logic has no forge dimension, but two hosts can now enqueue an item
@@ -17,128 +15,132 @@ const ITEM_ID_SEPARATOR = "::";
  * batchClaim would default to github.com, potentially claiming a DIFFERENT row than the one the engine selected.
  */
 export function queueItemId(apiBaseUrl, repoFullName, identifier) {
-  return `${apiBaseUrl}${ITEM_ID_SEPARATOR}${repoFullName}${ITEM_ID_SEPARATOR}${identifier}`;
+    return `${apiBaseUrl}${ITEM_ID_SEPARATOR}${repoFullName}${ITEM_ID_SEPARATOR}${identifier}`;
 }
-
 /** Reverse {@link queueItemId} after engine selection so claims can target SQLite primary keys. */
 export function parseQueueItemId(id) {
-  if (typeof id !== "string") throw new Error("invalid_queue_item_id");
-  const lastSeparatorIndex = id.lastIndexOf(ITEM_ID_SEPARATOR);
-  if (lastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
-  const identifier = id.slice(lastSeparatorIndex + ITEM_ID_SEPARATOR.length);
-  if (!identifier) throw new Error("invalid_queue_item_id");
-  const beforeIdentifier = id.slice(0, lastSeparatorIndex);
-  const secondLastSeparatorIndex = beforeIdentifier.lastIndexOf(ITEM_ID_SEPARATOR);
-  if (secondLastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
-  const repoFullName = beforeIdentifier.slice(secondLastSeparatorIndex + ITEM_ID_SEPARATOR.length);
-  if (!repoFullName) throw new Error("invalid_queue_item_id");
-  const apiBaseUrl = beforeIdentifier.slice(0, secondLastSeparatorIndex);
-  if (!apiBaseUrl) throw new Error("invalid_queue_item_id");
-  return { apiBaseUrl, repoFullName, identifier };
+    if (typeof id !== "string")
+        throw new Error("invalid_queue_item_id");
+    const lastSeparatorIndex = id.lastIndexOf(ITEM_ID_SEPARATOR);
+    if (lastSeparatorIndex <= 0)
+        throw new Error("invalid_queue_item_id");
+    const identifier = id.slice(lastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+    if (!identifier)
+        throw new Error("invalid_queue_item_id");
+    const beforeIdentifier = id.slice(0, lastSeparatorIndex);
+    const secondLastSeparatorIndex = beforeIdentifier.lastIndexOf(ITEM_ID_SEPARATOR);
+    if (secondLastSeparatorIndex <= 0)
+        throw new Error("invalid_queue_item_id");
+    const repoFullName = beforeIdentifier.slice(secondLastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+    if (!repoFullName)
+        throw new Error("invalid_queue_item_id");
+    const apiBaseUrl = beforeIdentifier.slice(0, secondLastSeparatorIndex);
+    // Unreachable at runtime: secondLastSeparatorIndex > 0 (guarded above), so slice(0, >0) is always non-empty --
+    // this guard has no reachable input. Kept as defense-in-depth mirroring the other segment checks.
+    /* v8 ignore next -- unreachable: secondLastSeparatorIndex > 0 guarantees a non-empty apiBaseUrl slice */
+    if (!apiBaseUrl)
+        throw new Error("invalid_queue_item_id");
+    return { apiBaseUrl, repoFullName, identifier };
 }
-
 /** Coerce caps to finite non-negative integers (mirrors the engine's normalizeCaps posture). */
 export function normalizePortfolioCaps(caps = {}) {
-  const globalWipCap = Number.isFinite(caps.globalWipCap) ? Math.max(0, Math.trunc(caps.globalWipCap)) : 0;
-  const perRepoWipCap = Number.isFinite(caps.perRepoWipCap) ? Math.max(0, Math.trunc(caps.perRepoWipCap)) : 0;
-  return { globalWipCap, perRepoWipCap };
+    const globalWipCap = Number.isFinite(caps.globalWipCap) ? Math.max(0, Math.trunc(caps.globalWipCap)) : 0;
+    const perRepoWipCap = Number.isFinite(caps.perRepoWipCap) ? Math.max(0, Math.trunc(caps.perRepoWipCap)) : 0;
+    return { globalWipCap, perRepoWipCap };
 }
-
 /** Project persisted queue rows into the engine's in-memory PortfolioQueue (done rows omitted). Pure. */
 export function entriesToPortfolioQueue(entries) {
-  const activeEntries = Array.isArray(entries) ? entries.filter((entry) => entry?.status !== "done") : [];
-  const bucketsByRepo = new Map();
-  const bucketOrder = [];
-  for (const entry of activeEntries) {
-    const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName.trim() : "";
-    const identifier = typeof entry.identifier === "string" ? entry.identifier.trim() : "";
-    if (!repoFullName || !identifier) continue;
-    // Falls back to the github.com default (matching every store's own normalizeApiBaseUrl) so a row from
-    // before #5563 threaded apiBaseUrl through this fold still gets a valid, host-scoped id.
-    const apiBaseUrl = typeof entry.apiBaseUrl === "string" && entry.apiBaseUrl.trim() ? entry.apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
-    // Host-qualify the engine's per-repo WIP grouping key (#7224). nextEligibleItems groups its per-repo cap by each
-    // item's `repoFullName`, which it treats as an OPAQUE string -- the engine has no apiBaseUrl concept, the host is
-    // smuggled through the opaque `id` (queueItemId, #5563). The store keys rows by apiBaseUrl too, so two forge
-    // hosts' same-named repos are distinct backlogs; without qualifying the grouping key by host here, a per-repo cap
-    // was shared across them (e.g. perRepoWipCap: 1 let only ONE host's backlog advance). The `id` still carries the
-    // TRUE repoFullName and selectEligibleBatch maps results back via parseQueueItemId(id), so the real repo/host
-    // survive to the caller. Single-host behavior is unchanged: one apiBaseUrl means one grouping key per repo.
-    const repoLower = repoFullName.toLowerCase();
-    const repoKey = `${apiBaseUrl}\n${repoLower}`;
-    if (!bucketsByRepo.has(repoKey)) {
-      // The bucket's own repoFullName stays the plain repo (display/diversification), while each ITEM carries the
-      // host-qualified key the engine groups on -- so the returned bucket shape is unchanged for single-host.
-      bucketsByRepo.set(repoKey, { repoFullName: repoLower, items: [] });
-      bucketOrder.push(repoKey);
+    const activeEntries = Array.isArray(entries) ? entries.filter((entry) => entry?.status !== "done") : [];
+    const bucketsByRepo = new Map();
+    const bucketOrder = [];
+    for (const entry of activeEntries) {
+        const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName.trim() : "";
+        const identifier = typeof entry.identifier === "string" ? entry.identifier.trim() : "";
+        if (!repoFullName || !identifier)
+            continue;
+        // Falls back to the github.com default (matching every store's own normalizeApiBaseUrl) so a row from
+        // before #5563 threaded apiBaseUrl through this fold still gets a valid, host-scoped id.
+        const apiBaseUrl = typeof entry.apiBaseUrl === "string" && entry.apiBaseUrl.trim() ? entry.apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
+        // Host-qualify the engine's per-repo WIP grouping key (#7224). nextEligibleItems groups its per-repo cap by each
+        // item's `repoFullName`, which it treats as an OPAQUE string -- the engine has no apiBaseUrl concept, the host is
+        // smuggled through the opaque `id` (queueItemId, #5563). The store keys rows by apiBaseUrl too, so two forge
+        // hosts' same-named repos are distinct backlogs; without qualifying the grouping key by host here, a per-repo cap
+        // was shared across them (e.g. perRepoWipCap: 1 let only ONE host's backlog advance). The `id` still carries the
+        // TRUE repoFullName and selectEligibleBatch maps results back via parseQueueItemId(id), so the real repo/host
+        // survive to the caller. Single-host behavior is unchanged: one apiBaseUrl means one grouping key per repo.
+        const repoLower = repoFullName.toLowerCase();
+        const repoKey = `${apiBaseUrl}\n${repoLower}`;
+        if (!bucketsByRepo.has(repoKey)) {
+            // The bucket's own repoFullName stays the plain repo (display/diversification), while each ITEM carries the
+            // host-qualified key the engine groups on -- so the returned bucket shape is unchanged for single-host.
+            bucketsByRepo.set(repoKey, { repoFullName: repoLower, items: [] });
+            bucketOrder.push(repoKey);
+        }
+        bucketsByRepo.get(repoKey).items.push({
+            id: queueItemId(apiBaseUrl, repoFullName, identifier),
+            repoFullName: repoKey,
+            state: entry.status === "in_progress" ? "in_progress" : "queued",
+        });
     }
-    bucketsByRepo.get(repoKey).items.push({
-      id: queueItemId(apiBaseUrl, repoFullName, identifier),
-      repoFullName: repoKey,
-      state: entry.status === "in_progress" ? "in_progress" : "queued",
-    });
-  }
-  return {
-    buckets: bucketOrder.map((repoKey) => {
-      const bucket = bucketsByRepo.get(repoKey);
-      return { repoFullName: bucket.repoFullName, items: bucket.items };
-    }),
-  };
+    return {
+        buckets: bucketOrder.map((repoKey) => {
+            const bucket = bucketsByRepo.get(repoKey);
+            return { repoFullName: bucket.repoFullName, items: bucket.items };
+        }),
+    };
 }
-
 /** Select the next eligible batch from active rows using the engine primitive. Pure. */
 export function selectEligibleBatch(entries, caps) {
-  const normalizedCaps = normalizePortfolioCaps(caps);
-  const queue = entriesToPortfolioQueue(entries);
-  return nextEligibleItems(queue, normalizedCaps).map((item) => parseQueueItemId(item.id));
+    const normalizedCaps = normalizePortfolioCaps(caps);
+    const queue = entriesToPortfolioQueue(entries);
+    return nextEligibleItems(queue, normalizedCaps).map((item) => parseQueueItemId(item.id));
 }
-
 /**
  * Open a caps-aware portfolio queue manager backed by the local SQLite store. The existing single-row
  * `dequeueNext()` CLI surface is untouched — this adds `claimNextBatch()` for fleet-style batch claiming.
  */
 export function initPortfolioQueueManager(options = {}) {
-  const caps = normalizePortfolioCaps(options.caps ?? { globalWipCap: 1, perRepoWipCap: 1 });
-  const store = options.store ?? initPortfolioQueueStore(options.dbPath);
-  // A lease older than this means the process that claimed the item almost certainly died; the item is swept back
-  // to 'queued' so it no longer occupies WIP capacity forever (#4827).
-  const staleLeaseMs = Number.isFinite(options.staleLeaseMs) ? options.staleLeaseMs : DEFAULT_MAX_LEASE_MS;
-
-  return {
-    caps,
-    store,
-    dbPath: store.dbPath,
-    enqueue(item) {
-      return store.enqueue(item);
-    },
-    listQueue(repoFullName) {
-      return store.listQueue(repoFullName);
-    },
-    markDone(repoFullName, identifier, apiBaseUrl) {
-      return store.markDone(repoFullName, identifier, apiBaseUrl);
-    },
-    markFailed(repoFullName, identifier, apiBaseUrl) {
-      return store.markFailed(repoFullName, identifier, apiBaseUrl);
-    },
-    /** Sweep leases orphaned by a crashed/killed process back to 'queued', returning the reclaimed items (#4827). */
-    reclaimStuckItems(maxLeaseMs = staleLeaseMs) {
-      return sweepStuckItems(store, Date.now(), maxLeaseMs);
-    },
-    // The engine primitive itself (@loopover/engine's nextEligibleItems) has no apiBaseUrl concept --
-    // it only ever sees the opaque `id` string. queueItemId/parseQueueItemId (#5563) smuggle the host through
-    // that id round-trip, so selectFn's output below correctly carries each selected item's OWN apiBaseUrl into
-    // batchClaim, instead of every claim defaulting to github.com regardless of which host's row was selected.
-    claimNextBatch() {
-      // Reclaim orphaned leases first, so an item stranded 'in_progress' by a dead process becomes eligible again
-      // instead of permanently consuming a WIP slot and starving the queue.
-      sweepStuckItems(store, Date.now(), staleLeaseMs);
-      return store.batchClaim((entries) => selectEligibleBatch(entries, caps));
-    },
-    close() {
-      store.close();
-    },
-  };
+    const caps = normalizePortfolioCaps(options.caps ?? { globalWipCap: 1, perRepoWipCap: 1 });
+    const store = options.store ?? initPortfolioQueueStore(options.dbPath);
+    // A lease older than this means the process that claimed the item almost certainly died; the item is swept back
+    // to 'queued' so it no longer occupies WIP capacity forever (#4827).
+    const staleLeaseMs = Number.isFinite(options.staleLeaseMs) ? options.staleLeaseMs : DEFAULT_MAX_LEASE_MS;
+    return {
+        caps,
+        store,
+        dbPath: store.dbPath,
+        enqueue(item) {
+            return store.enqueue(item);
+        },
+        listQueue(repoFullName) {
+            return store.listQueue(repoFullName);
+        },
+        markDone(repoFullName, identifier, apiBaseUrl) {
+            return store.markDone(repoFullName, identifier, apiBaseUrl);
+        },
+        markFailed(repoFullName, identifier, apiBaseUrl) {
+            return store.markFailed(repoFullName, identifier, apiBaseUrl);
+        },
+        /** Sweep leases orphaned by a crashed/killed process back to 'queued', returning the reclaimed items (#4827). */
+        reclaimStuckItems(maxLeaseMs = staleLeaseMs) {
+            return sweepStuckItems(store, Date.now(), maxLeaseMs);
+        },
+        // The engine primitive itself (@loopover/engine's nextEligibleItems) has no apiBaseUrl concept --
+        // it only ever sees the opaque `id` string. queueItemId/parseQueueItemId (#5563) smuggle the host through
+        // that id round-trip, so selectFn's output below correctly carries each selected item's OWN apiBaseUrl into
+        // batchClaim, instead of every claim defaulting to github.com regardless of which host's row was selected.
+        claimNextBatch() {
+            // Reclaim orphaned leases first, so an item stranded 'in_progress' by a dead process becomes eligible again
+            // instead of permanently consuming a WIP slot and starving the queue.
+            sweepStuckItems(store, Date.now(), staleLeaseMs);
+            return store.batchClaim((entries) => selectEligibleBatch(entries, caps));
+        },
+        close() {
+            store.close();
+        },
+    };
 }
-
 export function closeDefaultPortfolioQueueManager() {
-  // Reserved for symmetry with other miner stores; managers are opened explicitly today.
+    // Reserved for symmetry with other miner stores; managers are opened explicitly today.
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGZvbGlvLXF1ZXVlLW1hbmFnZXIuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJwb3J0Zm9saW8tcXVldWUtbWFuYWdlci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSw2RkFBNkY7QUFDN0YsMEdBQTBHO0FBQzFHLDZHQUE2RztBQUM3RyxvR0FBb0c7QUFDcEcsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0sa0JBQWtCLENBQUM7QUFFckQsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFDekQsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFFL0QsT0FBTyxFQUFFLG9CQUFvQixFQUFFLGVBQWUsRUFBRSxNQUFNLDZCQUE2QixDQUFDO0FBRXBGLE1BQU0saUJBQWlCLEdBQUcsSUFBSSxDQUFDO0FBUS9COzs7Ozs7R0FNRztBQUNILE1BQU0sVUFBVSxXQUFXLENBQUMsVUFBa0IsRUFBRSxZQUFvQixFQUFFLFVBQWtCO0lBQ3RGLE9BQU8sR0FBRyxVQUFVLEdBQUcsaUJBQWlCLEdBQUcsWUFBWSxHQUFHLGlCQUFpQixHQUFHLFVBQVUsRUFBRSxDQUFDO0FBQzdGLENBQUM7QUFFRCxtR0FBbUc7QUFDbkcsTUFBTSxVQUFVLGdCQUFnQixDQUFDLEVBQVc7SUFDMUMsSUFBSSxPQUFPLEVBQUUsS0FBSyxRQUFRO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx1QkFBdUIsQ0FBQyxDQUFDO0lBQ3JFLE1BQU0sa0JBQWtCLEdBQUcsRUFBRSxDQUFDLFdBQVcsQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDO0lBQzdELElBQUksa0JBQWtCLElBQUksQ0FBQztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsdUJBQXVCLENBQUMsQ0FBQztJQUN0RSxNQUFNLFVBQVUsR0FBRyxFQUFFLENBQUMsS0FBSyxDQUFDLGtCQUFrQixHQUFHLGlCQUFpQixDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQzNFLElBQUksQ0FBQyxVQUFVO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx1QkFBdUIsQ0FBQyxDQUFDO0lBQzFELE1BQU0sZ0JBQWdCLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsa0JBQWtCLENBQUMsQ0FBQztJQUN6RCxNQUFNLHdCQUF3QixHQUFHLGdCQUFnQixDQUFDLFdBQVcsQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDO0lBQ2pGLElBQUksd0JBQXdCLElBQUksQ0FBQztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsdUJBQXVCLENBQUMsQ0FBQztJQUM1RSxNQUFNLFlBQVksR0FBRyxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsd0JBQXdCLEdBQUcsaUJBQWlCLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDakcsSUFBSSxDQUFDLFlBQVk7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHVCQUF1QixDQUFDLENBQUM7SUFDNUQsTUFBTSxVQUFVLEdBQUcsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSx3QkFBd0IsQ0FBQyxDQUFDO0lBQ3ZFLCtHQUErRztJQUMvRyxrR0FBa0c7SUFDbEcseUdBQXlHO0lBQ3pHLElBQUksQ0FBQyxVQUFVO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyx1QkFBdUIsQ0FBQyxDQUFDO0lBQzFELE9BQU8sRUFBRSxVQUFVLEVBQUUsWUFBWSxFQUFFLFVBQVUsRUFBRSxDQUFDO0FBQ2xELENBQUM7QUFFRCxnR0FBZ0c7QUFDaEcsTUFBTSxVQUFVLHNCQUFzQixDQUFDLE9BQStCLEVBQUU7SUFDdEUsTUFBTSxZQUFZLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLFlBQXNCLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDbkgsTUFBTSxhQUFhLEdBQUcsTUFBTSxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLGFBQXVCLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDdEgsT0FBTyxFQUFFLFlBQVksRUFBRSxhQUFhLEVBQUUsQ0FBQztBQUN6QyxDQUFDO0FBRUQseUdBQXlHO0FBQ3pHLE1BQU0sVUFBVSx1QkFBdUIsQ0FBQyxPQUFxQjtJQU0zRCxNQUFNLGFBQWEsR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLEVBQUUsTUFBTSxLQUFLLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDeEcsTUFBTSxhQUFhLEdBQUcsSUFBSSxHQUFHLEVBRzFCLENBQUM7SUFDSixNQUFNLFdBQVcsR0FBYSxFQUFFLENBQUM7SUFDakMsS0FBSyxNQUFNLEtBQUssSUFBSSxhQUFhLEVBQUUsQ0FBQztRQUNsQyxNQUFNLFlBQVksR0FBRyxPQUFPLEtBQUssQ0FBQyxZQUFZLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7UUFDN0YsTUFBTSxVQUFVLEdBQUcsT0FBTyxLQUFLLENBQUMsVUFBVSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3ZGLElBQUksQ0FBQyxZQUFZLElBQUksQ0FBQyxVQUFVO1lBQUUsU0FBUztRQUMzQyxzR0FBc0c7UUFDdEcseUZBQXlGO1FBQ3pGLE1BQU0sVUFBVSxHQUFHLE9BQU8sS0FBSyxDQUFDLFVBQVUsS0FBSyxRQUFRLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLFVBQVUsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsb0JBQW9CLENBQUMsVUFBVSxDQUFDO1FBQy9JLGlIQUFpSDtRQUNqSCxrSEFBa0g7UUFDbEgsNkdBQTZHO1FBQzdHLGtIQUFrSDtRQUNsSCxpSEFBaUg7UUFDakgsOEdBQThHO1FBQzlHLDRHQUE0RztRQUM1RyxNQUFNLFNBQVMsR0FBRyxZQUFZLENBQUMsV0FBVyxFQUFFLENBQUM7UUFDN0MsTUFBTSxPQUFPLEdBQUcsR0FBRyxVQUFVLEtBQUssU0FBUyxFQUFFLENBQUM7UUFDOUMsSUFBSSxDQUFDLGFBQWEsQ0FBQyxHQUFHLENBQUMsT0FBTyxDQUFDLEVBQUUsQ0FBQztZQUNoQyw0R0FBNEc7WUFDNUcsd0dBQXdHO1lBQ3hHLGFBQWEsQ0FBQyxHQUFHLENBQUMsT0FBTyxFQUFFLEVBQUUsWUFBWSxFQUFFLFNBQVMsRUFBRSxLQUFLLEVBQUUsRUFBRSxFQUFFLENBQUMsQ0FBQztZQUNuRSxXQUFXLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO1FBQzVCLENBQUM7UUFDRCxhQUFhLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBRSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUM7WUFDckMsRUFBRSxFQUFFLFdBQVcsQ0FBQyxVQUFVLEVBQUUsWUFBWSxFQUFFLFVBQVUsQ0FBQztZQUNyRCxZQUFZLEVBQUUsT0FBTztZQUNyQixLQUFLLEVBQUUsS0FBSyxDQUFDLE1BQU0sS0FBSyxhQUFhLENBQUMsQ0FBQyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsUUFBUTtTQUNqRSxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQ0QsT0FBTztRQUNMLE9BQU8sRUFBRSxXQUFXLENBQUMsR0FBRyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUU7WUFDbkMsTUFBTSxNQUFNLEdBQUcsYUFBYSxDQUFDLEdBQUcsQ0FBQyxPQUFPLENBQUUsQ0FBQztZQUMzQyxPQUFPLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsS0FBSyxFQUFFLE1BQU0sQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNwRSxDQUFDLENBQUM7S0FDSCxDQUFDO0FBQ0osQ0FBQztBQUVELHdGQUF3RjtBQUN4RixNQUFNLFVBQVUsbUJBQW1CLENBQUMsT0FBcUIsRUFBRSxJQUFtQjtJQUM1RSxNQUFNLGNBQWMsR0FBRyxzQkFBc0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNwRCxNQUFNLEtBQUssR0FBRyx1QkFBdUIsQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUMvQyxPQUFPLGlCQUFpQixDQUFDLEtBQUssRUFBRSxjQUFjLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxJQUFJLEVBQUUsRUFBRSxDQUFDLGdCQUFnQixDQUFDLElBQUksQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO0FBQzNGLENBQUM7QUFzQkQ7OztHQUdHO0FBQ0gsTUFBTSxVQUFVLHlCQUF5QixDQUFDLFVBQTRDLEVBQUU7SUFDdEYsTUFBTSxJQUFJLEdBQUcsc0JBQXNCLENBQUMsT0FBTyxDQUFDLElBQUksSUFBSSxFQUFFLFlBQVksRUFBRSxDQUFDLEVBQUUsYUFBYSxFQUFFLENBQUMsRUFBRSxDQUFDLENBQUM7SUFDM0YsTUFBTSxLQUFLLEdBQUcsT0FBTyxDQUFDLEtBQUssSUFBSSx1QkFBdUIsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDdkUsZ0hBQWdIO0lBQ2hILHFFQUFxRTtJQUNyRSxNQUFNLFlBQVksR0FBRyxNQUFNLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLENBQUUsT0FBTyxDQUFDLFlBQXVCLENBQUMsQ0FBQyxDQUFDLG9CQUFvQixDQUFDO0lBRXJILE9BQU87UUFDTCxJQUFJO1FBQ0osS0FBSztRQUNMLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTTtRQUNwQixPQUFPLENBQUMsSUFBSTtZQUNWLE9BQU8sS0FBSyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsQ0FBQztRQUM3QixDQUFDO1FBQ0QsU0FBUyxDQUFDLFlBQVk7WUFDcEIsT0FBTyxLQUFLLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxDQUFDO1FBQ3ZDLENBQUM7UUFDRCxRQUFRLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxVQUFVO1lBQzNDLE9BQU8sS0FBSyxDQUFDLFFBQVEsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLFVBQVUsQ0FBQyxDQUFDO1FBQzlELENBQUM7UUFDRCxVQUFVLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxVQUFVO1lBQzdDLE9BQU8sS0FBSyxDQUFDLFVBQVUsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLFVBQVUsQ0FBQyxDQUFDO1FBQ2hFLENBQUM7UUFDRCxpSEFBaUg7UUFDakgsaUJBQWlCLENBQUMsVUFBVSxHQUFHLFlBQVk7WUFDekMsT0FBTyxlQUFlLENBQUMsS0FBSyxFQUFFLElBQUksQ0FBQyxHQUFHLEVBQUUsRUFBRSxVQUFVLENBQUMsQ0FBQztRQUN4RCxDQUFDO1FBQ0Qsa0dBQWtHO1FBQ2xHLDBHQUEwRztRQUMxRyw0R0FBNEc7UUFDNUcsMkdBQTJHO1FBQzNHLGNBQWM7WUFDWiw0R0FBNEc7WUFDNUcsc0VBQXNFO1lBQ3RFLGVBQWUsQ0FBQyxLQUFLLEVBQUUsSUFBSSxDQUFDLEdBQUcsRUFBRSxFQUFFLFlBQVksQ0FBQyxDQUFDO1lBQ2pELE9BQU8sS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDLE9BQU8sRUFBRSxFQUFFLENBQUMsbUJBQW1CLENBQUMsT0FBTyxFQUFFLElBQUksQ0FBQyxDQUFDLENBQUM7UUFDM0UsQ0FBQztRQUNELEtBQUs7WUFDSCxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDaEIsQ0FBQztLQUNGLENBQUM7QUFDSixDQUFDO0FBRUQsTUFBTSxVQUFVLGlDQUFpQztJQUMvQyx1RkFBdUY7QUFDekYsQ0FBQyJ9

--- a/packages/loopover-miner/lib/portfolio-queue-manager.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-manager.ts
@@ -1,0 +1,183 @@
+// Stateful PortfolioQueueManager (#4285): compose the persisted SQLite portfolio/queue store
+// (portfolio-queue.js, #2292) with the pure engine selector (nextEligibleItems, queue.ts, #2326) so batch
+// claiming respects global/per-repo WIP caps and cross-repo diversification instead of a naive priority-only
+// single-row dequeue. Caps are plain constructor arguments — not wired to .loopover-miner.yml here.
+import { nextEligibleItems } from "@loopover/engine";
+import type { PortfolioCaps } from "@loopover/engine";
+import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import type { EnqueueItem, PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
+import { DEFAULT_MAX_LEASE_MS, sweepStuckItems } from "./portfolio-queue-expiry.js";
+
+const ITEM_ID_SEPARATOR = "::";
+
+export type PortfolioQueueClaimTarget = {
+  apiBaseUrl: string;
+  repoFullName: string;
+  identifier: string;
+};
+
+/**
+ * Stable composite id for projecting SQLite rows into the engine's PortfolioQueueItem shape. Encodes apiBaseUrl
+ * too (#5563) — the engine's own selection logic has no forge dimension, but two hosts can now enqueue an item
+ * under the same repoFullName+identifier (post-#5563 scoping), and the id is the ONLY thing selectEligibleBatch's
+ * output threads back to batchClaim; without the host baked in here, a selected item's host would be lost and
+ * batchClaim would default to github.com, potentially claiming a DIFFERENT row than the one the engine selected.
+ */
+export function queueItemId(apiBaseUrl: string, repoFullName: string, identifier: string): string {
+  return `${apiBaseUrl}${ITEM_ID_SEPARATOR}${repoFullName}${ITEM_ID_SEPARATOR}${identifier}`;
+}
+
+/** Reverse {@link queueItemId} after engine selection so claims can target SQLite primary keys. */
+export function parseQueueItemId(id: unknown): PortfolioQueueClaimTarget {
+  if (typeof id !== "string") throw new Error("invalid_queue_item_id");
+  const lastSeparatorIndex = id.lastIndexOf(ITEM_ID_SEPARATOR);
+  if (lastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
+  const identifier = id.slice(lastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+  if (!identifier) throw new Error("invalid_queue_item_id");
+  const beforeIdentifier = id.slice(0, lastSeparatorIndex);
+  const secondLastSeparatorIndex = beforeIdentifier.lastIndexOf(ITEM_ID_SEPARATOR);
+  if (secondLastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
+  const repoFullName = beforeIdentifier.slice(secondLastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+  if (!repoFullName) throw new Error("invalid_queue_item_id");
+  const apiBaseUrl = beforeIdentifier.slice(0, secondLastSeparatorIndex);
+  // Unreachable at runtime: secondLastSeparatorIndex > 0 (guarded above), so slice(0, >0) is always non-empty --
+  // this guard has no reachable input. Kept as defense-in-depth mirroring the other segment checks.
+  /* v8 ignore next -- unreachable: secondLastSeparatorIndex > 0 guarantees a non-empty apiBaseUrl slice */
+  if (!apiBaseUrl) throw new Error("invalid_queue_item_id");
+  return { apiBaseUrl, repoFullName, identifier };
+}
+
+/** Coerce caps to finite non-negative integers (mirrors the engine's normalizeCaps posture). */
+export function normalizePortfolioCaps(caps: Partial<PortfolioCaps> = {}): PortfolioCaps {
+  const globalWipCap = Number.isFinite(caps.globalWipCap) ? Math.max(0, Math.trunc(caps.globalWipCap as number)) : 0;
+  const perRepoWipCap = Number.isFinite(caps.perRepoWipCap) ? Math.max(0, Math.trunc(caps.perRepoWipCap as number)) : 0;
+  return { globalWipCap, perRepoWipCap };
+}
+
+/** Project persisted queue rows into the engine's in-memory PortfolioQueue (done rows omitted). Pure. */
+export function entriesToPortfolioQueue(entries: QueueEntry[]): {
+  buckets: Array<{
+    repoFullName: string;
+    items: Array<{ id: string; repoFullName: string; state: "queued" | "in_progress" }>;
+  }>;
+} {
+  const activeEntries = Array.isArray(entries) ? entries.filter((entry) => entry?.status !== "done") : [];
+  const bucketsByRepo = new Map<
+    string,
+    { repoFullName: string; items: Array<{ id: string; repoFullName: string; state: "queued" | "in_progress" }> }
+  >();
+  const bucketOrder: string[] = [];
+  for (const entry of activeEntries) {
+    const repoFullName = typeof entry.repoFullName === "string" ? entry.repoFullName.trim() : "";
+    const identifier = typeof entry.identifier === "string" ? entry.identifier.trim() : "";
+    if (!repoFullName || !identifier) continue;
+    // Falls back to the github.com default (matching every store's own normalizeApiBaseUrl) so a row from
+    // before #5563 threaded apiBaseUrl through this fold still gets a valid, host-scoped id.
+    const apiBaseUrl = typeof entry.apiBaseUrl === "string" && entry.apiBaseUrl.trim() ? entry.apiBaseUrl.trim() : DEFAULT_FORGE_CONFIG.apiBaseUrl;
+    // Host-qualify the engine's per-repo WIP grouping key (#7224). nextEligibleItems groups its per-repo cap by each
+    // item's `repoFullName`, which it treats as an OPAQUE string -- the engine has no apiBaseUrl concept, the host is
+    // smuggled through the opaque `id` (queueItemId, #5563). The store keys rows by apiBaseUrl too, so two forge
+    // hosts' same-named repos are distinct backlogs; without qualifying the grouping key by host here, a per-repo cap
+    // was shared across them (e.g. perRepoWipCap: 1 let only ONE host's backlog advance). The `id` still carries the
+    // TRUE repoFullName and selectEligibleBatch maps results back via parseQueueItemId(id), so the real repo/host
+    // survive to the caller. Single-host behavior is unchanged: one apiBaseUrl means one grouping key per repo.
+    const repoLower = repoFullName.toLowerCase();
+    const repoKey = `${apiBaseUrl}\n${repoLower}`;
+    if (!bucketsByRepo.has(repoKey)) {
+      // The bucket's own repoFullName stays the plain repo (display/diversification), while each ITEM carries the
+      // host-qualified key the engine groups on -- so the returned bucket shape is unchanged for single-host.
+      bucketsByRepo.set(repoKey, { repoFullName: repoLower, items: [] });
+      bucketOrder.push(repoKey);
+    }
+    bucketsByRepo.get(repoKey)!.items.push({
+      id: queueItemId(apiBaseUrl, repoFullName, identifier),
+      repoFullName: repoKey,
+      state: entry.status === "in_progress" ? "in_progress" : "queued",
+    });
+  }
+  return {
+    buckets: bucketOrder.map((repoKey) => {
+      const bucket = bucketsByRepo.get(repoKey)!;
+      return { repoFullName: bucket.repoFullName, items: bucket.items };
+    }),
+  };
+}
+
+/** Select the next eligible batch from active rows using the engine primitive. Pure. */
+export function selectEligibleBatch(entries: QueueEntry[], caps: PortfolioCaps): PortfolioQueueClaimTarget[] {
+  const normalizedCaps = normalizePortfolioCaps(caps);
+  const queue = entriesToPortfolioQueue(entries);
+  return nextEligibleItems(queue, normalizedCaps).map((item) => parseQueueItemId(item.id));
+}
+
+export type PortfolioQueueManager = {
+  caps: PortfolioCaps;
+  store: PortfolioQueueStore;
+  dbPath: string;
+  enqueue(item: EnqueueItem): QueueEntry;
+  listQueue(repoFullName?: string | null): QueueEntry[];
+  markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  reclaimStuckItems(maxLeaseMs?: number): QueueEntry[];
+  claimNextBatch(): QueueEntry[];
+  close(): void;
+};
+
+export type InitPortfolioQueueManagerOptions = {
+  caps?: Partial<PortfolioCaps>;
+  store?: PortfolioQueueStore;
+  dbPath?: string;
+  staleLeaseMs?: number;
+};
+
+/**
+ * Open a caps-aware portfolio queue manager backed by the local SQLite store. The existing single-row
+ * `dequeueNext()` CLI surface is untouched — this adds `claimNextBatch()` for fleet-style batch claiming.
+ */
+export function initPortfolioQueueManager(options: InitPortfolioQueueManagerOptions = {}): PortfolioQueueManager {
+  const caps = normalizePortfolioCaps(options.caps ?? { globalWipCap: 1, perRepoWipCap: 1 });
+  const store = options.store ?? initPortfolioQueueStore(options.dbPath);
+  // A lease older than this means the process that claimed the item almost certainly died; the item is swept back
+  // to 'queued' so it no longer occupies WIP capacity forever (#4827).
+  const staleLeaseMs = Number.isFinite(options.staleLeaseMs) ? (options.staleLeaseMs as number) : DEFAULT_MAX_LEASE_MS;
+
+  return {
+    caps,
+    store,
+    dbPath: store.dbPath,
+    enqueue(item) {
+      return store.enqueue(item);
+    },
+    listQueue(repoFullName) {
+      return store.listQueue(repoFullName);
+    },
+    markDone(repoFullName, identifier, apiBaseUrl) {
+      return store.markDone(repoFullName, identifier, apiBaseUrl);
+    },
+    markFailed(repoFullName, identifier, apiBaseUrl) {
+      return store.markFailed(repoFullName, identifier, apiBaseUrl);
+    },
+    /** Sweep leases orphaned by a crashed/killed process back to 'queued', returning the reclaimed items (#4827). */
+    reclaimStuckItems(maxLeaseMs = staleLeaseMs) {
+      return sweepStuckItems(store, Date.now(), maxLeaseMs);
+    },
+    // The engine primitive itself (@loopover/engine's nextEligibleItems) has no apiBaseUrl concept --
+    // it only ever sees the opaque `id` string. queueItemId/parseQueueItemId (#5563) smuggle the host through
+    // that id round-trip, so selectFn's output below correctly carries each selected item's OWN apiBaseUrl into
+    // batchClaim, instead of every claim defaulting to github.com regardless of which host's row was selected.
+    claimNextBatch() {
+      // Reclaim orphaned leases first, so an item stranded 'in_progress' by a dead process becomes eligible again
+      // instead of permanently consuming a WIP slot and starving the queue.
+      sweepStuckItems(store, Date.now(), staleLeaseMs);
+      return store.batchClaim((entries) => selectEligibleBatch(entries, caps));
+    },
+    close() {
+      store.close();
+    },
+  };
+}
+
+export function closeDefaultPortfolioQueueManager(): void {
+  // Reserved for symmetry with other miner stores; managers are opened explicitly today.
+}

--- a/packages/loopover-miner/lib/pr-disposition-poller.d.ts
+++ b/packages/loopover-miner/lib/pr-disposition-poller.d.ts
@@ -1,27 +1,41 @@
 export type PrDisposition = {
-  state: "open" | "closed";
-  merged: boolean;
-  closedAt: string | null;
-  attempts: number;
+    state: "open" | "closed";
+    merged: boolean;
+    closedAt: string | null;
+    attempts: number;
 };
-
 export type PollPrDispositionOptions = {
-  apiBaseUrl?: string;
-  fetchFn?: typeof fetch;
-  githubToken?: string;
-  maxAttempts?: number;
-  minIntervalMs?: number;
-  maxIntervalMs?: number;
-  requestTimeoutMs?: number;
-  sleepFn?: (delayMs: number) => Promise<void>;
+    apiBaseUrl?: string;
+    fetchFn?: typeof fetch;
+    githubToken?: string;
+    maxAttempts?: number;
+    minIntervalMs?: number;
+    maxIntervalMs?: number;
+    requestTimeoutMs?: number;
+    sleepFn?: (delayMs: number) => Promise<void>;
 };
-
-export function pollPrDisposition(
-  repoFullName: string,
-  prNumber: number,
-  options?: PollPrDispositionOptions,
-): Promise<PrDisposition>;
-
-export function classifyPrDisposition(
-  disposition: Pick<PrDisposition, "state" | "merged">,
-): "merged" | "disengaged" | "other";
+/**
+ * Poll a real PR's own merge/close disposition (distinct from its CI check-run conclusion, ci-poller.js's
+ * concern) with exponential backoff, until it reaches a terminal `state: "closed"` or `maxAttempts` is
+ * exhausted -- whichever comes first. A still-`"open"` PR after the last attempt is returned as-is, not an
+ * error: an unattended loop cycle should treat "still open" as "not yet resolved", not fail.
+ *
+ * @param {string} repoFullName
+ * @param {number} prNumber
+ * @param {{
+ *   apiBaseUrl?: string, fetchFn?: typeof fetch, githubToken?: string, maxAttempts?: number,
+ *   minIntervalMs?: number, maxIntervalMs?: number, sleepFn?: (delayMs: number) => Promise<void>,
+ * }} [options]
+ * @returns {Promise<{ state: "open"|"closed", merged: boolean, closedAt: string|null, attempts: number }>}
+ */
+export declare function pollPrDisposition(repoFullName: string, prNumber: number, options?: PollPrDispositionOptions): Promise<PrDisposition>;
+/**
+ * Classify a real, terminal PR disposition into loop-reentry.js's own `candidate.outcome` vocabulary
+ * (`"merged"|"disengaged"|"other"`). A still-open disposition (not yet resolved) classifies as `"other"` --
+ * the same bucket a runMinerAttempt outcome that never opened a PR at all falls into (nothing to re-enter on
+ * yet, in either case).
+ *
+ * @param {{ state: "open"|"closed", merged: boolean }} disposition
+ * @returns {"merged"|"disengaged"|"other"}
+ */
+export declare function classifyPrDisposition(disposition: Pick<PrDisposition, "state" | "merged">): "merged" | "disengaged" | "other";

--- a/packages/loopover-miner/lib/pr-disposition-poller.js
+++ b/packages/loopover-miner/lib/pr-disposition-poller.js
@@ -10,124 +10,110 @@
 // check-run poll's "pending" means "wait for the SAME head commit's checks to finish"; a disposition poll's
 // "open" means "wait for a human to actually merge or close the PR", a potentially much longer, unbounded
 // wait) -- composing them into one poller would conflate two different backoff/timeout policies.
-
 import { fetchWithRetry } from "./http-retry.js";
-
 const defaultApiBaseUrl = "https://api.github.com";
 const defaultMinIntervalMs = 60_000;
 const defaultMaxIntervalMs = 5 * 60_000;
 const defaultMaxAttempts = 1;
 const defaultRequestTimeoutMs = 10_000;
 const githubApiVersion = "2022-11-28";
-
 function normalizeApiBaseUrl(value) {
-  if (value === undefined) return defaultApiBaseUrl;
-  if (typeof value !== "string" || !value.trim()) return defaultApiBaseUrl;
-  let parsed;
-  try {
-    parsed = new URL(value.trim());
-  } catch {
-    throw new Error("invalid_api_base_url");
-  }
-  if (parsed.protocol !== "https:" || parsed.hostname !== "api.github.com") {
-    throw new Error("invalid_api_base_url");
-  }
-  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
-  parsed.search = "";
-  parsed.hash = "";
-  return parsed.toString().replace(/\/+$/, "");
+    if (value === undefined)
+        return defaultApiBaseUrl;
+    if (typeof value !== "string" || !value.trim())
+        return defaultApiBaseUrl;
+    let parsed;
+    try {
+        parsed = new URL(value.trim());
+    }
+    catch {
+        throw new Error("invalid_api_base_url");
+    }
+    if (parsed.protocol !== "https:" || parsed.hostname !== "api.github.com") {
+        throw new Error("invalid_api_base_url");
+    }
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/+$/, "");
 }
-
 function normalizePositiveInt(value, fallback, min, max) {
-  if (!Number.isFinite(value)) return fallback;
-  return Math.min(max, Math.max(min, Math.floor(value)));
+    if (!Number.isFinite(value))
+        return fallback;
+    return Math.min(max, Math.max(min, Math.floor(value)));
 }
-
 function normalizeOptions(options = {}) {
-  return {
-    apiBaseUrl: normalizeApiBaseUrl(options.apiBaseUrl),
-    fetchFn: options.fetchFn ?? fetch,
-    githubToken: typeof options.githubToken === "string" ? options.githubToken.trim() : "",
-    maxAttempts: normalizePositiveInt(options.maxAttempts, defaultMaxAttempts, 1, 20),
-    minIntervalMs: normalizePositiveInt(options.minIntervalMs, defaultMinIntervalMs, 1, 60 * 60_000),
-    maxIntervalMs: normalizePositiveInt(options.maxIntervalMs, defaultMaxIntervalMs, 1, 60 * 60_000),
-    requestTimeoutMs: normalizePositiveInt(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
-    sleepFn:
-      options.sleepFn ??
-      ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))),
-  };
+    return {
+        apiBaseUrl: normalizeApiBaseUrl(options.apiBaseUrl),
+        fetchFn: options.fetchFn ?? fetch,
+        githubToken: typeof options.githubToken === "string" ? options.githubToken.trim() : "",
+        maxAttempts: normalizePositiveInt(options.maxAttempts, defaultMaxAttempts, 1, 20),
+        minIntervalMs: normalizePositiveInt(options.minIntervalMs, defaultMinIntervalMs, 1, 60 * 60_000),
+        maxIntervalMs: normalizePositiveInt(options.maxIntervalMs, defaultMaxIntervalMs, 1, 60 * 60_000),
+        requestTimeoutMs: normalizePositiveInt(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
+        sleepFn: options.sleepFn ??
+            ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))),
+    };
 }
-
 function parseRepoFullName(repoFullName) {
-  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner?.trim() || !repo?.trim() || extra !== undefined) {
-    throw new Error("invalid_repo_full_name");
-  }
-  return { owner: owner.trim(), repo: repo.trim() };
+    if (typeof repoFullName !== "string")
+        throw new Error("invalid_repo_full_name");
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner?.trim() || !repo?.trim() || extra !== undefined) {
+        throw new Error("invalid_repo_full_name");
+    }
+    return { owner: owner.trim(), repo: repo.trim() };
 }
-
 function normalizePullNumber(value) {
-  if (!Number.isInteger(value) || value <= 0) throw new Error("invalid_pr_number");
-  return value;
+    if (!Number.isInteger(value) || value <= 0)
+        throw new Error("invalid_pr_number");
+    return value;
 }
-
 function githubHeaders(githubToken) {
-  const headers = {
-    accept: "application/vnd.github+json",
-    "user-agent": "loopover-miner",
-    "x-github-api-version": githubApiVersion,
-  };
-  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
-  return headers;
+    const headers = {
+        accept: "application/vnd.github+json",
+        "user-agent": "loopover-miner",
+        "x-github-api-version": githubApiVersion,
+    };
+    if (githubToken)
+        headers.authorization = `Bearer ${githubToken}`;
+    return headers;
 }
-
 function repoPath(target, suffix) {
-  return `/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}${suffix}`;
+    return `/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}${suffix}`;
 }
-
 function apiUrl(apiBaseUrl, path) {
-  return `${apiBaseUrl}${path}`;
+    return `${apiBaseUrl}${path}`;
 }
-
 function githubError(response, payload) {
-  const code = `github_${response.status}`;
-  const githubMessage =
-    typeof payload?.message === "string" && payload.message.trim() ? payload.message : null;
-  const message = githubMessage ? `${code}: ${githubMessage}` : code;
-  return Object.assign(new Error(message), { code, githubMessage });
+    const code = `github_${response.status}`;
+    const githubMessage = typeof payload?.message === "string" && payload.message.trim() ? payload.message : null;
+    const message = githubMessage ? `${code}: ${githubMessage}` : code;
+    return Object.assign(new Error(message), { code, githubMessage });
 }
-
 async function fetchPullRequest(target, prNumber, options) {
-  // Retry transient network errors / 5xx around this single call (#4829), matching ci-poller.js's
-  // githubGetJsonResponse -- distinct from this poller's OWN outer pending-retry loop. requestTimeoutMs bounds
-  // each individual attempt with a fresh AbortSignal.timeout() (a stalled connection can't hang a poll cycle
-  // forever -- #miner-github-read-timeouts); the injected sleepFn keeps the retry backoff instant in tests.
-  const response = await fetchWithRetry(
-    options.fetchFn,
-    apiUrl(options.apiBaseUrl, repoPath(target, `/pulls/${prNumber}`)),
-    { method: "GET", headers: githubHeaders(options.githubToken) },
-    { sleepFn: options.sleepFn, timeoutMs: options.requestTimeoutMs },
-  );
-  const payload = await response.json().catch(() => null);
-  if (!response.ok) throw githubError(response, payload);
-  return payload;
+    // Retry transient network errors / 5xx around this single call (#4829), matching ci-poller.js's
+    // githubGetJsonResponse -- distinct from this poller's OWN outer pending-retry loop. requestTimeoutMs bounds
+    // each individual attempt with a fresh AbortSignal.timeout() (a stalled connection can't hang a poll cycle
+    // forever -- #miner-github-read-timeouts); the injected sleepFn keeps the retry backoff instant in tests.
+    const response = await fetchWithRetry(options.fetchFn, apiUrl(options.apiBaseUrl, repoPath(target, `/pulls/${prNumber}`)), { method: "GET", headers: githubHeaders(options.githubToken) }, { sleepFn: options.sleepFn, timeoutMs: options.requestTimeoutMs });
+    const payload = (await response.json().catch(() => null));
+    if (!response.ok)
+        throw githubError(response, payload);
+    return payload;
 }
-
 /** GitHub's own vocabulary is `state: "open"|"closed"` plus a separate `merged: boolean` -- "closed and not
  *  merged" is the disengaged case. A still-open PR is never terminal for this poller's purposes. */
 function normalizeDisposition(payload) {
-  const state = payload?.state === "closed" ? "closed" : "open";
-  const merged = Boolean(payload?.merged);
-  const closedAt = typeof payload?.closed_at === "string" ? payload.closed_at : null;
-  return { state, merged, closedAt };
+    const state = payload?.state === "closed" ? "closed" : "open";
+    const merged = Boolean(payload?.merged);
+    const closedAt = typeof payload?.closed_at === "string" ? payload.closed_at : null;
+    return { state, merged, closedAt };
 }
-
 function backoffDelayMs(attemptIndex, options) {
-  const exponent = Math.min(10, Math.max(0, attemptIndex));
-  return Math.min(options.maxIntervalMs, options.minIntervalMs * 2 ** exponent);
+    const exponent = Math.min(10, Math.max(0, attemptIndex));
+    return Math.min(options.maxIntervalMs, options.minIntervalMs * 2 ** exponent);
 }
-
 /**
  * Poll a real PR's own merge/close disposition (distinct from its CI check-run conclusion, ci-poller.js's
  * concern) with exponential backoff, until it reaches a terminal `state: "closed"` or `maxAttempts` is
@@ -143,21 +129,24 @@ function backoffDelayMs(attemptIndex, options) {
  * @returns {Promise<{ state: "open"|"closed", merged: boolean, closedAt: string|null, attempts: number }>}
  */
 export async function pollPrDisposition(repoFullName, prNumber, options = {}) {
-  const target = parseRepoFullName(repoFullName);
-  const normalizedPrNumber = normalizePullNumber(prNumber);
-  const normalizedOptions = normalizeOptions(options);
-
-  let latest = { state: "open", merged: false, closedAt: null, attempts: 0 };
-  for (let attempt = 0; attempt < normalizedOptions.maxAttempts; attempt += 1) {
-    const payload = await fetchPullRequest(target, normalizedPrNumber, normalizedOptions);
-    latest = { ...normalizeDisposition(payload), attempts: attempt + 1 };
-    if (latest.state === "closed") return latest;
-    if (attempt === normalizedOptions.maxAttempts - 1) return latest;
-    await normalizedOptions.sleepFn(backoffDelayMs(attempt, normalizedOptions));
-  }
-  return latest;
+    const target = parseRepoFullName(repoFullName);
+    const normalizedPrNumber = normalizePullNumber(prNumber);
+    const normalizedOptions = normalizeOptions(options);
+    let latest = { state: "open", merged: false, closedAt: null, attempts: 0 };
+    for (let attempt = 0; attempt < normalizedOptions.maxAttempts; attempt += 1) {
+        const payload = await fetchPullRequest(target, normalizedPrNumber, normalizedOptions);
+        latest = { ...normalizeDisposition(payload), attempts: attempt + 1 };
+        if (latest.state === "closed")
+            return latest;
+        if (attempt === normalizedOptions.maxAttempts - 1)
+            return latest;
+        await normalizedOptions.sleepFn(backoffDelayMs(attempt, normalizedOptions));
+    }
+    // Unreachable at runtime: maxAttempts is normalized to >= 1, so the loop always returns on its final iteration
+    // (the `attempt === maxAttempts - 1` guard). Kept only to satisfy the compiler's all-paths-return requirement.
+    /* v8 ignore next -- unreachable: the normalized maxAttempts >= 1 loop always returns before falling through */
+    return latest;
 }
-
 /**
  * Classify a real, terminal PR disposition into loop-reentry.js's own `candidate.outcome` vocabulary
  * (`"merged"|"disengaged"|"other"`). A still-open disposition (not yet resolved) classifies as `"other"` --
@@ -168,6 +157,8 @@ export async function pollPrDisposition(repoFullName, prNumber, options = {}) {
  * @returns {"merged"|"disengaged"|"other"}
  */
 export function classifyPrDisposition(disposition) {
-  if (disposition.state !== "closed") return "other";
-  return disposition.merged ? "merged" : "disengaged";
+    if (disposition.state !== "closed")
+        return "other";
+    return disposition.merged ? "merged" : "disengaged";
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHItZGlzcG9zaXRpb24tcG9sbGVyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsicHItZGlzcG9zaXRpb24tcG9sbGVyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDRHQUE0RztBQUM1RywyR0FBMkc7QUFDM0csOEdBQThHO0FBQzlHLGtHQUFrRztBQUNsRywyR0FBMkc7QUFDM0csZ0ZBQWdGO0FBQ2hGLEVBQUU7QUFDRixxR0FBcUc7QUFDckcsd0dBQXdHO0FBQ3hHLDRHQUE0RztBQUM1RywwR0FBMEc7QUFDMUcsaUdBQWlHO0FBRWpHLE9BQU8sRUFBRSxjQUFjLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQTBDakQsTUFBTSxpQkFBaUIsR0FBRyx3QkFBd0IsQ0FBQztBQUNuRCxNQUFNLG9CQUFvQixHQUFHLE1BQU0sQ0FBQztBQUNwQyxNQUFNLG9CQUFvQixHQUFHLENBQUMsR0FBRyxNQUFNLENBQUM7QUFDeEMsTUFBTSxrQkFBa0IsR0FBRyxDQUFDLENBQUM7QUFDN0IsTUFBTSx1QkFBdUIsR0FBRyxNQUFNLENBQUM7QUFDdkMsTUFBTSxnQkFBZ0IsR0FBRyxZQUFZLENBQUM7QUFFdEMsU0FBUyxtQkFBbUIsQ0FBQyxLQUFjO0lBQ3pDLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLGlCQUFpQixDQUFDO0lBQ2xELElBQUksT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRTtRQUFFLE9BQU8saUJBQWlCLENBQUM7SUFDekUsSUFBSSxNQUFNLENBQUM7SUFDWCxJQUFJLENBQUM7UUFDSCxNQUFNLEdBQUcsSUFBSSxHQUFHLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUM7SUFDakMsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLE1BQU0sSUFBSSxLQUFLLENBQUMsc0JBQXNCLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBQ0QsSUFBSSxNQUFNLENBQUMsUUFBUSxLQUFLLFFBQVEsSUFBSSxNQUFNLENBQUMsUUFBUSxLQUFLLGdCQUFnQixFQUFFLENBQUM7UUFDekUsTUFBTSxJQUFJLEtBQUssQ0FBQyxzQkFBc0IsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFDRCxNQUFNLENBQUMsUUFBUSxHQUFHLE1BQU0sQ0FBQyxRQUFRLENBQUMsT0FBTyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUMsQ0FBQztJQUN0RCxNQUFNLENBQUMsTUFBTSxHQUFHLEVBQUUsQ0FBQztJQUNuQixNQUFNLENBQUMsSUFBSSxHQUFHLEVBQUUsQ0FBQztJQUNqQixPQUFPLE1BQU0sQ0FBQyxRQUFRLEVBQUUsQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxDQUFDO0FBQy9DLENBQUM7QUFFRCxTQUFTLG9CQUFvQixDQUFDLEtBQWMsRUFBRSxRQUFnQixFQUFFLEdBQVcsRUFBRSxHQUFXO0lBQ3RGLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQztRQUFFLE9BQU8sUUFBUSxDQUFDO0lBQzdDLE9BQU8sSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLEVBQUUsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLEVBQUUsSUFBSSxDQUFDLEtBQUssQ0FBQyxLQUFlLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDbkUsQ0FBQztBQUVELFNBQVMsZ0JBQWdCLENBQUMsVUFBb0MsRUFBRTtJQUM5RCxPQUFPO1FBQ0wsVUFBVSxFQUFFLG1CQUFtQixDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUM7UUFDbkQsT0FBTyxFQUFFLE9BQU8sQ0FBQyxPQUFPLElBQUksS0FBSztRQUNqQyxXQUFXLEVBQUUsT0FBTyxPQUFPLENBQUMsV0FBVyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRTtRQUN0RixXQUFXLEVBQUUsb0JBQW9CLENBQUMsT0FBTyxDQUFDLFdBQVcsRUFBRSxrQkFBa0IsRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ2pGLGFBQWEsRUFBRSxvQkFBb0IsQ0FBQyxPQUFPLENBQUMsYUFBYSxFQUFFLG9CQUFvQixFQUFFLENBQUMsRUFBRSxFQUFFLEdBQUcsTUFBTSxDQUFDO1FBQ2hHLGFBQWEsRUFBRSxvQkFBb0IsQ0FBQyxPQUFPLENBQUMsYUFBYSxFQUFFLG9CQUFvQixFQUFFLENBQUMsRUFBRSxFQUFFLEdBQUcsTUFBTSxDQUFDO1FBQ2hHLGdCQUFnQixFQUFFLG9CQUFvQixDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsRUFBRSx1QkFBdUIsRUFBRSxDQUFDLEVBQUUsTUFBTSxDQUFDO1FBQ3BHLE9BQU8sRUFDTCxPQUFPLENBQUMsT0FBTztZQUNmLENBQUMsQ0FBQyxPQUFlLEVBQWlCLEVBQUUsQ0FBQyxJQUFJLE9BQU8sQ0FBQyxDQUFDLE9BQU8sRUFBRSxFQUFFLENBQUMsVUFBVSxDQUFDLE9BQU8sRUFBRSxPQUFPLENBQUMsQ0FBQyxDQUFDO0tBQy9GLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxpQkFBaUIsQ0FBQyxZQUFxQjtJQUM5QyxJQUFJLE9BQU8sWUFBWSxLQUFLLFFBQVE7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7SUFDaEYsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsWUFBWSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNyRCxJQUFJLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztRQUMzRCxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixDQUFDLENBQUM7SUFDNUMsQ0FBQztJQUNELE9BQU8sRUFBRSxLQUFLLEVBQUUsS0FBSyxDQUFDLElBQUksRUFBRSxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQztBQUNwRCxDQUFDO0FBRUQsU0FBUyxtQkFBbUIsQ0FBQyxLQUFhO0lBQ3hDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssSUFBSSxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQyxtQkFBbUIsQ0FBQyxDQUFDO0lBQ2pGLE9BQU8sS0FBSyxDQUFDO0FBQ2YsQ0FBQztBQUVELFNBQVMsYUFBYSxDQUFDLFdBQW1CO0lBQ3hDLE1BQU0sT0FBTyxHQUEyQjtRQUN0QyxNQUFNLEVBQUUsNkJBQTZCO1FBQ3JDLFlBQVksRUFBRSxnQkFBZ0I7UUFDOUIsc0JBQXNCLEVBQUUsZ0JBQWdCO0tBQ3pDLENBQUM7SUFDRixJQUFJLFdBQVc7UUFBRSxPQUFPLENBQUMsYUFBYSxHQUFHLFVBQVUsV0FBVyxFQUFFLENBQUM7SUFDakUsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVELFNBQVMsUUFBUSxDQUFDLE1BQWtCLEVBQUUsTUFBYztJQUNsRCxPQUFPLFVBQVUsa0JBQWtCLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxJQUFJLGtCQUFrQixDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsR0FBRyxNQUFNLEVBQUUsQ0FBQztBQUNsRyxDQUFDO0FBRUQsU0FBUyxNQUFNLENBQUMsVUFBa0IsRUFBRSxJQUFZO0lBQzlDLE9BQU8sR0FBRyxVQUFVLEdBQUcsSUFBSSxFQUFFLENBQUM7QUFDaEMsQ0FBQztBQUVELFNBQVMsV0FBVyxDQUFDLFFBQTRCLEVBQUUsT0FBaUM7SUFDbEYsTUFBTSxJQUFJLEdBQUcsVUFBVSxRQUFRLENBQUMsTUFBTSxFQUFFLENBQUM7SUFDekMsTUFBTSxhQUFhLEdBQ2pCLE9BQU8sT0FBTyxFQUFFLE9BQU8sS0FBSyxRQUFRLElBQUksT0FBTyxDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQzFGLE1BQU0sT0FBTyxHQUFHLGFBQWEsQ0FBQyxDQUFDLENBQUMsR0FBRyxJQUFJLEtBQUssYUFBYSxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUNuRSxPQUFPLE1BQU0sQ0FBQyxNQUFNLENBQUMsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLEVBQUUsRUFBRSxJQUFJLEVBQUUsYUFBYSxFQUFFLENBQUMsQ0FBQztBQUNwRSxDQUFDO0FBRUQsS0FBSyxVQUFVLGdCQUFnQixDQUM3QixNQUFrQixFQUNsQixRQUFnQixFQUNoQixPQUEwQjtJQUUxQixnR0FBZ0c7SUFDaEcsNkdBQTZHO0lBQzdHLDJHQUEyRztJQUMzRywwR0FBMEc7SUFDMUcsTUFBTSxRQUFRLEdBQUcsTUFBTSxjQUFjLENBQ25DLE9BQU8sQ0FBQyxPQUE4RCxFQUN0RSxNQUFNLENBQUMsT0FBTyxDQUFDLFVBQVUsRUFBRSxRQUFRLENBQUMsTUFBTSxFQUFFLFVBQVUsUUFBUSxFQUFFLENBQUMsQ0FBQyxFQUNsRSxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFFLGFBQWEsQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDLEVBQUUsRUFDOUQsRUFBRSxPQUFPLEVBQUUsT0FBTyxDQUFDLE9BQU8sRUFBRSxTQUFTLEVBQUUsT0FBTyxDQUFDLGdCQUFnQixFQUFFLENBQ2xFLENBQUM7SUFDRixNQUFNLE9BQU8sR0FBRyxDQUFDLE1BQU0sUUFBUSxDQUFDLElBQUksRUFBRSxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxJQUFJLENBQUMsQ0FBNkIsQ0FBQztJQUN0RixJQUFJLENBQUMsUUFBUSxDQUFDLEVBQUU7UUFBRSxNQUFNLFdBQVcsQ0FBQyxRQUFRLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDdkQsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVEO29HQUNvRztBQUNwRyxTQUFTLG9CQUFvQixDQUFDLE9BQWlDO0lBQzdELE1BQU0sS0FBSyxHQUFHLE9BQU8sRUFBRSxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQztJQUM5RCxNQUFNLE1BQU0sR0FBRyxPQUFPLENBQUMsT0FBTyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ3hDLE1BQU0sUUFBUSxHQUFHLE9BQU8sT0FBTyxFQUFFLFNBQVMsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztJQUNuRixPQUFPLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxRQUFRLEVBQUUsQ0FBQztBQUNyQyxDQUFDO0FBRUQsU0FBUyxjQUFjLENBQUMsWUFBb0IsRUFBRSxPQUEwQjtJQUN0RSxNQUFNLFFBQVEsR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsRUFBRSxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxZQUFZLENBQUMsQ0FBQyxDQUFDO0lBQ3pELE9BQU8sSUFBSSxDQUFDLEdBQUcsQ0FBQyxPQUFPLENBQUMsYUFBYSxFQUFFLE9BQU8sQ0FBQyxhQUFhLEdBQUcsQ0FBQyxJQUFJLFFBQVEsQ0FBQyxDQUFDO0FBQ2hGLENBQUM7QUFFRDs7Ozs7Ozs7Ozs7OztHQWFHO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSxpQkFBaUIsQ0FDckMsWUFBb0IsRUFDcEIsUUFBZ0IsRUFDaEIsVUFBb0MsRUFBRTtJQUV0QyxNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMvQyxNQUFNLGtCQUFrQixHQUFHLG1CQUFtQixDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQ3pELE1BQU0saUJBQWlCLEdBQUcsZ0JBQWdCLENBQUMsT0FBTyxDQUFDLENBQUM7SUFFcEQsSUFBSSxNQUFNLEdBQWtCLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLFFBQVEsRUFBRSxJQUFJLEVBQUUsUUFBUSxFQUFFLENBQUMsRUFBRSxDQUFDO0lBQzFGLEtBQUssSUFBSSxPQUFPLEdBQUcsQ0FBQyxFQUFFLE9BQU8sR0FBRyxpQkFBaUIsQ0FBQyxXQUFXLEVBQUUsT0FBTyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQzVFLE1BQU0sT0FBTyxHQUFHLE1BQU0sZ0JBQWdCLENBQUMsTUFBTSxFQUFFLGtCQUFrQixFQUFFLGlCQUFpQixDQUFDLENBQUM7UUFDdEYsTUFBTSxHQUFHLEVBQUUsR0FBRyxvQkFBb0IsQ0FBQyxPQUFPLENBQUMsRUFBRSxRQUFRLEVBQUUsT0FBTyxHQUFHLENBQUMsRUFBRSxDQUFDO1FBQ3JFLElBQUksTUFBTSxDQUFDLEtBQUssS0FBSyxRQUFRO1lBQUUsT0FBTyxNQUFNLENBQUM7UUFDN0MsSUFBSSxPQUFPLEtBQUssaUJBQWlCLENBQUMsV0FBVyxHQUFHLENBQUM7WUFBRSxPQUFPLE1BQU0sQ0FBQztRQUNqRSxNQUFNLGlCQUFpQixDQUFDLE9BQU8sQ0FBQyxjQUFjLENBQUMsT0FBTyxFQUFFLGlCQUFpQixDQUFDLENBQUMsQ0FBQztJQUM5RSxDQUFDO0lBQ0QsK0dBQStHO0lBQy9HLCtHQUErRztJQUMvRywrR0FBK0c7SUFDL0csT0FBTyxNQUFNLENBQUM7QUFDaEIsQ0FBQztBQUVEOzs7Ozs7OztHQVFHO0FBQ0gsTUFBTSxVQUFVLHFCQUFxQixDQUNuQyxXQUFvRDtJQUVwRCxJQUFJLFdBQVcsQ0FBQyxLQUFLLEtBQUssUUFBUTtRQUFFLE9BQU8sT0FBTyxDQUFDO0lBQ25ELE9BQU8sV0FBVyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxZQUFZLENBQUM7QUFDdEQsQ0FBQyJ9

--- a/packages/loopover-miner/lib/pr-disposition-poller.ts
+++ b/packages/loopover-miner/lib/pr-disposition-poller.ts
@@ -1,0 +1,226 @@
+// Real PR-disposition poller (#5135, Wave 3.5 -- the autonomous loop). ci-poller.js already polls a PR's CI
+// check-runs, but that answers a DIFFERENT question ("did the checks pass") from what the supervising loop
+// needs at cycle-close time ("did the PR itself get merged or closed"). Nothing in this package answered that
+// second question before this file: pr-outcome.js already has a real store for the classification
+// (recordPrOutcomeSnapshot/readPrOutcomes), but every existing caller of it was a test -- this is the real
+// GitHub fetch that produces the classification pr-outcome.js's writer expects.
+//
+// Deliberately its own module, not folded into ci-poller.js: the two pollers ask genuinely different
+// questions (check-run conclusion vs. PR merge/close disposition) with different terminal conditions (a
+// check-run poll's "pending" means "wait for the SAME head commit's checks to finish"; a disposition poll's
+// "open" means "wait for a human to actually merge or close the PR", a potentially much longer, unbounded
+// wait) -- composing them into one poller would conflate two different backoff/timeout policies.
+
+import { fetchWithRetry } from "./http-retry.js";
+
+export type PrDisposition = {
+  state: "open" | "closed";
+  merged: boolean;
+  closedAt: string | null;
+  attempts: number;
+};
+
+export type PollPrDispositionOptions = {
+  apiBaseUrl?: string;
+  fetchFn?: typeof fetch;
+  githubToken?: string;
+  maxAttempts?: number;
+  minIntervalMs?: number;
+  maxIntervalMs?: number;
+  requestTimeoutMs?: number;
+  sleepFn?: (delayMs: number) => Promise<void>;
+};
+
+type NormalizedOptions = {
+  apiBaseUrl: string;
+  fetchFn: typeof fetch;
+  githubToken: string;
+  maxAttempts: number;
+  minIntervalMs: number;
+  maxIntervalMs: number;
+  requestTimeoutMs: number;
+  sleepFn: (delayMs: number) => Promise<void>;
+};
+
+type RepoTarget = { owner: string; repo: string };
+
+/** Minimal shape of a raw GitHub pull-request payload -- every field is read defensively (`typeof` guarded)
+ *  since it comes straight off the wire. */
+type GithubPullPayload = {
+  state?: unknown;
+  merged?: unknown;
+  closed_at?: unknown;
+  message?: unknown;
+};
+
+const defaultApiBaseUrl = "https://api.github.com";
+const defaultMinIntervalMs = 60_000;
+const defaultMaxIntervalMs = 5 * 60_000;
+const defaultMaxAttempts = 1;
+const defaultRequestTimeoutMs = 10_000;
+const githubApiVersion = "2022-11-28";
+
+function normalizeApiBaseUrl(value: unknown): string {
+  if (value === undefined) return defaultApiBaseUrl;
+  if (typeof value !== "string" || !value.trim()) return defaultApiBaseUrl;
+  let parsed;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    throw new Error("invalid_api_base_url");
+  }
+  if (parsed.protocol !== "https:" || parsed.hostname !== "api.github.com") {
+    throw new Error("invalid_api_base_url");
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function normalizePositiveInt(value: unknown, fallback: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value as number)));
+}
+
+function normalizeOptions(options: PollPrDispositionOptions = {}): NormalizedOptions {
+  return {
+    apiBaseUrl: normalizeApiBaseUrl(options.apiBaseUrl),
+    fetchFn: options.fetchFn ?? fetch,
+    githubToken: typeof options.githubToken === "string" ? options.githubToken.trim() : "",
+    maxAttempts: normalizePositiveInt(options.maxAttempts, defaultMaxAttempts, 1, 20),
+    minIntervalMs: normalizePositiveInt(options.minIntervalMs, defaultMinIntervalMs, 1, 60 * 60_000),
+    maxIntervalMs: normalizePositiveInt(options.maxIntervalMs, defaultMaxIntervalMs, 1, 60 * 60_000),
+    requestTimeoutMs: normalizePositiveInt(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
+    sleepFn:
+      options.sleepFn ??
+      ((delayMs: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, delayMs))),
+  };
+}
+
+function parseRepoFullName(repoFullName: unknown): RepoTarget {
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner?.trim() || !repo?.trim() || extra !== undefined) {
+    throw new Error("invalid_repo_full_name");
+  }
+  return { owner: owner.trim(), repo: repo.trim() };
+}
+
+function normalizePullNumber(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) throw new Error("invalid_pr_number");
+  return value;
+}
+
+function githubHeaders(githubToken: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "loopover-miner",
+    "x-github-api-version": githubApiVersion,
+  };
+  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
+  return headers;
+}
+
+function repoPath(target: RepoTarget, suffix: string): string {
+  return `/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}${suffix}`;
+}
+
+function apiUrl(apiBaseUrl: string, path: string): string {
+  return `${apiBaseUrl}${path}`;
+}
+
+function githubError(response: { status: number }, payload: GithubPullPayload | null): Error {
+  const code = `github_${response.status}`;
+  const githubMessage =
+    typeof payload?.message === "string" && payload.message.trim() ? payload.message : null;
+  const message = githubMessage ? `${code}: ${githubMessage}` : code;
+  return Object.assign(new Error(message), { code, githubMessage });
+}
+
+async function fetchPullRequest(
+  target: RepoTarget,
+  prNumber: number,
+  options: NormalizedOptions,
+): Promise<GithubPullPayload | null> {
+  // Retry transient network errors / 5xx around this single call (#4829), matching ci-poller.js's
+  // githubGetJsonResponse -- distinct from this poller's OWN outer pending-retry loop. requestTimeoutMs bounds
+  // each individual attempt with a fresh AbortSignal.timeout() (a stalled connection can't hang a poll cycle
+  // forever -- #miner-github-read-timeouts); the injected sleepFn keeps the retry backoff instant in tests.
+  const response = await fetchWithRetry(
+    options.fetchFn as (url: unknown, init?: unknown) => Promise<Response>,
+    apiUrl(options.apiBaseUrl, repoPath(target, `/pulls/${prNumber}`)),
+    { method: "GET", headers: githubHeaders(options.githubToken) },
+    { sleepFn: options.sleepFn, timeoutMs: options.requestTimeoutMs },
+  );
+  const payload = (await response.json().catch(() => null)) as GithubPullPayload | null;
+  if (!response.ok) throw githubError(response, payload);
+  return payload;
+}
+
+/** GitHub's own vocabulary is `state: "open"|"closed"` plus a separate `merged: boolean` -- "closed and not
+ *  merged" is the disengaged case. A still-open PR is never terminal for this poller's purposes. */
+function normalizeDisposition(payload: GithubPullPayload | null): Omit<PrDisposition, "attempts"> {
+  const state = payload?.state === "closed" ? "closed" : "open";
+  const merged = Boolean(payload?.merged);
+  const closedAt = typeof payload?.closed_at === "string" ? payload.closed_at : null;
+  return { state, merged, closedAt };
+}
+
+function backoffDelayMs(attemptIndex: number, options: NormalizedOptions): number {
+  const exponent = Math.min(10, Math.max(0, attemptIndex));
+  return Math.min(options.maxIntervalMs, options.minIntervalMs * 2 ** exponent);
+}
+
+/**
+ * Poll a real PR's own merge/close disposition (distinct from its CI check-run conclusion, ci-poller.js's
+ * concern) with exponential backoff, until it reaches a terminal `state: "closed"` or `maxAttempts` is
+ * exhausted -- whichever comes first. A still-`"open"` PR after the last attempt is returned as-is, not an
+ * error: an unattended loop cycle should treat "still open" as "not yet resolved", not fail.
+ *
+ * @param {string} repoFullName
+ * @param {number} prNumber
+ * @param {{
+ *   apiBaseUrl?: string, fetchFn?: typeof fetch, githubToken?: string, maxAttempts?: number,
+ *   minIntervalMs?: number, maxIntervalMs?: number, sleepFn?: (delayMs: number) => Promise<void>,
+ * }} [options]
+ * @returns {Promise<{ state: "open"|"closed", merged: boolean, closedAt: string|null, attempts: number }>}
+ */
+export async function pollPrDisposition(
+  repoFullName: string,
+  prNumber: number,
+  options: PollPrDispositionOptions = {},
+): Promise<PrDisposition> {
+  const target = parseRepoFullName(repoFullName);
+  const normalizedPrNumber = normalizePullNumber(prNumber);
+  const normalizedOptions = normalizeOptions(options);
+
+  let latest: PrDisposition = { state: "open", merged: false, closedAt: null, attempts: 0 };
+  for (let attempt = 0; attempt < normalizedOptions.maxAttempts; attempt += 1) {
+    const payload = await fetchPullRequest(target, normalizedPrNumber, normalizedOptions);
+    latest = { ...normalizeDisposition(payload), attempts: attempt + 1 };
+    if (latest.state === "closed") return latest;
+    if (attempt === normalizedOptions.maxAttempts - 1) return latest;
+    await normalizedOptions.sleepFn(backoffDelayMs(attempt, normalizedOptions));
+  }
+  // Unreachable at runtime: maxAttempts is normalized to >= 1, so the loop always returns on its final iteration
+  // (the `attempt === maxAttempts - 1` guard). Kept only to satisfy the compiler's all-paths-return requirement.
+  /* v8 ignore next -- unreachable: the normalized maxAttempts >= 1 loop always returns before falling through */
+  return latest;
+}
+
+/**
+ * Classify a real, terminal PR disposition into loop-reentry.js's own `candidate.outcome` vocabulary
+ * (`"merged"|"disengaged"|"other"`). A still-open disposition (not yet resolved) classifies as `"other"` --
+ * the same bucket a runMinerAttempt outcome that never opened a PR at all falls into (nothing to re-enter on
+ * yet, in either case).
+ *
+ * @param {{ state: "open"|"closed", merged: boolean }} disposition
+ * @returns {"merged"|"disengaged"|"other"}
+ */
+export function classifyPrDisposition(
+  disposition: Pick<PrDisposition, "state" | "merged">,
+): "merged" | "disengaged" | "other" {
+  if (disposition.state !== "closed") return "other";
+  return disposition.merged ? "merged" : "disengaged";
+}

--- a/packages/loopover-miner/lib/ranked-candidates.d.ts
+++ b/packages/loopover-miner/lib/ranked-candidates.d.ts
@@ -1,51 +1,44 @@
 export type RankedCandidateInput = {
-  repoFullName: string;
-  issueNumber: number;
-  title?: string;
-  htmlUrl?: string | null;
-  rankScore: number;
-  laneFit?: number;
-  freshness?: number;
-  potential?: number;
-  feasibility?: number;
-  dupRisk?: number;
+    repoFullName: string;
+    issueNumber: number;
+    title?: string;
+    htmlUrl?: string | null;
+    rankScore: number;
+    laneFit?: number;
+    freshness?: number;
+    potential?: number;
+    feasibility?: number;
+    dupRisk?: number;
 };
-
 export type RankedCandidateRow = {
-  repoFullName: string;
-  issueNumber: number;
-  title: string;
-  htmlUrl: string | null;
-  rankScore: number;
-  laneFit: number;
-  freshness: number;
-  potential: number;
-  feasibility: number;
-  dupRisk: number;
-  rankedAt: string;
+    repoFullName: string;
+    issueNumber: number;
+    title: string;
+    htmlUrl: string | null;
+    rankScore: number;
+    laneFit: number;
+    freshness: number;
+    potential: number;
+    feasibility: number;
+    dupRisk: number;
+    rankedAt: string;
 };
-
 export type RankedCandidatesSaveResult = {
-  count: number;
-  rankedAt: string;
+    count: number;
+    rankedAt: string;
 };
-
 export type RankedCandidatesStore = {
-  dbPath: string;
-  saveRankedCandidates(candidates: RankedCandidateInput[], nowMs?: number): RankedCandidatesSaveResult;
-  listRankedCandidates(): RankedCandidateRow[];
-  close(): void;
+    dbPath: string;
+    saveRankedCandidates(candidates: RankedCandidateInput[], nowMs?: number): RankedCandidatesSaveResult;
+    listRankedCandidates(): RankedCandidateRow[];
+    close(): void;
 };
-
-export function resolveRankedCandidatesDbPath(env?: Record<string, string | undefined>): string;
-
-export function initRankedCandidatesStore(dbPath?: string): RankedCandidatesStore;
-
-export function saveRankedCandidates(
-  candidates: RankedCandidateInput[],
-  nowMs?: number,
-): RankedCandidatesSaveResult;
-
-export function listRankedCandidates(): RankedCandidateRow[];
-
-export function closeDefaultRankedCandidatesStore(): void;
+export declare function resolveRankedCandidatesDbPath(env?: Record<string, string | undefined>): string;
+/**
+ * Opens the 100% local/client-side ranked-candidates snapshot store. The database only lives on this machine;
+ * this module never uploads, syncs, or phones home with its contents.
+ */
+export declare function initRankedCandidatesStore(dbPath?: string): RankedCandidatesStore;
+export declare function saveRankedCandidates(candidates: RankedCandidateInput[], nowMs?: number): RankedCandidatesSaveResult;
+export declare function listRankedCandidates(): RankedCandidateRow[];
+export declare function closeDefaultRankedCandidatesStore(): void;

--- a/packages/loopover-miner/lib/ranked-candidates.js
+++ b/packages/loopover-miner/lib/ranked-candidates.js
@@ -1,87 +1,71 @@
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
-
-// Last-discover-run ranked-candidates snapshot (#4859 prerequisite): `discover-cli.js`'s runDiscover already
-// computes the FULL per-issue ranking breakdown (rankScore/laneFit/freshness/potential/feasibility/dupRisk, via
-// opportunity-ranker.js) and prints it to stdout with `--json`, but nothing durable ever stores it -- the
-// portfolio queue only carries a single derived `priority` number, not the per-dimension detail. The browser
-// extension's opportunity badge (apps/loopover-miner-extension/opportunity-badge.js) needs exactly that detail
-// to render its "why" reasoning, and today can only get it via a manual copy/paste of `discover --json`'s output
-// (#4859's whole premise). This module gives that output a durable home so a local HTTP endpoint can serve it.
-//
-// Deliberately a SNAPSHOT, not a ledger: each real (non-dry-run) discover invocation REPLACES the whole table
-// wholesale (this run's candidates are what's live-fetchable now; a stale prior run's rows would be actively
-// misleading, not historically useful the way an append-only ledger's rows are). No forge (api_base_url) scoping
-// either -- unlike the portfolio-queue/claim-ledger/governor-state stores, which track ongoing state across many
-// runs and many repos over time, this is a disposable "the miner's current opinion" cache for one local
-// operator's browsing session; if a later run targets a different forge, replacing the whole snapshot is exactly
-// the right behavior, not a gap.
-
 const defaultDbFileName = "ranked-candidates.sqlite3";
 let defaultRankedCandidatesStore = null;
-
 export function resolveRankedCandidatesDbPath(env = process.env) {
-  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_RANKED_CANDIDATES_DB", env);
+    return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_RANKED_CANDIDATES_DB", env);
 }
-
 function normalizeDbPath(dbPath) {
-  return normalizeLocalStoreDbPath(dbPath, resolveRankedCandidatesDbPath(), "invalid_ranked_candidates_db_path");
+    return normalizeLocalStoreDbPath(dbPath, resolveRankedCandidatesDbPath(), "invalid_ranked_candidates_db_path");
 }
-
 function normalizeFiniteRankDimension(value, fallback) {
-  return Number.isFinite(value) ? value : fallback;
+    return Number.isFinite(value) ? value : fallback;
 }
-
 function normalizeCandidate(candidate) {
-  if (!candidate || typeof candidate !== "object") throw new Error("invalid_ranked_candidate");
-  const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
-  const [owner, repo, extra] = repoFullName.split("/");
-  if (!owner || !repo || extra !== undefined) throw new Error("invalid_ranked_candidate");
-  const issueNumber = candidate.issueNumber;
-  if (!Number.isInteger(issueNumber) || issueNumber <= 0) throw new Error("invalid_ranked_candidate");
-  const rankScore = Number(candidate.rankScore);
-  if (!Number.isFinite(rankScore)) throw new Error("invalid_ranked_candidate");
-  return {
-    repoFullName: `${owner}/${repo}`,
-    issueNumber,
-    title: typeof candidate.title === "string" ? candidate.title : "",
-    htmlUrl: typeof candidate.htmlUrl === "string" ? candidate.htmlUrl : null,
-    rankScore,
-    // A dimension the ranker didn't supply degrades to the SAME neutral defaults opportunity-ranker.js's own
-    // normalizeCandidate uses for a missing signal (0 for a benefit dimension, 1 -- max risk -- for dupRisk),
-    // rather than silently coercing a non-finite value to 0 across the board.
-    laneFit: normalizeFiniteRankDimension(candidate.laneFit, 0),
-    freshness: normalizeFiniteRankDimension(candidate.freshness, 0),
-    potential: normalizeFiniteRankDimension(candidate.potential, 0),
-    feasibility: normalizeFiniteRankDimension(candidate.feasibility, 0),
-    dupRisk: normalizeFiniteRankDimension(candidate.dupRisk, 1),
-  };
+    if (!candidate || typeof candidate !== "object")
+        throw new Error("invalid_ranked_candidate");
+    const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+    const [owner, repo, extra] = repoFullName.split("/");
+    if (!owner || !repo || extra !== undefined)
+        throw new Error("invalid_ranked_candidate");
+    const issueNumber = candidate.issueNumber;
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0)
+        throw new Error("invalid_ranked_candidate");
+    const rankScore = Number(candidate.rankScore);
+    if (!Number.isFinite(rankScore))
+        throw new Error("invalid_ranked_candidate");
+    return {
+        repoFullName: `${owner}/${repo}`,
+        issueNumber,
+        title: typeof candidate.title === "string" ? candidate.title : "",
+        htmlUrl: typeof candidate.htmlUrl === "string" ? candidate.htmlUrl : null,
+        rankScore,
+        // A dimension the ranker didn't supply degrades to the SAME neutral defaults opportunity-ranker.js's own
+        // normalizeCandidate uses for a missing signal (0 for a benefit dimension, 1 -- max risk -- for dupRisk),
+        // rather than silently coercing a non-finite value to 0 across the board.
+        laneFit: normalizeFiniteRankDimension(candidate.laneFit, 0),
+        freshness: normalizeFiniteRankDimension(candidate.freshness, 0),
+        potential: normalizeFiniteRankDimension(candidate.potential, 0),
+        feasibility: normalizeFiniteRankDimension(candidate.feasibility, 0),
+        dupRisk: normalizeFiniteRankDimension(candidate.dupRisk, 1),
+    };
 }
-
 function rowToCandidate(row) {
-  return {
-    repoFullName: row.repo_full_name,
-    issueNumber: row.issue_number,
-    title: row.title,
-    htmlUrl: row.html_url,
-    rankScore: row.rank_score,
-    laneFit: row.lane_fit,
-    freshness: row.freshness,
-    potential: row.potential,
-    feasibility: row.feasibility,
-    dupRisk: row.dup_risk,
-    rankedAt: row.ranked_at,
-  };
+    return {
+        repoFullName: row.repo_full_name,
+        issueNumber: row.issue_number,
+        title: row.title,
+        htmlUrl: row.html_url,
+        rankScore: row.rank_score,
+        laneFit: row.lane_fit,
+        freshness: row.freshness,
+        potential: row.potential,
+        feasibility: row.feasibility,
+        dupRisk: row.dup_risk,
+        rankedAt: row.ranked_at,
+    };
 }
-
+function asRankedCandidateDbRow(row) {
+    return row;
+}
 /**
  * Opens the 100% local/client-side ranked-candidates snapshot store. The database only lives on this machine;
  * this module never uploads, syncs, or phones home with its contents.
  */
 export function initRankedCandidatesStore(dbPath = resolveRankedCandidatesDbPath()) {
-  const resolvedPath = normalizeDbPath(dbPath);
-  const db = openLocalStoreDb(resolvedPath);
-  db.exec(`
+    const resolvedPath = normalizeDbPath(dbPath);
+    const db = openLocalStoreDb(resolvedPath);
+    db.exec(`
     CREATE TABLE IF NOT EXISTS miner_ranked_candidates (
       repo_full_name TEXT NOT NULL,
       issue_number INTEGER NOT NULL,
@@ -97,82 +81,66 @@ export function initRankedCandidatesStore(dbPath = resolveRankedCandidatesDbPath
       PRIMARY KEY (repo_full_name, issue_number)
     )
   `);
-  // Schema-version convention (#4832): stamp the baseline. No post-baseline migrations yet -- this is a new store.
-  applySchemaMigrations(db, []);
-
-  const deleteAllStatement = db.prepare("DELETE FROM miner_ranked_candidates");
-  const insertStatement = db.prepare(`
+    // Schema-version convention (#4832): stamp the baseline. No post-baseline migrations yet -- this is a new store.
+    applySchemaMigrations(db, []);
+    const deleteAllStatement = db.prepare("DELETE FROM miner_ranked_candidates");
+    const insertStatement = db.prepare(`
     INSERT INTO miner_ranked_candidates
       (repo_full_name, issue_number, title, html_url, rank_score, lane_fit, freshness, potential, feasibility, dup_risk, ranked_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
-  const listStatement = db.prepare("SELECT * FROM miner_ranked_candidates ORDER BY rank_score DESC");
-
-  // Atomic replace: a reader between the DELETE and the INSERTs must never observe an empty table mid-write.
-  // node:sqlite's DatabaseSync has no `.transaction()` helper (unlike better-sqlite3) -- mirrors
-  // portfolio-queue.js's batchClaim: explicit BEGIN IMMEDIATE/COMMIT, ROLLBACK + rethrow on failure.
-  function replaceAll(normalizedCandidates, rankedAt) {
-    db.exec("BEGIN IMMEDIATE");
-    try {
-      deleteAllStatement.run();
-      for (const candidate of normalizedCandidates) {
-        insertStatement.run(
-          candidate.repoFullName,
-          candidate.issueNumber,
-          candidate.title,
-          candidate.htmlUrl,
-          candidate.rankScore,
-          candidate.laneFit,
-          candidate.freshness,
-          candidate.potential,
-          candidate.feasibility,
-          candidate.dupRisk,
-          rankedAt,
-        );
-      }
-      db.exec("COMMIT");
-    } catch (error) {
-      db.exec("ROLLBACK");
-      throw error;
+    const listStatement = db.prepare("SELECT * FROM miner_ranked_candidates ORDER BY rank_score DESC");
+    // Atomic replace: a reader between the DELETE and the INSERTs must never observe an empty table mid-write.
+    // node:sqlite's DatabaseSync has no `.transaction()` helper (unlike better-sqlite3) -- mirrors
+    // portfolio-queue.js's batchClaim: explicit BEGIN IMMEDIATE/COMMIT, ROLLBACK + rethrow on failure.
+    function replaceAll(normalizedCandidates, rankedAt) {
+        db.exec("BEGIN IMMEDIATE");
+        try {
+            deleteAllStatement.run();
+            for (const candidate of normalizedCandidates) {
+                insertStatement.run(candidate.repoFullName, candidate.issueNumber, candidate.title, candidate.htmlUrl, candidate.rankScore, candidate.laneFit, candidate.freshness, candidate.potential, candidate.feasibility, candidate.dupRisk, rankedAt);
+            }
+            db.exec("COMMIT");
+        }
+        catch (error) {
+            db.exec("ROLLBACK");
+            throw error;
+        }
     }
-  }
-
-  return {
-    dbPath: resolvedPath,
-    /** Replaces the whole snapshot wholesale with this run's ranked candidates. `nowMs` is caller-supplied
-     *  (never reads the clock internally) so tests get a deterministic `rankedAt`. */
-    saveRankedCandidates(candidates, nowMs) {
-      const normalized = (Array.isArray(candidates) ? candidates : []).map(normalizeCandidate);
-      const rankedAt = new Date(Number.isFinite(nowMs) ? nowMs : Date.now()).toISOString();
-      replaceAll(normalized, rankedAt);
-      return { count: normalized.length, rankedAt };
-    },
-    /** Every candidate from the last saved run, highest rankScore first. Empty (not an error) before any
-     *  discover run has ever saved a snapshot, or if the last run found zero candidates. */
-    listRankedCandidates() {
-      return listStatement.all().map(rowToCandidate);
-    },
-    close() {
-      db.close();
-    },
-  };
+    return {
+        dbPath: resolvedPath,
+        /** Replaces the whole snapshot wholesale with this run's ranked candidates. `nowMs` is caller-supplied
+         *  (never reads the clock internally) so tests get a deterministic `rankedAt`. */
+        saveRankedCandidates(candidates, nowMs) {
+            const normalized = (Array.isArray(candidates) ? candidates : []).map(normalizeCandidate);
+            const rankedAt = new Date(Number.isFinite(nowMs) ? nowMs : Date.now()).toISOString();
+            replaceAll(normalized, rankedAt);
+            return { count: normalized.length, rankedAt };
+        },
+        /** Every candidate from the last saved run, highest rankScore first. Empty (not an error) before any
+         *  discover run has ever saved a snapshot, or if the last run found zero candidates. */
+        listRankedCandidates() {
+            return listStatement.all().map((row) => rowToCandidate(asRankedCandidateDbRow(row)));
+        },
+        close() {
+            db.close();
+        },
+    };
 }
-
 function getDefaultRankedCandidatesStore() {
-  defaultRankedCandidatesStore ??= initRankedCandidatesStore();
-  return defaultRankedCandidatesStore;
+    defaultRankedCandidatesStore ??= initRankedCandidatesStore();
+    return defaultRankedCandidatesStore;
 }
-
 export function saveRankedCandidates(candidates, nowMs) {
-  return getDefaultRankedCandidatesStore().saveRankedCandidates(candidates, nowMs);
+    return getDefaultRankedCandidatesStore().saveRankedCandidates(candidates, nowMs);
 }
-
 export function listRankedCandidates() {
-  return getDefaultRankedCandidatesStore().listRankedCandidates();
+    return getDefaultRankedCandidatesStore().listRankedCandidates();
 }
-
 export function closeDefaultRankedCandidatesStore() {
-  if (!defaultRankedCandidatesStore) return;
-  defaultRankedCandidatesStore.close();
-  defaultRankedCandidatesStore = null;
+    if (!defaultRankedCandidatesStore)
+        return;
+    defaultRankedCandidatesStore.close();
+    defaultRankedCandidatesStore = null;
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmFua2VkLWNhbmRpZGF0ZXMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJyYW5rZWQtY2FuZGlkYXRlcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFDQSxPQUFPLEVBQUUseUJBQXlCLEVBQUUsZ0JBQWdCLEVBQUUsdUJBQXVCLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUN4RyxPQUFPLEVBQUUscUJBQXFCLEVBQUUsTUFBTSxxQkFBcUIsQ0FBQztBQXNGNUQsTUFBTSxpQkFBaUIsR0FBRywyQkFBMkIsQ0FBQztBQUN0RCxJQUFJLDRCQUE0QixHQUFpQyxJQUFJLENBQUM7QUFFdEUsTUFBTSxVQUFVLDZCQUE2QixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQ2pHLE9BQU8sdUJBQXVCLENBQUMsaUJBQWlCLEVBQUUscUNBQXFDLEVBQUUsR0FBRyxDQUFDLENBQUM7QUFDaEcsQ0FBQztBQUVELFNBQVMsZUFBZSxDQUFDLE1BQWM7SUFDckMsT0FBTyx5QkFBeUIsQ0FBQyxNQUFNLEVBQUUsNkJBQTZCLEVBQUUsRUFBRSxtQ0FBbUMsQ0FBQyxDQUFDO0FBQ2pILENBQUM7QUFFRCxTQUFTLDRCQUE0QixDQUFDLEtBQWMsRUFBRSxRQUFnQjtJQUNwRSxPQUFPLE1BQU0sQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFFLEtBQWdCLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQztBQUMvRCxDQUFDO0FBRUQsU0FBUyxrQkFBa0IsQ0FBQyxTQUErQjtJQUN6RCxJQUFJLENBQUMsU0FBUyxJQUFJLE9BQU8sU0FBUyxLQUFLLFFBQVE7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLDBCQUEwQixDQUFDLENBQUM7SUFDN0YsTUFBTSxZQUFZLEdBQUcsT0FBTyxTQUFTLENBQUMsWUFBWSxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQ3JHLE1BQU0sQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxHQUFHLFlBQVksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDckQsSUFBSSxDQUFDLEtBQUssSUFBSSxDQUFDLElBQUksSUFBSSxLQUFLLEtBQUssU0FBUztRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsMEJBQTBCLENBQUMsQ0FBQztJQUN4RixNQUFNLFdBQVcsR0FBRyxTQUFTLENBQUMsV0FBVyxDQUFDO0lBQzFDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLFdBQVcsQ0FBQyxJQUFJLFdBQVcsSUFBSSxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywwQkFBMEIsQ0FBQyxDQUFDO0lBQ3BHLE1BQU0sU0FBUyxHQUFHLE1BQU0sQ0FBQyxTQUFTLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDOUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsU0FBUyxDQUFDO1FBQUUsTUFBTSxJQUFJLEtBQUssQ0FBQywwQkFBMEIsQ0FBQyxDQUFDO0lBQzdFLE9BQU87UUFDTCxZQUFZLEVBQUUsR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFO1FBQ2hDLFdBQVc7UUFDWCxLQUFLLEVBQUUsT0FBTyxTQUFTLENBQUMsS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsRUFBRTtRQUNqRSxPQUFPLEVBQUUsT0FBTyxTQUFTLENBQUMsT0FBTyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsSUFBSTtRQUN6RSxTQUFTO1FBQ1QseUdBQXlHO1FBQ3pHLDBHQUEwRztRQUMxRywwRUFBMEU7UUFDMUUsT0FBTyxFQUFFLDRCQUE0QixDQUFDLFNBQVMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDO1FBQzNELFNBQVMsRUFBRSw0QkFBNEIsQ0FBQyxTQUFTLENBQUMsU0FBUyxFQUFFLENBQUMsQ0FBQztRQUMvRCxTQUFTLEVBQUUsNEJBQTRCLENBQUMsU0FBUyxDQUFDLFNBQVMsRUFBRSxDQUFDLENBQUM7UUFDL0QsV0FBVyxFQUFFLDRCQUE0QixDQUFDLFNBQVMsQ0FBQyxXQUFXLEVBQUUsQ0FBQyxDQUFDO1FBQ25FLE9BQU8sRUFBRSw0QkFBNEIsQ0FBQyxTQUFTLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQztLQUM1RCxDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMsY0FBYyxDQUFDLEdBQXlCO0lBQy9DLE9BQU87UUFDTCxZQUFZLEVBQUUsR0FBRyxDQUFDLGNBQWM7UUFDaEMsV0FBVyxFQUFFLEdBQUcsQ0FBQyxZQUFZO1FBQzdCLEtBQUssRUFBRSxHQUFHLENBQUMsS0FBSztRQUNoQixPQUFPLEVBQUUsR0FBRyxDQUFDLFFBQVE7UUFDckIsU0FBUyxFQUFFLEdBQUcsQ0FBQyxVQUFVO1FBQ3pCLE9BQU8sRUFBRSxHQUFHLENBQUMsUUFBUTtRQUNyQixTQUFTLEVBQUUsR0FBRyxDQUFDLFNBQVM7UUFDeEIsU0FBUyxFQUFFLEdBQUcsQ0FBQyxTQUFTO1FBQ3hCLFdBQVcsRUFBRSxHQUFHLENBQUMsV0FBVztRQUM1QixPQUFPLEVBQUUsR0FBRyxDQUFDLFFBQVE7UUFDckIsUUFBUSxFQUFFLEdBQUcsQ0FBQyxTQUFTO0tBQ3hCLENBQUM7QUFDSixDQUFDO0FBRUQsU0FBUyxzQkFBc0IsQ0FBQyxHQUFtQztJQUNqRSxPQUFPLEdBQXNDLENBQUM7QUFDaEQsQ0FBQztBQUVEOzs7R0FHRztBQUNILE1BQU0sVUFBVSx5QkFBeUIsQ0FBQyxTQUFpQiw2QkFBNkIsRUFBRTtJQUN4RixNQUFNLFlBQVksR0FBRyxlQUFlLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDN0MsTUFBTSxFQUFFLEdBQUcsZ0JBQWdCLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDMUMsRUFBRSxDQUFDLElBQUksQ0FBQzs7Ozs7Ozs7Ozs7Ozs7O0dBZVAsQ0FBQyxDQUFDO0lBQ0gsaUhBQWlIO0lBQ2pILHFCQUFxQixDQUFDLEVBQUUsRUFBRSxFQUFFLENBQUMsQ0FBQztJQUU5QixNQUFNLGtCQUFrQixHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUMscUNBQXFDLENBQUMsQ0FBQztJQUM3RSxNQUFNLGVBQWUsR0FBRyxFQUFFLENBQUMsT0FBTyxDQUFDOzs7O0dBSWxDLENBQUMsQ0FBQztJQUNILE1BQU0sYUFBYSxHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUMsZ0VBQWdFLENBQUMsQ0FBQztJQUVuRywyR0FBMkc7SUFDM0csK0ZBQStGO0lBQy9GLG1HQUFtRztJQUNuRyxTQUFTLFVBQVUsQ0FBQyxvQkFBaUQsRUFBRSxRQUFnQjtRQUNyRixFQUFFLENBQUMsSUFBSSxDQUFDLGlCQUFpQixDQUFDLENBQUM7UUFDM0IsSUFBSSxDQUFDO1lBQ0gsa0JBQWtCLENBQUMsR0FBRyxFQUFFLENBQUM7WUFDekIsS0FBSyxNQUFNLFNBQVMsSUFBSSxvQkFBb0IsRUFBRSxDQUFDO2dCQUM3QyxlQUFlLENBQUMsR0FBRyxDQUNqQixTQUFTLENBQUMsWUFBWSxFQUN0QixTQUFTLENBQUMsV0FBVyxFQUNyQixTQUFTLENBQUMsS0FBSyxFQUNmLFNBQVMsQ0FBQyxPQUFPLEVBQ2pCLFNBQVMsQ0FBQyxTQUFTLEVBQ25CLFNBQVMsQ0FBQyxPQUFPLEVBQ2pCLFNBQVMsQ0FBQyxTQUFTLEVBQ25CLFNBQVMsQ0FBQyxTQUFTLEVBQ25CLFNBQVMsQ0FBQyxXQUFXLEVBQ3JCLFNBQVMsQ0FBQyxPQUFPLEVBQ2pCLFFBQVEsQ0FDVCxDQUFDO1lBQ0osQ0FBQztZQUNELEVBQUUsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLENBQUM7UUFDcEIsQ0FBQztRQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7WUFDZixFQUFFLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ3BCLE1BQU0sS0FBSyxDQUFDO1FBQ2QsQ0FBQztJQUNILENBQUM7SUFFRCxPQUFPO1FBQ0wsTUFBTSxFQUFFLFlBQVk7UUFDcEI7MEZBQ2tGO1FBQ2xGLG9CQUFvQixDQUFDLFVBQVUsRUFBRSxLQUFLO1lBQ3BDLE1BQU0sVUFBVSxHQUFHLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxHQUFHLENBQUMsa0JBQWtCLENBQUMsQ0FBQztZQUN6RixNQUFNLFFBQVEsR0FBRyxJQUFJLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBRSxLQUFnQixDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQyxXQUFXLEVBQUUsQ0FBQztZQUNqRyxVQUFVLENBQUMsVUFBVSxFQUFFLFFBQVEsQ0FBQyxDQUFDO1lBQ2pDLE9BQU8sRUFBRSxLQUFLLEVBQUUsVUFBVSxDQUFDLE1BQU0sRUFBRSxRQUFRLEVBQUUsQ0FBQztRQUNoRCxDQUFDO1FBQ0Q7Z0dBQ3dGO1FBQ3hGLG9CQUFvQjtZQUNsQixPQUFPLGFBQWEsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLGNBQWMsQ0FBQyxzQkFBc0IsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDdkYsQ0FBQztRQUNELEtBQUs7WUFDSCxFQUFFLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDYixDQUFDO0tBQ0YsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLCtCQUErQjtJQUN0Qyw0QkFBNEIsS0FBSyx5QkFBeUIsRUFBRSxDQUFDO0lBQzdELE9BQU8sNEJBQTRCLENBQUM7QUFDdEMsQ0FBQztBQUVELE1BQU0sVUFBVSxvQkFBb0IsQ0FBQyxVQUFrQyxFQUFFLEtBQWM7SUFDckYsT0FBTywrQkFBK0IsRUFBRSxDQUFDLG9CQUFvQixDQUFDLFVBQVUsRUFBRSxLQUFLLENBQUMsQ0FBQztBQUNuRixDQUFDO0FBRUQsTUFBTSxVQUFVLG9CQUFvQjtJQUNsQyxPQUFPLCtCQUErQixFQUFFLENBQUMsb0JBQW9CLEVBQUUsQ0FBQztBQUNsRSxDQUFDO0FBRUQsTUFBTSxVQUFVLGlDQUFpQztJQUMvQyxJQUFJLENBQUMsNEJBQTRCO1FBQUUsT0FBTztJQUMxQyw0QkFBNEIsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNyQyw0QkFBNEIsR0FBRyxJQUFJLENBQUM7QUFDdEMsQ0FBQyJ9

--- a/packages/loopover-miner/lib/ranked-candidates.ts
+++ b/packages/loopover-miner/lib/ranked-candidates.ts
@@ -1,0 +1,251 @@
+import type { SQLOutputValue } from "node:sqlite";
+import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { applySchemaMigrations } from "./schema-version.js";
+
+// Last-discover-run ranked-candidates snapshot (#4859 prerequisite): `discover-cli.js`'s runDiscover already
+// computes the FULL per-issue ranking breakdown (rankScore/laneFit/freshness/potential/feasibility/dupRisk, via
+// opportunity-ranker.js) and prints it to stdout with `--json`, but nothing durable ever stores it -- the
+// portfolio queue only carries a single derived `priority` number, not the per-dimension detail. The browser
+// extension's opportunity badge (apps/loopover-miner-extension/opportunity-badge.js) needs exactly that detail
+// to render its "why" reasoning, and today can only get it via a manual copy/paste of `discover --json`'s output
+// (#4859's whole premise). This module gives that output a durable home so a local HTTP endpoint can serve it.
+//
+// Deliberately a SNAPSHOT, not a ledger: each real (non-dry-run) discover invocation REPLACES the whole table
+// wholesale (this run's candidates are what's live-fetchable now; a stale prior run's rows would be actively
+// misleading, not historically useful the way an append-only ledger's rows are). No forge (api_base_url) scoping
+// either -- unlike the portfolio-queue/claim-ledger/governor-state stores, which track ongoing state across many
+// runs and many repos over time, this is a disposable "the miner's current opinion" cache for one local
+// operator's browsing session; if a later run targets a different forge, replacing the whole snapshot is exactly
+// the right behavior, not a gap.
+
+export type RankedCandidateInput = {
+  repoFullName: string;
+  issueNumber: number;
+  title?: string;
+  htmlUrl?: string | null;
+  rankScore: number;
+  laneFit?: number;
+  freshness?: number;
+  potential?: number;
+  feasibility?: number;
+  dupRisk?: number;
+};
+
+export type RankedCandidateRow = {
+  repoFullName: string;
+  issueNumber: number;
+  title: string;
+  htmlUrl: string | null;
+  rankScore: number;
+  laneFit: number;
+  freshness: number;
+  potential: number;
+  feasibility: number;
+  dupRisk: number;
+  rankedAt: string;
+};
+
+export type RankedCandidatesSaveResult = {
+  count: number;
+  rankedAt: string;
+};
+
+export type RankedCandidatesStore = {
+  dbPath: string;
+  saveRankedCandidates(candidates: RankedCandidateInput[], nowMs?: number): RankedCandidatesSaveResult;
+  listRankedCandidates(): RankedCandidateRow[];
+  close(): void;
+};
+
+/** Private shape of a normalized candidate (a `RankedCandidateRow` minus its store-assigned `rankedAt`). */
+type NormalizedRankedCandidate = {
+  repoFullName: string;
+  issueNumber: number;
+  title: string;
+  htmlUrl: string | null;
+  rankScore: number;
+  laneFit: number;
+  freshness: number;
+  potential: number;
+  feasibility: number;
+  dupRisk: number;
+};
+
+/** Private shape of a `miner_ranked_candidates` SELECT * row after casting off `Record<string, SQLOutputValue>`. */
+type RankedCandidateDbRow = {
+  repo_full_name: string;
+  issue_number: number;
+  title: string;
+  html_url: string | null;
+  rank_score: number;
+  lane_fit: number;
+  freshness: number;
+  potential: number;
+  feasibility: number;
+  dup_risk: number;
+  ranked_at: string;
+};
+
+const defaultDbFileName = "ranked-candidates.sqlite3";
+let defaultRankedCandidatesStore: RankedCandidatesStore | null = null;
+
+export function resolveRankedCandidatesDbPath(env: Record<string, string | undefined> = process.env): string {
+  return resolveLocalStoreDbPath(defaultDbFileName, "LOOPOVER_MINER_RANKED_CANDIDATES_DB", env);
+}
+
+function normalizeDbPath(dbPath: string): string {
+  return normalizeLocalStoreDbPath(dbPath, resolveRankedCandidatesDbPath(), "invalid_ranked_candidates_db_path");
+}
+
+function normalizeFiniteRankDimension(value: unknown, fallback: number): number {
+  return Number.isFinite(value) ? (value as number) : fallback;
+}
+
+function normalizeCandidate(candidate: RankedCandidateInput): NormalizedRankedCandidate {
+  if (!candidate || typeof candidate !== "object") throw new Error("invalid_ranked_candidate");
+  const repoFullName = typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_ranked_candidate");
+  const issueNumber = candidate.issueNumber;
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) throw new Error("invalid_ranked_candidate");
+  const rankScore = Number(candidate.rankScore);
+  if (!Number.isFinite(rankScore)) throw new Error("invalid_ranked_candidate");
+  return {
+    repoFullName: `${owner}/${repo}`,
+    issueNumber,
+    title: typeof candidate.title === "string" ? candidate.title : "",
+    htmlUrl: typeof candidate.htmlUrl === "string" ? candidate.htmlUrl : null,
+    rankScore,
+    // A dimension the ranker didn't supply degrades to the SAME neutral defaults opportunity-ranker.js's own
+    // normalizeCandidate uses for a missing signal (0 for a benefit dimension, 1 -- max risk -- for dupRisk),
+    // rather than silently coercing a non-finite value to 0 across the board.
+    laneFit: normalizeFiniteRankDimension(candidate.laneFit, 0),
+    freshness: normalizeFiniteRankDimension(candidate.freshness, 0),
+    potential: normalizeFiniteRankDimension(candidate.potential, 0),
+    feasibility: normalizeFiniteRankDimension(candidate.feasibility, 0),
+    dupRisk: normalizeFiniteRankDimension(candidate.dupRisk, 1),
+  };
+}
+
+function rowToCandidate(row: RankedCandidateDbRow): RankedCandidateRow {
+  return {
+    repoFullName: row.repo_full_name,
+    issueNumber: row.issue_number,
+    title: row.title,
+    htmlUrl: row.html_url,
+    rankScore: row.rank_score,
+    laneFit: row.lane_fit,
+    freshness: row.freshness,
+    potential: row.potential,
+    feasibility: row.feasibility,
+    dupRisk: row.dup_risk,
+    rankedAt: row.ranked_at,
+  };
+}
+
+function asRankedCandidateDbRow(row: Record<string, SQLOutputValue>): RankedCandidateDbRow {
+  return row as unknown as RankedCandidateDbRow;
+}
+
+/**
+ * Opens the 100% local/client-side ranked-candidates snapshot store. The database only lives on this machine;
+ * this module never uploads, syncs, or phones home with its contents.
+ */
+export function initRankedCandidatesStore(dbPath: string = resolveRankedCandidatesDbPath()): RankedCandidatesStore {
+  const resolvedPath = normalizeDbPath(dbPath);
+  const db = openLocalStoreDb(resolvedPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS miner_ranked_candidates (
+      repo_full_name TEXT NOT NULL,
+      issue_number INTEGER NOT NULL,
+      title TEXT NOT NULL,
+      html_url TEXT,
+      rank_score REAL NOT NULL,
+      lane_fit REAL NOT NULL,
+      freshness REAL NOT NULL,
+      potential REAL NOT NULL,
+      feasibility REAL NOT NULL,
+      dup_risk REAL NOT NULL,
+      ranked_at TEXT NOT NULL,
+      PRIMARY KEY (repo_full_name, issue_number)
+    )
+  `);
+  // Schema-version convention (#4832): stamp the baseline. No post-baseline migrations yet -- this is a new store.
+  applySchemaMigrations(db, []);
+
+  const deleteAllStatement = db.prepare("DELETE FROM miner_ranked_candidates");
+  const insertStatement = db.prepare(`
+    INSERT INTO miner_ranked_candidates
+      (repo_full_name, issue_number, title, html_url, rank_score, lane_fit, freshness, potential, feasibility, dup_risk, ranked_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const listStatement = db.prepare("SELECT * FROM miner_ranked_candidates ORDER BY rank_score DESC");
+
+  // Atomic replace: a reader between the DELETE and the INSERTs must never observe an empty table mid-write.
+  // node:sqlite's DatabaseSync has no `.transaction()` helper (unlike better-sqlite3) -- mirrors
+  // portfolio-queue.js's batchClaim: explicit BEGIN IMMEDIATE/COMMIT, ROLLBACK + rethrow on failure.
+  function replaceAll(normalizedCandidates: NormalizedRankedCandidate[], rankedAt: string): void {
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      deleteAllStatement.run();
+      for (const candidate of normalizedCandidates) {
+        insertStatement.run(
+          candidate.repoFullName,
+          candidate.issueNumber,
+          candidate.title,
+          candidate.htmlUrl,
+          candidate.rankScore,
+          candidate.laneFit,
+          candidate.freshness,
+          candidate.potential,
+          candidate.feasibility,
+          candidate.dupRisk,
+          rankedAt,
+        );
+      }
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  return {
+    dbPath: resolvedPath,
+    /** Replaces the whole snapshot wholesale with this run's ranked candidates. `nowMs` is caller-supplied
+     *  (never reads the clock internally) so tests get a deterministic `rankedAt`. */
+    saveRankedCandidates(candidates, nowMs) {
+      const normalized = (Array.isArray(candidates) ? candidates : []).map(normalizeCandidate);
+      const rankedAt = new Date(Number.isFinite(nowMs) ? (nowMs as number) : Date.now()).toISOString();
+      replaceAll(normalized, rankedAt);
+      return { count: normalized.length, rankedAt };
+    },
+    /** Every candidate from the last saved run, highest rankScore first. Empty (not an error) before any
+     *  discover run has ever saved a snapshot, or if the last run found zero candidates. */
+    listRankedCandidates() {
+      return listStatement.all().map((row) => rowToCandidate(asRankedCandidateDbRow(row)));
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+function getDefaultRankedCandidatesStore(): RankedCandidatesStore {
+  defaultRankedCandidatesStore ??= initRankedCandidatesStore();
+  return defaultRankedCandidatesStore;
+}
+
+export function saveRankedCandidates(candidates: RankedCandidateInput[], nowMs?: number): RankedCandidatesSaveResult {
+  return getDefaultRankedCandidatesStore().saveRankedCandidates(candidates, nowMs);
+}
+
+export function listRankedCandidates(): RankedCandidateRow[] {
+  return getDefaultRankedCandidatesStore().listRankedCandidates();
+}
+
+export function closeDefaultRankedCandidatesStore(): void {
+  if (!defaultRankedCandidatesStore) return;
+  defaultRankedCandidatesStore.close();
+  defaultRankedCandidatesStore = null;
+}

--- a/packages/loopover-miner/lib/store-db-adapter.d.ts
+++ b/packages/loopover-miner/lib/store-db-adapter.d.ts
@@ -1,30 +1,49 @@
 import type { DatabaseSync } from "node:sqlite";
-
 /** Sync SQLite primitive both node:sqlite and (later) Postgres-backed drivers satisfy (#7175). */
 export interface SqliteDriver {
-  query(
-    sql: string,
-    params: unknown[],
-  ): { rows: Record<string, unknown>[]; changes: number; lastInsertRowid: number };
-  exec(sql: string): void;
+    query(sql: string, params: unknown[]): {
+        rows: Record<string, unknown>[];
+        changes: number;
+        lastInsertRowid: number;
+    };
+    exec(sql: string): void;
 }
-
 /** Minimal D1-shaped surface returned by `createD1Adapter` (async wrappers over SqliteDriver). */
 export interface MinerD1Database {
-  prepare(sql: string): MinerD1PreparedStatement;
-  batch(statements: MinerD1PreparedStatement[]): Promise<unknown[]>;
-  exec(sql: string): Promise<{ count: number; duration: number }>;
-  dump(): Promise<ArrayBuffer>;
+    prepare(sql: string): MinerD1PreparedStatement;
+    batch(statements: MinerD1PreparedStatement[]): Promise<unknown[]>;
+    exec(sql: string): Promise<{
+        count: number;
+        duration: number;
+    }>;
+    dump(): Promise<ArrayBuffer>;
 }
-
 export interface MinerD1PreparedStatement {
-  bind(...values: unknown[]): MinerD1PreparedStatement;
-  all<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }>;
-  run<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }>;
-  first<T = unknown>(colName?: string): Promise<T | null>;
-  raw<T = unknown>(): Promise<T[]>;
+    bind(...values: unknown[]): MinerD1PreparedStatement;
+    all<T = unknown>(): Promise<{
+        results: T[];
+        success: true;
+        meta: Record<string, unknown>;
+    }>;
+    run<T = unknown>(): Promise<{
+        results: T[];
+        success: true;
+        meta: Record<string, unknown>;
+    }>;
+    first<T = unknown>(colName?: string): Promise<T | null>;
+    raw<T = unknown>(): Promise<T[]>;
 }
-
-export function createD1Adapter(driver: SqliteDriver): MinerD1Database;
-
-export function nodeSqliteDriver(db: DatabaseSync): SqliteDriver;
+/**
+ * Wrap a synchronous SqliteDriver as a D1-shaped database (async prepare/batch/exec).
+ */
+export declare function createD1Adapter(driver: SqliteDriver): MinerD1Database;
+/**
+ * Build a SqliteDriver from a node:sqlite DatabaseSync.
+ * A statement with zero result columns is a WRITE; otherwise a READ.
+ *
+ * LIMITATION (#7175 follow-up): `INSERT/UPDATE/DELETE … RETURNING` statements report result columns, so
+ * this heuristic would treat them as reads and drop `changes`/`lastInsertRowid`. claim-ledger and other
+ * RETURNING callers must not migrate onto `driver.query` until the heuristic is sharpened (e.g. statement
+ * class detection) or those stores use `createD1Adapter`/`run` exclusively.
+ */
+export declare function nodeSqliteDriver(db: DatabaseSync): SqliteDriver;

--- a/packages/loopover-miner/lib/store-db-adapter.js
+++ b/packages/loopover-miner/lib/store-db-adapter.js
@@ -4,103 +4,81 @@
 // inventing a second abstraction. Self-host default remains node:sqlite via `nodeSqliteDriver`.
 // Keep this surface in sync with the ORB module when either side grows (Postgres interactive txn /
 // `runOn` arrives in a later #7175 slice — not this file yet).
-
-/**
- * @typedef {{
- *   query: (sql: string, params: unknown[]) => { rows: Record<string, unknown>[]; changes: number; lastInsertRowid: number };
- *   exec: (sql: string) => void;
- * }} SqliteDriver
- */
-
 function meta(changes = 0, lastRowId = 0) {
-  return {
-    duration: 0,
-    size_after: 0,
-    rows_read: 0,
-    rows_written: changes,
-    last_row_id: lastRowId,
-    changed_db: changes > 0,
-    changes,
-  };
+    return {
+        duration: 0,
+        size_after: 0,
+        rows_read: 0,
+        rows_written: changes,
+        last_row_id: lastRowId,
+        changed_db: changes > 0,
+        changes,
+    };
 }
-
 /** One prepared (and optionally bound) statement — D1 statements are immutable after bind. */
 class Statement {
-  /**
-   * @param {SqliteDriver} driver
-   * @param {string} sql
-   * @param {unknown[]} [values]
-   */
-  constructor(driver, sql, values = []) {
-    this.driver = driver;
-    this.sql = sql;
-    this.values = values;
-  }
-
-  /** @param {...unknown} values */
-  bind(...values) {
-    return new Statement(this.driver, this.sql, values);
-  }
-
-  execSync() {
-    const r = this.driver.query(this.sql, this.values);
-    return { results: r.rows, success: true, meta: meta(r.changes, r.lastInsertRowid) };
-  }
-
-  async all() {
-    return this.execSync();
-  }
-
-  async run() {
-    return this.execSync();
-  }
-
-  /** @param {string} [colName] */
-  async first(colName) {
-    const row = this.driver.query(this.sql, this.values).rows[0];
-    if (row == null) return null;
-    return (colName != null ? row[colName] : row) ?? null;
-  }
-
-  async raw() {
-    return this.driver.query(this.sql, this.values).rows.map((row) => Object.values(row));
-  }
+    constructor(driver, sql, values = []) {
+        this.driver = driver;
+        this.sql = sql;
+        this.values = values;
+    }
+    bind(...values) {
+        return new Statement(this.driver, this.sql, values);
+    }
+    execSync() {
+        const r = this.driver.query(this.sql, this.values);
+        return { results: r.rows, success: true, meta: meta(r.changes, r.lastInsertRowid) };
+    }
+    async all() {
+        return this.execSync();
+    }
+    async run() {
+        return this.execSync();
+    }
+    async first(colName) {
+        const row = this.driver.query(this.sql, this.values).rows[0];
+        if (row == null)
+            return null;
+        return ((colName != null ? row[colName] : row) ?? null);
+    }
+    async raw() {
+        return this.driver.query(this.sql, this.values).rows.map((row) => Object.values(row));
+    }
 }
-
 /**
  * Wrap a synchronous SqliteDriver as a D1-shaped database (async prepare/batch/exec).
- * @param {SqliteDriver} driver
  */
 export function createD1Adapter(driver) {
-  return {
-    prepare(sql) {
-      return new Statement(driver, sql);
-    },
-    async batch(statements) {
-      driver.exec("BEGIN");
-      try {
-        const out = statements.map((s) => s.execSync());
-        driver.exec("COMMIT");
-        return out;
-      } catch (error) {
-        try {
-          driver.exec("ROLLBACK");
-        } catch {
-          /* ignore */
-        }
-        throw error;
-      }
-    },
-    async exec(sql) {
-      driver.exec(sql);
-      return { count: (sql.match(/;/g) ?? []).length || 1, duration: 0 };
-    },
-    async dump() {
-      return new ArrayBuffer(0);
-    },
-  };
+    return {
+        prepare(sql) {
+            return new Statement(driver, sql);
+        },
+        async batch(statements) {
+            driver.exec("BEGIN");
+            try {
+                const out = statements.map((s) => s.execSync());
+                driver.exec("COMMIT");
+                return out;
+            }
+            catch (error) {
+                try {
+                    driver.exec("ROLLBACK");
+                }
+                catch {
+                    /* ignore */
+                }
+                throw error;
+            }
+        },
+        async exec(sql) {
+            driver.exec(sql);
+            return { count: (sql.match(/;/g) ?? []).length || 1, duration: 0 };
+        },
+        async dump() {
+            return new ArrayBuffer(0);
+        },
+    };
 }
-
 /**
  * Build a SqliteDriver from a node:sqlite DatabaseSync.
  * A statement with zero result columns is a WRITE; otherwise a READ.
@@ -109,21 +87,20 @@ export function createD1Adapter(driver) {
  * this heuristic would treat them as reads and drop `changes`/`lastInsertRowid`. claim-ledger and other
  * RETURNING callers must not migrate onto `driver.query` until the heuristic is sharpened (e.g. statement
  * class detection) or those stores use `createD1Adapter`/`run` exclusively.
- * @param {{ prepare: (sql: string) => { columns: () => unknown[]; all: (...p: unknown[]) => unknown[]; run: (...p: unknown[]) => { changes: number | bigint; lastInsertRowid: number | bigint } }; exec: (sql: string) => void }} db
- * @returns {SqliteDriver}
  */
 export function nodeSqliteDriver(db) {
-  return {
-    query(sql, params) {
-      const stmt = db.prepare(sql);
-      if (stmt.columns().length > 0) {
-        return { rows: /** @type {Record<string, unknown>[]} */ (stmt.all(...params)), changes: 0, lastInsertRowid: 0 };
-      }
-      const info = stmt.run(...params);
-      return { rows: [], changes: Number(info.changes), lastInsertRowid: Number(info.lastInsertRowid) };
-    },
-    exec(sql) {
-      db.exec(sql);
-    },
-  };
+    return {
+        query(sql, params) {
+            const stmt = db.prepare(sql);
+            if (stmt.columns().length > 0) {
+                return { rows: stmt.all(...params), changes: 0, lastInsertRowid: 0 };
+            }
+            const info = stmt.run(...params);
+            return { rows: [], changes: Number(info.changes), lastInsertRowid: Number(info.lastInsertRowid) };
+        },
+        exec(sql) {
+            db.exec(sql);
+        },
+    };
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic3RvcmUtZGItYWRhcHRlci5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInN0b3JlLWRiLWFkYXB0ZXIudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsNkVBQTZFO0FBQzdFLEVBQUU7QUFDRix1R0FBdUc7QUFDdkcsZ0dBQWdHO0FBQ2hHLG1HQUFtRztBQUNuRywrREFBK0Q7QUE2Qi9ELFNBQVMsSUFBSSxDQUFDLE9BQU8sR0FBRyxDQUFDLEVBQUUsU0FBUyxHQUFHLENBQUM7SUFDdEMsT0FBTztRQUNMLFFBQVEsRUFBRSxDQUFDO1FBQ1gsVUFBVSxFQUFFLENBQUM7UUFDYixTQUFTLEVBQUUsQ0FBQztRQUNaLFlBQVksRUFBRSxPQUFPO1FBQ3JCLFdBQVcsRUFBRSxTQUFTO1FBQ3RCLFVBQVUsRUFBRSxPQUFPLEdBQUcsQ0FBQztRQUN2QixPQUFPO0tBQ1IsQ0FBQztBQUNKLENBQUM7QUFFRCw4RkFBOEY7QUFDOUYsTUFBTSxTQUFTO0lBS2IsWUFBWSxNQUFvQixFQUFFLEdBQVcsRUFBRSxTQUFvQixFQUFFO1FBQ25FLElBQUksQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDO1FBQ3JCLElBQUksQ0FBQyxHQUFHLEdBQUcsR0FBRyxDQUFDO1FBQ2YsSUFBSSxDQUFDLE1BQU0sR0FBRyxNQUFNLENBQUM7SUFDdkIsQ0FBQztJQUVELElBQUksQ0FBQyxHQUFHLE1BQWlCO1FBQ3ZCLE9BQU8sSUFBSSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ3RELENBQUM7SUFFRCxRQUFRO1FBQ04sTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUM7UUFDbkQsT0FBTyxFQUFFLE9BQU8sRUFBRSxDQUFDLENBQUMsSUFBSSxFQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxlQUFlLENBQUMsRUFBRSxDQUFDO0lBQ3RGLENBQUM7SUFFRCxLQUFLLENBQUMsR0FBRztRQUNQLE9BQU8sSUFBSSxDQUFDLFFBQVEsRUFBb0UsQ0FBQztJQUMzRixDQUFDO0lBRUQsS0FBSyxDQUFDLEdBQUc7UUFDUCxPQUFPLElBQUksQ0FBQyxRQUFRLEVBQW9FLENBQUM7SUFDM0YsQ0FBQztJQUVELEtBQUssQ0FBQyxLQUFLLENBQWMsT0FBZ0I7UUFDdkMsTUFBTSxHQUFHLEdBQUcsSUFBSSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzdELElBQUksR0FBRyxJQUFJLElBQUk7WUFBRSxPQUFPLElBQUksQ0FBQztRQUM3QixPQUFPLENBQUMsQ0FBQyxPQUFPLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxJQUFJLElBQUksQ0FBYSxDQUFDO0lBQ3RFLENBQUM7SUFFRCxLQUFLLENBQUMsR0FBRztRQUNQLE9BQU8sSUFBSSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQUcsRUFBRSxFQUFFLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBUSxDQUFDO0lBQy9GLENBQUM7Q0FDRjtBQUVEOztHQUVHO0FBQ0gsTUFBTSxVQUFVLGVBQWUsQ0FBQyxNQUFvQjtJQUNsRCxPQUFPO1FBQ0wsT0FBTyxDQUFDLEdBQVc7WUFDakIsT0FBTyxJQUFJLFNBQVMsQ0FBQyxNQUFNLEVBQUUsR0FBRyxDQUFDLENBQUM7UUFDcEMsQ0FBQztRQUNELEtBQUssQ0FBQyxLQUFLLENBQUMsVUFBdUI7WUFDakMsTUFBTSxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQztZQUNyQixJQUFJLENBQUM7Z0JBQ0gsTUFBTSxHQUFHLEdBQUcsVUFBVSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUMsQ0FBQyxDQUFDLFFBQVEsRUFBRSxDQUFDLENBQUM7Z0JBQ2hELE1BQU0sQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLENBQUM7Z0JBQ3RCLE9BQU8sR0FBRyxDQUFDO1lBQ2IsQ0FBQztZQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7Z0JBQ2YsSUFBSSxDQUFDO29CQUNILE1BQU0sQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUM7Z0JBQzFCLENBQUM7Z0JBQUMsTUFBTSxDQUFDO29CQUNQLFlBQVk7Z0JBQ2QsQ0FBQztnQkFDRCxNQUFNLEtBQUssQ0FBQztZQUNkLENBQUM7UUFDSCxDQUFDO1FBQ0QsS0FBSyxDQUFDLElBQUksQ0FBQyxHQUFXO1lBQ3BCLE1BQU0sQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7WUFDakIsT0FBTyxFQUFFLEtBQUssRUFBRSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsTUFBTSxJQUFJLENBQUMsRUFBRSxRQUFRLEVBQUUsQ0FBQyxFQUFFLENBQUM7UUFDckUsQ0FBQztRQUNELEtBQUssQ0FBQyxJQUFJO1lBQ1IsT0FBTyxJQUFJLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUM1QixDQUFDO0tBQ0YsQ0FBQztBQUNKLENBQUM7QUFFRDs7Ozs7Ozs7R0FRRztBQUNILE1BQU0sVUFBVSxnQkFBZ0IsQ0FBQyxFQUFnQjtJQUMvQyxPQUFPO1FBQ0wsS0FBSyxDQUFDLEdBQUcsRUFBRSxNQUFNO1lBQ2YsTUFBTSxJQUFJLEdBQUcsRUFBRSxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQztZQUM3QixJQUFJLElBQUksQ0FBQyxPQUFPLEVBQUUsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQzlCLE9BQU8sRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFJLE1BQTBCLENBQUMsRUFBRSxPQUFPLEVBQUUsQ0FBQyxFQUFFLGVBQWUsRUFBRSxDQUFDLEVBQUUsQ0FBQztZQUM1RixDQUFDO1lBQ0QsTUFBTSxJQUFJLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFJLE1BQTBCLENBQUMsQ0FBQztZQUN0RCxPQUFPLEVBQUUsSUFBSSxFQUFFLEVBQUUsRUFBRSxPQUFPLEVBQUUsTUFBTSxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsRUFBRSxlQUFlLEVBQUUsTUFBTSxDQUFDLElBQUksQ0FBQyxlQUFlLENBQUMsRUFBRSxDQUFDO1FBQ3BHLENBQUM7UUFDRCxJQUFJLENBQUMsR0FBRztZQUNOLEVBQUUsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDZixDQUFDO0tBQ0YsQ0FBQztBQUNKLENBQUMifQ==

--- a/packages/loopover-miner/lib/store-db-adapter.ts
+++ b/packages/loopover-miner/lib/store-db-adapter.ts
@@ -1,0 +1,143 @@
+// Shared SqliteDriver / D1 adapter seam for AMS local stores (#7175 part 1).
+//
+// Mirrors ORB's `src/selfhost/d1-adapter.ts` so hosted AMS can later swap in `createPgAdapter` without
+// inventing a second abstraction. Self-host default remains node:sqlite via `nodeSqliteDriver`.
+// Keep this surface in sync with the ORB module when either side grows (Postgres interactive txn /
+// `runOn` arrives in a later #7175 slice — not this file yet).
+
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+
+/** Sync SQLite primitive both node:sqlite and (later) Postgres-backed drivers satisfy (#7175). */
+export interface SqliteDriver {
+  query(
+    sql: string,
+    params: unknown[],
+  ): { rows: Record<string, unknown>[]; changes: number; lastInsertRowid: number };
+  exec(sql: string): void;
+}
+
+/** Minimal D1-shaped surface returned by `createD1Adapter` (async wrappers over SqliteDriver). */
+export interface MinerD1Database {
+  prepare(sql: string): MinerD1PreparedStatement;
+  batch(statements: MinerD1PreparedStatement[]): Promise<unknown[]>;
+  exec(sql: string): Promise<{ count: number; duration: number }>;
+  dump(): Promise<ArrayBuffer>;
+}
+
+export interface MinerD1PreparedStatement {
+  bind(...values: unknown[]): MinerD1PreparedStatement;
+  all<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }>;
+  run<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }>;
+  first<T = unknown>(colName?: string): Promise<T | null>;
+  raw<T = unknown>(): Promise<T[]>;
+}
+
+function meta(changes = 0, lastRowId = 0) {
+  return {
+    duration: 0,
+    size_after: 0,
+    rows_read: 0,
+    rows_written: changes,
+    last_row_id: lastRowId,
+    changed_db: changes > 0,
+    changes,
+  };
+}
+
+/** One prepared (and optionally bound) statement — D1 statements are immutable after bind. */
+class Statement {
+  declare driver: SqliteDriver;
+  declare sql: string;
+  declare values: unknown[];
+
+  constructor(driver: SqliteDriver, sql: string, values: unknown[] = []) {
+    this.driver = driver;
+    this.sql = sql;
+    this.values = values;
+  }
+
+  bind(...values: unknown[]): Statement {
+    return new Statement(this.driver, this.sql, values);
+  }
+
+  execSync(): { results: unknown[]; success: true; meta: Record<string, unknown> } {
+    const r = this.driver.query(this.sql, this.values);
+    return { results: r.rows, success: true, meta: meta(r.changes, r.lastInsertRowid) };
+  }
+
+  async all<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }> {
+    return this.execSync() as { results: T[]; success: true; meta: Record<string, unknown> };
+  }
+
+  async run<T = unknown>(): Promise<{ results: T[]; success: true; meta: Record<string, unknown> }> {
+    return this.execSync() as { results: T[]; success: true; meta: Record<string, unknown> };
+  }
+
+  async first<T = unknown>(colName?: string): Promise<T | null> {
+    const row = this.driver.query(this.sql, this.values).rows[0];
+    if (row == null) return null;
+    return ((colName != null ? row[colName] : row) ?? null) as T | null;
+  }
+
+  async raw<T = unknown>(): Promise<T[]> {
+    return this.driver.query(this.sql, this.values).rows.map((row) => Object.values(row)) as T[];
+  }
+}
+
+/**
+ * Wrap a synchronous SqliteDriver as a D1-shaped database (async prepare/batch/exec).
+ */
+export function createD1Adapter(driver: SqliteDriver): MinerD1Database {
+  return {
+    prepare(sql: string) {
+      return new Statement(driver, sql);
+    },
+    async batch(statements: Statement[]) {
+      driver.exec("BEGIN");
+      try {
+        const out = statements.map((s) => s.execSync());
+        driver.exec("COMMIT");
+        return out;
+      } catch (error) {
+        try {
+          driver.exec("ROLLBACK");
+        } catch {
+          /* ignore */
+        }
+        throw error;
+      }
+    },
+    async exec(sql: string) {
+      driver.exec(sql);
+      return { count: (sql.match(/;/g) ?? []).length || 1, duration: 0 };
+    },
+    async dump() {
+      return new ArrayBuffer(0);
+    },
+  };
+}
+
+/**
+ * Build a SqliteDriver from a node:sqlite DatabaseSync.
+ * A statement with zero result columns is a WRITE; otherwise a READ.
+ *
+ * LIMITATION (#7175 follow-up): `INSERT/UPDATE/DELETE … RETURNING` statements report result columns, so
+ * this heuristic would treat them as reads and drop `changes`/`lastInsertRowid`. claim-ledger and other
+ * RETURNING callers must not migrate onto `driver.query` until the heuristic is sharpened (e.g. statement
+ * class detection) or those stores use `createD1Adapter`/`run` exclusively.
+ */
+export function nodeSqliteDriver(db: DatabaseSync): SqliteDriver {
+  return {
+    query(sql, params) {
+      const stmt = db.prepare(sql);
+      if (stmt.columns().length > 0) {
+        return { rows: stmt.all(...(params as SQLInputValue[])), changes: 0, lastInsertRowid: 0 };
+      }
+      const info = stmt.run(...(params as SQLInputValue[]));
+      return { rows: [], changes: Number(info.changes), lastInsertRowid: Number(info.lastInsertRowid) };
+    },
+    exec(sql) {
+      db.exec(sql);
+    },
+  };
+}

--- a/packages/loopover-miner/lib/tenant-client.d.ts
+++ b/packages/loopover-miner/lib/tenant-client.d.ts
@@ -1,27 +1,51 @@
-export const CONTROL_PLANE_FLAG: string;
-export const CONTROL_PLANE_URL_FLAG: string;
-export const CONTROL_PLANE_ADMIN_TOKEN_FLAG: string;
-
+/** Admin client for the hosted control-plane's tenant-provisioning API (#7275, part of the #7173 ORB+AMS hosting
+ * control-plane; talks to #7180's provisioning API). Opt-in and completely inert unless
+ * LOOPOVER_MINER_CONTROL_PLANE is set AND a URL is configured -- mirroring discovery-index-client.js's env-gated,
+ * never-auto-enabled posture. But UNLIKE that client's deliberately fail-OPEN opportunistic supplement, every
+ * call here FAILS LOUD: create/list/destroy are deliberate admin actions, so a disabled/unconfigured/unreachable/
+ * non-2xx/malformed-response condition throws a clear Error (surfaced by tenant-cli.js as a non-zero exit and
+ * message) rather than silently degrading. Bearer-authed with an ADMIN credential, distinct from any tenant's own
+ * per-instance secrets. Lifecycle states (`provisioning`/`active`/`suspended`/`torn down`) are passed through
+ * exactly as the API reports them -- no AMS-specific state vocabulary is invented here. A single bounded request
+ * per call (no retry): a create is not idempotent, so it must not be silently re-sent. */
+export declare const CONTROL_PLANE_FLAG = "LOOPOVER_MINER_CONTROL_PLANE";
+export declare const CONTROL_PLANE_URL_FLAG = "LOOPOVER_MINER_CONTROL_PLANE_URL";
+export declare const CONTROL_PLANE_ADMIN_TOKEN_FLAG = "LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN";
 export type TenantClientOptions = {
-  env?: Record<string, string | undefined>;
-  /** Always called as `fetchImpl(url, init)` with a plain string URL -- narrower than `typeof fetch` on
-   *  purpose, since that's the only shape this module ever actually calls it with. */
-  fetchImpl?: (url: string, init: RequestInit) => Promise<Response>;
-  requestTimeoutMs?: number;
+    env?: Record<string, string | undefined>;
+    /** Always called as `fetchImpl(url, init)` with a plain string URL -- narrower than `typeof fetch` on
+     *  purpose, since that's the only shape this module ever actually calls it with. */
+    fetchImpl?: (url: string, init: RequestInit) => Promise<Response>;
+    requestTimeoutMs?: number;
 };
-
 export type CreateTenantOptions = TenantClientOptions & {
-  product?: string;
+    product?: string;
 };
-
 /** A tenant record as reported by the control plane. Lifecycle `state` is passed through verbatim (the API owns
  *  the vocabulary, e.g. `provisioning` / `active` / `suspended` / `torn down`); other fields vary by product. */
 export type TenantRecord = Record<string, unknown>;
-
-export function isControlPlaneEnabled(env?: Record<string, string | undefined>): boolean;
-
-export function createTenant(name: string, options?: CreateTenantOptions): Promise<TenantRecord>;
-
-export function listTenants(options?: TenantClientOptions): Promise<TenantRecord[]>;
-
-export function destroyTenant(name: string, options?: TenantClientOptions): Promise<TenantRecord>;
+/** Master opt-in (default off): no control-plane traffic is possible until this is truthy. */
+export declare function isControlPlaneEnabled(env?: Record<string, string | undefined>): boolean;
+/**
+ * Create a hosted tenant instance. Returns the created tenant record exactly as the control plane reports it
+ * (including its lifecycle `state`). `options.product` defaults to `"ams"`.
+ *
+ * @param {string} name
+ * @param {{ product?: string, env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
+ */
+export declare function createTenant(name: string, options?: CreateTenantOptions): Promise<TenantRecord>;
+/**
+ * List all hosted tenant instances the admin credential can see. Returns the `tenants` array as reported.
+ *
+ * @param {{ env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export declare function listTenants(options?: TenantClientOptions): Promise<TenantRecord[]>;
+/**
+ * Tear down a hosted tenant instance by name. Returns the control plane's final record for it (typically the
+ * transitional `torn down` lifecycle state).
+ *
+ * @param {string} name
+ * @param {{ env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
+ */
+export declare function destroyTenant(name: string, options?: TenantClientOptions): Promise<TenantRecord>;

--- a/packages/loopover-miner/lib/tenant-client.js
+++ b/packages/loopover-miner/lib/tenant-client.js
@@ -8,49 +8,42 @@
  * per-instance secrets. Lifecycle states (`provisioning`/`active`/`suspended`/`torn down`) are passed through
  * exactly as the API reports them -- no AMS-specific state vocabulary is invented here. A single bounded request
  * per call (no retry): a create is not idempotent, so it must not be silently re-sent. */
-
 export const CONTROL_PLANE_FLAG = "LOOPOVER_MINER_CONTROL_PLANE";
 export const CONTROL_PLANE_URL_FLAG = "LOOPOVER_MINER_CONTROL_PLANE_URL";
 export const CONTROL_PLANE_ADMIN_TOKEN_FLAG = "LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN";
-
 const TRUTHY_ENV_VALUE = /^(1|true|yes|on)$/i;
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
-
 function isTruthyEnvValue(value) {
-  return TRUTHY_ENV_VALUE.test(String(value).trim());
+    return TRUTHY_ENV_VALUE.test(String(value).trim());
 }
-
 // Reads below use literal `env.LOOPOVER_MINER_*` property access (not the *_FLAG constants) because
 // scripts/generate-env-reference.mjs statically greps for exactly this `env.NAME ?? "..."` shape to keep the
 // generated env reference honest -- a dynamic `env[SOME_CONST]` lookup is invisible to it.
-
 /** Master opt-in (default off): no control-plane traffic is possible until this is truthy. */
 export function isControlPlaneEnabled(env = process.env) {
-  return isTruthyEnvValue(env.LOOPOVER_MINER_CONTROL_PLANE ?? "");
+    return isTruthyEnvValue(env.LOOPOVER_MINER_CONTROL_PLANE ?? "");
 }
-
 function resolveControlPlaneUrl(env) {
-  const raw = (env.LOOPOVER_MINER_CONTROL_PLANE_URL ?? "").trim();
-  return raw ? raw.replace(/\/+$/, "") : null;
+    const raw = (env.LOOPOVER_MINER_CONTROL_PLANE_URL ?? "").trim();
+    return raw ? raw.replace(/\/+$/, "") : null;
 }
-
 function resolveAdminToken(env) {
-  const raw = typeof env.LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN === "string" ? env.LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN.trim() : "";
-  return raw || null;
+    const raw = typeof env.LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN === "string" ? env.LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN.trim() : "";
+    return raw || null;
 }
-
 /** Resolve + validate the control-plane connection, or throw a clear admin-facing error (fail loud). */
 function resolveControlPlane(env) {
-  if (!isControlPlaneEnabled(env)) {
-    throw new Error(`control plane disabled: set ${CONTROL_PLANE_FLAG}=1 to enable tenant admin commands`);
-  }
-  const baseUrl = resolveControlPlaneUrl(env);
-  if (!baseUrl) throw new Error(`control plane URL unconfigured: set ${CONTROL_PLANE_URL_FLAG}`);
-  const token = resolveAdminToken(env);
-  if (!token) throw new Error(`control plane admin token unconfigured: set ${CONTROL_PLANE_ADMIN_TOKEN_FLAG}`);
-  return { baseUrl, token };
+    if (!isControlPlaneEnabled(env)) {
+        throw new Error(`control plane disabled: set ${CONTROL_PLANE_FLAG}=1 to enable tenant admin commands`);
+    }
+    const baseUrl = resolveControlPlaneUrl(env);
+    if (!baseUrl)
+        throw new Error(`control plane URL unconfigured: set ${CONTROL_PLANE_URL_FLAG}`);
+    const token = resolveAdminToken(env);
+    if (!token)
+        throw new Error(`control plane admin token unconfigured: set ${CONTROL_PLANE_ADMIN_TOKEN_FLAG}`);
+    return { baseUrl, token };
 }
-
 /**
  * One bounded, Bearer-authed request against the control plane. Throws a clear Error on any failure: disabled/
  * unconfigured plane, unreachable host or timeout, non-2xx status, or a non-JSON/non-object body.
@@ -62,32 +55,31 @@ function resolveControlPlane(env) {
  * @returns {Promise<Record<string, unknown>>}
  */
 async function controlPlaneRequest(method, path, body, options) {
-  const env = options.env ?? process.env;
-  const { baseUrl, token } = resolveControlPlane(env);
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const timeoutMs = Number.isFinite(options.requestTimeoutMs) ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
-
-  let response;
-  try {
-    response = await fetchImpl(`${baseUrl}${path}`, {
-      method,
-      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (error) {
-    throw new Error(`control plane unreachable for ${method} ${path}: ${error instanceof Error ? error.message : String(error)}`);
-  }
-  if (!response.ok) {
-    throw new Error(`control plane returned http_${response.status} for ${method} ${path}`);
-  }
-  const payload = await response.json().catch(() => null);
-  if (payload === null || typeof payload !== "object") {
-    throw new Error(`control plane returned a malformed response for ${method} ${path}`);
-  }
-  return payload;
+    const env = options.env ?? process.env;
+    const { baseUrl, token } = resolveControlPlane(env);
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const timeoutMs = Number.isFinite(options.requestTimeoutMs) ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
+    let response;
+    try {
+        response = await fetchImpl(`${baseUrl}${path}`, {
+            method,
+            headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+            ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+    }
+    catch (error) {
+        throw new Error(`control plane unreachable for ${method} ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (!response.ok) {
+        throw new Error(`control plane returned http_${response.status} for ${method} ${path}`);
+    }
+    const payload = (await response.json().catch(() => null));
+    if (payload === null || typeof payload !== "object") {
+        throw new Error(`control plane returned a malformed response for ${method} ${path}`);
+    }
+    return payload;
 }
-
 /**
  * Create a hosted tenant instance. Returns the created tenant record exactly as the control plane reports it
  * (including its lifecycle `state`). `options.product` defaults to `"ams"`.
@@ -96,10 +88,9 @@ async function controlPlaneRequest(method, path, body, options) {
  * @param {{ product?: string, env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
  */
 export async function createTenant(name, options = {}) {
-  const product = typeof options.product === "string" && options.product.trim() ? options.product.trim() : "ams";
-  return controlPlaneRequest("POST", "/v1/tenants", { name, product }, options);
+    const product = typeof options.product === "string" && options.product.trim() ? options.product.trim() : "ams";
+    return controlPlaneRequest("POST", "/v1/tenants", { name, product }, options);
 }
-
 /**
  * List all hosted tenant instances the admin credential can see. Returns the `tenants` array as reported.
  *
@@ -107,10 +98,9 @@ export async function createTenant(name, options = {}) {
  * @returns {Promise<Array<Record<string, unknown>>>}
  */
 export async function listTenants(options = {}) {
-  const payload = await controlPlaneRequest("GET", "/v1/tenants", undefined, options);
-  return Array.isArray(payload.tenants) ? payload.tenants : [];
+    const payload = await controlPlaneRequest("GET", "/v1/tenants", undefined, options);
+    return Array.isArray(payload.tenants) ? payload.tenants : [];
 }
-
 /**
  * Tear down a hosted tenant instance by name. Returns the control plane's final record for it (typically the
  * transitional `torn down` lifecycle state).
@@ -119,5 +109,6 @@ export async function listTenants(options = {}) {
  * @param {{ env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
  */
 export async function destroyTenant(name, options = {}) {
-  return controlPlaneRequest("DELETE", `/v1/tenants/${encodeURIComponent(name)}`, undefined, options);
+    return controlPlaneRequest("DELETE", `/v1/tenants/${encodeURIComponent(name)}`, undefined, options);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVuYW50LWNsaWVudC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInRlbmFudC1jbGllbnQudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7Ozs7Ozs7OzswRkFTMEY7QUFFMUYsTUFBTSxDQUFDLE1BQU0sa0JBQWtCLEdBQUcsOEJBQThCLENBQUM7QUFDakUsTUFBTSxDQUFDLE1BQU0sc0JBQXNCLEdBQUcsa0NBQWtDLENBQUM7QUFDekUsTUFBTSxDQUFDLE1BQU0sOEJBQThCLEdBQUcsMENBQTBDLENBQUM7QUFrQnpGLE1BQU0sZ0JBQWdCLEdBQUcsb0JBQW9CLENBQUM7QUFDOUMsTUFBTSwwQkFBMEIsR0FBRyxNQUFNLENBQUM7QUFFMUMsU0FBUyxnQkFBZ0IsQ0FBQyxLQUFhO0lBQ3JDLE9BQU8sZ0JBQWdCLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDO0FBQ3JELENBQUM7QUFFRCxvR0FBb0c7QUFDcEcsNkdBQTZHO0FBQzdHLDJGQUEyRjtBQUUzRiw4RkFBOEY7QUFDOUYsTUFBTSxVQUFVLHFCQUFxQixDQUFDLE1BQTBDLE9BQU8sQ0FBQyxHQUFHO0lBQ3pGLE9BQU8sZ0JBQWdCLENBQUMsR0FBRyxDQUFDLDRCQUE0QixJQUFJLEVBQUUsQ0FBQyxDQUFDO0FBQ2xFLENBQUM7QUFFRCxTQUFTLHNCQUFzQixDQUFDLEdBQXVDO0lBQ3JFLE1BQU0sR0FBRyxHQUFHLENBQUMsR0FBRyxDQUFDLGdDQUFnQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQ2hFLE9BQU8sR0FBRyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsT0FBTyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0FBQzlDLENBQUM7QUFFRCxTQUFTLGlCQUFpQixDQUFDLEdBQXVDO0lBQ2hFLE1BQU0sR0FBRyxHQUFHLE9BQU8sR0FBRyxDQUFDLHdDQUF3QyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLHdDQUF3QyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDeEksT0FBTyxHQUFHLElBQUksSUFBSSxDQUFDO0FBQ3JCLENBQUM7QUFFRCx3R0FBd0c7QUFDeEcsU0FBUyxtQkFBbUIsQ0FBQyxHQUF1QztJQUNsRSxJQUFJLENBQUMscUJBQXFCLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNoQyxNQUFNLElBQUksS0FBSyxDQUFDLCtCQUErQixrQkFBa0Isb0NBQW9DLENBQUMsQ0FBQztJQUN6RyxDQUFDO0lBQ0QsTUFBTSxPQUFPLEdBQUcsc0JBQXNCLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDNUMsSUFBSSxDQUFDLE9BQU87UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLHVDQUF1QyxzQkFBc0IsRUFBRSxDQUFDLENBQUM7SUFDL0YsTUFBTSxLQUFLLEdBQUcsaUJBQWlCLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDckMsSUFBSSxDQUFDLEtBQUs7UUFBRSxNQUFNLElBQUksS0FBSyxDQUFDLCtDQUErQyw4QkFBOEIsRUFBRSxDQUFDLENBQUM7SUFDN0csT0FBTyxFQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUM1QixDQUFDO0FBRUQ7Ozs7Ozs7OztHQVNHO0FBQ0gsS0FBSyxVQUFVLG1CQUFtQixDQUNoQyxNQUFpQyxFQUNqQyxJQUFZLEVBQ1osSUFBYSxFQUNiLE9BQTRCO0lBRTVCLE1BQU0sR0FBRyxHQUFHLE9BQU8sQ0FBQyxHQUFHLElBQUksT0FBTyxDQUFDLEdBQUcsQ0FBQztJQUN2QyxNQUFNLEVBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxHQUFHLG1CQUFtQixDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3BELE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxTQUFTLElBQUssS0FBK0QsQ0FBQztJQUN4RyxNQUFNLFNBQVMsR0FBRyxNQUFNLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDLENBQUMsQ0FBRSxPQUFPLENBQUMsZ0JBQTJCLENBQUMsQ0FBQyxDQUFDLDBCQUEwQixDQUFDO0lBRWhJLElBQUksUUFBa0IsQ0FBQztJQUN2QixJQUFJLENBQUM7UUFDSCxRQUFRLEdBQUcsTUFBTSxTQUFTLENBQUMsR0FBRyxPQUFPLEdBQUcsSUFBSSxFQUFFLEVBQUU7WUFDOUMsTUFBTTtZQUNOLE9BQU8sRUFBRSxFQUFFLGNBQWMsRUFBRSxrQkFBa0IsRUFBRSxhQUFhLEVBQUUsVUFBVSxLQUFLLEVBQUUsRUFBRTtZQUNqRixHQUFHLENBQUMsSUFBSSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsU0FBUyxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUM7WUFDN0QsTUFBTSxFQUFFLFdBQVcsQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDO1NBQ3ZDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsTUFBTSxJQUFJLEtBQUssQ0FBQyxpQ0FBaUMsTUFBTSxJQUFJLElBQUksS0FBSyxLQUFLLFlBQVksS0FBSyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ2hJLENBQUM7SUFDRCxJQUFJLENBQUMsUUFBUSxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ2pCLE1BQU0sSUFBSSxLQUFLLENBQUMsK0JBQStCLFFBQVEsQ0FBQyxNQUFNLFFBQVEsTUFBTSxJQUFJLElBQUksRUFBRSxDQUFDLENBQUM7SUFDMUYsQ0FBQztJQUNELE1BQU0sT0FBTyxHQUFHLENBQUMsTUFBTSxRQUFRLENBQUMsSUFBSSxFQUFFLENBQUMsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLElBQUksQ0FBQyxDQUFtQyxDQUFDO0lBQzVGLElBQUksT0FBTyxLQUFLLElBQUksSUFBSSxPQUFPLE9BQU8sS0FBSyxRQUFRLEVBQUUsQ0FBQztRQUNwRCxNQUFNLElBQUksS0FBSyxDQUFDLG1EQUFtRCxNQUFNLElBQUksSUFBSSxFQUFFLENBQUMsQ0FBQztJQUN2RixDQUFDO0lBQ0QsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVEOzs7Ozs7R0FNRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsWUFBWSxDQUFDLElBQVksRUFBRSxVQUErQixFQUFFO0lBQ2hGLE1BQU0sT0FBTyxHQUFHLE9BQU8sT0FBTyxDQUFDLE9BQU8sS0FBSyxRQUFRLElBQUksT0FBTyxDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDO0lBQy9HLE9BQU8sbUJBQW1CLENBQUMsTUFBTSxFQUFFLGFBQWEsRUFBRSxFQUFFLElBQUksRUFBRSxPQUFPLEVBQUUsRUFBRSxPQUFPLENBQUMsQ0FBQztBQUNoRixDQUFDO0FBRUQ7Ozs7O0dBS0c7QUFDSCxNQUFNLENBQUMsS0FBSyxVQUFVLFdBQVcsQ0FBQyxVQUErQixFQUFFO0lBQ2pFLE1BQU0sT0FBTyxHQUFHLE1BQU0sbUJBQW1CLENBQUMsS0FBSyxFQUFFLGFBQWEsRUFBRSxTQUFTLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDcEYsT0FBTyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0FBQy9ELENBQUM7QUFFRDs7Ozs7O0dBTUc7QUFDSCxNQUFNLENBQUMsS0FBSyxVQUFVLGFBQWEsQ0FBQyxJQUFZLEVBQUUsVUFBK0IsRUFBRTtJQUNqRixPQUFPLG1CQUFtQixDQUFDLFFBQVEsRUFBRSxlQUFlLGtCQUFrQixDQUFDLElBQUksQ0FBQyxFQUFFLEVBQUUsU0FBUyxFQUFFLE9BQU8sQ0FBQyxDQUFDO0FBQ3RHLENBQUMifQ==

--- a/packages/loopover-miner/lib/tenant-client.ts
+++ b/packages/loopover-miner/lib/tenant-client.ts
@@ -1,0 +1,144 @@
+/** Admin client for the hosted control-plane's tenant-provisioning API (#7275, part of the #7173 ORB+AMS hosting
+ * control-plane; talks to #7180's provisioning API). Opt-in and completely inert unless
+ * LOOPOVER_MINER_CONTROL_PLANE is set AND a URL is configured -- mirroring discovery-index-client.js's env-gated,
+ * never-auto-enabled posture. But UNLIKE that client's deliberately fail-OPEN opportunistic supplement, every
+ * call here FAILS LOUD: create/list/destroy are deliberate admin actions, so a disabled/unconfigured/unreachable/
+ * non-2xx/malformed-response condition throws a clear Error (surfaced by tenant-cli.js as a non-zero exit and
+ * message) rather than silently degrading. Bearer-authed with an ADMIN credential, distinct from any tenant's own
+ * per-instance secrets. Lifecycle states (`provisioning`/`active`/`suspended`/`torn down`) are passed through
+ * exactly as the API reports them -- no AMS-specific state vocabulary is invented here. A single bounded request
+ * per call (no retry): a create is not idempotent, so it must not be silently re-sent. */
+
+export const CONTROL_PLANE_FLAG = "LOOPOVER_MINER_CONTROL_PLANE";
+export const CONTROL_PLANE_URL_FLAG = "LOOPOVER_MINER_CONTROL_PLANE_URL";
+export const CONTROL_PLANE_ADMIN_TOKEN_FLAG = "LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN";
+
+export type TenantClientOptions = {
+  env?: Record<string, string | undefined>;
+  /** Always called as `fetchImpl(url, init)` with a plain string URL -- narrower than `typeof fetch` on
+   *  purpose, since that's the only shape this module ever actually calls it with. */
+  fetchImpl?: (url: string, init: RequestInit) => Promise<Response>;
+  requestTimeoutMs?: number;
+};
+
+export type CreateTenantOptions = TenantClientOptions & {
+  product?: string;
+};
+
+/** A tenant record as reported by the control plane. Lifecycle `state` is passed through verbatim (the API owns
+ *  the vocabulary, e.g. `provisioning` / `active` / `suspended` / `torn down`); other fields vary by product. */
+export type TenantRecord = Record<string, unknown>;
+
+const TRUTHY_ENV_VALUE = /^(1|true|yes|on)$/i;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+function isTruthyEnvValue(value: string): boolean {
+  return TRUTHY_ENV_VALUE.test(String(value).trim());
+}
+
+// Reads below use literal `env.LOOPOVER_MINER_*` property access (not the *_FLAG constants) because
+// scripts/generate-env-reference.mjs statically greps for exactly this `env.NAME ?? "..."` shape to keep the
+// generated env reference honest -- a dynamic `env[SOME_CONST]` lookup is invisible to it.
+
+/** Master opt-in (default off): no control-plane traffic is possible until this is truthy. */
+export function isControlPlaneEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return isTruthyEnvValue(env.LOOPOVER_MINER_CONTROL_PLANE ?? "");
+}
+
+function resolveControlPlaneUrl(env: Record<string, string | undefined>): string | null {
+  const raw = (env.LOOPOVER_MINER_CONTROL_PLANE_URL ?? "").trim();
+  return raw ? raw.replace(/\/+$/, "") : null;
+}
+
+function resolveAdminToken(env: Record<string, string | undefined>): string | null {
+  const raw = typeof env.LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN === "string" ? env.LOOPOVER_MINER_CONTROL_PLANE_ADMIN_TOKEN.trim() : "";
+  return raw || null;
+}
+
+/** Resolve + validate the control-plane connection, or throw a clear admin-facing error (fail loud). */
+function resolveControlPlane(env: Record<string, string | undefined>): { baseUrl: string; token: string } {
+  if (!isControlPlaneEnabled(env)) {
+    throw new Error(`control plane disabled: set ${CONTROL_PLANE_FLAG}=1 to enable tenant admin commands`);
+  }
+  const baseUrl = resolveControlPlaneUrl(env);
+  if (!baseUrl) throw new Error(`control plane URL unconfigured: set ${CONTROL_PLANE_URL_FLAG}`);
+  const token = resolveAdminToken(env);
+  if (!token) throw new Error(`control plane admin token unconfigured: set ${CONTROL_PLANE_ADMIN_TOKEN_FLAG}`);
+  return { baseUrl, token };
+}
+
+/**
+ * One bounded, Bearer-authed request against the control plane. Throws a clear Error on any failure: disabled/
+ * unconfigured plane, unreachable host or timeout, non-2xx status, or a non-JSON/non-object body.
+ *
+ * @param {"GET"|"POST"|"DELETE"} method
+ * @param {string} path
+ * @param {unknown} body request body (JSON-encoded), or undefined for none
+ * @param {{ env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} options
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function controlPlaneRequest(
+  method: "GET" | "POST" | "DELETE",
+  path: string,
+  body: unknown,
+  options: TenantClientOptions,
+): Promise<Record<string, unknown>> {
+  const env = options.env ?? process.env;
+  const { baseUrl, token } = resolveControlPlane(env);
+  const fetchImpl = options.fetchImpl ?? (fetch as (url: string, init: RequestInit) => Promise<Response>);
+  const timeoutMs = Number.isFinite(options.requestTimeoutMs) ? (options.requestTimeoutMs as number) : DEFAULT_REQUEST_TIMEOUT_MS;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${baseUrl}${path}`, {
+      method,
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new Error(`control plane unreachable for ${method} ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`control plane returned http_${response.status} for ${method} ${path}`);
+  }
+  const payload = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+  if (payload === null || typeof payload !== "object") {
+    throw new Error(`control plane returned a malformed response for ${method} ${path}`);
+  }
+  return payload;
+}
+
+/**
+ * Create a hosted tenant instance. Returns the created tenant record exactly as the control plane reports it
+ * (including its lifecycle `state`). `options.product` defaults to `"ams"`.
+ *
+ * @param {string} name
+ * @param {{ product?: string, env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
+ */
+export async function createTenant(name: string, options: CreateTenantOptions = {}): Promise<TenantRecord> {
+  const product = typeof options.product === "string" && options.product.trim() ? options.product.trim() : "ams";
+  return controlPlaneRequest("POST", "/v1/tenants", { name, product }, options);
+}
+
+/**
+ * List all hosted tenant instances the admin credential can see. Returns the `tenants` array as reported.
+ *
+ * @param {{ env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export async function listTenants(options: TenantClientOptions = {}): Promise<TenantRecord[]> {
+  const payload = await controlPlaneRequest("GET", "/v1/tenants", undefined, options);
+  return Array.isArray(payload.tenants) ? payload.tenants : [];
+}
+
+/**
+ * Tear down a hosted tenant instance by name. Returns the control plane's final record for it (typically the
+ * transitional `torn down` lifecycle state).
+ *
+ * @param {string} name
+ * @param {{ env?: Record<string, string | undefined>, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
+ */
+export async function destroyTenant(name: string, options: TenantClientOptions = {}): Promise<TenantRecord> {
+  return controlPlaneRequest("DELETE", `/v1/tenants/${encodeURIComponent(name)}`, undefined, options);
+}

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -210,6 +210,20 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     expect(rankCandidateIssues(undefined as never, { nowMs: NOW })).toEqual([]);
   });
 
+  it("normalizes malformed candidate fields to safe fallbacks (non-array labels, non-finite comments, unknown ai-policy source)", () => {
+    const ranked = rankCandidateIssues(
+      [rawIssue({ labels: "not-an-array", commentsCount: Number.NaN, aiPolicySource: "README.md" })],
+      { nowMs: NOW },
+    );
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]).toMatchObject({ labels: [], commentsCount: 0, aiPolicySource: "none" });
+  });
+
+  it("keeps only non-empty string labels and trims them, dropping non-string / blank entries", () => {
+    const ranked = rankCandidateIssues([rawIssue({ labels: ["  keep  ", "", 42, null] })], { nowMs: NOW });
+    expect(ranked[0]?.labels).toEqual(["keep"]);
+  });
+
   it("accepts pre-parsed goal specs and normalizes ai policy metadata", () => {
     const ranked = rankCandidateIssues(
       [

--- a/test/unit/miner-portfolio-queue-manager.test.ts
+++ b/test/unit/miner-portfolio-queue-manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  closeDefaultPortfolioQueueManager,
   entriesToPortfolioQueue,
   initPortfolioQueueManager,
   normalizePortfolioCaps,
@@ -96,6 +97,20 @@ describe("entriesToPortfolioQueue() / selectEligibleBatch() (#4285)", () => {
       repoFullName: "acme/alpha",
       identifier: "x",
     });
+  });
+
+  it("entriesToPortfolioQueue tolerates a non-array input, omits done rows, and skips rows with a blank repo/identifier", () => {
+    expect(entriesToPortfolioQueue(undefined as never)).toEqual({ buckets: [] });
+    const buckets = entriesToPortfolioQueue([
+      { apiBaseUrl: "https://api.github.com", repoFullName: "acme/a", identifier: "keep", priority: 1, status: "queued", enqueuedAt: "t1" },
+      { apiBaseUrl: "https://api.github.com", repoFullName: "acme/a", identifier: "done-row", priority: 1, status: "done", enqueuedAt: "t2" },
+      { apiBaseUrl: "https://api.github.com", repoFullName: 42 as never, identifier: "bad-repo", priority: 1, status: "queued", enqueuedAt: "t3" },
+      { apiBaseUrl: "https://api.github.com", repoFullName: "acme/a", identifier: "   ", priority: 1, status: "queued", enqueuedAt: "t4" },
+      { apiBaseUrl: "https://api.github.com", repoFullName: "acme/a", identifier: 99 as never, priority: 1, status: "queued", enqueuedAt: "t5" },
+    ] as QueueEntry[]).buckets;
+    const items = buckets.flatMap((bucket) => bucket.items);
+    expect(items).toHaveLength(1);
+    expect(parseQueueItemId(items[0]!.id).identifier).toBe("keep");
   });
 
   it("returns nothing when either cap is zero", () => {
@@ -197,5 +212,30 @@ describe("initPortfolioQueueManager().claimNextBatch() (#4285)", () => {
     });
 
     expect(claimed.map((entry) => entry.identifier)).toEqual(["two"]);
+  });
+
+  it("applies default caps when none are given, honors a custom staleLeaseMs, and close() closes the store", () => {
+    const store = initPortfolioQueueStore(":memory:");
+    // caps omitted -> the default { globalWipCap: 1, perRepoWipCap: 1 }; staleLeaseMs supplied -> its finite branch.
+    const manager = initPortfolioQueueManager({ store, staleLeaseMs: 1000 });
+    manager.enqueue({ repoFullName: "acme/a", identifier: "1", priority: 2 });
+    manager.enqueue({ repoFullName: "acme/a", identifier: "2", priority: 1 });
+    // Default perRepoWipCap of 1 means exactly one item is claimed from the same repo per batch.
+    expect(manager.claimNextBatch()).toHaveLength(1);
+    // The manager owns its store's lifecycle; close() delegates to store.close(). Deliberately NOT pushed to the
+    // shared `stores` cleanup list, so afterEach never double-closes it (node:sqlite throws on a second close).
+    expect(() => manager.close()).not.toThrow();
+  });
+
+  it("opens its own store from options.dbPath when no store is injected", () => {
+    // options.store omitted -> the `?? initPortfolioQueueStore(options.dbPath)` fallback opens an in-memory store.
+    const manager = initPortfolioQueueManager({ dbPath: ":memory:" });
+    manager.enqueue({ repoFullName: "acme/a", identifier: "1", priority: 1 });
+    expect(manager.claimNextBatch().map((target) => target.identifier)).toEqual(["1"]);
+    manager.close();
+  });
+
+  it("closeDefaultPortfolioQueueManager is a no-op today (symmetry with the other miner stores)", () => {
+    expect(() => closeDefaultPortfolioQueueManager()).not.toThrow();
   });
 });

--- a/test/unit/miner-pr-disposition-poller.test.ts
+++ b/test/unit/miner-pr-disposition-poller.test.ts
@@ -110,6 +110,53 @@ describe("PR disposition poller (#5135)", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
+  it("treats a blank apiBaseUrl as the default GitHub base, and rejects a non-string repoFullName", async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL) =>
+      prResponse({ state: "closed", merged: true, closed_at: "2026-07-12T00:00:00Z" }),
+    );
+    const result = await pollPrDisposition("acme/widgets", 5, { apiBaseUrl: "   ", fetchFn });
+    expect(String(fetchFn.mock.calls[0]![0])).toBe("https://api.github.com/repos/acme/widgets/pulls/5");
+    expect(result.merged).toBe(true);
+    await expect(pollPrDisposition(123 as never, 5, { fetchFn })).rejects.toThrow("invalid_repo_full_name");
+  });
+
+  it("falls back to the global fetch when fetchFn is omitted", async () => {
+    const stub = vi.fn(async () => prResponse({ state: "closed", merged: false, closed_at: "2026-07-12T00:00:00Z" }));
+    vi.stubGlobal("fetch", stub);
+    try {
+      const result = await pollPrDisposition("acme/widgets", 6, { apiBaseUrl: API });
+      expect(result).toMatchObject({ state: "closed", merged: false, attempts: 1 });
+      expect(stub).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("surfaces a GitHub error with its message, and one without a message, as deterministic errors", async () => {
+    const withMessage = vi.fn(async () => jsonResponse({ message: "Not Found" }, { status: 404 }));
+    await expect(
+      pollPrDisposition("acme/widgets", 7, { apiBaseUrl: API, fetchFn: withMessage, sleepFn: async () => {} }),
+    ).rejects.toThrow("github_404: Not Found");
+    // A 5xx with no usable message body surfaces as the bare status code (after fetchWithRetry's own retries).
+    const noMessage = vi.fn(async () => jsonResponse({}, { status: 500 }));
+    await expect(
+      pollPrDisposition("acme/widgets", 8, { apiBaseUrl: API, fetchFn: noMessage, sleepFn: async () => {} }),
+    ).rejects.toThrow(/^github_500$/);
+  });
+
+  it("treats an unparseable PR response body as an empty (still-open) disposition", async () => {
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("bad json");
+      },
+    }));
+    // response.json() rejects -> the `.catch(() => null)` yields a null payload -> normalized as still-open.
+    const result = await pollPrDisposition("acme/widgets", 13, { apiBaseUrl: API, fetchFn: fetchFn as never });
+    expect(result).toMatchObject({ state: "open", merged: false, attempts: 1 });
+  });
+
   it("backs off between polls while the PR stays open, until it reaches a terminal disposition", async () => {
     const sleeps: number[] = [];
     const fetchFn = vi
@@ -132,6 +179,25 @@ describe("PR disposition poller (#5135)", () => {
     expect(result).toEqual({ state: "closed", merged: true, closedAt: "2026-07-12T01:00:00Z", attempts: 3 });
     expect(sleeps).toEqual([100, 150]);
     expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses the built-in setTimeout backoff when sleepFn is omitted", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(prResponse({ state: "open" }))
+      .mockResolvedValueOnce(prResponse({ state: "closed", merged: false, closed_at: "2026-07-12T01:00:00Z" }));
+
+    // No sleepFn -> the real setTimeout-based default runs; minIntervalMs/maxIntervalMs pin the backoff to 1ms.
+    const result = await pollPrDisposition("acme/widgets", 12, {
+      apiBaseUrl: API,
+      fetchFn,
+      maxAttempts: 2,
+      minIntervalMs: 1,
+      maxIntervalMs: 1,
+    });
+
+    expect(result).toMatchObject({ state: "closed", merged: false, attempts: 2 });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
   it("returns the last-observed open disposition once maxAttempts is exhausted, without throwing", async () => {

--- a/test/unit/miner-store-db-adapter.test.ts
+++ b/test/unit/miner-store-db-adapter.test.ts
@@ -38,6 +38,17 @@ describe("miner store-db-adapter seam (#7175 part 1)", () => {
     expect(await d1.prepare("SELECT id, name FROM t").raw()).toEqual([[1, "a"]]);
   });
 
+  it("first(colName) plucks a single column value and coalesces a SQL NULL to null", async () => {
+    const db = new DatabaseSync(":memory:");
+    const d1 = createD1Adapter(nodeSqliteDriver(db));
+    await d1.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, note TEXT)");
+    await d1.prepare("INSERT INTO t (name, note) VALUES (?, ?)").bind("a", null).run();
+    // With a column name, first() returns just that column's value rather than the whole row...
+    expect(await d1.prepare("SELECT name FROM t WHERE id = 1").first<string>("name")).toBe("a");
+    // ...and a SQL NULL column coalesces to null (the `?? null` arm), never undefined.
+    expect(await d1.prepare("SELECT note FROM t WHERE id = 1").first<string>("note")).toBeNull();
+  });
+
   it("batch is atomic and rolls back on error", async () => {
     const db = new DatabaseSync(":memory:");
     const d1 = createD1Adapter(nodeSqliteDriver(db));


### PR DESCRIPTION
## Summary

Phase-4 **batch 4.2** of the #7290 TypeScript migration: convert the batch's foundational, most-depended-on `packages/loopover-miner/lib` modules from hand-maintained `.js` + `.d.ts` to real TypeScript, compiled in place via the package's existing `tsc` pipeline.

Files: `opportunity-ranker`, `store-db-adapter`, `claim-conflict-resolver`, `harness-submission-trigger`, `portfolio-queue-manager`, `pr-disposition-poller`, `ranked-candidates`, `tenant-client`.

(The issue noted `tenant-client.js` might not exist yet — it has since landed, so it's included as the issue directs.) The public API of each module is preserved **exactly** — every exported name and signature matches the removed hand-written `.d.ts` — and the compiled `.js` is **behavior-identical** to the original: only type annotations, identity row-cast helpers, and tsc formatting differ. No `tsconfig.json` change is needed (its `lib/**/*.ts` include glob picks the files up automatically). Verified byte-identical by diffing each freshly-compiled `.js` against the original with comments/whitespace normalized away — every remaining difference is tsc reformatting or an erasable cast.

## Coverage

**All 8 converted files are at 100% line + branch + function** (`390/390` statements, `323/323` branches, `103/103` functions, `331/331` lines). Because a migration re-marks a module's every line as changed, this required covering the pre-existing untested branches these high-fan-in modules carried. Added tests for: `opportunity-ranker`'s malformed-candidate fallbacks (non-array labels, non-finite comment counts, unknown ai-policy source) and label filtering; `store-db-adapter`'s `first(colName)` column-pluck + SQL-NULL coalesce; `portfolio-queue-manager`'s `entriesToPortfolioQueue` non-array/blank-row skipping, `initPortfolioQueueManager` default caps + injected-store fallback + custom `staleLeaseMs`, and `close()` / `closeDefaultPortfolioQueueManager`; and `pr-disposition-poller`'s blank-`apiBaseUrl` default, non-string repo rejection, global-`fetch` fallback, GitHub-error message/no-message paths, unparseable-body handling, and the built-in `setTimeout` backoff. Two genuinely-unreachable defensive guards (`pr-disposition-poller`'s all-paths-return after a `maxAttempts >= 1` loop, and `parseQueueItemId`'s `!apiBaseUrl` check that a prior `secondLastSeparatorIndex > 0` guard makes impossible) carry a documented `/* v8 ignore */`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root `tsc --noEmit`) and the `@loopover/miner` package `tsc` build both green
- [x] All 8 converted files at **100% line + branch + function** (verified via `--coverage` over the modules' dedicated + importer tests)
- [x] `npm run build:miner` regenerates the committed `.js`/`.d.ts` with **zero drift**; `npm run test:miner-pack` confirms **0 `.ts` files leak** into the published package; `npm run miner:env-reference:check` clean
- [x] All existing tests for the modules pass unmodified; new tests added only for the branches the migration newly tracks

Not run here (out of scope for a `packages/loopover-miner/lib/**`-only, behavior-identical migration; no such surface changed): `ui:*`, `build:mcp`/`test:mcp-pack`, `ui:openapi:check`. No API/OpenAPI/MCP/UI/DB/wrangler surface is touched.

## Safety

- [x] No secrets, wallets, hotkeys/coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence anywhere.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/GitHub App/Cloudflare/session: N/A — none changed.
- [x] API/OpenAPI/MCP: N/A — none changed.
- [x] UI: N/A — no UI change.
- [x] No changelog edit; no `site/`/`CNAME`/`lovable` changes.

Closes #7310
