### PR TITLE
chore(miner): migrate the CLI-command lib modules to TypeScript (#7307 batch 3.3)

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.d.ts
+++ b/packages/loopover-miner/lib/attempt-cli.d.ts
@@ -1,108 +1,128 @@
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
+import { resolveClaimConflict } from "./claim-conflict-resolver.js";
+import { resolveRejectionSignaled } from "./rejection-signal.js";
+import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
+import { fetchSelfReviewContext } from "./self-review-context.js";
+import { buildCodingTaskSpec } from "./coding-task-spec.js";
+import { resolveAmsPolicy } from "./ams-policy.js";
+import { checkMinerKillSwitch } from "./governor-kill-switch.js";
+import { getAttemptHistory } from "./portfolio-queue.js";
+import { recordOwnSubmission } from "./governor-state.js";
+import { runMinerAttempt } from "./attempt-runner.js";
+import { submitSoftClaim } from "./discovery-index-client.js";
 import type { CodingAgentExecutionMode, FeasibilityVerdict, LocalWriteActionSpec } from "@loopover/engine";
-import type { AttemptDeps, AttemptResult as RunMinerAttemptResult, runMinerAttempt } from "./attempt-runner.js";
+import type { AttemptDeps, AttemptResult as RunMinerAttemptResult } from "./attempt-runner.js";
 import type { ClaimLedger } from "./claim-ledger.js";
 import type { EventLedger } from "./event-ledger.js";
 import type { AttemptLog } from "./attempt-log.js";
 import type { GovernorLedger } from "./governor-ledger.js";
 import type { WorktreeAllocator } from "./worktree-allocator.js";
-import type { resolveRejectionSignaled } from "./rejection-signal.js";
-import type { SelfReviewContextFetch, fetchSelfReviewContext } from "./self-review-context.js";
-import type { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
-import type { buildCodingTaskSpec } from "./coding-task-spec.js";
-import type { resolveAmsPolicy } from "./ams-policy.js";
-import type { checkMinerKillSwitch } from "./governor-kill-switch.js";
-import type { resolveMinerGoalSpec } from "./miner-goal-spec.js";
-import type { ClaimConflictResult, resolveClaimConflict } from "./claim-conflict-resolver.js";
-import type { recordOwnSubmission } from "./governor-state.js";
-import type { getAttemptHistory } from "./portfolio-queue.js";
-import type { submitSoftClaim } from "./discovery-index-client.js";
-
+import type { SelfReviewContextFetch } from "./self-review-context.js";
+import type { ClaimConflictResult } from "./claim-conflict-resolver.js";
 type CommonAttemptResultFields = {
-  repoFullName: string;
-  issueNumber: number;
-  minerLogin: string;
-  base: string;
-  mode: CodingAgentExecutionMode;
-  attemptId: string;
+    repoFullName: string;
+    issueNumber: number;
+    minerLogin: string;
+    base: string;
+    mode: CodingAgentExecutionMode;
+    attemptId: string;
 };
-
 /** The result runAttempt reports at every real return point, threaded to `options.onResult` (in addition to
  *  the plain exit-code return runAttempt itself still returns, unchanged, so bin/loopover-miner.js's own
  *  `process.exit(exitCode)` usage never breaks) -- the loop orchestrator's real caller for this data. */
-export type AttemptCliResult =
-  | (CommonAttemptResultFields & { outcome: "dry_run" })
-  | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
-  | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
-  | (CommonAttemptResultFields & {
-      outcome: "blocked_infeasible";
-      reason: string;
-      verdict: FeasibilityVerdict;
-      avoidReasons: string[];
-      raiseReasons: string[];
-    })
-  | (CommonAttemptResultFields & {
-      outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
-      submissionMode: "observe" | "enforce";
-      totalTurnsUsed: number;
-      totalCostUsd: number;
-      totalTokensUsed: number;
-      iterationsUsed: number;
-      reason?: string;
-      decision?: unknown;
-      spec?: LocalWriteActionSpec;
-      execResult?: unknown;
-      claimConflict?: ClaimConflictResult;
-    });
-
-export type ParsedAttemptArgs =
-  | { error: string }
-  | {
-      repoFullName: string;
-      issueNumber: number;
-      minerLogin: string;
-      base: string;
-      live: boolean;
-      dryRun: boolean;
-      json: boolean;
-    };
-
-export function parseAttemptArgs(args: string[]): ParsedAttemptArgs;
-
-export function buildAttemptDeps(
-  env: Record<string, string | undefined>,
-  ledgers: { claimLedger: ClaimLedger; eventLedger: EventLedger; attemptLog: AttemptLog; governorLedger: GovernorLedger; nowMs: number },
-): AttemptDeps;
-
-export type RunAttemptOptions = {
-  env?: Record<string, string | undefined>;
-  nowMs?: number;
-  attemptId?: string;
-  resolveCodingAgentModeFromConfig?: (config: { env?: Record<string, string | undefined> }) => CodingAgentExecutionMode;
-  openWorktreeAllocator?: () => WorktreeAllocator;
-  openClaimLedger?: () => ClaimLedger;
-  initEventLedger?: () => EventLedger;
-  initAttemptLog?: () => AttemptLog;
-  initGovernorLedger?: () => GovernorLedger;
-  buildAttemptDeps?: typeof buildAttemptDeps;
-  resolveRejectionSignaled?: typeof resolveRejectionSignaled;
-  fetchImpl?: SelfReviewContextFetch;
-  prepareAttemptWorktree?: typeof prepareAttemptWorktree;
-  cleanupAttemptWorktree?: typeof cleanupAttemptWorktree;
-  fetchSelfReviewContext?: typeof fetchSelfReviewContext;
-  buildCodingTaskSpec?: typeof buildCodingTaskSpec;
-  resolveAmsPolicy?: typeof resolveAmsPolicy;
-  checkMinerKillSwitch?: typeof checkMinerKillSwitch;
-  resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
-  runMinerAttempt?: typeof runMinerAttempt;
-  resolveClaimConflict?: typeof resolveClaimConflict;
-  recordOwnSubmission?: typeof recordOwnSubmission;
-  getAttemptHistory?: typeof getAttemptHistory;
-  /** Hosted soft-claim coordination at work-start/work-end, when the plane is enabled (#7168). Defaults to
-   *  discovery-index-client.js's own submitSoftClaim. */
-  submitSoftClaim?: typeof submitSoftClaim;
-  /** Invoked with the real structured result at every return point, in addition to (never instead of) the
-   *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
-  onResult?: (result: AttemptCliResult) => void;
+export type AttemptCliResult = (CommonAttemptResultFields & {
+    outcome: "dry_run";
+}) | (CommonAttemptResultFields & {
+    outcome: "blocked_rejection_signaled";
+    reason: string;
+}) | (CommonAttemptResultFields & {
+    outcome: "blocked_worktree_preparation_failed";
+    reason: string;
+}) | (CommonAttemptResultFields & {
+    outcome: "blocked_infeasible";
+    reason: string;
+    verdict: FeasibilityVerdict;
+    avoidReasons: string[];
+    raiseReasons: string[];
+}) | (CommonAttemptResultFields & {
+    outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
+    submissionMode: "observe" | "enforce";
+    totalTurnsUsed: number;
+    totalCostUsd: number;
+    totalTokensUsed: number;
+    iterationsUsed: number;
+    reason?: string;
+    decision?: unknown;
+    spec?: LocalWriteActionSpec;
+    execResult?: unknown;
+    claimConflict?: ClaimConflictResult;
+});
+export type ParsedAttemptArgs = {
+    error: string;
+} | {
+    repoFullName: string;
+    issueNumber: number;
+    minerLogin: string;
+    base: string;
+    live: boolean;
+    dryRun: boolean;
+    json: boolean;
 };
-
-export function runAttempt(args: string[], options?: RunAttemptOptions): Promise<number>;
+export type RunAttemptOptions = {
+    env?: Record<string, string | undefined>;
+    nowMs?: number;
+    attemptId?: string;
+    resolveCodingAgentModeFromConfig?: (config: {
+        env?: Record<string, string | undefined>;
+    }) => CodingAgentExecutionMode;
+    openWorktreeAllocator?: () => WorktreeAllocator;
+    openClaimLedger?: () => ClaimLedger;
+    initEventLedger?: () => EventLedger;
+    initAttemptLog?: () => AttemptLog;
+    initGovernorLedger?: () => GovernorLedger;
+    buildAttemptDeps?: typeof buildAttemptDeps;
+    resolveRejectionSignaled?: typeof resolveRejectionSignaled;
+    fetchImpl?: SelfReviewContextFetch;
+    prepareAttemptWorktree?: typeof prepareAttemptWorktree;
+    cleanupAttemptWorktree?: typeof cleanupAttemptWorktree;
+    fetchSelfReviewContext?: typeof fetchSelfReviewContext;
+    buildCodingTaskSpec?: typeof buildCodingTaskSpec;
+    resolveAmsPolicy?: typeof resolveAmsPolicy;
+    checkMinerKillSwitch?: typeof checkMinerKillSwitch;
+    resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
+    runMinerAttempt?: typeof runMinerAttempt;
+    resolveClaimConflict?: typeof resolveClaimConflict;
+    recordOwnSubmission?: typeof recordOwnSubmission;
+    getAttemptHistory?: typeof getAttemptHistory;
+    /** Hosted soft-claim coordination at work-start/work-end, when the plane is enabled (#7168). Defaults to
+     *  discovery-index-client.js's own submitSoftClaim. */
+    submitSoftClaim?: typeof submitSoftClaim;
+    /** Invoked with the real structured result at every return point, in addition to (never instead of) the
+     *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
+    onResult?: (result: AttemptCliResult) => void;
+};
+export declare function parseAttemptArgs(args: string[]): ParsedAttemptArgs;
+/**
+ * Assemble a real AttemptDeps object: every field wired to a genuine implementation (the #5131 driver, the
+ * #5133 slop assessor, the four real ledgers passed in, and the fetchLiveIssueSnapshot/executeLocalWrite
+ * built alongside this file). Throws if the coding-agent driver is unconfigured (fails closed, matching
+ * constructProductionCodingAgentDriver's own contract) -- callers should report that clearly rather than
+ * silently falling back to a driver that could never run.
+ */
+export declare function buildAttemptDeps(env: Record<string, string | undefined>, ledgers: {
+    claimLedger: ClaimLedger;
+    eventLedger: EventLedger;
+    attemptLog: AttemptLog;
+    governorLedger: GovernorLedger;
+    nowMs: number;
+}): AttemptDeps;
+/**
+ * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
+ * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
+ * SelfReviewContext -> build a real coding-task spec (blocks on an infeasible verdict) -> resolve the real
+ * AmsPolicySpec execution policy -> assemble the real IterateLoopInput + Governor context -> call
+ * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) in `finally`.
+ * See this file's header for the documented gaps (real convergence history).
+ */
+export declare function runAttempt(args: string[], options?: RunAttemptOptions): Promise<number>;
+export {};

--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -12,7 +12,6 @@
 // governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted (chokepoint.ts's own design treats
 // that as "skip that stage entirely"). governor.convergenceInput is now a real per-issue portfolio-queue.js read
 // (#5654) and governor.reputationHistory a real per-repo governor-state.js read (#5675), not placeholders.
-
 import { fingerprintFromChangedFiles, resolveCodingAgentModeFromConfig, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { constructProductionCodingAgentDriver } from "./coding-agent-construction.js";
@@ -41,115 +40,107 @@ import { loadReputationHistory, recordOwnSubmission } from "./governor-state.js"
 import { runMinerAttempt } from "./attempt-runner.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
 import { isDiscoveryPlaneEnabled, submitSoftClaim } from "./discovery-index-client.js";
-
-const ATTEMPT_USAGE =
-  "Usage: loopover-miner attempt <owner/repo> <issue#> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--json]";
-
+const ATTEMPT_USAGE = "Usage: loopover-miner attempt <owner/repo> <issue#> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--json]";
 function parseRepoTarget(value) {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
-  return `${owner}/${repo}`;
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo))
+        return null;
+    return `${owner}/${repo}`;
 }
-
 export function parseAttemptArgs(args) {
-  const options = { json: false, minerLogin: null, base: "main", live: false, dryRun: false };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, minerLogin: null, base: "main", live: false, dryRun: false };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // Opt-in only: resolveCodingAgentModeFromConfig's own default (no agentDryRun override) is "live", not
+        // "dry_run" -- so #5132's "dry-run is default" acceptance criteria (#2342) has to be enforced HERE, by
+        // requiring an explicit --live flag before this command will ever request live mode.
+        if (token === "--live") {
+            options.live = true;
+            continue;
+        }
+        // #4847: distinct from --live's absence above -- --live only ever gated the coding-agent DRIVER's mode,
+        // but a non---live run still opened every store and made real worktree/claim/ledger writes. --dry-run
+        // short-circuits BEFORE any of that infrastructure is even opened, guaranteeing zero writes rather than
+        // merely skipping the driver.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--miner-login") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: ATTEMPT_USAGE };
+            options.minerLogin = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--base") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: ATTEMPT_USAGE };
+            options.base = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        positional.push(token);
     }
-    // Opt-in only: resolveCodingAgentModeFromConfig's own default (no agentDryRun override) is "live", not
-    // "dry_run" -- so #5132's "dry-run is default" acceptance criteria (#2342) has to be enforced HERE, by
-    // requiring an explicit --live flag before this command will ever request live mode.
-    if (token === "--live") {
-      options.live = true;
-      continue;
+    if (positional.length !== 2)
+        return { error: ATTEMPT_USAGE };
+    const repoFullName = parseRepoTarget(positional[0]);
+    if (!repoFullName)
+        return { error: `Repository must be in owner/repo form: ${positional[0]}` };
+    const issueNumber = Number(positional[1]);
+    if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+        return { error: `Issue number must be a positive integer: ${positional[1]}` };
     }
-    // #4847: distinct from --live's absence above -- --live only ever gated the coding-agent DRIVER's mode,
-    // but a non---live run still opened every store and made real worktree/claim/ledger writes. --dry-run
-    // short-circuits BEFORE any of that infrastructure is even opened, guaranteeing zero writes rather than
-    // merely skipping the driver.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--miner-login") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
-      options.minerLogin = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--base") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
-      options.base = value;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) return { error: ATTEMPT_USAGE };
-  const repoFullName = parseRepoTarget(positional[0]);
-  if (!repoFullName) return { error: `Repository must be in owner/repo form: ${positional[0]}` };
-  const issueNumber = Number(positional[1]);
-  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
-    return { error: `Issue number must be a positive integer: ${positional[1]}` };
-  }
-  if (!options.minerLogin) return { error: `--miner-login is required. ${ATTEMPT_USAGE}` };
-
-  return {
-    repoFullName,
-    issueNumber,
-    minerLogin: options.minerLogin,
-    base: options.base,
-    live: options.live,
-    dryRun: options.dryRun,
-    json: options.json,
-  };
+    if (!options.minerLogin)
+        return { error: `--miner-login is required. ${ATTEMPT_USAGE}` };
+    return {
+        repoFullName,
+        issueNumber,
+        minerLogin: options.minerLogin,
+        base: options.base,
+        live: options.live,
+        dryRun: options.dryRun,
+        json: options.json,
+    };
 }
-
 /**
  * Assemble a real AttemptDeps object: every field wired to a genuine implementation (the #5131 driver, the
  * #5133 slop assessor, the four real ledgers passed in, and the fetchLiveIssueSnapshot/executeLocalWrite
  * built alongside this file). Throws if the coding-agent driver is unconfigured (fails closed, matching
  * constructProductionCodingAgentDriver's own contract) -- callers should report that clearly rather than
  * silently falling back to a driver that could never run.
- *
- * @param {Record<string, string | undefined>} env
- * @param {{
- *   claimLedger: import("./claim-ledger.js").ClaimLedger,
- *   eventLedger: import("./event-ledger.js").EventLedger,
- *   attemptLog: import("./attempt-log.js").AttemptLog,
- *   governorLedger: import("./governor-ledger.js").GovernorLedger,
- *   nowMs: number,
- * }} ledgers
- * @returns {import("./attempt-runner.js").AttemptDeps}
  */
 export function buildAttemptDeps(env, ledgers) {
-  return {
-    driver: constructProductionCodingAgentDriver(env),
-    runSlopAssessment: (input) => runSlopAssessment(input),
-    appendAttemptLogEvent: (event) => ledgers.attemptLog.appendAttemptLogEvent(event),
-    claimLedger: ledgers.claimLedger,
-    // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
-    // authenticated `loopover-mcp login` session -- cached in memory, so repeat calls within this process
-    // don't repeatedly hit the session-fetch endpoint after the first successful resolution.
-    fetchLiveIssueSnapshot: async (repoFullName, issueNumber) => fetchLiveIssueSnapshot(repoFullName, issueNumber, { githubToken: await resolveGitHubToken(env) }),
-    eventLedger: ledgers.eventLedger,
-    governorLedgerAppend: (event) => ledgers.governorLedger.appendGovernorEvent(event),
-    nowMs: ledgers.nowMs,
-    executeLocalWrite: (spec) => executeLocalWrite(spec),
-  };
+    return {
+        driver: constructProductionCodingAgentDriver(env),
+        runSlopAssessment: (input) => runSlopAssessment(input),
+        appendAttemptLogEvent: (event) => ledgers.attemptLog.appendAttemptLogEvent(event),
+        // The real ClaimLedger is a valid claim ledger for AttemptDeps' narrower SubmissionFreshnessClaimLedger view;
+        // its listClaims types `status` as the concrete ClaimStatus rather than the view's looser `string`, so the
+        // structural check needs an explicit bridge (runtime shape is identical).
+        claimLedger: ledgers.claimLedger,
+        // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+        // authenticated `loopover-mcp login` session -- cached in memory, so repeat calls within this process
+        // don't repeatedly hit the session-fetch endpoint after the first successful resolution.
+        fetchLiveIssueSnapshot: async (repoFullName, issueNumber) => fetchLiveIssueSnapshot(repoFullName, issueNumber, { githubToken: (await resolveGitHubToken(env)) }),
+        eventLedger: ledgers.eventLedger,
+        governorLedgerAppend: (event) => ledgers.governorLedger.appendGovernorEvent(event),
+        nowMs: ledgers.nowMs,
+        executeLocalWrite: (spec) => executeLocalWrite(spec),
+    };
 }
-
 /**
  * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
  * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
@@ -159,573 +150,536 @@ export function buildAttemptDeps(env, ledgers) {
  * See this file's header for the documented gaps (real convergence history).
  */
 export async function runAttempt(args, options = {}) {
-  const parsed = parseAttemptArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const env = options.env ?? process.env;
-  const nowMs = options.nowMs ?? Date.now();
-  const resolveMode = options.resolveCodingAgentModeFromConfig ?? resolveCodingAgentModeFromConfig;
-  const mode = resolveMode({ env, agentDryRun: !parsed.live });
-
-  if (mode === "paused") {
-    return reportCliFailure(
-      parsed.json,
-      `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`,
-      3,
-    );
-  }
-
-  const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
-
-  // #4847: reports what a real run would do and returns BEFORE any store (allocator/claim/event/attempt-log/
-  // governor ledger) is even opened, so this is a provable zero-write path -- not just "opened but didn't
-  // write to" the local stores, and nowhere near the real worktree clone, claim, or coding-agent driver.
-  if (parsed.dryRun) {
-    const dryRunResult = {
-      outcome: "dry_run",
-      repoFullName: parsed.repoFullName,
-      issueNumber: parsed.issueNumber,
-      minerLogin: parsed.minerLogin,
-      base: parsed.base,
-      mode,
-      attemptId,
-    };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(
-        `DRY RUN: would attempt ${parsed.repoFullName}#${parsed.issueNumber} for ${parsed.minerLogin} (mode: ${mode}, base: ${parsed.base}). No worktree, claim, or ledger writes were made.`,
-      );
+    const parsed = parseAttemptArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    options.onResult?.(dryRunResult);
-    return 0;
-  }
-
-  let allocator = null;
-  let claimLedger = null;
-  let eventLedger = null;
-  let attemptLog = null;
-  let governorLedger = null;
-  let allocation = null;
-  let worktreeResult = null;
-  let claimedIssue = false;
-  let claimRecord = null;
-
-  try {
-    allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
-    claimLedger = (options.openClaimLedger ?? openClaimLedger)();
-    eventLedger = (options.initEventLedger ?? initEventLedger)();
-    attemptLog = (options.initAttemptLog ?? initAttemptLog)();
-    governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
-
-    // Checked before acquiring a worktree slot: a rejection-signaled repo should never consume one.
-    // resolveRejectionSignaled resolves both documented triggers (#5132 policy ban, #5655 own-rejection
-    // history) and returns a trigger-specific reason string for accurate audit-trail labeling.
-    const resolveRejection = options.resolveRejectionSignaled ?? resolveRejectionSignaled;
-    const rejectionSignal = await resolveRejection(parsed.repoFullName, { fetchImpl: options.fetchImpl });
-    if (rejectionSignal) {
-      const reason =
-        rejectionSignal === true ? REJECTION_REASON_AI_USAGE_POLICY_BAN : rejectionSignal;
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const rejectedResult = {
-        outcome: "blocked_rejection_signaled",
-        reason,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(rejectedResult, null, 2));
-      } else {
-        console.error(
-          reason === REJECTION_REASON_OWN_SUBMISSION_REJECTED
-            ? `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this miner was previously rejected on this repo.`
-            : `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's AI-usage policy bans automated/AI-authored contributions.`,
-        );
-      }
-      options.onResult?.(rejectedResult);
-      return 5;
+    const env = options.env ?? process.env;
+    const nowMs = options.nowMs ?? Date.now();
+    const resolveMode = options.resolveCodingAgentModeFromConfig ?? resolveCodingAgentModeFromConfig;
+    const mode = resolveMode({ env, agentDryRun: !parsed.live });
+    if (mode === "paused") {
+        return reportCliFailure(parsed.json, `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`, 3);
     }
-
-    allocation = allocator.acquire(attemptId, parsed.repoFullName);
-
-    let deps;
-    try {
-      const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
-      deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
-    } catch (error) {
-      const reason = describeCliError(error);
-      return reportCliFailure(
-        parsed.json,
-        `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`,
-        3,
-      );
-    }
-
-    // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
-    // reserves a concurrency SLOT (worktree-allocator.js's own `slot-N` placeholder dirs never receive real
-    // git content) -- this is the step that actually clones/fetches the target repo and creates a real
-    // `git worktree` for this attempt. Its own path, NOT the allocator's slot path, is the real
-    // workingDirectory a future runMinerAttempt call must use.
-    const prepareWorktree = options.prepareAttemptWorktree ?? prepareAttemptWorktree;
-    worktreeResult = await prepareWorktree(parsed.repoFullName, attemptId, { baseBranch: parsed.base, env });
-    if (!worktreeResult.ok) {
-      const reason = worktreeResult.error;
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const worktreeFailureResult = {
-        outcome: "blocked_worktree_preparation_failed",
-        reason,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(worktreeFailureResult, null, 2));
-      } else {
-        console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: real worktree preparation failed: ${reason}`);
-      }
-      options.onResult?.(worktreeFailureResult);
-      return 6;
-    }
-
-    // Real SelfReviewContext (#5145): issue/PR/manifest data at live-gate fidelity for the target repo.
-    const fetchReviewContext = options.fetchSelfReviewContext ?? fetchSelfReviewContext;
-    const reviewContext = await fetchReviewContext(parsed.repoFullName, {
-      githubToken: await resolveGitHubToken(env),
-      contributorLogin: parsed.minerLogin,
-      linkedIssues: [parsed.issueNumber],
-    });
-
-    // The target issue's own real record, when present in the fetched context. When absent (e.g. already
-    // closed, or genuinely not found), buildCodingTaskSpec's own feasibility check reports target_not_found
-    // and this placeholder's empty title/body are never surfaced anywhere -- not fabricated content, just an
-    // inert shape for a verdict that immediately blocks.
-    const targetIssue = reviewContext.issues.find((candidate) => candidate.number === parsed.issueNumber) ?? {
-      number: parsed.issueNumber,
-      title: "",
-      body: null,
-      labels: [],
-    };
-
-    const buildTaskSpec = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
-    const codingTaskSpec = buildTaskSpec({
-      repoFullName: parsed.repoFullName,
-      issue: targetIssue,
-      context: { issues: reviewContext.issues, pullRequests: reviewContext.pullRequests },
-      claimLedger,
-      workingDirectory: worktreeResult.worktreePath,
-    });
-
-    if (!codingTaskSpec.ready) {
-      const reason = `infeasible_${codingTaskSpec.verdict}`;
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, feasibility: codingTaskSpec.feasibility },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const infeasibleResult = {
-        outcome: "blocked_infeasible",
-        reason,
-        verdict: codingTaskSpec.verdict,
-        avoidReasons: codingTaskSpec.feasibility.avoidReasons,
-        raiseReasons: codingTaskSpec.feasibility.raiseReasons,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(infeasibleResult, null, 2));
-      } else {
-        console.error(
-          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: feasibility verdict "${codingTaskSpec.verdict}" (${[...codingTaskSpec.feasibility.avoidReasons, ...codingTaskSpec.feasibility.raiseReasons].join(", ")}).`,
-        );
-      }
-      options.onResult?.(infeasibleResult);
-      return 4;
-    }
-
-    const amsPolicy = await (options.resolveAmsPolicy ?? resolveAmsPolicy)(parsed.repoFullName, { env });
-
-    // Real per-repo pause (#5392): read straight from the already-cloned worktree's own .loopover-miner.yml
-    // (resolveMinerGoalSpec never throws -- a missing/malformed file degrades to killSwitch.paused: false, so
-    // this can't fail this attempt on its own). Threaded into BOTH checkMinerKillSwitch (killSwitchScope, used
-    // by the freshness/submission gate) and the governor context (killSwitchRepoPaused, used by the Governor
-    // chokepoint) -- the same two places the GLOBAL kill switch already reaches.
-    const resolveGoalSpec = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
-    const minerGoalSpec = resolveGoalSpec(worktreeResult.repoPath);
-    const repoPaused = minerGoalSpec.spec.killSwitch.paused;
-
-    const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
-    const recordKillTransition = options.recordMinerKillSwitchTransition ?? recordMinerKillSwitchTransition;
-    let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
-    let previousKillSwitchScope = killSwitchScope;
-
-    const resolveLiveKillSwitch = () => {
-      // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
-      const liveRepoPaused = resolveGoalSpec(worktreeResult.repoPath).spec.killSwitch.paused;
-      const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
-      if (live.scope !== previousKillSwitchScope) {
-        try {
-          recordKillTransition({
-            repoFullName: parsed.repoFullName,
-            actionClass: "attempt",
-            previousScope: previousKillSwitchScope,
-            scope: live.scope,
-          });
-        } catch (error) {
-          // Ledger append must never crash an aborting attempt (kept), but was previously silent -- a
-          // kill-switch flip mid-attempt (a compliance-relevant event) could vanish with no record (#6011).
-          captureMinerError(error, { kind: "kill_switch_transition_record_failed", repoFullName: parsed.repoFullName, scope: live.scope });
-        }
-        previousKillSwitchScope = live.scope;
-      }
-      killSwitchScope = live.scope;
-      return live;
-    };
-
-    const shouldAbort = () => {
-      const live = resolveLiveKillSwitch();
-      if (!live.active) return false;
-      return {
-        abort: true,
-        reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
-      };
-    };
-
-    const loopInput = buildAttemptLoopInput({
-      codingTaskSpec,
-      reviewContext,
-      worktreePath: worktreeResult.worktreePath,
-      attemptId,
-      mode,
-      repoFullName: parsed.repoFullName,
-      minerLogin: parsed.minerLogin,
-      rejectionSignaled: false,
-      amsPolicySpec: amsPolicy.spec,
-      branchRef: worktreeResult.branchName,
-    });
-
-    // Real per-issue attempt history (#5654): portfolio-queue.js's own claim/reclaim/requeue/done counters,
-    // keyed the same way opportunity-fanout.js enqueues issue-shaped candidates (`issue:<number>`). No
-    // apiBaseUrl: this file has no multi-forge host context of its own today, so this reads (and every
-    // pre-#5563 single-forge caller already reads) the github.com default.
-    const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
-    const convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
-    // Real per-repo reputation history (#5675): the miner's own decided/unfavorable outcome streak for this repo,
-    // read from governor-state.js so the chokepoint's self-reputation throttle sees real data instead of nothing.
-    const readReputationHistory = options.loadReputationHistory ?? loadReputationHistory;
-    const reputationHistory = readReputationHistory(parsed.repoFullName);
-    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
-
-    // Real maxConcurrentClaims enforcement (#6758): the repo's .loopover-miner.yml cap is honored ATOMICALLY by
-    // the ledger's count-and-claim, not by a listActiveClaims pre-check here. The old check-then-act split -- read
-    // the count in this file, then record the claim in a separate claimLedger call -- let two sibling miner
-    // processes racing the same repo both pass a stale sub-cap count and both claim, exceeding the cap.
-    // claimIssueWithinCap fuses the count and the insert into one transaction; the loser gets `claimed: false`
-    // and is reported below rather than silently dropped. This is also the real soft-claim (#5393): once it
-    // returns claimed, a sibling process sees it via claimLedger.listActiveClaims while this attempt is in
-    // flight, it is released in `finally` on every terminal outcome (mirroring the worktree allocation slot's
-    // acquire-then-always-release), and its claimedAt feeds the post-submission conflict check further down (#4848).
-    const claimResult = claimLedger.claimIssueWithinCap(
-      parsed.repoFullName,
-      parsed.issueNumber,
-      `attempt:${attemptId}`,
-      undefined,
-      minerGoalSpec.spec.maxConcurrentClaims,
-    );
-    if (!claimResult.claimed) {
-      const reason = "max_concurrent_claims_exceeded";
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_aborted",
-        attemptId,
-        actionClass: "open_pr",
-        mode,
-        reason,
-        payload: {
-          repoFullName: parsed.repoFullName,
-          issueNumber: parsed.issueNumber,
-          maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
-          activeClaimCount: claimResult.activeClaimCount,
-        },
-      });
-      eventLedger.appendEvent({
-        type: "attempt_blocked",
-        repoFullName: parsed.repoFullName,
-        payload: { issueNumber: parsed.issueNumber, reason },
-      });
-      const blockedResult = {
-        outcome: "blocked_max_concurrent_claims",
-        reason,
-        maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
-        activeClaimCount: claimResult.activeClaimCount,
-        repoFullName: parsed.repoFullName,
-        issueNumber: parsed.issueNumber,
-        minerLogin: parsed.minerLogin,
-        base: parsed.base,
-        mode,
-        attemptId,
-      };
-      if (parsed.json) {
-        console.log(JSON.stringify(blockedResult, null, 2));
-      } else {
-        console.error(
-          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${claimResult.activeClaimCount} active claim(s)).`,
-        );
-      }
-      options.onResult?.(blockedResult);
-      return 11;
-    }
-
-    claimRecord = claimResult.claim;
-    claimedIssue = true;
-    // Hosted soft-claim coordination (#7168), opt-in via LOOPOVER_MINER_DISCOVERY_PLANE -- gated HERE at the
-    // call site (not left to submitSoftClaim's own internal check alone) so a disabled plane costs zero calls,
-    // matching discover-cli.js's supplementWithDiscoveryIndex gating; a caller-injected options.submitSoftClaim
-    // (tests, or a future programmatic caller) can't accidentally bypass the opt-in this way either. Awaited
-    // (not fire-and-forget) so a sibling instance racing the same issue is genuinely less likely to start
-    // duplicate work in the window before this attempt's claim reaches the shared index -- the whole point of
-    // coordinating BEFORE work begins, not after.
-    if (isDiscoveryPlaneEnabled(env)) {
-      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
-      await submitClaim(claimRecord, { env });
-    }
-
-    const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
-    let result;
-    try {
-      result = await runAttemptPipeline(
-        {
-          loopInput,
-          issueNumber: parsed.issueNumber,
-          minerLogin: parsed.minerLogin,
-          base: parsed.base,
-          killSwitchScope,
-          slopThreshold: amsPolicy.spec.slopThreshold,
-          submissionMode: amsPolicy.spec.submissionMode,
-          governor,
-        },
-        {
-          ...deps,
-          shouldAbort,
-          resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
-        },
-      );
-    } catch (error) {
-      // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
-      // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
-      // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
-      // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
-      worktreeResult.attemptOk = false;
-      throw error;
-    }
-
-    worktreeResult.attemptOk = result.outcome === "submitted";
-
-    // Real claim-conflict resolution (#4848): only meaningful once a real PR exists, so this only ever runs
-    // on a real "submitted" outcome. checkSubmissionFreshness (inside runMinerAttempt) already caught the
-    // common pre-submission case; this closes the narrower TOCTOU window where two miners raced past that
-    // check almost simultaneously -- see claim-conflict-resolver.js's own header for why the adjudicator
-    // can only run POST-submission (it needs a real PR number on both sides of the election).
-    let claimConflict;
-    if (result.outcome === "submitted") {
-      const selfPrNumber = parsePrNumberFromExecResult(result.execResult, parsed.repoFullName);
-      if (selfPrNumber !== null) {
-        const resolveConflict = options.resolveClaimConflict ?? resolveClaimConflict;
-        claimConflict = await resolveConflict(
-          {
+    const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
+    // #4847: reports what a real run would do and returns BEFORE any store (allocator/claim/event/attempt-log/
+    // governor ledger) is even opened, so this is a provable zero-write path -- not just "opened but didn't
+    // write to" the local stores, and nowhere near the real worktree clone, claim, or coding-agent driver.
+    if (parsed.dryRun) {
+        const dryRunResult = {
+            outcome: "dry_run",
             repoFullName: parsed.repoFullName,
             issueNumber: parsed.issueNumber,
-            selfPrNumber,
-            selfClaimedAt: claimRecord.claimedAt,
             minerLogin: parsed.minerLogin,
-          },
-          { fetchLiveIssueSnapshot: deps.fetchLiveIssueSnapshot, executeLocalWrite: deps.executeLocalWrite },
-        );
-      }
-
-      // Real own-submission history (#5655 follow-up): governor-state.js's recordOwnSubmission/
-      // listRecentOwnSubmissions store (#5134) existed and was already READ by resolveOwnRejectionHistory
-      // (#5655), but nothing ever WROTE to it -- attempt-runner.js's own header names this exact gap
-      // ("real persistence primitives... but isn't auto-loaded here yet"). Left unfixed, that trigger is a
-      // silent no-op in every real deployment: an empty table always resolves "no prior submissions found."
-      // The fingerprint is the real changed-files set from the loop's own handoff packet (never fabricated) --
-      // omitted (not recorded as an empty placeholder) when the packet reports no changed files at all. A
-      // logging failure must never fail an otherwise-successful attempt, matching the summary-event write below.
-      const changedFiles = result.loopResult.handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
-      const fingerprint = fingerprintFromChangedFiles(changedFiles);
-      if (fingerprint) {
-        try {
-          const record = options.recordOwnSubmission ?? recordOwnSubmission;
-          record({
-            repoFullName: parsed.repoFullName,
-            fingerprint,
-            submittedAt: new Date(nowMs).toISOString(),
-            pullRequestNumber: selfPrNumber,
-            issueNumber: parsed.issueNumber,
-          });
-        } catch (error) {
-          // A logging failure must never fail an otherwise-successful attempt (kept), but was previously
-          // silent -- if this write fails AFTER a real PR has already opened, future self-plagiarism checks go
-          // permanently blind to this exact submission with nobody told (#6011).
-          captureMinerError(error, { kind: "record_own_submission_failed", repoFullName: parsed.repoFullName, pullRequestNumber: selfPrNumber });
+            base: parsed.base,
+            mode,
+            attemptId,
+        };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
         }
-      }
-    }
-
-    const finalResult = {
-      outcome: `attempt_${result.outcome}`,
-      repoFullName: parsed.repoFullName,
-      issueNumber: parsed.issueNumber,
-      minerLogin: parsed.minerLogin,
-      base: parsed.base,
-      mode,
-      attemptId,
-      submissionMode: amsPolicy.spec.submissionMode,
-      // Every runMinerAttempt outcome carries a real loopResult (#5135's loop needs its genuine turn-usage and
-      // cost to save real GovernorCapUsage via governor-state.js's saveCapUsage -- nothing else in the codebase
-      // calls it yet). Surfaced flat rather than the whole loopResult object, matching this result's own
-      // shallow shape. costUsd is real only for the agent-sdk provider (its own SDK result message reports
-      // total_cost_usd); CLI-subprocess providers (claude-cli/codex-cli) report no cost signal today, so this
-      // is 0 for those -- an honest absence, not a fabricated number.
-      totalTurnsUsed: result.loopResult.totalTurnsUsed,
-      totalCostUsd: result.loopResult.totalCostUsd,
-      // Real accumulated tokens (#5653) -- read from finalMeterTotals rather than a flat totalTokensUsed field
-      // (IterateLoopResult has no such flat field, unlike turns/cost). 0 when no driver reported a token signal
-      // on any iteration this attempt ran, never fabricated.
-      totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
-      iterationsUsed: result.loopResult.iterationsUsed,
-      ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
-        ? { abandonReason: result.loopResult.finalDecision.abandonReason }
-        : {}),
-      ...("reason" in result ? { reason: result.reason } : {}),
-      ...("decision" in result ? { decision: result.decision } : {}),
-      ...("spec" in result ? { spec: result.spec } : {}),
-      ...("execResult" in result ? { execResult: result.execResult } : {}),
-      // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
-      // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
-      // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).
-      ...(claimConflict !== undefined ? { claimConflict } : {}),
-    };
-
-    // One summary row per completed attempt (#5185), for the Grafana per-provider usage dashboard the redacted
-    // AMS reporting export exposes -- distinct from the per-iteration attempt_started/attempt_tool_edit/... trail
-    // iterate-loop.ts already writes. No fallback for an unconfigured provider: buildAttemptDeps already fails
-    // closed (throws) on the same env before a worktree is even allocated, so reaching this point guarantees
-    // resolveFirstConfiguredCodingAgentDriverName(env) resolves a real name. costUsd/tokensUsed are both real,
-    // driver-reported accumulated totals (#5653) -- 0 when no iteration's driver reported a signal, never
-    // fabricated. A logging failure must never fail an otherwise-successful attempt -- mirrors iterate-loop.ts's
-    // own safeAppendAttemptLogEvent non-fatal handling.
-    try {
-      attemptLog.appendAttemptLogEvent({
-        eventType: "attempt_outcome_summary",
-        attemptId,
-        actionClass: finalResult.outcome,
-        mode,
-        reason: `attempt finished with outcome: ${result.outcome}`,
-        provider: resolveFirstConfiguredCodingAgentDriverName(env),
-        costUsd: finalResult.totalCostUsd,
-        tokensUsed: finalResult.totalTokensUsed,
-      });
-    } catch (error) {
-      // A logging failure must never fail an otherwise-successful attempt (kept), but was previously silent --
-      // per docs/observability.md this row feeds the Grafana per-provider cost/usage dashboard, so a failure
-      // here silently drops the attempt from operator-facing metrics with nobody told (#6011).
-      captureMinerError(error, { kind: "attempt_outcome_summary_append_failed", attemptId, repoFullName: parsed.repoFullName });
-    }
-
-    if (parsed.json) {
-      console.log(JSON.stringify(finalResult, null, 2));
-    } else {
-      console.log(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} finished with outcome: ${result.outcome}.`);
-    }
-    options.onResult?.(finalResult);
-
-    switch (result.outcome) {
-      case "submitted":
+        else {
+            console.log(`DRY RUN: would attempt ${parsed.repoFullName}#${parsed.issueNumber} for ${parsed.minerLogin} (mode: ${mode}, base: ${parsed.base}). No worktree, claim, or ledger writes were made.`);
+        }
+        options.onResult?.(dryRunResult);
         return 0;
-      case "abandon":
-        return 7;
-      case "stale":
-        return 8;
-      case "blocked":
-        return 9;
-      case "governed":
-        return 10;
-      default:
-        return 2;
     }
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
-    // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
-    // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
-    // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
-    // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
-    // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
-    if (worktreeResult?.ok) {
-      const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;
-      await cleanupWorktree(worktreeResult.repoPath, worktreeResult.worktreePath, worktreeResult.attemptOk ?? true);
+    let allocator = null;
+    let claimLedger = null;
+    let eventLedger = null;
+    let attemptLog = null;
+    let governorLedger = null;
+    let allocation = null;
+    let worktreeResult = null;
+    let claimedIssue = false;
+    let claimRecord = null;
+    try {
+        allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
+        claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+        eventLedger = (options.initEventLedger ?? initEventLedger)();
+        attemptLog = (options.initAttemptLog ?? initAttemptLog)();
+        governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+        // Checked before acquiring a worktree slot: a rejection-signaled repo should never consume one.
+        // resolveRejectionSignaled resolves both documented triggers (#5132 policy ban, #5655 own-rejection
+        // history) and returns a trigger-specific reason string for accurate audit-trail labeling.
+        const resolveRejection = options.resolveRejectionSignaled ?? resolveRejectionSignaled;
+        const rejectionSignal = await resolveRejection(parsed.repoFullName, { fetchImpl: options.fetchImpl });
+        if (rejectionSignal) {
+            const reason = rejectionSignal === true ? REJECTION_REASON_AI_USAGE_POLICY_BAN : rejectionSignal;
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const rejectedResult = {
+                outcome: "blocked_rejection_signaled",
+                reason,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(rejectedResult, null, 2));
+            }
+            else {
+                console.error(reason === REJECTION_REASON_OWN_SUBMISSION_REJECTED
+                    ? `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this miner was previously rejected on this repo.`
+                    : `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's AI-usage policy bans automated/AI-authored contributions.`);
+            }
+            options.onResult?.(rejectedResult);
+            return 5;
+        }
+        allocation = allocator.acquire(attemptId, parsed.repoFullName);
+        let deps;
+        try {
+            const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
+            deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
+        }
+        catch (error) {
+            const reason = describeCliError(error);
+            return reportCliFailure(parsed.json, `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`, 3);
+        }
+        // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
+        // reserves a concurrency SLOT (worktree-allocator.js's own `slot-N` placeholder dirs never receive real
+        // git content) -- this is the step that actually clones/fetches the target repo and creates a real
+        // `git worktree` for this attempt. Its own path, NOT the allocator's slot path, is the real
+        // workingDirectory a future runMinerAttempt call must use.
+        const prepareWorktree = options.prepareAttemptWorktree ?? prepareAttemptWorktree;
+        worktreeResult = await prepareWorktree(parsed.repoFullName, attemptId, { baseBranch: parsed.base, env });
+        if (!worktreeResult.ok) {
+            const reason = worktreeResult.error;
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const worktreeFailureResult = {
+                outcome: "blocked_worktree_preparation_failed",
+                reason,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(worktreeFailureResult, null, 2));
+            }
+            else {
+                console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: real worktree preparation failed: ${reason}`);
+            }
+            options.onResult?.(worktreeFailureResult);
+            return 6;
+        }
+        // Real SelfReviewContext (#5145): issue/PR/manifest data at live-gate fidelity for the target repo.
+        const fetchReviewContext = options.fetchSelfReviewContext ?? fetchSelfReviewContext;
+        const reviewContext = await fetchReviewContext(parsed.repoFullName, {
+            githubToken: (await resolveGitHubToken(env)),
+            contributorLogin: parsed.minerLogin,
+            linkedIssues: [parsed.issueNumber],
+        });
+        // The target issue's own real record, when present in the fetched context. When absent (e.g. already
+        // closed, or genuinely not found), buildCodingTaskSpec's own feasibility check reports target_not_found
+        // and this placeholder's empty title/body are never surfaced anywhere -- not fabricated content, just an
+        // inert shape for a verdict that immediately blocks.
+        const targetIssue = reviewContext.issues.find((candidate) => candidate.number === parsed.issueNumber) ?? {
+            number: parsed.issueNumber,
+            title: "",
+            body: null,
+            labels: [],
+        };
+        const buildTaskSpec = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
+        const codingTaskSpec = buildTaskSpec({
+            repoFullName: parsed.repoFullName,
+            issue: targetIssue,
+            context: { issues: reviewContext.issues, pullRequests: reviewContext.pullRequests },
+            // Same narrower-view bridge as AttemptDeps.claimLedger above: buildCodingTaskSpec only needs a listClaims
+            // reader (CodingTaskClaimLedger), whose `status: string` is looser than the real ledger's ClaimStatus.
+            claimLedger: claimLedger,
+            workingDirectory: worktreeResult.worktreePath,
+        });
+        if (!codingTaskSpec.ready) {
+            const reason = `infeasible_${codingTaskSpec.verdict}`;
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, feasibility: codingTaskSpec.feasibility },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const infeasibleResult = {
+                outcome: "blocked_infeasible",
+                reason,
+                verdict: codingTaskSpec.verdict,
+                avoidReasons: codingTaskSpec.feasibility.avoidReasons,
+                raiseReasons: codingTaskSpec.feasibility.raiseReasons,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(infeasibleResult, null, 2));
+            }
+            else {
+                console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: feasibility verdict "${codingTaskSpec.verdict}" (${[...codingTaskSpec.feasibility.avoidReasons, ...codingTaskSpec.feasibility.raiseReasons].join(", ")}).`);
+            }
+            options.onResult?.(infeasibleResult);
+            return 4;
+        }
+        const amsPolicy = await (options.resolveAmsPolicy ?? resolveAmsPolicy)(parsed.repoFullName, { env });
+        // Real per-repo pause (#5392): read straight from the already-cloned worktree's own .loopover-miner.yml
+        // (resolveMinerGoalSpec never throws -- a missing/malformed file degrades to killSwitch.paused: false, so
+        // this can't fail this attempt on its own). Threaded into BOTH checkMinerKillSwitch (killSwitchScope, used
+        // by the freshness/submission gate) and the governor context (killSwitchRepoPaused, used by the Governor
+        // chokepoint) -- the same two places the GLOBAL kill switch already reaches.
+        const resolveGoalSpec = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+        const minerGoalSpec = resolveGoalSpec(worktreeResult.repoPath);
+        const repoPaused = minerGoalSpec.spec.killSwitch.paused;
+        const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
+        const recordKillTransition = options.recordMinerKillSwitchTransition ??
+            recordMinerKillSwitchTransition;
+        let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
+        let previousKillSwitchScope = killSwitchScope;
+        const resolveLiveKillSwitch = () => {
+            // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
+            const liveRepoPaused = resolveGoalSpec(worktreeResult.repoPath).spec.killSwitch.paused;
+            const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
+            if (live.scope !== previousKillSwitchScope) {
+                try {
+                    recordKillTransition({
+                        repoFullName: parsed.repoFullName,
+                        actionClass: "attempt",
+                        previousScope: previousKillSwitchScope,
+                        scope: live.scope,
+                    });
+                }
+                catch (error) {
+                    // Ledger append must never crash an aborting attempt (kept), but was previously silent -- a
+                    // kill-switch flip mid-attempt (a compliance-relevant event) could vanish with no record (#6011).
+                    captureMinerError(error, { kind: "kill_switch_transition_record_failed", repoFullName: parsed.repoFullName, scope: live.scope });
+                }
+                previousKillSwitchScope = live.scope;
+            }
+            killSwitchScope = live.scope;
+            return live;
+        };
+        const shouldAbort = () => {
+            const live = resolveLiveKillSwitch();
+            if (!live.active)
+                return false;
+            return {
+                abort: true,
+                reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
+            };
+        };
+        const loopInput = buildAttemptLoopInput({
+            codingTaskSpec,
+            reviewContext,
+            worktreePath: worktreeResult.worktreePath,
+            attemptId,
+            mode,
+            repoFullName: parsed.repoFullName,
+            minerLogin: parsed.minerLogin,
+            rejectionSignaled: false,
+            amsPolicySpec: amsPolicy.spec,
+            branchRef: worktreeResult.branchName,
+        });
+        // Real per-issue attempt history (#5654): portfolio-queue.js's own claim/reclaim/requeue/done counters,
+        // keyed the same way opportunity-fanout.js enqueues issue-shaped candidates (`issue:<number>`). No
+        // apiBaseUrl: this file has no multi-forge host context of its own today, so this reads (and every
+        // pre-#5563 single-forge caller already reads) the github.com default.
+        const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
+        const convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
+        // Real per-repo reputation history (#5675): the miner's own decided/unfavorable outcome streak for this repo,
+        // read from governor-state.js so the chokepoint's self-reputation throttle sees real data instead of nothing.
+        const readReputationHistory = options.loadReputationHistory ?? loadReputationHistory;
+        const reputationHistory = readReputationHistory(parsed.repoFullName);
+        const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
+        // Real maxConcurrentClaims enforcement (#6758): the repo's .loopover-miner.yml cap is honored ATOMICALLY by
+        // the ledger's count-and-claim, not by a listActiveClaims pre-check here. The old check-then-act split -- read
+        // the count in this file, then record the claim in a separate claimLedger call -- let two sibling miner
+        // processes racing the same repo both pass a stale sub-cap count and both claim, exceeding the cap.
+        // claimIssueWithinCap fuses the count and the insert into one transaction; the loser gets `claimed: false`
+        // and is reported below rather than silently dropped. This is also the real soft-claim (#5393): once it
+        // returns claimed, a sibling process sees it via claimLedger.listActiveClaims while this attempt is in
+        // flight, it is released in `finally` on every terminal outcome (mirroring the worktree allocation slot's
+        // acquire-then-always-release), and its claimedAt feeds the post-submission conflict check further down (#4848).
+        const claimResult = claimLedger.claimIssueWithinCap(parsed.repoFullName, parsed.issueNumber, `attempt:${attemptId}`, undefined, minerGoalSpec.spec.maxConcurrentClaims);
+        if (!claimResult.claimed) {
+            const reason = "max_concurrent_claims_exceeded";
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_aborted",
+                attemptId,
+                actionClass: "open_pr",
+                mode,
+                reason,
+                payload: {
+                    repoFullName: parsed.repoFullName,
+                    issueNumber: parsed.issueNumber,
+                    maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+                    activeClaimCount: claimResult.activeClaimCount,
+                },
+            });
+            eventLedger.appendEvent({
+                type: "attempt_blocked",
+                repoFullName: parsed.repoFullName,
+                payload: { issueNumber: parsed.issueNumber, reason },
+            });
+            const blockedResult = {
+                outcome: "blocked_max_concurrent_claims",
+                reason,
+                maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+                activeClaimCount: claimResult.activeClaimCount,
+                repoFullName: parsed.repoFullName,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                mode,
+                attemptId,
+            };
+            if (parsed.json) {
+                console.log(JSON.stringify(blockedResult, null, 2));
+            }
+            else {
+                console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${claimResult.activeClaimCount} active claim(s)).`);
+            }
+            // `blocked_max_concurrent_claims` (#6758) is an internal cap-rejection outcome the public AttemptCliResult
+            // union does not enumerate; the onResult hook still receives the real structured payload here, so bridge
+            // its shape without widening the exported result type.
+            options.onResult?.(blockedResult);
+            return 11;
+        }
+        claimRecord = claimResult.claim;
+        claimedIssue = true;
+        // Hosted soft-claim coordination (#7168), opt-in via LOOPOVER_MINER_DISCOVERY_PLANE -- gated HERE at the
+        // call site (not left to submitSoftClaim's own internal check alone) so a disabled plane costs zero calls,
+        // matching discover-cli.js's supplementWithDiscoveryIndex gating; a caller-injected options.submitSoftClaim
+        // (tests, or a future programmatic caller) can't accidentally bypass the opt-in this way either. Awaited
+        // (not fire-and-forget) so a sibling instance racing the same issue is genuinely less likely to start
+        // duplicate work in the window before this attempt's claim reaches the shared index -- the whole point of
+        // coordinating BEFORE work begins, not after.
+        if (isDiscoveryPlaneEnabled(env)) {
+            const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+            await submitClaim(claimRecord, { env });
+        }
+        const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
+        let result;
+        try {
+            result = await runAttemptPipeline({
+                loopInput,
+                issueNumber: parsed.issueNumber,
+                minerLogin: parsed.minerLogin,
+                base: parsed.base,
+                killSwitchScope,
+                slopThreshold: amsPolicy.spec.slopThreshold,
+                submissionMode: amsPolicy.spec.submissionMode,
+                governor,
+            }, {
+                ...deps,
+                shouldAbort,
+                resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
+            });
+        }
+        catch (error) {
+            // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
+            // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
+            // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
+            // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
+            worktreeResult.attemptOk = false;
+            throw error;
+        }
+        worktreeResult.attemptOk = result.outcome === "submitted";
+        // Real claim-conflict resolution (#4848): only meaningful once a real PR exists, so this only ever runs
+        // on a real "submitted" outcome. checkSubmissionFreshness (inside runMinerAttempt) already caught the
+        // common pre-submission case; this closes the narrower TOCTOU window where two miners raced past that
+        // check almost simultaneously -- see claim-conflict-resolver.js's own header for why the adjudicator
+        // can only run POST-submission (it needs a real PR number on both sides of the election).
+        let claimConflict;
+        if (result.outcome === "submitted") {
+            const selfPrNumber = parsePrNumberFromExecResult(result.execResult, parsed.repoFullName);
+            if (selfPrNumber !== null) {
+                const resolveConflict = options.resolveClaimConflict ?? resolveClaimConflict;
+                claimConflict = await resolveConflict({
+                    repoFullName: parsed.repoFullName,
+                    issueNumber: parsed.issueNumber,
+                    selfPrNumber,
+                    selfClaimedAt: claimRecord.claimedAt,
+                    minerLogin: parsed.minerLogin,
+                }, { fetchLiveIssueSnapshot: deps.fetchLiveIssueSnapshot, executeLocalWrite: deps.executeLocalWrite });
+            }
+            // Real own-submission history (#5655 follow-up): governor-state.js's recordOwnSubmission/
+            // listRecentOwnSubmissions store (#5134) existed and was already READ by resolveOwnRejectionHistory
+            // (#5655), but nothing ever WROTE to it -- attempt-runner.js's own header names this exact gap
+            // ("real persistence primitives... but isn't auto-loaded here yet"). Left unfixed, that trigger is a
+            // silent no-op in every real deployment: an empty table always resolves "no prior submissions found."
+            // The fingerprint is the real changed-files set from the loop's own handoff packet (never fabricated) --
+            // omitted (not recorded as an empty placeholder) when the packet reports no changed files at all. A
+            // logging failure must never fail an otherwise-successful attempt, matching the summary-event write below.
+            const changedFiles = result.loopResult.handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
+            const fingerprint = fingerprintFromChangedFiles(changedFiles);
+            if (fingerprint) {
+                try {
+                    const record = options.recordOwnSubmission ?? recordOwnSubmission;
+                    record({
+                        repoFullName: parsed.repoFullName,
+                        fingerprint,
+                        submittedAt: new Date(nowMs).toISOString(),
+                        pullRequestNumber: selfPrNumber,
+                        issueNumber: parsed.issueNumber,
+                    });
+                }
+                catch (error) {
+                    // A logging failure must never fail an otherwise-successful attempt (kept), but was previously
+                    // silent -- if this write fails AFTER a real PR has already opened, future self-plagiarism checks go
+                    // permanently blind to this exact submission with nobody told (#6011).
+                    captureMinerError(error, { kind: "record_own_submission_failed", repoFullName: parsed.repoFullName, pullRequestNumber: selfPrNumber });
+                }
+            }
+        }
+        const finalResult = {
+            outcome: `attempt_${result.outcome}`,
+            repoFullName: parsed.repoFullName,
+            issueNumber: parsed.issueNumber,
+            minerLogin: parsed.minerLogin,
+            base: parsed.base,
+            mode,
+            attemptId,
+            submissionMode: amsPolicy.spec.submissionMode,
+            // Every runMinerAttempt outcome carries a real loopResult (#5135's loop needs its genuine turn-usage and
+            // cost to save real GovernorCapUsage via governor-state.js's saveCapUsage -- nothing else in the codebase
+            // calls it yet). Surfaced flat rather than the whole loopResult object, matching this result's own
+            // shallow shape. costUsd is real only for the agent-sdk provider (its own SDK result message reports
+            // total_cost_usd); CLI-subprocess providers (claude-cli/codex-cli) report no cost signal today, so this
+            // is 0 for those -- an honest absence, not a fabricated number.
+            totalTurnsUsed: result.loopResult.totalTurnsUsed,
+            totalCostUsd: result.loopResult.totalCostUsd,
+            // Real accumulated tokens (#5653) -- read from finalMeterTotals rather than a flat totalTokensUsed field
+            // (IterateLoopResult has no such flat field, unlike turns/cost). 0 when no driver reported a token signal
+            // on any iteration this attempt ran, never fabricated.
+            totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
+            iterationsUsed: result.loopResult.iterationsUsed,
+            ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
+                ? { abandonReason: result.loopResult.finalDecision.abandonReason }
+                : {}),
+            ...("reason" in result ? { reason: result.reason } : {}),
+            ...("decision" in result ? { decision: result.decision } : {}),
+            ...("spec" in result ? { spec: result.spec } : {}),
+            ...("execResult" in result ? { execResult: result.execResult } : {}),
+            // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
+            // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
+            // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).
+            ...(claimConflict !== undefined ? { claimConflict } : {}),
+        };
+        // One summary row per completed attempt (#5185), for the Grafana per-provider usage dashboard the redacted
+        // AMS reporting export exposes -- distinct from the per-iteration attempt_started/attempt_tool_edit/... trail
+        // iterate-loop.ts already writes. No fallback for an unconfigured provider: buildAttemptDeps already fails
+        // closed (throws) on the same env before a worktree is even allocated, so reaching this point guarantees
+        // resolveFirstConfiguredCodingAgentDriverName(env) resolves a real name. costUsd/tokensUsed are both real,
+        // driver-reported accumulated totals (#5653) -- 0 when no iteration's driver reported a signal, never
+        // fabricated. A logging failure must never fail an otherwise-successful attempt -- mirrors iterate-loop.ts's
+        // own safeAppendAttemptLogEvent non-fatal handling.
+        try {
+            attemptLog.appendAttemptLogEvent({
+                eventType: "attempt_outcome_summary",
+                attemptId,
+                actionClass: finalResult.outcome,
+                mode,
+                reason: `attempt finished with outcome: ${result.outcome}`,
+                provider: resolveFirstConfiguredCodingAgentDriverName(env),
+                costUsd: finalResult.totalCostUsd,
+                tokensUsed: finalResult.totalTokensUsed,
+            });
+        }
+        catch (error) {
+            // A logging failure must never fail an otherwise-successful attempt (kept), but was previously silent --
+            // per docs/observability.md this row feeds the Grafana per-provider cost/usage dashboard, so a failure
+            // here silently drops the attempt from operator-facing metrics with nobody told (#6011).
+            captureMinerError(error, { kind: "attempt_outcome_summary_append_failed", attemptId, repoFullName: parsed.repoFullName });
+        }
+        if (parsed.json) {
+            console.log(JSON.stringify(finalResult, null, 2));
+        }
+        else {
+            console.log(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} finished with outcome: ${result.outcome}.`);
+        }
+        options.onResult?.(finalResult);
+        switch (result.outcome) {
+            case "submitted":
+                return 0;
+            case "abandon":
+                return 7;
+            case "stale":
+                return 8;
+            case "blocked":
+                return 9;
+            case "governed":
+                return 10;
+            default:
+                return 2;
+        }
     }
-    // Every terminal outcome past the claim point (submitted/abandon/stale/blocked/governed, or an
-    // unexpected throw) releases the soft-claim -- a claim that outlives its own attempt process would
-    // wrongly tell a sibling miner this issue is still in flight.
-    if (claimedIssue && claimLedger) claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
-    // Paired hosted release (#7168): same call-site opt-in gate as the claim submission above. Only fires when
-    // the initial claim submission actually ran (claimRecord is only set once claimedIssue is), so a run that
-    // never reached the claim point (e.g. blocked_max_concurrent_claims) has nothing to release remotely.
-    if (claimedIssue && claimRecord && isDiscoveryPlaneEnabled(env)) {
-      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
-      await submitClaim({ ...claimRecord, status: "released" }, { env });
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
     }
-    if (allocation && allocator) allocator.release(attemptId);
-    allocator?.close();
-    claimLedger?.close();
-    eventLedger?.close();
-    attemptLog?.close();
-    governorLedger?.close();
-  }
+    finally {
+        // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
+        // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
+        // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
+        // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
+        // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
+        // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
+        if (worktreeResult?.ok) {
+            const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;
+            await cleanupWorktree(worktreeResult.repoPath, worktreeResult.worktreePath, worktreeResult.attemptOk ?? true);
+        }
+        // Every terminal outcome past the claim point (submitted/abandon/stale/blocked/governed, or an
+        // unexpected throw) releases the soft-claim -- a claim that outlives its own attempt process would
+        // wrongly tell a sibling miner this issue is still in flight.
+        if (claimedIssue && claimLedger)
+            claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
+        // Paired hosted release (#7168): same call-site opt-in gate as the claim submission above. Only fires when
+        // the initial claim submission actually ran (claimRecord is only set once claimedIssue is), so a run that
+        // never reached the claim point (e.g. blocked_max_concurrent_claims) has nothing to release remotely.
+        if (claimedIssue && claimRecord && isDiscoveryPlaneEnabled(env)) {
+            const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+            await submitClaim({ ...claimRecord, status: "released" }, { env });
+        }
+        if (allocation && allocator)
+            allocator.release(attemptId);
+        allocator?.close();
+        claimLedger?.close();
+        eventLedger?.close();
+        attemptLog?.close();
+        governorLedger?.close();
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYXR0ZW1wdC1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJhdHRlbXB0LWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxvSEFBb0g7QUFDcEgscUdBQXFHO0FBQ3JHLDBHQUEwRztBQUMxRyw2R0FBNkc7QUFDN0csOEdBQThHO0FBQzlHLDJHQUEyRztBQUMzRyxxR0FBcUc7QUFDckcsMkZBQTJGO0FBQzNGLHFGQUFxRjtBQUNyRixFQUFFO0FBQ0YsMEdBQTBHO0FBQzFHLGtIQUFrSDtBQUNsSCxpSEFBaUg7QUFDakgsMkdBQTJHO0FBRTNHLE9BQU8sRUFBRSwyQkFBMkIsRUFBRSxnQ0FBZ0MsRUFBRSwyQ0FBMkMsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBQzlJLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsb0NBQW9DLEVBQUUsTUFBTSxnQ0FBZ0MsQ0FBQztBQUN0RixPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUN6RCxPQUFPLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSwwQkFBMEIsQ0FBQztBQUNsRSxPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSwwQkFBMEIsQ0FBQztBQUM3RCxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFDcEQsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDNUQsT0FBTyxFQUFFLG9CQUFvQixFQUFFLE1BQU0sOEJBQThCLENBQUM7QUFDcEUsT0FBTyxFQUFFLDJCQUEyQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDbkUsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ3BELE9BQU8sRUFBRSxjQUFjLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUNsRCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUMxRCxPQUFPLEVBQUUscUJBQXFCLEVBQUUsTUFBTSx5QkFBeUIsQ0FBQztBQUNoRSxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUNyRCxPQUFPLEVBQUUsb0NBQW9DLEVBQUUsd0NBQXdDLEVBQUUsd0JBQXdCLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUNqSixPQUFPLEVBQUUsc0JBQXNCLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUN2RixPQUFPLEVBQUUsc0JBQXNCLEVBQUUsTUFBTSwwQkFBMEIsQ0FBQztBQUNsRSxPQUFPLEVBQUUsbUJBQW1CLEVBQUUsTUFBTSx1QkFBdUIsQ0FBQztBQUM1RCxPQUFPLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUNuRCxPQUFPLEVBQUUsb0JBQW9CLEVBQUUsK0JBQStCLEVBQUUsTUFBTSwyQkFBMkIsQ0FBQztBQUNsRyxPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxhQUFhLENBQUM7QUFDaEQsT0FBTyxFQUFFLDJCQUEyQixFQUFFLHFCQUFxQixFQUFFLE1BQU0sNEJBQTRCLENBQUM7QUFDaEcsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDekQsT0FBTyxFQUFFLHFCQUFxQixFQUFFLG1CQUFtQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFDakYsT0FBTyxFQUFFLGVBQWUsRUFBRSxNQUFNLHFCQUFxQixDQUFDO0FBQ3RELE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBQ2xFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxlQUFlLEVBQUUsTUFBTSw2QkFBNkIsQ0FBQztBQThGdkYsTUFBTSxhQUFhLEdBQ2pCLDJIQUEySCxDQUFDO0FBRTlILFNBQVMsZUFBZSxDQUFDLEtBQWE7SUFDcEMsTUFBTSxPQUFPLEdBQUcsT0FBTyxLQUFLLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUM5RCxNQUFNLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxLQUFLLENBQUMsR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ2hELElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxJQUFJLElBQUksS0FBSyxLQUFLLFNBQVM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN4RCxJQUFJLENBQUMsa0JBQWtCLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsQ0FBQyxJQUFJLENBQUM7UUFBRSxPQUFPLElBQUksQ0FBQztJQUN6RSxPQUFPLEdBQUcsS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO0FBQzVCLENBQUM7QUFFRCxNQUFNLFVBQVUsZ0JBQWdCLENBQUMsSUFBYztJQUM3QyxNQUFNLE9BQU8sR0FBRyxFQUFFLElBQUksRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFFLElBQXFCLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUM3RyxNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELHVHQUF1RztRQUN2Ryx1R0FBdUc7UUFDdkcscUZBQXFGO1FBQ3JGLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0Qsd0dBQXdHO1FBQ3hHLHNHQUFzRztRQUN0Ryx3R0FBd0c7UUFDeEcsOEJBQThCO1FBQzlCLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssZUFBZSxFQUFFLENBQUM7WUFDOUIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsYUFBYSxFQUFFLENBQUM7WUFDckUsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsYUFBYSxFQUFFLENBQUM7WUFDckUsT0FBTyxDQUFDLElBQUksR0FBRyxLQUFLLENBQUM7WUFDckIsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsbUJBQW1CLEtBQUssRUFBRSxFQUFFLENBQUM7UUFDeEUsVUFBVSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUN6QixDQUFDO0lBRUQsSUFBSSxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGFBQWEsRUFBRSxDQUFDO0lBQzdELE1BQU0sWUFBWSxHQUFHLGVBQWUsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFFLENBQUMsQ0FBQztJQUNyRCxJQUFJLENBQUMsWUFBWTtRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsMENBQTBDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUM7SUFDL0YsTUFBTSxXQUFXLEdBQUcsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQzFDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLFdBQVcsQ0FBQyxJQUFJLFdBQVcsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUN0RCxPQUFPLEVBQUUsS0FBSyxFQUFFLDRDQUE0QyxVQUFVLENBQUMsQ0FBQyxDQUFDLEVBQUUsRUFBRSxDQUFDO0lBQ2hGLENBQUM7SUFDRCxJQUFJLENBQUMsT0FBTyxDQUFDLFVBQVU7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLDhCQUE4QixhQUFhLEVBQUUsRUFBRSxDQUFDO0lBRXpGLE9BQU87UUFDTCxZQUFZO1FBQ1osV0FBVztRQUNYLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtRQUM5QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7UUFDbEIsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO1FBQ2xCLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTTtRQUN0QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7S0FDbkIsQ0FBQztBQUNKLENBQUM7QUFFRDs7Ozs7O0dBTUc7QUFDSCxNQUFNLFVBQVUsZ0JBQWdCLENBQzlCLEdBQXVDLEVBQ3ZDLE9BQXNJO0lBRXRJLE9BQU87UUFDTCxNQUFNLEVBQUUsb0NBQW9DLENBQUMsR0FBRyxDQUFDO1FBQ2pELGlCQUFpQixFQUFFLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxpQkFBaUIsQ0FBQyxLQUFnRCxDQUFDO1FBQ2pHLHFCQUFxQixFQUFFLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLHFCQUFxQixDQUFDLEtBQXVFLENBQUM7UUFDbkosOEdBQThHO1FBQzlHLDJHQUEyRztRQUMzRywwRUFBMEU7UUFDMUUsV0FBVyxFQUFFLE9BQU8sQ0FBQyxXQUFvRDtRQUN6RSxrR0FBa0c7UUFDbEcsc0dBQXNHO1FBQ3RHLHlGQUF5RjtRQUN6RixzQkFBc0IsRUFBRSxLQUFLLEVBQUUsWUFBWSxFQUFFLFdBQVcsRUFBRSxFQUFFLENBQUMsc0JBQXNCLENBQUMsWUFBWSxFQUFFLFdBQVcsRUFBRSxFQUFFLFdBQVcsRUFBRSxDQUFDLE1BQU0sa0JBQWtCLENBQUMsR0FBRyxDQUFDLENBQVcsRUFBRSxDQUFDO1FBQzFLLFdBQVcsRUFBRSxPQUFPLENBQUMsV0FBVztRQUNoQyxvQkFBb0IsRUFBRSxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsT0FBTyxDQUFDLGNBQWMsQ0FBQyxtQkFBbUIsQ0FBQyxLQUF5RSxDQUFDO1FBQ3RKLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSztRQUNwQixpQkFBaUIsRUFBRSxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsaUJBQWlCLENBQUMsSUFBSSxDQUFDO0tBQ3JELENBQUM7QUFDSixDQUFDO0FBRUQ7Ozs7Ozs7R0FPRztBQUNILE1BQU0sQ0FBQyxLQUFLLFVBQVUsVUFBVSxDQUFDLElBQWMsRUFBRSxVQUE2QixFQUFFO0lBQzlFLE1BQU0sTUFBTSxHQUFHLGdCQUFnQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3RDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsTUFBTSxHQUFHLEdBQUcsT0FBTyxDQUFDLEdBQUcsSUFBSSxPQUFPLENBQUMsR0FBRyxDQUFDO0lBQ3ZDLE1BQU0sS0FBSyxHQUFHLE9BQU8sQ0FBQyxLQUFLLElBQUksSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQzFDLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxnQ0FBZ0MsSUFBSSxnQ0FBZ0MsQ0FBQztJQUNqRyxNQUFNLElBQUksR0FBRyxXQUFXLENBQUMsRUFBRSxHQUFHLEVBQUUsV0FBVyxFQUFFLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDLENBQUM7SUFFN0QsSUFBSSxJQUFJLEtBQUssUUFBUSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FDckIsTUFBTSxDQUFDLElBQUksRUFDWCxrR0FBa0csTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVyxHQUFHLEVBQzlJLENBQUMsQ0FDRixDQUFDO0lBQ0osQ0FBQztJQUVELE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxTQUFTLElBQUksR0FBRyxNQUFNLENBQUMsWUFBWSxDQUFDLE9BQU8sQ0FBQyxHQUFHLEVBQUUsR0FBRyxDQUFDLElBQUksTUFBTSxDQUFDLFdBQVcsSUFBSSxLQUFLLEVBQUUsQ0FBQztJQUVqSCwyR0FBMkc7SUFDM0csd0dBQXdHO0lBQ3hHLHVHQUF1RztJQUN2RyxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixNQUFNLFlBQVksR0FBcUI7WUFDckMsT0FBTyxFQUFFLFNBQVM7WUFDbEIsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO1lBQ2pDLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVztZQUMvQixVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7WUFDN0IsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJO1lBQ2pCLElBQUk7WUFDSixTQUFTO1NBQ1YsQ0FBQztRQUNGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDckQsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUNULDBCQUEwQixNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLFFBQVEsTUFBTSxDQUFDLFVBQVUsV0FBVyxJQUFJLFdBQVcsTUFBTSxDQUFDLElBQUksb0RBQW9ELENBQ3RMLENBQUM7UUFDSixDQUFDO1FBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLFlBQVksQ0FBQyxDQUFDO1FBQ2pDLE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksU0FBUyxHQUE2QixJQUFJLENBQUM7SUFDL0MsSUFBSSxXQUFXLEdBQXVCLElBQUksQ0FBQztJQUMzQyxJQUFJLFdBQVcsR0FBdUIsSUFBSSxDQUFDO0lBQzNDLElBQUksVUFBVSxHQUFzQixJQUFJLENBQUM7SUFDekMsSUFBSSxjQUFjLEdBQTBCLElBQUksQ0FBQztJQUNqRCxJQUFJLFVBQVUsR0FBRyxJQUFJLENBQUM7SUFDdEIsSUFBSSxjQUFjLEdBQW9FLElBQUksQ0FBQztJQUMzRixJQUFJLFlBQVksR0FBRyxLQUFLLENBQUM7SUFDekIsSUFBSSxXQUFXLEdBQXNCLElBQUksQ0FBQztJQUUxQyxJQUFJLENBQUM7UUFDSCxTQUFTLEdBQUcsQ0FBQyxPQUFPLENBQUMscUJBQXFCLElBQUkscUJBQXFCLENBQUMsRUFBRSxDQUFDO1FBQ3ZFLFdBQVcsR0FBRyxDQUFDLE9BQU8sQ0FBQyxlQUFlLElBQUksZUFBZSxDQUFDLEVBQUUsQ0FBQztRQUM3RCxXQUFXLEdBQUcsQ0FBQyxPQUFPLENBQUMsZUFBZSxJQUFJLGVBQWUsQ0FBQyxFQUFFLENBQUM7UUFDN0QsVUFBVSxHQUFHLENBQUMsT0FBTyxDQUFDLGNBQWMsSUFBSSxjQUFjLENBQUMsRUFBRSxDQUFDO1FBQzFELGNBQWMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxrQkFBa0IsSUFBSSxrQkFBa0IsQ0FBQyxFQUFFLENBQUM7UUFFdEUsZ0dBQWdHO1FBQ2hHLG9HQUFvRztRQUNwRywyRkFBMkY7UUFDM0YsTUFBTSxnQkFBZ0IsR0FBRyxPQUFPLENBQUMsd0JBQXdCLElBQUksd0JBQXdCLENBQUM7UUFDdEYsTUFBTSxlQUFlLEdBQUcsTUFBTSxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsWUFBWSxFQUFFLEVBQUUsU0FBUyxFQUFFLE9BQU8sQ0FBQyxTQUFVLEVBQUUsQ0FBQyxDQUFDO1FBQ3ZHLElBQUksZUFBZSxFQUFFLENBQUM7WUFDcEIsTUFBTSxNQUFNLEdBQ1YsZUFBZSxLQUFLLElBQUksQ0FBQyxDQUFDLENBQUMsb0NBQW9DLENBQUMsQ0FBQyxDQUFDLGVBQWUsQ0FBQztZQUNwRixVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSxpQkFBaUI7Z0JBQzVCLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFNBQVM7Z0JBQ3RCLElBQUk7Z0JBQ0osTUFBTTtnQkFDTixPQUFPLEVBQUUsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRTthQUNoRixDQUFDLENBQUM7WUFDSCxXQUFXLENBQUMsV0FBVyxDQUFDO2dCQUN0QixJQUFJLEVBQUUsaUJBQWlCO2dCQUN2QixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLE9BQU8sRUFBRSxFQUFFLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sRUFBRTthQUNyRCxDQUFDLENBQUM7WUFDSCxNQUFNLGNBQWMsR0FBcUI7Z0JBQ3ZDLE9BQU8sRUFBRSw0QkFBNEI7Z0JBQ3JDLE1BQU07Z0JBQ04sWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO2dCQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7Z0JBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtnQkFDN0IsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJO2dCQUNqQixJQUFJO2dCQUNKLFNBQVM7YUFDVixDQUFDO1lBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxjQUFjLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDdkQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxLQUFLLENBQ1gsTUFBTSxLQUFLLHdDQUF3QztvQkFDakQsQ0FBQyxDQUFDLGVBQWUsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVywrREFBK0Q7b0JBQ3pILENBQUMsQ0FBQyxlQUFlLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFdBQVcsb0ZBQW9GLENBQ2pKLENBQUM7WUFDSixDQUFDO1lBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLGNBQWMsQ0FBQyxDQUFDO1lBQ25DLE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQztRQUVELFVBQVUsR0FBRyxTQUFTLENBQUMsT0FBTyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7UUFFL0QsSUFBSSxJQUFpQixDQUFDO1FBQ3RCLElBQUksQ0FBQztZQUNILE1BQU0sU0FBUyxHQUFHLE9BQU8sQ0FBQyxnQkFBZ0IsSUFBSSxnQkFBZ0IsQ0FBQztZQUMvRCxJQUFJLEdBQUcsU0FBUyxDQUFDLEdBQUcsRUFBRSxFQUFFLFdBQVcsRUFBRSxXQUFXLEVBQUUsVUFBVSxFQUFFLGNBQWMsRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO1FBQ3pGLENBQUM7UUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1lBQ2YsTUFBTSxNQUFNLEdBQUcsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUM7WUFDdkMsT0FBTyxnQkFBZ0IsQ0FDckIsTUFBTSxDQUFDLElBQUksRUFDWCxlQUFlLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFdBQVcsZ0JBQWdCLE1BQU0sRUFBRSxFQUNoRixDQUFDLENBQ0YsQ0FBQztRQUNKLENBQUM7UUFFRCxtR0FBbUc7UUFDbkcsd0dBQXdHO1FBQ3hHLG1HQUFtRztRQUNuRyw0RkFBNEY7UUFDNUYsMkRBQTJEO1FBQzNELE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsSUFBSSxzQkFBc0IsQ0FBQztRQUNqRixjQUFjLEdBQUcsTUFBTSxlQUFlLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRSxTQUFTLEVBQUUsRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLElBQUksRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQ3pHLElBQUksQ0FBQyxjQUFjLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDdkIsTUFBTSxNQUFNLEdBQUcsY0FBYyxDQUFDLEtBQUssQ0FBQztZQUNwQyxVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSxpQkFBaUI7Z0JBQzVCLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFNBQVM7Z0JBQ3RCLElBQUk7Z0JBQ0osTUFBTTtnQkFDTixPQUFPLEVBQUUsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRTthQUNoRixDQUFDLENBQUM7WUFDSCxXQUFXLENBQUMsV0FBVyxDQUFDO2dCQUN0QixJQUFJLEVBQUUsaUJBQWlCO2dCQUN2QixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLE9BQU8sRUFBRSxFQUFFLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sRUFBRTthQUNyRCxDQUFDLENBQUM7WUFDSCxNQUFNLHFCQUFxQixHQUFxQjtnQkFDOUMsT0FBTyxFQUFFLHFDQUFxQztnQkFDOUMsTUFBTTtnQkFDTixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVztnQkFDL0IsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVO2dCQUM3QixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7Z0JBQ2pCLElBQUk7Z0JBQ0osU0FBUzthQUNWLENBQUM7WUFDRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLHFCQUFxQixFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQzlELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsS0FBSyxDQUFDLGVBQWUsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsV0FBVyxrREFBa0QsTUFBTSxFQUFFLENBQUMsQ0FBQztZQUNwSSxDQUFDO1lBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLHFCQUFxQixDQUFDLENBQUM7WUFDMUMsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDO1FBRUQsb0dBQW9HO1FBQ3BHLE1BQU0sa0JBQWtCLEdBQUcsT0FBTyxDQUFDLHNCQUFzQixJQUFJLHNCQUFzQixDQUFDO1FBQ3BGLE1BQU0sYUFBYSxHQUFHLE1BQU0sa0JBQWtCLENBQUMsTUFBTSxDQUFDLFlBQVksRUFBRTtZQUNsRSxXQUFXLEVBQUUsQ0FBQyxNQUFNLGtCQUFrQixDQUFDLEdBQUcsQ0FBQyxDQUFXO1lBQ3RELGdCQUFnQixFQUFFLE1BQU0sQ0FBQyxVQUFVO1lBQ25DLFlBQVksRUFBRSxDQUFDLE1BQU0sQ0FBQyxXQUFXLENBQUM7U0FDbkMsQ0FBQyxDQUFDO1FBRUgscUdBQXFHO1FBQ3JHLHdHQUF3RztRQUN4Ryx5R0FBeUc7UUFDekcscURBQXFEO1FBQ3JELE1BQU0sV0FBVyxHQUFHLGFBQWEsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsU0FBUyxFQUFFLEVBQUUsQ0FBQyxTQUFTLENBQUMsTUFBTSxLQUFLLE1BQU0sQ0FBQyxXQUFXLENBQUMsSUFBSTtZQUN2RyxNQUFNLEVBQUUsTUFBTSxDQUFDLFdBQVc7WUFDMUIsS0FBSyxFQUFFLEVBQUU7WUFDVCxJQUFJLEVBQUUsSUFBSTtZQUNWLE1BQU0sRUFBRSxFQUFFO1NBQ1gsQ0FBQztRQUVGLE1BQU0sYUFBYSxHQUFHLE9BQU8sQ0FBQyxtQkFBbUIsSUFBSSxtQkFBbUIsQ0FBQztRQUN6RSxNQUFNLGNBQWMsR0FBRyxhQUFhLENBQUM7WUFDbkMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO1lBQ2pDLEtBQUssRUFBRSxXQUFXO1lBQ2xCLE9BQU8sRUFBRSxFQUFFLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTSxFQUFFLFlBQVksRUFBRSxhQUFhLENBQUMsWUFBWSxFQUFFO1lBQ25GLDBHQUEwRztZQUMxRyx1R0FBdUc7WUFDdkcsV0FBVyxFQUFFLFdBQTRFO1lBQ3pGLGdCQUFnQixFQUFFLGNBQWMsQ0FBQyxZQUFZO1NBQzlDLENBQUMsQ0FBQztRQUVILElBQUksQ0FBQyxjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7WUFDMUIsTUFBTSxNQUFNLEdBQUcsY0FBYyxjQUFjLENBQUMsT0FBTyxFQUFFLENBQUM7WUFDdEQsVUFBVSxDQUFDLHFCQUFxQixDQUFDO2dCQUMvQixTQUFTLEVBQUUsaUJBQWlCO2dCQUM1QixTQUFTO2dCQUNULFdBQVcsRUFBRSxTQUFTO2dCQUN0QixJQUFJO2dCQUNKLE1BQU07Z0JBQ04sT0FBTyxFQUFFLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXLEVBQUUsV0FBVyxFQUFFLGNBQWMsQ0FBQyxXQUFXLEVBQUU7YUFDekgsQ0FBQyxDQUFDO1lBQ0gsV0FBVyxDQUFDLFdBQVcsQ0FBQztnQkFDdEIsSUFBSSxFQUFFLGlCQUFpQjtnQkFDdkIsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO2dCQUNqQyxPQUFPLEVBQUUsRUFBRSxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVcsRUFBRSxNQUFNLEVBQUU7YUFDckQsQ0FBQyxDQUFDO1lBQ0gsTUFBTSxnQkFBZ0IsR0FBcUI7Z0JBQ3pDLE9BQU8sRUFBRSxvQkFBb0I7Z0JBQzdCLE1BQU07Z0JBQ04sT0FBTyxFQUFFLGNBQWMsQ0FBQyxPQUFPO2dCQUMvQixZQUFZLEVBQUUsY0FBYyxDQUFDLFdBQVcsQ0FBQyxZQUF3QjtnQkFDakUsWUFBWSxFQUFFLGNBQWMsQ0FBQyxXQUFXLENBQUMsWUFBd0I7Z0JBQ2pFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtnQkFDakMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO2dCQUMvQixVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7Z0JBQzdCLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSTtnQkFDakIsSUFBSTtnQkFDSixTQUFTO2FBQ1YsQ0FBQztZQUNGLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsZ0JBQWdCLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDekQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxLQUFLLENBQ1gsZUFBZSxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLHFDQUFxQyxjQUFjLENBQUMsT0FBTyxNQUFNLENBQUMsR0FBRyxjQUFjLENBQUMsV0FBVyxDQUFDLFlBQVksRUFBRSxHQUFHLGNBQWMsQ0FBQyxXQUFXLENBQUMsWUFBWSxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQ2pPLENBQUM7WUFDSixDQUFDO1lBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLGdCQUFnQixDQUFDLENBQUM7WUFDckMsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDO1FBRUQsTUFBTSxTQUFTLEdBQUcsTUFBTSxDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsSUFBSSxnQkFBZ0IsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBRXJHLHdHQUF3RztRQUN4RywwR0FBMEc7UUFDMUcsMkdBQTJHO1FBQzNHLHlHQUF5RztRQUN6Ryw2RUFBNkU7UUFDN0UsTUFBTSxlQUFlLEdBQUcsT0FBTyxDQUFDLG9CQUFvQixJQUFJLG9CQUFvQixDQUFDO1FBQzdFLE1BQU0sYUFBYSxHQUFHLGVBQWUsQ0FBQyxjQUFjLENBQUMsUUFBUSxDQUFDLENBQUM7UUFDL0QsTUFBTSxVQUFVLEdBQUcsYUFBYSxDQUFDLElBQUksQ0FBQyxVQUFVLENBQUMsTUFBTSxDQUFDO1FBRXhELE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQyxvQkFBb0IsSUFBSSxvQkFBb0IsQ0FBQztRQUM3RSxNQUFNLG9CQUFvQixHQUN2QixPQUF3RixDQUFDLCtCQUErQjtZQUN6SCwrQkFBK0IsQ0FBQztRQUNsQyxJQUFJLGVBQWUsR0FBRyxlQUFlLENBQUMsRUFBRSxHQUFHLEVBQUUsVUFBVSxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUM7UUFDakUsSUFBSSx1QkFBdUIsR0FBRyxlQUFlLENBQUM7UUFFOUMsTUFBTSxxQkFBcUIsR0FBRyxHQUFHLEVBQUU7WUFDakMsaUdBQWlHO1lBQ2pHLE1BQU0sY0FBYyxHQUFHLGVBQWUsQ0FBQyxjQUFlLENBQUMsUUFBUyxDQUFDLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxNQUFNLENBQUM7WUFDekYsTUFBTSxJQUFJLEdBQUcsZUFBZSxDQUFDLEVBQUUsR0FBRyxFQUFFLFVBQVUsRUFBRSxjQUFjLEVBQUUsQ0FBQyxDQUFDO1lBQ2xFLElBQUksSUFBSSxDQUFDLEtBQUssS0FBSyx1QkFBdUIsRUFBRSxDQUFDO2dCQUMzQyxJQUFJLENBQUM7b0JBQ0gsb0JBQW9CLENBQUM7d0JBQ25CLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTt3QkFDakMsV0FBVyxFQUFFLFNBQVM7d0JBQ3RCLGFBQWEsRUFBRSx1QkFBdUI7d0JBQ3RDLEtBQUssRUFBRSxJQUFJLENBQUMsS0FBSztxQkFDbEIsQ0FBQyxDQUFDO2dCQUNMLENBQUM7Z0JBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztvQkFDZiw0RkFBNEY7b0JBQzVGLGtHQUFrRztvQkFDbEcsaUJBQWlCLENBQUMsS0FBSyxFQUFFLEVBQUUsSUFBSSxFQUFFLHNDQUFzQyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLEtBQUssRUFBRSxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQztnQkFDbkksQ0FBQztnQkFDRCx1QkFBdUIsR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDO1lBQ3ZDLENBQUM7WUFDRCxlQUFlLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQztZQUM3QixPQUFPLElBQUksQ0FBQztRQUNkLENBQUMsQ0FBQztRQUVGLE1BQU0sV0FBVyxHQUFHLEdBQUcsRUFBRTtZQUN2QixNQUFNLElBQUksR0FBRyxxQkFBcUIsRUFBRSxDQUFDO1lBQ3JDLElBQUksQ0FBQyxJQUFJLENBQUMsTUFBTTtnQkFBRSxPQUFPLEtBQUssQ0FBQztZQUMvQixPQUFPO2dCQUNMLEtBQUssRUFBRSxJQUFJO2dCQUNYLE1BQU0sRUFBRSxnQkFBZ0IsSUFBSSxDQUFDLEtBQUssOEVBQThFO2FBQ2pILENBQUM7UUFDSixDQUFDLENBQUM7UUFFRixNQUFNLFNBQVMsR0FBRyxxQkFBcUIsQ0FBQztZQUN0QyxjQUFjO1lBQ2QsYUFBYTtZQUNiLFlBQVksRUFBRSxjQUFjLENBQUMsWUFBWTtZQUN6QyxTQUFTO1lBQ1QsSUFBSTtZQUNKLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtZQUNqQyxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7WUFDN0IsaUJBQWlCLEVBQUUsS0FBSztZQUN4QixhQUFhLEVBQUUsU0FBUyxDQUFDLElBQUk7WUFDN0IsU0FBUyxFQUFFLGNBQWMsQ0FBQyxVQUFVO1NBQ3JDLENBQUMsQ0FBQztRQUVILHdHQUF3RztRQUN4RyxtR0FBbUc7UUFDbkcsbUdBQW1HO1FBQ25HLHVFQUF1RTtRQUN2RSxNQUFNLGtCQUFrQixHQUFHLE9BQU8sQ0FBQyxpQkFBaUIsSUFBSSxpQkFBaUIsQ0FBQztRQUMxRSxNQUFNLGdCQUFnQixHQUFHLGtCQUFrQixDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsU0FBUyxNQUFNLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQztRQUNoRyw4R0FBOEc7UUFDOUcsOEdBQThHO1FBQzlHLE1BQU0scUJBQXFCLEdBQ3hCLE9BQW9FLENBQUMscUJBQXFCLElBQUkscUJBQXFCLENBQUM7UUFDdkgsTUFBTSxpQkFBaUIsR0FBRyxxQkFBcUIsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7UUFDckUsTUFBTSxRQUFRLEdBQUcsMkJBQTJCLENBQUMsR0FBRyxFQUFFLFNBQVMsQ0FBQyxJQUFJLEVBQUUsVUFBVSxFQUFFLGdCQUFnQixFQUFFLGlCQUFpQixDQUFDLENBQUM7UUFFbkgsNEdBQTRHO1FBQzVHLCtHQUErRztRQUMvRyx3R0FBd0c7UUFDeEcsb0dBQW9HO1FBQ3BHLDJHQUEyRztRQUMzRyx3R0FBd0c7UUFDeEcsdUdBQXVHO1FBQ3ZHLDBHQUEwRztRQUMxRyxpSEFBaUg7UUFDakgsTUFBTSxXQUFXLEdBQUcsV0FBVyxDQUFDLG1CQUFtQixDQUNqRCxNQUFNLENBQUMsWUFBWSxFQUNuQixNQUFNLENBQUMsV0FBVyxFQUNsQixXQUFXLFNBQVMsRUFBRSxFQUN0QixTQUFTLEVBQ1QsYUFBYSxDQUFDLElBQUksQ0FBQyxtQkFBbUIsQ0FDdkMsQ0FBQztRQUNGLElBQUksQ0FBQyxXQUFXLENBQUMsT0FBTyxFQUFFLENBQUM7WUFDekIsTUFBTSxNQUFNLEdBQUcsZ0NBQWdDLENBQUM7WUFDaEQsVUFBVSxDQUFDLHFCQUFxQixDQUFDO2dCQUMvQixTQUFTLEVBQUUsaUJBQWlCO2dCQUM1QixTQUFTO2dCQUNULFdBQVcsRUFBRSxTQUFTO2dCQUN0QixJQUFJO2dCQUNKLE1BQU07Z0JBQ04sT0FBTyxFQUFFO29CQUNQLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWTtvQkFDakMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO29CQUMvQixtQkFBbUIsRUFBRSxhQUFhLENBQUMsSUFBSSxDQUFDLG1CQUFtQjtvQkFDM0QsZ0JBQWdCLEVBQUUsV0FBVyxDQUFDLGdCQUFnQjtpQkFDL0M7YUFDRixDQUFDLENBQUM7WUFDSCxXQUFXLENBQUMsV0FBVyxDQUFDO2dCQUN0QixJQUFJLEVBQUUsaUJBQWlCO2dCQUN2QixZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7Z0JBQ2pDLE9BQU8sRUFBRSxFQUFFLFdBQVcsRUFBRSxNQUFNLENBQUMsV0FBVyxFQUFFLE1BQU0sRUFBRTthQUNyRCxDQUFDLENBQUM7WUFDSCxNQUFNLGFBQWEsR0FBRztnQkFDcEIsT0FBTyxFQUFFLCtCQUErQjtnQkFDeEMsTUFBTTtnQkFDTixtQkFBbUIsRUFBRSxhQUFhLENBQUMsSUFBSSxDQUFDLG1CQUFtQjtnQkFDM0QsZ0JBQWdCLEVBQUUsV0FBVyxDQUFDLGdCQUFnQjtnQkFDOUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO2dCQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7Z0JBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtnQkFDN0IsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJO2dCQUNqQixJQUFJO2dCQUNKLFNBQVM7YUFDVixDQUFDO1lBQ0YsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxhQUFhLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDdEQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxLQUFLLENBQ1gsZUFBZSxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLHFEQUFxRCxhQUFhLENBQUMsSUFBSSxDQUFDLG1CQUFtQixxQkFBcUIsV0FBVyxDQUFDLGdCQUFnQixvQkFBb0IsQ0FDek4sQ0FBQztZQUNKLENBQUM7WUFDRCwyR0FBMkc7WUFDM0cseUdBQXlHO1lBQ3pHLHVEQUF1RDtZQUN2RCxPQUFPLENBQUMsUUFBUSxFQUFFLENBQUMsYUFBaUMsQ0FBQyxDQUFDO1lBQ3RELE9BQU8sRUFBRSxDQUFDO1FBQ1osQ0FBQztRQUVELFdBQVcsR0FBRyxXQUFXLENBQUMsS0FBSyxDQUFDO1FBQ2hDLFlBQVksR0FBRyxJQUFJLENBQUM7UUFDcEIseUdBQXlHO1FBQ3pHLDJHQUEyRztRQUMzRyw0R0FBNEc7UUFDNUcseUdBQXlHO1FBQ3pHLHNHQUFzRztRQUN0RywwR0FBMEc7UUFDMUcsOENBQThDO1FBQzlDLElBQUksdUJBQXVCLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUNqQyxNQUFNLFdBQVcsR0FBRyxPQUFPLENBQUMsZUFBZSxJQUFJLGVBQWUsQ0FBQztZQUMvRCxNQUFNLFdBQVcsQ0FBQyxXQUFXLEVBQUUsRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQzFDLENBQUM7UUFFRCxNQUFNLGtCQUFrQixHQUFHLE9BQU8sQ0FBQyxlQUFlLElBQUksZUFBZSxDQUFDO1FBQ3RFLElBQUksTUFBTSxDQUFDO1FBQ1gsSUFBSSxDQUFDO1lBQ0gsTUFBTSxHQUFHLE1BQU0sa0JBQWtCLENBQy9CO2dCQUNFLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO2dCQUMvQixVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7Z0JBQzdCLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSTtnQkFDakIsZUFBZTtnQkFDZixhQUFhLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxhQUFhO2dCQUMzQyxjQUFjLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxjQUFjO2dCQUM3QyxRQUFRO2FBQ1QsRUFDRDtnQkFDRSxHQUFHLElBQUk7Z0JBQ1AsV0FBVztnQkFDWCxzQkFBc0IsRUFBRSxHQUFHLEVBQUUsQ0FBQyxxQkFBcUIsRUFBRSxDQUFDLEtBQUs7YUFDNUQsQ0FDRixDQUFDO1FBQ0osQ0FBQztRQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7WUFDZixvR0FBb0c7WUFDcEcsa0dBQWtHO1lBQ2xHLHdHQUF3RztZQUN4RyxrR0FBa0c7WUFDbEcsY0FBYyxDQUFDLFNBQVMsR0FBRyxLQUFLLENBQUM7WUFDakMsTUFBTSxLQUFLLENBQUM7UUFDZCxDQUFDO1FBRUQsY0FBYyxDQUFDLFNBQVMsR0FBRyxNQUFNLENBQUMsT0FBTyxLQUFLLFdBQVcsQ0FBQztRQUUxRCx3R0FBd0c7UUFDeEcsc0dBQXNHO1FBQ3RHLHNHQUFzRztRQUN0RyxxR0FBcUc7UUFDckcsMEZBQTBGO1FBQzFGLElBQUksYUFBOEMsQ0FBQztRQUNuRCxJQUFJLE1BQU0sQ0FBQyxPQUFPLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDbkMsTUFBTSxZQUFZLEdBQUcsMkJBQTJCLENBQUMsTUFBTSxDQUFDLFVBQStELEVBQUUsTUFBTSxDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQzlJLElBQUksWUFBWSxLQUFLLElBQUksRUFBRSxDQUFDO2dCQUMxQixNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsb0JBQW9CLElBQUksb0JBQW9CLENBQUM7Z0JBQzdFLGFBQWEsR0FBRyxNQUFNLGVBQWUsQ0FDbkM7b0JBQ0UsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZO29CQUNqQyxXQUFXLEVBQUUsTUFBTSxDQUFDLFdBQVc7b0JBQy9CLFlBQVk7b0JBQ1osYUFBYSxFQUFFLFdBQVcsQ0FBQyxTQUFTO29CQUNwQyxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7aUJBQzlCLEVBQ0QsRUFBRSxzQkFBc0IsRUFBRSxJQUFJLENBQUMsc0JBQXNCLEVBQUUsaUJBQWlCLEVBQUUsSUFBSSxDQUFDLGlCQUFpQixFQUFFLENBQ25HLENBQUM7WUFDSixDQUFDO1lBRUQsMEZBQTBGO1lBQzFGLG9HQUFvRztZQUNwRywrRkFBK0Y7WUFDL0YscUdBQXFHO1lBQ3JHLHNHQUFzRztZQUN0Ryx5R0FBeUc7WUFDekcsb0dBQW9HO1lBQ3BHLDJHQUEyRztZQUMzRyxNQUFNLFlBQVksR0FBRyxNQUFNLENBQUMsVUFBVSxDQUFDLGFBQWEsRUFBRSxZQUFZLEVBQUUsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ25HLE1BQU0sV0FBVyxHQUFHLDJCQUEyQixDQUFDLFlBQVksQ0FBQyxDQUFDO1lBQzlELElBQUksV0FBVyxFQUFFLENBQUM7Z0JBQ2hCLElBQUksQ0FBQztvQkFDSCxNQUFNLE1BQU0sR0FBRyxPQUFPLENBQUMsbUJBQW1CLElBQUksbUJBQW1CLENBQUM7b0JBQ2xFLE1BQU0sQ0FBQzt3QkFDTCxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7d0JBQ2pDLFdBQVc7d0JBQ1gsV0FBVyxFQUFFLElBQUksSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLFdBQVcsRUFBRTt3QkFDMUMsaUJBQWlCLEVBQUUsWUFBWTt3QkFDL0IsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO3FCQUNoQyxDQUFDLENBQUM7Z0JBQ0wsQ0FBQztnQkFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO29CQUNmLCtGQUErRjtvQkFDL0YscUdBQXFHO29CQUNyRyx1RUFBdUU7b0JBQ3ZFLGlCQUFpQixDQUFDLEtBQUssRUFBRSxFQUFFLElBQUksRUFBRSw4QkFBOEIsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxpQkFBaUIsRUFBRSxZQUFZLEVBQUUsQ0FBQyxDQUFDO2dCQUN6SSxDQUFDO1lBQ0gsQ0FBQztRQUNILENBQUM7UUFFRCxNQUFNLFdBQVcsR0FBcUI7WUFDcEMsT0FBTyxFQUFFLFdBQVcsTUFBTSxDQUFDLE9BQU8sRUFBRTtZQUNwQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVk7WUFDakMsV0FBVyxFQUFFLE1BQU0sQ0FBQyxXQUFXO1lBQy9CLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVTtZQUM3QixJQUFJLEVBQUUsTUFBTSxDQUFDLElBQUk7WUFDakIsSUFBSTtZQUNKLFNBQVM7WUFDVCxjQUFjLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxjQUFjO1lBQzdDLHlHQUF5RztZQUN6RywwR0FBMEc7WUFDMUcsbUdBQW1HO1lBQ25HLHFHQUFxRztZQUNyRyx3R0FBd0c7WUFDeEcsZ0VBQWdFO1lBQ2hFLGNBQWMsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLGNBQWM7WUFDaEQsWUFBWSxFQUFFLE1BQU0sQ0FBQyxVQUFVLENBQUMsWUFBWTtZQUM1Qyx5R0FBeUc7WUFDekcsMEdBQTBHO1lBQzFHLHVEQUF1RDtZQUN2RCxlQUFlLEVBQUUsTUFBTSxDQUFDLFVBQVUsQ0FBQyxnQkFBZ0IsQ0FBQyxNQUFNO1lBQzFELGNBQWMsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLGNBQWM7WUFDaEQsR0FBRyxDQUFDLE1BQU0sQ0FBQyxPQUFPLEtBQUssU0FBUyxJQUFJLE1BQU0sQ0FBQyxVQUFVLENBQUMsYUFBYSxFQUFFLGFBQWE7Z0JBQ2hGLENBQUMsQ0FBQyxFQUFFLGFBQWEsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLGFBQWEsQ0FBQyxhQUFhLEVBQUU7Z0JBQ2xFLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDUCxHQUFHLENBQUMsUUFBUSxJQUFJLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDeEQsR0FBRyxDQUFDLFVBQVUsSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUUsUUFBUSxFQUFFLE1BQU0sQ0FBQyxRQUFRLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQzlELEdBQUcsQ0FBQyxNQUFNLElBQUksTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztZQUNsRCxHQUFHLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDcEUsd0dBQXdHO1lBQ3hHLHdHQUF3RztZQUN4RyxvRkFBb0Y7WUFDcEYsR0FBRyxDQUFDLGFBQWEsS0FBSyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsYUFBYSxFQUFFLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztTQUMxRCxDQUFDO1FBRUYsMkdBQTJHO1FBQzNHLDhHQUE4RztRQUM5RywyR0FBMkc7UUFDM0cseUdBQXlHO1FBQ3pHLDJHQUEyRztRQUMzRyxzR0FBc0c7UUFDdEcsNkdBQTZHO1FBQzdHLG9EQUFvRDtRQUNwRCxJQUFJLENBQUM7WUFDSCxVQUFVLENBQUMscUJBQXFCLENBQUM7Z0JBQy9CLFNBQVMsRUFBRSx5QkFBeUI7Z0JBQ3BDLFNBQVM7Z0JBQ1QsV0FBVyxFQUFFLFdBQVcsQ0FBQyxPQUFPO2dCQUNoQyxJQUFJO2dCQUNKLE1BQU0sRUFBRSxrQ0FBa0MsTUFBTSxDQUFDLE9BQU8sRUFBRTtnQkFDMUQsUUFBUSxFQUFFLDJDQUEyQyxDQUFDLEdBQUcsQ0FBQztnQkFDMUQsT0FBTyxFQUFFLFdBQVcsQ0FBQyxZQUFZO2dCQUNqQyxVQUFVLEVBQUUsV0FBVyxDQUFDLGVBQWU7YUFDeEMsQ0FBQyxDQUFDO1FBQ0wsQ0FBQztRQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7WUFDZix5R0FBeUc7WUFDekcsdUdBQXVHO1lBQ3ZHLHlGQUF5RjtZQUN6RixpQkFBaUIsQ0FBQyxLQUFLLEVBQUUsRUFBRSxJQUFJLEVBQUUsdUNBQXVDLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLENBQUMsQ0FBQztRQUM1SCxDQUFDO1FBRUQsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFdBQVcsRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNwRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZUFBZSxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxXQUFXLDJCQUEyQixNQUFNLENBQUMsT0FBTyxHQUFHLENBQUMsQ0FBQztRQUNwSCxDQUFDO1FBQ0QsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLFdBQVcsQ0FBQyxDQUFDO1FBRWhDLFFBQVEsTUFBTSxDQUFDLE9BQU8sRUFBRSxDQUFDO1lBQ3ZCLEtBQUssV0FBVztnQkFDZCxPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssU0FBUztnQkFDWixPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssT0FBTztnQkFDVixPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssU0FBUztnQkFDWixPQUFPLENBQUMsQ0FBQztZQUNYLEtBQUssVUFBVTtnQkFDYixPQUFPLEVBQUUsQ0FBQztZQUNaO2dCQUNFLE9BQU8sQ0FBQyxDQUFDO1FBQ2IsQ0FBQztJQUNILENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztZQUFTLENBQUM7UUFDVCx3R0FBd0c7UUFDeEcsMEdBQTBHO1FBQzFHLHVHQUF1RztRQUN2Ryx3R0FBd0c7UUFDeEcseUdBQXlHO1FBQ3pHLCtGQUErRjtRQUMvRixJQUFJLGNBQWMsRUFBRSxFQUFFLEVBQUUsQ0FBQztZQUN2QixNQUFNLGVBQWUsR0FBRyxPQUFPLENBQUMsc0JBQXNCLElBQUksc0JBQXNCLENBQUM7WUFDakYsTUFBTSxlQUFlLENBQUMsY0FBYyxDQUFDLFFBQVEsRUFBRSxjQUFjLENBQUMsWUFBWSxFQUFFLGNBQWMsQ0FBQyxTQUFTLElBQUksSUFBSSxDQUFDLENBQUM7UUFDaEgsQ0FBQztRQUNELCtGQUErRjtRQUMvRixtR0FBbUc7UUFDbkcsOERBQThEO1FBQzlELElBQUksWUFBWSxJQUFJLFdBQVc7WUFBRSxXQUFXLENBQUMsWUFBWSxDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFdBQVcsQ0FBQyxDQUFDO1FBQ25HLDJHQUEyRztRQUMzRywwR0FBMEc7UUFDMUcsc0dBQXNHO1FBQ3RHLElBQUksWUFBWSxJQUFJLFdBQVcsSUFBSSx1QkFBdUIsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO1lBQ2hFLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxlQUFlLElBQUksZUFBZSxDQUFDO1lBQy9ELE1BQU0sV0FBVyxDQUFDLEVBQUUsR0FBRyxXQUFXLEVBQUUsTUFBTSxFQUFFLFVBQVUsRUFBRSxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztRQUNyRSxDQUFDO1FBQ0QsSUFBSSxVQUFVLElBQUksU0FBUztZQUFFLFNBQVMsQ0FBQyxPQUFPLENBQUMsU0FBUyxDQUFDLENBQUM7UUFDMUQsU0FBUyxFQUFFLEtBQUssRUFBRSxDQUFDO1FBQ25CLFdBQVcsRUFBRSxLQUFLLEVBQUUsQ0FBQztRQUNyQixXQUFXLEVBQUUsS0FBSyxFQUFFLENBQUM7UUFDckIsVUFBVSxFQUFFLEtBQUssRUFBRSxDQUFDO1FBQ3BCLGNBQWMsRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUMxQixDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -1,0 +1,827 @@
+// CLI dispatch for the real attempt pipeline (#5132, Wave 3.5 -- the final assembly). Wires bin/loopover-miner.js's
+// `attempt` subcommand to real infrastructure end to end: worktree allocation + real git preparation
+// (worktree-allocator.js + attempt-worktree.js), the four ledgers (claim/event/attempt-log/governor), the
+// real coding-agent driver (#5131) and slop assessor (#5133), a live SelfReviewContext fetch (#5145), a real
+// coding-task spec (#5239), the operator's AmsPolicySpec execution policy (#5249), rejectionSignaled (#5241),
+// a real runMinerAttempt call -- the first point in this epic where a real coding agent actually runs, not
+// just checks-and-reports-blocked -- and, only on a real "submitted" outcome, a real post-submission
+// claim-conflict resolution (#4848, claim-conflict-resolver.js) for the narrow race window
+// checkSubmissionFreshness cannot see (two miners submitting almost simultaneously).
+//
+// KNOWN, DOCUMENTED GAPS (not fabricated -- see attempt-input-builder.js's own header for the full list):
+// governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted (chokepoint.ts's own design treats
+// that as "skip that stage entirely"). governor.convergenceInput is now a real per-issue portfolio-queue.js read
+// (#5654) and governor.reputationHistory a real per-repo governor-state.js read (#5675), not placeholders.
+
+import { fingerprintFromChangedFiles, resolveCodingAgentModeFromConfig, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { constructProductionCodingAgentDriver } from "./coding-agent-construction.js";
+import { runSlopAssessment } from "./slop-assessment.js";
+import { fetchLiveIssueSnapshot } from "./live-issue-snapshot.js";
+import { executeLocalWrite } from "./execute-local-write.js";
+import { openClaimLedger } from "./claim-ledger.js";
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
+import { resolveClaimConflict } from "./claim-conflict-resolver.js";
+import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
+import { initEventLedger } from "./event-ledger.js";
+import { initAttemptLog } from "./attempt-log.js";
+import { initGovernorLedger } from "./governor-ledger.js";
+import { openWorktreeAllocator } from "./worktree-allocator.js";
+import { isValidRepoSegment } from "./repo-clone.js";
+import { REJECTION_REASON_AI_USAGE_POLICY_BAN, REJECTION_REASON_OWN_SUBMISSION_REJECTED, resolveRejectionSignaled } from "./rejection-signal.js";
+import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
+import { fetchSelfReviewContext } from "./self-review-context.js";
+import { buildCodingTaskSpec } from "./coding-task-spec.js";
+import { resolveAmsPolicy } from "./ams-policy.js";
+import { checkMinerKillSwitch, recordMinerKillSwitchTransition } from "./governor-kill-switch.js";
+import { captureMinerError } from "./sentry.js";
+import { buildAttemptGovernorContext, buildAttemptLoopInput } from "./attempt-input-builder.js";
+import { getAttemptHistory } from "./portfolio-queue.js";
+import { loadReputationHistory, recordOwnSubmission } from "./governor-state.js";
+import { runMinerAttempt } from "./attempt-runner.js";
+import { resolveGitHubToken } from "./github-token-resolution.js";
+import { isDiscoveryPlaneEnabled, submitSoftClaim } from "./discovery-index-client.js";
+
+import type { CodingAgentExecutionMode, FeasibilityVerdict, LocalWriteActionSpec } from "@loopover/engine";
+import type { AttemptDeps, AttemptResult as RunMinerAttemptResult } from "./attempt-runner.js";
+import type { ClaimEntry, ClaimLedger } from "./claim-ledger.js";
+import type { EventLedger } from "./event-ledger.js";
+import type { AttemptLog } from "./attempt-log.js";
+import type { GovernorLedger } from "./governor-ledger.js";
+import type { WorktreeAllocator } from "./worktree-allocator.js";
+import type { SelfReviewContextFetch } from "./self-review-context.js";
+import type { ClaimConflictResult } from "./claim-conflict-resolver.js";
+import type { PrepareAttemptWorktreeResult } from "./attempt-worktree.js";
+
+type CommonAttemptResultFields = {
+  repoFullName: string;
+  issueNumber: number;
+  minerLogin: string;
+  base: string;
+  mode: CodingAgentExecutionMode;
+  attemptId: string;
+};
+
+/** The result runAttempt reports at every real return point, threaded to `options.onResult` (in addition to
+ *  the plain exit-code return runAttempt itself still returns, unchanged, so bin/loopover-miner.js's own
+ *  `process.exit(exitCode)` usage never breaks) -- the loop orchestrator's real caller for this data. */
+export type AttemptCliResult =
+  | (CommonAttemptResultFields & { outcome: "dry_run" })
+  | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
+  | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
+  | (CommonAttemptResultFields & {
+      outcome: "blocked_infeasible";
+      reason: string;
+      verdict: FeasibilityVerdict;
+      avoidReasons: string[];
+      raiseReasons: string[];
+    })
+  | (CommonAttemptResultFields & {
+      outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
+      submissionMode: "observe" | "enforce";
+      totalTurnsUsed: number;
+      totalCostUsd: number;
+      totalTokensUsed: number;
+      iterationsUsed: number;
+      reason?: string;
+      decision?: unknown;
+      spec?: LocalWriteActionSpec;
+      execResult?: unknown;
+      claimConflict?: ClaimConflictResult;
+    });
+
+export type ParsedAttemptArgs =
+  | { error: string }
+  | {
+      repoFullName: string;
+      issueNumber: number;
+      minerLogin: string;
+      base: string;
+      live: boolean;
+      dryRun: boolean;
+      json: boolean;
+    };
+
+export type RunAttemptOptions = {
+  env?: Record<string, string | undefined>;
+  nowMs?: number;
+  attemptId?: string;
+  resolveCodingAgentModeFromConfig?: (config: { env?: Record<string, string | undefined> }) => CodingAgentExecutionMode;
+  openWorktreeAllocator?: () => WorktreeAllocator;
+  openClaimLedger?: () => ClaimLedger;
+  initEventLedger?: () => EventLedger;
+  initAttemptLog?: () => AttemptLog;
+  initGovernorLedger?: () => GovernorLedger;
+  buildAttemptDeps?: typeof buildAttemptDeps;
+  resolveRejectionSignaled?: typeof resolveRejectionSignaled;
+  fetchImpl?: SelfReviewContextFetch;
+  prepareAttemptWorktree?: typeof prepareAttemptWorktree;
+  cleanupAttemptWorktree?: typeof cleanupAttemptWorktree;
+  fetchSelfReviewContext?: typeof fetchSelfReviewContext;
+  buildCodingTaskSpec?: typeof buildCodingTaskSpec;
+  resolveAmsPolicy?: typeof resolveAmsPolicy;
+  checkMinerKillSwitch?: typeof checkMinerKillSwitch;
+  resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
+  runMinerAttempt?: typeof runMinerAttempt;
+  resolveClaimConflict?: typeof resolveClaimConflict;
+  recordOwnSubmission?: typeof recordOwnSubmission;
+  getAttemptHistory?: typeof getAttemptHistory;
+  /** Hosted soft-claim coordination at work-start/work-end, when the plane is enabled (#7168). Defaults to
+   *  discovery-index-client.js's own submitSoftClaim. */
+  submitSoftClaim?: typeof submitSoftClaim;
+  /** Invoked with the real structured result at every return point, in addition to (never instead of) the
+   *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
+  onResult?: (result: AttemptCliResult) => void;
+};
+
+const ATTEMPT_USAGE =
+  "Usage: loopover-miner attempt <owner/repo> <issue#> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--json]";
+
+function parseRepoTarget(value: string): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
+  return `${owner}/${repo}`;
+}
+
+export function parseAttemptArgs(args: string[]): ParsedAttemptArgs {
+  const options = { json: false, minerLogin: null as string | null, base: "main", live: false, dryRun: false };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // Opt-in only: resolveCodingAgentModeFromConfig's own default (no agentDryRun override) is "live", not
+    // "dry_run" -- so #5132's "dry-run is default" acceptance criteria (#2342) has to be enforced HERE, by
+    // requiring an explicit --live flag before this command will ever request live mode.
+    if (token === "--live") {
+      options.live = true;
+      continue;
+    }
+    // #4847: distinct from --live's absence above -- --live only ever gated the coding-agent DRIVER's mode,
+    // but a non---live run still opened every store and made real worktree/claim/ledger writes. --dry-run
+    // short-circuits BEFORE any of that infrastructure is even opened, guaranteeing zero writes rather than
+    // merely skipping the driver.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--miner-login") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
+      options.minerLogin = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--base") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: ATTEMPT_USAGE };
+      options.base = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) return { error: ATTEMPT_USAGE };
+  const repoFullName = parseRepoTarget(positional[0]!);
+  if (!repoFullName) return { error: `Repository must be in owner/repo form: ${positional[0]}` };
+  const issueNumber = Number(positional[1]);
+  if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+    return { error: `Issue number must be a positive integer: ${positional[1]}` };
+  }
+  if (!options.minerLogin) return { error: `--miner-login is required. ${ATTEMPT_USAGE}` };
+
+  return {
+    repoFullName,
+    issueNumber,
+    minerLogin: options.minerLogin,
+    base: options.base,
+    live: options.live,
+    dryRun: options.dryRun,
+    json: options.json,
+  };
+}
+
+/**
+ * Assemble a real AttemptDeps object: every field wired to a genuine implementation (the #5131 driver, the
+ * #5133 slop assessor, the four real ledgers passed in, and the fetchLiveIssueSnapshot/executeLocalWrite
+ * built alongside this file). Throws if the coding-agent driver is unconfigured (fails closed, matching
+ * constructProductionCodingAgentDriver's own contract) -- callers should report that clearly rather than
+ * silently falling back to a driver that could never run.
+ */
+export function buildAttemptDeps(
+  env: Record<string, string | undefined>,
+  ledgers: { claimLedger: ClaimLedger; eventLedger: EventLedger; attemptLog: AttemptLog; governorLedger: GovernorLedger; nowMs: number },
+): AttemptDeps {
+  return {
+    driver: constructProductionCodingAgentDriver(env),
+    runSlopAssessment: (input) => runSlopAssessment(input as Parameters<typeof runSlopAssessment>[0]),
+    appendAttemptLogEvent: (event) => ledgers.attemptLog.appendAttemptLogEvent(event as Parameters<typeof ledgers.attemptLog.appendAttemptLogEvent>[0]),
+    // The real ClaimLedger is a valid claim ledger for AttemptDeps' narrower SubmissionFreshnessClaimLedger view;
+    // its listClaims types `status` as the concrete ClaimStatus rather than the view's looser `string`, so the
+    // structural check needs an explicit bridge (runtime shape is identical).
+    claimLedger: ledgers.claimLedger as unknown as AttemptDeps["claimLedger"],
+    // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+    // authenticated `loopover-mcp login` session -- cached in memory, so repeat calls within this process
+    // don't repeatedly hit the session-fetch endpoint after the first successful resolution.
+    fetchLiveIssueSnapshot: async (repoFullName, issueNumber) => fetchLiveIssueSnapshot(repoFullName, issueNumber, { githubToken: (await resolveGitHubToken(env)) as string }),
+    eventLedger: ledgers.eventLedger,
+    governorLedgerAppend: (event) => ledgers.governorLedger.appendGovernorEvent(event as Parameters<typeof ledgers.governorLedger.appendGovernorEvent>[0]),
+    nowMs: ledgers.nowMs,
+    executeLocalWrite: (spec) => executeLocalWrite(spec),
+  };
+}
+
+/**
+ * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
+ * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
+ * SelfReviewContext -> build a real coding-task spec (blocks on an infeasible verdict) -> resolve the real
+ * AmsPolicySpec execution policy -> assemble the real IterateLoopInput + Governor context -> call
+ * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) in `finally`.
+ * See this file's header for the documented gaps (real convergence history).
+ */
+export async function runAttempt(args: string[], options: RunAttemptOptions = {}): Promise<number> {
+  const parsed = parseAttemptArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  const env = options.env ?? process.env;
+  const nowMs = options.nowMs ?? Date.now();
+  const resolveMode = options.resolveCodingAgentModeFromConfig ?? resolveCodingAgentModeFromConfig;
+  const mode = resolveMode({ env, agentDryRun: !parsed.live });
+
+  if (mode === "paused") {
+    return reportCliFailure(
+      parsed.json,
+      `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`,
+      3,
+    );
+  }
+
+  const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
+
+  // #4847: reports what a real run would do and returns BEFORE any store (allocator/claim/event/attempt-log/
+  // governor ledger) is even opened, so this is a provable zero-write path -- not just "opened but didn't
+  // write to" the local stores, and nowhere near the real worktree clone, claim, or coding-agent driver.
+  if (parsed.dryRun) {
+    const dryRunResult: AttemptCliResult = {
+      outcome: "dry_run",
+      repoFullName: parsed.repoFullName,
+      issueNumber: parsed.issueNumber,
+      minerLogin: parsed.minerLogin,
+      base: parsed.base,
+      mode,
+      attemptId,
+    };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(
+        `DRY RUN: would attempt ${parsed.repoFullName}#${parsed.issueNumber} for ${parsed.minerLogin} (mode: ${mode}, base: ${parsed.base}). No worktree, claim, or ledger writes were made.`,
+      );
+    }
+    options.onResult?.(dryRunResult);
+    return 0;
+  }
+
+  let allocator: WorktreeAllocator | null = null;
+  let claimLedger: ClaimLedger | null = null;
+  let eventLedger: EventLedger | null = null;
+  let attemptLog: AttemptLog | null = null;
+  let governorLedger: GovernorLedger | null = null;
+  let allocation = null;
+  let worktreeResult: (PrepareAttemptWorktreeResult & { attemptOk?: boolean }) | null = null;
+  let claimedIssue = false;
+  let claimRecord: ClaimEntry | null = null;
+
+  try {
+    allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
+    claimLedger = (options.openClaimLedger ?? openClaimLedger)();
+    eventLedger = (options.initEventLedger ?? initEventLedger)();
+    attemptLog = (options.initAttemptLog ?? initAttemptLog)();
+    governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+
+    // Checked before acquiring a worktree slot: a rejection-signaled repo should never consume one.
+    // resolveRejectionSignaled resolves both documented triggers (#5132 policy ban, #5655 own-rejection
+    // history) and returns a trigger-specific reason string for accurate audit-trail labeling.
+    const resolveRejection = options.resolveRejectionSignaled ?? resolveRejectionSignaled;
+    const rejectionSignal = await resolveRejection(parsed.repoFullName, { fetchImpl: options.fetchImpl! });
+    if (rejectionSignal) {
+      const reason =
+        rejectionSignal === true ? REJECTION_REASON_AI_USAGE_POLICY_BAN : rejectionSignal;
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const rejectedResult: AttemptCliResult = {
+        outcome: "blocked_rejection_signaled",
+        reason,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(rejectedResult, null, 2));
+      } else {
+        console.error(
+          reason === REJECTION_REASON_OWN_SUBMISSION_REJECTED
+            ? `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this miner was previously rejected on this repo.`
+            : `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's AI-usage policy bans automated/AI-authored contributions.`,
+        );
+      }
+      options.onResult?.(rejectedResult);
+      return 5;
+    }
+
+    allocation = allocator.acquire(attemptId, parsed.repoFullName);
+
+    let deps: AttemptDeps;
+    try {
+      const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
+      deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
+    } catch (error) {
+      const reason = describeCliError(error);
+      return reportCliFailure(
+        parsed.json,
+        `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`,
+        3,
+      );
+    }
+
+    // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
+    // reserves a concurrency SLOT (worktree-allocator.js's own `slot-N` placeholder dirs never receive real
+    // git content) -- this is the step that actually clones/fetches the target repo and creates a real
+    // `git worktree` for this attempt. Its own path, NOT the allocator's slot path, is the real
+    // workingDirectory a future runMinerAttempt call must use.
+    const prepareWorktree = options.prepareAttemptWorktree ?? prepareAttemptWorktree;
+    worktreeResult = await prepareWorktree(parsed.repoFullName, attemptId, { baseBranch: parsed.base, env });
+    if (!worktreeResult.ok) {
+      const reason = worktreeResult.error;
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const worktreeFailureResult: AttemptCliResult = {
+        outcome: "blocked_worktree_preparation_failed",
+        reason,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(worktreeFailureResult, null, 2));
+      } else {
+        console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: real worktree preparation failed: ${reason}`);
+      }
+      options.onResult?.(worktreeFailureResult);
+      return 6;
+    }
+
+    // Real SelfReviewContext (#5145): issue/PR/manifest data at live-gate fidelity for the target repo.
+    const fetchReviewContext = options.fetchSelfReviewContext ?? fetchSelfReviewContext;
+    const reviewContext = await fetchReviewContext(parsed.repoFullName, {
+      githubToken: (await resolveGitHubToken(env)) as string,
+      contributorLogin: parsed.minerLogin,
+      linkedIssues: [parsed.issueNumber],
+    });
+
+    // The target issue's own real record, when present in the fetched context. When absent (e.g. already
+    // closed, or genuinely not found), buildCodingTaskSpec's own feasibility check reports target_not_found
+    // and this placeholder's empty title/body are never surfaced anywhere -- not fabricated content, just an
+    // inert shape for a verdict that immediately blocks.
+    const targetIssue = reviewContext.issues.find((candidate) => candidate.number === parsed.issueNumber) ?? {
+      number: parsed.issueNumber,
+      title: "",
+      body: null,
+      labels: [],
+    };
+
+    const buildTaskSpec = options.buildCodingTaskSpec ?? buildCodingTaskSpec;
+    const codingTaskSpec = buildTaskSpec({
+      repoFullName: parsed.repoFullName,
+      issue: targetIssue,
+      context: { issues: reviewContext.issues, pullRequests: reviewContext.pullRequests },
+      // Same narrower-view bridge as AttemptDeps.claimLedger above: buildCodingTaskSpec only needs a listClaims
+      // reader (CodingTaskClaimLedger), whose `status: string` is looser than the real ledger's ClaimStatus.
+      claimLedger: claimLedger as unknown as Parameters<typeof buildTaskSpec>[0]["claimLedger"],
+      workingDirectory: worktreeResult.worktreePath,
+    });
+
+    if (!codingTaskSpec.ready) {
+      const reason = `infeasible_${codingTaskSpec.verdict}`;
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber, feasibility: codingTaskSpec.feasibility },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const infeasibleResult: AttemptCliResult = {
+        outcome: "blocked_infeasible",
+        reason,
+        verdict: codingTaskSpec.verdict,
+        avoidReasons: codingTaskSpec.feasibility.avoidReasons as string[],
+        raiseReasons: codingTaskSpec.feasibility.raiseReasons as string[],
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(infeasibleResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: feasibility verdict "${codingTaskSpec.verdict}" (${[...codingTaskSpec.feasibility.avoidReasons, ...codingTaskSpec.feasibility.raiseReasons].join(", ")}).`,
+        );
+      }
+      options.onResult?.(infeasibleResult);
+      return 4;
+    }
+
+    const amsPolicy = await (options.resolveAmsPolicy ?? resolveAmsPolicy)(parsed.repoFullName, { env });
+
+    // Real per-repo pause (#5392): read straight from the already-cloned worktree's own .loopover-miner.yml
+    // (resolveMinerGoalSpec never throws -- a missing/malformed file degrades to killSwitch.paused: false, so
+    // this can't fail this attempt on its own). Threaded into BOTH checkMinerKillSwitch (killSwitchScope, used
+    // by the freshness/submission gate) and the governor context (killSwitchRepoPaused, used by the Governor
+    // chokepoint) -- the same two places the GLOBAL kill switch already reaches.
+    const resolveGoalSpec = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+    const minerGoalSpec = resolveGoalSpec(worktreeResult.repoPath);
+    const repoPaused = minerGoalSpec.spec.killSwitch.paused;
+
+    const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
+    const recordKillTransition =
+      (options as { recordMinerKillSwitchTransition?: typeof recordMinerKillSwitchTransition }).recordMinerKillSwitchTransition ??
+      recordMinerKillSwitchTransition;
+    let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
+    let previousKillSwitchScope = killSwitchScope;
+
+    const resolveLiveKillSwitch = () => {
+      // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
+      const liveRepoPaused = resolveGoalSpec(worktreeResult!.repoPath!).spec.killSwitch.paused;
+      const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
+      if (live.scope !== previousKillSwitchScope) {
+        try {
+          recordKillTransition({
+            repoFullName: parsed.repoFullName,
+            actionClass: "attempt",
+            previousScope: previousKillSwitchScope,
+            scope: live.scope,
+          });
+        } catch (error) {
+          // Ledger append must never crash an aborting attempt (kept), but was previously silent -- a
+          // kill-switch flip mid-attempt (a compliance-relevant event) could vanish with no record (#6011).
+          captureMinerError(error, { kind: "kill_switch_transition_record_failed", repoFullName: parsed.repoFullName, scope: live.scope });
+        }
+        previousKillSwitchScope = live.scope;
+      }
+      killSwitchScope = live.scope;
+      return live;
+    };
+
+    const shouldAbort = () => {
+      const live = resolveLiveKillSwitch();
+      if (!live.active) return false;
+      return {
+        abort: true,
+        reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
+      };
+    };
+
+    const loopInput = buildAttemptLoopInput({
+      codingTaskSpec,
+      reviewContext,
+      worktreePath: worktreeResult.worktreePath,
+      attemptId,
+      mode,
+      repoFullName: parsed.repoFullName,
+      minerLogin: parsed.minerLogin,
+      rejectionSignaled: false,
+      amsPolicySpec: amsPolicy.spec,
+      branchRef: worktreeResult.branchName,
+    });
+
+    // Real per-issue attempt history (#5654): portfolio-queue.js's own claim/reclaim/requeue/done counters,
+    // keyed the same way opportunity-fanout.js enqueues issue-shaped candidates (`issue:<number>`). No
+    // apiBaseUrl: this file has no multi-forge host context of its own today, so this reads (and every
+    // pre-#5563 single-forge caller already reads) the github.com default.
+    const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
+    const convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
+    // Real per-repo reputation history (#5675): the miner's own decided/unfavorable outcome streak for this repo,
+    // read from governor-state.js so the chokepoint's self-reputation throttle sees real data instead of nothing.
+    const readReputationHistory =
+      (options as { loadReputationHistory?: typeof loadReputationHistory }).loadReputationHistory ?? loadReputationHistory;
+    const reputationHistory = readReputationHistory(parsed.repoFullName);
+    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
+
+    // Real maxConcurrentClaims enforcement (#6758): the repo's .loopover-miner.yml cap is honored ATOMICALLY by
+    // the ledger's count-and-claim, not by a listActiveClaims pre-check here. The old check-then-act split -- read
+    // the count in this file, then record the claim in a separate claimLedger call -- let two sibling miner
+    // processes racing the same repo both pass a stale sub-cap count and both claim, exceeding the cap.
+    // claimIssueWithinCap fuses the count and the insert into one transaction; the loser gets `claimed: false`
+    // and is reported below rather than silently dropped. This is also the real soft-claim (#5393): once it
+    // returns claimed, a sibling process sees it via claimLedger.listActiveClaims while this attempt is in
+    // flight, it is released in `finally` on every terminal outcome (mirroring the worktree allocation slot's
+    // acquire-then-always-release), and its claimedAt feeds the post-submission conflict check further down (#4848).
+    const claimResult = claimLedger.claimIssueWithinCap(
+      parsed.repoFullName,
+      parsed.issueNumber,
+      `attempt:${attemptId}`,
+      undefined,
+      minerGoalSpec.spec.maxConcurrentClaims,
+    );
+    if (!claimResult.claimed) {
+      const reason = "max_concurrent_claims_exceeded";
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: {
+          repoFullName: parsed.repoFullName,
+          issueNumber: parsed.issueNumber,
+          maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+          activeClaimCount: claimResult.activeClaimCount,
+        },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const blockedResult = {
+        outcome: "blocked_max_concurrent_claims",
+        reason,
+        maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+        activeClaimCount: claimResult.activeClaimCount,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(blockedResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${claimResult.activeClaimCount} active claim(s)).`,
+        );
+      }
+      // `blocked_max_concurrent_claims` (#6758) is an internal cap-rejection outcome the public AttemptCliResult
+      // union does not enumerate; the onResult hook still receives the real structured payload here, so bridge
+      // its shape without widening the exported result type.
+      options.onResult?.(blockedResult as AttemptCliResult);
+      return 11;
+    }
+
+    claimRecord = claimResult.claim;
+    claimedIssue = true;
+    // Hosted soft-claim coordination (#7168), opt-in via LOOPOVER_MINER_DISCOVERY_PLANE -- gated HERE at the
+    // call site (not left to submitSoftClaim's own internal check alone) so a disabled plane costs zero calls,
+    // matching discover-cli.js's supplementWithDiscoveryIndex gating; a caller-injected options.submitSoftClaim
+    // (tests, or a future programmatic caller) can't accidentally bypass the opt-in this way either. Awaited
+    // (not fire-and-forget) so a sibling instance racing the same issue is genuinely less likely to start
+    // duplicate work in the window before this attempt's claim reaches the shared index -- the whole point of
+    // coordinating BEFORE work begins, not after.
+    if (isDiscoveryPlaneEnabled(env)) {
+      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+      await submitClaim(claimRecord, { env });
+    }
+
+    const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
+    let result;
+    try {
+      result = await runAttemptPipeline(
+        {
+          loopInput,
+          issueNumber: parsed.issueNumber,
+          minerLogin: parsed.minerLogin,
+          base: parsed.base,
+          killSwitchScope,
+          slopThreshold: amsPolicy.spec.slopThreshold,
+          submissionMode: amsPolicy.spec.submissionMode,
+          governor,
+        },
+        {
+          ...deps,
+          shouldAbort,
+          resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
+        },
+      );
+    } catch (error) {
+      // A real attempt that CRASHED is exactly the case that most needs its worktree kept for post-mortem
+      // inspection, so record the failure explicitly before unwinding. Without this, `attemptOk` stayed
+      // `undefined` and the finally block's `?? true` default (meant for the earlier blocked paths that never
+      // ran anything in the worktree) deleted it -- inverting shouldRetainWorktree's documented policy.
+      worktreeResult.attemptOk = false;
+      throw error;
+    }
+
+    worktreeResult.attemptOk = result.outcome === "submitted";
+
+    // Real claim-conflict resolution (#4848): only meaningful once a real PR exists, so this only ever runs
+    // on a real "submitted" outcome. checkSubmissionFreshness (inside runMinerAttempt) already caught the
+    // common pre-submission case; this closes the narrower TOCTOU window where two miners raced past that
+    // check almost simultaneously -- see claim-conflict-resolver.js's own header for why the adjudicator
+    // can only run POST-submission (it needs a real PR number on both sides of the election).
+    let claimConflict: ClaimConflictResult | undefined;
+    if (result.outcome === "submitted") {
+      const selfPrNumber = parsePrNumberFromExecResult(result.execResult as Parameters<typeof parsePrNumberFromExecResult>[0], parsed.repoFullName);
+      if (selfPrNumber !== null) {
+        const resolveConflict = options.resolveClaimConflict ?? resolveClaimConflict;
+        claimConflict = await resolveConflict(
+          {
+            repoFullName: parsed.repoFullName,
+            issueNumber: parsed.issueNumber,
+            selfPrNumber,
+            selfClaimedAt: claimRecord.claimedAt,
+            minerLogin: parsed.minerLogin,
+          },
+          { fetchLiveIssueSnapshot: deps.fetchLiveIssueSnapshot, executeLocalWrite: deps.executeLocalWrite },
+        );
+      }
+
+      // Real own-submission history (#5655 follow-up): governor-state.js's recordOwnSubmission/
+      // listRecentOwnSubmissions store (#5134) existed and was already READ by resolveOwnRejectionHistory
+      // (#5655), but nothing ever WROTE to it -- attempt-runner.js's own header names this exact gap
+      // ("real persistence primitives... but isn't auto-loaded here yet"). Left unfixed, that trigger is a
+      // silent no-op in every real deployment: an empty table always resolves "no prior submissions found."
+      // The fingerprint is the real changed-files set from the loop's own handoff packet (never fabricated) --
+      // omitted (not recorded as an empty placeholder) when the packet reports no changed files at all. A
+      // logging failure must never fail an otherwise-successful attempt, matching the summary-event write below.
+      const changedFiles = result.loopResult.handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
+      const fingerprint = fingerprintFromChangedFiles(changedFiles);
+      if (fingerprint) {
+        try {
+          const record = options.recordOwnSubmission ?? recordOwnSubmission;
+          record({
+            repoFullName: parsed.repoFullName,
+            fingerprint,
+            submittedAt: new Date(nowMs).toISOString(),
+            pullRequestNumber: selfPrNumber,
+            issueNumber: parsed.issueNumber,
+          });
+        } catch (error) {
+          // A logging failure must never fail an otherwise-successful attempt (kept), but was previously
+          // silent -- if this write fails AFTER a real PR has already opened, future self-plagiarism checks go
+          // permanently blind to this exact submission with nobody told (#6011).
+          captureMinerError(error, { kind: "record_own_submission_failed", repoFullName: parsed.repoFullName, pullRequestNumber: selfPrNumber });
+        }
+      }
+    }
+
+    const finalResult: AttemptCliResult = {
+      outcome: `attempt_${result.outcome}`,
+      repoFullName: parsed.repoFullName,
+      issueNumber: parsed.issueNumber,
+      minerLogin: parsed.minerLogin,
+      base: parsed.base,
+      mode,
+      attemptId,
+      submissionMode: amsPolicy.spec.submissionMode,
+      // Every runMinerAttempt outcome carries a real loopResult (#5135's loop needs its genuine turn-usage and
+      // cost to save real GovernorCapUsage via governor-state.js's saveCapUsage -- nothing else in the codebase
+      // calls it yet). Surfaced flat rather than the whole loopResult object, matching this result's own
+      // shallow shape. costUsd is real only for the agent-sdk provider (its own SDK result message reports
+      // total_cost_usd); CLI-subprocess providers (claude-cli/codex-cli) report no cost signal today, so this
+      // is 0 for those -- an honest absence, not a fabricated number.
+      totalTurnsUsed: result.loopResult.totalTurnsUsed,
+      totalCostUsd: result.loopResult.totalCostUsd,
+      // Real accumulated tokens (#5653) -- read from finalMeterTotals rather than a flat totalTokensUsed field
+      // (IterateLoopResult has no such flat field, unlike turns/cost). 0 when no driver reported a token signal
+      // on any iteration this attempt ran, never fabricated.
+      totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
+      iterationsUsed: result.loopResult.iterationsUsed,
+      ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
+        ? { abandonReason: result.loopResult.finalDecision.abandonReason }
+        : {}),
+      ...("reason" in result ? { reason: result.reason } : {}),
+      ...("decision" in result ? { decision: result.decision } : {}),
+      ...("spec" in result ? { spec: result.spec } : {}),
+      ...("execResult" in result ? { execResult: result.execResult } : {}),
+      // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
+      // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
+      // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).
+      ...(claimConflict !== undefined ? { claimConflict } : {}),
+    };
+
+    // One summary row per completed attempt (#5185), for the Grafana per-provider usage dashboard the redacted
+    // AMS reporting export exposes -- distinct from the per-iteration attempt_started/attempt_tool_edit/... trail
+    // iterate-loop.ts already writes. No fallback for an unconfigured provider: buildAttemptDeps already fails
+    // closed (throws) on the same env before a worktree is even allocated, so reaching this point guarantees
+    // resolveFirstConfiguredCodingAgentDriverName(env) resolves a real name. costUsd/tokensUsed are both real,
+    // driver-reported accumulated totals (#5653) -- 0 when no iteration's driver reported a signal, never
+    // fabricated. A logging failure must never fail an otherwise-successful attempt -- mirrors iterate-loop.ts's
+    // own safeAppendAttemptLogEvent non-fatal handling.
+    try {
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_outcome_summary",
+        attemptId,
+        actionClass: finalResult.outcome,
+        mode,
+        reason: `attempt finished with outcome: ${result.outcome}`,
+        provider: resolveFirstConfiguredCodingAgentDriverName(env),
+        costUsd: finalResult.totalCostUsd,
+        tokensUsed: finalResult.totalTokensUsed,
+      });
+    } catch (error) {
+      // A logging failure must never fail an otherwise-successful attempt (kept), but was previously silent --
+      // per docs/observability.md this row feeds the Grafana per-provider cost/usage dashboard, so a failure
+      // here silently drops the attempt from operator-facing metrics with nobody told (#6011).
+      captureMinerError(error, { kind: "attempt_outcome_summary_append_failed", attemptId, repoFullName: parsed.repoFullName });
+    }
+
+    if (parsed.json) {
+      console.log(JSON.stringify(finalResult, null, 2));
+    } else {
+      console.log(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} finished with outcome: ${result.outcome}.`);
+    }
+    options.onResult?.(finalResult);
+
+    switch (result.outcome) {
+      case "submitted":
+        return 0;
+      case "abandon":
+        return 7;
+      case "stale":
+        return 8;
+      case "blocked":
+        return 9;
+      case "governed":
+        return 10;
+      default:
+        return 2;
+    }
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
+    // happens, and explicitly to `false` when that call THROWS -- a crashed attempt is precisely what needs a
+    // retained worktree to postmortem, so it must never fall through to the `?? true` default below. Every
+    // earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since nothing ran in
+    // the worktree to postmortem -- those are the cases that default to `true` (nothing to retain), matching
+    // cleanupAttemptWorktree's own retention policy (a failed REAL attempt is what gets retained).
+    if (worktreeResult?.ok) {
+      const cleanupWorktree = options.cleanupAttemptWorktree ?? cleanupAttemptWorktree;
+      await cleanupWorktree(worktreeResult.repoPath, worktreeResult.worktreePath, worktreeResult.attemptOk ?? true);
+    }
+    // Every terminal outcome past the claim point (submitted/abandon/stale/blocked/governed, or an
+    // unexpected throw) releases the soft-claim -- a claim that outlives its own attempt process would
+    // wrongly tell a sibling miner this issue is still in flight.
+    if (claimedIssue && claimLedger) claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
+    // Paired hosted release (#7168): same call-site opt-in gate as the claim submission above. Only fires when
+    // the initial claim submission actually ran (claimRecord is only set once claimedIssue is), so a run that
+    // never reached the claim point (e.g. blocked_max_concurrent_claims) has nothing to release remotely.
+    if (claimedIssue && claimRecord && isDiscoveryPlaneEnabled(env)) {
+      const submitClaim = options.submitSoftClaim ?? submitSoftClaim;
+      await submitClaim({ ...claimRecord, status: "released" }, { env });
+    }
+    if (allocation && allocator) allocator.release(attemptId);
+    allocator?.close();
+    claimLedger?.close();
+    eventLedger?.close();
+    attemptLog?.close();
+    governorLedger?.close();
+  }
+}

--- a/packages/loopover-miner/lib/discover-cli.d.ts
+++ b/packages/loopover-miner/lib/discover-cli.d.ts
@@ -1,135 +1,104 @@
+import { queryDiscoveryIndex } from "./discovery-index-client.js";
 import type { ForgeConfig } from "./forge-config.js";
-import type {
-  CandidateIssueWarning,
-  FanoutOptions,
-  FanoutTarget,
-  RawCandidateIssue,
-} from "./opportunity-fanout.js";
-import type {
-  RankCandidateIssuesOptions,
-  RankedCandidateIssue,
-  RankedCandidateSummary,
-} from "./opportunity-ranker.js";
+import type { CandidateIssueWarning, FanoutOptions, FanoutTarget, RawCandidateIssue } from "./opportunity-fanout.js";
+import type { RankCandidateIssuesOptions, RankedCandidateIssue, RankedCandidateSummary } from "./opportunity-ranker.js";
 import type { PolicyDocCacheStore } from "./policy-doc-cache.js";
 import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
 import type { EnqueueRankedDiscoverySummary } from "./portfolio-discovery.js";
 import type { PortfolioQueueStore } from "./portfolio-queue.js";
 import type { RankedCandidatesStore } from "./ranked-candidates.js";
-import type { queryDiscoveryIndex } from "./discovery-index-client.js";
-
-export type ParsedDiscoverArgs =
-  | {
-      targets: FanoutTarget[];
-      search: string | null;
-      dryRun: boolean;
-      json: boolean;
-      /** Present only when `--api-base-url` is supplied (#4784); threads the tenant's forge host to the fan-out. */
-      apiBaseUrl?: string;
-      /** Present only when `--token-env` is supplied (#4784); names the credential env var to read. */
-      tokenEnv?: string;
-    }
-  | { error: string };
-
+export type ParsedDiscoverArgs = {
+    targets: FanoutTarget[];
+    search: string | null;
+    dryRun: boolean;
+    json: boolean;
+    /** Present only when `--api-base-url` is supplied (#4784); threads the tenant's forge host to the fan-out. */
+    apiBaseUrl?: string;
+    /** Present only when `--token-env` is supplied (#4784); names the credential env var to read. */
+    tokenEnv?: string;
+} | {
+    error: string;
+};
 /** The subset of `CandidateIssueSummary` runDiscover actually reads. It surfaces the rate-limit telemetry (#4837),
  * so a fake must supply it. A real `fetchCandidateIssuesWithSummary` result satisfies this, since it is a superset. */
 export type DiscoverFanOutSummary = {
-  issues: RawCandidateIssue[];
-  warnings: CandidateIssueWarning[];
-  rateLimitRemaining: number | null;
-  rateLimitResetAt: string | null;
+    issues: RawCandidateIssue[];
+    warnings: CandidateIssueWarning[];
+    rateLimitRemaining: number | null;
+    rateLimitResetAt: string | null;
 };
-
 /** The subset of a ranked entry that `renderDiscoverSummary` reads for its top-candidates listing. */
-export type DiscoverRankedEntry = Pick<
-  RankedCandidateIssue,
-  "repoFullName" | "issueNumber" | "title" | "rankScore"
->;
-
+export type DiscoverRankedEntry = Pick<RankedCandidateIssue, "repoFullName" | "issueNumber" | "title" | "rankScore">;
 export type DiscoverResult = {
-  fanOutCount: number;
-  warnings: CandidateIssueWarning[];
-  rateLimitRemaining: number | null;
-  rateLimitResetAt: string | null;
-  ranked: DiscoverRankedEntry[];
-  /** Candidates the eligibility filter dropped, each with the repo/issue and the reason (#6798). */
-  excluded?: Array<{
-    repoFullName: string;
-    issueNumber: number;
-    reason: string;
-  }>;
-  /** True when ranking fell back to the built-in default goal spec because no per-tenant spec was supplied (#4784). */
-  usedDefaultGoalSpec?: boolean;
-  enqueueSummary: EnqueueRankedDiscoverySummary;
+    fanOutCount: number;
+    warnings: CandidateIssueWarning[];
+    rateLimitRemaining: number | null;
+    rateLimitResetAt: string | null;
+    ranked: DiscoverRankedEntry[];
+    /** Candidates the eligibility filter dropped, each with the repo/issue and the reason (#6798). */
+    excluded?: Array<{
+        repoFullName: string;
+        issueNumber: number;
+        reason: string;
+    }>;
+    /** True when ranking fell back to the built-in default goal spec because no per-tenant spec was supplied (#4784). */
+    usedDefaultGoalSpec?: boolean;
+    enqueueSummary: EnqueueRankedDiscoverySummary;
 };
-
 export type RunDiscoverOptions = {
-  /** Read for the discovery-index opt-in gate (#7168) -- defaults to `process.env`. */
-  env?: Record<string, string | undefined>;
-  githubToken?: string;
-  apiBaseUrl?: string;
-  /** Per-tenant credential env var name (#4784); defaults to GITHUB_TOKEN. Overridden by a `--token-env` flag. */
-  tokenEnv?: string;
-  /** Per-tenant forge knobs beyond the host (#4784), forwarded to the fan-out. */
-  forge?: Partial<ForgeConfig>;
-  nowMs?: number;
-  /** Per-tenant goal specs threaded to the ranker so lane fit uses the tenant's conventions, not the defaults (#4784). */
-  goalSpecsByRepo?: RankCandidateIssuesOptions["goalSpecsByRepo"];
-  goalSpecContentByRepo?: RankCandidateIssuesOptions["goalSpecContentByRepo"];
-  initPortfolioQueue?: () => PortfolioQueueStore;
-  initPolicyDocCache?: () => PolicyDocCacheStore;
-  initPolicyVerdictCache?: () => PolicyVerdictCacheStore;
-  initRankedCandidatesStore?: () => RankedCandidatesStore;
-  fetchCandidateIssuesWithSummary?: (
-    targets: FanoutTarget[],
-    githubToken: string,
-    options?: FanoutOptions,
-  ) => Promise<DiscoverFanOutSummary>;
-  searchCandidateIssuesWithSummary?: (
-    searchQuery: string,
-    githubToken: string,
-    options?: FanoutOptions,
-  ) => Promise<DiscoverFanOutSummary>;
-  rankCandidateIssuesWithSummary?: (
-    candidates: RawCandidateIssue[],
-    options?: RankCandidateIssuesOptions,
-  ) => RankedCandidateSummary;
-  enqueueRankedDiscovery?: (
-    rankedIssues: RankedCandidateIssue[],
-    options: { queueStore: PortfolioQueueStore },
-  ) => EnqueueRankedDiscoverySummary;
-  /** Supplements the local fan-out with hosted discovery-index results for the same scope, when the plane is
-   *  enabled (#7168). Defaults to discovery-index-client.js's own queryDiscoveryIndex. */
-  queryDiscoveryIndex?: typeof queryDiscoveryIndex;
-  /** Invoked with the real structured result at each success return point (dry-run and full-run), in addition
-   *  to (never instead of) the plain exit-code return -- mirrors `RunAttemptOptions.onResult`. Never fires on a
-   *  parse-error/unexpected-error `reportCliFailure` branch, matching runAttempt's own asymmetry (#6522). */
-  onResult?: (result: DiscoverResult) => void;
-  /** Resolve each candidate repo's ContributionProfile for eligibility filtering (#6798). Defaults to
-   *  resolveContributionProfilesForDiscover; injectable so tests avoid the network. */
-  resolveContributionProfiles?: (
-    repoFullNames: string[],
-    ctx: { githubToken?: string; apiBaseUrl?: string; nowMs?: number },
-  ) => Promise<Map<string, unknown>>;
+    /** Read for the discovery-index opt-in gate (#7168) -- defaults to `process.env`. */
+    env?: Record<string, string | undefined>;
+    githubToken?: string;
+    apiBaseUrl?: string;
+    /** Per-tenant credential env var name (#4784); defaults to GITHUB_TOKEN. Overridden by a `--token-env` flag. */
+    tokenEnv?: string;
+    /** Per-tenant forge knobs beyond the host (#4784), forwarded to the fan-out. */
+    forge?: Partial<ForgeConfig>;
+    nowMs?: number;
+    /** Per-tenant goal specs threaded to the ranker so lane fit uses the tenant's conventions, not the defaults (#4784). */
+    goalSpecsByRepo?: RankCandidateIssuesOptions["goalSpecsByRepo"];
+    goalSpecContentByRepo?: RankCandidateIssuesOptions["goalSpecContentByRepo"];
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initPolicyDocCache?: () => PolicyDocCacheStore;
+    initPolicyVerdictCache?: () => PolicyVerdictCacheStore;
+    initRankedCandidatesStore?: () => RankedCandidatesStore;
+    fetchCandidateIssuesWithSummary?: (targets: FanoutTarget[], githubToken: string, options?: FanoutOptions) => Promise<DiscoverFanOutSummary>;
+    searchCandidateIssuesWithSummary?: (searchQuery: string, githubToken: string, options?: FanoutOptions) => Promise<DiscoverFanOutSummary>;
+    rankCandidateIssuesWithSummary?: (candidates: RawCandidateIssue[], options?: RankCandidateIssuesOptions) => RankedCandidateSummary;
+    enqueueRankedDiscovery?: (rankedIssues: RankedCandidateIssue[], options: {
+        queueStore: PortfolioQueueStore;
+    }) => EnqueueRankedDiscoverySummary;
+    /** Supplements the local fan-out with hosted discovery-index results for the same scope, when the plane is
+     *  enabled (#7168). Defaults to discovery-index-client.js's own queryDiscoveryIndex. */
+    queryDiscoveryIndex?: typeof queryDiscoveryIndex;
+    /** Invoked with the real structured result at each success return point (dry-run and full-run), in addition
+     *  to (never instead of) the plain exit-code return -- mirrors `RunAttemptOptions.onResult`. Never fires on a
+     *  parse-error/unexpected-error `reportCliFailure` branch, matching runAttempt's own asymmetry (#6522). */
+    onResult?: (result: DiscoverResult) => void;
+    /** Resolve each candidate repo's ContributionProfile for eligibility filtering (#6798). Defaults to
+     *  resolveContributionProfilesForDiscover; injectable so tests avoid the network. */
+    resolveContributionProfiles?: (repoFullNames: string[], ctx: {
+        githubToken?: string;
+        apiBaseUrl?: string;
+        nowMs?: number;
+    }) => Promise<Map<string, unknown>>;
 };
-
-export function resolveContributionProfilesForDiscover(
-  repoFullNames: string[],
-  ctx?: {
+export declare function sanitizeDiscoverDisplayText(value: unknown): string;
+export declare function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs;
+export declare function renderDiscoverSummary(result: DiscoverResult): string;
+/**
+ * Default per-repo ContributionProfile resolver (#6798): reads the local cache and, on a miss/stale entry,
+ * extracts a fresh profile and caches it. Returns a Map keyed by repoFullName.
+ *
+ * WITHOUT a github token this returns an empty map and does no network work at all — AMS can't reliably read a
+ * repo's label taxonomy/docs unauthenticated (rate limits), so it safe-defaults to no eligibility filtering.
+ * That also keeps callers that don't supply a token (the common CLI path, and every test) hermetic.
+ */
+export declare function resolveContributionProfilesForDiscover(repoFullNames: string[], ctx?: {
     githubToken?: string;
     apiBaseUrl?: string;
     nowMs?: number;
     initCache?: unknown;
     extract?: unknown;
-  },
-): Promise<Map<string, unknown>>;
-
-export function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs;
-
-export function sanitizeDiscoverDisplayText(value: unknown): string;
-
-export function renderDiscoverSummary(result: DiscoverResult): string;
-
-export function runDiscover(
-  args: string[],
-  options?: RunDiscoverOptions,
-): Promise<number>;
+}): Promise<Map<string, unknown>>;
+export declare function runDiscover(args: string[], options?: RunDiscoverOptions): Promise<number>;

--- a/packages/loopover-miner/lib/discover-cli.js
+++ b/packages/loopover-miner/lib/discover-cli.js
@@ -1,10 +1,7 @@
 /** `discover` CLI command (#4247): wires the existing fanout -> rank -> enqueue pipeline together so a miner
  * can actually run it. Every piece already exists and is independently tested; this module only composes them. */
 import { resolveForgeConfig } from "./forge-config.js";
-import {
-  fetchCandidateIssuesWithSummary,
-  searchCandidateIssuesWithSummary,
-} from "./opportunity-fanout.js";
+import { fetchCandidateIssuesWithSummary, searchCandidateIssuesWithSummary, } from "./opportunity-fanout.js";
 import { rankCandidateIssuesWithSummary } from "./opportunity-ranker.js";
 import { initPolicyDocCacheStore } from "./policy-doc-cache.js";
 import { initPolicyVerdictCacheStore } from "./policy-verdict-cache.js";
@@ -16,31 +13,25 @@ import { initContributionProfileCache } from "./contribution-profile-cache.js";
 import { filterCandidatesByProfiles } from "./contribution-profile-filter.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { isDiscoveryPlaneEnabled, queryDiscoveryIndex, recordDiscoveryTelemetry } from "./discovery-index-client.js";
-
-const DISCOVER_USAGE =
-  "Usage: loopover-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--dry-run] [--json] [--api-base-url <url>] [--token-env <VAR>]";
-
+const DISCOVER_USAGE = "Usage: loopover-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--dry-run] [--json] [--api-base-url <url>] [--token-env <VAR>]";
 const MAX_DISCOVER_TITLE_DISPLAY_LENGTH = 240;
 const OSC_SEQUENCE_PATTERN = /\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g;
 const ANSI_ESCAPE_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|[@-_])/g;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/g;
 const BIDI_CONTROL_PATTERN = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
-
 export function sanitizeDiscoverDisplayText(value) {
-  return String(value ?? "")
-    .replace(OSC_SEQUENCE_PATTERN, "")
-    .replace(ANSI_ESCAPE_PATTERN, "")
-    .replace(CONTROL_CHARACTER_PATTERN, " ")
-    .replace(BIDI_CONTROL_PATTERN, "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, MAX_DISCOVER_TITLE_DISPLAY_LENGTH);
+    return String(value ?? "")
+        .replace(OSC_SEQUENCE_PATTERN, "")
+        .replace(ANSI_ESCAPE_PATTERN, "")
+        .replace(CONTROL_CHARACTER_PATTERN, " ")
+        .replace(BIDI_CONTROL_PATTERN, "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, MAX_DISCOVER_TITLE_DISPLAY_LENGTH);
 }
-
 function dedupeKey(repoFullName, issueNumber) {
-  return `${repoFullName.toLowerCase()}#${issueNumber}`;
+    return `${repoFullName.toLowerCase()}#${issueNumber}`;
 }
-
 /**
  * Supplements `fanOut.issues` with hosted discovery-index results for the same scope (#7168) -- a complete
  * no-op (returns `fanOut` unchanged) unless the plane is enabled, so a run with the flag unset behaves exactly
@@ -51,139 +42,142 @@ function dedupeKey(repoFullName, issueNumber) {
  * filter.js's assignee-exclusion rule treats that identically to "no assignees on this issue".
  */
 async function supplementWithDiscoveryIndex(fanOut, queryScope, options) {
-  const env = options.env ?? process.env;
-  if (!isDiscoveryPlaneEnabled(env)) return fanOut;
-  const queryIndex = options.queryDiscoveryIndex ?? queryDiscoveryIndex;
-  const response = await queryIndex(queryScope, { env });
-  recordDiscoveryTelemetry("discover_query", response.candidates.length > 0 ? "supplemented" : "empty", { env });
-  if (response.candidates.length === 0) return fanOut;
-
-  const seen = new Set(fanOut.issues.map((issue) => dedupeKey(issue.repoFullName, issue.issueNumber)));
-  const supplemented = response.candidates
-    .filter((candidate) => !seen.has(dedupeKey(candidate.repoFullName, candidate.issueNumber)))
-    .map((candidate) => ({ ...candidate, assignees: [] }));
-  if (supplemented.length === 0) return fanOut;
-  return { ...fanOut, issues: [...fanOut.issues, ...supplemented] };
+    const env = options.env ?? process.env;
+    if (!isDiscoveryPlaneEnabled(env))
+        return fanOut;
+    const queryIndex = options.queryDiscoveryIndex ?? queryDiscoveryIndex;
+    const response = await queryIndex(queryScope, { env });
+    recordDiscoveryTelemetry("discover_query", response.candidates.length > 0 ? "supplemented" : "empty", { env });
+    if (response.candidates.length === 0)
+        return fanOut;
+    const seen = new Set(fanOut.issues.map((issue) => dedupeKey(issue.repoFullName, issue.issueNumber)));
+    const supplemented = response.candidates
+        .filter((candidate) => !seen.has(dedupeKey(candidate.repoFullName, candidate.issueNumber)))
+        .map((candidate) => ({ ...candidate, assignees: [] }));
+    if (supplemented.length === 0)
+        return fanOut;
+    return { ...fanOut, issues: [...fanOut.issues, ...supplemented] };
 }
-
 function parseRepoTarget(value) {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  return { owner, repo };
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    return { owner, repo };
 }
-
 export function parseDiscoverArgs(args) {
-  // `--api-base-url` and `--token-env` (#4784) thread the tenant's forge host and credential env var into the
-  // fan-out; they are kept off the parsed result unless supplied, so callers that pass neither see the exact
-  // pre-#4784 `{ targets, search, json }` shape.
-  const options = { json: false, dryRun: false, search: null, apiBaseUrl: null, tokenEnv: null };
-  const targets = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    // `--api-base-url` and `--token-env` (#4784) thread the tenant's forge host and credential env var into the
+    // fan-out; they are kept off the parsed result unless supplied, so callers that pass neither see the exact
+    // pre-#4784 `{ targets, search, json }` shape.
+    const options = {
+        json: false,
+        dryRun: false,
+        search: null,
+        apiBaseUrl: null,
+        tokenEnv: null,
+    };
+    const targets = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: fetches + ranks exactly as a real run, but skips opening any local store and makes zero writes.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--search") {
+            const query = args[index + 1];
+            if (!query || query.startsWith("-"))
+                return { error: DISCOVER_USAGE };
+            options.search = query;
+            index += 1;
+            continue;
+        }
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: DISCOVER_USAGE };
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--token-env") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: DISCOVER_USAGE };
+            options.tokenEnv = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        const target = parseRepoTarget(token);
+        if (!target)
+            return { error: `Repository must be in owner/repo form: ${token}` };
+        targets.push(target);
     }
-    // #4847: fetches + ranks exactly as a real run, but skips opening any local store and makes zero writes.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
+    if (options.search === null && targets.length === 0) {
+        return { error: DISCOVER_USAGE };
     }
-    if (token === "--search") {
-      const query = args[index + 1];
-      if (!query || query.startsWith("-")) return { error: DISCOVER_USAGE };
-      options.search = query;
-      index += 1;
-      continue;
+    if (options.search !== null && targets.length > 0) {
+        return { error: "Pass either repository targets or --search, not both." };
     }
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--token-env") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
-      options.tokenEnv = value;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    const target = parseRepoTarget(token);
-    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
-    targets.push(target);
-  }
-
-  if (options.search === null && targets.length === 0) {
-    return { error: DISCOVER_USAGE };
-  }
-  if (options.search !== null && targets.length > 0) {
-    return { error: "Pass either repository targets or --search, not both." };
-  }
-
-  return {
-    targets,
-    search: options.search,
-    dryRun: options.dryRun,
-    json: options.json,
-    ...(options.apiBaseUrl !== null ? { apiBaseUrl: options.apiBaseUrl } : {}),
-    ...(options.tokenEnv !== null ? { tokenEnv: options.tokenEnv } : {}),
-  };
+    return {
+        targets,
+        search: options.search,
+        dryRun: options.dryRun,
+        json: options.json,
+        ...(options.apiBaseUrl !== null ? { apiBaseUrl: options.apiBaseUrl } : {}),
+        ...(options.tokenEnv !== null ? { tokenEnv: options.tokenEnv } : {}),
+    };
 }
-
 // The rate-limit line surfaces the telemetry the fanout already records (#4837) so an operator sees how close a
 // `discover` run is to being throttled without running a separate command. `unknown` covers the no-fetch/no-header
 // case where the fanout captured no remaining count.
 function renderRateLimitLine(result) {
-  const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
-  const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
-  return `rate-limit remaining: ${remaining}${resetSuffix}`;
+    const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
+    const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
+    return `rate-limit remaining: ${remaining}${resetSuffix}`;
 }
-
 export function renderDiscoverSummary(result) {
-  const lines = [
-    `fanned out: ${result.fanOutCount} candidate issue(s)`,
-    `ai-policy warnings: ${result.warnings.length}`,
-    `ranked: ${result.ranked.length}`,
-    `enqueued: ${result.enqueueSummary.enqueued}`,
-    renderRateLimitLine(result),
-  ];
-  if (result.enqueueSummary.skippedBelowMinRank > 0) {
-    lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
-  }
-  // #6798: surface what the eligibility filter dropped and why, so a human sees AMS's inference.
-  const excluded = result.excluded ?? [];
-  if (excluded.length > 0) {
-    lines.push(`excluded (eligibility): ${excluded.length}`);
-    for (const entry of excluded.slice(0, 10)) {
-      lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  ${entry.reason}`);
+    const lines = [
+        `fanned out: ${result.fanOutCount} candidate issue(s)`,
+        `ai-policy warnings: ${result.warnings.length}`,
+        `ranked: ${result.ranked.length}`,
+        `enqueued: ${result.enqueueSummary.enqueued}`,
+        renderRateLimitLine(result),
+    ];
+    if (result.enqueueSummary.skippedBelowMinRank > 0) {
+        lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
     }
-  }
-  // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
-  // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
-  if (result.usedDefaultGoalSpec) {
-    lines.push(
-      "note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)",
-    );
-  }
-  if (result.ranked.length === 0) {
-    lines.push("", "no candidates found.");
+    // #6798: surface what the eligibility filter dropped and why, so a human sees AMS's inference.
+    const excluded = result.excluded ?? [];
+    if (excluded.length > 0) {
+        lines.push(`excluded (eligibility): ${excluded.length}`);
+        for (const entry of excluded.slice(0, 10)) {
+            lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  ${entry.reason}`);
+        }
+    }
+    // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
+    // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
+    if (result.usedDefaultGoalSpec) {
+        lines.push("note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)");
+    }
+    if (result.ranked.length === 0) {
+        lines.push("", "no candidates found.");
+        return lines.join("\n");
+    }
+    lines.push("", "top candidates:");
+    for (const entry of result.ranked.slice(0, 10)) {
+        const title = sanitizeDiscoverDisplayText(entry.title);
+        lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${title}`);
+    }
     return lines.join("\n");
-  }
-  lines.push("", "top candidates:");
-  for (const entry of result.ranked.slice(0, 10)) {
-    const title = sanitizeDiscoverDisplayText(entry.title);
-    lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${title}`);
-  }
-  return lines.join("\n");
 }
-
 /**
  * Default per-repo ContributionProfile resolver (#6798): reads the local cache and, on a miss/stale entry,
  * extracts a fresh profile and caches it. Returns a Map keyed by repoFullName.
@@ -191,239 +185,244 @@ export function renderDiscoverSummary(result) {
  * WITHOUT a github token this returns an empty map and does no network work at all — AMS can't reliably read a
  * repo's label taxonomy/docs unauthenticated (rate limits), so it safe-defaults to no eligibility filtering.
  * That also keeps callers that don't supply a token (the common CLI path, and every test) hermetic.
- *
- * @param {string[]} repoFullNames unique repos among the fanned-out candidates
- * @param {{ githubToken?: string, apiBaseUrl?: string, nowMs?: number, initCache?: typeof initContributionProfileCache, extract?: typeof extractContributionProfile }} ctx
- * @returns {Promise<Map<string, object>>}
  */
 export async function resolveContributionProfilesForDiscover(repoFullNames, ctx = {}) {
-  const profiles = new Map();
-  if (!ctx.githubToken) return profiles;
-  const initCache = ctx.initCache ?? initContributionProfileCache;
-  const extract = ctx.extract ?? extractContributionProfile;
-  const cache = initCache();
-  try {
-    for (const repoFullName of repoFullNames) {
-      const cached = cache.get(repoFullName, ctx.nowMs);
-      if (cached && !cached.stale) {
-        profiles.set(repoFullName, cached.profile);
-        continue;
-      }
-      const profile = await extract(repoFullName, { githubToken: ctx.githubToken, apiBaseUrl: ctx.apiBaseUrl });
-      cache.put(profile, ctx.nowMs);
-      profiles.set(repoFullName, profile);
+    const profiles = new Map();
+    if (!ctx.githubToken)
+        return profiles;
+    const initCache = (ctx.initCache ?? initContributionProfileCache);
+    const extract = (ctx.extract ?? extractContributionProfile);
+    const cache = initCache();
+    try {
+        for (const repoFullName of repoFullNames) {
+            const cached = cache.get(repoFullName, ctx.nowMs);
+            if (cached && !cached.stale) {
+                profiles.set(repoFullName, cached.profile);
+                continue;
+            }
+            const profile = await extract(repoFullName, {
+                githubToken: ctx.githubToken,
+                apiBaseUrl: ctx.apiBaseUrl,
+            });
+            cache.put(profile, ctx.nowMs);
+            profiles.set(repoFullName, profile);
+        }
     }
-  } finally {
-    cache.close();
-  }
-  return profiles;
+    finally {
+        cache.close();
+    }
+    return profiles;
 }
-
 export async function runDiscover(args, options = {}) {
-  const parsed = parseDiscoverArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
-  // non-`GITHUB_TOKEN` variable so a non-github.com forge's token is reachable. The default falls through to the
-  // forge adapter's own `tokenEnvVar` (github.com's `GITHUB_TOKEN`), so there's a single source of truth for the
-  // default credential env instead of a second hardcoded literal that could drift from `DEFAULT_FORGE_CONFIG`.
-  const tokenEnv = parsed.tokenEnv ?? options.tokenEnv ?? resolveForgeConfig(options.forge).tokenEnvVar;
-  const githubToken = options.githubToken ?? process.env[tokenEnv] ?? "";
-  // A `--api-base-url` flag (or `options.apiBaseUrl`) surfaces the fan-out's existing forge-host override at the CLI
-  // (#4784); `options.forge` carries any remaining per-tenant forge knobs for a programmatic caller.
-  const apiBaseUrl = parsed.apiBaseUrl ?? options.apiBaseUrl;
-  const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
-  const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
-  const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
-  const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
-  // Eligibility filtering (#6798): resolve each candidate repo's ContributionProfile and drop candidates the
-  // repo's own conventions would reject, BEFORE ranking. Safe by default -- see resolveContributionProfilesForDiscover.
-  const resolveProfiles = options.resolveContributionProfiles ?? resolveContributionProfilesForDiscover;
-  // Same scope this run already asks GitHub about (#7168) -- the discovery-index supplement, when enabled,
-  // asks the shared hosted index about the identical targets/search rather than a different query entirely.
-  const discoveryQueryScope =
-    parsed.search !== null
-      ? { repos: [], orgs: [], searchTerms: [parsed.search] }
-      : { repos: parsed.targets.map((target) => `${target.owner}/${target.repo}`), orgs: [], searchTerms: [] };
-
-  // #4847: fetch + rank are read-only GitHub GETs and pure local computation, so a dry run still does them for
-  // real (that's the useful "what would this discover?" output) -- but it never opens any local store (portfolio
-  // queue, policy-doc cache, policy-verdict cache), since opening a not-yet-existing SQLite store file is itself
-  // a write. The ranked issues are fed through a no-op queue stub so enqueueRankedDiscovery's own classification
-  // logic (valid/invalid, below-min-rank) still runs for real, just without ever touching the real queue.
-  if (parsed.dryRun) {
-    const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache: null, policyVerdictCache: null };
+    const parsed = parseDiscoverArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
+    // non-`GITHUB_TOKEN` variable so a non-github.com forge's token is reachable. The default falls through to the
+    // forge adapter's own `tokenEnvVar` (github.com's `GITHUB_TOKEN`), so there's a single source of truth for the
+    // default credential env instead of a second hardcoded literal that could drift from `DEFAULT_FORGE_CONFIG`.
+    const tokenEnv = parsed.tokenEnv ?? options.tokenEnv ?? resolveForgeConfig(options.forge).tokenEnvVar;
+    const githubToken = options.githubToken ?? process.env[tokenEnv] ?? "";
+    // A `--api-base-url` flag (or `options.apiBaseUrl`) surfaces the fan-out's existing forge-host override at the CLI
+    // (#4784); `options.forge` carries any remaining per-tenant forge knobs for a programmatic caller.
+    const apiBaseUrl = parsed.apiBaseUrl ?? options.apiBaseUrl;
+    const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
+    const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
+    const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
+    const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
+    // Eligibility filtering (#6798): resolve each candidate repo's ContributionProfile and drop candidates the
+    // repo's own conventions would reject, BEFORE ranking. Safe by default -- see resolveContributionProfilesForDiscover.
+    const resolveProfiles = options.resolveContributionProfiles ?? resolveContributionProfilesForDiscover;
+    // Same scope this run already asks GitHub about (#7168) -- the discovery-index supplement, when enabled,
+    // asks the shared hosted index about the identical targets/search rather than a different query entirely.
+    const discoveryQueryScope = parsed.search !== null
+        ? { repos: [], orgs: [], searchTerms: [parsed.search] }
+        : { repos: parsed.targets.map((target) => `${target.owner}/${target.repo}`), orgs: [], searchTerms: [] };
+    // #4847: fetch + rank are read-only GitHub GETs and pure local computation, so a dry run still does them for
+    // real (that's the useful "what would this discover?" output) -- but it never opens any local store (portfolio
+    // queue, policy-doc cache, policy-verdict cache), since opening a not-yet-existing SQLite store file is itself
+    // a write. The ranked issues are fed through a no-op queue stub so enqueueRankedDiscovery's own classification
+    // logic (valid/invalid, below-min-rank) still runs for real, just without ever touching the real queue.
+    if (parsed.dryRun) {
+        const fanOutOptions = {
+            apiBaseUrl,
+            forge: options.forge,
+            policyDocCache: null,
+            policyVerdictCache: null,
+        };
+        try {
+            let fanOut = parsed.search !== null
+                ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+                : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+            fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+            // #6798: same eligibility filter as the real path, so a dry run shows the exact candidate set a real run
+            // would enqueue (and the same excluded set), rather than an unfiltered preview.
+            const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+            const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
+            const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
+            const rankedSummary = rankIssues(kept, {
+                nowMs: options.nowMs,
+                goalSpecsByRepo: options.goalSpecsByRepo,
+                goalSpecContentByRepo: options.goalSpecContentByRepo,
+            });
+            const noopQueueStore = { enqueue: () => { } };
+            const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: noopQueueStore });
+            const result = {
+                outcome: "dry_run",
+                fanOutCount: fanOut.issues.length,
+                warnings: fanOut.warnings,
+                rateLimitRemaining: fanOut.rateLimitRemaining,
+                rateLimitResetAt: fanOut.rateLimitResetAt,
+                ranked: rankedSummary.issues,
+                excluded: excluded.map((entry) => ({
+                    repoFullName: entry.candidate.repoFullName,
+                    issueNumber: entry.candidate.issueNumber,
+                    reason: entry.reason,
+                })),
+                usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+                enqueueSummary,
+            };
+            // Structured-outcome hook (#6522), mirroring runAttempt's onResult convention: fires only at a real
+            // structured success point (never the reportCliFailure branches), in addition to -- never instead of --
+            // the plain exit-code return, so a non-CLI caller (the /api/discover route) can read the result.
+            options.onResult?.(result);
+            if (parsed.json) {
+                console.log(JSON.stringify(result, null, 2));
+            }
+            else {
+                console.log(renderDiscoverSummary(result));
+                console.log("\nDRY RUN: no portfolio-queue write was made.");
+            }
+            return 0;
+        }
+        catch (error) {
+            return reportCliFailure(parsed.json, describeCliError(error));
+        }
+    }
+    const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+    let portfolioQueue;
     try {
-      let fanOut =
-        parsed.search !== null
-          ? await searchTargets(parsed.search, githubToken, fanOutOptions)
-          : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
-      fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
-      // #6798: same eligibility filter as the real path, so a dry run shows the exact candidate set a real run
-      // would enqueue (and the same excluded set), rather than an unfiltered preview.
-      const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
-      const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
-      const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
-      const rankedSummary = rankIssues(kept, {
-        nowMs: options.nowMs,
-        goalSpecsByRepo: options.goalSpecsByRepo,
-        goalSpecContentByRepo: options.goalSpecContentByRepo,
-      });
-      const noopQueueStore = { enqueue: () => {} };
-      const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: noopQueueStore });
-      const result = {
-        outcome: "dry_run",
-        fanOutCount: fanOut.issues.length,
-        warnings: fanOut.warnings,
-        rateLimitRemaining: fanOut.rateLimitRemaining,
-        rateLimitResetAt: fanOut.rateLimitResetAt,
-        ranked: rankedSummary.issues,
-        excluded: excluded.map((entry) => ({
-          repoFullName: entry.candidate.repoFullName,
-          issueNumber: entry.candidate.issueNumber,
-          reason: entry.reason,
-        })),
-        usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
-        enqueueSummary,
-      };
-      // Structured-outcome hook (#6522), mirroring runAttempt's onResult convention: fires only at a real
-      // structured success point (never the reportCliFailure branches), in addition to -- never instead of --
-      // the plain exit-code return, so a non-CLI caller (the /api/discover route) can read the result.
-      options.onResult?.(result);
-      if (parsed.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(renderDiscoverSummary(result));
-        console.log("\nDRY RUN: no portfolio-queue write was made.");
-      }
-      return 0;
-    } catch (error) {
-      return reportCliFailure(parsed.json, describeCliError(error));
+        portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
     }
-  }
-
-  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
-  let portfolioQueue;
-  try {
-    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
-
-  // Local ETag cache so a repeated discover revalidates each repo's policy docs with a conditional GET instead of
-  // re-downloading them (#4842). Opened inside its OWN try/catch, separate from the portfolio queue above: the
-  // queue is required infrastructure (discovery genuinely cannot enqueue anything without it, so a real open
-  // failure should abort the run), but the policy-doc cache is a pure performance optimization -- a corrupt or
-  // unwritable cache DB must degrade to "no cache" (every doc fetched in full, exactly as before #4842) rather
-  // than fail discovery outright.
-  let policyDocCache = null;
-  let ownsPolicyDocCache = false;
-  try {
-    ownsPolicyDocCache = options.initPolicyDocCache === undefined;
-    policyDocCache = (options.initPolicyDocCache ?? initPolicyDocCacheStore)();
-  } catch {
-    policyDocCache = null;
-    ownsPolicyDocCache = false;
-  }
-
-  // Persisted cache of resolved policy verdicts (#4843), same "own try/catch, degrade to null" discipline as the
-  // doc cache above and for the same reason: purely a performance optimization the feature is inert without, so a
-  // corrupt/unwritable cache DB must never abort a run.
-  let policyVerdictCache = null;
-  let ownsPolicyVerdictCache = false;
-  try {
-    ownsPolicyVerdictCache = options.initPolicyVerdictCache === undefined;
-    policyVerdictCache = (options.initPolicyVerdictCache ?? initPolicyVerdictCacheStore)();
-  } catch {
-    policyVerdictCache = null;
-    ownsPolicyVerdictCache = false;
-  }
-
-  // Snapshot of this run's full ranked output (#4859 prerequisite), so a local HTTP endpoint (and eventually the
-  // miner-ui/browser-extension live-fetch it's meant for) can serve the same per-issue breakdown `--json` prints,
-  // without the operator re-running discover or hand-pasting its output. Same "own try/catch, degrade to null"
-  // discipline as the two caches above: a corrupt/unwritable snapshot store must never abort discovery's actual
-  // job (fan out, rank, enqueue). Unlike the caches, this store is a WRITE target, not a read optimization -- the
-  // save call itself gets its own try/catch below for the same reason.
-  let rankedCandidatesStore = null;
-  let ownsRankedCandidatesStore = false;
-  try {
-    ownsRankedCandidatesStore = options.initRankedCandidatesStore === undefined;
-    rankedCandidatesStore = (options.initRankedCandidatesStore ?? initRankedCandidatesStore)();
-  } catch {
-    rankedCandidatesStore = null;
-    ownsRankedCandidatesStore = false;
-  }
-  const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache, policyVerdictCache };
-
-  try {
-    let fanOut =
-      parsed.search !== null
-        ? await searchTargets(parsed.search, githubToken, fanOutOptions)
-        : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
-    fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
-
-    // Eligibility filter (#6798): drop candidates a target repo's own conventions would reject, before ranking.
-    // A repo with no trustworthy eligibility profile keeps every candidate (filterCandidatesByProfiles' safe
-    // default), so this never silently skips real work on a repo whose conventions AMS couldn't read.
-    const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
-    const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
-    const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
-
-    // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
-    // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
-    // `usedDefaultGoalSpec` below rather than hidden.
-    const rankedSummary = rankIssues(kept, {
-      nowMs: options.nowMs,
-      goalSpecsByRepo: options.goalSpecsByRepo,
-      goalSpecContentByRepo: options.goalSpecContentByRepo,
-    });
-    const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue, apiBaseUrl });
-
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    // Local ETag cache so a repeated discover revalidates each repo's policy docs with a conditional GET instead of
+    // re-downloading them (#4842). Opened inside its OWN try/catch, separate from the portfolio queue above: the
+    // queue is required infrastructure (discovery genuinely cannot enqueue anything without it, so a real open
+    // failure should abort the run), but the policy-doc cache is a pure performance optimization -- a corrupt or
+    // unwritable cache DB must degrade to "no cache" (every doc fetched in full, exactly as before #4842) rather
+    // than fail discovery outright.
+    let policyDocCache = null;
+    let ownsPolicyDocCache = false;
     try {
-      // Optional chaining rather than an `if (rankedCandidatesStore)` guard: a null store (open failed above)
-      // short-circuits to a no-op read, so the same try/catch below also covers the open-failed case without a
-      // second explicit branch.
-      rankedCandidatesStore?.saveRankedCandidates(rankedSummary.issues, options.nowMs);
-    } catch {
-      // Non-fatal: the ranked-candidates snapshot is a nice-to-have for the local HTTP endpoint, not a
-      // requirement for discover's own job (fan out, rank, enqueue), which already succeeded above.
+        ownsPolicyDocCache = options.initPolicyDocCache === undefined;
+        policyDocCache = (options.initPolicyDocCache ?? initPolicyDocCacheStore)();
     }
-
-    const result = {
-      fanOutCount: fanOut.issues.length,
-      warnings: fanOut.warnings,
-      rateLimitRemaining: fanOut.rateLimitRemaining,
-      rateLimitResetAt: fanOut.rateLimitResetAt,
-      ranked: rankedSummary.issues,
-      // #6798: candidates the eligibility filter dropped, each with the repo + issue + reason, so a human sees
-      // what AMS inferred and why a candidate was skipped. Empty when no profile was trustworthy enough to filter.
-      excluded: excluded.map((entry) => ({
-        repoFullName: entry.candidate.repoFullName,
-        issueNumber: entry.candidate.issueNumber,
-        reason: entry.reason,
-      })),
-      usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
-      enqueueSummary,
-    };
-
-    // Structured-outcome hook (#6522) for the full-run success point -- same convention as the dry-run branch
-    // above and as runAttempt's onResult: real result only, additive to the unchanged exit-code return.
-    options.onResult?.(result);
-    if (parsed.json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      console.log(renderDiscoverSummary(result));
+    catch {
+        policyDocCache = null;
+        ownsPolicyDocCache = false;
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsPortfolioQueue && portfolioQueue) portfolioQueue.close();
-    if (ownsPolicyDocCache && policyDocCache) policyDocCache.close();
-    if (ownsPolicyVerdictCache && policyVerdictCache) policyVerdictCache.close();
-    if (ownsRankedCandidatesStore && rankedCandidatesStore) rankedCandidatesStore.close();
-  }
+    // Persisted cache of resolved policy verdicts (#4843), same "own try/catch, degrade to null" discipline as the
+    // doc cache above and for the same reason: purely a performance optimization the feature is inert without, so a
+    // corrupt/unwritable cache DB must never abort a run.
+    let policyVerdictCache = null;
+    let ownsPolicyVerdictCache = false;
+    try {
+        ownsPolicyVerdictCache = options.initPolicyVerdictCache === undefined;
+        policyVerdictCache = (options.initPolicyVerdictCache ?? initPolicyVerdictCacheStore)();
+    }
+    catch {
+        policyVerdictCache = null;
+        ownsPolicyVerdictCache = false;
+    }
+    // Snapshot of this run's full ranked output (#4859 prerequisite), so a local HTTP endpoint (and eventually the
+    // miner-ui/browser-extension live-fetch it's meant for) can serve the same per-issue breakdown `--json` prints,
+    // without the operator re-running discover or hand-pasting its output. Same "own try/catch, degrade to null"
+    // discipline as the two caches above: a corrupt/unwritable snapshot store must never abort discovery's actual
+    // job (fan out, rank, enqueue). Unlike the caches, this store is a WRITE target, not a read optimization -- the
+    // save call itself gets its own try/catch below for the same reason.
+    let rankedCandidatesStore = null;
+    let ownsRankedCandidatesStore = false;
+    try {
+        ownsRankedCandidatesStore = options.initRankedCandidatesStore === undefined;
+        rankedCandidatesStore = (options.initRankedCandidatesStore ?? initRankedCandidatesStore)();
+    }
+    catch {
+        rankedCandidatesStore = null;
+        ownsRankedCandidatesStore = false;
+    }
+    const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache, policyVerdictCache };
+    try {
+        let fanOut = parsed.search !== null
+            ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+            : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+        fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+        // Eligibility filter (#6798): drop candidates a target repo's own conventions would reject, before ranking.
+        // A repo with no trustworthy eligibility profile keeps every candidate (filterCandidatesByProfiles' safe
+        // default), so this never silently skips real work on a repo whose conventions AMS couldn't read.
+        const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+        const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs });
+        const { kept, excluded } = filterCandidatesByProfiles(fanOut.issues, profilesByRepo);
+        // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
+        // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
+        // `usedDefaultGoalSpec` below rather than hidden.
+        const rankedSummary = rankIssues(kept, {
+            nowMs: options.nowMs,
+            goalSpecsByRepo: options.goalSpecsByRepo,
+            goalSpecContentByRepo: options.goalSpecContentByRepo,
+        });
+        const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue, apiBaseUrl });
+        try {
+            // Optional chaining rather than an `if (rankedCandidatesStore)` guard: a null store (open failed above)
+            // short-circuits to a no-op read, so the same try/catch below also covers the open-failed case without a
+            // second explicit branch.
+            rankedCandidatesStore?.saveRankedCandidates(rankedSummary.issues, options.nowMs);
+        }
+        catch {
+            // Non-fatal: the ranked-candidates snapshot is a nice-to-have for the local HTTP endpoint, not a
+            // requirement for discover's own job (fan out, rank, enqueue), which already succeeded above.
+        }
+        const result = {
+            fanOutCount: fanOut.issues.length,
+            warnings: fanOut.warnings,
+            rateLimitRemaining: fanOut.rateLimitRemaining,
+            rateLimitResetAt: fanOut.rateLimitResetAt,
+            ranked: rankedSummary.issues,
+            // #6798: candidates the eligibility filter dropped, each with the repo + issue + reason, so a human sees
+            // what AMS inferred and why a candidate was skipped. Empty when no profile was trustworthy enough to filter.
+            excluded: excluded.map((entry) => ({
+                repoFullName: entry.candidate.repoFullName,
+                issueNumber: entry.candidate.issueNumber,
+                reason: entry.reason,
+            })),
+            usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+            enqueueSummary,
+        };
+        // Structured-outcome hook (#6522) for the full-run success point -- same convention as the dry-run branch
+        // above and as runAttempt's onResult: real result only, additive to the unchanged exit-code return.
+        options.onResult?.(result);
+        if (parsed.json) {
+            console.log(JSON.stringify(result, null, 2));
+        }
+        else {
+            console.log(renderDiscoverSummary(result));
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    finally {
+        if (ownsPortfolioQueue && portfolioQueue)
+            portfolioQueue.close();
+        if (ownsPolicyDocCache && policyDocCache)
+            policyDocCache.close();
+        if (ownsPolicyVerdictCache && policyVerdictCache)
+            policyVerdictCache.close();
+        if (ownsRankedCandidatesStore && rankedCandidatesStore)
+            rankedCandidatesStore.close();
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGlzY292ZXItY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZGlzY292ZXItY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO2tIQUNrSDtBQUNsSCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxtQkFBbUIsQ0FBQztBQUN2RCxPQUFPLEVBQ0wsK0JBQStCLEVBQy9CLGdDQUFnQyxHQUNqQyxNQUFNLHlCQUF5QixDQUFDO0FBQ2pDLE9BQU8sRUFBRSw4QkFBOEIsRUFBRSxNQUFNLHlCQUF5QixDQUFDO0FBQ3pFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLHVCQUF1QixDQUFDO0FBQ2hFLE9BQU8sRUFBRSwyQkFBMkIsRUFBRSxNQUFNLDJCQUEyQixDQUFDO0FBQ3hFLE9BQU8sRUFBRSxzQkFBc0IsRUFBRSxNQUFNLDBCQUEwQixDQUFDO0FBQ2xFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBQy9ELE9BQU8sRUFBRSx5QkFBeUIsRUFBRSxNQUFNLHdCQUF3QixDQUFDO0FBQ25FLE9BQU8sRUFBRSwwQkFBMEIsRUFBRSxNQUFNLG1DQUFtQyxDQUFDO0FBQy9FLE9BQU8sRUFBRSw0QkFBNEIsRUFBRSxNQUFNLGlDQUFpQyxDQUFDO0FBQy9FLE9BQU8sRUFBRSwwQkFBMEIsRUFBRSxNQUFNLGtDQUFrQyxDQUFDO0FBQzlFLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsdUJBQXVCLEVBQUUsbUJBQW1CLEVBQUUsd0JBQXdCLEVBQUUsTUFBTSw2QkFBNkIsQ0FBQztBQW1IckgsTUFBTSxjQUFjLEdBQ2xCLGtKQUFrSixDQUFDO0FBRXJKLE1BQU0saUNBQWlDLEdBQUcsR0FBRyxDQUFDO0FBQzlDLE1BQU0sb0JBQW9CLEdBQUcsc0NBQXNDLENBQUM7QUFDcEUsTUFBTSxtQkFBbUIsR0FBRyxzQ0FBc0MsQ0FBQztBQUNuRSxNQUFNLHlCQUF5QixHQUFHLCtCQUErQixDQUFDO0FBQ2xFLE1BQU0sb0JBQW9CLEdBQUcsMkNBQTJDLENBQUM7QUFFekUsTUFBTSxVQUFVLDJCQUEyQixDQUFDLEtBQWM7SUFDeEQsT0FBTyxNQUFNLENBQUMsS0FBSyxJQUFJLEVBQUUsQ0FBQztTQUN2QixPQUFPLENBQUMsb0JBQW9CLEVBQUUsRUFBRSxDQUFDO1NBQ2pDLE9BQU8sQ0FBQyxtQkFBbUIsRUFBRSxFQUFFLENBQUM7U0FDaEMsT0FBTyxDQUFDLHlCQUF5QixFQUFFLEdBQUcsQ0FBQztTQUN2QyxPQUFPLENBQUMsb0JBQW9CLEVBQUUsRUFBRSxDQUFDO1NBQ2pDLE9BQU8sQ0FBQyxNQUFNLEVBQUUsR0FBRyxDQUFDO1NBQ3BCLElBQUksRUFBRTtTQUNOLEtBQUssQ0FBQyxDQUFDLEVBQUUsaUNBQWlDLENBQUMsQ0FBQztBQUNqRCxDQUFDO0FBRUQsU0FBUyxTQUFTLENBQUMsWUFBb0IsRUFBRSxXQUFtQjtJQUMxRCxPQUFPLEdBQUcsWUFBWSxDQUFDLFdBQVcsRUFBRSxJQUFJLFdBQVcsRUFBRSxDQUFDO0FBQ3hELENBQUM7QUFFRDs7Ozs7Ozs7R0FRRztBQUNILEtBQUssVUFBVSw0QkFBNEIsQ0FDekMsTUFBNkIsRUFDN0IsVUFBcUQsRUFDckQsT0FBMkI7SUFFM0IsTUFBTSxHQUFHLEdBQUcsT0FBTyxDQUFDLEdBQUcsSUFBSSxPQUFPLENBQUMsR0FBRyxDQUFDO0lBQ3ZDLElBQUksQ0FBQyx1QkFBdUIsQ0FBQyxHQUFHLENBQUM7UUFBRSxPQUFPLE1BQU0sQ0FBQztJQUNqRCxNQUFNLFVBQVUsR0FBRyxPQUFPLENBQUMsbUJBQW1CLElBQUksbUJBQW1CLENBQUM7SUFDdEUsTUFBTSxRQUFRLEdBQUcsTUFBTSxVQUFVLENBQUMsVUFBVSxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztJQUN2RCx3QkFBd0IsQ0FBQyxnQkFBZ0IsRUFBRSxRQUFRLENBQUMsVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLGNBQWMsQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztJQUMvRyxJQUFJLFFBQVEsQ0FBQyxVQUFVLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLE1BQU0sQ0FBQztJQUVwRCxNQUFNLElBQUksR0FBRyxJQUFJLEdBQUcsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNyRyxNQUFNLFlBQVksR0FBRyxRQUFRLENBQUMsVUFBVTtTQUNyQyxNQUFNLENBQUMsQ0FBQyxTQUFTLEVBQUUsRUFBRSxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxTQUFTLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxTQUFTLENBQUMsV0FBVyxDQUFDLENBQUMsQ0FBQztTQUMxRixHQUFHLENBQUMsQ0FBQyxTQUFTLEVBQUUsRUFBRSxDQUFDLENBQUMsRUFBRSxHQUFHLFNBQVMsRUFBRSxTQUFTLEVBQUUsRUFBRSxFQUFFLENBQWlDLENBQUMsQ0FBQztJQUN6RixJQUFJLFlBQVksQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sTUFBTSxDQUFDO0lBQzdDLE9BQU8sRUFBRSxHQUFHLE1BQU0sRUFBRSxNQUFNLEVBQUUsQ0FBQyxHQUFHLE1BQU0sQ0FBQyxNQUFNLEVBQUUsR0FBRyxZQUFZLENBQUMsRUFBRSxDQUFDO0FBQ3BFLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxLQUFhO0lBQ3BDLE1BQU0sT0FBTyxHQUFHLE9BQU8sS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDOUQsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDeEQsT0FBTyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsQ0FBQztBQUN6QixDQUFDO0FBRUQsTUFBTSxVQUFVLGlCQUFpQixDQUFDLElBQWM7SUFDOUMsNEdBQTRHO0lBQzVHLDJHQUEyRztJQUMzRywrQ0FBK0M7SUFDL0MsTUFBTSxPQUFPLEdBQUc7UUFDZCxJQUFJLEVBQUUsS0FBSztRQUNYLE1BQU0sRUFBRSxLQUFLO1FBQ2IsTUFBTSxFQUFFLElBQXFCO1FBQzdCLFVBQVUsRUFBRSxJQUFxQjtRQUNqQyxRQUFRLEVBQUUsSUFBcUI7S0FDaEMsQ0FBQztJQUNGLE1BQU0sT0FBTyxHQUFtQixFQUFFLENBQUM7SUFFbkMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELHlHQUF5RztRQUN6RyxJQUFJLEtBQUssS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUMxQixPQUFPLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQztZQUN0QixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFVBQVUsRUFBRSxDQUFDO1lBQ3pCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLEtBQUssSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztnQkFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGNBQWMsRUFBRSxDQUFDO1lBQ3RFLE9BQU8sQ0FBQyxNQUFNLEdBQUcsS0FBSyxDQUFDO1lBQ3ZCLEtBQUssSUFBSSxDQUFDLENBQUM7WUFDWCxTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLGdCQUFnQixFQUFFLENBQUM7WUFDL0IsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsY0FBYyxFQUFFLENBQUM7WUFDdEUsT0FBTyxDQUFDLFVBQVUsR0FBRyxLQUFLLENBQUM7WUFDM0IsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssYUFBYSxFQUFFLENBQUM7WUFDNUIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsY0FBYyxFQUFFLENBQUM7WUFDdEUsT0FBTyxDQUFDLFFBQVEsR0FBRyxLQUFLLENBQUM7WUFDekIsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7WUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUMvQyxDQUFDO1FBQ0QsTUFBTSxNQUFNLEdBQUcsZUFBZSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQ3RDLElBQUksQ0FBQyxNQUFNO1lBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSwwQ0FBMEMsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUNqRixPQUFPLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ3ZCLENBQUM7SUFFRCxJQUFJLE9BQU8sQ0FBQyxNQUFNLEtBQUssSUFBSSxJQUFJLE9BQU8sQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDcEQsT0FBTyxFQUFFLEtBQUssRUFBRSxjQUFjLEVBQUUsQ0FBQztJQUNuQyxDQUFDO0lBQ0QsSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLElBQUksSUFBSSxPQUFPLENBQUMsTUFBTSxHQUFHLENBQUMsRUFBRSxDQUFDO1FBQ2xELE9BQU8sRUFBRSxLQUFLLEVBQUUsdURBQXVELEVBQUUsQ0FBQztJQUM1RSxDQUFDO0lBRUQsT0FBTztRQUNMLE9BQU87UUFDUCxNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU07UUFDdEIsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNO1FBQ3RCLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtRQUNsQixHQUFHLENBQUMsT0FBTyxDQUFDLFVBQVUsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQzFFLEdBQUcsQ0FBQyxPQUFPLENBQUMsUUFBUSxLQUFLLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBRSxRQUFRLEVBQUUsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7S0FDckUsQ0FBQztBQUNKLENBQUM7QUFFRCxnSEFBZ0g7QUFDaEgsbUhBQW1IO0FBQ25ILHFEQUFxRDtBQUNyRCxTQUFTLG1CQUFtQixDQUFDLE1BQXNCO0lBQ2pELE1BQU0sU0FBUyxHQUFHLE1BQU0sQ0FBQyxrQkFBa0IsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO0lBQ3JHLE1BQU0sV0FBVyxHQUFHLE1BQU0sQ0FBQyxnQkFBZ0IsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsWUFBWSxNQUFNLENBQUMsZ0JBQWdCLEdBQUcsQ0FBQztJQUNuRyxPQUFPLHlCQUF5QixTQUFTLEdBQUcsV0FBVyxFQUFFLENBQUM7QUFDNUQsQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxNQUFzQjtJQUMxRCxNQUFNLEtBQUssR0FBRztRQUNaLGVBQWUsTUFBTSxDQUFDLFdBQVcscUJBQXFCO1FBQ3RELHVCQUF1QixNQUFNLENBQUMsUUFBUSxDQUFDLE1BQU0sRUFBRTtRQUMvQyxXQUFXLE1BQU0sQ0FBQyxNQUFNLENBQUMsTUFBTSxFQUFFO1FBQ2pDLGFBQWEsTUFBTSxDQUFDLGNBQWMsQ0FBQyxRQUFRLEVBQUU7UUFDN0MsbUJBQW1CLENBQUMsTUFBTSxDQUFDO0tBQzVCLENBQUM7SUFDRixJQUFJLE1BQU0sQ0FBQyxjQUFjLENBQUMsbUJBQW1CLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDbEQsS0FBSyxDQUFDLElBQUksQ0FBQyw2QkFBNkIsTUFBTSxDQUFDLGNBQWMsQ0FBQyxtQkFBbUIsRUFBRSxDQUFDLENBQUM7SUFDdkYsQ0FBQztJQUNELCtGQUErRjtJQUMvRixNQUFNLFFBQVEsR0FBRyxNQUFNLENBQUMsUUFBUSxJQUFJLEVBQUUsQ0FBQztJQUN2QyxJQUFJLFFBQVEsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDeEIsS0FBSyxDQUFDLElBQUksQ0FBQywyQkFBMkIsUUFBUSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7UUFDekQsS0FBSyxNQUFNLEtBQUssSUFBSSxRQUFRLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUMsRUFBRSxDQUFDO1lBQzFDLEtBQUssQ0FBQyxJQUFJLENBQUMsS0FBSyxLQUFLLENBQUMsWUFBWSxJQUFJLEtBQUssQ0FBQyxXQUFXLEtBQUssS0FBSyxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7UUFDOUUsQ0FBQztJQUNILENBQUM7SUFDRCwrR0FBK0c7SUFDL0csa0dBQWtHO0lBQ2xHLElBQUksTUFBTSxDQUFDLG1CQUFtQixFQUFFLENBQUM7UUFDL0IsS0FBSyxDQUFDLElBQUksQ0FDUiwrRkFBK0YsQ0FDaEcsQ0FBQztJQUNKLENBQUM7SUFDRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLENBQUMsTUFBTSxLQUFLLENBQUMsRUFBRSxDQUFDO1FBQy9CLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRSxFQUFFLHNCQUFzQixDQUFDLENBQUM7UUFDdkMsT0FBTyxLQUFLLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQzFCLENBQUM7SUFDRCxLQUFLLENBQUMsSUFBSSxDQUFDLEVBQUUsRUFBRSxpQkFBaUIsQ0FBQyxDQUFDO0lBQ2xDLEtBQUssTUFBTSxLQUFLLElBQUksTUFBTSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxFQUFFLENBQUM7UUFDL0MsTUFBTSxLQUFLLEdBQUcsMkJBQTJCLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQ3ZELEtBQUssQ0FBQyxJQUFJLENBQUMsS0FBSyxLQUFLLENBQUMsWUFBWSxJQUFJLEtBQUssQ0FBQyxXQUFXLFdBQVcsS0FBSyxDQUFDLFNBQVMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLEtBQUssS0FBSyxFQUFFLENBQUMsQ0FBQztJQUM1RyxDQUFDO0lBQ0QsT0FBTyxLQUFLLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQzFCLENBQUM7QUFFRDs7Ozs7OztHQU9HO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSxzQ0FBc0MsQ0FDMUQsYUFBdUIsRUFDdkIsTUFNSSxFQUFFO0lBRU4sTUFBTSxRQUFRLEdBQUcsSUFBSSxHQUFHLEVBQW1CLENBQUM7SUFDNUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxXQUFXO1FBQUUsT0FBTyxRQUFRLENBQUM7SUFDdEMsTUFBTSxTQUFTLEdBQUcsQ0FBQyxHQUFHLENBQUMsU0FBUyxJQUFJLDRCQUE0QixDQUF3QyxDQUFDO0lBQ3pHLE1BQU0sT0FBTyxHQUFHLENBQUMsR0FBRyxDQUFDLE9BQU8sSUFBSSwwQkFBMEIsQ0FBc0MsQ0FBQztJQUNqRyxNQUFNLEtBQUssR0FBRyxTQUFTLEVBQUUsQ0FBQztJQUMxQixJQUFJLENBQUM7UUFDSCxLQUFLLE1BQU0sWUFBWSxJQUFJLGFBQWEsRUFBRSxDQUFDO1lBQ3pDLE1BQU0sTUFBTSxHQUFHLEtBQUssQ0FBQyxHQUFHLENBQUMsWUFBWSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUNsRCxJQUFJLE1BQU0sSUFBSSxDQUFDLE1BQU0sQ0FBQyxLQUFLLEVBQUUsQ0FBQztnQkFDNUIsUUFBUSxDQUFDLEdBQUcsQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDO2dCQUMzQyxTQUFTO1lBQ1gsQ0FBQztZQUNELE1BQU0sT0FBTyxHQUFHLE1BQU0sT0FBTyxDQUFDLFlBQVksRUFBRTtnQkFDMUMsV0FBVyxFQUFFLEdBQUcsQ0FBQyxXQUFXO2dCQUM1QixVQUFVLEVBQUUsR0FBRyxDQUFDLFVBQVU7YUFDc0IsQ0FBQyxDQUFDO1lBQ3BELEtBQUssQ0FBQyxHQUFHLENBQUMsT0FBTyxFQUFFLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUM5QixRQUFRLENBQUMsR0FBRyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsQ0FBQztRQUN0QyxDQUFDO0lBQ0gsQ0FBQztZQUFTLENBQUM7UUFDVCxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUM7SUFDaEIsQ0FBQztJQUNELE9BQU8sUUFBUSxDQUFDO0FBQ2xCLENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLFdBQVcsQ0FBQyxJQUFjLEVBQUUsVUFBOEIsRUFBRTtJQUNoRixNQUFNLE1BQU0sR0FBRyxpQkFBaUIsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN2QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELDJHQUEyRztJQUMzRywrR0FBK0c7SUFDL0csK0dBQStHO0lBQy9HLDZHQUE2RztJQUM3RyxNQUFNLFFBQVEsR0FBRyxNQUFNLENBQUMsUUFBUSxJQUFJLE9BQU8sQ0FBQyxRQUFRLElBQUksa0JBQWtCLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQyxDQUFDLFdBQVcsQ0FBQztJQUN0RyxNQUFNLFdBQVcsR0FBRyxPQUFPLENBQUMsV0FBVyxJQUFJLE9BQU8sQ0FBQyxHQUFHLENBQUMsUUFBUSxDQUFDLElBQUksRUFBRSxDQUFDO0lBQ3ZFLG1IQUFtSDtJQUNuSCxtR0FBbUc7SUFDbkcsTUFBTSxVQUFVLEdBQUcsTUFBTSxDQUFDLFVBQVUsSUFBSSxPQUFPLENBQUMsVUFBVSxDQUFDO0lBQzNELE1BQU0sWUFBWSxHQUFHLE9BQU8sQ0FBQywrQkFBK0IsSUFBSSwrQkFBK0IsQ0FBQztJQUNoRyxNQUFNLGFBQWEsR0FBRyxPQUFPLENBQUMsZ0NBQWdDLElBQUksZ0NBQWdDLENBQUM7SUFDbkcsTUFBTSxVQUFVLEdBQUcsT0FBTyxDQUFDLDhCQUE4QixJQUFJLDhCQUE4QixDQUFDO0lBQzVGLE1BQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsSUFBSSxzQkFBc0IsQ0FBQztJQUN6RSwyR0FBMkc7SUFDM0csc0hBQXNIO0lBQ3RILE1BQU0sZUFBZSxHQUFHLE9BQU8sQ0FBQywyQkFBMkIsSUFBSSxzQ0FBc0MsQ0FBQztJQUN0Ryx5R0FBeUc7SUFDekcsMEdBQTBHO0lBQzFHLE1BQU0sbUJBQW1CLEdBQ3ZCLE1BQU0sQ0FBQyxNQUFNLEtBQUssSUFBSTtRQUNwQixDQUFDLENBQUMsRUFBRSxLQUFLLEVBQUUsRUFBRSxFQUFFLElBQUksRUFBRSxFQUFFLEVBQUUsV0FBVyxFQUFFLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFO1FBQ3ZELENBQUMsQ0FBQyxFQUFFLEtBQUssRUFBRSxNQUFNLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxFQUFFLENBQUMsR0FBRyxNQUFNLENBQUMsS0FBSyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQyxFQUFFLElBQUksRUFBRSxFQUFFLEVBQUUsV0FBVyxFQUFFLEVBQUUsRUFBRSxDQUFDO0lBRTdHLDZHQUE2RztJQUM3RywrR0FBK0c7SUFDL0csK0dBQStHO0lBQy9HLCtHQUErRztJQUMvRyx3R0FBd0c7SUFDeEcsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxhQUFhLEdBQUc7WUFDcEIsVUFBVTtZQUNWLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSztZQUNwQixjQUFjLEVBQUUsSUFBSTtZQUNwQixrQkFBa0IsRUFBRSxJQUFJO1NBQ1IsQ0FBQztRQUNuQixJQUFJLENBQUM7WUFDSCxJQUFJLE1BQU0sR0FDUixNQUFNLENBQUMsTUFBTSxLQUFLLElBQUk7Z0JBQ3BCLENBQUMsQ0FBQyxNQUFNLGFBQWEsQ0FBQyxNQUFNLENBQUMsTUFBTSxFQUFFLFdBQVcsRUFBRSxhQUFhLENBQUM7Z0JBQ2hFLENBQUMsQ0FBQyxNQUFNLFlBQVksQ0FBQyxNQUFNLENBQUMsT0FBTyxFQUFFLFdBQVcsRUFBRSxhQUFhLENBQUMsQ0FBQztZQUNyRSxNQUFNLEdBQUcsTUFBTSw0QkFBNEIsQ0FBQyxNQUFNLEVBQUUsbUJBQW1CLEVBQUUsT0FBTyxDQUFDLENBQUM7WUFDbEYseUdBQXlHO1lBQ3pHLGdGQUFnRjtZQUNoRixNQUFNLGFBQWEsR0FBRyxDQUFDLEdBQUcsSUFBSSxHQUFHLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDckYsTUFBTSxjQUFjLEdBQUcsTUFBTSxlQUFlLENBQUMsYUFBYSxFQUFFLEVBQUUsV0FBVyxFQUFFLFVBQVUsRUFBRSxLQUFLLEVBQUUsT0FBTyxDQUFDLEtBQUssRUFJMUcsQ0FBQyxDQUFDO1lBQ0gsTUFBTSxFQUFFLElBQUksRUFBRSxRQUFRLEVBQUUsR0FBRywwQkFBMEIsQ0FDbkQsTUFBTSxDQUFDLE1BQU0sRUFDYixjQUFrRSxDQUNuRSxDQUFDO1lBQ0YsTUFBTSxhQUFhLEdBQUcsVUFBVSxDQUFDLElBQUksRUFBRTtnQkFDckMsS0FBSyxFQUFFLE9BQU8sQ0FBQyxLQUFLO2dCQUNwQixlQUFlLEVBQUUsT0FBTyxDQUFDLGVBQWU7Z0JBQ3hDLHFCQUFxQixFQUFFLE9BQU8sQ0FBQyxxQkFBcUI7YUFDdkIsQ0FBQyxDQUFDO1lBQ2pDLE1BQU0sY0FBYyxHQUFHLEVBQUUsT0FBTyxFQUFFLEdBQUcsRUFBRSxHQUFFLENBQUMsRUFBb0MsQ0FBQztZQUMvRSxNQUFNLGNBQWMsR0FBRyxPQUFPLENBQUMsYUFBYSxDQUFDLE1BQU0sRUFBRSxFQUFFLFVBQVUsRUFBRSxjQUFjLEVBQUUsQ0FBQyxDQUFDO1lBQ3JGLE1BQU0sTUFBTSxHQUFHO2dCQUNiLE9BQU8sRUFBRSxTQUFTO2dCQUNsQixXQUFXLEVBQUUsTUFBTSxDQUFDLE1BQU0sQ0FBQyxNQUFNO2dCQUNqQyxRQUFRLEVBQUUsTUFBTSxDQUFDLFFBQVE7Z0JBQ3pCLGtCQUFrQixFQUFFLE1BQU0sQ0FBQyxrQkFBa0I7Z0JBQzdDLGdCQUFnQixFQUFFLE1BQU0sQ0FBQyxnQkFBZ0I7Z0JBQ3pDLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTTtnQkFDNUIsUUFBUSxFQUFFLFFBQVEsQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLENBQUM7b0JBQ2pDLFlBQVksRUFBRSxLQUFLLENBQUMsU0FBUyxDQUFDLFlBQVk7b0JBQzFDLFdBQVcsRUFBRSxLQUFLLENBQUMsU0FBUyxDQUFDLFdBQVc7b0JBQ3hDLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTTtpQkFDckIsQ0FBQyxDQUFDO2dCQUNILG1CQUFtQixFQUFFLGFBQWEsQ0FBQyxtQkFBbUI7Z0JBQ3RELGNBQWM7YUFDZixDQUFDO1lBQ0Ysb0dBQW9HO1lBQ3BHLHdHQUF3RztZQUN4RyxpR0FBaUc7WUFDakcsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzNCLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO2dCQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsTUFBTSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQy9DLENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHFCQUFxQixDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7Z0JBQzNDLE9BQU8sQ0FBQyxHQUFHLENBQUMsK0NBQStDLENBQUMsQ0FBQztZQUMvRCxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDO1FBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztZQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO1FBQ2hFLENBQUM7SUFDSCxDQUFDO0lBRUQsTUFBTSxrQkFBa0IsR0FBRyxPQUFPLENBQUMsa0JBQWtCLEtBQUssU0FBUyxDQUFDO0lBQ3BFLElBQUksY0FBbUMsQ0FBQztJQUN4QyxJQUFJLENBQUM7UUFDSCxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQzdFLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztJQUVELGdIQUFnSDtJQUNoSCw2R0FBNkc7SUFDN0csMkdBQTJHO0lBQzNHLDZHQUE2RztJQUM3Ryw2R0FBNkc7SUFDN0csZ0NBQWdDO0lBQ2hDLElBQUksY0FBYyxHQUErQixJQUFJLENBQUM7SUFDdEQsSUFBSSxrQkFBa0IsR0FBRyxLQUFLLENBQUM7SUFDL0IsSUFBSSxDQUFDO1FBQ0gsa0JBQWtCLEdBQUcsT0FBTyxDQUFDLGtCQUFrQixLQUFLLFNBQVMsQ0FBQztRQUM5RCxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksdUJBQXVCLENBQUMsRUFBRSxDQUFDO0lBQzdFLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxjQUFjLEdBQUcsSUFBSSxDQUFDO1FBQ3RCLGtCQUFrQixHQUFHLEtBQUssQ0FBQztJQUM3QixDQUFDO0lBRUQsK0dBQStHO0lBQy9HLGdIQUFnSDtJQUNoSCxzREFBc0Q7SUFDdEQsSUFBSSxrQkFBa0IsR0FBbUMsSUFBSSxDQUFDO0lBQzlELElBQUksc0JBQXNCLEdBQUcsS0FBSyxDQUFDO0lBQ25DLElBQUksQ0FBQztRQUNILHNCQUFzQixHQUFHLE9BQU8sQ0FBQyxzQkFBc0IsS0FBSyxTQUFTLENBQUM7UUFDdEUsa0JBQWtCLEdBQUcsQ0FBQyxPQUFPLENBQUMsc0JBQXNCLElBQUksMkJBQTJCLENBQUMsRUFBRSxDQUFDO0lBQ3pGLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxrQkFBa0IsR0FBRyxJQUFJLENBQUM7UUFDMUIsc0JBQXNCLEdBQUcsS0FBSyxDQUFDO0lBQ2pDLENBQUM7SUFFRCwrR0FBK0c7SUFDL0csZ0hBQWdIO0lBQ2hILDZHQUE2RztJQUM3Ryw4R0FBOEc7SUFDOUcsZ0hBQWdIO0lBQ2hILHFFQUFxRTtJQUNyRSxJQUFJLHFCQUFxQixHQUFpQyxJQUFJLENBQUM7SUFDL0QsSUFBSSx5QkFBeUIsR0FBRyxLQUFLLENBQUM7SUFDdEMsSUFBSSxDQUFDO1FBQ0gseUJBQXlCLEdBQUcsT0FBTyxDQUFDLHlCQUF5QixLQUFLLFNBQVMsQ0FBQztRQUM1RSxxQkFBcUIsR0FBRyxDQUFDLE9BQU8sQ0FBQyx5QkFBeUIsSUFBSSx5QkFBeUIsQ0FBQyxFQUFFLENBQUM7SUFDN0YsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLHFCQUFxQixHQUFHLElBQUksQ0FBQztRQUM3Qix5QkFBeUIsR0FBRyxLQUFLLENBQUM7SUFDcEMsQ0FBQztJQUNELE1BQU0sYUFBYSxHQUFHLEVBQUUsVUFBVSxFQUFFLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSyxFQUFFLGNBQWMsRUFBRSxrQkFBa0IsRUFBbUIsQ0FBQztJQUVoSCxJQUFJLENBQUM7UUFDSCxJQUFJLE1BQU0sR0FDUixNQUFNLENBQUMsTUFBTSxLQUFLLElBQUk7WUFDcEIsQ0FBQyxDQUFDLE1BQU0sYUFBYSxDQUFDLE1BQU0sQ0FBQyxNQUFNLEVBQUUsV0FBVyxFQUFFLGFBQWEsQ0FBQztZQUNoRSxDQUFDLENBQUMsTUFBTSxZQUFZLENBQUMsTUFBTSxDQUFDLE9BQU8sRUFBRSxXQUFXLEVBQUUsYUFBYSxDQUFDLENBQUM7UUFDckUsTUFBTSxHQUFHLE1BQU0sNEJBQTRCLENBQUMsTUFBTSxFQUFFLG1CQUFtQixFQUFFLE9BQU8sQ0FBQyxDQUFDO1FBRWxGLDRHQUE0RztRQUM1Ryx5R0FBeUc7UUFDekcsa0dBQWtHO1FBQ2xHLE1BQU0sYUFBYSxHQUFHLENBQUMsR0FBRyxJQUFJLEdBQUcsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRixNQUFNLGNBQWMsR0FBRyxNQUFNLGVBQWUsQ0FBQyxhQUFhLEVBQUUsRUFBRSxXQUFXLEVBQUUsVUFBVSxFQUFFLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSyxFQUl4RyxDQUFDLENBQUM7UUFDTCxNQUFNLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxHQUFHLDBCQUEwQixDQUNuRCxNQUFNLENBQUMsTUFBTSxFQUNiLGNBQWtFLENBQ25FLENBQUM7UUFFRixxR0FBcUc7UUFDckcsNEdBQTRHO1FBQzVHLGtEQUFrRDtRQUNsRCxNQUFNLGFBQWEsR0FBRyxVQUFVLENBQUMsSUFBSSxFQUFFO1lBQ3JDLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSztZQUNwQixlQUFlLEVBQUUsT0FBTyxDQUFDLGVBQWU7WUFDeEMscUJBQXFCLEVBQUUsT0FBTyxDQUFDLHFCQUFxQjtTQUN2QixDQUFDLENBQUM7UUFDakMsTUFBTSxjQUFjLEdBQUcsT0FBTyxDQUFDLGFBQWEsQ0FBQyxNQUFNLEVBQUUsRUFBRSxVQUFVLEVBQUUsY0FBYyxFQUFFLFVBQVUsRUFHNUYsQ0FBQyxDQUFDO1FBRUgsSUFBSSxDQUFDO1lBQ0gsd0dBQXdHO1lBQ3hHLHlHQUF5RztZQUN6RywwQkFBMEI7WUFDMUIscUJBQXFCLEVBQUUsb0JBQW9CLENBQUMsYUFBYSxDQUFDLE1BQU0sRUFBRSxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDbkYsQ0FBQztRQUFDLE1BQU0sQ0FBQztZQUNQLGlHQUFpRztZQUNqRyw4RkFBOEY7UUFDaEcsQ0FBQztRQUVELE1BQU0sTUFBTSxHQUFHO1lBQ2IsV0FBVyxFQUFFLE1BQU0sQ0FBQyxNQUFNLENBQUMsTUFBTTtZQUNqQyxRQUFRLEVBQUUsTUFBTSxDQUFDLFFBQVE7WUFDekIsa0JBQWtCLEVBQUUsTUFBTSxDQUFDLGtCQUFrQjtZQUM3QyxnQkFBZ0IsRUFBRSxNQUFNLENBQUMsZ0JBQWdCO1lBQ3pDLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTTtZQUM1Qix5R0FBeUc7WUFDekcsNkdBQTZHO1lBQzdHLFFBQVEsRUFBRSxRQUFRLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxDQUFDO2dCQUNqQyxZQUFZLEVBQUUsS0FBSyxDQUFDLFNBQVMsQ0FBQyxZQUFZO2dCQUMxQyxXQUFXLEVBQUUsS0FBSyxDQUFDLFNBQVMsQ0FBQyxXQUFXO2dCQUN4QyxNQUFNLEVBQUUsS0FBSyxDQUFDLE1BQU07YUFDckIsQ0FBQyxDQUFDO1lBQ0gsbUJBQW1CLEVBQUUsYUFBYSxDQUFDLG1CQUFtQjtZQUN0RCxjQUFjO1NBQ2YsQ0FBQztRQUVGLDBHQUEwRztRQUMxRyxvR0FBb0c7UUFDcEcsT0FBTyxDQUFDLFFBQVEsRUFBRSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQzNCLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxNQUFNLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDL0MsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHFCQUFxQixDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7UUFDN0MsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksa0JBQWtCLElBQUksY0FBYztZQUFFLGNBQWMsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNqRSxJQUFJLGtCQUFrQixJQUFJLGNBQWM7WUFBRSxjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDakUsSUFBSSxzQkFBc0IsSUFBSSxrQkFBa0I7WUFBRSxrQkFBa0IsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUM3RSxJQUFJLHlCQUF5QixJQUFJLHFCQUFxQjtZQUFFLHFCQUFxQixDQUFDLEtBQUssRUFBRSxDQUFDO0lBQ3hGLENBQUM7QUFDSCxDQUFDIn0=

--- a/packages/loopover-miner/lib/discover-cli.ts
+++ b/packages/loopover-miner/lib/discover-cli.ts
@@ -1,0 +1,582 @@
+/** `discover` CLI command (#4247): wires the existing fanout -> rank -> enqueue pipeline together so a miner
+ * can actually run it. Every piece already exists and is independently tested; this module only composes them. */
+import { resolveForgeConfig } from "./forge-config.js";
+import {
+  fetchCandidateIssuesWithSummary,
+  searchCandidateIssuesWithSummary,
+} from "./opportunity-fanout.js";
+import { rankCandidateIssuesWithSummary } from "./opportunity-ranker.js";
+import { initPolicyDocCacheStore } from "./policy-doc-cache.js";
+import { initPolicyVerdictCacheStore } from "./policy-verdict-cache.js";
+import { enqueueRankedDiscovery } from "./portfolio-discovery.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { initRankedCandidatesStore } from "./ranked-candidates.js";
+import { extractContributionProfile } from "./contribution-profile-extract.js";
+import { initContributionProfileCache } from "./contribution-profile-cache.js";
+import { filterCandidatesByProfiles } from "./contribution-profile-filter.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isDiscoveryPlaneEnabled, queryDiscoveryIndex, recordDiscoveryTelemetry } from "./discovery-index-client.js";
+
+import type { ForgeConfig } from "./forge-config.js";
+import type {
+  CandidateIssueWarning,
+  FanoutOptions,
+  FanoutTarget,
+  RawCandidateIssue,
+} from "./opportunity-fanout.js";
+import type {
+  RankCandidateIssuesOptions,
+  RankedCandidateIssue,
+  RankedCandidateSummary,
+} from "./opportunity-ranker.js";
+import type { PolicyDocCacheStore } from "./policy-doc-cache.js";
+import type { PolicyVerdictCacheStore } from "./policy-verdict-cache.js";
+import type { EnqueueRankedDiscoverySummary } from "./portfolio-discovery.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+import type { RankedCandidatesStore } from "./ranked-candidates.js";
+
+export type ParsedDiscoverArgs =
+  | {
+      targets: FanoutTarget[];
+      search: string | null;
+      dryRun: boolean;
+      json: boolean;
+      /** Present only when `--api-base-url` is supplied (#4784); threads the tenant's forge host to the fan-out. */
+      apiBaseUrl?: string;
+      /** Present only when `--token-env` is supplied (#4784); names the credential env var to read. */
+      tokenEnv?: string;
+    }
+  | { error: string };
+
+/** The subset of `CandidateIssueSummary` runDiscover actually reads. It surfaces the rate-limit telemetry (#4837),
+ * so a fake must supply it. A real `fetchCandidateIssuesWithSummary` result satisfies this, since it is a superset. */
+export type DiscoverFanOutSummary = {
+  issues: RawCandidateIssue[];
+  warnings: CandidateIssueWarning[];
+  rateLimitRemaining: number | null;
+  rateLimitResetAt: string | null;
+};
+
+/** The subset of a ranked entry that `renderDiscoverSummary` reads for its top-candidates listing. */
+export type DiscoverRankedEntry = Pick<
+  RankedCandidateIssue,
+  "repoFullName" | "issueNumber" | "title" | "rankScore"
+>;
+
+export type DiscoverResult = {
+  fanOutCount: number;
+  warnings: CandidateIssueWarning[];
+  rateLimitRemaining: number | null;
+  rateLimitResetAt: string | null;
+  ranked: DiscoverRankedEntry[];
+  /** Candidates the eligibility filter dropped, each with the repo/issue and the reason (#6798). */
+  excluded?: Array<{
+    repoFullName: string;
+    issueNumber: number;
+    reason: string;
+  }>;
+  /** True when ranking fell back to the built-in default goal spec because no per-tenant spec was supplied (#4784). */
+  usedDefaultGoalSpec?: boolean;
+  enqueueSummary: EnqueueRankedDiscoverySummary;
+};
+
+export type RunDiscoverOptions = {
+  /** Read for the discovery-index opt-in gate (#7168) -- defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+  githubToken?: string;
+  apiBaseUrl?: string;
+  /** Per-tenant credential env var name (#4784); defaults to GITHUB_TOKEN. Overridden by a `--token-env` flag. */
+  tokenEnv?: string;
+  /** Per-tenant forge knobs beyond the host (#4784), forwarded to the fan-out. */
+  forge?: Partial<ForgeConfig>;
+  nowMs?: number;
+  /** Per-tenant goal specs threaded to the ranker so lane fit uses the tenant's conventions, not the defaults (#4784). */
+  goalSpecsByRepo?: RankCandidateIssuesOptions["goalSpecsByRepo"];
+  goalSpecContentByRepo?: RankCandidateIssuesOptions["goalSpecContentByRepo"];
+  initPortfolioQueue?: () => PortfolioQueueStore;
+  initPolicyDocCache?: () => PolicyDocCacheStore;
+  initPolicyVerdictCache?: () => PolicyVerdictCacheStore;
+  initRankedCandidatesStore?: () => RankedCandidatesStore;
+  fetchCandidateIssuesWithSummary?: (
+    targets: FanoutTarget[],
+    githubToken: string,
+    options?: FanoutOptions,
+  ) => Promise<DiscoverFanOutSummary>;
+  searchCandidateIssuesWithSummary?: (
+    searchQuery: string,
+    githubToken: string,
+    options?: FanoutOptions,
+  ) => Promise<DiscoverFanOutSummary>;
+  rankCandidateIssuesWithSummary?: (
+    candidates: RawCandidateIssue[],
+    options?: RankCandidateIssuesOptions,
+  ) => RankedCandidateSummary;
+  enqueueRankedDiscovery?: (
+    rankedIssues: RankedCandidateIssue[],
+    options: { queueStore: PortfolioQueueStore },
+  ) => EnqueueRankedDiscoverySummary;
+  /** Supplements the local fan-out with hosted discovery-index results for the same scope, when the plane is
+   *  enabled (#7168). Defaults to discovery-index-client.js's own queryDiscoveryIndex. */
+  queryDiscoveryIndex?: typeof queryDiscoveryIndex;
+  /** Invoked with the real structured result at each success return point (dry-run and full-run), in addition
+   *  to (never instead of) the plain exit-code return -- mirrors `RunAttemptOptions.onResult`. Never fires on a
+   *  parse-error/unexpected-error `reportCliFailure` branch, matching runAttempt's own asymmetry (#6522). */
+  onResult?: (result: DiscoverResult) => void;
+  /** Resolve each candidate repo's ContributionProfile for eligibility filtering (#6798). Defaults to
+   *  resolveContributionProfilesForDiscover; injectable so tests avoid the network. */
+  resolveContributionProfiles?: (
+    repoFullNames: string[],
+    ctx: { githubToken?: string; apiBaseUrl?: string; nowMs?: number },
+  ) => Promise<Map<string, unknown>>;
+};
+
+const DISCOVER_USAGE =
+  "Usage: loopover-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--dry-run] [--json] [--api-base-url <url>] [--token-env <VAR>]";
+
+const MAX_DISCOVER_TITLE_DISPLAY_LENGTH = 240;
+const OSC_SEQUENCE_PATTERN = /\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g;
+const ANSI_ESCAPE_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|[@-_])/g;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/g;
+const BIDI_CONTROL_PATTERN = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
+
+export function sanitizeDiscoverDisplayText(value: unknown): string {
+  return String(value ?? "")
+    .replace(OSC_SEQUENCE_PATTERN, "")
+    .replace(ANSI_ESCAPE_PATTERN, "")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(BIDI_CONTROL_PATTERN, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_DISCOVER_TITLE_DISPLAY_LENGTH);
+}
+
+function dedupeKey(repoFullName: string, issueNumber: number): string {
+  return `${repoFullName.toLowerCase()}#${issueNumber}`;
+}
+
+/**
+ * Supplements `fanOut.issues` with hosted discovery-index results for the same scope (#7168) -- a complete
+ * no-op (returns `fanOut` unchanged) unless the plane is enabled, so a run with the flag unset behaves exactly
+ * as before this feature existed. Local results always win on a duplicate issue (the discovery-index candidate
+ * is dropped, not merged over it) -- this instance's own live fan-out is more current than a cached shared
+ * index entry. Discovery-index candidates lack `assignees` (not part of the public contract), so they're
+ * annotated with an empty array to match opportunity-fanout.js's own candidate shape; contribution-profile-
+ * filter.js's assignee-exclusion rule treats that identically to "no assignees on this issue".
+ */
+async function supplementWithDiscoveryIndex(
+  fanOut: DiscoverFanOutSummary,
+  queryScope: Parameters<typeof queryDiscoveryIndex>[0],
+  options: RunDiscoverOptions,
+): Promise<DiscoverFanOutSummary> {
+  const env = options.env ?? process.env;
+  if (!isDiscoveryPlaneEnabled(env)) return fanOut;
+  const queryIndex = options.queryDiscoveryIndex ?? queryDiscoveryIndex;
+  const response = await queryIndex(queryScope, { env });
+  recordDiscoveryTelemetry("discover_query", response.candidates.length > 0 ? "supplemented" : "empty", { env });
+  if (response.candidates.length === 0) return fanOut;
+
+  const seen = new Set(fanOut.issues.map((issue) => dedupeKey(issue.repoFullName, issue.issueNumber)));
+  const supplemented = response.candidates
+    .filter((candidate) => !seen.has(dedupeKey(candidate.repoFullName, candidate.issueNumber)))
+    .map((candidate) => ({ ...candidate, assignees: [] }) as unknown as RawCandidateIssue);
+  if (supplemented.length === 0) return fanOut;
+  return { ...fanOut, issues: [...fanOut.issues, ...supplemented] };
+}
+
+function parseRepoTarget(value: string): FanoutTarget | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return { owner, repo };
+}
+
+export function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs {
+  // `--api-base-url` and `--token-env` (#4784) thread the tenant's forge host and credential env var into the
+  // fan-out; they are kept off the parsed result unless supplied, so callers that pass neither see the exact
+  // pre-#4784 `{ targets, search, json }` shape.
+  const options = {
+    json: false,
+    dryRun: false,
+    search: null as string | null,
+    apiBaseUrl: null as string | null,
+    tokenEnv: null as string | null,
+  };
+  const targets: FanoutTarget[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: fetches + ranks exactly as a real run, but skips opening any local store and makes zero writes.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--search") {
+      const query = args[index + 1];
+      if (!query || query.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.search = query;
+      index += 1;
+      continue;
+    }
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--token-env") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.tokenEnv = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    const target = parseRepoTarget(token);
+    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
+    targets.push(target);
+  }
+
+  if (options.search === null && targets.length === 0) {
+    return { error: DISCOVER_USAGE };
+  }
+  if (options.search !== null && targets.length > 0) {
+    return { error: "Pass either repository targets or --search, not both." };
+  }
+
+  return {
+    targets,
+    search: options.search,
+    dryRun: options.dryRun,
+    json: options.json,
+    ...(options.apiBaseUrl !== null ? { apiBaseUrl: options.apiBaseUrl } : {}),
+    ...(options.tokenEnv !== null ? { tokenEnv: options.tokenEnv } : {}),
+  };
+}
+
+// The rate-limit line surfaces the telemetry the fanout already records (#4837) so an operator sees how close a
+// `discover` run is to being throttled without running a separate command. `unknown` covers the no-fetch/no-header
+// case where the fanout captured no remaining count.
+function renderRateLimitLine(result: DiscoverResult): string {
+  const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
+  const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
+  return `rate-limit remaining: ${remaining}${resetSuffix}`;
+}
+
+export function renderDiscoverSummary(result: DiscoverResult): string {
+  const lines = [
+    `fanned out: ${result.fanOutCount} candidate issue(s)`,
+    `ai-policy warnings: ${result.warnings.length}`,
+    `ranked: ${result.ranked.length}`,
+    `enqueued: ${result.enqueueSummary.enqueued}`,
+    renderRateLimitLine(result),
+  ];
+  if (result.enqueueSummary.skippedBelowMinRank > 0) {
+    lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
+  }
+  // #6798: surface what the eligibility filter dropped and why, so a human sees AMS's inference.
+  const excluded = result.excluded ?? [];
+  if (excluded.length > 0) {
+    lines.push(`excluded (eligibility): ${excluded.length}`);
+    for (const entry of excluded.slice(0, 10)) {
+      lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  ${entry.reason}`);
+    }
+  }
+  // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
+  // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
+  if (result.usedDefaultGoalSpec) {
+    lines.push(
+      "note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)",
+    );
+  }
+  if (result.ranked.length === 0) {
+    lines.push("", "no candidates found.");
+    return lines.join("\n");
+  }
+  lines.push("", "top candidates:");
+  for (const entry of result.ranked.slice(0, 10)) {
+    const title = sanitizeDiscoverDisplayText(entry.title);
+    lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${title}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Default per-repo ContributionProfile resolver (#6798): reads the local cache and, on a miss/stale entry,
+ * extracts a fresh profile and caches it. Returns a Map keyed by repoFullName.
+ *
+ * WITHOUT a github token this returns an empty map and does no network work at all — AMS can't reliably read a
+ * repo's label taxonomy/docs unauthenticated (rate limits), so it safe-defaults to no eligibility filtering.
+ * That also keeps callers that don't supply a token (the common CLI path, and every test) hermetic.
+ */
+export async function resolveContributionProfilesForDiscover(
+  repoFullNames: string[],
+  ctx: {
+    githubToken?: string;
+    apiBaseUrl?: string;
+    nowMs?: number;
+    initCache?: unknown;
+    extract?: unknown;
+  } = {},
+): Promise<Map<string, unknown>> {
+  const profiles = new Map<string, unknown>();
+  if (!ctx.githubToken) return profiles;
+  const initCache = (ctx.initCache ?? initContributionProfileCache) as typeof initContributionProfileCache;
+  const extract = (ctx.extract ?? extractContributionProfile) as typeof extractContributionProfile;
+  const cache = initCache();
+  try {
+    for (const repoFullName of repoFullNames) {
+      const cached = cache.get(repoFullName, ctx.nowMs);
+      if (cached && !cached.stale) {
+        profiles.set(repoFullName, cached.profile);
+        continue;
+      }
+      const profile = await extract(repoFullName, {
+        githubToken: ctx.githubToken,
+        apiBaseUrl: ctx.apiBaseUrl,
+      } as { githubToken?: string; apiBaseUrl?: string });
+      cache.put(profile, ctx.nowMs);
+      profiles.set(repoFullName, profile);
+    }
+  } finally {
+    cache.close();
+  }
+  return profiles;
+}
+
+export async function runDiscover(args: string[], options: RunDiscoverOptions = {}): Promise<number> {
+  const parsed = parseDiscoverArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
+  // non-`GITHUB_TOKEN` variable so a non-github.com forge's token is reachable. The default falls through to the
+  // forge adapter's own `tokenEnvVar` (github.com's `GITHUB_TOKEN`), so there's a single source of truth for the
+  // default credential env instead of a second hardcoded literal that could drift from `DEFAULT_FORGE_CONFIG`.
+  const tokenEnv = parsed.tokenEnv ?? options.tokenEnv ?? resolveForgeConfig(options.forge).tokenEnvVar;
+  const githubToken = options.githubToken ?? process.env[tokenEnv] ?? "";
+  // A `--api-base-url` flag (or `options.apiBaseUrl`) surfaces the fan-out's existing forge-host override at the CLI
+  // (#4784); `options.forge` carries any remaining per-tenant forge knobs for a programmatic caller.
+  const apiBaseUrl = parsed.apiBaseUrl ?? options.apiBaseUrl;
+  const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
+  const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
+  const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
+  const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
+  // Eligibility filtering (#6798): resolve each candidate repo's ContributionProfile and drop candidates the
+  // repo's own conventions would reject, BEFORE ranking. Safe by default -- see resolveContributionProfilesForDiscover.
+  const resolveProfiles = options.resolveContributionProfiles ?? resolveContributionProfilesForDiscover;
+  // Same scope this run already asks GitHub about (#7168) -- the discovery-index supplement, when enabled,
+  // asks the shared hosted index about the identical targets/search rather than a different query entirely.
+  const discoveryQueryScope =
+    parsed.search !== null
+      ? { repos: [], orgs: [], searchTerms: [parsed.search] }
+      : { repos: parsed.targets.map((target) => `${target.owner}/${target.repo}`), orgs: [], searchTerms: [] };
+
+  // #4847: fetch + rank are read-only GitHub GETs and pure local computation, so a dry run still does them for
+  // real (that's the useful "what would this discover?" output) -- but it never opens any local store (portfolio
+  // queue, policy-doc cache, policy-verdict cache), since opening a not-yet-existing SQLite store file is itself
+  // a write. The ranked issues are fed through a no-op queue stub so enqueueRankedDiscovery's own classification
+  // logic (valid/invalid, below-min-rank) still runs for real, just without ever touching the real queue.
+  if (parsed.dryRun) {
+    const fanOutOptions = {
+      apiBaseUrl,
+      forge: options.forge,
+      policyDocCache: null,
+      policyVerdictCache: null,
+    } as FanoutOptions;
+    try {
+      let fanOut =
+        parsed.search !== null
+          ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+          : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+      fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+      // #6798: same eligibility filter as the real path, so a dry run shows the exact candidate set a real run
+      // would enqueue (and the same excluded set), rather than an unfiltered preview.
+      const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+      const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs } as {
+        githubToken?: string;
+        apiBaseUrl?: string;
+        nowMs?: number;
+      });
+      const { kept, excluded } = filterCandidatesByProfiles(
+        fanOut.issues,
+        profilesByRepo as Parameters<typeof filterCandidatesByProfiles>[1],
+      );
+      const rankedSummary = rankIssues(kept, {
+        nowMs: options.nowMs,
+        goalSpecsByRepo: options.goalSpecsByRepo,
+        goalSpecContentByRepo: options.goalSpecContentByRepo,
+      } as RankCandidateIssuesOptions);
+      const noopQueueStore = { enqueue: () => {} } as unknown as PortfolioQueueStore;
+      const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: noopQueueStore });
+      const result = {
+        outcome: "dry_run",
+        fanOutCount: fanOut.issues.length,
+        warnings: fanOut.warnings,
+        rateLimitRemaining: fanOut.rateLimitRemaining,
+        rateLimitResetAt: fanOut.rateLimitResetAt,
+        ranked: rankedSummary.issues,
+        excluded: excluded.map((entry) => ({
+          repoFullName: entry.candidate.repoFullName,
+          issueNumber: entry.candidate.issueNumber,
+          reason: entry.reason,
+        })),
+        usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+        enqueueSummary,
+      };
+      // Structured-outcome hook (#6522), mirroring runAttempt's onResult convention: fires only at a real
+      // structured success point (never the reportCliFailure branches), in addition to -- never instead of --
+      // the plain exit-code return, so a non-CLI caller (the /api/discover route) can read the result.
+      options.onResult?.(result);
+      if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(renderDiscoverSummary(result));
+        console.log("\nDRY RUN: no portfolio-queue write was made.");
+      }
+      return 0;
+    } catch (error) {
+      return reportCliFailure(parsed.json, describeCliError(error));
+    }
+  }
+
+  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+  let portfolioQueue: PortfolioQueueStore;
+  try {
+    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+
+  // Local ETag cache so a repeated discover revalidates each repo's policy docs with a conditional GET instead of
+  // re-downloading them (#4842). Opened inside its OWN try/catch, separate from the portfolio queue above: the
+  // queue is required infrastructure (discovery genuinely cannot enqueue anything without it, so a real open
+  // failure should abort the run), but the policy-doc cache is a pure performance optimization -- a corrupt or
+  // unwritable cache DB must degrade to "no cache" (every doc fetched in full, exactly as before #4842) rather
+  // than fail discovery outright.
+  let policyDocCache: PolicyDocCacheStore | null = null;
+  let ownsPolicyDocCache = false;
+  try {
+    ownsPolicyDocCache = options.initPolicyDocCache === undefined;
+    policyDocCache = (options.initPolicyDocCache ?? initPolicyDocCacheStore)();
+  } catch {
+    policyDocCache = null;
+    ownsPolicyDocCache = false;
+  }
+
+  // Persisted cache of resolved policy verdicts (#4843), same "own try/catch, degrade to null" discipline as the
+  // doc cache above and for the same reason: purely a performance optimization the feature is inert without, so a
+  // corrupt/unwritable cache DB must never abort a run.
+  let policyVerdictCache: PolicyVerdictCacheStore | null = null;
+  let ownsPolicyVerdictCache = false;
+  try {
+    ownsPolicyVerdictCache = options.initPolicyVerdictCache === undefined;
+    policyVerdictCache = (options.initPolicyVerdictCache ?? initPolicyVerdictCacheStore)();
+  } catch {
+    policyVerdictCache = null;
+    ownsPolicyVerdictCache = false;
+  }
+
+  // Snapshot of this run's full ranked output (#4859 prerequisite), so a local HTTP endpoint (and eventually the
+  // miner-ui/browser-extension live-fetch it's meant for) can serve the same per-issue breakdown `--json` prints,
+  // without the operator re-running discover or hand-pasting its output. Same "own try/catch, degrade to null"
+  // discipline as the two caches above: a corrupt/unwritable snapshot store must never abort discovery's actual
+  // job (fan out, rank, enqueue). Unlike the caches, this store is a WRITE target, not a read optimization -- the
+  // save call itself gets its own try/catch below for the same reason.
+  let rankedCandidatesStore: RankedCandidatesStore | null = null;
+  let ownsRankedCandidatesStore = false;
+  try {
+    ownsRankedCandidatesStore = options.initRankedCandidatesStore === undefined;
+    rankedCandidatesStore = (options.initRankedCandidatesStore ?? initRankedCandidatesStore)();
+  } catch {
+    rankedCandidatesStore = null;
+    ownsRankedCandidatesStore = false;
+  }
+  const fanOutOptions = { apiBaseUrl, forge: options.forge, policyDocCache, policyVerdictCache } as FanoutOptions;
+
+  try {
+    let fanOut =
+      parsed.search !== null
+        ? await searchTargets(parsed.search, githubToken, fanOutOptions)
+        : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
+    fanOut = await supplementWithDiscoveryIndex(fanOut, discoveryQueryScope, options);
+
+    // Eligibility filter (#6798): drop candidates a target repo's own conventions would reject, before ranking.
+    // A repo with no trustworthy eligibility profile keeps every candidate (filterCandidatesByProfiles' safe
+    // default), so this never silently skips real work on a repo whose conventions AMS couldn't read.
+    const repoFullNames = [...new Set(fanOut.issues.map((issue) => issue.repoFullName))];
+    const profilesByRepo = await resolveProfiles(repoFullNames, { githubToken, apiBaseUrl, nowMs: options.nowMs } as {
+        githubToken?: string;
+        apiBaseUrl?: string;
+        nowMs?: number;
+      });
+    const { kept, excluded } = filterCandidatesByProfiles(
+      fanOut.issues,
+      profilesByRepo as Parameters<typeof filterCandidatesByProfiles>[1],
+    );
+
+    // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
+    // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
+    // `usedDefaultGoalSpec` below rather than hidden.
+    const rankedSummary = rankIssues(kept, {
+      nowMs: options.nowMs,
+      goalSpecsByRepo: options.goalSpecsByRepo,
+      goalSpecContentByRepo: options.goalSpecContentByRepo,
+    } as RankCandidateIssuesOptions);
+    const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue, apiBaseUrl } as {
+      queueStore: PortfolioQueueStore;
+      apiBaseUrl?: string;
+    });
+
+    try {
+      // Optional chaining rather than an `if (rankedCandidatesStore)` guard: a null store (open failed above)
+      // short-circuits to a no-op read, so the same try/catch below also covers the open-failed case without a
+      // second explicit branch.
+      rankedCandidatesStore?.saveRankedCandidates(rankedSummary.issues, options.nowMs);
+    } catch {
+      // Non-fatal: the ranked-candidates snapshot is a nice-to-have for the local HTTP endpoint, not a
+      // requirement for discover's own job (fan out, rank, enqueue), which already succeeded above.
+    }
+
+    const result = {
+      fanOutCount: fanOut.issues.length,
+      warnings: fanOut.warnings,
+      rateLimitRemaining: fanOut.rateLimitRemaining,
+      rateLimitResetAt: fanOut.rateLimitResetAt,
+      ranked: rankedSummary.issues,
+      // #6798: candidates the eligibility filter dropped, each with the repo + issue + reason, so a human sees
+      // what AMS inferred and why a candidate was skipped. Empty when no profile was trustworthy enough to filter.
+      excluded: excluded.map((entry) => ({
+        repoFullName: entry.candidate.repoFullName,
+        issueNumber: entry.candidate.issueNumber,
+        reason: entry.reason,
+      })),
+      usedDefaultGoalSpec: rankedSummary.usedDefaultGoalSpec,
+      enqueueSummary,
+    };
+
+    // Structured-outcome hook (#6522) for the full-run success point -- same convention as the dry-run branch
+    // above and as runAttempt's onResult: real result only, additive to the unchanged exit-code return.
+    options.onResult?.(result);
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(renderDiscoverSummary(result));
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsPortfolioQueue && portfolioQueue) portfolioQueue.close();
+    if (ownsPolicyDocCache && policyDocCache) policyDocCache.close();
+    if (ownsPolicyVerdictCache && policyVerdictCache) policyVerdictCache.close();
+    if (ownsRankedCandidatesStore && rankedCandidatesStore) rankedCandidatesStore.close();
+  }
+}

--- a/packages/loopover-miner/lib/governor-metrics-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-metrics-cli.d.ts
@@ -1,16 +1,14 @@
 import type { GovernorCapUsage } from "@loopover/engine";
 import type { GovernorRateLimitState, GovernorState } from "./governor-state.js";
-
-export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO: string;
-export const GOVERNOR_CAP_USAGE_RATIO: string;
-
-export function renderGovernorMetrics(
-  rateLimitState: GovernorRateLimitState,
-  capUsage: GovernorCapUsage,
-  nowMs: number,
-): string;
-
-export function runGovernorMetrics(
-  args: string[],
-  options?: { openGovernorState?: () => GovernorState; nowMs?: number },
-): Promise<number>;
+export declare const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
+export declare const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
+/**
+ * @param {import("./governor-state.js").GovernorRateLimitState} rateLimitState
+ * @param {import("@loopover/engine").GovernorCapUsage} capUsage
+ * @param {number} nowMs
+ */
+export declare function renderGovernorMetrics(rateLimitState: GovernorRateLimitState, capUsage: GovernorCapUsage, nowMs: number): string;
+export declare function runGovernorMetrics(args: string[], options?: {
+    openGovernorState?: () => GovernorState;
+    nowMs?: number;
+}): Promise<number>;

--- a/packages/loopover-miner/lib/governor-metrics-cli.js
+++ b/packages/loopover-miner/lib/governor-metrics-cli.js
@@ -1,12 +1,6 @@
-import {
-  DEFAULT_AMS_POLICY_SPEC,
-  DEFAULT_WRITE_RATE_LIMIT_POLICIES,
-  evaluateGovernorCaps,
-  evaluateLocalRateLimit,
-} from "@loopover/engine";
+import { DEFAULT_AMS_POLICY_SPEC, DEFAULT_WRITE_RATE_LIMIT_POLICIES, evaluateGovernorCaps, evaluateLocalRateLimit, } from "@loopover/engine";
 import { openGovernorState } from "./governor-state.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 // `governor metrics` (#5187): render the governor's persisted rate-limit + cap-usage state (#5134,
 // governor-state.js) as Prometheus text-exposition, so an operator's Alertmanager can page on rate-limit/
 // budget pressure without hand-rolling a scrape. Strictly read-only, mirroring queue-cli.js's `queue metrics`
@@ -23,32 +17,27 @@ import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js
 // per-repo capLimits override from a resolved `.loopover-miner.yml` has no matching per-repo usage row to
 // pair it with here. Using the fleet-wide DEFAULT_AMS_POLICY_SPEC.capLimits is the same approximation
 // loop-cli.js itself already makes for any repo without its own override.
-
 const GOVERNOR_METRICS_USAGE = "Usage: loopover-miner governor metrics";
-
 export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
 export const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeMetricsHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /** Prometheus label-value escaping — backslash, double-quote, newline (mirrors event-ledger-cli.js's
  *  escapeLabelValue). */
 function escapeLabelValue(value) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
-
 /** buckets.perRepo is keyed by writeRateLimitRepoKey(actionClass, repoFullName) = "actionClass:repoFullName"
  *  (write-rate-limit.ts). actionClass is a fixed identifier (never contains ":"), so splitting on the FIRST
  *  colon recovers both parts even though repoFullName itself contains a "/". */
 function splitPerRepoKey(key) {
-  const separatorIndex = key.indexOf(":");
-  if (separatorIndex === -1) return { actionClass: key, repoFullName: "" };
-  return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
+    const separatorIndex = key.indexOf(":");
+    if (separatorIndex === -1)
+        return { actionClass: key, repoFullName: "" };
+    return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
 }
-
 // evaluateLocalRateLimit's own `remaining` field answers "how many MORE writes are allowed AFTER one more write
 // right now" (rate-limit.ts: `remaining = allowed ? limit - effectiveCount - 1 : 0`) -- it is NOT current
 // headroom. At count=2/limit=3 that field is already 0, identical to a fully exhausted count=3/limit=3 bucket,
@@ -58,114 +47,105 @@ function splitPerRepoKey(key) {
 // has already passed the DEFAULT_WRITE_RATE_LIMIT_POLICIES lookup above, so decision.limit is always one of the
 // frozen, non-zero policy limits -- no zero-limit guard needed.
 function remainingRatio(decision) {
-  const headroom = decision.allowed ? decision.remaining + 1 : 0;
-  return headroom / decision.limit;
+    const headroom = decision.allowed ? decision.remaining + 1 : 0;
+    return headroom / decision.limit;
 }
-
 function collectRateLimitRows(buckets, nowMs) {
-  const rows = [];
-  for (const [actionClass, bucket] of Object.entries(buckets.global)) {
-    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
-    if (!config) continue;
-    rows.push({
-      scope: "global",
-      actionClass,
-      repoFullName: "",
-      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    const rows = [];
+    for (const [actionClass, bucket] of Object.entries(buckets.global)) {
+        const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
+        if (!config)
+            continue;
+        rows.push({
+            scope: "global",
+            actionClass,
+            repoFullName: "",
+            ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+        });
+    }
+    for (const [key, bucket] of Object.entries(buckets.perRepo)) {
+        const { actionClass, repoFullName } = splitPerRepoKey(key);
+        const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
+        if (!config)
+            continue;
+        rows.push({
+            scope: "per_repo",
+            actionClass,
+            repoFullName,
+            ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+        });
+    }
+    rows.sort((a, b) => {
+        if (a.scope !== b.scope)
+            return a.scope.localeCompare(b.scope);
+        if (a.actionClass !== b.actionClass)
+            return a.actionClass.localeCompare(b.actionClass);
+        return a.repoFullName.localeCompare(b.repoFullName);
     });
-  }
-  for (const [key, bucket] of Object.entries(buckets.perRepo)) {
-    const { actionClass, repoFullName } = splitPerRepoKey(key);
-    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
-    if (!config) continue;
-    rows.push({
-      scope: "per_repo",
-      actionClass,
-      repoFullName,
-      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
-    });
-  }
-  rows.sort((a, b) => {
-    if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
-    if (a.actionClass !== b.actionClass) return a.actionClass.localeCompare(b.actionClass);
-    return a.repoFullName.localeCompare(b.repoFullName);
-  });
-  return rows;
+    return rows;
 }
-
 // DEFAULT_AMS_POLICY_SPEC.capLimits is a frozen, non-zero constant for every dimension -- no zero-limit guard
 // needed, mirroring remainingRatio()'s reasoning above.
 function collectCapUsageRows(capUsage) {
-  const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
-  return [
-    { dimension: "budget", dimensionReport: report.budget },
-    { dimension: "turns", dimensionReport: report.turns },
-    { dimension: "elapsed_ms", dimensionReport: report.termination },
-  ].map(({ dimension, dimensionReport }) => ({
-    dimension,
-    ratio: dimensionReport.used / dimensionReport.limit,
-  }));
+    const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
+    return [
+        { dimension: "budget", dimensionReport: report.budget },
+        { dimension: "turns", dimensionReport: report.turns },
+        { dimension: "elapsed_ms", dimensionReport: report.termination },
+    ].map(({ dimension, dimensionReport }) => ({
+        dimension,
+        ratio: dimensionReport.used / dimensionReport.limit,
+    }));
 }
-
 /**
  * @param {import("./governor-state.js").GovernorRateLimitState} rateLimitState
  * @param {import("@loopover/engine").GovernorCapUsage} capUsage
  * @param {number} nowMs
  */
 export function renderGovernorMetrics(rateLimitState, capUsage, nowMs) {
-  const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
-  const capRows = collectCapUsageRows(capUsage);
-
-  const lines = [
-    `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText(
-      "Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.",
-    )}`,
-    `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
-  ];
-  for (const row of rateLimitRows) {
-    const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
-    lines.push(
-      `${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`,
-    );
-  }
-
-  lines.push(
-    `# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText(
-      "The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.",
-    )}`,
-  );
-  lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
-  for (const row of capRows) {
-    lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
-  }
-
-  return `${lines.join("\n")}\n`;
+    const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
+    const capRows = collectCapUsageRows(capUsage);
+    const lines = [
+        `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText("Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.")}`,
+        `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
+    ];
+    for (const row of rateLimitRows) {
+        const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
+        lines.push(`${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`);
+    }
+    lines.push(`# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText("The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.")}`);
+    lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
+    for (const row of capRows) {
+        lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
+    }
+    return `${lines.join("\n")}\n`;
 }
-
 async function withGovernorState(options, run) {
-  const ownsGovernorState = options.openGovernorState === undefined;
-  const governorState = (options.openGovernorState ?? openGovernorState)();
-  try {
-    return run(governorState);
-  } finally {
-    if (ownsGovernorState) governorState.close();
-  }
+    const ownsGovernorState = options.openGovernorState === undefined;
+    const governorState = (options.openGovernorState ?? openGovernorState)();
+    try {
+        return run(governorState);
+    }
+    finally {
+        if (ownsGovernorState)
+            governorState.close();
+    }
 }
-
 export async function runGovernorMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
-      const rateLimitState = governorState.loadRateLimitState();
-      const capUsage = governorState.loadCapUsage();
-      console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const nowMs = typeof options.nowMs === "number" && Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+            const rateLimitState = governorState.loadRateLimitState();
+            const capUsage = governorState.loadCapUsage();
+            console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItbWV0cmljcy1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJnb3Zlcm5vci1tZXRyaWNzLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLEVBQ0wsdUJBQXVCLEVBQ3ZCLGlDQUFpQyxFQUNqQyxvQkFBb0IsRUFDcEIsc0JBQXNCLEdBQ3ZCLE1BQU0sa0JBQWtCLENBQUM7QUFDMUIsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFDeEQsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBSWxGLG1HQUFtRztBQUNuRywwR0FBMEc7QUFDMUcsOEdBQThHO0FBQzlHLDZHQUE2RztBQUM3Ryx1R0FBdUc7QUFDdkcsNkdBQTZHO0FBQzdHLCtHQUErRztBQUMvRyw4R0FBOEc7QUFDOUcsOEdBQThHO0FBQzlHLDBDQUEwQztBQUMxQyxFQUFFO0FBQ0YsOEdBQThHO0FBQzlHLDBHQUEwRztBQUMxRywwR0FBMEc7QUFDMUcsc0dBQXNHO0FBQ3RHLDBFQUEwRTtBQUUxRSxNQUFNLHNCQUFzQixHQUFHLHdDQUF3QyxDQUFDO0FBRXhFLE1BQU0sQ0FBQyxNQUFNLG1DQUFtQyxHQUFHLG9EQUFvRCxDQUFDO0FBQ3hHLE1BQU0sQ0FBQyxNQUFNLHdCQUF3QixHQUFHLHlDQUF5QyxDQUFDO0FBRWxGLHVHQUF1RztBQUN2RyxTQUFTLHFCQUFxQixDQUFDLElBQVk7SUFDekMsT0FBTyxJQUFJLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxNQUFNLENBQUMsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO0FBQzNELENBQUM7QUFFRDt5QkFDeUI7QUFDekIsU0FBUyxnQkFBZ0IsQ0FBQyxLQUFhO0lBQ3JDLE9BQU8sS0FBSyxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsTUFBTSxDQUFDLENBQUMsT0FBTyxDQUFDLElBQUksRUFBRSxLQUFLLENBQUMsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO0FBQ2pGLENBQUM7QUFFRDs7Z0ZBRWdGO0FBQ2hGLFNBQVMsZUFBZSxDQUFDLEdBQVc7SUFDbEMsTUFBTSxjQUFjLEdBQUcsR0FBRyxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUN4QyxJQUFJLGNBQWMsS0FBSyxDQUFDLENBQUM7UUFBRSxPQUFPLEVBQUUsV0FBVyxFQUFFLEdBQUcsRUFBRSxZQUFZLEVBQUUsRUFBRSxFQUFFLENBQUM7SUFDekUsT0FBTyxFQUFFLFdBQVcsRUFBRSxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxjQUFjLENBQUMsRUFBRSxZQUFZLEVBQUUsR0FBRyxDQUFDLEtBQUssQ0FBQyxjQUFjLEdBQUcsQ0FBQyxDQUFDLEVBQUUsQ0FBQztBQUNwRyxDQUFDO0FBRUQsZ0hBQWdIO0FBQ2hILDBHQUEwRztBQUMxRywrR0FBK0c7QUFDL0csNEdBQTRHO0FBQzVHLDhHQUE4RztBQUM5Ryw2R0FBNkc7QUFDN0csZ0hBQWdIO0FBQ2hILGdFQUFnRTtBQUNoRSxTQUFTLGNBQWMsQ0FBQyxRQUFtRDtJQUN6RSxNQUFNLFFBQVEsR0FBRyxRQUFRLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsU0FBUyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQy9ELE9BQU8sUUFBUSxHQUFHLFFBQVEsQ0FBQyxLQUFLLENBQUM7QUFDbkMsQ0FBQztBQUVELFNBQVMsb0JBQW9CLENBQUMsT0FBMEMsRUFBRSxLQUFhO0lBQ3JGLE1BQU0sSUFBSSxHQUFHLEVBQUUsQ0FBQztJQUNoQixLQUFLLE1BQU0sQ0FBQyxXQUFXLEVBQUUsTUFBTSxDQUFDLElBQUksTUFBTSxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNuRSxNQUFNLE1BQU0sR0FBRyxpQ0FBaUMsQ0FBQyxNQUFNLENBQUMsV0FBVyxDQUFDLENBQUM7UUFDckUsSUFBSSxDQUFDLE1BQU07WUFBRSxTQUFTO1FBQ3RCLElBQUksQ0FBQyxJQUFJLENBQUM7WUFDUixLQUFLLEVBQUUsUUFBUTtZQUNmLFdBQVc7WUFDWCxZQUFZLEVBQUUsRUFBRTtZQUNoQixLQUFLLEVBQUUsY0FBYyxDQUFDLHNCQUFzQixDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsS0FBSyxDQUFDLENBQUM7U0FDckUsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUNELEtBQUssTUFBTSxDQUFDLEdBQUcsRUFBRSxNQUFNLENBQUMsSUFBSSxNQUFNLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsRUFBRSxDQUFDO1FBQzVELE1BQU0sRUFBRSxXQUFXLEVBQUUsWUFBWSxFQUFFLEdBQUcsZUFBZSxDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQzNELE1BQU0sTUFBTSxHQUFHLGlDQUFpQyxDQUFDLE9BQU8sQ0FBQyxXQUFXLENBQUMsQ0FBQztRQUN0RSxJQUFJLENBQUMsTUFBTTtZQUFFLFNBQVM7UUFDdEIsSUFBSSxDQUFDLElBQUksQ0FBQztZQUNSLEtBQUssRUFBRSxVQUFVO1lBQ2pCLFdBQVc7WUFDWCxZQUFZO1lBQ1osS0FBSyxFQUFFLGNBQWMsQ0FBQyxzQkFBc0IsQ0FBQyxNQUFNLEVBQUUsTUFBTSxFQUFFLEtBQUssQ0FBQyxDQUFDO1NBQ3JFLENBQUMsQ0FBQztJQUNMLENBQUM7SUFDRCxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsRUFBRSxFQUFFO1FBQ2pCLElBQUksQ0FBQyxDQUFDLEtBQUssS0FBSyxDQUFDLENBQUMsS0FBSztZQUFFLE9BQU8sQ0FBQyxDQUFDLEtBQUssQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQy9ELElBQUksQ0FBQyxDQUFDLFdBQVcsS0FBSyxDQUFDLENBQUMsV0FBVztZQUFFLE9BQU8sQ0FBQyxDQUFDLFdBQVcsQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLFdBQVcsQ0FBQyxDQUFDO1FBQ3ZGLE9BQU8sQ0FBQyxDQUFDLFlBQVksQ0FBQyxhQUFhLENBQUMsQ0FBQyxDQUFDLFlBQVksQ0FBQyxDQUFDO0lBQ3RELENBQUMsQ0FBQyxDQUFDO0lBQ0gsT0FBTyxJQUFJLENBQUM7QUFDZCxDQUFDO0FBRUQsOEdBQThHO0FBQzlHLHdEQUF3RDtBQUN4RCxTQUFTLG1CQUFtQixDQUFDLFFBQTBCO0lBQ3JELE1BQU0sTUFBTSxHQUFHLG9CQUFvQixDQUFDLFFBQVEsRUFBRSx1QkFBdUIsQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUNqRixPQUFPO1FBQ0wsRUFBRSxTQUFTLEVBQUUsUUFBUSxFQUFFLGVBQWUsRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFO1FBQ3ZELEVBQUUsU0FBUyxFQUFFLE9BQU8sRUFBRSxlQUFlLEVBQUUsTUFBTSxDQUFDLEtBQUssRUFBRTtRQUNyRCxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsZUFBZSxFQUFFLE1BQU0sQ0FBQyxXQUFXLEVBQUU7S0FDakUsQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLFNBQVMsRUFBRSxlQUFlLEVBQUUsRUFBRSxFQUFFLENBQUMsQ0FBQztRQUN6QyxTQUFTO1FBQ1QsS0FBSyxFQUFFLGVBQWUsQ0FBQyxJQUFJLEdBQUcsZUFBZSxDQUFDLEtBQUs7S0FDcEQsQ0FBQyxDQUFDLENBQUM7QUFDTixDQUFDO0FBRUQ7Ozs7R0FJRztBQUNILE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxjQUFzQyxFQUFFLFFBQTBCLEVBQUUsS0FBYTtJQUNySCxNQUFNLGFBQWEsR0FBRyxvQkFBb0IsQ0FBQyxjQUFjLENBQUMsT0FBTyxFQUFFLEtBQUssQ0FBQyxDQUFDO0lBQzFFLE1BQU0sT0FBTyxHQUFHLG1CQUFtQixDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBRTlDLE1BQU0sS0FBSyxHQUFHO1FBQ1osVUFBVSxtQ0FBbUMsSUFBSSxxQkFBcUIsQ0FDcEUscU1BQXFNLENBQ3RNLEVBQUU7UUFDSCxVQUFVLG1DQUFtQyxRQUFRO0tBQ3RELENBQUM7SUFDRixLQUFLLE1BQU0sR0FBRyxJQUFJLGFBQWEsRUFBRSxDQUFDO1FBQ2hDLE1BQU0sU0FBUyxHQUFHLEdBQUcsQ0FBQyxLQUFLLEtBQUssVUFBVSxDQUFDLENBQUMsQ0FBQyxVQUFVLGdCQUFnQixDQUFDLEdBQUcsQ0FBQyxZQUFZLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7UUFDbEcsS0FBSyxDQUFDLElBQUksQ0FDUixHQUFHLG1DQUFtQyxXQUFXLEdBQUcsQ0FBQyxLQUFLLG1CQUFtQixnQkFBZ0IsQ0FBQyxHQUFHLENBQUMsV0FBVyxDQUFDLElBQUksU0FBUyxLQUFLLEdBQUcsQ0FBQyxLQUFLLEVBQUUsQ0FDNUksQ0FBQztJQUNKLENBQUM7SUFFRCxLQUFLLENBQUMsSUFBSSxDQUNSLFVBQVUsd0JBQXdCLElBQUkscUJBQXFCLENBQ3pELHNLQUFzSyxDQUN2SyxFQUFFLENBQ0osQ0FBQztJQUNGLEtBQUssQ0FBQyxJQUFJLENBQUMsVUFBVSx3QkFBd0IsUUFBUSxDQUFDLENBQUM7SUFDdkQsS0FBSyxNQUFNLEdBQUcsSUFBSSxPQUFPLEVBQUUsQ0FBQztRQUMxQixLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsd0JBQXdCLGVBQWUsR0FBRyxDQUFDLFNBQVMsTUFBTSxHQUFHLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQztJQUN2RixDQUFDO0lBRUQsT0FBTyxHQUFHLEtBQUssQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQztBQUNqQyxDQUFDO0FBRUQsS0FBSyxVQUFVLGlCQUFpQixDQUFJLE9BQW9FLEVBQUUsR0FBd0M7SUFDaEosTUFBTSxpQkFBaUIsR0FBRyxPQUFPLENBQUMsaUJBQWlCLEtBQUssU0FBUyxDQUFDO0lBQ2xFLE1BQU0sYUFBYSxHQUFHLENBQUMsT0FBTyxDQUFDLGlCQUFpQixJQUFJLGlCQUFpQixDQUFDLEVBQUUsQ0FBQztJQUN6RSxJQUFJLENBQUM7UUFDSCxPQUFPLEdBQUcsQ0FBQyxhQUFhLENBQUMsQ0FBQztJQUM1QixDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksaUJBQWlCO1lBQUUsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQy9DLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxrQkFBa0IsQ0FBQyxJQUFjLEVBQUUsVUFBdUUsRUFBRTtJQUNoSSxJQUFJLElBQUksQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDcEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsc0JBQXNCLENBQUMsQ0FBQztJQUN0RSxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sS0FBSyxHQUFHLE9BQU8sT0FBTyxDQUFDLEtBQUssS0FBSyxRQUFRLElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQztZQUMvRyxNQUFNLGNBQWMsR0FBRyxhQUFhLENBQUMsa0JBQWtCLEVBQUUsQ0FBQztZQUMxRCxNQUFNLFFBQVEsR0FBRyxhQUFhLENBQUMsWUFBWSxFQUFFLENBQUM7WUFDOUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxxQkFBcUIsQ0FBQyxjQUFjLEVBQUUsUUFBUSxFQUFFLEtBQUssQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUM7WUFDOUUsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUN2RSxDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/governor-metrics-cli.ts
+++ b/packages/loopover-miner/lib/governor-metrics-cli.ts
@@ -1,0 +1,173 @@
+import {
+  DEFAULT_AMS_POLICY_SPEC,
+  DEFAULT_WRITE_RATE_LIMIT_POLICIES,
+  evaluateGovernorCaps,
+  evaluateLocalRateLimit,
+} from "@loopover/engine";
+import { openGovernorState } from "./governor-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import type { GovernorCapUsage } from "@loopover/engine";
+import type { GovernorRateLimitState, GovernorState } from "./governor-state.js";
+
+// `governor metrics` (#5187): render the governor's persisted rate-limit + cap-usage state (#5134,
+// governor-state.js) as Prometheus text-exposition, so an operator's Alertmanager can page on rate-limit/
+// budget pressure without hand-rolling a scrape. Strictly read-only, mirroring queue-cli.js's `queue metrics`
+// (#5186) and event-ledger-cli.js's `ledger metrics` (#4841): opens the local governor-state store, composes
+// its EXISTING loadRateLimitState()/loadCapUsage() with the engine's already-exported PURE calculators
+// (evaluateLocalRateLimit, evaluateGovernorCaps) against the SAME defaults the production loop (loop-cli.js)
+// already falls back to when no `.loopover-ams.yml` override is configured (DEFAULT_WRITE_RATE_LIMIT_POLICIES,
+// DEFAULT_AMS_POLICY_SPEC.capLimits) -- it never invents a threshold of its own, and it does not gate, retry,
+// mutate, or otherwise touch governor decision logic (governor-chokepoint.js/governor-chokepoint-persisted.js
+// are completely untouched by this file).
+//
+// capLimits is intentionally NOT read per-repo: governor-state.js's capUsage row is a single global scalar (a
+// run-scoped cumulative counter, not indexed by repo -- see governor-state.js's own header comment), so a
+// per-repo capLimits override from a resolved `.loopover-miner.yml` has no matching per-repo usage row to
+// pair it with here. Using the fleet-wide DEFAULT_AMS_POLICY_SPEC.capLimits is the same approximation
+// loop-cli.js itself already makes for any repo without its own override.
+
+const GOVERNOR_METRICS_USAGE = "Usage: loopover-miner governor metrics";
+
+export const GOVERNOR_RATE_LIMIT_REMAINING_RATIO = "loopover_miner_governor_rate_limit_remaining_ratio";
+export const GOVERNOR_CAP_USAGE_RATIO = "loopover_miner_governor_cap_usage_ratio";
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeMetricsHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping — backslash, double-quote, newline (mirrors event-ledger-cli.js's
+ *  escapeLabelValue). */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/** buckets.perRepo is keyed by writeRateLimitRepoKey(actionClass, repoFullName) = "actionClass:repoFullName"
+ *  (write-rate-limit.ts). actionClass is a fixed identifier (never contains ":"), so splitting on the FIRST
+ *  colon recovers both parts even though repoFullName itself contains a "/". */
+function splitPerRepoKey(key: string): { actionClass: string; repoFullName: string } {
+  const separatorIndex = key.indexOf(":");
+  if (separatorIndex === -1) return { actionClass: key, repoFullName: "" };
+  return { actionClass: key.slice(0, separatorIndex), repoFullName: key.slice(separatorIndex + 1) };
+}
+
+// evaluateLocalRateLimit's own `remaining` field answers "how many MORE writes are allowed AFTER one more write
+// right now" (rate-limit.ts: `remaining = allowed ? limit - effectiveCount - 1 : 0`) -- it is NOT current
+// headroom. At count=2/limit=3 that field is already 0, identical to a fully exhausted count=3/limit=3 bucket,
+// even though the count=2 bucket still has one write available. Recover true current headroom algebraically
+// instead: when allowed, decision.remaining + 1 is exactly limit - effectiveCount (undo the "-1 for this next
+// write" the decision already applied); when not allowed, headroom is 0. Every actionClass this loop reaches
+// has already passed the DEFAULT_WRITE_RATE_LIMIT_POLICIES lookup above, so decision.limit is always one of the
+// frozen, non-zero policy limits -- no zero-limit guard needed.
+function remainingRatio(decision: ReturnType<typeof evaluateLocalRateLimit>): number {
+  const headroom = decision.allowed ? decision.remaining + 1 : 0;
+  return headroom / decision.limit;
+}
+
+function collectRateLimitRows(buckets: GovernorRateLimitState["buckets"], nowMs: number) {
+  const rows = [];
+  for (const [actionClass, bucket] of Object.entries(buckets.global)) {
+    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.global[actionClass];
+    if (!config) continue;
+    rows.push({
+      scope: "global",
+      actionClass,
+      repoFullName: "",
+      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    });
+  }
+  for (const [key, bucket] of Object.entries(buckets.perRepo)) {
+    const { actionClass, repoFullName } = splitPerRepoKey(key);
+    const config = DEFAULT_WRITE_RATE_LIMIT_POLICIES.perRepo[actionClass];
+    if (!config) continue;
+    rows.push({
+      scope: "per_repo",
+      actionClass,
+      repoFullName,
+      ratio: remainingRatio(evaluateLocalRateLimit(bucket, config, nowMs)),
+    });
+  }
+  rows.sort((a, b) => {
+    if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
+    if (a.actionClass !== b.actionClass) return a.actionClass.localeCompare(b.actionClass);
+    return a.repoFullName.localeCompare(b.repoFullName);
+  });
+  return rows;
+}
+
+// DEFAULT_AMS_POLICY_SPEC.capLimits is a frozen, non-zero constant for every dimension -- no zero-limit guard
+// needed, mirroring remainingRatio()'s reasoning above.
+function collectCapUsageRows(capUsage: GovernorCapUsage) {
+  const report = evaluateGovernorCaps(capUsage, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  return [
+    { dimension: "budget", dimensionReport: report.budget },
+    { dimension: "turns", dimensionReport: report.turns },
+    { dimension: "elapsed_ms", dimensionReport: report.termination },
+  ].map(({ dimension, dimensionReport }) => ({
+    dimension,
+    ratio: dimensionReport.used / dimensionReport.limit,
+  }));
+}
+
+/**
+ * @param {import("./governor-state.js").GovernorRateLimitState} rateLimitState
+ * @param {import("@loopover/engine").GovernorCapUsage} capUsage
+ * @param {number} nowMs
+ */
+export function renderGovernorMetrics(rateLimitState: GovernorRateLimitState, capUsage: GovernorCapUsage, nowMs: number): string {
+  const rateLimitRows = collectRateLimitRows(rateLimitState.buckets, nowMs);
+  const capRows = collectCapUsageRows(capUsage);
+
+  const lines = [
+    `# HELP ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} ${escapeMetricsHelpText(
+      "Remaining headroom in the governor's current write-rate-limit window, as a fraction of the configured limit (1 = empty bucket, 0 = exhausted). Evaluated against DEFAULT_WRITE_RATE_LIMIT_POLICIES.",
+    )}`,
+    `# TYPE ${GOVERNOR_RATE_LIMIT_REMAINING_RATIO} gauge`,
+  ];
+  for (const row of rateLimitRows) {
+    const repoLabel = row.scope === "per_repo" ? `,repo="${escapeLabelValue(row.repoFullName)}"` : "";
+    lines.push(
+      `${GOVERNOR_RATE_LIMIT_REMAINING_RATIO}{scope="${row.scope}",action_class="${escapeLabelValue(row.actionClass)}"${repoLabel}} ${row.ratio}`,
+    );
+  }
+
+  lines.push(
+    `# HELP ${GOVERNOR_CAP_USAGE_RATIO} ${escapeMetricsHelpText(
+      "The governor's persisted cumulative cap usage as a fraction of DEFAULT_AMS_POLICY_SPEC.capLimits (1 = ceiling reached). dimension is one of budget|turns|elapsed_ms.",
+    )}`,
+  );
+  lines.push(`# TYPE ${GOVERNOR_CAP_USAGE_RATIO} gauge`);
+  for (const row of capRows) {
+    lines.push(`${GOVERNOR_CAP_USAGE_RATIO}{dimension="${row.dimension}"} ${row.ratio}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function withGovernorState<T>(options: { openGovernorState?: () => GovernorState; nowMs?: number }, run: (governorState: GovernorState) => T): Promise<T> {
+  const ownsGovernorState = options.openGovernorState === undefined;
+  const governorState = (options.openGovernorState ?? openGovernorState)();
+  try {
+    return run(governorState);
+  } finally {
+    if (ownsGovernorState) governorState.close();
+  }
+}
+
+export async function runGovernorMetrics(args: string[], options: { openGovernorState?: () => GovernorState; nowMs?: number } = {}): Promise<number> {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), GOVERNOR_METRICS_USAGE);
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const nowMs = typeof options.nowMs === "number" && Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+      const rateLimitState = governorState.loadRateLimitState();
+      const capUsage = governorState.loadCapUsage();
+      console.log(renderGovernorMetrics(rateLimitState, capUsage, nowMs).trimEnd());
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}

--- a/packages/loopover-miner/lib/governor-pause-cli.d.ts
+++ b/packages/loopover-miner/lib/governor-pause-cli.d.ts
@@ -1,23 +1,27 @@
 import type { GovernorState } from "./governor-state.js";
-
-export type ParsedGovernorPauseArgs =
-  | { json: boolean; dryRun: boolean; reason: string | null }
-  | { error: string };
-
-export type ParsedGovernorResumeArgs = { json: boolean; dryRun: boolean } | { error: string };
-
-export type ParsedGovernorNoArgsSubcommand = { json: boolean } | { error: string };
-
-export type GovernorPauseCliOptions = {
-  openGovernorState?: () => GovernorState;
+export type ParsedGovernorPauseArgs = {
+    json: boolean;
+    dryRun: boolean;
+    reason: string | null;
+} | {
+    error: string;
 };
-
-export function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs;
-
-export function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs;
-
-export function runGovernorPause(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
-
-export function runGovernorResume(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
-
-export function runGovernorStatus(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export type ParsedGovernorResumeArgs = {
+    json: boolean;
+    dryRun: boolean;
+} | {
+    error: string;
+};
+export type ParsedGovernorNoArgsSubcommand = {
+    json: boolean;
+} | {
+    error: string;
+};
+export type GovernorPauseCliOptions = {
+    openGovernorState?: () => GovernorState;
+};
+export declare function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs;
+export declare function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs;
+export declare function runGovernorPause(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export declare function runGovernorResume(args: string[], options?: GovernorPauseCliOptions): Promise<number>;
+export declare function runGovernorStatus(args: string[], options?: GovernorPauseCliOptions): Promise<number>;

--- a/packages/loopover-miner/lib/governor-pause-cli.js
+++ b/packages/loopover-miner/lib/governor-pause-cli.js
@@ -5,162 +5,158 @@
 // path) -- this is the first genuinely operator/governor-writable stop/go control. Persisted on governor-state.js's
 // existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
 // same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
-
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { openGovernorState } from "./governor-state.js";
-
 const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
 const GOVERNOR_RESUME_USAGE = "Usage: loopover-miner governor resume [--dry-run] [--json]";
 const GOVERNOR_STATUS_USAGE = "Usage: loopover-miner governor status [--json]";
-
 export function parseGovernorPauseArgs(args) {
-  const options = { json: false, dryRun: false, reason: null };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false, reason: null };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what pausing would do and returns before writing to governor-state.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--reason") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: GOVERNOR_PAUSE_USAGE };
+            options.reason = value;
+            index += 1;
+            continue;
+        }
+        return { error: `Unknown option: ${token}` };
     }
-    // #4847: reports what pausing would do and returns before writing to governor-state.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--reason") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: GOVERNOR_PAUSE_USAGE };
-      options.reason = value;
-      index += 1;
-      continue;
-    }
-    return { error: `Unknown option: ${token}` };
-  }
-
-  return options;
+    return options;
 }
-
 export function parseGovernorResumeArgs(args) {
-  const options = { json: false, dryRun: false };
-
-  for (const token of args) {
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false };
+    for (const token of args) {
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what resuming would do and returns before writing to governor-state.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        return { error: GOVERNOR_RESUME_USAGE };
     }
-    // #4847: reports what resuming would do and returns before writing to governor-state.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    return { error: GOVERNOR_RESUME_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 function parseNoArgsSubcommand(args, usage) {
-  if (args.length === 0) return { json: false };
-  if (args.length === 1 && args[0] === "--json") return { json: true };
-  return { error: usage };
+    if (args.length === 0)
+        return { json: false };
+    if (args.length === 1 && args[0] === "--json")
+        return { json: true };
+    return { error: usage };
 }
-
 async function withGovernorState(options, run) {
-  const ownsGovernorState = options.openGovernorState === undefined;
-  const governorState = (options.openGovernorState ?? openGovernorState)();
-  try {
-    return run(governorState);
-  } finally {
-    if (ownsGovernorState) governorState.close();
-  }
+    const ownsGovernorState = options.openGovernorState === undefined;
+    const governorState = (options.openGovernorState ?? openGovernorState)();
+    try {
+        return run(governorState);
+    }
+    finally {
+        if (ownsGovernorState)
+            governorState.close();
+    }
 }
-
 function renderPauseState(pauseState) {
-  if (!pauseState.paused) return "governor is not paused";
-  const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
-  return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
+    if (!pauseState.paused)
+        return "governor is not paused";
+    const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
+    return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
 }
-
 export async function runGovernorPause(args, options = {}) {
-  const parsed = parseGovernorPauseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      const reason = parsed.reason ? ` (${parsed.reason})` : "";
-      console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+    const parsed = parseGovernorPauseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            const reason = parsed.reason ? ` (${parsed.reason})` : "";
+            console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorResume(args, options = {}) {
-  const parsed = parseGovernorResumeArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", paused: false };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult));
-    } else {
-      console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+    const parsed = parseGovernorResumeArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.savePauseState({ paused: false });
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", paused: false };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult));
+        }
+        else {
+            console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+        }
+        return 0;
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.savePauseState({ paused: false });
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export async function runGovernorStatus(args, options = {}) {
-  const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return await withGovernorState(options, (governorState) => {
-      const pauseState = governorState.loadPauseState();
-      if (parsed.json) {
-        console.log(JSON.stringify(pauseState));
-      } else {
-        console.log(renderPauseState(pauseState));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return await withGovernorState(options, (governorState) => {
+            const pauseState = governorState.loadPauseState();
+            if (parsed.json) {
+                console.log(JSON.stringify(pauseState));
+            }
+            else {
+                console.log(renderPauseState(pauseState));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ292ZXJub3ItcGF1c2UtY2xpLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZ292ZXJub3ItcGF1c2UtY2xpLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLCtHQUErRztBQUMvRywrR0FBK0c7QUFDL0csaUhBQWlIO0FBQ2pILCtHQUErRztBQUMvRyxvSEFBb0g7QUFDcEgsOEdBQThHO0FBQzlHLG1HQUFtRztBQUVuRyxPQUFPLEVBQUUsWUFBWSxFQUFFLGdCQUFnQixFQUFFLGdCQUFnQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbEYsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0scUJBQXFCLENBQUM7QUFleEQsTUFBTSxvQkFBb0IsR0FBRyw2RUFBNkUsQ0FBQztBQUMzRyxNQUFNLHFCQUFxQixHQUFHLDREQUE0RCxDQUFDO0FBQzNGLE1BQU0scUJBQXFCLEdBQUcsZ0RBQWdELENBQUM7QUFFL0UsTUFBTSxVQUFVLHNCQUFzQixDQUFDLElBQWM7SUFDbkQsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsTUFBTSxFQUFFLElBQXFCLEVBQUUsQ0FBQztJQUU5RSxLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsSUFBSSxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDcEQsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0QscUZBQXFGO1FBQ3JGLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssVUFBVSxFQUFFLENBQUM7WUFDekIsTUFBTSxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztZQUM5QixJQUFJLENBQUMsS0FBSyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO2dCQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsb0JBQW9CLEVBQUUsQ0FBQztZQUM1RSxPQUFPLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQztZQUN2QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO0lBQy9DLENBQUM7SUFFRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsTUFBTSxVQUFVLHVCQUF1QixDQUFDLElBQWM7SUFDcEQsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUUvQyxLQUFLLE1BQU0sS0FBSyxJQUFJLElBQUksRUFBRSxDQUFDO1FBQ3pCLElBQUksS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO1lBQ3ZCLE9BQU8sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBQ3BCLFNBQVM7UUFDWCxDQUFDO1FBQ0Qsc0ZBQXNGO1FBQ3RGLElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsT0FBTyxFQUFFLEtBQUssRUFBRSxxQkFBcUIsRUFBRSxDQUFDO0lBQzFDLENBQUM7SUFFRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsU0FBUyxxQkFBcUIsQ0FBQyxJQUFjLEVBQUUsS0FBYTtJQUMxRCxJQUFJLElBQUksQ0FBQyxNQUFNLEtBQUssQ0FBQztRQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLENBQUM7SUFDOUMsSUFBSSxJQUFJLENBQUMsTUFBTSxLQUFLLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLEtBQUssUUFBUTtRQUFFLE9BQU8sRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLENBQUM7SUFDckUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUMxQixDQUFDO0FBRUQsS0FBSyxVQUFVLGlCQUFpQixDQUFJLE9BQWdDLEVBQUUsR0FBd0M7SUFDNUcsTUFBTSxpQkFBaUIsR0FBRyxPQUFPLENBQUMsaUJBQWlCLEtBQUssU0FBUyxDQUFDO0lBQ2xFLE1BQU0sYUFBYSxHQUFHLENBQUMsT0FBTyxDQUFDLGlCQUFpQixJQUFJLGlCQUFpQixDQUFDLEVBQUUsQ0FBQztJQUN6RSxJQUFJLENBQUM7UUFDSCxPQUFPLEdBQUcsQ0FBQyxhQUFhLENBQUMsQ0FBQztJQUM1QixDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksaUJBQWlCO1lBQUUsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBQy9DLENBQUM7QUFDSCxDQUFDO0FBRUQsU0FBUyxnQkFBZ0IsQ0FBQyxVQUE4QjtJQUN0RCxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU07UUFBRSxPQUFPLHdCQUF3QixDQUFDO0lBQ3hELE1BQU0sTUFBTSxHQUFHLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEtBQUssVUFBVSxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDbEUsT0FBTyw0QkFBNEIsVUFBVSxDQUFDLFFBQVEsR0FBRyxNQUFNLEVBQUUsQ0FBQztBQUNwRSxDQUFDO0FBRUQsTUFBTSxDQUFDLEtBQUssVUFBVSxnQkFBZ0IsQ0FBQyxJQUFjLEVBQUUsVUFBbUMsRUFBRTtJQUMxRixNQUFNLE1BQU0sR0FBRyxzQkFBc0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUM1QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDakYsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUM7UUFDNUMsQ0FBQzthQUFNLENBQUM7WUFDTixNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxLQUFLLE1BQU0sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1lBQzFELE9BQU8sQ0FBQyxHQUFHLENBQUMsb0NBQW9DLE1BQU0scUNBQXFDLENBQUMsQ0FBQztRQUMvRixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLENBQUMsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLE1BQU0sRUFBRSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQztZQUN6RixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDMUMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLGlCQUFpQixDQUFDLElBQWMsRUFBRSxVQUFtQyxFQUFFO0lBQzNGLE1BQU0sTUFBTSxHQUFHLHVCQUF1QixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQzdDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztRQUMzRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQztRQUM1QyxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsdUVBQXVFLENBQUMsQ0FBQztRQUN2RixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLENBQUMsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztZQUNuRSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDMUMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLENBQUMsS0FBSyxVQUFVLGlCQUFpQixDQUFDLElBQWMsRUFBRSxVQUFtQyxFQUFFO0lBQzNGLE1BQU0sTUFBTSxHQUFHLHFCQUFxQixDQUFDLElBQUksRUFBRSxxQkFBcUIsQ0FBQyxDQUFDO0lBQ2xFLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxNQUFNLGlCQUFpQixDQUFDLE9BQU8sRUFBRSxDQUFDLGFBQWEsRUFBRSxFQUFFO1lBQ3hELE1BQU0sVUFBVSxHQUFHLGFBQWEsQ0FBQyxjQUFjLEVBQUUsQ0FBQztZQUNsRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7WUFDMUMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUM1QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUMifQ==

--- a/packages/loopover-miner/lib/governor-pause-cli.ts
+++ b/packages/loopover-miner/lib/governor-pause-cli.ts
@@ -1,0 +1,179 @@
+// The governor pause/resume control surface (#4851): a real, persisted pause flag an operator (or, in a future
+// wave, the governor itself) can toggle via this CLI, that loop-cli.js's iteration loop actually checks before
+// each cycle. Distinct from governor-kill-switch.js (a read-only resolver over pre-existing env/YAML inputs this
+// package never itself writes) and governor-run-halt.js (a one-way, run-scoped terminal breaker with no resume
+// path) -- this is the first genuinely operator/governor-writable stop/go control. Persisted on governor-state.js's
+// existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
+// same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
+
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { openGovernorState } from "./governor-state.js";
+import type { GovernorPauseState, GovernorState } from "./governor-state.js";
+
+export type ParsedGovernorPauseArgs =
+  | { json: boolean; dryRun: boolean; reason: string | null }
+  | { error: string };
+
+export type ParsedGovernorResumeArgs = { json: boolean; dryRun: boolean } | { error: string };
+
+export type ParsedGovernorNoArgsSubcommand = { json: boolean } | { error: string };
+
+export type GovernorPauseCliOptions = {
+  openGovernorState?: () => GovernorState;
+};
+
+const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
+const GOVERNOR_RESUME_USAGE = "Usage: loopover-miner governor resume [--dry-run] [--json]";
+const GOVERNOR_STATUS_USAGE = "Usage: loopover-miner governor status [--json]";
+
+export function parseGovernorPauseArgs(args: string[]): ParsedGovernorPauseArgs {
+  const options = { json: false, dryRun: false, reason: null as string | null };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what pausing would do and returns before writing to governor-state.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--reason") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: GOVERNOR_PAUSE_USAGE };
+      options.reason = value;
+      index += 1;
+      continue;
+    }
+    return { error: `Unknown option: ${token}` };
+  }
+
+  return options;
+}
+
+export function parseGovernorResumeArgs(args: string[]): ParsedGovernorResumeArgs {
+  const options = { json: false, dryRun: false };
+
+  for (const token of args) {
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what resuming would do and returns before writing to governor-state.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    return { error: GOVERNOR_RESUME_USAGE };
+  }
+
+  return options;
+}
+
+function parseNoArgsSubcommand(args: string[], usage: string): ParsedGovernorNoArgsSubcommand {
+  if (args.length === 0) return { json: false };
+  if (args.length === 1 && args[0] === "--json") return { json: true };
+  return { error: usage };
+}
+
+async function withGovernorState<T>(options: GovernorPauseCliOptions, run: (governorState: GovernorState) => T): Promise<T> {
+  const ownsGovernorState = options.openGovernorState === undefined;
+  const governorState = (options.openGovernorState ?? openGovernorState)();
+  try {
+    return run(governorState);
+  } finally {
+    if (ownsGovernorState) governorState.close();
+  }
+}
+
+function renderPauseState(pauseState: GovernorPauseState): string {
+  if (!pauseState.paused) return "governor is not paused";
+  const reason = pauseState.reason ? ` (${pauseState.reason})` : "";
+  return `governor is PAUSED since ${pauseState.pausedAt}${reason}`;
+}
+
+export async function runGovernorPause(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorPauseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", paused: true, reason: parsed.reason };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      const reason = parsed.reason ? ` (${parsed.reason})` : "";
+      console.log(`DRY RUN: would pause the governor${reason}. No governor-state write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.savePauseState({ paused: true, reason: parsed.reason });
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorResume(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseGovernorResumeArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", paused: false };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult));
+    } else {
+      console.log("DRY RUN: would resume the governor. No governor-state write was made.");
+    }
+    return 0;
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.savePauseState({ paused: false });
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export async function runGovernorStatus(args: string[], options: GovernorPauseCliOptions = {}): Promise<number> {
+  const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return await withGovernorState(options, (governorState) => {
+      const pauseState = governorState.loadPauseState();
+      if (parsed.json) {
+        console.log(JSON.stringify(pauseState));
+      } else {
+        console.log(renderPauseState(pauseState));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}

--- a/packages/loopover-miner/lib/loop-cli.d.ts
+++ b/packages/loopover-miner/lib/loop-cli.d.ts
@@ -6,61 +6,129 @@ import type { GovernorLedger } from "./governor-ledger.js";
 import type { RunStateStore } from "./run-state.js";
 import type { PollPrDispositionOptions } from "./pr-disposition-poller.js";
 import type { CheckRunConclusion, PollCheckRunsOptions } from "./ci-poller.js";
-
-export type ParsedLoopArgs =
-  | { error: string }
-  | {
-      targets: string[];
-      search: string | null;
-      minerLogin: string;
-      base: string;
-      live: boolean;
-      dryRun: boolean;
-      maxCycles: number | undefined;
-      cycleDelayMs: number;
-      json: boolean;
-    };
-
-export function parseLoopArgs(args: string[]): ParsedLoopArgs;
-
+export type ParsedLoopArgs = {
+    error: string;
+} | {
+    targets: string[];
+    search: string | null;
+    minerLogin: string;
+    base: string;
+    live: boolean;
+    dryRun: boolean;
+    maxCycles: number | undefined;
+    cycleDelayMs: number;
+    json: boolean;
+};
 export type LoopCycleSummary = {
-  cycle: number;
-  outcome: "idle_queue_empty" | "halted" | "attempted" | "skipped_malformed_identifier";
-  reason?: string;
-  repoFullName?: string;
-  identifier?: string;
-  attemptOutcome?: AttemptCliResult["outcome"] | "attempt_error";
-  reentryOutcome?: "merged" | "disengaged" | "other";
-  prNumber?: number | null;
-  ciConclusion?: CheckRunConclusion | null;
-  reentered?: boolean;
-  reasons?: string[];
+    cycle: number;
+    outcome: "idle_queue_empty" | "halted" | "attempted" | "skipped_malformed_identifier";
+    reason?: string;
+    repoFullName?: string;
+    identifier?: string;
+    attemptOutcome?: AttemptCliResult["outcome"] | "attempt_error";
+    reentryOutcome?: "merged" | "disengaged" | "other";
+    prNumber?: number | null;
+    ciConclusion?: CheckRunConclusion | null;
+    reentered?: boolean;
+    reasons?: string[];
 };
-
 export type RunLoopOptions = {
-  env?: Record<string, string | undefined>;
-  nowMs?: number;
-  githubToken?: string;
-  apiBaseUrl?: string;
-  sleepFn?: (delayMs: number) => Promise<void>;
-  openGovernorState?: () => GovernorState;
-  initEventLedger?: () => EventLedger;
-  initGovernorLedger?: () => GovernorLedger;
-  initPortfolioQueue?: () => PortfolioQueueStore;
-  initRunStateStore?: () => RunStateStore;
-  runDiscover?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
-  runAttempt?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
-  resolveAmsPolicy?: (repoFullName: string, options?: Record<string, unknown>) => Promise<{ spec: Record<string, unknown>; source: string; warnings: string[] }>;
-  checkMinerKillSwitch?: (input?: { env?: Record<string, string | undefined>; repoPaused?: boolean }) => { scope: "global" | "repo" | "none"; active: boolean };
-  evaluateRunLoopBoundaryGate?: (input: unknown, options?: unknown) => { verdict: { reason: string }; canClaimNext: boolean };
-  pollPrDisposition?: (repoFullName: string, prNumber: number, options?: PollPrDispositionOptions) => Promise<{ state: "open" | "closed"; merged: boolean; closedAt: string | null; attempts: number }>;
-  pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<{ conclusion: CheckRunConclusion; checks: unknown[]; headSha: string; attempts: number }>;
-  recordPrOutcomeSnapshot?: (input: unknown, options?: unknown) => unknown;
-  buildLoopClosureSummary?: (sources: unknown, options?: unknown) => { sinceSeq: number | null; lastSeq: number };
-  attemptLoopReentry?: (candidate: unknown, deps: unknown) => { decision: { reenter: boolean; reasons: string[] }; dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null };
-  attemptOptions?: Record<string, unknown>;
-  prDispositionOptions?: PollPrDispositionOptions;
-  ciPollOptions?: PollCheckRunsOptions;
+    env?: Record<string, string | undefined>;
+    nowMs?: number;
+    githubToken?: string;
+    apiBaseUrl?: string;
+    sleepFn?: (delayMs: number) => Promise<void>;
+    openGovernorState?: () => GovernorState;
+    initEventLedger?: () => EventLedger;
+    initGovernorLedger?: () => GovernorLedger;
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initRunStateStore?: () => RunStateStore;
+    runDiscover?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+    runAttempt?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+    resolveAmsPolicy?: (repoFullName: string, options?: Record<string, unknown>) => Promise<{
+        spec: Record<string, unknown>;
+        source: string;
+        warnings: string[];
+    }>;
+    checkMinerKillSwitch?: (input?: {
+        env?: Record<string, string | undefined>;
+        repoPaused?: boolean;
+    }) => {
+        scope: "global" | "repo" | "none";
+        active: boolean;
+    };
+    evaluateRunLoopBoundaryGate?: (input: unknown, options?: unknown) => {
+        verdict: {
+            reason: string;
+        };
+        canClaimNext: boolean;
+    };
+    pollPrDisposition?: (repoFullName: string, prNumber: number, options?: PollPrDispositionOptions) => Promise<{
+        state: "open" | "closed";
+        merged: boolean;
+        closedAt: string | null;
+        attempts: number;
+    }>;
+    pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<{
+        conclusion: CheckRunConclusion;
+        checks: unknown[];
+        headSha: string;
+        attempts: number;
+    }>;
+    recordPrOutcomeSnapshot?: (input: unknown, options?: unknown) => unknown;
+    buildLoopClosureSummary?: (sources: unknown, options?: unknown) => {
+        sinceSeq: number | null;
+        lastSeq: number;
+    };
+    attemptLoopReentry?: (candidate: unknown, deps: unknown) => {
+        decision: {
+            reenter: boolean;
+            reasons: string[];
+        };
+        dequeued: {
+            repoFullName: string;
+            identifier: string;
+            priority: number;
+            status: string;
+            enqueuedAt: string;
+        } | null;
+    };
+    attemptOptions?: Record<string, unknown>;
+    prDispositionOptions?: PollPrDispositionOptions;
+    ciPollOptions?: PollCheckRunsOptions;
 };
-
-export function runLoop(args: string[], options?: RunLoopOptions): Promise<number>;
+export declare function parseLoopArgs(args: string[]): ParsedLoopArgs;
+/**
+ * Run one full discover -> claim -> attempt -> observe -> reenter cycle repeatedly until a kill-switch trips,
+ * the run-loop boundary gate halts (non-convergence or a real budget/turn/elapsed cap), re-entry is declined,
+ * or `--max-cycles` is reached. Fails closed: refuses to start at all if governor state cannot be loaded.
+ *
+ * @param {string[]} args
+ * @param {{
+ *   env?: Record<string, string | undefined>,
+ *   nowMs?: number,
+ *   githubToken?: string,
+ *   apiBaseUrl?: string,
+ *   sleepFn?: (delayMs: number) => Promise<void>,
+ *   openGovernorState?: typeof openGovernorState,
+ *   initEventLedger?: typeof initEventLedger,
+ *   initGovernorLedger?: typeof initGovernorLedger,
+ *   initPortfolioQueue?: () => import("./portfolio-queue.js").PortfolioQueueStore,
+ *   initRunStateStore?: typeof initRunStateStore,
+ *   runDiscover?: typeof runDiscover,
+ *   runAttempt?: typeof runAttempt,
+ *   resolveAmsPolicy?: typeof resolveAmsPolicy,
+ *   checkMinerKillSwitch?: typeof checkMinerKillSwitch,
+ *   evaluateRunLoopBoundaryGate?: typeof evaluateRunLoopBoundaryGate,
+ *   pollPrDisposition?: typeof pollPrDisposition,
+ *   pollCheckRuns?: typeof pollCheckRuns,
+ *   recordPrOutcomeSnapshot?: typeof recordPrOutcomeSnapshot,
+ *   buildLoopClosureSummary?: typeof buildLoopClosureSummary,
+ *   attemptLoopReentry?: typeof attemptLoopReentry,
+ *   attemptOptions?: Record<string, unknown>,
+ *   prDispositionOptions?: Record<string, unknown>,
+ *   ciPollOptions?: Record<string, unknown>,
+ * }} [options]
+ * @returns {Promise<number>}
+ */
+export declare function runLoop(args: string[], options?: RunLoopOptions): Promise<number>;

--- a/packages/loopover-miner/lib/loop-cli.js
+++ b/packages/loopover-miner/lib/loop-cli.js
@@ -21,7 +21,6 @@
 // dequeueNext claim + markDone/markFailed calls below already maintain -- the same source a one-shot `attempt`
 // invocation reads (#5654), so both share one source of truth and the counters survive a loop-daemon restart
 // (crash/deploy/systemd bounce) instead of resetting with the process (#5677).
-
 import { checkMinerKillSwitch } from "./governor-kill-switch.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { evaluateRunLoopBoundaryGate } from "./governor-run-halt.js";
@@ -42,131 +41,133 @@ import { attemptLoopReentry } from "./loop-reentry.js";
 import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
 import { DEFAULT_AMS_POLICY_SPEC } from "@loopover/engine";
-
-const LOOP_USAGE =
-  "Usage: loopover-miner loop <owner/repo> [<owner/repo>...] | --search <query> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]";
+const LOOP_USAGE = "Usage: loopover-miner loop <owner/repo> [<owner/repo>...] | --search <query> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]";
 const DEFAULT_CYCLE_DELAY_MS = 60_000;
 const ISSUE_IDENTIFIER_PATTERN = /^issue:(\d+)$/;
-
 function parseRepoTarget(value) {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) return null;
-  return `${owner}/${repo}`;
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined)
+        return null;
+    return `${owner}/${repo}`;
 }
-
 function normalizeOptionalPositiveInt(value, label) {
-  const parsedValue = Number(value);
-  if (!Number.isFinite(parsedValue) || !Number.isInteger(parsedValue) || parsedValue < 0) {
-    throw new Error(`${label} must be a non-negative integer: ${value}`);
-  }
-  return parsedValue;
+    const parsedValue = Number(value);
+    if (!Number.isFinite(parsedValue) || !Number.isInteger(parsedValue) || parsedValue < 0) {
+        throw new Error(`${label} must be a non-negative integer: ${value}`);
+    }
+    return parsedValue;
 }
-
 export function parseLoopArgs(args) {
-  const options = {
-    json: false,
-    minerLogin: null,
-    base: "main",
-    live: false,
-    dryRun: false,
-    search: null,
-    maxCycles: undefined,
-    cycleDelayMs: DEFAULT_CYCLE_DELAY_MS,
-  };
-  const targets = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        minerLogin: null,
+        base: "main",
+        live: false,
+        dryRun: false,
+        search: null,
+        maxCycles: undefined,
+        cycleDelayMs: DEFAULT_CYCLE_DELAY_MS,
+    };
+    const targets = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--live") {
+            options.live = true;
+            continue;
+        }
+        // #4847: see attempt-cli.js's own --dry-run comment -- distinct from --live's absence, this short-circuits
+        // BEFORE governor state or any other store is opened, guaranteeing zero discovery/queue/ledger writes.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--search") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            options.search = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--miner-login") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            options.minerLogin = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--base") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            options.base = value;
+            index += 1;
+            continue;
+        }
+        if (token === "--max-cycles") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            try {
+                options.maxCycles = normalizeOptionalPositiveInt(value, "--max-cycles");
+            }
+            catch (error) {
+                return { error: error instanceof Error ? error.message : String(error) };
+            }
+            index += 1;
+            continue;
+        }
+        if (token === "--cycle-delay-ms") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-"))
+                return { error: LOOP_USAGE };
+            try {
+                options.cycleDelayMs = normalizeOptionalPositiveInt(value, "--cycle-delay-ms");
+            }
+            catch (error) {
+                return { error: error instanceof Error ? error.message : String(error) };
+            }
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-"))
+            return { error: `Unknown option: ${token}` };
+        const target = parseRepoTarget(token);
+        if (!target)
+            return { error: `Repository must be in owner/repo form: ${token}` };
+        targets.push(target);
     }
-    if (token === "--live") {
-      options.live = true;
-      continue;
-    }
-    // #4847: see attempt-cli.js's own --dry-run comment -- distinct from --live's absence, this short-circuits
-    // BEFORE governor state or any other store is opened, guaranteeing zero discovery/queue/ledger writes.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--search") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      options.search = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--miner-login") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      options.minerLogin = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--base") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      options.base = value;
-      index += 1;
-      continue;
-    }
-    if (token === "--max-cycles") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      try {
-        options.maxCycles = normalizeOptionalPositiveInt(value, "--max-cycles");
-      } catch (error) {
-        return { error: error instanceof Error ? error.message : String(error) };
-      }
-      index += 1;
-      continue;
-    }
-    if (token === "--cycle-delay-ms") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
-      try {
-        options.cycleDelayMs = normalizeOptionalPositiveInt(value, "--cycle-delay-ms");
-      } catch (error) {
-        return { error: error instanceof Error ? error.message : String(error) };
-      }
-      index += 1;
-      continue;
-    }
-    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
-    const target = parseRepoTarget(token);
-    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
-    targets.push(target);
-  }
-
-  if (options.search === null && targets.length === 0) return { error: LOOP_USAGE };
-  if (options.search !== null && targets.length > 0) return { error: "Pass either repository targets or --search, not both." };
-  if (!options.minerLogin) return { error: `--miner-login is required. ${LOOP_USAGE}` };
-
-  return {
-    targets,
-    search: options.search,
-    minerLogin: options.minerLogin,
-    base: options.base,
-    live: options.live,
-    dryRun: options.dryRun,
-    maxCycles: options.maxCycles,
-    cycleDelayMs: options.cycleDelayMs,
-    json: options.json,
-  };
+    if (options.search === null && targets.length === 0)
+        return { error: LOOP_USAGE };
+    if (options.search !== null && targets.length > 0)
+        return { error: "Pass either repository targets or --search, not both." };
+    if (!options.minerLogin)
+        return { error: `--miner-login is required. ${LOOP_USAGE}` };
+    return {
+        targets,
+        search: options.search,
+        minerLogin: options.minerLogin,
+        base: options.base,
+        live: options.live,
+        dryRun: options.dryRun,
+        maxCycles: options.maxCycles,
+        cycleDelayMs: options.cycleDelayMs,
+        json: options.json,
+    };
 }
-
 function discoverArgv(parsed) {
-  return parsed.search !== null ? ["--search", parsed.search] : [...parsed.targets];
+    return parsed.search !== null ? ["--search", parsed.search] : [...parsed.targets];
 }
-
 function parseIssueNumberFromIdentifier(identifier) {
-  const match = typeof identifier === "string" ? identifier.match(ISSUE_IDENTIFIER_PATTERN) : null;
-  return match ? Number(match[1]) : null;
+    const match = typeof identifier === "string" ? identifier.match(ISSUE_IDENTIFIER_PATTERN) : null;
+    return match ? Number(match[1]) : null;
 }
-
 /**
  * Run one full discover -> claim -> attempt -> observe -> reenter cycle repeatedly until a kill-switch trips,
  * the run-loop boundary gate halts (non-convergence or a real budget/turn/elapsed cap), re-entry is declined,
@@ -201,390 +202,349 @@ function parseIssueNumberFromIdentifier(identifier) {
  * @returns {Promise<number>}
  */
 export async function runLoop(args, options = {}) {
-  const parsed = parseLoopArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const env = options.env ?? process.env;
-  const sleepFn = options.sleepFn ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
-  const nowMsFn = () => options.nowMs ?? Date.now();
-  const sessionStartMs = nowMsFn();
-
-  // #4847: reports what a real loop invocation would target and returns BEFORE governor state or any other
-  // store (event/governor ledger, portfolio queue, run state) is opened -- a provable zero-write path, not just
-  // "opened but didn't write." The loop's own discovery call enqueues newly-found candidates into the LOCAL
-  // portfolio queue even before any attempt happens, so a faithful dry run cannot call it either.
-  if (parsed.dryRun) {
-    const dryRunResult = {
-      outcome: "dry_run",
-      targets: parsed.targets,
-      search: parsed.search,
-      minerLogin: parsed.minerLogin,
-      base: parsed.base,
-      live: parsed.live,
-      maxCycles: parsed.maxCycles ?? null,
-    };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      const target = parsed.search !== null ? `--search ${parsed.search}` : parsed.targets.join(", ");
-      console.log(
-        `DRY RUN: would run an autonomous loop against ${target} for ${parsed.minerLogin} (base: ${parsed.base}, live: ${parsed.live}). No discovery, queue, or ledger writes were made.`,
-      );
+    const parsed = parseLoopArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  let governorState;
-  try {
-    governorState = (options.openGovernorState ?? openGovernorState)();
-  } catch (error) {
-    return reportCliFailure(
-      parsed.json,
-      `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`,
-      3,
-    );
-  }
-
-  const eventLedger = (options.initEventLedger ?? initEventLedger)();
-  const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  const runState = (options.initRunStateStore ?? initRunStateStore)();
-
-  const runDiscoverFn = options.runDiscover ?? runDiscover;
-  const runAttemptFn = options.runAttempt ?? runAttempt;
-  const resolveAmsPolicyFn = options.resolveAmsPolicy ?? resolveAmsPolicy;
-  const checkKillSwitchFn = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
-  const evaluateBoundaryGateFn = options.evaluateRunLoopBoundaryGate ?? evaluateRunLoopBoundaryGate;
-  const pollPrDispositionFn = options.pollPrDisposition ?? pollPrDisposition;
-  const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
-  const recordPrOutcomeSnapshotFn = options.recordPrOutcomeSnapshot ?? recordPrOutcomeSnapshot;
-  const buildLoopClosureSummaryFn = options.buildLoopClosureSummary ?? buildLoopClosureSummary;
-  const attemptLoopReentryFn = options.attemptLoopReentry ?? attemptLoopReentry;
-
-  // Resolved ONCE, at the CLI-entrypoint layer, mirroring manage-poll.js's own runManagePoll (its
-  // recordManagePollSnapshot callee has no env fallback of its own either -- the top-level CLI function is
-  // where the GitHub token gets resolved, then threaded down explicitly to every real GitHub caller).
-  // pollPrDisposition (unlike runDiscover, which falls back to process.env.GITHUB_TOKEN internally) has NO
-  // such fallback -- an unresolved githubToken here would silently poll unauthenticated.
-  // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
-  // authenticated `loopover-mcp login` session -- cached in memory for this process's lifetime.
-  const githubToken = options.githubToken ?? (await resolveGitHubToken(env)) ?? "";
-
-  async function runDiscoveryOnce() {
-    await runDiscoverFn(discoverArgv(parsed), {
-      initPortfolioQueue: () => portfolioQueue,
-      githubToken,
-      apiBaseUrl: options.apiBaseUrl,
-      nowMs: nowMsFn(),
-    });
-  }
-
-  let usage = governorState.loadCapUsage();
-  const cycles = [];
-  let sinceSeq = eventLedger.readEvents({}).at(-1)?.seq ?? 0;
-  let haltReason = null;
-
-  try {
-    // Checked BEFORE any work at all -- including the very first discovery call -- so an already-active kill
-    // switch OR an already-active pause (#4851) halts the loop without ever touching GitHub or the queue. The
-    // pause flag is real, persisted, operator/governor-writable state on governorState (toggled via
-    // `loopover-miner governor pause`/`resume`) -- unlike the kill switch, a paused run resumes simply by being
-    // re-invoked: every piece of per-cycle state this loop reads (portfolioQueue, runState, governorState's own
-    // cap usage) is already durable, so clearing the flag and restarting continues exactly where it left off.
-    const initialKillSwitch = checkKillSwitchFn({ env });
-    const initialPauseState = governorState.loadPauseState();
-    let claimed = null;
-    if (initialKillSwitch.active) {
-      haltReason = `kill_switch_${initialKillSwitch.scope}`;
-      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
-    } else if (initialPauseState.paused) {
-      haltReason = "paused";
-      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
-    } else {
-      await runDiscoveryOnce();
-      claimed = portfolioQueue.dequeueNext();
+    // Narrowed once here so nested closures (runDiscoveryOnce) see the non-error branch: TS control-flow
+    // narrowing from the `in` guard above does not flow into a captured closure's body.
+    const parsedRun = parsed;
+    const env = options.env ?? process.env;
+    const sleepFn = options.sleepFn ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+    const nowMsFn = () => options.nowMs ?? Date.now();
+    const sessionStartMs = nowMsFn();
+    // #4847: reports what a real loop invocation would target and returns BEFORE governor state or any other
+    // store (event/governor ledger, portfolio queue, run state) is opened -- a provable zero-write path, not just
+    // "opened but didn't write." The loop's own discovery call enqueues newly-found candidates into the LOCAL
+    // portfolio queue even before any attempt happens, so a faithful dry run cannot call it either.
+    if (parsed.dryRun) {
+        const dryRunResult = {
+            outcome: "dry_run",
+            targets: parsed.targets,
+            search: parsed.search,
+            minerLogin: parsed.minerLogin,
+            base: parsed.base,
+            live: parsed.live,
+            maxCycles: parsed.maxCycles ?? null,
+        };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            const target = parsed.search !== null ? `--search ${parsed.search}` : parsed.targets.join(", ");
+            console.log(`DRY RUN: would run an autonomous loop against ${target} for ${parsed.minerLogin} (base: ${parsed.base}, live: ${parsed.live}). No discovery, queue, or ledger writes were made.`);
+        }
+        return 0;
     }
-
-    let cycleIndex = haltReason !== null ? 1 : 0;
-    while (haltReason === null && (parsed.maxCycles === undefined || cycleIndex < parsed.maxCycles)) {
-      cycleIndex += 1;
-
-      const killSwitch = checkKillSwitchFn({ env });
-      if (killSwitch.active) {
-        haltReason = `kill_switch_${killSwitch.scope}`;
-        // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
-        if (claimed) {
-          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-        }
-        cycles.push({
-          cycle: cycleIndex,
-          outcome: "halted",
-          reason: haltReason,
-          ...(claimed
-            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
-            : {}),
-        });
-        break;
-      }
-
-      const pauseState = governorState.loadPauseState();
-      if (pauseState.paused) {
-        haltReason = "paused";
-        if (claimed) {
-          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-        }
-        cycles.push({
-          cycle: cycleIndex,
-          outcome: "halted",
-          reason: haltReason,
-          ...(claimed
-            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
-            : {}),
-        });
-        break;
-      }
-
-      if (!claimed) {
-        cycles.push({ cycle: cycleIndex, outcome: "idle_queue_empty" });
-        await sleepFn(parsed.cycleDelayMs);
-        await runDiscoveryOnce();
-        claimed = portfolioQueue.dequeueNext();
-        continue;
-      }
-
-      const issueNumber = parseIssueNumberFromIdentifier(claimed.identifier);
-      if (issueNumber === null) {
-        // Never produced by enqueueRankedDiscovery in practice (always "issue:N") -- fail soft rather than
-        // crash the whole run: this exact item can never be attempted, so it will never resolve on retry.
-        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-        cycles.push({ cycle: cycleIndex, outcome: "skipped_malformed_identifier", identifier: claimed.identifier });
-        claimed = portfolioQueue.dequeueNext();
-        continue;
-      }
-
-      const amsPolicy = await resolveAmsPolicyFn(claimed.repoFullName, { env });
-      // Real, SQLite-persisted per-item convergence history (#5677): the dequeueNext claim above already recorded
-      // this attempt and the markDone/markFailed calls below record the outcome, so reading it back here shares one
-      // source of truth with attempt-cli.js (#5654) and survives a loop-daemon restart instead of resetting.
-      const convergenceInput = portfolioQueue.getAttemptHistory(
-        claimed.repoFullName,
-        claimed.identifier,
-        claimed.apiBaseUrl,
-      );
-
-      const boundary = evaluateBoundaryGateFn(
-        {
-          runHalted: false,
-          usage,
-          limits: amsPolicy.spec.capLimits ?? DEFAULT_AMS_POLICY_SPEC.capLimits,
-          convergence: convergenceInput,
-          convergenceThresholds: amsPolicy.spec.convergenceThresholds ?? DEFAULT_AMS_POLICY_SPEC.convergenceThresholds,
-          inFlightItem: { repoFullName: claimed.repoFullName, identifier: claimed.identifier },
-          // Echoes claimed.apiBaseUrl (#5563), NOT the callback's own repoFullName/identifier alone -- two forge
-          // hosts can share an in-flight item with the same repo name+identifier.
-          markFailed: (repoFullName, identifier) => portfolioQueue.markFailed(repoFullName, identifier, claimed.apiBaseUrl),
-        },
-        { append: (event) => governorLedger.appendGovernorEvent(event) },
-      );
-
-      if (!boundary.canClaimNext) {
-        haltReason = `boundary_${boundary.verdict.reason}`;
-        cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason, repoFullName: claimed.repoFullName, identifier: claimed.identifier });
-        break;
-      }
-
-      const cycleStartMs = nowMsFn();
-      let lastResult = null;
-      const attemptArgv = [
-        claimed.repoFullName,
-        String(issueNumber),
-        "--miner-login",
-        parsed.minerLogin,
-        "--base",
-        parsed.base,
-        ...(parsed.live ? ["--live"] : []),
-      ];
-      await runAttemptFn(attemptArgv, {
-        ...(options.attemptOptions ?? {}),
-        env,
-        onResult: (result) => {
-          lastResult = result;
-        },
-      });
-      const cycleElapsedMs = nowMsFn() - cycleStartMs;
-
-      usage = {
-        // Real for the agent-sdk provider (its own SDK result message reports total_cost_usd, wired through
-        // runMinerAttempt's real loopResult.totalCostUsd); the CLI-subprocess providers (claude-cli/codex-cli)
-        // report no cost signal today, so this contributes 0 for those runs -- an honest absence, not a
-        // fabricated number. A capLimits.budget dimension only ever meaningfully trips against agent-sdk spend.
-        budgetSpent: usage.budgetSpent + (lastResult?.totalCostUsd ?? 0),
-        turnsTaken: usage.turnsTaken + (lastResult?.totalTurnsUsed ?? 0),
-        elapsedMs: usage.elapsedMs + cycleElapsedMs,
-      };
-      governorState.saveCapUsage(usage);
-
-      const attemptOutcome = lastResult?.outcome ?? "attempt_error";
-      const submitted = attemptOutcome === "attempt_submitted";
-      // A repo-wide AI-usage-policy ban will never resolve on retry -- stop re-queuing it (matches
-      // rejection-signal.js's own "this repo bans automated contributions" semantics). Every other blocked/
-      // abandoned/stale/governed outcome MAY resolve on a later retry (transient infra, contention, a
-      // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
-      // (reenqueues threshold) rather than silently retried forever.
-      const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
-      // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
-      // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
-      const killSwitchAbandon = lastResult?.abandonReason === "kill_switch_engaged";
-
-      if (submitted || permanentBlock) {
-        // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
-        // so neither is re-queued. markDone also clears the persisted consecutive-failure streak.
-        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-      } else {
-        // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
-        // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
-        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-      }
-
-      if (killSwitchAbandon) {
-        const liveKill = checkKillSwitchFn({ env });
-        haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
-        cycles.push({
-          cycle: cycleIndex,
-          outcome: "halted",
-          reason: haltReason,
-          repoFullName: claimed.repoFullName,
-          identifier: claimed.identifier,
-          attemptOutcome,
-        });
-        break;
-      }
-
-      let reentryOutcome = "other";
-      let prNumber = null;
-      let prDisposition = null;
-      let ciConclusion = null;
-      if (submitted) {
-        prNumber = parsePrNumberFromExecResult(lastResult?.execResult, claimed.repoFullName);
-        if (prNumber !== null) {
-          // Real CI-status observation (#5394): recorded BEFORE the disposition poll below, so a submitted
-          // PR's check-run state is captured even while it's still open, not just at its eventual merge/close.
-          // ci-poller.js's real GitHub check-run polling is a heuristic proxy for the gate verdict; the
-          // authoritative terminal merge/close outcome comes from pollPrDispositionFn below, sourced directly
-          // from GitHub's own PR state rather than a server-internal endpoint (#5450).
-          const ciStatus = await pollCheckRunsFn(claimed.repoFullName, prNumber, {
+    let governorState;
+    try {
+        governorState = (options.openGovernorState ?? openGovernorState)();
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`, 3);
+    }
+    const eventLedger = (options.initEventLedger ?? initEventLedger)();
+    const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    const runState = (options.initRunStateStore ?? initRunStateStore)();
+    const runDiscoverFn = options.runDiscover ?? runDiscover;
+    const runAttemptFn = options.runAttempt ?? runAttempt;
+    const resolveAmsPolicyFn = options.resolveAmsPolicy ?? resolveAmsPolicy;
+    const checkKillSwitchFn = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
+    const evaluateBoundaryGateFn = options.evaluateRunLoopBoundaryGate ?? evaluateRunLoopBoundaryGate;
+    const pollPrDispositionFn = options.pollPrDisposition ?? pollPrDisposition;
+    const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
+    const recordPrOutcomeSnapshotFn = options.recordPrOutcomeSnapshot ?? recordPrOutcomeSnapshot;
+    const buildLoopClosureSummaryFn = options.buildLoopClosureSummary ?? buildLoopClosureSummary;
+    const attemptLoopReentryFn = options.attemptLoopReentry ?? attemptLoopReentry;
+    // Resolved ONCE, at the CLI-entrypoint layer, mirroring manage-poll.js's own runManagePoll (its
+    // recordManagePollSnapshot callee has no env fallback of its own either -- the top-level CLI function is
+    // where the GitHub token gets resolved, then threaded down explicitly to every real GitHub caller).
+    // pollPrDisposition (unlike runDiscover, which falls back to process.env.GITHUB_TOKEN internally) has NO
+    // such fallback -- an unresolved githubToken here would silently poll unauthenticated.
+    // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+    // authenticated `loopover-mcp login` session -- cached in memory for this process's lifetime.
+    const githubToken = options.githubToken ?? (await resolveGitHubToken(env)) ?? "";
+    async function runDiscoveryOnce() {
+        await runDiscoverFn(discoverArgv(parsedRun), {
+            initPortfolioQueue: () => portfolioQueue,
             githubToken,
-            apiBaseUrl: options.apiBaseUrl,
-            ...(options.ciPollOptions ?? {}),
-          });
-          ciConclusion = ciStatus.conclusion;
-          eventLedger.appendEvent({
-            type: "ci_status_observed",
-            repoFullName: claimed.repoFullName,
-            payload: { prNumber, conclusion: ciStatus.conclusion, checkCount: ciStatus.checks.length, source: "ci-poller" },
-          });
-
-          prDisposition = await pollPrDispositionFn(claimed.repoFullName, prNumber, {
-            githubToken,
-            apiBaseUrl: options.apiBaseUrl,
-            ...(options.prDispositionOptions ?? {}),
-          });
-          if (prDisposition.state === "closed") {
-            recordPrOutcomeSnapshotFn(
-              {
+            ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+            nowMs: nowMsFn(),
+        });
+    }
+    let usage = governorState.loadCapUsage();
+    const cycles = [];
+    let sinceSeq = eventLedger.readEvents({}).at(-1)?.seq ?? 0;
+    let haltReason = null;
+    try {
+        // Checked BEFORE any work at all -- including the very first discovery call -- so an already-active kill
+        // switch OR an already-active pause (#4851) halts the loop without ever touching GitHub or the queue. The
+        // pause flag is real, persisted, operator/governor-writable state on governorState (toggled via
+        // `loopover-miner governor pause`/`resume`) -- unlike the kill switch, a paused run resumes simply by being
+        // re-invoked: every piece of per-cycle state this loop reads (portfolioQueue, runState, governorState's own
+        // cap usage) is already durable, so clearing the flag and restarting continues exactly where it left off.
+        const initialKillSwitch = checkKillSwitchFn({ env });
+        const initialPauseState = governorState.loadPauseState();
+        let claimed = null;
+        if (initialKillSwitch.active) {
+            haltReason = `kill_switch_${initialKillSwitch.scope}`;
+            cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+        }
+        else if (initialPauseState.paused) {
+            haltReason = "paused";
+            cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+        }
+        else {
+            await runDiscoveryOnce();
+            claimed = portfolioQueue.dequeueNext();
+        }
+        let cycleIndex = haltReason !== null ? 1 : 0;
+        while (haltReason === null && (parsed.maxCycles === undefined || cycleIndex < parsed.maxCycles)) {
+            cycleIndex += 1;
+            const killSwitch = checkKillSwitchFn({ env });
+            if (killSwitch.active) {
+                haltReason = `kill_switch_${killSwitch.scope}`;
+                // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
+                if (claimed) {
+                    portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+                }
+                cycles.push({
+                    cycle: cycleIndex,
+                    outcome: "halted",
+                    reason: haltReason,
+                    ...(claimed
+                        ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+                        : {}),
+                });
+                break;
+            }
+            const pauseState = governorState.loadPauseState();
+            if (pauseState.paused) {
+                haltReason = "paused";
+                if (claimed) {
+                    portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+                }
+                cycles.push({
+                    cycle: cycleIndex,
+                    outcome: "halted",
+                    reason: haltReason,
+                    ...(claimed
+                        ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+                        : {}),
+                });
+                break;
+            }
+            if (!claimed) {
+                cycles.push({ cycle: cycleIndex, outcome: "idle_queue_empty" });
+                await sleepFn(parsed.cycleDelayMs);
+                await runDiscoveryOnce();
+                claimed = portfolioQueue.dequeueNext();
+                continue;
+            }
+            const issueNumber = parseIssueNumberFromIdentifier(claimed.identifier);
+            if (issueNumber === null) {
+                // Never produced by enqueueRankedDiscovery in practice (always "issue:N") -- fail soft rather than
+                // crash the whole run: this exact item can never be attempted, so it will never resolve on retry.
+                portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+                cycles.push({ cycle: cycleIndex, outcome: "skipped_malformed_identifier", identifier: claimed.identifier });
+                claimed = portfolioQueue.dequeueNext();
+                continue;
+            }
+            const amsPolicy = await resolveAmsPolicyFn(claimed.repoFullName, { env });
+            // Real, SQLite-persisted per-item convergence history (#5677): the dequeueNext claim above already recorded
+            // this attempt and the markDone/markFailed calls below record the outcome, so reading it back here shares one
+            // source of truth with attempt-cli.js (#5654) and survives a loop-daemon restart instead of resetting.
+            const convergenceInput = portfolioQueue.getAttemptHistory(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            const boundary = evaluateBoundaryGateFn({
+                runHalted: false,
+                usage,
+                limits: (amsPolicy.spec.capLimits ?? DEFAULT_AMS_POLICY_SPEC.capLimits),
+                convergence: convergenceInput,
+                convergenceThresholds: (amsPolicy.spec.convergenceThresholds ?? DEFAULT_AMS_POLICY_SPEC.convergenceThresholds),
+                inFlightItem: { repoFullName: claimed.repoFullName, identifier: claimed.identifier },
+                // Echoes claimed.apiBaseUrl (#5563), NOT the callback's own repoFullName/identifier alone -- two forge
+                // hosts can share an in-flight item with the same repo name+identifier.
+                markFailed: (repoFullName, identifier) => portfolioQueue.markFailed(repoFullName, identifier, claimed.apiBaseUrl),
+            }, { append: (event) => governorLedger.appendGovernorEvent(event) });
+            if (!boundary.canClaimNext) {
+                haltReason = `boundary_${boundary.verdict.reason}`;
+                cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason, repoFullName: claimed.repoFullName, identifier: claimed.identifier });
+                break;
+            }
+            const cycleStartMs = nowMsFn();
+            // Held on an object rather than a bare `let`: the value is assigned inside the runAttempt `onResult`
+            // callback below, and TS's control-flow analysis would otherwise narrow a callback-only-assigned `let`
+            // back to its `null` initializer at the reads after the await. A property read is not narrowed that way.
+            const lastResultHolder = { value: null };
+            const attemptArgv = [
+                claimed.repoFullName,
+                String(issueNumber),
+                "--miner-login",
+                parsed.minerLogin,
+                "--base",
+                parsed.base,
+                ...(parsed.live ? ["--live"] : []),
+            ];
+            await runAttemptFn(attemptArgv, {
+                ...(options.attemptOptions ?? {}),
+                env,
+                onResult: (result) => {
+                    lastResultHolder.value = result;
+                },
+            });
+            const cycleElapsedMs = nowMsFn() - cycleStartMs;
+            usage = {
+                // Real for the agent-sdk provider (its own SDK result message reports total_cost_usd, wired through
+                // runMinerAttempt's real loopResult.totalCostUsd); the CLI-subprocess providers (claude-cli/codex-cli)
+                // report no cost signal today, so this contributes 0 for those runs -- an honest absence, not a
+                // fabricated number. A capLimits.budget dimension only ever meaningfully trips against agent-sdk spend.
+                budgetSpent: usage.budgetSpent + (lastResultHolder.value?.totalCostUsd ?? 0),
+                turnsTaken: usage.turnsTaken + (lastResultHolder.value?.totalTurnsUsed ?? 0),
+                elapsedMs: usage.elapsedMs + cycleElapsedMs,
+            };
+            governorState.saveCapUsage(usage);
+            const attemptOutcome = lastResultHolder.value?.outcome ?? "attempt_error";
+            const submitted = attemptOutcome === "attempt_submitted";
+            // A repo-wide AI-usage-policy ban will never resolve on retry -- stop re-queuing it (matches
+            // rejection-signal.js's own "this repo bans automated contributions" semantics). Every other blocked/
+            // abandoned/stale/governed outcome MAY resolve on a later retry (transient infra, contention, a
+            // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
+            // (reenqueues threshold) rather than silently retried forever.
+            const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
+            // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
+            // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
+            const killSwitchAbandon = lastResultHolder.value?.abandonReason === "kill_switch_engaged";
+            if (submitted || permanentBlock) {
+                // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
+                // so neither is re-queued. markDone also clears the persisted consecutive-failure streak.
+                portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            }
+            else {
+                // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
+                // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
+                portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            }
+            if (killSwitchAbandon) {
+                const liveKill = checkKillSwitchFn({ env });
+                haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
+                cycles.push({
+                    cycle: cycleIndex,
+                    outcome: "halted",
+                    reason: haltReason,
+                    repoFullName: claimed.repoFullName,
+                    identifier: claimed.identifier,
+                    attemptOutcome,
+                });
+                break;
+            }
+            let reentryOutcome = "other";
+            let prNumber = null;
+            let prDisposition = null;
+            let ciConclusion = null;
+            if (submitted) {
+                prNumber = parsePrNumberFromExecResult(lastResultHolder.value?.execResult, claimed.repoFullName);
+                if (prNumber !== null) {
+                    // Real CI-status observation (#5394): recorded BEFORE the disposition poll below, so a submitted
+                    // PR's check-run state is captured even while it's still open, not just at its eventual merge/close.
+                    // ci-poller.js's real GitHub check-run polling is a heuristic proxy for the gate verdict; the
+                    // authoritative terminal merge/close outcome comes from pollPrDispositionFn below, sourced directly
+                    // from GitHub's own PR state rather than a server-internal endpoint (#5450).
+                    const ciStatus = await pollCheckRunsFn(claimed.repoFullName, prNumber, {
+                        githubToken,
+                        ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+                        ...(options.ciPollOptions ?? {}),
+                    });
+                    ciConclusion = ciStatus.conclusion;
+                    eventLedger.appendEvent({
+                        type: "ci_status_observed",
+                        repoFullName: claimed.repoFullName,
+                        payload: { prNumber, conclusion: ciStatus.conclusion, checkCount: ciStatus.checks.length, source: "ci-poller" },
+                    });
+                    prDisposition = await pollPrDispositionFn(claimed.repoFullName, prNumber, {
+                        githubToken,
+                        ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+                        ...(options.prDispositionOptions ?? {}),
+                    });
+                    if (prDisposition.state === "closed") {
+                        recordPrOutcomeSnapshotFn({
+                            repoFullName: claimed.repoFullName,
+                            prNumber,
+                            decision: prDisposition.merged ? "merged" : "closed",
+                            closedAt: prDisposition.closedAt,
+                        }, { eventLedger });
+                        // Real per-repo reputation history (#5675): a resolved terminal outcome updates the decided/unfavorable
+                        // counts the Governor's self-reputation throttle reads on this repo's next attempt. `decided` always;
+                        // `unfavorable` only on a closed-without-merge (rejection-state-machine.js's isRejectedPr, matching
+                        // #5655's own-rejection classification). Forge-scoped by claimed.apiBaseUrl (#5563), like every other
+                        // governor-state write here.
+                        const priorReputation = governorState.loadReputationHistory(claimed.repoFullName, claimed.apiBaseUrl);
+                        governorState.saveReputationHistory(claimed.repoFullName, {
+                            decided: priorReputation.decided + 1,
+                            unfavorable: priorReputation.unfavorable + (isRejectedPr(prDisposition) ? 1 : 0),
+                        }, claimed.apiBaseUrl);
+                        reentryOutcome = classifyPrDisposition(prDisposition);
+                    }
+                }
+            }
+            const loopSummary = buildLoopClosureSummaryFn({ eventLedger, portfolioQueue, runState }, { sinceSeq, repoFullName: claimed.repoFullName });
+            sinceSeq = loopSummary.lastSeq;
+            const reentry = attemptLoopReentryFn({ killSwitchScope: killSwitch.scope, repoFullName: claimed.repoFullName, outcome: reentryOutcome }, { eventLedger, portfolioQueue, runState, nowMs: nowMsFn(), sessionStartMs, loopSummary });
+            cycles.push({
+                cycle: cycleIndex,
+                outcome: "attempted",
                 repoFullName: claimed.repoFullName,
+                identifier: claimed.identifier,
+                attemptOutcome,
+                reentryOutcome,
                 prNumber,
-                decision: prDisposition.merged ? "merged" : "closed",
-                closedAt: prDisposition.closedAt,
-              },
-              { eventLedger },
-            );
-            // Real per-repo reputation history (#5675): a resolved terminal outcome updates the decided/unfavorable
-            // counts the Governor's self-reputation throttle reads on this repo's next attempt. `decided` always;
-            // `unfavorable` only on a closed-without-merge (rejection-state-machine.js's isRejectedPr, matching
-            // #5655's own-rejection classification). Forge-scoped by claimed.apiBaseUrl (#5563), like every other
-            // governor-state write here.
-            const priorReputation = governorState.loadReputationHistory(claimed.repoFullName, claimed.apiBaseUrl);
-            governorState.saveReputationHistory(
-              claimed.repoFullName,
-              {
-                decided: priorReputation.decided + 1,
-                unfavorable: priorReputation.unfavorable + (isRejectedPr(prDisposition) ? 1 : 0),
-              },
-              claimed.apiBaseUrl,
-            );
-            reentryOutcome = classifyPrDisposition(prDisposition);
-          }
+                ciConclusion,
+                reentered: reentry.decision.reenter,
+                reasons: reentry.decision.reasons,
+            });
+            if (!reentry.decision.reenter) {
+                haltReason = `reentry_declined:${reentry.decision.reasons.join(",")}`;
+                break;
+            }
+            if (reentry.dequeued) {
+                claimed = reentry.dequeued;
+                await sleepFn(parsed.cycleDelayMs);
+            }
+            else {
+                await sleepFn(parsed.cycleDelayMs);
+                await runDiscoveryOnce();
+                claimed = portfolioQueue.dequeueNext();
+            }
         }
-      }
-
-      const loopSummary = buildLoopClosureSummaryFn(
-        { eventLedger, portfolioQueue, runState },
-        { sinceSeq, repoFullName: claimed.repoFullName },
-      );
-      sinceSeq = loopSummary.lastSeq;
-
-      const reentry = attemptLoopReentryFn(
-        { killSwitchScope: killSwitch.scope, repoFullName: claimed.repoFullName, outcome: reentryOutcome },
-        { eventLedger, portfolioQueue, runState, nowMs: nowMsFn(), sessionStartMs, loopSummary },
-      );
-
-      cycles.push({
-        cycle: cycleIndex,
-        outcome: "attempted",
-        repoFullName: claimed.repoFullName,
-        identifier: claimed.identifier,
-        attemptOutcome,
-        reentryOutcome,
-        prNumber,
-        ciConclusion,
-        reentered: reentry.decision.reenter,
-        reasons: reentry.decision.reasons,
-      });
-
-      if (!reentry.decision.reenter) {
-        haltReason = `reentry_declined:${reentry.decision.reasons.join(",")}`;
-        break;
-      }
-
-      if (reentry.dequeued) {
-        claimed = reentry.dequeued;
-        await sleepFn(parsed.cycleDelayMs);
-      } else {
-        await sleepFn(parsed.cycleDelayMs);
-        await runDiscoveryOnce();
-        claimed = portfolioQueue.dequeueNext();
-      }
+        if (haltReason === null && parsed.maxCycles !== undefined) {
+            haltReason = "max_cycles_reached";
+            // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
+            // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
+            // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
+            // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
+            // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
+            if (claimed) {
+                portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+            }
+        }
+        const summary = { haltReason, cyclesRun: cycles.length, cycles };
+        if (parsed.json) {
+            console.log(JSON.stringify(summary, null, 2));
+        }
+        else {
+            console.log(`Loop finished after ${cycles.length} cycle(s): ${haltReason ?? "unknown"}.`);
+        }
+        return 0;
     }
-
-    if (haltReason === null && parsed.maxCycles !== undefined) {
-      haltReason = "max_cycles_reached";
-      // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
-      // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
-      // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
-      // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
-      // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
-      if (claimed) {
-        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
-      }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
     }
-
-    const summary = { haltReason, cyclesRun: cycles.length, cycles };
-    if (parsed.json) {
-      console.log(JSON.stringify(summary, null, 2));
-    } else {
-      console.log(`Loop finished after ${cycles.length} cycle(s): ${haltReason ?? "unknown"}.`);
+    finally {
+        governorState.close();
+        eventLedger.close();
+        governorLedger.close();
+        portfolioQueue.close();
+        runState.close();
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    governorState.close();
-    eventLedger.close();
-    governorLedger.close();
-    portfolioQueue.close();
-    runState.close();
-  }
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9vcC1jbGkuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJsb29wLWNsaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxzR0FBc0c7QUFDdEcsaUdBQWlHO0FBQ2pHLHlHQUF5RztBQUN6RyxtR0FBbUc7QUFDbkcsRUFBRTtBQUNGLHFHQUFxRztBQUNyRyx5R0FBeUc7QUFDekcscUZBQXFGO0FBQ3JGLDZHQUE2RztBQUM3RyxzREFBc0Q7QUFDdEQscUdBQXFHO0FBQ3JHLDBHQUEwRztBQUMxRyw4R0FBOEc7QUFDOUcsNkdBQTZHO0FBQzdHLDJEQUEyRDtBQUMzRCxFQUFFO0FBQ0YsdUdBQXVHO0FBQ3ZHLDBHQUEwRztBQUMxRyw4R0FBOEc7QUFDOUcsNEdBQTRHO0FBQzVHLCtHQUErRztBQUMvRyw2R0FBNkc7QUFDN0csK0VBQStFO0FBRS9FLE9BQU8sRUFBRSxvQkFBb0IsRUFBRSxNQUFNLDJCQUEyQixDQUFDO0FBQ2pFLE9BQU8sRUFBRSxZQUFZLEVBQUUsZ0JBQWdCLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRixPQUFPLEVBQUUsMkJBQTJCLEVBQUUsTUFBTSx3QkFBd0IsQ0FBQztBQUNyRSxPQUFPLEVBQUUsaUJBQWlCLEVBQUUsTUFBTSxxQkFBcUIsQ0FBQztBQUN4RCxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsTUFBTSxzQkFBc0IsQ0FBQztBQUMxRCxPQUFPLEVBQUUsZUFBZSxFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFDcEQsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDL0QsT0FBTyxFQUFFLGlCQUFpQixFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDbkQsT0FBTyxFQUFFLFdBQVcsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ2hELE9BQU8sRUFBRSxVQUFVLEVBQUUsTUFBTSxrQkFBa0IsQ0FBQztBQUM5QyxPQUFPLEVBQUUsZ0JBQWdCLEVBQUUsTUFBTSxpQkFBaUIsQ0FBQztBQUNuRCxPQUFPLEVBQUUsaUJBQWlCLEVBQUUscUJBQXFCLEVBQUUsTUFBTSw0QkFBNEIsQ0FBQztBQUN0RixPQUFPLEVBQUUsYUFBYSxFQUFFLE1BQU0sZ0JBQWdCLENBQUM7QUFDL0MsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0saUJBQWlCLENBQUM7QUFDMUQsT0FBTyxFQUFFLFlBQVksRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBQzVELE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQzVELE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBQ3ZELE9BQU8sRUFBRSwyQkFBMkIsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBQ25FLE9BQU8sRUFBRSxrQkFBa0IsRUFBRSxNQUFNLDhCQUE4QixDQUFDO0FBQ2xFLE9BQU8sRUFBRSx1QkFBdUIsRUFBRSxNQUFNLGtCQUFrQixDQUFDO0FBWTNELE1BQU0sVUFBVSxHQUNkLCtMQUErTCxDQUFDO0FBQ2xNLE1BQU0sc0JBQXNCLEdBQUcsTUFBTSxDQUFDO0FBQ3RDLE1BQU0sd0JBQXdCLEdBQUcsZUFBZSxDQUFDO0FBNkVqRCxTQUFTLGVBQWUsQ0FBQyxLQUFhO0lBQ3BDLE1BQU0sT0FBTyxHQUFHLE9BQU8sS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDOUQsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFDeEQsT0FBTyxHQUFHLEtBQUssSUFBSSxJQUFJLEVBQUUsQ0FBQztBQUM1QixDQUFDO0FBRUQsU0FBUyw0QkFBNEIsQ0FBQyxLQUFhLEVBQUUsS0FBYTtJQUNoRSxNQUFNLFdBQVcsR0FBRyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDbEMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsV0FBVyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLFdBQVcsQ0FBQyxJQUFJLFdBQVcsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUN2RixNQUFNLElBQUksS0FBSyxDQUFDLEdBQUcsS0FBSyxvQ0FBb0MsS0FBSyxFQUFFLENBQUMsQ0FBQztJQUN2RSxDQUFDO0lBQ0QsT0FBTyxXQUFXLENBQUM7QUFDckIsQ0FBQztBQUVELE1BQU0sVUFBVSxhQUFhLENBQUMsSUFBYztJQUMxQyxNQUFNLE9BQU8sR0FBRztRQUNkLElBQUksRUFBRSxLQUFLO1FBQ1gsVUFBVSxFQUFFLElBQXFCO1FBQ2pDLElBQUksRUFBRSxNQUFNO1FBQ1osSUFBSSxFQUFFLEtBQUs7UUFDWCxNQUFNLEVBQUUsS0FBSztRQUNiLE1BQU0sRUFBRSxJQUFxQjtRQUM3QixTQUFTLEVBQUUsU0FBK0I7UUFDMUMsWUFBWSxFQUFFLHNCQUFzQjtLQUNyQyxDQUFDO0lBQ0YsTUFBTSxPQUFPLEdBQWEsRUFBRSxDQUFDO0lBRTdCLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELDJHQUEyRztRQUMzRyx1R0FBdUc7UUFDdkcsSUFBSSxLQUFLLEtBQUssV0FBVyxFQUFFLENBQUM7WUFDMUIsT0FBTyxDQUFDLE1BQU0sR0FBRyxJQUFJLENBQUM7WUFDdEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxVQUFVLEVBQUUsQ0FBQztZQUN6QixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsQ0FBQztZQUNsRSxPQUFPLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQztZQUN2QixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxlQUFlLEVBQUUsQ0FBQztZQUM5QixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsQ0FBQztZQUNsRSxPQUFPLENBQUMsVUFBVSxHQUFHLEtBQUssQ0FBQztZQUMzQixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsQ0FBQztZQUNsRSxPQUFPLENBQUMsSUFBSSxHQUFHLEtBQUssQ0FBQztZQUNyQixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxjQUFjLEVBQUUsQ0FBQztZQUM3QixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsQ0FBQztZQUNsRSxJQUFJLENBQUM7Z0JBQ0gsT0FBTyxDQUFDLFNBQVMsR0FBRyw0QkFBNEIsQ0FBQyxLQUFLLEVBQUUsY0FBYyxDQUFDLENBQUM7WUFDMUUsQ0FBQztZQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7Z0JBQ2YsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLFlBQVksS0FBSyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLEVBQUUsQ0FBQztZQUMzRSxDQUFDO1lBQ0QsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssa0JBQWtCLEVBQUUsQ0FBQztZQUNqQyxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7Z0JBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsQ0FBQztZQUNsRSxJQUFJLENBQUM7Z0JBQ0gsT0FBTyxDQUFDLFlBQVksR0FBRyw0QkFBNEIsQ0FBQyxLQUFLLEVBQUUsa0JBQWtCLENBQUMsQ0FBQztZQUNqRixDQUFDO1lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztnQkFDZixPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssWUFBWSxLQUFLLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDO1lBQzNFLENBQUM7WUFDRCxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO1lBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxtQkFBbUIsS0FBSyxFQUFFLEVBQUUsQ0FBQztRQUN4RSxNQUFNLE1BQU0sR0FBRyxlQUFlLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDdEMsSUFBSSxDQUFDLE1BQU07WUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLDBDQUEwQyxLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQ2pGLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDdkIsQ0FBQztJQUVELElBQUksT0FBTyxDQUFDLE1BQU0sS0FBSyxJQUFJLElBQUksT0FBTyxDQUFDLE1BQU0sS0FBSyxDQUFDO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsQ0FBQztJQUNsRixJQUFJLE9BQU8sQ0FBQyxNQUFNLEtBQUssSUFBSSxJQUFJLE9BQU8sQ0FBQyxNQUFNLEdBQUcsQ0FBQztRQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsdURBQXVELEVBQUUsQ0FBQztJQUM3SCxJQUFJLENBQUMsT0FBTyxDQUFDLFVBQVU7UUFBRSxPQUFPLEVBQUUsS0FBSyxFQUFFLDhCQUE4QixVQUFVLEVBQUUsRUFBRSxDQUFDO0lBRXRGLE9BQU87UUFDTCxPQUFPO1FBQ1AsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNO1FBQ3RCLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtRQUM5QixJQUFJLEVBQUUsT0FBTyxDQUFDLElBQUk7UUFDbEIsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO1FBQ2xCLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTTtRQUN0QixTQUFTLEVBQUUsT0FBTyxDQUFDLFNBQVM7UUFDNUIsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZO1FBQ2xDLElBQUksRUFBRSxPQUFPLENBQUMsSUFBSTtLQUNuQixDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMsWUFBWSxDQUFDLE1BQXFCO0lBQ3pDLE9BQU8sTUFBTSxDQUFDLE1BQU0sS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsVUFBVSxFQUFFLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHLE1BQU0sQ0FBQyxPQUFPLENBQUMsQ0FBQztBQUNwRixDQUFDO0FBRUQsU0FBUyw4QkFBOEIsQ0FBQyxVQUFrQjtJQUN4RCxNQUFNLEtBQUssR0FBRyxPQUFPLFVBQVUsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxLQUFLLENBQUMsd0JBQXdCLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDO0lBQ2pHLE9BQU8sS0FBSyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQztBQUN6QyxDQUFDO0FBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0dBZ0NHO0FBQ0gsTUFBTSxDQUFDLEtBQUssVUFBVSxPQUFPLENBQUMsSUFBYyxFQUFFLFVBQTBCLEVBQUU7SUFDeEUsTUFBTSxNQUFNLEdBQUcsYUFBYSxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ25DLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBQ0QscUdBQXFHO0lBQ3JHLG9GQUFvRjtJQUNwRixNQUFNLFNBQVMsR0FBa0IsTUFBTSxDQUFDO0lBRXhDLE1BQU0sR0FBRyxHQUFHLE9BQU8sQ0FBQyxHQUFHLElBQUksT0FBTyxDQUFDLEdBQUcsQ0FBQztJQUN2QyxNQUFNLE9BQU8sR0FBRyxPQUFPLENBQUMsT0FBTyxJQUFJLENBQUMsQ0FBQyxPQUFlLEVBQUUsRUFBRSxDQUFDLElBQUksT0FBTyxDQUFPLENBQUMsT0FBTyxFQUFFLEVBQUUsQ0FBQyxVQUFVLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUN2SCxNQUFNLE9BQU8sR0FBRyxHQUFHLEVBQUUsQ0FBQyxPQUFPLENBQUMsS0FBSyxJQUFJLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUNsRCxNQUFNLGNBQWMsR0FBRyxPQUFPLEVBQUUsQ0FBQztJQUVqQyx5R0FBeUc7SUFDekcsOEdBQThHO0lBQzlHLDBHQUEwRztJQUMxRyxnR0FBZ0c7SUFDaEcsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUc7WUFDbkIsT0FBTyxFQUFFLFNBQVM7WUFDbEIsT0FBTyxFQUFFLE1BQU0sQ0FBQyxPQUFPO1lBQ3ZCLE1BQU0sRUFBRSxNQUFNLENBQUMsTUFBTTtZQUNyQixVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVU7WUFDN0IsSUFBSSxFQUFFLE1BQU0sQ0FBQyxJQUFJO1lBQ2pCLElBQUksRUFBRSxNQUFNLENBQUMsSUFBSTtZQUNqQixTQUFTLEVBQUUsTUFBTSxDQUFDLFNBQVMsSUFBSSxJQUFJO1NBQ3BDLENBQUM7UUFDRixJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxDQUFDO1lBQ04sTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLFlBQVksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztZQUNoRyxPQUFPLENBQUMsR0FBRyxDQUNULGlEQUFpRCxNQUFNLFFBQVEsTUFBTSxDQUFDLFVBQVUsV0FBVyxNQUFNLENBQUMsSUFBSSxXQUFXLE1BQU0sQ0FBQyxJQUFJLHFEQUFxRCxDQUNsTCxDQUFDO1FBQ0osQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksYUFBNEIsQ0FBQztJQUNqQyxJQUFJLENBQUM7UUFDSCxhQUFhLEdBQUcsQ0FBQyxPQUFPLENBQUMsaUJBQWlCLElBQUksaUJBQWlCLENBQUMsRUFBRSxDQUFDO0lBQ3JFLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FDckIsTUFBTSxDQUFDLElBQUksRUFDWCwyREFBMkQsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLEVBQUUsRUFDcEYsQ0FBQyxDQUNGLENBQUM7SUFDSixDQUFDO0lBRUQsTUFBTSxXQUFXLEdBQUcsQ0FBQyxPQUFPLENBQUMsZUFBZSxJQUFJLGVBQWUsQ0FBQyxFQUFFLENBQUM7SUFDbkUsTUFBTSxjQUFjLEdBQUcsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLElBQUksa0JBQWtCLENBQUMsRUFBRSxDQUFDO0lBQzVFLE1BQU0sY0FBYyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLHVCQUF1QixDQUFDLEVBQUUsQ0FBQztJQUNqRixNQUFNLFFBQVEsR0FBRyxDQUFDLE9BQU8sQ0FBQyxpQkFBaUIsSUFBSSxpQkFBaUIsQ0FBQyxFQUFFLENBQUM7SUFFcEUsTUFBTSxhQUFhLEdBQUcsT0FBTyxDQUFDLFdBQVcsSUFBSSxXQUFXLENBQUM7SUFDekQsTUFBTSxZQUFZLEdBQUcsT0FBTyxDQUFDLFVBQVUsSUFBSSxVQUFVLENBQUM7SUFDdEQsTUFBTSxrQkFBa0IsR0FBRyxPQUFPLENBQUMsZ0JBQWdCLElBQUksZ0JBQWdCLENBQUM7SUFDeEUsTUFBTSxpQkFBaUIsR0FBRyxPQUFPLENBQUMsb0JBQW9CLElBQUksb0JBQW9CLENBQUM7SUFDL0UsTUFBTSxzQkFBc0IsR0FBRyxPQUFPLENBQUMsMkJBQTJCLElBQUksMkJBQTJCLENBQUM7SUFDbEcsTUFBTSxtQkFBbUIsR0FBRyxPQUFPLENBQUMsaUJBQWlCLElBQUksaUJBQWlCLENBQUM7SUFDM0UsTUFBTSxlQUFlLEdBQUcsT0FBTyxDQUFDLGFBQWEsSUFBSSxhQUFhLENBQUM7SUFDL0QsTUFBTSx5QkFBeUIsR0FBRyxPQUFPLENBQUMsdUJBQXVCLElBQUksdUJBQXVCLENBQUM7SUFDN0YsTUFBTSx5QkFBeUIsR0FBRyxPQUFPLENBQUMsdUJBQXVCLElBQUksdUJBQXVCLENBQUM7SUFDN0YsTUFBTSxvQkFBb0IsR0FBRyxPQUFPLENBQUMsa0JBQWtCLElBQUksa0JBQWtCLENBQUM7SUFFOUUsZ0dBQWdHO0lBQ2hHLHlHQUF5RztJQUN6RyxvR0FBb0c7SUFDcEcseUdBQXlHO0lBQ3pHLHVGQUF1RjtJQUN2RixrR0FBa0c7SUFDbEcsOEZBQThGO0lBQzlGLE1BQU0sV0FBVyxHQUFHLE9BQU8sQ0FBQyxXQUFXLElBQUksQ0FBQyxNQUFNLGtCQUFrQixDQUFDLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO0lBRWpGLEtBQUssVUFBVSxnQkFBZ0I7UUFDN0IsTUFBTSxhQUFhLENBQUMsWUFBWSxDQUFDLFNBQVMsQ0FBQyxFQUFFO1lBQzNDLGtCQUFrQixFQUFFLEdBQUcsRUFBRSxDQUFDLGNBQWM7WUFDeEMsV0FBVztZQUNYLEdBQUcsQ0FBQyxPQUFPLENBQUMsVUFBVSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7WUFDL0UsS0FBSyxFQUFFLE9BQU8sRUFBRTtTQUNqQixDQUFDLENBQUM7SUFDTCxDQUFDO0lBRUQsSUFBSSxLQUFLLEdBQUcsYUFBYSxDQUFDLFlBQVksRUFBRSxDQUFDO0lBQ3pDLE1BQU0sTUFBTSxHQUF1QixFQUFFLENBQUM7SUFDdEMsSUFBSSxRQUFRLEdBQUcsV0FBVyxDQUFDLFVBQVUsQ0FBQyxFQUFFLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxHQUFHLElBQUksQ0FBQyxDQUFDO0lBQzNELElBQUksVUFBVSxHQUFrQixJQUFJLENBQUM7SUFFckMsSUFBSSxDQUFDO1FBQ0gseUdBQXlHO1FBQ3pHLDBHQUEwRztRQUMxRyxnR0FBZ0c7UUFDaEcsNEdBQTRHO1FBQzVHLDRHQUE0RztRQUM1RywwR0FBMEc7UUFDMUcsTUFBTSxpQkFBaUIsR0FBRyxpQkFBaUIsQ0FBQyxFQUFFLEdBQUcsRUFBRSxDQUFDLENBQUM7UUFDckQsTUFBTSxpQkFBaUIsR0FBRyxhQUFhLENBQUMsY0FBYyxFQUFFLENBQUM7UUFDekQsSUFBSSxPQUFPLEdBQTJCLElBQUksQ0FBQztRQUMzQyxJQUFJLGlCQUFpQixDQUFDLE1BQU0sRUFBRSxDQUFDO1lBQzdCLFVBQVUsR0FBRyxlQUFlLGlCQUFpQixDQUFDLEtBQUssRUFBRSxDQUFDO1lBQ3RELE1BQU0sQ0FBQyxJQUFJLENBQUMsRUFBRSxLQUFLLEVBQUUsQ0FBQyxFQUFFLE9BQU8sRUFBRSxRQUFRLEVBQUUsTUFBTSxFQUFFLFVBQVUsRUFBRSxDQUFDLENBQUM7UUFDbkUsQ0FBQzthQUFNLElBQUksaUJBQWlCLENBQUMsTUFBTSxFQUFFLENBQUM7WUFDcEMsVUFBVSxHQUFHLFFBQVEsQ0FBQztZQUN0QixNQUFNLENBQUMsSUFBSSxDQUFDLEVBQUUsS0FBSyxFQUFFLENBQUMsRUFBRSxPQUFPLEVBQUUsUUFBUSxFQUFFLE1BQU0sRUFBRSxVQUFVLEVBQUUsQ0FBQyxDQUFDO1FBQ25FLENBQUM7YUFBTSxDQUFDO1lBQ04sTUFBTSxnQkFBZ0IsRUFBRSxDQUFDO1lBQ3pCLE9BQU8sR0FBRyxjQUFjLENBQUMsV0FBVyxFQUFFLENBQUM7UUFDekMsQ0FBQztRQUVELElBQUksVUFBVSxHQUFHLFVBQVUsS0FBSyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzdDLE9BQU8sVUFBVSxLQUFLLElBQUksSUFBSSxDQUFDLE1BQU0sQ0FBQyxTQUFTLEtBQUssU0FBUyxJQUFJLFVBQVUsR0FBRyxNQUFNLENBQUMsU0FBUyxDQUFDLEVBQUUsQ0FBQztZQUNoRyxVQUFVLElBQUksQ0FBQyxDQUFDO1lBRWhCLE1BQU0sVUFBVSxHQUFHLGlCQUFpQixDQUFDLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztZQUM5QyxJQUFJLFVBQVUsQ0FBQyxNQUFNLEVBQUUsQ0FBQztnQkFDdEIsVUFBVSxHQUFHLGVBQWUsVUFBVSxDQUFDLEtBQUssRUFBRSxDQUFDO2dCQUMvQyxnR0FBZ0c7Z0JBQ2hHLElBQUksT0FBTyxFQUFFLENBQUM7b0JBQ1osY0FBYyxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO2dCQUMxRixDQUFDO2dCQUNELE1BQU0sQ0FBQyxJQUFJLENBQUM7b0JBQ1YsS0FBSyxFQUFFLFVBQVU7b0JBQ2pCLE9BQU8sRUFBRSxRQUFRO29CQUNqQixNQUFNLEVBQUUsVUFBVTtvQkFDbEIsR0FBRyxDQUFDLE9BQU87d0JBQ1QsQ0FBQyxDQUFDLEVBQUUsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUU7d0JBQ3hFLENBQUMsQ0FBQyxFQUFFLENBQUM7aUJBQ1IsQ0FBQyxDQUFDO2dCQUNILE1BQU07WUFDUixDQUFDO1lBRUQsTUFBTSxVQUFVLEdBQUcsYUFBYSxDQUFDLGNBQWMsRUFBRSxDQUFDO1lBQ2xELElBQUksVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDO2dCQUN0QixVQUFVLEdBQUcsUUFBUSxDQUFDO2dCQUN0QixJQUFJLE9BQU8sRUFBRSxDQUFDO29CQUNaLGNBQWMsQ0FBQyxVQUFVLENBQUMsT0FBTyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQztnQkFDMUYsQ0FBQztnQkFDRCxNQUFNLENBQUMsSUFBSSxDQUFDO29CQUNWLEtBQUssRUFBRSxVQUFVO29CQUNqQixPQUFPLEVBQUUsUUFBUTtvQkFDakIsTUFBTSxFQUFFLFVBQVU7b0JBQ2xCLEdBQUcsQ0FBQyxPQUFPO3dCQUNULENBQUMsQ0FBQyxFQUFFLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFO3dCQUN4RSxDQUFDLENBQUMsRUFBRSxDQUFDO2lCQUNSLENBQUMsQ0FBQztnQkFDSCxNQUFNO1lBQ1IsQ0FBQztZQUVELElBQUksQ0FBQyxPQUFPLEVBQUUsQ0FBQztnQkFDYixNQUFNLENBQUMsSUFBSSxDQUFDLEVBQUUsS0FBSyxFQUFFLFVBQVUsRUFBRSxPQUFPLEVBQUUsa0JBQWtCLEVBQUUsQ0FBQyxDQUFDO2dCQUNoRSxNQUFNLE9BQU8sQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7Z0JBQ25DLE1BQU0sZ0JBQWdCLEVBQUUsQ0FBQztnQkFDekIsT0FBTyxHQUFHLGNBQWMsQ0FBQyxXQUFXLEVBQUUsQ0FBQztnQkFDdkMsU0FBUztZQUNYLENBQUM7WUFFRCxNQUFNLFdBQVcsR0FBRyw4QkFBOEIsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDdkUsSUFBSSxXQUFXLEtBQUssSUFBSSxFQUFFLENBQUM7Z0JBQ3pCLG1HQUFtRztnQkFDbkcsa0dBQWtHO2dCQUNsRyxjQUFjLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7Z0JBQ3RGLE1BQU0sQ0FBQyxJQUFJLENBQUMsRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFFLE9BQU8sRUFBRSw4QkFBOEIsRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUM7Z0JBQzVHLE9BQU8sR0FBRyxjQUFjLENBQUMsV0FBVyxFQUFFLENBQUM7Z0JBQ3ZDLFNBQVM7WUFDWCxDQUFDO1lBRUQsTUFBTSxTQUFTLEdBQUcsTUFBTSxrQkFBa0IsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztZQUMxRSw0R0FBNEc7WUFDNUcsOEdBQThHO1lBQzlHLHVHQUF1RztZQUN2RyxNQUFNLGdCQUFnQixHQUFHLGNBQWMsQ0FBQyxpQkFBaUIsQ0FDdkQsT0FBTyxDQUFDLFlBQVksRUFDcEIsT0FBTyxDQUFDLFVBQVUsRUFDbEIsT0FBTyxDQUFDLFVBQVUsQ0FDbkIsQ0FBQztZQUVGLE1BQU0sUUFBUSxHQUFHLHNCQUFzQixDQUNyQztnQkFDRSxTQUFTLEVBQUUsS0FBSztnQkFDaEIsS0FBSztnQkFDTCxNQUFNLEVBQUUsQ0FBQyxTQUFTLENBQUMsSUFBSSxDQUFDLFNBQVMsSUFBSSx1QkFBdUIsQ0FBQyxTQUFTLENBQStDO2dCQUNySCxXQUFXLEVBQUUsZ0JBQWdCO2dCQUM3QixxQkFBcUIsRUFBRSxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMscUJBQXFCLElBQUksdUJBQXVCLENBQUMscUJBQXFCLENBQTJFO2dCQUN4TCxZQUFZLEVBQUUsRUFBRSxZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRTtnQkFDcEYsdUdBQXVHO2dCQUN2Ryx3RUFBd0U7Z0JBQ3hFLFVBQVUsRUFBRSxDQUFDLFlBQW9CLEVBQUUsVUFBa0IsRUFBRSxFQUFFLENBQUMsY0FBYyxDQUFDLFVBQVUsQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLE9BQVEsQ0FBQyxVQUFVLENBQUM7YUFDbkksRUFDRCxFQUFFLE1BQU0sRUFBRSxDQUFDLEtBQTJELEVBQUUsRUFBRSxDQUFDLGNBQWMsQ0FBQyxtQkFBbUIsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUN2SCxDQUFDO1lBRUYsSUFBSSxDQUFDLFFBQVEsQ0FBQyxZQUFZLEVBQUUsQ0FBQztnQkFDM0IsVUFBVSxHQUFHLFlBQVksUUFBUSxDQUFDLE9BQU8sQ0FBQyxNQUFNLEVBQUUsQ0FBQztnQkFDbkQsTUFBTSxDQUFDLElBQUksQ0FBQyxFQUFFLEtBQUssRUFBRSxVQUFVLEVBQUUsT0FBTyxFQUFFLFFBQVEsRUFBRSxNQUFNLEVBQUUsVUFBVSxFQUFFLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQztnQkFDOUksTUFBTTtZQUNSLENBQUM7WUFFRCxNQUFNLFlBQVksR0FBRyxPQUFPLEVBQUUsQ0FBQztZQUMvQixxR0FBcUc7WUFDckcsdUdBQXVHO1lBQ3ZHLHlHQUF5RztZQUN6RyxNQUFNLGdCQUFnQixHQUF3QyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsQ0FBQztZQUM5RSxNQUFNLFdBQVcsR0FBRztnQkFDbEIsT0FBTyxDQUFDLFlBQVk7Z0JBQ3BCLE1BQU0sQ0FBQyxXQUFXLENBQUM7Z0JBQ25CLGVBQWU7Z0JBQ2YsTUFBTSxDQUFDLFVBQVU7Z0JBQ2pCLFFBQVE7Z0JBQ1IsTUFBTSxDQUFDLElBQUk7Z0JBQ1gsR0FBRyxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQzthQUNuQyxDQUFDO1lBQ0YsTUFBTSxZQUFZLENBQUMsV0FBVyxFQUFFO2dCQUM5QixHQUFHLENBQUMsT0FBTyxDQUFDLGNBQWMsSUFBSSxFQUFFLENBQUM7Z0JBQ2pDLEdBQUc7Z0JBQ0gsUUFBUSxFQUFFLENBQUMsTUFBd0IsRUFBRSxFQUFFO29CQUNyQyxnQkFBZ0IsQ0FBQyxLQUFLLEdBQUcsTUFBTSxDQUFDO2dCQUNsQyxDQUFDO2FBQ0YsQ0FBQyxDQUFDO1lBQ0gsTUFBTSxjQUFjLEdBQUcsT0FBTyxFQUFFLEdBQUcsWUFBWSxDQUFDO1lBRWhELEtBQUssR0FBRztnQkFDTixvR0FBb0c7Z0JBQ3BHLHVHQUF1RztnQkFDdkcsZ0dBQWdHO2dCQUNoRyx3R0FBd0c7Z0JBQ3hHLFdBQVcsRUFBRSxLQUFLLENBQUMsV0FBVyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsS0FBSyxFQUFFLFlBQVksSUFBSSxDQUFDLENBQUM7Z0JBQzVFLFVBQVUsRUFBRSxLQUFLLENBQUMsVUFBVSxHQUFHLENBQUMsZ0JBQWdCLENBQUMsS0FBSyxFQUFFLGNBQWMsSUFBSSxDQUFDLENBQUM7Z0JBQzVFLFNBQVMsRUFBRSxLQUFLLENBQUMsU0FBUyxHQUFHLGNBQWM7YUFDNUMsQ0FBQztZQUNGLGFBQWEsQ0FBQyxZQUFZLENBQUMsS0FBSyxDQUFDLENBQUM7WUFFbEMsTUFBTSxjQUFjLEdBQUcsZ0JBQWdCLENBQUMsS0FBSyxFQUFFLE9BQU8sSUFBSSxlQUFlLENBQUM7WUFDMUUsTUFBTSxTQUFTLEdBQUcsY0FBYyxLQUFLLG1CQUFtQixDQUFDO1lBQ3pELDZGQUE2RjtZQUM3RixzR0FBc0c7WUFDdEcsZ0dBQWdHO1lBQ2hHLHFHQUFxRztZQUNyRywrREFBK0Q7WUFDL0QsTUFBTSxjQUFjLEdBQUcsY0FBYyxLQUFLLDRCQUE0QixDQUFDO1lBQ3ZFLHNHQUFzRztZQUN0RyxzR0FBc0c7WUFDdEcsTUFBTSxpQkFBaUIsR0FBRyxnQkFBZ0IsQ0FBQyxLQUFLLEVBQUUsYUFBYSxLQUFLLHFCQUFxQixDQUFDO1lBRTFGLElBQUksU0FBUyxJQUFJLGNBQWMsRUFBRSxDQUFDO2dCQUNoQywwR0FBMEc7Z0JBQzFHLDBGQUEwRjtnQkFDMUYsY0FBYyxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ3hGLENBQUM7aUJBQU0sQ0FBQztnQkFDTiw2R0FBNkc7Z0JBQzdHLHFHQUFxRztnQkFDckcsY0FBYyxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsWUFBWSxFQUFFLE9BQU8sQ0FBQyxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQzFGLENBQUM7WUFFRCxJQUFJLGlCQUFpQixFQUFFLENBQUM7Z0JBQ3RCLE1BQU0sUUFBUSxHQUFHLGlCQUFpQixDQUFDLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztnQkFDNUMsVUFBVSxHQUFHLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLGVBQWUsUUFBUSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxxQkFBcUIsQ0FBQztnQkFDdkYsTUFBTSxDQUFDLElBQUksQ0FBQztvQkFDVixLQUFLLEVBQUUsVUFBVTtvQkFDakIsT0FBTyxFQUFFLFFBQVE7b0JBQ2pCLE1BQU0sRUFBRSxVQUFVO29CQUNsQixZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVk7b0JBQ2xDLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtvQkFDOUIsY0FBYztpQkFDZixDQUFDLENBQUM7Z0JBQ0gsTUFBTTtZQUNSLENBQUM7WUFFRCxJQUFJLGNBQWMsR0FBc0MsT0FBTyxDQUFDO1lBQ2hFLElBQUksUUFBUSxHQUFrQixJQUFJLENBQUM7WUFDbkMsSUFBSSxhQUFhLEdBQXlCLElBQUksQ0FBQztZQUMvQyxJQUFJLFlBQVksR0FBOEIsSUFBSSxDQUFDO1lBQ25ELElBQUksU0FBUyxFQUFFLENBQUM7Z0JBQ2QsUUFBUSxHQUFHLDJCQUEyQixDQUNwQyxnQkFBZ0IsQ0FBQyxLQUFLLEVBQUUsVUFBK0QsRUFDdkYsT0FBTyxDQUFDLFlBQVksQ0FDckIsQ0FBQztnQkFDRixJQUFJLFFBQVEsS0FBSyxJQUFJLEVBQUUsQ0FBQztvQkFDdEIsaUdBQWlHO29CQUNqRyxxR0FBcUc7b0JBQ3JHLDhGQUE4RjtvQkFDOUYsb0dBQW9HO29CQUNwRyw2RUFBNkU7b0JBQzdFLE1BQU0sUUFBUSxHQUFHLE1BQU0sZUFBZSxDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsUUFBUSxFQUFFO3dCQUNyRSxXQUFXO3dCQUNYLEdBQUcsQ0FBQyxPQUFPLENBQUMsVUFBVSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7d0JBQy9FLEdBQUcsQ0FBQyxPQUFPLENBQUMsYUFBYSxJQUFJLEVBQUUsQ0FBQztxQkFDakMsQ0FBQyxDQUFDO29CQUNILFlBQVksR0FBRyxRQUFRLENBQUMsVUFBVSxDQUFDO29CQUNuQyxXQUFXLENBQUMsV0FBVyxDQUFDO3dCQUN0QixJQUFJLEVBQUUsb0JBQW9CO3dCQUMxQixZQUFZLEVBQUUsT0FBTyxDQUFDLFlBQVk7d0JBQ2xDLE9BQU8sRUFBRSxFQUFFLFFBQVEsRUFBRSxVQUFVLEVBQUUsUUFBUSxDQUFDLFVBQVUsRUFBRSxVQUFVLEVBQUUsUUFBUSxDQUFDLE1BQU0sQ0FBQyxNQUFNLEVBQUUsTUFBTSxFQUFFLFdBQVcsRUFBRTtxQkFDaEgsQ0FBQyxDQUFDO29CQUVILGFBQWEsR0FBRyxNQUFNLG1CQUFtQixDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsUUFBUSxFQUFFO3dCQUN4RSxXQUFXO3dCQUNYLEdBQUcsQ0FBQyxPQUFPLENBQUMsVUFBVSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxVQUFVLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7d0JBQy9FLEdBQUcsQ0FBQyxPQUFPLENBQUMsb0JBQW9CLElBQUksRUFBRSxDQUFDO3FCQUN4QyxDQUFDLENBQUM7b0JBQ0gsSUFBSSxhQUFhLENBQUMsS0FBSyxLQUFLLFFBQVEsRUFBRSxDQUFDO3dCQUNyQyx5QkFBeUIsQ0FDdkI7NEJBQ0UsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZOzRCQUNsQyxRQUFROzRCQUNSLFFBQVEsRUFBRSxhQUFhLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLFFBQVE7NEJBQ3BELFFBQVEsRUFBRSxhQUFhLENBQUMsUUFBUTt5QkFDakMsRUFDRCxFQUFFLFdBQVcsRUFBRSxDQUNoQixDQUFDO3dCQUNGLHdHQUF3Rzt3QkFDeEcsc0dBQXNHO3dCQUN0RyxvR0FBb0c7d0JBQ3BHLHNHQUFzRzt3QkFDdEcsNkJBQTZCO3dCQUM3QixNQUFNLGVBQWUsR0FBRyxhQUFhLENBQUMscUJBQXFCLENBQUMsT0FBTyxDQUFDLFlBQVksRUFBRSxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7d0JBQ3RHLGFBQWEsQ0FBQyxxQkFBcUIsQ0FDakMsT0FBTyxDQUFDLFlBQVksRUFDcEI7NEJBQ0UsT0FBTyxFQUFFLGVBQWUsQ0FBQyxPQUFPLEdBQUcsQ0FBQzs0QkFDcEMsV0FBVyxFQUFFLGVBQWUsQ0FBQyxXQUFXLEdBQUcsQ0FBQyxZQUFZLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO3lCQUNqRixFQUNELE9BQU8sQ0FBQyxVQUFVLENBQ25CLENBQUM7d0JBQ0YsY0FBYyxHQUFHLHFCQUFxQixDQUFDLGFBQWEsQ0FBQyxDQUFDO29CQUN4RCxDQUFDO2dCQUNILENBQUM7WUFDSCxDQUFDO1lBRUQsTUFBTSxXQUFXLEdBQUcseUJBQXlCLENBQzNDLEVBQUUsV0FBVyxFQUFFLGNBQWMsRUFBRSxRQUFRLEVBQUUsRUFDekMsRUFBRSxRQUFRLEVBQUUsWUFBWSxFQUFFLE9BQU8sQ0FBQyxZQUFZLEVBQUUsQ0FDakQsQ0FBQztZQUNGLFFBQVEsR0FBRyxXQUFXLENBQUMsT0FBTyxDQUFDO1lBRS9CLE1BQU0sT0FBTyxHQUFHLG9CQUFvQixDQUNsQyxFQUFFLGVBQWUsRUFBRSxVQUFVLENBQUMsS0FBSyxFQUFFLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWSxFQUFFLE9BQU8sRUFBRSxjQUFjLEVBQUUsRUFDbEcsRUFBRSxXQUFXLEVBQUUsY0FBYyxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFFLEVBQUUsY0FBYyxFQUFFLFdBQVcsRUFBRSxDQUN6RixDQUFDO1lBRUYsTUFBTSxDQUFDLElBQUksQ0FBQztnQkFDVixLQUFLLEVBQUUsVUFBVTtnQkFDakIsT0FBTyxFQUFFLFdBQVc7Z0JBQ3BCLFlBQVksRUFBRSxPQUFPLENBQUMsWUFBWTtnQkFDbEMsVUFBVSxFQUFFLE9BQU8sQ0FBQyxVQUFVO2dCQUM5QixjQUFjO2dCQUNkLGNBQWM7Z0JBQ2QsUUFBUTtnQkFDUixZQUFZO2dCQUNaLFNBQVMsRUFBRSxPQUFPLENBQUMsUUFBUSxDQUFDLE9BQU87Z0JBQ25DLE9BQU8sRUFBRSxPQUFPLENBQUMsUUFBUSxDQUFDLE9BQU87YUFDbEMsQ0FBQyxDQUFDO1lBRUgsSUFBSSxDQUFDLE9BQU8sQ0FBQyxRQUFRLENBQUMsT0FBTyxFQUFFLENBQUM7Z0JBQzlCLFVBQVUsR0FBRyxvQkFBb0IsT0FBTyxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUM7Z0JBQ3RFLE1BQU07WUFDUixDQUFDO1lBRUQsSUFBSSxPQUFPLENBQUMsUUFBUSxFQUFFLENBQUM7Z0JBQ3JCLE9BQU8sR0FBRyxPQUFPLENBQUMsUUFBUSxDQUFDO2dCQUMzQixNQUFNLE9BQU8sQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7WUFDckMsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE1BQU0sT0FBTyxDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQztnQkFDbkMsTUFBTSxnQkFBZ0IsRUFBRSxDQUFDO2dCQUN6QixPQUFPLEdBQUcsY0FBYyxDQUFDLFdBQVcsRUFBRSxDQUFDO1lBQ3pDLENBQUM7UUFDSCxDQUFDO1FBRUQsSUFBSSxVQUFVLEtBQUssSUFBSSxJQUFJLE1BQU0sQ0FBQyxTQUFTLEtBQUssU0FBUyxFQUFFLENBQUM7WUFDMUQsVUFBVSxHQUFHLG9CQUFvQixDQUFDO1lBQ2xDLGtHQUFrRztZQUNsRyxxR0FBcUc7WUFDckcsb0dBQW9HO1lBQ3BHLHNHQUFzRztZQUN0Ryw4RUFBOEU7WUFDOUUsSUFBSSxPQUFPLEVBQUUsQ0FBQztnQkFDWixjQUFjLENBQUMsVUFBVSxDQUFDLE9BQU8sQ0FBQyxZQUFZLEVBQUUsT0FBTyxDQUFDLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDMUYsQ0FBQztRQUNILENBQUM7UUFFRCxNQUFNLE9BQU8sR0FBRyxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsTUFBTSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsQ0FBQztRQUNqRSxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsT0FBTyxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ2hELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyx1QkFBdUIsTUFBTSxDQUFDLE1BQU0sY0FBYyxVQUFVLElBQUksU0FBUyxHQUFHLENBQUMsQ0FBQztRQUM1RixDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDO0lBQ2hFLENBQUM7WUFBUyxDQUFDO1FBQ1QsYUFBYSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3RCLFdBQVcsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNwQixjQUFjLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDdkIsY0FBYyxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3ZCLFFBQVEsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNuQixDQUFDO0FBQ0gsQ0FBQyJ9

--- a/packages/loopover-miner/lib/loop-cli.ts
+++ b/packages/loopover-miner/lib/loop-cli.ts
@@ -1,0 +1,684 @@
+// The autonomous supervising loop (#5135, Wave 3.5): the missing daemon/watch layer over the one-shot
+// `discover`/`attempt` subcommands. Every existing piece it composes -- runDiscover, runAttempt,
+// evaluateRunLoopBoundaryGate, attemptLoopReentry, buildLoopClosureSummary, governor-state.js -- already
+// existed; this is the first caller that actually chains them into a real repeat-until-halted run.
+//
+// STRUCTURE (one cycle): kill-switch check -> pause-flag check (#4851, governor-state.js's persisted
+// paused/reason/pausedAt) -> real-per-repo-policy-aware run-loop boundary gate (before claiming) -> real
+// runAttempt -> real CI-status poll (ci-poller.js, #5394) + real PR-disposition poll
+// (pr-disposition-poller.js, on a submitted outcome) -> real loop-closure summary -> real attemptLoopReentry
+// decision. `attemptLoopReentry`'s own dequeue is the
+// AUTHORITATIVE claim for every cycle after the first (its own doc: "if allowed -- dequeues the next
+// candidate") -- this loop does not ALSO call portfolioQueue.dequeueNext() on a successful reentry, which
+// would silently double-claim (the reentry's own claim would then leak as a permanently 'in_progress', never-
+// attempted row). A manual dequeueNext() is used only to prime the very first cycle (no prior outcome exists
+// yet to reenter from) and to refill after an empty queue.
+//
+// REAL, NOT FABRICATED: this loop is the first production caller of governor-state.js's `saveCapUsage`
+// (turnsTaken from runMinerAttempt's own real `loopResult.totalTurnsUsed`, elapsedMs from real wall-clock
+// measurement). Its per-identifier convergence history (attempts/consecutiveFailures/reenqueues) is the real,
+// SQLite-persisted portfolio-queue attempt-history (portfolio-queue.js's getAttemptHistory, #5654) that the
+// dequeueNext claim + markDone/markFailed calls below already maintain -- the same source a one-shot `attempt`
+// invocation reads (#5654), so both share one source of truth and the counters survive a loop-daemon restart
+// (crash/deploy/systemd bounce) instead of resetting with the process (#5677).
+
+import { checkMinerKillSwitch } from "./governor-kill-switch.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { evaluateRunLoopBoundaryGate } from "./governor-run-halt.js";
+import { openGovernorState } from "./governor-state.js";
+import { initGovernorLedger } from "./governor-ledger.js";
+import { initEventLedger } from "./event-ledger.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { initRunStateStore } from "./run-state.js";
+import { runDiscover } from "./discover-cli.js";
+import { runAttempt } from "./attempt-cli.js";
+import { resolveAmsPolicy } from "./ams-policy.js";
+import { pollPrDisposition, classifyPrDisposition } from "./pr-disposition-poller.js";
+import { pollCheckRuns } from "./ci-poller.js";
+import { recordPrOutcomeSnapshot } from "./pr-outcome.js";
+import { isRejectedPr } from "./rejection-state-machine.js";
+import { buildLoopClosureSummary } from "./loop-closure.js";
+import { attemptLoopReentry } from "./loop-reentry.js";
+import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
+import { resolveGitHubToken } from "./github-token-resolution.js";
+import { DEFAULT_AMS_POLICY_SPEC } from "@loopover/engine";
+
+import type { AttemptCliResult } from "./attempt-cli.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+import type { GovernorState } from "./governor-state.js";
+import type { EventLedger } from "./event-ledger.js";
+import type { GovernorLedger } from "./governor-ledger.js";
+import type { RunStateStore } from "./run-state.js";
+import type { PrDisposition, PollPrDispositionOptions } from "./pr-disposition-poller.js";
+import type { CheckRunConclusion, PollCheckRunsOptions } from "./ci-poller.js";
+import type { EvaluateRunLoopBoundaryGateInput } from "./governor-run-halt.js";
+
+const LOOP_USAGE =
+  "Usage: loopover-miner loop <owner/repo> [<owner/repo>...] | --search <query> --miner-login <login> [--base <branch>] [--live] [--dry-run] [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]";
+const DEFAULT_CYCLE_DELAY_MS = 60_000;
+const ISSUE_IDENTIFIER_PATTERN = /^issue:(\d+)$/;
+
+export type ParsedLoopArgs =
+  | { error: string }
+  | {
+      targets: string[];
+      search: string | null;
+      minerLogin: string;
+      base: string;
+      live: boolean;
+      dryRun: boolean;
+      maxCycles: number | undefined;
+      cycleDelayMs: number;
+      json: boolean;
+    };
+
+// The non-error branch of ParsedLoopArgs, as narrowed after runLoop's `if ("error" in parsed) return`.
+type ParsedLoopRun = Exclude<ParsedLoopArgs, { error: string }>;
+
+// The claimed portfolio item, widened to the common shape of both sources: portfolioQueue.dequeueNext()
+// (a full QueueEntry, apiBaseUrl always present) and attemptLoopReentry's `dequeued` (no apiBaseUrl field).
+// Only these three fields are ever read off it, and apiBaseUrl only ever feeds an `apiBaseUrl?`-optional arg.
+type LoopClaimedItem = { repoFullName: string; identifier: string; apiBaseUrl?: string };
+
+// loop-cli reads a few fields off the AttemptCliResult its runAttempt callback captured. Some exist only on the
+// `attempt_*` outcome member, and `abandonReason` is emitted at runtime for the kill-switch/abandon case but is
+// not declared on AttemptCliResult (attempt-cli.ts). Read them optimistically off a standalone all-optional shape
+// so the existing `?.` / `?? 0` reads type-check without narrowing the union or changing any behavior. An
+// AttemptCliResult is assignable to this (every field is optional here).
+type LoopAttemptResult = {
+  outcome?: AttemptCliResult["outcome"];
+  totalTurnsUsed?: number;
+  totalCostUsd?: number;
+  execResult?: unknown;
+  abandonReason?: string;
+};
+
+export type LoopCycleSummary = {
+  cycle: number;
+  outcome: "idle_queue_empty" | "halted" | "attempted" | "skipped_malformed_identifier";
+  reason?: string;
+  repoFullName?: string;
+  identifier?: string;
+  attemptOutcome?: AttemptCliResult["outcome"] | "attempt_error";
+  reentryOutcome?: "merged" | "disengaged" | "other";
+  prNumber?: number | null;
+  ciConclusion?: CheckRunConclusion | null;
+  reentered?: boolean;
+  reasons?: string[];
+};
+
+export type RunLoopOptions = {
+  env?: Record<string, string | undefined>;
+  nowMs?: number;
+  githubToken?: string;
+  apiBaseUrl?: string;
+  sleepFn?: (delayMs: number) => Promise<void>;
+  openGovernorState?: () => GovernorState;
+  initEventLedger?: () => EventLedger;
+  initGovernorLedger?: () => GovernorLedger;
+  initPortfolioQueue?: () => PortfolioQueueStore;
+  initRunStateStore?: () => RunStateStore;
+  runDiscover?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+  runAttempt?: (args: string[], options?: Record<string, unknown>) => Promise<number>;
+  resolveAmsPolicy?: (repoFullName: string, options?: Record<string, unknown>) => Promise<{ spec: Record<string, unknown>; source: string; warnings: string[] }>;
+  checkMinerKillSwitch?: (input?: { env?: Record<string, string | undefined>; repoPaused?: boolean }) => { scope: "global" | "repo" | "none"; active: boolean };
+  evaluateRunLoopBoundaryGate?: (input: unknown, options?: unknown) => { verdict: { reason: string }; canClaimNext: boolean };
+  pollPrDisposition?: (repoFullName: string, prNumber: number, options?: PollPrDispositionOptions) => Promise<{ state: "open" | "closed"; merged: boolean; closedAt: string | null; attempts: number }>;
+  pollCheckRuns?: (repoFullName: string, prNumber: number, options?: PollCheckRunsOptions) => Promise<{ conclusion: CheckRunConclusion; checks: unknown[]; headSha: string; attempts: number }>;
+  recordPrOutcomeSnapshot?: (input: unknown, options?: unknown) => unknown;
+  buildLoopClosureSummary?: (sources: unknown, options?: unknown) => { sinceSeq: number | null; lastSeq: number };
+  attemptLoopReentry?: (candidate: unknown, deps: unknown) => { decision: { reenter: boolean; reasons: string[] }; dequeued: { repoFullName: string; identifier: string; priority: number; status: string; enqueuedAt: string } | null };
+  attemptOptions?: Record<string, unknown>;
+  prDispositionOptions?: PollPrDispositionOptions;
+  ciPollOptions?: PollCheckRunsOptions;
+};
+
+function parseRepoTarget(value: string): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return `${owner}/${repo}`;
+}
+
+function normalizeOptionalPositiveInt(value: string, label: string): number {
+  const parsedValue = Number(value);
+  if (!Number.isFinite(parsedValue) || !Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`${label} must be a non-negative integer: ${value}`);
+  }
+  return parsedValue;
+}
+
+export function parseLoopArgs(args: string[]): ParsedLoopArgs {
+  const options = {
+    json: false,
+    minerLogin: null as string | null,
+    base: "main",
+    live: false,
+    dryRun: false,
+    search: null as string | null,
+    maxCycles: undefined as number | undefined,
+    cycleDelayMs: DEFAULT_CYCLE_DELAY_MS,
+  };
+  const targets: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--live") {
+      options.live = true;
+      continue;
+    }
+    // #4847: see attempt-cli.js's own --dry-run comment -- distinct from --live's absence, this short-circuits
+    // BEFORE governor state or any other store is opened, guaranteeing zero discovery/queue/ledger writes.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--search") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      options.search = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--miner-login") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      options.minerLogin = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--base") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      options.base = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--max-cycles") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      try {
+        options.maxCycles = normalizeOptionalPositiveInt(value, "--max-cycles");
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+      index += 1;
+      continue;
+    }
+    if (token === "--cycle-delay-ms") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) return { error: LOOP_USAGE };
+      try {
+        options.cycleDelayMs = normalizeOptionalPositiveInt(value, "--cycle-delay-ms");
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) return { error: `Unknown option: ${token}` };
+    const target = parseRepoTarget(token);
+    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
+    targets.push(target);
+  }
+
+  if (options.search === null && targets.length === 0) return { error: LOOP_USAGE };
+  if (options.search !== null && targets.length > 0) return { error: "Pass either repository targets or --search, not both." };
+  if (!options.minerLogin) return { error: `--miner-login is required. ${LOOP_USAGE}` };
+
+  return {
+    targets,
+    search: options.search,
+    minerLogin: options.minerLogin,
+    base: options.base,
+    live: options.live,
+    dryRun: options.dryRun,
+    maxCycles: options.maxCycles,
+    cycleDelayMs: options.cycleDelayMs,
+    json: options.json,
+  };
+}
+
+function discoverArgv(parsed: ParsedLoopRun): string[] {
+  return parsed.search !== null ? ["--search", parsed.search] : [...parsed.targets];
+}
+
+function parseIssueNumberFromIdentifier(identifier: string): number | null {
+  const match = typeof identifier === "string" ? identifier.match(ISSUE_IDENTIFIER_PATTERN) : null;
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Run one full discover -> claim -> attempt -> observe -> reenter cycle repeatedly until a kill-switch trips,
+ * the run-loop boundary gate halts (non-convergence or a real budget/turn/elapsed cap), re-entry is declined,
+ * or `--max-cycles` is reached. Fails closed: refuses to start at all if governor state cannot be loaded.
+ *
+ * @param {string[]} args
+ * @param {{
+ *   env?: Record<string, string | undefined>,
+ *   nowMs?: number,
+ *   githubToken?: string,
+ *   apiBaseUrl?: string,
+ *   sleepFn?: (delayMs: number) => Promise<void>,
+ *   openGovernorState?: typeof openGovernorState,
+ *   initEventLedger?: typeof initEventLedger,
+ *   initGovernorLedger?: typeof initGovernorLedger,
+ *   initPortfolioQueue?: () => import("./portfolio-queue.js").PortfolioQueueStore,
+ *   initRunStateStore?: typeof initRunStateStore,
+ *   runDiscover?: typeof runDiscover,
+ *   runAttempt?: typeof runAttempt,
+ *   resolveAmsPolicy?: typeof resolveAmsPolicy,
+ *   checkMinerKillSwitch?: typeof checkMinerKillSwitch,
+ *   evaluateRunLoopBoundaryGate?: typeof evaluateRunLoopBoundaryGate,
+ *   pollPrDisposition?: typeof pollPrDisposition,
+ *   pollCheckRuns?: typeof pollCheckRuns,
+ *   recordPrOutcomeSnapshot?: typeof recordPrOutcomeSnapshot,
+ *   buildLoopClosureSummary?: typeof buildLoopClosureSummary,
+ *   attemptLoopReentry?: typeof attemptLoopReentry,
+ *   attemptOptions?: Record<string, unknown>,
+ *   prDispositionOptions?: Record<string, unknown>,
+ *   ciPollOptions?: Record<string, unknown>,
+ * }} [options]
+ * @returns {Promise<number>}
+ */
+export async function runLoop(args: string[], options: RunLoopOptions = {}): Promise<number> {
+  const parsed = parseLoopArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+  // Narrowed once here so nested closures (runDiscoveryOnce) see the non-error branch: TS control-flow
+  // narrowing from the `in` guard above does not flow into a captured closure's body.
+  const parsedRun: ParsedLoopRun = parsed;
+
+  const env = options.env ?? process.env;
+  const sleepFn = options.sleepFn ?? ((delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
+  const nowMsFn = () => options.nowMs ?? Date.now();
+  const sessionStartMs = nowMsFn();
+
+  // #4847: reports what a real loop invocation would target and returns BEFORE governor state or any other
+  // store (event/governor ledger, portfolio queue, run state) is opened -- a provable zero-write path, not just
+  // "opened but didn't write." The loop's own discovery call enqueues newly-found candidates into the LOCAL
+  // portfolio queue even before any attempt happens, so a faithful dry run cannot call it either.
+  if (parsed.dryRun) {
+    const dryRunResult = {
+      outcome: "dry_run",
+      targets: parsed.targets,
+      search: parsed.search,
+      minerLogin: parsed.minerLogin,
+      base: parsed.base,
+      live: parsed.live,
+      maxCycles: parsed.maxCycles ?? null,
+    };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      const target = parsed.search !== null ? `--search ${parsed.search}` : parsed.targets.join(", ");
+      console.log(
+        `DRY RUN: would run an autonomous loop against ${target} for ${parsed.minerLogin} (base: ${parsed.base}, live: ${parsed.live}). No discovery, queue, or ledger writes were made.`,
+      );
+    }
+    return 0;
+  }
+
+  let governorState: GovernorState;
+  try {
+    governorState = (options.openGovernorState ?? openGovernorState)();
+  } catch (error) {
+    return reportCliFailure(
+      parsed.json,
+      `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`,
+      3,
+    );
+  }
+
+  const eventLedger = (options.initEventLedger ?? initEventLedger)();
+  const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  const runState = (options.initRunStateStore ?? initRunStateStore)();
+
+  const runDiscoverFn = options.runDiscover ?? runDiscover;
+  const runAttemptFn = options.runAttempt ?? runAttempt;
+  const resolveAmsPolicyFn = options.resolveAmsPolicy ?? resolveAmsPolicy;
+  const checkKillSwitchFn = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
+  const evaluateBoundaryGateFn = options.evaluateRunLoopBoundaryGate ?? evaluateRunLoopBoundaryGate;
+  const pollPrDispositionFn = options.pollPrDisposition ?? pollPrDisposition;
+  const pollCheckRunsFn = options.pollCheckRuns ?? pollCheckRuns;
+  const recordPrOutcomeSnapshotFn = options.recordPrOutcomeSnapshot ?? recordPrOutcomeSnapshot;
+  const buildLoopClosureSummaryFn = options.buildLoopClosureSummary ?? buildLoopClosureSummary;
+  const attemptLoopReentryFn = options.attemptLoopReentry ?? attemptLoopReentry;
+
+  // Resolved ONCE, at the CLI-entrypoint layer, mirroring manage-poll.js's own runManagePoll (its
+  // recordManagePollSnapshot callee has no env fallback of its own either -- the top-level CLI function is
+  // where the GitHub token gets resolved, then threaded down explicitly to every real GitHub caller).
+  // pollPrDisposition (unlike runDiscover, which falls back to process.env.GITHUB_TOKEN internally) has NO
+  // such fallback -- an unresolved githubToken here would silently poll unauthenticated.
+  // resolveGitHubToken (#6116): GITHUB_TOKEN env override wins outright, else a live token from the
+  // authenticated `loopover-mcp login` session -- cached in memory for this process's lifetime.
+  const githubToken = options.githubToken ?? (await resolveGitHubToken(env)) ?? "";
+
+  async function runDiscoveryOnce() {
+    await runDiscoverFn(discoverArgv(parsedRun), {
+      initPortfolioQueue: () => portfolioQueue,
+      githubToken,
+      ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+      nowMs: nowMsFn(),
+    });
+  }
+
+  let usage = governorState.loadCapUsage();
+  const cycles: LoopCycleSummary[] = [];
+  let sinceSeq = eventLedger.readEvents({}).at(-1)?.seq ?? 0;
+  let haltReason: string | null = null;
+
+  try {
+    // Checked BEFORE any work at all -- including the very first discovery call -- so an already-active kill
+    // switch OR an already-active pause (#4851) halts the loop without ever touching GitHub or the queue. The
+    // pause flag is real, persisted, operator/governor-writable state on governorState (toggled via
+    // `loopover-miner governor pause`/`resume`) -- unlike the kill switch, a paused run resumes simply by being
+    // re-invoked: every piece of per-cycle state this loop reads (portfolioQueue, runState, governorState's own
+    // cap usage) is already durable, so clearing the flag and restarting continues exactly where it left off.
+    const initialKillSwitch = checkKillSwitchFn({ env });
+    const initialPauseState = governorState.loadPauseState();
+    let claimed: LoopClaimedItem | null = null;
+    if (initialKillSwitch.active) {
+      haltReason = `kill_switch_${initialKillSwitch.scope}`;
+      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+    } else if (initialPauseState.paused) {
+      haltReason = "paused";
+      cycles.push({ cycle: 1, outcome: "halted", reason: haltReason });
+    } else {
+      await runDiscoveryOnce();
+      claimed = portfolioQueue.dequeueNext();
+    }
+
+    let cycleIndex = haltReason !== null ? 1 : 0;
+    while (haltReason === null && (parsed.maxCycles === undefined || cycleIndex < parsed.maxCycles)) {
+      cycleIndex += 1;
+
+      const killSwitch = checkKillSwitchFn({ env });
+      if (killSwitch.active) {
+        haltReason = `kill_switch_${killSwitch.scope}`;
+        // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
+        if (claimed) {
+          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        }
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          ...(claimed
+            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+            : {}),
+        });
+        break;
+      }
+
+      const pauseState = governorState.loadPauseState();
+      if (pauseState.paused) {
+        haltReason = "paused";
+        if (claimed) {
+          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        }
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          ...(claimed
+            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+            : {}),
+        });
+        break;
+      }
+
+      if (!claimed) {
+        cycles.push({ cycle: cycleIndex, outcome: "idle_queue_empty" });
+        await sleepFn(parsed.cycleDelayMs);
+        await runDiscoveryOnce();
+        claimed = portfolioQueue.dequeueNext();
+        continue;
+      }
+
+      const issueNumber = parseIssueNumberFromIdentifier(claimed.identifier);
+      if (issueNumber === null) {
+        // Never produced by enqueueRankedDiscovery in practice (always "issue:N") -- fail soft rather than
+        // crash the whole run: this exact item can never be attempted, so it will never resolve on retry.
+        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        cycles.push({ cycle: cycleIndex, outcome: "skipped_malformed_identifier", identifier: claimed.identifier });
+        claimed = portfolioQueue.dequeueNext();
+        continue;
+      }
+
+      const amsPolicy = await resolveAmsPolicyFn(claimed.repoFullName, { env });
+      // Real, SQLite-persisted per-item convergence history (#5677): the dequeueNext claim above already recorded
+      // this attempt and the markDone/markFailed calls below record the outcome, so reading it back here shares one
+      // source of truth with attempt-cli.js (#5654) and survives a loop-daemon restart instead of resetting.
+      const convergenceInput = portfolioQueue.getAttemptHistory(
+        claimed.repoFullName,
+        claimed.identifier,
+        claimed.apiBaseUrl,
+      );
+
+      const boundary = evaluateBoundaryGateFn(
+        {
+          runHalted: false,
+          usage,
+          limits: (amsPolicy.spec.capLimits ?? DEFAULT_AMS_POLICY_SPEC.capLimits) as EvaluateRunLoopBoundaryGateInput["limits"],
+          convergence: convergenceInput,
+          convergenceThresholds: (amsPolicy.spec.convergenceThresholds ?? DEFAULT_AMS_POLICY_SPEC.convergenceThresholds) as NonNullable<EvaluateRunLoopBoundaryGateInput["convergenceThresholds"]>,
+          inFlightItem: { repoFullName: claimed.repoFullName, identifier: claimed.identifier },
+          // Echoes claimed.apiBaseUrl (#5563), NOT the callback's own repoFullName/identifier alone -- two forge
+          // hosts can share an in-flight item with the same repo name+identifier.
+          markFailed: (repoFullName: string, identifier: string) => portfolioQueue.markFailed(repoFullName, identifier, claimed!.apiBaseUrl),
+        },
+        { append: (event: Parameters<GovernorLedger["appendGovernorEvent"]>[0]) => governorLedger.appendGovernorEvent(event) },
+      );
+
+      if (!boundary.canClaimNext) {
+        haltReason = `boundary_${boundary.verdict.reason}`;
+        cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason, repoFullName: claimed.repoFullName, identifier: claimed.identifier });
+        break;
+      }
+
+      const cycleStartMs = nowMsFn();
+      // Held on an object rather than a bare `let`: the value is assigned inside the runAttempt `onResult`
+      // callback below, and TS's control-flow analysis would otherwise narrow a callback-only-assigned `let`
+      // back to its `null` initializer at the reads after the await. A property read is not narrowed that way.
+      const lastResultHolder: { value: LoopAttemptResult | null } = { value: null };
+      const attemptArgv = [
+        claimed.repoFullName,
+        String(issueNumber),
+        "--miner-login",
+        parsed.minerLogin,
+        "--base",
+        parsed.base,
+        ...(parsed.live ? ["--live"] : []),
+      ];
+      await runAttemptFn(attemptArgv, {
+        ...(options.attemptOptions ?? {}),
+        env,
+        onResult: (result: AttemptCliResult) => {
+          lastResultHolder.value = result;
+        },
+      });
+      const cycleElapsedMs = nowMsFn() - cycleStartMs;
+
+      usage = {
+        // Real for the agent-sdk provider (its own SDK result message reports total_cost_usd, wired through
+        // runMinerAttempt's real loopResult.totalCostUsd); the CLI-subprocess providers (claude-cli/codex-cli)
+        // report no cost signal today, so this contributes 0 for those runs -- an honest absence, not a
+        // fabricated number. A capLimits.budget dimension only ever meaningfully trips against agent-sdk spend.
+        budgetSpent: usage.budgetSpent + (lastResultHolder.value?.totalCostUsd ?? 0),
+        turnsTaken: usage.turnsTaken + (lastResultHolder.value?.totalTurnsUsed ?? 0),
+        elapsedMs: usage.elapsedMs + cycleElapsedMs,
+      };
+      governorState.saveCapUsage(usage);
+
+      const attemptOutcome = lastResultHolder.value?.outcome ?? "attempt_error";
+      const submitted = attemptOutcome === "attempt_submitted";
+      // A repo-wide AI-usage-policy ban will never resolve on retry -- stop re-queuing it (matches
+      // rejection-signal.js's own "this repo bans automated contributions" semantics). Every other blocked/
+      // abandoned/stale/governed outcome MAY resolve on a later retry (transient infra, contention, a
+      // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
+      // (reenqueues threshold) rather than silently retried forever.
+      const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
+      // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
+      // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
+      const killSwitchAbandon = lastResultHolder.value?.abandonReason === "kill_switch_engaged";
+
+      if (submitted || permanentBlock) {
+        // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
+        // so neither is re-queued. markDone also clears the persisted consecutive-failure streak.
+        portfolioQueue.markDone(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      } else {
+        // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
+        // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
+        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      }
+
+      if (killSwitchAbandon) {
+        const liveKill = checkKillSwitchFn({ env });
+        haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          repoFullName: claimed.repoFullName,
+          identifier: claimed.identifier,
+          attemptOutcome,
+        });
+        break;
+      }
+
+      let reentryOutcome: "merged" | "disengaged" | "other" = "other";
+      let prNumber: number | null = null;
+      let prDisposition: PrDisposition | null = null;
+      let ciConclusion: CheckRunConclusion | null = null;
+      if (submitted) {
+        prNumber = parsePrNumberFromExecResult(
+          lastResultHolder.value?.execResult as Parameters<typeof parsePrNumberFromExecResult>[0],
+          claimed.repoFullName,
+        );
+        if (prNumber !== null) {
+          // Real CI-status observation (#5394): recorded BEFORE the disposition poll below, so a submitted
+          // PR's check-run state is captured even while it's still open, not just at its eventual merge/close.
+          // ci-poller.js's real GitHub check-run polling is a heuristic proxy for the gate verdict; the
+          // authoritative terminal merge/close outcome comes from pollPrDispositionFn below, sourced directly
+          // from GitHub's own PR state rather than a server-internal endpoint (#5450).
+          const ciStatus = await pollCheckRunsFn(claimed.repoFullName, prNumber, {
+            githubToken,
+            ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+            ...(options.ciPollOptions ?? {}),
+          });
+          ciConclusion = ciStatus.conclusion;
+          eventLedger.appendEvent({
+            type: "ci_status_observed",
+            repoFullName: claimed.repoFullName,
+            payload: { prNumber, conclusion: ciStatus.conclusion, checkCount: ciStatus.checks.length, source: "ci-poller" },
+          });
+
+          prDisposition = await pollPrDispositionFn(claimed.repoFullName, prNumber, {
+            githubToken,
+            ...(options.apiBaseUrl !== undefined ? { apiBaseUrl: options.apiBaseUrl } : {}),
+            ...(options.prDispositionOptions ?? {}),
+          });
+          if (prDisposition.state === "closed") {
+            recordPrOutcomeSnapshotFn(
+              {
+                repoFullName: claimed.repoFullName,
+                prNumber,
+                decision: prDisposition.merged ? "merged" : "closed",
+                closedAt: prDisposition.closedAt,
+              },
+              { eventLedger },
+            );
+            // Real per-repo reputation history (#5675): a resolved terminal outcome updates the decided/unfavorable
+            // counts the Governor's self-reputation throttle reads on this repo's next attempt. `decided` always;
+            // `unfavorable` only on a closed-without-merge (rejection-state-machine.js's isRejectedPr, matching
+            // #5655's own-rejection classification). Forge-scoped by claimed.apiBaseUrl (#5563), like every other
+            // governor-state write here.
+            const priorReputation = governorState.loadReputationHistory(claimed.repoFullName, claimed.apiBaseUrl);
+            governorState.saveReputationHistory(
+              claimed.repoFullName,
+              {
+                decided: priorReputation.decided + 1,
+                unfavorable: priorReputation.unfavorable + (isRejectedPr(prDisposition) ? 1 : 0),
+              },
+              claimed.apiBaseUrl,
+            );
+            reentryOutcome = classifyPrDisposition(prDisposition);
+          }
+        }
+      }
+
+      const loopSummary = buildLoopClosureSummaryFn(
+        { eventLedger, portfolioQueue, runState },
+        { sinceSeq, repoFullName: claimed.repoFullName },
+      );
+      sinceSeq = loopSummary.lastSeq;
+
+      const reentry = attemptLoopReentryFn(
+        { killSwitchScope: killSwitch.scope, repoFullName: claimed.repoFullName, outcome: reentryOutcome },
+        { eventLedger, portfolioQueue, runState, nowMs: nowMsFn(), sessionStartMs, loopSummary },
+      );
+
+      cycles.push({
+        cycle: cycleIndex,
+        outcome: "attempted",
+        repoFullName: claimed.repoFullName,
+        identifier: claimed.identifier,
+        attemptOutcome,
+        reentryOutcome,
+        prNumber,
+        ciConclusion,
+        reentered: reentry.decision.reenter,
+        reasons: reentry.decision.reasons,
+      });
+
+      if (!reentry.decision.reenter) {
+        haltReason = `reentry_declined:${reentry.decision.reasons.join(",")}`;
+        break;
+      }
+
+      if (reentry.dequeued) {
+        claimed = reentry.dequeued;
+        await sleepFn(parsed.cycleDelayMs);
+      } else {
+        await sleepFn(parsed.cycleDelayMs);
+        await runDiscoveryOnce();
+        claimed = portfolioQueue.dequeueNext();
+      }
+    }
+
+    if (haltReason === null && parsed.maxCycles !== undefined) {
+      haltReason = "max_cycles_reached";
+      // The next cycle's item is primed (dequeued → 'in_progress') BEFORE the while-condition re-checks
+      // maxCycles -- both at the initial priming above and at each cycle's tail -- so exhausting maxCycles
+      // ends the run holding a claim no cycle ever processed. Release it, mirroring the kill-switch/pause
+      // halts (#5670): dequeueNext() only pulls 'queued' rows, so an unreleased claim is invisible to every
+      // future loop/attempt run until an out-of-band stale-lease sweep reclaims it.
+      if (claimed) {
+        portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      }
+    }
+
+    const summary = { haltReason, cyclesRun: cycles.length, cycles };
+    if (parsed.json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      console.log(`Loop finished after ${cycles.length} cycle(s): ${haltReason ?? "unknown"}.`);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    governorState.close();
+    eventLedger.close();
+    governorLedger.close();
+    portfolioQueue.close();
+    runState.close();
+  }
+}

--- a/packages/loopover-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.d.ts
@@ -1,101 +1,113 @@
 import type { PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
 import type { PortfolioQueueManager } from "./portfolio-queue-manager.js";
-
-export type ParsedQueueListArgs =
-  | {
-      json: boolean;
-      repoFullName: string | null;
-    }
-  | { error: string };
-
-export type ParsedQueueNextArgs =
-  | { json: boolean; dryRun: boolean; globalWipCap: number | undefined; perRepoWipCap: number | undefined }
-  | { error: string };
-
-export type QueueClaimTarget = { repoFullName: string; identifier: string; apiBaseUrl: string };
-
-export function selectNextEligibleTarget(
-  entries: Array<{ repoFullName: string; identifier: string; apiBaseUrl: string; status: string }>,
-  caps: { globalWipCap: number; perRepoWipCap: number } | null,
-): QueueClaimTarget[];
-
-export type ParsedQueueDoneArgs =
-  | {
-      repoFullName: string;
-      identifier: string;
-      dryRun: boolean;
-      json: boolean;
-      apiBaseUrl: string | undefined;
-    }
-  | { error: string };
-
-export function parseQueueListArgs(args: string[]): ParsedQueueListArgs;
-
-export function parseQueueNextArgs(args: string[]): ParsedQueueNextArgs;
-
-export function parseQueueDoneArgs(args: string[]): ParsedQueueDoneArgs;
-
-export function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs;
-
-export function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs;
-
-export type ParsedQueueClaimBatchArgs =
-  | { json: boolean; dryRun: boolean; globalWipCap: number; perRepoWipCap: number }
-  | { error: string };
-
-export function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs;
-
-export function renderQueueTable(entries: QueueEntry[]): string;
-
-export function runQueueList(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueNext(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueDone(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueRelease(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueRequeue(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
-): number;
-
-export function runQueueClaimBatch(
-  args: string[],
-  options?: { initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager },
-): number;
-
-export const QUEUE_ITEMS: string;
-export const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS: string;
-
-export function renderPortfolioQueueMetrics(
-  queueEntries: Array<{ status: string }>,
-  leaseEntries: Array<{ leasedAt: string | null }>,
-  nowMs: number,
-): string;
-
-export function runQueueMetrics(
-  args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore; nowMs?: number },
-): number;
-
-export function runQueueCli(
-  subcommand: string | undefined,
-  args: string[],
-  options?: {
+export type ParsedQueueListArgs = {
+    json: boolean;
+    repoFullName: string | null;
+} | {
+    error: string;
+};
+export declare function parseQueueListArgs(args: string[]): ParsedQueueListArgs;
+export type ParsedQueueNextArgs = {
+    json: boolean;
+    dryRun: boolean;
+    globalWipCap: number | undefined;
+    perRepoWipCap: number | undefined;
+} | {
+    error: string;
+};
+export declare function parseQueueNextArgs(args: string[]): ParsedQueueNextArgs;
+export type QueueClaimTarget = {
+    repoFullName: string;
+    identifier: string;
+    apiBaseUrl: string;
+};
+/**
+ * Pick at most one atomically-claimable target from the store's already-priority-ordered active rows (queued
+ * AND in_progress interleaved, exactly `batchClaim`'s own `entries` shape). `caps` of `null` replicates the
+ * pre-#4850 behavior: the single highest-priority queued row, unconditionally. When caps are set, refuses to
+ * select anything once the global or the target row's own per-repo in-progress count has reached its cap --
+ * "stops claiming once the cap is reached" (#4850), not a diversifying batch selection (that remains
+ * claim-batch's job via the engine's own `nextEligibleItems`).
+ */
+export declare function selectNextEligibleTarget(entries: Array<{
+    repoFullName: string;
+    identifier: string;
+    apiBaseUrl: string;
+    status: string;
+}>, caps: {
+    globalWipCap: number;
+    perRepoWipCap: number;
+} | null): QueueClaimTarget[];
+export type ParsedQueueDoneArgs = {
+    repoFullName: string;
+    identifier: string;
+    dryRun: boolean;
+    json: boolean;
+    apiBaseUrl: string | undefined;
+} | {
+    error: string;
+};
+export declare function parseQueueDoneArgs(args: string[]): ParsedQueueDoneArgs;
+export declare function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs;
+export declare function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs;
+export declare function renderQueueTable(entries: QueueEntry[]): string;
+export declare function runQueueList(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+export declare function runQueueNext(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+export declare function runQueueDone(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+/** `release <owner/repo> <identifier>`: manually give up a CLAIMED (in_progress) item, returning it to the queue
+ *  (the manual counterpart to the automated stuck-lease sweep). Exit 2 when there is no in-flight item to release. */
+export declare function runQueueRelease(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+/** `requeue <owner/repo> <identifier>`: manually put a COMPLETED (done) item back on the queue so it is picked up
+ *  again, keeping its original FIFO position. Exit 2 when there is no done item to requeue (already queued,
+ *  in-flight — release it instead — or absent). */
+export declare function runQueueRequeue(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+}): number;
+export type ParsedQueueClaimBatchArgs = {
+    json: boolean;
+    dryRun: boolean;
+    globalWipCap: number;
+    perRepoWipCap: number;
+} | {
+    error: string;
+};
+export declare function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs;
+/** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
+ *  reclaims any leases orphaned by a crashed process first (#4833 wires the previously caller-less claimer). */
+export declare function runQueueClaimBatch(args: string[], options?: {
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+}): number;
+export declare const QUEUE_ITEMS = "loopover_miner_portfolio_queue_items";
+export declare const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS = "loopover_miner_portfolio_queue_oldest_in_progress_lease_age_seconds";
+/**
+ * Render portfolio-queue backlog health as Prometheus text-exposition gauges: current item count per status, and
+ * the age of the OLDEST still-in-flight lease -- the concrete "is anything stuck" signal a
+ * `loopover_queue_oldest_maintenance_pending_age_seconds`-style alert rule can threshold on (#5186). Pure and
+ * side-effect-free: the caller supplies the rows and `nowMs` (no internal clock read, matching
+ * store-maintenance.js's pruneLedgerByRetention convention) and prints the result. Deterministic (status series
+ * sorted); always emits HELP/TYPE so an empty queue is still a well-formed exposition document, and the lease-age
+ * gauge reads 0 (never stuck) rather than being omitted when nothing is in-flight.
+ * @param queueEntries - every row, any status (e.g. store.listQueue()'s output).
+ * @param leaseEntries - in-flight rows only (store.listInProgress()'s output).
+ */
+export declare function renderPortfolioQueueMetrics(queueEntries: Array<{
+    status: string;
+}>, leaseEntries: Array<{
+    leasedAt: string | null;
+}>, nowMs: number): string;
+export declare function runQueueMetrics(args: string[], options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    nowMs?: number;
+}): number;
+export declare function runQueueCli(subcommand: string | undefined, args: string[], options?: {
     initPortfolioQueue?: () => PortfolioQueueStore;
     initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
-  },
-): number;
+}): number;

--- a/packages/loopover-miner/lib/portfolio-queue-cli.js
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.js
@@ -2,104 +2,98 @@ import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
-
 const QUEUE_LIST_USAGE = "Usage: loopover-miner queue list [--repo <owner/repo>] [--json]";
-const QUEUE_NEXT_USAGE =
-  "Usage: loopover-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
-const QUEUE_DONE_USAGE =
-  "Usage: loopover-miner queue done <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
-const QUEUE_RELEASE_USAGE =
-  "Usage: loopover-miner queue release <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
-const QUEUE_REQUEUE_USAGE =
-  "Usage: loopover-miner queue requeue <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
-const QUEUE_CLAIM_BATCH_USAGE =
-  "Usage: loopover-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
-
+const QUEUE_NEXT_USAGE = "Usage: loopover-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
+const QUEUE_DONE_USAGE = "Usage: loopover-miner queue done <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_RELEASE_USAGE = "Usage: loopover-miner queue release <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_REQUEUE_USAGE = "Usage: loopover-miner queue requeue <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_CLAIM_BATCH_USAGE = "Usage: loopover-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
 function parseRepoArg(value, usage) {
-  if (!value) return { error: usage };
-  const trimmed = value.trim();
-  const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
-    return { error: "Repository must be in owner/repo form." };
-  }
-  return { repoFullName: `${owner}/${repo}` };
+    if (!value)
+        return { error: usage };
+    const trimmed = value.trim();
+    const [owner, repo, extra] = trimmed.split("/");
+    if (!owner || !repo || extra !== undefined) {
+        return { error: "Repository must be in owner/repo form." };
+    }
+    return { repoFullName: `${owner}/${repo}` };
 }
-
 export function parseQueueListArgs(args) {
-  const options = { json: false, repoFullName: null };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, repoFullName: null };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--repo") {
+            const repoArg = args[index + 1];
+            if (!repoArg || repoArg.startsWith("-")) {
+                return { error: QUEUE_LIST_USAGE };
+            }
+            const repo = parseRepoArg(repoArg, QUEUE_LIST_USAGE);
+            if ("error" in repo)
+                return repo;
+            options.repoFullName = repo.repoFullName;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--repo") {
-      const repoArg = args[index + 1];
-      if (!repoArg || repoArg.startsWith("-")) {
+    if (positional.length > 0) {
         return { error: QUEUE_LIST_USAGE };
-      }
-      const repo = parseRepoArg(repoArg, QUEUE_LIST_USAGE);
-      if ("error" in repo) return repo;
-      options.repoFullName = repo.repoFullName;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length > 0) {
-    return { error: QUEUE_LIST_USAGE };
-  }
-
-  return options;
+    return options;
 }
-
 // #4850: --global-wip/--per-repo-wip are OMITTED (undefined) by default -- queue next stays uncapped, byte-
 // identical to its pre-#4850 behavior, unless an operator explicitly opts in. Mirrors queue claim-batch's own
 // flag names (portfolio-queue-manager.js's WIP-cap-aware claimer), but claim-batch's OWN default of 1/1 is not
 // reused here: claim-batch's whole purpose is cap enforcement, while queue next has always been a plain
 // highest-priority dequeue and must not silently start capping existing callers that never asked for it.
 export function parseQueueNextArgs(args) {
-  const options = { json: false, dryRun: false, globalWipCap: undefined, perRepoWipCap: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = {
+        json: false,
+        dryRun: false,
+        globalWipCap: undefined,
+        perRepoWipCap: undefined,
+    };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--global-wip" || token === "--per-repo-wip") {
+            const value = Number(args[index + 1]);
+            if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+                return { error: QUEUE_NEXT_USAGE };
+            }
+            if (token === "--global-wip")
+                options.globalWipCap = value;
+            else
+                options.perRepoWipCap = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--global-wip" || token === "--per-repo-wip") {
-      const value = Number(args[index + 1]);
-      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+    if (positional.length > 0) {
         return { error: QUEUE_NEXT_USAGE };
-      }
-      if (token === "--global-wip") options.globalWipCap = value;
-      else options.perRepoWipCap = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
-    }
-    positional.push(token);
-  }
-
-  if (positional.length > 0) {
-    return { error: QUEUE_NEXT_USAGE };
-  }
-  return options;
+    return options;
 }
-
 /**
  * Pick at most one atomically-claimable target from the store's already-priority-ordered active rows (queued
  * AND in_progress interleaved, exactly `batchClaim`'s own `entries` shape). `caps` of `null` replicates the
@@ -107,396 +101,382 @@ export function parseQueueNextArgs(args) {
  * select anything once the global or the target row's own per-repo in-progress count has reached its cap --
  * "stops claiming once the cap is reached" (#4850), not a diversifying batch selection (that remains
  * claim-batch's job via the engine's own `nextEligibleItems`).
- * @param {Array<{ repoFullName: string, identifier: string, apiBaseUrl: string, status: string }>} entries
- * @param {{ globalWipCap: number, perRepoWipCap: number } | null} caps
  */
 export function selectNextEligibleTarget(entries, caps) {
-  const topQueued = entries.find((entry) => entry.status === "queued");
-  if (!topQueued) return [];
-  if (!caps) {
+    const topQueued = entries.find((entry) => entry.status === "queued");
+    if (!topQueued)
+        return [];
+    if (!caps) {
+        return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
+    }
+    const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
+    if (globalActiveCount >= caps.globalWipCap)
+        return [];
+    // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
+    // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
+    // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
+    const repoActiveCount = entries.filter((entry) => entry.status === "in_progress" &&
+        entry.repoFullName === topQueued.repoFullName &&
+        entry.apiBaseUrl === topQueued.apiBaseUrl).length;
+    if (repoActiveCount >= caps.perRepoWipCap)
+        return [];
     return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
-  }
-  const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
-  if (globalActiveCount >= caps.globalWipCap) return [];
-  // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
-  // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
-  // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
-  const repoActiveCount = entries.filter(
-    (entry) =>
-      entry.status === "in_progress" &&
-      entry.repoFullName === topQueued.repoFullName &&
-      entry.apiBaseUrl === topQueued.apiBaseUrl,
-  ).length;
-  if (repoActiveCount >= caps.perRepoWipCap) return [];
-  return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
 }
-
 /** Shared `<owner/repo> <identifier> [--api-base-url <url>] [--json]` parse for the item-targeting subcommands
  *  (done/release/requeue). `usage` is the command-specific message surfaced on a malformed argv. */
 function parseRepoIdentifierArgs(args, usage) {
-  const options = { json: false, dryRun: false, apiBaseUrl: undefined };
-  const positional = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
+    const options = { json: false, dryRun: false, apiBaseUrl: undefined };
+    const positional = [];
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        // #5563: scope the target to a non-default forge host, so it doesn't collide with (or get confused for) a
+        // same-named repo on the default github.com host.
+        if (token === "--api-base-url") {
+            const value = args[index + 1];
+            if (!value || value.startsWith("-")) {
+                return { error: usage };
+            }
+            options.apiBaseUrl = value;
+            index += 1;
+            continue;
+        }
+        if (token.startsWith("-")) {
+            return { error: `Unknown option: ${token}` };
+        }
+        positional.push(token);
     }
-    // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    // #5563: scope the target to a non-default forge host, so it doesn't collide with (or get confused for) a
-    // same-named repo on the default github.com host.
-    if (token === "--api-base-url") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
+    if (positional.length !== 2) {
         return { error: usage };
-      }
-      options.apiBaseUrl = value;
-      index += 1;
-      continue;
     }
-    if (token.startsWith("-")) {
-      return { error: `Unknown option: ${token}` };
+    const repo = parseRepoArg(positional[0], usage);
+    if ("error" in repo)
+        return repo;
+    const identifier = positional[1]?.trim();
+    if (!identifier) {
+        return { error: usage };
     }
-    positional.push(token);
-  }
-
-  if (positional.length !== 2) {
-    return { error: usage };
-  }
-
-  const repo = parseRepoArg(positional[0], usage);
-  if ("error" in repo) return repo;
-
-  const identifier = positional[1]?.trim();
-  if (!identifier) {
-    return { error: usage };
-  }
-
-  return {
-    repoFullName: repo.repoFullName,
-    identifier,
-    dryRun: options.dryRun,
-    json: options.json,
-    apiBaseUrl: options.apiBaseUrl,
-  };
+    return {
+        repoFullName: repo.repoFullName,
+        identifier,
+        dryRun: options.dryRun,
+        json: options.json,
+        apiBaseUrl: options.apiBaseUrl,
+    };
 }
-
 export function parseQueueDoneArgs(args) {
-  return parseRepoIdentifierArgs(args, QUEUE_DONE_USAGE);
+    return parseRepoIdentifierArgs(args, QUEUE_DONE_USAGE);
 }
-
 export function parseQueueReleaseArgs(args) {
-  return parseRepoIdentifierArgs(args, QUEUE_RELEASE_USAGE);
+    return parseRepoIdentifierArgs(args, QUEUE_RELEASE_USAGE);
 }
-
 export function parseQueueRequeueArgs(args) {
-  return parseRepoIdentifierArgs(args, QUEUE_REQUEUE_USAGE);
+    return parseRepoIdentifierArgs(args, QUEUE_REQUEUE_USAGE);
 }
-
 function display(value) {
-  if (value === null || value === undefined) return "-";
-  return String(value);
+    if (value === null || value === undefined)
+        return "-";
+    return String(value);
 }
-
 export function renderQueueTable(entries) {
-  if (!Array.isArray(entries) || entries.length === 0) return "no portfolio queue entries";
-  const header = [
-    "repo".padEnd(24),
-    "identifier".padEnd(16),
-    // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
-    // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
-    "host".padEnd(30),
-    "status".padEnd(12),
-    "pri".padStart(4),
-    "enqueued-at".padEnd(24),
-  ].join(" ");
-  const lines = entries.map((entry) =>
-    [
-      entry.repoFullName.padEnd(24),
-      entry.identifier.padEnd(16),
-      display(entry.apiBaseUrl).padEnd(30),
-      entry.status.padEnd(12),
-      display(entry.priority).padStart(4),
-      display(entry.enqueuedAt).padEnd(24),
-    ].join(" "),
-  );
-  return [header, ...lines].join("\n");
+    if (!Array.isArray(entries) || entries.length === 0)
+        return "no portfolio queue entries";
+    const header = [
+        "repo".padEnd(24),
+        "identifier".padEnd(16),
+        // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
+        // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
+        "host".padEnd(30),
+        "status".padEnd(12),
+        "pri".padStart(4),
+        "enqueued-at".padEnd(24),
+    ].join(" ");
+    const lines = entries.map((entry) => [
+        entry.repoFullName.padEnd(24),
+        entry.identifier.padEnd(16),
+        display(entry.apiBaseUrl).padEnd(30),
+        entry.status.padEnd(12),
+        display(entry.priority).padStart(4),
+        display(entry.enqueuedAt).padEnd(24),
+    ].join(" "));
+    return [header, ...lines].join("\n");
 }
-
 function withPortfolioQueue(options, run) {
-  const ownsStore = options.initPortfolioQueue === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
-  try {
-    return run(portfolioQueue);
-  } finally {
-    if (ownsStore) portfolioQueue.close();
-  }
+    const ownsStore = options.initPortfolioQueue === undefined;
+    const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+    try {
+        return run(portfolioQueue);
+    }
+    finally {
+        if (ownsStore)
+            portfolioQueue.close();
+    }
 }
-
 export function runQueueList(args, options = {}) {
-  const parsed = parseQueueListArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entries = portfolioQueue.listQueue(parsed.repoFullName);
-      if (parsed.json) {
-        console.log(JSON.stringify({ entries }, null, 2));
-      } else {
-        console.log(renderQueueTable(entries));
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const parsed = parseQueueListArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entries = portfolioQueue.listQueue(parsed.repoFullName);
+            if (parsed.json) {
+                console.log(JSON.stringify({ entries }, null, 2));
+            }
+            else {
+                console.log(renderQueueTable(entries));
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runQueueNext(args, options = {}) {
-  const parsed = parseQueueNextArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  const capsRequested = parsed.globalWipCap !== undefined || parsed.perRepoWipCap !== undefined;
-  if (parsed.dryRun) {
-    const dryRunResult = capsRequested
-      ? { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap }
-      : { outcome: "dry_run" };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else if (capsRequested) {
-      console.log(
-        `DRY RUN: would dequeue the highest-priority queued item within WIP caps (global-wip: ${parsed.globalWipCap ?? "unset"}, per-repo-wip: ${parsed.perRepoWipCap ?? "unset"}). No portfolio-queue write was made.`,
-      );
-    } else {
-      console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+    const parsed = parseQueueNextArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      let entry;
-      if (capsRequested) {
-        // Unset dimensions stay genuinely uncapped (Infinity), not silently defaulted to 1 like claim-batch.
-        const caps = {
-          globalWipCap: parsed.globalWipCap ?? Number.POSITIVE_INFINITY,
-          perRepoWipCap: parsed.perRepoWipCap ?? Number.POSITIVE_INFINITY,
-        };
-        const claimed = portfolioQueue.batchClaim((entries) => selectNextEligibleTarget(entries, caps));
-        entry = claimed[0] ?? null;
-      } else {
-        entry = portfolioQueue.dequeueNext();
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry ? entry.identifier : "none");
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    const capsRequested = parsed.globalWipCap !== undefined || parsed.perRepoWipCap !== undefined;
+    if (parsed.dryRun) {
+        const dryRunResult = capsRequested
+            ? { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap }
+            : { outcome: "dry_run" };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else if (capsRequested) {
+            console.log(`DRY RUN: would dequeue the highest-priority queued item within WIP caps (global-wip: ${parsed.globalWipCap ?? "unset"}, per-repo-wip: ${parsed.perRepoWipCap ?? "unset"}). No portfolio-queue write was made.`);
+        }
+        else {
+            console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            let entry;
+            if (capsRequested) {
+                // Unset dimensions stay genuinely uncapped (Infinity), not silently defaulted to 1 like claim-batch.
+                const caps = {
+                    globalWipCap: parsed.globalWipCap ?? Number.POSITIVE_INFINITY,
+                    perRepoWipCap: parsed.perRepoWipCap ?? Number.POSITIVE_INFINITY,
+                };
+                const claimed = portfolioQueue.batchClaim((entries) => selectNextEligibleTarget(entries, caps));
+                entry = claimed[0] ?? null;
+            }
+            else {
+                entry = portfolioQueue.dequeueNext();
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry ? entry.identifier : "none");
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function runQueueDone(args, options = {}) {
-  const parsed = parseQueueDoneArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would mark ${parsed.repoFullName} ${parsed.identifier} done. No portfolio-queue write was made.`);
+    const parsed = parseQueueDoneArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
-      if (!entry) {
-        return reportCliFailure(parsed.json, "queue_entry_not_found");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would mark ${parsed.repoFullName} ${parsed.identifier} done. No portfolio-queue write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+            if (!entry) {
+                return reportCliFailure(parsed.json, "queue_entry_not_found");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 /** `release <owner/repo> <identifier>`: manually give up a CLAIMED (in_progress) item, returning it to the queue
  *  (the manual counterpart to the automated stuck-lease sweep). Exit 2 when there is no in-flight item to release. */
 export function runQueueRelease(args, options = {}) {
-  const parsed = parseQueueReleaseArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would release ${parsed.repoFullName} ${parsed.identifier} back to the queue. No portfolio-queue write was made.`);
+    const parsed = parseQueueReleaseArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
-      if (!entry) {
-        return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would release ${parsed.repoFullName} ${parsed.identifier} back to the queue. No portfolio-queue write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+            if (!entry) {
+                return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 /** `requeue <owner/repo> <identifier>`: manually put a COMPLETED (done) item back on the queue so it is picked up
  *  again, keeping its original FIFO position. Exit 2 when there is no done item to requeue (already queued,
  *  in-flight — release it instead — or absent). */
 export function runQueueRequeue(args, options = {}) {
-  const parsed = parseQueueRequeueArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(`DRY RUN: would requeue ${parsed.repoFullName} ${parsed.identifier}. No portfolio-queue write was made.`);
+    const parsed = parseQueueRequeueArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
-      if (!entry) {
-        return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
-      }
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry.status);
-      }
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  }
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would requeue ${parsed.repoFullName} ${parsed.identifier}. No portfolio-queue write was made.`);
+        }
+        return 0;
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+            if (!entry) {
+                return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
+            }
+            if (parsed.json) {
+                console.log(JSON.stringify({ entry }, null, 2));
+            }
+            else {
+                console.log(entry.status);
+            }
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
 }
-
 export function parseQueueClaimBatchArgs(args) {
-  const options = { json: false, dryRun: false, globalWipCap: 1, perRepoWipCap: 1 };
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
-    }
-    if (token === "--dry-run") {
-      options.dryRun = true;
-      continue;
-    }
-    if (token === "--global-wip" || token === "--per-repo-wip") {
-      const value = Number(args[index + 1]);
-      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+    const options = { json: false, dryRun: false, globalWipCap: 1, perRepoWipCap: 1 };
+    for (let index = 0; index < args.length; index += 1) {
+        const token = args[index];
+        if (token === "--json") {
+            options.json = true;
+            continue;
+        }
+        if (token === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+        if (token === "--global-wip" || token === "--per-repo-wip") {
+            const value = Number(args[index + 1]);
+            if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+                return { error: QUEUE_CLAIM_BATCH_USAGE };
+            }
+            if (token === "--global-wip")
+                options.globalWipCap = value;
+            else
+                options.perRepoWipCap = value;
+            index += 1;
+            continue;
+        }
         return { error: QUEUE_CLAIM_BATCH_USAGE };
-      }
-      if (token === "--global-wip") options.globalWipCap = value;
-      else options.perRepoWipCap = value;
-      index += 1;
-      continue;
     }
-    return { error: QUEUE_CLAIM_BATCH_USAGE };
-  }
-  return options;
+    return options;
 }
-
 /** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
  *  reclaims any leases orphaned by a crashed process first (#4833 wires the previously caller-less claimer). */
 export function runQueueClaimBatch(args, options = {}) {
-  const parsed = parseQueueClaimBatchArgs(args);
-  if ("error" in parsed) {
-    return reportCliFailure(argsWantJson(args), parsed.error);
-  }
-
-  if (parsed.dryRun) {
-    const dryRunResult = { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap };
-    if (parsed.json) {
-      console.log(JSON.stringify(dryRunResult, null, 2));
-    } else {
-      console.log(
-        `DRY RUN: would claim a batch (global-wip: ${parsed.globalWipCap}, per-repo-wip: ${parsed.perRepoWipCap}). No portfolio-queue write was made.`,
-      );
+    const parsed = parseQueueClaimBatchArgs(args);
+    if ("error" in parsed) {
+        return reportCliFailure(argsWantJson(args), parsed.error);
     }
-    return 0;
-  }
-
-  // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
-  // close with `?.` since the initializer may have thrown before assigning.
-  const ownsManager = options.initPortfolioQueueManager === undefined;
-  let manager;
-  try {
-    manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
-      caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
-    });
-    const claimed = manager.claimNextBatch();
-    if (parsed.json) {
-      console.log(JSON.stringify({ claimed }, null, 2));
-    } else {
-      console.log(claimed.length === 0 ? "none" : claimed.map((entry) => entry.identifier).join("\n"));
+    if (parsed.dryRun) {
+        const dryRunResult = { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap };
+        if (parsed.json) {
+            console.log(JSON.stringify(dryRunResult, null, 2));
+        }
+        else {
+            console.log(`DRY RUN: would claim a batch (global-wip: ${parsed.globalWipCap}, per-repo-wip: ${parsed.perRepoWipCap}). No portfolio-queue write was made.`);
+        }
+        return 0;
     }
-    return 0;
-  } catch (error) {
-    return reportCliFailure(parsed.json, describeCliError(error));
-  } finally {
-    if (ownsManager) manager?.close();
-  }
+    // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
+    // close with `?.` since the initializer may have thrown before assigning.
+    const ownsManager = options.initPortfolioQueueManager === undefined;
+    let manager;
+    try {
+        manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+            caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+        });
+        const claimed = manager.claimNextBatch();
+        if (parsed.json) {
+            console.log(JSON.stringify({ claimed }, null, 2));
+        }
+        else {
+            console.log(claimed.length === 0 ? "none" : claimed.map((entry) => entry.identifier).join("\n"));
+        }
+        return 0;
+    }
+    catch (error) {
+        return reportCliFailure(parsed.json, describeCliError(error));
+    }
+    finally {
+        if (ownsManager)
+            manager?.close();
+    }
 }
-
 const QUEUE_METRICS_USAGE = "Usage: loopover-miner queue metrics";
-
 // Prometheus metric names for the portfolio-queue gauges (#5186). Mirrors the `loopover_miner_*` naming and
 // HELP/TYPE/label conventions of event-ledger-cli.js's renderEventLedgerMetrics / the engine's
 // renderMinerPredictionMetrics, rather than importing across the package boundary.
 export const QUEUE_ITEMS = "loopover_miner_portfolio_queue_items";
 export const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS = "loopover_miner_portfolio_queue_oldest_in_progress_lease_age_seconds";
-
 /** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
 function escapeMetricsHelpText(help) {
-  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+    return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
 }
-
 /**
  * Render portfolio-queue backlog health as Prometheus text-exposition gauges: current item count per status, and
  * the age of the OLDEST still-in-flight lease -- the concrete "is anything stuck" signal a
@@ -505,69 +485,69 @@ function escapeMetricsHelpText(help) {
  * store-maintenance.js's pruneLedgerByRetention convention) and prints the result. Deterministic (status series
  * sorted); always emits HELP/TYPE so an empty queue is still a well-formed exposition document, and the lease-age
  * gauge reads 0 (never stuck) rather than being omitted when nothing is in-flight.
- * @param {Array<{ status: string }>} queueEntries - every row, any status (e.g. store.listQueue()'s output).
- * @param {Array<{ leasedAt: string | null }>} leaseEntries - in-flight rows only (store.listInProgress()'s output).
- * @param {number} nowMs
+ * @param queueEntries - every row, any status (e.g. store.listQueue()'s output).
+ * @param leaseEntries - in-flight rows only (store.listInProgress()'s output).
  */
 export function renderPortfolioQueueMetrics(queueEntries, leaseEntries, nowMs) {
-  const countByStatus = new Map();
-  for (const entry of queueEntries) {
-    countByStatus.set(entry.status, (countByStatus.get(entry.status) ?? 0) + 1);
-  }
-
-  let oldestLeaseAgeSeconds = 0;
-  for (const lease of leaseEntries) {
-    const leasedAtMs = Date.parse(lease.leasedAt ?? "");
-    if (!Number.isFinite(leasedAtMs)) continue;
-    const ageSeconds = Math.max(0, (nowMs - leasedAtMs) / 1000);
-    if (ageSeconds > oldestLeaseAgeSeconds) oldestLeaseAgeSeconds = ageSeconds;
-  }
-
-  const lines = [
-    `# HELP ${QUEUE_ITEMS} ${escapeMetricsHelpText("Current portfolio-queue item count, by status.")}`,
-    `# TYPE ${QUEUE_ITEMS} gauge`,
-  ];
-  for (const [status, count] of [...countByStatus.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-    lines.push(`${QUEUE_ITEMS}{status="${status}"} ${count}`);
-  }
-
-  lines.push(
-    `# HELP ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${escapeMetricsHelpText("Age in seconds of the oldest still-in-flight (in_progress) claim lease. 0 when nothing is in-flight.")}`,
-  );
-  lines.push(`# TYPE ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} gauge`);
-  lines.push(`${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${oldestLeaseAgeSeconds}`);
-
-  return `${lines.join("\n")}\n`;
+    const countByStatus = new Map();
+    for (const entry of queueEntries) {
+        countByStatus.set(entry.status, (countByStatus.get(entry.status) ?? 0) + 1);
+    }
+    let oldestLeaseAgeSeconds = 0;
+    for (const lease of leaseEntries) {
+        const leasedAtMs = Date.parse(lease.leasedAt ?? "");
+        if (!Number.isFinite(leasedAtMs))
+            continue;
+        const ageSeconds = Math.max(0, (nowMs - leasedAtMs) / 1000);
+        if (ageSeconds > oldestLeaseAgeSeconds)
+            oldestLeaseAgeSeconds = ageSeconds;
+    }
+    const lines = [
+        `# HELP ${QUEUE_ITEMS} ${escapeMetricsHelpText("Current portfolio-queue item count, by status.")}`,
+        `# TYPE ${QUEUE_ITEMS} gauge`,
+    ];
+    for (const [status, count] of [...countByStatus.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+        lines.push(`${QUEUE_ITEMS}{status="${status}"} ${count}`);
+    }
+    lines.push(`# HELP ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${escapeMetricsHelpText("Age in seconds of the oldest still-in-flight (in_progress) claim lease. 0 when nothing is in-flight.")}`);
+    lines.push(`# TYPE ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} gauge`);
+    lines.push(`${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${oldestLeaseAgeSeconds}`);
+    return `${lines.join("\n")}\n`;
 }
-
 export function runQueueMetrics(args, options = {}) {
-  if (args.length > 0) {
-    return reportCliFailure(argsWantJson(args), QUEUE_METRICS_USAGE);
-  }
-
-  try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
-      // renderPortfolioQueueMetrics returns a newline-terminated document; console.log re-adds the terminator, so
-      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
-      console.log(
-        renderPortfolioQueueMetrics(portfolioQueue.listQueue(), portfolioQueue.listInProgress(), nowMs).trimEnd(),
-      );
-      return 0;
-    });
-  } catch (error) {
-    return reportCliFailure(argsWantJson(args), describeCliError(error));
-  }
+    if (args.length > 0) {
+        return reportCliFailure(argsWantJson(args), QUEUE_METRICS_USAGE);
+    }
+    try {
+        return withPortfolioQueue(options, (portfolioQueue) => {
+            const nowMs = typeof options.nowMs === "number" && Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+            // renderPortfolioQueueMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+            // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+            console.log(renderPortfolioQueueMetrics(portfolioQueue.listQueue(), portfolioQueue.listInProgress(), nowMs).trimEnd());
+            return 0;
+        });
+    }
+    catch (error) {
+        return reportCliFailure(argsWantJson(args), describeCliError(error));
+    }
 }
-
 export function runQueueCli(subcommand, args, options = {}) {
-  if (subcommand === "list") return runQueueList(args, options);
-  if (subcommand === "next") return runQueueNext(args, options);
-  if (subcommand === "done") return runQueueDone(args, options);
-  if (subcommand === "release") return runQueueRelease(args, options);
-  if (subcommand === "requeue") return runQueueRequeue(args, options);
-  if (subcommand === "claim-batch") return runQueueClaimBatch(args, options);
-  if (subcommand === "metrics") return runQueueMetrics(args, options);
-  if (subcommand === "dashboard") return runPortfolioDashboard(args, options);
-  return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
+    if (subcommand === "list")
+        return runQueueList(args, options);
+    if (subcommand === "next")
+        return runQueueNext(args, options);
+    if (subcommand === "done")
+        return runQueueDone(args, options);
+    if (subcommand === "release")
+        return runQueueRelease(args, options);
+    if (subcommand === "requeue")
+        return runQueueRequeue(args, options);
+    if (subcommand === "claim-batch")
+        return runQueueClaimBatch(args, options);
+    if (subcommand === "metrics")
+        return runQueueMetrics(args, options);
+    if (subcommand === "dashboard")
+        return runPortfolioDashboard(args, options);
+    return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9ydGZvbGlvLXF1ZXVlLWNsaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInBvcnRmb2xpby1xdWV1ZS1jbGkudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLHVCQUF1QixFQUFFLE1BQU0sc0JBQXNCLENBQUM7QUFDL0QsT0FBTyxFQUFFLHlCQUF5QixFQUFFLE1BQU0sOEJBQThCLENBQUM7QUFDekUsT0FBTyxFQUFFLHFCQUFxQixFQUFFLE1BQU0sMEJBQTBCLENBQUM7QUFDakUsT0FBTyxFQUFFLFlBQVksRUFBRSxnQkFBZ0IsRUFBRSxnQkFBZ0IsRUFBRSxNQUFNLGdCQUFnQixDQUFDO0FBSWxGLE1BQU0sZ0JBQWdCLEdBQUcsaUVBQWlFLENBQUM7QUFDM0YsTUFBTSxnQkFBZ0IsR0FDcEIsK0ZBQStGLENBQUM7QUFDbEcsTUFBTSxnQkFBZ0IsR0FDcEIsd0dBQXdHLENBQUM7QUFDM0csTUFBTSxtQkFBbUIsR0FDdkIsMkdBQTJHLENBQUM7QUFDOUcsTUFBTSxtQkFBbUIsR0FDdkIsMkdBQTJHLENBQUM7QUFDOUcsTUFBTSx1QkFBdUIsR0FDM0Isc0dBQXNHLENBQUM7QUFFekcsU0FBUyxZQUFZLENBQUMsS0FBeUIsRUFBRSxLQUFhO0lBQzVELElBQUksQ0FBQyxLQUFLO1FBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUNwQyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDN0IsTUFBTSxDQUFDLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNoRCxJQUFJLENBQUMsS0FBSyxJQUFJLENBQUMsSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTLEVBQUUsQ0FBQztRQUMzQyxPQUFPLEVBQUUsS0FBSyxFQUFFLHdDQUF3QyxFQUFFLENBQUM7SUFDN0QsQ0FBQztJQUNELE9BQU8sRUFBRSxZQUFZLEVBQUUsR0FBRyxLQUFLLElBQUksSUFBSSxFQUFFLEVBQUUsQ0FBQztBQUM5QyxDQUFDO0FBU0QsTUFBTSxVQUFVLGtCQUFrQixDQUFDLElBQWM7SUFDL0MsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLFlBQVksRUFBRSxJQUFxQixFQUFFLENBQUM7SUFDckUsTUFBTSxVQUFVLEdBQWEsRUFBRSxDQUFDO0lBRWhDLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFFLENBQUM7UUFDM0IsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQ2hDLElBQUksQ0FBQyxPQUFPLElBQUksT0FBTyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUN4QyxPQUFPLEVBQUUsS0FBSyxFQUFFLGdCQUFnQixFQUFFLENBQUM7WUFDckMsQ0FBQztZQUNELE1BQU0sSUFBSSxHQUFHLFlBQVksQ0FBQyxPQUFPLEVBQUUsZ0JBQWdCLENBQUMsQ0FBQztZQUNyRCxJQUFJLE9BQU8sSUFBSSxJQUFJO2dCQUFFLE9BQU8sSUFBSSxDQUFDO1lBQ2pDLE9BQU8sQ0FBQyxZQUFZLEdBQUcsSUFBSSxDQUFDLFlBQVksQ0FBQztZQUN6QyxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxnQkFBZ0IsRUFBRSxDQUFDO0lBQ3JDLENBQUM7SUFFRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBTUQsNEdBQTRHO0FBQzVHLDhHQUE4RztBQUM5RywrR0FBK0c7QUFDL0csd0dBQXdHO0FBQ3hHLHlHQUF5RztBQUN6RyxNQUFNLFVBQVUsa0JBQWtCLENBQUMsSUFBYztJQUMvQyxNQUFNLE9BQU8sR0FBRztRQUNkLElBQUksRUFBRSxLQUFLO1FBQ1gsTUFBTSxFQUFFLEtBQUs7UUFDYixZQUFZLEVBQUUsU0FBK0I7UUFDN0MsYUFBYSxFQUFFLFNBQStCO0tBQy9DLENBQUM7SUFDRixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLFdBQVcsRUFBRSxDQUFDO1lBQzFCLE9BQU8sQ0FBQyxNQUFNLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLFNBQVM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxLQUFLLEtBQUssY0FBYyxJQUFJLEtBQUssS0FBSyxnQkFBZ0IsRUFBRSxDQUFDO1lBQzNELE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDdEMsSUFBSSxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxLQUFLLFNBQVMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUMxRSxPQUFPLEVBQUUsS0FBSyxFQUFFLGdCQUFnQixFQUFFLENBQUM7WUFDckMsQ0FBQztZQUNELElBQUksS0FBSyxLQUFLLGNBQWM7Z0JBQUUsT0FBTyxDQUFDLFlBQVksR0FBRyxLQUFLLENBQUM7O2dCQUN0RCxPQUFPLENBQUMsYUFBYSxHQUFHLEtBQUssQ0FBQztZQUNuQyxLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLENBQUM7UUFDMUIsT0FBTyxFQUFFLEtBQUssRUFBRSxnQkFBZ0IsRUFBRSxDQUFDO0lBQ3JDLENBQUM7SUFDRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBSUQ7Ozs7Ozs7R0FPRztBQUNILE1BQU0sVUFBVSx3QkFBd0IsQ0FDdEMsT0FBZ0csRUFDaEcsSUFBNEQ7SUFFNUQsTUFBTSxTQUFTLEdBQUcsT0FBTyxDQUFDLElBQUksQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLE1BQU0sS0FBSyxRQUFRLENBQUMsQ0FBQztJQUNyRSxJQUFJLENBQUMsU0FBUztRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQzFCLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNWLE9BQU8sQ0FBQyxFQUFFLFlBQVksRUFBRSxTQUFTLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxTQUFTLENBQUMsVUFBVSxFQUFFLFVBQVUsRUFBRSxTQUFTLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQztJQUN4SCxDQUFDO0lBQ0QsTUFBTSxpQkFBaUIsR0FBRyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxLQUFLLGFBQWEsQ0FBQyxDQUFDLE1BQU0sQ0FBQztJQUMzRixJQUFJLGlCQUFpQixJQUFJLElBQUksQ0FBQyxZQUFZO1FBQUUsT0FBTyxFQUFFLENBQUM7SUFDdEQsa0hBQWtIO0lBQ2xILDZHQUE2RztJQUM3Ryx1SEFBdUg7SUFDdkgsTUFBTSxlQUFlLEdBQUcsT0FBTyxDQUFDLE1BQU0sQ0FDcEMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUNSLEtBQUssQ0FBQyxNQUFNLEtBQUssYUFBYTtRQUM5QixLQUFLLENBQUMsWUFBWSxLQUFLLFNBQVMsQ0FBQyxZQUFZO1FBQzdDLEtBQUssQ0FBQyxVQUFVLEtBQUssU0FBUyxDQUFDLFVBQVUsQ0FDNUMsQ0FBQyxNQUFNLENBQUM7SUFDVCxJQUFJLGVBQWUsSUFBSSxJQUFJLENBQUMsYUFBYTtRQUFFLE9BQU8sRUFBRSxDQUFDO0lBQ3JELE9BQU8sQ0FBQyxFQUFFLFlBQVksRUFBRSxTQUFTLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxTQUFTLENBQUMsVUFBVSxFQUFFLFVBQVUsRUFBRSxTQUFTLENBQUMsVUFBVSxFQUFFLENBQUMsQ0FBQztBQUN4SCxDQUFDO0FBWUQ7b0dBQ29HO0FBQ3BHLFNBQVMsdUJBQXVCLENBQUMsSUFBYyxFQUFFLEtBQWE7SUFDNUQsTUFBTSxPQUFPLEdBQUcsRUFBRSxJQUFJLEVBQUUsS0FBSyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFFLFNBQStCLEVBQUUsQ0FBQztJQUM1RixNQUFNLFVBQVUsR0FBYSxFQUFFLENBQUM7SUFFaEMsS0FBSyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsS0FBSyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsS0FBSyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BELE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUUsQ0FBQztRQUMzQixJQUFJLEtBQUssS0FBSyxRQUFRLEVBQUUsQ0FBQztZQUN2QixPQUFPLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQztZQUNwQixTQUFTO1FBQ1gsQ0FBQztRQUNELHNHQUFzRztRQUN0RyxJQUFJLEtBQUssS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUMxQixPQUFPLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQztZQUN0QixTQUFTO1FBQ1gsQ0FBQztRQUNELDBHQUEwRztRQUMxRyxrREFBa0Q7UUFDbEQsSUFBSSxLQUFLLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQztZQUMvQixNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzlCLElBQUksQ0FBQyxLQUFLLElBQUksS0FBSyxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDO2dCQUNwQyxPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO1lBQzFCLENBQUM7WUFDRCxPQUFPLENBQUMsVUFBVSxHQUFHLEtBQUssQ0FBQztZQUMzQixLQUFLLElBQUksQ0FBQyxDQUFDO1lBQ1gsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQztZQUMxQixPQUFPLEVBQUUsS0FBSyxFQUFFLG1CQUFtQixLQUFLLEVBQUUsRUFBRSxDQUFDO1FBQy9DLENBQUM7UUFDRCxVQUFVLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3pCLENBQUM7SUFFRCxJQUFJLFVBQVUsQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDNUIsT0FBTyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUMxQixDQUFDO0lBRUQsTUFBTSxJQUFJLEdBQUcsWUFBWSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxLQUFLLENBQUMsQ0FBQztJQUNoRCxJQUFJLE9BQU8sSUFBSSxJQUFJO1FBQUUsT0FBTyxJQUFJLENBQUM7SUFFakMsTUFBTSxVQUFVLEdBQUcsVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksRUFBRSxDQUFDO0lBQ3pDLElBQUksQ0FBQyxVQUFVLEVBQUUsQ0FBQztRQUNoQixPQUFPLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxDQUFDO0lBQzFCLENBQUM7SUFFRCxPQUFPO1FBQ0wsWUFBWSxFQUFFLElBQUksQ0FBQyxZQUFZO1FBQy9CLFVBQVU7UUFDVixNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU07UUFDdEIsSUFBSSxFQUFFLE9BQU8sQ0FBQyxJQUFJO1FBQ2xCLFVBQVUsRUFBRSxPQUFPLENBQUMsVUFBVTtLQUMvQixDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxrQkFBa0IsQ0FBQyxJQUFjO0lBQy9DLE9BQU8sdUJBQXVCLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLENBQUM7QUFDekQsQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxJQUFjO0lBQ2xELE9BQU8sdUJBQXVCLENBQUMsSUFBSSxFQUFFLG1CQUFtQixDQUFDLENBQUM7QUFDNUQsQ0FBQztBQUVELE1BQU0sVUFBVSxxQkFBcUIsQ0FBQyxJQUFjO0lBQ2xELE9BQU8sdUJBQXVCLENBQUMsSUFBSSxFQUFFLG1CQUFtQixDQUFDLENBQUM7QUFDNUQsQ0FBQztBQUVELFNBQVMsT0FBTyxDQUFDLEtBQWM7SUFDN0IsSUFBSSxLQUFLLEtBQUssSUFBSSxJQUFJLEtBQUssS0FBSyxTQUFTO1FBQUUsT0FBTyxHQUFHLENBQUM7SUFDdEQsT0FBTyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7QUFDdkIsQ0FBQztBQUVELE1BQU0sVUFBVSxnQkFBZ0IsQ0FBQyxPQUFxQjtJQUNwRCxJQUFJLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsSUFBSSxPQUFPLENBQUMsTUFBTSxLQUFLLENBQUM7UUFBRSxPQUFPLDRCQUE0QixDQUFDO0lBQ3pGLE1BQU0sTUFBTSxHQUFHO1FBQ2IsTUFBTSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDakIsWUFBWSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDdkIsMEdBQTBHO1FBQzFHLG9HQUFvRztRQUNwRyxNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNqQixRQUFRLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUNuQixLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztRQUNqQixhQUFhLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztLQUN6QixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNaLE1BQU0sS0FBSyxHQUFHLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUNsQztRQUNFLEtBQUssQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUM3QixLQUFLLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUM7UUFDM0IsT0FBTyxDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQ3BDLEtBQUssQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUN2QixPQUFPLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDbkMsT0FBTyxDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO0tBQ3JDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUNaLENBQUM7SUFDRixPQUFPLENBQUMsTUFBTSxFQUFFLEdBQUcsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3ZDLENBQUM7QUFFRCxTQUFTLGtCQUFrQixDQUN6QixPQUEyRCxFQUMzRCxHQUFvRDtJQUVwRCxNQUFNLFNBQVMsR0FBRyxPQUFPLENBQUMsa0JBQWtCLEtBQUssU0FBUyxDQUFDO0lBQzNELE1BQU0sY0FBYyxHQUFHLENBQUMsT0FBTyxDQUFDLGtCQUFrQixJQUFJLHVCQUF1QixDQUFDLEVBQUUsQ0FBQztJQUNqRixJQUFJLENBQUM7UUFDSCxPQUFPLEdBQUcsQ0FBQyxjQUFjLENBQUMsQ0FBQztJQUM3QixDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksU0FBUztZQUFFLGNBQWMsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUN4QyxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxZQUFZLENBQzFCLElBQWMsRUFDZCxVQUE4RCxFQUFFO0lBRWhFLE1BQU0sTUFBTSxHQUFHLGtCQUFrQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3hDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxrQkFBa0IsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxjQUFjLEVBQUUsRUFBRTtZQUNwRCxNQUFNLE9BQU8sR0FBRyxjQUFjLENBQUMsU0FBUyxDQUFDLE1BQU0sQ0FBQyxZQUFZLENBQUMsQ0FBQztZQUM5RCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsT0FBTyxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDcEQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsZ0JBQWdCLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQztZQUN6QyxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLFVBQVUsWUFBWSxDQUMxQixJQUFjLEVBQ2QsVUFBOEQsRUFBRTtJQUVoRSxNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELE1BQU0sYUFBYSxHQUFHLE1BQU0sQ0FBQyxZQUFZLEtBQUssU0FBUyxJQUFJLE1BQU0sQ0FBQyxhQUFhLEtBQUssU0FBUyxDQUFDO0lBQzlGLElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLGFBQWE7WUFDaEMsQ0FBQyxDQUFDLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxhQUFhLEVBQUUsTUFBTSxDQUFDLGFBQWEsRUFBRTtZQUNoRyxDQUFDLENBQUMsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLENBQUM7UUFDM0IsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxDQUFDO2FBQU0sSUFBSSxhQUFhLEVBQUUsQ0FBQztZQUN6QixPQUFPLENBQUMsR0FBRyxDQUNULHdGQUF3RixNQUFNLENBQUMsWUFBWSxJQUFJLE9BQU8sbUJBQW1CLE1BQU0sQ0FBQyxhQUFhLElBQUksT0FBTyx1Q0FBdUMsQ0FDaE4sQ0FBQztRQUNKLENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyw2RkFBNkYsQ0FBQyxDQUFDO1FBQzdHLENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGtCQUFrQixDQUFDLE9BQU8sRUFBRSxDQUFDLGNBQWMsRUFBRSxFQUFFO1lBQ3BELElBQUksS0FBd0IsQ0FBQztZQUM3QixJQUFJLGFBQWEsRUFBRSxDQUFDO2dCQUNsQixxR0FBcUc7Z0JBQ3JHLE1BQU0sSUFBSSxHQUFHO29CQUNYLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxpQkFBaUI7b0JBQzdELGFBQWEsRUFBRSxNQUFNLENBQUMsYUFBYSxJQUFJLE1BQU0sQ0FBQyxpQkFBaUI7aUJBQ2hFLENBQUM7Z0JBQ0YsTUFBTSxPQUFPLEdBQUcsY0FBYyxDQUFDLFVBQVUsQ0FBQyxDQUFDLE9BQU8sRUFBRSxFQUFFLENBQUMsd0JBQXdCLENBQUMsT0FBTyxFQUFFLElBQUksQ0FBQyxDQUFDLENBQUM7Z0JBQ2hHLEtBQUssR0FBRyxPQUFPLENBQUMsQ0FBQyxDQUFDLElBQUksSUFBSSxDQUFDO1lBQzdCLENBQUM7aUJBQU0sQ0FBQztnQkFDTixLQUFLLEdBQUcsY0FBYyxDQUFDLFdBQVcsRUFBRSxDQUFDO1lBQ3ZDLENBQUM7WUFDRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsS0FBSyxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbEQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUNqRCxDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLFVBQVUsWUFBWSxDQUMxQixJQUFjLEVBQ2QsVUFBOEQsRUFBRTtJQUVoRSxNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4QyxJQUFJLE9BQU8sSUFBSSxNQUFNLEVBQUUsQ0FBQztRQUN0QixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDNUQsQ0FBQztJQUVELElBQUksTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDO1FBQ2xCLE1BQU0sWUFBWSxHQUFHLEVBQUUsT0FBTyxFQUFFLFNBQVMsRUFBRSxZQUFZLEVBQUUsTUFBTSxDQUFDLFlBQVksRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxDQUFDO1FBQzlHLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxZQUFZLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDckQsQ0FBQzthQUFNLENBQUM7WUFDTixPQUFPLENBQUMsR0FBRyxDQUFDLHVCQUF1QixNQUFNLENBQUMsWUFBWSxJQUFJLE1BQU0sQ0FBQyxVQUFVLDJDQUEyQyxDQUFDLENBQUM7UUFDMUgsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELElBQUksQ0FBQztRQUNILE9BQU8sa0JBQWtCLENBQUMsT0FBTyxFQUFFLENBQUMsY0FBYyxFQUFFLEVBQUU7WUFDcEQsTUFBTSxLQUFLLEdBQUcsY0FBYyxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ2pHLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQztnQkFDWCxPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsdUJBQXVCLENBQUMsQ0FBQztZQUNoRSxDQUFDO1lBQ0QsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLEtBQUssRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2xELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUM1QixDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRDtzSEFDc0g7QUFDdEgsTUFBTSxVQUFVLGVBQWUsQ0FDN0IsSUFBYyxFQUNkLFVBQThELEVBQUU7SUFFaEUsTUFBTSxNQUFNLEdBQUcscUJBQXFCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDM0MsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixNQUFNLFlBQVksR0FBRyxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsVUFBVSxFQUFFLE1BQU0sQ0FBQyxVQUFVLEVBQUUsQ0FBQztRQUM5RyxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQywwQkFBMEIsTUFBTSxDQUFDLFlBQVksSUFBSSxNQUFNLENBQUMsVUFBVSx3REFBd0QsQ0FBQyxDQUFDO1FBQzFJLENBQUM7UUFDRCxPQUFPLENBQUMsQ0FBQztJQUNYLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGtCQUFrQixDQUFDLE9BQU8sRUFBRSxDQUFDLGNBQWMsRUFBRSxFQUFFO1lBQ3BELE1BQU0sS0FBSyxHQUFHLGNBQWMsQ0FBQyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsWUFBWSxFQUFFLE1BQU0sQ0FBQyxVQUFVLEVBQUUsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQ3pHLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQztnQkFDWCxPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsNkJBQTZCLENBQUMsQ0FBQztZQUN0RSxDQUFDO1lBQ0QsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7Z0JBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLEtBQUssRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2xELENBQUM7aUJBQU0sQ0FBQztnQkFDTixPQUFPLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUM1QixDQUFDO1lBQ0QsT0FBTyxDQUFDLENBQUM7UUFDWCxDQUFDLENBQUMsQ0FBQztJQUNMLENBQUM7SUFBQyxPQUFPLEtBQUssRUFBRSxDQUFDO1FBQ2YsT0FBTyxnQkFBZ0IsQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDaEUsQ0FBQztBQUNILENBQUM7QUFFRDs7bURBRW1EO0FBQ25ELE1BQU0sVUFBVSxlQUFlLENBQzdCLElBQWMsRUFDZCxVQUE4RCxFQUFFO0lBRWhFLE1BQU0sTUFBTSxHQUFHLHFCQUFxQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQzNDLElBQUksT0FBTyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQ3RCLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM1RCxDQUFDO0lBRUQsSUFBSSxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbEIsTUFBTSxZQUFZLEdBQUcsRUFBRSxPQUFPLEVBQUUsU0FBUyxFQUFFLFlBQVksRUFBRSxNQUFNLENBQUMsWUFBWSxFQUFFLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVSxFQUFFLENBQUM7UUFDOUcsSUFBSSxNQUFNLENBQUMsSUFBSSxFQUFFLENBQUM7WUFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLFlBQVksRUFBRSxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxDQUFDO2FBQU0sQ0FBQztZQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsMEJBQTBCLE1BQU0sQ0FBQyxZQUFZLElBQUksTUFBTSxDQUFDLFVBQVUsc0NBQXNDLENBQUMsQ0FBQztRQUN4SCxDQUFDO1FBQ0QsT0FBTyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBRUQsSUFBSSxDQUFDO1FBQ0gsT0FBTyxrQkFBa0IsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxjQUFjLEVBQUUsRUFBRTtZQUNwRCxNQUFNLEtBQUssR0FBRyxjQUFjLENBQUMsV0FBVyxDQUFDLE1BQU0sQ0FBQyxZQUFZLEVBQUUsTUFBTSxDQUFDLFVBQVUsRUFBRSxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDcEcsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDO2dCQUNYLE9BQU8sZ0JBQWdCLENBQUMsTUFBTSxDQUFDLElBQUksRUFBRSw0QkFBNEIsQ0FBQyxDQUFDO1lBQ3JFLENBQUM7WUFDRCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFDaEIsT0FBTyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLEVBQUUsS0FBSyxFQUFFLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbEQsQ0FBQztpQkFBTSxDQUFDO2dCQUNOLE9BQU8sQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzVCLENBQUM7WUFDRCxPQUFPLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO0FBQ0gsQ0FBQztBQU1ELE1BQU0sVUFBVSx3QkFBd0IsQ0FBQyxJQUFjO0lBQ3JELE1BQU0sT0FBTyxHQUFHLEVBQUUsSUFBSSxFQUFFLEtBQUssRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLFlBQVksRUFBRSxDQUFDLEVBQUUsYUFBYSxFQUFFLENBQUMsRUFBRSxDQUFDO0lBQ2xGLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUNwRCxNQUFNLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDMUIsSUFBSSxLQUFLLEtBQUssUUFBUSxFQUFFLENBQUM7WUFDdkIsT0FBTyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUM7WUFDcEIsU0FBUztRQUNYLENBQUM7UUFDRCxJQUFJLEtBQUssS0FBSyxXQUFXLEVBQUUsQ0FBQztZQUMxQixPQUFPLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQztZQUN0QixTQUFTO1FBQ1gsQ0FBQztRQUNELElBQUksS0FBSyxLQUFLLGNBQWMsSUFBSSxLQUFLLEtBQUssZ0JBQWdCLEVBQUUsQ0FBQztZQUMzRCxNQUFNLEtBQUssR0FBRyxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3RDLElBQUksSUFBSSxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsS0FBSyxTQUFTLElBQUksQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssR0FBRyxDQUFDLEVBQUUsQ0FBQztnQkFDMUUsT0FBTyxFQUFFLEtBQUssRUFBRSx1QkFBdUIsRUFBRSxDQUFDO1lBQzVDLENBQUM7WUFDRCxJQUFJLEtBQUssS0FBSyxjQUFjO2dCQUFFLE9BQU8sQ0FBQyxZQUFZLEdBQUcsS0FBSyxDQUFDOztnQkFDdEQsT0FBTyxDQUFDLGFBQWEsR0FBRyxLQUFLLENBQUM7WUFDbkMsS0FBSyxJQUFJLENBQUMsQ0FBQztZQUNYLFNBQVM7UUFDWCxDQUFDO1FBQ0QsT0FBTyxFQUFFLEtBQUssRUFBRSx1QkFBdUIsRUFBRSxDQUFDO0lBQzVDLENBQUM7SUFDRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQ7Z0hBQ2dIO0FBQ2hILE1BQU0sVUFBVSxrQkFBa0IsQ0FDaEMsSUFBYyxFQUNkLFVBQW9GLEVBQUU7SUFFdEYsTUFBTSxNQUFNLEdBQUcsd0JBQXdCLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDOUMsSUFBSSxPQUFPLElBQUksTUFBTSxFQUFFLENBQUM7UUFDdEIsT0FBTyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNsQixNQUFNLFlBQVksR0FBRyxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsYUFBYSxFQUFFLE1BQU0sQ0FBQyxhQUFhLEVBQUUsQ0FBQztRQUNwSCxJQUFJLE1BQU0sQ0FBQyxJQUFJLEVBQUUsQ0FBQztZQUNoQixPQUFPLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsWUFBWSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3JELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FDVCw2Q0FBNkMsTUFBTSxDQUFDLFlBQVksbUJBQW1CLE1BQU0sQ0FBQyxhQUFhLHVDQUF1QyxDQUMvSSxDQUFDO1FBQ0osQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUVELGdIQUFnSDtJQUNoSCwwRUFBMEU7SUFDMUUsTUFBTSxXQUFXLEdBQUcsT0FBTyxDQUFDLHlCQUF5QixLQUFLLFNBQVMsQ0FBQztJQUNwRSxJQUFJLE9BQTBDLENBQUM7SUFDL0MsSUFBSSxDQUFDO1FBQ0gsT0FBTyxHQUFHLENBQUMsT0FBTyxDQUFDLHlCQUF5QixJQUFJLHlCQUF5QixDQUFDLENBQUM7WUFDekUsSUFBSSxFQUFFLEVBQUUsWUFBWSxFQUFFLE1BQU0sQ0FBQyxZQUFZLEVBQUUsYUFBYSxFQUFFLE1BQU0sQ0FBQyxhQUFhLEVBQUU7U0FDakYsQ0FBQyxDQUFDO1FBQ0gsTUFBTSxPQUFPLEdBQUcsT0FBTyxDQUFDLGNBQWMsRUFBRSxDQUFDO1FBQ3pDLElBQUksTUFBTSxDQUFDLElBQUksRUFBRSxDQUFDO1lBQ2hCLE9BQU8sQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE9BQU8sRUFBRSxFQUFFLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3BELENBQUM7YUFBTSxDQUFDO1lBQ04sT0FBTyxDQUFDLEdBQUcsQ0FBQyxPQUFPLENBQUMsTUFBTSxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUM7UUFDbkcsQ0FBQztRQUNELE9BQU8sQ0FBQyxDQUFDO0lBQ1gsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLGdCQUFnQixDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUUsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztJQUNoRSxDQUFDO1lBQVMsQ0FBQztRQUNULElBQUksV0FBVztZQUFFLE9BQU8sRUFBRSxLQUFLLEVBQUUsQ0FBQztJQUNwQyxDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sbUJBQW1CLEdBQUcscUNBQXFDLENBQUM7QUFFbEUsNEdBQTRHO0FBQzVHLCtGQUErRjtBQUMvRixtRkFBbUY7QUFDbkYsTUFBTSxDQUFDLE1BQU0sV0FBVyxHQUFHLHNDQUFzQyxDQUFDO0FBQ2xFLE1BQU0sQ0FBQyxNQUFNLDBDQUEwQyxHQUFHLHFFQUFxRSxDQUFDO0FBRWhJLHVHQUF1RztBQUN2RyxTQUFTLHFCQUFxQixDQUFDLElBQVk7SUFDekMsT0FBTyxJQUFJLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxNQUFNLENBQUMsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO0FBQzNELENBQUM7QUFFRDs7Ozs7Ozs7OztHQVVHO0FBQ0gsTUFBTSxVQUFVLDJCQUEyQixDQUN6QyxZQUF1QyxFQUN2QyxZQUFnRCxFQUNoRCxLQUFhO0lBRWIsTUFBTSxhQUFhLEdBQUcsSUFBSSxHQUFHLEVBQWtCLENBQUM7SUFDaEQsS0FBSyxNQUFNLEtBQUssSUFBSSxZQUFZLEVBQUUsQ0FBQztRQUNqQyxhQUFhLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBQyxhQUFhLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztJQUM5RSxDQUFDO0lBRUQsSUFBSSxxQkFBcUIsR0FBRyxDQUFDLENBQUM7SUFDOUIsS0FBSyxNQUFNLEtBQUssSUFBSSxZQUFZLEVBQUUsQ0FBQztRQUNqQyxNQUFNLFVBQVUsR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxRQUFRLElBQUksRUFBRSxDQUFDLENBQUM7UUFDcEQsSUFBSSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsVUFBVSxDQUFDO1lBQUUsU0FBUztRQUMzQyxNQUFNLFVBQVUsR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxDQUFDLEtBQUssR0FBRyxVQUFVLENBQUMsR0FBRyxJQUFJLENBQUMsQ0FBQztRQUM1RCxJQUFJLFVBQVUsR0FBRyxxQkFBcUI7WUFBRSxxQkFBcUIsR0FBRyxVQUFVLENBQUM7SUFDN0UsQ0FBQztJQUVELE1BQU0sS0FBSyxHQUFHO1FBQ1osVUFBVSxXQUFXLElBQUkscUJBQXFCLENBQUMsZ0RBQWdELENBQUMsRUFBRTtRQUNsRyxVQUFVLFdBQVcsUUFBUTtLQUM5QixDQUFDO0lBQ0YsS0FBSyxNQUFNLENBQUMsTUFBTSxFQUFFLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxhQUFhLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsYUFBYSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUNwRyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsV0FBVyxZQUFZLE1BQU0sTUFBTSxLQUFLLEVBQUUsQ0FBQyxDQUFDO0lBQzVELENBQUM7SUFFRCxLQUFLLENBQUMsSUFBSSxDQUNSLFVBQVUsMENBQTBDLElBQUkscUJBQXFCLENBQUMsc0dBQXNHLENBQUMsRUFBRSxDQUN4TCxDQUFDO0lBQ0YsS0FBSyxDQUFDLElBQUksQ0FBQyxVQUFVLDBDQUEwQyxRQUFRLENBQUMsQ0FBQztJQUN6RSxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsMENBQTBDLElBQUkscUJBQXFCLEVBQUUsQ0FBQyxDQUFDO0lBRXJGLE9BQU8sR0FBRyxLQUFLLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUM7QUFDakMsQ0FBQztBQUVELE1BQU0sVUFBVSxlQUFlLENBQzdCLElBQWMsRUFDZCxVQUE4RSxFQUFFO0lBRWhGLElBQUksSUFBSSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUNwQixPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSxtQkFBbUIsQ0FBQyxDQUFDO0lBQ25FLENBQUM7SUFFRCxJQUFJLENBQUM7UUFDSCxPQUFPLGtCQUFrQixDQUFDLE9BQU8sRUFBRSxDQUFDLGNBQWMsRUFBRSxFQUFFO1lBQ3BELE1BQU0sS0FBSyxHQUFHLE9BQU8sT0FBTyxDQUFDLEtBQUssS0FBSyxRQUFRLElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQztZQUMvRyw0R0FBNEc7WUFDNUcsc0ZBQXNGO1lBQ3RGLE9BQU8sQ0FBQyxHQUFHLENBQ1QsMkJBQTJCLENBQUMsY0FBYyxDQUFDLFNBQVMsRUFBRSxFQUFFLGNBQWMsQ0FBQyxjQUFjLEVBQUUsRUFBRSxLQUFLLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FDMUcsQ0FBQztZQUNGLE9BQU8sQ0FBQyxDQUFDO1FBQ1gsQ0FBQyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBQUMsT0FBTyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sZ0JBQWdCLENBQUMsWUFBWSxDQUFDLElBQUksQ0FBQyxFQUFFLGdCQUFnQixDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7SUFDdkUsQ0FBQztBQUNILENBQUM7QUFFRCxNQUFNLFVBQVUsV0FBVyxDQUN6QixVQUE4QixFQUM5QixJQUFjLEVBQ2QsVUFHSSxFQUFFO0lBRU4sSUFBSSxVQUFVLEtBQUssTUFBTTtRQUFFLE9BQU8sWUFBWSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM5RCxJQUFJLFVBQVUsS0FBSyxNQUFNO1FBQUUsT0FBTyxZQUFZLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQzlELElBQUksVUFBVSxLQUFLLE1BQU07UUFBRSxPQUFPLFlBQVksQ0FBQyxJQUFJLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDOUQsSUFBSSxVQUFVLEtBQUssU0FBUztRQUFFLE9BQU8sZUFBZSxDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUNwRSxJQUFJLFVBQVUsS0FBSyxTQUFTO1FBQUUsT0FBTyxlQUFlLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3BFLElBQUksVUFBVSxLQUFLLGFBQWE7UUFBRSxPQUFPLGtCQUFrQixDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUMzRSxJQUFJLFVBQVUsS0FBSyxTQUFTO1FBQUUsT0FBTyxlQUFlLENBQUMsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ3BFLElBQUksVUFBVSxLQUFLLFdBQVc7UUFBRSxPQUFPLHFCQUFxQixDQUFDLElBQUksRUFBRSxPQUFPLENBQUMsQ0FBQztJQUM1RSxPQUFPLGdCQUFnQixDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsRUFBRSw2QkFBNkIsVUFBVSxJQUFJLEVBQUUsS0FBSyxnQkFBZ0IsRUFBRSxDQUFDLENBQUM7QUFDcEgsQ0FBQyJ9

--- a/packages/loopover-miner/lib/portfolio-queue-cli.ts
+++ b/packages/loopover-miner/lib/portfolio-queue-cli.ts
@@ -1,0 +1,642 @@
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
+import { runPortfolioDashboard } from "./portfolio-dashboard.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import type { PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
+import type { PortfolioQueueManager } from "./portfolio-queue-manager.js";
+
+const QUEUE_LIST_USAGE = "Usage: loopover-miner queue list [--repo <owner/repo>] [--json]";
+const QUEUE_NEXT_USAGE =
+  "Usage: loopover-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
+const QUEUE_DONE_USAGE =
+  "Usage: loopover-miner queue done <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_RELEASE_USAGE =
+  "Usage: loopover-miner queue release <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_REQUEUE_USAGE =
+  "Usage: loopover-miner queue requeue <owner/repo> <identifier> [--api-base-url <url>] [--dry-run] [--json]";
+const QUEUE_CLAIM_BATCH_USAGE =
+  "Usage: loopover-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--dry-run] [--json]";
+
+function parseRepoArg(value: string | undefined, usage: string): { error: string } | { repoFullName: string } {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export type ParsedQueueListArgs =
+  | {
+      json: boolean;
+      repoFullName: string | null;
+    }
+  | { error: string };
+
+export function parseQueueListArgs(args: string[]): ParsedQueueListArgs {
+  const options = { json: false, repoFullName: null as string | null };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--repo") {
+      const repoArg = args[index + 1];
+      if (!repoArg || repoArg.startsWith("-")) {
+        return { error: QUEUE_LIST_USAGE };
+      }
+      const repo = parseRepoArg(repoArg, QUEUE_LIST_USAGE);
+      if ("error" in repo) return repo;
+      options.repoFullName = repo.repoFullName;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    return { error: QUEUE_LIST_USAGE };
+  }
+
+  return options;
+}
+
+export type ParsedQueueNextArgs =
+  | { json: boolean; dryRun: boolean; globalWipCap: number | undefined; perRepoWipCap: number | undefined }
+  | { error: string };
+
+// #4850: --global-wip/--per-repo-wip are OMITTED (undefined) by default -- queue next stays uncapped, byte-
+// identical to its pre-#4850 behavior, unless an operator explicitly opts in. Mirrors queue claim-batch's own
+// flag names (portfolio-queue-manager.js's WIP-cap-aware claimer), but claim-batch's OWN default of 1/1 is not
+// reused here: claim-batch's whole purpose is cap enforcement, while queue next has always been a plain
+// highest-priority dequeue and must not silently start capping existing callers that never asked for it.
+export function parseQueueNextArgs(args: string[]): ParsedQueueNextArgs {
+  const options = {
+    json: false,
+    dryRun: false,
+    globalWipCap: undefined as number | undefined,
+    perRepoWipCap: undefined as number | undefined,
+  };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--global-wip" || token === "--per-repo-wip") {
+      const value = Number(args[index + 1]);
+      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+        return { error: QUEUE_NEXT_USAGE };
+      }
+      if (token === "--global-wip") options.globalWipCap = value;
+      else options.perRepoWipCap = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    return { error: QUEUE_NEXT_USAGE };
+  }
+  return options;
+}
+
+export type QueueClaimTarget = { repoFullName: string; identifier: string; apiBaseUrl: string };
+
+/**
+ * Pick at most one atomically-claimable target from the store's already-priority-ordered active rows (queued
+ * AND in_progress interleaved, exactly `batchClaim`'s own `entries` shape). `caps` of `null` replicates the
+ * pre-#4850 behavior: the single highest-priority queued row, unconditionally. When caps are set, refuses to
+ * select anything once the global or the target row's own per-repo in-progress count has reached its cap --
+ * "stops claiming once the cap is reached" (#4850), not a diversifying batch selection (that remains
+ * claim-batch's job via the engine's own `nextEligibleItems`).
+ */
+export function selectNextEligibleTarget(
+  entries: Array<{ repoFullName: string; identifier: string; apiBaseUrl: string; status: string }>,
+  caps: { globalWipCap: number; perRepoWipCap: number } | null,
+): QueueClaimTarget[] {
+  const topQueued = entries.find((entry) => entry.status === "queued");
+  if (!topQueued) return [];
+  if (!caps) {
+    return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
+  }
+  const globalActiveCount = entries.filter((entry) => entry.status === "in_progress").length;
+  if (globalActiveCount >= caps.globalWipCap) return [];
+  // Host-scope the per-repo active count (#7224): a same-named repo on a DIFFERENT forge host is a distinct backlog
+  // (the store keys rows by apiBaseUrl too, #5563), so an in-progress item on host A must not consume host B's
+  // per-repo WIP budget. Single-host is unchanged: every entry shares one apiBaseUrl, so the added match is always true.
+  const repoActiveCount = entries.filter(
+    (entry) =>
+      entry.status === "in_progress" &&
+      entry.repoFullName === topQueued.repoFullName &&
+      entry.apiBaseUrl === topQueued.apiBaseUrl,
+  ).length;
+  if (repoActiveCount >= caps.perRepoWipCap) return [];
+  return [{ repoFullName: topQueued.repoFullName, identifier: topQueued.identifier, apiBaseUrl: topQueued.apiBaseUrl }];
+}
+
+export type ParsedQueueDoneArgs =
+  | {
+      repoFullName: string;
+      identifier: string;
+      dryRun: boolean;
+      json: boolean;
+      apiBaseUrl: string | undefined;
+    }
+  | { error: string };
+
+/** Shared `<owner/repo> <identifier> [--api-base-url <url>] [--json]` parse for the item-targeting subcommands
+ *  (done/release/requeue). `usage` is the command-specific message surfaced on a malformed argv. */
+function parseRepoIdentifierArgs(args: string[], usage: string): ParsedQueueDoneArgs {
+  const options = { json: false, dryRun: false, apiBaseUrl: undefined as string | undefined };
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    // #4847: reports what a real mutation would do and returns before opening the portfolio queue at all.
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    // #5563: scope the target to a non-default forge host, so it doesn't collide with (or get confused for) a
+    // same-named repo on the default github.com host.
+    if (token === "--api-base-url") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        return { error: usage };
+      }
+      options.apiBaseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: usage };
+  }
+
+  const repo = parseRepoArg(positional[0], usage);
+  if ("error" in repo) return repo;
+
+  const identifier = positional[1]?.trim();
+  if (!identifier) {
+    return { error: usage };
+  }
+
+  return {
+    repoFullName: repo.repoFullName,
+    identifier,
+    dryRun: options.dryRun,
+    json: options.json,
+    apiBaseUrl: options.apiBaseUrl,
+  };
+}
+
+export function parseQueueDoneArgs(args: string[]): ParsedQueueDoneArgs {
+  return parseRepoIdentifierArgs(args, QUEUE_DONE_USAGE);
+}
+
+export function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs {
+  return parseRepoIdentifierArgs(args, QUEUE_RELEASE_USAGE);
+}
+
+export function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs {
+  return parseRepoIdentifierArgs(args, QUEUE_REQUEUE_USAGE);
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  return String(value);
+}
+
+export function renderQueueTable(entries: QueueEntry[]): string {
+  if (!Array.isArray(entries) || entries.length === 0) return "no portfolio queue entries";
+  const header = [
+    "repo".padEnd(24),
+    "identifier".padEnd(16),
+    // #7225: surface the host so a reader of the plain-text table can supply the `--api-base-url` a follow-up
+    // done/release/requeue needs to disambiguate two rows sharing a repo+identifier across forge hosts.
+    "host".padEnd(30),
+    "status".padEnd(12),
+    "pri".padStart(4),
+    "enqueued-at".padEnd(24),
+  ].join(" ");
+  const lines = entries.map((entry) =>
+    [
+      entry.repoFullName.padEnd(24),
+      entry.identifier.padEnd(16),
+      display(entry.apiBaseUrl).padEnd(30),
+      entry.status.padEnd(12),
+      display(entry.priority).padStart(4),
+      display(entry.enqueuedAt).padEnd(24),
+    ].join(" "),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function withPortfolioQueue(
+  options: { initPortfolioQueue?: () => PortfolioQueueStore },
+  run: (portfolioQueue: PortfolioQueueStore) => number,
+): number {
+  const ownsStore = options.initPortfolioQueue === undefined;
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  try {
+    return run(portfolioQueue);
+  } finally {
+    if (ownsStore) portfolioQueue.close();
+  }
+}
+
+export function runQueueList(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueListArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entries = portfolioQueue.listQueue(parsed.repoFullName);
+      if (parsed.json) {
+        console.log(JSON.stringify({ entries }, null, 2));
+      } else {
+        console.log(renderQueueTable(entries));
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runQueueNext(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueNextArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  const capsRequested = parsed.globalWipCap !== undefined || parsed.perRepoWipCap !== undefined;
+  if (parsed.dryRun) {
+    const dryRunResult = capsRequested
+      ? { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap }
+      : { outcome: "dry_run" };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else if (capsRequested) {
+      console.log(
+        `DRY RUN: would dequeue the highest-priority queued item within WIP caps (global-wip: ${parsed.globalWipCap ?? "unset"}, per-repo-wip: ${parsed.perRepoWipCap ?? "unset"}). No portfolio-queue write was made.`,
+      );
+    } else {
+      console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      let entry: QueueEntry | null;
+      if (capsRequested) {
+        // Unset dimensions stay genuinely uncapped (Infinity), not silently defaulted to 1 like claim-batch.
+        const caps = {
+          globalWipCap: parsed.globalWipCap ?? Number.POSITIVE_INFINITY,
+          perRepoWipCap: parsed.perRepoWipCap ?? Number.POSITIVE_INFINITY,
+        };
+        const claimed = portfolioQueue.batchClaim((entries) => selectNextEligibleTarget(entries, caps));
+        entry = claimed[0] ?? null;
+      } else {
+        entry = portfolioQueue.dequeueNext();
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry ? entry.identifier : "none");
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export function runQueueDone(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueDoneArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would mark ${parsed.repoFullName} ${parsed.identifier} done. No portfolio-queue write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+      if (!entry) {
+        return reportCliFailure(parsed.json, "queue_entry_not_found");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+/** `release <owner/repo> <identifier>`: manually give up a CLAIMED (in_progress) item, returning it to the queue
+ *  (the manual counterpart to the automated stuck-lease sweep). Exit 2 when there is no in-flight item to release. */
+export function runQueueRelease(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueReleaseArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would release ${parsed.repoFullName} ${parsed.identifier} back to the queue. No portfolio-queue write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+      if (!entry) {
+        return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+/** `requeue <owner/repo> <identifier>`: manually put a COMPLETED (done) item back on the queue so it is picked up
+ *  again, keeping its original FIFO position. Exit 2 when there is no done item to requeue (already queued,
+ *  in-flight — release it instead — or absent). */
+export function runQueueRequeue(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore } = {},
+): number {
+  const parsed = parseQueueRequeueArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", repoFullName: parsed.repoFullName, identifier: parsed.identifier };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(`DRY RUN: would requeue ${parsed.repoFullName} ${parsed.identifier}. No portfolio-queue write was made.`);
+    }
+    return 0;
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier, parsed.apiBaseUrl);
+      if (!entry) {
+        return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
+      }
+      if (parsed.json) {
+        console.log(JSON.stringify({ entry }, null, 2));
+      } else {
+        console.log(entry.status);
+      }
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+export type ParsedQueueClaimBatchArgs =
+  | { json: boolean; dryRun: boolean; globalWipCap: number; perRepoWipCap: number }
+  | { error: string };
+
+export function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs {
+  const options = { json: false, dryRun: false, globalWipCap: 1, perRepoWipCap: 1 };
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === "--global-wip" || token === "--per-repo-wip") {
+      const value = Number(args[index + 1]);
+      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+        return { error: QUEUE_CLAIM_BATCH_USAGE };
+      }
+      if (token === "--global-wip") options.globalWipCap = value;
+      else options.perRepoWipCap = value;
+      index += 1;
+      continue;
+    }
+    return { error: QUEUE_CLAIM_BATCH_USAGE };
+  }
+  return options;
+}
+
+/** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
+ *  reclaims any leases orphaned by a crashed process first (#4833 wires the previously caller-less claimer). */
+export function runQueueClaimBatch(
+  args: string[],
+  options: { initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager } = {},
+): number {
+  const parsed = parseQueueClaimBatchArgs(args);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+
+  if (parsed.dryRun) {
+    const dryRunResult = { outcome: "dry_run", globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap };
+    if (parsed.json) {
+      console.log(JSON.stringify(dryRunResult, null, 2));
+    } else {
+      console.log(
+        `DRY RUN: would claim a batch (global-wip: ${parsed.globalWipCap}, per-repo-wip: ${parsed.perRepoWipCap}). No portfolio-queue write was made.`,
+      );
+    }
+    return 0;
+  }
+
+  // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
+  // close with `?.` since the initializer may have thrown before assigning.
+  const ownsManager = options.initPortfolioQueueManager === undefined;
+  let manager: PortfolioQueueManager | undefined;
+  try {
+    manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+      caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+    });
+    const claimed = manager.claimNextBatch();
+    if (parsed.json) {
+      console.log(JSON.stringify({ claimed }, null, 2));
+    } else {
+      console.log(claimed.length === 0 ? "none" : claimed.map((entry) => entry.identifier).join("\n"));
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  } finally {
+    if (ownsManager) manager?.close();
+  }
+}
+
+const QUEUE_METRICS_USAGE = "Usage: loopover-miner queue metrics";
+
+// Prometheus metric names for the portfolio-queue gauges (#5186). Mirrors the `loopover_miner_*` naming and
+// HELP/TYPE/label conventions of event-ledger-cli.js's renderEventLedgerMetrics / the engine's
+// renderMinerPredictionMetrics, rather than importing across the package boundary.
+export const QUEUE_ITEMS = "loopover_miner_portfolio_queue_items";
+export const QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS = "loopover_miner_portfolio_queue_oldest_in_progress_lease_age_seconds";
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeMetricsHelpText(help: string): string {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/**
+ * Render portfolio-queue backlog health as Prometheus text-exposition gauges: current item count per status, and
+ * the age of the OLDEST still-in-flight lease -- the concrete "is anything stuck" signal a
+ * `loopover_queue_oldest_maintenance_pending_age_seconds`-style alert rule can threshold on (#5186). Pure and
+ * side-effect-free: the caller supplies the rows and `nowMs` (no internal clock read, matching
+ * store-maintenance.js's pruneLedgerByRetention convention) and prints the result. Deterministic (status series
+ * sorted); always emits HELP/TYPE so an empty queue is still a well-formed exposition document, and the lease-age
+ * gauge reads 0 (never stuck) rather than being omitted when nothing is in-flight.
+ * @param queueEntries - every row, any status (e.g. store.listQueue()'s output).
+ * @param leaseEntries - in-flight rows only (store.listInProgress()'s output).
+ */
+export function renderPortfolioQueueMetrics(
+  queueEntries: Array<{ status: string }>,
+  leaseEntries: Array<{ leasedAt: string | null }>,
+  nowMs: number,
+): string {
+  const countByStatus = new Map<string, number>();
+  for (const entry of queueEntries) {
+    countByStatus.set(entry.status, (countByStatus.get(entry.status) ?? 0) + 1);
+  }
+
+  let oldestLeaseAgeSeconds = 0;
+  for (const lease of leaseEntries) {
+    const leasedAtMs = Date.parse(lease.leasedAt ?? "");
+    if (!Number.isFinite(leasedAtMs)) continue;
+    const ageSeconds = Math.max(0, (nowMs - leasedAtMs) / 1000);
+    if (ageSeconds > oldestLeaseAgeSeconds) oldestLeaseAgeSeconds = ageSeconds;
+  }
+
+  const lines = [
+    `# HELP ${QUEUE_ITEMS} ${escapeMetricsHelpText("Current portfolio-queue item count, by status.")}`,
+    `# TYPE ${QUEUE_ITEMS} gauge`,
+  ];
+  for (const [status, count] of [...countByStatus.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`${QUEUE_ITEMS}{status="${status}"} ${count}`);
+  }
+
+  lines.push(
+    `# HELP ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${escapeMetricsHelpText("Age in seconds of the oldest still-in-flight (in_progress) claim lease. 0 when nothing is in-flight.")}`,
+  );
+  lines.push(`# TYPE ${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} gauge`);
+  lines.push(`${QUEUE_OLDEST_IN_PROGRESS_LEASE_AGE_SECONDS} ${oldestLeaseAgeSeconds}`);
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function runQueueMetrics(
+  args: string[],
+  options: { initPortfolioQueue?: () => PortfolioQueueStore; nowMs?: number } = {},
+): number {
+  if (args.length > 0) {
+    return reportCliFailure(argsWantJson(args), QUEUE_METRICS_USAGE);
+  }
+
+  try {
+    return withPortfolioQueue(options, (portfolioQueue) => {
+      const nowMs = typeof options.nowMs === "number" && Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+      // renderPortfolioQueueMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+      console.log(
+        renderPortfolioQueueMetrics(portfolioQueue.listQueue(), portfolioQueue.listInProgress(), nowMs).trimEnd(),
+      );
+      return 0;
+    });
+  } catch (error) {
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
+  }
+}
+
+export function runQueueCli(
+  subcommand: string | undefined,
+  args: string[],
+  options: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+  } = {},
+): number {
+  if (subcommand === "list") return runQueueList(args, options);
+  if (subcommand === "next") return runQueueNext(args, options);
+  if (subcommand === "done") return runQueueDone(args, options);
+  if (subcommand === "release") return runQueueRelease(args, options);
+  if (subcommand === "requeue") return runQueueRequeue(args, options);
+  if (subcommand === "claim-batch") return runQueueClaimBatch(args, options);
+  if (subcommand === "metrics") return runQueueMetrics(args, options);
+  if (subcommand === "dashboard") return runPortfolioDashboard(args, options);
+  return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
+}


### PR DESCRIPTION
Closes #7307

Converts **all six** files in issue #7307's Phase 3 batch 3.3 from `.js` to real TypeScript, using Phase 1's (#7299) existing in-place-emit tsc pipeline:

- `lib/portfolio-queue-cli`, `lib/loop-cli`, `lib/governor-metrics-cli`, `lib/discover-cli`, `lib/governor-pause-cli`, `lib/attempt-cli`

## How
- Each file's hand-maintained `.d.ts` sibling was removed and is regenerated by tsc from the types folded back into the `.ts` source (function signatures + the exported type declarations from the old `.d.ts`, verbatim).
- No `tsconfig.json` change — the `lib/**/*.ts` include glob picks them up automatically.
- **Types only, no runtime behavior change.** Two internal-typing notes: `loop-cli` reads a few `AttemptCliResult` fields that are member-specific or (for `abandonReason`) emitted-at-runtime-but-undeclared, so they're read off a standalone all-optional shape; and the callback-captured result is held on an object so TS's flow analysis doesn't narrow it back to its `null` initializer.

## Validation
- `npm run build --workspace @loopover/miner` (build:tsc + `node --check` on all 121 bin/lib files) — clean.
- `npm run test:miner-pack` — clean (the `.ts` sources are excluded from the pack via the package's `files` field; only the compiled `.js`/`.d.ts` ship).
- **288 tests pass unmodified** across the 10 CLI/alert test files that exercise these six modules (governor-pause, governor-metrics, discover, portfolio-queue, loop, attempt + json-error-coverage, wire-cli-modules, and the two alert suites).