### PR TITLE
feat(ui): add the scoped-permissions confirmation step to the install flow

### DIFF
--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -20,9 +20,11 @@ import { Route as AppRouteImport } from './routes/app'
 import { Route as ApiRouteImport } from './routes/api'
 import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as InstallIndexRouteImport } from './routes/install.index'
 import { Route as DocsIndexRouteImport } from './routes/docs.index'
 import { Route as AppIndexRouteImport } from './routes/app.index'
 import { Route as ApiIndexRouteImport } from './routes/api.index'
+import { Route as InstallPermissionsRouteImport } from './routes/install.permissions'
 import { Route as DocsUpstreamDriftRouteImport } from './routes/docs.upstream-drift'
 import { Route as DocsTuningRouteImport } from './routes/docs.tuning'
 import { Route as DocsTroubleshootingRouteImport } from './routes/docs.troubleshooting'
@@ -142,6 +144,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InstallIndexRoute = InstallIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => InstallRoute,
+} as any)
 const DocsIndexRoute = DocsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -156,6 +163,11 @@ const ApiIndexRoute = ApiIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => ApiRoute,
+} as any)
+const InstallPermissionsRoute = InstallPermissionsRouteImport.update({
+  id: '/permissions',
+  path: '/permissions',
+  getParentRoute: () => InstallRoute,
 } as any)
 const DocsUpstreamDriftRoute = DocsUpstreamDriftRouteImport.update({
   id: '/upstream-drift',
@@ -498,7 +510,7 @@ export interface FileRoutesByFullPath {
   '/changelog': typeof ChangelogRoute
   '/docs': typeof DocsRouteWithChildren
   '/extension': typeof ExtensionRoute
-  '/install': typeof InstallRoute
+  '/install': typeof InstallRouteWithChildren
   '/maintainers': typeof MaintainersRoute
   '/miners': typeof MinersRoute
   '/roadmap': typeof RoadmapRoute
@@ -564,9 +576,11 @@ export interface FileRoutesByFullPath {
   '/docs/troubleshooting': typeof DocsTroubleshootingRoute
   '/docs/tuning': typeof DocsTuningRoute
   '/docs/upstream-drift': typeof DocsUpstreamDriftRoute
+  '/install/permissions': typeof InstallPermissionsRoute
   '/api/': typeof ApiIndexRoute
   '/app/': typeof AppIndexRoute
   '/docs/': typeof DocsIndexRoute
+  '/install/': typeof InstallIndexRoute
   '/repos/$owner/$repo/quality': typeof ReposOwnerRepoQualityRoute
 }
 export interface FileRoutesByTo {
@@ -574,7 +588,6 @@ export interface FileRoutesByTo {
   '/agents': typeof AgentsRoute
   '/changelog': typeof ChangelogRoute
   '/extension': typeof ExtensionRoute
-  '/install': typeof InstallRoute
   '/maintainers': typeof MaintainersRoute
   '/miners': typeof MinersRoute
   '/roadmap': typeof RoadmapRoute
@@ -640,9 +653,11 @@ export interface FileRoutesByTo {
   '/docs/troubleshooting': typeof DocsTroubleshootingRoute
   '/docs/tuning': typeof DocsTuningRoute
   '/docs/upstream-drift': typeof DocsUpstreamDriftRoute
+  '/install/permissions': typeof InstallPermissionsRoute
   '/api': typeof ApiIndexRoute
   '/app': typeof AppIndexRoute
   '/docs': typeof DocsIndexRoute
+  '/install': typeof InstallIndexRoute
   '/repos/$owner/$repo/quality': typeof ReposOwnerRepoQualityRoute
 }
 export interface FileRoutesById {
@@ -654,7 +669,7 @@ export interface FileRoutesById {
   '/changelog': typeof ChangelogRoute
   '/docs': typeof DocsRouteWithChildren
   '/extension': typeof ExtensionRoute
-  '/install': typeof InstallRoute
+  '/install': typeof InstallRouteWithChildren
   '/maintainers': typeof MaintainersRoute
   '/miners': typeof MinersRoute
   '/roadmap': typeof RoadmapRoute
@@ -720,9 +735,11 @@ export interface FileRoutesById {
   '/docs/troubleshooting': typeof DocsTroubleshootingRoute
   '/docs/tuning': typeof DocsTuningRoute
   '/docs/upstream-drift': typeof DocsUpstreamDriftRoute
+  '/install/permissions': typeof InstallPermissionsRoute
   '/api/': typeof ApiIndexRoute
   '/app/': typeof AppIndexRoute
   '/docs/': typeof DocsIndexRoute
+  '/install/': typeof InstallIndexRoute
   '/repos/$owner/$repo/quality': typeof ReposOwnerRepoQualityRoute
 }
 export interface FileRouteTypes {
@@ -801,9 +818,11 @@ export interface FileRouteTypes {
     | '/docs/troubleshooting'
     | '/docs/tuning'
     | '/docs/upstream-drift'
+    | '/install/permissions'
     | '/api/'
     | '/app/'
     | '/docs/'
+    | '/install/'
     | '/repos/$owner/$repo/quality'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -811,7 +830,6 @@ export interface FileRouteTypes {
     | '/agents'
     | '/changelog'
     | '/extension'
-    | '/install'
     | '/maintainers'
     | '/miners'
     | '/roadmap'
@@ -877,9 +895,11 @@ export interface FileRouteTypes {
     | '/docs/troubleshooting'
     | '/docs/tuning'
     | '/docs/upstream-drift'
+    | '/install/permissions'
     | '/api'
     | '/app'
     | '/docs'
+    | '/install'
     | '/repos/$owner/$repo/quality'
   id:
     | '__root__'
@@ -956,9 +976,11 @@ export interface FileRouteTypes {
     | '/docs/troubleshooting'
     | '/docs/tuning'
     | '/docs/upstream-drift'
+    | '/install/permissions'
     | '/api/'
     | '/app/'
     | '/docs/'
+    | '/install/'
     | '/repos/$owner/$repo/quality'
   fileRoutesById: FileRoutesById
 }
@@ -970,7 +992,7 @@ export interface RootRouteChildren {
   ChangelogRoute: typeof ChangelogRoute
   DocsRoute: typeof DocsRouteWithChildren
   ExtensionRoute: typeof ExtensionRoute
-  InstallRoute: typeof InstallRoute
+  InstallRoute: typeof InstallRouteWithChildren
   MaintainersRoute: typeof MaintainersRoute
   MinersRoute: typeof MinersRoute
   RoadmapRoute: typeof RoadmapRoute
@@ -1056,6 +1078,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/install/': {
+      id: '/install/'
+      path: '/'
+      fullPath: '/install/'
+      preLoaderRoute: typeof InstallIndexRouteImport
+      parentRoute: typeof InstallRoute
+    }
     '/docs/': {
       id: '/docs/'
       path: '/'
@@ -1076,6 +1105,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/'
       preLoaderRoute: typeof ApiIndexRouteImport
       parentRoute: typeof ApiRoute
+    }
+    '/install/permissions': {
+      id: '/install/permissions'
+      path: '/permissions'
+      fullPath: '/install/permissions'
+      preLoaderRoute: typeof InstallPermissionsRouteImport
+      parentRoute: typeof InstallRoute
     }
     '/docs/upstream-drift': {
       id: '/docs/upstream-drift'
@@ -1675,6 +1711,19 @@ const DocsRouteChildren: DocsRouteChildren = {
 
 const DocsRouteWithChildren = DocsRoute._addFileChildren(DocsRouteChildren)
 
+interface InstallRouteChildren {
+  InstallPermissionsRoute: typeof InstallPermissionsRoute
+  InstallIndexRoute: typeof InstallIndexRoute
+}
+
+const InstallRouteChildren: InstallRouteChildren = {
+  InstallPermissionsRoute: InstallPermissionsRoute,
+  InstallIndexRoute: InstallIndexRoute,
+}
+
+const InstallRouteWithChildren =
+  InstallRoute._addFileChildren(InstallRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AgentsRoute: AgentsRoute,
@@ -1683,7 +1732,7 @@ const rootRouteChildren: RootRouteChildren = {
   ChangelogRoute: ChangelogRoute,
   DocsRoute: DocsRouteWithChildren,
   ExtensionRoute: ExtensionRoute,
-  InstallRoute: InstallRoute,
+  InstallRoute: InstallRouteWithChildren,
   MaintainersRoute: MaintainersRoute,
   MinersRoute: MinersRoute,
   RoadmapRoute: RoadmapRoute,

--- a/apps/loopover-ui/src/routes/install.index.tsx
+++ b/apps/loopover-ui/src/routes/install.index.tsx
@@ -1,0 +1,139 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRight, UserPlus, Github, ShieldCheck } from "lucide-react";
+
+import { Section, SectionTitle, Card, Callout, Eyebrow } from "@/components/site/primitives";
+
+// Self-serve signup & App-install entry surface (part of #4802). This is the front door of the
+// signup -> install -> confirm-scoped-permissions flow: it explains the three steps and routes a new
+// customer to the existing GitHub App configuration guide, with a link to the scoped-permissions
+// confirmation step (/install/permissions). It reads no secrets and changes no auth backend -- the
+// install itself is completed on GitHub.
+
+export const Route = createFileRoute("/install/")({
+  head: () => ({
+    meta: [
+      { title: "Install LoopOver — self-serve setup" },
+      {
+        name: "description",
+        content:
+          "Sign up, install the LoopOver App on your own repository, and confirm the scoped permissions being granted — self-serve, no engineering step required.",
+      },
+      { property: "og:title", content: "Install LoopOver — self-serve setup" },
+      {
+        property: "og:description",
+        content:
+          "A self-serve signup-through-install flow: connect your repository and grant scoped permissions.",
+      },
+      { property: "og:url", content: "/install" },
+    ],
+    links: [{ rel: "canonical", href: "/install" }],
+  }),
+  component: InstallPage,
+});
+
+const STEPS = [
+  {
+    icon: UserPlus,
+    title: "Sign up",
+    description:
+      "Create your account. No engineering involvement — you own the connection to your repository from the start.",
+  },
+  {
+    icon: Github,
+    title: "Install the App",
+    description:
+      "Add the LoopOver GitHub App to the repositories you want reviewed. You choose which repos it can see.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Confirm scoped permissions",
+    description:
+      "Review exactly which permissions you're granting before you finish — scoped to what review needs, nothing more.",
+    to: "/install/permissions" as const,
+  },
+];
+
+export function InstallPage() {
+  return (
+    <>
+      <Section className="pt-16 pb-12 sm:pt-24">
+        <div className="max-w-3xl">
+          <Eyebrow accent>Self-serve setup</Eyebrow>
+          <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
+            Connect your repository in three steps.
+          </h1>
+          <p className="mt-4 max-w-2xl text-token-md text-muted-foreground">
+            Sign up, install the LoopOver App on your own repository, and confirm the scoped
+            permissions being granted — without a manual or engineering step.
+          </p>
+          <div className="mt-7 flex flex-wrap items-center gap-2">
+            <Link
+              to="/docs/github-app"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
+            >
+              Install on GitHub
+              <ArrowRight className="size-3.5" />
+            </Link>
+            <Link
+              to="/docs/beta-onboarding"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token border border-border bg-transparent px-4 text-token-sm font-medium text-foreground transition-colors duration-150 hover:bg-accent focus-ring motion-reduce:transition-none"
+            >
+              Read the onboarding guide
+            </Link>
+          </div>
+        </div>
+      </Section>
+
+      <Section className="py-0">
+        <SectionTitle
+          eyebrow="How it works"
+          title="From signup to a connected repo"
+          description="Each step is self-serve. You stay in control of which repositories the App can access and what it's allowed to do."
+        />
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {STEPS.map((step, index) => {
+            const Icon = step.icon;
+            return (
+              <Card key={step.title}>
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Icon aria-hidden className="size-4" />
+                  <span className="font-mono text-token-2xs uppercase tracking-wider">
+                    Step {index + 1}
+                  </span>
+                </div>
+                <h3 className="mt-3 text-token-md font-medium text-foreground">{step.title}</h3>
+                <p className="mt-1.5 text-token-sm text-muted-foreground">{step.description}</p>
+                {"to" in step && step.to ? (
+                  <Link
+                    to={step.to}
+                    className="mt-3 inline-flex items-center gap-1 text-token-sm font-medium text-foreground underline underline-offset-2 focus-ring"
+                  >
+                    Review the exact scopes
+                    <ArrowRight className="size-3.5" />
+                  </Link>
+                ) : null}
+              </Card>
+            );
+          })}
+        </div>
+      </Section>
+
+      <Section className="pt-12 pb-24">
+        <div className="max-w-3xl">
+          <Callout variant="safety" title="Scoped by design">
+            LoopOver requests only the permissions review needs, on only the repositories you
+            choose. You confirm the exact scopes on GitHub before the install completes, and you can
+            review or revoke them at any time from your repository's installed-Apps settings. See{" "}
+            <Link
+              to="/docs/privacy-security"
+              className="text-foreground underline underline-offset-2"
+            >
+              privacy &amp; security
+            </Link>{" "}
+            for what is and isn't stored.
+          </Callout>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/apps/loopover-ui/src/routes/install.permissions.tsx
+++ b/apps/loopover-ui/src/routes/install.permissions.tsx
@@ -1,0 +1,218 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeft, ShieldCheck, Eye, PencilLine, Bell } from "lucide-react";
+
+import { Section, SectionTitle, Card, Callout, Eyebrow } from "@/components/site/primitives";
+
+// Self-serve "confirm scoped permissions" surface (part of #4802). This is the third step of the
+// signup -> install -> confirm-scoped-permissions flow whose entry lives at /install: before a
+// customer finishes the GitHub install, this page shows exactly which repository permissions the App
+// requests and why, so the grant on GitHub holds no surprises. The permission set mirrors the
+// canonical REQUIRED_INSTALLATION_PERMISSIONS / OPTIONAL_* constants in src/github/backfill.ts (the
+// same source install-health checks against) -- baseline access is always requested; the write scopes
+// are only exercised when the matching repo setting is enabled, so they are shown as opt-in. This is a
+// read-only informational surface: it reads no secrets and changes no auth backend, and the real grant
+// still happens on GitHub.
+
+export const Route = createFileRoute("/install/permissions")({
+  head: () => ({
+    meta: [
+      { title: "Scoped permissions — LoopOver install" },
+      {
+        name: "description",
+        content:
+          "Review exactly which repository permissions the LoopOver GitHub App requests, and why, before you finish installing — scoped to what review needs, nothing more.",
+      },
+      { property: "og:title", content: "Scoped permissions — LoopOver install" },
+      {
+        property: "og:description",
+        content:
+          "The exact scopes the LoopOver App requests: baseline read access plus opt-in write scopes only for the output you enable.",
+      },
+      { property: "og:url", content: "/install/permissions" },
+    ],
+    links: [{ rel: "canonical", href: "/install/permissions" }],
+  }),
+  component: InstallPermissionsPage,
+});
+
+type Scope = {
+  icon: typeof Eye;
+  name: string;
+  access: "Read" | "Write";
+  summary: string;
+};
+
+// Baseline scopes every installation requests (REQUIRED_INSTALLATION_PERMISSIONS in
+// src/github/backfill.ts: metadata:read, pull_requests:read, issues:write).
+const REQUIRED_SCOPES: Scope[] = [
+  {
+    icon: Eye,
+    name: "Metadata",
+    access: "Read",
+    summary:
+      "Baseline access GitHub requires for any App — the repository's name, description, and topology. No file contents.",
+  },
+  {
+    icon: Eye,
+    name: "Pull requests",
+    access: "Read",
+    summary:
+      "Read the diff, title, and description of a pull request so the review agent has something to review.",
+  },
+  {
+    icon: PencilLine,
+    name: "Issues",
+    access: "Write",
+    summary:
+      "Post the review as a comment and apply the review labels. GitHub routes PR comments and labels through the Issues endpoints, so this is what publishing the result needs.",
+  },
+];
+
+// Opt-in scopes: only requested/exercised when the matching repository setting is enabled
+// (OPTIONAL_CHECK_RUN_PERMISSION / OPTIONAL_PR_WRITE_PERMISSION / OPTIONAL_CONTENTS_WRITE_PERMISSION).
+const OPTIONAL_SCOPES: Array<Scope & { enabledBy: string }> = [
+  {
+    icon: ShieldCheck,
+    name: "Checks",
+    access: "Write",
+    summary:
+      "Publish the LoopOver Orb Review Agent check run on the pull request, so its verdict shows in the PR's checks.",
+    enabledBy: "Enabled when you turn on check-run or review-agent enforcement.",
+  },
+  {
+    icon: PencilLine,
+    name: "Pull requests",
+    access: "Write",
+    summary:
+      "Act on pull-request state — merge, close, approve, or request changes — when you let the agent enforce outcomes rather than only advise.",
+    enabledBy: "Enabled when autonomy is set to act on PR state.",
+  },
+  {
+    icon: PencilLine,
+    name: "Contents",
+    access: "Write",
+    summary:
+      "Write suggested fixes back to a branch when fix-handoff is turned on. Left at read-only otherwise.",
+    enabledBy: "Enabled when fix-handoff writes are turned on.",
+  },
+];
+
+// Webhook events the installation subscribes to (REQUIRED_INSTALLATION_EVENTS).
+const EVENTS = ["issues", "issue_comment", "pull_request", "repository"];
+
+function ScopeCard({ scope, footer }: { scope: Scope; footer?: string }) {
+  const Icon = scope.icon;
+  return (
+    <Card>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Icon aria-hidden className="size-4" />
+          <h3 className="text-token-md font-medium text-foreground">{scope.name}</h3>
+        </div>
+        <span className="rounded-token border border-border px-2 py-0.5 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+          {scope.access}
+        </span>
+      </div>
+      <p className="mt-2 text-token-sm text-muted-foreground">{scope.summary}</p>
+      {footer ? <p className="mt-2 text-token-2xs text-muted-foreground/80">{footer}</p> : null}
+    </Card>
+  );
+}
+
+export function InstallPermissionsPage() {
+  return (
+    <>
+      <Section className="pt-16 pb-12 sm:pt-24">
+        <div className="max-w-3xl">
+          <Eyebrow accent>Step 3 · Confirm scoped permissions</Eyebrow>
+          <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
+            Exactly what you&apos;re granting.
+          </h1>
+          <p className="mt-4 max-w-2xl text-token-md text-muted-foreground">
+            Before you finish the install, here is every repository permission the LoopOver App
+            requests — and why. GitHub shows you the same list to approve; nothing is granted until
+            you confirm it there.
+          </p>
+          <div className="mt-7">
+            <Link
+              to="/install"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token border border-border bg-transparent px-4 text-token-sm font-medium text-foreground transition-colors duration-150 hover:bg-accent focus-ring motion-reduce:transition-none"
+            >
+              <ArrowLeft className="size-3.5" />
+              Back to setup steps
+            </Link>
+          </div>
+        </div>
+      </Section>
+
+      <Section className="py-0">
+        <SectionTitle
+          eyebrow="Always requested"
+          title="Baseline access"
+          description="These scopes are needed for a review to happen at all: read the pull request, then publish the result."
+        />
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {REQUIRED_SCOPES.map((scope) => (
+            <ScopeCard key={scope.name} scope={scope} />
+          ))}
+        </div>
+      </Section>
+
+      <Section className="pt-12 pb-0">
+        <SectionTitle
+          eyebrow="Only if you enable it"
+          title="Opt-in write scopes"
+          description="LoopOver requests these only when the matching setting is on. Leave the setting off and the scope stays unused — advisory-only reviews never need them."
+        />
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {OPTIONAL_SCOPES.map((scope) => (
+            <ScopeCard
+              key={`${scope.name}-${scope.access}`}
+              scope={scope}
+              footer={scope.enabledBy}
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section className="pt-12 pb-0">
+        <div className="max-w-3xl">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Bell aria-hidden className="size-4" />
+            <h2 className="text-token-md font-medium text-foreground">Events it listens for</h2>
+          </div>
+          <p className="mt-2 text-token-sm text-muted-foreground">
+            The installation subscribes to these webhook events so it knows when there&apos;s a pull
+            request to review:
+          </p>
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {EVENTS.map((event) => (
+              <li
+                key={event}
+                className="rounded-token border border-border px-2.5 py-1 font-mono text-token-2xs text-muted-foreground"
+              >
+                {event}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Section>
+
+      <Section className="pt-12 pb-24">
+        <div className="max-w-3xl">
+          <Callout variant="safety" title="You stay in control">
+            You grant these on only the repositories you choose, and you can review or revoke them
+            at any time from your repository&apos;s installed-Apps settings on GitHub. See{" "}
+            <Link
+              to="/docs/privacy-security"
+              className="text-foreground underline underline-offset-2"
+            >
+              privacy &amp; security
+            </Link>{" "}
+            for what is and isn&apos;t stored.
+          </Callout>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/apps/loopover-ui/src/routes/install.test.tsx
+++ b/apps/loopover-ui/src/routes/install.test.tsx
@@ -7,7 +7,7 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
 }));
 
-import { InstallPage } from "./install";
+import { InstallPage } from "./install.index";
 
 // Self-serve signup & App-install entry surface (part of #4802).
 describe("InstallPage (#4802 self-serve install entry)", () => {

--- a/apps/loopover-ui/src/routes/install.tsx
+++ b/apps/loopover-ui/src/routes/install.tsx
@@ -1,129 +1,13 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRight, UserPlus, Github, ShieldCheck } from "lucide-react";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
-import { Section, SectionTitle, Card, Callout, Eyebrow } from "@/components/site/primitives";
-
-// Self-serve signup & App-install entry surface (part of #4802). This is the front door of the
-// signup -> install -> confirm-scoped-permissions flow: it explains the three steps and routes a new
-// customer to the existing GitHub App configuration guide. It reads no secrets and changes no auth
-// backend -- the install itself is completed on GitHub, and post-install permission confirmation is a
-// deliberate follow-up so this slice stays a small, reviewable UI surface.
-
+// Layout for the self-serve install flow (part of #4802). `/install` is the signup->install->confirm
+// entry (install.index.tsx); `/install/permissions` is the scoped-permissions confirmation step. This
+// route only provides the shared outlet so those sibling pages render under the /install path -- it
+// holds no content of its own and reads no secrets.
 export const Route = createFileRoute("/install")({
-  head: () => ({
-    meta: [
-      { title: "Install LoopOver — self-serve setup" },
-      {
-        name: "description",
-        content:
-          "Sign up, install the LoopOver App on your own repository, and confirm the scoped permissions being granted — self-serve, no engineering step required.",
-      },
-      { property: "og:title", content: "Install LoopOver — self-serve setup" },
-      {
-        property: "og:description",
-        content:
-          "A self-serve signup-through-install flow: connect your repository and grant scoped permissions.",
-      },
-      { property: "og:url", content: "/install" },
-    ],
-    links: [{ rel: "canonical", href: "/install" }],
-  }),
-  component: InstallPage,
+  component: InstallLayout,
 });
 
-const STEPS = [
-  {
-    icon: UserPlus,
-    title: "Sign up",
-    description:
-      "Create your account. No engineering involvement — you own the connection to your repository from the start.",
-  },
-  {
-    icon: Github,
-    title: "Install the App",
-    description:
-      "Add the LoopOver GitHub App to the repositories you want reviewed. You choose which repos it can see.",
-  },
-  {
-    icon: ShieldCheck,
-    title: "Confirm scoped permissions",
-    description:
-      "Review exactly which permissions you're granting before you finish — scoped to what review needs, nothing more.",
-  },
-];
-
-export function InstallPage() {
-  return (
-    <>
-      <Section className="pt-16 pb-12 sm:pt-24">
-        <div className="max-w-3xl">
-          <Eyebrow accent>Self-serve setup</Eyebrow>
-          <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
-            Connect your repository in three steps.
-          </h1>
-          <p className="mt-4 max-w-2xl text-token-md text-muted-foreground">
-            Sign up, install the LoopOver App on your own repository, and confirm the scoped
-            permissions being granted — without a manual or engineering step.
-          </p>
-          <div className="mt-7 flex flex-wrap items-center gap-2">
-            <Link
-              to="/docs/github-app"
-              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
-            >
-              Install on GitHub
-              <ArrowRight className="size-3.5" />
-            </Link>
-            <Link
-              to="/docs/beta-onboarding"
-              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token border border-border bg-transparent px-4 text-token-sm font-medium text-foreground transition-colors duration-150 hover:bg-accent focus-ring motion-reduce:transition-none"
-            >
-              Read the onboarding guide
-            </Link>
-          </div>
-        </div>
-      </Section>
-
-      <Section className="py-0">
-        <SectionTitle
-          eyebrow="How it works"
-          title="From signup to a connected repo"
-          description="Each step is self-serve. You stay in control of which repositories the App can access and what it's allowed to do."
-        />
-        <div className="mt-8 grid gap-4 sm:grid-cols-3">
-          {STEPS.map((step, index) => {
-            const Icon = step.icon;
-            return (
-              <Card key={step.title}>
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Icon aria-hidden className="size-4" />
-                  <span className="font-mono text-token-2xs uppercase tracking-wider">
-                    Step {index + 1}
-                  </span>
-                </div>
-                <h3 className="mt-3 text-token-md font-medium text-foreground">{step.title}</h3>
-                <p className="mt-1.5 text-token-sm text-muted-foreground">{step.description}</p>
-              </Card>
-            );
-          })}
-        </div>
-      </Section>
-
-      <Section className="pt-12 pb-24">
-        <div className="max-w-3xl">
-          <Callout variant="safety" title="Scoped by design">
-            LoopOver requests only the permissions review needs, on only the repositories you
-            choose. You confirm the exact scopes on GitHub before the install completes, and you can
-            review or revoke them at any time from your repository's installed-Apps settings. See{" "}
-            <Link
-              to="/docs/privacy-security"
-              className="text-foreground underline underline-offset-2"
-            >
-              privacy &amp; security
-            </Link>{" "}
-            for what is and isn't stored.
-          </Callout>
-        </div>
-      </Section>
-    </>
-  );
+export function InstallLayout() {
+  return <Outlet />;
 }


### PR DESCRIPTION
## What

Adds the **scoped-permissions confirmation step** to the self-serve install flow — a new `/install/permissions` route that is the third step (“Confirm scoped permissions”) of the signup → install → confirm flow described in #4802. Before a customer finishes the GitHub install, this page shows exactly which repository permissions the LoopOver App requests, and why, so the grant on GitHub holds no surprises.

This is a **scoped slice of #4802**, continuing the `/install` entry surface (#7203) whose third step previously pointed only to a follow-up. That step now links here.

## Details

- **`/install/permissions`** (`install.permissions.tsx`) lists the real permission set, grouped:
  - **Baseline access** (always requested): Metadata (read), Pull requests (read), Issues (write).
  - **Opt-in write scopes** (only when the matching setting is on): Checks (write), Pull requests (write), Contents (write), each with the setting that enables it.
  - **Events it listens for**: `issues`, `issue_comment`, `pull_request`, `repository`.
  - A “You stay in control” safety callout linking to privacy & security.
- The permission set mirrors the canonical `REQUIRED_INSTALLATION_PERMISSIONS` / `OPTIONAL_CHECK_RUN_PERMISSION` / `OPTIONAL_PR_WRITE_PERMISSION` / `OPTIONAL_CONTENTS_WRITE_PERMISSION` / `REQUIRED_INSTALLATION_EVENTS` constants in `src/github/backfill.ts` (the same source install-health checks against), so it stays accurate rather than fabricated.
- `/install` is split into a thin layout (`install.tsx`, renders an `<Outlet />`) plus its index page (`install.index.tsx`, the existing three-step surface, unchanged in content) so `/install` and `/install/permissions` render as sibling pages under the shared path — the same layout/index pattern `app.tsx`/`app.index.tsx` and `docs.tsx` already use. The regenerated `routeTree.gen.ts` reflects only these two new routes.
- The `/install` step-3 card now links to the new page (“Review the exact scopes →”).

Built on the shared design-system primitives (`Section`, `Card`, `Callout`, `Eyebrow`, design tokens) per the issue’s design-system boundary. Read-only informational surface: reads no secrets, changes no auth backend; the real grant still happens on GitHub.

## Validation

- `npm run ui:typecheck`, `npm run ui:lint` — pass.
- Existing `install.test.tsx` updated for the moved `InstallPage` import and passing; full UI test suite green (one unrelated REES-analyzer test is a resource-contention timeout that passes in isolation).
- `git diff --check` clean; the diff is exactly the five install-flow files (no doc/openapi churn).

## UI Evidence

| Confirm scoped permissions (`/install/permissions`) | Mobile | Install entry, step-3 link |
|---|---|---|
| <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/permissions-desktop.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/permissions-desktop.png" alt="Desktop layout" width="240"></a> | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/permissions-mobile.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/permissions-mobile.png" alt="Mobile layout" width="240"></a> | <a href="https://raw.githubusercontent.com/shin-core/loopover/screenshots/install-index-desktop.png"><img src="https://raw.githubusercontent.com/shin-core/loopover/screenshots/install-index-desktop.png" alt="Install entry" width="240"></a> |

Closes #4802
