### PR TITLE
fix(ci): switch fetch-test-timing.mjs to Codecov's test-analytics endpoint

### DIFF
--- a/scripts/fetch-test-timing.mjs
+++ b/scripts/fetch-test-timing.mjs
@@ -14,6 +14,13 @@
 // existing CODECOV_TOKEN secret -- that one is an upload-only token and doesn't authenticate this read
 // API. Codecov's docs don't publish a numeric rate limit for this endpoint, so this is deliberately run
 // on a schedule (test-timing-refresh.yml), not per-PR.
+//
+// Uses /test-analytics/, not /test-results/: the latter is now deprecated (confirmed by actually
+// running this script -- Codecov returns a 301 with "This endpoint has been deprecated. Please use
+// /test-analytics/ instead."). Verified via Codecov's live OpenAPI schema (api.codecov.io/api/v2/schema/)
+// that /test-analytics/ returns the identical PaginatedTestrunList wrapper and Testrun field shape
+// (filename, duration_seconds, commit_sha, etc.) -- a URL rename, not a schema change, so nothing else
+// in this file needed to change.
 
 import { writeFileSync } from "node:fs";
 
@@ -47,7 +54,7 @@ async function fetchWithRetry(url, maxAttempts = 4) {
 
 async function fetchAllTestRuns() {
   const rows = [];
-  let url = `https://api.codecov.io/api/v2/gh/${owner}/repos/${repoName}/test-results/?branch=main&page_size=100`;
+  let url = `https://api.codecov.io/api/v2/gh/${owner}/repos/${repoName}/test-analytics/?branch=main&page_size=100`;
   let pages = 0;
   while (url && pages < MAX_PAGES) {
     const body = await fetchWithRetry(url);


### PR DESCRIPTION
## Summary

`scripts/fetch-test-timing.mjs` (added in the duration-aware sharding PR, #7381) called Codecov's `/test-results/` endpoint. You manually ran `test-timing-refresh.yml` via `workflow_dispatch` and it failed immediately with a live 301: `"This endpoint has been deprecated. Please use /test-analytics/ instead."` — Codecov apparently deprecated it after the original research for #7381 checked their spec, or the finding was already stale by the time it shipped.

Fixed by pointing at `/test-analytics/` instead. Verified against Codecov's live OpenAPI schema (`api.codecov.io/api/v2/schema/`) that the replacement endpoint returns the identical `PaginatedTestrunList` wrapper and `Testrun` field shape (`filename`, `duration_seconds`, `commit_sha`, etc.) — a pure URL rename, so the aggregation logic in the rest of the file is untouched.

Until this merges, `test-timing-refresh.yml` fails every run, so `compute-test-shards.mjs` keeps using its round-robin fallback (safe, already verified — just not the actual duration-weighted balancing this whole feature exists for).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — a single-line URL fix plus an explanatory comment.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-initiated build-tooling work.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `node --check scripts/fetch-test-timing.mjs`
- [x] Confirmed the new endpoint's response schema is identical to the old one via Codecov's live OpenAPI schema before assuming the URL-only fix was sufficient, rather than just swapping the string and hoping.
- [ ] Can't verify the live API call itself in this session (no access to `CODECOV_API_TOKEN`, by design) — the real end-to-end check is the next scheduled/manual run of `test-timing-refresh.yml` after this merges.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.

## Notes

- Touches only a script under `scripts/`, not `.github/workflows/**` itself — may not need the same manual-hold treatment as the workflow-file PRs this session, but flagging since it's still CI-adjacent infrastructure.
- Worth a manual `workflow_dispatch` re-run of `test-timing-refresh.yml` after this merges to confirm the fix actually works end-to-end, not just that the URL matches the deprecation notice's stated replacement.