### PR TITLE
chore(mcp): convert lib/local-branch to TypeScript

### DIFF
--- a/packages/loopover-mcp/lib/local-branch.js
+++ b/packages/loopover-mcp/lib/local-branch.js
@@ -1,592 +1,585 @@
 import { execFileSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isCodeFile, isTestPath as isTestFile } from "@loopover/engine/signals/test-evidence";
 import { redactLocalPath } from "./redact-local-path.js";
-
 export { isCodeFile, isTestFile };
 export { redactLocalPath };
-
 function stripTrailingSlashes(value) {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
-  return end === value.length ? value : value.slice(0, end);
+    let end = value.length;
+    while (end > 0 && value.charCodeAt(end - 1) === 47)
+        end -= 1;
+    return end === value.length ? value : value.slice(0, end);
 }
-
 export function parseGitRemote(remoteUrl) {
-  const trimmed = stripTrailingSlashes(String(remoteUrl ?? "").trim());
-  const patterns = [
-    /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
-    /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
-    /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
-  ];
-  for (const pattern of patterns) {
-    const match = trimmed.match(pattern);
-    if (match?.[1] && match[2]) return `${match[1]}/${match[2].replace(/\.git$/, "")}`;
-  }
-  return undefined;
+    const trimmed = stripTrailingSlashes(String(remoteUrl ?? "").trim());
+    const patterns = [
+        /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
+        /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+        /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    ];
+    for (const pattern of patterns) {
+        const match = trimmed.match(pattern);
+        if (match?.[1] && match[2])
+            return `${match[1]}/${match[2].replace(/\.git$/, "")}`;
+    }
+    return undefined;
 }
-
 export function collectLocalDiff(cwd, baseRef, workspaceRoots) {
-  const metadata = collectLocalBranchMetadata({ cwd, baseRef, login: "local", workspaceRoots });
-  return {
-    title: metadata.title ?? "Local diff preflight",
-    commitMessage: metadata.commitMessages.join("\n\n").trim(),
-    changedFiles: metadata.changedFiles.map((file) => file.path),
-    changedLineCount: metadata.changedFiles.reduce((sum, file) => sum + (file.additions ?? 0) + (file.deletions ?? 0), 0),
-    testFiles: metadata.changedFiles.map((file) => file.path).filter(isTestFile),
-    codeFiles: metadata.changedFiles.map((file) => file.path).filter(isCodeFile),
-  };
-}
-
-export function collectLocalBranchMetadata(input) {
-  assertSourceUploadDisabled();
-  const workspace = resolveWorkspaceCwd(input);
-  const cwd = workspace.cwd;
-  const baseRef = input.baseRef ?? defaultBaseRef(cwd);
-  const remoteUrl = gitLines(cwd, ["config", "--get", "remote.origin.url"])[0] ?? "";
-  const repoFullName = input.repoFullName ?? parseGitRemote(remoteUrl);
-  if (!repoFullName) throw new Error("Could not infer repoFullName from git remote; pass --repo owner/repo.");
-  const branchName = input.branchName ?? gitLines(cwd, ["branch", "--show-current"])[0] ?? "local-branch";
-  const headRef = input.headRef ?? gitLines(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])[0] ?? branchName;
-  const baseSha = gitLines(cwd, ["rev-parse", "--verify", baseRef])[0];
-  const headSha = gitLines(cwd, ["rev-parse", "--verify", "HEAD"])[0];
-  const mergeBaseSha = gitLines(cwd, ["merge-base", baseRef, "HEAD"])[0];
-  const remoteTrackingSha = collectRemoteTrackingSha(cwd, baseRef);
-  const changedFiles = collectChangedFiles(cwd, baseRef);
-  const pendingCommitCount = input.pendingCommitCount ?? collectPendingCommitCount(cwd, baseRef);
-  const ciStatusHints = input.ciStatusHints ?? collectCiStatusHints(cwd, baseRef, changedFiles);
-  const commitMessages = input.commitMessages ?? collectCommitMessages(cwd, baseRef);
-  const title = input.title ?? titleFromBranch(branchName) ?? firstCommitTitle(commitMessages);
-  const linkedIssues = [...new Set([...(input.linkedIssues ?? []), ...extractLinkedIssues([branchName, title, input.body, ...commitMessages].filter(Boolean).join("\n"))])].sort(
-    (left, right) => left - right,
-  );
-  const payload = {
-    login: input.login,
-    repoFullName,
-    baseRef,
-    headRef,
-    branchName,
-    baseSha,
-    headSha,
-    mergeBaseSha,
-    remoteTrackingSha,
-    commitMessages,
-    changedFiles,
-    validation: input.validation,
-    linkedIssues,
-    labels: input.labels,
-    title,
-    body: input.body,
-    pendingMergedPrCount: input.pendingMergedPrCount,
-    pendingClosedPrCount: input.pendingClosedPrCount,
-    approvedPrCount: input.approvedPrCount,
-    expectedOpenPrCountAfterMerge: input.expectedOpenPrCountAfterMerge,
-    projectedCredibility: input.projectedCredibility,
-    scenarioNotes: input.scenarioNotes,
-    pendingCommitCount,
-    ciStatusHints,
-    branchEligibility: input.branchEligibility,
-  };
-  return stripUndefined(payload);
-}
-
-export function collectPendingCommitCount(cwd, baseRef) {
-  const count = gitLines(cwd, ["rev-list", "--count", `${baseRef}..HEAD`])[0];
-  const parsed = Number(count);
-  return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : 0;
-}
-
-export function collectCiStatusHints(cwd, baseRef, changedFiles = []) {
-  const hints = [];
-  const paths = changedFiles.map((file) => file.path).filter(Boolean);
-  if (paths.some((path) => /^\.github\/workflows\//i.test(path))) {
-    hints.push("Workflow files changed; CI required-check behavior may change after merge.");
-  }
-  if (paths.some((path) => /(^|\/)(Makefile|Dockerfile|package\.json|pyproject\.toml|go\.mod|Cargo\.toml)$/i.test(path))) {
-    hints.push("Build or dependency manifests changed; rerun the repo's standard validation commands.");
-  }
-  const pendingCommits = collectPendingCommitCount(cwd, baseRef);
-  if (pendingCommits > 0) {
-    hints.push(`${pendingCommits} local commit(s) ahead of ${baseRef}; push or rebase before reviewers rely on the latest diff.`);
-  }
-  return hints;
-}
-
-export function buildBranchAnalysisPayload(input) {
-  const workspace = resolveWorkspaceCwd(input);
-  const metadata = collectLocalBranchMetadata({ ...input, cwd: workspace.cwd });
-  const scorerMetadata = { ...metadata, repoRoot: workspace.cwd };
-  const scorerCommand = resolveScorePreviewCommand(input);
-  const externalPreview = runExternalScorePreview(scorerMetadata, scorerCommand);
-  const localScorer = externalPreview.ok ? normalizeScorerOutput(externalPreview.payload) : metadataOnlyScorer(externalPreview);
-  return {
-    ...metadata,
-    localScorer,
-    localScorerStatus: sanitizeLocalScorerStatus(externalPreview),
-  };
-}
-
-export function resolveWorkspaceCwd(input = {}) {
-  const workspaceRoots = normalizeMcpWorkspaceRoots(input.workspaceRoots);
-  if (workspaceRoots.length === 0) {
+    const metadata = collectLocalBranchMetadata({ cwd, baseRef, login: "local", workspaceRoots });
     return {
-      cwd: safeResolvedPath(input.cwd ?? process.cwd()),
-      rootsAvailable: false,
-      rootCount: 0,
+        title: metadata.title ?? "Local diff preflight",
+        commitMessage: metadata.commitMessages.join("\n\n").trim(),
+        changedFiles: metadata.changedFiles.map((file) => file.path),
+        changedLineCount: metadata.changedFiles.reduce((sum, file) => sum + (file.additions ?? 0) + (file.deletions ?? 0), 0),
+        testFiles: metadata.changedFiles.map((file) => file.path).filter(isTestFile),
+        codeFiles: metadata.changedFiles.map((file) => file.path).filter(isCodeFile),
     };
-  }
-
-  const selectedRoot = workspaceRoots[0];
-  const requestedCwd =
-    input.cwd === undefined || input.cwd === null || input.cwd === ""
-      ? selectedRoot.path
-      : isAbsolute(String(input.cwd))
-        ? String(input.cwd)
-        : resolve(selectedRoot.path, String(input.cwd));
-  const cwd = safeResolvedPath(requestedCwd);
-  const containingRoot = workspaceRoots.find((root) => pathIsInside(cwd, root.path));
-  if (!containingRoot) {
-    throw new Error("Selected workspace is outside the MCP roots exposed by the client.");
-  }
-
-  return {
-    cwd,
-    rootsAvailable: true,
-    rootCount: workspaceRoots.length,
-  };
 }
-
-export function normalizeMcpWorkspaceRoots(roots) {
-  if (!Array.isArray(roots)) return [];
-  const normalized = [];
-  const seen = new Set();
-  for (const root of roots) {
-    const uri = typeof root?.uri === "string" ? root.uri : "";
-    if (!uri.startsWith("file:")) continue;
-    try {
-      const path = safeResolvedPath(fileURLToPath(uri));
-      if (seen.has(path)) continue;
-      seen.add(path);
-      normalized.push({ path });
-    } catch {
-      // Ignore non-local or malformed root URIs. Clients without usable roots fall back to cwd.
+export function collectLocalBranchMetadata(input) {
+    assertSourceUploadDisabled();
+    const workspace = resolveWorkspaceCwd(input);
+    const cwd = workspace.cwd;
+    const baseRef = input.baseRef ?? defaultBaseRef(cwd);
+    const remoteUrl = gitLines(cwd, ["config", "--get", "remote.origin.url"])[0] ?? "";
+    const repoFullName = input.repoFullName ?? parseGitRemote(remoteUrl);
+    if (!repoFullName)
+        throw new Error("Could not infer repoFullName from git remote; pass --repo owner/repo.");
+    const branchName = input.branchName ?? gitLines(cwd, ["branch", "--show-current"])[0] ?? "local-branch";
+    const headRef = input.headRef ?? gitLines(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])[0] ?? branchName;
+    const baseSha = gitLines(cwd, ["rev-parse", "--verify", baseRef])[0];
+    const headSha = gitLines(cwd, ["rev-parse", "--verify", "HEAD"])[0];
+    const mergeBaseSha = gitLines(cwd, ["merge-base", baseRef, "HEAD"])[0];
+    const remoteTrackingSha = collectRemoteTrackingSha(cwd, baseRef);
+    const changedFiles = collectChangedFiles(cwd, baseRef);
+    const pendingCommitCount = input.pendingCommitCount ?? collectPendingCommitCount(cwd, baseRef);
+    const ciStatusHints = input.ciStatusHints ?? collectCiStatusHints(cwd, baseRef, changedFiles);
+    const commitMessages = input.commitMessages ?? collectCommitMessages(cwd, baseRef);
+    const title = input.title ?? titleFromBranch(branchName) ?? firstCommitTitle(commitMessages);
+    const linkedIssues = [...new Set([...(input.linkedIssues ?? []), ...extractLinkedIssues([branchName, title, input.body, ...commitMessages].filter(Boolean).join("\n"))])].sort((left, right) => left - right);
+    const payload = {
+        login: input.login,
+        repoFullName,
+        baseRef,
+        headRef,
+        branchName,
+        baseSha,
+        headSha,
+        mergeBaseSha,
+        remoteTrackingSha,
+        commitMessages,
+        changedFiles,
+        validation: input.validation,
+        linkedIssues,
+        labels: input.labels,
+        title,
+        body: input.body,
+        pendingMergedPrCount: input.pendingMergedPrCount,
+        pendingClosedPrCount: input.pendingClosedPrCount,
+        approvedPrCount: input.approvedPrCount,
+        expectedOpenPrCountAfterMerge: input.expectedOpenPrCountAfterMerge,
+        projectedCredibility: input.projectedCredibility,
+        scenarioNotes: input.scenarioNotes,
+        pendingCommitCount,
+        ciStatusHints,
+        branchEligibility: input.branchEligibility,
+    };
+    return stripUndefined(payload);
+}
+export function collectPendingCommitCount(cwd, baseRef) {
+    const count = gitLines(cwd, ["rev-list", "--count", `${baseRef}..HEAD`])[0];
+    const parsed = Number(count);
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : 0;
+}
+export function collectCiStatusHints(cwd, baseRef, changedFiles = []) {
+    const hints = [];
+    const paths = changedFiles.map((file) => file.path).filter(Boolean);
+    if (paths.some((path) => /^\.github\/workflows\//i.test(path))) {
+        hints.push("Workflow files changed; CI required-check behavior may change after merge.");
     }
-  }
-  return normalized;
+    if (paths.some((path) => /(^|\/)(Makefile|Dockerfile|package\.json|pyproject\.toml|go\.mod|Cargo\.toml)$/i.test(path))) {
+        hints.push("Build or dependency manifests changed; rerun the repo's standard validation commands.");
+    }
+    const pendingCommits = collectPendingCommitCount(cwd, baseRef);
+    if (pendingCommits > 0) {
+        hints.push(`${pendingCommits} local commit(s) ahead of ${baseRef}; push or rebase before reviewers rely on the latest diff.`);
+    }
+    return hints;
 }
-
-function safeResolvedPath(path) {
-  const resolved = resolve(String(path));
-  try {
-    return realpathSync(resolved);
-  } catch {
-    return resolved;
-  }
-}
-
-function pathIsInside(candidate, root) {
-  const child = safeResolvedPath(candidate);
-  const parent = safeResolvedPath(root);
-  const childRelativeToParent = relative(parent, child);
-  return childRelativeToParent === "" || (!!childRelativeToParent && !childRelativeToParent.startsWith("..") && !isAbsolute(childRelativeToParent));
-}
-
-export function resolveScorePreviewCommand(input = {}) {
-  const explicit = input.scorePreviewCommand ?? process.env.GITTENSOR_SCORE_PREVIEW_CMD;
-  if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
-  return undefined;
-}
-
-export function referenceScorePreviewExample(kind = "metadata") {
-  const script = kind === "gittensor" ? "gittensor-score-preview.py" : "gittensor-score-preview.mjs";
-  const interpreter = kind === "gittensor" ? "python3" : "node";
-  return `${interpreter} ./node_modules/@loopover/mcp/scripts/${script}`;
-}
-
-export function redactScorerCommand(command) {
-  const text = String(command ?? "").trim();
-  if (!text) return text;
-  const parts = splitCommand(text);
-  const interpreter = parts[0]?.split(/[\\/]/).pop() ?? "command";
-  const script = parts.at(-1)?.split(/[\\/]/).pop();
-  if (script && /\.(mjs|js|cjs|py)$/i.test(script)) return `${interpreter} <scorer-script>/${script}`;
-  return "<configured-scorer-command>";
-}
-
-export function sanitizeLocalScorerStatus(status) {
-  if (!status || typeof status !== "object") return status;
-  return stripUndefined({
-    ...status,
-    reason: status.reason ? redactLocalPath(String(status.reason)) : undefined,
-    stderr: status.stderr ? redactLocalPath(String(status.stderr)) : undefined,
-    scorerCommand: status.scorerCommand ? redactScorerCommand(status.scorerCommand) : undefined,
-  });
-}
-
-export function runExternalScorePreview(metadata, scorerCommand) {
-  const timeoutMs = scorePreviewTimeoutMs();
-  if (!scorerCommand) {
-    return scorerFailure("missing_scorer_command", "GITTENSOR_SCORE_PREVIEW_CMD is not configured.");
-  }
-  const parts = splitCommand(scorerCommand);
-  const command = parts[0];
-  const args = parts.slice(1);
-  if (!command) {
-    return scorerFailure("empty_scorer_command", "GITTENSOR_SCORE_PREVIEW_CMD is empty.");
-  }
-
-  const startedAt = Date.now();
-  try {
-    const output = execFileSync(command, args, {
-      input: JSON.stringify({
+export function buildBranchAnalysisPayload(input) {
+    const workspace = resolveWorkspaceCwd(input);
+    const metadata = collectLocalBranchMetadata({ ...input, cwd: workspace.cwd });
+    const scorerMetadata = { ...metadata, repoRoot: workspace.cwd };
+    const scorerCommand = resolveScorePreviewCommand(input);
+    const externalPreview = runExternalScorePreview(scorerMetadata, scorerCommand);
+    const localScorer = externalPreview.ok ? normalizeScorerOutput(externalPreview.payload) : metadataOnlyScorer(externalPreview);
+    return {
         ...metadata,
-        repoRoot: metadata.repoRoot ?? metadata.cwd,
-        gittensorRoot: process.env.GITTENSOR_ROOT,
-      }),
-      encoding: "utf8",
-      timeout: timeoutMs,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    const durationMs = Date.now() - startedAt;
-    let payload;
+        localScorer,
+        localScorerStatus: sanitizeLocalScorerStatus(externalPreview),
+    };
+}
+export function resolveWorkspaceCwd(input = {}) {
+    const workspaceRoots = normalizeMcpWorkspaceRoots(input.workspaceRoots);
+    if (workspaceRoots.length === 0) {
+        return {
+            cwd: safeResolvedPath(input.cwd ?? process.cwd()),
+            rootsAvailable: false,
+            rootCount: 0,
+        };
+    }
+    const selectedRoot = workspaceRoots[0];
+    const requestedCwd = input.cwd === undefined || input.cwd === null || input.cwd === ""
+        ? selectedRoot.path
+        : isAbsolute(String(input.cwd))
+            ? String(input.cwd)
+            : resolve(selectedRoot.path, String(input.cwd));
+    const cwd = safeResolvedPath(requestedCwd);
+    const containingRoot = workspaceRoots.find((root) => pathIsInside(cwd, root.path));
+    if (!containingRoot) {
+        throw new Error("Selected workspace is outside the MCP roots exposed by the client.");
+    }
+    return {
+        cwd,
+        rootsAvailable: true,
+        rootCount: workspaceRoots.length,
+    };
+}
+export function normalizeMcpWorkspaceRoots(roots) {
+    if (!Array.isArray(roots))
+        return [];
+    const normalized = [];
+    const seen = new Set();
+    for (const root of roots) {
+        const uri = typeof root?.uri === "string" ? root.uri : "";
+        if (!uri.startsWith("file:"))
+            continue;
+        try {
+            const path = safeResolvedPath(fileURLToPath(uri));
+            if (seen.has(path))
+                continue;
+            seen.add(path);
+            normalized.push({ path });
+        }
+        catch {
+            // Ignore non-local or malformed root URIs. Clients without usable roots fall back to cwd.
+        }
+    }
+    return normalized;
+}
+function safeResolvedPath(path) {
+    const resolved = resolve(String(path));
     try {
-      payload = JSON.parse(output);
-    } catch {
-      return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
-        durationMs,
-        stderr: truncateText(output),
-        fallbackMode: "metadata_only",
-      });
+        return realpathSync(resolved);
     }
-    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-      return scorerFailure("malformed_json", "External scorer stdout must be a JSON object.", {
-        durationMs,
-        fallbackMode: "metadata_only",
-      });
+    catch {
+        return resolved;
     }
-    const normalized = normalizeScorerOutput(payload);
-    if (normalized.sourceTokenScore === undefined && normalized.totalTokenScore === undefined) {
-      return scorerFailure("malformed_json", "External scorer JSON must include sourceTokenScore or totalTokenScore.", {
-        durationMs,
-        fallbackMode: "metadata_only",
-      });
-    }
-    return stripUndefined({
-      ok: true,
-      code: "success",
-      reason: "external_scorer_succeeded",
-      durationMs,
-      payload,
-      fallbackMode: "external_command",
-    });
-  } catch (error) {
-    return classifyScorerExecFailure(error, Date.now() - startedAt, scorerCommand);
-  }
 }
-
+function pathIsInside(candidate, root) {
+    const child = safeResolvedPath(candidate);
+    const parent = safeResolvedPath(root);
+    const childRelativeToParent = relative(parent, child);
+    return childRelativeToParent === "" || (!!childRelativeToParent && !childRelativeToParent.startsWith("..") && !isAbsolute(childRelativeToParent));
+}
+export function resolveScorePreviewCommand(input = {}) {
+    const explicit = input.scorePreviewCommand ?? process.env.GITTENSOR_SCORE_PREVIEW_CMD;
+    if (typeof explicit === "string" && explicit.trim())
+        return explicit.trim();
+    return undefined;
+}
+export function referenceScorePreviewExample(kind = "metadata") {
+    const script = kind === "gittensor" ? "gittensor-score-preview.py" : "gittensor-score-preview.mjs";
+    const interpreter = kind === "gittensor" ? "python3" : "node";
+    return `${interpreter} ./node_modules/@loopover/mcp/scripts/${script}`;
+}
+export function redactScorerCommand(command) {
+    const text = String(command ?? "").trim();
+    if (!text)
+        return text;
+    const parts = splitCommand(text);
+    const interpreter = parts[0]?.split(/[\\/]/).pop() ?? "command";
+    const script = parts.at(-1)?.split(/[\\/]/).pop();
+    if (script && /\.(mjs|js|cjs|py)$/i.test(script))
+        return `${interpreter} <scorer-script>/${script}`;
+    return "<configured-scorer-command>";
+}
+export function sanitizeLocalScorerStatus(status) {
+    if (!status || typeof status !== "object")
+        return status;
+    const bag = status;
+    return stripUndefined({
+        ...bag,
+        reason: bag.reason ? redactLocalPath(String(bag.reason)) : undefined,
+        stderr: bag.stderr ? redactLocalPath(String(bag.stderr)) : undefined,
+        scorerCommand: bag.scorerCommand ? redactScorerCommand(bag.scorerCommand) : undefined,
+    });
+}
+export function runExternalScorePreview(metadata, scorerCommand) {
+    const timeoutMs = scorePreviewTimeoutMs();
+    if (!scorerCommand) {
+        return scorerFailure("missing_scorer_command", "GITTENSOR_SCORE_PREVIEW_CMD is not configured.");
+    }
+    const parts = splitCommand(scorerCommand);
+    const command = parts[0];
+    const args = parts.slice(1);
+    if (!command) {
+        return scorerFailure("empty_scorer_command", "GITTENSOR_SCORE_PREVIEW_CMD is empty.");
+    }
+    const startedAt = Date.now();
+    try {
+        const output = execFileSync(command, args, {
+            input: JSON.stringify({
+                ...metadata,
+                repoRoot: metadata.repoRoot ?? metadata.cwd,
+                gittensorRoot: process.env.GITTENSOR_ROOT,
+            }),
+            encoding: "utf8",
+            timeout: timeoutMs,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        const durationMs = Date.now() - startedAt;
+        let payload;
+        try {
+            payload = JSON.parse(output);
+        }
+        catch {
+            return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
+                durationMs,
+                stderr: truncateText(output),
+                fallbackMode: "metadata_only",
+            });
+        }
+        if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+            return scorerFailure("malformed_json", "External scorer stdout must be a JSON object.", {
+                durationMs,
+                fallbackMode: "metadata_only",
+            });
+        }
+        const normalized = normalizeScorerOutput(payload);
+        if (normalized.sourceTokenScore === undefined && normalized.totalTokenScore === undefined) {
+            return scorerFailure("malformed_json", "External scorer JSON must include sourceTokenScore or totalTokenScore.", {
+                durationMs,
+                fallbackMode: "metadata_only",
+            });
+        }
+        return stripUndefined({
+            ok: true,
+            code: "success",
+            reason: "external_scorer_succeeded",
+            durationMs,
+            payload,
+            fallbackMode: "external_command",
+        });
+    }
+    catch (error) {
+        return classifyScorerExecFailure(error, Date.now() - startedAt, scorerCommand);
+    }
+}
 export function setupGuidanceForLocalScorer(status) {
-  if (status.ok) return [];
-  const safeStatus = sanitizeLocalScorerStatus(status);
-  const code = safeStatus.code ?? inferScorerCode(safeStatus.reason);
-  const guidance = [
-    "LoopOver used metadata-only analysis because no external scorer succeeded.",
-  ];
-  switch (code) {
-    case "missing_scorer_command":
-      guidance.push(`Set GITTENSOR_SCORE_PREVIEW_CMD, for example: export GITTENSOR_SCORE_PREVIEW_CMD="${referenceScorePreviewExample("metadata")}"`);
-      guidance.push(`For tree-sitter scoring with a local gittensor checkout: export GITTENSOR_ROOT=<local-gittensor-checkout> && export GITTENSOR_SCORE_PREVIEW_CMD="${referenceScorePreviewExample("gittensor")}"`);
-      break;
-    case "empty_scorer_command":
-      guidance.push("GITTENSOR_SCORE_PREVIEW_CMD is set but empty; provide a command that reads branch metadata JSON from stdin.");
-      break;
-    case "timeout":
-      guidance.push(`External scorer exceeded ${scorePreviewTimeoutMs()}ms; simplify the scorer or raise GITTENSOR_SCORE_PREVIEW_TIMEOUT_MS.`);
-      break;
-    case "malformed_json":
-      guidance.push("External scorer must print one JSON object with sourceTokenScore/totalTokenScore fields to stdout.");
-      if (safeStatus.stderr) guidance.push(`Last scorer stdout snippet: ${truncateText(safeStatus.stderr, 160)}`);
-      break;
-    case "non_zero_exit":
-      guidance.push("External scorer exited with a non-zero status; inspect stderr and run loopover-mcp doctor.");
-      if (safeStatus.stderr) guidance.push(`Scorer stderr: ${truncateText(safeStatus.stderr, 160)}`);
-      if (typeof safeStatus.exitCode === "number") guidance.push(`Exit code: ${safeStatus.exitCode}`);
-      break;
-    default:
-      guidance.push("Set GITTENSOR_SCORE_PREVIEW_CMD to a command that reads branch metadata JSON from stdin and emits scoring metrics JSON.");
-      if (safeStatus.reason) guidance.push(`Last scorer error: ${safeStatus.reason}`);
-      break;
-  }
-  guidance.push("Local scorer output stays on your machine; LoopOver never uploads source contents.");
-  return guidance;
-}
-
-export function probeLocalScorer(scorerCommand = resolveScorePreviewCommand()) {
-  return sanitizeLocalScorerStatus(
-    runExternalScorePreview(
-    {
-      repoFullName: "JSONbored/loopover",
-      branchName: "doctor-probe",
-      changedFiles: [{ path: "src/example.ts", additions: 12, deletions: 2, status: "modified" }],
-      repoRoot: process.cwd(),
-    },
-      scorerCommand,
-    ),
-  );
-}
-
-function gitOutput(cwd, args) {
-  try {
-    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
-  } catch {
-    return "";
-  }
-}
-
-export function gitLines(cwd, args) {
-  return gitOutput(cwd, args)
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-}
-
-function collectChangedFiles(cwd, baseRef) {
-  // Read both halves with `-z`: the human format quotes non-ASCII/control-char paths, so a quoted
-  // name-status key would never match the verbatim numstat key and the file's stats would be lost.
-  const numstat = new Map(parseNumstat(cwd, baseRef).map((entry) => [entry.path, entry]));
-  return parseNameStatus(cwd, baseRef).map((entry) => {
-    const stats = numstat.get(entry.path) ?? { additions: 0, deletions: 0, binary: false };
-    return stripUndefined({
-      path: entry.path,
-      previousPath: entry.previousPath,
-      additions: stats.additions,
-      deletions: stats.deletions,
-      status: statusFromCode(entry.code),
-      binary: stats.binary,
-    });
-  });
-}
-
-function parseNameStatus(cwd, baseRef) {
-  // `-z`: the status code is its own field and paths are verbatim; a rename is followed by the old
-  // then the new path, any other status by a single path.
-  const records = gitOutput(cwd, ["diff", "--name-status", "-M", "-z", baseRef, "--"]).split("\0");
-  const entries = [];
-  for (let index = 0; index < records.length; index += 1) {
-    const code = records[index];
-    if (!code) continue;
-    const isRename = code.startsWith("R");
-    const previousPath = isRename ? records[index + 1] : undefined;
-    const path = records[index + (isRename ? 2 : 1)];
-    index += isRename ? 2 : 1;
-    entries.push({ code, path, previousPath });
-  }
-  return entries;
-}
-
-function parseNumstat(cwd, baseRef) {
-  // `-z`: paths are verbatim and a rename emits old/new as separate fields, not the lossy
-  // "{a => b}" / "a => b" human form that left cross-directory renames keyed by an unmatchable string.
-  const records = gitOutput(cwd, ["diff", "--numstat", "-M", "-z", baseRef, "--"]).split("\0");
-  const entries = [];
-  for (let index = 0; index < records.length; index += 1) {
-    const stat = records[index];
-    if (!stat) continue;
-    const [added, deleted, inlinePath] = splitNumstatStat(stat);
-    // An empty inline path marks a rename: the new path is the second of the two following fields.
-    let path = inlinePath;
-    if (inlinePath === "") {
-      path = records[index + 2];
-      index += 2;
+    if (status.ok)
+        return [];
+    const safeStatus = sanitizeLocalScorerStatus(status);
+    const code = safeStatus.code ?? inferScorerCode(safeStatus.reason);
+    const guidance = [
+        "LoopOver used metadata-only analysis because no external scorer succeeded.",
+    ];
+    switch (code) {
+        case "missing_scorer_command":
+            guidance.push(`Set GITTENSOR_SCORE_PREVIEW_CMD, for example: export GITTENSOR_SCORE_PREVIEW_CMD="${referenceScorePreviewExample("metadata")}"`);
+            guidance.push(`For tree-sitter scoring with a local gittensor checkout: export GITTENSOR_ROOT=<local-gittensor-checkout> && export GITTENSOR_SCORE_PREVIEW_CMD="${referenceScorePreviewExample("gittensor")}"`);
+            break;
+        case "empty_scorer_command":
+            guidance.push("GITTENSOR_SCORE_PREVIEW_CMD is set but empty; provide a command that reads branch metadata JSON from stdin.");
+            break;
+        case "timeout":
+            guidance.push(`External scorer exceeded ${scorePreviewTimeoutMs()}ms; simplify the scorer or raise GITTENSOR_SCORE_PREVIEW_TIMEOUT_MS.`);
+            break;
+        case "malformed_json":
+            guidance.push("External scorer must print one JSON object with sourceTokenScore/totalTokenScore fields to stdout.");
+            if (safeStatus.stderr)
+                guidance.push(`Last scorer stdout snippet: ${truncateText(safeStatus.stderr, 160)}`);
+            break;
+        case "non_zero_exit":
+            guidance.push("External scorer exited with a non-zero status; inspect stderr and run loopover-mcp doctor.");
+            if (safeStatus.stderr)
+                guidance.push(`Scorer stderr: ${truncateText(safeStatus.stderr, 160)}`);
+            if (typeof safeStatus.exitCode === "number")
+                guidance.push(`Exit code: ${safeStatus.exitCode}`);
+            break;
+        default:
+            guidance.push("Set GITTENSOR_SCORE_PREVIEW_CMD to a command that reads branch metadata JSON from stdin and emits scoring metrics JSON.");
+            if (safeStatus.reason)
+                guidance.push(`Last scorer error: ${safeStatus.reason}`);
+            break;
     }
-    const binary = added === "-";
-    entries.push({ path, additions: binary ? 0 : Number(added), deletions: binary ? 0 : Number(deleted), binary });
-  }
-  return entries;
+    guidance.push("Local scorer output stays on your machine; LoopOver never uploads source contents.");
+    return guidance;
 }
-
+export function probeLocalScorer(scorerCommand = resolveScorePreviewCommand()) {
+    return sanitizeLocalScorerStatus(runExternalScorePreview({
+        repoFullName: "JSONbored/loopover",
+        branchName: "doctor-probe",
+        changedFiles: [{ path: "src/example.ts", additions: 12, deletions: 2, status: "modified" }],
+        repoRoot: process.cwd(),
+    }, scorerCommand));
+}
+function gitOutput(cwd, args) {
+    try {
+        return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
+    }
+    catch {
+        return "";
+    }
+}
+export function gitLines(cwd, args) {
+    return gitOutput(cwd, args)
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+}
+function collectChangedFiles(cwd, baseRef) {
+    // Read both halves with `-z`: the human format quotes non-ASCII/control-char paths, so a quoted
+    // name-status key would never match the verbatim numstat key and the file's stats would be lost.
+    const numstat = new Map(parseNumstat(cwd, baseRef).map((entry) => [entry.path, entry]));
+    return parseNameStatus(cwd, baseRef).map((entry) => {
+        const stats = numstat.get(entry.path) ?? { additions: 0, deletions: 0, binary: false };
+        return stripUndefined({
+            path: entry.path,
+            previousPath: entry.previousPath,
+            additions: stats.additions,
+            deletions: stats.deletions,
+            status: statusFromCode(entry.code),
+            binary: stats.binary,
+        });
+    });
+}
+function parseNameStatus(cwd, baseRef) {
+    // `-z`: the status code is its own field and paths are verbatim; a rename is followed by the old
+    // then the new path, any other status by a single path.
+    const records = gitOutput(cwd, ["diff", "--name-status", "-M", "-z", baseRef, "--"]).split("\0");
+    const entries = [];
+    for (let index = 0; index < records.length; index += 1) {
+        const code = records[index];
+        if (!code)
+            continue;
+        const isRename = code.startsWith("R");
+        const previousPath = isRename ? records[index + 1] : undefined;
+        const path = records[index + (isRename ? 2 : 1)];
+        index += isRename ? 2 : 1;
+        entries.push({ code, path: path, previousPath });
+    }
+    return entries;
+}
+function parseNumstat(cwd, baseRef) {
+    // `-z`: paths are verbatim and a rename emits old/new as separate fields, not the lossy
+    // "{a => b}" / "a => b" human form that left cross-directory renames keyed by an unmatchable string.
+    const records = gitOutput(cwd, ["diff", "--numstat", "-M", "-z", baseRef, "--"]).split("\0");
+    const entries = [];
+    for (let index = 0; index < records.length; index += 1) {
+        const stat = records[index];
+        if (!stat)
+            continue;
+        const [added, deleted, inlinePath] = splitNumstatStat(stat);
+        // An empty inline path marks a rename: the new path is the second of the two following fields.
+        let path = inlinePath;
+        if (inlinePath === "") {
+            path = records[index + 2];
+            index += 2;
+        }
+        const binary = added === "-";
+        entries.push({ path: path, additions: binary ? 0 : Number(added), deletions: binary ? 0 : Number(deleted), binary });
+    }
+    return entries;
+}
 function splitNumstatStat(stat) {
-  // "<added>\t<deleted>\t<path?>" -- keep the path slice intact even if it contains tabs.
-  const firstTab = stat.indexOf("\t");
-  const secondTab = stat.indexOf("\t", firstTab + 1);
-  return [stat.slice(0, firstTab), stat.slice(firstTab + 1, secondTab), stat.slice(secondTab + 1)];
+    // "<added>\t<deleted>\t<path?>" -- keep the path slice intact even if it contains tabs.
+    const firstTab = stat.indexOf("\t");
+    const secondTab = stat.indexOf("\t", firstTab + 1);
+    return [stat.slice(0, firstTab), stat.slice(firstTab + 1, secondTab), stat.slice(secondTab + 1)];
 }
-
 function collectCommitMessages(cwd, baseRef) {
-  const rangeMessages = gitLines(cwd, ["log", "--pretty=%B%x1e", `${baseRef}..HEAD`]).join("\n");
-  const messages = rangeMessages
-    .split("\u001e")
-    .map((message) => message.trim())
-    .filter(Boolean);
-  if (messages.length > 0) return messages.slice(0, 30);
-  const last = gitLines(cwd, ["log", "-1", "--pretty=%B"]).join("\n").trim();
-  return last ? [last] : [];
+    const rangeMessages = gitLines(cwd, ["log", "--pretty=%B%x1e", `${baseRef}..HEAD`]).join("\n");
+    const messages = rangeMessages
+        .split("\u001e")
+        .map((message) => message.trim())
+        .filter(Boolean);
+    if (messages.length > 0)
+        return messages.slice(0, 30);
+    const last = gitLines(cwd, ["log", "-1", "--pretty=%B"]).join("\n").trim();
+    return last ? [last] : [];
 }
-
 function defaultBaseRef(cwd) {
-  const originHead = gitLines(cwd, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"])[0];
-  if (originHead) return originHead;
-  if (gitLines(cwd, ["rev-parse", "--verify", "origin/main"]).length > 0) return "origin/main";
-  if (gitLines(cwd, ["rev-parse", "--verify", "origin/master"]).length > 0) return "origin/master";
-  return "HEAD";
+    const originHead = gitLines(cwd, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"])[0];
+    if (originHead)
+        return originHead;
+    if (gitLines(cwd, ["rev-parse", "--verify", "origin/main"]).length > 0)
+        return "origin/main";
+    if (gitLines(cwd, ["rev-parse", "--verify", "origin/master"]).length > 0)
+        return "origin/master";
+    return "HEAD";
 }
-
 function collectRemoteTrackingSha(cwd, baseRef) {
-  const match = String(baseRef ?? "").replace(/^refs\/remotes\//, "").match(/^origin\/(.+)$/);
-  const branch = match?.[1];
-  if (!branch) return undefined;
-  const remoteRow = gitLines(cwd, ["ls-remote", "--heads", "origin", branch])[0];
-  return remoteRow?.split(/\s+/)[0];
+    const match = String(baseRef ?? "").replace(/^refs\/remotes\//, "").match(/^origin\/(.+)$/);
+    const branch = match?.[1];
+    if (!branch)
+        return undefined;
+    const remoteRow = gitLines(cwd, ["ls-remote", "--heads", "origin", branch])[0];
+    return remoteRow?.split(/\s+/)[0];
 }
-
 function normalizeScorerOutput(payload) {
-  return stripUndefined({
-    mode: "external_command",
-    activeModel: stringValue(payload.activeModel ?? payload.active_model),
-    sourceTokenScore: numberValue(payload.sourceTokenScore ?? payload.source_token_score ?? payload.source?.tokenScore),
-    totalTokenScore: numberValue(payload.totalTokenScore ?? payload.total_token_score ?? payload.total?.tokenScore),
-    sourceLines: numberValue(payload.sourceLines ?? payload.source_lines ?? payload.source?.lines),
-    testTokenScore: numberValue(payload.testTokenScore ?? payload.test_token_score ?? payload.tests?.tokenScore),
-    nonCodeTokenScore: numberValue(payload.nonCodeTokenScore ?? payload.non_code_token_score ?? payload.nonCode?.tokenScore),
-    warnings: Array.isArray(payload.warnings) ? payload.warnings.map(String) : undefined,
-  });
+    const source = payload.source;
+    const total = payload.total;
+    const tests = payload.tests;
+    const nonCode = payload.nonCode;
+    return stripUndefined({
+        mode: "external_command",
+        activeModel: stringValue(payload.activeModel ?? payload.active_model),
+        sourceTokenScore: numberValue(payload.sourceTokenScore ?? payload.source_token_score ?? source?.tokenScore),
+        totalTokenScore: numberValue(payload.totalTokenScore ?? payload.total_token_score ?? total?.tokenScore),
+        sourceLines: numberValue(payload.sourceLines ?? payload.source_lines ?? source?.lines),
+        testTokenScore: numberValue(payload.testTokenScore ?? payload.test_token_score ?? tests?.tokenScore),
+        nonCodeTokenScore: numberValue(payload.nonCodeTokenScore ?? payload.non_code_token_score ?? nonCode?.tokenScore),
+        warnings: Array.isArray(payload.warnings) ? payload.warnings.map(String) : undefined,
+    });
 }
-
 function metadataOnlyScorer(status) {
-  return {
-    mode: "metadata_only",
-    warnings: [status.reason ?? status.code ?? "external_scorer_unavailable"],
-  };
+    return {
+        mode: "metadata_only",
+        warnings: [status.reason ?? status.code ?? "external_scorer_unavailable"],
+    };
 }
-
 function scorerFailure(code, reason, extra = {}) {
-  return stripUndefined({
-    ok: false,
-    code,
-    reason,
-    fallbackMode: "metadata_only",
-    ...extra,
-  });
+    return stripUndefined({
+        ok: false,
+        code,
+        reason,
+        fallbackMode: "metadata_only",
+        ...extra,
+    });
 }
-
 function classifyScorerExecFailure(error, durationMs, scorerCommand) {
-  const execError = error && typeof error === "object" ? error : undefined;
-  const stdout = String(execError?.stdout ?? execError?.output?.[1] ?? "").trim();
-  const stderr = truncateText(execError?.stderr ?? execError?.output?.[2] ?? "");
-  const exitCode = typeof execError?.status === "number" ? execError.status : undefined;
-  if (stdout && !looksLikeScorerJson(stdout)) {
-    return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
-      durationMs,
-      stderr: truncateText(stdout),
-      scorerCommand: redactScorerCommand(scorerCommand),
-      fallbackMode: "metadata_only",
-    });
-  }
-  if (execError?.code === "ETIMEDOUT" || (execError?.killed && execError?.signal === "SIGTERM")) {
-    return scorerFailure("timeout", `External scorer timed out after ${scorePreviewTimeoutMs()}ms.`, { durationMs, stderr, scorerCommand: redactScorerCommand(scorerCommand) });
-  }
-  if (typeof exitCode === "number" && exitCode !== 0) {
-    return scorerFailure("non_zero_exit", `External scorer exited with status ${exitCode}.`, { durationMs, stderr, exitCode, scorerCommand: redactScorerCommand(scorerCommand) });
-  }
-  const message = error instanceof Error ? error.message : "external_scorer_failed";
-  if (/JSON/i.test(message)) {
-    return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", { durationMs, stderr, scorerCommand: redactScorerCommand(scorerCommand) });
-  }
-  if (stderr && !looksLikeScorerJson(stderr)) {
-    return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
-      durationMs,
-      stderr: truncateText(stderr),
-      scorerCommand: redactScorerCommand(scorerCommand),
-      fallbackMode: "metadata_only",
-    });
-  }
-  return scorerFailure("scorer_failed", redactLocalPath(message), { durationMs, stderr, exitCode, scorerCommand: redactScorerCommand(scorerCommand) });
+    const execError = error && typeof error === "object" ? error : undefined;
+    const stdout = String(execError?.stdout ?? execError?.output?.[1] ?? "").trim();
+    const stderr = truncateText(execError?.stderr ?? execError?.output?.[2] ?? "");
+    const exitCode = typeof execError?.status === "number" ? execError.status : undefined;
+    if (stdout && !looksLikeScorerJson(stdout)) {
+        return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
+            durationMs,
+            stderr: truncateText(stdout),
+            scorerCommand: redactScorerCommand(scorerCommand),
+            fallbackMode: "metadata_only",
+        });
+    }
+    if (execError?.code === "ETIMEDOUT" || (execError?.killed && execError?.signal === "SIGTERM")) {
+        return scorerFailure("timeout", `External scorer timed out after ${scorePreviewTimeoutMs()}ms.`, { durationMs, stderr, scorerCommand: redactScorerCommand(scorerCommand) });
+    }
+    if (typeof exitCode === "number" && exitCode !== 0) {
+        return scorerFailure("non_zero_exit", `External scorer exited with status ${exitCode}.`, { durationMs, stderr, exitCode, scorerCommand: redactScorerCommand(scorerCommand) });
+    }
+    const message = error instanceof Error ? error.message : "external_scorer_failed";
+    if (/JSON/i.test(message)) {
+        return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", { durationMs, stderr, scorerCommand: redactScorerCommand(scorerCommand) });
+    }
+    if (stderr && !looksLikeScorerJson(stderr)) {
+        return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
+            durationMs,
+            stderr: truncateText(stderr),
+            scorerCommand: redactScorerCommand(scorerCommand),
+            fallbackMode: "metadata_only",
+        });
+    }
+    return scorerFailure("scorer_failed", redactLocalPath(message), { durationMs, stderr, exitCode, scorerCommand: redactScorerCommand(scorerCommand) });
 }
-
 function looksLikeScorerJson(output) {
-  try {
-    const payload = JSON.parse(output);
-    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
-    const normalized = normalizeScorerOutput(payload);
-    return normalized.sourceTokenScore !== undefined || normalized.totalTokenScore !== undefined;
-  } catch {
-    return false;
-  }
+    try {
+        const payload = JSON.parse(output);
+        if (!payload || typeof payload !== "object" || Array.isArray(payload))
+            return false;
+        const normalized = normalizeScorerOutput(payload);
+        return normalized.sourceTokenScore !== undefined || normalized.totalTokenScore !== undefined;
+    }
+    catch {
+        return false;
+    }
 }
-
 function inferScorerCode(reason) {
-  const text = String(reason ?? "");
-  if (text.includes("missing_scorer_command")) return "missing_scorer_command";
-  if (text.includes("empty_scorer_command")) return "empty_scorer_command";
-  if (/timed out|ETIMEDOUT/i.test(text)) return "timeout";
-  if (/JSON/i.test(text)) return "malformed_json";
-  if (/status \d+/i.test(text)) return "non_zero_exit";
-  return "scorer_failed";
+    const text = String(reason ?? "");
+    if (text.includes("missing_scorer_command"))
+        return "missing_scorer_command";
+    if (text.includes("empty_scorer_command"))
+        return "empty_scorer_command";
+    if (/timed out|ETIMEDOUT/i.test(text))
+        return "timeout";
+    if (/JSON/i.test(text))
+        return "malformed_json";
+    if (/status \d+/i.test(text))
+        return "non_zero_exit";
+    return "scorer_failed";
 }
-
 function scorePreviewTimeoutMs() {
-  const parsed = Number(process.env.GITTENSOR_SCORE_PREVIEW_TIMEOUT_MS ?? 15000);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
+    const parsed = Number(process.env.GITTENSOR_SCORE_PREVIEW_TIMEOUT_MS ?? 15000);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
 }
-
 function truncateText(value, maxLength = 240) {
-  const text = String(value ?? "").trim();
-  if (!text) return undefined;
-  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
+    const text = String(value ?? "").trim();
+    if (!text)
+        return undefined;
+    return text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
 }
-
 function splitCommand(command) {
-  return String(command).match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? [];
+    return String(command).match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? [];
 }
-
 function assertSourceUploadDisabled() {
-  if (/^(1|true|yes)$/i.test(process.env.LOOPOVER_UPLOAD_SOURCE ?? "false")) {
-    throw new Error("LOOPOVER_UPLOAD_SOURCE=true is not supported in v1; local MCP sends metadata only.");
-  }
+    if (/^(1|true|yes)$/i.test(process.env.LOOPOVER_UPLOAD_SOURCE ?? "false")) {
+        throw new Error("LOOPOVER_UPLOAD_SOURCE=true is not supported in v1; local MCP sends metadata only.");
+    }
 }
-
 // Word-boundary the closing keywords (as the server-side extractors in src/db/repositories.ts and
 // src/signals/engine.ts already do) so a keyword embedded in a longer word does not spuriously link an
 // issue: without \b, `hotfix 5` / `prefixes 12` matched the `fix`/`fixes` substring and captured the
 // trailing number. The bare `#` branch stays boundary-free so `#123` still matches anywhere.
 export function extractLinkedIssues(text) {
-  const issues = [];
-  for (const match of String(text).matchAll(/(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)|#)\s*#?(\d+)/gi)) issues.push(Number(match[1]));
-  return issues.filter((issue) => Number.isInteger(issue) && issue > 0);
+    const issues = [];
+    for (const match of String(text).matchAll(/(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)|#)\s*#?(\d+)/gi))
+        issues.push(Number(match[1]));
+    return issues.filter((issue) => Number.isInteger(issue) && issue > 0);
 }
-
 function statusFromCode(code) {
-  if (code.startsWith("A")) return "added";
-  if (code.startsWith("M")) return "modified";
-  if (code.startsWith("D")) return "deleted";
-  if (code.startsWith("R")) return "renamed";
-  if (code.startsWith("C")) return "copied";
-  return "unknown";
+    if (code.startsWith("A"))
+        return "added";
+    if (code.startsWith("M"))
+        return "modified";
+    if (code.startsWith("D"))
+        return "deleted";
+    if (code.startsWith("R"))
+        return "renamed";
+    if (code.startsWith("C"))
+        return "copied";
+    return "unknown";
 }
-
 function titleFromBranch(branchName) {
-  return String(branchName ?? "")
-    .replace(/^[-/_.\w]+\/(?=[^/]+$)/, "")
-    .replace(/[-_]+/g, " ")
-    .trim();
+    return String(branchName ?? "")
+        .replace(/^[-/_.\w]+\/(?=[^/]+$)/, "")
+        .replace(/[-_]+/g, " ")
+        .trim();
 }
-
 function firstCommitTitle(messages) {
-  return messages.find((message) => message.trim().length > 0)?.split("\n")[0]?.trim();
+    return messages.find((message) => message.trim().length > 0)?.split("\n")[0]?.trim();
 }
-
 function numberValue(value) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : undefined;
+    const number = Number(value);
+    return Number.isFinite(number) ? number : undefined;
 }
-
 function stringValue(value) {
-  return typeof value === "string" && value.trim() ? value : undefined;
+    return typeof value === "string" && value.trim() ? value : undefined;
 }
-
 function stripUndefined(value) {
-  if (Array.isArray(value)) return value.map(stripUndefined);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined).map(([key, entry]) => [key, stripUndefined(entry)]));
+    if (Array.isArray(value))
+        return value.map(stripUndefined);
+    if (!value || typeof value !== "object")
+        return value;
+    return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined).map(([key, entry]) => [key, stripUndefined(entry)]));
 }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9jYWwtYnJhbmNoLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsibG9jYWwtYnJhbmNoLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sRUFBRSxZQUFZLEVBQUUsTUFBTSxvQkFBb0IsQ0FBQztBQUNsRCxPQUFPLEVBQUUsWUFBWSxFQUFFLE1BQU0sU0FBUyxDQUFDO0FBQ3ZDLE9BQU8sRUFBRSxVQUFVLEVBQVEsUUFBUSxFQUFFLE9BQU8sRUFBRSxNQUFNLFdBQVcsQ0FBQztBQUNoRSxPQUFPLEVBQUUsYUFBYSxFQUFFLE1BQU0sVUFBVSxDQUFDO0FBQ3pDLE9BQU8sRUFBRSxVQUFVLEVBQUUsVUFBVSxJQUFJLFVBQVUsRUFBRSxNQUFNLHdDQUF3QyxDQUFDO0FBQzlGLE9BQU8sRUFBRSxlQUFlLEVBQUUsTUFBTSx3QkFBd0IsQ0FBQztBQUV6RCxPQUFPLEVBQUUsVUFBVSxFQUFFLFVBQVUsRUFBRSxDQUFDO0FBQ2xDLE9BQU8sRUFBRSxlQUFlLEVBQUUsQ0FBQztBQW1EM0IsU0FBUyxvQkFBb0IsQ0FBQyxLQUFhO0lBQ3pDLElBQUksR0FBRyxHQUFHLEtBQUssQ0FBQyxNQUFNLENBQUM7SUFDdkIsT0FBTyxHQUFHLEdBQUcsQ0FBQyxJQUFJLEtBQUssQ0FBQyxVQUFVLENBQUMsR0FBRyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUU7UUFBRSxHQUFHLElBQUksQ0FBQyxDQUFDO0lBQzdELE9BQU8sR0FBRyxLQUFLLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsR0FBRyxDQUFDLENBQUM7QUFDNUQsQ0FBQztBQUVELE1BQU0sVUFBVSxjQUFjLENBQUMsU0FBa0I7SUFDL0MsTUFBTSxPQUFPLEdBQUcsb0JBQW9CLENBQUMsTUFBTSxDQUFDLFNBQVMsSUFBSSxFQUFFLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDO0lBQ3JFLE1BQU0sUUFBUSxHQUFHO1FBQ2YsNENBQTRDO1FBQzVDLG1EQUFtRDtRQUNuRCxxREFBcUQ7S0FDdEQsQ0FBQztJQUNGLEtBQUssTUFBTSxPQUFPLElBQUksUUFBUSxFQUFFLENBQUM7UUFDL0IsTUFBTSxLQUFLLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUNyQyxJQUFJLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLEtBQUssQ0FBQyxDQUFDLENBQUM7WUFBRSxPQUFPLEdBQUcsS0FBSyxDQUFDLENBQUMsQ0FBQyxJQUFJLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsUUFBUSxFQUFFLEVBQUUsQ0FBQyxFQUFFLENBQUM7SUFDckYsQ0FBQztJQUNELE9BQU8sU0FBUyxDQUFDO0FBQ25CLENBQUM7QUFFRCxNQUFNLFVBQVUsZ0JBQWdCLENBQUMsR0FBVyxFQUFFLE9BQTJCLEVBQUUsY0FBdUI7SUFDaEcsTUFBTSxRQUFRLEdBQUcsMEJBQTBCLENBQUMsRUFBRSxHQUFHLEVBQUUsT0FBTyxFQUFFLEtBQUssRUFBRSxPQUFPLEVBQUUsY0FBYyxFQUFFLENBQUMsQ0FBQztJQUM5RixPQUFPO1FBQ0wsS0FBSyxFQUFFLFFBQVEsQ0FBQyxLQUFLLElBQUksc0JBQXNCO1FBQy9DLGFBQWEsRUFBRSxRQUFRLENBQUMsY0FBYyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQyxJQUFJLEVBQUU7UUFDMUQsWUFBWSxFQUFFLFFBQVEsQ0FBQyxZQUFZLENBQUMsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDO1FBQzVELGdCQUFnQixFQUFFLFFBQVEsQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLENBQUMsR0FBRyxFQUFFLElBQUksRUFBRSxFQUFFLENBQUMsR0FBRyxHQUFHLENBQUMsSUFBSSxDQUFDLFNBQVMsSUFBSSxDQUFDLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxTQUFTLElBQUksQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDO1FBQ3JILFNBQVMsRUFBRSxRQUFRLENBQUMsWUFBWSxDQUFDLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUM7UUFDNUUsU0FBUyxFQUFFLFFBQVEsQ0FBQyxZQUFZLENBQUMsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsTUFBTSxDQUFDLFVBQVUsQ0FBQztLQUM3RSxDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSwwQkFBMEIsQ0FBQyxLQUF1QjtJQUNoRSwwQkFBMEIsRUFBRSxDQUFDO0lBQzdCLE1BQU0sU0FBUyxHQUFHLG1CQUFtQixDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQzdDLE1BQU0sR0FBRyxHQUFHLFNBQVMsQ0FBQyxHQUFHLENBQUM7SUFDMUIsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLE9BQU8sSUFBSSxjQUFjLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDckQsTUFBTSxTQUFTLEdBQUcsUUFBUSxDQUFDLEdBQUcsRUFBRSxDQUFDLFFBQVEsRUFBRSxPQUFPLEVBQUUsbUJBQW1CLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUNuRixNQUFNLFlBQVksR0FBRyxLQUFLLENBQUMsWUFBWSxJQUFJLGNBQWMsQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUNyRSxJQUFJLENBQUMsWUFBWTtRQUFFLE1BQU0sSUFBSSxLQUFLLENBQUMsdUVBQXVFLENBQUMsQ0FBQztJQUM1RyxNQUFNLFVBQVUsR0FBRyxLQUFLLENBQUMsVUFBVSxJQUFJLFFBQVEsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxRQUFRLEVBQUUsZ0JBQWdCLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLGNBQWMsQ0FBQztJQUN4RyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxJQUFJLFFBQVEsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxXQUFXLEVBQUUsY0FBYyxFQUFFLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksVUFBVSxDQUFDO0lBQ3ZHLE1BQU0sT0FBTyxHQUFHLFFBQVEsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxXQUFXLEVBQUUsVUFBVSxFQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDckUsTUFBTSxPQUFPLEdBQUcsUUFBUSxDQUFDLEdBQUcsRUFBRSxDQUFDLFdBQVcsRUFBRSxVQUFVLEVBQUUsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNwRSxNQUFNLFlBQVksR0FBRyxRQUFRLENBQUMsR0FBRyxFQUFFLENBQUMsWUFBWSxFQUFFLE9BQU8sRUFBRSxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ3ZFLE1BQU0saUJBQWlCLEdBQUcsd0JBQXdCLENBQUMsR0FBRyxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ2pFLE1BQU0sWUFBWSxHQUFHLG1CQUFtQixDQUFDLEdBQUcsRUFBRSxPQUFPLENBQUMsQ0FBQztJQUN2RCxNQUFNLGtCQUFrQixHQUFHLEtBQUssQ0FBQyxrQkFBa0IsSUFBSSx5QkFBeUIsQ0FBQyxHQUFHLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFDL0YsTUFBTSxhQUFhLEdBQUcsS0FBSyxDQUFDLGFBQWEsSUFBSSxvQkFBb0IsQ0FBQyxHQUFHLEVBQUUsT0FBTyxFQUFFLFlBQVksQ0FBQyxDQUFDO0lBQzlGLE1BQU0sY0FBYyxHQUFHLEtBQUssQ0FBQyxjQUFjLElBQUkscUJBQXFCLENBQUMsR0FBRyxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBQ25GLE1BQU0sS0FBSyxHQUFHLEtBQUssQ0FBQyxLQUFLLElBQUksZUFBZSxDQUFDLFVBQVUsQ0FBQyxJQUFJLGdCQUFnQixDQUFDLGNBQWMsQ0FBQyxDQUFDO0lBQzdGLE1BQU0sWUFBWSxHQUFHLENBQUMsR0FBRyxJQUFJLEdBQUcsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsWUFBWSxJQUFJLEVBQUUsQ0FBQyxFQUFFLEdBQUcsbUJBQW1CLENBQUMsQ0FBQyxVQUFVLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxJQUFJLEVBQUUsR0FBRyxjQUFjLENBQUMsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUM1SyxDQUFDLElBQUksRUFBRSxLQUFLLEVBQUUsRUFBRSxDQUFDLElBQUksR0FBRyxLQUFLLENBQzlCLENBQUM7SUFDRixNQUFNLE9BQU8sR0FBRztRQUNkLEtBQUssRUFBRSxLQUFLLENBQUMsS0FBSztRQUNsQixZQUFZO1FBQ1osT0FBTztRQUNQLE9BQU87UUFDUCxVQUFVO1FBQ1YsT0FBTztRQUNQLE9BQU87UUFDUCxZQUFZO1FBQ1osaUJBQWlCO1FBQ2pCLGNBQWM7UUFDZCxZQUFZO1FBQ1osVUFBVSxFQUFFLEtBQUssQ0FBQyxVQUFVO1FBQzVCLFlBQVk7UUFDWixNQUFNLEVBQUUsS0FBSyxDQUFDLE1BQU07UUFDcEIsS0FBSztRQUNMLElBQUksRUFBRSxLQUFLLENBQUMsSUFBSTtRQUNoQixvQkFBb0IsRUFBRSxLQUFLLENBQUMsb0JBQW9CO1FBQ2hELG9CQUFvQixFQUFFLEtBQUssQ0FBQyxvQkFBb0I7UUFDaEQsZUFBZSxFQUFFLEtBQUssQ0FBQyxlQUFlO1FBQ3RDLDZCQUE2QixFQUFFLEtBQUssQ0FBQyw2QkFBNkI7UUFDbEUsb0JBQW9CLEVBQUUsS0FBSyxDQUFDLG9CQUFvQjtRQUNoRCxhQUFhLEVBQUUsS0FBSyxDQUFDLGFBQWE7UUFDbEMsa0JBQWtCO1FBQ2xCLGFBQWE7UUFDYixpQkFBaUIsRUFBRSxLQUFLLENBQUMsaUJBQWlCO0tBQzNDLENBQUM7SUFDRixPQUFPLGNBQWMsQ0FBQyxPQUFPLENBQUMsQ0FBQztBQUNqQyxDQUFDO0FBRUQsTUFBTSxVQUFVLHlCQUF5QixDQUFDLEdBQVcsRUFBRSxPQUFlO0lBQ3BFLE1BQU0sS0FBSyxHQUFHLFFBQVEsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxVQUFVLEVBQUUsU0FBUyxFQUFFLEdBQUcsT0FBTyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQzVFLE1BQU0sTUFBTSxHQUFHLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM3QixPQUFPLE1BQU0sQ0FBQyxRQUFRLENBQUMsTUFBTSxDQUFDLElBQUksTUFBTSxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQ3pFLENBQUM7QUFFRCxNQUFNLFVBQVUsb0JBQW9CLENBQUMsR0FBVyxFQUFFLE9BQWUsRUFBRSxlQUE4QixFQUFFO0lBQ2pHLE1BQU0sS0FBSyxHQUFHLEVBQUUsQ0FBQztJQUNqQixNQUFNLEtBQUssR0FBRyxZQUFZLENBQUMsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ3BFLElBQUksS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMseUJBQXlCLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUMvRCxLQUFLLENBQUMsSUFBSSxDQUFDLDRFQUE0RSxDQUFDLENBQUM7SUFDM0YsQ0FBQztJQUNELElBQUksS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsaUZBQWlGLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLEVBQUUsQ0FBQztRQUN2SCxLQUFLLENBQUMsSUFBSSxDQUFDLHVGQUF1RixDQUFDLENBQUM7SUFDdEcsQ0FBQztJQUNELE1BQU0sY0FBYyxHQUFHLHlCQUF5QixDQUFDLEdBQUcsRUFBRSxPQUFPLENBQUMsQ0FBQztJQUMvRCxJQUFJLGNBQWMsR0FBRyxDQUFDLEVBQUUsQ0FBQztRQUN2QixLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsY0FBYyw2QkFBNkIsT0FBTyw0REFBNEQsQ0FBQyxDQUFDO0lBQ2hJLENBQUM7SUFDRCxPQUFPLEtBQUssQ0FBQztBQUNmLENBQUM7QUFFRCxNQUFNLFVBQVUsMEJBQTBCLENBQUMsS0FBdUI7SUFDaEUsTUFBTSxTQUFTLEdBQUcsbUJBQW1CLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDN0MsTUFBTSxRQUFRLEdBQUcsMEJBQTBCLENBQUMsRUFBRSxHQUFHLEtBQUssRUFBRSxHQUFHLEVBQUUsU0FBUyxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUM7SUFDOUUsTUFBTSxjQUFjLEdBQUcsRUFBRSxHQUFHLFFBQVEsRUFBRSxRQUFRLEVBQUUsU0FBUyxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQ2hFLE1BQU0sYUFBYSxHQUFHLDBCQUEwQixDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3hELE1BQU0sZUFBZSxHQUFHLHVCQUF1QixDQUFDLGNBQWMsRUFBRSxhQUFhLENBQUMsQ0FBQztJQUMvRSxNQUFNLFdBQVcsR0FBRyxlQUFlLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxxQkFBcUIsQ0FBQyxlQUFlLENBQUMsT0FBd0IsQ0FBQyxDQUFDLENBQUMsQ0FBQyxrQkFBa0IsQ0FBQyxlQUFlLENBQUMsQ0FBQztJQUMvSSxPQUFPO1FBQ0wsR0FBRyxRQUFRO1FBQ1gsV0FBVztRQUNYLGlCQUFpQixFQUFFLHlCQUF5QixDQUFDLGVBQWUsQ0FBQztLQUM5RCxDQUFDO0FBQ0osQ0FBQztBQUVELE1BQU0sVUFBVSxtQkFBbUIsQ0FBQyxRQUEwQixFQUFFO0lBQzlELE1BQU0sY0FBYyxHQUFHLDBCQUEwQixDQUFDLEtBQUssQ0FBQyxjQUFjLENBQUMsQ0FBQztJQUN4RSxJQUFJLGNBQWMsQ0FBQyxNQUFNLEtBQUssQ0FBQyxFQUFFLENBQUM7UUFDaEMsT0FBTztZQUNMLEdBQUcsRUFBRSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsR0FBRyxJQUFJLE9BQU8sQ0FBQyxHQUFHLEVBQUUsQ0FBQztZQUNqRCxjQUFjLEVBQUUsS0FBSztZQUNyQixTQUFTLEVBQUUsQ0FBQztTQUNiLENBQUM7SUFDSixDQUFDO0lBRUQsTUFBTSxZQUFZLEdBQUcsY0FBYyxDQUFDLENBQUMsQ0FBRSxDQUFDO0lBQ3hDLE1BQU0sWUFBWSxHQUNoQixLQUFLLENBQUMsR0FBRyxLQUFLLFNBQVMsSUFBSSxLQUFLLENBQUMsR0FBRyxLQUFLLElBQUksSUFBSSxLQUFLLENBQUMsR0FBRyxLQUFLLEVBQUU7UUFDL0QsQ0FBQyxDQUFDLFlBQVksQ0FBQyxJQUFJO1FBQ25CLENBQUMsQ0FBQyxVQUFVLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztZQUM3QixDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUM7WUFDbkIsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxZQUFZLENBQUMsSUFBSSxFQUFFLE1BQU0sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztJQUN0RCxNQUFNLEdBQUcsR0FBRyxnQkFBZ0IsQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUMzQyxNQUFNLGNBQWMsR0FBRyxjQUFjLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxZQUFZLENBQUMsR0FBRyxFQUFFLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO0lBQ25GLElBQUksQ0FBQyxjQUFjLEVBQUUsQ0FBQztRQUNwQixNQUFNLElBQUksS0FBSyxDQUFDLG9FQUFvRSxDQUFDLENBQUM7SUFDeEYsQ0FBQztJQUVELE9BQU87UUFDTCxHQUFHO1FBQ0gsY0FBYyxFQUFFLElBQUk7UUFDcEIsU0FBUyxFQUFFLGNBQWMsQ0FBQyxNQUFNO0tBQ2pDLENBQUM7QUFDSixDQUFDO0FBRUQsTUFBTSxVQUFVLDBCQUEwQixDQUFDLEtBQWM7SUFDdkQsSUFBSSxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDO1FBQUUsT0FBTyxFQUFFLENBQUM7SUFDckMsTUFBTSxVQUFVLEdBQXVCLEVBQUUsQ0FBQztJQUMxQyxNQUFNLElBQUksR0FBRyxJQUFJLEdBQUcsRUFBVSxDQUFDO0lBQy9CLEtBQUssTUFBTSxJQUFJLElBQUksS0FBSyxFQUFFLENBQUM7UUFDekIsTUFBTSxHQUFHLEdBQUcsT0FBTyxJQUFJLEVBQUUsR0FBRyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQzFELElBQUksQ0FBQyxHQUFHLENBQUMsVUFBVSxDQUFDLE9BQU8sQ0FBQztZQUFFLFNBQVM7UUFDdkMsSUFBSSxDQUFDO1lBQ0gsTUFBTSxJQUFJLEdBQUcsZ0JBQWdCLENBQUMsYUFBYSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUM7WUFDbEQsSUFBSSxJQUFJLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQztnQkFBRSxTQUFTO1lBQzdCLElBQUksQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLENBQUM7WUFDZixVQUFVLENBQUMsSUFBSSxDQUFDLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQztRQUM1QixDQUFDO1FBQUMsTUFBTSxDQUFDO1lBQ1AsMEZBQTBGO1FBQzVGLENBQUM7SUFDSCxDQUFDO0lBQ0QsT0FBTyxVQUFVLENBQUM7QUFDcEIsQ0FBQztBQUVELFNBQVMsZ0JBQWdCLENBQUMsSUFBWTtJQUNwQyxNQUFNLFFBQVEsR0FBRyxPQUFPLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUM7SUFDdkMsSUFBSSxDQUFDO1FBQ0gsT0FBTyxZQUFZLENBQUMsUUFBUSxDQUFDLENBQUM7SUFDaEMsQ0FBQztJQUFDLE1BQU0sQ0FBQztRQUNQLE9BQU8sUUFBUSxDQUFDO0lBQ2xCLENBQUM7QUFDSCxDQUFDO0FBRUQsU0FBUyxZQUFZLENBQUMsU0FBaUIsRUFBRSxJQUFZO0lBQ25ELE1BQU0sS0FBSyxHQUFHLGdCQUFnQixDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQzFDLE1BQU0sTUFBTSxHQUFHLGdCQUFnQixDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3RDLE1BQU0scUJBQXFCLEdBQUcsUUFBUSxDQUFDLE1BQU0sRUFBRSxLQUFLLENBQUMsQ0FBQztJQUN0RCxPQUFPLHFCQUFxQixLQUFLLEVBQUUsSUFBSSxDQUFDLENBQUMsQ0FBQyxxQkFBcUIsSUFBSSxDQUFDLHFCQUFxQixDQUFDLFVBQVUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxxQkFBcUIsQ0FBQyxDQUFDLENBQUM7QUFDcEosQ0FBQztBQUVELE1BQU0sVUFBVSwwQkFBMEIsQ0FBQyxRQUEwQixFQUFFO0lBQ3JFLE1BQU0sUUFBUSxHQUFHLEtBQUssQ0FBQyxtQkFBbUIsSUFBSSxPQUFPLENBQUMsR0FBRyxDQUFDLDJCQUEyQixDQUFDO0lBQ3RGLElBQUksT0FBTyxRQUFRLEtBQUssUUFBUSxJQUFJLFFBQVEsQ0FBQyxJQUFJLEVBQUU7UUFBRSxPQUFPLFFBQVEsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM1RSxPQUFPLFNBQVMsQ0FBQztBQUNuQixDQUFDO0FBRUQsTUFBTSxVQUFVLDRCQUE0QixDQUFDLE9BQWUsVUFBVTtJQUNwRSxNQUFNLE1BQU0sR0FBRyxJQUFJLEtBQUssV0FBVyxDQUFDLENBQUMsQ0FBQyw0QkFBNEIsQ0FBQyxDQUFDLENBQUMsNkJBQTZCLENBQUM7SUFDbkcsTUFBTSxXQUFXLEdBQUcsSUFBSSxLQUFLLFdBQVcsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUM7SUFDOUQsT0FBTyxHQUFHLFdBQVcseUNBQXlDLE1BQU0sRUFBRSxDQUFDO0FBQ3pFLENBQUM7QUFFRCxNQUFNLFVBQVUsbUJBQW1CLENBQUMsT0FBZ0I7SUFDbEQsTUFBTSxJQUFJLEdBQUcsTUFBTSxDQUFDLE9BQU8sSUFBSSxFQUFFLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUMxQyxJQUFJLENBQUMsSUFBSTtRQUFFLE9BQU8sSUFBSSxDQUFDO0lBQ3ZCLE1BQU0sS0FBSyxHQUFHLFlBQVksQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNqQyxNQUFNLFdBQVcsR0FBRyxLQUFLLENBQUMsQ0FBQyxDQUFDLEVBQUUsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLEdBQUcsRUFBRSxJQUFJLFNBQVMsQ0FBQztJQUNoRSxNQUFNLE1BQU0sR0FBRyxLQUFLLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQ2xELElBQUksTUFBTSxJQUFJLHFCQUFxQixDQUFDLElBQUksQ0FBQyxNQUFNLENBQUM7UUFBRSxPQUFPLEdBQUcsV0FBVyxvQkFBb0IsTUFBTSxFQUFFLENBQUM7SUFDcEcsT0FBTyw2QkFBNkIsQ0FBQztBQUN2QyxDQUFDO0FBRUQsTUFBTSxVQUFVLHlCQUF5QixDQUFDLE1BQWU7SUFDdkQsSUFBSSxDQUFDLE1BQU0sSUFBSSxPQUFPLE1BQU0sS0FBSyxRQUFRO1FBQUUsT0FBTyxNQUFNLENBQUM7SUFDekQsTUFBTSxHQUFHLEdBQUcsTUFBc0IsQ0FBQztJQUNuQyxPQUFPLGNBQWMsQ0FBQztRQUNwQixHQUFHLEdBQUc7UUFDTixNQUFNLEVBQUUsR0FBRyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsZUFBZSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUztRQUNwRSxNQUFNLEVBQUUsR0FBRyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsZUFBZSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUztRQUNwRSxhQUFhLEVBQUUsR0FBRyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsbUJBQW1CLENBQUMsR0FBRyxDQUFDLGFBQWEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxTQUFTO0tBQ3RGLENBQUMsQ0FBQztBQUNMLENBQUM7QUFFRCxNQUFNLFVBQVUsdUJBQXVCLENBQUMsUUFBaUMsRUFBRSxhQUFpQztJQUMxRyxNQUFNLFNBQVMsR0FBRyxxQkFBcUIsRUFBRSxDQUFDO0lBQzFDLElBQUksQ0FBQyxhQUFhLEVBQUUsQ0FBQztRQUNuQixPQUFPLGFBQWEsQ0FBQyx3QkFBd0IsRUFBRSxnREFBZ0QsQ0FBQyxDQUFDO0lBQ25HLENBQUM7SUFDRCxNQUFNLEtBQUssR0FBRyxZQUFZLENBQUMsYUFBYSxDQUFDLENBQUM7SUFDMUMsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ3pCLE1BQU0sSUFBSSxHQUFHLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDNUIsSUFBSSxDQUFDLE9BQU8sRUFBRSxDQUFDO1FBQ2IsT0FBTyxhQUFhLENBQUMsc0JBQXNCLEVBQUUsdUNBQXVDLENBQUMsQ0FBQztJQUN4RixDQUFDO0lBRUQsTUFBTSxTQUFTLEdBQUcsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQzdCLElBQUksQ0FBQztRQUNILE1BQU0sTUFBTSxHQUFHLFlBQVksQ0FBQyxPQUFPLEVBQUUsSUFBSSxFQUFFO1lBQ3pDLEtBQUssRUFBRSxJQUFJLENBQUMsU0FBUyxDQUFDO2dCQUNwQixHQUFHLFFBQVE7Z0JBQ1gsUUFBUSxFQUFFLFFBQVEsQ0FBQyxRQUFRLElBQUksUUFBUSxDQUFDLEdBQUc7Z0JBQzNDLGFBQWEsRUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLGNBQWM7YUFDMUMsQ0FBQztZQUNGLFFBQVEsRUFBRSxNQUFNO1lBQ2hCLE9BQU8sRUFBRSxTQUFTO1lBQ2xCLEtBQUssRUFBRSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDO1NBQ2hDLENBQUMsQ0FBQztRQUNILE1BQU0sVUFBVSxHQUFHLElBQUksQ0FBQyxHQUFHLEVBQUUsR0FBRyxTQUFTLENBQUM7UUFDMUMsSUFBSSxPQUFPLENBQUM7UUFDWixJQUFJLENBQUM7WUFDSCxPQUFPLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUMvQixDQUFDO1FBQUMsTUFBTSxDQUFDO1lBQ1AsT0FBTyxhQUFhLENBQUMsZ0JBQWdCLEVBQUUsNENBQTRDLEVBQUU7Z0JBQ25GLFVBQVU7Z0JBQ1YsTUFBTSxFQUFFLFlBQVksQ0FBQyxNQUFNLENBQUM7Z0JBQzVCLFlBQVksRUFBRSxlQUFlO2FBQzlCLENBQUMsQ0FBQztRQUNMLENBQUM7UUFDRCxJQUFJLENBQUMsT0FBTyxJQUFJLE9BQU8sT0FBTyxLQUFLLFFBQVEsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxFQUFFLENBQUM7WUFDdEUsT0FBTyxhQUFhLENBQUMsZ0JBQWdCLEVBQUUsK0NBQStDLEVBQUU7Z0JBQ3RGLFVBQVU7Z0JBQ1YsWUFBWSxFQUFFLGVBQWU7YUFDOUIsQ0FBQyxDQUFDO1FBQ0wsQ0FBQztRQUNELE1BQU0sVUFBVSxHQUFHLHFCQUFxQixDQUFDLE9BQU8sQ0FBQyxDQUFDO1FBQ2xELElBQUksVUFBVSxDQUFDLGdCQUFnQixLQUFLLFNBQVMsSUFBSSxVQUFVLENBQUMsZUFBZSxLQUFLLFNBQVMsRUFBRSxDQUFDO1lBQzFGLE9BQU8sYUFBYSxDQUFDLGdCQUFnQixFQUFFLHdFQUF3RSxFQUFFO2dCQUMvRyxVQUFVO2dCQUNWLFlBQVksRUFBRSxlQUFlO2FBQzlCLENBQUMsQ0FBQztRQUNMLENBQUM7UUFDRCxPQUFPLGNBQWMsQ0FBQztZQUNwQixFQUFFLEVBQUUsSUFBSTtZQUNSLElBQUksRUFBRSxTQUFTO1lBQ2YsTUFBTSxFQUFFLDJCQUEyQjtZQUNuQyxVQUFVO1lBQ1YsT0FBTztZQUNQLFlBQVksRUFBRSxrQkFBa0I7U0FDakMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUFDLE9BQU8sS0FBSyxFQUFFLENBQUM7UUFDZixPQUFPLHlCQUF5QixDQUFDLEtBQUssRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLEdBQUcsU0FBUyxFQUFFLGFBQWEsQ0FBQyxDQUFDO0lBQ2pGLENBQUM7QUFDSCxDQUFDO0FBRUQsTUFBTSxVQUFVLDJCQUEyQixDQUFDLE1BQW9CO0lBQzlELElBQUksTUFBTSxDQUFDLEVBQUU7UUFBRSxPQUFPLEVBQUUsQ0FBQztJQUN6QixNQUFNLFVBQVUsR0FBRyx5QkFBeUIsQ0FBQyxNQUFNLENBQWlCLENBQUM7SUFDckUsTUFBTSxJQUFJLEdBQUcsVUFBVSxDQUFDLElBQUksSUFBSSxlQUFlLENBQUMsVUFBVSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ25FLE1BQU0sUUFBUSxHQUFHO1FBQ2YsNEVBQTRFO0tBQzdFLENBQUM7SUFDRixRQUFRLElBQUksRUFBRSxDQUFDO1FBQ2IsS0FBSyx3QkFBd0I7WUFDM0IsUUFBUSxDQUFDLElBQUksQ0FBQyxxRkFBcUYsNEJBQTRCLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxDQUFDO1lBQ2hKLFFBQVEsQ0FBQyxJQUFJLENBQUMsb0pBQW9KLDRCQUE0QixDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsQ0FBQztZQUNoTixNQUFNO1FBQ1IsS0FBSyxzQkFBc0I7WUFDekIsUUFBUSxDQUFDLElBQUksQ0FBQyw2R0FBNkcsQ0FBQyxDQUFDO1lBQzdILE1BQU07UUFDUixLQUFLLFNBQVM7WUFDWixRQUFRLENBQUMsSUFBSSxDQUFDLDRCQUE0QixxQkFBcUIsRUFBRSxzRUFBc0UsQ0FBQyxDQUFDO1lBQ3pJLE1BQU07UUFDUixLQUFLLGdCQUFnQjtZQUNuQixRQUFRLENBQUMsSUFBSSxDQUFDLG9HQUFvRyxDQUFDLENBQUM7WUFDcEgsSUFBSSxVQUFVLENBQUMsTUFBTTtnQkFBRSxRQUFRLENBQUMsSUFBSSxDQUFDLCtCQUErQixZQUFZLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxHQUFHLENBQUMsRUFBRSxDQUFDLENBQUM7WUFDNUcsTUFBTTtRQUNSLEtBQUssZUFBZTtZQUNsQixRQUFRLENBQUMsSUFBSSxDQUFDLDRGQUE0RixDQUFDLENBQUM7WUFDNUcsSUFBSSxVQUFVLENBQUMsTUFBTTtnQkFBRSxRQUFRLENBQUMsSUFBSSxDQUFDLGtCQUFrQixZQUFZLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxHQUFHLENBQUMsRUFBRSxDQUFDLENBQUM7WUFDL0YsSUFBSSxPQUFPLFVBQVUsQ0FBQyxRQUFRLEtBQUssUUFBUTtnQkFBRSxRQUFRLENBQUMsSUFBSSxDQUFDLGNBQWMsVUFBVSxDQUFDLFFBQVEsRUFBRSxDQUFDLENBQUM7WUFDaEcsTUFBTTtRQUNSO1lBQ0UsUUFBUSxDQUFDLElBQUksQ0FBQyx5SEFBeUgsQ0FBQyxDQUFDO1lBQ3pJLElBQUksVUFBVSxDQUFDLE1BQU07Z0JBQUUsUUFBUSxDQUFDLElBQUksQ0FBQyxzQkFBc0IsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7WUFDaEYsTUFBTTtJQUNWLENBQUM7SUFDRCxRQUFRLENBQUMsSUFBSSxDQUFDLG9GQUFvRixDQUFDLENBQUM7SUFDcEcsT0FBTyxRQUFRLENBQUM7QUFDbEIsQ0FBQztBQUVELE1BQU0sVUFBVSxnQkFBZ0IsQ0FBQyxnQkFBb0MsMEJBQTBCLEVBQUU7SUFDL0YsT0FBTyx5QkFBeUIsQ0FDOUIsdUJBQXVCLENBQ3ZCO1FBQ0UsWUFBWSxFQUFFLG9CQUFvQjtRQUNsQyxVQUFVLEVBQUUsY0FBYztRQUMxQixZQUFZLEVBQUUsQ0FBQyxFQUFFLElBQUksRUFBRSxnQkFBZ0IsRUFBRSxTQUFTLEVBQUUsRUFBRSxFQUFFLFNBQVMsRUFBRSxDQUFDLEVBQUUsTUFBTSxFQUFFLFVBQVUsRUFBRSxDQUFDO1FBQzNGLFFBQVEsRUFBRSxPQUFPLENBQUMsR0FBRyxFQUFFO0tBQ3hCLEVBQ0MsYUFBYSxDQUNkLENBQ0YsQ0FBQztBQUNKLENBQUM7QUFFRCxTQUFTLFNBQVMsQ0FBQyxHQUFXLEVBQUUsSUFBYztJQUM1QyxJQUFJLENBQUM7UUFDSCxPQUFPLFlBQVksQ0FBQyxLQUFLLEVBQUUsSUFBSSxFQUFFLEVBQUUsR0FBRyxFQUFFLFFBQVEsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUMsUUFBUSxFQUFFLE1BQU0sRUFBRSxRQUFRLENBQUMsRUFBRSxPQUFPLEVBQUUsSUFBSSxFQUFFLENBQUMsQ0FBQztJQUNsSCxDQUFDO0lBQUMsTUFBTSxDQUFDO1FBQ1AsT0FBTyxFQUFFLENBQUM7SUFDWixDQUFDO0FBQ0gsQ0FBQztBQUVELE1BQU0sVUFBVSxRQUFRLENBQUMsR0FBVyxFQUFFLElBQWM7SUFDbEQsT0FBTyxTQUFTLENBQUMsR0FBRyxFQUFFLElBQUksQ0FBQztTQUN4QixLQUFLLENBQUMsSUFBSSxDQUFDO1NBQ1gsR0FBRyxDQUFDLENBQUMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7U0FDMUIsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0FBQ3JCLENBQUM7QUFFRCxTQUFTLG1CQUFtQixDQUFDLEdBQVcsRUFBRSxPQUFlO0lBQ3ZELGdHQUFnRztJQUNoRyxpR0FBaUc7SUFDakcsTUFBTSxPQUFPLEdBQUcsSUFBSSxHQUFHLENBQUMsWUFBWSxDQUFDLEdBQUcsRUFBRSxPQUFPLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFLLEVBQUUsRUFBRSxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxLQUFLLENBQVUsQ0FBQyxDQUFDLENBQUM7SUFDakcsT0FBTyxlQUFlLENBQUMsR0FBRyxFQUFFLE9BQU8sQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxFQUFFO1FBQ2pELE1BQU0sS0FBSyxHQUFHLE9BQU8sQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLEVBQUUsU0FBUyxFQUFFLENBQUMsRUFBRSxTQUFTLEVBQUUsQ0FBQyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztRQUN2RixPQUFPLGNBQWMsQ0FBQztZQUNwQixJQUFJLEVBQUUsS0FBSyxDQUFDLElBQUk7WUFDaEIsWUFBWSxFQUFFLEtBQUssQ0FBQyxZQUFZO1lBQ2hDLFNBQVMsRUFBRSxLQUFLLENBQUMsU0FBUztZQUMxQixTQUFTLEVBQUUsS0FBSyxDQUFDLFNBQVM7WUFDMUIsTUFBTSxFQUFFLGNBQWMsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDO1lBQ2xDLE1BQU0sRUFBRSxLQUFLLENBQUMsTUFBTTtTQUNyQixDQUFDLENBQUM7SUFDTCxDQUFDLENBQUMsQ0FBQztBQUNMLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxHQUFXLEVBQUUsT0FBZTtJQUNuRCxpR0FBaUc7SUFDakcsd0RBQXdEO0lBQ3hELE1BQU0sT0FBTyxHQUFHLFNBQVMsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxNQUFNLEVBQUUsZUFBZSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsT0FBTyxFQUFFLElBQUksQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ2pHLE1BQU0sT0FBTyxHQUFHLEVBQUUsQ0FBQztJQUNuQixLQUFLLElBQUksS0FBSyxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsT0FBTyxDQUFDLE1BQU0sRUFBRSxLQUFLLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDdkQsTUFBTSxJQUFJLEdBQUcsT0FBTyxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzVCLElBQUksQ0FBQyxJQUFJO1lBQUUsU0FBUztRQUNwQixNQUFNLFFBQVEsR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQ3RDLE1BQU0sWUFBWSxHQUFHLFFBQVEsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO1FBQy9ELE1BQU0sSUFBSSxHQUFHLE9BQU8sQ0FBQyxLQUFLLEdBQUcsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNqRCxLQUFLLElBQUksUUFBUSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUMxQixPQUFPLENBQUMsSUFBSSxDQUFDLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFjLEVBQUUsWUFBWSxFQUFFLENBQUMsQ0FBQztJQUM3RCxDQUFDO0lBQ0QsT0FBTyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQUVELFNBQVMsWUFBWSxDQUFDLEdBQVcsRUFBRSxPQUFlO0lBQ2hELHdGQUF3RjtJQUN4RixxR0FBcUc7SUFDckcsTUFBTSxPQUFPLEdBQUcsU0FBUyxDQUFDLEdBQUcsRUFBRSxDQUFDLE1BQU0sRUFBRSxXQUFXLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxPQUFPLEVBQUUsSUFBSSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDN0YsTUFBTSxPQUFPLEdBQUcsRUFBRSxDQUFDO0lBQ25CLEtBQUssSUFBSSxLQUFLLEdBQUcsQ0FBQyxFQUFFLEtBQUssR0FBRyxPQUFPLENBQUMsTUFBTSxFQUFFLEtBQUssSUFBSSxDQUFDLEVBQUUsQ0FBQztRQUN2RCxNQUFNLElBQUksR0FBRyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDNUIsSUFBSSxDQUFDLElBQUk7WUFBRSxTQUFTO1FBQ3BCLE1BQU0sQ0FBQyxLQUFLLEVBQUUsT0FBTyxFQUFFLFVBQVUsQ0FBQyxHQUFHLGdCQUFnQixDQUFDLElBQUksQ0FBQyxDQUFDO1FBQzVELCtGQUErRjtRQUMvRixJQUFJLElBQUksR0FBdUIsVUFBVSxDQUFDO1FBQzFDLElBQUksVUFBVSxLQUFLLEVBQUUsRUFBRSxDQUFDO1lBQ3RCLElBQUksR0FBRyxPQUFPLENBQUMsS0FBSyxHQUFHLENBQUMsQ0FBQyxDQUFDO1lBQzFCLEtBQUssSUFBSSxDQUFDLENBQUM7UUFDYixDQUFDO1FBQ0QsTUFBTSxNQUFNLEdBQUcsS0FBSyxLQUFLLEdBQUcsQ0FBQztRQUM3QixPQUFPLENBQUMsSUFBSSxDQUFDLEVBQUUsSUFBSSxFQUFFLElBQWMsRUFBRSxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsRUFBRSxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUMsRUFBRSxNQUFNLEVBQUUsQ0FBQyxDQUFDO0lBQ2pJLENBQUM7SUFDRCxPQUFPLE9BQU8sQ0FBQztBQUNqQixDQUFDO0FBRUQsU0FBUyxnQkFBZ0IsQ0FBQyxJQUFZO0lBQ3BDLHdGQUF3RjtJQUN4RixNQUFNLFFBQVEsR0FBRyxJQUFJLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ3BDLE1BQU0sU0FBUyxHQUFHLElBQUksQ0FBQyxPQUFPLENBQUMsSUFBSSxFQUFFLFFBQVEsR0FBRyxDQUFDLENBQUMsQ0FBQztJQUNuRCxPQUFPLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsUUFBUSxDQUFDLEVBQUUsSUFBSSxDQUFDLEtBQUssQ0FBQyxRQUFRLEdBQUcsQ0FBQyxFQUFFLFNBQVMsQ0FBQyxFQUFFLElBQUksQ0FBQyxLQUFLLENBQUMsU0FBUyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDbkcsQ0FBQztBQUVELFNBQVMscUJBQXFCLENBQUMsR0FBVyxFQUFFLE9BQWU7SUFDekQsTUFBTSxhQUFhLEdBQUcsUUFBUSxDQUFDLEdBQUcsRUFBRSxDQUFDLEtBQUssRUFBRSxpQkFBaUIsRUFBRSxHQUFHLE9BQU8sUUFBUSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDL0YsTUFBTSxRQUFRLEdBQUcsYUFBYTtTQUMzQixLQUFLLENBQUMsUUFBUSxDQUFDO1NBQ2YsR0FBRyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUUsQ0FBQyxPQUFPLENBQUMsSUFBSSxFQUFFLENBQUM7U0FDaEMsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ25CLElBQUksUUFBUSxDQUFDLE1BQU0sR0FBRyxDQUFDO1FBQUUsT0FBTyxRQUFRLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUMsQ0FBQztJQUN0RCxNQUFNLElBQUksR0FBRyxRQUFRLENBQUMsR0FBRyxFQUFFLENBQUMsS0FBSyxFQUFFLElBQUksRUFBRSxhQUFhLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUMzRSxPQUFPLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0FBQzVCLENBQUM7QUFFRCxTQUFTLGNBQWMsQ0FBQyxHQUFXO0lBQ2pDLE1BQU0sVUFBVSxHQUFHLFFBQVEsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxjQUFjLEVBQUUsU0FBUyxFQUFFLFNBQVMsRUFBRSwwQkFBMEIsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDeEcsSUFBSSxVQUFVO1FBQUUsT0FBTyxVQUFVLENBQUM7SUFDbEMsSUFBSSxRQUFRLENBQUMsR0FBRyxFQUFFLENBQUMsV0FBVyxFQUFFLFVBQVUsRUFBRSxhQUFhLENBQUMsQ0FBQyxDQUFDLE1BQU0sR0FBRyxDQUFDO1FBQUUsT0FBTyxhQUFhLENBQUM7SUFDN0YsSUFBSSxRQUFRLENBQUMsR0FBRyxFQUFFLENBQUMsV0FBVyxFQUFFLFVBQVUsRUFBRSxlQUFlLENBQUMsQ0FBQyxDQUFDLE1BQU0sR0FBRyxDQUFDO1FBQUUsT0FBTyxlQUFlLENBQUM7SUFDakcsT0FBTyxNQUFNLENBQUM7QUFDaEIsQ0FBQztBQUVELFNBQVMsd0JBQXdCLENBQUMsR0FBVyxFQUFFLE9BQWU7SUFDNUQsTUFBTSxLQUFLLEdBQUcsTUFBTSxDQUFDLE9BQU8sSUFBSSxFQUFFLENBQUMsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLEVBQUUsRUFBRSxDQUFDLENBQUMsS0FBSyxDQUFDLGdCQUFnQixDQUFDLENBQUM7SUFDNUYsTUFBTSxNQUFNLEdBQUcsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDMUIsSUFBSSxDQUFDLE1BQU07UUFBRSxPQUFPLFNBQVMsQ0FBQztJQUM5QixNQUFNLFNBQVMsR0FBRyxRQUFRLENBQUMsR0FBRyxFQUFFLENBQUMsV0FBVyxFQUFFLFNBQVMsRUFBRSxRQUFRLEVBQUUsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUMvRSxPQUFPLFNBQVMsRUFBRSxLQUFLLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDcEMsQ0FBQztBQUVELFNBQVMscUJBQXFCLENBQUMsT0FBc0I7SUFDbkQsTUFBTSxNQUFNLEdBQUcsT0FBTyxDQUFDLE1BQW1DLENBQUM7SUFDM0QsTUFBTSxLQUFLLEdBQUcsT0FBTyxDQUFDLEtBQWtDLENBQUM7SUFDekQsTUFBTSxLQUFLLEdBQUcsT0FBTyxDQUFDLEtBQWtDLENBQUM7SUFDekQsTUFBTSxPQUFPLEdBQUcsT0FBTyxDQUFDLE9BQW9DLENBQUM7SUFDN0QsT0FBTyxjQUFjLENBQUM7UUFDcEIsSUFBSSxFQUFFLGtCQUFrQjtRQUN4QixXQUFXLEVBQUUsV0FBVyxDQUFDLE9BQU8sQ0FBQyxXQUFXLElBQUksT0FBTyxDQUFDLFlBQVksQ0FBQztRQUNyRSxnQkFBZ0IsRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLGdCQUFnQixJQUFJLE9BQU8sQ0FBQyxrQkFBa0IsSUFBSSxNQUFNLEVBQUUsVUFBVSxDQUFDO1FBQzNHLGVBQWUsRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLGVBQWUsSUFBSSxPQUFPLENBQUMsaUJBQWlCLElBQUksS0FBSyxFQUFFLFVBQVUsQ0FBQztRQUN2RyxXQUFXLEVBQUUsV0FBVyxDQUFDLE9BQU8sQ0FBQyxXQUFXLElBQUksT0FBTyxDQUFDLFlBQVksSUFBSSxNQUFNLEVBQUUsS0FBSyxDQUFDO1FBQ3RGLGNBQWMsRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLGNBQWMsSUFBSSxPQUFPLENBQUMsZ0JBQWdCLElBQUksS0FBSyxFQUFFLFVBQVUsQ0FBQztRQUNwRyxpQkFBaUIsRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLGlCQUFpQixJQUFJLE9BQU8sQ0FBQyxvQkFBb0IsSUFBSSxPQUFPLEVBQUUsVUFBVSxDQUFDO1FBQ2hILFFBQVEsRUFBRSxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLFFBQVEsQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLFNBQVM7S0FDckYsQ0FBQyxDQUFDO0FBQ0wsQ0FBQztBQUVELFNBQVMsa0JBQWtCLENBQUMsTUFBb0I7SUFDOUMsT0FBTztRQUNMLElBQUksRUFBRSxlQUFlO1FBQ3JCLFFBQVEsRUFBRSxDQUFDLE1BQU0sQ0FBQyxNQUFNLElBQUksTUFBTSxDQUFDLElBQUksSUFBSSw2QkFBNkIsQ0FBQztLQUMxRSxDQUFDO0FBQ0osQ0FBQztBQUVELFNBQVMsYUFBYSxDQUFDLElBQVksRUFBRSxNQUFjLEVBQUUsUUFBaUMsRUFBRTtJQUN0RixPQUFPLGNBQWMsQ0FBQztRQUNwQixFQUFFLEVBQUUsS0FBSztRQUNULElBQUk7UUFDSixNQUFNO1FBQ04sWUFBWSxFQUFFLGVBQWU7UUFDN0IsR0FBRyxLQUFLO0tBQ1QsQ0FBQyxDQUFDO0FBQ0wsQ0FBQztBQUVELFNBQVMseUJBQXlCLENBQUMsS0FBYyxFQUFFLFVBQWtCLEVBQUUsYUFBaUM7SUFDdEcsTUFBTSxTQUFTLEdBQVEsS0FBSyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVEsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7SUFDOUUsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLFNBQVMsRUFBRSxNQUFNLElBQUksU0FBUyxFQUFFLE1BQU0sRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQ2hGLE1BQU0sTUFBTSxHQUFHLFlBQVksQ0FBQyxTQUFTLEVBQUUsTUFBTSxJQUFJLFNBQVMsRUFBRSxNQUFNLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQztJQUMvRSxNQUFNLFFBQVEsR0FBRyxPQUFPLFNBQVMsRUFBRSxNQUFNLEtBQUssUUFBUSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7SUFDdEYsSUFBSSxNQUFNLElBQUksQ0FBQyxtQkFBbUIsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDO1FBQzNDLE9BQU8sYUFBYSxDQUFDLGdCQUFnQixFQUFFLDRDQUE0QyxFQUFFO1lBQ25GLFVBQVU7WUFDVixNQUFNLEVBQUUsWUFBWSxDQUFDLE1BQU0sQ0FBQztZQUM1QixhQUFhLEVBQUUsbUJBQW1CLENBQUMsYUFBYSxDQUFDO1lBQ2pELFlBQVksRUFBRSxlQUFlO1NBQzlCLENBQUMsQ0FBQztJQUNMLENBQUM7SUFDRCxJQUFJLFNBQVMsRUFBRSxJQUFJLEtBQUssV0FBVyxJQUFJLENBQUMsU0FBUyxFQUFFLE1BQU0sSUFBSSxTQUFTLEVBQUUsTUFBTSxLQUFLLFNBQVMsQ0FBQyxFQUFFLENBQUM7UUFDOUYsT0FBTyxhQUFhLENBQUMsU0FBUyxFQUFFLG1DQUFtQyxxQkFBcUIsRUFBRSxLQUFLLEVBQUUsRUFBRSxVQUFVLEVBQUUsTUFBTSxFQUFFLGFBQWEsRUFBRSxtQkFBbUIsQ0FBQyxhQUFhLENBQUMsRUFBRSxDQUFDLENBQUM7SUFDOUssQ0FBQztJQUNELElBQUksT0FBTyxRQUFRLEtBQUssUUFBUSxJQUFJLFFBQVEsS0FBSyxDQUFDLEVBQUUsQ0FBQztRQUNuRCxPQUFPLGFBQWEsQ0FBQyxlQUFlLEVBQUUsc0NBQXNDLFFBQVEsR0FBRyxFQUFFLEVBQUUsVUFBVSxFQUFFLE1BQU0sRUFBRSxRQUFRLEVBQUUsYUFBYSxFQUFFLG1CQUFtQixDQUFDLGFBQWEsQ0FBQyxFQUFFLENBQUMsQ0FBQztJQUNoTCxDQUFDO0lBQ0QsTUFBTSxPQUFPLEdBQUcsS0FBSyxZQUFZLEtBQUssQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsd0JBQXdCLENBQUM7SUFDbEYsSUFBSSxPQUFPLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxFQUFFLENBQUM7UUFDMUIsT0FBTyxhQUFhLENBQUMsZ0JBQWdCLEVBQUUsNENBQTRDLEVBQUUsRUFBRSxVQUFVLEVBQUUsTUFBTSxFQUFFLGFBQWEsRUFBRSxtQkFBbUIsQ0FBQyxhQUFhLENBQUMsRUFBRSxDQUFDLENBQUM7SUFDbEssQ0FBQztJQUNELElBQUksTUFBTSxJQUFJLENBQUMsbUJBQW1CLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQztRQUMzQyxPQUFPLGFBQWEsQ0FBQyxnQkFBZ0IsRUFBRSw0Q0FBNEMsRUFBRTtZQUNuRixVQUFVO1lBQ1YsTUFBTSxFQUFFLFlBQVksQ0FBQyxNQUFNLENBQUM7WUFDNUIsYUFBYSxFQUFFLG1CQUFtQixDQUFDLGFBQWEsQ0FBQztZQUNqRCxZQUFZLEVBQUUsZUFBZTtTQUM5QixDQUFDLENBQUM7SUFDTCxDQUFDO0lBQ0QsT0FBTyxhQUFhLENBQUMsZUFBZSxFQUFFLGVBQWUsQ0FBQyxPQUFPLENBQUMsRUFBRSxFQUFFLFVBQVUsRUFBRSxNQUFNLEVBQUUsUUFBUSxFQUFFLGFBQWEsRUFBRSxtQkFBbUIsQ0FBQyxhQUFhLENBQUMsRUFBRSxDQUFDLENBQUM7QUFDdkosQ0FBQztBQUVELFNBQVMsbUJBQW1CLENBQUMsTUFBYztJQUN6QyxJQUFJLENBQUM7UUFDSCxNQUFNLE9BQU8sR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQ25DLElBQUksQ0FBQyxPQUFPLElBQUksT0FBTyxPQUFPLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDO1lBQUUsT0FBTyxLQUFLLENBQUM7UUFDcEYsTUFBTSxVQUFVLEdBQUcscUJBQXFCLENBQUMsT0FBTyxDQUFDLENBQUM7UUFDbEQsT0FBTyxVQUFVLENBQUMsZ0JBQWdCLEtBQUssU0FBUyxJQUFJLFVBQVUsQ0FBQyxlQUFlLEtBQUssU0FBUyxDQUFDO0lBQy9GLENBQUM7SUFBQyxNQUFNLENBQUM7UUFDUCxPQUFPLEtBQUssQ0FBQztJQUNmLENBQUM7QUFDSCxDQUFDO0FBRUQsU0FBUyxlQUFlLENBQUMsTUFBZTtJQUN0QyxNQUFNLElBQUksR0FBRyxNQUFNLENBQUMsTUFBTSxJQUFJLEVBQUUsQ0FBQyxDQUFDO0lBQ2xDLElBQUksSUFBSSxDQUFDLFFBQVEsQ0FBQyx3QkFBd0IsQ0FBQztRQUFFLE9BQU8sd0JBQXdCLENBQUM7SUFDN0UsSUFBSSxJQUFJLENBQUMsUUFBUSxDQUFDLHNCQUFzQixDQUFDO1FBQUUsT0FBTyxzQkFBc0IsQ0FBQztJQUN6RSxJQUFJLHNCQUFzQixDQUFDLElBQUksQ0FBQyxJQUFJLENBQUM7UUFBRSxPQUFPLFNBQVMsQ0FBQztJQUN4RCxJQUFJLE9BQU8sQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDO1FBQUUsT0FBTyxnQkFBZ0IsQ0FBQztJQUNoRCxJQUFJLGFBQWEsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDO1FBQUUsT0FBTyxlQUFlLENBQUM7SUFDckQsT0FBTyxlQUFlLENBQUM7QUFDekIsQ0FBQztBQUVELFNBQVMscUJBQXFCO0lBQzVCLE1BQU0sTUFBTSxHQUFHLE1BQU0sQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLGtDQUFrQyxJQUFJLEtBQUssQ0FBQyxDQUFDO0lBQy9FLE9BQU8sTUFBTSxDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsSUFBSSxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQztBQUNoRSxDQUFDO0FBRUQsU0FBUyxZQUFZLENBQUMsS0FBYyxFQUFFLFNBQVMsR0FBRyxHQUFHO0lBQ25ELE1BQU0sSUFBSSxHQUFHLE1BQU0sQ0FBQyxLQUFLLElBQUksRUFBRSxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDeEMsSUFBSSxDQUFDLElBQUk7UUFBRSxPQUFPLFNBQVMsQ0FBQztJQUM1QixPQUFPLElBQUksQ0FBQyxNQUFNLElBQUksU0FBUyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLEVBQUUsU0FBUyxHQUFHLENBQUMsQ0FBQyxLQUFLLENBQUM7QUFDaEYsQ0FBQztBQUVELFNBQVMsWUFBWSxDQUFDLE9BQWdCO0lBQ3BDLE9BQU8sTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDLEtBQUssQ0FBQyx1QkFBdUIsQ0FBQyxFQUFFLEdBQUcsQ0FBQyxDQUFDLElBQUksRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxRQUFRLEVBQUUsRUFBRSxDQUFDLENBQUMsSUFBSSxFQUFFLENBQUM7QUFDekcsQ0FBQztBQUVELFNBQVMsMEJBQTBCO0lBQ2pDLElBQUksaUJBQWlCLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsc0JBQXNCLElBQUksT0FBTyxDQUFDLEVBQUUsQ0FBQztRQUMxRSxNQUFNLElBQUksS0FBSyxDQUFDLG9GQUFvRixDQUFDLENBQUM7SUFDeEcsQ0FBQztBQUNILENBQUM7QUFFRCxrR0FBa0c7QUFDbEcsdUdBQXVHO0FBQ3ZHLHFHQUFxRztBQUNyRyw2RkFBNkY7QUFDN0YsTUFBTSxVQUFVLG1CQUFtQixDQUFDLElBQWE7SUFDL0MsTUFBTSxNQUFNLEdBQUcsRUFBRSxDQUFDO0lBQ2xCLEtBQUssTUFBTSxLQUFLLElBQUksTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQywrREFBK0QsQ0FBQztRQUFFLE1BQU0sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDMUksT0FBTyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLEtBQUssQ0FBQyxJQUFJLEtBQUssR0FBRyxDQUFDLENBQUMsQ0FBQztBQUN4RSxDQUFDO0FBRUQsU0FBUyxjQUFjLENBQUMsSUFBWTtJQUNsQyxJQUFJLElBQUksQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO1FBQUUsT0FBTyxPQUFPLENBQUM7SUFDekMsSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztRQUFFLE9BQU8sVUFBVSxDQUFDO0lBQzVDLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxHQUFHLENBQUM7UUFBRSxPQUFPLFNBQVMsQ0FBQztJQUMzQyxJQUFJLElBQUksQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDO1FBQUUsT0FBTyxTQUFTLENBQUM7SUFDM0MsSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQztRQUFFLE9BQU8sUUFBUSxDQUFDO0lBQzFDLE9BQU8sU0FBUyxDQUFDO0FBQ25CLENBQUM7QUFFRCxTQUFTLGVBQWUsQ0FBQyxVQUFtQjtJQUMxQyxPQUFPLE1BQU0sQ0FBQyxVQUFVLElBQUksRUFBRSxDQUFDO1NBQzVCLE9BQU8sQ0FBQyx3QkFBd0IsRUFBRSxFQUFFLENBQUM7U0FDckMsT0FBTyxDQUFDLFFBQVEsRUFBRSxHQUFHLENBQUM7U0FDdEIsSUFBSSxFQUFFLENBQUM7QUFDWixDQUFDO0FBRUQsU0FBUyxnQkFBZ0IsQ0FBQyxRQUFrQjtJQUMxQyxPQUFPLFFBQVEsQ0FBQyxJQUFJLENBQUMsQ0FBQyxPQUFPLEVBQUUsRUFBRSxDQUFDLE9BQU8sQ0FBQyxJQUFJLEVBQUUsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLEVBQUUsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksRUFBRSxDQUFDO0FBQ3ZGLENBQUM7QUFFRCxTQUFTLFdBQVcsQ0FBQyxLQUFjO0lBQ2pDLE1BQU0sTUFBTSxHQUFHLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUM3QixPQUFPLE1BQU0sQ0FBQyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO0FBQ3RELENBQUM7QUFFRCxTQUFTLFdBQVcsQ0FBQyxLQUFjO0lBQ2pDLE9BQU8sT0FBTyxLQUFLLEtBQUssUUFBUSxJQUFJLEtBQUssQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7QUFDdkUsQ0FBQztBQUVELFNBQVMsY0FBYyxDQUFJLEtBQVE7SUFDakMsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssQ0FBQztRQUFFLE9BQU8sS0FBSyxDQUFDLEdBQUcsQ0FBQyxjQUFjLENBQU0sQ0FBQztJQUNoRSxJQUFJLENBQUMsS0FBSyxJQUFJLE9BQU8sS0FBSyxLQUFLLFFBQVE7UUFBRSxPQUFPLEtBQUssQ0FBQztJQUN0RCxPQUFPLE1BQU0sQ0FBQyxXQUFXLENBQUMsTUFBTSxDQUFDLE9BQU8sQ0FBQyxLQUFnQyxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLEtBQUssQ0FBQyxFQUFFLEVBQUUsQ0FBQyxLQUFLLEtBQUssU0FBUyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxHQUFHLEVBQUUsS0FBSyxDQUFDLEVBQUUsRUFBRSxDQUFDLENBQUMsR0FBRyxFQUFFLGNBQWMsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQU0sQ0FBQztBQUNsTCxDQUFDIn0=

--- a/packages/loopover-mcp/lib/local-branch.ts
+++ b/packages/loopover-mcp/lib/local-branch.ts
@@ -1,0 +1,646 @@
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isCodeFile, isTestPath as isTestFile } from "@loopover/engine/signals/test-evidence";
+import { redactLocalPath } from "./redact-local-path.js";
+
+export { isCodeFile, isTestFile };
+export { redactLocalPath };
+
+// A single changed-file entry in a local diff. `path` is always present; the stat fields are absent
+// for a binary file (git reports `-`/`-`) or an unparseable numstat row and are filled in as 0.
+export type ChangedFile = {
+  path: string;
+  previousPath?: string | undefined;
+  additions?: number | undefined;
+  deletions?: number | undefined;
+  status?: string | undefined;
+  binary?: boolean | undefined;
+};
+
+// The MCP roots a client exposes, normalized to local filesystem paths (see normalizeMcpWorkspaceRoots).
+export type McpWorkspaceRoot = { path: string };
+
+// Caller-supplied branch context. Every field is optional: whatever is not passed is derived from the
+// local git checkout. Kept open (no exhaustive enumeration of the pass-through scenario fields) because
+// the bin forwards a superset straight through to the analysis payload.
+export type LocalBranchInput = {
+  cwd?: string | null | undefined;
+  baseRef?: string | undefined;
+  headRef?: string | undefined;
+  branchName?: string | undefined;
+  repoFullName?: string | undefined;
+  login?: string | undefined;
+  title?: string | undefined;
+  body?: string | undefined;
+  labels?: unknown;
+  linkedIssues?: number[] | undefined;
+  commitMessages?: string[] | undefined;
+  validation?: unknown;
+  pendingCommitCount?: number | undefined;
+  ciStatusHints?: string[] | undefined;
+  pendingMergedPrCount?: unknown;
+  pendingClosedPrCount?: unknown;
+  approvedPrCount?: unknown;
+  expectedOpenPrCountAfterMerge?: unknown;
+  projectedCredibility?: unknown;
+  scenarioNotes?: unknown;
+  branchEligibility?: unknown;
+  workspaceRoots?: unknown;
+  scorePreviewCommand?: string | undefined;
+};
+
+// The external scorer runs as a separate process and its status/diagnostic bag varies by failure mode
+// (see scorerFailure / classifyScorerExecFailure), so both the status and the scorer's own JSON stay
+// open records rather than a closed shape that every branch would have to satisfy exactly.
+type ScorerStatus = Record<string, unknown>;
+type ScorerPayload = Record<string, unknown>;
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
+export function parseGitRemote(remoteUrl: unknown): string | undefined {
+  const trimmed = stripTrailingSlashes(String(remoteUrl ?? "").trim());
+  const patterns = [
+    /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
+    /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+  ];
+  for (const pattern of patterns) {
+    const match = trimmed.match(pattern);
+    if (match?.[1] && match[2]) return `${match[1]}/${match[2].replace(/\.git$/, "")}`;
+  }
+  return undefined;
+}
+
+export function collectLocalDiff(cwd: string, baseRef: string | undefined, workspaceRoots: unknown) {
+  const metadata = collectLocalBranchMetadata({ cwd, baseRef, login: "local", workspaceRoots });
+  return {
+    title: metadata.title ?? "Local diff preflight",
+    commitMessage: metadata.commitMessages.join("\n\n").trim(),
+    changedFiles: metadata.changedFiles.map((file) => file.path),
+    changedLineCount: metadata.changedFiles.reduce((sum, file) => sum + (file.additions ?? 0) + (file.deletions ?? 0), 0),
+    testFiles: metadata.changedFiles.map((file) => file.path).filter(isTestFile),
+    codeFiles: metadata.changedFiles.map((file) => file.path).filter(isCodeFile),
+  };
+}
+
+export function collectLocalBranchMetadata(input: LocalBranchInput) {
+  assertSourceUploadDisabled();
+  const workspace = resolveWorkspaceCwd(input);
+  const cwd = workspace.cwd;
+  const baseRef = input.baseRef ?? defaultBaseRef(cwd);
+  const remoteUrl = gitLines(cwd, ["config", "--get", "remote.origin.url"])[0] ?? "";
+  const repoFullName = input.repoFullName ?? parseGitRemote(remoteUrl);
+  if (!repoFullName) throw new Error("Could not infer repoFullName from git remote; pass --repo owner/repo.");
+  const branchName = input.branchName ?? gitLines(cwd, ["branch", "--show-current"])[0] ?? "local-branch";
+  const headRef = input.headRef ?? gitLines(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])[0] ?? branchName;
+  const baseSha = gitLines(cwd, ["rev-parse", "--verify", baseRef])[0];
+  const headSha = gitLines(cwd, ["rev-parse", "--verify", "HEAD"])[0];
+  const mergeBaseSha = gitLines(cwd, ["merge-base", baseRef, "HEAD"])[0];
+  const remoteTrackingSha = collectRemoteTrackingSha(cwd, baseRef);
+  const changedFiles = collectChangedFiles(cwd, baseRef);
+  const pendingCommitCount = input.pendingCommitCount ?? collectPendingCommitCount(cwd, baseRef);
+  const ciStatusHints = input.ciStatusHints ?? collectCiStatusHints(cwd, baseRef, changedFiles);
+  const commitMessages = input.commitMessages ?? collectCommitMessages(cwd, baseRef);
+  const title = input.title ?? titleFromBranch(branchName) ?? firstCommitTitle(commitMessages);
+  const linkedIssues = [...new Set([...(input.linkedIssues ?? []), ...extractLinkedIssues([branchName, title, input.body, ...commitMessages].filter(Boolean).join("\n"))])].sort(
+    (left, right) => left - right,
+  );
+  const payload = {
+    login: input.login,
+    repoFullName,
+    baseRef,
+    headRef,
+    branchName,
+    baseSha,
+    headSha,
+    mergeBaseSha,
+    remoteTrackingSha,
+    commitMessages,
+    changedFiles,
+    validation: input.validation,
+    linkedIssues,
+    labels: input.labels,
+    title,
+    body: input.body,
+    pendingMergedPrCount: input.pendingMergedPrCount,
+    pendingClosedPrCount: input.pendingClosedPrCount,
+    approvedPrCount: input.approvedPrCount,
+    expectedOpenPrCountAfterMerge: input.expectedOpenPrCountAfterMerge,
+    projectedCredibility: input.projectedCredibility,
+    scenarioNotes: input.scenarioNotes,
+    pendingCommitCount,
+    ciStatusHints,
+    branchEligibility: input.branchEligibility,
+  };
+  return stripUndefined(payload);
+}
+
+export function collectPendingCommitCount(cwd: string, baseRef: string): number {
+  const count = gitLines(cwd, ["rev-list", "--count", `${baseRef}..HEAD`])[0];
+  const parsed = Number(count);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : 0;
+}
+
+export function collectCiStatusHints(cwd: string, baseRef: string, changedFiles: ChangedFile[] = []): string[] {
+  const hints = [];
+  const paths = changedFiles.map((file) => file.path).filter(Boolean);
+  if (paths.some((path) => /^\.github\/workflows\//i.test(path))) {
+    hints.push("Workflow files changed; CI required-check behavior may change after merge.");
+  }
+  if (paths.some((path) => /(^|\/)(Makefile|Dockerfile|package\.json|pyproject\.toml|go\.mod|Cargo\.toml)$/i.test(path))) {
+    hints.push("Build or dependency manifests changed; rerun the repo's standard validation commands.");
+  }
+  const pendingCommits = collectPendingCommitCount(cwd, baseRef);
+  if (pendingCommits > 0) {
+    hints.push(`${pendingCommits} local commit(s) ahead of ${baseRef}; push or rebase before reviewers rely on the latest diff.`);
+  }
+  return hints;
+}
+
+export function buildBranchAnalysisPayload(input: LocalBranchInput) {
+  const workspace = resolveWorkspaceCwd(input);
+  const metadata = collectLocalBranchMetadata({ ...input, cwd: workspace.cwd });
+  const scorerMetadata = { ...metadata, repoRoot: workspace.cwd };
+  const scorerCommand = resolveScorePreviewCommand(input);
+  const externalPreview = runExternalScorePreview(scorerMetadata, scorerCommand);
+  const localScorer = externalPreview.ok ? normalizeScorerOutput(externalPreview.payload as ScorerPayload) : metadataOnlyScorer(externalPreview);
+  return {
+    ...metadata,
+    localScorer,
+    localScorerStatus: sanitizeLocalScorerStatus(externalPreview),
+  };
+}
+
+export function resolveWorkspaceCwd(input: LocalBranchInput = {}) {
+  const workspaceRoots = normalizeMcpWorkspaceRoots(input.workspaceRoots);
+  if (workspaceRoots.length === 0) {
+    return {
+      cwd: safeResolvedPath(input.cwd ?? process.cwd()),
+      rootsAvailable: false,
+      rootCount: 0,
+    };
+  }
+
+  const selectedRoot = workspaceRoots[0]!;
+  const requestedCwd =
+    input.cwd === undefined || input.cwd === null || input.cwd === ""
+      ? selectedRoot.path
+      : isAbsolute(String(input.cwd))
+        ? String(input.cwd)
+        : resolve(selectedRoot.path, String(input.cwd));
+  const cwd = safeResolvedPath(requestedCwd);
+  const containingRoot = workspaceRoots.find((root) => pathIsInside(cwd, root.path));
+  if (!containingRoot) {
+    throw new Error("Selected workspace is outside the MCP roots exposed by the client.");
+  }
+
+  return {
+    cwd,
+    rootsAvailable: true,
+    rootCount: workspaceRoots.length,
+  };
+}
+
+export function normalizeMcpWorkspaceRoots(roots: unknown): McpWorkspaceRoot[] {
+  if (!Array.isArray(roots)) return [];
+  const normalized: McpWorkspaceRoot[] = [];
+  const seen = new Set<string>();
+  for (const root of roots) {
+    const uri = typeof root?.uri === "string" ? root.uri : "";
+    if (!uri.startsWith("file:")) continue;
+    try {
+      const path = safeResolvedPath(fileURLToPath(uri));
+      if (seen.has(path)) continue;
+      seen.add(path);
+      normalized.push({ path });
+    } catch {
+      // Ignore non-local or malformed root URIs. Clients without usable roots fall back to cwd.
+    }
+  }
+  return normalized;
+}
+
+function safeResolvedPath(path: string): string {
+  const resolved = resolve(String(path));
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function pathIsInside(candidate: string, root: string): boolean {
+  const child = safeResolvedPath(candidate);
+  const parent = safeResolvedPath(root);
+  const childRelativeToParent = relative(parent, child);
+  return childRelativeToParent === "" || (!!childRelativeToParent && !childRelativeToParent.startsWith("..") && !isAbsolute(childRelativeToParent));
+}
+
+export function resolveScorePreviewCommand(input: LocalBranchInput = {}): string | undefined {
+  const explicit = input.scorePreviewCommand ?? process.env.GITTENSOR_SCORE_PREVIEW_CMD;
+  if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
+  return undefined;
+}
+
+export function referenceScorePreviewExample(kind: string = "metadata"): string {
+  const script = kind === "gittensor" ? "gittensor-score-preview.py" : "gittensor-score-preview.mjs";
+  const interpreter = kind === "gittensor" ? "python3" : "node";
+  return `${interpreter} ./node_modules/@loopover/mcp/scripts/${script}`;
+}
+
+export function redactScorerCommand(command: unknown): string {
+  const text = String(command ?? "").trim();
+  if (!text) return text;
+  const parts = splitCommand(text);
+  const interpreter = parts[0]?.split(/[\\/]/).pop() ?? "command";
+  const script = parts.at(-1)?.split(/[\\/]/).pop();
+  if (script && /\.(mjs|js|cjs|py)$/i.test(script)) return `${interpreter} <scorer-script>/${script}`;
+  return "<configured-scorer-command>";
+}
+
+export function sanitizeLocalScorerStatus(status: unknown): unknown {
+  if (!status || typeof status !== "object") return status;
+  const bag = status as ScorerStatus;
+  return stripUndefined({
+    ...bag,
+    reason: bag.reason ? redactLocalPath(String(bag.reason)) : undefined,
+    stderr: bag.stderr ? redactLocalPath(String(bag.stderr)) : undefined,
+    scorerCommand: bag.scorerCommand ? redactScorerCommand(bag.scorerCommand) : undefined,
+  });
+}
+
+export function runExternalScorePreview(metadata: Record<string, unknown>, scorerCommand: string | undefined): ScorerStatus {
+  const timeoutMs = scorePreviewTimeoutMs();
+  if (!scorerCommand) {
+    return scorerFailure("missing_scorer_command", "GITTENSOR_SCORE_PREVIEW_CMD is not configured.");
+  }
+  const parts = splitCommand(scorerCommand);
+  const command = parts[0];
+  const args = parts.slice(1);
+  if (!command) {
+    return scorerFailure("empty_scorer_command", "GITTENSOR_SCORE_PREVIEW_CMD is empty.");
+  }
+
+  const startedAt = Date.now();
+  try {
+    const output = execFileSync(command, args, {
+      input: JSON.stringify({
+        ...metadata,
+        repoRoot: metadata.repoRoot ?? metadata.cwd,
+        gittensorRoot: process.env.GITTENSOR_ROOT,
+      }),
+      encoding: "utf8",
+      timeout: timeoutMs,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const durationMs = Date.now() - startedAt;
+    let payload;
+    try {
+      payload = JSON.parse(output);
+    } catch {
+      return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
+        durationMs,
+        stderr: truncateText(output),
+        fallbackMode: "metadata_only",
+      });
+    }
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return scorerFailure("malformed_json", "External scorer stdout must be a JSON object.", {
+        durationMs,
+        fallbackMode: "metadata_only",
+      });
+    }
+    const normalized = normalizeScorerOutput(payload);
+    if (normalized.sourceTokenScore === undefined && normalized.totalTokenScore === undefined) {
+      return scorerFailure("malformed_json", "External scorer JSON must include sourceTokenScore or totalTokenScore.", {
+        durationMs,
+        fallbackMode: "metadata_only",
+      });
+    }
+    return stripUndefined({
+      ok: true,
+      code: "success",
+      reason: "external_scorer_succeeded",
+      durationMs,
+      payload,
+      fallbackMode: "external_command",
+    });
+  } catch (error) {
+    return classifyScorerExecFailure(error, Date.now() - startedAt, scorerCommand);
+  }
+}
+
+export function setupGuidanceForLocalScorer(status: ScorerStatus): string[] {
+  if (status.ok) return [];
+  const safeStatus = sanitizeLocalScorerStatus(status) as ScorerStatus;
+  const code = safeStatus.code ?? inferScorerCode(safeStatus.reason);
+  const guidance = [
+    "LoopOver used metadata-only analysis because no external scorer succeeded.",
+  ];
+  switch (code) {
+    case "missing_scorer_command":
+      guidance.push(`Set GITTENSOR_SCORE_PREVIEW_CMD, for example: export GITTENSOR_SCORE_PREVIEW_CMD="${referenceScorePreviewExample("metadata")}"`);
+      guidance.push(`For tree-sitter scoring with a local gittensor checkout: export GITTENSOR_ROOT=<local-gittensor-checkout> && export GITTENSOR_SCORE_PREVIEW_CMD="${referenceScorePreviewExample("gittensor")}"`);
+      break;
+    case "empty_scorer_command":
+      guidance.push("GITTENSOR_SCORE_PREVIEW_CMD is set but empty; provide a command that reads branch metadata JSON from stdin.");
+      break;
+    case "timeout":
+      guidance.push(`External scorer exceeded ${scorePreviewTimeoutMs()}ms; simplify the scorer or raise GITTENSOR_SCORE_PREVIEW_TIMEOUT_MS.`);
+      break;
+    case "malformed_json":
+      guidance.push("External scorer must print one JSON object with sourceTokenScore/totalTokenScore fields to stdout.");
+      if (safeStatus.stderr) guidance.push(`Last scorer stdout snippet: ${truncateText(safeStatus.stderr, 160)}`);
+      break;
+    case "non_zero_exit":
+      guidance.push("External scorer exited with a non-zero status; inspect stderr and run loopover-mcp doctor.");
+      if (safeStatus.stderr) guidance.push(`Scorer stderr: ${truncateText(safeStatus.stderr, 160)}`);
+      if (typeof safeStatus.exitCode === "number") guidance.push(`Exit code: ${safeStatus.exitCode}`);
+      break;
+    default:
+      guidance.push("Set GITTENSOR_SCORE_PREVIEW_CMD to a command that reads branch metadata JSON from stdin and emits scoring metrics JSON.");
+      if (safeStatus.reason) guidance.push(`Last scorer error: ${safeStatus.reason}`);
+      break;
+  }
+  guidance.push("Local scorer output stays on your machine; LoopOver never uploads source contents.");
+  return guidance;
+}
+
+export function probeLocalScorer(scorerCommand: string | undefined = resolveScorePreviewCommand()): unknown {
+  return sanitizeLocalScorerStatus(
+    runExternalScorePreview(
+    {
+      repoFullName: "JSONbored/loopover",
+      branchName: "doctor-probe",
+      changedFiles: [{ path: "src/example.ts", additions: 12, deletions: 2, status: "modified" }],
+      repoRoot: process.cwd(),
+    },
+      scorerCommand,
+    ),
+  );
+}
+
+function gitOutput(cwd: string, args: string[]): string {
+  try {
+    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
+  } catch {
+    return "";
+  }
+}
+
+export function gitLines(cwd: string, args: string[]): string[] {
+  return gitOutput(cwd, args)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function collectChangedFiles(cwd: string, baseRef: string): ChangedFile[] {
+  // Read both halves with `-z`: the human format quotes non-ASCII/control-char paths, so a quoted
+  // name-status key would never match the verbatim numstat key and the file's stats would be lost.
+  const numstat = new Map(parseNumstat(cwd, baseRef).map((entry) => [entry.path, entry] as const));
+  return parseNameStatus(cwd, baseRef).map((entry) => {
+    const stats = numstat.get(entry.path) ?? { additions: 0, deletions: 0, binary: false };
+    return stripUndefined({
+      path: entry.path,
+      previousPath: entry.previousPath,
+      additions: stats.additions,
+      deletions: stats.deletions,
+      status: statusFromCode(entry.code),
+      binary: stats.binary,
+    });
+  });
+}
+
+function parseNameStatus(cwd: string, baseRef: string) {
+  // `-z`: the status code is its own field and paths are verbatim; a rename is followed by the old
+  // then the new path, any other status by a single path.
+  const records = gitOutput(cwd, ["diff", "--name-status", "-M", "-z", baseRef, "--"]).split("\0");
+  const entries = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const code = records[index];
+    if (!code) continue;
+    const isRename = code.startsWith("R");
+    const previousPath = isRename ? records[index + 1] : undefined;
+    const path = records[index + (isRename ? 2 : 1)];
+    index += isRename ? 2 : 1;
+    entries.push({ code, path: path as string, previousPath });
+  }
+  return entries;
+}
+
+function parseNumstat(cwd: string, baseRef: string) {
+  // `-z`: paths are verbatim and a rename emits old/new as separate fields, not the lossy
+  // "{a => b}" / "a => b" human form that left cross-directory renames keyed by an unmatchable string.
+  const records = gitOutput(cwd, ["diff", "--numstat", "-M", "-z", baseRef, "--"]).split("\0");
+  const entries = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const stat = records[index];
+    if (!stat) continue;
+    const [added, deleted, inlinePath] = splitNumstatStat(stat);
+    // An empty inline path marks a rename: the new path is the second of the two following fields.
+    let path: string | undefined = inlinePath;
+    if (inlinePath === "") {
+      path = records[index + 2];
+      index += 2;
+    }
+    const binary = added === "-";
+    entries.push({ path: path as string, additions: binary ? 0 : Number(added), deletions: binary ? 0 : Number(deleted), binary });
+  }
+  return entries;
+}
+
+function splitNumstatStat(stat: string): [string, string, string] {
+  // "<added>\t<deleted>\t<path?>" -- keep the path slice intact even if it contains tabs.
+  const firstTab = stat.indexOf("\t");
+  const secondTab = stat.indexOf("\t", firstTab + 1);
+  return [stat.slice(0, firstTab), stat.slice(firstTab + 1, secondTab), stat.slice(secondTab + 1)];
+}
+
+function collectCommitMessages(cwd: string, baseRef: string): string[] {
+  const rangeMessages = gitLines(cwd, ["log", "--pretty=%B%x1e", `${baseRef}..HEAD`]).join("\n");
+  const messages = rangeMessages
+    .split("\u001e")
+    .map((message) => message.trim())
+    .filter(Boolean);
+  if (messages.length > 0) return messages.slice(0, 30);
+  const last = gitLines(cwd, ["log", "-1", "--pretty=%B"]).join("\n").trim();
+  return last ? [last] : [];
+}
+
+function defaultBaseRef(cwd: string): string {
+  const originHead = gitLines(cwd, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"])[0];
+  if (originHead) return originHead;
+  if (gitLines(cwd, ["rev-parse", "--verify", "origin/main"]).length > 0) return "origin/main";
+  if (gitLines(cwd, ["rev-parse", "--verify", "origin/master"]).length > 0) return "origin/master";
+  return "HEAD";
+}
+
+function collectRemoteTrackingSha(cwd: string, baseRef: string): string | undefined {
+  const match = String(baseRef ?? "").replace(/^refs\/remotes\//, "").match(/^origin\/(.+)$/);
+  const branch = match?.[1];
+  if (!branch) return undefined;
+  const remoteRow = gitLines(cwd, ["ls-remote", "--heads", "origin", branch])[0];
+  return remoteRow?.split(/\s+/)[0];
+}
+
+function normalizeScorerOutput(payload: ScorerPayload) {
+  const source = payload.source as ScorerPayload | undefined;
+  const total = payload.total as ScorerPayload | undefined;
+  const tests = payload.tests as ScorerPayload | undefined;
+  const nonCode = payload.nonCode as ScorerPayload | undefined;
+  return stripUndefined({
+    mode: "external_command",
+    activeModel: stringValue(payload.activeModel ?? payload.active_model),
+    sourceTokenScore: numberValue(payload.sourceTokenScore ?? payload.source_token_score ?? source?.tokenScore),
+    totalTokenScore: numberValue(payload.totalTokenScore ?? payload.total_token_score ?? total?.tokenScore),
+    sourceLines: numberValue(payload.sourceLines ?? payload.source_lines ?? source?.lines),
+    testTokenScore: numberValue(payload.testTokenScore ?? payload.test_token_score ?? tests?.tokenScore),
+    nonCodeTokenScore: numberValue(payload.nonCodeTokenScore ?? payload.non_code_token_score ?? nonCode?.tokenScore),
+    warnings: Array.isArray(payload.warnings) ? payload.warnings.map(String) : undefined,
+  });
+}
+
+function metadataOnlyScorer(status: ScorerStatus) {
+  return {
+    mode: "metadata_only",
+    warnings: [status.reason ?? status.code ?? "external_scorer_unavailable"],
+  };
+}
+
+function scorerFailure(code: string, reason: string, extra: Record<string, unknown> = {}): ScorerStatus {
+  return stripUndefined({
+    ok: false,
+    code,
+    reason,
+    fallbackMode: "metadata_only",
+    ...extra,
+  });
+}
+
+function classifyScorerExecFailure(error: unknown, durationMs: number, scorerCommand: string | undefined): ScorerStatus {
+  const execError: any = error && typeof error === "object" ? error : undefined;
+  const stdout = String(execError?.stdout ?? execError?.output?.[1] ?? "").trim();
+  const stderr = truncateText(execError?.stderr ?? execError?.output?.[2] ?? "");
+  const exitCode = typeof execError?.status === "number" ? execError.status : undefined;
+  if (stdout && !looksLikeScorerJson(stdout)) {
+    return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
+      durationMs,
+      stderr: truncateText(stdout),
+      scorerCommand: redactScorerCommand(scorerCommand),
+      fallbackMode: "metadata_only",
+    });
+  }
+  if (execError?.code === "ETIMEDOUT" || (execError?.killed && execError?.signal === "SIGTERM")) {
+    return scorerFailure("timeout", `External scorer timed out after ${scorePreviewTimeoutMs()}ms.`, { durationMs, stderr, scorerCommand: redactScorerCommand(scorerCommand) });
+  }
+  if (typeof exitCode === "number" && exitCode !== 0) {
+    return scorerFailure("non_zero_exit", `External scorer exited with status ${exitCode}.`, { durationMs, stderr, exitCode, scorerCommand: redactScorerCommand(scorerCommand) });
+  }
+  const message = error instanceof Error ? error.message : "external_scorer_failed";
+  if (/JSON/i.test(message)) {
+    return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", { durationMs, stderr, scorerCommand: redactScorerCommand(scorerCommand) });
+  }
+  if (stderr && !looksLikeScorerJson(stderr)) {
+    return scorerFailure("malformed_json", "External scorer stdout was not valid JSON.", {
+      durationMs,
+      stderr: truncateText(stderr),
+      scorerCommand: redactScorerCommand(scorerCommand),
+      fallbackMode: "metadata_only",
+    });
+  }
+  return scorerFailure("scorer_failed", redactLocalPath(message), { durationMs, stderr, exitCode, scorerCommand: redactScorerCommand(scorerCommand) });
+}
+
+function looksLikeScorerJson(output: string): boolean {
+  try {
+    const payload = JSON.parse(output);
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+    const normalized = normalizeScorerOutput(payload);
+    return normalized.sourceTokenScore !== undefined || normalized.totalTokenScore !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+function inferScorerCode(reason: unknown): string {
+  const text = String(reason ?? "");
+  if (text.includes("missing_scorer_command")) return "missing_scorer_command";
+  if (text.includes("empty_scorer_command")) return "empty_scorer_command";
+  if (/timed out|ETIMEDOUT/i.test(text)) return "timeout";
+  if (/JSON/i.test(text)) return "malformed_json";
+  if (/status \d+/i.test(text)) return "non_zero_exit";
+  return "scorer_failed";
+}
+
+function scorePreviewTimeoutMs(): number {
+  const parsed = Number(process.env.GITTENSOR_SCORE_PREVIEW_TIMEOUT_MS ?? 15000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
+}
+
+function truncateText(value: unknown, maxLength = 240): string | undefined {
+  const text = String(value ?? "").trim();
+  if (!text) return undefined;
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
+}
+
+function splitCommand(command: unknown): string[] {
+  return String(command).match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? [];
+}
+
+function assertSourceUploadDisabled(): void {
+  if (/^(1|true|yes)$/i.test(process.env.LOOPOVER_UPLOAD_SOURCE ?? "false")) {
+    throw new Error("LOOPOVER_UPLOAD_SOURCE=true is not supported in v1; local MCP sends metadata only.");
+  }
+}
+
+// Word-boundary the closing keywords (as the server-side extractors in src/db/repositories.ts and
+// src/signals/engine.ts already do) so a keyword embedded in a longer word does not spuriously link an
+// issue: without \b, `hotfix 5` / `prefixes 12` matched the `fix`/`fixes` substring and captured the
+// trailing number. The bare `#` branch stays boundary-free so `#123` still matches anywhere.
+export function extractLinkedIssues(text: unknown): number[] {
+  const issues = [];
+  for (const match of String(text).matchAll(/(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)|#)\s*#?(\d+)/gi)) issues.push(Number(match[1]));
+  return issues.filter((issue) => Number.isInteger(issue) && issue > 0);
+}
+
+function statusFromCode(code: string): string {
+  if (code.startsWith("A")) return "added";
+  if (code.startsWith("M")) return "modified";
+  if (code.startsWith("D")) return "deleted";
+  if (code.startsWith("R")) return "renamed";
+  if (code.startsWith("C")) return "copied";
+  return "unknown";
+}
+
+function titleFromBranch(branchName: unknown): string {
+  return String(branchName ?? "")
+    .replace(/^[-/_.\w]+\/(?=[^/]+$)/, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+}
+
+function firstCommitTitle(messages: string[]): string | undefined {
+  return messages.find((message) => message.trim().length > 0)?.split("\n")[0]?.trim();
+}
+
+function numberValue(value: unknown): number | undefined {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(stripUndefined) as T;
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([, entry]) => entry !== undefined).map(([key, entry]) => [key, stripUndefined(entry)])) as T;
+}


### PR DESCRIPTION
Phase 2 of the `packages/loopover-mcp` TypeScript migration (#7291), building on the tsc build pipeline that landed in Phase 1 (#7409).

## What
Port `lib/local-branch.js` → `lib/local-branch.ts`. The tsconfig `include` glob (`lib/**/*.ts`) picks the new source up automatically, and it compiles in place to `lib/local-branch.js` (inline source map, no `.d.ts`) — exactly the layout the package already ships, so no consumer import path changes.

## Behavior
Runtime behavior and the public export surface are unchanged — every exported function keeps its name and semantics, and `bin/loopover-mcp.js` consumes the compiled `.js` exactly as before. The shipped `lib/local-branch.js` is now compiler-emitted rather than hand-maintained. Types were added at the process/JSON boundaries as open records (matching the existing converted `lib/` files), keeping the strict build clean without narrowing the dynamic scorer/git-diff shapes.

Closes #7329