### PR TITLE
fix(orb): index orb_relay_pending by created_at so the relay-drain prune stops full-scanning

### DIFF
--- a/migrations/0167_orb_relay_pending_created_at_index.sql
+++ b/migrations/0167_orb_relay_pending_created_at_index.sql
@@ -1,0 +1,10 @@
+-- #7430: pruneRelayPending (run on every pull-mode relay-drain, fleet-wide, every 30s) filters
+-- orb_relay_pending by a bare created_at predicate:
+--   SELECT ... WHERE created_at < ? ORDER BY created_at, delivery_id LIMIT ?
+--   DELETE     WHERE created_at < ?
+-- Both existing indexes lead with installation_id (idx_orb_relay_pending_install /
+-- idx_orb_relay_pending_coalesce), so neither serves a created_at-only predicate — the SELECT and
+-- DELETE full-scan the table and can exceed the pull request's AbortSignal.timeout(30_000) budget.
+-- A (created_at, delivery_id) index turns both into range scans and lets the SELECT satisfy its
+-- ORDER BY (created_at, delivery_id) from the index without a sort.
+CREATE INDEX IF NOT EXISTS idx_orb_relay_pending_created_at ON orb_relay_pending (created_at, delivery_id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -879,6 +879,10 @@ export const orbRelayPending = sqliteTable(
     coalesce: index("idx_orb_relay_pending_coalesce")
       .on(table.installationId, table.coalesceKey)
       .where(sql`coalesce_key IS NOT NULL`),
+    // #7430: pruneRelayPending filters by a bare created_at predicate (no installation_id), which the
+    // two installation_id-leading indexes above can't serve — this one keeps that fleet-wide 30s drain
+    // prune a range scan instead of a full table scan.
+    createdAt: index("idx_orb_relay_pending_created_at").on(table.createdAt, table.deliveryId),
   }),
 );
 

--- a/test/unit/orb-relay-pending-index.test.ts
+++ b/test/unit/orb-relay-pending-index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../helpers/d1";
+
+describe("orb_relay_pending created_at prune index", () => {
+  it("creates the (created_at, delivery_id) index and pruneRelayPending's queries use it (SEARCH, not SCAN)", async () => {
+    const env = createTestEnv();
+
+    const idx = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+      .bind("idx_orb_relay_pending_created_at")
+      .first<{ name: string }>();
+    expect(idx?.name).toBe("idx_orb_relay_pending_created_at");
+
+    // pruneRelayPending's SELECT: WHERE created_at < ? ORDER BY created_at, delivery_id — must SEARCH via
+    // the new index, whose column order matches the ORDER BY so no separate sort (temp B-tree) is needed.
+    const selectPlan = await env.DB.prepare(
+      "EXPLAIN QUERY PLAN SELECT delivery_id, event_name, installation_id FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours') ORDER BY created_at, delivery_id LIMIT ?",
+    )
+      .bind(24, 20)
+      .all<{ detail: string }>();
+    const selectDetail = (selectPlan.results ?? []).map((row) => row.detail).join(" ");
+    expect(selectDetail).toContain("idx_orb_relay_pending_created_at");
+    expect(selectDetail).not.toContain("SCAN orb_relay_pending ");
+    expect(selectDetail).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+
+    // pruneRelayPending's DELETE: WHERE created_at < ? — must SEARCH via the same index.
+    const deletePlan = await env.DB.prepare(
+      "EXPLAIN QUERY PLAN DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')",
+    )
+      .bind(24)
+      .all<{ detail: string }>();
+    const deleteDetail = (deletePlan.results ?? []).map((row) => row.detail).join(" ");
+    expect(deleteDetail).toContain("idx_orb_relay_pending_created_at");
+    expect(deleteDetail).not.toContain("SCAN orb_relay_pending ");
+  });
+});


### PR DESCRIPTION
## Summary

- `pruneRelayPending` runs on every pull-mode relay-drain (`POST /v1/orb/relay/pull`, fleet-wide, every 30s) and filters `orb_relay_pending` by a bare `created_at` predicate. Both existing indexes lead with `installation_id`, so neither can serve it — the SELECT and DELETE full-scan the table and can exceed the pull request's `AbortSignal.timeout(30_000)` budget, surfacing as the recurring `TimeoutError` in Sentry since 2026-07-15.
- Adds a `(created_at, delivery_id)` index (`idx_orb_relay_pending_created_at`) — declared in `src/db/schema.ts` and created in `migrations/0167_orb_relay_pending_created_at_index.sql`. It turns both the SELECT (`WHERE created_at < ? ORDER BY created_at, delivery_id`) and the DELETE (`WHERE created_at < ?`) into index range scans, and lets the SELECT satisfy its `ORDER BY` from the index with no temp-B-tree sort.

Closes #7430

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7430`).

## Validation

- [x] `git diff --check`
- [x] `npm run db:migrations:check` (contiguous 0001..0167, no new duplicates)
- [x] `npm run db:schema-drift:check` (schema.ts matches migrations/)
- [x] `npm run typecheck`
- [x] New regression test `test/unit/orb-relay-pending-index.test.ts` asserts the index exists and that both of `pruneRelayPending`'s queries `EXPLAIN QUERY PLAN` as a SEARCH via `idx_orb_relay_pending_created_at` (not a `SCAN`, and with no temp-B-tree sort). It fails before this change (full scan) and passes after.
- [x] `test/integration/orb-relay.test.ts` (83 tests) still green.
- [x] `codecov/patch`: the only measured diff line is the schema.ts index declaration, executed at module import like its sibling index declarations; the migration and test files are not coverage-measured.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, or private evidence exposed.
- [x] Pure DB-index change: no behavior change to query results, only their access path — existing relay tests confirm identical outcomes.

## Notes

- The index mirrors the SELECT's `ORDER BY (created_at, delivery_id)` column order so the drain prune needs neither a full scan nor a sort step.
