### PR TITLE
fix(miner-ui): give ChatComposer's textarea an accessible name

### DIFF
--- a/apps/loopover-miner-ui/src/chat-composer.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-composer.test.tsx
@@ -9,7 +9,8 @@ const MAX_HEIGHT_PX = 160;
 function setup(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
   const onSubmit = vi.fn();
   render(<ChatComposer onSubmit={onSubmit} {...props} />);
-  const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+  // #7440: query by accessible name so this pins that the composer's textarea actually has one.
+  const textarea = screen.getByRole("textbox", { name: /chat message/i }) as HTMLTextAreaElement;
   return { onSubmit, textarea, button: screen.getByRole("button", { name: /send/i }) };
 }
 

--- a/apps/loopover-miner-ui/src/components/chat-composer.tsx
+++ b/apps/loopover-miner-ui/src/components/chat-composer.tsx
@@ -58,6 +58,10 @@ export function ChatComposer({
     <div className="flex items-end gap-2">
       <Textarea
         ref={textareaRef}
+        // #7440: the ui-kit Textarea is a bare native <textarea> with no label of its own, and a
+        // placeholder is not a reliable accessible name (it vanishes once typing starts and is exposed
+        // to AT inconsistently). Give it a stable, purpose-describing name independent of `placeholder`.
+        aria-label="Chat message"
         value={value}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={(event) => {


### PR DESCRIPTION
## Summary

`ChatComposer`'s `<Textarea>` (`apps/loopover-miner-ui/src/components/chat-composer.tsx`) had no `aria-label`/`aria-labelledby`/wrapping label. The ui-kit `Textarea` is a deliberately bare native `<textarea>`, so the caller must supply a name; `placeholder` isn't a substitute (WCAG 2.1 SC 3.3.2 / 4.1.2 — it disappears on input and its exposure to assistive tech as an accessible name is inconsistent).

## Fix

Add a stable `aria-label="Chat message"` to the Textarea — hardcoded and independent of the `placeholder` prop (which callers can override), matching how the other bare/icon-only controls in this codebase (`theme-toggle`, the copy button, `back-to-top`, …) are labelled.

## Verification

`chat-composer.test.tsx`'s `setup()` now queries `getByRole("textbox", { name: /chat message/i })`, so the test asserts the accessible name exists and pins the fix. All chat-composer and chat-conversation tests pass (21).

Closes #7440
