### PR TITLE
docs(ci): fix stale vitest.config.ts comment about lib/cli-error.js coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,10 +51,10 @@ export default defineConfig({
         "packages/discovery-index/src/**/*.ts",
         // packages/loopover-mcp/lib/*.js are plain JS today; issue #7291 migrates them to real TypeScript,
         // keeping the same .js/.ts/.d.ts triplet shape packages/loopover-miner/lib/** already has (so
-        // coverage is wired BEFORE that PR lands, not as a follow-up fix). 4 of the 5 files
-        // (format-table/local-branch/redact-local-path/telemetry) are already imported in-process by
-        // test/unit/*.test.ts; lib/cli-error.js currently has no in-process test at all, so it will need
-        // one before a PR touching it can pass codecov/patch -- that's intended enforcement, not a bug.
+        // coverage is wired BEFORE that PR lands, not as a follow-up fix). All 5 files
+        // (format-table/local-branch/redact-local-path/telemetry/cli-error) are now imported in-process
+        // by test/unit/*.test.ts (cli-error's own test/unit/mcp-cli-error.test.ts landed in #7409), so a
+        // PR touching any of them is covered by codecov/patch -- that's intended enforcement, not a bug.
         "packages/loopover-mcp/lib/**/*.js",
         "packages/loopover-mcp/lib/**/*.ts",
         // packages/loopover-mcp/bin/loopover-mcp.js (~6,600 of ~7,400 lines in the package) is tested


### PR DESCRIPTION
Closes #7435

## What

`vitest.config.ts`'s comment above the `packages/loopover-mcp/lib/**/*.js` `coverage.include` entry claimed `lib/cli-error.js` had **no in-process test**. That was true when written (`80b59c64`), but **#7409** (merged 2026-07-20) added `test/unit/mcp-cli-error.test.ts`, which imports `cli-error.js` in-process and exercises all three of its exports. The comment was never updated, so it now tells a contributor something false about the package's test-coverage state.

This corrects the sentence to reflect that all five of the package's `lib/` files (`format-table`/`local-branch`/`redact-local-path`/`telemetry`/`cli-error`) now have in-process tests.

## Scope

- **Comment-only** — no `coverage.include`/`coverage.exclude` glob or any other behavior changed (verified: the diff is 4 comment lines).
- Nothing to regression-test (no executable code path affected).
