### PR TITLE
fix(review): compute public-stats accuracyPct from own-ledger merged/closed only

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -377,6 +377,13 @@ export async function getPublicStats(
   // Snapshot before Orb merge: effort SQL only covers allowlisted own-ledger publishes, while `reviewed`
   // below includes Orb fleet outcomes folded into totals.merged/closed.
   const ownLedgerReviewed = reviewedOf(totals);
+  // #7449: also snapshot the pre-fold own-ledger merged/closed. totals.reversed stays own-ledger-only (the Orb
+  // aggregate has no reversal concept), so the published global accuracyPct below is computed from THESE, not the
+  // fleet-folded totals.merged/closed -- otherwise the denominator would grow with every newly registered install
+  // while the numerator stayed own-ledger-scoped, trending the percentage toward 100 independent of real reversal
+  // behavior. The fleet fold still (correctly) inflates reviewed/handled/minutesSaved, which have no such pairing.
+  const ownLedgerMerged = totals.merged;
+  const ownLedgerClosed = totals.closed;
   const orb = await getOrbGlobalStats(env);
   totals.merged += orb.merged;
   totals.closed += orb.closed;
@@ -398,7 +405,10 @@ export async function getPublicStats(
       ...totals,
       reviewed,
       filteredPct: filteredPct(reviewed, totals.merged),
-      accuracyPct: accuracyPct(totals.merged, totals.closed, totals.reversed),
+      // Option 1 of #7449: compute the global accuracy from the OWN-LEDGER merged/closed snapshot (not the
+      // fleet-folded totals.merged/closed), so its numerator (own-ledger reversed) and denominator are drawn
+      // from the same population. See the ownLedgerMerged/ownLedgerClosed snapshot above the Orb fold for why.
+      accuracyPct: accuracyPct(ownLedgerMerged, ownLedgerClosed, totals.reversed),
       minutesSaved,
     },
     weekly: { reviewed: w.reviewed ?? 0, merged: w.merged ?? 0 },

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -311,6 +311,28 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     expect(out.totals.minutesSaved).toBe(2742 * MINUTES_SAVED_PER_PR + 80 * MINUTES_SAVED_PER_PR);
   });
 
+  it("REGRESSION (#7449): global accuracyPct reflects the own-ledger population, not the Orb-fleet-inflated merged/closed denominator", async () => {
+    // Own-ledger: 100 decided (all merged), 10 real reversals -> a true 90% accuracy. A huge registered Orb fleet
+    // (6000 merged + 4000 closed, with no reversal data at all) must NOT dilute the denominator toward 100.
+    const handler = (sql: string): Row[] => {
+      if (isDispositions(sql)) return [{ project: "JSONbored/loopover", reviewed: 100, merged: 100, closed: 0, inReview: 0 }];
+      if (isReversal(sql)) return [{ project: "JSONbored/loopover", reversed: 10 }];
+      if (sql.includes("orb_pr_outcomes")) return [{ merged: 6000, closed: 4000, total: 10000 }];
+      return [];
+    };
+    const out = await getPublicStats(stubEnv(handler), NOW);
+    // The fleet fold still (correctly) inflates the raw aggregate counts...
+    expect(out.totals.merged).toBe(100 + 6000);
+    expect(out.totals.closed).toBe(0 + 4000);
+    expect(out.totals.handled).toBe(100 + 10000);
+    // ...but accuracy is computed from own-ledger only: 1 - 10/(100 + 0) = 90.0%.
+    expect(out.totals.accuracyPct).toBe(90);
+    // The pre-fix fleet-inflated denominator would have produced 1 - 10/(6100 + 4000) = 99.0% -- guard against it.
+    expect(out.totals.accuracyPct).not.toBe(99);
+    // Per-project accuracy is already same-scope and stays unchanged: 1 - 10/100 = 90.
+    expect(out.byProject[0]!.accuracyPct).toBe(90);
+  });
+
   it("keeps own-ledger per-PR effort sum separate from Orb fleet flat credit", async () => {
     const withOrbAndEffort = (sql: string): Row[] => {
       if (sql.includes("orb_pr_outcomes")) return [{ merged: 10, closed: 5, total: 15 }];


### PR DESCRIPTION
## Summary

Fixes #7449. `getPublicStats` computed the homepage's global `totals.accuracyPct` as `accuracyPct(totals.merged, totals.closed, totals.reversed)`, but those inputs are drawn from **structurally different, independently-growing populations**: `totals.merged`/`totals.closed` are folded with the whole registered Orb fleet's counts (via `getOrbGlobalStats`, which has no reversal concept), while `totals.reversed` stays own-ledger-only. Since `accuracyPct` is `1 - min(1, reversed / (merged + closed))`, the denominator grows with every newly registered install while the numerator stays fixed to the own-ledger repos — so the published accuracy trended toward 100% as more self-hosted installations registered, independent of the fleet's actual reversal behavior.

## Fix (option 1 from the issue)

Snapshot the pre-fold **own-ledger** `merged`/`closed` (right beside the existing `ownLedgerReviewed` snapshot) and compute the global `accuracyPct` from those, so its numerator and denominator come from the same population. The Orb-fleet fold still (correctly) inflates the raw `reviewed`/`handled`/`minutesSaved` totals — those have no numerator/denominator pairing and are working as intended per the file's own comments. `accuracyPct`'s formula/signature is untouched, and per-project `byProject[].accuracyPct` was already same-scope (each computed from its own merged/closed/reversed) and is unchanged. A code comment at the call site (and at the snapshot) documents the choice, matching the file's house style of documenting non-obvious metric-composition decisions.

Option 2 (fold a fleet-wide reversal count into `totals.reversed`) was not chosen: `getOrbGlobalStats` (`src/orb/outcomes.ts`) reports only `{ merged, closed, total }` with no reversal tracking, so option 2 would require a schema/query extension for no additional accuracy over option 1.

## Tests

`test/unit/public-stats.test.ts` adds a regression test running the real `getPublicStats` end-to-end (own-ledger disposition + reversal reads and the `orb_pr_outcomes` aggregate all mocked): 100 own-ledger decided PRs with 10 real reversals (a true 90% accuracy) plus a huge 10,000-PR Orb fleet fold. It asserts the raw counts still fold (`merged`/`closed`/`handled`) **but** `accuracyPct` is `90`, not the pre-fix fleet-inflated `99`, and that per-project accuracy stays `90`. All existing `getPublicStats` field tests (`reviewed`/`handled`/`minutesSaved`/per-project `accuracyPct`, the Orb-fold tests) pass unchanged. Every changed line + branch is covered (verified via `--coverage`), so `codecov/patch` holds.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root `tsc --noEmit`) green
- [x] `npm run test:coverage` on the affected suite: **100% of changed lines + branches covered**; existing `public-stats` unit + integration-route tests pass unmodified
- [x] Scope is `src/review/public-stats.ts` + its unit test only. The returned stats object's fields/shape are unchanged (same `accuracyPct: number | null`), so no OpenAPI/schema/generated artifact needs regeneration

## Safety

- [x] No secrets, wallets, hotkeys/coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence.
- [x] Public-facing metric change only makes the published number more honest (can no longer be inflated toward 100% by fleet growth); no new data is exposed.
- [x] Auth/CORS/session: N/A. API/OpenAPI/MCP: N/A (response shape unchanged). UI: N/A. No changelog edit; no `site/`/`CNAME`/`lovable` changes.

Closes #7449
