### PR TITLE
feat(mcp): add repo-agnostic AI issue-planning tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -84,6 +84,7 @@ import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } 
 import { getRepositoryCollaboratorPermission } from "../github/app";
 import { performRepoDocRefresh } from "../github/repo-doc-refresh-runner";
 import { generateContributorIssueDrafts } from "../services/contributor-issue-draft";
+import { generateIssuePlanDrafts } from "../services/issue-plan-draft";
 import { sanitizePublicComment } from "../github/commands";
 import { fetchPublicContributorProfile } from "../github/public";
 import { listLatestRegistrySnapshots } from "../registry/sync";
@@ -660,6 +661,48 @@ const generateContributorIssueDraftsOutputSchema = {
   skippedUnsafe: z.number(),
   created: z.number(),
   skippedCreateFailed: z.number(),
+};
+
+// #7426: dryRun/create/limit mirror generateContributorIssueDraftsShape's own bounds/defaults (create alone is
+// rejected -- the handler re-applies the explicit_create_requires_dry_run_false guard). `limit` is capped lower
+// (10, not 20): every draft here costs real LLM spend, unlike that tool's zero-cost static signals.
+const planRepoIssuesShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  goal: z.string().min(1).max(2000),
+  dryRun: z.boolean().optional().default(true),
+  create: z.boolean().optional().default(false),
+  limit: z.number().int().min(1).max(10).optional().default(5),
+};
+
+const planRepoIssuesOutputSchema = {
+  repoFullName: z.string(),
+  generatedAt: z.string(),
+  status: z.string(),
+  dryRun: z.boolean(),
+  createRequested: z.boolean(),
+  proposed: z.number(),
+  skippedDuplicate: z.number(),
+  skippedDeclined: z.number(),
+  skippedUnsafe: z.number(),
+  created: z.number(),
+  skippedCreateFailed: z.number(),
+  // Unlike generateContributorIssueDraftsOutputSchema, this INCLUDES each draft's title/body/labels: the content
+  // is generated fresh from the caller's own goal for their own repo (no loopover-internal signal to scrub), and
+  // the whole point of the dry-run-by-default posture is letting a maintainer actually read the proposal before
+  // deciding to create it.
+  drafts: z
+    .array(
+      z.object({
+        title: z.string(),
+        body: z.string(),
+        labels: z.array(z.string()),
+        status: z.string(),
+        issueNumber: z.number().optional(),
+        issueUrl: z.string().optional(),
+      }),
+    )
+    .optional(),
 };
 
 // #784 (MCP slice) — the agent audit feed: executed actions + approval decisions for a repo.
@@ -1810,6 +1853,7 @@ export const MCP_TOOL_CATEGORIES: Record<string, McpToolCategory> = {
   loopover_decide_pending_action: "agent",
   loopover_refresh_repo_docs: "maintainer",
   loopover_generate_contributor_issue_drafts: "maintainer",
+  loopover_plan_repo_issues: "maintainer",
   loopover_get_agent_audit_feed: "agent",
   loopover_explain_score_breakdown: "review",
   loopover_explain_review_risk: "review",
@@ -2572,6 +2616,17 @@ export class LoopoverMcp {
         outputSchema: generateContributorIssueDraftsOutputSchema,
       },
       async (input) => this.toolResult(await this.generateContributorIssueDrafts(input)),
+    );
+
+    register(
+      "loopover_plan_repo_issues",
+      {
+        description:
+          "AI-plan a small set of concrete GitHub issues from a maintainer-supplied free-form goal, for ANY repo the caller's App/Orb is installed on -- repo-agnostic and gittensor-optional (#7426). Dry-run BY DEFAULT: only PREVIEWS drafts (full title/body/labels) unless the caller passes BOTH create:true and dryRun:false, so it can never silently open issues. Creates exclusively via the installation-token/Orb-broker path (#7425), never a flat PAT. Makes a real LLM call subject to the shared daily AI budget and the fleet AI_SUMMARIES_ENABLED/AI_PUBLIC_COMMENTS_ENABLED switches. Maintainer access required.",
+        inputSchema: planRepoIssuesShape,
+        outputSchema: planRepoIssuesOutputSchema,
+      },
+      async (input) => this.toolResult(await this.planRepoIssues(input)),
     );
 
     register(
@@ -4236,6 +4291,49 @@ export class LoopoverMcp {
         skippedUnsafe: result.skippedUnsafe,
         created: result.created,
         skippedCreateFailed: result.skippedCreateFailed,
+      },
+    };
+  }
+
+  // #7426: repo-agnostic counterpart to generateContributorIssueDrafts above. requireRepoManageAccess is checked
+  // FIRST, then the SAME explicit_create_requires_dry_run_false guard is re-applied here (the service itself
+  // still overlays the global agent kill-switch on top). Unlike generateContributorIssueDrafts, the response
+  // includes each draft's full title/body/labels -- see planRepoIssuesOutputSchema's doc comment for why that's
+  // safe here (no loopover-internal signal to scrub).
+  private async planRepoIssues(input: z.infer<z.ZodObject<typeof planRepoIssuesShape>>): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoManageAccess(fullName);
+    if (input.create && input.dryRun !== false) {
+      throw new Error("explicit_create_requires_dry_run_false: pass create:true together with dryRun:false to open issues.");
+    }
+    const result = await generateIssuePlanDrafts(this.env, fullName, input.goal, {
+      dryRun: input.dryRun,
+      create: input.create,
+      limit: input.limit,
+      requestedBy: this.identity.kind === "session" ? this.identity.actor : "mcp",
+    });
+    return {
+      summary: `Issue plan for ${fullName} (status=${result.status}, dryRun=${result.dryRun}): ${result.proposed} proposed, ${result.created} created, ${result.skippedDuplicate} duplicate, ${result.skippedDeclined} declined, ${result.skippedUnsafe} unsafe.`,
+      data: {
+        repoFullName: result.repoFullName,
+        generatedAt: result.generatedAt,
+        status: result.status,
+        dryRun: result.dryRun,
+        createRequested: result.createRequested,
+        proposed: result.proposed,
+        skippedDuplicate: result.skippedDuplicate,
+        skippedDeclined: result.skippedDeclined,
+        skippedUnsafe: result.skippedUnsafe,
+        created: result.created,
+        skippedCreateFailed: result.skippedCreateFailed,
+        drafts: result.drafts.map((draft) => ({
+          title: draft.title,
+          body: draft.body,
+          labels: draft.labels,
+          status: draft.status,
+          ...(draft.issue?.number !== undefined ? { issueNumber: draft.issue.number } : {}),
+          ...(draft.issue?.url !== undefined ? { issueUrl: draft.issue.url } : {}),
+        })),
       },
     };
   }

--- a/src/services/issue-plan-draft.ts
+++ b/src/services/issue-plan-draft.ts
@@ -1,0 +1,417 @@
+// Repo-agnostic AI issue planning (#7426, sub-issue of the ORB self-hoster planning epic #7424). Given a
+// maintainer-supplied free-form goal, generates a small set of structured GitHub issue drafts (title/body/labels)
+// for ANY repo the caller's App/Orb is installed on -- unlike generateContributorIssueDrafts (contributor-issue-
+// draft.ts), which derives candidates purely from loopover-specific static signals (policy readiness, upstream
+// drift, focus-manifest wanted paths) with zero LLM cost. This is genuinely generative: it calls the configured
+// AI reviewer (mirroring review/planner.ts's `@loopover plan` shape) and is subject to the shared daily AI budget.
+//
+// Creates exclusively via the installation-token/Orb-broker path (src/github/issues.ts, #7425) -- never a flat
+// PAT -- so it only works on a repo the caller's own App/Orb-brokered install actually covers.
+
+import {
+  type AiReviewActualUsage,
+  BEST_REVIEW_MODELS,
+  clampNumber,
+  coerceAiText,
+  coerceAiUsage,
+  estimateNeurons,
+  extractLastJsonObject,
+  isEnabled,
+  isRateLimitError,
+  RELIABLE_FALLBACK_MODELS,
+  utcDayStartIso,
+} from "./ai-review";
+import { createInstallationIssue } from "../github/issues";
+import { isMaintainerAssociation } from "../github/commands";
+import {
+  getRepository,
+  isGlobalAgentFrozen,
+  listClosedContributorDraftIssues,
+  listOpenIssues,
+  listRepoLabels,
+  recordAiUsageEvent,
+  recordAuditEvent,
+  sumAiEstimatedNeuronsSince,
+} from "../db/repositories";
+import { isGlobalAgentPause } from "../settings/agent-execution";
+import { isFocusManifestPublicSafe } from "../signals/focus-manifest";
+import { normalizeIssueTitleKey } from "./contributor-issue-draft";
+import type { IssueRecord } from "../types";
+import { sha256Hex } from "../utils/crypto";
+import { errorMessage, nowIso } from "../utils/json";
+
+export const ISSUE_PLAN_DRAFT_MARKER_PREFIX = "loopover-issue-plan-draft";
+
+export function issuePlanDraftMarker(fingerprint: string): string {
+  return `<!-- ${ISSUE_PLAN_DRAFT_MARKER_PREFIX}:${fingerprint} -->`;
+}
+
+export async function issuePlanDraftFingerprint(repoFullName: string, titleKey: string): Promise<string> {
+  return sha256Hex(`${ISSUE_PLAN_DRAFT_MARKER_PREFIX}:v1:${repoFullName.toLowerCase()}:${titleKey}`);
+}
+
+export type IssuePlanDraftStatus = "proposed" | "skipped_duplicate" | "skipped_declined" | "skipped_unsafe" | "created" | "skipped_create_failed";
+
+export type IssuePlanDraft = {
+  fingerprint: string;
+  title: string;
+  body: string;
+  labels: string[];
+  status: IssuePlanDraftStatus;
+  duplicateOf?: { number: number; title: string; reason: "marker" | "title" } | undefined;
+  declinedBy?: { number: number; title: string; reason: "wontfix" | "cooldown" } | undefined;
+  issue?: { number: number; url: string } | undefined;
+};
+
+// Marker/title dedup, duplicated from contributor-issue-draft.ts's findDuplicateContributorDraft rather than
+// imported: that function hardcodes CONTRIBUTOR_ISSUE_DRAFT_MARKER_PREFIX internally, so reusing it here would
+// tag these AI-planned drafts with the wrong (misleading) marker family. normalizeIssueTitleKey itself has no
+// prefix coupling and is imported directly.
+export function findDuplicateIssuePlanDraft(
+  openIssues: IssueRecord[],
+  draft: Pick<IssuePlanDraft, "fingerprint" | "title">,
+): { number: number; title: string; reason: "marker" | "title" } | null {
+  const marker = issuePlanDraftMarker(draft.fingerprint);
+  for (const issue of openIssues) {
+    if (issue.state !== "open") continue;
+    if (issue.body?.includes(marker)) return { number: issue.number, title: issue.title, reason: "marker" };
+  }
+  const titleKey = normalizeIssueTitleKey(draft.title);
+  if (!titleKey) return null;
+  for (const issue of openIssues) {
+    if (issue.state !== "open") continue;
+    if (normalizeIssueTitleKey(issue.title) === titleKey) return { number: issue.number, title: issue.title, reason: "title" };
+  }
+  return null;
+}
+
+export const ISSUE_PLAN_DRAFT_DECLINED_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+const DECLINED_ISSUE_PLAN_WONTFIX_LABELS = new Set(["wontfix", "wont-fix", "invalid", "duplicate", "not-planned"]);
+
+/** Mirrors contributor-issue-draft.ts's findDeclinedContributorDraft exactly (same wontfix/cooldown/maintainer-
+ *  authorship contract) but keyed off this module's own marker family -- see findDuplicateIssuePlanDraft's doc. */
+export function findDeclinedIssuePlanDraft(
+  closedIssues: IssueRecord[],
+  draft: Pick<IssuePlanDraft, "fingerprint">,
+  options: { now?: number | undefined; cooldownMs?: number | undefined } = {},
+): { number: number; title: string; reason: "wontfix" | "cooldown" } | null {
+  const marker = issuePlanDraftMarker(draft.fingerprint);
+  const nowMs = options.now ?? Date.now();
+  const cooldownMs = options.cooldownMs ?? ISSUE_PLAN_DRAFT_DECLINED_COOLDOWN_MS;
+  for (const issue of closedIssues) {
+    if (issue.state !== "closed") continue;
+    if (!issue.body?.includes(marker)) continue;
+    if (issue.labels.some((label) => DECLINED_ISSUE_PLAN_WONTFIX_LABELS.has(label.trim().toLowerCase()))) {
+      return { number: issue.number, title: issue.title, reason: "wontfix" };
+    }
+    if (!isMaintainerAssociation(issue.authorAssociation)) continue;
+    const closedAtMs = issue.closedAt ? Date.parse(issue.closedAt) : Number.NaN;
+    if (!Number.isFinite(closedAtMs) || nowMs - closedAtMs < cooldownMs) return { number: issue.number, title: issue.title, reason: "cooldown" };
+  }
+  return null;
+}
+
+const ISSUE_PLAN_SYSTEM_PROMPT = [
+  "You are a senior open-source maintainer assistant. Given a repository's existing labels and a maintainer's",
+  "planning goal, propose a SMALL set of concrete, actionable GitHub issues that move that goal forward. Respond",
+  'with ONLY a JSON object of this exact shape: {"issues":[{"title":string,"body":string,"labels":string[]}]}.',
+  "Each issue's body must be GitHub-flavored markdown with a one-line **Summary**, a **Proposed approach**",
+  "(2-4 bullets), and **Acceptance criteria**. Prefer reusing the repository's existing labels over inventing new",
+  "ones; only propose a new label when none of the existing ones fit. Keep each issue narrowly scoped -- one",
+  "coherent change per issue, not a mega-issue. Never invent file paths you are not reasonably confident about.",
+  "Do NOT include secrets, credentials, tokens, wallet/hotkey/coldkey details, trust scores, reward or payout",
+  'figures, or any private data. If the goal is too vague to plan from, respond with {"issues":[]}.',
+].join(" ");
+
+const MAX_GOAL_CHARS = 2_000;
+const MAX_TITLE_CHARS = 200;
+const MAX_BODY_CHARS = 4_000;
+const MAX_LABELS_PER_DRAFT = 4;
+const MAX_EXISTING_LABELS_IN_PROMPT = 40;
+// Needs room for several full issue bodies at once, unlike the planner's single-plan PLANNER_MAX_TOKENS=1_200.
+const ISSUE_PLAN_MAX_TOKENS = 3_000;
+const ISSUE_PLAN_MODEL_COUNT = 4;
+const DEFAULT_LIMIT = 5;
+// Lower than contributor-issue-draft.ts's static MAX_LIMIT=20: every draft here costs real LLM spend, the static
+// generator's candidates cost none.
+const MAX_LIMIT = 10;
+
+function issuePlanDailyBudget(env: Env): number {
+  const raw = Number(env.AI_DAILY_NEURON_BUDGET);
+  return clampNumber(env.AI_DAILY_NEURON_BUDGET && Number.isFinite(raw) ? raw : 10_000_000, 0, 10_000_000);
+}
+
+async function recordIssuePlanUsage(
+  env: Env,
+  args: {
+    repoFullName: string;
+    requestedBy?: string | null | undefined;
+    status: string;
+    estimatedNeurons: number;
+    detail: string;
+    usage?: AiReviewActualUsage | undefined;
+  },
+): Promise<void> {
+  await recordAiUsageEvent(env, {
+    feature: "issue_plan_drafts",
+    actor: args.requestedBy ?? null,
+    route: "mcp.issue_plan_drafts",
+    model: [BEST_REVIEW_MODELS[0], RELIABLE_FALLBACK_MODELS[0]].join("+"),
+    status: args.status,
+    estimatedNeurons: args.estimatedNeurons,
+    provider: args.usage?.provider,
+    effort: args.usage?.effort,
+    inputTokens: args.usage?.inputTokens,
+    outputTokens: args.usage?.outputTokens,
+    totalTokens: args.usage?.totalTokens,
+    costUsd: args.usage?.costUsd,
+    detail: args.detail,
+    metadata: { repoFullName: args.repoFullName },
+  });
+}
+
+type RawIssuePlanCandidate = { title?: unknown; body?: unknown; labels?: unknown };
+type IssuePlanModelResult = { issues: RawIssuePlanCandidate[]; usage?: AiReviewActualUsage | undefined };
+
+function parseIssuePlanModelOutput(text: string): RawIssuePlanCandidate[] {
+  const jsonText = extractLastJsonObject(text);
+  if (!jsonText) return [];
+  try {
+    const parsed = JSON.parse(jsonText) as { issues?: unknown };
+    if (!Array.isArray(parsed.issues)) return [];
+    return parsed.issues.filter((entry): entry is RawIssuePlanCandidate => typeof entry === "object" && entry !== null);
+  } catch {
+    return [];
+  }
+}
+
+/** One reviewer completion for the issue planner (whichever provider `env.AI` resolves to). Mirrors
+ *  review/planner.ts's runPlannerModel exactly: primary model, one reliable fallback, a single retry each,
+ *  short-circuiting retries on a rate limit so a 429 doesn't burn the remaining attempt budget for zero chance
+ *  of success. Fail-safe -- any error or unparseable/empty output returns no issues. */
+async function runIssuePlanModel(env: Env, system: string, user: string): Promise<IssuePlanModelResult> {
+  const ai = env.AI as unknown as { run?: (model: string, options: Record<string, unknown>, extra?: unknown) => Promise<unknown> } | undefined;
+  if (!ai || typeof ai.run !== "function") return { issues: [] };
+  const gatewayId = env.AI_GATEWAY_ID?.trim();
+  const extra = gatewayId ? { gateway: { id: gatewayId } } : undefined;
+  const models = [BEST_REVIEW_MODELS[0], RELIABLE_FALLBACK_MODELS[0]];
+  for (const [modelIndex, model] of models.entries()) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const result = await ai.run(
+          model,
+          {
+            max_tokens: ISSUE_PLAN_MAX_TOKENS,
+            temperature: 0.2,
+            messages: [{ role: "system", content: system }, { role: "user", content: user }],
+            finalAttempt: attempt === 1 && modelIndex === models.length - 1,
+          },
+          extra,
+        );
+        const issues = parseIssuePlanModelOutput(coerceAiText(result));
+        if (issues.length > 0) return { issues, usage: coerceAiUsage(result) };
+      } catch (error) {
+        if (isRateLimitError(error)) break;
+      }
+    }
+  }
+  return { issues: [] };
+}
+
+function buildIssuePlanUserPrompt(goal: string, existingLabelNames: string[]): string {
+  const labelsLine = existingLabelNames.length > 0 ? existingLabelNames.slice(0, MAX_EXISTING_LABELS_IN_PROMPT).join(", ") : "(no labels configured yet)";
+  return `Planning goal:\n${goal}\n\nRepository's existing labels (prefer reusing these):\n${labelsLine}`;
+}
+
+function normalizeIssuePlanCandidate(raw: RawIssuePlanCandidate): { title: string; body: string; labels: string[] } | null {
+  const title = typeof raw.title === "string" ? raw.title.trim().slice(0, MAX_TITLE_CHARS) : "";
+  const body = typeof raw.body === "string" ? raw.body.trim().slice(0, MAX_BODY_CHARS) : "";
+  if (!title || !body) return null;
+  const labels = Array.isArray(raw.labels)
+    ? [...new Set(raw.labels.filter((label): label is string => typeof label === "string" && label.trim().length > 0).map((label) => label.trim()))].slice(0, MAX_LABELS_PER_DRAFT)
+    : [];
+  return { title, body, labels };
+}
+
+/** Creates via the installation-token/Orb-broker path (#7425) -- never a flat PAT -- so a missing installation
+ *  fails closed exactly like contributor-issue-draft.ts's createGitHubContributorIssue. Catches broadly: Octokit
+ *  throws on a non-2xx response or a malformed repoFullName, and this function's callers rely on a null return
+ *  (never a throw) to mark a draft skipped_create_failed instead of failing the whole batch. */
+async function createIssuePlanDraftIssue(
+  env: Env,
+  repoFullName: string,
+  draft: Pick<IssuePlanDraft, "title" | "body" | "labels">,
+  installationId: number | null | undefined,
+): Promise<{ number: number; url: string } | null> {
+  if (!installationId) return null;
+  try {
+    return await createInstallationIssue(env, installationId, repoFullName, { title: draft.title, body: draft.body, labels: draft.labels });
+  } catch (error) {
+    console.warn(
+      JSON.stringify({ level: "warn", event: "issue_plan_draft_create_failed", repoFullName, message: errorMessage(error).slice(0, 200) }),
+    );
+    return null;
+  }
+}
+
+export type IssuePlanDraftOptions = {
+  dryRun?: boolean | undefined;
+  create?: boolean | undefined;
+  limit?: number | undefined;
+  requestedBy?: string | undefined;
+};
+
+export type IssuePlanGenerationStatus = "ok" | "disabled" | "unavailable" | "quota_exceeded" | "no_output";
+
+export type IssuePlanGenerationResult = {
+  repoFullName: string;
+  generatedAt: string;
+  status: IssuePlanGenerationStatus;
+  dryRun: boolean;
+  createRequested: boolean;
+  proposed: number;
+  skippedDuplicate: number;
+  skippedDeclined: number;
+  skippedUnsafe: number;
+  created: number;
+  skippedCreateFailed: number;
+  drafts: IssuePlanDraft[];
+};
+
+function emptyIssuePlanResult(
+  repoFullName: string,
+  generatedAt: string,
+  status: IssuePlanGenerationStatus,
+  dryRun: boolean,
+  createRequested: boolean,
+): IssuePlanGenerationResult {
+  return { repoFullName, generatedAt, status, dryRun, createRequested, proposed: 0, skippedDuplicate: 0, skippedDeclined: 0, skippedUnsafe: 0, created: 0, skippedCreateFailed: 0, drafts: [] };
+}
+
+/**
+ * AI-plan a small set of GitHub issue drafts for `repoFullName` from a maintainer-supplied free-form `goal`.
+ * Defaults to dryRun (preview only); an explicit {create:true, dryRun:false} is required to actually write to
+ * GitHub, via the installation-token/Orb-broker path only (#7425) -- there is no flat-PAT fallback, so a repo
+ * with no installation degrades every draft to skipped_create_failed rather than failing this call outright.
+ *
+ * Unlike review/planner.ts's generateIssuePlan (which relies purely on its OWN dedicated isPlannerEnabled/
+ * settings.plannerMode gate, checked by its webhook-triggered caller), this function has no per-repo enable
+ * flag of its own -- it is opt-in simply by a maintainer calling the MCP tool that wraps it. It still checks the
+ * SAME fleet-wide AI_SUMMARIES_ENABLED/AI_PUBLIC_COMMENTS_ENABLED kill switches runLoopOverAiReview uses, so an
+ * operator who has globally disabled AI-generated public content is never surprised by this tool posting any --
+ * a reasonable substitute for a dedicated flag given this capability's primary safety layer is the MCP access
+ * check (requireRepoManageAccess), not fleet-wide default-off config-as-code.
+ */
+export async function generateIssuePlanDrafts(env: Env, repoFullName: string, goal: string, options: IssuePlanDraftOptions = {}): Promise<IssuePlanGenerationResult> {
+  const generatedAt = nowIso();
+  const dryRun = options.dryRun !== false || isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env));
+  const createRequested = options.create === true;
+  const limit = Math.min(MAX_LIMIT, Math.max(1, options.limit ?? DEFAULT_LIMIT));
+  const empty = (status: IssuePlanGenerationStatus) => emptyIssuePlanResult(repoFullName, generatedAt, status, dryRun, createRequested);
+
+  if (!isEnabled(env.AI_SUMMARIES_ENABLED) || !isEnabled(env.AI_PUBLIC_COMMENTS_ENABLED)) return empty("disabled");
+  if (!env.AI) return empty("unavailable");
+
+  const trimmedGoal = goal.trim().slice(0, MAX_GOAL_CHARS);
+  if (!trimmedGoal) return empty("no_output");
+
+  const [repo, openIssues, declinedIssues, labels] = await Promise.all([
+    getRepository(env, repoFullName),
+    listOpenIssues(env, repoFullName),
+    listClosedContributorDraftIssues(env, repoFullName, `<!-- ${ISSUE_PLAN_DRAFT_MARKER_PREFIX}`),
+    listRepoLabels(env, repoFullName),
+  ]);
+
+  const system = ISSUE_PLAN_SYSTEM_PROMPT;
+  const user = buildIssuePlanUserPrompt(trimmedGoal, labels.map((label) => label.name));
+  const estimatedNeurons = estimateNeurons(system.length + user.length, ISSUE_PLAN_MAX_TOKENS, ISSUE_PLAN_MODEL_COUNT);
+  const remainingBudget = Math.max(0, issuePlanDailyBudget(env) - (await sumAiEstimatedNeuronsSince(env, utcDayStartIso())));
+  if (estimatedNeurons > remainingBudget) {
+    await recordIssuePlanUsage(env, { repoFullName, requestedBy: options.requestedBy, status: "quota_exceeded", estimatedNeurons: 0, detail: `estimated ${estimatedNeurons} neurons exceeds remaining ${remainingBudget}` });
+    return empty("quota_exceeded");
+  }
+
+  const { issues: rawCandidates, usage } = await runIssuePlanModel(env, system, user);
+  await recordIssuePlanUsage(env, {
+    repoFullName,
+    requestedBy: options.requestedBy,
+    status: rawCandidates.length > 0 ? "ok" : "no_output",
+    estimatedNeurons: rawCandidates.length > 0 ? estimatedNeurons : 0,
+    detail: rawCandidates.length > 0 ? `${rawCandidates.length} issue draft(s) generated` : "no usable output",
+    usage,
+  });
+  if (rawCandidates.length === 0) return empty("no_output");
+
+  const drafts: IssuePlanDraft[] = [];
+  let proposed = 0;
+  let skippedDuplicate = 0;
+  let skippedDeclined = 0;
+  let skippedUnsafe = 0;
+  let created = 0;
+  let skippedCreateFailed = 0;
+
+  for (const rawCandidate of rawCandidates.slice(0, limit)) {
+    const normalized = normalizeIssuePlanCandidate(rawCandidate);
+    if (!normalized) continue; // malformed model output for this one entry -- skip silently, not a whole-batch failure
+
+    const fingerprint = await issuePlanDraftFingerprint(repoFullName, normalizeIssueTitleKey(normalized.title) || normalized.title);
+    const body = [
+      issuePlanDraftMarker(fingerprint),
+      "",
+      normalized.body,
+      "",
+      "---",
+      "*AI-generated from a maintainer-supplied planning goal. Review before relying on it; verify against the codebase.*",
+    ].join("\n");
+    const draft: IssuePlanDraft = { fingerprint, title: normalized.title, body, labels: normalized.labels, status: "proposed" };
+
+    if (!isFocusManifestPublicSafe(draft.title) || !isFocusManifestPublicSafe(draft.body)) {
+      draft.status = "skipped_unsafe";
+      skippedUnsafe += 1;
+      drafts.push(draft);
+      continue;
+    }
+    const duplicate = findDuplicateIssuePlanDraft(openIssues, draft);
+    if (duplicate) {
+      draft.status = "skipped_duplicate";
+      draft.duplicateOf = duplicate;
+      skippedDuplicate += 1;
+      drafts.push(draft);
+      continue;
+    }
+    const declined = findDeclinedIssuePlanDraft(declinedIssues, draft);
+    if (declined) {
+      draft.status = "skipped_declined";
+      draft.declinedBy = declined;
+      skippedDeclined += 1;
+      drafts.push(draft);
+      continue;
+    }
+
+    if (!dryRun && createRequested) {
+      const issue = await createIssuePlanDraftIssue(env, repoFullName, draft, repo?.installationId);
+      if (issue) {
+        draft.status = "created";
+        draft.issue = issue;
+        created += 1;
+        openIssues.push({ repoFullName, number: issue.number, title: draft.title, state: "open", labels: draft.labels, linkedPrs: [], body: draft.body });
+      } else {
+        draft.status = "skipped_create_failed";
+        skippedCreateFailed += 1;
+      }
+    } else {
+      proposed += 1;
+    }
+    drafts.push(draft);
+  }
+
+  if (!dryRun && createRequested && created > 0) {
+    await recordAuditEvent(env, {
+      eventType: "issue_plan.drafts_created",
+      outcome: "completed",
+      metadata: { repoFullName, created, requestedBy: options.requestedBy ?? "mcp", fingerprints: drafts.filter((draft) => draft.status === "created").map((draft) => draft.fingerprint) },
+    });
+  }
+
+  return { repoFullName, generatedAt, status: "ok", dryRun, createRequested, proposed, skippedDuplicate, skippedDeclined, skippedUnsafe, created, skippedCreateFailed, drafts };
+}

--- a/test/unit/issue-plan-draft.test.ts
+++ b/test/unit/issue-plan-draft.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { createTestEnv } from "../helpers/d1";
+import { clearInstallationTokenCacheForTest } from "../../src/github/app";
+import * as repositories from "../../src/db/repositories";
+import type { IssueRecord, RepositoryRecord } from "../../src/types";
+import {
+  findDeclinedIssuePlanDraft,
+  findDuplicateIssuePlanDraft,
+  generateIssuePlanDrafts,
+  issuePlanDraftFingerprint,
+  issuePlanDraftMarker,
+} from "../../src/services/issue-plan-draft";
+
+const FORBIDDEN = /wallet|hotkey|raw trust score|payout|reward estimate|farming|private reviewability|public score estimate/i;
+
+function openIssue(number: number, title: string, body?: string): IssueRecord {
+  return { repoFullName: "acme/widgets", number, title, state: "open", labels: [], linkedPrs: [], body: body ?? null };
+}
+
+function installedRepo(fullName: string): RepositoryRecord {
+  const [owner = "", name = ""] = fullName.split("/");
+  return { fullName, owner, name, installationId: 123, isInstalled: true, isRegistered: true, isPrivate: false };
+}
+
+function generateRsaPrivateKeyPem(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+}
+
+function issuesResponse(issues: Array<Record<string, unknown>>): { response: string } {
+  return { response: JSON.stringify({ issues }) };
+}
+
+const AI_ENABLED_ENV = { AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" };
+
+function baseEnv(overrides: Partial<Env> = {}) {
+  return createTestEnv({ ...AI_ENABLED_ENV, ...overrides });
+}
+
+describe("generateIssuePlanDrafts (#7426)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    clearInstallationTokenCacheForTest();
+  });
+
+  it("is disabled when either AI_SUMMARIES_ENABLED or AI_PUBLIC_COMMENTS_ENABLED is off", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const summariesOff = createTestEnv({ AI_PUBLIC_COMMENTS_ENABLED: "true", AI: { run } as unknown as Ai });
+    expect((await generateIssuePlanDrafts(summariesOff, "acme/widgets", "goal")).status).toBe("disabled");
+    const commentsOff = createTestEnv({ AI_SUMMARIES_ENABLED: "true", AI: { run } as unknown as Ai });
+    expect((await generateIssuePlanDrafts(commentsOff, "acme/widgets", "goal")).status).toBe("disabled");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("is unavailable when no AI binding is configured", async () => {
+    const result = await generateIssuePlanDrafts(baseEnv(), "acme/widgets", "goal");
+    expect(result.status).toBe("unavailable");
+  });
+
+  it("returns no_output when env.AI is truthy but lacks a run() function", async () => {
+    const env = baseEnv({ AI: {} as unknown as Ai });
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.status).toBe("no_output");
+  });
+
+  it("returns no_output for an empty or whitespace-only goal without calling the model", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    expect((await generateIssuePlanDrafts(env, "acme/widgets", "")).status).toBe("no_output");
+    expect((await generateIssuePlanDrafts(env, "acme/widgets", "   ")).status).toBe("no_output");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("does not call the model when the shared daily neuron budget is exhausted", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, AI_DAILY_NEURON_BUDGET: "0" });
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "plan the migration");
+    expect(result.status).toBe("quota_exceeded");
+    expect(run).not.toHaveBeenCalled();
+    const usage = await env.DB.prepare("select feature, status, estimated_neurons from ai_usage_events where feature = ?").bind("issue_plan_drafts").first<{ feature: string; status: string; estimated_neurons: number }>();
+    expect(usage).toMatchObject({ feature: "issue_plan_drafts", status: "quota_exceeded", estimated_neurons: 0 });
+  });
+
+  it("returns no_output when the model returns nothing usable (empty/unparseable/thrown)", async () => {
+    const empty = vi.fn(async () => ({ response: "   " }));
+    expect((await generateIssuePlanDrafts(baseEnv({ AI: { run: empty } as unknown as Ai }), "acme/widgets", "goal")).status).toBe("no_output");
+
+    const malformed = vi.fn(async () => ({ response: "not json at all" }));
+    expect((await generateIssuePlanDrafts(baseEnv({ AI: { run: malformed } as unknown as Ai }), "acme/widgets", "goal")).status).toBe("no_output");
+
+    // Brace-balanced (so extractLastJsonObject extracts it) but not valid JSON syntax (single-quoted key) --
+    // exercises parseIssuePlanModelOutput's JSON.parse catch branch specifically, distinct from `malformed` above
+    // which has no braces at all and never reaches JSON.parse.
+    const invalidJsonSyntax = vi.fn(async () => ({ response: "{'issues': []}" }));
+    expect((await generateIssuePlanDrafts(baseEnv({ AI: { run: invalidJsonSyntax } as unknown as Ai }), "acme/widgets", "goal")).status).toBe("no_output");
+
+    const emptyArray = vi.fn(async () => issuesResponse([]));
+    expect((await generateIssuePlanDrafts(baseEnv({ AI: { run: emptyArray } as unknown as Ai }), "acme/widgets", "goal")).status).toBe("no_output");
+
+    // A valid JSON object whose `issues` field isn't an array at all -- distinct from an empty array above.
+    const nonArrayIssues = vi.fn(async () => ({ response: JSON.stringify({ issues: "not-an-array" }) }));
+    expect((await generateIssuePlanDrafts(baseEnv({ AI: { run: nonArrayIssues } as unknown as Ai }), "acme/widgets", "goal")).status).toBe("no_output");
+
+    const throwing = vi.fn(async () => {
+      throw new Error("ai down");
+    });
+    expect((await generateIssuePlanDrafts(baseEnv({ AI: { run: throwing } as unknown as Ai }), "acme/widgets", "goal")).status).toBe("no_output");
+    expect(throwing).toHaveBeenCalledTimes(4); // 2 models x 2 attempts each -- a non-429 error burns the full budget
+  });
+
+  it("REGRESSION: stops retrying a model after one 429 rate-limit error instead of burning its full attempt budget", async () => {
+    const throwing = vi.fn(async () => {
+      throw new Error("claude_code_error_429");
+    });
+    await generateIssuePlanDrafts(baseEnv({ AI: { run: throwing } as unknown as Ai }), "acme/widgets", "goal");
+    expect(throwing).toHaveBeenCalledTimes(2); // 1 attempt per model (2 models), not the full 4-call budget
+  });
+
+  it("routes through the AI Gateway when AI_GATEWAY_ID is configured", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Improve caching", body: "Do the caching work." }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, AI_GATEWAY_ID: "gw-1" });
+    await generateIssuePlanDrafts(env, "acme/widgets", "improve performance");
+    expect((run.mock.calls[0] as unknown as unknown[])[2]).toEqual({ gateway: { id: "gw-1" } });
+  });
+
+  it("generates, proposes (dry-run default), and dedupes drafts by marker and by title", async () => {
+    const run = vi.fn(async () =>
+      issuesResponse([
+        { title: "Add retry to the sync job", body: "Retries transient failures with backoff.", labels: ["enhancement", "enhancement", "  ", 42, "bug"] },
+      ]),
+    );
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "getRepository").mockResolvedValue(installedRepo("acme/widgets"));
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    vi.spyOn(repositories, "listRepoLabels").mockResolvedValue([{ name: "enhancement", color: "x", description: null }, { name: "bug", color: "x", description: null }] as never);
+
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "improve sync reliability");
+    expect(result.status).toBe("ok");
+    expect(result.dryRun).toBe(true);
+    expect(result.proposed).toBe(1);
+    expect(result.drafts).toHaveLength(1);
+    const draft = result.drafts[0]!;
+    expect(draft.status).toBe("proposed");
+    expect(draft.title).toBe("Add retry to the sync job");
+    expect(draft.labels).toEqual(["enhancement", "bug"]); // dedup, trimmed, non-strings/blank dropped
+    expect(draft.body).toContain(issuePlanDraftMarker(draft.fingerprint));
+    expect(draft.body).not.toMatch(FORBIDDEN);
+  });
+
+  it("skips a malformed individual candidate without failing the whole batch", async () => {
+    const run = vi.fn(async () =>
+      issuesResponse([
+        { title: "", body: "no title" },
+        { title: "Valid issue", body: "" },
+        { title: 42, body: "title is not a string" },
+        { title: "body is not a string", body: null },
+        { title: "Real issue", body: "Has both fields." },
+      ]),
+    );
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]?.title).toBe("Real issue");
+  });
+
+  it("still fingerprints a title that normalizes to an empty key (symbols only)", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "###", body: "A title made only of symbols." }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]?.title).toBe("###");
+  });
+
+  it("clamps the requested limit to at least one and to MAX_LIMIT", async () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ title: `Issue ${i}`, body: `Body ${i}` }));
+    const run = vi.fn(async () => issuesResponse(many));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const low = await generateIssuePlanDrafts(env, "acme/widgets", "goal", { limit: 0 });
+    expect(low.drafts.length).toBeLessThanOrEqual(1);
+    const high = await generateIssuePlanDrafts(env, "acme/widgets", "goal", { limit: 100 });
+    expect(high.drafts.length).toBeLessThanOrEqual(10);
+  });
+
+  it("skips unsafe drafts (public/private boundary)", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "estimate your reward payout", body: "wallet details inside" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.skippedUnsafe).toBe(1);
+    expect(result.drafts[0]?.status).toBe("skipped_unsafe");
+  });
+
+  it("skips a draft that duplicates an already-open issue by marker", async () => {
+    const title = "Add retry to the sync job";
+    const fingerprint = await issuePlanDraftFingerprint("acme/widgets", "add retry to the sync job");
+    const run = vi.fn(async () => issuesResponse([{ title, body: "Retries transient failures." }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([openIssue(5, "unrelated title", issuePlanDraftMarker(fingerprint))]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.skippedDuplicate).toBe(1);
+    expect(result.drafts[0]?.duplicateOf).toMatchObject({ number: 5, reason: "marker" });
+  });
+
+  it("skips a draft that duplicates an already-open issue by normalized title", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Feat(Issues): Address Validation!", body: "Body" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([openIssue(9, "feat issues address validation")]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.skippedDuplicate).toBe(1);
+    expect(result.drafts[0]?.duplicateOf).toMatchObject({ number: 9, reason: "title" });
+  });
+
+  it("skips a draft declined by a maintainer-closed wontfix marker regardless of age", async () => {
+    const title = "Add retry to the sync job";
+    const fingerprint = await issuePlanDraftFingerprint("acme/widgets", "add retry to the sync job");
+    const run = vi.fn(async () => issuesResponse([{ title, body: "Retries transient failures." }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    const closed: IssueRecord = { ...openIssue(3, "old title", issuePlanDraftMarker(fingerprint)), state: "closed", authorAssociation: "NONE", labels: ["wontfix"], closedAt: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString() };
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    vi.spyOn(repositories, "listClosedContributorDraftIssues").mockResolvedValue([closed]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.skippedDeclined).toBe(1);
+    expect(result.drafts[0]?.declinedBy).toMatchObject({ number: 3, reason: "wontfix" });
+  });
+
+  it("skips a recently-declined maintainer-authored draft within the cooldown, but not an untrusted author or a stale one", async () => {
+    const title = "Add retry to the sync job";
+    const fingerprint = await issuePlanDraftFingerprint("acme/widgets", "add retry to the sync job");
+    const run = vi.fn(async () => issuesResponse([{ title, body: "Retries transient failures." }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    const recentMaintainer: IssueRecord = { ...openIssue(4, "old title", issuePlanDraftMarker(fingerprint)), state: "closed", authorAssociation: "OWNER", closedAt: new Date().toISOString() };
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    vi.spyOn(repositories, "listClosedContributorDraftIssues").mockResolvedValue([recentMaintainer]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(result.skippedDeclined).toBe(1);
+    expect(result.drafts[0]?.declinedBy).toMatchObject({ reason: "cooldown" });
+  });
+
+  it("does not create anything by default even with create requested unless dryRun is explicitly false", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Add retry", body: "Body" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal", { create: true });
+    expect(result.dryRun).toBe(true);
+    expect(result.created).toBe(0);
+    expect(result.proposed).toBe(1);
+  });
+
+  it("creates via the installation-token path when dryRun:false and create:true, and records an audit event", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Add retry to the sync job", body: "Retries transient failures." }]));
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      return Response.json({ number: 900, html_url: "https://github.com/acme/widgets/issues/900" });
+    });
+    const auditSpy = vi.spyOn(repositories, "recordAuditEvent").mockResolvedValue(undefined);
+    vi.spyOn(repositories, "getRepository").mockResolvedValue(installedRepo("acme/widgets"));
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const env = baseEnv({ AI: { run } as unknown as Ai, GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal", { create: true, dryRun: false, requestedBy: "maintainer" });
+    expect(result.created).toBe(1);
+    expect(result.drafts[0]).toMatchObject({ status: "created", issue: { number: 900, url: "https://github.com/acme/widgets/issues/900" } });
+    expect(auditSpy).toHaveBeenCalledWith(env, expect.objectContaining({ eventType: "issue_plan.drafts_created", metadata: expect.objectContaining({ requestedBy: "maintainer", created: 1 }) }));
+  });
+
+  it("defaults the audit event's requestedBy to \"mcp\" when the caller omits it", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Add retry to the sync job", body: "Retries transient failures." }]));
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      return Response.json({ number: 901, html_url: "https://github.com/acme/widgets/issues/901" });
+    });
+    const auditSpy = vi.spyOn(repositories, "recordAuditEvent").mockResolvedValue(undefined);
+    vi.spyOn(repositories, "getRepository").mockResolvedValue(installedRepo("acme/widgets"));
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const env = baseEnv({ AI: { run } as unknown as Ai, GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal", { create: true, dryRun: false });
+    expect(auditSpy).toHaveBeenCalledWith(env, expect.objectContaining({ metadata: expect.objectContaining({ requestedBy: "mcp" }) }));
+  });
+
+  it("records skipped_create_failed when there is no installation for this repo", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Add retry", body: "Body" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai });
+    vi.spyOn(repositories, "getRepository").mockResolvedValue(null);
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal", { create: true, dryRun: false });
+    expect(result.skippedCreateFailed).toBe(1);
+    expect(result.drafts[0]?.status).toBe("skipped_create_failed");
+  });
+
+  it("records skipped_create_failed when GitHub returns a non-2xx response", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Add retry", body: "Body" }]));
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      return new Response("nope", { status: 403 });
+    });
+    vi.spyOn(repositories, "getRepository").mockResolvedValue(installedRepo("acme/widgets"));
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    const env = baseEnv({ AI: { run } as unknown as Ai, GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+    const result = await generateIssuePlanDrafts(env, "acme/widgets", "goal", { create: true, dryRun: false });
+    expect(result.skippedCreateFailed).toBe(1);
+  });
+
+  it("REGRESSION: the global agent brake / freeze overrides {dryRun:false}, so nothing is created", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "Add retry", body: "Body" }]));
+    vi.spyOn(repositories, "getRepository").mockResolvedValue(installedRepo("acme/widgets"));
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+
+    const frozenEnv = baseEnv({ AI: { run } as unknown as Ai });
+    await repositories.setGlobalAgentFrozen(frozenEnv, true);
+    const frozen = await generateIssuePlanDrafts(frozenEnv, "acme/widgets", "goal", { create: true, dryRun: false });
+    expect(frozen.dryRun).toBe(true);
+    expect(frozen.created).toBe(0);
+
+    const pausedEnv = baseEnv({ AI: { run } as unknown as Ai, AGENT_ACTIONS_PAUSED: "true" });
+    const paused = await generateIssuePlanDrafts(pausedEnv, "acme/widgets", "goal", { create: true, dryRun: false });
+    expect(paused.dryRun).toBe(true);
+    expect(paused.created).toBe(0);
+  });
+});
+
+describe("findDuplicateIssuePlanDraft", () => {
+  it("returns null for an empty title key or no matches", () => {
+    expect(findDuplicateIssuePlanDraft([], { fingerprint: "fp", title: "!!!" })).toBeNull();
+    expect(findDuplicateIssuePlanDraft([openIssue(1, "closed one")], { fingerprint: "fp", title: "closed one" })).not.toBeNull();
+    expect(findDuplicateIssuePlanDraft([{ ...openIssue(1, "x"), state: "closed" }], { fingerprint: "fp", title: "x" })).toBeNull();
+  });
+
+  it("scans past a non-matching open issue's title before concluding there is no duplicate", () => {
+    expect(findDuplicateIssuePlanDraft([openIssue(1, "an unrelated open issue")], { fingerprint: "fp", title: "a completely different title" })).toBeNull();
+  });
+});
+
+describe("findDeclinedIssuePlanDraft", () => {
+  it("ignores open issues, missing markers, and other fingerprints", () => {
+    const marker = issuePlanDraftMarker("fp");
+    expect(findDeclinedIssuePlanDraft([{ ...openIssue(1, "t", marker), state: "open" }], { fingerprint: "fp" })).toBeNull();
+    expect(findDeclinedIssuePlanDraft([{ ...openIssue(1, "t", "no marker here"), state: "closed" }], { fingerprint: "fp" })).toBeNull();
+    expect(findDeclinedIssuePlanDraft([{ ...openIssue(1, "t", marker), state: "closed", authorAssociation: "NONE", closedAt: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString() }], { fingerprint: "other" })).toBeNull();
+  });
+
+  it("does not suppress an untrusted (non-maintainer) closed issue without a wontfix label", () => {
+    const marker = issuePlanDraftMarker("fp");
+    const result = findDeclinedIssuePlanDraft([{ ...openIssue(1, "t", marker), state: "closed", authorAssociation: "NONE", closedAt: new Date().toISOString() }], { fingerprint: "fp" });
+    expect(result).toBeNull();
+  });
+
+  it("treats a missing close timestamp on a trusted maintainer-authored issue as still within cooldown (suppress)", () => {
+    const marker = issuePlanDraftMarker("fp");
+    const result = findDeclinedIssuePlanDraft([{ ...openIssue(1, "t", marker), state: "closed", authorAssociation: "OWNER", closedAt: undefined }], { fingerprint: "fp" });
+    expect(result).toMatchObject({ reason: "cooldown" });
+  });
+
+  it("resurfaces after the cooldown window for a maintainer-authored closure without a wontfix label", () => {
+    const marker = issuePlanDraftMarker("fp");
+    const result = findDeclinedIssuePlanDraft(
+      [{ ...openIssue(1, "t", marker), state: "closed", authorAssociation: "OWNER", closedAt: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString(), updatedAt: new Date().toISOString() }],
+      { fingerprint: "fp" },
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/test/unit/mcp-plan-repo-issues.test.ts
+++ b/test/unit/mcp-plan-repo-issues.test.ts
@@ -1,0 +1,136 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { clearInstallationTokenCacheForTest } from "../../src/github/app";
+import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { generateIssuePlanDrafts } from "../../src/services/issue-plan-draft";
+import type { AuthIdentity } from "../../src/auth/security";
+import { createTestEnv } from "../helpers/d1";
+
+const REPO = "owner/widgets";
+const AI_ENABLED = { AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" };
+
+function issuesResponse(issues: Array<Record<string, unknown>>): { response: string } {
+  return { response: JSON.stringify({ issues }) };
+}
+
+function generateRsaPrivateKeyPem(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+}
+
+async function connect(env: Env, identity?: AuthIdentity) {
+  const server = (identity ? new LoopoverMcp(env, identity) : new LoopoverMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "loopover-plan-repo-issues-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedRepo(env: ReturnType<typeof createTestEnv>): Promise<void> {
+  await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: REPO, private: false, owner: { login: "owner" }, default_branch: "main" }, 555);
+}
+
+// The api static identity is unconditionally trusted (matches mcp-generate-contributor-issue-drafts.test.ts), so
+// it exercises the happy path without needing an actuation allowlist.
+const API_IDENTITY = { kind: "static", actor: "api" } as AuthIdentity;
+
+describe("MCP loopover_plan_repo_issues (#7426)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearInstallationTokenCacheForTest();
+  });
+
+  it("previews drafts on a dry run and returns full draft content (unlike the scrubbed contributor-drafts tool)", async () => {
+    const run = async () => issuesResponse([{ title: "Add retry to the sync job", body: "Retries transient failures with backoff." }]);
+    const env = createTestEnv({ ...AI_ENABLED, AI: { run } as unknown as Ai });
+    await seedRepo(env);
+    const client = await connect(env, API_IDENTITY);
+    const result = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "improve sync reliability" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({ repoFullName: REPO, status: "ok", dryRun: true, createRequested: false, created: 0 });
+    const drafts = data.drafts as Array<{ title: string; body: string }>;
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]?.title).toBe("Add retry to the sync job");
+    expect(drafts[0]?.body).toContain("Retries transient failures");
+  });
+
+  it("surfaces the created issue's number and url in the response when create succeeds", async () => {
+    const run = async () => issuesResponse([{ title: "Add retry to the sync job", body: "Retries transient failures." }]);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      return Response.json({ number: 42, html_url: "https://github.com/owner/widgets/issues/42" });
+    });
+    const env = createTestEnv({ ...AI_ENABLED, AI: { run } as unknown as Ai, GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+    await seedRepo(env);
+    const client = await connect(env, API_IDENTITY);
+    const result = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "improve sync reliability", create: true, dryRun: false } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    const drafts = data.drafts as Array<{ status: string; issueNumber?: number; issueUrl?: string }>;
+    expect(drafts[0]).toMatchObject({ status: "created", issueNumber: 42, issueUrl: "https://github.com/owner/widgets/issues/42" });
+  });
+
+  it("REJECTS create without an explicit dryRun:false — the tool can never silently create", async () => {
+    const env = createTestEnv({ ...AI_ENABLED });
+    await seedRepo(env);
+    const client = await connect(env, API_IDENTITY);
+    const result = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "improve sync reliability", create: true } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toMatch(/explicit_create_requires_dry_run_false/);
+  });
+
+  it("rejects a missing or empty goal", async () => {
+    const env = createTestEnv({ ...AI_ENABLED });
+    await seedRepo(env);
+    const client = await connect(env, API_IDENTITY);
+    const missing = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets" } });
+    expect(missing.isError).toBe(true);
+    const empty = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "" } });
+    expect(empty.isError).toBe(true);
+  });
+
+  it("denies a static MCP-token caller when the repo is not in MCP_ACTUATION_REPO_ALLOWLIST", async () => {
+    const env = createTestEnv({ ...AI_ENABLED, MCP_ACTUATION_REPO_ALLOWLIST: "" });
+    await seedRepo(env);
+    const client = await connect(env); // default identity: { kind: "static", actor: "mcp" }
+    const result = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "improve sync reliability" } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toMatch(/MCP_ACTUATION_REPO_ALLOWLIST/);
+  });
+
+  it("allows an operator session and attributes the request to that actor", async () => {
+    const env = createTestEnv({ ...AI_ENABLED, ADMIN_GITHUB_LOGINS: "maintainer-login" });
+    await seedRepo(env);
+    const client = await connect(env, { kind: "session", actor: "maintainer-login" } as AuthIdentity);
+    const result = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "improve sync reliability" } });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({ repoFullName: REPO, dryRun: true, createRequested: false });
+  });
+
+  it("the MCP tool's output mirrors the underlying service for identical input (surface parity)", async () => {
+    const env = createTestEnv({ ...AI_ENABLED });
+    await seedRepo(env);
+    const direct = await generateIssuePlanDrafts(env, REPO, "improve sync reliability", { dryRun: true, limit: 5, requestedBy: "api" });
+    const client = await connect(env, API_IDENTITY);
+    const result = await client.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "owner", repo: "widgets", goal: "improve sync reliability", limit: 5 } });
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({
+      repoFullName: direct.repoFullName,
+      status: direct.status,
+      dryRun: direct.dryRun,
+      createRequested: direct.createRequested,
+      proposed: direct.proposed,
+      skippedDuplicate: direct.skippedDuplicate,
+      skippedDeclined: direct.skippedDeclined,
+      skippedUnsafe: direct.skippedUnsafe,
+      created: direct.created,
+      skippedCreateFailed: direct.skippedCreateFailed,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `loopover_plan_repo_issues`, a new MCP tool: given a maintainer-supplied free-form planning goal, AI-generates a small set of structured GitHub issue drafts (title/body/labels) for **any** repo the caller's App/Orb-brokered install is actually installed on.
- This is genuinely generative — unlike `generateContributorIssueDrafts` (`src/services/contributor-issue-draft.ts`), which derives candidates purely from loopover-specific static signals (policy readiness, upstream drift, focus-manifest wanted paths) at zero LLM cost, the new `src/services/issue-plan-draft.ts` calls the configured AI reviewer, mirroring `src/review/planner.ts`'s `@loopover plan` model-call/retry/budget shape closely (same primary+fallback model, same rate-limit short-circuit, same `AI_DAILY_NEURON_BUDGET` accounting).
- Dry-run by default; an explicit `{create:true, dryRun:false}` is required to write, and creation goes **exclusively** through the installation-token/Orb-broker path added in [#7425](https://github.com/JSONbored/loopover/issues/7425)/[#7467](https://github.com/JSONbored/loopover/pull/7467) — never a flat PAT — so it only works on a repo the caller's own App/Orb actually covers.
- The MCP response includes each draft's full title/body/labels (unlike `generateContributorIssueDrafts`'s deliberate scrub of that field): the content here is generated fresh from the caller's own goal for their own repo, so there is no loopover-internal signal to hide, and the whole point of the dry-run-by-default posture is letting a maintainer actually read the proposal before deciding to create it.
- Reuses the dedup/decline machinery's shape (marker/fingerprint/wontfix/cooldown) from `contributor-issue-draft.ts` but with its own marker prefix (`loopover-issue-plan-draft`) — that module's own marker functions are hardcoded to its own prefix, so directly reusing them would mistag these drafts.
- **Deliberate scope decision, documented for future reference:** no dedicated per-repo `.loopover.yml settings.advisoryAiRouting.issuePlanning`-style enable flag was added, unlike the other 4 advisory-tier AI capabilities (`slop`, `e2eTestGen`, `planner`, `summaries`). This capability is opt-in simply by a maintainer calling the tool (gated by `requireRepoManageAccess`), and additionally respects the existing fleet-wide `AI_SUMMARIES_ENABLED`/`AI_PUBLIC_COMMENTS_ENABLED` kill switches — a reasonable substitute given the primary safety layer here is access control, not automatic/webhook-triggered firing. A dedicated advisory-routing flag (full config-as-code wiring: schema + resolver + `.loopover.yml` schema + docs) is a good candidate for a fast-follow if a self-hoster asks for cost-conscious local-model routing on this specific capability.
- Sub-issue of [#7424](https://github.com/JSONbored/loopover/issues/7424) (Epic: ORB self-hoster issue & milestone planning routine). Milestone assignment is out of scope here — tracked separately as [#7427](https://github.com/JSONbored/loopover/issues/7427).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — full unsharded suite: 1011 files / 19224 tests passed, 2 skipped. The same 9 pre-existing failures in 3 unrelated miner test files (`local-branch.test.ts`, `miner-init-verify-token.test.ts`, `miner-self-review-context.test.ts`) reproduce identically on a clean checkout with this branch's changes stashed out (confirmed separately, tracked independently, unrelated to this PR). New code (`src/services/issue-plan-draft.ts`, the new MCP wiring in `src/mcp/server.ts`) is 100% branch-covered.
- [x] `npm run selfhost:env-reference:check` / `npm run ui:openapi:check` / `npm run docs:drift-check` / `npm run manifest:drift-check` — all clean; no new env vars introduced (reuses the already-documented `AI_SUMMARIES_ENABLED`/`AI_PUBLIC_COMMENTS_ENABLED`/`AI_DAILY_NEURON_BUDGET`/`AI_GATEWAY_ID`), no OpenAPI/manifest surface touched (MCP-only).
- [ ] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — not run; this PR touches no files under `apps/loopover-ui/**`.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — `test/unit/issue-plan-draft.test.ts` (29 tests, 100% branch coverage of the new service) and `test/unit/mcp-plan-repo-issues.test.ts` (7 tests: access control, the `explicit_create_requires_dry_run_false` guard, goal validation, and surface parity with the underlying service).

If any required check was skipped, explain why:

- `ui:lint`/`ui:typecheck`/`ui:build`: no `apps/loopover-ui/**` files changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics — every generated draft's title/body is checked with `isFocusManifestPublicSafe` before ever being proposed or created, matching `contributor-issue-draft.ts`'s own contract.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — MCP access-control denial, missing installation, non-2xx GitHub response, and global agent pause/freeze overlay are all covered.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — new MCP tool fully tested; no HTTP/OpenAPI surface added.
- [ ] UI changes use live API data or real empty/error/loading states. (N/A — no UI.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — backend/MCP-only change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no user-facing docs surface for MCP tool additions in this repo beyond the tool's own description string, which is included in this diff.)

## UI Evidence

N/A — this is a backend/MCP-only change with no visible UI, frontend, or docs surface.

## Notes

- Sub-issue of [#7424](https://github.com/JSONbored/loopover/issues/7424). Builds directly on [#7425](https://github.com/JSONbored/loopover/issues/7425)'s installation-token/Orb-broker issue-write path (already merged, [#7467](https://github.com/JSONbored/loopover/pull/7467)).

Closes #7426
