### PR TITLE
fix(content-lane): add snake_case aliases to protectedFrontmatterFields

### DIFF
--- a/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
+++ b/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
@@ -66,6 +66,30 @@ export const AWESOME_CLAUDE_CONTENT_SPEC: ContentRepoSpec = {
     "submittedByUrl",
     "sourceSubmissionNumber",
     "sourceSubmissionUrl",
+    // snake_case aliases, matching urlFields/sourceUrlFields's pairing convention (#7445, same divergence class as
+    // #7250): protectedFrontmatterChanges compares before[field]/after[field] by the literal parsed key, so a
+    // protected field written in the legitimately-accepted snake_case convention (e.g. `download_url`) was invisible
+    // to this gate — a real protected-close bypass. `author`, `category`, `disclosure`, `slug` are single
+    // all-lowercase words (camelCase and snake_case are byte-identical), so no separate alias is needed for them.
+    "affiliate_url",
+    "author_profile_url",
+    "claim_status",
+    "claim_url",
+    "date_added",
+    "download_url",
+    "import_pr_number",
+    "import_pr_url",
+    "package_url",
+    "package_verified",
+    "pricing_model",
+    "reviewed_at",
+    "reviewed_by",
+    "reviewed_pr_number",
+    "submitted_at",
+    "submitted_by",
+    "submitted_by_url",
+    "source_submission_number",
+    "source_submission_url",
   ]),
   urlFields: new Set([
     "documentationUrl",

--- a/test/unit/content-lane-duplicates.test.ts
+++ b/test/unit/content-lane-duplicates.test.ts
@@ -96,6 +96,24 @@ describe("protectedFrontmatterChanges", () => {
     const after = mdx({ title: "T", slug: "a", author: "Alice" });
     expect(protectedFrontmatterChanges(before, after)).toEqual([]);
   });
+
+  it("flags a changed protected field written in the snake_case alias (e.g. download_url), matching the camelCase behavior (#7445)", () => {
+    // Before #7445, protectedFrontmatterFields listed only downloadUrl (camelCase), so an entry using the
+    // legitimately-accepted snake_case key was invisible to this gate even though urlFields already treats
+    // download_url as an equally-valid alias for duplicate detection.
+    const before = mdx({ title: "T", slug: "a", download_url: "https://example.com/old.zip" });
+    const after = mdx({ title: "T", slug: "a", download_url: "https://example.com/new.zip" });
+    expect(protectedFrontmatterChanges(before, after)).toEqual(["download_url"]);
+  });
+
+  it("every multi-word camelCase protectedFrontmatterFields member has its snake_case alias present too (#7445, mirrors #7250's urlFields pairing assertion)", () => {
+    const singleLowercaseWords = new Set(["author", "category", "disclosure", "slug"]);
+    const toSnakeCase = (field: string): string => field.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+    for (const field of AWESOME_CLAUDE_CONTENT_SPEC.protectedFrontmatterFields) {
+      if (singleLowercaseWords.has(field) || field.includes("_")) continue;
+      expect(AWESOME_CLAUDE_CONTENT_SPEC.protectedFrontmatterFields.has(toSnakeCase(field))).toBe(true);
+    }
+  });
 });
 
 describe("extractContentDuplicateSignals + strict match", () => {


### PR DESCRIPTION
Closes #7445

## Summary

`protectedFrontmatterFields` (`packages/loopover-engine/src/review/content-lane/content-repo-spec.ts`)
listed every protected field in camelCase only, so an entry that wrote a protected field in the
legitimately-accepted snake_case convention (e.g. `download_url:` instead of `downloadUrl:`) was
invisible to `protectedFrontmatterChanges` (`src/review/content-lane/duplicates.ts:154`) — the gate
compares `before["downloadUrl"]`/`after["downloadUrl"]` by literal parsed key, both `undefined`, sees
no change, and the protected-close never fires even though the underlying value actually changed. A
real bypass of the identity/provenance/monetization protected-edit gate, based purely on which naming
convention a submission happens to use.

This is the same divergence class as #7250 (`urlFields` vs `sourceUrlFields`), already fixed in this
exact file via #7269. This PR mirrors that fix's shape exactly: adds the 19 snake_case aliases for
every multi-word camelCase member of `protectedFrontmatterFields` (`author`, `category`, `disclosure`,
`slug` are single all-lowercase words — byte-identical in both conventions, so no separate alias is
needed). Pure data addition to the `Set`; `protectedFrontmatterChanges`'s comparison logic and every
other field list in `content-repo-spec.ts` are untouched.

## Scope

- [x] Conventional Commit title; focused (one spec constant + its tests); no `site/`/`CNAME`/`lovable`; no new dependency.
- [x] Linked a currently open issue (`Closes #7445`).

## Validation

- [x] `git diff --check` — clean
- [x] `npm run typecheck` (root) — clean
- [x] `npm run engine-parity:drift-check` — ok
- [x] `npm run build --workspace @loopover/engine` — clean
- [x] Targeted coverage (`vitest run --coverage`, scoped to the two changed files): **100%
      statements/branches/functions/lines** (193/193, 211/211, 42/42, 175/175)
- [x] Full `test/unit/content-lane-*.test.ts` suite (11 files, 549 tests) — all pass
- [x] Two new regression tests in `test/unit/content-lane-duplicates.test.ts`: (1) an end-to-end
      before/after `download_url:` frontmatter change through `parseSimpleFrontmatter` is now
      reported by `protectedFrontmatterChanges`, matching what the equivalent camelCase-keyed edit
      already produced; (2) a pairing assertion that every multi-word camelCase member of
      `protectedFrontmatterFields` has its snake_case counterpart also present in the set, mirroring
      #7250's `sourceUrlFields`/`urlFields` pairing-assertion test.

If any required check was skipped, explain why:

- Change confined to `packages/loopover-engine/src/review/content-lane/content-repo-spec.ts` (one
  constant) + its test file; `src/review/content-lane/content-repo-spec.ts` is the `export *`
  re-export shim documented in its own header comment and picks up the change automatically — not
  duplicated there, per the issue's explicit requirement.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, trust scores, or private data exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session/API/OpenAPI/MCP surface change — a spec-constant data fix; it only makes
      the protected-close gate recognize the same fields duplicate-detection (`urlFields`) already did.
- [x] No UI change — no UI Evidence needed.
