### PR TITLE
test(ci): cover the extension build scripts' hand-written zip writer

### DIFF
--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -1,18 +1,13 @@
-import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
+import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { createStoredZip } from "./extension-zip-core.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const source = resolve(root, "apps/loopover-extension");
 const outDir = resolve(root, "apps/loopover-extension/dist/package");
 const zipPath = resolve(root, "apps/loopover-ui/public/downloads/loopover-extension.zip");
-const crcTable = Array.from({ length: 256 }, (_, index) => {
-  let value = index;
-  for (let bit = 0; bit < 8; bit += 1) {
-    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-  }
-  return value >>> 0;
-});
 
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
@@ -26,83 +21,3 @@ rmSync(zipPath, { force: true });
 writeFileSync(zipPath, createStoredZip(outDir));
 
 console.log(`wrote ${zipPath.replace(`${root}/`, "")}`);
-
-function createStoredZip(directory) {
-  const files = listFiles(directory);
-  const localParts = [];
-  const centralParts = [];
-  let offset = 0;
-
-  for (const file of files) {
-    const name = relative(directory, file).replaceAll("\\", "/");
-    const nameBuffer = Buffer.from(name);
-    const data = readFileSync(file);
-    const crc = crc32(data);
-    const localHeader = Buffer.alloc(30);
-    localHeader.writeUInt32LE(0x04034b50, 0);
-    localHeader.writeUInt16LE(10, 4);
-    localHeader.writeUInt16LE(0, 6);
-    localHeader.writeUInt16LE(0, 8);
-    localHeader.writeUInt16LE(0, 10);
-    localHeader.writeUInt16LE(33, 12);
-    localHeader.writeUInt32LE(crc, 14);
-    localHeader.writeUInt32LE(data.length, 18);
-    localHeader.writeUInt32LE(data.length, 22);
-    localHeader.writeUInt16LE(nameBuffer.length, 26);
-    localHeader.writeUInt16LE(0, 28);
-    localParts.push(localHeader, nameBuffer, data);
-
-    const centralHeader = Buffer.alloc(46);
-    centralHeader.writeUInt32LE(0x02014b50, 0);
-    centralHeader.writeUInt16LE(20, 4);
-    centralHeader.writeUInt16LE(10, 6);
-    centralHeader.writeUInt16LE(0, 8);
-    centralHeader.writeUInt16LE(0, 10);
-    centralHeader.writeUInt16LE(0, 12);
-    centralHeader.writeUInt16LE(33, 14);
-    centralHeader.writeUInt32LE(crc, 16);
-    centralHeader.writeUInt32LE(data.length, 20);
-    centralHeader.writeUInt32LE(data.length, 24);
-    centralHeader.writeUInt16LE(nameBuffer.length, 28);
-    centralHeader.writeUInt16LE(0, 30);
-    centralHeader.writeUInt16LE(0, 32);
-    centralHeader.writeUInt16LE(0, 34);
-    centralHeader.writeUInt16LE(0, 36);
-    centralHeader.writeUInt32LE(0, 38);
-    centralHeader.writeUInt32LE(offset, 42);
-    centralParts.push(centralHeader, nameBuffer);
-
-    offset += localHeader.length + nameBuffer.length + data.length;
-  }
-
-  const centralDirectory = Buffer.concat(centralParts);
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(0, 4);
-  end.writeUInt16LE(0, 6);
-  end.writeUInt16LE(files.length, 8);
-  end.writeUInt16LE(files.length, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(offset, 16);
-  end.writeUInt16LE(0, 20);
-
-  return Buffer.concat([...localParts, centralDirectory, end]);
-}
-
-function listFiles(directory) {
-  return readdirSync(directory, { withFileTypes: true })
-    .flatMap((entry) => {
-      const path = resolve(directory, entry.name);
-      return entry.isDirectory() ? listFiles(path) : [path];
-    })
-    .filter((path) => statSync(path).isFile())
-    .sort();
-}
-
-function crc32(buffer) {
-  let value = 0xffffffff;
-  for (const byte of buffer) {
-    value = crcTable[(value ^ byte) & 0xff] ^ (value >>> 8);
-  }
-  return (value ^ 0xffffffff) >>> 0;
-}

--- a/scripts/build-miner-extension.mjs
+++ b/scripts/build-miner-extension.mjs
@@ -1,17 +1,12 @@
-import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { createStoredZip } from "./extension-zip-core.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const source = resolve(root, "apps/loopover-miner-extension");
 const outDir = resolve(source, "dist/package");
-const crcTable = Array.from({ length: 256 }, (_, index) => {
-  let value = index;
-  for (let bit = 0; bit < 8; bit += 1) {
-    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-  }
-  return value >>> 0;
-});
 
 const PACKAGE_FILES = [
   "manifest.json",
@@ -42,83 +37,3 @@ rmSync(zipPath, { force: true });
 writeFileSync(zipPath, createStoredZip(outDir));
 
 console.log(`wrote ${relative(root, zipPath)}`);
-
-function createStoredZip(directory) {
-  const files = listFiles(directory);
-  const localParts = [];
-  const centralParts = [];
-  let offset = 0;
-
-  for (const file of files) {
-    const name = relative(directory, file).replaceAll("\\", "/");
-    const nameBuffer = Buffer.from(name);
-    const data = readFileSync(file);
-    const crc = crc32(data);
-    const localHeader = Buffer.alloc(30);
-    localHeader.writeUInt32LE(0x04034b50, 0);
-    localHeader.writeUInt16LE(10, 4);
-    localHeader.writeUInt16LE(0, 6);
-    localHeader.writeUInt16LE(0, 8);
-    localHeader.writeUInt16LE(0, 10);
-    localHeader.writeUInt16LE(33, 12);
-    localHeader.writeUInt32LE(crc, 14);
-    localHeader.writeUInt32LE(data.length, 18);
-    localHeader.writeUInt32LE(data.length, 22);
-    localHeader.writeUInt16LE(nameBuffer.length, 26);
-    localHeader.writeUInt16LE(0, 28);
-    localParts.push(localHeader, nameBuffer, data);
-
-    const centralHeader = Buffer.alloc(46);
-    centralHeader.writeUInt32LE(0x02014b50, 0);
-    centralHeader.writeUInt16LE(20, 4);
-    centralHeader.writeUInt16LE(10, 6);
-    centralHeader.writeUInt16LE(0, 8);
-    centralHeader.writeUInt16LE(0, 10);
-    centralHeader.writeUInt16LE(0, 12);
-    centralHeader.writeUInt16LE(33, 14);
-    centralHeader.writeUInt32LE(crc, 16);
-    centralHeader.writeUInt32LE(data.length, 20);
-    centralHeader.writeUInt32LE(data.length, 24);
-    centralHeader.writeUInt16LE(nameBuffer.length, 28);
-    centralHeader.writeUInt16LE(0, 30);
-    centralHeader.writeUInt16LE(0, 32);
-    centralHeader.writeUInt16LE(0, 34);
-    centralHeader.writeUInt16LE(0, 36);
-    centralHeader.writeUInt32LE(0, 38);
-    centralHeader.writeUInt32LE(offset, 42);
-    centralParts.push(centralHeader, nameBuffer);
-
-    offset += localHeader.length + nameBuffer.length + data.length;
-  }
-
-  const centralDirectory = Buffer.concat(centralParts);
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(0, 4);
-  end.writeUInt16LE(0, 6);
-  end.writeUInt16LE(files.length, 8);
-  end.writeUInt16LE(files.length, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(offset, 16);
-  end.writeUInt16LE(0, 20);
-
-  return Buffer.concat([...localParts, centralDirectory, end]);
-}
-
-function listFiles(directory) {
-  return readdirSync(directory, { withFileTypes: true })
-    .flatMap((entry) => {
-      const path = resolve(directory, entry.name);
-      return entry.isDirectory() ? listFiles(path) : [path];
-    })
-    .filter((path) => statSync(path).isFile())
-    .sort();
-}
-
-function crc32(buffer) {
-  let value = 0xffffffff;
-  for (const byte of buffer) {
-    value = crcTable[(value ^ byte) & 0xff] ^ (value >>> 8);
-  }
-  return (value ^ 0xffffffff) >>> 0;
-}

--- a/scripts/extension-zip-core.d.mts
+++ b/scripts/extension-zip-core.d.mts
@@ -1,0 +1,3 @@
+export function crc32(buffer: Buffer | Uint8Array): number;
+export function listFiles(directory: string): string[];
+export function createStoredZip(directory: string): Buffer;

--- a/scripts/extension-zip-core.mjs
+++ b/scripts/extension-zip-core.mjs
@@ -1,0 +1,96 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+// Shared byte-level ZIP writer for the browser-extension download bundles produced by
+// build-extension.mjs and build-miner-extension.mjs. Both scripts hand-write a STORED
+// (uncompressed) archive so the shipped .zip needs no runtime deflate dependency; keeping
+// the writer here means a regression in any of the manual byte offsets is caught once, by
+// test/unit/build-extension-zip-script.test.ts, instead of by a user's own unzip tool.
+
+const crcTable = Array.from({ length: 256 }, (_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+export function crc32(buffer) {
+  let value = 0xffffffff;
+  for (const byte of buffer) {
+    value = crcTable[(value ^ byte) & 0xff] ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+export function listFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = resolve(directory, entry.name);
+      return entry.isDirectory() ? listFiles(path) : [path];
+    })
+    .filter((path) => statSync(path).isFile())
+    .sort();
+}
+
+export function createStoredZip(directory) {
+  const files = listFiles(directory);
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const name = relative(directory, file).replaceAll("\\", "/");
+    const nameBuffer = Buffer.from(name);
+    const data = readFileSync(file);
+    const crc = crc32(data);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(10, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(0, 8);
+    localHeader.writeUInt16LE(0, 10);
+    localHeader.writeUInt16LE(33, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(data.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(nameBuffer.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+    localParts.push(localHeader, nameBuffer, data);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(10, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(0, 10);
+    centralHeader.writeUInt16LE(0, 12);
+    centralHeader.writeUInt16LE(33, 14);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(data.length, 20);
+    centralHeader.writeUInt32LE(data.length, 24);
+    centralHeader.writeUInt16LE(nameBuffer.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    centralParts.push(centralHeader, nameBuffer);
+
+    offset += localHeader.length + nameBuffer.length + data.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(files.length, 8);
+  end.writeUInt16LE(files.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}

--- a/test/unit/build-extension-zip-script.test.ts
+++ b/test/unit/build-extension-zip-script.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { crc32, createStoredZip, listFiles } from "../../scripts/extension-zip-core.mjs";
+
+// Minimal reader for the STORED (uncompressed) archives createStoredZip writes. It walks the
+// end-of-central-directory + central directory rather than trusting insertion order, so a wrong
+// byte offset anywhere in the writer (the running `offset` accumulator, a header field length, a
+// signature) surfaces as a parse failure or a content mismatch instead of a corrupted download.
+const SIG_LOCAL = 0x04034b50;
+const SIG_CENTRAL = 0x02014b50;
+const SIG_EOCD = 0x06054b50;
+
+interface ExtractedEntry {
+  name: string;
+  data: Buffer;
+  storedCrc: number;
+}
+
+function readStoredZip(zip: Buffer): ExtractedEntry[] {
+  const eocdOffset = zip.length - 22;
+  expect(zip.readUInt32LE(eocdOffset)).toBe(SIG_EOCD);
+  const entryCount = zip.readUInt16LE(eocdOffset + 10);
+  const centralSize = zip.readUInt32LE(eocdOffset + 12);
+  const centralOffset = zip.readUInt32LE(eocdOffset + 16);
+  expect(centralOffset + centralSize).toBe(eocdOffset);
+
+  const entries: ExtractedEntry[] = [];
+  let cursor = centralOffset;
+  for (let index = 0; index < entryCount; index += 1) {
+    expect(zip.readUInt32LE(cursor)).toBe(SIG_CENTRAL);
+    const storedCrc = zip.readUInt32LE(cursor + 16);
+    const uncompressedSize = zip.readUInt32LE(cursor + 24);
+    const nameLength = zip.readUInt16LE(cursor + 28);
+    const extraLength = zip.readUInt16LE(cursor + 30);
+    const commentLength = zip.readUInt16LE(cursor + 32);
+    const localOffset = zip.readUInt32LE(cursor + 42);
+    const name = zip.toString("utf8", cursor + 46, cursor + 46 + nameLength);
+
+    // Follow the central directory's pointer into the local file header and slice the payload.
+    expect(zip.readUInt32LE(localOffset)).toBe(SIG_LOCAL);
+    const localNameLength = zip.readUInt16LE(localOffset + 26);
+    const localExtraLength = zip.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    const data = zip.subarray(dataStart, dataStart + uncompressedSize);
+
+    entries.push({ name, data: Buffer.from(data), storedCrc });
+    cursor += 46 + nameLength + extraLength + commentLength;
+  }
+  expect(cursor).toBe(eocdOffset);
+  return entries;
+}
+
+describe("build-extension.mjs zip writer (#7464)", () => {
+  describe("crc32", () => {
+    it("matches the canonical CRC-32 test vector", () => {
+      // crc32("123456789") === 0xCBF43926 is the standard reference vector for CRC-32/ISO-HDLC.
+      expect(crc32(Buffer.from("123456789"))).toBe(0xcbf43926);
+    });
+
+    it("returns 0 for empty input and an unsigned 32-bit result for arbitrary bytes", () => {
+      expect(crc32(Buffer.alloc(0))).toBe(0);
+      const value = crc32(Buffer.from([0x00, 0xff, 0x10, 0x80]));
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(0xffffffff);
+      expect(Number.isInteger(value)).toBe(true);
+    });
+  });
+
+  describe("listFiles", () => {
+    let dir: string;
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "loopover-listfiles-"));
+    });
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("returns every nested file as a sorted absolute path", () => {
+      mkdirSync(join(dir, "icons"), { recursive: true });
+      writeFileSync(join(dir, "manifest.json"), "{}");
+      writeFileSync(join(dir, "background.js"), "//");
+      writeFileSync(join(dir, "icons", "icon-16.png"), "png");
+
+      const files = listFiles(dir);
+      expect(files).toEqual([
+        join(dir, "background.js"),
+        join(dir, "icons", "icon-16.png"),
+        join(dir, "manifest.json"),
+      ]);
+    });
+  });
+
+  describe("createStoredZip", () => {
+    let dir: string;
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "loopover-storedzip-"));
+    });
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("round-trips every fixture file back out byte-for-byte", () => {
+      const fixtures: Record<string, Buffer> = {
+        "manifest.json": Buffer.from('{"name":"loopover","version":"1.0.0"}'),
+        "background.js": Buffer.from("console.log('bg');\n"),
+        // Binary content with the full byte range exercises the CRC and the length fields.
+        "icons/icon-16.png": Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x10, 0x42]),
+        "empty.txt": Buffer.alloc(0),
+      };
+      mkdirSync(join(dir, "icons"), { recursive: true });
+      for (const [name, data] of Object.entries(fixtures)) {
+        writeFileSync(join(dir, name), data);
+      }
+
+      const zip = createStoredZip(dir);
+      const entries = readStoredZip(zip);
+
+      // listFiles sorts, so the archive lists names in sorted order.
+      expect(entries.map((entry) => entry.name)).toEqual([
+        "background.js",
+        "empty.txt",
+        "icons/icon-16.png",
+        "manifest.json",
+      ]);
+
+      for (const entry of entries) {
+        const expected = fixtures[entry.name];
+        expect(expected).toBeDefined();
+        expect(entry.data).toEqual(expected);
+        // The CRC recorded in the header must be the real CRC of the stored bytes.
+        expect(entry.storedCrc).toBe(crc32(entry.data));
+      }
+    });
+
+    it("preserves a directory-name separator in stored entry names", () => {
+      mkdirSync(join(dir, "nested"), { recursive: true });
+      writeFileSync(join(dir, "nested", "file.js"), "x");
+
+      const entries = readStoredZip(createStoredZip(dir));
+      expect(entries.map((entry) => entry.name)).toEqual(["nested/file.js"]);
+    });
+  });
+});


### PR DESCRIPTION
test(ci): cover the extension build scripts' hand-written zip writer

scripts/build-extension.mjs and scripts/build-miner-extension.mjs each
hand-write a STORED (uncompressed) ZIP archive byte-for-byte -- their own
CRC-32 table, manual local-file-header/central-directory/end-of-central-
directory construction, and a running offset accumulator -- to produce the
extension downloads a real user unzips and loads. The two writers were
byte-identical copies, and the only test mentioning either script asserted
wiring strings in package.json/ci.yml, never exercising the zip format, so
a regression in any of the ~15 manually-computed offsets would only surface
in a user's own unzip tool.

Extract the shared crc32/listFiles/createStoredZip into scripts/
extension-zip-core.mjs (following the existing scripts/*-core.mjs pattern)
so both build scripts import one implementation, and add a test that:
- asserts the canonical crc32("123456789") === 0xCBF43926 vector,
- round-trips a fixture directory (including a nested path and binary and
  empty entries) through createStoredZip, parsing the archive via the
  end-of-central-directory + central directory and verifying every file
  extracts byte-identically with a matching stored CRC.

Closes #7464

