### PR TITLE
test(ci): add unit-test seam for fetch-test-timing aggregateByFile

### DIFF
--- a/scripts/fetch-test-timing.d.mts
+++ b/scripts/fetch-test-timing.d.mts
@@ -1,0 +1,15 @@
+export type CodecovTestRunRow = {
+  filename?: string | null | undefined;
+  commit_sha?: string | null | undefined;
+  duration_seconds?: number | null | undefined;
+};
+
+export declare const RETRYABLE_STATUS: ReadonlySet<number>;
+
+export declare function shouldRetryCodecovFetch(
+  status: number,
+  attempt: number,
+  maxAttempts: number,
+): boolean;
+
+export declare function aggregateByFile(rows: CodecovTestRunRow[]): Record<string, number>;

--- a/scripts/fetch-test-timing.mjs
+++ b/scripts/fetch-test-timing.mjs
@@ -21,51 +21,22 @@
 // that /test-analytics/ returns the identical PaginatedTestrunList wrapper and Testrun field shape
 // (filename, duration_seconds, commit_sha, etc.) -- a URL rename, not a schema change, so nothing else
 // in this file needed to change.
+//
+// #7457: aggregateByFile (and the retry-decision helper) are named exports so unit tests can cover the
+// per-commit-then-across-commits averaging without hitting the live Codecov driver. That driver runs
+// only when this file is the process entrypoint.
 
 import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const MAX_PAGES = Number(process.argv.find((a) => a.startsWith("--max-pages="))?.split("=")[1] ?? 20);
-const outputArg = process.argv.find((a) => a.startsWith("--output="));
-const OUTPUT_PATH = outputArg ? outputArg.split("=")[1] : null;
+export const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 
-const repo = process.env.GITHUB_REPOSITORY;
-if (!repo) throw new Error("GITHUB_REPOSITORY is required (e.g. JSONbored/loopover)");
-const [owner, repoName] = repo.split("/");
-const token = process.env.CODECOV_API_TOKEN;
-if (!token) throw new Error("CODECOV_API_TOKEN is required");
-
-const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
-
-async function fetchWithRetry(url, maxAttempts = 4) {
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const response = await fetch(url, {
-      headers: { Authorization: `bearer ${token}`, Accept: "application/json" },
-    });
-    if (response.ok) return response.json();
-    if (!RETRYABLE_STATUS.has(response.status) || attempt === maxAttempts) {
-      throw new Error(`Codecov API error ${response.status} on ${url}: ${await response.text()}`);
-    }
-    const delayMs = 2 ** attempt * 1000;
-    console.warn(`Codecov API returned ${response.status} (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms`);
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
-  throw new Error("unreachable");
+/** True when a Codecov response status should be retried (and attempt budget remains). */
+export function shouldRetryCodecovFetch(status, attempt, maxAttempts) {
+  return RETRYABLE_STATUS.has(status) && attempt < maxAttempts;
 }
 
-async function fetchAllTestRuns() {
-  const rows = [];
-  let url = `https://api.codecov.io/api/v2/gh/${owner}/repos/${repoName}/test-analytics/?branch=main&page_size=100`;
-  let pages = 0;
-  while (url && pages < MAX_PAGES) {
-    const body = await fetchWithRetry(url);
-    rows.push(...body.results);
-    url = body.next;
-    pages += 1;
-  }
-  return { rows, truncated: url !== null };
-}
-
-function aggregateByFile(rows) {
+export function aggregateByFile(rows) {
   // Per-file duration must be averaged ACROSS RUNS, not just summed across every row: a file with many
   // test cases would otherwise dwarf a file with few, and a file that appears in many historical rows
   // (many runs) would inflate further with each additional run pooled in -- neither reflects "how long
@@ -88,21 +59,69 @@ function aggregateByFile(rows) {
   return averages;
 }
 
-const { rows, truncated } = await fetchAllTestRuns();
-const averageSecondsByFile = aggregateByFile(rows);
+async function fetchWithRetry(url, token, maxAttempts = 4) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const response = await fetch(url, {
+      headers: { Authorization: `bearer ${token}`, Accept: "application/json" },
+    });
+    if (response.ok) return response.json();
+    if (!shouldRetryCodecovFetch(response.status, attempt, maxAttempts)) {
+      throw new Error(`Codecov API error ${response.status} on ${url}: ${await response.text()}`);
+    }
+    const delayMs = 2 ** attempt * 1000;
+    console.warn(`Codecov API returned ${response.status} (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw new Error("unreachable");
+}
 
-const report = {
-  fetchedAt: new Date().toISOString(),
-  sourceRowCount: rows.length,
-  fileCount: Object.keys(averageSecondsByFile).length,
-  truncated, // true if MAX_PAGES was hit before the API ran out of pages -- more history existed than was pulled
-  averageSecondsByFile,
-};
+async function fetchAllTestRuns({ owner, repoName, token, maxPages }) {
+  const rows = [];
+  let url = `https://api.codecov.io/api/v2/gh/${owner}/repos/${repoName}/test-analytics/?branch=main&page_size=100`;
+  let pages = 0;
+  while (url && pages < maxPages) {
+    const body = await fetchWithRetry(url, token);
+    rows.push(...body.results);
+    url = body.next;
+    pages += 1;
+  }
+  return { rows, truncated: url !== null };
+}
 
-const json = JSON.stringify(report, null, 2);
-if (OUTPUT_PATH) {
-  writeFileSync(OUTPUT_PATH, json);
-  console.log(`Wrote ${report.fileCount} files' timing data (from ${report.sourceRowCount} rows) to ${OUTPUT_PATH}`);
-} else {
-  process.stdout.write(`${json}\n`);
+async function main() {
+  const maxPages = Number(process.argv.find((a) => a.startsWith("--max-pages="))?.split("=")[1] ?? 20);
+  const outputArg = process.argv.find((a) => a.startsWith("--output="));
+  const outputPath = outputArg ? outputArg.split("=")[1] : null;
+
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error("GITHUB_REPOSITORY is required (e.g. JSONbored/loopover)");
+  const [owner, repoName] = repo.split("/");
+  const token = process.env.CODECOV_API_TOKEN;
+  if (!token) throw new Error("CODECOV_API_TOKEN is required");
+
+  const { rows, truncated } = await fetchAllTestRuns({ owner, repoName, token, maxPages });
+  const averageSecondsByFile = aggregateByFile(rows);
+
+  const report = {
+    fetchedAt: new Date().toISOString(),
+    sourceRowCount: rows.length,
+    fileCount: Object.keys(averageSecondsByFile).length,
+    truncated, // true if MAX_PAGES was hit before the API ran out of pages -- more history existed than was pulled
+    averageSecondsByFile,
+  };
+
+  const json = JSON.stringify(report, null, 2);
+  if (outputPath) {
+    writeFileSync(outputPath, json);
+    console.log(`Wrote ${report.fileCount} files' timing data (from ${report.sourceRowCount} rows) to ${outputPath}`);
+  } else {
+    process.stdout.write(`${json}\n`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/test/unit/fetch-test-timing-script.test.ts
+++ b/test/unit/fetch-test-timing-script.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateByFile,
+  RETRYABLE_STATUS,
+  shouldRetryCodecovFetch,
+} from "../../scripts/fetch-test-timing.mjs";
+
+describe("fetch-test-timing.mjs (#7457)", () => {
+  describe("aggregateByFile", () => {
+    it("sums multiple rows for the same file within one commit before averaging across commits", () => {
+      // Two test cases in commit A (2s + 3s = 5s that run), one case in commit B (1s). Average across
+      // commits must be (5 + 1) / 2 = 3 — NOT the flat mean of the three rows ((2+3+1)/3 = 2), which would
+      // be the "many test cases dwarf few" failure mode the function's header comment warns about.
+      const averages = aggregateByFile([
+        { filename: "test/unit/a.test.ts", commit_sha: "aaa", duration_seconds: 2 },
+        { filename: "test/unit/a.test.ts", commit_sha: "aaa", duration_seconds: 3 },
+        { filename: "test/unit/a.test.ts", commit_sha: "bbb", duration_seconds: 1 },
+      ]);
+
+      expect(averages).toEqual({ "test/unit/a.test.ts": 3 });
+    });
+
+    it("averages the same file across commits instead of summing every historical row", () => {
+      // Same file in three commits at 10s each: average is 10, not 30 (the "many historical rows inflate
+      // further with every pooled run" failure mode).
+      const averages = aggregateByFile([
+        { filename: "test/unit/b.test.ts", commit_sha: "c1", duration_seconds: 10 },
+        { filename: "test/unit/b.test.ts", commit_sha: "c2", duration_seconds: 10 },
+        { filename: "test/unit/b.test.ts", commit_sha: "c3", duration_seconds: 10 },
+      ]);
+
+      expect(averages).toEqual({ "test/unit/b.test.ts": 10 });
+    });
+
+    it("skips rows with a missing filename or null/undefined duration_seconds", () => {
+      const averages = aggregateByFile([
+        { filename: "", commit_sha: "c1", duration_seconds: 5 },
+        { filename: null, commit_sha: "c1", duration_seconds: 5 },
+        { filename: undefined, commit_sha: "c1", duration_seconds: 5 },
+        { filename: "test/unit/c.test.ts", commit_sha: "c1", duration_seconds: null },
+        { filename: "test/unit/c.test.ts", commit_sha: "c1", duration_seconds: undefined },
+        { filename: "test/unit/c.test.ts", commit_sha: "c1", duration_seconds: 4 },
+        { filename: "test/unit/c.test.ts", commit_sha: "c2", duration_seconds: 6 },
+      ]);
+
+      expect(averages).toEqual({ "test/unit/c.test.ts": 5 });
+    });
+
+    it("aggregates independent files without cross-contaminating their averages", () => {
+      const averages = aggregateByFile([
+        { filename: "test/unit/fast.test.ts", commit_sha: "c1", duration_seconds: 1 },
+        { filename: "test/unit/slow.test.ts", commit_sha: "c1", duration_seconds: 2 },
+        { filename: "test/unit/slow.test.ts", commit_sha: "c1", duration_seconds: 2 },
+        { filename: "test/unit/slow.test.ts", commit_sha: "c2", duration_seconds: 8 },
+      ]);
+
+      expect(averages).toEqual({
+        "test/unit/fast.test.ts": 1,
+        "test/unit/slow.test.ts": 6, // commit c1 summed to 4, then (4 + 8) / 2
+      });
+    });
+
+    it("returns an empty object for an empty input", () => {
+      expect(aggregateByFile([])).toEqual({});
+    });
+  });
+
+  describe("shouldRetryCodecovFetch", () => {
+    it("retries the documented transient statuses while attempts remain", () => {
+      for (const status of RETRYABLE_STATUS) {
+        expect(shouldRetryCodecovFetch(status, 1, 4)).toBe(true);
+        expect(shouldRetryCodecovFetch(status, 3, 4)).toBe(true);
+      }
+    });
+
+    it("does not retry a non-retryable status or the final attempt", () => {
+      expect(shouldRetryCodecovFetch(400, 1, 4)).toBe(false);
+      expect(shouldRetryCodecovFetch(401, 1, 4)).toBe(false);
+      expect(shouldRetryCodecovFetch(404, 1, 4)).toBe(false);
+      expect(shouldRetryCodecovFetch(429, 4, 4)).toBe(false);
+      expect(shouldRetryCodecovFetch(500, 4, 4)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Export `aggregateByFile` and `shouldRetryCodecovFetch` from `scripts/fetch-test-timing.mjs` so the per-commit-then-across-commits averaging algorithm can be unit-tested without hitting Codecov.
- Gate the live Codecov fetch/report driver behind an entrypoint guard (`import.meta.url` / `pathToFileURL`), matching other CLI scripts in `scripts/`.
- Add `test/unit/fetch-test-timing-script.test.ts` covering within-commit summing, across-commit averaging, null/missing filename/duration skips, multi-file isolation, and retry-decision branches.

Closes #7457

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Scripts-only change (`scripts/**` is outside Codecov `coverage.include`). Ran `npx vitest run test/unit/fetch-test-timing-script.test.ts` (7 pass) and verified importing the module no longer requires env vars while direct CLI invocation still fails closed without `GITHUB_REPOSITORY`. Remaining `test:ci` surface is unchanged and will run in CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — CI script / unit-test seam only; no visible UI change.

## Notes

- Analogues: `scripts/validate-observability-configs.mjs` + `test/unit/validate-observability-configs-script.test.ts`, `scripts/gittensor-impact-card.mjs` entrypoint guard.