### PR TITLE
test(ci): add unit-test seam for ci-duration-report.mjs percentile/summarize

### DIFF
--- a/scripts/ci-duration-report.d.mts
+++ b/scripts/ci-duration-report.d.mts
@@ -1,0 +1,18 @@
+export type WorkflowRun = {
+  conclusion: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CiDurationSummary = {
+  count: number;
+  excludedCancelled: number;
+  p50Seconds: number | null;
+  p95Seconds: number | null;
+  failureRate: number | null;
+  failures: number;
+};
+
+export declare function durationSeconds(run: WorkflowRun): number;
+export declare function percentile(sortedValues: number[], p: number): number | null;
+export declare function summarize(allRuns: WorkflowRun[]): CiDurationSummary;

--- a/scripts/ci-duration-report.mjs
+++ b/scripts/ci-duration-report.mjs
@@ -7,17 +7,9 @@
 // including queue time), not the sum of individual job durations.
 
 import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const WINDOW_DAYS = Number(process.argv.find((a) => a.startsWith("--days="))?.split("=")[1] ?? 7);
-const outputArg = process.argv.find((a) => a.startsWith("--output="));
-const OUTPUT_PATH = outputArg ? outputArg.split("=")[1] : null;
-
-const repo = process.env.GITHUB_REPOSITORY;
-if (!repo) throw new Error("GITHUB_REPOSITORY is required");
-const token = process.env.GITHUB_TOKEN;
-if (!token) throw new Error("GITHUB_TOKEN is required");
-
-async function fetchAllRuns(sinceIso) {
+async function fetchAllRuns(repo, token, sinceIso) {
   const runs = [];
   let page = 1;
   for (;;) {
@@ -43,17 +35,17 @@ async function fetchAllRuns(sinceIso) {
   return runs;
 }
 
-function durationSeconds(run) {
+export function durationSeconds(run) {
   return (new Date(run.updated_at).getTime() - new Date(run.created_at).getTime()) / 1000;
 }
 
-function percentile(sortedValues, p) {
+export function percentile(sortedValues, p) {
   if (sortedValues.length === 0) return null;
   const index = Math.min(sortedValues.length - 1, Math.ceil((p / 100) * sortedValues.length) - 1);
   return sortedValues[Math.max(0, index)];
 }
 
-function summarize(allRuns) {
+export function summarize(allRuns) {
   // "cancelled" excluded entirely, not just from the failure count: this workflow's own
   // cancel-in-progress concurrency setting means a cancelled run is almost always a rapid re-push
   // superseding its predecessor mid-run, not CI breaking -- counting it as a failure (or even as a
@@ -72,19 +64,37 @@ function summarize(allRuns) {
   };
 }
 
-const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
-const runs = await fetchAllRuns(since);
+// Entrypoint guard (#7456): the pure percentile/summarize/durationSeconds logic above is importable for
+// tests without this driving code -- which reads required env, makes a live GitHub API call, and writes
+// output -- ever running. Only executes when the file is invoked directly as a script.
+async function main() {
+  const WINDOW_DAYS = Number(process.argv.find((a) => a.startsWith("--days="))?.split("=")[1] ?? 7);
+  const outputArg = process.argv.find((a) => a.startsWith("--output="));
+  const OUTPUT_PATH = outputArg ? outputArg.split("=")[1] : null;
 
-const report = {
-  windowDays: WINDOW_DAYS,
-  generatedAt: new Date().toISOString(),
-  push: summarize(runs.filter((r) => r.event === "push")),
-  pullRequest: summarize(runs.filter((r) => r.event === "pull_request")),
-};
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error("GITHUB_REPOSITORY is required");
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN is required");
 
-const json = JSON.stringify(report, null, 2);
-if (OUTPUT_PATH) {
-  writeFileSync(OUTPUT_PATH, json);
-} else {
-  process.stdout.write(`${json}\n`);
+  const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const runs = await fetchAllRuns(repo, token, since);
+
+  const report = {
+    windowDays: WINDOW_DAYS,
+    generatedAt: new Date().toISOString(),
+    push: summarize(runs.filter((r) => r.event === "push")),
+    pullRequest: summarize(runs.filter((r) => r.event === "pull_request")),
+  };
+
+  const json = JSON.stringify(report, null, 2);
+  if (OUTPUT_PATH) {
+    writeFileSync(OUTPUT_PATH, json);
+  } else {
+    process.stdout.write(`${json}\n`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
 }

--- a/test/unit/ci-duration-report-script.test.ts
+++ b/test/unit/ci-duration-report-script.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  durationSeconds,
+  percentile,
+  summarize,
+} from "../../scripts/ci-duration-report.mjs";
+
+// #7456: percentile/summarize/durationSeconds are the non-obvious pure logic in ci-duration-report.mjs
+// (a specific nearest-rank percentile with a floor clamp; a summarize() that excludes `cancelled` runs from
+// both the duration set and the failure-rate denominator, while treating `skipped` as a success). Importing
+// the module must not trigger its live-fetch driver -- the entrypoint guard now keeps that behind `main()`,
+// so these imports resolve to just the pure functions.
+
+type Run = { conclusion: string; created_at: string; updated_at: string; event?: string };
+
+function run(conclusion: string, durationMinutes: number): Run {
+  const created = new Date("2026-01-01T00:00:00.000Z");
+  const updated = new Date(created.getTime() + durationMinutes * 60 * 1000);
+  return { conclusion, created_at: created.toISOString(), updated_at: updated.toISOString() };
+}
+
+describe("percentile (#7456)", () => {
+  const sorted = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+  it("returns the nearest-rank p50 and p95 of a known sorted array", () => {
+    expect(percentile(sorted, 50)).toBe(50);
+    expect(percentile(sorted, 95)).toBe(100);
+  });
+
+  it("returns the sole element for every percentile of a single-element array", () => {
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 95)).toBe(42);
+  });
+
+  it("returns null for an empty array", () => {
+    expect(percentile([], 50)).toBeNull();
+    expect(percentile([], 95)).toBeNull();
+  });
+});
+
+describe("durationSeconds (#7456)", () => {
+  it("measures wall-clock span as (updated_at - created_at) in seconds", () => {
+    expect(durationSeconds(run("success", 10))).toBe(600);
+  });
+});
+
+describe("summarize (#7456)", () => {
+  it("excludes cancelled runs from count and the failure-rate denominator, but reports them as excludedCancelled", () => {
+    const summary = summarize([
+      run("success", 10),
+      run("failure", 20),
+      run("skipped", 5),
+      run("cancelled", 99),
+      run("cancelled", 1),
+    ]);
+
+    // cancelled runs are dropped from the counted set entirely...
+    expect(summary.count).toBe(3);
+    expect(summary.excludedCancelled).toBe(2);
+    // ...and from the failure-rate denominator: 1 failure out of the 3 non-cancelled runs.
+    expect(summary.failures).toBe(1);
+    expect(summary.failureRate).toBe(1 / 3);
+    // durations only reflect the 3 non-cancelled runs (5/10/20 min -> 300/600/1200s).
+    expect(summary.p50Seconds).toBe(600);
+    expect(summary.p95Seconds).toBe(1200);
+  });
+
+  it("treats a skipped run as a success, not a failure", () => {
+    const summary = summarize([run("success", 10), run("skipped", 5)]);
+    expect(summary.count).toBe(2);
+    expect(summary.failures).toBe(0);
+    expect(summary.failureRate).toBe(0);
+  });
+
+  it("returns a null failureRate and null percentiles for an empty run set", () => {
+    const summary = summarize([]);
+    expect(summary.count).toBe(0);
+    expect(summary.excludedCancelled).toBe(0);
+    expect(summary.failures).toBe(0);
+    expect(summary.failureRate).toBeNull();
+    expect(summary.p50Seconds).toBeNull();
+    expect(summary.p95Seconds).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #7456

## What

`scripts/ci-duration-report.mjs`'s `percentile()` (nearest-rank with a floor clamp) and `summarize()` (excludes `cancelled` runs from both the duration set and the failure-rate denominator; treats `skipped` as a success) carried real, non-obvious behavior but only ran inside the un-guarded top-level body, which also makes a live GitHub API call — untestable in isolation.

- Exports `percentile`, `summarize`, `durationSeconds` as named exports.
- Moves the env-reading + live-fetch + report-assembly driver into `main()` behind an **entrypoint guard**, so importing the module for tests never fetches. Running the script directly is unchanged.
- Adds `scripts/ci-duration-report.d.mts` (the declaration that pairs with every imported `.mjs` under `scripts/`, so the test's typed import resolves).
- Adds `test/unit/ci-duration-report-script.test.ts`.

## Tests (green locally under `vitest run test/unit`)

- `percentile` p50/p95 on a known sorted array, plus single-element and empty (`null`).
- `summarize` excludes `cancelled` from `count` and the failure-rate denominator (reporting them as `excludedCancelled`); treats `skipped` as a success; returns `null` percentiles/failureRate for an empty set.
- `durationSeconds` = `(updated_at − created_at)` in seconds.

Verified: importing with empty env neither throws nor fetches; the typed `.mjs` import resolves via the `.d.mts` (no `TS7016`). `scripts/**` isn't in `coverage.include`, so no numeric patch gate.
