### PR TITLE
fix(extension): drop dead issue-page content-script match

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -1,20 +1,21 @@
 const target = matchGitHubPageTarget(location.pathname);
 
-if (target?.kind === "pull_request") {
+if (target) {
   mountOverlay(target);
 }
 
+// #7462: pull-request pages only — issue classification was dead (manifest matched issues/*
+// but nothing consumed kind:"issue", and there is no issue-context backend route).
 function matchGitHubPageTarget(pathname) {
-  const match = String(pathname ?? "").match(/^\/([^/]+)\/([^/]+)\/(pull|issues)\/(\d+)(?:\/|$)/);
+  const match = String(pathname ?? "").match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/);
   if (!match) return null;
-  const [, owner, repo, surface, number] = match;
-  if (surface === "pull") return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
-  return { kind: "issue", owner, repo, issueNumber: Number(number) };
+  const [, owner, repo, number] = match;
+  return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
 function matchPullRequestTarget(pathname) {
   const target = matchGitHubPageTarget(pathname);
-  if (target?.kind !== "pull_request") return null;
+  if (!target) return null;
   return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
 }
 

--- a/apps/loopover-extension/manifest.json
+++ b/apps/loopover-extension/manifest.json
@@ -11,7 +11,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://github.com/*/*/pull/*", "https://github.com/*/*/issues/*"],
+      "matches": ["https://github.com/*/*/pull/*"],
       "js": ["content.js"],
       "css": ["styles.css"],
       "run_at": "document_idle"

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -3,9 +3,17 @@ import { Script, createContext } from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 
 const contentScript = readFileSync("apps/loopover-extension/content.js", "utf8");
+const manifest = JSON.parse(readFileSync("apps/loopover-extension/manifest.json", "utf8")) as {
+  content_scripts: Array<{ matches: string[] }>;
+};
 
 describe("extension content script", () => {
-  it("detects GitHub pull request and issue routes while only mounting pull overlays", () => {
+  it("declares content-script matches for pull pages only (#7462)", () => {
+    expect(manifest.content_scripts[0]?.matches).toEqual(["https://github.com/*/*/pull/*"]);
+    expect(manifest.content_scripts[0]?.matches.join("\n")).not.toContain("issues");
+  });
+
+  it("detects GitHub pull request routes and treats issue pages as out of scope", () => {
     const internals = loadContentInternals();
 
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pull/146")).toEqual({
@@ -14,12 +22,8 @@ describe("extension content script", () => {
       repo: "loopover",
       pullNumber: 146,
     });
-    expect(internals.matchGitHubPageTarget("/JSONbored/loopover/issues/145")).toEqual({
-      kind: "issue",
-      owner: "JSONbored",
-      repo: "loopover",
-      issueNumber: 145,
-    });
+    // Issue pages are out of scope — no kind:"issue" classification, and no match.
+    expect(internals.matchGitHubPageTarget("/JSONbored/loopover/issues/145")).toBeNull();
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pulls")).toBeNull();
     expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146")).toEqual({
       owner: "JSONbored",
@@ -91,7 +95,7 @@ function loadContentInternals() {
   return vmContext.__loopoverContentInternals as {
     matchGitHubPageTarget: (
       pathname: string,
-    ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | { kind: "issue"; owner: string; repo: string; issueNumber: number } | null;
+    ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | null;
     matchPullRequestTarget: (pathname: string) => { owner: string; repo: string; pullNumber: number } | null;
     renderPullContext: (payload: unknown) => string;
   };


### PR DESCRIPTION
## Summary

- Remove `https://github.com/*/*/issues/*` from the maintainer overlay content-script matches so the extension no longer loads on issue pages it never acts on.
- Narrow `matchGitHubPageTarget` to pull-request URLs only and simplify `matchPullRequestTarget` now that `kind: "issue"` cannot be produced.
- Update `test/unit/extension-content.test.ts` with a regression that issue URLs are out of scope and that the manifest no longer declares an issues match.

Closes #7462

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Extension-only Option A fix (`apps/**` is outside Codecov `coverage.include`). Ran `npx vitest run test/unit/extension-content.test.ts` (4 pass). Remaining `test:ci` surface is unchanged and will run in CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible overlay change. PR pages still mount the same private pull-context overlay; issue pages already did nothing and are now simply not matched by the content script.

## Notes

- Implements Option A from #7462 (narrow scope). Does not touch `apps/loopover-miner-extension`, which correctly targets issue pages.

