### PR TITLE
fix(content-lane): recognize snake_case distribution and primary source fields

### DIFF
--- a/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
+++ b/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
@@ -143,7 +143,10 @@ export const AWESOME_CLAUDE_CONTENT_SPEC: ContentRepoSpec = {
     "website_url",
   ],
   sourceUrlListFields: new Set(["sourceUrls", "retrievalSources"]),
-  distributionSourceFields: new Set(["downloadUrl", "packageUrl"]),
+  // snake_case aliases match urlFields / sourceUrlFields (#7446): without them, a site-relative
+  // `download_url`/`package_url` is misclassified as canonical (spurious invalid_url), and a
+  // retryable `github_url`/`repo_url`/`repository_url`/`source_url` is silently downgradable.
+  distributionSourceFields: new Set(["downloadUrl", "packageUrl", "download_url", "package_url"]),
   distributionSourceHosts: new Set([
     "crates.io",
     "files.pythonhosted.org",
@@ -160,5 +163,14 @@ export const AWESOME_CLAUDE_CONTENT_SPEC: ContentRepoSpec = {
     "rubygems.org",
     "www.npmjs.com",
   ]),
-  primaryCanonicalSourceFields: new Set(["githubUrl", "repoUrl", "repositoryUrl", "sourceUrl"]),
+  primaryCanonicalSourceFields: new Set([
+    "githubUrl",
+    "repoUrl",
+    "repositoryUrl",
+    "sourceUrl",
+    "github_url",
+    "repo_url",
+    "repository_url",
+    "source_url",
+  ]),
 };

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -52,6 +52,16 @@ describe("extractSubmittedSourceUrls", () => {
     expect(urls).toHaveLength(0);
   });
 
+  it("drops a site-relative snake_case download_url the same way as downloadUrl (#7446)", () => {
+    // Before #7446, distributionSourceFields was camelCase-only, so download_url:/… stayed in the
+    // extracted set, was classified as canonical, and produced a spurious invalid_url hard failure.
+    expect(extractSubmittedSourceUrls(mdx({ download_url: "/downloads/skills/foo.zip" }))).toHaveLength(0);
+    expect(extractSubmittedSourceUrls(mdx({ package_url: "/packages/foo.tgz" }))).toHaveLength(0);
+    for (const field of ["download_url", "package_url"]) {
+      expect(AWESOME_CLAUDE_CONTENT_SPEC.distributionSourceFields.has(field)).toBe(true);
+    }
+  });
+
   it("reads snake_case source fields (e.g. the canonical source_url), matching urlFields (#7250)", () => {
     // Before #7250, sourceUrlFields listed only the camelCase names, so a legitimately-aliased snake_case field
     // was invisible to the source-evidence gate even though duplicates.ts (which reads urlFields) saw it.
@@ -815,6 +825,25 @@ describe("downgrade rules (hasVerifiableCanonicalSource / isDowngradableInconclu
     const primary = report.urls.find((u) => u.field === "sourceUrl");
     expect(primary?.blocking).toBe(true);
     expect(report.status).toBe("retryable");
+  });
+
+  it("does NOT downgrade a snake_case PRIMARY-field retryable either (#7446)", async () => {
+    // Before #7446, primaryCanonicalSourceFields was camelCase-only, so a retryable source_url was
+    // treated as non-primary and silently downgraded whenever another canonical was reachable.
+    const src = mdx({
+      githubUrl: "https://github.com/acme/anchor",
+      source_url: "https://flaky.example/primary-snake",
+    });
+    const report = await checkSubmittedSourceEvidence(
+      src,
+      fakeFetch({ "https://github.com/acme/anchor": 200, "https://flaky.example/primary-snake": 503 }),
+    );
+    const primary = report.urls.find((u) => u.field === "source_url");
+    expect(primary?.blocking).toBe(true);
+    expect(report.status).toBe("retryable");
+    for (const field of ["github_url", "repo_url", "repository_url", "source_url"]) {
+      expect(AWESOME_CLAUDE_CONTENT_SPEC.primaryCanonicalSourceFields.has(field)).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION

Closes #7446

## Scope

- [ ] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [ ] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [ ] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries


## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

