### PR TITLE
fix(review): guarantee newlineChunks forward progress under high overlap

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -195,9 +195,9 @@ export function chunkFile(path: string, text: string, namespace = "", opts?: Chu
   // file re-failed the whole upsert batch (up to 49 otherwise-good chunks rolled back with it) on every
   // push and cron retry (GITTENSORY-D).
   text = text.replace(/(?![\t\n\r])\p{Cc}/gu, " ");
-  // Clamp to safe ranges: chunkChars must be >= 1 (a 0/negative budget makes newlineChunks loop forever on an
-  // oversized file — a misconfig DOS) and overlap must be < chunkChars (else `end - overlap` can't advance).
-  // (#rag-verify infinite-loop guard)
+  // Clamp to safe ranges: chunkChars must be >= 1 (a 0/negative budget never advances the window) and
+  // overlap must be < chunkChars. Overlap alone is NOT enough to prevent stalls — newline snap can shrink
+  // `end` so `end - overlap <= start`; newlineChunks floors the next start at `start + 1` (#7447 / #rag-verify).
   const chunkChars = Math.max(1, Math.floor(opts?.chunkChars ?? CHUNK_CHARS));
   const chunkOverlap = Math.min(Math.max(0, Math.floor(opts?.chunkOverlap ?? CHUNK_OVERLAP)), chunkChars - 1);
   // JS/TS: cut on LOGICAL boundaries (function/class/export) instead of arbitrary newlines, so a retrieved
@@ -291,7 +291,10 @@ function newlineChunks(path: string, text: string, kind: RagKind, namespace: str
     chunks.push({ id: chunkId(namespace, path, idx), path, chunkIndex: idx, kind, text: text.slice(start, end), boundary: "file" });
     idx += 1;
     if (end >= text.length) break;
-    start = Math.max(0, end - chunkOverlap);
+    // #7447: newline snap can shrink `end` well below `start + chunkChars`, so `end - chunkOverlap` may not
+    // advance past the previous `start` even when overlap < chunkChars. Floor at start + 1 so every
+    // iteration makes forward progress (Math.max(0, …) is redundant once start >= 0, which the loop maintains).
+    start = Math.max(start + 1, end - chunkOverlap);
   }
   return chunks;
 }

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -240,6 +240,46 @@ describe("rag: per-file chunking", () => {
     expect(chunks.every((c) => c.text.length > 0)).toBe(true);
   });
 
+  it("REGRESSION (#7447): does NOT hang when newline snap + near-budget overlap would stall `end - overlap <= start`", () => {
+    // Exact repro from the issue: early qualifying newline (~index 60 > chunkChars/2) shrinks `end`, and
+    // chunkOverlap=99 (allowed by the old clamp of chunkChars-1) makes `end - overlap` land at/before the
+    // previous start. Without the start+1 floor this never returns.
+    const text = `${"x".repeat(60)}\n${"y".repeat(5000)}`;
+    const chunks = chunkFile("f.py", text, "", { chunkChars: 100, chunkOverlap: 99 });
+    expect(chunks.length).toBeGreaterThan(1);
+    // Worst case every iteration advances exactly 1 char → at most text.length chunks.
+    expect(chunks.length).toBeLessThanOrEqual(text.length);
+    expect(chunks.every((c) => c.text.length > 0)).toBe(true);
+  });
+
+  it.each([
+    { chunkChars: 100, chunkOverlap: 99 },
+    { chunkChars: 100, chunkOverlap: 50 },
+    { chunkChars: 50, chunkOverlap: 49 },
+    { chunkChars: 20, chunkOverlap: 19 },
+    { chunkChars: 1, chunkOverlap: 0 },
+    { chunkChars: 1, chunkOverlap: 999 }, // clamped to 0
+  ])(
+    "REGRESSION (#7447): chunkFile returns finitely for chunkChars=$chunkChars chunkOverlap=$chunkOverlap (forward progress)",
+    ({ chunkChars, chunkOverlap }) => {
+      const text = `${"x".repeat(60)}\n${"y".repeat(5000)}`;
+      const chunks = chunkFile("f.py", text, "", { chunkChars, chunkOverlap });
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.length).toBeLessThanOrEqual(text.length);
+    },
+  );
+
+  it("REGRESSION (#7447): chunkJsTs oversized-unit fallback through newlineChunks also cannot stall on high overlap", () => {
+    // Two logical units so chunkJsTs runs; the first exceeds chunkChars and falls back to newlineChunks with
+    // the caller-supplied (near-budget) overlap — the other production path that must stay hang-free.
+    const huge = `export function big() {\n${"x".repeat(60)}\n${"y".repeat(5000)}\n}\n`;
+    const small = "export function small() { return 1; }\n";
+    const text = huge + small;
+    const chunks = chunkFile("src/huge.ts", text, "", { chunkChars: 100, chunkOverlap: 99 });
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThanOrEqual(text.length);
+  });
+
   it("PACKS a small multi-function JS file into one chunk (free-tier vector budget unaffected) (#282)", () => {
     const chunks = chunkFile("src/small.ts", "export function a(){return 1;}\nexport function b(){return 2;}\nexport function c(){return 3;}\n");
     expect(chunks).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Floor the next `start` in `newlineChunks` at `start + 1` so newline snap + near-budget `chunkOverlap` cannot stall the loop (`end - overlap <= previous start`).
- Clarify the incomplete `#rag-verify` clamp comment: `chunkOverlap < chunkChars` alone does not guarantee forward progress once newline snap shrinks `end`.
- Add regression coverage for the exact hang repro (`chunkChars: 100`, `chunkOverlap: 99`), a table sweep of boundary overlaps, and the `chunkJsTs` oversized-unit fallback path through `newlineChunks`.

Closes #7447

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Focused `src/review/rag.ts` defensive fix. Ran `npx vitest run test/unit/rag.test.ts -t "#7447|#rag-verify infinite-loop|newlineChunks newline-boundary|#4996"` (12 pass). Production call sites never pass `opts` (defaults `CHUNK_CHARS`/`CHUNK_OVERLAP` stay outside the stall region); remaining `test:ci` surface will run in CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend RAG chunker defensive fix only; no visible UI change.

## Notes

- Approach: loop-side `Math.max(start + 1, end - chunkOverlap)` rather than tightening the overlap clamp further, so every `chunkChars >= 1` / clamp-allowed overlap pair has a hard forward-progress proof even after newline snap.

Made with [Cursor](https://cursor.com)