### PR TITLE
test(extension): cover background.js message routing and options.js session UI

### DIFF
--- a/test/unit/extension-background.test.ts
+++ b/test/unit/extension-background.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from "node:fs";
+import { Script, createContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+// background.js statically imports its two handlers from ./auth.js. The vm `Script` runner cannot
+// execute a top-level ESM `import`, so we strip that line and inject stubbed handlers as context
+// globals -- the free identifiers `requestPullContext`/`logoutExtensionSession` resolve from them.
+// This mirrors content.js's `__LOOPOVER_EXTENSION_TEST__` seam while keeping background.js's real
+// message-routing and error-to-response mapping (lines 3-8) under test.
+const backgroundSource = readFileSync(
+  "apps/loopover-extension/background.js",
+  "utf8",
+).replace(/^import\s*\{[\s\S]*?\}\s*from\s*["']\.\/auth\.js["'];?\n?/, "");
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("extension background message router", () => {
+  it("resolves loopover:pull-context via requestPullContext and responds { ok: true, payload }", async () => {
+    const requestPullContext = vi.fn(async () => ({ panels: [] }));
+    const logoutExtensionSession = vi.fn();
+    const { listener } = loadBackground({
+      requestPullContext,
+      logoutExtensionSession,
+    });
+    const sendResponse = vi.fn();
+
+    const message = {
+      type: "loopover:pull-context",
+      owner: "JSONbored",
+      repo: "loopover",
+      pullNumber: 148,
+    };
+    const returned = listener(message, {}, sendResponse);
+    await flush();
+
+    expect(returned).toBe(true);
+    expect(requestPullContext).toHaveBeenCalledWith(message);
+    expect(logoutExtensionSession).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: true,
+      payload: { panels: [] },
+    });
+  });
+
+  it("resolves loopover:logout via logoutExtensionSession and responds { ok: true, payload }", async () => {
+    const requestPullContext = vi.fn();
+    const logoutExtensionSession = vi.fn(async () => ({ ok: true }));
+    const { listener } = loadBackground({
+      requestPullContext,
+      logoutExtensionSession,
+    });
+    const sendResponse = vi.fn();
+
+    const returned = listener({ type: "loopover:logout" }, {}, sendResponse);
+    await flush();
+
+    expect(returned).toBe(true);
+    expect(logoutExtensionSession).toHaveBeenCalledTimes(1);
+    expect(requestPullContext).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: true,
+      payload: { ok: true },
+    });
+  });
+
+  it("maps a rejected Error to { ok: false, error: message }", async () => {
+    const requestPullContext = vi.fn(async () => {
+      throw new Error("pull context unavailable");
+    });
+    const { listener } = loadBackground({
+      requestPullContext,
+      logoutExtensionSession: vi.fn(),
+    });
+    const sendResponse = vi.fn();
+
+    listener({ type: "loopover:pull-context" }, {}, sendResponse);
+    await flush();
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: "pull context unavailable",
+    });
+  });
+
+  it("maps a rejected non-Error value to { ok: false, error: String(value) }", async () => {
+    const logoutExtensionSession = vi.fn(async () => {
+      // eslint-disable-next-line no-throw-literal
+      throw "session gone";
+    });
+    const { listener } = loadBackground({
+      requestPullContext: vi.fn(),
+      logoutExtensionSession,
+    });
+    const sendResponse = vi.fn();
+
+    listener({ type: "loopover:logout" }, {}, sendResponse);
+    await flush();
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: "session gone",
+    });
+  });
+
+  it("returns false for an unrecognized message type without dispatching either handler", () => {
+    const requestPullContext = vi.fn();
+    const logoutExtensionSession = vi.fn();
+    const { listener } = loadBackground({
+      requestPullContext,
+      logoutExtensionSession,
+    });
+    const sendResponse = vi.fn();
+
+    expect(listener({ type: "loopover:unknown" }, {}, sendResponse)).toBe(
+      false,
+    );
+    expect(requestPullContext).not.toHaveBeenCalled();
+    expect(logoutExtensionSession).not.toHaveBeenCalled();
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it("returns false for a nullish message without dispatching either handler", () => {
+    const requestPullContext = vi.fn();
+    const logoutExtensionSession = vi.fn();
+    const { listener } = loadBackground({
+      requestPullContext,
+      logoutExtensionSession,
+    });
+
+    expect(listener(null, {}, vi.fn())).toBe(false);
+    expect(requestPullContext).not.toHaveBeenCalled();
+    expect(logoutExtensionSession).not.toHaveBeenCalled();
+  });
+});
+
+function loadBackground(handlers: {
+  requestPullContext: (...args: unknown[]) => unknown;
+  logoutExtensionSession: (...args: unknown[]) => unknown;
+}) {
+  let listener:
+    | ((
+        message: unknown,
+        sender: unknown,
+        sendResponse: (response: unknown) => void,
+      ) => unknown)
+    | undefined;
+  const context: Record<string, unknown> = {
+    // Share the host Error so background.js's `error instanceof Error` matches the errors our stubs
+    // throw -- a contextified vm has its own Error intrinsic, unlike the extension's single realm.
+    Error,
+    chrome: {
+      runtime: {
+        onMessage: {
+          addListener: (fn: typeof listener) => {
+            listener = fn;
+          },
+        },
+      },
+    },
+    requestPullContext: handlers.requestPullContext,
+    logoutExtensionSession: handlers.logoutExtensionSession,
+  };
+  context.globalThis = context;
+  const vmContext = createContext(context);
+  new Script(backgroundSource).runInContext(vmContext);
+  if (!listener)
+    throw new Error("background.js did not register an onMessage listener");
+  return { listener };
+}

--- a/test/unit/extension-options.test.ts
+++ b/test/unit/extension-options.test.ts
@@ -1,0 +1,291 @@
+import { readFileSync } from "node:fs";
+import { Script, createContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+// options.js statically imports its auth helpers from ./auth.js. As with background.js, the vm
+// `Script` runner cannot execute a top-level ESM `import`, so we strip that block and inject stubbed
+// auth helpers plus a fake DOM as context globals. options.js runs `void refreshSettings()` and wires
+// up its form/logout listeners at load time, so each `loadOptions(...)` exercises `refreshSettings()`
+// once and hands back the fake elements plus the captured event handlers.
+const optionsSource = readFileSync(
+  "apps/loopover-extension/options.js",
+  "utf8",
+).replace(/^import\s*\{[\s\S]*?\}\s*from\s*["']\.\/auth\.js["'];?\n?/, "");
+
+const DEFAULT_API_ORIGIN = "https://api.loopover.ai";
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("extension options page", () => {
+  it("refreshSettings shows the no-session summary and disables session controls", async () => {
+    const { dom } = await loadOptions({
+      session: session({ sessionToken: "" }),
+    });
+
+    expect(dom.sessionSummary.textContent).toBe("No extension session stored.");
+    expect(dom.apiOrigin.value).toBe(DEFAULT_API_ORIGIN);
+    expect(dom.sessionToken.placeholder).toBe(
+      "Paste gts_ extension session token",
+    );
+    expect(dom.logout.disabled).toBe(true);
+    expect(dom.clearLocal.disabled).toBe(true);
+  });
+
+  it("refreshSettings flags an expired session", async () => {
+    const { dom } = await loadOptions({
+      session: session({
+        sessionToken: "gts_stored",
+        expired: true,
+        expiresAt: "2020-01-01T00:00:00.000Z",
+      }),
+    });
+
+    expect(dom.sessionSummary.textContent).toBe(
+      "Stored extension session is expired. Save a fresh token or clear local state.",
+    );
+    expect(dom.logout.disabled).toBe(false);
+    expect(dom.clearLocal.disabled).toBe(false);
+    expect(dom.sessionToken.placeholder).toBe(
+      "Stored locally - leave blank to keep current token",
+    );
+  });
+
+  it("refreshSettings reports a valid session and appends the expiry when present", async () => {
+    const { dom } = await loadOptions({
+      session: session({
+        sessionToken: "gts_stored",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      }),
+    });
+
+    expect(dom.sessionSummary.textContent).toBe(
+      "Extension session stored in browser local storage. Expires 2030-01-01T00:00:00.000Z.",
+    );
+    expect(dom.apiOrigin.value).toBe(DEFAULT_API_ORIGIN);
+    expect(dom.sessionExpiresAt.value).toBe("2030-01-01T00:00:00.000Z");
+  });
+
+  it("refreshSettings omits the expiry sentence for a valid session without an expiresAt", async () => {
+    const { dom } = await loadOptions({
+      session: session({ sessionToken: "gts_stored", expiresAt: "" }),
+    });
+
+    expect(dom.sessionSummary.textContent).toBe(
+      "Extension session stored in browser local storage.",
+    );
+  });
+
+  it("submit stores a token when one is entered and reports the saved-session status", async () => {
+    const auth = authStubs();
+    const { dom, handlers } = await loadOptions({
+      session: session({ sessionToken: "" }),
+      auth,
+    });
+    dom.apiOrigin.value = "  https://api.loopover.test  ";
+    dom.sessionToken.value = `  gts_${"a".repeat(64)}  `;
+    dom.sessionExpiresAt.value = " 2030-01-01T00:00:00.000Z ";
+    const event = { preventDefault: vi.fn() };
+
+    await handlers.submit(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(auth.saveExtensionApiOrigin).toHaveBeenCalledWith(
+      "https://api.loopover.test",
+    );
+    expect(auth.storeExtensionSessionToken).toHaveBeenCalledWith({
+      token: `gts_${"a".repeat(64)}`,
+      expiresAt: "2030-01-01T00:00:00.000Z",
+      scopes: ["extension:pull_context"],
+    });
+    expect(dom.status.textContent).toBe("Extension session saved locally.");
+  });
+
+  it("submit falls back to the default origin and skips token storage when the field is blank", async () => {
+    const auth = authStubs();
+    const { dom, handlers } = await loadOptions({
+      session: session({ sessionToken: "" }),
+      auth,
+    });
+    dom.apiOrigin.value = "   ";
+    dom.sessionToken.value = "   ";
+
+    await handlers.submit({ preventDefault: vi.fn() });
+
+    expect(auth.saveExtensionApiOrigin).toHaveBeenCalledWith(
+      DEFAULT_API_ORIGIN,
+    );
+    expect(auth.storeExtensionSessionToken).not.toHaveBeenCalled();
+    expect(dom.status.textContent).toBe("Settings saved.");
+  });
+
+  it("submit surfaces the error message when saving fails", async () => {
+    const auth = authStubs();
+    auth.saveExtensionApiOrigin.mockRejectedValueOnce(
+      new Error("origin rejected"),
+    );
+    const { dom, handlers } = await loadOptions({
+      session: session({ sessionToken: "" }),
+      auth,
+    });
+
+    await handlers.submit({ preventDefault: vi.fn() });
+
+    expect(dom.status.textContent).toBe("origin rejected");
+  });
+
+  it("logout clears local state and refreshes on the happy path", async () => {
+    const auth = authStubs();
+    const { dom, handlers } = await loadOptions({
+      session: session({ sessionToken: "gts_stored" }),
+      auth,
+    });
+
+    await handlers.logout();
+
+    expect(auth.logoutExtensionSession).toHaveBeenCalledTimes(1);
+    expect(auth.clearExtensionSession).not.toHaveBeenCalled();
+    expect(dom.status.textContent).toBe(
+      "Logged out and cleared the local extension session.",
+    );
+    expect(dom.logout.disabled).toBe(false);
+  });
+
+  it("logout still clears local state when the revoke call throws", async () => {
+    const auth = authStubs();
+    auth.logoutExtensionSession.mockRejectedValueOnce(
+      new Error("network down"),
+    );
+    const { dom, handlers } = await loadOptions({
+      session: session({ sessionToken: "gts_stored" }),
+      auth,
+    });
+
+    await handlers.logout();
+
+    expect(auth.clearExtensionSession).toHaveBeenCalledTimes(1);
+    expect(dom.status.textContent).toBe("network down");
+    expect(dom.logout.disabled).toBe(false);
+  });
+
+  it("clearLocal wipes the session and reports the cleared status", async () => {
+    const auth = authStubs();
+    const { dom, handlers } = await loadOptions({
+      session: session({ sessionToken: "gts_stored" }),
+      auth,
+    });
+
+    await handlers.clearLocal();
+
+    expect(auth.clearExtensionSession).toHaveBeenCalledTimes(1);
+    expect(dom.status.textContent).toBe("Local extension session cleared.");
+  });
+});
+
+type Session = {
+  apiOrigin: string;
+  sessionToken: string;
+  expiresAt: string;
+  expired: boolean;
+};
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    apiOrigin: DEFAULT_API_ORIGIN,
+    sessionToken: "",
+    expiresAt: "",
+    expired: false,
+    ...overrides,
+  };
+}
+
+function authStubs() {
+  return {
+    DEFAULT_API_ORIGIN,
+    clearExtensionSession: vi.fn(async () => {}),
+    loadExtensionSession: vi.fn(async () => session()),
+    logoutExtensionSession: vi.fn(async () => ({ ok: true })),
+    saveExtensionApiOrigin: vi.fn(async () => {}),
+    storeExtensionSessionToken: vi.fn(async () => {}),
+  };
+}
+
+async function loadOptions(opts: {
+  session: Session;
+  auth?: ReturnType<typeof authStubs>;
+}) {
+  const auth = opts.auth ?? authStubs();
+  auth.loadExtensionSession.mockImplementation(async () => opts.session);
+
+  const dom = fakeDom();
+
+  const context: Record<string, unknown> = {
+    ...auth,
+    // Share the host Error so options.js's `error instanceof Error` matches the errors our stubs
+    // throw -- a contextified vm has its own Error intrinsic, unlike the extension's single realm.
+    Error,
+    document: {
+      querySelector: (selector: string) => dom.bySelector[selector] ?? null,
+    },
+    // setTimeout is left inert so showStatus() does not asynchronously wipe the text we assert on.
+    window: { setTimeout: vi.fn() },
+  };
+  context.globalThis = context;
+  const vmContext = createContext(context);
+  new Script(optionsSource).runInContext(vmContext);
+
+  const handlers = {
+    submit: (event?: unknown) => dom.form.dispatch("submit", event),
+    logout: () => dom.logout.dispatch("click"),
+    clearLocal: () => dom.clearLocal.dispatch("click"),
+  };
+
+  // Let the load-time `void refreshSettings()` settle before assertions.
+  await flush();
+  return { dom, handlers };
+}
+
+function fakeElement() {
+  const listeners: Record<string, (event?: unknown) => unknown> = {};
+  return {
+    value: "",
+    placeholder: "",
+    textContent: "",
+    disabled: false,
+    addEventListener(type: string, fn: (event?: unknown) => unknown) {
+      listeners[type] = fn;
+    },
+    async dispatch(type: string, event?: unknown) {
+      return listeners[type]?.(event);
+    },
+  };
+}
+
+function fakeDom() {
+  const form = fakeElement();
+  const status = fakeElement();
+  const apiOrigin = fakeElement();
+  const sessionToken = fakeElement();
+  const sessionExpiresAt = fakeElement();
+  const sessionSummary = fakeElement();
+  const logout = fakeElement();
+  const clearLocal = fakeElement();
+  return {
+    form,
+    status,
+    apiOrigin,
+    sessionToken,
+    sessionExpiresAt,
+    sessionSummary,
+    logout,
+    clearLocal,
+    bySelector: {
+      "#settings": form,
+      "#status": status,
+      "#apiOrigin": apiOrigin,
+      "#sessionToken": sessionToken,
+      "#sessionExpiresAt": sessionExpiresAt,
+      "#sessionSummary": sessionSummary,
+      "#logout": logout,
+      "#clearLocal": clearLocal,
+    } as Record<string, ReturnType<typeof fakeElement>>,
+  };
+}


### PR DESCRIPTION
test(extension): cover background.js message routing and options.js session UI

background.js (the service-worker onMessage router) and options.js (the
options-page controller) had no unit tests, unlike auth.js and content.js.
A regression in either -- background.js returning false instead of true and
silently breaking every async response, or refreshSettings() misclassifying an
expired session as valid -- would only surface by manually loading the unpacked
extension.

Add extension-background.test.ts and extension-options.test.ts using the vm
Script/createContext technique extension-content.test.ts established. Both files
statically import from auth.js, which a plain vm Script cannot execute, so the
import line is stripped and the handlers/auth helpers are injected as context
globals (the host Error is shared so 'error instanceof Error' matches the
single-realm extension). Covers background.js's pull-context/logout dispatch,
its Error-vs-stringified error mapping, and the unrecognized/nullish return
false paths; and options.js's refreshSettings() three display branches, the
conditional token-store submit path, and the logout error-recovery fallback.

Closes #7461

