### PR TITLE
fix(ui-kit): make StateBoundary's onFailureNotify edge-triggered

### DIFF
--- a/apps/loopover-ui/src/components/site/state-views.test.tsx
+++ b/apps/loopover-ui/src/components/site/state-views.test.tsx
@@ -138,3 +138,52 @@ describe("StateBoundary retry/refresh actions (#793 regression guard)", () => {
     expect(screen.getByText("content")).toBeTruthy();
   });
 });
+
+describe("StateBoundary onFailureNotify edge-triggered dedupe (#7436 regression)", () => {
+  it("fires onFailureNotify exactly once across re-renders while isError stays true, even as onRetry's identity changes", () => {
+    notifyApiFailure.mockClear();
+    // Each render passes a brand-new onRetry closure -- this mirrors the real app wrapper, which
+    // also constructs a fresh onFailureNotify arrow function on every render (#6506) -- so an
+    // unrelated re-render while the boundary is still in the error state must not re-notify.
+    const { rerender } = render(
+      <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 3; i++) {
+      rerender(
+        <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+          <div>content</div>
+        </StateBoundary>,
+      );
+    }
+
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again exactly once on a fresh false->true transition after leaving the error state", () => {
+    notifyApiFailure.mockClear();
+    const { rerender } = render(
+      <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <StateBoundary isError={false} errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/loopover-ui-kit/src/components/state-views.tsx
+++ b/packages/loopover-ui-kit/src/components/state-views.tsx
@@ -1,5 +1,5 @@
 import { Loader2, Inbox, AlertTriangle, RefreshCw, WifiOff } from "lucide-react";
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { cn } from "../utils";
@@ -264,9 +264,16 @@ export function StateBoundary({
       ? undefined
       : "The data source did not respond. Retry the request, or check back once the service has recovered.");
 
-  // When this boundary flips into the error state, surface a toast with Retry.
+  // When this boundary flips into the error state, surface a toast with Retry. Tracked via a ref
+  // (mirroring the `wasError` pattern in apps/loopover-ui/src/components/site/mcp-version-badge.tsx)
+  // so this only fires on the false->true edge, not on every re-render while isError stays true --
+  // onRetry/onFailureNotify are ordinary function props that get new identities on unrelated
+  // re-renders, and without edge detection those identity changes alone would re-run this effect.
+  const wasErrorRef = useRef(false);
   useEffect(() => {
-    if (isError && errorLabel) {
+    const enteredError = isError && !wasErrorRef.current;
+    wasErrorRef.current = Boolean(isError);
+    if (enteredError && errorLabel) {
       onFailureNotify?.({
         label: errorLabel,
         kind: errorKind ?? "network",


### PR DESCRIPTION
## Summary

- `StateBoundary`'s `onFailureNotify` effect (`packages/loopover-ui-kit/src/components/state-views.tsx`) was level-triggered instead of edge-triggered: with no memory of the previous `isError` value, it re-ran on any render where `isError` was already `true` and any of its deps (including the ordinary function props `onRetry`/`onFailureNotify`) changed identity — not just on the false→true transition its own leading comment describes.
- Fixed by tracking the previous `isError` value in a `useRef<boolean>` (mirroring the existing `wasError` pattern in `apps/loopover-ui/src/components/site/mcp-version-badge.tsx`) and only invoking `onFailureNotify` on the real false→true edge. It still correctly re-fires if the boundary leaves and re-enters the error state.
- `onRetry`'s click-triggered call path is untouched; only the passive `onFailureNotify` effect changed.
- Added two regression tests to `apps/loopover-ui/src/components/site/state-views.test.tsx`: one asserting `onFailureNotify` fires exactly once across several re-renders with a fresh `onRetry` identity each time while `isError` stays `true`, and one asserting it fires again exactly once after an error → ready → error transition.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #7436

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — skipped; the whole-repo `tsc --noEmit` reliably OOMs in this constrained sandbox and this change touches no backend/`src/**` code. Ran the scoped `npm run ui:typecheck` instead (builds `@loopover/ui-kit`, then typechecks `@loopover/ui` and `@loopover/ui-miner`) — clean.
- [ ] `npm run test:coverage` — skipped the whole-repo unsharded run; this diff is entirely inside `packages/loopover-ui-kit/**` and `apps/loopover-ui/**`, neither of which is in `codecov.yml`'s/`vitest.config.ts`'s coverage-measured set, so there is no `codecov/patch` obligation for this PR. Ran `npm run ui:test` instead (`@loopover/ui`: 400/400 passing including the two new regression tests; `@loopover/ui-miner`: 332/332; `@loopover/miner-extension`: 33/33, 100% branch-adjacent coverage on its own files).
- [ ] `npm run test:workers` — skipped; this change touches no Cloudflare Worker/backend code.
- [ ] `npm run build:mcp` — skipped; this change touches no MCP package code.
- [ ] `npm run test:mcp-pack` — skipped; same reason.
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — reports 2 pre-existing high-severity findings (`adm-zip` < 0.6.0, transitive via the `github-actionlint` devDependency, no fix available). Confirmed present on `main` before this change too; unrelated to this PR's diff.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — the two new regression tests were verified to fail against the pre-fix (level-triggered) implementation and pass against the fix, confirming they discriminate the bug.

If any required check was skipped, explain why:

- See the unchecked items above — each explains why it was skipped (the OOM-prone whole-repo `typecheck`, the out-of-scope worker/mcp checks, and the coverage run for a diff outside Codecov's measured set).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, this PR makes no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed (`ui:openapi:check` confirms no drift).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots... — N/A, this fix has no new visible UI shape. It only changes *when* an existing toast notification fires (deduping a re-render-triggered re-notify into a real state-transition-triggered notify); there is no new visual surface, and every existing screen/toast still renders byte-identically to before.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A, no docs/changelog changes needed for this internal bug fix.

## UI Evidence

N/A — no new or changed visible UI surface. This PR only changes the timing of an existing `notifyApiFailure` toast call (fires once per real error-state entry instead of once per re-render while already in the error state); the toast's appearance and every rendered state view are unchanged.

## Notes

- `packages/loopover-ui-kit` has no `.prettierrc`/format script of its own and is not covered by `ui:lint`'s ESLint config, so the diff follows the file's existing ~100-column style by hand rather than running a blanket `prettier --write` (which, with no local config for that package, defaults to an 80-column width and would have reformatted the entire file).
