### PR TITLE
fix(discovery-index): record the declared cache-lookup and github-request-outcome metrics

### DIFF
--- a/packages/discovery-index/src/discovery-query.ts
+++ b/packages/discovery-index/src/discovery-query.ts
@@ -18,6 +18,7 @@ import {
 import type { TtlCache } from "./cache.js";
 import { decodeCursor, encodeCursor } from "./cursor.js";
 import type { GitHubIssue } from "./github-client.js";
+import { incr } from "./metrics.js";
 
 /** The subset of GitHubClient this module actually calls — kept as an interface so tests can inject a plain
  *  stub instead of a real GitHubClient (which would need a real/mocked global fetch). */
@@ -93,7 +94,9 @@ function buildCandidate(repoFullName: string, issue: GitHubIssue, verdict: AiPol
  *  otherwise fall through to CONTRIBUTING.md — mirrors opportunity-fanout.js's resolveRepoAiPolicy exactly
  *  (a present-but-blank AI-USAGE.md must not silently fail open past a ban declared in CONTRIBUTING.md). */
 async function resolveRepoAiPolicy(repoFullName: string, deps: DiscoveryQueryDeps): Promise<AiPolicyVerdict> {
-  return deps.policyCache.getOrCompute(repoFullName, deps.cacheTtlMs, async () => {
+  let missed = false;
+  const verdict = await deps.policyCache.getOrCompute(repoFullName, deps.cacheTtlMs, async () => {
+    missed = true;
     const aiUsage = await deps.github.fetchRepoFile(repoFullName, "AI-USAGE.md");
     if (aiUsage.content !== null && aiUsage.content.trim().length > 0) {
       return resolveAiPolicyVerdict({ aiUsage: aiUsage.content, contributing: null });
@@ -101,6 +104,8 @@ async function resolveRepoAiPolicy(repoFullName: string, deps: DiscoveryQueryDep
     const contributing = await deps.github.fetchRepoFile(repoFullName, "CONTRIBUTING.md");
     return resolveAiPolicyVerdict({ aiUsage: null, contributing: contributing.content });
   });
+  incr("discovery_index_cache_lookups_total", { cache: "policy", outcome: missed ? "miss" : "hit" });
+  return verdict;
 }
 
 function scopeCacheKey(query: DiscoveryIndexQuery): string {
@@ -168,7 +173,12 @@ async function computeCandidates(query: DiscoveryIndexQuery, deps: DiscoveryQuer
  */
 export async function runDiscoveryQuery(query: DiscoveryIndexQuery, deps: DiscoveryQueryDeps): Promise<DiscoveryIndexResponse> {
   const scopeKey = scopeCacheKey(query);
-  const allCandidates = await deps.resultCache.getOrCompute(scopeKey, deps.cacheTtlMs, () => computeCandidates(query, deps));
+  let missed = false;
+  const allCandidates = await deps.resultCache.getOrCompute(scopeKey, deps.cacheTtlMs, () => {
+    missed = true;
+    return computeCandidates(query, deps);
+  });
+  incr("discovery_index_cache_lookups_total", { cache: "result", outcome: missed ? "miss" : "hit" });
   const offset = decodeCursor(query.cursor);
   const page = allCandidates.slice(offset, offset + query.limit);
   const nextOffset = offset + page.length;

--- a/packages/discovery-index/src/github-client.ts
+++ b/packages/discovery-index/src/github-client.ts
@@ -6,6 +6,8 @@
 // historical-backfill system this single-forge server-side fan-out doesn't need) — same retry/backoff/
 // rate-limit-observation shape, proportionately smaller.
 
+import { incr } from "./metrics.js";
+
 const API_BASE_URL = "https://api.github.com";
 const DEFAULT_PER_PAGE = 100;
 const DEFAULT_MAX_PAGES = 10;
@@ -165,7 +167,11 @@ export class GitHubClient {
         this.requestTimeoutMs && this.requestTimeoutMs > 0 ? { ...init, signal: AbortSignal.timeout(this.requestTimeoutMs) } : init,
       );
       this.recordRateLimit(response);
-      if (!isRetryableStatus(response) || attempt >= this.maxAttempts) return response;
+      if (!isRetryableStatus(response) || attempt >= this.maxAttempts) {
+        incr("discovery_index_github_requests_total", { outcome: response.ok ? "ok" : "failed" });
+        return response;
+      }
+      incr("discovery_index_github_requests_total", { outcome: "retried" });
       await this.sleepFn(retryDelayMs(response, attempt, this.backoffMs));
     }
   }

--- a/test/unit/discovery-index/discovery-query.test.ts
+++ b/test/unit/discovery-index/discovery-query.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { DISCOVERY_INDEX_CONTRACT_VERSION, type AiPolicyVerdict, type DiscoveryIndexCandidate, type DiscoveryIndexQuery } from "@loopover/engine";
 import { TtlCache } from "../../../packages/discovery-index/src/cache";
 import { decodeCursor } from "../../../packages/discovery-index/src/cursor";
 import { runDiscoveryQuery, type DiscoveryQueryDeps, type GitHubClientLike } from "../../../packages/discovery-index/src/discovery-query";
 import type { GitHubIssue } from "../../../packages/discovery-index/src/github-client";
+import { counterValue, resetMetrics } from "../../../packages/discovery-index/src/metrics";
 
 const ALLOWED_AI_USAGE = "We welcome AI-assisted contributions.";
 const BANNED_AI_USAGE = "No AI-generated pull requests are allowed.";
@@ -53,6 +54,10 @@ function query(overrides: Partial<DiscoveryIndexQuery> = {}): DiscoveryIndexQuer
 }
 
 describe("discovery-index runDiscoveryQuery (#7164)", () => {
+  beforeEach(() => {
+    resetMetrics();
+  });
+
   it("builds candidates from an allowed repo's issues, filtering PRs and invalid entries", async () => {
     const { github, calls } = makeStubGitHub({
       issuesByRepo: {
@@ -241,5 +246,36 @@ describe("discovery-index runDiscoveryQuery (#7164)", () => {
     const response = await runDiscoveryQuery(query(), makeDeps(github));
     expect(response).toEqual({ contractVersion: DISCOVERY_INDEX_CONTRACT_VERSION, candidates: [], nextCursor: null });
     expect(calls).toEqual([]);
+  });
+
+  it("records a result-cache miss then a hit on a repeated identical query scope", async () => {
+    const { github } = makeStubGitHub({
+      issuesByRepo: { "acme/one": [{ number: 1, title: "T" }] },
+      filesByRepo: { "acme/one": { "AI-USAGE.md": ALLOWED_AI_USAGE } },
+    });
+    const deps = makeDeps(github);
+
+    await runDiscoveryQuery(query({ repos: ["acme/one"] }), deps);
+    expect(counterValue("discovery_index_cache_lookups_total", { cache: "result", outcome: "miss" })).toBe(1);
+    expect(counterValue("discovery_index_cache_lookups_total", { cache: "result", outcome: "hit" })).toBe(0);
+
+    await runDiscoveryQuery(query({ repos: ["acme/one"] }), deps);
+    expect(counterValue("discovery_index_cache_lookups_total", { cache: "result", outcome: "miss" })).toBe(1);
+    expect(counterValue("discovery_index_cache_lookups_total", { cache: "result", outcome: "hit" })).toBe(1);
+  });
+
+  it("records a policy-cache miss then a hit when the same repo's policy is resolved twice", async () => {
+    // acme/one is reached via both the org search (#1) and the search term (#9); its policy is computed
+    // once (miss) then reused (hit) within the same query.
+    const { github } = makeStubGitHub({
+      searchResults: {
+        "org:acme state:open type:issue": [{ number: 1, title: "Org", repository_url: "https://api.github.com/repos/acme/one" }],
+        "flaky state:open type:issue": [{ number: 9, title: "Term", repository_url: "https://api.github.com/repos/acme/one" }],
+      },
+      filesByRepo: { "acme/one": { "AI-USAGE.md": ALLOWED_AI_USAGE } },
+    });
+    await runDiscoveryQuery(query({ orgs: ["acme"], searchTerms: ["flaky"] }), makeDeps(github));
+    expect(counterValue("discovery_index_cache_lookups_total", { cache: "policy", outcome: "miss" })).toBe(1);
+    expect(counterValue("discovery_index_cache_lookups_total", { cache: "policy", outcome: "hit" })).toBe(1);
   });
 });

--- a/test/unit/discovery-index/github-client.test.ts
+++ b/test/unit/discovery-index/github-client.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClient } from "../../../packages/discovery-index/src/github-client";
+import { counterValue, resetMetrics } from "../../../packages/discovery-index/src/metrics";
 
 interface FetchCall {
   url: string;
@@ -19,6 +20,10 @@ function makeFetchStub(responses: Response[]) {
 }
 
 describe("discovery-index GitHubClient (#7164)", () => {
+  beforeEach(() => {
+    resetMetrics();
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -329,6 +334,43 @@ describe("discovery-index GitHubClient (#7164)", () => {
       const { fetchImpl: notObject } = makeFetchStub([new Response("null", { status: 200 })]);
       const client3 = new GitHubClient({ token: "tok", fetchImpl: notObject, sleepFn: vi.fn() });
       expect((await client3.fetchRepoFile("o/r", "X.md")).content).toBeNull();
+    });
+  });
+
+  describe("discovery_index_github_requests_total metric", () => {
+    const ok = () => counterValue("discovery_index_github_requests_total", { outcome: "ok" });
+    const retried = () => counterValue("discovery_index_github_requests_total", { outcome: "retried" });
+    const failed = () => counterValue("discovery_index_github_requests_total", { outcome: "failed" });
+
+    it("emits exactly one ok for a single successful request", async () => {
+      const { fetchImpl } = makeFetchStub([new Response("[]", { status: 200 })]);
+      const client = new GitHubClient({ token: "tok", fetchImpl, sleepFn: vi.fn() });
+      await client.fetchRepoIssues("owner/repo");
+      expect(ok()).toBe(1);
+      expect(retried()).toBe(0);
+      expect(failed()).toBe(0);
+    });
+
+    it("emits one retried then one ok for a request that 5xx-es once then succeeds", async () => {
+      const { fetchImpl } = makeFetchStub([new Response("err", { status: 500 }), new Response("[]", { status: 200 })]);
+      const client = new GitHubClient({ token: "tok", fetchImpl, sleepFn: vi.fn(), maxAttempts: 3 });
+      await client.fetchRepoIssues("owner/repo");
+      expect(retried()).toBe(1);
+      expect(ok()).toBe(1);
+      expect(failed()).toBe(0);
+    });
+
+    it("emits one retried per extra attempt then one failed when maxAttempts is exhausted", async () => {
+      const { fetchImpl } = makeFetchStub([
+        new Response("err", { status: 500 }),
+        new Response("err", { status: 500 }),
+        new Response("err", { status: 500 }),
+      ]);
+      const client = new GitHubClient({ token: "tok", fetchImpl, sleepFn: vi.fn(), maxAttempts: 3 });
+      await client.fetchRepoIssues("owner/repo");
+      expect(retried()).toBe(2); // two retries before the third (final) attempt
+      expect(failed()).toBe(1);
+      expect(ok()).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## What

Wires up two metrics that `packages/discovery-index` already declares in `DEFAULT_METRIC_META` but never actually records, so `discovery_index_cache_lookups_total` and `discovery_index_github_requests_total` stay at zero on a live instance.

Closes #7432

## Details

- **`discovery-query.ts`** — at both `TtlCache.getOrCompute` call sites (the result cache in `runDiscoveryQuery`, the policy cache in `resolveRepoAiPolicy`), record `discovery_index_cache_lookups_total { cache: "result"|"policy", outcome: "hit"|"miss" }`. `"miss"` = the compute callback actually ran; `"hit"` = it didn't. Detected with a `missed` flag set as the first line of the compute callback, then `incr(...)` after the call resolves.
- **`github-client.ts`** — in `fetchWithRetry`, record `discovery_index_github_requests_total { outcome: "ok"|"retried"|"failed" }`: one `"retried"` immediately before each `sleepFn` (per attempt beyond the first), and one `"ok"`/`"failed"` (`response.ok ? "ok" : "failed"`) at the return — the retried increments are in addition to, never instead of, the terminal ok/failed. Adds the file's first `import { incr } from "./metrics.js"`.

No retry/return logic changed, and `DEFAULT_METRIC_META` / the metric contract is untouched — this is purely wiring the missing `incr()` calls.

## Validation

- Added tests to the existing `test/unit/discovery-index/{discovery-query,github-client}.test.ts`: cache miss-then-hit for both the result and policy caches; a single 200 → one `ok`; a 500-then-200 → one `retried` + one `ok`; an all-500 max-attempts exhaustion → `retried`-per-extra-attempt + one `failed`. Counters are reset per test.
- Both suites pass (45 tests). Coverage on the two changed files is **100% branch** on every added line. `git diff --check` clean; the discovery-index contract test still passes (18/18).
