### PR TITLE
fix(ui-kit): edge-trigger StateBoundary failure notifications

### DIFF
--- a/apps/loopover-ui/src/components/site/state-views.test.tsx
+++ b/apps/loopover-ui/src/components/site/state-views.test.tsx
@@ -138,3 +138,42 @@ describe("StateBoundary retry/refresh actions (#793 regression guard)", () => {
     expect(screen.getByText("content")).toBeTruthy();
   });
 });
+
+describe("StateBoundary onFailureNotify edge-trigger (#7436)", () => {
+  it("notifies exactly once while staying in error across unstable callback identities, then again on re-entry", () => {
+    notifyApiFailure.mockClear();
+    const { rerender } = render(
+      <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+
+    // Simulate the app wrapper's fresh onFailureNotify arrow + a fresh onRetry each parent render
+    // while isError stays true — must NOT re-fire.
+    for (let i = 0; i < 4; i += 1) {
+      rerender(
+        <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+          <div>content</div>
+        </StateBoundary>,
+      );
+    }
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+
+    // Leave the error state…
+    rerender(
+      <StateBoundary isError={false} errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(1);
+
+    // …then re-enter: exactly one more notification for the second false→true edge.
+    rerender(
+      <StateBoundary isError errorLabel="Widgets" onRetry={() => {}}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/loopover-ui-kit/src/components/state-views.tsx
+++ b/packages/loopover-ui-kit/src/components/state-views.tsx
@@ -1,5 +1,5 @@
 import { Loader2, Inbox, AlertTriangle, RefreshCw, WifiOff } from "lucide-react";
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { cn } from "../utils";
@@ -265,8 +265,14 @@ export function StateBoundary({
       : "The data source did not respond. Retry the request, or check back once the service has recovered.");
 
   // When this boundary flips into the error state, surface a toast with Retry.
+  // Edge-triggered (#7436): only fire on false→true of (isError && errorLabel). Level-triggering here
+  // re-notified on every re-render while already errored because app wrappers pass a fresh
+  // `onFailureNotify` arrow each render (see apps/loopover-ui site/state-views.tsx). Mirrors the
+  // wasError-ref pattern used by mcp-version-badge for transition detection.
+  const wasFailureNotifyActive = useRef(false);
   useEffect(() => {
-    if (isError && errorLabel) {
+    const failureNotifyActive = Boolean(isError && errorLabel);
+    if (isError && errorLabel && !wasFailureNotifyActive.current) {
       onFailureNotify?.({
         label: errorLabel,
         kind: errorKind ?? "network",
@@ -277,6 +283,7 @@ export function StateBoundary({
         retry: onRetry,
       });
     }
+    wasFailureNotifyActive.current = failureNotifyActive;
   }, [isError, errorLabel, errorKind, resolvedErrorDescription, onRetry, onFailureNotify]);
 
   if (isLoading) {


### PR DESCRIPTION
## Summary

- Make `StateBoundary`'s `onFailureNotify` effect edge-triggered (false→true of `isError && errorLabel`) via a `wasFailureNotifyActive` ref, matching the documented "flips into" intent.
- Narrow with `if (isError && errorLabel && !wasFailureNotifyActive.current)` so `errorLabel` is typed without a non-null assertion.
- Add a regression test that re-renders with fresh callback identities while still in error (exactly one notify), then leaves and re-enters error (second notify).

Closes #7436

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local gates: `npm run build --workspace @loopover/ui-kit` and `npm run test --workspace @loopover/ui -- src/components/site/state-views.test.tsx` (15 pass). Remaining checks deferred to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Behavior-only fix (notification edge-trigger). No at-rest visual delta — before and after are the same production dark-mode captures at each required viewport. loopover-ui is dark-mode-only.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [![Desktop · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-desktop-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-desktop-dark.png) | [![Desktop · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-desktop-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-desktop-dark.png) |
| Tablet · Dark | [![Tablet · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-tablet-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-tablet-dark.png) | [![Tablet · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-tablet-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-tablet-dark.png) |
| Mobile · Dark | [![Mobile · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-mobile-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-mobile-dark.png) | [![Mobile · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-mobile-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7436/state-boundary-mobile-dark.png) |

## Notes

- Fresh PR after #7502 (approved on code, auto-closed for incomplete screenshot matrix). Does not reopen #7502.
