### PR TITLE
fix(ui): page skipped-PR audit feed by offset instead of growing limit

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -11061,11 +11061,16 @@
                 "remediation"
               ]
             }
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0
           }
         },
         "required": [
           "generatedAt",
           "limit",
+          "offset",
           "hasMore",
           "filters",
           "items"
@@ -17899,6 +17904,16 @@
           {
             "schema": {
               "type": "string",
+              "example": "0"
+            },
+            "required": false,
+            "description": "Number of parsed skip events to skip before returning rows (non-negative).",
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "example": "JSONbored/loopover"
             },
             "required": false,
@@ -17909,6 +17924,7 @@
           {
             "schema": {
               "type": "string",
+              "example": "not_official_gittensor_miner",
               "enum": [
                 "surface_off",
                 "missing_author",
@@ -17917,8 +17933,7 @@
                 "maintainer_author",
                 "miner_detection_unavailable",
                 "not_official_gittensor_miner"
-              ],
-              "example": "not_official_gittensor_miner"
+              ]
             },
             "required": false,
             "description": "Optional PR skip reason filter.",

--- a/apps/loopover-ui/src/components/site/audit-feed-model.ts
+++ b/apps/loopover-ui/src/components/site/audit-feed-model.ts
@@ -86,7 +86,8 @@ export function normalizeSkippedPrAuditExport(data: unknown): SkippedPrAuditExpo
   return {
     generatedAt: raw.generatedAt,
     limit: typeof raw.limit === "number" ? raw.limit : items.length,
-    offset: typeof raw.offset === "number" && Number.isFinite(raw.offset) ? Math.max(0, raw.offset) : 0,
+    offset:
+      typeof raw.offset === "number" && Number.isFinite(raw.offset) ? Math.max(0, raw.offset) : 0,
     hasMore: Boolean(raw.hasMore),
     filters: {
       repoFullName:

--- a/apps/loopover-ui/src/components/site/audit-feed-model.ts
+++ b/apps/loopover-ui/src/components/site/audit-feed-model.ts
@@ -17,6 +17,7 @@ export type SkippedPrAuditItem = {
 export type SkippedPrAuditExport = {
   generatedAt: string;
   limit: number;
+  offset: number;
   hasMore: boolean;
   filters: {
     repoFullName: string | null;
@@ -38,12 +39,14 @@ export const SKIP_REASON_OPTIONS: Array<{ value: "" | SkippedPrAuditReason; labe
 
 export function buildSkippedPrAuditPath(options: {
   limit: number;
+  offset?: number;
   repoFullName?: string;
   reason?: SkippedPrAuditReason;
   since?: string;
 }): string {
   const params = new URLSearchParams();
   params.set("limit", String(options.limit));
+  params.set("offset", String(Math.max(0, options.offset ?? 0)));
   if (options.repoFullName?.trim()) params.set("repoFullName", options.repoFullName.trim());
   if (options.reason) params.set("reason", options.reason);
   if (options.since?.trim()) params.set("since", options.since.trim());
@@ -83,6 +86,7 @@ export function normalizeSkippedPrAuditExport(data: unknown): SkippedPrAuditExpo
   return {
     generatedAt: raw.generatedAt,
     limit: typeof raw.limit === "number" ? raw.limit : items.length,
+    offset: typeof raw.offset === "number" && Number.isFinite(raw.offset) ? Math.max(0, raw.offset) : 0,
     hasMore: Boolean(raw.hasMore),
     filters: {
       repoFullName:

--- a/apps/loopover-ui/src/components/site/audit-feed.test.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.test.tsx
@@ -46,7 +46,9 @@ const SAMPLE: {
 
 describe("audit feed helpers", () => {
   it("builds query paths for skipped PR audit filters", () => {
-    expect(buildSkippedPrAuditPath({ limit: 25 })).toBe("/v1/app/skipped-pr-audit?limit=25&offset=0");
+    expect(buildSkippedPrAuditPath({ limit: 25 })).toBe(
+      "/v1/app/skipped-pr-audit?limit=25&offset=0",
+    );
     expect(
       buildSkippedPrAuditPath({
         limit: 50,

--- a/apps/loopover-ui/src/components/site/audit-feed.test.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.test.tsx
@@ -17,6 +17,7 @@ import { AuditFeed } from "@/components/site/audit-feed";
 const SAMPLE: {
   generatedAt: string;
   limit: number;
+  offset: number;
   hasMore: boolean;
   filters: { repoFullName: null; reason: null; since: null };
   items: Array<{
@@ -29,6 +30,7 @@ const SAMPLE: {
 } = {
   generatedAt: "2026-05-28T00:00:05.000Z",
   limit: 50,
+  offset: 0,
   hasMore: false,
   filters: { repoFullName: null, reason: null, since: null },
   items: [
@@ -44,16 +46,17 @@ const SAMPLE: {
 
 describe("audit feed helpers", () => {
   it("builds query paths for skipped PR audit filters", () => {
-    expect(buildSkippedPrAuditPath({ limit: 25 })).toBe("/v1/app/skipped-pr-audit?limit=25");
+    expect(buildSkippedPrAuditPath({ limit: 25 })).toBe("/v1/app/skipped-pr-audit?limit=25&offset=0");
     expect(
       buildSkippedPrAuditPath({
         limit: 50,
+        offset: 50,
         repoFullName: "repo-owner/owned-repo",
         reason: "bot_author",
         since: "2026-05-28T00:00:00.000Z",
       }),
     ).toBe(
-      "/v1/app/skipped-pr-audit?limit=50&repoFullName=repo-owner%2Fowned-repo&reason=bot_author&since=2026-05-28T00%3A00%3A00.000Z",
+      "/v1/app/skipped-pr-audit?limit=50&offset=50&repoFullName=repo-owner%2Fowned-repo&reason=bot_author&since=2026-05-28T00%3A00%3A00.000Z",
     );
   });
 
@@ -111,7 +114,7 @@ describe("AuditFeed", () => {
       "https://github.com/repo-owner/owned-repo/pull/6",
     );
     expect(apiFetch).toHaveBeenCalledWith(
-      "https://api.test/v1/app/skipped-pr-audit?limit=50",
+      "https://api.test/v1/app/skipped-pr-audit?limit=50&offset=0",
       expect.objectContaining({ credentials: "include" }),
     );
   });
@@ -194,24 +197,110 @@ describe("AuditFeed", () => {
     expect(apiFetch).not.toHaveBeenCalled();
   });
 
-  it("loads more rows until the maximum page size", async () => {
-    apiFetch.mockResolvedValue({ ok: true, data: { ...SAMPLE, hasMore: true } });
+  it("appends the next offset page without replacing already-visible rows (#7438)", async () => {
+    const firstPage = {
+      ...SAMPLE,
+      hasMore: true,
+      offset: 0,
+      items: [
+        {
+          repoFullName: "repo-owner/owned-repo",
+          pullNumber: 6,
+          reason: "surface_off",
+          timestamp: "2026-05-28T00:00:04.000Z",
+          remediation: "Enable a PR public surface in repository settings.",
+        },
+      ],
+    };
+    const secondPage = {
+      ...SAMPLE,
+      hasMore: false,
+      offset: 1,
+      items: [
+        {
+          repoFullName: "repo-owner/owned-repo",
+          pullNumber: 5,
+          reason: "bot_author",
+          timestamp: "2026-05-28T00:00:03.000Z",
+          remediation: "Bot authors are excluded from public PR surfaces.",
+        },
+      ],
+    };
+    apiFetch.mockResolvedValue({ ok: true, data: firstPage });
     render(<AuditFeed />);
-    await screen.findByText("repo-owner/owned-repo");
+    expect(await screen.findByText("#6")).toBeTruthy();
     apiFetch.mockClear();
-    apiFetch.mockResolvedValue({ ok: true, data: { ...SAMPLE, hasMore: true, limit: 100 } });
+    apiFetch.mockResolvedValue({ ok: true, data: secondPage });
 
     fireEvent.click(screen.getByRole("button", { name: /load more/i }));
 
     await waitFor(() =>
       expect(apiFetch).toHaveBeenCalledWith(
-        "https://api.test/v1/app/skipped-pr-audit?limit=100",
+        "https://api.test/v1/app/skipped-pr-audit?limit=50&offset=1",
         expect.any(Object),
       ),
     );
 
-    expect(screen.getByText(/maximum page size \(100\)/i)).toBeTruthy();
+    expect(screen.getByText("#6")).toBeTruthy();
+    expect(await screen.findByText("#5")).toBeTruthy();
+    expect(screen.getByText("2 event(s)")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /load more/i })).toBeNull();
+    expect(screen.queryByText(/maximum page size/i)).toBeNull();
+  });
+
+  it("resets to offset 0 when filters are applied after load-more (#7438)", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        ...SAMPLE,
+        hasMore: true,
+        items: [
+          {
+            repoFullName: "repo-owner/owned-repo",
+            pullNumber: 6,
+            reason: "surface_off",
+            timestamp: "2026-05-28T00:00:04.000Z",
+            remediation: "Enable a PR public surface in repository settings.",
+          },
+        ],
+      },
+    });
+    render(<AuditFeed />);
+    await screen.findByText("#6");
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        ...SAMPLE,
+        hasMore: false,
+        offset: 1,
+        items: [
+          {
+            repoFullName: "repo-owner/owned-repo",
+            pullNumber: 5,
+            reason: "bot_author",
+            timestamp: "2026-05-28T00:00:03.000Z",
+            remediation: "Bot authors are excluded from public PR surfaces.",
+          },
+        ],
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+    await screen.findByText("#5");
+
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValue({ ok: true, data: SAMPLE });
+    fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
+      target: { value: "repo-owner/owned-repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /apply filters/i }));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/skipped-pr-audit?limit=50&offset=0&repoFullName=repo-owner%2Fowned-repo",
+        expect.any(Object),
+      ),
+    );
   });
 
   it("shows an error state when the audit response is malformed", async () => {

--- a/apps/loopover-ui/src/components/site/audit-feed.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.tsx
@@ -29,7 +29,6 @@ const fieldClass =
   "mt-1 w-full rounded-token border border-border bg-background/40 px-3 py-2 text-token-sm text-foreground focus-ring";
 
 const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 100;
 
 type AuditFeedProps = {
   enabled?: boolean;
@@ -41,20 +40,21 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
   const [repoFullName, setRepoFullName] = useState("");
   const [sinceInput, setSinceInput] = useState("");
   const [sinceIso, setSinceIso] = useState("");
-  const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [error, setError] = useState<string | null>(null);
   const [data, setData] = useState<SkippedPrAuditExport | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
-  const queryPath = useMemo(
+  const filterPath = useMemo(
     () =>
       buildSkippedPrAuditPath({
-        limit,
+        limit: DEFAULT_LIMIT,
+        offset: 0,
         repoFullName: repoFullName || undefined,
         reason: reason || undefined,
         since: sinceIso || undefined,
       }),
-    [limit, reason, repoFullName, sinceIso],
+    [reason, repoFullName, sinceIso],
   );
 
   const load = useCallback(async () => {
@@ -67,7 +67,7 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
     setStatus("loading");
     setError(null);
     const origin = getApiOrigin().replace(/\/$/, "");
-    const result = await apiFetch<SkippedPrAuditExport>(`${origin}${queryPath}`, {
+    const result = await apiFetch<SkippedPrAuditExport>(`${origin}${filterPath}`, {
       label: "Skipped PR audit",
       credentials: "include",
       headers: { Accept: "application/json" },
@@ -87,7 +87,7 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
     setData(null);
     setError(result.message);
     setStatus("error");
-  }, [enabled, queryPath]);
+  }, [enabled, filterPath]);
 
   useEffect(() => {
     void load();
@@ -96,7 +96,6 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
   const applyFilters = () => {
     setSinceIso(normalizeSinceInput(sinceInput));
     setRepoFullName(repoDraft.trim());
-    setLimit(DEFAULT_LIMIT);
   };
 
   const resetFilters = () => {
@@ -105,11 +104,43 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
     setRepoFullName("");
     setSinceInput("");
     setSinceIso("");
-    setLimit(DEFAULT_LIMIT);
   };
 
-  const loadMore = () => {
-    setLimit((current) => Math.min(current + DEFAULT_LIMIT, MAX_LIMIT));
+  const loadMore = async () => {
+    if (!enabled || !data?.hasMore || loadingMore) return;
+    setLoadingMore(true);
+    setError(null);
+    const nextOffset = data.items.length;
+    const origin = getApiOrigin().replace(/\/$/, "");
+    const path = buildSkippedPrAuditPath({
+      limit: DEFAULT_LIMIT,
+      offset: nextOffset,
+      repoFullName: repoFullName || undefined,
+      reason: reason || undefined,
+      since: sinceIso || undefined,
+    });
+    const result = await apiFetch<SkippedPrAuditExport>(`${origin}${path}`, {
+      label: "Skipped PR audit",
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    setLoadingMore(false);
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+    const normalized = normalizeSkippedPrAuditExport(result.data);
+    if (!normalized) {
+      setError("The skipped PR audit endpoint returned an unexpected response.");
+      return;
+    }
+    // Append-not-replace (#7438): keep already-rendered rows; only grow with the next page.
+    setData({
+      ...normalized,
+      items: [...data.items, ...normalized.items],
+      // Surface the next page's paging cursor so subsequent Load more advances correctly.
+      offset: nextOffset,
+    });
   };
 
   if (status === "loading" && !data) {
@@ -138,10 +169,7 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
           reason={reason}
           repoDraft={repoDraft}
           sinceInput={sinceInput}
-          onReasonChange={(value) => {
-            setReason(value);
-            setLimit(DEFAULT_LIMIT);
-          }}
+          onReasonChange={setReason}
           onRepoDraftChange={setRepoDraft}
           onSinceInputChange={setSinceInput}
           onApply={applyFilters}
@@ -175,10 +203,7 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
         reason={reason}
         repoDraft={repoDraft}
         sinceInput={sinceInput}
-        onReasonChange={(value) => {
-          setReason(value);
-          setLimit(DEFAULT_LIMIT);
-        }}
+        onReasonChange={setReason}
         onRepoDraftChange={setRepoDraft}
         onSinceInputChange={setSinceInput}
         onApply={applyFilters}
@@ -249,14 +274,12 @@ export function AuditFeed({ enabled = true }: AuditFeedProps) {
       </TableScroll>
 
       <div className="flex flex-wrap items-center gap-3">
-        {data.hasMore && limit < MAX_LIMIT ? (
-          <StateActionButton onClick={loadMore}>Load more</StateActionButton>
+        {data.hasMore ? (
+          <StateActionButton onClick={() => void loadMore()} disabled={loadingMore}>
+            {loadingMore ? "Loading…" : "Load more"}
+          </StateActionButton>
         ) : null}
-        {data.hasMore && limit >= MAX_LIMIT ? (
-          <p className="text-token-xs text-muted-foreground">
-            Showing the maximum page size ({MAX_LIMIT}). Narrow filters to inspect older events.
-          </p>
-        ) : null}
+        {error ? <p className="text-token-xs text-destructive">{error}</p> : null}
         <StateActionButton onClick={() => void load()}>Refresh</StateActionButton>
       </div>
     </div>

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -672,6 +672,7 @@ const selfhostDeadLetterQueueQuerySchema = z
 const skippedPrAuditQuerySchema = z
   .object({
     limit: z.coerce.number().int().optional(),
+    offset: z.coerce.number().int().optional(),
     repoFullName: z.string().trim().min(3).max(200).optional(),
     reason: z.enum(PUBLIC_SURFACE_SKIP_REASONS).optional(),
     since: z.string().trim().min(1).max(64).optional(),
@@ -1725,6 +1726,7 @@ export function createApp() {
     if (repoFullNames instanceof Response) return repoFullNames;
     const page = await listPrVisibilitySkipAuditEvents(c.env, {
       limit: clampInteger(parsed.data.limit ?? 50, 1, 100),
+      offset: Math.max(0, parsed.data.offset ?? 0),
       repoFullNames,
       reason: parsed.data.reason,
       sinceIso,
@@ -1732,6 +1734,7 @@ export function createApp() {
     return c.json({
       generatedAt: nowIso(),
       limit: page.limit,
+      offset: page.offset,
       hasMore: page.hasMore,
       filters: {
         repoFullName: requestedRepo ?? null,

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3191,6 +3191,7 @@ export type PrVisibilitySkipAuditEvent = {
 
 export type PrVisibilitySkipAuditPage = {
   limit: number;
+  offset: number;
   hasMore: boolean;
   items: PrVisibilitySkipAuditEvent[];
 };
@@ -3199,14 +3200,17 @@ export async function listPrVisibilitySkipAuditEvents(
   env: Env,
   options: {
     limit?: number | undefined;
+    offset?: number | undefined;
     repoFullNames?: string[] | undefined;
     reason?: string | undefined;
     sinceIso?: string | undefined;
   } = {},
 ): Promise<PrVisibilitySkipAuditPage> {
   const limit = clampInteger(options.limit ?? 50, 1, 100);
+  // Offset is non-negative; unbounded above so callers can page past the first window (#7438).
+  const offset = Number.isFinite(options.offset) ? Math.max(0, Math.trunc(options.offset as number)) : 0;
   const scopedRepoNames = options.repoFullNames === undefined ? undefined : uniqueRepoNames(options.repoFullNames.map((name) => name.trim()).filter(Boolean));
-  if (scopedRepoNames !== undefined && scopedRepoNames.length === 0) return { limit, hasMore: false, items: [] };
+  if (scopedRepoNames !== undefined && scopedRepoNames.length === 0) return { limit, offset, hasMore: false, items: [] };
 
   const conditions: SQL[] = [eq(auditEvents.eventType, "github_app.pr_visibility_skipped")];
   if (options.reason) conditions.push(eq(auditEvents.detail, options.reason));
@@ -3221,7 +3225,10 @@ export async function listPrVisibilitySkipAuditEvents(
     if (repoFilter) conditions.push(repoFilter);
   }
 
-  const rowLimit = Math.min(500, limit * 5 + 20);
+  // Over-fetch SQL rows (some targetKeys fail to parse) far enough to cover offset + limit + a
+  // one-item peek for hasMore. Cap keeps a single page request bounded.
+  const neededParsed = offset + limit + 1;
+  const rowLimit = Math.min(2500, neededParsed * 5 + 20);
   const rows = await getDb(env.DB)
     .select({
       targetKey: auditEvents.targetKey,
@@ -3246,7 +3253,12 @@ export async function listPrVisibilitySkipAuditEvents(
       },
     ];
   });
-  return { limit, hasMore: items.length > limit, items: items.slice(0, limit) };
+  return {
+    limit,
+    offset,
+    hasMore: items.length > offset + limit,
+    items: items.slice(offset, offset + limit),
+  };
 }
 
 /** Repo-scoped rollups of gate-outcome audit rows for the maintainer dashboard (#2203). Counts only

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -946,11 +946,13 @@ const skippedPrAuditShape = {
   reason: z.enum(PUBLIC_SURFACE_SKIP_REASONS).optional(),
   since: z.string().trim().min(1).max(64).optional(),
   limit: z.number().int().positive().optional(),
+  offset: z.number().int().nonnegative().optional(),
 };
 
 const skippedPrAuditOutputSchema = {
   generatedAt: z.string().optional(),
   limit: z.number().optional(),
+  offset: z.number().optional(),
   hasMore: z.boolean().optional(),
   filters: z.unknown().optional(),
   items: z.array(z.unknown()).optional(),
@@ -3449,6 +3451,7 @@ export class LoopoverMcp {
     reason?: PublicSurfaceSkipReason | undefined;
     since?: string | undefined;
     limit?: number | undefined;
+    offset?: number | undefined;
   }): Promise<ToolPayload> {
     const repoFullNames = await this.requireSkippedPrAuditAccess(input.repoFullName);
     let sinceIso: string | undefined;
@@ -3457,12 +3460,19 @@ export class LoopoverMcp {
       if (!Number.isFinite(timestamp)) throw new Error(`Invalid since: "${input.since}" is not a parseable date.`);
       sinceIso = new Date(timestamp).toISOString();
     }
-    const page = await listPrVisibilitySkipAuditEvents(this.env, { limit: input.limit, repoFullNames, reason: input.reason, sinceIso });
+    const page = await listPrVisibilitySkipAuditEvents(this.env, {
+      limit: input.limit,
+      offset: input.offset,
+      repoFullNames,
+      reason: input.reason,
+      sinceIso,
+    });
     return {
-      summary: `LoopOver skipped-PR audit: ${page.items.length} event(s) (limit ${page.limit}${page.hasMore ? ", more available" : ""}).`,
+      summary: `LoopOver skipped-PR audit: ${page.items.length} event(s) (limit ${page.limit}, offset ${page.offset}${page.hasMore ? ", more available" : ""}).`,
       data: {
         generatedAt: nowIso(),
         limit: page.limit,
+        offset: page.offset,
         hasMore: page.hasMore,
         filters: {
           repoFullName: input.repoFullName ?? null,

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1132,6 +1132,7 @@ export const SkippedPrAuditExportSchema = z
   .object({
     generatedAt: z.string(),
     limit: z.number().int().min(1).max(100),
+    offset: z.number().int().min(0),
     hasMore: z.boolean(),
     filters: z.object({
       repoFullName: z.string().nullable(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -1202,6 +1202,10 @@ export function buildOpenApiSpec() {
           param: { description: "Maximum rows to return, clamped from 1 to 100." },
           example: "50",
         }),
+        offset: z.string().optional().openapi({
+          param: { description: "Number of parsed skip events to skip before returning rows (non-negative)." },
+          example: "0",
+        }),
         repoFullName: z.string().optional().openapi({
           param: { description: "Optional repository filter. Browser sessions must have control-panel access to this repo." },
           example: "JSONbored/loopover",

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -4476,10 +4476,12 @@ describe("api routes", () => {
     expect(bounded.status).toBe(200);
     const boundedBody = (await bounded.json()) as {
       limit: number;
+      offset: number;
       hasMore: boolean;
       items: Array<{ repoFullName: string; pullNumber: number; reason: string; timestamp: string; remediation: string }>;
     };
     expect(boundedBody.limit).toBe(3);
+    expect(boundedBody.offset).toBe(0);
     expect(boundedBody.hasMore).toBe(true);
     expect(boundedBody.items).toEqual([
       expect.objectContaining({ repoFullName: "victim-org/secret-repo", pullNumber: 7, reason: "maintainer_author" }),
@@ -4488,6 +4490,25 @@ describe("api routes", () => {
     ]);
     expect(boundedBody.items[1]?.remediation).toContain("repository settings");
     expect(JSON.stringify(boundedBody)).not.toMatch(/private-author|bot-secret|detector-secret|surface-secret|victim-secret|delivery-secret|github_pat|wallet|hotkey|raw trust/i);
+
+    const paged = await app.request("/v1/app/skipped-pr-audit?limit=2&offset=3", { headers: apiHeaders(env) }, env);
+    expect(paged.status).toBe(200);
+    const pagedBody = (await paged.json()) as {
+      limit: number;
+      offset: number;
+      hasMore: boolean;
+      items: Array<{ pullNumber: number }>;
+    };
+    expect(pagedBody).toMatchObject({ limit: 2, offset: 3, hasMore: true });
+    expect(pagedBody.items.map((item) => item.pullNumber)).toEqual([8, 4]);
+    const lastPage = await app.request("/v1/app/skipped-pr-audit?limit=2&offset=6", { headers: apiHeaders(env) }, env);
+    expect(lastPage.status).toBe(200);
+    await expect(lastPage.json()).resolves.toMatchObject({
+      limit: 2,
+      offset: 6,
+      hasMore: false,
+      items: [expect.objectContaining({ pullNumber: 2 }), expect.objectContaining({ pullNumber: 1 })],
+    });
 
     const reasonFiltered = await app.request("/v1/app/skipped-pr-audit?reason=bot_author&limit=500", { headers: apiHeaders(env) }, env);
     expect(reasonFiltered.status).toBe(200);

--- a/test/unit/mcp-skipped-pr-audit.test.ts
+++ b/test/unit/mcp-skipped-pr-audit.test.ts
@@ -31,6 +31,7 @@ async function seedOwnedRepo(env: Env, installationId: number, owner: string, na
 type SkippedPrAuditData = {
   generatedAt: string;
   limit: number;
+  offset: number;
   hasMore: boolean;
   filters: { repoFullName: string | null; reason: string | null; since: string | null };
   items: Array<{ repoFullName: string; pullNumber: number; reason: string; timestamp: string; remediation: string }>;
@@ -68,6 +69,7 @@ describe("MCP loopover_get_skipped_pr_audit (#5825)", () => {
     expect(data.items).toEqual([expect.objectContaining({ repoFullName: "repo-owner/owned-repo", pullNumber: 4, reason: "bot_author" })]);
     expect(data.items[0]?.remediation).toContain("intentionally kept quiet");
     expect(data.limit).toBe(50);
+    expect(data.offset).toBe(0);
     expect(data.hasMore).toBe(false);
     expect(data.filters).toEqual({ repoFullName: null, reason: null, since: null });
     expect(JSON.stringify(result.content)).not.toContain("github_pat_should_not_export");

--- a/test/unit/skipped-pr-audit.test.ts
+++ b/test/unit/skipped-pr-audit.test.ts
@@ -49,13 +49,14 @@ describe("skipped PR audit repository export", () => {
     });
 
     const emptyScope = await listPrVisibilitySkipAuditEvents(env, { repoFullNames: [] });
-    expect(emptyScope).toMatchObject({ limit: 50, hasMore: false, items: [] });
+    expect(emptyScope).toMatchObject({ limit: 50, offset: 0, hasMore: false, items: [] });
 
     const scoped = await listPrVisibilitySkipAuditEvents(env, {
       limit: Number.NaN,
       repoFullNames: ["owner/re_po", "OWNER/re_po"],
     });
     expect(scoped.limit).toBe(1);
+    expect(scoped.offset).toBe(0);
     expect(scoped.items).toEqual([
       {
         repoFullName: "owner/re_po",
@@ -68,6 +69,39 @@ describe("skipped PR audit repository export", () => {
 
     const unscoped = await listPrVisibilitySkipAuditEvents(env);
     expect(unscoped.limit).toBe(50);
+    expect(unscoped.offset).toBe(0);
     expect(unscoped.items.map((item) => item.pullNumber)).toEqual([8, 7]);
+  });
+
+  it("pages by offset without dropping earlier parsed rows (#7438)", async () => {
+    const env = createTestEnv();
+    for (let i = 1; i <= 5; i += 1) {
+      await recordAuditEvent(env, {
+        eventType: "github_app.pr_visibility_skipped",
+        targetKey: `owner/page-repo#${i}`,
+        outcome: "completed",
+        detail: "bot_author",
+        createdAt: `2026-05-28T00:00:0${i}.000Z`,
+      });
+    }
+
+    const first = await listPrVisibilitySkipAuditEvents(env, { limit: 2, offset: 0 });
+    expect(first).toMatchObject({ limit: 2, offset: 0, hasMore: true });
+    expect(first.items.map((item) => item.pullNumber)).toEqual([5, 4]);
+
+    const second = await listPrVisibilitySkipAuditEvents(env, { limit: 2, offset: 2 });
+    expect(second).toMatchObject({ limit: 2, offset: 2, hasMore: true });
+    expect(second.items.map((item) => item.pullNumber)).toEqual([3, 2]);
+
+    const last = await listPrVisibilitySkipAuditEvents(env, { limit: 2, offset: 4 });
+    expect(last).toMatchObject({ limit: 2, offset: 4, hasMore: false });
+    expect(last.items.map((item) => item.pullNumber)).toEqual([1]);
+
+    const pastEnd = await listPrVisibilitySkipAuditEvents(env, { limit: 2, offset: 5 });
+    expect(pastEnd).toMatchObject({ limit: 2, offset: 5, hasMore: false, items: [] });
+
+    const negativeOffset = await listPrVisibilitySkipAuditEvents(env, { limit: 2, offset: -10 });
+    expect(negativeOffset.offset).toBe(0);
+    expect(negativeOffset.items.map((item) => item.pullNumber)).toEqual([5, 4]);
   });
 });


### PR DESCRIPTION
## Summary

- Add a real `offset` query parameter to `/v1/app/skipped-pr-audit` (and MCP `loopover_get_skipped_pr_audit`) so pages are sliced server-side instead of growing `limit`.
- Change `AuditFeed` "Load more" to request the next offset page and **append** rows, so already-visible events never drop or reorder when newer skips land.
- Filter apply/reset (and reason changes) reload from `offset=0` and replace the list.

Closes #7438

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi` (regenerated `apps/loopover-ui/public/openapi.json`)
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local: `vitest` for `skipped-pr-audit`, `mcp-skipped-pr-audit`, integration skipped-PR audit case, and `audit-feed.test.tsx` (all green). Remaining checks deferred to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Behavior-only pagination fix on the auth-gated AuditFeed ("Load more" appends via `offset`). No at-rest public visual delta — before/after are the same production dark-mode captures at each required viewport. loopover-ui is dark-mode-only.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [![Desktop · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-desktop-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-desktop-dark.png) | [![Desktop · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-desktop-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-desktop-dark.png) |
| Tablet · Dark | [![Tablet · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-tablet-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-tablet-dark.png) | [![Tablet · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-tablet-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-tablet-dark.png) |
| Mobile · Dark | [![Mobile · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-mobile-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-mobile-dark.png) | [![Mobile · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-mobile-dark.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-7438/audit-feed-offset-mobile-dark.png) |

## Notes

- Mirrors the dead-letter queue's `offset` request shape; AuditFeed keeps append UX (not Prev/Next page replace).
