### PR TITLE
fix(orb): index orb_relay_pending.created_at to stop full table scans

### DIFF
--- a/migrations/0167_orb_relay_pending_created_at_index.sql
+++ b/migrations/0167_orb_relay_pending_created_at_index.sql
@@ -1,0 +1,5 @@
+-- pruneRelayPending (src/orb/relay.ts) runs a fleet-wide TTL sweep filtered ONLY by created_at (not scoped to
+-- one installation_id), on every orb-relay-drain pull (#7430). Both existing indexes on this table lead with
+-- installation_id, so that predicate couldn't use either one -- the SELECT and DELETE both fell back to a
+-- full table scan, occasionally exceeding the pull request's 30s timeout budget.
+CREATE INDEX IF NOT EXISTS idx_orb_relay_pending_created_at ON orb_relay_pending (created_at);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -879,6 +879,9 @@ export const orbRelayPending = sqliteTable(
     coalesce: index("idx_orb_relay_pending_coalesce")
       .on(table.installationId, table.coalesceKey)
       .where(sql`coalesce_key IS NOT NULL`),
+    // pruneRelayPending (src/orb/relay.ts) filters/deletes by created_at alone (fleet-wide TTL sweep, not
+    // scoped to one installation) -- neither index above leads with created_at, so that scan was unindexed.
+    createdAt: index("idx_orb_relay_pending_created_at").on(table.createdAt),
   }),
 );
 

--- a/test/unit/orb-relay-pending-created-at-index.test.ts
+++ b/test/unit/orb-relay-pending-created-at-index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../helpers/d1";
+
+// Regression test for #7430: pruneRelayPending (src/orb/relay.ts) filters/deletes by created_at alone
+// (a fleet-wide TTL sweep, not scoped to one installation_id). Neither pre-existing index on
+// orb_relay_pending leads with created_at, so both queries fell back to a full table scan -- occasionally
+// exceeding the orb-relay-drain pull's 30s timeout budget under fleet load.
+describe("orb_relay_pending created_at index", () => {
+  it("creates the created_at index and pruneRelayPending's queries use it (SEARCH, not SCAN)", async () => {
+    const env = createTestEnv();
+
+    const idx = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+      .bind("idx_orb_relay_pending_created_at")
+      .first<{ name: string }>();
+    expect(idx?.name).toBe("idx_orb_relay_pending_created_at");
+
+    // The drop-log sample SELECT: WHERE created_at < ? ORDER BY created_at, delivery_id LIMIT ?.
+    const selectPlan = await env.DB.prepare(
+      "EXPLAIN QUERY PLAN SELECT delivery_id, event_name, installation_id FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours') ORDER BY created_at, delivery_id LIMIT ?",
+    )
+      .bind(24, 20)
+      .all<{ detail: string }>();
+    const selectDetail = (selectPlan.results ?? []).map((row) => row.detail).join(" ");
+    expect(selectDetail).toContain("idx_orb_relay_pending_created_at");
+    expect(selectDetail).not.toContain("SCAN orb_relay_pending");
+
+    // The prune DELETE: WHERE created_at < ?.
+    const deletePlan = await env.DB.prepare(
+      "EXPLAIN QUERY PLAN DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')",
+    )
+      .bind(24)
+      .all<{ detail: string }>();
+    const deleteDetail = (deletePlan.results ?? []).map((row) => row.detail).join(" ");
+    expect(deleteDetail).toContain("idx_orb_relay_pending_created_at");
+    expect(deleteDetail).not.toContain("SCAN orb_relay_pending");
+  });
+});


### PR DESCRIPTION
## Summary

`orb-relay-drain`'s periodic pull-mode drain has been timing out since 2026-07-15 and is still recurring (Sentry `orb_relay_drain`/`TimeoutError`, 13+ occurrences, most recent within hours). Its handler unconditionally runs `pruneRelayPending` first on every 30s pull. That function issues a SELECT and a DELETE against `orb_relay_pending` filtered only by `created_at` — but both existing indexes on that table lead with `installation_id`, so neither query could use an index. Both fell back to a full table scan, fleet-wide, every 30 seconds, occasionally exceeding the pull request's own 30s timeout budget.

This adds the missing `created_at` index (migration `0167`, mirrored in `src/db/schema.ts`) so both queries become index range scans instead.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #7430

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — new regression test (`test/unit/orb-relay-pending-created-at-index.test.ts`) asserts `EXPLAIN QUERY PLAN` uses the new index (`SEARCH`, not `SCAN`) for both queries `pruneRelayPending` runs; `npm run db:migrations:check` and `npm run db:schema-drift:check` both clean (0167 confirmed as the next free migration number)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `apps/loopover-ui`'s `ui:test` (vitest/jsdom) fails locally with `window.localStorage` undefined, on this sandbox's Node v26.5.0 (the repo pins Node 22 via `.nvmrc`, unavailable via `nvm` in this environment). Verified this reproduces identically on a clean, unmodified `origin/main` checkout with a fresh `npm ci` — it is a pre-existing local Node-version artifact unrelated to this change (which touches no `apps/loopover-ui` files), not a regression. Confirmed real GitHub Actions CI (`validate-tests` shards 1–6 + merge) is green on the exact `main` commit this branches from.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI change; this is a DB index + migration only.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — internal query-plan fix, no user-facing behavior or doc change.)

## Notes

- Root-caused via Sentry (`orb_relay_drain`) triage: `pruneRelayPending`'s SELECT was added by a same-day commit on 2026-07-15, doubling the pre-existing unindexed DELETE's scan work — matching the exact day this Sentry issue started firing.
