### PR TITLE
fix(selfhost): distinguish stale codex-reviewer env var, cool down its circuit breaker

### DIFF
--- a/scripts/branding-drift-baseline.json
+++ b/scripts/branding-drift-baseline.json
@@ -25,7 +25,7 @@
   "src/review/repo-doc-render.ts": 2,
   "src/review/repo-skill-render.ts": 2,
   "src/review/selftune-wire.ts": 1,
-  "src/selfhost/ai.ts": 6,
+  "src/selfhost/ai.ts": 9,
   "src/selfhost/health.ts": 3,
   "src/selfhost/monitored-work.ts": 1,
   "src/selfhost/orb-collector.ts": 1,

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -479,6 +479,17 @@ function assertCodexCredentialIsolation(env: Record<string, string | undefined>)
   // Fail closed until Codex exposes a brokered credential mode that does not put auth.json in the review sandbox.
   // Strict "1"-only, matching health.ts's codexAuthReadinessProbe and this flag's narrow opt-in convention.
   if (env.CODEX_HOME || env.LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER !== "1") {
+    // #7466: GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER was the only name for this opt-in until the LOOPOVER_
+    // rebrand (#5652) retired dual-read support repo-wide. An operator whose .env still uses the old name
+    // silently reverts to fully-disabled with no distinguishing signal -- surface that specific, actionable
+    // case instead of the generic message so an upgrading self-hoster knows to rename the var rather than
+    // assuming Codex was never configured at all. CODEX_HOME being the actual cause takes priority: renaming
+    // the flag can't fix that one.
+    if (!env.CODEX_HOME && env.GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER === "1") {
+      throw new Error(
+        "codex_credential_isolation_required: GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER is set but no longer read -- rename it to LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER",
+      );
+    }
     throw new Error("codex_credential_isolation_required");
   }
 }

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -1022,15 +1022,21 @@ export function isRateLimitError(error: unknown): boolean {
 }
 
 /** True for a provider's own STRUCTURAL misconfiguration signal (`src/selfhost/ai.ts`'s
- *  `codex_auth_not_configured` / `codex_no_auth` — a missing or expired credential file). Unlike a transient
+ *  `codex_auth_not_configured` / `codex_no_auth` / `codex_credential_isolation_required` — a missing or
+ *  expired credential file, or the credential-isolation guard refusing to run at all). Unlike a transient
  *  timeout or rate limit, this will fail identically on every future attempt until an operator re-runs
- *  `codex auth` -- confirmed live (GITTENSORY-K/8: 2094 + 544 events over 16 days from one unfixed
- *  misconfiguration, the credential file was never present the whole time). Mirrors
+ *  `codex auth` (or fixes their env var) -- confirmed live (GITTENSORY-K/8: 2094 + 544 events over 16 days
+ *  from one unfixed misconfiguration, the credential file was never present the whole time; #7466:
+ *  `codex_credential_isolation_required` repeating on the default 60s cooldown instead of the hour-long
+ *  structural one, because this regex didn't recognize it yet). Mirrors
  *  {@link isSubscriptionCliTimeout}/{@link isRateLimitError}'s identical non-transient-error short-circuit.
  *  Exported so `src/selfhost/ai.ts`'s circuit breaker can give this failure class a much longer cooldown
  *  than a genuinely transient one. */
 export function isStructuralProviderConfigError(error: unknown): boolean {
-  return error instanceof Error && /^codex_(?:auth_not_configured|no_auth):/.test(error.message);
+  return (
+    error instanceof Error &&
+    /^codex_(?:auth_not_configured|no_auth|credential_isolation_required)(?::|$)/.test(error.message)
+  );
 }
 
 /** Cap on the diagnostic prefix logged for an unparseable model response (#observability-unparseable) -- long

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -3084,6 +3084,21 @@ describe("pure helpers", () => {
     expect(isStructuralProviderConfigError(undefined)).toBe(false);
   });
 
+  it("isStructuralProviderConfigError matches codex_credential_isolation_required, bare or with a detail suffix (#7466)", () => {
+    // The generic throw (assertCodexCredentialIsolation's no-CODEX_HOME, non-legacy-var case): no colon, no suffix.
+    expect(isStructuralProviderConfigError(new Error("codex_credential_isolation_required"))).toBe(true);
+    // The specific legacy-env-var rename hint: same prefix, colon-separated detail.
+    expect(
+      isStructuralProviderConfigError(
+        new Error(
+          "codex_credential_isolation_required: GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER is set but no longer read -- rename it to LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER",
+        ),
+      ),
+    ).toBe(true);
+    // Not a bare match or a colon-suffixed one -- some other, unrelated code string sharing only the prefix.
+    expect(isStructuralProviderConfigError(new Error("codex_credential_isolation_requiredXYZ"))).toBe(false);
+  });
+
   it("runWorkersOpinion still retries a genuinely transient (non-timeout, non-429) error up to the full budget", async () => {
     let attempts = 0;
     const run = vi.fn(async () => {

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -1945,6 +1945,32 @@ describe("subscription CLI helpers + fail-safe", () => {
     ).rejects.toThrow(/codex_credential_isolation_required/);
   });
 
+  it("credential isolation surfaces a specific rename hint when only the legacy GITTENSORY_ var is set (#7466)", async () => {
+    const shouldNotSpawn: StubSpawn = async () => {
+      throw new Error("spawned");
+    };
+    await expect(
+      createCodexAi(
+        { GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" },
+        shouldNotSpawn,
+      ).run("gpt-5", { prompt: "x" }),
+    ).rejects.toThrow(
+      /^codex_credential_isolation_required: GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER is set but no longer read -- rename it to LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER$/,
+    );
+  });
+
+  it("credential isolation: CODEX_HOME being the actual blocker still wins over the legacy-var rename hint", async () => {
+    const shouldNotSpawn: StubSpawn = async () => {
+      throw new Error("spawned");
+    };
+    await expect(
+      createCodexAi(
+        { CODEX_HOME: "/home/node/.codex", GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" },
+        shouldNotSpawn,
+      ).run("gpt-5", { prompt: "x" }),
+    ).rejects.toThrow(/^codex_credential_isolation_required$/);
+  });
+
   it("resolveCodexAuthPath: CODEX_HOME wins, else HOME/.codex, else ~/.codex", () => {
     expect(resolveCodexAuthPath({ CODEX_HOME: "/data/codex", HOME: "/home/node" })).toBe(
       "/data/codex/auth.json",


### PR DESCRIPTION
## Summary

`codex_credential_isolation_required` errors have been recurring since 2026-07-16 on a self-host install that was previously working (Sentry: LOOPOVER-28/2A/2C/29). The credential-isolation guard itself (`assertCodexCredentialIsolation`, `src/selfhost/ai.ts`) is correct, intentional security hardening from `#1609` — not a bug. The problem is upstream: the `GITTENSORY_`→`LOOPOVER_` env var rebrand (`#5652`) retired dual-read support and hardcoded a strict `LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER === "1"` check. An operator whose `.env` still uses the legacy name silently reverts to fully-disabled, with the exact same generic error as never having configured it at all.

This is compounded by `isStructuralProviderConfigError`'s regex not matching `codex_credential_isolation_required`, so the per-provider circuit breaker gives this deterministic failure the default 60s cooldown instead of the hour-long structural one — the exact flood pattern that circuit breaker was built to prevent (its own comment cites `LOOPOVER-K/8`'s 2094 + 544 events).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #7466

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — new test cases cover both the legacy-var rename hint and the CODEX_HOME-takes-priority case (`test/unit/selfhost-ai.test.ts`), and both the bare + colon-suffixed `codex_credential_isolation_required` forms of the circuit-breaker regex (`test/unit/ai-review.test.ts`); isolated coverage on both changed files is 100% for the new code (the two pre-existing uncovered lines the full-file report shows are unrelated defaults elsewhere in each file)
- [x] `npm run branding-drift:check` — regenerated the baseline (`npm run branding-drift:update`) since the fix's own legacy-var detection necessarily references "gittensory" 3 more times in `src/selfhost/ai.ts`; a real, intentional increase, not drift
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The same pre-existing, local-environment-only failures noted in #7510 (this sandbox's Node v26.5.0 vs. the repo's pinned Node 22, and 2 unrelated miner-CLI test files) reproduce identically here; confirmed unrelated to this change and not present in real GitHub Actions CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched; this only refines an existing security guard's error message and its circuit-breaker classification.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — internal error-message + circuit-breaker classification fix; `apps/loopover-ui/content/docs/self-hosting-ai-providers.mdx` already documents `codex_credential_isolation_required` correctly.)

## Notes

- Root-caused via Sentry triage, cross-referencing `git log -S dualPrefixEnvFlag` and `git show` on the rebrand commit to confirm the env-var retirement was deliberate (not itself a bug) before designing this fix.
