### PR TITLE
test(unit): isolate loopover-mcp/miner tests from real machine state

### DIFF
--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -2472,19 +2472,23 @@ describe("local MCP git metadata collection (#7329 coverage)", () => {
     const root = join(tempDir, "root");
     mkdirSync(join(root, "nested"), { recursive: true });
     const roots = [{ uri: pathToFileURL(root).href }];
+    // resolveWorkspaceCwd resolves symlinks via realpathSync (safeResolvedPath), so the expected path must
+    // too -- on macOS, os.tmpdir() lives under /var/folders/..., itself a symlink to /private/var/folders/....
+    const expectedNested = realpathSync(join(root, "nested"));
 
     const relative = resolveWorkspaceCwd({ cwd: "nested", workspaceRoots: roots });
-    expect(relative).toMatchObject({ cwd: join(root, "nested"), rootsAvailable: true });
+    expect(relative).toMatchObject({ cwd: expectedNested, rootsAvailable: true });
 
     const absolute = resolveWorkspaceCwd({ cwd: join(root, "nested"), workspaceRoots: roots });
-    expect(absolute).toMatchObject({ cwd: join(root, "nested"), rootsAvailable: true });
+    expect(absolute).toMatchObject({ cwd: expectedNested, rootsAvailable: true });
   });
 
   it("normalizeMcpWorkspaceRoots ignores a root with a non-string uri and dedupes repeated paths", async () => {
     const { normalizeMcpWorkspaceRoots } = await import("../../packages/loopover-mcp/lib/local-branch.js");
     tempDir = mkdtempSync(join(tmpdir(), "loopover-local-"));
     const uri = pathToFileURL(tempDir).href;
-    expect(normalizeMcpWorkspaceRoots([{ uri: 42 as unknown as string }, { uri }, { uri }])).toEqual([{ path: tempDir }]);
+    // normalizeMcpWorkspaceRoots resolves symlinks via realpathSync (safeResolvedPath) -- see the note above.
+    expect(normalizeMcpWorkspaceRoots([{ uri: 42 as unknown as string }, { uri }, { uri }])).toEqual([{ path: realpathSync(tempDir) }]);
     expect(normalizeMcpWorkspaceRoots(undefined)).toEqual([]);
   });
 

--- a/test/unit/miner-init-verify-token.test.ts
+++ b/test/unit/miner-init-verify-token.test.ts
@@ -9,10 +9,21 @@ const tempDirs = new Set<string>();
 function makeTempEnv() {
   const configDir = mkdtempSync(join(tmpdir(), "loopover-miner-init-"));
   tempDirs.add(configDir);
+  // Isolate from any real loopover-mcp session on disk: runInit's --verify-token path resolves a GitHub
+  // token via resolveGitHubToken (packages/loopover-miner/lib/github-token-resolution.js), which falls back
+  // to a live session-token fetch when ~/.config/loopover/config.json (or an inherited GITHUB_TOKEN) has
+  // real credentials -- a contributor machine with `loopover-mcp login` already run would otherwise make an
+  // extra fetch call and read a real token into these tests instead of the mocked one.
+  const loopoverConfigDir = mkdtempSync(join(tmpdir(), "loopover-miner-init-mcp-config-"));
+  tempDirs.add(loopoverConfigDir);
   return {
     env: {
       ...process.env,
       LOOPOVER_MINER_CONFIG_DIR: configDir,
+      LOOPOVER_CONFIG_DIR: loopoverConfigDir,
+      LOOPOVER_CONFIG_PATH: undefined,
+      XDG_CONFIG_HOME: undefined,
+      GITHUB_TOKEN: undefined,
     },
     configDir,
     dbPath: join(configDir, "laptop-state.sqlite3"),

--- a/test/unit/miner-self-review-context.test.ts
+++ b/test/unit/miner-self-review-context.test.ts
@@ -143,6 +143,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       contributorLogin: "miner-bot",
       linkedIssues: [7],
       fetchImpl: fetchImpl as never,
+      loopoverAuth: null,
     });
 
     expect(result.repo).toEqual({
@@ -225,7 +226,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { linkedIssues: [7], fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { linkedIssues: [7], fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.inDuplicateCluster).toBe(true);
   });
 
@@ -238,7 +239,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.issueQuality?.issues).toHaveLength(1);
     expect(result.issueQuality?.issues[0]).toMatchObject({ number: 7, status: expect.any(String) });
     expect(result.issueQuality?.repoFullName).toBe("acme/widgets");
@@ -260,7 +261,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.issues[0]?.linkedPrs).toEqual([]);
   });
 
@@ -273,7 +274,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.issues[0]?.linkedPrs).toEqual([501]);
   });
   it("returns false for inDuplicateCluster when no linkedIssues are supplied", async () => {
@@ -285,7 +286,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.inDuplicateCluster).toBe(false);
   });
 
@@ -298,7 +299,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.issues.map((issue) => issue.number)).toEqual([7]);
   });
 
@@ -318,7 +319,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, perPage: 2 });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, perPage: 2, loopoverAuth: null });
     expect(result.issues.map((issue) => issue.number)).toEqual([11, 12, 21, 22, 99]);
     expect(issuePage).toBe(3);
   });
@@ -337,7 +338,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, perPage: 1 });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, perPage: 1, loopoverAuth: null });
     expect(result.issues.map((issue) => issue.number)).toEqual([7]);
   });
 
@@ -350,7 +351,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.repo).toBeNull();
   });
 
@@ -368,7 +369,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(requestedPaths).toEqual([
       "https://raw.githubusercontent.com/acme/widgets/HEAD/.loopover.yml",
       "https://raw.githubusercontent.com/acme/widgets/HEAD/.github/loopover.yml",
@@ -392,7 +393,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(manifestRequests).toBe(4);
     expect(result.manifest.present).toBe(false);
     expect(result.manifest.warnings).toEqual([]);
@@ -410,7 +411,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(cancelCount).toBe(4);
     expect(result.manifest.present).toBe(false);
   });
@@ -429,7 +430,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(requestedPaths).toHaveLength(1);
     expect(result.manifest.gate?.duplicates).toBe("advisory");
   });
@@ -448,7 +449,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.confirmedContributor).toBe(false);
     expect(minersCalled).toBe(false);
   });
@@ -461,7 +462,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
       "raw.githubusercontent.com": () => jsonResponse(null, 404),
     });
-    expect((await fetchSelfReviewContext("acme/widgets", { contributorLogin: "Miner-Bot", fetchImpl: miss as never })).confirmedContributor).toBe(false);
+    expect((await fetchSelfReviewContext("acme/widgets", { contributorLogin: "Miner-Bot", fetchImpl: miss as never, loopoverAuth: null })).confirmedContributor).toBe(false);
 
     const notOk = routedFetch({
       "api.gittensor.io/miners": () => jsonResponse(null, 500),
@@ -470,7 +471,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
       "raw.githubusercontent.com": () => jsonResponse(null, 404),
     });
-    expect((await fetchSelfReviewContext("acme/widgets", { contributorLogin: "miner-bot", fetchImpl: notOk as never })).confirmedContributor).toBe(false);
+    expect((await fetchSelfReviewContext("acme/widgets", { contributorLogin: "miner-bot", fetchImpl: notOk as never, loopoverAuth: null })).confirmedContributor).toBe(false);
 
     const throwing = async (url: string) => {
       if (url.includes("api.gittensor.io/miners")) throw new Error("network down");
@@ -480,7 +481,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       if (url.includes("raw.githubusercontent.com")) return jsonResponse(null, 404);
       return jsonResponse(null, 404);
     };
-    expect((await fetchSelfReviewContext("acme/widgets", { contributorLogin: "miner-bot", fetchImpl: throwing as never })).confirmedContributor).toBe(false);
+    expect((await fetchSelfReviewContext("acme/widgets", { contributorLogin: "miner-bot", fetchImpl: throwing as never, loopoverAuth: null })).confirmedContributor).toBe(false);
   });
 
   it("matches a confirmed contributor case-insensitively", async () => {
@@ -491,7 +492,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
       "raw.githubusercontent.com": () => jsonResponse(null, 404),
     });
-    const result = await fetchSelfReviewContext("acme/widgets", { contributorLogin: "miner-bot", fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { contributorLogin: "miner-bot", fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.confirmedContributor).toBe(true);
   });
 
@@ -510,7 +511,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.pullRequests[0]?.linkedIssues).toEqual([7]);
   });
 
@@ -523,7 +524,7 @@ describe("fetchSelfReviewContext (#5145)", () => {
       "api.gittensor.io/miners": () => jsonResponse([]),
     });
 
-    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
     expect(result.pullRequests.find((pr) => pr.number === 51)?.mergeableState).toBe("dirty");
     expect(result.pullRequests.find((pr) => pr.number === 52)?.mergeableState).toBeNull();
   });
@@ -563,7 +564,11 @@ describe("fetchSelfReviewContext (#5145)", () => {
         if (url.includes("api.gittensor.io/miners")) return jsonResponse([]);
         return jsonResponse(null, 404);
       };
-      await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+      // loopoverAuth: null forces the ORB live-gate-thresholds probe off (#6487) -- without it, a real
+      // loopover-mcp session recorded on disk (e.g. from `loopover-mcp login` on a contributor's machine)
+      // would fire an extra concurrent fetch whose "Bearer <session token>" header could race with and
+      // overwrite capturedAuth, since its URL also matches this test's own "/repos/acme/widgets" routing.
+      await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, loopoverAuth: null });
       expect(capturedAuth).toBe("Bearer env-token");
     } finally {
       if (original === undefined) delete process.env.GITHUB_TOKEN;
@@ -584,7 +589,9 @@ describe("fetchSelfReviewContext (#5145)", () => {
       return jsonResponse(null, 404);
     };
 
-    await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, contributorLogin: "miner-bot" });
+    // loopoverAuth: null keeps this test's call count and 10s-default assertion honest -- see the note on
+    // the "defaults GITHUB_TOKEN" test above for why an unforced probe is a real-environment hazard here too.
+    await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, contributorLogin: "miner-bot", loopoverAuth: null });
 
     // repo + issues + pulls (githubGetJson) + 4 manifest candidates + 1 contributor lookup = 8 calls, every one bounded.
     expect(capturedSignals.length).toBeGreaterThanOrEqual(7);


### PR DESCRIPTION
## Summary

- `test/unit/local-branch.test.ts`, `test/unit/miner-init-verify-token.test.ts`, and
  `test/unit/miner-self-review-context.test.ts` fail non-deterministically depending on the
  host machine, independent of any working-tree change (reproduces on a clean `main`
  checkout). Root-caused and fixed both distinct bugs; see `#7512` for the full writeup.
- `local-branch.test.ts`: two assertions compared against the raw `os.tmpdir()` path instead
  of the `realpathSync`-resolved form `safeResolvedPath` (the code under test) actually
  produces — diverges on macOS, where `os.tmpdir()` lives under a `/var` → `/private/var`
  symlink. Fixed by resolving the expected path through `realpathSync` too.
- `miner-init-verify-token.test.ts` / `miner-self-review-context.test.ts`: several calls
  didn't isolate `env`/`loopoverAuth`, so `resolveGitHubToken` / `resolveLoopoverBackendSession`
  fell through to a real `~/.config/loopover/config.json` on any machine that has run
  `loopover-mcp login`, firing an extra concurrent fetch that raced with and corrupted other
  captured fetch calls/headers/timeouts in the same `Promise.all` (confirmed by temporarily
  moving the real config file aside — all 9 originally-reported failures vanished). Fixed by
  isolating `makeTempEnv()`'s `LOOPOVER_CONFIG_DIR`/`LOOPOVER_CONFIG_PATH`/`XDG_CONFIG_HOME`/
  `GITHUB_TOKEN`, and by passing `loopoverAuth: null` to every `fetchSelfReviewContext(...)`
  call site that isn't itself testing the live-gate-thresholds probe (matching that file's own
  existing convention for the tests that already do this).

Closes #7512

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:ci` ran end-to-end and every one of its 35 chained steps passed except
  `ui:test` (which blocked the final `ui:build` step behind it via `&&`). `ui:test` fails in
  this sandbox because it is running **Node v26.5.0**, not the repo's pinned **Node 22**
  (`.nvmrc`) — under v26, jsdom 25.0.1's `window.localStorage` does not initialize correctly
  inside vitest's jsdom environment (`Cannot read properties of undefined (reading 'clear')`),
  affecting all 5 pre-existing `apps/loopover-ui` test files that touch `localStorage`, not
  just ones near this diff. Confirmed unrelated to this PR: this diff touches zero files under
  `apps/loopover-ui/**`; a clean `npm ci` reproduces the same failure; and the same failure
  reproduces on unrelated files (`src/lib/use-local-storage.test.ts`,
  `src/lib/analytics-window.test.ts`) that share nothing with this change. Real CI installs
  Node 22 per `.nvmrc`, so this is a local sandbox environment mismatch, not a code defect —
  not filed as a tracked issue since it isn't expected to reproduce there.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this PR touches only `test/unit/**` files; no UI/frontend/docs/extension change.

## Notes

- All three fixed test files are outside Codecov's `coverage.include` (`src/**` only), so this
  PR carries no `codecov/patch` obligation.
