### PR TITLE
feat(review): enrich issue planning with gittensor type-label taxonomy when enrolled

### DIFF
--- a/src/services/issue-plan-draft.ts
+++ b/src/services/issue-plan-draft.ts
@@ -34,8 +34,12 @@ import {
   recordAuditEvent,
   sumAiEstimatedNeuronsSince,
 } from "../db/repositories";
+import { isGittensorPluginEnabled, shouldEnableGittensorForRepo } from "../review/gittensor-wire";
 import { isGlobalAgentPause } from "../settings/agent-execution";
+import { DEFAULT_TYPE_LABELS } from "../settings/pr-type-label";
+import { resolveRepositorySettings } from "../settings/repository-settings";
 import { isFocusManifestPublicSafe } from "../signals/focus-manifest";
+import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { normalizeIssueTitleKey } from "./contributor-issue-draft";
 import type { IssueRecord } from "../types";
 import { sha256Hex } from "../utils/crypto";
@@ -224,6 +228,32 @@ function buildIssuePlanUserPrompt(goal: string, existingLabelNames: string[]): s
   return `Planning goal:\n${goal}\n\nRepository's existing labels (prefer reusing these):\n${labelsLine}`;
 }
 
+/**
+ * Gittensor-enrollment-aware enrichment (#7428): when this repo has opted into the gittensor plugin
+ * (LOOPOVER_EXPERIMENTAL_GITTENSOR AND the repo's own `.loopover.yml experimental.gittensor: true` --
+ * shouldEnableGittensorForRepo, gittensor-wire.ts), this repo's configured bug/feature/priority type-label
+ * taxonomy is merged into the "existing labels" the prompt already prefers reusing (buildIssuePlanUserPrompt) --
+ * purely additive, no new prompt section, so a plan generated for a gittensor repo just sees a few more labels
+ * to choose from. Label NAMES only, never any scoring weight/multiplier -- those never leave the private
+ * scoring pipeline.
+ *
+ * ZERO FOOTPRINT when the plugin is off (the fleet-wide default, matching gittensor-wire.ts's own contract): the
+ * global flag check short-circuits before this ever loads a manifest or repository settings, so a plain
+ * self-host instance with no gittensor affiliation makes no additional reads for this at all.
+ *
+ * Uses resolveRepositorySettings (DB overlaid with `.loopover.yml`), NOT the raw DB-only getRepositorySettings:
+ * typeLabels/typeLabelsEnabled are config-as-code only now (no DB column backs them, #6443) -- reading the raw
+ * DB row would silently ignore a repo's actual configured taxonomy and always see the built-in default.
+ */
+async function resolveGittensorLabelEnrichment(env: Env, repoFullName: string): Promise<string[]> {
+  if (!isGittensorPluginEnabled(env)) return [];
+  const manifest = await loadRepoFocusManifest(env, repoFullName);
+  if (!shouldEnableGittensorForRepo(env, manifest.experimental.gittensor)) return [];
+  const settings = await resolveRepositorySettings(env, repoFullName);
+  if (settings.typeLabelsEnabled !== true) return [];
+  return Object.values(settings.typeLabels ?? DEFAULT_TYPE_LABELS);
+}
+
 function normalizeIssuePlanCandidate(raw: RawIssuePlanCandidate): { title: string; body: string; labels: string[] } | null {
   const title = typeof raw.title === "string" ? raw.title.trim().slice(0, MAX_TITLE_CHARS) : "";
   const body = typeof raw.body === "string" ? raw.body.trim().slice(0, MAX_BODY_CHARS) : "";
@@ -362,15 +392,17 @@ export async function generateIssuePlanDrafts(env: Env, repoFullName: string, go
   const trimmedGoal = goal.trim().slice(0, MAX_GOAL_CHARS);
   if (!trimmedGoal) return empty("no_output");
 
-  const [repo, openIssues, declinedIssues, labels] = await Promise.all([
+  const [repo, openIssues, declinedIssues, labels, gittensorTypeLabels] = await Promise.all([
     getRepository(env, repoFullName),
     listOpenIssues(env, repoFullName),
     listClosedContributorDraftIssues(env, repoFullName, `<!-- ${ISSUE_PLAN_DRAFT_MARKER_PREFIX}`),
     listRepoLabels(env, repoFullName),
+    resolveGittensorLabelEnrichment(env, repoFullName),
   ]);
 
   const system = ISSUE_PLAN_SYSTEM_PROMPT;
-  const user = buildIssuePlanUserPrompt(trimmedGoal, labels.map((label) => label.name));
+  const promptLabelNames = [...new Set([...labels.map((label) => label.name), ...gittensorTypeLabels])];
+  const user = buildIssuePlanUserPrompt(trimmedGoal, promptLabelNames);
   const estimatedNeurons = estimateNeurons(system.length + user.length, ISSUE_PLAN_MAX_TOKENS, ISSUE_PLAN_MODEL_COUNT);
   const remainingBudget = Math.max(0, issuePlanDailyBudget(env) - (await sumAiEstimatedNeuronsSince(env, utcDayStartIso())));
   if (estimatedNeurons > remainingBudget) {

--- a/test/unit/issue-plan-draft.test.ts
+++ b/test/unit/issue-plan-draft.test.ts
@@ -3,6 +3,8 @@ import { generateKeyPairSync } from "node:crypto";
 import { createTestEnv } from "../helpers/d1";
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import * as repositories from "../../src/db/repositories";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
+import * as repositorySettings from "../../src/settings/repository-settings";
 import type { IssueRecord, RepositoryRecord } from "../../src/types";
 import {
   findDeclinedIssuePlanDraft,
@@ -453,6 +455,82 @@ describe("generateIssuePlanDrafts (#7426)", () => {
     const paused = await generateIssuePlanDrafts(pausedEnv, "acme/widgets", "goal", { create: true, dryRun: false });
     expect(paused.dryRun).toBe(true);
     expect(paused.created).toBe(0);
+  });
+});
+
+function capturedUserMessage(run: ReturnType<typeof vi.fn>): string {
+  const opts = (run.mock.calls[0] as unknown as [string, { messages?: Array<{ role: string; content: string }> }])[1];
+  return opts?.messages?.find((message) => message.role === "user")?.content ?? "";
+}
+
+describe("gittensor label-taxonomy enrichment (#7428)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    clearInstallationTokenCacheForTest();
+  });
+
+  it("makes zero additional reads and enriches nothing when the plugin is off fleet-wide (default), even if the repo's own manifest opts in", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai }); // LOOPOVER_EXPERIMENTAL_GITTENSOR unset
+    const manifestSpy = vi.spyOn(repositories, "getRepositorySettings");
+    await upsertRepoFocusManifest(env, "acme/widgets", { experimental: { gittensor: true } });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(capturedUserMessage(run)).not.toContain("gittensor:bug");
+    expect(manifestSpy).not.toHaveBeenCalled(); // short-circuits before even reading repository settings
+  });
+
+  it("does not enrich when the global flag is on but the repo's own manifest does not opt in", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, LOOPOVER_EXPERIMENTAL_GITTENSOR: "true" });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(capturedUserMessage(run)).not.toContain("gittensor:bug");
+  });
+
+  it("merges the repo's default type-label taxonomy into the prompt when both the global flag and the repo's manifest are enabled", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, LOOPOVER_EXPERIMENTAL_GITTENSOR: "true" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { experimental: { gittensor: true } });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    const userMessage = capturedUserMessage(run);
+    expect(userMessage).toContain("gittensor:bug");
+    expect(userMessage).toContain("gittensor:feature");
+    expect(userMessage).toContain("gittensor:priority");
+  });
+
+  it("does not enrich when typeLabelsEnabled is explicitly false for the repo (config-as-code, #6443)", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, LOOPOVER_EXPERIMENTAL_GITTENSOR: "true" });
+    // typeLabels/typeLabelsEnabled have no DB column anymore -- only `.loopover.yml settings.*` can set them.
+    await upsertRepoFocusManifest(env, "acme/widgets", { experimental: { gittensor: true }, settings: { typeLabelsEnabled: false } });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(capturedUserMessage(run)).not.toContain("gittensor:bug");
+  });
+
+  it("falls back to DEFAULT_TYPE_LABELS when resolved settings carry no typeLabels value at all", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, LOOPOVER_EXPERIMENTAL_GITTENSOR: "true" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { experimental: { gittensor: true } });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    vi.spyOn(repositorySettings, "resolveRepositorySettings").mockResolvedValue({ repoFullName: "acme/widgets", typeLabelsEnabled: true, typeLabels: undefined } as never);
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    expect(capturedUserMessage(run)).toContain("gittensor:bug");
+  });
+
+  it("honors a custom typeLabels override (config-as-code) instead of the gittensor:* defaults", async () => {
+    const run = vi.fn(async () => issuesResponse([{ title: "T", body: "B" }]));
+    const env = baseEnv({ AI: { run } as unknown as Ai, LOOPOVER_EXPERIMENTAL_GITTENSOR: "true" });
+    await upsertRepoFocusManifest(env, "acme/widgets", { experimental: { gittensor: true }, settings: { typeLabels: { bug: "kind:bug", feature: "kind:feature" } } });
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    await generateIssuePlanDrafts(env, "acme/widgets", "goal");
+    const userMessage = capturedUserMessage(run);
+    expect(userMessage).toContain("kind:bug");
+    expect(userMessage).toContain("kind:feature");
+    expect(userMessage).not.toContain("gittensor:bug");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds gittensor-enrollment-aware enrichment to `loopover_plan_repo_issues` ([#7426](https://github.com/JSONbored/loopover/issues/7426)): when the target repo has opted into the gittensor plugin (`LOOPOVER_EXPERIMENTAL_GITTENSOR` AND the repo's own `.loopover.yml experimental.gittensor: true` — `shouldEnableGittensorForRepo`, `src/review/gittensor-wire.ts`), the repo's configured bug/feature/priority type-label taxonomy is merged into the "existing labels" the prompt already prefers reusing.
- Purely additive — no new prompt section, no system-prompt change. The gittensor type labels are just merged into the same array of label names already passed to `buildIssuePlanUserPrompt`, so the model treats them exactly like any other repo label to prefer reusing.
- **Zero footprint when the plugin is off** (the fleet-wide default): `isGittensorPluginEnabled(env)` short-circuits before this ever loads a manifest or resolved settings, matching `gittensor-wire.ts`'s own documented contract ("a self-host instance with no gittensor affiliation has zero footprint from it").
- Uses `resolveRepositorySettings` (DB overlaid with `.loopover.yml`), **not** the raw DB-only `getRepositorySettings`: `typeLabels`/`typeLabelsEnabled` are config-as-code only now (no DB column backs them, per an existing `#6443` comment in `src/db/repositories.ts`) — reading the raw DB row would have silently ignored a repo's actual configured taxonomy and always produced the built-in default.
- Label names only — never any scoring weight/multiplier. Those never leave the private scoring pipeline.
- Sub-issue of [#7424](https://github.com/JSONbored/loopover/issues/7424) (Epic: ORB self-hoster issue & milestone planning routine).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — full unsharded suite: 1021 files / 19392 tests passed, 2 skipped. The same 9 pre-existing failures in 3 unrelated miner test files (already tracked separately, currently under independent investigation) reproduce identically regardless of this change. New/changed code in `src/services/issue-plan-draft.ts` is 100% branch-covered.
- [x] `npm run selfhost:env-reference:check` / `npm run ui:openapi:check` / `npm run docs:drift-check` / `npm run manifest:drift-check` — all clean; no new env vars, no OpenAPI/manifest/MCP-schema surface touched (this PR only changes internal prompt-building logic, no new tool input/output shape).
- [ ] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` / `npm run test:workers` — not run; no `apps/loopover-ui/**` or workers-pool-specific files changed.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 6 new tests in `test/unit/issue-plan-draft.test.ts`: zero-footprint when the plugin is off fleet-wide (even with the repo's own manifest opted in), no enrichment when only one of the two gates is on, full default taxonomy merged when both gates are on, no enrichment when `typeLabelsEnabled` is explicitly false (config-as-code), a custom `typeLabels` override taking precedence over the `gittensor:*` defaults, and the `DEFAULT_TYPE_LABELS` fallback branch.

If any required check was skipped, explain why:

- `ui:lint`/`ui:typecheck`/`ui:build`/`test:workers`: no `apps/loopover-ui/**` or workers-pool-specific files changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed — only public label NAMES are ever read into the prompt, never scoring weights/multipliers.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics — every generated draft still passes through the existing `isFocusManifestPublicSafe` check unchanged.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A here — no auth/session surface touched; covered instead by the zero-footprint/disabled-gate tests above, which are this PR's equivalent negative paths.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — no MCP input/output schema change; this is purely an internal enrichment of the existing tool's generation step, already covered by the existing MCP surface-parity test.
- [ ] UI changes use live API data or real empty/error/loading states. (N/A — no UI.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — backend-only change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no user-facing docs surface; the MCP tool's own description string is unchanged since no input/output shape changed.)

## UI Evidence

N/A — this is a backend-only change with no visible UI, frontend, or docs surface.

## Notes

- Sub-issue of [#7424](https://github.com/JSONbored/loopover/issues/7424). Enriches [#7426](https://github.com/JSONbored/loopover/issues/7426)'s `loopover_plan_repo_issues` tool (already merged, [#7476](https://github.com/JSONbored/loopover/pull/7476)).

Closes #7428
