### PR TITLE
fix(review): short-circuit the retry loop on a deliberate INCOHERENT_DIFF_ASSESSMENT bail

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -452,7 +452,7 @@ export type ModelReview = {
 export type AiReviewDiagnostic = {
   model: string;
   attempt: number;
-  status: "parsed" | "empty_output" | "unparseable_output" | "provider_error";
+  status: "parsed" | "empty_output" | "unparseable_output" | "incoherent_diff_bail" | "provider_error";
   responseChars?: number | undefined;
   hasJsonObject?: boolean | undefined;
   error?: string | undefined;
@@ -793,6 +793,29 @@ export function parseModelReview(text: string): ModelReview | null {
   }
 }
 
+/** True when `text` is the model's DELIBERATE incoherent-diff bail — a clean, well-formed response whose
+ *  `assessment` is exactly {@link INCOHERENT_DIFF_ASSESSMENT} (the prompt instructs the model to emit this
+ *  verbatim rather than rubber-stamp a diff it cannot map to the PR head). `parseModelReview` folds it into
+ *  `null`, identical to a genuine parse failure, so a `null` review alone can't tell the two apart. Unlike an
+ *  unparseable/empty response, this is the model's confident, considered answer about THIS diff: a same-model
+ *  retry re-asks the identical question and gets the identical bail, burning the per-model retry budget for
+ *  zero additional chance of success. `runWorkersOpinion` uses it to short-circuit that model's remaining
+ *  retries — same as a CLI timeout / 429 / structural config error — and move straight to the fallback.
+ *  #7518-sentry (LOOPOVER-1P/2B/29). */
+export function isIncoherentDiffBail(text: string): boolean {
+  const jsonText = extractLastJsonObject(text);
+  if (!jsonText) return false;
+  try {
+    const obj = JSON.parse(jsonText) as Record<string, unknown>;
+    return (
+      typeof obj.assessment === "string" &&
+      obj.assessment.trim() === INCOHERENT_DIFF_ASSESSMENT
+    );
+  } catch {
+    return false;
+  }
+}
+
 // Aggregate ceiling across ALL optional context sections combined (#3900). Each section below already
 // enforces its OWN per-section cap (FILE_CONTENT_BUDGET, MAX_CONTEXT_CHARS, MAX_PROMPT_CHARS,
 // MAX_ENRICHMENT_PROMPT_SECTION_CHARS...), but nothing previously bounded the COMBINED total: with every
@@ -1120,6 +1143,25 @@ async function runWorkersOpinion(
           return { review: parsed };
         }
         const hasJsonObject = Boolean(extractLastJsonObject(text));
+        // The model's DELIBERATE incoherent-diff bail (#7518): a clean, well-formed response that `parseModelReview`
+        // folds into `null` just like a genuine parse failure -- but unlike an unparseable response, it is the model's
+        // confident, considered answer about THIS diff. Retrying the same model re-asks the identical question and gets
+        // the identical bail, so it short-circuits that model's remaining retries (the fallback below still gets its own
+        // full budget, since a different model may map the diff fine) -- exactly like the catch block's CLI-timeout / 429
+        // / structural-config short-circuits below. Recorded under its own status so it is distinct from truly-unparseable
+        // noise in the diagnostics/Sentry trail, yet still marks the review inconclusive downstream (like unparseable).
+        if (isIncoherentDiffBail(text)) {
+          diagnostics.push({ model, attempt, status: "incoherent_diff_bail", responseChars: text.length, hasJsonObject, ...usageFields });
+          console.warn(
+            JSON.stringify({
+              level: "warn",
+              event: "ai_review_provider_incoherent_diff_bail",
+              model,
+              attempt,
+            }),
+          );
+          break;
+        }
         const trimmedText = text.trim();
         const status = trimmedText ? "unparseable_output" : "empty_output";
         diagnostics.push({ model, attempt, status, responseChars: text.length, hasJsonObject, ...usageFields });
@@ -2348,7 +2390,14 @@ export async function runLoopOverAiReview(
   if (
     reviewsForNotes.length === 0 &&
     (fallbackNotes.length > 0 ||
-      reviewDiagnostics.some((diagnostic) => diagnostic.status === "unparseable_output"))
+      reviewDiagnostics.some(
+        (diagnostic) =>
+          diagnostic.status === "unparseable_output" ||
+          // A deliberate incoherent-diff bail (#7518) is just as inconclusive as an unparseable one -- the model
+          // produced no usable verdict, it merely did so on purpose. Kept equivalent here so short-circuiting its
+          // retries (which relabels the diagnostic) doesn't silently drop the review out of the inconclusive path.
+          diagnostic.status === "incoherent_diff_bail",
+      ))
   )
     inconclusive = true;
   // Observability (#2540): the single canonical point where `inconclusive` reaches its final value for this
@@ -2511,6 +2560,7 @@ async function record(
 
 export const __aiReviewInternals = {
   parseModelReview,
+  isIncoherentDiffBail,
   parseReviewConfidence,
   parseDualAiTieBreakJudgeResponse,
   coerceAiText,

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -21,6 +21,7 @@ import { sanitizePublicComment as sanitizePublicCommentGithubCommands } from "..
 
 const {
   parseModelReview,
+  isIncoherentDiffBail,
   parseReviewConfidence,
   parseDualAiTieBreakJudgeResponse,
   coerceAiText,
@@ -104,6 +105,20 @@ function reviewJson(
         : []),
     nits: over.nits ?? ["Edge case on empty input is untested."],
     suggestions: over.suggestions ?? ["Add a unit test for the new branch."],
+  });
+}
+
+// The exact text the review prompt instructs a model to emit when it cannot map the diff to the PR head
+// (mirrors src/services/ai-review.ts's INCOHERENT_DIFF_ASSESSMENT). #7518.
+const INCOHERENT_DIFF_BAIL =
+  "Cannot review — the diff appears out of sync with the PR head.";
+// A clean, well-formed response carrying only that deliberate bail.
+function incoherentDiffBailJson(): string {
+  return JSON.stringify({
+    assessment: INCOHERENT_DIFF_BAIL,
+    blockers: [],
+    nits: [],
+    suggestions: [],
   });
 }
 
@@ -755,6 +770,24 @@ describe("runLoopOverAiReview block mode (consensus)", () => {
     expect(result.inconclusive).toBe(true); // FAIL-CLOSED: a missing second opinion holds the PR, never passes it
     expect(result.advisoryNotes).not.toBeNull(); // notes still come from the one parseable opinion
     // Observability (#2540): the single canonical increment fires once for this inconclusive review.
+    expect(await renderMetrics()).toContain('loopover_ai_review_inconclusive_total{mode="block"} 1');
+  });
+
+  it("REGRESSION (#7518): both models' deliberate incoherent-diff bail → inconclusive, recorded as incoherent_diff_bail (not unparseable)", async () => {
+    // Every model emits the deliberate bail: no usable review, so the PR must be held inconclusive (fail-closed),
+    // and the bail must keep marking the review inconclusive even though it now carries its own diagnostic status.
+    const env = envWith(async () => ({ response: incoherentDiffBailJson() }));
+    const result = await runLoopOverAiReview(env, {
+      ...baseInput,
+      mode: "block",
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.consensusDefect).toBeNull();
+    expect(result.inconclusive).toBe(true);
+    expect(result.reviewDiagnostics?.every((d) => d.status === "incoherent_diff_bail")).toBe(true);
+    // No diagnostic is mislabelled as unparseable -- the model gave a clean, deliberate answer.
+    expect(result.reviewDiagnostics?.some((d) => d.status === "unparseable_output")).toBe(false);
     expect(await renderMetrics()).toContain('loopover_ai_review_inconclusive_total{mode="block"} 1');
   });
 
@@ -2001,6 +2034,31 @@ describe("pure helpers", () => {
     );
   });
 
+  it("isIncoherentDiffBail detects ONLY the model's deliberate incoherent-diff bail, never other or malformed responses (#7518)", () => {
+    // The deliberate bail: a clean JSON object whose assessment is exactly the sentinel.
+    expect(isIncoherentDiffBail(incoherentDiffBailJson())).toBe(true);
+    // Wrapped in prose / a markdown fence -- extractLastJsonObject still resolves it.
+    expect(
+      isIncoherentDiffBail(
+        "Here is my verdict:\n```json\n" +
+          JSON.stringify({ assessment: INCOHERENT_DIFF_BAIL }) +
+          "\n```",
+      ),
+    ).toBe(true);
+    // Assessment is trimmed before comparison, so a whitespace-padded sentinel still counts.
+    expect(
+      isIncoherentDiffBail(JSON.stringify({ assessment: `  ${INCOHERENT_DIFF_BAIL}  ` })),
+    ).toBe(true);
+    // A normal, parseable review is NOT a bail.
+    expect(isIncoherentDiffBail(reviewJson())).toBe(false);
+    // A non-string assessment can't be the sentinel (guards the typeof check).
+    expect(isIncoherentDiffBail(JSON.stringify({ assessment: 42 }))).toBe(false);
+    // No JSON object at all → false, never throws.
+    expect(isIncoherentDiffBail("not json, just prose")).toBe(false);
+    // A JSON-object-looking-but-malformed payload → false (JSON.parse throws, caught).
+    expect(isIncoherentDiffBail("{ assessment: unquoted }")).toBe(false);
+  });
+
   it("parseModelReview coerces non-string/non-array fields to safe defaults", () => {
     const parsed = parseModelReview(
       '{"assessment":"ok","suggestions":"not-an-array","blockers":7,"nits":null}',
@@ -3094,6 +3152,48 @@ describe("pure helpers", () => {
     expect(isStructuralProviderConfigError(new Error("wrapped: codex_auth_not_configured: nested"))).toBe(false);
     expect(isStructuralProviderConfigError("codex_auth_not_configured: not an Error instance")).toBe(false);
     expect(isStructuralProviderConfigError(undefined)).toBe(false);
+  });
+
+  it("REGRESSION (#7518): runWorkersOpinion stops retrying a model after ONE deliberate incoherent-diff bail, but the fallback still gets its full retry budget", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let primaryAttempts = 0;
+    const run = vi.fn(async (model: string) => {
+      if (model === "fallback") return { response: reviewJson() };
+      primaryAttempts += 1;
+      return { response: incoherentDiffBailJson() };
+    });
+    const env = createTestEnv({ AI: { run } as unknown as Ai });
+    const diagnostics: AiReviewDiagnostic[] = [];
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics);
+    expect(parsed.review?.assessment).toContain("reasonable");
+    expect(primaryAttempts).toBe(1); // NOT 3 -- the model's own deliberate bail won't change on a same-model retry.
+    expect(run).toHaveBeenCalledTimes(2); // 1 primary (bailed) + 1 fallback (succeeded on its first try).
+    // Recorded under its own status (distinct from unparseable noise) and surfaced as a warn, never a provider error.
+    expect(diagnostics.some((d) => d.model === "primary" && d.status === "incoherent_diff_bail")).toBe(true);
+    expect(
+      warnSpy.mock.calls
+        .map((c) => c[0])
+        .some((l) => typeof l === "string" && l.includes("ai_review_provider_incoherent_diff_bail")),
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("REGRESSION (#7518): when both models deliberately bail, runWorkersOpinion tries each ONCE and does NOT emit the misleading unparseable-exhausted error", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const run = vi.fn(async () => ({ response: incoherentDiffBailJson() }));
+    const env = createTestEnv({ AI: { run } as unknown as Ai });
+    const diagnostics: AiReviewDiagnostic[] = [];
+    const result = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics);
+    expect(result).toEqual({ review: null });
+    expect(run).toHaveBeenCalledTimes(2); // each model tried once -- no wasted same-model retries (was 6 before #7518)
+    expect(diagnostics.map((d) => d.status)).toEqual(["incoherent_diff_bail", "incoherent_diff_bail"]);
+    // The bail is expected behavior, not a provider outage -- neither exhausted-error log fires.
+    const logged = logSpy.mock.calls.map((c) => c[0]);
+    expect(logged.some((l) => typeof l === "string" && l.includes("ai_review_provider_unparseable_exhausted"))).toBe(false);
+    expect(logged.some((l) => typeof l === "string" && l.includes("ai_review_provider_exhausted"))).toBe(false);
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it("runWorkersOpinion still retries a genuinely transient (non-timeout, non-429) error up to the full budget", async () => {


### PR DESCRIPTION
fix(review): short-circuit the retry loop on a deliberate INCOHERENT_DIFF_ASSESSMENT bail

`parseModelReview` folds the model's deliberate incoherent-diff bail (a clean,
well-formed response whose `assessment` is exactly `INCOHERENT_DIFF_ASSESSMENT`)
into `null`, identical to a genuine parse failure. `runWorkersOpinion` couldn't
tell the two apart from the null alone, so it burned the full 3-attempt budget
per model (6 across primary + fallback) re-asking the same model the same
question it already answered on purpose.

Add `isIncoherentDiffBail` and short-circuit that model's remaining retries the
moment it bails -- exactly like the existing CLI-timeout / 429 / structural
config-error short-circuits -- while the fallback model still gets its own full
budget. The bail is recorded under its own `incoherent_diff_bail` diagnostic
status so it is distinct from truly-unparseable noise in the Sentry trail, yet
still marks the review inconclusive downstream (like an unparseable response).

Closes #7518

