### PR TITLE
fix(scripts): extend forbidden-content.mjs with the repo's other known-precise secret formats

### DIFF
--- a/scripts/forbidden-content.mjs
+++ b/scripts/forbidden-content.mjs
@@ -4,5 +4,17 @@
 // the AMS MCP contract test (test/unit/miner-mcp-contract.test.ts) reuses the SAME pattern to assert no MCP tool
 // response ever leaks one — importing it here rather than hand-duplicating the regex keeps the two byte-for-byte in
 // sync instead of relying on manual vigilance.
+//
+// #7433: extended with 12 additional concrete secret formats (aws_access_key, slack_token, google_api_key,
+// gitlab_token, npm_token, stripe_secret_key, sendgrid_key, huggingface_token, voyage_api_key, firecrawl_api_key,
+// openai_api_key, anthropic_api_key), hand-copied byte-for-byte from src/review/secret-patterns.ts's
+// SECRET_PATTERNS rather than imported: check-miner-package.mjs/check-mcp-package.mjs both run via plain
+// `node scripts/*.mjs` (package.json's test:miner-pack/test:mcp-pack), and plain Node cannot resolve a `.ts`
+// import ("Unknown file extension \".ts\"" against this repo's Node 22 runtime) without a TS loader neither
+// script registers -- unlike scripts/check-engine-parity.ts, which runs via `tsx`. jwt, seed_or_mnemonic, and
+// bittensor_key were deliberately left out: jwt is out of scope for this issue, and seed_or_mnemonic/
+// bittensor_key are documented in secret-patterns.ts as weak, false-positive-prone heuristics (a
+// `coldkey:`/`hotkey =` line or the word "mnemonic" in ordinary Bittensor docs is not a leaked credential)
+// excluded from HARD_SECRET_KINDS there for the same reason.
 export const FORBIDDEN_CONTENT =
-  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
+  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=|\bAKIA[0-9A-Z]{16}\b|\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\bAIza[0-9A-Za-z_-]{35}\b|\bglpat-[0-9A-Za-z_-]{20}(?![0-9A-Za-z_-])|\bnpm_[A-Za-z0-9]{36}\b|\b(?:sk|rk)_live_[0-9A-Za-z]{24,}\b|\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])|\bhf_[A-Za-z0-9]{34}\b|\b(?:pa|al)-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])|\bfc-[A-Za-z0-9]{16,}(?![A-Za-z0-9_-])|\bsk-(?:proj-|svcacct-|admin-)?[A-Za-z0-9_-]{20,}T3BlbkFJ[A-Za-z0-9_-]{20,}\b|\bsk-ant-api03-[A-Za-z0-9_-]{93}AA\b)/;

--- a/test/unit/forbidden-content.test.ts
+++ b/test/unit/forbidden-content.test.ts
@@ -81,3 +81,46 @@ describe("FORBIDDEN_CONTENT is the single source of truth (#6290)", () => {
     expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
   });
 });
+
+// #7433: FORBIDDEN_CONTENT only matched 4 shapes (private-key block, github_pat_, gh[pousr]_, gts_, and a
+// generic TOKEN/SECRET/PRIVATE_KEY= assignment) even though this same repo already ships a materially larger,
+// individually-verified-precise set of concrete secret-format patterns in src/review/secret-patterns.ts's
+// SECRET_PATTERNS. Each fixture below is assembled from fragments (never a contiguous credential-shaped literal
+// in this file's own source) and uses the same fake bodies the repo's own secrets-scan.test.ts and
+// content-lane-security-scan.test.ts already use for these exact formats.
+describe("FORBIDDEN_CONTENT matches the repo's other known-precise secret formats (#7433)", () => {
+  it.each([
+    ["aws_access_key", "AKIA" + "ABCDEFGHIJKLMNOP"],
+    ["slack_token", "xoxb-" + "123456789012-ABCDEFabcdef"],
+    ["google_api_key", "AIza" + "SyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"],
+    ["gitlab_token", "glpat-" + "aBcDeFgHiJkLmNoPqRsT"],
+    ["npm_token", "npm_" + "a".repeat(36)],
+    ["stripe_secret_key", "sk_live_" + "a".repeat(24)],
+    ["sendgrid_key", "SG." + "a".repeat(22) + "." + "b".repeat(43)],
+    ["huggingface_token", "hf_" + "a".repeat(34)],
+    ["voyage_api_key", "pa-" + "aK9xQ2mZw7Ln4Rv8Pt3B"],
+    ["firecrawl_api_key", "fc-" + "aK9xQ2mZw7Ln4Rv8"],
+    ["openai_api_key", "sk-" + "a".repeat(20) + "T3BlbkFJ" + "b".repeat(20)],
+    ["anthropic_api_key", "sk-ant-api03-" + "a".repeat(93) + "AA"],
+  ])("matches a %s-shaped value", (_kind, fixture) => {
+    expect(FORBIDDEN_CONTENT.test(fixture)).toBe(true);
+  });
+
+  it("still matches the 4 pre-existing formats unchanged", () => {
+    expect(FORBIDDEN_CONTENT.test("-----BEGIN RSA PRIVATE KEY-----")).toBe(true);
+    expect(FORBIDDEN_CONTENT.test("github_pat_" + "a".repeat(20))).toBe(true);
+    expect(FORBIDDEN_CONTENT.test("ghp_" + "a".repeat(20))).toBe(true);
+    expect(FORBIDDEN_CONTENT.test("gts_" + "0123456789abcdef".repeat(4))).toBe(true);
+    expect(FORBIDDEN_CONTENT.test(SECRET_SHAPED_PROBE)).toBe(true);
+  });
+
+  // jwt/seed_or_mnemonic/bittensor_key were deliberately left out of this widening (see the code comment on
+  // FORBIDDEN_CONTENT) -- pinned here so a future edit can't silently reintroduce them without this test
+  // flagging the scope change.
+  it("does NOT match jwt/seed_or_mnemonic/bittensor_key shapes (deliberately out of scope)", () => {
+    const jwtShaped = "eyJ" + "a".repeat(10) + "." + "b".repeat(10) + "." + "c".repeat(10);
+    expect(FORBIDDEN_CONTENT.test(jwtShaped)).toBe(false);
+    expect(FORBIDDEN_CONTENT.test("our seed phrase backup process")).toBe(false);
+    expect(FORBIDDEN_CONTENT.test("hotkey = ss58addresshere")).toBe(false);
+  });
+});

--- a/test/unit/miner-mcp-contract.test.ts
+++ b/test/unit/miner-mcp-contract.test.ts
@@ -294,6 +294,11 @@ describe("contract assertions catch violations (canary)", () => {
     expect(() => assertNoSecretShapedValue(withText(JSON.stringify({ token: PLANTED_SECRET })))).toThrow();
   });
 
+  it("assertNoSecretShapedValue also throws on a newly-widened shape (#7433: aws_access_key)", () => {
+    const awsShapedKey = "AKIA" + "ABCDEFGHIJKLMNOP";
+    expect(() => assertNoSecretShapedValue(withText(JSON.stringify({ token: awsShapedKey })))).toThrow();
+  });
+
   it("assertNoExcludedColumn throws when an excluded column is present", () => {
     expect(() => assertNoExcludedColumn(withText(JSON.stringify({ payload_json: "x" })), ["payload_json"])).toThrow();
   });


### PR DESCRIPTION
## Summary
- `FORBIDDEN_CONTENT` (`scripts/forbidden-content.mjs`) — the packaged-secret detector used by `check-miner-package.mjs`, `check-mcp-package.mjs`, and `miner-mcp-contract.test.ts` — only matched 4 secret shapes, even though this repo already ships a materially larger, individually-verified-precise set of concrete secret-format patterns in `src/review/secret-patterns.ts`'s `SECRET_PATTERNS`.
- Extended `FORBIDDEN_CONTENT` with the 12 additional formats from `HARD_SECRET_KINDS` (minus `jwt`): `aws_access_key`, `slack_token`, `google_api_key`, `gitlab_token`, `npm_token`, `stripe_secret_key`, `sendgrid_key`, `huggingface_token`, `voyage_api_key`, `firecrawl_api_key`, `openai_api_key`, `anthropic_api_key` — using the exact same regex bodies already defined for each.
- **Approach taken:** hand-copied the regex bodies into a single literal `RegExp` rather than importing from `src/review/secret-patterns.ts`. `check-miner-package.mjs`/`check-mcp-package.mjs` both run via plain `node scripts/*.mjs` (`package.json`'s `test:miner-pack`/`test:mcp-pack`), and plain Node cannot resolve a `.ts` import (`Unknown file extension ".ts"`, confirmed against this repo's Node 22 runtime) without a TS loader neither script registers — unlike `scripts/check-engine-parity.ts`, which runs via `tsx`. This is documented in a code comment on `FORBIDDEN_CONTENT`.
- `jwt`, `seed_or_mnemonic`, and `bittensor_key` were deliberately **not** added: `jwt` is out of scope for this issue (noted in the code comment), and `seed_or_mnemonic`/`bittensor_key` are documented in `secret-patterns.ts` as weak, false-positive-prone heuristics excluded from `HARD_SECRET_KINDS` there for the same reason (a `coldkey:`/`hotkey =` line or the word "mnemonic" in ordinary Bittensor docs is not a leaked credential).
- Zero changes to `check-miner-package.mjs`, `check-mcp-package.mjs`, or `miner-mcp-contract.test.ts`'s call sites — this is purely a widening of what the shared constant matches.

## Tests
- `test/unit/forbidden-content.test.ts`: added a parameterized case per new format (fixtures assembled from fragments, reusing the same fake bodies `test/unit/secrets-scan.test.ts`/`test/unit/content-lane-security-scan.test.ts` already use for these exact formats) plus a test pinning the 4 pre-existing formats as unchanged, and a test confirming `jwt`/`seed_or_mnemonic`/`bittensor_key`-shaped values are deliberately NOT matched.
- `test/unit/miner-mcp-contract.test.ts`: extended the existing secret-shape assertion with a newly-added shape (`aws_access_key`) to confirm the widening actually reaches that consumer.
- Verified no real-package false positive: scanned the actual packed `@loopover/mcp`/`@loopover/miner` file lists (via `npm pack --dry-run --json`) against all 12 new patterns directly — zero matches. The `check-mcp-package.test.ts`/`check-miner-package.test.ts` "passes on the real workspace package" tests fail identically on a clean pre-change baseline in this environment (`npm pack failed` — a pre-existing Windows `spawnSync` issue unrelated to this change), confirmed via a throwaway `git worktree` at the pre-change commit.

## Validation
- [x] `npx vitest run test/unit/forbidden-content.test.ts test/unit/miner-mcp-contract.test.ts` — 54/54 passing
- [x] `npx vitest run test/unit/secret-patterns.test.ts test/unit/secrets-scan.test.ts test/unit/content-lane-security-scan.test.ts` — 169/169 passing (no regression in the sibling detectors this was copied from)
- [x] `npm run typecheck` — clean (one pre-existing, unrelated error in `packages/loopover-miner/lib/discover-cli.ts` confirmed present on a clean `main` baseline too)
- [x] `npm run test:engine-parity && npm run test:live-gate-parity && npm run test:driver-parity` — all passing
- [x] `npm run db:migrations:check && npm run db:schema-drift:check && npm run selfhost:env-reference:check && npm run miner:env-reference:check && npm run selfhost:validate-observability && npm run command-reference:check && npm run docs:drift-check && npm run manifest:drift-check` — all clean
- [x] `npm run cf-typegen:check` — no drift
- [x] `npm run actionlint` — clean
- [x] `git diff --check` — clean
- `scripts/**` and `test/**` are excluded from Codecov's `coverage.include` list per `codecov.yml`, so this PR carries no patch-coverage obligation — the tests above are real behavioral assertions per this issue's own "Test Coverage Requirements" section, not for gate purposes.

Closes #7433