### PR TITLE
fix(engine): diffFilePriority's vendored-directory pattern misses vendored/third_party/third-party/bower_components/jspm_packages

### DIFF
--- a/packages/loopover-engine/src/review/diff-file-priority.ts
+++ b/packages/loopover-engine/src/review/diff-file-priority.ts
@@ -2,7 +2,10 @@ import { isTestPath } from "../signals/test-evidence.js";
 
 export function diffFilePriority(path: string): number {
   if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
-  if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
+  // Must stay in sync with signals/path-matchers.ts's isVendoredFileFrom -- the two already had this
+  // obligation implicitly (bower_components/jspm_packages were added there in #2777 with no corresponding
+  // update here, #7526) and now match the same directory-name set exactly.
+  if (/(^|\/)(dist|build|out|coverage|vendor|vendored|third_party|third-party|node_modules|bower_components|jspm_packages)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;
   return 0;

--- a/packages/loopover-engine/test/diff-file-priority.test.ts
+++ b/packages/loopover-engine/test/diff-file-priority.test.ts
@@ -30,3 +30,23 @@ test("predictedGateEngineInternals.sharesMeaningfulFile: a shared Cartfile.resol
   );
   assert.equal(predictedGateEngineInternals.sharesMeaningfulFile(["src/app.ts"], ["src/app.ts"]), true);
 });
+
+test("diffFilePriority: ranks every vendored-directory name path-matchers.ts's isVendoredFileFrom recognizes (#7526)", () => {
+  assert.equal(diffFilePriority("vendor/x.js"), 4);
+  assert.equal(diffFilePriority("vendored/x.js"), 4);
+  assert.equal(diffFilePriority("third_party/x.js"), 4);
+  assert.equal(diffFilePriority("third-party/x.js"), 4);
+  assert.equal(diffFilePriority("bower_components/x.js"), 4);
+  assert.equal(diffFilePriority("jspm_packages/x.js"), 4);
+});
+
+test("predictedGateEngineInternals.sharesMeaningfulFile: a file shared only under a vendored directory is not meaningful collision evidence (#7526)", () => {
+  assert.equal(
+    predictedGateEngineInternals.sharesMeaningfulFile(["third_party/lib.js"], ["third_party/lib.js"]),
+    false,
+  );
+  assert.equal(
+    predictedGateEngineInternals.sharesMeaningfulFile(["bower_components/lib.js"], ["bower_components/lib.js"]),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- `diffFilePriority`'s priority-4 ("least-useful-to-review, never real collision evidence") directory alternation only matched `vendor` (singular), while the sibling `isVendoredFileFrom` matcher in `packages/loopover-engine/src/signals/path-matchers.ts` already recognizes `vendor`, `vendored`, `third_party`, `third-party`, `bower_components`, and `jspm_packages`.
- `path-matchers.ts` had this full set from its original creation (#752/#1045) and later additions (#2777 added `bower_components`/`jspm_packages`) with no corresponding update to `diff-file-priority.ts` — the two matchers silently drifted apart.
- Practical effect: a file shared between two unrelated PRs under e.g. `third_party/foo.js`, `vendored/bar.js`, or `bower_components/baz.js` was ranked priority 0 ("ordinary source") instead of 4, so `sharesMeaningfulFile` (both call sites: `packages/loopover-engine/src/signals/engine.ts` and `packages/loopover-engine/src/signals/predicted-gate-engine.ts`) treated it as real collision evidence — inflating the collision/duplicate-cluster signal on exactly the kind of vendored-artifact path both call sites' own doc comments say should be excluded.
- Extended `diffFilePriority`'s directory alternation to the full `isVendoredFileFrom` set, with a code comment cross-referencing `path-matchers.ts` as the source of truth to keep in sync. No other branches of `diffFilePriority` (lockfile/doc/test) were touched, per the issue's stated scope.
- Scope note: `src/review/review-diff.ts` and `src/review/review-grounding.ts` carry their own host-side copies of `diffFilePriority` with the identical gap, but are out of scope for this issue (not referenced in its Requirements/Links) and `scripts/check-engine-parity.ts`'s twin-pair drift check only verifies marker *presence* (not byte-identical bodies) for this pair, so this scoped fix doesn't trip it.

## Tests
- `packages/loopover-engine/test/diff-file-priority.test.ts`: added a case asserting priority 4 for a path under each newly-added directory name (`vendored/x.js`, `third_party/x.js`, `third-party/x.js`, `bower_components/x.js`, `jspm_packages/x.js`), plus a `sharesMeaningfulFile` regression test confirming a file shared only under `third_party/`/`bower_components/` no longer counts as meaningful collision evidence.

## Validation
- [x] `npm run test --workspace @loopover/engine` — 594/594 passing
- [x] `npm run build --workspace @loopover/engine && npm run typecheck` — clean
- [x] `npm run engine-parity:drift-check` — ok, 5 hand-duplicated file pairs agree
- [x] `npm run test:engine-parity && npm run test:live-gate-parity && npm run test:driver-parity` — all passing
- [x] `npm run db:migrations:check && npm run db:schema-drift:check && npm run selfhost:env-reference:check && npm run miner:env-reference:check && npm run selfhost:validate-observability && npm run command-reference:check && npm run docs:drift-check && npm run manifest:drift-check` — all clean
- [x] `npm run cf-typegen:check` — no drift
- [x] `npm run actionlint` — clean
- [x] `git diff --check` — clean
- No UI-visible change, so no screenshots.

Closes #7526