### PR TITLE
fix(ui): stop renderInline from italicizing intraword underscores in commands-panel

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel-model.test.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel-model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { splitInlineMarkup } from "@/components/site/app-panels/commands-panel-model";
+
+describe("splitInlineMarkup intraword-underscore fix (#7531)", () => {
+  it("does NOT split underscores inside a longer identifier (env vars / snake_case)", () => {
+    // The exact repro from the issue: no intraword fragment is pulled out as an italics token, so the
+    // identifiers survive verbatim as plain runs.
+    expect(
+      splitInlineMarkup(
+        "Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly.",
+      ),
+    ).toEqual(["Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly."]);
+    expect(splitInlineMarkup("DISCORD_REPO_WEBHOOKS")).toEqual(["DISCORD_REPO_WEBHOOKS"]);
+    expect(splitInlineMarkup("set PAGERDUTY_REPO_ROUTING_KEYS now")).toEqual([
+      "set PAGERDUTY_REPO_ROUTING_KEYS now",
+    ]);
+  });
+
+  it("still treats a word-boundary _italic_ token as italics", () => {
+    // Flanked by whitespace/punctuation → a real emphasis token (kept with its underscores for the renderer
+    // to strip).
+    expect(splitInlineMarkup("this is _important_ text")).toEqual([
+      "this is ",
+      "_important_",
+      " text",
+    ]);
+    expect(splitInlineMarkup("_leading_ then trailing _tail_")).toEqual([
+      "_leading_",
+      " then trailing ",
+      "_tail_",
+    ]);
+    // Punctuation-flanked (a common real case): "(_note_)" italicizes the inner word.
+    expect(splitInlineMarkup("see (_note_) here")).toEqual(["see (", "_note_", ") here"]);
+  });
+
+  it("still tokenizes bold and inline code, and leaves them alongside the underscore fix", () => {
+    expect(splitInlineMarkup("run **build** then `npm_ci` on FOO_BAR")).toEqual([
+      "run ",
+      "**build**",
+      " then ",
+      "`npm_ci`",
+      " on FOO_BAR",
+    ]);
+  });
+
+  it("returns a single plain run for text with no markup", () => {
+    expect(splitInlineMarkup("plain text only")).toEqual(["plain text only"]);
+  });
+
+  it("returns an empty array for an empty line (filtered)", () => {
+    expect(splitInlineMarkup("")).toEqual([]);
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel-model.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel-model.ts
@@ -1,0 +1,16 @@
+// Commands-panel model (#7531). The markdown-lite inline tokenizer lives here (not in the .tsx) so the
+// component file exports only components (react-refresh/only-export-components), and so the split logic —
+// the part that carried the intraword-underscore bug — is directly unit-testable.
+
+/** Split a single line into markdown-lite tokens: `**bold**`, `` `code` ``, `_italic_`, and plain runs.
+ *
+ *  The `_..._` italics alternative is anchored to word boundaries (#7531) so it never matches underscores
+ *  INSIDE a longer identifier — `LOOPOVER_ENABLE_PAGERDUTY` / `repo_full_name` must tokenize as one plain
+ *  run, not have an arbitrary intraword fragment split out and italicized. Mirrors CommonMark's intraword-
+ *  underscore rule: `_` only opens/closes emphasis when it is not flanked by an alphanumeric on the outside.
+ */
+export function splitInlineMarkup(line: string): string[] {
+  return line
+    .split(/(\*\*[^*]+\*\*|`[^`]+`|(?<![A-Za-z0-9])_[^_]+_(?![A-Za-z0-9]))/g)
+    .filter(Boolean);
+}

--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -9,6 +9,7 @@ import { getApiOrigin } from "@/lib/api/origin";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
+import { splitInlineMarkup } from "@/components/site/app-panels/commands-panel-model";
 
 type CommandSample = {
   id: string;
@@ -268,7 +269,8 @@ function BotReply({ boundary, body }: { boundary: CommandSample["boundary"]; bod
 }
 
 function renderInline(line: string) {
-  const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`|_[^_]+_)/g).filter(Boolean);
+  // Tokenizer (incl. the #7531 intraword-underscore fix) lives in commands-panel-model.ts so it's unit-testable.
+  const parts = splitInlineMarkup(line);
   return parts.map((part, index) => {
     if (part.startsWith("**") && part.endsWith("**"))
       return <strong key={index}>{part.slice(2, -2)}</strong>;


### PR DESCRIPTION
## What

Fixes `renderInline` in the Commands panel (`/app/workbench?tab=commands` live command simulator) corrupting underscore-heavy text (#7531). Its markdown-lite italics alternative `_[^_]+_` had no word-boundary anchor, so it matched underscores *inside* a longer identifier — an env var like `LOOPOVER_ENABLE_PAGERDUTY` or a `repo_full_name` snake_case token got an arbitrary intraword fragment italicized and its underscores silently stripped.

The exact repro from the issue:
```
"Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly."
// old split → ["Use LOOPOVER","_ENABLE_","PAGERDUTY to opt in, and set repo","_full_","name accordingly."]
```

## The fix

Anchored the `_..._` italics alternative to word boundaries, mirroring CommonMark's intraword-underscore rule — `_` only opens/closes emphasis when it is **not** flanked by an alphanumeric on the outside:

```
(?<![A-Za-z0-9])_[^_]+_(?![A-Za-z0-9])
```

So `_important_` (whitespace/punctuation-flanked) still italicizes, but `FOO_BAR_BAZ` tokenizes as one plain run.

The tokenizer was extracted into a sibling `commands-panel-model.ts` (`splitInlineMarkup`) so the component file keeps exporting only components (`react-refresh/only-export-components`) and the split logic — the part that carried the bug — is directly unit-testable. `renderInline` in the `.tsx` now calls it; its bold/code/plain rendering is otherwise unchanged.

## Validation

- New `commands-panel-model.test.ts` (5 cases): the issue's exact intraword repro + `DISCORD_REPO_WEBHOOKS`/`PAGERDUTY_REPO_ROUTING_KEYS` stay one plain run; a real word-boundary `_italic_` (whitespace- and punctuation-flanked) still tokenizes as italics; bold + inline code still tokenize alongside the underscore fix; plain and empty lines. The intraword assertions are a genuine regression guard — they split into 5 parts against the old regex, 1 against the fixed one.
- `npm run ui:lint`, `@loopover/ui` `typecheck` pass; `git diff --check` clean. `apps/loopover-ui/**` carries no Codecov obligation, but the fix is covered by the new unit tests per this repo's testing discipline.

This is a self-contained, one-surface rendering-logic fix — there's no shared mini-markdown renderer elsewhere in `apps/loopover-ui` (only this file matched), so no cross-cutting impact.

Closes #7531
