### PR TITLE
fix(ui): stop renderInline corrupting underscore-heavy text in the commands panel

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the API layer so the component never touches the network.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: (...args: unknown[]) => useApiResource(...args),
+}));
+
+import { CommandsPanel } from "@/components/site/app-panels/commands-panel";
+
+const COMMAND = {
+  id: "gate-override",
+  command: "/loopover gate-override",
+  audience: "Maintainers",
+  boundary: "public" as const,
+  description: "Override the gate verdict.",
+  endpoint: "POST /v1/app/commands/preview",
+};
+
+/** Drive the panel to a valid repo/PR context so the preview effect fires. */
+function enterContext() {
+  fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
+    target: { value: "acme/widgets" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("123"), { target: { value: "12" } });
+}
+
+function mockPreview(body: string) {
+  apiFetch.mockResolvedValue({
+    ok: true,
+    data: { preview: { boundary: "public" as const, body } },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useApiResource.mockReturnValue({
+    status: "ready",
+    data: { commands: [COMMAND] },
+    reload: vi.fn(),
+  });
+});
+
+describe("CommandsPanel bot-reply rendering (#7531)", () => {
+  it("keeps underscore-heavy identifiers intact instead of italicizing a fragment", async () => {
+    mockPreview("Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly.");
+    const { container } = render(<CommandsPanel />);
+    enterContext();
+
+    // The whole line survives as one text node -- previously `_ENABLE_` and `_full_` were split out
+    // and rendered as <em>, silently dropping the underscores from both identifiers.
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly.",
+        ),
+      ).toBeTruthy();
+    });
+    expect(container.querySelectorAll("em")).toHaveLength(0);
+  });
+
+  it("still renders genuine markdown italics as <em>", async () => {
+    mockPreview("This is _emphasized_ text.");
+    const { container } = render(<CommandsPanel />);
+    enterContext();
+
+    await waitFor(() => {
+      const emphasis = container.querySelectorAll("em");
+      expect(emphasis).toHaveLength(1);
+      expect(emphasis[0]?.textContent).toBe("emphasized");
+    });
+  });
+
+  it("leaves underscores inside a code span alone", async () => {
+    mockPreview("Set `repo_full_name` in the payload.");
+    const { container } = render(<CommandsPanel />);
+    enterContext();
+
+    await waitFor(() => {
+      const code = container.querySelectorAll("code");
+      expect(code).toHaveLength(1);
+      expect(code[0]?.textContent).toBe("repo_full_name");
+    });
+    expect(container.querySelectorAll("em")).toHaveLength(0);
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -268,7 +268,13 @@ function BotReply({ boundary, body }: { boundary: CommandSample["boundary"]; bod
 }
 
 function renderInline(line: string) {
-  const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`|_[^_]+_)/g).filter(Boolean);
+  // The `_..._` italic alternative is anchored to non-word boundaries on BOTH sides. Without the
+  // lookarounds it matches any span between two underscores anywhere in a line, so an identifier
+  // carrying more than one -- `LOOPOVER_ENABLE_PAGERDUTY`, `repo_full_name`, and the rest of this
+  // product's env-var/snake_case vocabulary -- gets split mid-token and rendered as <em>, silently
+  // eating the underscores. Real italics (`_word_`, delimiters sitting against whitespace or the
+  // line edge) still match.
+  const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`|(?<!\w)_[^_]+_(?!\w))/g).filter(Boolean);
   return parts.map((part, index) => {
     if (part.startsWith("**") && part.endsWith("**"))
       return <strong key={index}>{part.slice(2, -2)}</strong>;


### PR DESCRIPTION
## Problem

`renderInline`'s italic alternative is `_[^_]+_` — no boundary anchor, so it matches any span between two underscores *anywhere* in a line. Identifiers carrying more than one underscore get split mid-token and rendered as `<em>`, silently eating the underscores.

Reproducing the issue's exact case:

```
"Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly."
before → ["Use LOOPOVER", "_ENABLE_", "PAGERDUTY to opt in, and set repo", "_full_", "name accordingly."]
after  → ["Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly."]
```

## Fix

Anchor both delimiters to non-word boundaries (`(?<!\w)_[^_]+_(?!\w)`). Genuine italics — delimiters against whitespace or a line edge — still match; identifiers pass through untouched. Backtick code spans already win the alternation, so they are unaffected. Lookbehind is ES2018 and this app targets ES2022.

## Tests

`commands-panel` was the only panel in `app-panels/` without a test file; this adds one following the sibling convention (mocked API layer, no network), covering:
- the corruption case — the full line survives with **no** `<em>`
- genuine `_emphasized_` still renders as `<em>`
- underscores inside a code span stay intact

**Verified the test actually catches the bug:** with the old regex restored, "keeps underscore-heavy identifiers intact" fails; with the fix it passes (3/3).

`ui:typecheck` exits 0 and `ui:lint` reports 0 errors. `apps/**` is outside Codecov's scope, so this carries no `codecov/patch` obligation.

Closes #7531