### PR TITLE
fix(ui): stop workflowHeadline contradicting the Accepted pill when accepted-but-not-ready

### DIFF
--- a/apps/loopover-ui/src/lib/registration-workspace.test.ts
+++ b/apps/loopover-ui/src/lib/registration-workspace.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { workflowHeadline } from "@/lib/registration-workspace";
+
+describe("workflowHeadline (#7535)", () => {
+  it("reports Accepted when the buckets are clear and readiness is ready", () => {
+    expect(workflowHeadline("accepted", true)).toBe(
+      "Accepted — contributor intake posture matches the recommended registration mode.",
+    );
+  });
+
+  it("does not contradict the Accepted pill when accepted but readiness is false", () => {
+    // overallState is "accepted" (every bucket clear) so the pill above the headline reads "Accepted";
+    // the headline must not fall through to the generic "Needs cleanup" copy, which would both contradict
+    // the pill and imply an actionable bucket item exists when none does.
+    const headline = workflowHeadline("accepted", false);
+    expect(headline).toBe(
+      "Accepted — the workflow buckets are all clear, but an overall readiness check outside them is still blocking; resolve it before scaling intake.",
+    );
+    expect(headline.startsWith("Accepted")).toBe(true);
+    expect(headline).not.toContain("Needs cleanup");
+  });
+
+  it("reports Not ready for the not_ready state regardless of readiness", () => {
+    const expected =
+      "Not ready — resolve blockers in the workflow buckets before inviting more contributors.";
+    expect(workflowHeadline("not_ready", false)).toBe(expected);
+    expect(workflowHeadline("not_ready", true)).toBe(expected);
+  });
+
+  it("reports Needs cleanup only for the needs_cleanup state", () => {
+    const expected =
+      "Needs cleanup — some areas are acceptable but require maintainer follow-up before scaling intake.";
+    expect(workflowHeadline("needs_cleanup", false)).toBe(expected);
+    expect(workflowHeadline("needs_cleanup", true)).toBe(expected);
+  });
+});

--- a/apps/loopover-ui/src/lib/registration-workspace.ts
+++ b/apps/loopover-ui/src/lib/registration-workspace.ts
@@ -661,9 +661,16 @@ function workflowRank(state: OwnerWorkflowState): number {
   return 2;
 }
 
-function workflowHeadline(state: OwnerWorkflowState, ready: boolean): string {
+export function workflowHeadline(state: OwnerWorkflowState, ready: boolean): string {
   if (state === "accepted" && ready) {
     return "Accepted — contributor intake posture matches the recommended registration mode.";
+  }
+  // #7535: `state` is bucket-derived (every bucket "accepted"), while `ready` (readiness.ready) is an
+  // independent API-side signal. When the buckets are all clear but readiness is still false there is no
+  // actionable bucket item, so falling through to the generic "needs cleanup — some areas require follow-up"
+  // default contradicts the "Accepted" pill rendered from the same overallState. Say so truthfully instead.
+  if (state === "accepted" && !ready) {
+    return "Accepted — the workflow buckets are all clear, but an overall readiness check outside them is still blocking; resolve it before scaling intake.";
   }
   if (state === "not_ready") {
     return "Not ready — resolve blockers in the workflow buckets before inviting more contributors.";


### PR DESCRIPTION
## Summary

`workflowHeadline` (`apps/loopover-ui/src/lib/registration-workspace.ts`) builds the owner-workflow headline from the bucket-derived `overallState` **and** `readiness.ready` — two independent signals nothing keeps in lockstep. When every bucket is clear (`state === "accepted"`) but `readiness.ready === false`, it skipped the accepted branch (ready is false) and the `not_ready` branch, falling through to the default **"Needs cleanup — some areas … require maintainer follow-up"**.

That directly contradicts the **"Accepted"** status pill `RegistrationWorkspace` renders from the same `overallState` right above it, and implies an actionable bucket item exists when none does.

## Fix

Add an explicit `state === "accepted" && !ready` branch with truthful copy — the workflow buckets are all clear, but an out-of-bucket readiness check is still blocking — instead of the fallthrough. The `not_ready` and `needs_cleanup` branches are unchanged (the default now only serves `needs_cleanup`, which is correct).

## Tests

Adds `registration-workspace.test.ts` (the file had zero test coverage). Covers all four cases: `accepted`+ready, `accepted`+`!ready` (the fixed contradiction), `not_ready`, and `needs_cleanup`. The function is exported for the test. All pass.

Closes #7535
