### PR TITLE
fix(engine): trim attempt-id slug after truncation

### DIFF
--- a/packages/loopover-engine/src/miner/worktree-plan.ts
+++ b/packages/loopover-engine/src/miner/worktree-plan.ts
@@ -36,13 +36,18 @@ const MAX_SLUG_LENGTH = 64;
 
 /** Deterministically slugify an attempt id into a filesystem- and git-ref-safe token (same id → same slug). */
 function slugifyAttemptId(attemptId: string): string {
+  // Trim leading/trailing `-`/`.` both before and after truncation (#7528): `.` is allowed mid-slug, so a
+  // pre-trim-only pass misses the case where slice(0, MAX) lands on a literal `.`/`-` and leaves a
+  // git-ref-invalid trailing separator (git check-ref-format rejects refs ending in `.`).
   const slug = attemptId
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
     .replace(/^[-.]+|[-.]+$/g, "");
   if (!slug) throw new Error("invalid_attempt_id");
-  return slug.slice(0, MAX_SLUG_LENGTH);
+  return slug;
 }
 
 /**

--- a/test/unit/worktree-plan.test.ts
+++ b/test/unit/worktree-plan.test.ts
@@ -38,8 +38,32 @@ describe("planWorktree (#4269)", () => {
     expect(long.branchName).toBe(`${WORKTREE_BRANCH_PREFIX}${"x".repeat(64)}`);
   });
 
+  it("strips a trailing '.' produced by truncating at a mid-slug dot (#7528)", () => {
+    // 63 safe chars + '.' + more content past the cap → pre-trim keeps the dot (not at the edge),
+    // slice(0, 64) ends in '.', and the post-truncation trim must remove it for git ref-format.
+    const attemptId = `${"a".repeat(63)}.${"b".repeat(10)}`;
+    const plan = planWorktree({ repoPath: "/repo", attemptId });
+    expect(plan.branchName).toBe(`${WORKTREE_BRANCH_PREFIX}${"a".repeat(63)}`);
+    expect(plan.branchName.endsWith(".")).toBe(false);
+    expect(plan.branchName.endsWith("-")).toBe(false);
+  });
+
+  it("strips a trailing '-' produced by truncating at a mid-slug hyphen (#7528)", () => {
+    const attemptId = `${"a".repeat(63)}-${"b".repeat(10)}`;
+    const plan = planWorktree({ repoPath: "/repo", attemptId });
+    expect(plan.branchName).toBe(`${WORKTREE_BRANCH_PREFIX}${"a".repeat(63)}`);
+    expect(plan.branchName.endsWith("-")).toBe(false);
+  });
+
+  it("leaves a clean truncation boundary untouched when the 64th char is not a separator (#7528)", () => {
+    const attemptId = `${"a".repeat(64)}${"b".repeat(10)}`;
+    const plan = planWorktree({ repoPath: "/repo", attemptId });
+    expect(plan.branchName).toBe(`${WORKTREE_BRANCH_PREFIX}${"a".repeat(64)}`);
+  });
+
   it("rejects an attempt id that sanitizes to nothing", () => {
     expect(() => planWorktree({ repoPath: "/repo", attemptId: "  ---  " })).toThrow(/invalid_attempt_id/);
+    expect(() => planWorktree({ repoPath: "/repo", attemptId: "..." })).toThrow(/invalid_attempt_id/);
   });
 });
 


### PR DESCRIPTION
## Summary

`slugifyAttemptId` trimmed leading/trailing `-`/`.` **before** the 64-char `slice`, so a long attempt id whose 64th character was `.` (or `-`) produced a git-ref-invalid worktree branch name ending in that separator. Trim again **after** truncation so `planWorktree` / `addWorktree` never build a `git worktree add -b` ref that fails `check-ref-format`.

Closes #7528

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` (`@loopover/engine` package `tsc` build; workspace root typecheck needs a full workspace build first)
- [x] `npx vitest run --coverage test/unit/worktree-plan.test.ts` — `worktree-plan.ts` at 100% lines and 100% branches in lcov (global threshold N/A for single-file run); `codecov/patch` should cover the changed slugify path
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Engine-only change under `packages/loopover-engine` + `test/unit/worktree-plan.test.ts`. Skipped UI/MCP/workers/actionlint/audit — no matching path changes. Full `npm run test:ci` omitted in favor of targeted critical checks for this leaf fix.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension changes.

## Notes

Regression cases cover post-truncation trim firing (trailing `.` and `-`), clean non-separator truncation (no-op), and the empty-slug `invalid_attempt_id` throw path.