### PR TITLE
fix(ui): re-sync the session when a logout request fails, not just show a toast

### DIFF
--- a/apps/loopover-ui/src/lib/api/session.test.ts
+++ b/apps/loopover-ui/src/lib/api/session.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+}));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+const { toast } = vi.hoisted(() => {
+  const fn = Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() });
+  return { toast: fn };
+});
+vi.mock("sonner", () => ({ toast }));
+
+import { useSession } from "@/lib/api/session";
+
+const authedSession = {
+  status: "authenticated" as const,
+  login: "alice",
+  roles: ["maintainer"],
+  confirmed_miner: true,
+};
+
+// `apiFetch` is the single network seam for both `GET /v1/auth/session` (used by refresh) and
+// `POST /v1/auth/logout`. `loggedOut` models the server: once a logout SUCCEEDS the session endpoint reports
+// signed_out; a FAILED logout leaves the cookie valid, so the session endpoint keeps reporting authenticated.
+function mockServer({ logoutSucceeds }: { logoutSucceeds: boolean }) {
+  let loggedOut = false;
+  apiFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/v1/auth/logout")) {
+      if (!logoutSucceeds)
+        return { ok: false, message: "network blip", status: 500, durationMs: 1 };
+      loggedOut = true;
+      return { ok: true, data: { status: "signed_out" }, status: 200, durationMs: 1 };
+    }
+    return {
+      ok: true,
+      data: loggedOut ? { status: "signed_out" } : authedSession,
+      status: 200,
+      durationMs: 1,
+    };
+  });
+}
+
+describe("useSession signOut (#7533)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("REGRESSION: restores the session when the logout request fails, instead of leaving it optimistically null", async () => {
+    mockServer({ logoutSucceeds: false });
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.session?.login).toBe("alice"));
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    // The logout failed, so the server cookie is still valid -- signOut must re-sync from the server rather
+    // than leaving the optimistic `null`, so the hook (and every other useSession consumer) stays authenticated.
+    await waitFor(() => expect(result.current.session?.login).toBe("alice"));
+    expect(result.current.session).not.toBeNull();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Sign out failed",
+      expect.objectContaining({ description: expect.anything() }),
+    );
+  });
+
+  it("shows the success toast on a successful logout, without taking the failure re-sync path (unchanged behavior)", async () => {
+    mockServer({ logoutSucceeds: true });
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.session?.login).toBe("alice"));
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    // Success path is unchanged: the "Signed out" toast fires and the failure-only error toast / re-sync
+    // does not run.
+    expect(toast).toHaveBeenCalledWith(
+      "Signed out",
+      expect.objectContaining({ description: expect.anything() }),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/loopover-ui/src/lib/api/session.ts
+++ b/apps/loopover-ui/src/lib/api/session.ts
@@ -128,6 +128,12 @@ export function useSession() {
     });
     if (!result.ok) {
       toast.error("Sign out failed", { description: result.message });
+      // The optimistic setSession(null)/emitSessionChanged above cleared the client session before the server
+      // confirmed the logout. A failed request means the server cookie is still valid, so re-sync from the
+      // server (the definitive source of truth) and re-broadcast — restoring the still-authenticated session
+      // instead of leaving this hook and every other useSession() consumer falsely signed out (#7533).
+      await refresh();
+      emitSessionChanged();
       return;
     }
     toast("Signed out", { description: "The browser session cookie was cleared." });


### PR DESCRIPTION
## Summary

`useSession`'s `signOut` optimistically ran `setSession(null)` + `emitSessionChanged()` **before** the `POST /v1/auth/logout` request resolved. On a failed request (network blip, 5xx, timeout) the error branch only showed a toast and returned — leaving the app-wide session state at the optimistically-cleared `null` even though the server-side session cookie was never actually cleared. Every role-gated route reading `useSession()` (e.g. `app.audit.tsx`'s `canAccess`) then fell back to the sign-in wall, and the user lost access until a manual reload re-synced them and discovered they were still logged in — a confusing false-negative logout (#7533).

**Fix:** on `result.ok === false`, `signOut` now `await refresh()`es — the definitive server re-sync the hook already exposes — and re-broadcasts `emitSessionChanged()`, restoring the still-authenticated session for this hook and every other `useSession()` consumer. The success path is unchanged: on `result.ok === true` the session stays cleared and the "Signed out" toast still fires.

## Tests

`session.ts` had **no test file**. Adds `session.test.ts`:
- **Regression:** a failing `apiFetch` logout — the hook's `session` is restored (not left `null`) and the "Sign out failed" toast fires.
- The success path still clears the session + fires the "Signed out" toast and does not take the failure re-sync.

## Validation

- [x] `@loopover/ui` typecheck, lint (prettier-clean), **test** (404 pass incl. the new suite), and build all green
- [x] `ui:version-audit` clean; rebased onto latest `main`
- [x] UI-only change (`apps/loopover-ui/**`) — 2 files, no backend surface

Closes #7533
