### PR TITLE
fix(engine): fail closed on non-finite opportunityCompetitionFactor inputs

### DIFF
--- a/packages/loopover-engine/src/reward-risk.ts
+++ b/packages/loopover-engine/src/reward-risk.ts
@@ -8,6 +8,7 @@
 // (#4256).
 import type { ScorePreviewResult } from "./scoring/preview.js";
 import { buildScorePreview } from "./scoring/preview.js";
+import { computeOpportunityCompetition } from "./opportunity-competition.js";
 import { isSuspiciousConfiguredLabel } from "./scoring/label-match.js";
 import { isFailingCheckSummary } from "./signals/check-summary.js";
 import { nowIso } from "./utils/json.js";
@@ -897,7 +898,14 @@ function buildEligibilityGap(analyses: RepoRewardRisk[]): EligibilityGapEntry[] 
 }
 
 function opportunityCompetitionFactor(highRiskDuplicateClusters: number, openPullRequests: number): number {
-  return round(clamp(highRiskDuplicateClusters / Math.max(1, openPullRequests), 0, 1));
+  // Delegates to the pure mirror rather than repeating its arithmetic (#7529). The inline version this
+  // replaced fed both arguments straight into the expression, so a non-finite `openPullRequests` made
+  // `Math.max(1, NaN)` NaN, which `clamp`'s own Math.min/Math.max then propagated -- yielding a NaN
+  // competition factor instead of a bounded score. `computeOpportunityCompetition` already guards both
+  // inputs (clusters fail CLOSED to maximal pressure, open PRs fail open to 0) and is arithmetically
+  // identical for finite inputs: its `round4`/`clamp` are byte-for-byte this module's `round`/`clamp`.
+  // Delegating -- rather than duplicating the guards -- is what stops the two drifting apart again.
+  return computeOpportunityCompetition(highRiskDuplicateClusters, openPullRequests);
 }
 
 function opportunityFreshnessFactor(issues: IssueRecord[]): number {
@@ -985,5 +993,9 @@ export const rewardRiskFreshnessInternals = {
   pickIssueTimestamp,
   issueAgeDays,
   bestFitLabels,
+};
+
+export const rewardRiskCompetitionInternals = {
+  opportunityCompetitionFactor,
 };
 /* v8 ignore stop */

--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -37,7 +37,10 @@ export type {
   RewardRiskActionKind,
   RewardRiskActionSeverity,
 } from "../../packages/loopover-engine/src/reward-risk.js";
-export { rewardRiskFreshnessInternals } from "../../packages/loopover-engine/src/reward-risk.js";
+export {
+  rewardRiskCompetitionInternals,
+  rewardRiskFreshnessInternals,
+} from "../../packages/loopover-engine/src/reward-risk.js";
 
 // The real `src`-side builders, bound once and injected into the engine implementations. Their argument
 // records are wider than (assignable to) the engine's subset mirrors and their return types are covariantly

--- a/test/unit/reward-risk-competition-fail-closed.test.ts
+++ b/test/unit/reward-risk-competition-fail-closed.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { computeOpportunityCompetition } from "../../packages/loopover-engine/src/opportunity-competition";
+import { rewardRiskCompetitionInternals } from "../../src/signals/reward-risk";
+
+const { opportunityCompetitionFactor } = rewardRiskCompetitionInternals;
+
+/**
+ * #7529: the hosted `opportunityCompetitionFactor` fed both arguments straight into
+ * `clamp(clusters / Math.max(1, openPrs), 0, 1)`. A non-finite `openPullRequests` made `Math.max(1, NaN)`
+ * NaN, which clamp's own Math.min/Math.max then propagated, so the factor came back NaN instead of a
+ * bounded score. Its pure mirror `computeOpportunityCompetition` already guarded both inputs; these tests
+ * pin the hosted path to that same fail-closed contract so the two cannot drift apart again.
+ */
+describe("opportunityCompetitionFactor fail-closed guards (#7529)", () => {
+  it("never returns NaN for a non-finite open-PR count", () => {
+    for (const openPrs of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const factor = opportunityCompetitionFactor(2, openPrs);
+      expect(Number.isFinite(factor)).toBe(true);
+      expect(factor).toBeGreaterThanOrEqual(0);
+      expect(factor).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("fails CLOSED to maximal pressure when the duplicate-cluster signal is broken", () => {
+    // A broken cluster signal means "unknown risk", which must read as maximum competition (1), not 0 --
+    // otherwise a NaN upstream reading would silently look like a wide-open opportunity.
+    for (const clusters of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(opportunityCompetitionFactor(clusters, 10)).toBe(1);
+    }
+  });
+
+  it("treats a negative reading as zero pressure rather than a negative factor", () => {
+    expect(opportunityCompetitionFactor(-5, 10)).toBe(0);
+    expect(opportunityCompetitionFactor(2, -10)).toBe(1);
+  });
+
+  it("is unchanged for ordinary finite inputs", () => {
+    expect(opportunityCompetitionFactor(0, 10)).toBe(0);
+    expect(opportunityCompetitionFactor(1, 4)).toBe(0.25);
+    expect(opportunityCompetitionFactor(3, 4)).toBe(0.75);
+    // Clamped at 1 when clusters exceed open PRs, and Math.max(1, …) floors the divisor at 1.
+    expect(opportunityCompetitionFactor(9, 4)).toBe(1);
+    expect(opportunityCompetitionFactor(1, 0)).toBe(1);
+  });
+
+  it("agrees with the pure mirror it delegates to, across the whole input matrix", () => {
+    const values = [0, 1, 2, 3, 9, -5, 0.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+    for (const clusters of values) {
+      for (const openPrs of values) {
+        expect(opportunityCompetitionFactor(clusters, openPrs)).toBe(
+          computeOpportunityCompetition(clusters, openPrs),
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`opportunityCompetitionFactor` fed both arguments straight into the arithmetic:

```ts
return round(clamp(highRiskDuplicateClusters / Math.max(1, openPullRequests), 0, 1));
```

A non-finite `openPullRequests` makes `Math.max(1, NaN)` → `NaN` (one NaN operand makes `Math.max` return NaN unconditionally), and `clamp`'s own `Math.min`/`Math.max` propagate it — so the factor came back `NaN` instead of a bounded score.

Its documented pure mirror, `computeOpportunityCompetition`, was hardened for exactly this and the original never was.

## Fix

Delegate to the mirror rather than duplicating its guards — duplication is how the two drifted apart in the first place. This is safe and behavior-preserving for finite inputs:

- `round4` is byte-for-byte this module's `round` (`Math.round(v * 10000) / 10000`)
- `clamp` is byte-for-byte identical in both modules
- `opportunity-competition.ts` imports nothing, so there is **no cycle risk**
- `opportunityCompetitionFactor` has exactly one call site, left untouched

Semantics now match the mirror: a broken cluster signal fails **closed** to maximal pressure (1) rather than fail-open 0, and a non-finite open-PR count falls back to 0 so the divisor floor stays 1.

## Tests

Adds `rewardRiskCompetitionInternals`, mirroring the existing `rewardRiskFreshnessInternals` test-surface pattern (same `/* v8 ignore */` treatment), plus a regression test covering non-finite open-PR counts, fail-closed cluster pressure, negative readings, unchanged finite behavior, and full parity with the mirror across a 10×10 input matrix.

**Verified the test catches the bug:** with the old inline implementation restored, 3 of 5 tests fail; with the fix, 5/5 pass — and "unchanged for ordinary finite inputs" passes in *both*, confirming no behavior change for normal values.

126 tests pass across the reward-risk/opportunity/signals suites; `engine-parity:drift-check` and `test:engine-parity` (14 tests) both pass; root `typecheck` exits 0; changed lines have zero uncovered statements or branches.

Closes #7529