### PR TITLE
fix(ui): re-sync session after a failed logout instead of staying signed-out

### DIFF
--- a/apps/loopover-ui/src/lib/api/session.test.ts
+++ b/apps/loopover-ui/src/lib/api/session.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+vi.mock("sonner", () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }));
+
+import { useSession } from "@/lib/api/session";
+
+describe("useSession signOut (#7533)", () => {
+  it("re-syncs from the server AFTER a failed logout instead of staying optimistically signed out", async () => {
+    const authed = {
+      status: "authenticated",
+      login: "alice",
+      roles: ["maintainer"],
+      confirmed_miner: true,
+    };
+    // Record each call so we can prove a session re-sync happens *after* the logout fails — the emit-driven
+    // refresh fires before the logout POST, so only the fix's own post-failure refresh() lands after it.
+    const calls: string[] = [];
+    apiFetch.mockImplementation((url: string) => {
+      const kind = url.includes("/v1/auth/logout") ? "logout" : "session";
+      calls.push(kind);
+      // The logout POST fails; the session GET still reports authenticated, because a failed logout never
+      // cleared the server-side cookie — so the app must not remain optimistically signed out.
+      return kind === "logout"
+        ? Promise.resolve({ ok: false, kind: "http", message: "500", status: 500, durationMs: 1 })
+        : Promise.resolve({ ok: true, data: authed, status: 200, durationMs: 1 });
+    });
+
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.session?.login).toBe("alice"));
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    // Regression for #7533: the failed logout optimistically cleared the session; the fix re-syncs it from
+    // the server so the app is not left falsely signed out (hiding every role-gated route until a reload).
+    await waitFor(() => expect(result.current.session?.login).toBe("alice"));
+    expect(result.current.session).not.toBeNull();
+
+    // The fix specifically: a session re-sync runs AFTER the failed logout POST. Without it, the only
+    // refreshes are the mount hydrate + the pre-logout emit, so nothing follows the logout call.
+    const afterLogout = calls.slice(calls.indexOf("logout") + 1);
+    expect(afterLogout).toContain("session");
+  });
+});

--- a/apps/loopover-ui/src/lib/api/session.ts
+++ b/apps/loopover-ui/src/lib/api/session.ts
@@ -128,6 +128,11 @@ export function useSession() {
     });
     if (!result.ok) {
       toast.error("Sign out failed", { description: result.message });
+      // #7533: the optimistic setSession(null)/emitSessionChanged() above was never confirmed
+      // server-side (the logout call failed, so the session cookie is still valid). Re-sync from the
+      // server — the definitive source — instead of leaving the app in a false "signed out" state that
+      // hides every role-gated route/panel until the user manually reloads.
+      await refresh();
       return;
     }
     toast("Signed out", { description: "The browser session cookie was cleared." });


### PR DESCRIPTION
## Summary

`signOut` (`apps/loopover-ui/src/lib/api/session.ts`) optimistically cleared the session (`setSession(null)` + `emitSessionChanged()`) **before** awaiting `POST /v1/auth/logout`. On a failed logout — a network blip, 5xx, or timeout — the error branch only showed a toast and returned, never restoring the session. So the app-wide session state (and every role-gated route/panel reading `useSession()`) read **"signed out"** even though the server-side session cookie was never actually cleared and the user is still authenticated — a confusing false-negative logout that hides gated UI until a manual page reload.

## Fix

On `result.ok === false`, re-sync from the server via `refresh()` (the hook's existing, definitive session source) so the optimistically-cleared session is restored. The success path is unchanged (`result.ok === true` still leaves the session cleared and shows the "Signed out" toast).

## Tests

Adds `session.test.ts` (the file had zero tests). It mocks a failing `/v1/auth/logout` with a still-authenticated session endpoint and asserts (a) the hook's `session` is restored rather than left `null`, and (b) a session re-sync runs **after** the failed logout POST — the behavior unique to this fix (the pre-existing emit-driven refresh fires *before* the logout). Verified locally: the test fails if the `refresh()` line is removed.

Closes #7533
