### PR TITLE
fix(ui): warn once when getApiOrigin falls back to the unconfigured default origin

### DIFF
--- a/apps/loopover-ui/src/lib/api/origin.test.ts
+++ b/apps/loopover-ui/src/lib/api/origin.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+// Fresh module per call so the module-level "warned once" flag resets between cases.
+async function loadGetApiOrigin() {
+  vi.resetModules();
+  return (await import("@/lib/api/origin")).getApiOrigin;
+}
+
+describe("getApiOrigin (#7534)", () => {
+  it("returns the configured origin with trailing slashes trimmed, and does not warn", async () => {
+    vi.stubEnv("VITE_LOOPOVER_API_ORIGIN", "https://my-api.example.com//");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getApiOrigin = await loadGetApiOrigin();
+    expect(getApiOrigin()).toBe("https://my-api.example.com");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when explicitly pointed at the default origin on purpose", async () => {
+    // Gate is "env var unset", not "resolved value equals default" — a deliberate hosted-origin config
+    // must stay silent.
+    vi.stubEnv("VITE_LOOPOVER_API_ORIGIN", "https://api.loopover.ai");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getApiOrigin = await loadGetApiOrigin();
+    expect(getApiOrigin()).toBe("https://api.loopover.ai");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default origin and warns exactly once when unconfigured", async () => {
+    vi.stubEnv("VITE_LOOPOVER_API_ORIGIN", "");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getApiOrigin = await loadGetApiOrigin();
+    expect(getApiOrigin()).toBe("https://api.loopover.ai");
+    getApiOrigin();
+    getApiOrigin();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("VITE_LOOPOVER_API_ORIGIN");
+  });
+});

--- a/apps/loopover-ui/src/lib/api/origin.ts
+++ b/apps/loopover-ui/src/lib/api/origin.ts
@@ -1,7 +1,21 @@
 const DEFAULT_API_ORIGIN = "https://api.loopover.ai";
 
+// #7534: warn at most once when the origin was NOT explicitly configured, so a self-host deployment that
+// forgot to set VITE_LOOPOVER_API_ORIGIN at build time notices the UI is silently targeting the default
+// hosted API instead of its own. Gated on the env var being empty/unset — NOT on the resolved value
+// equalling the default — so someone who deliberately points at the hosted origin gets no warning.
+let warnedUnconfiguredOrigin = false;
+
 export function getApiOrigin(): string {
   const configured = import.meta.env.VITE_LOOPOVER_API_ORIGIN?.trim();
+  if (!configured && !warnedUnconfiguredOrigin) {
+    warnedUnconfiguredOrigin = true;
+    console.warn(
+      `VITE_LOOPOVER_API_ORIGIN is not set — the UI is targeting the default hosted API origin ` +
+        `${DEFAULT_API_ORIGIN}. Self-host deployments should set VITE_LOOPOVER_API_ORIGIN=https://your-api.example.com ` +
+        `at build time to point the UI at their own API.`,
+    );
+  }
   const origin = configured || DEFAULT_API_ORIGIN;
   return origin.replace(/\/+$/, "");
 }


### PR DESCRIPTION
## Summary

`getApiOrigin()` (`apps/loopover-ui/src/lib/api/origin.ts`) silently resolved to `DEFAULT_API_ORIGIN` (`https://api.loopover.ai`) whenever the build-time `VITE_LOOPOVER_API_ORIGIN` env var was empty/unset. In this self-host-first project, a deployment that forgot to set it at build time got no signal that the UI was targeting the default **hosted** API instead of its own — every `apiFetch` just quietly went to the wrong origin.

## Fix

Emit a single `console.warn` (module-level once flag, so it doesn't repeat on every `apiFetch`) when the fallback branch is taken, explaining the situation and how to override it.

Gated strictly on **the env var being empty/unset**, not on the resolved value equalling the default — so someone who *deliberately* points at the hosted origin (`VITE_LOOPOVER_API_ORIGIN=https://api.loopover.ai`) gets no self-host warning. The origin-resolution logic and default value are unchanged; this is purely additive.

## Tests

Adds `origin.test.ts` (the file had zero tests): explicitly-configured origin → no warning + trailing-slash trimming intact; explicit default origin → no warning; empty/unset → warns exactly once (verified across repeated calls) and returns the default. Module state is reset per case for the once-flag.

Closes #7534
