### PR TITLE
fix(engine): re-trim slugifyAttemptId after truncation to avoid a git-invalid trailing separator

### DIFF
--- a/packages/loopover-engine/src/miner/worktree-plan.ts
+++ b/packages/loopover-engine/src/miner/worktree-plan.ts
@@ -42,7 +42,12 @@ function slugifyAttemptId(attemptId: string): string {
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^[-.]+|[-.]+$/g, "");
   if (!slug) throw new Error("invalid_attempt_id");
-  return slug.slice(0, MAX_SLUG_LENGTH);
+  // Re-trim the TRAILING separators AFTER truncation: `.` survives the character-class replace and is a
+  // valid interior char, so slicing to MAX_SLUG_LENGTH can leave a trailing `.`/`-` that the pre-truncation
+  // trim never saw -- git rejects a ref ending in `.` (#7528). Only the trailing edge needs re-trimming: the
+  // pre-truncation trim already removed any leading separators, and slice(0, n) never introduces a new leading
+  // one, so the truncated slug always keeps its non-separator first char (never empties).
+  return slug.slice(0, MAX_SLUG_LENGTH).replace(/[-.]+$/g, "");
 }
 
 /**

--- a/test/unit/worktree-plan.test.ts
+++ b/test/unit/worktree-plan.test.ts
@@ -41,6 +41,24 @@ describe("planWorktree (#4269)", () => {
   it("rejects an attempt id that sanitizes to nothing", () => {
     expect(() => planWorktree({ repoPath: "/repo", attemptId: "  ---  " })).toThrow(/invalid_attempt_id/);
   });
+
+  it("REGRESSION (#7528): re-trims after truncation so a `.` landing on the 64-char boundary is not left trailing", () => {
+    // Slug is 63 'a's + '.' + 10 'b's (all survive the character class). Slicing to 64 keeps 63 'a's + '.',
+    // which would end in '.' -- a ref git rejects (`fatal: invalid reference`) -- unless we re-trim after slicing.
+    const attemptId = `${"a".repeat(63)}.${"b".repeat(10)}`;
+    const plan = planWorktree({ repoPath: "/repo", attemptId });
+    expect(plan.branchName).toBe(`${WORKTREE_BRANCH_PREFIX}${"a".repeat(63)}`);
+    expect(plan.branchName.endsWith(".")).toBe(false);
+    expect(plan.branchName.endsWith("-")).toBe(false);
+  });
+
+  it("REGRESSION (#7528): a trailing `-` landing exactly on the boundary is likewise re-trimmed", () => {
+    // Same boundary case with '-' rather than '.', confirming both separators are handled post-truncation.
+    const attemptId = `${"a".repeat(63)}-${"b".repeat(10)}`;
+    const plan = planWorktree({ repoPath: "/repo", attemptId });
+    expect(plan.branchName).toBe(`${WORKTREE_BRANCH_PREFIX}${"a".repeat(63)}`);
+    expect(plan.branchName.endsWith("-")).toBe(false);
+  });
 });
 
 describe("addWorktree", () => {


### PR DESCRIPTION
## What

`slugifyAttemptId` (`packages/loopover-engine/src/miner/worktree-plan.ts`) trimmed leading/trailing `-`/`.` **before** slicing to `MAX_SLUG_LENGTH`, not after. `.` is in the allowed character class, so it survives the sanitizing replace. When the pre-truncation slug is longer than 64 chars and its 64th character is a literal `.`, the truncated slug ends in `.` — a case the trim step never saw because it ran on the untruncated string.

That slug becomes the worktree branch name (`loopover/attempt/<slug>`), and `addWorktree` runs `git worktree add -b <branchName> …`. Git's ref-name rules reject a ref ending in `.` (`git help check-ref-format`), so this fails with `fatal: invalid reference`. It reproduces from the *default* attempt id `attempt-cli.ts` builds (`${repoFullName.replace("/","_")}-${issueNumber}-${nowMs}`) when a long owner/repo pair (repo names may contain dots, e.g. `socket.io`) puts a `.` at the 64-char boundary — no unusual input required.

## Fix

Re-trim the **trailing** separators after truncation:

```ts
return slug.slice(0, MAX_SLUG_LENGTH).replace(/[-.]+$/g, "");
```

Only the trailing edge needs re-trimming: the pre-truncation trim already removed any leading separators, and `slice(0, n)` never introduces a new leading one, so the truncated slug always keeps its non-separator first char and can never empty (so no extra empty-check branch is added).

## Tests

Two `REGRESSION (#7528)` cases in `test/unit/worktree-plan.test.ts`, each constructing an attempt id whose slug's 64th char is a separator (`.` and `-`) before truncation, asserting the final branch name is the 63-char prefix and ends in neither `.` nor `-`. Both are **proven** to fail against the pre-fix code (received `…a.`/`…a-`).

## Validation

- `npx vitest run test/unit/worktree-plan.test.ts` — 10/10 pass.
- `@loopover/engine` build + `npm run typecheck` — clean (exit 0).
- `git diff --check` clean.

Closes #7528
