### PR TITLE
fix(deps): update brace-expansion to 1.1.16 to clear GHSA-3jxr-9vmj-r5cp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10210,9 +10210,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

`npm audit --audit-level=moderate` reports `brace-expansion@1.1.15` as vulnerable to **GHSA-3jxr-9vmj-r5cp** — a high-severity ReDoS (DoS via exponential-time expansion of consecutive non-expanding `{}` groups). It's pulled in transitively (`eslint` → `minimatch@3.1.5` → `brace-expansion@^1.1.7`).

`brace-expansion@1.1.16` is published and already satisfies the existing `^1.1.7` range, so `npm update brace-expansion` resolves the advisory **in range** with a lockfile-only change.

## Scope

- **`package-lock.json` only** — 3 lines (version/resolved/integrity for the single `brace-expansion` entry). No `package.json` range change, no other packages moved.
- The separate `brace-expansion@5.0.7` entry (a different, non-vulnerable dep subtree) is untouched.

## Validation

- Before: `npm audit --audit-level=moderate` → 3 high-severity findings (incl. GHSA-3jxr-9vmj-r5cp on `brace-expansion`).
- After: **2** findings — the `brace-expansion` advisory is cleared. The remaining two are the out-of-range findings this issue explicitly scoped out.
- `npm ls brace-expansion` resolves the shared entry at `1.1.16`; `git diff --check` clean.

Closes #7568
