### PR TITLE
fix(ui): stop renderInline mangling underscore-heavy identifiers as italics

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderInline } from "./commands-panel";
+
+function renderLine(line: string) {
+  return render(<>{renderInline(line)}</>);
+}
+
+describe("renderInline (#7531)", () => {
+  it("still renders **bold** as <strong> and `code` as <code>", () => {
+    const { container } = renderLine("a **bold** and `code` here");
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+    expect(container.querySelector("code")?.textContent).toBe("code");
+  });
+
+  it("still renders a whitespace-flanked _italic_ span as <em>", () => {
+    const { container } = renderLine("an _emphasized_ word");
+    expect(container.querySelector("em")?.textContent).toBe("emphasized");
+    // At line start/end too.
+    expect(renderLine("_lead_ then").container.querySelector("em")?.textContent).toBe("lead");
+  });
+
+  it("leaves underscore-heavy identifiers intact with no spurious <em>", () => {
+    const { container } = renderLine(
+      "set LOOPOVER_ENABLE_PAGERDUTY and repo_full_name to slop_gate_min_score",
+    );
+    expect(container.querySelector("em")).toBeNull();
+    expect(container.textContent).toBe(
+      "set LOOPOVER_ENABLE_PAGERDUTY and repo_full_name to slop_gate_min_score",
+    );
+  });
+
+  it("does not italicize a digit-flanked underscore run either", () => {
+    const { container } = renderLine("v2_beta_channel stays literal");
+    expect(container.querySelector("em")).toBeNull();
+    expect(container.textContent).toBe("v2_beta_channel stays literal");
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -267,8 +267,18 @@ function BotReply({ boundary, body }: { boundary: CommandSample["boundary"]; bod
   );
 }
 
-function renderInline(line: string) {
-  const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`|_[^_]+_)/g).filter(Boolean);
+// Exported for direct unit testing (commands-panel.test.tsx). It returns JSX, so unlike the pure-logic
+// *-model.ts helpers in this directory it cannot live in a plain .ts module; the Fast-Refresh rule is a
+// dev-only concern that does not apply to this small stateless renderer.
+// eslint-disable-next-line react-refresh/only-export-components
+export function renderInline(line: string) {
+  // #7531: anchor the `_..._` italics alternative at word boundaries so it no longer matches inside
+  // underscore-heavy identifiers (env vars / snake_case like LOOPOVER_ENABLE_PAGERDUTY, repo_full_name).
+  // `**bold**` and `` `code` `` are untouched. Mirrors CommonMark's intraword-underscore rule: the flanking
+  // `_` opens/closes emphasis only when it is not bordered by an alphanumeric on the outside.
+  const parts = line
+    .split(/(\*\*[^*]+\*\*|`[^`]+`|(?<![A-Za-z0-9])_[^_]+_(?![A-Za-z0-9]))/g)
+    .filter(Boolean);
   return parts.map((part, index) => {
     if (part.startsWith("**") && part.endsWith("**"))
       return <strong key={index}>{part.slice(2, -2)}</strong>;


### PR DESCRIPTION
## Summary

`renderInline` (`commands-panel.tsx`) — the markdown-lite renderer for bot-reply text in the Commands panel — split lines on `/(\*\*[^*]+\*\*|` + "`[^`]+`" + `|_[^_]+_)/g`. The italics alternative `_[^_]+_` had no word-boundary anchor, so it matched **any** span between two underscores, including well inside a longer identifier that contains more than one underscore. This codebase's command/config vocabulary is full of that shape (`LOOPOVER_ENABLE_PAGERDUTY`, `repo_full_name`, `slop_gate_min_score`, …), so those got corrupted into spurious `<em>` spans.

## Fix

Anchor the italics alternative to word boundaries — `(?<![A-Za-z0-9])_[^_]+_(?![A-Za-z0-9])` — so `_..._` only opens/closes emphasis when the flanking underscore is not bordered by an alphanumeric (CommonMark's intraword-underscore rule). `**bold**` and `` `code` `` are untouched.

## Tests

Adds `commands-panel.test.tsx` (no tests today), covering `**bold**`, `` `code` ``, a genuine whitespace-flanked `_italic_` (and at line start), and the regressions: a multi-underscore identifier and a digit-flanked underscore run render as plain text with underscores intact and no `<em>`. `renderInline` is exported for the test (with a scoped `react-refresh` disable, since it returns JSX and can't live in a pure-logic `-model.ts` like the sibling helpers).

Closes #7531
