### PR TITLE
fix(review): stop dirty-base PRs deferring forever on missing CI context

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3570,7 +3570,21 @@ async function prReadyForReview(
       }).catch(() => undefined);
       return false;
     }
-    if (ci.hasMissingRequiredContext) {
+    // #3947 made this defer UNCONDITIONAL and INDEFINITE ("no finalize escape") specifically to stop a
+    // clean-base PR's gate from ever reading "passed" while an expected required check might still land
+    // red later -- a real risk when the base is otherwise mergeable and the PR's disposition genuinely
+    // depends on how that check resolves. A DIRTY base changes that calculus: agent-actions.ts's
+    // `isConflict` closes a contributor PR on mergeableState==="dirty" regardless of gate conclusion OR
+    // CI state (see `pendingCiMayStillCloseForTerminalReason` there), so the disposition is ALREADY
+    // decided the instant we know the base is dirty -- no future CI report, required or not, can change
+    // it. #3947's concern (a premature verdict later contradicted by CI) cannot occur here, and waiting
+    // can only make things worse: no amount of deferring makes an expected required context appear on a
+    // PR that needs a rebase. Excluding this case lets a dirty-base PR fall through to the same
+    // finalize-past-cap path below instead of deferring forever (#7537-class stuck PRs, #7556). Every
+    // OTHER missing-required-context PR keeps deferring unconditionally, exactly as #3947 intended: a
+    // clean-base PR really might still be waiting on a required check whose eventual result matters.
+    const isLiveBaseConflict = (liveMergeState ?? pr.mergeableState) === "dirty";
+    if (ci.hasMissingRequiredContext && !isLiveBaseConflict) {
       await recordAuditEvent(env, {
         eventType: "github_app.review_deferred_ci_pending",
         actor: "loopover",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2370,6 +2370,128 @@ describe("queue processors", () => {
     }
   });
 
+  it("REGRESSION (#7556): a dirty-base PR with missing required context finalizes past the short cap instead of deferring forever", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto", close: "auto" }, gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off", aiReviewMode: "off", reviewCheckMode: "required" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Dirty base, missing required context", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    // 3 minutes elapsed: past the 2-minute missing-required-context surfacing cap. Unlike the "past short cap"
+    // clean-base case above, a dirty base is terminal regardless of whether the expected required context ever
+    // arrives -- it must finalize here so the disposition planner (agent-actions.ts's isConflict) can close it,
+    // instead of deferring forever like PR #7537 did live.
+    await env.SELFHOST_TRANSIENT_CACHE?.set(
+      "ci-pending-first-seen:owner/agent-repo#7:a7",
+      String(Date.now() - 3 * 60 * 1000),
+      7 * 24 * 3600,
+    );
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "pending",
+      hasPending: true,
+      hasVisiblePending: false,
+      hasMissingRequiredContext: true,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      advisoryHoldDetails: [],
+      ciCompletenessWarning: null,
+    });
+    let gateChecks = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Dirty base, missing required context", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "dirty", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/check-runs") && (method === "POST" || method === "PATCH")) {
+        gateChecks += 1;
+        return Response.json({ id: 901 }, { status: method === "POST" ? 201 : 200 });
+      }
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "dirty-base-missing-context", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      expect(gateChecks).toBeGreaterThan(0);
+      const finalized = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.review_finalized_ci_stuck")
+        .first<{ n: number }>();
+      expect(finalized?.n).toBe(1);
+      const missingContextDefers = await env.DB.prepare(
+        "select count(*) as n from audit_events where event_type = ? and detail like ?",
+      )
+        .bind("github_app.review_deferred_ci_pending", "Required CI context is still missing%")
+        .first<{ n: number }>();
+      expect(missingContextDefers?.n).toBe(0);
+    } finally {
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
+  it("REGRESSION (#7556): falls back to the stored mergeable_state when the live re-fetch can't report one", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto", close: "auto" }, gatePack: "oss-anti-slop" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { settings: { checkRunMode: "off", commentMode: "off", publicSurface: "off", aiReviewMode: "off", reviewCheckMode: "required" } });
+    // Seed the STORED mergeable_state as dirty (persisted into payloadJson, reconstructed by getPullRequest).
+    // The mocked /pulls/7 GET below (the live re-fetch prReadyForReview and its caller both consult) reports the
+    // SAME head SHA but omits mergeable_state entirely, so the live read degrades to undefined and the stored
+    // value is what's left to fall back to -- exercising the `??`'s nullish side, not just its present side.
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Dirty base, live re-fetch can't report mergeable_state", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1", mergeable_state: "dirty" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    await env.SELFHOST_TRANSIENT_CACHE?.set(
+      "ci-pending-first-seen:owner/agent-repo#7:a7",
+      String(Date.now() - 3 * 60 * 1000),
+      7 * 24 * 3600,
+    );
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "pending",
+      hasPending: true,
+      hasVisiblePending: false,
+      hasMissingRequiredContext: true,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      advisoryHoldDetails: [],
+      ciCompletenessWarning: null,
+    });
+    let gateChecks = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // No mergeable_state field at all -- the live merge-state read (both reReviewStoredPullRequest's resync
+      // and prReadyForReview's own cachedLiveMergeState) resolves to undefined from this response.
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Dirty base, live re-fetch can't report mergeable_state", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/check-runs") && (method === "POST" || method === "PATCH")) {
+        gateChecks += 1;
+        return Response.json({ id: 901 }, { status: method === "POST" ? 201 : 200 });
+      }
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "dirty-base-fallback-mergeable-state", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      expect(gateChecks).toBeGreaterThan(0);
+      const finalized = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.review_finalized_ci_stuck")
+        .first<{ n: number }>();
+      expect(finalized?.n).toBe(1);
+    } finally {
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
   it("records an informational audit event when the live CI aggregate carries a completeness warning (#2137)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });


### PR DESCRIPTION
## Summary

- `prReadyForReview` (`src/queue/processors.ts`) deferred a PR with a missing required CI context **forever**, unlike its sibling "generic stuck CI" branch, which already finalizes past a cap. Live symptom: a real open pull request sat 40+ minutes with zero labels/gate check-run, repeating "Required CI context is still missing" every ~4 minutes, because its base was dirty and no required CI could ever arrive.
- Fix: when the PR's live `mergeableState` is `"dirty"`, skip the indefinite defer and fall through to the existing finalize-past-cap + per-head-SHA guard path, so the disposition planner (`agent-actions.ts`'s `isConflict`) can close it — the documented "base conflict → CLOSE" behavior that currently never gets a chance to run for this case.
- Narrows, not removes, an earlier design (see the `queue.test.ts` tests named `#selfhost-ci-deferral-staleness`) that made this defer unconditional for every OTHER missing-required-context PR — those regression tests, plus a related repair-budget test in `queue-2.test.ts`, are unchanged and still pass. That earlier design's concern was a clean-base PR's gate reading "passed" before a required check might still come back red; that can't happen for a dirty base, since `isConflict` closes the PR regardless of gate conclusion or CI outcome.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run ui:build`/`ui:test`: this machine runs Node v26.5.0 (repo pins Node 22 via `.nvmrc`); every `apps/loopover-ui`/`apps/loopover-miner-ui` test touching `window.localStorage` fails locally with `Cannot read properties of undefined (reading 'clear')`, reproducing on both UI workspaces and in isolation from this change — a vitest-jsdom/Node compatibility issue unrelated to this diff (those apps are untouched here). Every CI workflow pins Node via `.nvmrc`, so this isn't expected to reproduce in the real gate. `npm run test:ci` ran clean through `ui:typecheck`, including the full unsharded `test:coverage`, before hitting this pre-existing local-environment gap.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only change (`src/queue/processors.ts`, `test/unit/queue.test.ts`), no visible UI/frontend/docs surface.

## Notes

- Closes #7556
