### PR TITLE
fix(test): restore jsdom localStorage in vitest setup for Node 25+

### DIFF
--- a/apps/loopover-miner-ui/vitest.setup.ts
+++ b/apps/loopover-miner-ui/vitest.setup.ts
@@ -16,6 +16,23 @@ class ResizeObserverStub {
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 
+// #7576: Node 25+ ships a native globalThis.localStorage/sessionStorage that evaluates to `undefined`
+// (nodejs/node#60303) when no --localstorage-file is set. Because `"localStorage" in globalThis` is then
+// true, vitest's jsdom environment skips copying jsdom's own working Storage over (its getWindowKeys()
+// only copies a key that is not already present on the global), leaving window.localStorage undefined and
+// every localStorage-touching test throwing on the first `.clear()`/`.setItem()`. jsdom's real Storage is
+// still reachable via the raw JSDOM instance vitest exposes as `globalThis.jsdom`, so restore it from there
+// when the native global is broken. No-op on Node <=24 (the native global doesn't exist and jsdom's Storage
+// was copied normally), so it never affects the .nvmrc-pinned Node 22 that CI runs on.
+{
+  const jsdomWindow = (globalThis as { jsdom?: { window?: Record<string, unknown> } }).jsdom?.window;
+  for (const key of ["localStorage", "sessionStorage"] as const) {
+    if ((globalThis as Record<string, unknown>)[key] == null && jsdomWindow?.[key] != null) {
+      (globalThis as Record<string, unknown>)[key] = jsdomWindow[key];
+    }
+  }
+}
+
 // #7075: ChatConversation wires handlePortfolioQueueChatCommand, which imports chat-action-registry →
 // governor-chokepoint → governor-ledger → node:sqlite. jsdom/Vite cannot bundle that builtin (same twin
 // pattern as chat-governor-actions.test.tsx / chat-portfolio-queue-actions.test.tsx).

--- a/apps/loopover-ui/vitest.setup.ts
+++ b/apps/loopover-ui/vitest.setup.ts
@@ -15,3 +15,20 @@ class ResizeObserverStub {
   disconnect(): void {}
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
+// #7576: Node 25+ ships a native globalThis.localStorage/sessionStorage that evaluates to `undefined`
+// (nodejs/node#60303) when no --localstorage-file is set. Because `"localStorage" in globalThis` is then
+// true, vitest's jsdom environment skips copying jsdom's own working Storage over (its getWindowKeys()
+// only copies a key that is not already present on the global), leaving window.localStorage undefined and
+// every localStorage-touching test throwing on the first `.clear()`/`.setItem()`. jsdom's real Storage is
+// still reachable via the raw JSDOM instance vitest exposes as `globalThis.jsdom`, so restore it from there
+// when the native global is broken. No-op on Node <=24 (the native global doesn't exist and jsdom's Storage
+// was copied normally), so it never affects the .nvmrc-pinned Node 22 that CI runs on.
+{
+  const jsdomWindow = (globalThis as { jsdom?: { window?: Record<string, unknown> } }).jsdom?.window;
+  for (const key of ["localStorage", "sessionStorage"] as const) {
+    if ((globalThis as Record<string, unknown>)[key] == null && jsdomWindow?.[key] != null) {
+      (globalThis as Record<string, unknown>)[key] = jsdomWindow[key];
+    }
+  }
+}


### PR DESCRIPTION
Closes #7576

## What

On Node 25+, `globalThis.localStorage`/`sessionStorage` is a native accessor that evaluates to `undefined` (nodejs/node#60303) when no `--localstorage-file` is set. Because `"localStorage" in globalThis` is then `true`, vitest's jsdom environment skips copying jsdom's own working `Storage` over (its `getWindowKeys()` only copies a key that isn't already present on the global) — so `window.localStorage` is left `undefined`, and every localStorage-touching test under `apps/loopover-ui` and `apps/loopover-miner-ui` throws on the first `.clear()`/`.setItem()`. Filed upstream as vitest-dev/vitest#8757 and closed as "non-LTS not supported" — there's no upstream fix to wait for.

The working `Storage` is still reachable via the raw JSDOM instance vitest exposes as `globalThis.jsdom`, so each app's `vitest.setup.ts` now restores `localStorage`/`sessionStorage` from `globalThis.jsdom.window` when the native global is broken.

## Why it's safe

- **No-op on Node ≤24** (the native global doesn't exist and jsdom's Storage is copied normally), so the `.nvmrc`-pinned **Node 22 that CI runs on is unaffected**.
- Verified on Node 22 locally: the localStorage suites still pass, and both `apps/loopover-ui` and `apps/loopover-miner-ui` typecheck clean (`ui:typecheck`).
- `apps/**` isn't in `coverage.include`; no behavior change to app code, only the test harness.

Mirrors the existing `globalThis.ResizeObserver ??=` jsdom-polyfill pattern already in both setup files.
