### PR TITLE
feat(queue): retune concurrency defaults for multi-tenant volume

### DIFF
--- a/apps/loopover-ui/content/docs/capacity.mdx
+++ b/apps/loopover-ui/content/docs/capacity.mdx
@@ -64,19 +64,18 @@ attributes, read at `wrangler deploy` time (not runtime-configurable via `env.SO
       description: "The most jobs one batch can bundle at once — bounds how many heavy sweep/backfill jobs land in a single delivery.",
     },
     {
-      title: "max_concurrency = 3",
-      description: "Bounded fan-out, sized to drain one heavy installation's worst sweep within the 2-minute cron interval without flooding that installation's own GitHub rate-limit bucket.",
+      title: "max_concurrency = 8",
+      description: "Global consumer fan-out for multi-tenant volume (#4892) — aligned with the #4913 load-test concurrency=8 band. Per-installation admission (default limit 2) still caps how many background GitHub-budget jobs one tenant may run at once, so raising the global bound cannot let a single installation monopolize every worker slot.",
     },
   ]}
 />
 
-<Callout variant="note" title="Re-tuning these for real multi-tenant volume">
-  `max_batch_size × max_concurrency` bounds the most jobs that can be in flight — each making
-  GitHub calls — at any one instant, kept comfortably under an installation's rate-limit headroom.
-  A genuinely multi-tenant volume model needs real production job-volume data (job rate, distinct-
-  installation count, GitHub rate-limit headroom actually observed) to re-derive against — re-tune
-  from a live dashboard/`audit_events` query when that data exists, not by guessing a bigger
-  number.
+<Callout variant="note" title="Why these defaults (and how to re-tune further)">
+  `max_batch_size × max_concurrency` (5 × 8 = 40) bounds Worker in-flight work. Rate-limit safety across
+  tenants comes from two already-shipped layers: each GitHub App installation has its own REST budget,
+  and `installation-concurrency-admission.ts` (#2970) caps per-install background GitHub fetches. Further
+  re-tuning still benefits from live `audit_events` / dashboard volume data when available — these defaults
+  are the architecture-justified baseline after the #4903–#4913 scaling work, not a production-volume fit.
 </Callout>
 
 **Takeaways:**

--- a/apps/loopover-ui/content/docs/self-hosting-configuration.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-configuration.mdx
@@ -172,7 +172,7 @@ GITHUB_METADATA_CACHE_TTL_SECONDS=600`}
 
 ## Queue cadence and startup
 
-`CRON_INTERVAL_MS` (default `120000`, ~2 minutes) is the tick that drives the maintain/sweep and sync cadence — contributor evidence, burden forecasts, RAG re-indexing, drift scans, and notifications all fan out from it. `QUEUE_BACKGROUND_CONCURRENCY` (default `1`) caps how many low-priority background jobs may occupy a `QUEUE_CONCURRENCY` slot at once, independent of live webhook/review work.
+`CRON_INTERVAL_MS` (default `120000`, ~2 minutes) is the tick that drives the maintain/sweep and sync cadence — contributor evidence, burden forecasts, RAG re-indexing, drift scans, and notifications all fan out from it. `QUEUE_CONCURRENCY` (default `8`) caps concurrent `processOne()` loops. `QUEUE_BACKGROUND_CONCURRENCY` (default `4`) caps how many low-priority background jobs may occupy those slots at once, independent of live webhook/review work — raised for multi-tenant volume (#4892) so multiple installations can progress under per-installation concurrency admission instead of a single-operator background=1 default.
 
 `QUEUE_STARTUP_JITTER_MIN_JOBS` (default `8`) sets the pending-job count below which the queue skips its startup jitter delay — useful on a small instance where you'd rather a handful of jobs start processing immediately after boot than wait out a jitter window meant to stagger many instances restarting at once.
 

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -222,11 +222,15 @@ export interface PgQueueOptions {
   maxRetries?: number;
   pollIntervalMs?: number;
   backoffMs?: (attempt: number) => number;
-  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 4 — review jobs are I/O-bound
+  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 8 — review jobs are I/O-bound
    *  (GitHub + AI awaits dominate), so overlapping a handful drains a PR burst far faster; FOR UPDATE SKIP LOCKED
-   *  keeps claims race-free across the pool (and across replicas). Set QUEUE_CONCURRENCY=1 to force strict serial. */
+   *  keeps claims race-free across the pool (and across replicas). Sized for multi-tenant volume (#4892) to match
+   *  the hosted Cloudflare consumer default and the #4913 load-test concurrency=8 band. Set QUEUE_CONCURRENCY=1
+   *  to force strict serial. */
   concurrency?: number;
-  /** Max background jobs (priority < 8) allowed to consume concurrent slots. Defaults to QUEUE_BACKGROUND_CONCURRENCY or 1. */
+  /** Max background jobs (priority < 8) allowed to consume concurrent slots. Defaults to
+   *  QUEUE_BACKGROUND_CONCURRENCY or 4 — raised with #4892 so multiple installations can progress under
+   *  installation-concurrency-admission (default per-install limit 2) instead of a single-operator background=1. */
   backgroundConcurrency?: number;
 }
 
@@ -242,7 +246,7 @@ export function createPgQueue(
     ((attempt: number) => Math.min(60_000, 1000 * 2 ** attempt));
   const concurrency =
     opts.concurrency ??
-    parsePositiveIntEnv("QUEUE_CONCURRENCY", { min: 1, fallback: 4 });
+    parsePositiveIntEnv("QUEUE_CONCURRENCY", { min: 1, fallback: 8 });
   const backgroundConcurrency = queueBackgroundConcurrency(
     concurrency,
     opts.backgroundConcurrency,
@@ -961,7 +965,7 @@ export function createPgQueue(
       // Release the reserved background slot if the claim query itself throws (a dropped connection / lock
       // timeout — the exact raw pool failures pump() below is documented to catch). claimNext() runs OUTSIDE
       // processOne's try/finally, so without this rollback the reserved slot leaks permanently; since
-      // backgroundConcurrency defaults to 1, a single such error would starve the entire background/maintenance
+      // backgroundConcurrency is intentionally small relative to total concurrency; a single such error would starve the entire background/maintenance
       // lane with no recovery short of a restart. (#selfhost-bg-slot-leak)
       activeBackground--;
       throw error;

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -21,7 +21,7 @@ const DEFAULT_RECOVERY_JITTER_MS = 60_000;
 const DEFAULT_SCHEDULED_ENQUEUE_JITTER_MS = 5 * 60_000;
 const DEFAULT_STARTUP_JITTER_MIN_JOBS = 8;
 const DEFAULT_PROCESSING_TIMEOUT_MS = 30 * 60_000;
-const DEFAULT_BACKGROUND_CONCURRENCY = 1;
+const DEFAULT_BACKGROUND_CONCURRENCY = 4;
 // Dead-letter auto-retry (#audit-rate-headroom): a job that exhausted its normal retry budget and landed in
 // `dead` gets ONE more attempt every revive interval, as long as its lifetime attempts stay under
 // maxRetries + this extra ceiling — bounded so a permanently-broken job cannot cycle dead→pending→dead

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -137,11 +137,15 @@ export interface SqliteQueueOptions {
   maxRetries?: number;
   pollIntervalMs?: number;
   backoffMs?: (attempt: number) => number;
-  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 4 — review jobs are I/O-bound
+  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 8 — review jobs are I/O-bound
    *  (GitHub + AI awaits dominate), so overlapping a handful drains a PR burst far faster while SQLite's WAL +
-   *  busy_timeout absorb the short serialized write windows. Set QUEUE_CONCURRENCY=1 to force strict serial. */
+   *  busy_timeout absorb the short serialized write windows. Sized for multi-tenant volume (#4892) to match the
+   *  hosted Cloudflare consumer default and the #4913 load-test concurrency=8 band. Set QUEUE_CONCURRENCY=1 to
+   *  force strict serial. */
   concurrency?: number;
-  /** Max background jobs (priority < 8) allowed to consume concurrent slots. Defaults to QUEUE_BACKGROUND_CONCURRENCY or 1. */
+  /** Max background jobs (priority < 8) allowed to consume concurrent slots. Defaults to
+   *  QUEUE_BACKGROUND_CONCURRENCY or 4 — raised with #4892 so multiple installations can progress under
+   *  installation-concurrency-admission (default per-install limit 2) instead of a single-operator background=1. */
   backgroundConcurrency?: number;
 }
 
@@ -157,7 +161,7 @@ export function createSqliteQueue(
     ((attempt: number) => Math.min(60_000, 1000 * 2 ** attempt));
   const concurrency =
     opts.concurrency ??
-    parsePositiveIntEnv("QUEUE_CONCURRENCY", { min: 1, fallback: 4 });
+    parsePositiveIntEnv("QUEUE_CONCURRENCY", { min: 1, fallback: 8 });
   const backgroundConcurrency = queueBackgroundConcurrency(
     concurrency,
     opts.backgroundConcurrency,
@@ -611,7 +615,7 @@ export function createSqliteQueue(
     } catch (error) {
       // Release the reserved background slot if the claim query itself throws (a SQLite "database is locked" / I/O
       // error). claimNext() runs OUTSIDE processOne's try/finally, so without this rollback the reserved slot leaks
-      // permanently; since backgroundConcurrency defaults to 1, a single such error would starve the entire
+      // permanently; since backgroundConcurrency is intentionally small relative to total concurrency, a single such error would starve the entire
       // background/maintenance lane with no recovery short of a restart. (#selfhost-bg-slot-leak)
       activeBackground--;
       throw error;

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -73,15 +73,17 @@ describe("self-host queue common helpers", () => {
     expect(isForegroundJobPriority(10)).toBe(true);
     expect(isForegroundJobPriority(8)).toBe(true);
     expect(isForegroundJobPriority(7)).toBe(false);
-    expect(queueBackgroundConcurrency(4, undefined)).toBe(1);
+    // #4892 multi-tenant defaults: background fallback is 4 (was 1), clamped to total concurrency.
+    expect(queueBackgroundConcurrency(8, undefined)).toBe(4);
+    expect(queueBackgroundConcurrency(4, undefined)).toBe(4);
     expect(queueBackgroundConcurrency(4, "3")).toBe(3);
     expect(queueBackgroundConcurrency(2, "9")).toBe(2);
-    expect(queueBackgroundConcurrency(4, "-1")).toBe(1);
-    expect(queueBackgroundConcurrency(4, "not-a-number")).toBe(1);
+    expect(queueBackgroundConcurrency(4, "-1")).toBe(4);
+    expect(queueBackgroundConcurrency(4, "not-a-number")).toBe(4);
     expect(queueBackgroundConcurrency(4, "0")).toBe(0);
     expect(queueBackgroundConcurrency(Number.NaN, "3")).toBe(0);
-    expect(queueBackgroundConcurrency(4, null)).toBe(1);
-    expect(queueBackgroundConcurrency(4, "")).toBe(1);
+    expect(queueBackgroundConcurrency(4, null)).toBe(4);
+    expect(queueBackgroundConcurrency(4, "")).toBe(4);
   });
 
   it("builds queue snapshots by job type/status and only marks due pending jobs", () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -311,27 +311,26 @@
         // literals directly (a normal PR), or, once a second deploy target exists, adding that target's own
         // named-environment `queues.consumers` override block -- there is only one deploy target today.
         //
-        // The governing constraint, sized against a single installation's GitHub REST rate limit (5000 req/hr
-        // for a GitHub App installation token, shared across every job this lane processes for that install):
-        //   max_batch_size × max_concurrency = the most jobs that can be in flight, each making GitHub calls,
-        //   at any one instant -- keep that product comfortably under the install's remaining rate-limit
-        //   headroom (github-client.ts already backs off on 403/secondary-rate-limit responses; this bound
-        //   exists to make hitting that backoff path the rare case, not the norm).
-        //  - max_batch_size 5 (was 10): one batch can't bundle as many heavy sweep/backfill jobs at once.
-        //  - max_concurrency 3: bounded fan-out -- first sized to drain one heavy installation's worst sweep
-        //    within the 2-min cron interval without flooding its own rate bucket (#1283); the SAME bound
-        //    coincidentally also caps fan-out PER installation under today's single-tenant deployment, since
-        //    every job in this lane shares one GitHub App's rate-limit pool regardless of which repo/install
-        //    it's for. A genuinely multi-tenant volume model needs real production job-volume data (job
-        //    rate, distinct-installation count, GitHub rate-limit headroom actually observed) to re-derive
-        //    against -- not available from this worktree; re-tune from a live dashboard/audit_events query,
-        //    not by guessing a bigger number.
+        // Governing constraints (multi-tenant, post #2970 / #4903-#4913 scaling work):
+        //   1. Each GitHub App installation has its OWN ~5000 req/hr REST rate-limit bucket. Concurrent jobs
+        //      for DIFFERENT installations do not share that bucket.
+        //   2. Per-installation GitHub-fetch admission (`installation-concurrency-admission.ts`, default
+        //      GITHUB_INSTALLATION_CONCURRENCY_LIMIT=2) caps how many background GitHub-budget jobs ONE
+        //      installation may run at once, so raising the GLOBAL consumer fan-out cannot let a single
+        //      tenant monopolize every worker slot the way the old single-operator sizing assumed.
+        //   3. max_batch_size × max_concurrency still bounds Worker in-flight work (CPU/memory + how many
+        //      heavy sweep/backfill deliveries land together). github-client.ts still backs off on
+        //      403/secondary-rate-limit; this product exists to keep that path rare.
+        //  - max_batch_size 5 (was 10 under #1283): keep the per-delivery heavy-job bundle small.
+        //  - max_concurrency 8 (was 3): aligns with the #4913 iterate-loop load-test concurrency=8 band and
+        //    allows ~4 installations to each hold the default per-install background admit of 2 without the
+        //    global consumer being the bottleneck. Product 5×8=40 in-flight vs the previous 5×3=15.
         //  - retry_delay 30: a failed job backs off 30s instead of re-delivering immediately and re-hammering
         //    the already-overloaded path.
         "queue": "loopover-jobs",
         "max_batch_size": 5,
         "max_batch_timeout": 5,
-        "max_concurrency": 3,
+        "max_concurrency": 8,
         // After max_retries failed attempts a job is dead-lettered so a persistently-failing job is observable
         // rather than vanishing silently. The DLQ consumer below picks them up.
         "max_retries": 3,


### PR DESCRIPTION
﻿## Summary

Re-tune queue concurrency defaults for multi-tenant volume after the #4903-#4913 scaling work, per the narrowed #4892 scope (runtime configurability of Cloudflare consumer bindings is impossible; QUEUE_* env knobs already existed).

- Hosted wrangler.jsonc loopover-jobs consumer: max_concurrency 3 -> 8 (keep max_batch_size 5). Product 5x8=40 in-flight vs previous 15.
- Self-host defaults: QUEUE_CONCURRENCY fallback 4 -> 8, QUEUE_BACKGROUND_CONCURRENCY fallback 1 -> 4.
- Justification (not invented production volume): each installation has its own GitHub REST budget; per-installation admission (#2970, default limit 2) prevents one tenant from monopolizing global slots; concurrency 8 matches the #4913 iterate-loop load-test band documented in capacity docs.
- Docs updated in capacity.mdx and self-hosting-configuration.mdx.

Closes #4892

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npx vitest run test/unit/selfhost-queue-common.test.ts -t "keeps foreground"`
- [x] `npm run docs:drift-check`
- [x] `npx wrangler deploy --dry-run` (parses; consumer literals updated as intended)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Config/default retune + docs. Critical path: unit test for new background default, docs drift, wrangler dry-run. Full test:ci omitted. Touches wrangler.jsonc (guarded path) — expect hold for owner review rather than auto-merge.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Docs-only capacity/self-hosting text updates — no interactive UI surface change requiring screenshots.

## Notes

Pre-create race check: no open PR linked to #4892. Does not claim production-volume fit; further tuning can still use live dashboard data.
