### PR TITLE
fix(ui): stop renderInline from italicizing intraword underscores in the Commands panel

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BotReply } from "@/components/site/app-panels/commands-panel";
+
+describe("BotReply renderInline underscore handling (#7531)", () => {
+  it("REGRESSION: renders underscore-heavy identifiers verbatim, without italicizing an intraword fragment", () => {
+    const { container } = render(
+      <BotReply
+        boundary="public"
+        body="Use LOOPOVER_ENABLE_PAGERDUTY to opt in, and set repo_full_name accordingly."
+      />,
+    );
+    // Every underscore in the identifiers survives...
+    expect(container.textContent).toContain("LOOPOVER_ENABLE_PAGERDUTY");
+    expect(container.textContent).toContain("repo_full_name");
+    // ...and no intraword fragment was turned into an <em> (the pre-fix bug italicized "_ENABLE_"/"_full_").
+    expect(container.querySelector("em")).toBeNull();
+  });
+
+  it("still italicizes a genuine word-boundary _italic_ span", () => {
+    const { container } = render(
+      <BotReply boundary="public" body="This is _important_ context." />,
+    );
+    expect(container.querySelector("em")?.textContent).toBe("important");
+    // The underscores are stripped only for the genuine italic span; the surrounding text is intact.
+    expect(container.textContent).toContain("This is important context.");
+  });
+
+  it("leaves **bold** and `code` matching unchanged", () => {
+    const { container } = render(<BotReply boundary="public" body="Use **run** or `queue` now." />);
+    expect(container.querySelector("strong")?.textContent).toBe("run");
+    expect(container.querySelector("code")?.textContent).toBe("queue");
+    expect(container.querySelector("em")).toBeNull();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/commands-panel.tsx
@@ -228,7 +228,13 @@ function Comment({ author, body, muted }: { author: string; body: string; muted?
   );
 }
 
-function BotReply({ boundary, body }: { boundary: CommandSample["boundary"]; body: string }) {
+export function BotReply({
+  boundary,
+  body,
+}: {
+  boundary: CommandSample["boundary"];
+  body: string;
+}) {
   const isPrivate = boundary !== "public";
   return (
     <div
@@ -268,7 +274,11 @@ function BotReply({ boundary, body }: { boundary: CommandSample["boundary"]; bod
 }
 
 function renderInline(line: string) {
-  const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`|_[^_]+_)/g).filter(Boolean);
+  // The `_..._` italics alternative is anchored to word boundaries (`(?<!\w)`/`(?!\w)`) so it only emphasizes a
+  // genuine `_word_` span and never an underscore run inside an identifier (#7531) — command/config vocabulary
+  // like `LOOPOVER_ENABLE_PAGERDUTY` or `repo_full_name` must render verbatim, not with fragments italicized and
+  // the underscores stripped. Matches CommonMark's intraword-underscore rule. `**bold**`/`` `code` `` unchanged.
+  const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`|(?<!\w)_[^_]+_(?!\w))/g).filter(Boolean);
   return parts.map((part, index) => {
     if (part.startsWith("**") && part.endsWith("**"))
       return <strong key={index}>{part.slice(2, -2)}</strong>;


### PR DESCRIPTION
## Summary

`renderInline`'s markdown-lite splitter used `_[^_]+_` for italics with no word-boundary anchor, so it matched any underscore-bounded substring anywhere in a line — including inside a longer identifier with more than one underscore. This codebase's command/config vocabulary is full of that shape (`LOOPOVER_ENABLE_PAGERDUTY`, `repo_full_name`, …), so a bot-reply preview line mentioning one rendered a fragment as `<em>` and **dropped the underscores**, corrupting the identifier (#7531).

**Fix:** anchor the italics alternative to word boundaries — `(?<!\w)_[^_]+_(?!\w)` — matching CommonMark's intraword-underscore rule (`_` only creates emphasis when not flanked by a word character). A genuine `_word_` span still italicizes; `**bold**` and `\`code\`` are untouched.

## Tests

Adds `commands-panel.test.tsx` (none existed). `BotReply` is exported so the test asserts rendering directly: underscore-heavy identifiers render verbatim with no `<em>`, a genuine `_italic_` span still emphasizes, and bold/code are unchanged.

## UI Evidence

Commands panel (`/app/commands`) bot-reply preview, dark theme (loopover-ui is a dark-mode-only build — no light theme to capture). **Before**, `LOOPOVER_ENABLE_PAGERDUTY` renders as "LOOPOVER*ENABLE*PAGERDUTY" (fragment italicized, underscores dropped) and `repo_full_name` is mangled the same way; **after**, both render verbatim.

| Viewport · Dark | Before | After |
|---|---|---|
| Desktop | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-desktop-before.png" target="_blank" rel="noopener"><img width="360" alt="before Desktop" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-desktop-before.png"></a> | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-desktop-after.png" target="_blank" rel="noopener"><img width="360" alt="after Desktop" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-desktop-after.png"></a> |
| Tablet | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-tablet-before.png" target="_blank" rel="noopener"><img width="360" alt="before Tablet" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-tablet-before.png"></a> | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-tablet-after.png" target="_blank" rel="noopener"><img width="360" alt="after Tablet" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-tablet-after.png"></a> |
| Mobile | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-mobile-before.png" target="_blank" rel="noopener"><img width="200" alt="before Mobile" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-mobile-before.png"></a> | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-mobile-after.png" target="_blank" rel="noopener"><img width="200" alt="after Mobile" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7531/shots/commands-mobile-after.png"></a> |

## Validation

- [x] `@loopover/ui` typecheck, lint (prettier-clean), test (411 pass incl. the new suite), build, and version-audit all green; rebased onto latest `main`

Closes #7531
