### PR TITLE
fix(ui): give four app-panel form controls a programmatic accessible name

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/digest-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/digest-panel.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Drive the digest resource straight to a ready state so the SubscribeForm renders.
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: () => useApiResource(),
+}));
+vi.mock("@/lib/api/request", () => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+useApiResource.mockReturnValue({
+  status: "ready",
+  data: {
+    date: "2026-07-20",
+    signal: "ready",
+    items: [{ kind: "summary", title: "One update", detail: "Detail" }],
+    subscriptions: [],
+    delivery: { mode: "store_only", emailDeliveryEnabled: false },
+  },
+  reload: () => {},
+  error: null,
+  errorKind: undefined,
+  loadedAt: Date.now(),
+});
+
+import { DigestPanel } from "@/components/site/app-panels/digest-panel";
+
+describe("DigestPanel subscribe form accessible name (#7532)", () => {
+  it("exposes the email input by its aria-label", () => {
+    render(<DigestPanel />);
+    expect(screen.getByLabelText(/digest notification email/i)).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/digest-panel.tsx
@@ -216,6 +216,7 @@ function SubscribeForm({ subscribed, onStored }: { subscribed: boolean; onStored
       <Input
         type="email"
         required
+        aria-label="Digest notification email"
         placeholder="you@maintainer.dev"
         value={email}
         onChange={(event) => setEmail(event.target.value)}

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the API layer so the settings + focus-manifest loads resolve without a network.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
+
+describe("MaintainerSettings focus-manifest editor accessible name (#7532)", () => {
+  it("exposes the focus-manifest textarea by its aria-label once settings load", async () => {
+    apiFetch.mockImplementation((url: string) => {
+      if (url.endsWith("/focus-manifest")) {
+        return Promise.resolve({ ok: true, data: { manifest: { wanted: [] } } });
+      }
+      // /settings
+      return Promise.resolve({ ok: true, data: { autoLabelEnabled: false } });
+    });
+
+    render(<MaintainerSettings reviewability={[{ pr: "acme/widgets#1" }]} />);
+
+    expect(await screen.findByRole("textbox", { name: /focus manifest/i })).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -573,6 +573,7 @@ function FocusManifestEditor({ base }: { base: string | null }) {
         expectations, and gate overrides. Mirrors <code className="font-mono">.loopover.yml</code>.
       </p>
       <textarea
+        aria-label="Focus manifest editor"
         value={loading ? "Loading…" : text}
         onChange={(event) => setText(event.target.value)}
         readOnly={loading}

--- a/apps/loopover-ui/src/components/site/app-panels/owner-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/owner-panel.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub the data hook so the panel never touches the network; the Repository input
+// renders above the state boundary regardless of resource status.
+const { useApiResource } = vi.hoisted(() => ({ useApiResource: vi.fn() }));
+vi.mock("@/lib/api/use-api-resource", () => ({
+  useApiResource: () => useApiResource(),
+}));
+useApiResource.mockReturnValue({
+  status: "loading",
+  data: null,
+  reload: () => {},
+  reject: () => {},
+  error: null,
+  errorKind: undefined,
+  loadedAt: null,
+});
+
+import { OwnerPanel } from "@/components/site/app-panels/owner-panel";
+
+describe("OwnerPanel accessible name (#7532)", () => {
+  it("exposes the Repository input by its label's accessible name", () => {
+    render(<OwnerPanel />);
+    expect(screen.getByLabelText(/repository/i)).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/owner-panel.tsx
@@ -83,10 +83,14 @@ export function OwnerPanel() {
             </p>
           </div>
           <div className="w-full sm:w-64">
-            <label className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            <label
+              htmlFor="owner-repo"
+              className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground"
+            >
               Repository
             </label>
             <Input
+              id="owner-repo"
               value={repo}
               onChange={(e) => setRepo(e.target.value)}
               className="mt-1 font-mono text-token-xs"

--- a/apps/loopover-ui/src/components/site/app-panels/playground-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/playground-panel.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Keep the panel off the network — useSession()/live runs both go through apiFetch.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+apiFetch.mockResolvedValue({ ok: true, data: { status: "signed_out" } });
+
+import { PlaygroundPanel } from "@/components/site/app-panels/playground-panel";
+
+describe("PlaygroundPanel accessible names (#7532)", () => {
+  it("exposes the Tool, Repo, and Branch controls by their label accessible names", () => {
+    render(<PlaygroundPanel />);
+    expect(screen.getByRole("combobox", { name: /tool/i })).toBeTruthy();
+    expect(screen.getByRole("textbox", { name: /repo/i })).toBeTruthy();
+    expect(screen.getByRole("textbox", { name: /branch/i })).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/components/site/app-panels/playground-panel.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/playground-panel.tsx
@@ -213,10 +213,14 @@ export function PlaygroundPanel({ defaultTool = "preflight-branch" }: { defaultT
       <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)_240px]">
         <div className="space-y-4 rounded-token border-hairline bg-card p-5">
           <div>
-            <label className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            <label
+              htmlFor="playground-tool"
+              className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground"
+            >
               Tool
             </label>
             <select
+              id="playground-tool"
               value={tool}
               onChange={(e) => setTool(e.target.value as Tool)}
               className="mt-1 w-full rounded-token border-hairline bg-background/60 px-2 py-1.5 text-token-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
@@ -229,20 +233,28 @@ export function PlaygroundPanel({ defaultTool = "preflight-branch" }: { defaultT
             </select>
           </div>
           <div>
-            <label className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            <label
+              htmlFor="playground-repo"
+              className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground"
+            >
               Repo
             </label>
             <input
+              id="playground-repo"
               value={repo}
               onChange={(e) => setRepo(e.target.value)}
               className="mt-1 w-full rounded-token border-hairline bg-background/60 px-2 py-1.5 font-mono text-token-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
             />
           </div>
           <div>
-            <label className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            <label
+              htmlFor="playground-branch"
+              className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground"
+            >
               Branch
             </label>
             <input
+              id="playground-branch"
               value={branch}
               onChange={(e) => setBranch(e.target.value)}
               className="mt-1 w-full rounded-token border-hairline bg-background/60 px-2 py-1.5 font-mono text-token-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"


### PR DESCRIPTION
## Summary

Four form controls across the owner / playground / maintainer-settings / digest app panels had no programmatic accessible name — a sibling (non-associated) `<label>` or none at all — so a screen reader announced them with no name (WCAG 3.3.2 / 4.1.2). Fixed with association attributes only:

- **owner-panel** — `htmlFor="owner-repo"` on the Repository label + matching `id` on the Input.
- **playground-panel** — `htmlFor`/`id` pairs for the Tool select, Repo input, and Branch input.
- **maintainer-settings** (FocusManifestEditor) — `aria-label="Focus manifest editor"` on the JSON textarea.
- **digest-panel** (SubscribeForm) — `aria-label="Digest notification email"` on the email input.

**Zero visual diff:** these are association-attribute-only changes — no layout, style, text, or DOM-nesting change — so nothing rendered changes; the controls only gain a programmatic name.

## Tests

Adds one regression test per file (none existed), each asserting the fixed control is reachable by its accessible name via Testing Library `getByLabelText` / `getByRole({ name })` — a real guard against the name regressing.

## UI Evidence

Playground panel (`/app/playground`), dark theme (loopover-ui is a dark-mode-only build — no light theme to capture). The affected Tool / Repo / Branch controls are the labeled fields in the left column. Because the change is attribute-only, **before and after are pixel-identical by design** — that is the point of the fix: it adds a programmatic accessible name with no visual change.

| Viewport × Theme | Before | After |
|---|---|---|
| Desktop · Dark | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-desktop-before.png" target="_blank" rel="noopener"><img width="360" alt="Desktop · Dark before" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-desktop-before.png"></a> | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-desktop-after.png" target="_blank" rel="noopener"><img width="360" alt="Desktop · Dark after" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-desktop-after.png"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-tablet-before.png" target="_blank" rel="noopener"><img width="360" alt="Tablet · Dark before" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-tablet-before.png"></a> | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-tablet-after.png" target="_blank" rel="noopener"><img width="360" alt="Tablet · Dark after" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-tablet-after.png"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-mobile-before.png" target="_blank" rel="noopener"><img width="200" alt="Mobile · Dark before" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-mobile-before.png"></a> | <a href="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-mobile-after.png" target="_blank" rel="noopener"><img width="200" alt="Mobile · Dark after" src="https://raw.githubusercontent.com/xfodev/loopover/screenshots-7532/shots/playground-mobile-after.png"></a> |

## Validation

- [x] `@loopover/ui` typecheck, lint (0 errors), test (163 panel tests pass incl. the 4 new a11y suites), build, and version-audit all green; rebased onto latest `main`

Closes #7532
