### PR TITLE
fix(test): pin miner-ui jsdom localStorage over Node 26's broken global

### DIFF
--- a/apps/loopover-miner-ui/vitest.setup.ts
+++ b/apps/loopover-miner-ui/vitest.setup.ts
@@ -16,6 +16,25 @@ class ResizeObserverStub {
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 
+// Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
+// returns undefined unless the process was started with --localstorage-file. Because that property already
+// *exists* on globalThis before jsdom's env is installed, Vitest's populateGlobal skips copying jsdom's
+// working Storage over it, so any bare `localStorage.*` call (theme-toggle.test.tsx, mirroring
+// theme-toggle.tsx:39) throws "Cannot read properties of undefined". jsdom's real Storage still lives on the
+// raw JSDOM window (globalThis.jsdom.window, which is a distinct object from the `window`/globalThis alias);
+// point the global at it unconditionally -- a no-op on Node 22/24 where globalThis.localStorage already *is*
+// this object, and the actual fix on Node 26+. A `??=` guard would not help (the broken accessor already
+// counts as "present"); the property is configurable so redefining it is safe.
+const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom?.window
+  ?.localStorage;
+if (jsdomLocalStorage) {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: jsdomLocalStorage,
+    configurable: true,
+    writable: true,
+  });
+}
+
 // #7075: ChatConversation wires handlePortfolioQueueChatCommand, which imports chat-action-registry →
 // governor-chokepoint → governor-ledger → node:sqlite. jsdom/Vite cannot bundle that builtin (same twin
 // pattern as chat-governor-actions.test.tsx / chat-portfolio-queue-actions.test.tsx).


### PR DESCRIPTION
fix(test): pin miner-ui jsdom localStorage over Node 26's broken global

Node 26 predefines an experimental globalThis.localStorage accessor
(nodejs/node#60303) that returns undefined without --localstorage-file.
It exists on globalThis before jsdom's environment is installed, so
Vitest's populateGlobal skips copying jsdom's working Storage over it and
every bare localStorage call (theme-toggle.test.tsx, mirroring
theme-toggle.tsx) throws under Node 26 while passing on Node 22/24.

Point globalThis.localStorage at jsdom's real Storage from the raw JSDOM
window unconditionally: a no-op where the global already is that object,
the fix on Node 26+. A ??= guard would keep the broken accessor since it
already counts as present.

Closes #7592

