### PR TITLE
fix(review): retry an empty inline files fetch before trusting it

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2416,6 +2416,17 @@ function toPullRequestFileRecordFromGitHub(repoFullName: string, pullNumber: num
   };
 }
 
+// A brand-new or just-pushed PR can have GitHub return a clean, successful EMPTY files list because its diff
+// isn't computed yet — not a rate limit (the shared client in ./client.ts already retries those), so this
+// single short retry is the only thing standing between that timing gap and a permanently-empty diff. An empty
+// changedPaths list is what makes isGuardrailHit fail-safe to "hit" (#1062), and that manual-review hold, once
+// applied, is never auto-removed (agent-actions.ts's #stale-disposition-label-cleanup deliberately leaves
+// manualReview alone — it might be a human's own hold, not just a stale bot one) — so a guardrail-configured
+// repo's PR could otherwise sit "held for manual review" indefinitely over nothing but a fetch timing gap.
+const REVIEW_FILES_EMPTY_RETRY_DELAY_MS = 500;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Inline, best-effort file fetch for the REVIEW path (convergence). The PR-opened webhook can fire the review
  * BEFORE the async detail-sync has populated `pull_request_files`, leaving the AI review + grounding + unified
@@ -2423,6 +2434,10 @@ function toPullRequestFileRecordFromGitHub(repoFullName: string, pullNumber: num
  * time, the caller falls back here: fetch the PR's files straight from GitHub (REST → GraphQL, same paths the
  * detail-sync uses), persist them (so the rest of the same review run + any later read reuse them), and return
  * them mapped to the stored record shape.
+ *
+ * An empty first attempt is retried once, after a short delay (see {@link REVIEW_FILES_EMPTY_RETRY_DELAY_MS}),
+ * before being accepted — GitHub's own diff computation lagging a just-created/just-pushed PR is common enough
+ * that a single retry converts most of these into a real diff.
  *
  * Fail-safe by construction: a fetch failure returns `[]` (never throws), so the review degrades to the same
  * empty-diff state it has today rather than breaking. The persist is best-effort and only runs when the fetch
@@ -2436,7 +2451,12 @@ export async function fetchAndStorePullRequestFilesForReview(
   admissionKey?: GitHubRateLimitAdmissionKey,
 ): Promise<PullRequestFileRecord[]> {
   const warnings: string[] = [];
-  const files = await fetchPullRequestFiles(env, repoFullName, pullNumber, token, warnings, admissionKey, "live_review").catch(() => [] as GitHubFilePayload[]);
+  const fetchOnce = () => fetchPullRequestFiles(env, repoFullName, pullNumber, token, warnings, admissionKey, "live_review").catch(() => [] as GitHubFilePayload[]);
+  let files = await fetchOnce();
+  if (files.length === 0) {
+    await sleep(REVIEW_FILES_EMPTY_RETRY_DELAY_MS);
+    files = await fetchOnce();
+  }
   if (files.length === 0) return [];
   const records = files.map((file) => toPullRequestFileRecordFromGitHub(repoFullName, pullNumber, file));
   // Persist so the AI review, grounding, gate, check-run, and unified-comment reads in THIS run (and any later

--- a/test/unit/backfill-2.test.ts
+++ b/test/unit/backfill-2.test.ts
@@ -188,6 +188,42 @@ describe("GitHub backfill", () => {
       vi.stubGlobal("fetch", async () => new Response("boom", { status: 500 }));
       await expect(fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 99, "public-token")).resolves.toEqual([]);
     });
+
+    it("REGRESSION (#stale-disposition-label-cleanup / guardrail false-positive): retries once and recovers when GitHub's first response is empty because the diff isn't computed yet", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      let filesCalls = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/pulls/55/files")) {
+          filesCalls += 1;
+          if (filesCalls === 1) return Response.json([]);
+          return Response.json([{ filename: "src/bar.ts", status: "modified", additions: 3, deletions: 1, changes: 4, patch: "@@ -1 +1 @@\n-old\n+new" }]);
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const records = await fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 55, "public-token");
+      expect(filesCalls).toBe(2);
+      expect(records.map((r) => r.path)).toEqual(["src/bar.ts"]);
+      // Persisted from the SECOND (successful) attempt — a subsequent stored read reuses it.
+      expect((await listPullRequestFiles(env, "JSONbored/gittensory", 55)).map((r) => r.path)).toEqual(["src/bar.ts"]);
+    });
+
+    it("retries exactly once, not repeatedly, when both attempts come back empty", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      let filesCalls = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/pulls/56/files")) {
+          filesCalls += 1;
+          return Response.json([]);
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      await expect(fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 56, "public-token")).resolves.toEqual([]);
+      expect(filesCalls).toBe(2);
+    });
   });
 
   describe("fetchLiveCiAggregate", () => {


### PR DESCRIPTION
## Summary

- `fetchAndStorePullRequestFilesForReview` could accept a single empty GitHub files response as final, but GitHub can legitimately return a clean, successful, empty list for a PR whose diff it hasn't finished computing yet (common right after a PR is opened or pushed) — not a rate limit, so the existing retry in `src/github/client.ts` never sees it.
- That empty result trips `isGuardrailHit`'s deliberate fail-safe (empty changed-files → treat as a guardrail hit), which applies the `manual-review` label — and by design (`#stale-disposition-label-cleanup` in `agent-actions.ts`), that label is never auto-removed once applied, since the planner can't tell a bot-applied guardrail hold apart from a maintainer's own manual hold on the same label. So a single transient empty-files read can permanently lock an otherwise-clean PR into "held for manual review" until a human notices.
- Traced live to several JSONbored/awesome-claude PRs that sat held 8-9+ hours despite their actual changed files never touching any configured `hardGuardrailGlobs`.
- Fix: retry the inline files fetch once, after a short delay, when the first attempt comes back empty, before accepting it. Doesn't touch the fail-safe itself (a genuinely persistent failure still degrades to `[]`) or the "never auto-remove manualReview" invariant (left alone, intentionally) — it just makes the empty result far less likely to be a false positive.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

-

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only change (`src/github/backfill.ts`, `test/unit/backfill-2.test.ts`), no visible UI/frontend/docs surface.

## Notes

- Closes #7599
