### PR TITLE
fix(test): restore jsdom Web Storage in UI vitest setups on Node 25+

### DIFF
--- a/apps/loopover-miner-ui/vitest.setup.ts
+++ b/apps/loopover-miner-ui/vitest.setup.ts
@@ -16,6 +16,23 @@ class ResizeObserverStub {
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 
+// #7576: restore jsdom's Web Storage on Node 25+ -- same fix as apps/loopover-ui/vitest.setup.ts, and
+// needed independently here because `theme-toggle.test.tsx` reads localStorage. Node 25 shipped a native
+// `globalThis.localStorage` that evaluates to `undefined` without `--localstorage-file`
+// (nodejs/node#60303), and vitest's jsdom environment then skips copying jsdom's real Storage because the
+// key already "exists" (vitest-dev/vitest#8757, closed as non-LTS-unsupported). Reachable via the raw
+// JSDOM instance vitest exposes as `globalThis.jsdom`. No-op on Node <=24, where the key is absent and
+// jsdom's Storage is copied normally.
+const jsdomWindow = (globalThis as { jsdom?: { window?: Record<string, unknown> } }).jsdom?.window;
+for (const storageKey of ["localStorage", "sessionStorage"] as const) {
+  if (globalThis[storageKey] !== undefined || jsdomWindow?.[storageKey] === undefined) continue;
+  Object.defineProperty(globalThis, storageKey, {
+    value: jsdomWindow[storageKey],
+    configurable: true,
+    writable: true,
+  });
+}
+
 // #7075: ChatConversation wires handlePortfolioQueueChatCommand, which imports chat-action-registry →
 // governor-chokepoint → governor-ledger → node:sqlite. jsdom/Vite cannot bundle that builtin (same twin
 // pattern as chat-governor-actions.test.tsx / chat-portfolio-queue-actions.test.tsx).

--- a/apps/loopover-ui/src/lib/jsdom-web-storage.test.ts
+++ b/apps/loopover-ui/src/lib/jsdom-web-storage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * #7576: a canary for the jsdom test environment's Web Storage, not for app code.
+ *
+ * Node 25 shipped a native `globalThis.localStorage` that evaluates to `undefined` unless
+ * `--localstorage-file` is passed (nodejs/node#60303). Vitest's jsdom environment then skips copying
+ * jsdom's real `Storage` over, because the key already appears to exist (vitest-dev/vitest#8757, closed
+ * as "non-LTS is not supported"). `vitest.setup.ts` restores it from the raw JSDOM instance.
+ *
+ * `.nvmrc` pins Node 22 today, so this passes trivially on CI. Its job is to fail loudly the moment that
+ * pin moves past Node 24 with the shim removed or broken, instead of every localStorage-touching suite
+ * failing with an opaque `Cannot read properties of undefined (reading 'clear')`.
+ */
+describe("jsdom Web Storage availability (#7576)", () => {
+  it.each(["localStorage", "sessionStorage"] as const)("exposes a working window.%s", (key) => {
+    const storage = window[key];
+
+    expect(storage).toBeDefined();
+    expect(typeof storage.setItem).toBe("function");
+    expect(typeof storage.getItem).toBe("function");
+    expect(typeof storage.clear).toBe("function");
+
+    storage.clear();
+    storage.setItem("loopover.canary", "ok");
+    expect(storage.getItem("loopover.canary")).toBe("ok");
+    storage.clear();
+    expect(storage.getItem("loopover.canary")).toBeNull();
+  });
+
+  it("resolves the bare global to the same Storage as the window property", () => {
+    // The failure mode this guards is a global that exists but is undefined, so assert both handles
+    // agree rather than only checking `window`.
+    expect(globalThis.localStorage).toBe(window.localStorage);
+    expect(globalThis.sessionStorage).toBe(window.sessionStorage);
+  });
+});

--- a/apps/loopover-ui/vitest.setup.ts
+++ b/apps/loopover-ui/vitest.setup.ts
@@ -15,3 +15,23 @@ class ResizeObserverStub {
   disconnect(): void {}
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
+// #7576: restore jsdom's Web Storage on Node 25+. Node 25 shipped a native `globalThis.localStorage`
+// that evaluates to `undefined` unless `--localstorage-file` is passed (nodejs/node#60303, still open).
+// Vitest's jsdom environment copies a window key onto the test global only when that key is in its
+// static allowlist OR not already present on `global`; `localStorage`/`sessionStorage` are in neither
+// list, so on Node <=24 (where the key is absent) jsdom's real Storage is copied over, but on Node 25+
+// the key IS present -- Node's own broken accessor -- and the copy is skipped, leaving `undefined`
+// behind. Reported upstream as vitest-dev/vitest#8757 and closed as "non-LTS is not supported", so
+// there is no fix to wait for. jsdom's working Storage is still reachable via the raw JSDOM instance
+// vitest exposes as `globalThis.jsdom`, which needs no Node CLI flags (the suggested flag workarounds
+// are unrecognized by the Node 22 that `.nvmrc` pins, so they would break CI). No-op on Node <=24.
+const jsdomWindow = (globalThis as { jsdom?: { window?: Record<string, unknown> } }).jsdom?.window;
+for (const storageKey of ["localStorage", "sessionStorage"] as const) {
+  if (globalThis[storageKey] !== undefined || jsdomWindow?.[storageKey] === undefined) continue;
+  Object.defineProperty(globalThis, storageKey, {
+    value: jsdomWindow[storageKey],
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION
## Problem

Node 25 shipped a native `globalThis.localStorage` that evaluates to `undefined` unless `--localstorage-file` is passed ([nodejs/node#60303](https://github.com/nodejs/node/issues/60303), still open). Vitest's jsdom environment copies a window key onto the test global only when that key is in its static allowlist **or not already present** — `localStorage`/`sessionStorage` are in neither. So on Node ≤24 jsdom's real `Storage` is copied over, but on Node 25+ the key already exists (Node's broken accessor) and the copy is skipped, leaving `undefined`.

Result: all 6 storage-touching suites in `loopover-ui` and `theme-toggle.test.tsx` in `loopover-miner-ui` throw `Cannot read properties of undefined (reading 'clear')`. Reported upstream as [vitest-dev/vitest#8757](https://github.com/vitest-dev/vitest/issues/8757) and closed as "non-LTS is not supported", so there is no upstream fix to wait for. `.nvmrc` pins Node 22, so CI is unaffected today — this is a make-local-dev-work fix that becomes CI-breaking the moment `.nvmrc` moves past Node 24.

## Fix

Restore jsdom's Storage from the raw JSDOM instance vitest exposes as `globalThis.jsdom` — no Node CLI flags (the flag workarounds are unrecognized by the pinned Node 22, so they would break CI). Uses `Object.defineProperty` rather than direct assignment, since the DOM lib types `localStorage` as read-only. A strict no-op on Node ≤24, where the key is absent and jsdom's Storage was already copied.

## Verification

Node 22 is what `.nvmrc` pins and what I have locally, so the broken path can't reproduce here. Instead:

- **All 7 affected suites pass unchanged on Node 22** (34 + 4 tests) — confirming the shim is a strict no-op on the pinned version.
- **Simulated the exact Node 25 state** (key present, value `undefined`, jsdom Storage on `globalThis.jsdom`) and ran the shipped loop against it: it restores working `localStorage`/`sessionStorage` (setItem/getItem/clear all functional) on the 25+ condition and leaves an already-copied Storage untouched on the ≤24 condition.
- `ui:typecheck` exits 0; `ui:lint` reports **0 errors**; the two `loopover-miner-ui` typecheck errors are pre-existing (verified identical with these changes stashed).

## Canary test

`apps/loopover-ui/src/lib/jsdom-web-storage.test.ts` asserts the jsdom environment exposes working `localStorage`/`sessionStorage` and that the bare global resolves to the same object as the window property. It passes trivially on Node 22; its job is to fail on **one explicit assertion** the moment `.nvmrc` moves past Node 24 with this shim removed, instead of every storage-touching suite failing opaquely.

`apps/**` is outside Codecov's scope, so no `codecov/patch` obligation. Test infrastructure only — no visual change.

Closes #7576