### PR TITLE
docs(ams): land kill-switch incident runbook for misbehaving loops

### DIFF
--- a/apps/loopover-ui/content/docs/ams-config-precedence.mdx
+++ b/apps/loopover-ui/content/docs/ams-config-precedence.mdx
@@ -67,7 +67,8 @@ First existing file wins (engine `MINER_GOAL_SPEC_FILENAMES`):
 
 <Callout variant="note">
   There is **no CLI flag** for kill-switch today. `MINER_CODING_AGENT_PAUSED` is a separate axis
-  (coding-agent spawn only) and does not change kill-switch scope.
+  (coding-agent spawn only) and does not change kill-switch scope. For detection → activation →
+  post-incident audit, see the [kill-switch incident runbook](/docs/ams-kill-switch-incident).
 </Callout>
 
 ### Governor live write mode

--- a/apps/loopover-ui/content/docs/ams-kill-switch-incident.mdx
+++ b/apps/loopover-ui/content/docs/ams-kill-switch-incident.mdx
@@ -1,0 +1,151 @@
+---
+title: Kill-switch incident runbook
+description: Detect, activate, and audit a misbehaving Rent-a-Loop miner after the kill-switch stops it — grounded in the shipped #5670 mechanism.
+---
+
+Operator runbook for a **misbehaving autonomous miner loop** once the emergency kill-switch has
+been (or must be) engaged. Grounded in the shipped mechanism from #5670 (`packages/loopover-engine/src/governor/kill-switch.ts`,
+`packages/loopover-miner/lib/governor-kill-switch.ts`) — not a hypothetical design.
+
+<Callout variant="note">
+  Scope: AMS miner kill-switch only. For local SQLite corruption / multi-process collisions see the
+  [AMS operations runbook](/docs/ams-operations-runbook). Config precedence for the kill-switch
+  knobs is also summarized in [AMS config precedence](/docs/ams-config-precedence).
+</Callout>
+
+## Mechanism (what you are operating)
+
+Two independent triggers compose into one scope per repo:
+
+| Trigger | How | Scope reported |
+| --- | --- | --- |
+| Global | `LOOPOVER_MINER_KILL_SWITCH` env var (`1` / `true` / `yes` / `on`) | `"global"` — every repo |
+| Per-repo | `killSwitch.paused: true` in that repo's `.loopover-miner.yml` (`MinerGoalSpec`) | `"repo"` — that repo only |
+
+A global halt **always wins** and is reported as `"global"` even when the per-repo flag is also set.
+
+Since #5799 the check fires **mid-attempt**, not only between cycles: a running loop abandons with
+`abandonReason: "kill_switch_engaged"` and cleanly releases any in-flight queue claim.
+
+<Callout variant="warn">
+  **Not the same as** `loopover-miner governor pause` / `resume` / `status`. That is a separate,
+  independently persisted cooperative pause (stop before the next cycle). It does **not** read or
+  affect kill-switch state — do not reach for those commands during a kill-switch incident.
+</Callout>
+
+What activation does **not** undo: anything already submitted (a merged/pushed PR before the kill).
+Governance (#4782): in-flight actuation is not rolled back. The queue claim is released on abandon;
+nothing should hold a stale lock.
+
+## 1. Detection
+
+Flag a misbehaving loop from any of:
+
+1. Direct observation — destructive/off-scope file changes, a PR touching the wrong surface, repeated nonsensical commits.
+2. Soft-claim inventory — confirm what is in flight before you act:
+
+<CodeBlock
+  lang="bash"
+  code={`loopover-miner claim list --repo <owner/repo> --status active --json`}
+/>
+
+3. Fleet observability — error-rate spikes, abnormal claim/submission patterns, elevated
+   `consecutive_failures` / rejection-reason clustering, or an explicit customer/support escalation
+   (see the rented-loop escalation path from #4806).
+
+**Triage before acting:** decide one-repo vs fleet-wide. Prefer the narrowest scope that stops the
+harm so one bad tenant does not force an unnecessary global halt.
+
+**Target (detection → halt engaged):** ≤ **15 minutes** for a single-repo incident once an operator
+is on the page; treat anything longer as a follow-up gap (#5137-style post-incident obligations if a
+harmful change already merged).
+
+## 2. Activation
+
+### One repo misbehaving
+
+1. Edit that repo's `.loopover-miner.yml` — set `killSwitch.paused: true` under `MinerGoalSpec`.
+2. The next mid-attempt kill-switch check resolves `scope: "repo"` and abandons with
+   `kill_switch_engaged`.
+
+### Fleet-wide (systemic / not tenant-isolated)
+
+1. Set `LOOPOVER_MINER_KILL_SWITCH=true` in the miner process environment (restart or hot-reload
+   per your deployment's env-refresh mechanism).
+2. Every in-flight attempt abandons the same way; global always takes precedence over any per-repo flag.
+
+### Confirm the transition was recorded
+
+`resolveMinerKillSwitch` / `checkMinerKillSwitch` are pure — there is no separate "status" CLI. Verify by:
+
+1. Confirming the env var / yaml change is actually in place.
+2. Confirming `recordMinerKillSwitchTransition` wrote a governor-ledger row (it returns `null` and
+   appends nothing when the scope did not change — treat a failed/no-op append as "not confirmed").
+3. Observing the attempt/loop process abandon, and/or listing transitions:
+
+<CodeBlock
+  lang="bash"
+  code={`loopover-miner governor list --type kill_switch --repo <owner/repo> --json`}
+/>
+
+Notify internal ops and, when a rented tenant is affected, the customer via the support/escalation path (#4806).
+
+## 3. Post-incident audit-trail review
+
+Every scope **transition** (not every check) is recorded as a governor `kill_switch` event with
+`decision: "tripped" | "resumed"` and a `previousScope` / `scope` pair.
+
+1. Pull kill-switch transitions:
+
+<CodeBlock
+  lang="bash"
+  code={`loopover-miner governor list --type kill_switch [--repo <owner/repo>] [--json]`}
+/>
+
+2. Cross-reference claims and the manage event ledger around the trip time:
+
+<CodeBlock
+  lang="bash"
+  code={`loopover-miner claim list --repo <owner/repo> --json
+loopover-miner ledger list --repo <owner/repo> --json`}
+/>
+
+3. Confirm no further write activity after the recorded trip (the gap between "detected" and
+   "recorded" is the real exposure window — measure it).
+4. File a follow-up issue for any gap (detection lag, a write that slipped through, a missing alert)
+   rather than closing informally. If a harmful change already merged, escalate with the post-merge
+   incident process (#5137).
+5. Resume only after the misbehavior is understood and fixed — clear `killSwitch.paused` and/or the
+   env var. There is no separate re-arm command; the loop resumes on its own next check once triggers
+   are cleared. Confirm a `resumed` transition appears in `governor list --type kill_switch`.
+
+## Drill procedure (simulated misbehaving loop)
+
+Automated coverage already proves mid-attempt abandon at the unit level
+(`packages/loopover-engine/test/iterate-loop.test.ts` #5670 regressions). The operational drill
+below confirms the same path through real CLI / config:
+
+1. While a real attempt is mid-run against a throwaway sandbox repo, set
+   `killSwitch.paused: true` in that repo's `.loopover-miner.yml` (or set the global env for a
+   fleet drill).
+2. Confirm the running attempt abandons with `kill_switch_engaged` within one iteration boundary
+   (mid-attempt — do not wait for the next full cycle). **Target:** abandon observed within
+   **2 minutes** of the config/env change under a normal poll interval.
+3. Confirm `governor list --type kill_switch --repo <owner/repo> --json` shows a `tripped`
+   transition.
+4. Clear the flag/env; confirm `resumed` is recorded and the loop picks up on its next check.
+5. Record wall-clock **detection → trip recorded** time; open a follow-up if it exceeds the
+   15-minute operator target.
+
+<Callout variant="note">
+  A live drill against a real hosted Rent-a-Loop tenant is deferred until provisioning exists
+  (#7180). Until then, run the sandbox/self-host drill above and rely on the #5670 unit regressions
+  plus the runbook contract test in `test/unit/kill-switch-incident-runbook.test.ts`.
+</Callout>
+
+## Related docs
+
+- [AMS config precedence — kill switch](/docs/ams-config-precedence)
+- [Miner goal spec — `killSwitch`](/docs/ams-goal-spec)
+- [AMS operations runbook](/docs/ams-operations-runbook) (SQLite / local-state incidents)
+- [AMS observability](/docs/ams-observability)

--- a/apps/loopover-ui/content/docs/ams-operations-runbook.mdx
+++ b/apps/loopover-ui/content/docs/ams-operations-runbook.mdx
@@ -274,6 +274,7 @@ store filename.
 ## Related docs
 
 - [AMS deployment guide](/docs/ams-deployment) — laptop vs fleet, volumes, systemd, scaling rules
+- [Kill-switch incident runbook](/docs/ams-kill-switch-incident) — misbehaving-loop halt, audit trail, and drill
 - [`packages/loopover-miner/README.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/README.md#local-storage) — store inventory
 - [AMS environment variable reference](/docs/ams-env-reference) — per-store path overrides
 - [`packages/loopover-miner/docs/coding-agent-driver.md`](https://github.com/JSONbored/loopover/blob/main/packages/loopover-miner/docs/coding-agent-driver.md) — attempt log semantics

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -79,6 +79,7 @@ export const docsNav: DocsGroup[] = [
         items: [
           { to: "/docs/ams-deployment", label: "Deployment guide" },
           { to: "/docs/ams-operations-runbook", label: "Operations runbook" },
+          { to: "/docs/ams-kill-switch-incident", label: "Kill-switch incident runbook" },
           { to: "/docs/ams-observability", label: "Observing your miner" },
           { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
           { to: "/docs/ams-sizing", label: "Resource sizing" },

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -66,6 +66,7 @@ import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.a
 import { Route as DocsAmsSizingRouteImport } from './routes/docs.ams-sizing'
 import { Route as DocsAmsOperationsRunbookRouteImport } from './routes/docs.ams-operations-runbook'
 import { Route as DocsAmsObservabilityRouteImport } from './routes/docs.ams-observability'
+import { Route as DocsAmsKillSwitchIncidentRouteImport } from './routes/docs.ams-kill-switch-incident'
 import { Route as DocsAmsGoalSpecRouteImport } from './routes/docs.ams-goal-spec'
 import { Route as DocsAmsFleetManifestRouteImport } from './routes/docs.ams-fleet-manifest'
 import { Route as DocsAmsEnvReferenceRouteImport } from './routes/docs.ams-env-reference'
@@ -391,6 +392,12 @@ const DocsAmsObservabilityRoute = DocsAmsObservabilityRouteImport.update({
   path: '/ams-observability',
   getParentRoute: () => DocsRoute,
 } as any)
+const DocsAmsKillSwitchIncidentRoute =
+  DocsAmsKillSwitchIncidentRouteImport.update({
+    id: '/ams-kill-switch-incident',
+    path: '/ams-kill-switch-incident',
+    getParentRoute: () => DocsRoute,
+  } as any)
 const DocsAmsGoalSpecRoute = DocsAmsGoalSpecRouteImport.update({
   id: '/ams-goal-spec',
   path: '/ams-goal-spec',
@@ -535,6 +542,7 @@ export interface FileRoutesByFullPath {
   '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
   '/docs/ams-fleet-manifest': typeof DocsAmsFleetManifestRoute
   '/docs/ams-goal-spec': typeof DocsAmsGoalSpecRoute
+  '/docs/ams-kill-switch-incident': typeof DocsAmsKillSwitchIncidentRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -612,6 +620,7 @@ export interface FileRoutesByTo {
   '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
   '/docs/ams-fleet-manifest': typeof DocsAmsFleetManifestRoute
   '/docs/ams-goal-spec': typeof DocsAmsGoalSpecRoute
+  '/docs/ams-kill-switch-incident': typeof DocsAmsKillSwitchIncidentRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -694,6 +703,7 @@ export interface FileRoutesById {
   '/docs/ams-env-reference': typeof DocsAmsEnvReferenceRoute
   '/docs/ams-fleet-manifest': typeof DocsAmsFleetManifestRoute
   '/docs/ams-goal-spec': typeof DocsAmsGoalSpecRoute
+  '/docs/ams-kill-switch-incident': typeof DocsAmsKillSwitchIncidentRoute
   '/docs/ams-observability': typeof DocsAmsObservabilityRoute
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
@@ -777,6 +787,7 @@ export interface FileRouteTypes {
     | '/docs/ams-env-reference'
     | '/docs/ams-fleet-manifest'
     | '/docs/ams-goal-spec'
+    | '/docs/ams-kill-switch-incident'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -854,6 +865,7 @@ export interface FileRouteTypes {
     | '/docs/ams-env-reference'
     | '/docs/ams-fleet-manifest'
     | '/docs/ams-goal-spec'
+    | '/docs/ams-kill-switch-incident'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -935,6 +947,7 @@ export interface FileRouteTypes {
     | '/docs/ams-env-reference'
     | '/docs/ams-fleet-manifest'
     | '/docs/ams-goal-spec'
+    | '/docs/ams-kill-switch-incident'
     | '/docs/ams-observability'
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
@@ -1400,6 +1413,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsAmsObservabilityRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/ams-kill-switch-incident': {
+      id: '/docs/ams-kill-switch-incident'
+      path: '/ams-kill-switch-incident'
+      fullPath: '/docs/ams-kill-switch-incident'
+      preLoaderRoute: typeof DocsAmsKillSwitchIncidentRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/ams-goal-spec': {
       id: '/docs/ams-goal-spec'
       path: '/ams-goal-spec'
@@ -1613,6 +1633,7 @@ interface DocsRouteChildren {
   DocsAmsEnvReferenceRoute: typeof DocsAmsEnvReferenceRoute
   DocsAmsFleetManifestRoute: typeof DocsAmsFleetManifestRoute
   DocsAmsGoalSpecRoute: typeof DocsAmsGoalSpecRoute
+  DocsAmsKillSwitchIncidentRoute: typeof DocsAmsKillSwitchIncidentRoute
   DocsAmsObservabilityRoute: typeof DocsAmsObservabilityRoute
   DocsAmsOperationsRunbookRoute: typeof DocsAmsOperationsRunbookRoute
   DocsAmsSizingRoute: typeof DocsAmsSizingRoute
@@ -1665,6 +1686,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAmsEnvReferenceRoute: DocsAmsEnvReferenceRoute,
   DocsAmsFleetManifestRoute: DocsAmsFleetManifestRoute,
   DocsAmsGoalSpecRoute: DocsAmsGoalSpecRoute,
+  DocsAmsKillSwitchIncidentRoute: DocsAmsKillSwitchIncidentRoute,
   DocsAmsObservabilityRoute: DocsAmsObservabilityRoute,
   DocsAmsOperationsRunbookRoute: DocsAmsOperationsRunbookRoute,
   DocsAmsSizingRoute: DocsAmsSizingRoute,

--- a/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
+++ b/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
@@ -45,7 +45,7 @@ describe("docs route Suspense fallback (#6982)", () => {
       "docs.tsx",
     ]);
     const inScope = docsRouteFiles.filter((name) => !outOfScope.has(name));
-    expect(inScope.length).toBe(47);
+    expect(inScope.length).toBe(48);
 
     for (const file of inScope) {
       const source = readFileSync(join(routesDir, file), "utf8");

--- a/apps/loopover-ui/src/routes/docs.ams-kill-switch-incident.tsx
+++ b/apps/loopover-ui/src/routes/docs.ams-kill-switch-incident.tsx
@@ -1,0 +1,50 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
+import { docsClientLoader } from "@/lib/docs-client-loader";
+
+// Rendered from content/docs/ams-kill-switch-incident.mdx via fumadocs-mdx's browser entry
+// (docsClientLoader), through the existing DocsPage/Callout/CodeBlock
+// primitives -- not fumadocs-ui's bundled components. See docs-source.ts's comment
+// for why the loader below resolves only a plain, serializable path string.
+export const Route = createFileRoute("/docs/ams-kill-switch-incident")({
+  loader: async () => {
+    const { docsSource } = await import("@/lib/docs-source");
+    const page = docsSource.getPage(["ams-kill-switch-incident"]);
+    if (!page) throw notFound();
+    return { path: page.path, title: page.data.title, description: page.data.description };
+  },
+  head: () => ({
+    meta: [
+      { title: "Kill-switch incident runbook — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "Detect, activate, and audit a misbehaving Rent-a-Loop miner after the kill-switch stops it.",
+      },
+      { property: "og:title", content: "Kill-switch incident runbook — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "Detect, activate, and audit a misbehaving Rent-a-Loop miner after the kill-switch stops it.",
+      },
+      { property: "og:url", content: "/docs/ams-kill-switch-incident" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/ams-kill-switch-incident" }],
+  }),
+  component: AmsKillSwitchIncident,
+});
+
+function AmsKillSwitchIncident() {
+  const { path, title, description } = Route.useLoaderData();
+  const Content = docsClientLoader.getComponent(path);
+  return (
+    <DocsPage eyebrow="Maintainers" title={title} description={description}>
+      <Suspense fallback={<LoadingState />}>
+        <Content />
+      </Suspense>
+    </DocsPage>
+  );
+}

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -76,6 +76,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/federated-fleet-intelligence", label: "Federated fleet intelligence" },
       { to: "/docs/ams-deployment", label: "AMS deployment guide" },
       { to: "/docs/ams-operations-runbook", label: "AMS operations runbook" },
+      { to: "/docs/ams-kill-switch-incident", label: "Kill-switch incident runbook" },
       { to: "/docs/ams-observability", label: "Observing your miner" },
       { to: "/docs/ams-unattended-scheduling", label: "Unattended scheduling" },
       { to: "/docs/ams-sizing", label: "Resource sizing" },

--- a/test/unit/kill-switch-incident-runbook.test.ts
+++ b/test/unit/kill-switch-incident-runbook.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  MINER_KILL_SWITCH_ENV_VAR,
+  buildMinerKillSwitchTransitionGovernorLedgerEvent,
+  resolveMinerKillSwitch,
+} from "../../packages/loopover-engine/src/governor/kill-switch";
+
+const repoRoot = process.cwd();
+const runbookPath = join(repoRoot, "apps/loopover-ui/content/docs/ams-kill-switch-incident.mdx");
+const routePath = join(repoRoot, "apps/loopover-ui/src/routes/docs.ams-kill-switch-incident.tsx");
+const docsNavPath = join(repoRoot, "apps/loopover-ui/src/components/site/docs-nav.tsx");
+
+describe("kill-switch incident runbook (#4809)", () => {
+  it("exists as a wired docs page with nav entry", () => {
+    const runbook = readFileSync(runbookPath, "utf8");
+    const route = readFileSync(routePath, "utf8");
+    const nav = readFileSync(docsNavPath, "utf8");
+
+    expect(runbook).toContain("title: Kill-switch incident runbook");
+    expect(route).toContain('createFileRoute("/docs/ams-kill-switch-incident")');
+    expect(nav).toContain('to: "/docs/ams-kill-switch-incident"');
+  });
+
+  it("pins operator-facing facts to the shipped kill-switch mechanism", () => {
+    const runbook = readFileSync(runbookPath, "utf8");
+
+    expect(MINER_KILL_SWITCH_ENV_VAR).toBe("LOOPOVER_MINER_KILL_SWITCH");
+    expect(runbook).toContain(MINER_KILL_SWITCH_ENV_VAR);
+    expect(runbook).toContain("killSwitch.paused");
+    expect(runbook).toContain("kill_switch_engaged");
+    expect(runbook).toContain('governor list --type kill_switch');
+    expect(runbook).toContain("claim list --repo");
+    expect(runbook).toContain("15 minutes");
+    expect(runbook).toContain("2 minutes");
+    expect(runbook).toContain("#7180");
+
+    expect(resolveMinerKillSwitch({ global: true, repoPaused: true })).toBe("global");
+    expect(resolveMinerKillSwitch({ global: false, repoPaused: true })).toBe("repo");
+    expect(resolveMinerKillSwitch({ global: false, repoPaused: false })).toBe("none");
+
+    const tripped = buildMinerKillSwitchTransitionGovernorLedgerEvent({
+      actionClass: "test",
+      previousScope: "none",
+      scope: "repo",
+    });
+    expect(tripped).toMatchObject({
+      eventType: "kill_switch",
+      decision: "tripped",
+      payload: { previousScope: "none", scope: "repo" },
+    });
+
+    const resumed = buildMinerKillSwitchTransitionGovernorLedgerEvent({
+      actionClass: "test",
+      previousScope: "repo",
+      scope: "none",
+    });
+    expect(resumed).toMatchObject({
+      eventType: "kill_switch",
+      decision: "resumed",
+      payload: { previousScope: "repo", scope: "none" },
+    });
+
+    expect(
+      buildMinerKillSwitchTransitionGovernorLedgerEvent({
+        actionClass: "test",
+        previousScope: "repo",
+        scope: "repo",
+      }),
+    ).toBeNull();
+  });
+
+  it("warns operators off the cooperative governor pause CLI during kill-switch incidents", () => {
+    const runbook = readFileSync(runbookPath, "utf8");
+    expect(runbook).toMatch(/governor pause/);
+    expect(runbook).toMatch(/do not reach for those commands/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Lands the AMS **kill-switch incident runbook** (`/docs/ams-kill-switch-incident`) grounded in the shipped #5670 mechanism (`LOOPOVER_MINER_KILL_SWITCH`, `.loopover-miner.yml` `killSwitch.paused`, mid-attempt `kill_switch_engaged` abandon, governor `kill_switch` ledger transitions).
- Wires nav + docs index + cross-links from AMS operations / config-precedence, regenerates the route tree, and adds a contract test that pins operator-facing CLI/env/ledger facts to `resolveMinerKillSwitch` / `buildMinerKillSwitchTransitionGovernorLedgerEvent`.
- Fresh PR after [#7593](https://github.com/JSONbored/loopover/pull/7593) (closed for missing `Closes #`); this PR explicitly **Closes #4809**.

Closes #4809.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] Contract + loading-state tests: `npx vitest run test/unit/kill-switch-incident-runbook.test.ts`; `npm --prefix apps/loopover-ui test -- src/routes/docs-routes-loading-state.test.tsx`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Docs/content + route wiring only; coverage bar is the new contract test + existing docs Suspense LoadingState count bump. Full `test:ci` / UI build left to CI (local win32 Vite/MDX SSR cannot render `CodeBlock` for page screenshots; production/preview path is unchanged and matches sibling AMS runbook routes).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Docs are dark-mode-only. Matrix covers the new runbook route (production before = missing page) and the docs index (Maintainers list gains the new entry).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [![Desktop · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-desktop-dark-before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-desktop-dark-before.png) | [![Desktop · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-desktop-dark-after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-desktop-dark-after.png) |
| Tablet · Dark | [![Tablet · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-tablet-dark-before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-tablet-dark-before.png) | [![Tablet · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-tablet-dark-after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-tablet-dark-after.png) |
| Mobile · Dark | [![Mobile · Dark before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-mobile-dark-before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-mobile-dark-before.png) | [![Mobile · Dark after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-mobile-dark-after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/kill-switch-runbook-mobile-dark-after.png) |
| Desktop · Dark (/docs index) | [![Desktop · Dark docs before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-desktop-dark-before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-desktop-dark-before.png) | [![Desktop · Dark docs after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-desktop-dark-after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-desktop-dark-after.png) |
| Tablet · Dark (/docs index) | [![Tablet · Dark docs before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-tablet-dark-before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-tablet-dark-before.png) | [![Tablet · Dark docs after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-tablet-dark-after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-tablet-dark-after.png) |
| Mobile · Dark (/docs index) | [![Mobile · Dark docs before](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-mobile-dark-before.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-mobile-dark-before.png) | [![Mobile · Dark docs after](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-mobile-dark-after.png)](https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots-4809/docs-index-mobile-dark-after.png) |

## Notes

- Drill targets in the runbook: ≤15 minutes detection→halt; ≤2 minutes abandon after config/env change under a normal poll interval. Hosted-tenant drill deferred to #7180.
