### PR TITLE
test(unit): give the multi-scenario defaultBaseRef test a longer budget

### DIFF
--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -2419,7 +2419,7 @@ describe("local MCP git metadata collection (#7329 coverage)", () => {
     git(tempDir, "update-ref", "refs/remotes/origin/master", masterSha);
     const withOriginMaster = collectLocalBranchMetadata({ cwd: tempDir, login: "oktofeesh1" });
     expect(withOriginMaster.baseRef).toBe("origin/master");
-  });
+  }, 30_000);
 
   it("throws when repoFullName cannot be inferred from the remote and is not passed explicitly", async () => {
     const { collectLocalBranchMetadata } = await import("../../packages/loopover-mcp/lib/local-branch.js");


### PR DESCRIPTION
## Summary

- `test/unit/local-branch.test.ts`'s `"defaultBaseRef prefers a fetched origin/HEAD, then origin/main, then origin/master when present"` test does three full real-git round trips in sequence (each: `mkdtemp`, fixture init, an `execFileSync` git call, one or two `update-ref`/`symbolic-ref` calls, a `collectLocalBranchMetadata` call that itself shells out to git, then cleanup) to cover the origin/HEAD, origin/main, and origin/master precedence cases in one test.
- In isolation it reliably finishes in ~5-8s; under the CPU/I-O contention of the full ~19,500-test unsharded suite running concurrently, it can cross the default 15s vitest timeout even though nothing is actually hung — reproduced with a real timeout error (not an assertion failure), while real CI stayed green on the same commit.
- Fix: bump this specific test's timeout to 30s, the same per-test override pattern already used elsewhere in this suite for other legitimately slower tests (e.g. `test/unit/mcp-cli-maintain.test.ts`'s `45_000`). No logic or assertion changes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a test-only change (`test/unit/local-branch.test.ts`), no `src/**` touched, so it carries no Codecov patch obligation. `npm run ui:build`/`ui:test` did not complete locally: this machine runs Node v26.5.0 (repo pins Node 22 via `.nvmrc`), and every `apps/loopover-ui`/`apps/loopover-miner-ui` test touching `window.localStorage` fails locally with a vitest-jsdom/Node compatibility error unrelated to this diff (already tracked separately). The full backend gate ran clean through `ui:typecheck` other than one unrelated real-git-subprocess test (`test/unit/miner-attempt-worktree.test.ts`) that also timed out only under the same full-suite contention and passed cleanly (4.48s, all 8 tests) in isolation — the identical class of issue this PR fixes, in a different file, not touched here to keep this PR narrow.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — test-only change (`test/unit/local-branch.test.ts`), no visible UI/frontend/docs surface.

## Notes

- Closes #7600
