### PR TITLE
fix(ui): resolve "CodeBlock is not defined" crash on docs pages

### DIFF
--- a/apps/loopover-ui/content/docs/maintainer-workflow.mdx
+++ b/apps/loopover-ui/content/docs/maintainer-workflow.mdx
@@ -4,6 +4,7 @@ description: The default posture is silence. You opt into context. The repo stay
 ---
 
 import { MAINTAINER_COMMAND_LIST, PUBLIC_COMMAND_LIST } from "@/lib/command-reference";
+import { CodeBlock } from "@/components/site/primitives";
 
 export const steps = [
   {

--- a/apps/loopover-ui/src/routes/docs-mdx-eager-scope.test.ts
+++ b/apps/loopover-ui/src/routes/docs-mdx-eager-scope.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { docsMdxComponents } from "@/lib/docs-mdx-components";
+
+// #7578: content/docs/maintainer-workflow.mdx pulled its <WorkflowMirror> `steps` prop out into a
+// top-level `export const steps = [...]` ESM block containing `<CodeBlock>` JSX. fumadocs-mdx only
+// auto-resolves capitalized JSX tags against the `components` prop (with a friendly "missing
+// reference" guard) *inside* the markdown body, compiled into `_createMdxContent` -- a top-level
+// `export const` runs eagerly at module-evaluation time, before any `components` prop exists, so an
+// unimported provided-component name there is a bare, unresolved identifier: a raw ReferenceError,
+// not fumadocs' friendly message.
+//
+// That alone would only break the one page. It broke every docs page because docs-source.ts (used by
+// every docs.*.tsx route's server loader) imports fumadocs-mdx's generated collections/server module,
+// which globs *all* content/docs/*.mdx files with `eager: true` -- so one file with this defect throws
+// during module evaluation and takes down every docs route's SSR loader, not just its own page.
+//
+// Fixed by importing the component directly into the .mdx file (matching how
+// MAINTAINER_COMMAND_LIST/PUBLIC_COMMAND_LIST are already imported there), which MDX honors as a
+// normal JS binding instead of routing it through the components prop. This test guards the whole
+// class: any content/docs/*.mdx file whose top-level `export const` block references a
+// docsMdxComponents-provided tag it hasn't also imported directly would reproduce the same
+// eager-module-evaluation crash for every docs page.
+
+const DOCS_DIR = join(process.cwd(), "content/docs");
+
+// `a` is an intrinsic-element override (lowercase), not a capitalized custom component -- irrelevant
+// to this bug class, which only concerns capitalized JSX tags resolved via the provided `components`
+// prop (fumadocs never routes lowercase/intrinsic tags through it).
+const PROVIDED_COMPONENT_NAMES = Object.keys(docsMdxComponents).filter((name) =>
+  /^[A-Z]/.test(name),
+);
+
+/** Every top-level `export const NAME = ...` block, from its `export const` line through the `];`/`};` that closes it at column 0. */
+function extractTopLevelExportConstBlocks(source: string): string[] {
+  const blocks: string[] = [];
+  let current: string[] | null = null;
+  for (const line of source.split("\n")) {
+    if (!current && /^export const \w+ = /.test(line)) {
+      current = [line];
+      continue;
+    }
+    if (current) {
+      current.push(line);
+      if (/^(\];|\};)/.test(line)) {
+        blocks.push(current.join("\n"));
+        current = null;
+      }
+    }
+  }
+  return blocks;
+}
+
+/** Local binding names introduced by this file's own `import { ... } from "...";` statements (aliases resolved to their local name). */
+function extractImportedNames(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of source.matchAll(/^import\s*\{([^}]+)\}\s*from\s*["'][^"']+["'];?\s*$/gm)) {
+    for (const raw of match[1].split(",")) {
+      const localName = raw
+        .trim()
+        .split(/\s+as\s+/i)
+        .pop()
+        ?.trim();
+      if (localName) names.add(localName);
+    }
+  }
+  return names;
+}
+
+describe("docs .mdx top-level export const blocks don't reference provided-only components (#7578)", () => {
+  const mdxFiles = readdirSync(DOCS_DIR).filter((name) => name.endsWith(".mdx"));
+
+  it("found docs content files to scan (sanity check the scan itself isn't silently a no-op)", () => {
+    expect(mdxFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(mdxFiles)(
+    "%s: components used in a top-level export const are directly imported, not left to the components prop",
+    (file) => {
+      const source = readFileSync(join(DOCS_DIR, file), "utf8");
+      const importedNames = extractImportedNames(source);
+
+      for (const block of extractTopLevelExportConstBlocks(source)) {
+        for (const [, tagName] of block.matchAll(/<([A-Z]\w*)/g)) {
+          const isProvidedOnly =
+            PROVIDED_COMPONENT_NAMES.includes(tagName) && !importedNames.has(tagName);
+          expect(
+            isProvidedOnly,
+            `${file}: top-level export const references <${tagName}>, which is only supplied via the MDX ` +
+              `components prop and unresolved at eager module-evaluation time. Import it directly, e.g. ` +
+              `import { ${tagName} } from "@/components/site/primitives";`,
+          ).toBe(false);
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Root cause: `content/docs/maintainer-workflow.mdx` pulls its `<WorkflowMirror>` `steps` prop out into a top-level `export const steps = [...]` ESM block that embeds `<CodeBlock>` JSX. fumadocs-mdx only resolves capitalized JSX tags against the `components` prop (with a friendly "missing reference" guard) *inside* the markdown body, compiled into `_createMdxContent`. A top-level `export const` runs eagerly at module-evaluation time, before any `components` prop exists, so an unimported provided-component name there is a bare, unresolved identifier — a raw `ReferenceError: CodeBlock is not defined`, not fumadocs' friendly message.
- Why it broke *every* docs page, not just its own: `docs-source.ts` (used by every `docs.*.tsx` route's server loader) imports fumadocs-mdx's generated `collections/server` module, which globs **all** `content/docs/*.mdx` files with `eager: true`. One file throwing during module evaluation takes down every docs route's SSR loader, not just `/docs/maintainer-workflow`.
- Fix: import `CodeBlock` directly into the `.mdx` file (`import { CodeBlock } from "@/components/site/primitives";`), the same way it already imports `MAINTAINER_COMMAND_LIST`/`PUBLIC_COMMAND_LIST`. MDX treats an explicitly-imported identifier as a normal JS binding rather than routing it through the `components` prop, so it resolves correctly regardless of eager vs. lazy evaluation.
- Added a regression test (`apps/loopover-ui/src/routes/docs-mdx-eager-scope.test.ts`) that scans every `content/docs/*.mdx` file's top-level `export const` blocks for JSX tags that are only supplied via the MDX components prop (cross-checked against the real `docsMdxComponents` map) and not also directly imported — guarding the whole bug class, not just this one file.

Closes #7578

## Root cause detail (for reviewers)

The original issue's read-only investigation correctly ruled out dep-cache staleness, HMR, missing imports, and circular imports, and confirmed the compiled MDX output *looked* structurally correct — because it was. The actual failure never went through the rendering path it inspected. Instrumenting `docs-client-loader.tsx`'s `component()` callback showed it was **never called** before the crash. Capturing the real (unformatted) error stack — the React-proxied console log truncates it — showed the true origin:

```
ReferenceError: CodeBlock is not defined
    at http://localhost:8080/content/docs/maintainer-workflow.mdx?collection=docs:71:130
```

...thrown while `docs-source.ts`'s eager glob (`apps/loopover-ui/.source/server.ts`, `import.meta.glob([...], { eager: true })`) evaluated `maintainer-workflow.mdx`'s compiled module — triggered by literally any docs route's server loader (including `/docs/quickstart`, the page from the original report).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7578`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change touches only `apps/loopover-ui/**`, which Codecov's `codecov/patch` does not measure (only `src/**` counts); the new regression test lives in `apps/loopover-ui/src/routes/` and is exercised by `ui:test`.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — pre-existing findings (`adm-zip` via `github-actionlint`, `body-parser`) already tracked in #7607; unrelated to this diff (no `package.json`/lockfile changes here).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — see `docs-mdx-eager-scope.test.ts`; verified it fails on the pre-fix content (reverted the import locally, confirmed the test catches it) and passes on the fix.
- [x] `npm run test:ci` (full local gate)

Additional manual verification (this bug is an SSR-loader-time crash, so it needed real requests, not just unit tests):
- All 47 `docs.*.tsx` routes returned HTTP 500 before the fix and HTTP 200 after, in `vite dev` (curl + browser).
- All 47 routes verified again against a real production build served by `wrangler dev --config dist/server/wrangler.json` (this repo's nitro build targets the `cloudflare-module` preset; `vite preview` does not understand that output layout and 500s on an unrelated pre-existing `dist/server/server.js` module-resolution mismatch — not something this PR touches).
- Confirmed in-browser (both `vite dev` and the wrangler-served production build) that `/docs/quickstart` (the original repro) and `/docs/maintainer-workflow` (the actual broken file) render fully, including the previously-crashing `<CodeBlock>` elements inside `maintainer-workflow.mdx`'s `steps` array.

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/CORS/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — static docs content only.)
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots — **skipped**: this is an availability fix (every docs page 500ing vs. loading), which reproducible HTTP-status checks across all 47 routes evidence more rigorously than static before/after screenshots would. See the manual verification list above for exactly what was checked, in which environments.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit — this is a bug fix, not a release.)

## Notes

- The fumadocs-mdx "eager glob" behavior in `docs-source.ts` (server-only collection) means any future `content/docs/*.mdx` file that references a provided-only component (`Callout`, `CodeBlock`, `FeatureRow`, `AmsObservabilityCallout`, `CommandTable`, `WorkflowMirror`) inside a top-level `export const` — instead of within the markdown body — would reproduce this exact class of bug and take down every docs page again. The new `docs-mdx-eager-scope.test.ts` test guards against that going forward.
