### PR TITLE
fix(test): pin loopover-ui + ui-kit jsdom localStorage over Node 26's broken global

### DIFF
--- a/apps/loopover-ui/vitest.setup.ts
+++ b/apps/loopover-ui/vitest.setup.ts
@@ -15,3 +15,25 @@ class ResizeObserverStub {
   disconnect(): void {}
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
+// Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
+// returns undefined unless the process was started with --localstorage-file. Because that property already
+// *exists* on globalThis before jsdom's env is installed, Vitest's populateGlobal skips copying jsdom's
+// working Storage over it, so any bare `localStorage.*` call (use-local-storage.test.ts most directly,
+// plus routes/index.test.tsx, api/try-it.test.ts, app-panels/onboarding-preview-card.test.tsx, and
+// lib/analytics-window.test.ts) throws "Cannot read properties of undefined". jsdom's real Storage still
+// lives on the raw JSDOM window (globalThis.jsdom.window, a distinct object from the `window`/globalThis
+// alias); point the global at it
+// unconditionally -- a no-op on Node 22/24 where globalThis.localStorage already *is* this object, and the
+// actual fix on Node 26+. A `??=` guard would not help (the broken accessor already counts as "present");
+// the property is configurable so redefining it is safe. Mirrors apps/loopover-miner-ui/vitest.setup.ts's
+// own guard (#7597), which fixed the identical gap there but not here.
+const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom?.window
+  ?.localStorage;
+if (jsdomLocalStorage) {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: jsdomLocalStorage,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/apps/loopover-ui/vitest.setup.ts
+++ b/apps/loopover-ui/vitest.setup.ts
@@ -28,8 +28,8 @@ globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObse
 // actual fix on Node 26+. A `??=` guard would not help (the broken accessor already counts as "present");
 // the property is configurable so redefining it is safe. Mirrors apps/loopover-miner-ui/vitest.setup.ts's
 // own guard (#7597), which fixed the identical gap there but not here.
-const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom?.window
-  ?.localStorage;
+const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom
+  ?.window?.localStorage;
 if (jsdomLocalStorage) {
   Object.defineProperty(globalThis, "localStorage", {
     value: jsdomLocalStorage,

--- a/packages/loopover-ui-kit/vitest.setup.ts
+++ b/packages/loopover-ui-kit/vitest.setup.ts
@@ -6,3 +6,24 @@ import { afterEach } from "vitest";
 afterEach(() => {
   cleanup();
 });
+
+// Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
+// returns undefined unless the process was started with --localstorage-file. Because that property already
+// *exists* on globalThis before jsdom's env is installed, Vitest's populateGlobal skips copying jsdom's
+// working Storage over it, so any bare `localStorage.*` call would throw "Cannot read properties of
+// undefined" on Node 26+ -- no component here calls it today, but this package is a shared UI kit other
+// workspaces build on, so the guard is preventive rather than a fix for a currently-red test. jsdom's real
+// Storage still lives on the raw JSDOM window (globalThis.jsdom.window, a distinct object from the
+// `window`/globalThis alias); point the global at it unconditionally -- a no-op on Node 22/24 where
+// globalThis.localStorage already *is* this object, and the actual fix on Node 26+. A `??=` guard would not
+// help (the broken accessor already counts as "present"); the property is configurable so redefining it is
+// safe. Mirrors apps/loopover-miner-ui/vitest.setup.ts's own guard (#7597).
+const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom?.window
+  ?.localStorage;
+if (jsdomLocalStorage) {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: jsdomLocalStorage,
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION
Closes #7612

## Summary

- `apps/loopover-ui/vitest.setup.ts` and `packages/loopover-ui-kit/vitest.setup.ts` never received
  #7597's guard against Node 26's broken `globalThis.localStorage` global, so any bare `localStorage.*`
  call throws under Node 26 (while passing on Node 22/24, what CI actually runs). Mirrors the exact fix
  already accepted for `apps/loopover-miner-ui`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- No new test files: both changed files are `vitest.setup.ts` (outside Codecov's `src/**`-only include
  glob, so no patch-coverage obligation either way). The regression proof is the 5 previously-Node-26-red
  `apps/loopover-ui` test files (`routes/index`, `api/try-it`, `app-panels/onboarding-preview-card`,
  `lib/analytics-window`, `lib/use-local-storage`) turning green — verified directly on Node 26: 426/426
  in `apps/loopover-ui`, 19/19 in `packages/loopover-ui-kit`. `packages/loopover-ui-kit` has no test that
  currently touches `localStorage`, so its guard is preventive rather than fixing a currently-red test.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — test-infrastructure-only change, no visible UI/frontend difference.

## Notes

- Companion to #7613 (Node-version-drift enforcement), filed and scoped separately to keep each diff
  narrow — that one also closes the loop so this exact class of gap can't silently recur.
