### PR TITLE
fix(ui): render dark theme attrs on SSR html to stop hydration mismatch

### DIFF
--- a/apps/loopover-ui/src/components/site/theme-toggle.tsx
+++ b/apps/loopover-ui/src/components/site/theme-toggle.tsx
@@ -1,9 +1,0 @@
-// Dark-mode-only build. The toggle has been removed; this file now only
-// ships the no-flash script that locks <html> into dark mode on first paint.
-export const THEME_NOFLASH_SCRIPT = `
-(function(){try{
-  var r=document.documentElement;
-  r.classList.add('dark');
-  r.style.colorScheme='dark';
-}catch(e){}})();
-`;

--- a/apps/loopover-ui/src/routes/__root.tsx
+++ b/apps/loopover-ui/src/routes/__root.tsx
@@ -14,7 +14,6 @@ import { reportLovableError } from "../lib/lovable-error-reporting";
 import { captureBrowserError } from "../lib/browser-sentry";
 import { SiteHeader } from "@/components/site/site-header";
 import { SiteFooter } from "@/components/site/site-footer";
-import { THEME_NOFLASH_SCRIPT } from "@/components/site/theme-toggle";
 import { BackToTop } from "@/components/site/back-to-top";
 import { Toaster } from "@/components/ui/sonner";
 import { ApiProgressBar } from "@/components/site/api-progress-bar";
@@ -149,9 +148,6 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     ],
     scripts: [
       {
-        children: THEME_NOFLASH_SCRIPT,
-      },
-      {
         type: "application/ld+json",
         children: JSON.stringify({
           "@context": "https://schema.org",
@@ -177,7 +173,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 
 function RootShell({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark" style={{ colorScheme: "dark" }}>
       <head>
         <HeadContent />
       </head>


### PR DESCRIPTION
## Summary

- Every page load in `apps/loopover-ui` logged a React hydration-mismatch console error for the `<html>` element's `className="dark"` / `style={{color-scheme:"dark"}}` (SSR rendered neither; a pre-hydration no-flash script added both client-side before React ever hydrated, so React always detected a mismatch on first paint).
- `RootShell` (`apps/loopover-ui/src/routes/__root.tsx`) now renders `className="dark"` and `style={{ colorScheme: "dark" }}` directly on the server-rendered `<html>` tag, so SSR output already matches what the client needs.
- The app is dark-mode-only (the toggle itself was already removed), so the now-redundant `THEME_NOFLASH_SCRIPT` no-flash script and its `theme-toggle.tsx` module are deleted — nothing else imported them.

No behavioral or visual change: the app already always rendered dark; this only fixes how the `dark` class/style attributes get onto `<html>`, removing the console error and the (harmless but noisy) hydration patch-up work React did on every load.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: Closes #7618 (opened for this fix; as the repo's sole maintainer the contributor-only linked-issue hard-close rule doesn't bind owner PRs, but a tracking issue is still good hygiene).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` locally — full suite green (1036 files / 19,563 tests); this is a UI-only change under `apps/loopover-ui/**`, which Codecov's `codecov/patch` does not measure (only `src/**` is measured), so there's no patch-coverage obligation here.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` / `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`) — no API/schema changes, N/A but ran clean
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build` (also verified with `vite build` + a production preview — see below)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, no new logic branches; this is a static JSX attribute change with no conditional paths to test, verified instead by manual before/after console inspection (see Notes).

Manual verification: reproduced the hydration-mismatch console error on `npm --workspace @loopover/ui run dev` before the fix (every page load, e.g. `/docs/quickstart`), confirmed it is gone after the fix on a fresh page load in both `npm run dev` and a production build (`vite build`, served via `wrangler dev --config dist/server/wrangler.json` against the built Worker output — `vite preview` itself has an unrelated, pre-existing breakage in this repo, tracked separately). Confirmed `document.documentElement` still carries `class="dark"` / `style="color-scheme: dark"` correctly post-fix.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A — no auth/session/CORS changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. N/A — no API/OpenAPI/MCP changes.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. N/A — static JSX attributes only.
- [ ] Visible UI changes include a `UI Evidence` section — **not applicable**: this fix produces zero pixel/visual difference (the app already always rendered dark; only *how* the `dark` attributes reach `<html>` changed). The actual evidence is the browser console, not the rendered page, so a page screenshot would show nothing different before/after. See Notes for the console evidence instead.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. N/A.

## Notes

Console evidence (before → after), reproduced on `/docs/quickstart`:

**Before:**
```
A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. ...
  <html
    lang="en"
    ref={function ref}
-   className="dark"
-   style={{color-scheme:"dark"}}
  >
```

**After:** no console errors on a fresh page load; `document.documentElement` reports `{"className":"dark","colorScheme":"dark"}` as expected, sourced from the SSR HTML rather than a post-hydration script.