### PR TITLE
refactor(test): extract the duplicated Node 26 jsdom localStorage guard into a shared helper

### DIFF
--- a/apps/loopover-miner-ui/vitest.setup.ts
+++ b/apps/loopover-miner-ui/vitest.setup.ts
@@ -1,5 +1,6 @@
 ﻿import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
+import { patchJsdomLocalStorageForNode26 } from "../../test/helpers/vitest-jsdom-node26-localstorage";
 
 // Unmount React trees between tests so jsdom state never leaks across cases.
 afterEach(() => {
@@ -16,24 +17,9 @@ class ResizeObserverStub {
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 
-// Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
-// returns undefined unless the process was started with --localstorage-file. Because that property already
-// *exists* on globalThis before jsdom's env is installed, Vitest's populateGlobal skips copying jsdom's
-// working Storage over it, so any bare `localStorage.*` call (theme-toggle.test.tsx, mirroring
-// theme-toggle.tsx:39) throws "Cannot read properties of undefined". jsdom's real Storage still lives on the
-// raw JSDOM window (globalThis.jsdom.window, which is a distinct object from the `window`/globalThis alias);
-// point the global at it unconditionally -- a no-op on Node 22/24 where globalThis.localStorage already *is*
-// this object, and the actual fix on Node 26+. A `??=` guard would not help (the broken accessor already
-// counts as "present"); the property is configurable so redefining it is safe.
-const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom?.window
-  ?.localStorage;
-if (jsdomLocalStorage) {
-  Object.defineProperty(globalThis, "localStorage", {
-    value: jsdomLocalStorage,
-    configurable: true,
-    writable: true,
-  });
-}
+// See vitest-jsdom-node26-localstorage.ts's own header. Exercised directly by theme-toggle.test.tsx,
+// mirroring theme-toggle.tsx:39.
+patchJsdomLocalStorageForNode26();
 
 // #7075: ChatConversation wires handlePortfolioQueueChatCommand, which imports chat-action-registry →
 // governor-chokepoint → governor-ledger → node:sqlite. jsdom/Vite cannot bundle that builtin (same twin

--- a/apps/loopover-ui/vitest.setup.ts
+++ b/apps/loopover-ui/vitest.setup.ts
@@ -1,5 +1,6 @@
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
+import { patchJsdomLocalStorageForNode26 } from "../../test/helpers/vitest-jsdom-node26-localstorage";
 
 // Unmount React trees between tests so jsdom state never leaks across cases.
 afterEach(() => {
@@ -16,24 +17,8 @@ class ResizeObserverStub {
 }
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 
-// Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
-// returns undefined unless the process was started with --localstorage-file. Because that property already
-// *exists* on globalThis before jsdom's env is installed, Vitest's populateGlobal skips copying jsdom's
-// working Storage over it, so any bare `localStorage.*` call (use-local-storage.test.ts most directly,
-// plus routes/index.test.tsx, api/try-it.test.ts, app-panels/onboarding-preview-card.test.tsx, and
-// lib/analytics-window.test.ts) throws "Cannot read properties of undefined". jsdom's real Storage still
-// lives on the raw JSDOM window (globalThis.jsdom.window, a distinct object from the `window`/globalThis
-// alias); point the global at it
-// unconditionally -- a no-op on Node 22/24 where globalThis.localStorage already *is* this object, and the
-// actual fix on Node 26+. A `??=` guard would not help (the broken accessor already counts as "present");
-// the property is configurable so redefining it is safe. Mirrors apps/loopover-miner-ui/vitest.setup.ts's
-// own guard (#7597), which fixed the identical gap there but not here.
-const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom
-  ?.window?.localStorage;
-if (jsdomLocalStorage) {
-  Object.defineProperty(globalThis, "localStorage", {
-    value: jsdomLocalStorage,
-    configurable: true,
-    writable: true,
-  });
-}
+// See vitest-jsdom-node26-localstorage.ts's own header: Node 26's broken globalThis.localStorage
+// accessor shadows jsdom's real Storage before Vitest can install it. Exercised directly by
+// use-local-storage.test.ts, plus routes/index, api/try-it, app-panels/onboarding-preview-card, and
+// lib/analytics-window.
+patchJsdomLocalStorageForNode26();

--- a/packages/loopover-ui-kit/vitest.setup.ts
+++ b/packages/loopover-ui-kit/vitest.setup.ts
@@ -1,5 +1,6 @@
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
+import { patchJsdomLocalStorageForNode26 } from "../../test/helpers/vitest-jsdom-node26-localstorage";
 
 // Unmount React trees between tests so jsdom state never leaks across cases (mirrors
 // apps/loopover-miner-ui/vitest.setup.ts's own cleanup).
@@ -7,23 +8,6 @@ afterEach(() => {
   cleanup();
 });
 
-// Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
-// returns undefined unless the process was started with --localstorage-file. Because that property already
-// *exists* on globalThis before jsdom's env is installed, Vitest's populateGlobal skips copying jsdom's
-// working Storage over it, so any bare `localStorage.*` call would throw "Cannot read properties of
-// undefined" on Node 26+ -- no component here calls it today, but this package is a shared UI kit other
-// workspaces build on, so the guard is preventive rather than a fix for a currently-red test. jsdom's real
-// Storage still lives on the raw JSDOM window (globalThis.jsdom.window, a distinct object from the
-// `window`/globalThis alias); point the global at it unconditionally -- a no-op on Node 22/24 where
-// globalThis.localStorage already *is* this object, and the actual fix on Node 26+. A `??=` guard would not
-// help (the broken accessor already counts as "present"); the property is configurable so redefining it is
-// safe. Mirrors apps/loopover-miner-ui/vitest.setup.ts's own guard (#7597).
-const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom?.window
-  ?.localStorage;
-if (jsdomLocalStorage) {
-  Object.defineProperty(globalThis, "localStorage", {
-    value: jsdomLocalStorage,
-    configurable: true,
-    writable: true,
-  });
-}
+// See vitest-jsdom-node26-localstorage.ts's own header. No component here calls localStorage today --
+// this package is a shared UI kit other workspaces build on, so the guard is preventive.
+patchJsdomLocalStorageForNode26();

--- a/test/helpers/vitest-jsdom-node26-localstorage.ts
+++ b/test/helpers/vitest-jsdom-node26-localstorage.ts
@@ -1,0 +1,27 @@
+/**
+ * Node 26 predefines its own experimental `globalThis.localStorage` accessor (nodejs/node#60303) that
+ * returns undefined unless the process was started with --localstorage-file. Because that property
+ * already *exists* on globalThis before jsdom's environment is installed, Vitest's populateGlobal skips
+ * copying jsdom's working Storage over it, so any bare `localStorage.*` call throws "Cannot read
+ * properties of undefined" under Node 26 while passing on Node 22/24.
+ *
+ * Call this once from a jsdom-environment vitest.setup.ts. Points globalThis.localStorage at jsdom's
+ * real Storage from the raw JSDOM window unconditionally: a no-op where the global already is that
+ * object, the fix on Node 26+. A `??=` guard would not help (the broken accessor already counts as
+ * "present"); the property is configurable so redefining it is safe.
+ *
+ * Shared by apps/loopover-ui, apps/loopover-miner-ui, and packages/loopover-ui-kit's vitest.setup.ts
+ * (originally three separate copies of this same guard -- #7597, #7612) so a future jsdom-environment
+ * workspace only has to import this rather than rediscover the bug.
+ */
+export function patchJsdomLocalStorageForNode26(): void {
+  const jsdomLocalStorage = (globalThis as { jsdom?: { window?: { localStorage?: Storage } } }).jsdom
+    ?.window?.localStorage;
+  if (jsdomLocalStorage) {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: jsdomLocalStorage,
+      configurable: true,
+      writable: true,
+    });
+  }
+}


### PR DESCRIPTION
Closes #7620

## Summary

- Extracts the Node 26 jsdom `localStorage` guard (previously copy-pasted verbatim in
  `apps/loopover-miner-ui`, `apps/loopover-ui`, and `packages/loopover-ui-kit`'s `vitest.setup.ts`) into
  one shared `test/helpers/vitest-jsdom-node26-localstorage.ts` module all three now import. No behavior
  change — same guard, just one copy instead of three that could drift.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The shared helper lives under `test/**`, outside Codecov's `src/**`-only include glob. No dedicated
  unit test for the helper itself, matching this repo's existing `test/helpers/*.ts` convention (e.g.
  `test/helpers/d1.ts` has none either) — it's exercised directly and thoroughly by the real consuming
  test suites. Verified on Node 26 (not just asserted): all three consuming workspaces' full suites pass
  post-extraction (loopover-ui 79/79 files, ui-kit 3/3, ui-miner 28/28).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — pure test-infrastructure refactor, no visible UI/frontend difference.

## Notes

- Follow-up to #7612/#7616, closing a duplication nit the gate's own review flagged there.
