### PR TITLE
fix(ui): apps/loopover-ui's vite preview is broken for the Cloudflare Workers build target

### DIFF
--- a/.claude/skills/contributing-to-loopover/reference.md
+++ b/.claude/skills/contributing-to-loopover/reference.md
@@ -55,6 +55,20 @@ jobs run only if their path filter matched; on push to `main`, everything runs.
 | ui → typecheck | `tsc --noEmit` (UI) | `npm run ui:typecheck` | UI type error |
 | ui → tests | vitest jsdom (UI) | `npm run ui:test` | failing UI component test |
 | ui → build | UI build | `npm run ui:build` | build failure (note: it re-runs `ui:openapi` internally) |
+
+**Verifying the built artifact actually serves — do not use `apps/loopover-ui`'s `preview` in the raw
+TanStack Start template sense.** `apps/loopover-ui` targets nitro's `cloudflare-module` preset
+(`vite.config.ts`), which repackages the server build as `dist/server/index.mjs`. `@tanstack/start-plugin-core`'s
+`vite preview` integration derives the file it imports from the vite-level server entry's basename
+(`server.js`) and has no awareness of nitro's repackaging, so it 500s with `ERR_MODULE_NOT_FOUND` on
+every request after any build — no upstream fix exists as of `@tanstack/start-plugin-core@1.171.24`
+(confirmed identical to the installed `1.171.19`). `apps/loopover-ui/package.json`'s `preview` script is
+already fixed to use `wrangler dev --config dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local`
+instead (the same mechanism `deploy:built`/`version:built` use) — run `npm --workspace @loopover/ui run
+build && npm --workspace @loopover/ui run preview`, or `npm run ui:preview` from the repo root (which
+builds everything first), to actually exercise the production build locally. `test/unit/loopover-ui-preview-script.test.ts`
+regression-guards the script itself against reverting to `vite preview`.
+
 | ui → extension lint | `eslint` (VS Code + miner extensions) | `npm run extension:lint && npm run miner-extension:lint` | extension ESLint error (same `push \|\| ui==true` trigger as the `ui →` rows) |
 | ui → extension typecheck | `tsc --noEmit` (extensions) | `npm run extension:typecheck && npm run miner-extension:typecheck` | extension type error (same `push \|\| ui==true` trigger) |
 | security (PR only) | dependency-review (moderate+) | `npm audit --audit-level=moderate` | a **newly added** dep has a moderate+ advisory |

--- a/apps/loopover-ui/package.json
+++ b/apps/loopover-ui/package.json
@@ -14,7 +14,7 @@
     "build:dev": "vite build --mode development",
     "bundle-analysis": "bundle-analyzer ./dist/client --bundle-name=loopover-ui --upload-token=$CODECOV_TOKEN",
     "deploy:built": "wrangler deploy --config dist/server/wrangler.json",
-    "preview": "vite preview",
+    "preview": "wrangler dev --config dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
     "version:built": "wrangler versions upload --config dist/server/wrangler.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/test/unit/loopover-ui-preview-script.test.ts
+++ b/test/unit/loopover-ui-preview-script.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("apps/loopover-ui preview script", () => {
+  // Regression guard: @tanstack/start-plugin-core's preview-server-plugin derives the file it imports
+  // from the vite-level server entry's basename ("server" -> server.js), but this app's nitro
+  // cloudflare-module preset (vite.config.ts) repackages the server build as dist/server/index.mjs --
+  // server.js is never produced, so bare `vite preview` 500s on every request after any build, with no
+  // upstream fix available as of @tanstack/start-plugin-core@1.171.24 (latest at time of writing). wrangler
+  // dev against the real built Worker -- the same mechanism deploy:built/version:built already use just
+  // above this script -- is the only local command that actually serves this app's production build.
+  it("uses wrangler dev against the built Cloudflare Worker output, not the broken vite preview", () => {
+    const pkg = JSON.parse(readFileSync("apps/loopover-ui/package.json", "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(pkg.scripts?.preview).toBe(
+      "wrangler dev --config dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
+    );
+  });
+});


### PR DESCRIPTION
Closes #7621

## Summary

- `apps/loopover-ui`'s `preview` script (`vite preview`) 500s on every request after any build --
  reproduced directly on `main`: `Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '.../dist/server/server.js'`. Root cause: `@tanstack/start-plugin-core`'s preview integration derives
  the expected filename from the vite-level server entry (`server.js`), but this app's pinned nitro
  `cloudflare-module` preset repackages the build as `dist/server/index.mjs` instead -- confirmed via a
  real build, and confirmed no upstream fix exists yet (identical logic between the installed
  `@tanstack/start-plugin-core@1.171.19` and latest `1.171.24`). Fixes `apps/loopover-ui`'s own `preview`
  script to use `wrangler dev` against the real built Worker instead -- the same mechanism
  `deploy:built`/`version:built` already use, and what the root's existing `ui:preview` script already
  does for the full monorepo build.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The fix is a `package.json` script value + a `test/**` regression test + a docs update, none under
  `src/**`, so it owes no Codecov patch-coverage number. Verified end-to-end, not just asserted: built the
  real app, ran the fixed `preview` script, and confirmed a genuine `200` with real SSR-rendered HTML
  (correct `<title>`, meta tags, asset references) via a direct HTTP request — both the raw failure and
  the fix were reproduced against a real build, not inferred.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — fixes a broken local verification command, no change to the deployed app itself.

## Notes

- `apps/loopover-miner-ui`'s own `vite preview` is unaffected and unrelated (different, plain Node
  target with no nitro repackaging) — confirmed via its `vite.config.ts` and its own passing regression
  test for the analogous #7228, so it was deliberately left untouched.
