### PR TITLE
docs(contributing): SKILL.md's port-8080 strictPort claim is false outside a Lovable sandbox

### DIFF
--- a/.claude/skills/contributing-to-loopover/SKILL.md
+++ b/.claude/skills/contributing-to-loopover/SKILL.md
@@ -267,9 +267,14 @@ merge instead of a one-shot close.
 below needs real, clickable thumbnail URLs — here's how to get them when you can't drag-and-drop into
 GitHub's web editor (which needs a human browser session an AI coding tool can't drive end-to-end):
 
-1. **Local dev server:** `npm --prefix apps/loopover-ui run dev` (Vite forces port **8080** regardless
-   of what you request — use that port in any launch config, or `preview_screenshot`-style tooling just
-   hangs waiting for the server). For an auth-gated page, use the sanctioned local-preview escape hatch
+1. **Local dev server:** `npm --prefix apps/loopover-ui run dev`. Vite *defaults* to port **8080**, but
+   only *forces* it — hard-failing if taken — inside a Lovable sandbox; `@lovable.dev/vite-tanstack-config`'s
+   `strictPort: true` is gated on `isSandbox`. On a normal contributor machine, CI runner, or AI-agent
+   worktree, an already-occupied 8080 silently shifts to the next free port with only one easy-to-miss
+   console line (`Port 8080 is in use, trying another one...`) and no error. **Read the server's actual
+   `Local:` URL from its startup output before hardcoding a port into any launch config** — don't assume
+   8080; `preview_screenshot`-style tooling that assumes it unconditionally just hangs waiting for a
+   server that's actually listening on 8081+. For an auth-gated page, use the sanctioned local-preview escape hatch
    instead of real GitHub OAuth: `useSession().signInPreview()` (`apps/loopover-ui/src/lib/api/session.ts`),
    gated on `import.meta.env.DEV` — it sets a synthetic session client-side with no network write. Click
    the "Continue with local preview" button in the sign-in wall rather than calling the hook indirectly


### PR DESCRIPTION
Closes #7628

## Summary

- `SKILL.md` claimed Vite "forces port 8080 regardless of what you request" — false outside a Lovable
  sandbox (`strictPort: true` is gated on `isSandbox`). Reproduced directly: an occupied 8080 silently
  shifts to 8081 with no error. Corrects the doc to describe the actual best-effort behavior and tells
  the reader to check the server's real `Local:` URL instead of assuming the port.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Pure documentation change under `.claude/`, not a code change — no test coverage applies. Verified via
  direct reproduction (ran the dev server with port 8080 pre-occupied and observed the actual, undocumented
  fallback behavior) rather than a new test.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — documentation-only change.

## Notes

- Found via a repo-wide audit for the same class of "doc/script doesn't match reality" issue as #7621
  (the `vite preview` fix earlier in this line of work).
