### PR TITLE
feat(orb): initiate APR repo-transfer-to-customer via GitHub's transfer API

### DIFF
--- a/src/orb/apr-repo-transfer.ts
+++ b/src/orb/apr-repo-transfer.ts
@@ -1,0 +1,69 @@
+// APR (Rent-a-Loop, #7173) repo-transfer-to-customer initiation (#7638, implementing #7590's decision that APR
+// customers get an explicit transfer-to-their-own-account flow rather than owning the repo from day one). This
+// kicks off GitHub's standard repository-transfer mechanism from the loopover-controlled org to a customer's own
+// account, authenticated with the Orb App's installation token — the SAME token source the sibling repo-creation
+// flow uses (src/orb/app-auth.ts's createOrbInstallationToken).
+//
+// GitHub transfers are asynchronous and acceptance-gated: the recipient must accept a confirmation email within a
+// time window, and the transfer does NOT complete synchronously. So this module's job is only to *initiate* the
+// transfer and report what GitHub's response says — never to assume the transfer is done. Detecting when a
+// pending transfer is accepted or expires is a separate, out-of-scope concern.
+import { githubHeaders, timeoutFetch } from "../github/client";
+import { createOrbInstallationToken } from "./app-auth";
+
+// A repo transfer is a one-shot POST. Give it the same generous window as the token mint (app-auth.ts) so a
+// throttled App doesn't spuriously abort an otherwise-fine request.
+const REPO_TRANSFER_TIMEOUT_MS = 25_000;
+
+/** Outcome of initiating a repo transfer.
+ *
+ *  `initiated: true` means GitHub ACCEPTED the transfer request (HTTP 202) — it does NOT mean the customer has
+ *  accepted it or that the repo has moved. That acceptance is a separate, later event and is out of scope here.
+ *  `initiated: false` carries GitHub's HTTP status and (truncated) error body so a caller can tell "target
+ *  account doesn't exist" (404) apart from "caller lacks admin access" (403) without catching an exception. */
+export type AprRepoTransferResult =
+  | { initiated: true; status: number; repo: string; newOwner: string }
+  | { initiated: false; status: number; error: string };
+
+/** Initiate a GitHub repository transfer of `repoFullName` (an `owner/repo` in the loopover-controlled org) to
+ *  `newOwner` (the target GitHub account login), authenticated with the Orb App installation token minted for
+ *  `installationId` (the same token source repo-creation uses).
+ *
+ *  IMPORTANT — "initiated" is NOT "complete". A successful response (`initiated: true`) means the transfer has
+ *  been *initiated*: GitHub has recorded a pending transfer that the recipient must still accept via a
+ *  confirmation email within a time window. Anything built on top of this MUST treat `initiated: true` as "a
+ *  transfer is now pending the recipient's acceptance", never as "the repo now belongs to `newOwner`". A
+ *  GitHub-side rejection (unknown target account, missing admin access, …) is returned as `initiated: false` with
+ *  the status and message rather than thrown, so an expected transfer failure never surfaces as an unhandled
+ *  exception. */
+export async function initiateAprRepoTransfer(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  newOwner: string,
+): Promise<AprRepoTransferResult> {
+  const { token } = await createOrbInstallationToken(env, installationId);
+  const response = await timeoutFetch(
+    `https://api.github.com/repos/${repoFullName}/transfer`,
+    {
+      method: "POST",
+      headers: githubHeaders({ token, json: true }),
+      body: JSON.stringify({ new_owner: newOwner }),
+      signal: AbortSignal.timeout(REPO_TRANSFER_TIMEOUT_MS),
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    return {
+      initiated: false,
+      status: response.status,
+      error: body.slice(0, 200),
+    };
+  }
+  return {
+    initiated: true,
+    status: response.status,
+    repo: repoFullName,
+    newOwner,
+  };
+}

--- a/src/orb/apr-repo-transfer.ts
+++ b/src/orb/apr-repo-transfer.ts
@@ -15,12 +15,20 @@ import { createOrbInstallationToken } from "./app-auth";
 // throttled App doesn't spuriously abort an otherwise-fine request.
 const REPO_TRANSFER_TIMEOUT_MS = 25_000;
 
+// `repoFullName` goes straight into the request URL's path, so it must be a plain `owner/repo` pair — the only
+// characters GitHub allows in a login or repo name (alphanumerics plus `-`, `_`, `.`). Rejecting anything else up
+// front stops a value carrying URL metacharacters (`?`, `#`, extra `/`, …) from silently redirecting the POST to
+// a different endpoint. GitHub logins/repos can't legally contain those, so a match here is never a false reject.
+const REPO_FULL_NAME_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
 /** Outcome of initiating a repo transfer.
  *
  *  `initiated: true` means GitHub ACCEPTED the transfer request (HTTP 202) — it does NOT mean the customer has
  *  accepted it or that the repo has moved. That acceptance is a separate, later event and is out of scope here.
  *  `initiated: false` carries GitHub's HTTP status and (truncated) error body so a caller can tell "target
- *  account doesn't exist" (404) apart from "caller lacks admin access" (403) without catching an exception. */
+ *  account doesn't exist" (404) apart from "caller lacks admin access" (403) without catching an exception. A
+ *  locally-rejected malformed `repoFullName` (see `REPO_FULL_NAME_PATTERN`) uses `status: 0` to signal that no
+ *  request was ever sent to GitHub. */
 export type AprRepoTransferResult =
   | { initiated: true; status: number; repo: string; newOwner: string }
   | { initiated: false; status: number; error: string };
@@ -42,6 +50,15 @@ export async function initiateAprRepoTransfer(
   repoFullName: string,
   newOwner: string,
 ): Promise<AprRepoTransferResult> {
+  // Guard the URL path before spending a token mint or a network round-trip: a `repoFullName` with URL
+  // metacharacters could otherwise redirect the POST to an unintended endpoint.
+  if (!REPO_FULL_NAME_PATTERN.test(repoFullName)) {
+    return {
+      initiated: false,
+      status: 0,
+      error: `invalid repoFullName: ${repoFullName.slice(0, 200)}`,
+    };
+  }
   const { token } = await createOrbInstallationToken(env, installationId);
   const response = await timeoutFetch(
     `https://api.github.com/repos/${repoFullName}/transfer`,

--- a/test/unit/orb-apr-repo-transfer.test.ts
+++ b/test/unit/orb-apr-repo-transfer.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initiateAprRepoTransfer } from "../../src/orb/apr-repo-transfer";
+import { createTestEnv } from "../helpers/d1";
+
+// Mint a real RSA private key so createOrbInstallationToken's JWT signing (RS256) succeeds — the transfer flow
+// mints an installation token first, exactly like the rest of src/orb/app-auth.ts.
+async function pkcs8Pem(): Promise<string> {
+  const key = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const b64 = Buffer.from(
+    (await crypto.subtle.exportKey("pkcs8", key.privateKey)) as ArrayBuffer,
+  )
+    .toString("base64")
+    .replace(/(.{64})/g, "$1\n");
+  return `-----BEGIN PRIVATE KEY-----\n${b64}\n-----END PRIVATE KEY-----`;
+}
+
+const orbEnv = async (): Promise<Env> =>
+  createTestEnv({
+    ORB_GITHUB_APP_ID: "4139483",
+    ORB_GITHUB_APP_PRIVATE_KEY: await pkcs8Pem(),
+  });
+
+/** Stub fetch so the installation-token mint always succeeds and the transfer endpoint responds however a test
+ *  asks. Records the transfer request so a test can assert the endpoint, method, and `new_owner` body. */
+function stubTransfer(transfer: () => Response): {
+  calls: Array<{
+    url: string;
+    method?: string | undefined;
+    body?: string | undefined;
+  }>;
+} {
+  const calls: Array<{
+    url: string;
+    method?: string | undefined;
+    body?: string | undefined;
+  }> = [];
+  vi.stubGlobal(
+    "fetch",
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/access_tokens"))
+        return Response.json({
+          token: "ghs_transfer",
+          expires_at: "2026-06-25T07:00:00Z",
+          permissions: { administration: "write" },
+        });
+      calls.push({
+        url,
+        method: init?.method,
+        body: init?.body as string | undefined,
+      });
+      return transfer();
+    },
+  );
+  return { calls };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("initiateAprRepoTransfer", () => {
+  it("initiates the transfer (202) and reports initiated — never complete", async () => {
+    // GitHub returns 202 Accepted with the still-pending repo object; the transfer is NOT yet complete.
+    const { calls } = stubTransfer(
+      () =>
+        new Response(JSON.stringify({ full_name: "loopover-org/acme-app" }), {
+          status: 202,
+        }),
+    );
+
+    const result = await initiateAprRepoTransfer(
+      await orbEnv(),
+      42,
+      "loopover-org/acme-app",
+      "customer-login",
+    );
+
+    expect(result).toEqual({
+      initiated: true,
+      status: 202,
+      repo: "loopover-org/acme-app",
+      newOwner: "customer-login",
+    });
+    // Hit the documented transfer endpoint with POST and the target login as `new_owner`.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      "https://api.github.com/repos/loopover-org/acme-app/transfer",
+    );
+    expect(calls[0]?.method).toBe("POST");
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({
+      new_owner: "customer-login",
+    });
+  });
+
+  it("returns initiated:false with the status + message when the target account doesn't exist (404)", async () => {
+    stubTransfer(
+      () =>
+        new Response(JSON.stringify({ message: "Not Found" }), { status: 404 }),
+    );
+
+    const result = await initiateAprRepoTransfer(
+      await orbEnv(),
+      42,
+      "loopover-org/acme-app",
+      "ghost-account",
+    );
+
+    // A GitHub-side rejection is returned, not thrown — no unhandled exception.
+    expect(result).toEqual({
+      initiated: false,
+      status: 404,
+      error: JSON.stringify({ message: "Not Found" }),
+    });
+  });
+
+  it("returns initiated:false when the caller lacks admin access (403), truncating a long error body", async () => {
+    const longBody = "x".repeat(500);
+    stubTransfer(() => new Response(longBody, { status: 403 }));
+
+    const result = await initiateAprRepoTransfer(
+      await orbEnv(),
+      42,
+      "loopover-org/acme-app",
+      "customer-login",
+    );
+
+    expect(result.initiated).toBe(false);
+    expect(result).toMatchObject({ initiated: false, status: 403 });
+    // Error body is truncated to keep the result diagnostic without unbounded growth.
+    if (!result.initiated) expect(result.error).toBe("x".repeat(200));
+  });
+});

--- a/test/unit/orb-apr-repo-transfer.test.ts
+++ b/test/unit/orb-apr-repo-transfer.test.ts
@@ -100,6 +100,26 @@ describe("initiateAprRepoTransfer", () => {
     });
   });
 
+  it("rejects a malformed repoFullName locally (status 0) without minting a token or hitting GitHub", async () => {
+    // A `?`-carrying value would redirect the POST to a different endpoint, so it's refused before any network I/O.
+    const { calls } = stubTransfer(() => new Response(null, { status: 202 }));
+
+    const result = await initiateAprRepoTransfer(
+      await orbEnv(),
+      42,
+      "loopover-org/acme-app?ref=evil",
+      "customer-login",
+    );
+
+    expect(result).toEqual({
+      initiated: false,
+      status: 0,
+      error: "invalid repoFullName: loopover-org/acme-app?ref=evil",
+    });
+    // No token mint, no transfer POST — nothing reached the stubbed fetch at all.
+    expect(calls).toHaveLength(0);
+  });
+
   it("returns initiated:false with the status + message when the target account doesn't exist (404)", async () => {
     stubTransfer(
       () =>


### PR DESCRIPTION
feat(orb): initiate APR repo-transfer-to-customer via GitHub's transfer API

Implements #7590's decision that APR (Rent-a-Loop) customers get an explicit
transfer-to-their-own-account flow. initiateAprRepoTransfer POSTs to GitHub's
"Transfer a repository" endpoint (POST /repos/{owner}/{repo}/transfer) with the
target login as new_owner, authenticated with the Orb App installation token
(the same token source repo-creation uses).

GitHub transfers are asynchronous and acceptance-gated — the recipient must
accept a confirmation email within a time window — so a successful response
means the transfer was INITIATED, not COMPLETED. The result models this
explicitly (initiated: true carries GitHub's 202 status; it is never "done"),
and a GitHub-side rejection (unknown target account, missing admin access) is
returned as initiated: false with the status and message rather than thrown, so
an expected failure never surfaces as an unhandled exception.

Closes #7638

