### PR TITLE
feat(registry): add repoOrigin (BYOR/APR) to RegistryRepoConfig

### DIFF
--- a/src/registry/normalize.ts
+++ b/src/registry/normalize.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ISSUE_DISCOVERY_SHARE } from "../scoring/model";
-import type { JsonValue, RegistryRepoConfig, RegistrySnapshot, RepoPoolAssociation, RepoTimeDecayOverrides } from "../types";
+import type { JsonValue, RegistryRepoConfig, RegistrySnapshot, RepoOrigin, RepoPoolAssociation, RepoTimeDecayOverrides } from "../types";
 
 type RawRepoConfig = Record<string, JsonValue>;
 
@@ -77,6 +77,7 @@ function normalizeRepo(repo: string, config: RawRepoConfig): RegistryRepoConfig 
     eligibilityMode: stringValue(config.eligibility_mode),
     timeDecay: parseTimeDecayOverrides(config.scoring),
     poolAssociation: parsePoolAssociation(config),
+    repoOrigin: parseRepoOrigin(config),
     raw: config,
   };
 }
@@ -96,6 +97,29 @@ function parsePoolAssociation(config: RawRepoConfig): RepoPoolAssociation | null
 // #6099's pool-state reporting UI consume — the single place downstream code asks "is this repo pool-funded?".
 export function getRepoPoolAssociation(config: RegistryRepoConfig | null | undefined): RepoPoolAssociation | null {
   return config?.poolAssociation ?? null;
+}
+
+// Repo provisioning origin (#7589), from the registry's flat `repo_origin` (+ `hosting_org` for APR) fields.
+// Only an explicit marker yields an origin: an absent field parses to null (mirroring parsePoolAssociation),
+// because absent means "pre-dates this field / not yet known", NOT a confirmed BYOR. An `apr` marker missing
+// its hosting org is malformed and likewise treated as no origin, the same way a half-specified pool
+// association above collapses to null rather than a partial object. This is type-and-plumbing only — no
+// repo-creation or GitHub API logic lives here (#7590 covers that separately).
+function parseRepoOrigin(config: RawRepoConfig): RepoOrigin | null {
+  const kind = stringValue(config.repo_origin);
+  if (kind === "byor") return { kind: "byor" };
+  if (kind === "apr") {
+    const hostingOrg = stringValue(config.hosting_org);
+    return hostingOrg === null ? null : { kind: "apr", hostingOrg };
+  }
+  return null;
+}
+
+// Read accessor for a repo's provisioning origin (#7589), mirroring getRepoPoolAssociation: returns the origin
+// a repo was registered with, or null for a repo that pre-dates the field / has no config. The single place
+// downstream code asks "was this repo customer-provided (BYOR) or loopover-provisioned (APR)?".
+export function getRepoOrigin(config: RegistryRepoConfig | null | undefined): RepoOrigin | null {
+  return config?.repoOrigin ?? null;
 }
 
 // Per-repo time-decay overrides (#703), from the registry's nested `scoring.time_decay` (the same source

--- a/src/types.ts
+++ b/src/types.ts
@@ -449,6 +449,16 @@ export type RepoPoolAssociation = {
   subnetId: number;
 };
 
+/**
+ * Repo provisioning origin (#7589's BYOR+APR epic; #7590's hosting decision). BYOR = a customer's own
+ * pre-existing repo; APR = a loopover-provisioned repo, carrying the GitHub org it was created under. Present
+ * only when the registry explicitly records it — absent means "not yet known / pre-dates this field", NOT a
+ * confirmed BYOR, so an unmarked repo round-trips byte-identical to today. Read it via `getRepoOrigin`.
+ */
+export type RepoOrigin =
+  | { kind: "byor" }
+  | { kind: "apr"; hostingOrg: string };
+
 export type RegistryRepoConfig = {
   repo: string;
   emissionShare: number;
@@ -463,6 +473,8 @@ export type RegistryRepoConfig = {
   timeDecay?: RepoTimeDecayOverrides | null;
   /** Subnet-funded pool association (#6099); null/absent = an organic repo with no funding pool (#6320). */
   poolAssociation?: RepoPoolAssociation | null;
+  /** Repo provisioning origin (#7589); null/absent = pre-dates this field, unchanged behavior (do NOT assume BYOR). */
+  repoOrigin?: RepoOrigin | null;
   raw: Record<string, JsonValue>;
 };
 

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getRepository, upsertRepositoryFromGitHub } from "../../src/db/repositories";
-import { getRepoPoolAssociation, normalizeRegistryPayload } from "../../src/registry/normalize";
+import { getRepoOrigin, getRepoPoolAssociation, normalizeRegistryPayload } from "../../src/registry/normalize";
 import { DEFAULT_ISSUE_DISCOVERY_SHARE } from "../../src/scoring/model";
 import { getLatestRegistrySnapshot, persistRegistrySnapshot, refreshRegistry } from "../../src/registry/sync";
 import { createCloudTestEnv, createTestEnv } from "../helpers/d1";
@@ -116,6 +116,50 @@ describe("registry normalization", () => {
     expect(byName["JSONbored/organic"]!.poolAssociation ?? null).toBeNull();
     expect(byName["JSONbored/pool-only"]!.poolAssociation ?? null).toBeNull();
     expect(byName["JSONbored/subnet-only"]!.poolAssociation ?? null).toBeNull();
+  });
+
+  it("parses a repo provisioning origin (BYOR/APR) and leaves unmarked repos with none (#7589)", () => {
+    const snapshot = normalizeRegistryPayload(
+      {
+        // An explicit BYOR marker → the customer-provided origin reads back.
+        "JSONbored/byor": { emission_share: 0.02, repo_origin: "byor" },
+        // An APR marker carries the loopover org it was provisioned under → full APR origin.
+        "JSONbored/apr": { emission_share: 0.02, repo_origin: "apr", hosting_org: "loopover-repos" },
+        // An unmarked repo has no origin field → null, byte-identical to today (NOT assumed BYOR).
+        "JSONbored/legacy": { emission_share: 0.01 },
+        // An APR marker missing its hosting org is malformed → null, not a half-populated object.
+        "JSONbored/apr-no-org": { emission_share: 0.01, repo_origin: "apr" },
+        // An unrecognized origin string is ignored → null.
+        "JSONbored/bogus": { emission_share: 0.01, repo_origin: "mystery" },
+      },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+    const byName = Object.fromEntries(snapshot.repositories.map((r) => [r.repo, r]));
+    expect(byName["JSONbored/byor"]!.repoOrigin).toEqual({ kind: "byor" });
+    expect(byName["JSONbored/apr"]!.repoOrigin).toEqual({ kind: "apr", hostingOrg: "loopover-repos" });
+    expect(byName["JSONbored/legacy"]!.repoOrigin ?? null).toBeNull();
+    expect(byName["JSONbored/apr-no-org"]!.repoOrigin ?? null).toBeNull();
+    expect(byName["JSONbored/bogus"]!.repoOrigin ?? null).toBeNull();
+    // The unmarked repo carries NO origin key at all, so it round-trips byte-identical to before this field.
+    expect("repoOrigin" in byName["JSONbored/legacy"]!).toBe(true);
+    expect(byName["JSONbored/legacy"]!.repoOrigin).toBeNull();
+  });
+
+  it("reads a repo's origin via the getRepoOrigin accessor (#7589)", () => {
+    const snapshot = normalizeRegistryPayload(
+      { "JSONbored/apr": { emission_share: 0.02, repo_origin: "apr", hosting_org: "loopover-repos" } },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+    const config = snapshot.repositories.find((r) => r.repo === "JSONbored/apr")!;
+    expect(getRepoOrigin(config)).toEqual({ kind: "apr", hostingOrg: "loopover-repos" });
+    expect(getRepoOrigin(null)).toBeNull();
+    expect(getRepoOrigin(undefined)).toBeNull();
+    // A config object with no repoOrigin key at all resolves to null through the nullish accessor (the
+    // "pre-dates this field" case). Omit the key rather than set it to undefined, per exactOptionalPropertyTypes.
+    const { repoOrigin: _omitted, ...withoutOrigin } = config;
+    expect(getRepoOrigin(withoutOrigin)).toBeNull();
   });
 
   it("getRepoPoolAssociation reads a repo's pool association or null (#6320)", () => {


### PR DESCRIPTION
Closes #7636

## Summary

Adds an **optional** `repoOrigin` field to `RegistryRepoConfig`, mirroring `poolAssociation`'s exact null-safety convention from #6320. A repo that predates this field carries no origin and **round-trips byte-identical to today** — there is no behavior change for any existing repo.

`RepoOrigin` distinguishes **BYOR** (a customer's own pre-existing repo) from **APR** (a loopover-provisioned repo), the representation the BYOR+APR epic (#7589) needs so downstream consumers know which provisioning path a repo took.

## What changed (2 files, mirroring #6320's footprint exactly)

- **`src/types.ts`** — `RepoOrigin = { kind: "byor" } | { kind: "apr"; hostingOrg: string }`, and `repoOrigin?: RepoOrigin | null` on `RegistryRepoConfig`, with the same doc-comment convention `poolAssociation` uses. Per the issue, absent means *"pre-dates this field / not yet known"* — **deliberately not assumed BYOR**.
- **`src/registry/normalize.ts`** — `parseRepoOrigin(config)` reads the registry's flat `repo_origin` (+ `hosting_org` for APR) fields and is threaded into `normalizeRepo` right beside `parsePoolAssociation`; a `getRepoOrigin` accessor mirrors `getRepoPoolAssociation`.

An absent marker, an unrecognized origin string, or an `apr` marker **missing its hosting org** all parse to `null` — the same *"a partial one is treated as none"* collapse `parsePoolAssociation` already uses for a half-specified pool association, never a half-populated object.

**Type-and-plumbing only.** No repo-creation, GitHub API, or provisioning logic — that is #7590's scope, explicitly excluded here.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — see the closing reference at the top of this body.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (zero new errors vs base)
- [x] `npm run test:coverage` locally; **`codecov/patch` ≥99% of changed lines AND branches**
- [x] `npm run ui:openapi:check`
- [x] `npm run engine-parity:drift-check`
- [x] `npm run docs:drift-check`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

**Patch coverage: 100% (7/7 executable changed lines, both branches of the new field — present and absent).**

Tests in `test/unit/registry.test.ts` mirror #6320's `poolAssociation` test exactly: a `byor` marker → `{ kind: "byor" }`; a full APR origin → `{ kind: "apr", hostingOrg }`; an unmarked repo → `null` (byte-identical); a malformed `apr`-without-hosting-org → `null`; an unrecognized origin → `null`; plus the `getRepoOrigin` accessor over present / `null` / `undefined` / key-absent configs. All existing registry tests pass unchanged.

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed (no API/OpenAPI surface changes — this is an internal registry type; `ui:openapi:check` confirms no drift).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section. Not applicable — backend type + parser only.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this is a backend type addition plus its registry parser. No UI, frontend, docs, or extension surface is touched.

## Notes

- The field is optional and defaults to absent, so this is a pure additive change: `git diff` shows only additions to existing constructs, no modification to how any current repo normalizes.
- `getRepoOrigin` is exported-but-unconsumed for now, exactly as `getRepoPoolAssociation` was when #6320 landed — it is the read seam later APR work will consume.
