### PR TITLE
feat(registry): add CustomerPoolAssociation, parallel to RepoPoolAssociation

### DIFF
--- a/src/registry/normalize.ts
+++ b/src/registry/normalize.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ISSUE_DISCOVERY_SHARE } from "../scoring/model";
-import type { JsonValue, RegistryRepoConfig, RegistrySnapshot, RepoOrigin, RepoPoolAssociation, RepoTimeDecayOverrides } from "../types";
+import type { CustomerPoolAssociation, JsonValue, RegistryRepoConfig, RegistrySnapshot, RepoOrigin, RepoPoolAssociation, RepoTimeDecayOverrides } from "../types";
 
 type RawRepoConfig = Record<string, JsonValue>;
 
@@ -77,6 +77,7 @@ function normalizeRepo(repo: string, config: RawRepoConfig): RegistryRepoConfig 
     eligibilityMode: stringValue(config.eligibility_mode),
     timeDecay: parseTimeDecayOverrides(config.scoring),
     poolAssociation: parsePoolAssociation(config),
+    customerPoolAssociation: parseCustomerPoolAssociation(config),
     repoOrigin: parseRepoOrigin(config),
     raw: config,
   };
@@ -97,6 +98,25 @@ function parsePoolAssociation(config: RawRepoConfig): RepoPoolAssociation | null
 // #6099's pool-state reporting UI consume — the single place downstream code asks "is this repo pool-funded?".
 export function getRepoPoolAssociation(config: RegistryRepoConfig | null | undefined): RepoPoolAssociation | null {
   return config?.poolAssociation ?? null;
+}
+
+// Customer-funded pool association (#7679), from the registry's flat `pool_id`/`funder_account` fields —
+// parallel to parsePoolAssociation, but the funding source is a paying customer's account, not a subnet netuid.
+// Both must be present and non-empty for an association to exist; a repo missing either (i.e. every repo with
+// no customer-funded pool, including a subnet-funded one that carries `subnet_id` but no `funder_account`)
+// parses to null and stays byte-identical to today.
+function parseCustomerPoolAssociation(config: RawRepoConfig): CustomerPoolAssociation | null {
+  const poolId = stringValue(config.pool_id);
+  const funderAccount = stringValue(config.funder_account);
+  if (poolId === null || funderAccount === null) return null;
+  return { poolId, funderAccount };
+}
+
+// Read accessor for a repo's customer-funded pool association (#7679), mirroring getRepoPoolAssociation: the
+// single place downstream code asks "is this repo funded by a paying customer?", distinct from the subnet-funded
+// question getRepoPoolAssociation answers.
+export function getCustomerPoolAssociation(config: RegistryRepoConfig | null | undefined): CustomerPoolAssociation | null {
+  return config?.customerPoolAssociation ?? null;
 }
 
 // Repo provisioning origin (#7589), from the registry's flat `repo_origin` (+ `hosting_org` for APR) fields.

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,6 +450,21 @@ export type RepoPoolAssociation = {
 };
 
 /**
+ * Customer-funded pool association for a registered repo (#7679, Wave 5's "two demographics" per #4778). The
+ * parallel to {@link RepoPoolAssociation} for a pool funded by a paying CUSTOMER rather than a Bittensor subnet:
+ * both pay out to gittensor-registered contributors as emissions (same payout mechanism), but the funding source
+ * differs — so `subnetId` (meaningless for a non-subnet customer) is replaced by the funding customer's account.
+ * Kept a separate type rather than an optional `subnetId` on `RepoPoolAssociation` so the two funding models stay
+ * structurally distinct. Both fields are required for a valid association — a partial one (only one field) is
+ * treated as no association, so a repo with no customer-pool fields round-trips byte-identical to today. Read it
+ * via `getCustomerPoolAssociation`.
+ */
+export type CustomerPoolAssociation = {
+  poolId: string;
+  funderAccount: string;
+};
+
+/**
  * Repo provisioning origin (#7589's BYOR+APR epic; #7590's hosting decision). BYOR = a customer's own
  * pre-existing repo; APR = a loopover-provisioned repo, carrying the GitHub org it was created under. Present
  * only when the registry explicitly records it — absent means "not yet known / pre-dates this field", NOT a
@@ -473,6 +488,8 @@ export type RegistryRepoConfig = {
   timeDecay?: RepoTimeDecayOverrides | null;
   /** Subnet-funded pool association (#6099); null/absent = an organic repo with no funding pool (#6320). */
   poolAssociation?: RepoPoolAssociation | null;
+  /** Customer-funded pool association (#7679); null/absent = a repo with no customer-funded pool. */
+  customerPoolAssociation?: CustomerPoolAssociation | null;
   /** Repo provisioning origin (#7589); null/absent = pre-dates this field, unchanged behavior (do NOT assume BYOR). */
   repoOrigin?: RepoOrigin | null;
   raw: Record<string, JsonValue>;

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getRepository, upsertRepositoryFromGitHub } from "../../src/db/repositories";
-import { getRepoOrigin, getRepoPoolAssociation, normalizeRegistryPayload } from "../../src/registry/normalize";
+import { getCustomerPoolAssociation, getRepoOrigin, getRepoPoolAssociation, normalizeRegistryPayload } from "../../src/registry/normalize";
 import { DEFAULT_ISSUE_DISCOVERY_SHARE } from "../../src/scoring/model";
 import { getLatestRegistrySnapshot, persistRegistrySnapshot, refreshRegistry } from "../../src/registry/sync";
 import { createCloudTestEnv, createTestEnv } from "../helpers/d1";
@@ -116,6 +116,47 @@ describe("registry normalization", () => {
     expect(byName["JSONbored/organic"]!.poolAssociation ?? null).toBeNull();
     expect(byName["JSONbored/pool-only"]!.poolAssociation ?? null).toBeNull();
     expect(byName["JSONbored/subnet-only"]!.poolAssociation ?? null).toBeNull();
+  });
+
+  it("parses a customer-funded pool association, parallel to and distinct from the subnet-funded one (#7679)", () => {
+    const snapshot = normalizeRegistryPayload(
+      {
+        // A customer-funded repo carries a pool id and a funder account → a full customer association reads back.
+        "JSONbored/customer": { emission_share: 0.02, pool_id: "pool-cust", funder_account: "acme-corp" },
+        // A subnet-funded repo has pool_id + subnet_id but no funder_account → NO customer association (they stay distinct).
+        "JSONbored/subnet": { emission_share: 0.02, pool_id: "pool-74", subnet_id: 74 },
+        // An organic repo has neither → no customer association, byte-identical to today.
+        "JSONbored/organic": { emission_share: 0.01 },
+        // A partial customer association (pool id but no funder) is dropped, not a half-populated object.
+        "JSONbored/pool-only": { emission_share: 0.01, pool_id: "pool-x" },
+        // A partial customer association (funder but no pool id) is likewise dropped.
+        "JSONbored/funder-only": { emission_share: 0.01, funder_account: "acme-corp" },
+      },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+    const byName = Object.fromEntries(snapshot.repositories.map((r) => [r.repo, r]));
+    expect(byName["JSONbored/customer"]!.customerPoolAssociation).toEqual({ poolId: "pool-cust", funderAccount: "acme-corp" });
+    // The subnet-funded repo has its own poolAssociation but NO customer association — the two are independent.
+    expect(byName["JSONbored/subnet"]!.customerPoolAssociation ?? null).toBeNull();
+    expect(byName["JSONbored/subnet"]!.poolAssociation).toEqual({ poolId: "pool-74", subnetId: 74 });
+    expect(byName["JSONbored/organic"]!.customerPoolAssociation ?? null).toBeNull();
+    expect(byName["JSONbored/pool-only"]!.customerPoolAssociation ?? null).toBeNull();
+    expect(byName["JSONbored/funder-only"]!.customerPoolAssociation ?? null).toBeNull();
+  });
+
+  it("reads a repo's customer-funded pool via the getCustomerPoolAssociation accessor (#7679)", () => {
+    const snapshot = normalizeRegistryPayload(
+      { "JSONbored/customer": { emission_share: 0.02, pool_id: "pool-cust", funder_account: "acme-corp" } },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+    const config = snapshot.repositories.find((r) => r.repo === "JSONbored/customer")!;
+    expect(getCustomerPoolAssociation(config)).toEqual({ poolId: "pool-cust", funderAccount: "acme-corp" });
+    expect(getCustomerPoolAssociation(null)).toBeNull();
+    expect(getCustomerPoolAssociation(undefined)).toBeNull();
+    const { customerPoolAssociation: _omitted, ...withoutCustomerPool } = config;
+    expect(getCustomerPoolAssociation(withoutCustomerPool)).toBeNull();
   });
 
   it("parses a repo provisioning origin (BYOR/APR) and leaves unmarked repos with none (#7589)", () => {


### PR DESCRIPTION
Closes #7679

## Summary

Wave 5's "two demographics" (#4778) includes **customer-funded pools** — a paying customer, not necessarily a Bittensor subnet — which still pay out to gittensor-registered contributors as emissions (same payout mechanism, different funding source). `RepoPoolAssociation` requires a `subnetId`, which is meaningless for a non-subnet customer, so a customer-funded pool has **no data-model representation** today. This is purely that representation gap.

Adds a separate `CustomerPoolAssociation = { poolId; funderAccount }`, **parallel to** `RepoPoolAssociation` rather than overloading it with an optional `subnetId`, so the two funding models stay structurally distinct. It's threaded through exactly the sites `RepoPoolAssociation` touches, mirroring #6320's precedent (the checklist the issue points to).

## What changed (2 files, the #6320 footprint)

- **`src/types.ts`** — the `CustomerPoolAssociation` type + an **optional** `customerPoolAssociation?: CustomerPoolAssociation | null` on `RegistryRepoConfig`, with the same null-safety convention `poolAssociation` uses. Absent = a repo with no customer-funded pool, **byte-identical to today**.
- **`src/registry/normalize.ts`** — `parseCustomerPoolAssociation` reads the registry's flat `pool_id` / `funder_account` fields (both required; a partial one collapses to `null`, exactly as `parsePoolAssociation` treats a half-specified subnet association), threaded into `normalizeRepo` beside `parsePoolAssociation`; a `getCustomerPoolAssociation` accessor mirrors `getRepoPoolAssociation`.

The two associations are **independent**: a subnet-funded repo (`pool_id` + `subnet_id`, no `funder_account`) parses to a `poolAssociation` but a `null` `customerPoolAssociation`, and a customer-funded repo the reverse. Type-and-plumbing only — no economics or payout logic (the issue confirms the payout mechanism is unchanged; this is a data-representation gap).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — see the closing reference at the top of this body.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (zero new errors vs base)
- [x] `npm run test:coverage` locally; **`codecov/patch` ≥99% of changed lines AND branches**
- [x] `npm run ui:openapi:check`
- [x] `npm run docs:drift-check`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

**Patch coverage: 100% (5/5 executable changed lines, both present and absent branches of the new field).**

Tests in `test/unit/registry.test.ts` mirror #6320's `poolAssociation` test exactly: a full customer association; a subnet-funded repo confirmed to carry **no** customer association (proving the two stay distinct); an organic repo (`null`); a partial `pool-only` and a partial `funder-only` (both `null`); plus the `getCustomerPoolAssociation` accessor over present / `null` / `undefined` / key-absent configs. All existing registry tests pass unchanged.

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed (no API/OpenAPI surface change — internal registry type; `ui:openapi:check` confirms no drift).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section. Not applicable — backend type + parser only.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a backend type addition plus its registry parser. No UI, frontend, docs, or extension surface is touched.

## Notes

- Optional field, defaults to absent → pure additive change: `git diff` shows only additions to existing constructs, no change to how any current repo normalizes.
- `funderAccount` names the paying customer's account (the funding-source analogue of `subnetId`); `getCustomerPoolAssociation` is exported-but-unconsumed for now, exactly as `getRepoPoolAssociation` was when #6320 landed — the read seam later Wave-5 pool work consumes.
