### PR TITLE
feat(control-plane): add SettlementBackendDriver interface + fake driver

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -18,3 +18,13 @@ export {
   type TenantDeprovisioningResult,
   type TenantProvisioningResult,
 } from "./provisioning.js";
+export {
+  createFakeSettlementBackendDriver,
+  type FakeSettlementBackendDriver,
+  type FakeSettlementCall,
+  type FakeSettlementStep,
+  type PayoutEligibleEvent,
+  type PoolId,
+  type SettlementBackendDriver,
+  type SettlementReversalReason,
+} from "./settlement-backend-driver.js";

--- a/control-plane/src/settlement-backend-driver.ts
+++ b/control-plane/src/settlement-backend-driver.ts
@@ -1,0 +1,133 @@
+// `SettlementBackendDriver` interface seam (#7572, implementing #6098's design spec). Mirrors the sibling
+// `TenantProvisioningDriver` (control-plane/src/tenant-provisioning-driver.ts): a small, backend-agnostic
+// contract plus a minimal in-memory fake, so #4792's rental-ledger work and #4791's settlement-scenario policy
+// can build and test against a stable boundary regardless of which real backend — a future gittensor-owned
+// settlement service, or a self-built one — eventually lands behind it.
+//
+// The interface names exactly the four hook points #6098 specifies for the "pool funded → work discovered →
+// work delivered → payout owed" flow: fund a pool, query/decrement its balance, intake a payout-eligible event,
+// and reverse a prior obligation (refund/dispute/partial-completion). Real backends MAY perform real money
+// movement; this file defines only the contract and the fake — no real funds, credentials, or IO of any kind.
+//
+// GITTENSOR STRUCTURALLY IN THE PATH (#6098): every payout is keyed to a `gittensorContributor` — the
+// gittensor-registered identity the emission is owed to — so a settlement can only ever be expressed as a
+// gittensor-native payout. Even a self-built backend cannot decrement a pool for an unattributed recipient
+// through this contract, making "gittensor is in the settlement path" structurally true rather than a policy
+// promise. The actual refund/dispute POLICY stays #4791's job; this interface only names where it plugs in.
+
+/** A funded reward pool's opaque id (matches #6098's `SettlementBackend.poolId` / the registry's `pool_id`). */
+export type PoolId = string;
+
+/**
+ * A payout-eligible event (#6098): a merged PR against a subnet- or customer-funded repo, owing an emission to a
+ * gittensor-registered contributor from a specific pool. Carries exactly what a backend needs to attribute and
+ * settle the payout — not a ledger schema.
+ */
+export type PayoutEligibleEvent = {
+  poolId: PoolId;
+  /** The `owner/repo` whose merged PR triggered the payout. */
+  repoFullName: string;
+  /** The merged PR that delivered the work. */
+  prNumber: number;
+  /** The gittensor-registered contributor the emission is owed to. Keeping payouts keyed to a gittensor identity
+   *  is what keeps gittensor structurally in the settlement path (#6098). */
+  gittensorContributor: string;
+  /** Amount owed, in the pool's own units. Precision/rounding policy is #4791's, not this interface's. */
+  amount: number;
+};
+
+/** Why a prior payout obligation is being reversed (#6098's refund/dispute/partial-completion hook). The policy
+ *  behind each is #4791's; the interface only enumerates where that policy plugs in. */
+export type SettlementReversalReason = "refund" | "dispute" | "partial_completion";
+
+export interface SettlementBackendDriver {
+  /** "Pool funded" step: credit `amount` into a pool's allocation. Real backend → the funding source's transfer;
+   *  the fake adds to an in-memory balance. */
+  fundPool(poolId: PoolId, amount: number): Promise<void>;
+  /** Read side of the balance contract: a pool's remaining allocation. A pool never funded reads as 0. */
+  getPoolBalance(poolId: PoolId): Promise<number>;
+  /** "Payout owed" intake: record a payout-eligible event and decrement its pool's balance by `event.amount`.
+   *  MUST be idempotent per event (same repo+PR+pool+contributor) — re-recording a settled event is a no-op, so
+   *  a redelivered webhook never double-pays. */
+  recordPayoutEligibleEvent(event: PayoutEligibleEvent): Promise<void>;
+  /** Refund/dispute/partial-completion hook: reverse a previously-recorded payout, crediting `event.amount` back
+   *  to the pool. MUST be idempotent — reversing an unrecorded or already-reversed event is a no-op, never a
+   *  throw. The reason is threaded through for #4791's policy/audit; this contract does not interpret it. */
+  reversePayout(event: PayoutEligibleEvent, reason: SettlementReversalReason): Promise<void>;
+}
+
+/** The driver steps a fake records, for white-box assertions on call order and idempotency. */
+export type FakeSettlementStep = "fundPool" | "recordPayoutEligibleEvent" | "reversePayout";
+
+/** One recorded settlement call. */
+export type FakeSettlementCall = {
+  step: FakeSettlementStep;
+  poolId: PoolId;
+  amount: number;
+};
+
+/** A fake `SettlementBackendDriver` plus the recorded state a test inspects. */
+export type FakeSettlementBackendDriver = SettlementBackendDriver & {
+  /** Current remaining balance per pool (an in-memory stand-in for a real ledger). */
+  readonly balances: ReadonlyMap<PoolId, number>;
+  /** The keys of payout events currently recorded-and-not-reversed (`poolId|repo|pr|contributor`). */
+  readonly settledEventKeys: ReadonlySet<string>;
+  /** Every driver step this fake has run, in call order. */
+  readonly calls: readonly FakeSettlementCall[];
+};
+
+/** Stable idempotency key for a payout event: the same delivered work never settles or reverses twice. */
+function payoutEventKey(event: PayoutEligibleEvent): string {
+  return `${event.poolId}|${event.repoFullName}|${event.prNumber}|${event.gittensorContributor}`;
+}
+
+/**
+ * Minimal in-memory fake for contract/scenario tests — a balances map stands in for a real ledger, a set of
+ * settled event keys enforces per-event idempotency, and an ordered call log records every step. NO real funds,
+ * credentials, or IO. Mirrors `createFakeTenantProvisioningDriver`: implements the interface and exposes its
+ * recorded state as extra introspection surface beyond the contract.
+ */
+export function createFakeSettlementBackendDriver(): FakeSettlementBackendDriver {
+  const balances = new Map<PoolId, number>();
+  const settledEventKeys = new Set<string>();
+  const calls: FakeSettlementCall[] = [];
+
+  return {
+    get balances() {
+      return balances;
+    },
+    get settledEventKeys() {
+      return settledEventKeys;
+    },
+    get calls() {
+      return calls;
+    },
+    async fundPool(poolId, amount) {
+      calls.push({ step: "fundPool", poolId, amount });
+      balances.set(poolId, (balances.get(poolId) ?? 0) + amount);
+    },
+    async getPoolBalance(poolId) {
+      return balances.get(poolId) ?? 0;
+    },
+    async recordPayoutEligibleEvent(event) {
+      calls.push({ step: "recordPayoutEligibleEvent", poolId: event.poolId, amount: event.amount });
+      // Idempotent intake: a redelivered event (already settled) neither re-decrements the balance nor
+      // double-records — the else-path is the "already settled" no-op.
+      const key = payoutEventKey(event);
+      if (!settledEventKeys.has(key)) {
+        settledEventKeys.add(key);
+        balances.set(event.poolId, (balances.get(event.poolId) ?? 0) - event.amount);
+      }
+    },
+    async reversePayout(event, _reason) {
+      calls.push({ step: "reversePayout", poolId: event.poolId, amount: event.amount });
+      // Idempotent reversal: only a currently-settled event credits back; reversing an unrecorded or
+      // already-reversed event is a no-op, never a throw.
+      const key = payoutEventKey(event);
+      if (settledEventKeys.has(key)) {
+        settledEventKeys.delete(key);
+        balances.set(event.poolId, (balances.get(event.poolId) ?? 0) + event.amount);
+      }
+    },
+  };
+}

--- a/control-plane/test/settlement-backend-driver.test.ts
+++ b/control-plane/test/settlement-backend-driver.test.ts
@@ -1,0 +1,101 @@
+// Contract tests for the in-memory fake settlement backend (#7572): balances move with fund/record/reverse,
+// per-event idempotency holds on both the record and reverse sides, and every step is logged in call order.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createFakeSettlementBackendDriver,
+  type PayoutEligibleEvent,
+} from "../dist/index.js";
+
+const eventFor = (overrides: Partial<PayoutEligibleEvent> = {}): PayoutEligibleEvent => ({
+  poolId: "pool-1",
+  repoFullName: "acme/widgets",
+  prNumber: 42,
+  gittensorContributor: "dev",
+  amount: 100,
+  ...overrides,
+});
+
+test("fundPool credits a pool; an unfunded pool reads as 0", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  assert.equal(await driver.getPoolBalance("pool-1"), 0);
+
+  await driver.fundPool("pool-1", 500);
+  assert.equal(await driver.getPoolBalance("pool-1"), 500);
+  // Funding again accumulates rather than replaces.
+  await driver.fundPool("pool-1", 250);
+  assert.equal(await driver.getPoolBalance("pool-1"), 750);
+});
+
+test("recordPayoutEligibleEvent decrements the pool balance and records the event", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  await driver.fundPool("pool-1", 500);
+
+  await driver.recordPayoutEligibleEvent(eventFor({ amount: 100 }));
+  assert.equal(await driver.getPoolBalance("pool-1"), 400);
+  assert.ok(driver.settledEventKeys.has("pool-1|acme/widgets|42|dev"));
+});
+
+test("recordPayoutEligibleEvent is idempotent — a redelivered event never double-decrements", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  await driver.fundPool("pool-1", 500);
+
+  const event = eventFor({ amount: 100 });
+  await driver.recordPayoutEligibleEvent(event);
+  // else-branch: same key already settled — no second decrement.
+  await driver.recordPayoutEligibleEvent(event);
+  assert.equal(await driver.getPoolBalance("pool-1"), 400);
+  assert.equal(driver.settledEventKeys.size, 1);
+});
+
+test("reversePayout credits the amount back and clears the settled event", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  await driver.fundPool("pool-1", 500);
+  const event = eventFor({ amount: 100 });
+
+  await driver.recordPayoutEligibleEvent(event);
+  await driver.reversePayout(event, "dispute");
+  assert.equal(await driver.getPoolBalance("pool-1"), 500);
+  assert.equal(driver.settledEventKeys.has("pool-1|acme/widgets|42|dev"), false);
+});
+
+test("reversePayout is an idempotent no-op for an unrecorded or already-reversed event", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  await driver.fundPool("pool-1", 500);
+  const event = eventFor({ amount: 100 });
+
+  // Never recorded → else-branch no-op, balance untouched, no throw.
+  await driver.reversePayout(event, "refund");
+  assert.equal(await driver.getPoolBalance("pool-1"), 500);
+
+  await driver.recordPayoutEligibleEvent(event);
+  await driver.reversePayout(event, "partial_completion");
+  // Second reversal: already reversed → else-branch no-op, does not credit twice.
+  await driver.reversePayout(event, "partial_completion");
+  assert.equal(await driver.getPoolBalance("pool-1"), 500);
+});
+
+test("distinct events (different PR/contributor) settle independently against the same pool", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  await driver.fundPool("pool-1", 500);
+
+  await driver.recordPayoutEligibleEvent(eventFor({ prNumber: 1, gittensorContributor: "alice", amount: 100 }));
+  await driver.recordPayoutEligibleEvent(eventFor({ prNumber: 2, gittensorContributor: "bob", amount: 150 }));
+  assert.equal(await driver.getPoolBalance("pool-1"), 250);
+  assert.equal(driver.settledEventKeys.size, 2);
+});
+
+test("every step is recorded in call order for white-box assertions", async () => {
+  const driver = createFakeSettlementBackendDriver();
+  const event = eventFor({ amount: 100 });
+  await driver.fundPool("pool-1", 500);
+  await driver.recordPayoutEligibleEvent(event);
+  await driver.reversePayout(event, "refund");
+
+  assert.deepEqual(
+    driver.calls.map((call) => call.step),
+    ["fundPool", "recordPayoutEligibleEvent", "reversePayout"],
+  );
+  assert.deepEqual(driver.calls[0], { step: "fundPool", poolId: "pool-1", amount: 500 });
+});


### PR DESCRIPTION
Closes #7572

## Summary

#6098 specifies the settlement-backend contract (payout-eligible event intake, pool balance query/decrement, refund/dispute hook points) but nothing implements it yet — there's no `SettlementBackendDriver` type or fake driver the way `control-plane/src/tenant-provisioning-driver.ts` already has one for tenant provisioning.

Adds `SettlementBackendDriver` (interface) + `createFakeSettlementBackendDriver` (in-memory), **mirroring the tenant driver's exact shape** as the issue requires: interface + `createFake*Driver` factory, in-memory `Map`/`Set` state, idempotent methods, and an ordered call log for white-box assertions. So #4792's rental-ledger work and #4791's settlement-scenario policy can build and test against a stable boundary regardless of which real backend — gittensor-owned or self-built — eventually lands behind it.

### The interface maps 1:1 to #6098's hook points

For the "pool funded → work discovered → work delivered → payout owed" flow:

| Method | #6098 hook |
| --- | --- |
| `fundPool(poolId, amount)` | "pool funded" |
| `getPoolBalance(poolId)` | balance **query** (read side) |
| `recordPayoutEligibleEvent(event)` | "payout owed" intake — **decrements** balance (write side); idempotent per event, so a redelivered webhook never double-pays |
| `reversePayout(event, reason)` | refund / dispute / partial-completion — credits back; idempotent |

`PayoutEligibleEvent` carries exactly what a backend needs to attribute a payout (pool, repo, PR, contributor, amount) — not a ledger schema.

### Gittensor stays structurally in the settlement path (#6098)

Every payout is keyed to a `gittensorContributor` — the gittensor-registered identity the emission is owed to — so a settlement **cannot be expressed for an unattributed recipient through this contract**. Even a self-built backend can't quietly disintermediate gittensor as a fallback; the interface itself makes that structurally true rather than a policy promise. The actual refund/dispute **policy** stays #4791's job; this interface only names where it plugs in.

**No real funds, credentials, or IO** — only the fake is implemented (in-memory `Map` of balances + a settled-event `Set` for idempotency). Real backends (Cloudflare/Postgres/secret-broker analogues) are explicitly out of scope for this issue, exactly as the tenant driver left real provisioning out.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — see the closing reference at the top of this body.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (zero new errors vs base)
- [x] `npm run control-plane:test` — `build` (tsc) + `node --test`: **17/17 pass**, including the 7 new settlement tests
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and idempotency

Tests (`control-plane/test/settlement-backend-driver.test.ts`, `node:test`, mirroring `tenant-provisioning-driver.test.ts`): balances move with fund / record / reverse; **per-event idempotency on both sides** — the record side never double-decrements a redelivered event, and the reverse side never double-credits and is a no-op on an unrecorded event; distinct events (different PR/contributor) settle independently against the same pool; and the call log records every step in order. Every branch of the fake — including both idempotency else-paths — is exercised.

`control-plane/src/**` is validated by `control-plane`'s own `node:test` suite (not the root vitest/Codecov run), so there is no `codecov/patch` obligation on this package; the coverage is the passing contract tests above.

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The fake moves no real money and holds no credentials.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed (none — this is an internal control-plane contract).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section. Not applicable.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a backend interface + in-memory fake driver plus its contract tests. No UI, frontend, docs, or extension surface is touched.

## Notes

- Real settlement backends are deliberately absent (blocked on the gittensor-owned-vs-self-built decision), exactly mirroring how `tenant-provisioning-driver.ts` ships only the interface + fake and leaves real provisioning out of scope.
- The fake exposes `balances` / `settledEventKeys` / `calls` as read-only introspection beyond the contract, the same extra-surface pattern `createFakeTenantProvisioningDriver` uses.
