### PR TITLE
feat(miner-ui): reserve earnings dashboard placeholder

### DIFF
--- a/apps/loopover-miner-ui/src/components/theme-toggle.tsx
+++ b/apps/loopover-miner-ui/src/components/theme-toggle.tsx
@@ -6,7 +6,7 @@ import { Button } from "@loopover/ui-kit/components/button";
 // is present on <html> — so this control only flips that class, mirrors it into colorScheme (so native form
 // controls follow the theme), and persists the choice. index.html's inline no-flash script reads the same
 // persisted value to restore the theme before first paint. Compact ghost icon so the header row stays usable
-// beside the four nav links on narrow widths.
+// beside the primary nav links on narrow widths.
 const STORAGE_KEY = "loopover.miner_theme";
 
 function SunIcon() {

--- a/apps/loopover-miner-ui/src/earnings.test.tsx
+++ b/apps/loopover-miner-ui/src/earnings.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    createFileRoute: () => (options: { component: unknown }) => ({ options }),
+  };
+});
+
+import { EarningsPage } from "./routes/earnings";
+
+describe("EarningsPage (#7673)", () => {
+  it("renders the not-yet-available placeholder without inventing earnings figures", () => {
+    render(<EarningsPage />);
+
+    expect(screen.getByRole("heading", { name: "Earnings — not yet available" })).toBeTruthy();
+    expect(screen.getByText("Not yet available")).toBeTruthy();
+    expect(screen.getByText(/placeholder only/i)).toBeTruthy();
+    expect(screen.queryByText(/\d+(\.\d+)?\s*(alpha|tao|usd|\$)/i)).toBeNull();
+  });
+});

--- a/apps/loopover-miner-ui/src/root-shell-nav.test.tsx
+++ b/apps/loopover-miner-ui/src/root-shell-nav.test.tsx
@@ -106,7 +106,7 @@ describe("RootShell header nav (#6828)", () => {
     expect(portfolio.className).toMatch(/after:bg-mint/);
   });
 
-  it("highlights Run history and Ledgers on their own routes", () => {
+  it("highlights Run history, Ledgers, and Earnings on their own routes", () => {
     mockPath = "/run-history";
     const { rerender } = render(
       <RootShell>
@@ -123,6 +123,17 @@ describe("RootShell header nav (#6828)", () => {
     );
     expect(screen.getByRole("link", { name: "Ledgers" }).getAttribute("aria-current")).toBe("page");
     expect(screen.getByRole("link", { name: "Run history" }).getAttribute("aria-current")).toBeNull();
+
+    mockPath = "/earnings";
+    rerender(
+      <RootShell>
+        <div>page</div>
+      </RootShell>,
+    );
+    const earnings = screen.getByRole("link", { name: "Earnings — not yet available" });
+    expect(earnings.getAttribute("aria-current")).toBe("page");
+    expect(earnings.className).toMatch(/after:bg-mint/);
+    expect(screen.getByRole("link", { name: "Ledgers" }).getAttribute("aria-current")).toBeNull();
   });
 
   it("exposes a Primary nav landmark and sticky header chrome classes", () => {

--- a/apps/loopover-miner-ui/src/routeTree.gen.ts
+++ b/apps/loopover-miner-ui/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as RunHistoryRouteImport } from './routes/run-history'
 import { Route as PortfolioRouteImport } from './routes/portfolio'
 import { Route as LedgersRouteImport } from './routes/ledgers'
+import { Route as EarningsRouteImport } from './routes/earnings'
 import { Route as IndexRouteImport } from './routes/index'
 
 const RunHistoryRoute = RunHistoryRouteImport.update({
@@ -29,6 +30,11 @@ const LedgersRoute = LedgersRouteImport.update({
   path: '/ledgers',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EarningsRoute = EarningsRouteImport.update({
+  id: '/earnings',
+  path: '/earnings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -37,12 +43,14 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/earnings': typeof EarningsRoute
   '/ledgers': typeof LedgersRoute
   '/portfolio': typeof PortfolioRoute
   '/run-history': typeof RunHistoryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/earnings': typeof EarningsRoute
   '/ledgers': typeof LedgersRoute
   '/portfolio': typeof PortfolioRoute
   '/run-history': typeof RunHistoryRoute
@@ -50,20 +58,23 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/earnings': typeof EarningsRoute
   '/ledgers': typeof LedgersRoute
   '/portfolio': typeof PortfolioRoute
   '/run-history': typeof RunHistoryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/ledgers' | '/portfolio' | '/run-history'
+  fullPaths: '/' | '/earnings' | '/ledgers' | '/portfolio' | '/run-history'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/ledgers' | '/portfolio' | '/run-history'
-  id: '__root__' | '/' | '/ledgers' | '/portfolio' | '/run-history'
+  to: '/' | '/earnings' | '/ledgers' | '/portfolio' | '/run-history'
+  id:
+    '__root__' | '/' | '/earnings' | '/ledgers' | '/portfolio' | '/run-history'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  EarningsRoute: typeof EarningsRoute
   LedgersRoute: typeof LedgersRoute
   PortfolioRoute: typeof PortfolioRoute
   RunHistoryRoute: typeof RunHistoryRoute
@@ -92,6 +103,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LedgersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/earnings': {
+      id: '/earnings'
+      path: '/earnings'
+      fullPath: '/earnings'
+      preLoaderRoute: typeof EarningsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +122,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  EarningsRoute: EarningsRoute,
   LedgersRoute: LedgersRoute,
   PortfolioRoute: PortfolioRoute,
   RunHistoryRoute: RunHistoryRoute,

--- a/apps/loopover-miner-ui/src/routes/__root.tsx
+++ b/apps/loopover-miner-ui/src/routes/__root.tsx
@@ -22,6 +22,8 @@ const NAV_ITEMS = [
   { to: "/run-history", label: "Run history" },
   { to: "/portfolio", label: "Portfolio" },
   { to: "/ledgers", label: "Ledgers" },
+  // #7673: layout reservation only — the route is an empty placeholder until settlement data exists.
+  { to: "/earnings", label: "Earnings — not yet available" },
 ] as const;
 
 /** Shared nav-link chrome (#6828) — mint underline active cue mirrors loopover-ui's site-header. */
@@ -31,8 +33,8 @@ const NAV_LINK_CLASS =
 /**
  * The persistent app shell (#6513). Exported for unit testing. It owns the chat-rail open/collapsed state, and
  * because it's rendered by the root route, TanStack Router keeps it — and that state — mounted across
- * client-side navigation between the four routes, so the rail never resets on a route change. The routed page
- * is `children` (the `<Outlet/>` content), which is what swaps on navigation while this shell stays mounted.
+ * client-side navigation between the dashboard routes, so the rail never resets on a route change. The routed
+ * page is `children` (the `<Outlet/>` content), which is what swaps on navigation while this shell stays mounted.
  *
  * Header chrome (#6828): sticky translucent bar + mint-underline active routes (site-header language), without
  * adopting sidebar.tsx as primary nav (reserved for the chat rail's mobile sheet).

--- a/apps/loopover-miner-ui/src/routes/earnings.tsx
+++ b/apps/loopover-miner-ui/src/routes/earnings.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { Card, CardContent } from "@loopover/ui-kit/components/card";
+import { EmptyState } from "@loopover/ui-kit/components/state-views";
+
+export const Route = createFileRoute("/earnings")({
+  component: EarningsPage,
+});
+
+// Earnings / emissions slot (#7673): a navigation and layout reservation only. Real per-miner earnings data
+// is blocked on an external settlement decision — this route must not fetch, invent numbers, or assume which
+// settlement model lands. Keep the empty copy honest so the slot can later be wired without a nav redesign.
+
+export function EarningsPage() {
+  return (
+    <section className="grid gap-4" aria-labelledby="earnings-heading">
+      <div className="grid gap-1">
+        <h2 id="earnings-heading" className="font-display text-token-xl font-semibold">
+          Earnings — not yet available
+        </h2>
+        <p className="text-token-sm text-muted-foreground">
+          Reserved slot for per-miner earnings once the external settlement model is decided.
+        </p>
+      </div>
+      <Card>
+        <CardContent className="pt-6">
+          <EmptyState
+            title="Not yet available"
+            description="This page is a placeholder only — it does not load or display earnings data."
+          />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Add an `/earnings` miner-dashboard route that is clearly labeled not-yet-available.
- Reserve a primary-nav slot (`Earnings — not yet available`) so settlement data can land later without a nav redesign.
- Keep the page fetch-free: no backend calls, no invented earnings figures.

Closes #7673

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint` (`@loopover/ui-miner` lint — warnings only, matching sibling route files)
- [ ] `npm run ui:typecheck` (pre-existing `message-list.tsx` `viewportRef` error on main; earnings route typechecks clean)
- [x] `npm --workspace @loopover/ui-miner run build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Miner-UI-only placeholder (`apps/loopover-miner-ui/**`). No API/schema/MCP/worker changes. Ran miner-ui unit tests for the new route + nav (`6` passed), miner-ui build, and lint. Full root `test:ci` / unsharded coverage not required for Codecov on this path (`apps/**` is ignored by Codecov).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Desktop placeholder | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/earnings-7673-desktop.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/earnings-7673-desktop.png" alt="Desktop earnings placeholder" width="240"></a> |
| Mobile layout | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/earnings-7673-mobile.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/earnings-7673-mobile.png" alt="Mobile earnings placeholder" width="240"></a> |

## Notes

- Placeholder only: no settlement-model assumption and no earnings ledger wiring.
- Nav label matches the issue wording so the reserved slot is obvious in the shell.
