### PR TITLE
ci(perf): reduce backend test sharding from 6 to 3 to cut job-slot contention

### DIFF
--- a/.claude/skills/contributing-to-loopover/reference.md
+++ b/.claude/skills/contributing-to-loopover/reference.md
@@ -34,7 +34,7 @@ jobs run only if their path filter matched; on push to `main`, everything runs.
 | lint → miner-env-reference | miner/AMS env-var doc drift | `npm run miner:env-reference:check` | committed `packages/loopover-miner/docs/env-reference.md` / `apps/loopover-ui/src/lib/ams-env-reference.ts` is stale (run `npm run miner:env-reference`) — miner/AMS twin of the selfhost check above |
 | lint → observability | Grafana/Prometheus/alert config validation | `npm run selfhost:validate-observability` | a self-host observability config (dashboard/rule/datasource) is malformed |
 | lint → typecheck | `tsc --noEmit` | `npm run typecheck` | any backend type error |
-| test (1/6..6/6) | sharded vitest + coverage | `npm run test:coverage` (unsharded) | any failing `test/**/*.test.ts` (excl. `test/workers/**`) |
+| test (1/3..3/3) | sharded vitest + coverage | `npm run test:coverage` (unsharded) | any failing `test/**/*.test.ts` (excl. `test/workers/**`) |
 | workers | workers-pool vitest | `npm run test:workers` | any failing `test/workers/**` |
 | mcp → build | MCP pkg build | `npm run build:mcp` | MCP package build error |
 | mcp → pack | tarball hygiene | `npm run test:mcp-pack` | unexpected/forbidden file or stale README in the npm tarball |
@@ -101,7 +101,7 @@ these for a normal PR:**
 
 | Local command | Why it's not in the table above |
 |---|---|
-| `npm run test:engine-parity`, `npm run test:live-gate-parity`, `npm run test:driver-parity` | Plain `test/contract/*.test.ts` files — no dedicated CI job, but they DO run in CI as part of whichever `test (1/6..6/6)` shard happens to contain them (sharded `vitest run`). |
+| `npm run test:engine-parity`, `npm run test:live-gate-parity`, `npm run test:driver-parity` | Plain `test/contract/*.test.ts` files — no dedicated CI job, but they DO run in CI as part of whichever `test (1/3..3/3)` shard happens to contain them (sharded `vitest run`). |
 | `npm run test --workspace @loopover/engine` | The engine package's own `node --test` suite. **Not run by `ci.yml` on a PR at all** — only by `.github/workflows/publish-engine.yml` at release time. A regression here is invisible to Codecov and to every PR-gating CI check; `test:ci` locally is the only pre-merge signal. |
 
 This is a real, previously-hit gap, not a hypothetical: a past PR shipped a genuine, undetected
@@ -122,7 +122,7 @@ checks go green) is the only way to know you didn't break it.
 - **Ignored paths** (no coverage obligation): `apps/**`, `test/**`, `scripts/**`, `src/env.d.ts`.
   Coverage `include` is `src/**/*.ts` only. → A UI-only / test-only / script-only change owes **no**
   patch coverage; a backend `src/**` change owes coverage on **every changed line + branch**.
-- **Measure unsharded locally:** `npm run test:coverage`. CI shards into 6 and Codecov merges them,
+- **Measure unsharded locally:** `npm run test:coverage`. CI shards into 3 and Codecov merges them,
   so a single local shard under-reports — never trust it.
 - **Flaky tests are already tracked.** Every shard uploads a JUnit report (`report_type: test_results`),
   which auto-enables Codecov Test Analytics with no extra config — check a PR's "Tests" tab or its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,12 +728,12 @@ jobs:
     name: validate-tests
     needs: changes
     # Also runs on REES/mcp/engine/miner/discoveryIndex-only changes: Codecov holds codecov/patch until
-    # `after_n_builds` (6) coverage uploads land (codecov.yml), and a PR scoped to just one of those
+    # `after_n_builds` (3) coverage uploads land (codecov.yml), and a PR scoped to just one of those
     # self-contained packages doesn't otherwise touch `backend`, so without the shards it would upload no
     # coverage report at all and codecov/patch would never post -- not even a vacuous pass, no check at
     # all, and the required `validate` aggregate treats a skipped job as success (#7318-#7321: 3
     # packages/loopover-miner/lib-only PRs merged this way with validate-tests never running). Running the
-    # shards guarantees the 6 uploads so Codecov posts a real patch verdict covering whichever package
+    # shards guarantees the 3 uploads so Codecov posts a real patch verdict covering whichever package
     # actually changed (review-enrichment/** via the `rees` flag from validate-code; packages/loopover-mcp,
     # packages/loopover-engine, packages/loopover-miner, and packages/discovery-index via their entries in
     # vitest.config.ts's coverage.include, exercised by the root test/** suite these shards already run).
@@ -744,7 +744,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3]
     env:
       VITE_LOOPOVER_API_ORIGIN: https://api.loopover.ai
     steps:
@@ -805,7 +805,7 @@ jobs:
           key: test-timing-unused
           restore-keys: |
             test-timing-
-      - name: Test with coverage (shard ${{ matrix.shard }}/6)
+      - name: Test with coverage (shard ${{ matrix.shard }}/3)
         id: coverage
         env:
           # Disables vitest.config.ts's own global 90% threshold check for THIS per-shard invocation -- a
@@ -861,7 +861,7 @@ jobs:
             # ~2,900-file suite is 0% covered, polluting Codecov's project trend on every scoped PR. Real
             # coverage for files actually exercised is unaffected either way.
             SCOPE_ARGS+=(--changed=origin/main --coverage.all=false)
-            npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/6 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}" "${SCOPE_ARGS[@]}"
+            npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/3 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}" "${SCOPE_ARGS[@]}"
           else
             # Duration-aware sharding (#ci-duration-aware-sharding), full-suite case only: vitest's own
             # --shard splits by file COUNT alone, no duration awareness -- confirmed via real per-shard CI
@@ -869,18 +869,18 @@ jobs:
             # shards, every run sampled. Deliberately not applied to the scoped-selection branch above:
             # that file set isn't known until vitest resolves --changed itself, so a precomputed
             # assignment can't cover it without duplicating vitest's own dependency-graph resolution here.
-            # compute-test-shards.mjs enforces its own hard invariant (the union of all 6 shards' files
+            # compute-test-shards.mjs enforces its own hard invariant (the union of all 3 shards' files
             # must exactly equal the discovered file set, no file missing or duplicated) and refuses to
             # write output at all if that's ever violated, so a bug here fails this step loudly rather
             # than silently dropping a test file from CI.
-            node scripts/compute-test-shards.mjs --shards=6 --timing=test-timing.json --output=shard-assignment.json
+            node scripts/compute-test-shards.mjs --shards=3 --timing=test-timing.json --output=shard-assignment.json
             mapfile -t SHARD_FILES < <(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-assignment.json','utf8'))['${{ matrix.shard }}'].join('\n'))")
             npm run test:coverage -- --maxWorkers=4 "${SHARD_FILES[@]}" --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}"
           fi
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |
-          echo "::error title=Tests::The backend test coverage suite failed (shard ${{ matrix.shard }}/6)."
+          echo "::error title=Tests::The backend test coverage suite failed (shard ${{ matrix.shard }}/3)."
           echo "Coverage itself is gated by Codecov on changed lines (codecov/patch), computed from all shards' merged lcov."
           echo "Reproduce locally with: 'npm run test:coverage' (unsharded, runs the whole suite)."
       - name: Verify coverage report exists

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,21 +11,21 @@ codecov:
   # Don't post a verdict until the CI run that produced the report has finished.
   require_ci_to_pass: true
   notify:
-    # The 6 backend test shards (validate-tests matrix, ci.yml) each upload their own lcov.info
+    # The 3 backend test shards (validate-tests matrix, ci.yml) each upload their own lcov.info
     # directly (flags: shard-N) -- additive by design, but Codecov re-evaluates and re-posts the
     # status check after EVERY individual upload, not just the last one. Without this, codecov/patch
-    # can report a wildly wrong verdict (as low as ~20% "patch coverage") after only 1-2 of 6 shards
+    # can report a wildly wrong verdict (as low as ~20% "patch coverage") after only 1-2 of 3 shards
     # have landed, before self-correcting once the rest arrive -- require_ci_to_pass above only checks
     # the GH Actions run's own conclusion, it says nothing about upload completeness. Waiting for all
-    # 6 coverage uploads (JUnit test_results uploads are a separate stream and don't count here) before
+    # 3 coverage uploads (JUnit test_results uploads are a separate stream and don't count here) before
     # posting a status removes that premature-fail/premature-pass window entirely.
     #
-    # Stays 6, not 7, even though review-enrichment adds a `rees` upload on REES PRs: 6 is the count that
+    # Stays 3, not 4, even though review-enrichment adds a `rees` upload on REES PRs: 3 is the count that
     # ALWAYS lands whenever validate-tests runs (the minimum floor), while the `rees` upload only exists on
     # REES PRs. The `rees` report is produced by validate-code, which finishes its REES steps in seconds and
-    # so uploads well before any ~10-minute shard -- it is already merged in by the time the 6th shard trips
+    # so uploads well before any ~10-minute shard -- it is already merged in by the time the 3rd shard trips
     # this threshold, so no premature window opens for the review-enrichment diff either.
-    after_n_builds: 6
+    after_n_builds: 3
 
 coverage:
   status:

--- a/scripts/compute-test-shards.mjs
+++ b/scripts/compute-test-shards.mjs
@@ -2,8 +2,8 @@
 // Bin-packs the full test/**/*.test.ts file set into N balanced shards by historical duration (greedy
 // LPT -- Longest Processing Time first: sort files descending by duration, repeatedly assign the next
 // file to whichever shard currently has the smallest total), replacing vitest's own --shard (file
-// COUNT only, no duration awareness -- confirmed this session via real per-shard CI timing data to
-// produce a consistent ~20-30% gap between the slowest and fastest of 6 shards, every sampled run).
+// COUNT only, no duration awareness -- confirmed via real per-shard CI timing data to produce a
+// consistent ~20-30% gap between the slowest and fastest shard, every sampled run at the time).
 //
 // Deliberately scoped to the full-suite case only -- see ci.yml's "Test with coverage" step for how
 // this output is (and is NOT) consumed. A PR using scoped test selection (--changed=origin/main)
@@ -25,7 +25,7 @@ import { join } from "node:path";
 const TEST_ROOT = "test";
 const EXCLUDED_DIR = join(TEST_ROOT, "workers"); // mirrors vitest.config.ts's exclude: ["test/workers/**/*.test.ts"]
 
-const shardsArg = Number(process.argv.find((a) => a.startsWith("--shards="))?.split("=")[1] ?? 6);
+const shardsArg = Number(process.argv.find((a) => a.startsWith("--shards="))?.split("=")[1] ?? 3);
 const timingArg = process.argv.find((a) => a.startsWith("--timing="))?.split("=")[1];
 const outputArg = process.argv.find((a) => a.startsWith("--output="))?.split("=")[1];
 if (!outputArg) throw new Error("--output=<path> is required");


### PR DESCRIPTION
## Summary
- `validate-tests`' 6-shard matrix plus `changes`/`validate-code`/`validate-tests-merge`/`security` claims ~10 concurrent job slots per single CI run.
- Live data pulled today: with only 3 open PRs, jobs were sitting `queued` 25-30+ min waiting for a runner slot. `ci-duration-report.mjs` (7-day window) shows push-run p50 ≈ 8min but p95 ≈ 130min — a flat median with an exploding tail is the signature of a fixed-capacity job queue getting overrun in bursts, not tests getting slower.
- Real per-shard execution time at current suite size (measured from a recent completed run): ~3.5-6 min each. Halving shard count to 3 roughly doubles that to ~10-12min per shard — comfortably under the 20min job timeout with headroom for continued suite growth (test file count grew 168 → 1,046 in the last 30 days) — while cutting `validate-tests`' own job-slot footprint in half (6 → 3), which is the actual lever against the concurrent-job ceiling that's driving the queueing.
- Considered fully eliminating sharding instead: rejected. Each shard already runs `--maxWorkers=4` (a standard runner's real CPU ceiling), so collapsing to 1 shard doesn't add parallelism — it serializes ~27min of total suite work into one job, exceeding today's own 20min timeout and making *every* PR slower than today's median, not just the contended ones.
- `codecov.yml`'s `after_n_builds` is updated 6 → 3 in lockstep (hard-coupled to the shard upload count — Codecov re-posts a status after every upload, so a mismatch here reintroduces the premature-verdict window the original comment describes).
- `scripts/compute-test-shards.mjs`'s default fallback and doc comment updated to match; contributor-facing `reference.md` shard-count mentions updated so they don't go stale.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(...)"` — both `ci.yml` and `codecov.yml` parse as valid YAML.
- `node scripts/compute-test-shards.mjs --shards=3 --timing=<missing> --output=...` — dry run against the real `test/**` tree: 1,045 files split 349/348/348, hard invariant check passed.
- `npx vitest run test/unit/compute-test-shards.test.ts` — all 5 existing tests pass unchanged (none assert the script's default; all pass `--shards=` explicitly).
- Repo-wide grep swept for every other `6`-shard reference (`after_n_builds`, matrix list, `--shard=N/6`, step names, error strings, `reference.md`); no stragglers left, no false-positive files touched.