### PR TITLE
ci(perf): debounce rapid re-pushes to an open PR before the heavy fan-out starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,20 @@ jobs:
       rees: ${{ steps.filter.outputs.rees }}
       observability: ${{ steps.filter.outputs.observability }}
     steps:
+      # Debounce rapid re-pushes to an open PR: every job below (validate-code, all 3 validate-tests
+      # shards, validate-tests-merge, security) has `needs: changes` in its dependency chain, so none of
+      # them get queued for a runner until this job finishes -- and this job lives in the SAME PR-ref-scoped
+      # concurrency group as everything else (top of file), so a newer push cancels this job outright while
+      # it's asleep, well before it ever reaches "Filter changed paths". That means a rapid burst of pushes
+      # only ever lets the LAST push's `changes` run actually complete and unblock the expensive fan-out --
+      # every earlier push in the burst pays for one cheap, cancelled `changes` job instead of the full
+      # ~7-job-slot fan-out starting, queueing, and then getting killed mid-flight. No custom "is this SHA
+      # still current" check is needed: cancel-in-progress already does that for free the moment a newer
+      # push lands. Skipped on push (github.event_name == 'push', i.e. a merge to main) -- that's a
+      # once-per-merge event, not iterative amendment, and main's coverage signal shouldn't be delayed.
+      - name: Debounce rapid pushes
+        if: ${{ github.event_name == 'pull_request' }}
+        run: sleep 45
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:


### PR DESCRIPTION
## Summary
- Every heavy job (`validate-code`, all 3 `validate-tests` shards, `validate-tests-merge`, `security`) depends on `changes` finishing first.
- Adds a 45s `sleep` as `changes`' very first step, gated to `pull_request` events only (push-to-main is untouched).
- `changes` already lives in the same PR-ref-scoped `cancel-in-progress` concurrency group as every other job in this workflow. During a burst of rapid re-pushes, each earlier push's `changes` job gets cancelled outright while it's asleep -- well before it would ever unblock the expensive fan-out. Only the last push in a burst actually lets `changes` complete.
- Net effect: a rapid burst of N pushes to an open PR now costs N cheap, quickly-cancelled `changes` jobs (checkout hasn't even happened yet when cancelled) instead of N separate ~7-job-slot fan-outs each queueing for a runner and then getting killed mid-flight.
- No new cancellation/SHA-comparison logic was written -- this reuses the existing concurrency group mechanism by moving where in the dependency chain it takes effect.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(...)"` -- `ci.yml` parses as valid YAML.
- Logic reasoning verified against the existing concurrency block (top of `ci.yml`): the workflow-level `group: ci-${{ github.ref }}-...` with `cancel-in-progress: true` already cancels an entire superseded run's jobs, including one still in the sleep step -- no behavior change to that mechanism, only to when the expensive jobs become eligible to be queued.
- This PR's own CI run is a live example: single push, so the 45s debounce applies once and does not repeat.