### PR TITLE
fix(ci): let the automated beta-cut push a tag through a workflow-file change

### DIFF
--- a/.github/workflows/orb-beta-release.yml
+++ b/.github/workflows/orb-beta-release.yml
@@ -66,7 +66,16 @@ jobs:
         id: tag
         if: steps.report.outputs.due == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # A tag pointing at a commit that touches any .github/workflows/* file needs a token with the
+          # `workflow` OAuth scope (classic PAT) / "Workflows: write" (fine-grained PAT) to push -- GitHub
+          # hardcodes this against the default GITHUB_TOKEN regardless of this job's own `permissions:`
+          # block; there is no permissions-block setting that lifts it (confirmed live: the push failed with
+          # "refusing to allow a GitHub App to create or update workflow .github/workflows/ci.yml without
+          # `workflows` permission" even with contents/actions both set to write above). ORB_RELEASE_WORKFLOW_TOKEN
+          # is an OPTIONAL repo secret (a fine-grained PAT scoped to Contents: write + Workflows: write on
+          # this repo only) for exactly that case -- falls back to the default token when the secret is
+          # unset, which still works fine for any cut whose commits don't happen to touch a workflow file.
+          GH_TOKEN: ${{ secrets.ORB_RELEASE_WORKFLOW_TOKEN || github.token }}
           TAG: ${{ steps.report.outputs.tag }}
           VERSION: ${{ steps.report.outputs.version }}
         run: |


### PR DESCRIPTION
## Summary
- The automated `orb-beta-release` workflow's "Tag the new beta" step failed once a routine CI workflow edit landed between beta cuts: GitHub hardcodes a restriction where the default `GITHUB_TOKEN` can never push a ref that touches `.github/workflows/*` files, independent of the job's own `permissions:` block (`contents`/`actions` write were already both granted). There is no `permissions:` setting that lifts this — it's not a configurable scope.
- Uses an optional `ORB_RELEASE_WORKFLOW_TOKEN` repo secret (a fine-grained PAT scoped to `Contents: write` + `Workflows: write` on this repo only) for the git push specifically, falling back to the default token when the secret is unset — unchanged behavior for any cut whose commits don't happen to touch a workflow file, and for any fork/self-host that hasn't configured the secret.

Requires adding the `ORB_RELEASE_WORKFLOW_TOKEN` secret at `Settings > Secrets and variables > Actions` to actually take effect; the workflow degrades gracefully (today's exact behavior) without it.

## Test plan
- [x] `npm run actionlint` clean
- [x] `npm run lint:composite-actions` clean
- [x] Manually reproduced the failure this fixes: pushing a tag on a commit that touched `.github/workflows/ci.yml` with the default token failed with the exact error this PR addresses; verified the fallback expression resolves correctly for both the secret-set and secret-unset cases