### PR TITLE
feat(control-plane): page PagerDuty on tenant provisioning failures

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -13,8 +13,17 @@ export {
   type TenantProvisioningRequest,
 } from "./tenant-provisioning-driver.js";
 export {
+  buildTenantProvisioningFailureDedupKey,
+  buildTenantProvisioningFailureSummary,
+  notifyTenantProvisioningFailure,
+  type ProvisioningFailureStep,
+  type ProvisioningPagerDutySeverity,
+  type TriggerPagerDutyIncidentFn,
+} from "./notify-provisioning-failure.js";
+export {
   deprovisionTenant,
   provisionTenant,
+  type ProvisionTenantOptions,
   type TenantDeprovisioningResult,
   type TenantProvisioningResult,
 } from "./provisioning.js";

--- a/control-plane/src/notify-provisioning-failure.ts
+++ b/control-plane/src/notify-provisioning-failure.ts
@@ -1,0 +1,110 @@
+// PagerDuty paging on tenant provisioning failures (#7667). Reuses src/services/notify-pagerduty.ts's
+// triggerPagerDutyIncident exactly (same flag, routing key, dedup/cooldown/severity floor) — no second
+// alerting mechanism. The hosted control-plane runs with a Worker Env when paging is enabled; tests inject
+// a mock trigger so no live Events API call is made.
+
+import type { FakeDriverStep, Product, Tenant } from "./tenant-provisioning-driver.js";
+
+export type ProvisioningFailureStep = Extract<
+  FakeDriverStep,
+  "createContainer" | "provisionDatabase" | "injectSecrets"
+>;
+
+export type ProvisioningPagerDutySeverity = "critical" | "error" | "warning" | "info";
+
+export type TriggerPagerDutyIncidentFn = (
+  env: unknown,
+  params: {
+    repoFullName: string;
+    summary: string;
+    severity: ProvisioningPagerDutySeverity;
+    dedupKey: string;
+    customDetails?: Record<string, unknown> | undefined;
+  },
+) => Promise<void>;
+
+const DEFAULT_REPO_FULL_NAME = "loopover/hosting";
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "unknown error";
+}
+
+let cachedTrigger: TriggerPagerDutyIncidentFn | undefined;
+
+async function resolveTrigger(
+  override?: TriggerPagerDutyIncidentFn,
+): Promise<TriggerPagerDutyIncidentFn | null> {
+  if (override) return override;
+  if (cachedTrigger) return cachedTrigger;
+  try {
+    // Computed path keeps control-plane's tsc from pulling notify-pagerduty.ts under this package's rootDir.
+    const notifyPagerDutyModule = ["..", "..", "src", "services", "notify-pagerduty.js"].join("/");
+    const mod = (await import(notifyPagerDutyModule)) as {
+      triggerPagerDutyIncident: TriggerPagerDutyIncidentFn;
+    };
+    cachedTrigger = mod.triggerPagerDutyIncident;
+    return cachedTrigger;
+  } catch {
+    return null;
+  }
+}
+
+export function buildTenantProvisioningFailureDedupKey(input: {
+  tenant: Tenant;
+  product: Product;
+  step: ProvisioningFailureStep;
+}): string {
+  return `tenant_provisioning:${input.tenant.name}:${input.product}:${input.step}`;
+}
+
+export function buildTenantProvisioningFailureSummary(input: {
+  tenant: Tenant;
+  product: Product;
+  step: ProvisioningFailureStep;
+  error: unknown;
+}): string {
+  const message = errorMessage(input.error);
+  return `Tenant provisioning failed at ${input.step} for ${input.tenant.name} (${input.product}): ${message}`.slice(
+    0,
+    1024,
+  );
+}
+
+/** Best-effort PagerDuty page for a failed provisioning step (#7667). No-op when `env` is absent, when the
+ *  monorepo's notify-pagerduty module is unreachable (standalone package build), or when
+ *  triggerPagerDutyIncident denies the page (flag off, below severity floor, cooldown, etc.). Never throws. */
+export async function notifyTenantProvisioningFailure(
+  env: unknown,
+  input: {
+    tenant: Tenant;
+    product: Product;
+    step: ProvisioningFailureStep;
+    error: unknown;
+    repoFullName?: string | undefined;
+  },
+  options: { trigger?: TriggerPagerDutyIncidentFn } = {},
+): Promise<void> {
+  if (env == null) return;
+  const trigger = await resolveTrigger(options.trigger);
+  if (!trigger) return;
+  const repoFullName = (input.repoFullName ?? "").trim() || DEFAULT_REPO_FULL_NAME;
+  const message = errorMessage(input.error);
+  try {
+    await trigger(env, {
+      repoFullName,
+      summary: buildTenantProvisioningFailureSummary(input),
+      severity: "critical",
+      dedupKey: buildTenantProvisioningFailureDedupKey(input),
+      customDetails: {
+        tenant: input.tenant.name,
+        product: input.product,
+        step: input.step,
+        error: message.slice(0, 500),
+      },
+    });
+  } catch {
+    // triggerPagerDutyIncident is documented never-throw; this guards test mocks and future drift.
+  }
+}

--- a/control-plane/src/provisioning.ts
+++ b/control-plane/src/provisioning.ts
@@ -3,8 +3,13 @@
 // every driver step but never branched on. Provision runs #7180's three steps in order (create-container,
 // provision-DB, inject-secrets); deprovision tears them down in REVERSE (revoke-secrets, drop-DB,
 // destroy-container) so a secret is never left addressable after the DB/container it belonged to is gone.
+//
+// #7667: a provisioning-step failure pages via src/services/notify-pagerduty.ts's triggerPagerDutyIncident
+// (opt-in via env + LOOPOVER_ENABLE_PAGERDUTY) before rethrowing — best-effort, never blocks teardown.
 
+import { notifyTenantProvisioningFailure, type TriggerPagerDutyIncidentFn } from "./notify-provisioning-failure.js";
 import type {
+  FakeDriverStep,
   Product,
   Tenant,
   TenantLifecycleState,
@@ -27,17 +32,46 @@ export type TenantDeprovisioningResult = {
   state: Extract<TenantLifecycleState, "torn down">;
 };
 
+/** Optional paging context forwarded to notify-pagerduty.ts when a provisioning step throws (#7667). */
+export type ProvisionTenantOptions = {
+  /** Worker Env (or self-host env bag) passed through to triggerPagerDutyIncident. */
+  env?: unknown;
+  /** Repo key for PagerDuty routing; defaults to loopover/hosting. */
+  repoFullName?: string | undefined;
+  /** Test override for triggerPagerDutyIncident — mocks the PagerDuty Events API call. */
+  triggerPagerDuty?: TriggerPagerDutyIncidentFn;
+};
+
+const PROVISION_STEPS: Array<{
+  step: Extract<FakeDriverStep, "createContainer" | "provisionDatabase" | "injectSecrets">;
+  run: (driver: TenantProvisioningDriver, request: TenantProvisioningRequest) => Promise<void>;
+}> = [
+  { step: "createContainer", run: (driver, request) => driver.createContainer(request) },
+  { step: "provisionDatabase", run: (driver, request) => driver.provisionDatabase(request) },
+  { step: "injectSecrets", run: (driver, request) => driver.injectSecrets(request) },
+];
+
 /** Provision a tenant by running #7180's three steps in order against the injected driver. Product-agnostic:
  *  `product` is forwarded to every step, never branched on, so ORB and AMS share one call shape. */
 export async function provisionTenant(
   tenant: Tenant,
   product: Product,
   driver: TenantProvisioningDriver,
+  options: ProvisionTenantOptions = {},
 ): Promise<TenantProvisioningResult> {
   const request: TenantProvisioningRequest = { tenant, product };
-  await driver.createContainer(request);
-  await driver.provisionDatabase(request);
-  await driver.injectSecrets(request);
+  for (const { step, run } of PROVISION_STEPS) {
+    try {
+      await run(driver, request);
+    } catch (error) {
+      await notifyTenantProvisioningFailure(
+        options.env,
+        { tenant, product, step, error, repoFullName: options.repoFullName },
+        { trigger: options.triggerPagerDuty },
+      );
+      throw error;
+    }
+  }
   return { tenant, product, state: "active" };
 }
 

--- a/control-plane/test/provisioning-pagerduty.test.ts
+++ b/control-plane/test/provisioning-pagerduty.test.ts
@@ -1,0 +1,171 @@
+// PagerDuty paging tests for tenant provisioning failures (#7667). Mocks triggerPagerDutyIncident — no live
+// Events API calls.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildTenantProvisioningFailureDedupKey,
+  buildTenantProvisioningFailureSummary,
+  createFakeTenantProvisioningDriver,
+  notifyTenantProvisioningFailure,
+  provisionTenant,
+  type TriggerPagerDutyIncidentFn,
+  type Tenant,
+  type TenantProvisioningDriver,
+} from "../dist/index.js";
+
+function createFailingDriver(failAt: "createContainer" | "provisionDatabase" | "injectSecrets"): TenantProvisioningDriver {
+  const base = createFakeTenantProvisioningDriver();
+  return {
+    ...base,
+    async createContainer(request) {
+      if (failAt === "createContainer") throw new Error("container boom");
+      return base.createContainer(request);
+    },
+    async provisionDatabase(request) {
+      if (failAt === "provisionDatabase") throw new Error("database boom");
+      return base.provisionDatabase(request);
+    },
+    async injectSecrets(request) {
+      if (failAt === "injectSecrets") throw new Error("secrets boom");
+      return base.injectSecrets(request);
+    },
+  };
+}
+
+test("buildTenantProvisioningFailureDedupKey: stable per tenant/product/step (#7667)", () => {
+  const tenant: Tenant = { name: "acme" };
+  assert.equal(
+    buildTenantProvisioningFailureDedupKey({ tenant, product: "orb", step: "createContainer" }),
+    "tenant_provisioning:acme:orb:createContainer",
+  );
+});
+
+test("buildTenantProvisioningFailureSummary: includes step, tenant, product, and error (#7667)", () => {
+  const tenant: Tenant = { name: "acme" };
+  const summary = buildTenantProvisioningFailureSummary({
+    tenant,
+    product: "ams",
+    step: "injectSecrets",
+    error: new Error("secrets boom"),
+  });
+  assert.match(summary, /injectSecrets/);
+  assert.match(summary, /acme/);
+  assert.match(summary, /ams/);
+  assert.match(summary, /secrets boom/);
+});
+
+test("notifyTenantProvisioningFailure: no-op without env (#7667)", async () => {
+  let called = false;
+  const trigger: TriggerPagerDutyIncidentFn = async () => {
+    called = true;
+  };
+  await notifyTenantProvisioningFailure(
+    undefined,
+    { tenant: { name: "acme" }, product: "orb", step: "createContainer", error: new Error("boom") },
+    { trigger },
+  );
+  assert.equal(called, false);
+});
+
+test("notifyTenantProvisioningFailure: forwards critical page payload to trigger (#7667)", async () => {
+  const calls: Array<Parameters<TriggerPagerDutyIncidentFn>[1]> = [];
+  const trigger: TriggerPagerDutyIncidentFn = async (_env, params) => {
+    calls.push(params);
+  };
+  const tenant: Tenant = { name: "acme" };
+  await notifyTenantProvisioningFailure(
+    { LOOPOVER_ENABLE_PAGERDUTY: "1" },
+    { tenant, product: "orb", step: "provisionDatabase", error: new Error("database boom"), repoFullName: "acme/hosting" },
+    { trigger },
+  );
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    repoFullName: "acme/hosting",
+    summary: buildTenantProvisioningFailureSummary({
+      tenant,
+      product: "orb",
+      step: "provisionDatabase",
+      error: new Error("database boom"),
+    }),
+    severity: "critical",
+    dedupKey: "tenant_provisioning:acme:orb:provisionDatabase",
+    customDetails: {
+      tenant: "acme",
+      product: "orb",
+      step: "provisionDatabase",
+      error: "database boom",
+    },
+  });
+});
+
+test("notifyTenantProvisioningFailure: blank repoFullName falls back to loopover/hosting (#7667)", async () => {
+  const calls: Array<Parameters<TriggerPagerDutyIncidentFn>[1]> = [];
+  const trigger: TriggerPagerDutyIncidentFn = async (_env, params) => {
+    calls.push(params);
+  };
+  await notifyTenantProvisioningFailure(
+    {},
+    { tenant: { name: "acme" }, product: "orb", step: "createContainer", error: "boom", repoFullName: "   " },
+    { trigger },
+  );
+  assert.equal(calls[0]?.repoFullName, "loopover/hosting");
+});
+
+test("provisionTenant: pages then rethrows when a step fails (#7667)", async () => {
+  const tenant: Tenant = { name: "acme" };
+  const calls: Array<Parameters<TriggerPagerDutyIncidentFn>[1]> = [];
+  const trigger: TriggerPagerDutyIncidentFn = async (_env, params) => {
+    calls.push(params);
+  };
+  const driver = createFailingDriver("injectSecrets");
+
+  await assert.rejects(
+    () =>
+      provisionTenant(tenant, "ams", driver, {
+        env: { LOOPOVER_ENABLE_PAGERDUTY: "1" },
+        repoFullName: "acme/hosting",
+        triggerPagerDuty: trigger,
+      }),
+    /secrets boom/,
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.dedupKey, "tenant_provisioning:acme:ams:injectSecrets");
+  assert.equal(calls[0]?.severity, "critical");
+  // Prior steps completed before injectSecrets threw.
+  assert.deepEqual(
+    driver.calls.map((call) => call.step),
+    ["createContainer", "provisionDatabase"],
+  );
+});
+
+test("provisionTenant: success path does not page (#7667)", async () => {
+  const tenant: Tenant = { name: "acme" };
+  let called = false;
+  const trigger: TriggerPagerDutyIncidentFn = async () => {
+    called = true;
+  };
+  const driver = createFakeTenantProvisioningDriver();
+
+  const result = await provisionTenant(tenant, "orb", driver, {
+    env: { LOOPOVER_ENABLE_PAGERDUTY: "1" },
+    triggerPagerDuty: trigger,
+  });
+
+  assert.deepEqual(result, { tenant, product: "orb", state: "active" });
+  assert.equal(called, false);
+});
+
+test("provisionTenant: no env skips paging but still rethrows (#7667)", async () => {
+  let called = false;
+  const trigger: TriggerPagerDutyIncidentFn = async () => {
+    called = true;
+  };
+
+  await assert.rejects(
+    () => provisionTenant({ name: "acme" }, "orb", createFailingDriver("createContainer"), { triggerPagerDuty: trigger }),
+    /container boom/,
+  );
+  assert.equal(called, false);
+});


### PR DESCRIPTION
## Summary

- Wire `provisionTenant` step failures through `triggerPagerDutyIncident` from `src/services/notify-pagerduty.ts` (#7667) — same flag, routing key, dedup/cooldown/severity floor, no second alerting path.
- Add `notify-provisioning-failure.ts` with a lazy import of the existing integration plus optional `triggerPagerDuty` override for tests.
- Extend `provisionTenant` with optional `env` / `repoFullName` paging context; failures page best-effort then rethrow.

## Test plan

- [x] `npm run control-plane:test` — 25/25 pass, including mocked PagerDuty tests in `control-plane/test/provisioning-pagerduty.test.ts`
- [ ] CI green on fork PR

Closes #7667
