### PR TITLE
feat(engine): represent idea targetRepo as an existing-vs-provision union

### DIFF
--- a/packages/loopover-engine/src/idea-intake.ts
+++ b/packages/loopover-engine/src/idea-intake.ts
@@ -19,12 +19,16 @@ export const IDEA_CONSTRAINT_MAX_CHARS = 200;
 
 export type IdeaPriority = "normal" | "high";
 
+export type IdeaTarget =
+  | { kind: "existing"; repo: string }
+  | { kind: "provision" };
+
 /** The raw input a renter provides (spec §1). */
 export type IdeaSubmission = {
   id: string;
   title: string;
   body: string;
-  targetRepo: string;
+  targetRepo: IdeaTarget;
   constraints?: string[] | undefined;
   acceptanceHints?: string[] | undefined;
   priority?: IdeaPriority | undefined;
@@ -92,9 +96,15 @@ export function validateIdeaSubmission(raw: unknown): IdeaValidationResult {
   if (!isNonEmptyString(input.body)) errors.push("body_required");
   else if (input.body.length > IDEA_BODY_MAX_CHARS) errors.push("body_too_long");
   // `owner/name`, each segment a GitHub-legal slug — an uninstallable/malformed repo is rejected at intake,
-  // never scored, since it can never produce a `go`.
-  if (!isNonEmptyString(input.targetRepo)) errors.push("target_repo_required");
-  else if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(input.targetRepo)) errors.push("target_repo_malformed");
+  // never scored, since it can never produce a `go`. A bare non-empty STRING targetRepo is the back-compat
+  // wire form for an existing repo; a `{ kind: "provision" }` object requests a not-yet-created repo.
+  let resolvedTarget: IdeaTarget | undefined;
+  if (isNonEmptyString(input.targetRepo)) {
+    if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(input.targetRepo)) resolvedTarget = { kind: "existing", repo: input.targetRepo };
+    else errors.push("target_repo_malformed");
+  } else if (typeof input.targetRepo === "object" && input.targetRepo !== null && (input.targetRepo as Record<string, unknown>).kind === "provision") {
+    resolvedTarget = { kind: "provision" };
+  } else errors.push("target_repo_required");
 
   const constraints = input.constraints;
   if (constraints !== undefined) {
@@ -116,7 +126,7 @@ export function validateIdeaSubmission(raw: unknown): IdeaValidationResult {
       id: input.id as string,
       title: input.title as string,
       body: input.body as string,
-      targetRepo: input.targetRepo as string,
+      targetRepo: resolvedTarget as IdeaTarget,
       constraints: constraints as string[] | undefined,
       acceptanceHints: acceptanceHints as string[] | undefined,
       priority: priority as IdeaPriority | undefined,
@@ -224,6 +234,12 @@ export function buildTaskGraph(idea: IdeaSubmission, drafts?: ConstituentIssueDr
   const graph: TaskGraph = { ideaId: idea.id, issues, rubric: { verdict: "go", perIssue: [] } };
   graph.rubric = scoreTaskGraph(graph);
   return graph;
+}
+
+/** The repo a claim plan targets. buildClaimPlan stays repo-string-based (#7635 out of scope to change);
+ *  a not-yet-provisioned target has no repo yet, so it resolves to "". */
+export function claimPlanTargetRepo(target: IdeaTarget): string {
+  return target.kind === "existing" ? target.repo : "";
 }
 
 /** One constituent issue routed to a loop disposition, carrying the target repo the loop will act on. */

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -608,6 +608,7 @@ export {
 export {
   buildClaimPlan,
   buildTaskGraph,
+  claimPlanTargetRepo,
   scoreTaskGraph,
   validateIdeaSubmission,
   IDEA_TITLE_MAX_CHARS,
@@ -621,6 +622,7 @@ export {
   type ConstituentIssueDraft,
   type IdeaPriority,
   type IdeaSubmission,
+  type IdeaTarget,
   type IdeaValidationResult,
   type TaskGraph,
   type TaskGraphIssueScore,

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -27,7 +27,7 @@ import { buildResultsPayload } from "@loopover/engine";
 // #6753: the same pure composer the remote MCP tool + /v1/loop/progress-snapshot both call.
 import { buildProgressSnapshot } from "@loopover/engine";
 // #6755: the same pure bridge the remote MCP tool + /v1/loop/intake-idea both call.
-import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "@loopover/engine";
+import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan, claimPlanTargetRepo } from "@loopover/engine";
 import { z } from "zod";
 import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 import { formatTable } from "../lib/format-table.js";
@@ -1550,7 +1550,7 @@ registerStdioTool("loopover_plan_idea_claims", {
     if (!validated.ok)
         return toolResult(`Invalid idea submission: ${validated.errors.join(", ")}.`, { ok: false, errors: validated.errors });
     const graph = buildTaskGraph(validated.idea, input.decomposition);
-    const claimPlan = buildClaimPlan(graph, validated.idea.targetRepo);
+    const claimPlan = buildClaimPlan(graph, claimPlanTargetRepo(validated.idea.targetRepo));
     return toolResult(`Claim plan: ${claimPlan.claimable.length} claimable, ${claimPlan.deferred.length} deferred, ${claimPlan.skipped.length} skipped.`, { ok: true, verdict: claimPlan.graphVerdict, claimPlan });
 });
 registerStdioTool("loopover_check_issue_slop", {

--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -37,7 +37,7 @@ import { buildResultsPayload } from "@loopover/engine";
 // #6753: the same pure composer the remote MCP tool + /v1/loop/progress-snapshot both call.
 import { buildProgressSnapshot } from "@loopover/engine";
 // #6755: the same pure bridge the remote MCP tool + /v1/loop/intake-idea both call.
-import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "@loopover/engine";
+import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan, claimPlanTargetRepo } from "@loopover/engine";
 import { z } from "zod";
 import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 import { formatTable } from "../lib/format-table.js";
@@ -1750,7 +1750,7 @@ registerStdioTool(
     const validated = validateIdeaSubmission(input);
     if (!validated.ok) return toolResult(`Invalid idea submission: ${validated.errors.join(", ")}.`, { ok: false, errors: validated.errors });
     const graph = buildTaskGraph(validated.idea, input.decomposition);
-    const claimPlan = buildClaimPlan(graph, validated.idea.targetRepo);
+    const claimPlan = buildClaimPlan(graph, claimPlanTargetRepo(validated.idea.targetRepo));
     return toolResult(
       `Claim plan: ${claimPlan.claimable.length} claimable, ${claimPlan.deferred.length} deferred, ${claimPlan.skipped.length} skipped.`,
       { ok: true, verdict: claimPlan.graphVerdict, claimPlan },

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -217,7 +217,7 @@ import { buildStructuralImprovementAssessment } from "../signals/improvement";
 import { evaluateEscalation } from "../loop-escalation";
 import { buildResultsPayload } from "../results-payload";
 import { buildProgressSnapshot } from "../loop-progress";
-import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "../idea-intake";
+import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan, claimPlanTargetRepo } from "../idea-intake";
 import { loadPrAiReviewFindings } from "../mcp/pr-ai-review-findings";
 import {
   buildMcpCompatibilityMetadata,
@@ -3715,7 +3715,7 @@ export function createApp() {
     const validated = validateIdeaSubmission(parsed.data);
     if (!validated.ok) return c.json({ ok: false, errors: validated.errors }, 400);
     const graph = buildTaskGraph(validated.idea, parsed.data.decomposition);
-    const claimPlan = buildClaimPlan(graph, validated.idea.targetRepo);
+    const claimPlan = buildClaimPlan(graph, claimPlanTargetRepo(validated.idea.targetRepo));
     return c.json({ ok: true, verdict: claimPlan.graphVerdict, claimPlan });
   });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -172,7 +172,7 @@ import { buildPredictedGateVerdict, buildGateDispositions, type PredictedGateVer
 export { buildGateDispositions, type GateDisposition } from "../rules/predicted-gate";
 import { buildIssueSlopAssessment } from "../signals/issue-slop";
 import { buildSlopAssessment } from "../signals/slop";
-import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "../idea-intake";
+import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan, claimPlanTargetRepo } from "../idea-intake";
 import { buildResultsPayload } from "../results-payload";
 import { buildProgressSnapshot } from "../loop-progress";
 import { evaluateEscalation } from "../loop-escalation";
@@ -3700,7 +3700,7 @@ export class LoopoverMcp {
       };
     }
     const graph = buildTaskGraph(validated.idea, input.decomposition);
-    const claimPlan = buildClaimPlan(graph, validated.idea.targetRepo);
+    const claimPlan = buildClaimPlan(graph, claimPlanTargetRepo(validated.idea.targetRepo));
     return {
       summary: `Claim plan: ${claimPlan.claimable.length} claimable, ${claimPlan.deferred.length} deferred, ${claimPlan.skipped.length} skipped.`,
       data: { ok: true, verdict: claimPlan.graphVerdict, claimPlan } as unknown as Record<string, unknown>,

--- a/test/unit/idea-intake-bridge.test.ts
+++ b/test/unit/idea-intake-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildClaimPlan,
   buildTaskGraph,
+  claimPlanTargetRepo,
   scoreTaskGraph,
   validateIdeaSubmission,
   IDEA_TITLE_MAX_CHARS,
@@ -9,10 +10,15 @@ import {
   IDEA_CONSTRAINT_MAX_CHARS,
   type ConstituentIssueDraft,
   type IdeaSubmission,
+  type IdeaTarget,
   type TaskGraph,
 } from "../../packages/loopover-engine/src/idea-intake";
 
 function validIdea(overrides: Partial<IdeaSubmission> = {}): IdeaSubmission {
+  return { id: "idea-1", title: "One-line intent", body: "A freeform description of the outcome.", targetRepo: { kind: "existing", repo: "acme/widgets" }, ...overrides };
+}
+// Loose raw input for validateIdeaSubmission(unknown) — lets a test pass a bare-string or malformed targetRepo.
+function rawIdea(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return { id: "idea-1", title: "One-line intent", body: "A freeform description of the outcome.", targetRepo: "acme/widgets", ...overrides };
 }
 
@@ -47,44 +53,64 @@ describe("validateIdeaSubmission", () => {
   });
 
   it("flags over-length title and body", () => {
-    const r = validateIdeaSubmission(validIdea({ title: "x".repeat(IDEA_TITLE_MAX_CHARS + 1), body: "y".repeat(IDEA_BODY_MAX_CHARS + 1) }));
+    const r = validateIdeaSubmission(rawIdea({ title: "x".repeat(IDEA_TITLE_MAX_CHARS + 1), body: "y".repeat(IDEA_BODY_MAX_CHARS + 1) }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.errors).toEqual(expect.arrayContaining(["title_too_long", "body_too_long"]));
   });
 
   it("flags a malformed targetRepo (must be owner/name)", () => {
-    expect(validateIdeaSubmission(validIdea({ targetRepo: "no-slash" })).ok).toBe(false);
-    expect(validateIdeaSubmission(validIdea({ targetRepo: "a/b/c" })).ok).toBe(false);
-    expect(validateIdeaSubmission(validIdea({ targetRepo: "owner/name" })).ok).toBe(true);
+    expect(validateIdeaSubmission(rawIdea({ targetRepo: "no-slash" })).ok).toBe(false);
+    expect(validateIdeaSubmission(rawIdea({ targetRepo: "a/b/c" })).ok).toBe(false);
+    expect(validateIdeaSubmission(rawIdea({ targetRepo: "owner/name" })).ok).toBe(true);
+  });
+
+  it("resolves a back-compat string targetRepo to an { kind: existing } target", () => {
+    const r = validateIdeaSubmission(rawIdea({ targetRepo: "owner/name" }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.idea.targetRepo).toEqual({ kind: "existing", repo: "owner/name" });
+  });
+
+  it("accepts a { kind: provision } targetRepo for a not-yet-created repo", () => {
+    const r = validateIdeaSubmission(rawIdea({ targetRepo: { kind: "provision" } }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.idea.targetRepo).toEqual({ kind: "provision" });
+  });
+
+  it("rejects an object targetRepo that is not a provision request", () => {
+    for (const targetRepo of [{}, { kind: "existing" }]) {
+      const r = validateIdeaSubmission(rawIdea({ targetRepo }));
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.errors).toContain("target_repo_required");
+    }
   });
 
   it("flags invalid constraints (non-array, non-string element, over-length entry)", () => {
-    expect((validateIdeaSubmission(validIdea({ constraints: "x" as unknown as string[] }))).ok).toBe(false);
-    expect((validateIdeaSubmission(validIdea({ constraints: [1] as unknown as string[] }))).ok).toBe(false);
-    const long = validateIdeaSubmission(validIdea({ constraints: ["c".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1)] }));
+    expect((validateIdeaSubmission(rawIdea({ constraints: "x" as unknown as string[] }))).ok).toBe(false);
+    expect((validateIdeaSubmission(rawIdea({ constraints: [1] as unknown as string[] }))).ok).toBe(false);
+    const long = validateIdeaSubmission(rawIdea({ constraints: ["c".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1)] }));
     expect(long.ok).toBe(false);
     if (!long.ok) expect(long.errors).toContain("constraint_too_long");
-    expect(validateIdeaSubmission(validIdea({ constraints: ["ok"] })).ok).toBe(true);
+    expect(validateIdeaSubmission(rawIdea({ constraints: ["ok"] })).ok).toBe(true);
   });
 
   it("flags invalid acceptanceHints and an invalid priority", () => {
-    expect(validateIdeaSubmission(validIdea({ acceptanceHints: "x" as unknown as string[] })).ok).toBe(false);
-    expect(validateIdeaSubmission(validIdea({ acceptanceHints: [2] as unknown as string[] })).ok).toBe(false);
-    expect(validateIdeaSubmission(validIdea({ priority: "urgent" as unknown as IdeaSubmission["priority"] })).ok).toBe(false);
-    expect(validateIdeaSubmission(validIdea({ priority: "normal" })).ok).toBe(true);
+    expect(validateIdeaSubmission(rawIdea({ acceptanceHints: "x" as unknown as string[] })).ok).toBe(false);
+    expect(validateIdeaSubmission(rawIdea({ acceptanceHints: [2] as unknown as string[] })).ok).toBe(false);
+    expect(validateIdeaSubmission(rawIdea({ priority: "urgent" as unknown as IdeaSubmission["priority"] })).ok).toBe(false);
+    expect(validateIdeaSubmission(rawIdea({ priority: "normal" })).ok).toBe(true);
   });
 
   it("caps acceptanceHints entry length at IDEA_CONSTRAINT_MAX_CHARS, same bound as constraints (#7243)", () => {
-    const atCap = validateIdeaSubmission(validIdea({ acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS)] }));
+    const atCap = validateIdeaSubmission(rawIdea({ acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS)] }));
     expect(atCap.ok).toBe(true);
 
-    const overCap = validateIdeaSubmission(validIdea({ acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1)] }));
+    const overCap = validateIdeaSubmission(rawIdea({ acceptanceHints: ["h".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1)] }));
     expect(overCap.ok).toBe(false);
     if (!overCap.ok) expect(overCap.errors).toContain("acceptance_hint_too_long");
   });
 
   it("does not raise acceptance_hint_too_long for a malformed (non-array) acceptanceHints — shape error only", () => {
-    const r = validateIdeaSubmission(validIdea({ acceptanceHints: "x".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1) as unknown as string[] }));
+    const r = validateIdeaSubmission(rawIdea({ acceptanceHints: "x".repeat(IDEA_CONSTRAINT_MAX_CHARS + 1) as unknown as string[] }));
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.errors).toContain("acceptance_hints_invalid");
@@ -230,10 +256,10 @@ describe("scoreTaskGraph — graph verdict is the least-favorable across issues"
 });
 
 describe("buildClaimPlan — routes a scored task-graph into a loop claim plan (#4799)", () => {
-  const idea = validIdea({ id: "idea-C", targetRepo: "acme/widgets" });
+  const idea = validIdea({ id: "idea-C" });
 
   it("puts a lone go issue in claimable, carrying the target repo", () => {
-    const plan = buildClaimPlan(buildTaskGraph(idea, [{ key: "issue-1", title: "Add widget", body: "new" }]), idea.targetRepo);
+    const plan = buildClaimPlan(buildTaskGraph(idea, [{ key: "issue-1", title: "Add widget", body: "new" }]), claimPlanTargetRepo(idea.targetRepo));
     expect(plan.ideaId).toBe("idea-C");
     expect(plan.targetRepo).toBe("acme/widgets");
     expect(plan.graphVerdict).toBe("go");
@@ -249,11 +275,20 @@ describe("buildClaimPlan — routes a scored task-graph into a loop claim plan (
       { key: "issue-2", title: "Held", body: "b", dependsOn: ["issue-1"] }, // raise (dep not landed) -> deferred
       { key: "issue-3", title: "Unshippable", body: "b", feasibility: { issueStatus: "invalid" } }, // avoid -> skipped
     ]);
-    const plan = buildClaimPlan(graph, idea.targetRepo);
+    const plan = buildClaimPlan(graph, claimPlanTargetRepo(idea.targetRepo));
     expect(plan.claimable.map((s) => s.key)).toEqual(["issue-1"]);
     expect(plan.deferred.map((s) => s.key)).toEqual(["issue-2"]);
     expect(plan.deferred[0]?.reasons).toContain("dependency_not_landed");
     expect(plan.skipped.map((s) => s.key)).toEqual(["issue-3"]);
     expect(plan.graphVerdict).toBe("avoid"); // least-favorable across the graph
+  });
+});
+
+describe("claimPlanTargetRepo — resolves an IdeaTarget to the repo-string buildClaimPlan expects", () => {
+  it("returns the repo for an existing target and \"\" for a provision target", () => {
+    const existing: IdeaTarget = { kind: "existing", repo: "o/n" };
+    const provision: IdeaTarget = { kind: "provision" };
+    expect(claimPlanTargetRepo(existing)).toBe("o/n");
+    expect(claimPlanTargetRepo(provision)).toBe("");
   });
 });

--- a/test/unit/mcp-cli-plan-idea-claims-tool.test.ts
+++ b/test/unit/mcp-cli-plan-idea-claims-tool.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildClaimPlan, buildTaskGraph, validateIdeaSubmission } from "../../src/idea-intake";
+import { buildClaimPlan, buildTaskGraph, claimPlanTargetRepo, validateIdeaSubmission } from "../../src/idea-intake";
 
 // #6756: the local mirror of loopover_plan_idea_claims. Like its same-tier sibling loopover_check_slop_risk,
 // it computes IN-PROCESS from @loopover/engine — no API round-trip — so claim planning works fully offline.
@@ -27,7 +27,7 @@ function expectedPayload(body: unknown) {
   const validated = validateIdeaSubmission(body);
   if (!validated.ok) return { ok: false as const, errors: validated.errors };
   const graph = buildTaskGraph(validated.idea, (body as { decomposition?: never }).decomposition);
-  const claimPlan = buildClaimPlan(graph, validated.idea.targetRepo);
+  const claimPlan = buildClaimPlan(graph, claimPlanTargetRepo(validated.idea.targetRepo));
   return { ok: true as const, verdict: claimPlan.graphVerdict, claimPlan };
 }
 

--- a/test/unit/routes-plan-idea-claims.test.ts
+++ b/test/unit/routes-plan-idea-claims.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
-import { buildClaimPlan, buildTaskGraph, validateIdeaSubmission } from "../../src/idea-intake";
+import { buildClaimPlan, buildTaskGraph, claimPlanTargetRepo, validateIdeaSubmission } from "../../src/idea-intake";
 import { createTestEnv } from "../helpers/d1";
 
 // #6756: POST /v1/loop/plan-idea-claims — the REST mirror bringing loopover_plan_idea_claims to the same
@@ -28,7 +28,7 @@ function expectedPayload(body: unknown) {
   const validated = validateIdeaSubmission(body);
   if (!validated.ok) return { ok: false as const, errors: validated.errors };
   const graph = buildTaskGraph(validated.idea, (body as { decomposition?: never }).decomposition);
-  const claimPlan = buildClaimPlan(graph, validated.idea.targetRepo);
+  const claimPlan = buildClaimPlan(graph, claimPlanTargetRepo(validated.idea.targetRepo));
   return { ok: true as const, verdict: claimPlan.graphVerdict, claimPlan };
 }
 


### PR DESCRIPTION
## Problem

`IdeaSubmission.targetRepo` (`packages/loopover-engine/src/idea-intake.ts`) is a plain `string`, assuming a repo already exists (BYOR only). With auto-provisioned repos (#7589) confirmed direction, this pure IO-free bridge module needs to represent both cases so downstream consumers know which path a submission takes.

## Change

```ts
export type IdeaTarget =
  | { kind: "existing"; repo: string }
  | { kind: "provision" };
```
`IdeaSubmission.targetRepo` is retyped to `IdeaTarget`.

**Backward-compatible input (no wire-contract break).** Validation still accepts a bare `"owner/name"` string as the existing-repo form (same regex/error codes) and resolves it to `{ kind: "existing", repo }`; a `{ kind: "provision" }` object requests a not-yet-created repo. The zod request schemas are deliberately **unchanged** — an existing BYOR caller POSTing the historical bare string keeps working. Same error codes (`target_repo_required`, `target_repo_malformed`).

## Consumers (compile-clean)

Five sites fed `validated.idea.targetRepo` into `buildClaimPlan(_, string)`. `buildClaimPlan` stays repo-string-based (out of scope to change), so a pure helper resolves the union:
```ts
export function claimPlanTargetRepo(target: IdeaTarget): string {
  return target.kind === "existing" ? target.repo : "";
}
```
Each call site wraps its argument — no branching at the call site, so no new coverage obligation in the consuming files. The one `existing`/`provision` branch lives in the engine module and is fully covered by its own test.

## Verification

- `packages/loopover-engine/src/idea-intake.ts`: **100% — 90/90 statements, 96/96 branches** (both variants of the new validation and the helper, incl. provision, malformed, and object-without-provision-kind rejection).
- Root `npm run typecheck` exits 0; `@loopover/engine` build exits 0; the committed mcp bin was regenerated with `npm run build:mcp` (`check-build-drift mcp` clean).
- All affected suites pass: `idea-intake-bridge`, `routes-intake-idea`, `routes-plan-idea-claims`, `mcp-intake-idea`, `mcp-cli-intake-idea-tool`, `mcp-cli-plan-idea-claims-tool`. Bare-string input still validates, so the intake tests need no changes.

Closes #7635