### PR TITLE
feat(review): add a global cross-repo blended contributor trust score

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -300,7 +300,7 @@ import { computeOpsStats, isOpsEnabled, resolveOpsManifestOverride } from "../re
 import { handleInternalCalibration, handleInternalDecision, type OpsAgentConfig } from "../review/ops";
 import { computeParityReadiness, isParityAuditEnabled } from "../review/parity-wire";
 import { computePredictedGateAgreement } from "../review/predicted-gate-agreement";
-import { computeContributorGateEval, contributorFairnessFlags } from "../review/contributor-gate-eval";
+import { computeContributorGateEval, contributorFairnessFlags, computeBlendedContributorGateEval, contributorGlobalFairnessFlags } from "../review/contributor-gate-eval";
 import { getContributorTrustProfile } from "../review/contributor-trust-profile";
 import { backfillContributorGateHistory } from "../review/contributor-gate-history-backfill";
 import { isFairnessAnalyticsEnabled, resolveFairnessAnalyticsManifestOverride } from "../review/contributor-trust-profile-wire";
@@ -4482,25 +4482,44 @@ export function createApp() {
   // when LOOPOVER_FAIRNESS_ANALYTICS is off. NEVER exposed publicly -- see contributor-trust-profile.ts's design
   // note. The fleet-wide fairness flags need every contributor's rows to compute each project's median, so this
   // computes the full report and filters to :login rather than re-deriving a login-scoped median in isolation.
+  // Same reasoning applies to globalFairnessFlags (#global-contributor-trust) against the blended report.
   app.get("/v1/internal/fairness/contributors/:login", async (c) => {
     if (!isFairnessAnalyticsEnabled(c.env, await resolveFairnessAnalyticsManifestOverride(c.env))) return c.json({ error: "not_found" }, 404);
     const login = c.req.param("login");
     const nowMs = Date.now();
-    const [profile, evalReport] = await Promise.all([
+    const [profile, evalReport, blendedEvalReport] = await Promise.all([
       getContributorTrustProfile(c.env, login, { nowMs }),
       computeContributorGateEval(c.env, { days: 90, nowMs }),
+      computeBlendedContributorGateEval(c.env, { days: 90, nowMs }),
     ]);
     const flags = contributorFairnessFlags(evalReport.rows).filter((f) => f.login === login);
-    return c.json({ profile, fairnessFlags: flags });
+    const globalFlags = contributorGlobalFairnessFlags(blendedEvalReport.rows).filter((f) => f.login === login);
+    return c.json({ profile, fairnessFlags: flags, globalFairnessFlags: globalFlags });
   });
 
   // Fleet-wide fairness summary (#fairness-analytics): counts only, never individual contributor rows -- the
   // per-login detail lives behind the :login route above. Intended for the operator dashboard tile.
+  // globalFlaggedCount/contributorsEvaluatedGlobally (#global-contributor-trust) are the blended,
+  // pooled-across-every-repo counterparts to flaggedCount/contributorsEvaluated -- one row per LOGIN rather
+  // than one row per (login, project), so the two counts intentionally diverge for any login active on more
+  // than one repo.
   app.get("/v1/internal/fairness/contributors", async (c) => {
     if (!isFairnessAnalyticsEnabled(c.env, await resolveFairnessAnalyticsManifestOverride(c.env))) return c.json({ error: "not_found" }, 404);
-    const evalReport = await computeContributorGateEval(c.env, { days: 90, nowMs: Date.now() });
+    const nowMs = Date.now();
+    const [evalReport, blendedEvalReport] = await Promise.all([
+      computeContributorGateEval(c.env, { days: 90, nowMs }),
+      computeBlendedContributorGateEval(c.env, { days: 90, nowMs }),
+    ]);
     const flags = contributorFairnessFlags(evalReport.rows);
-    return c.json({ contributorsEvaluated: evalReport.rows.length, hasSignal: evalReport.hasSignal, flaggedCount: flags.length });
+    const globalFlags = contributorGlobalFairnessFlags(blendedEvalReport.rows);
+    return c.json({
+      contributorsEvaluated: evalReport.rows.length,
+      hasSignal: evalReport.hasSignal,
+      flaggedCount: flags.length,
+      contributorsEvaluatedGlobally: blendedEvalReport.rows.length,
+      globalHasSignal: blendedEvalReport.hasSignal,
+      globalFlaggedCount: globalFlags.length,
+    });
   });
 
   // Backfill (#fairness-analytics): reconstructs historical contributor_gate_history rows predating migration

--- a/src/review/contributor-gate-eval.ts
+++ b/src/review/contributor-gate-eval.ts
@@ -12,10 +12,21 @@
 // direction. It never asserts a contributor is gaming anything or that the gate is biased against them --
 // both are equally plausible explanations for an outlier, and a human decides which.
 //
-// SCOPE (read before adding a consumer): this table and anything derived from it must NEVER be rendered on any
-// public surface -- see contributor-calibration.ts's design note, which this module inherits verbatim. Consume
-// only via bearer-gated internal routes / the operator dashboard, matching contributor_gate_history's own
-// migration-note mandate ("never wire into exportOrbBatch").
+// computeBlendedContributorGateEval / contributorGlobalFairnessFlags (#global-contributor-trust) fold the SAME
+// underlying cells by login ALONE, pooling raw prediction/outcome counts across every project a login has
+// touched before computing one precision ratio -- this is volume-weighted, NOT an average of each project's
+// weightedAccuracy, so a login mostly active on a high-volume repo isn't distorted by a thin-sample row on a
+// second repo (see queryContributorGateCells's own note). This is possible with zero schema changes because
+// every one of this owner's self-hosted repos already shares ONE database with no tenant/installation boundary
+// column (mirrors packages/loopover-engine/src/settings/global-contributor-cap.ts's identical precedent:
+// cross-REPO-within-one-install only, never cross-instance/federated).
+//
+// SCOPE (read before adding a consumer): this table and anything derived from it -- per-project OR blended --
+// must NEVER be rendered on any public surface -- see contributor-calibration.ts's design note, which this
+// module inherits verbatim. A blended score is if anything MORE sensitive than any single per-project row (it
+// summarizes a login's entire history across every repo in one number), so this constraint applies at least as
+// strictly. Consume only via bearer-gated internal routes / the operator dashboard, matching
+// contributor_gate_history's own migration-note mandate ("never wire into exportOrbBatch").
 //
 // CONFIG-AS-CODE (#fairness-analytics): computeContributorGateEval excludes any project whose OWN
 // `.loopover.yml` sets `settings.fairnessAnalyticsMode: off` (resolveEligibleFairnessAnalyticsProjects,
@@ -58,15 +69,16 @@ function storage(env: Env): D1Database {
   return env.DB;
 }
 
+type ContributorGateCell = { login: string; project: string; pred: string; truth: string; reversed: number; n: number };
+
 /**
- * Per-(login, project) gate accuracy over contributor_gate_history's predictions vs review_audit's realized
- * outcome. Pure read; fail-safe -> empty report. Mirrors computeGateEval (parity.ts:92) with `login` added to
- * both the GROUP BY and the fold key -- see this file's header for why the ground-truth join is unchanged.
- * `opts.login`, when set, scopes the read to one contributor (mirrors computeGateEval's own optional `source`/
- * `minerOnly` scoping) -- a single-contributor trust-profile lookup should not fold every other contributor's
- * history just to discard it.
+ * Shared read: contributor_gate_history's predictions joined to review_audit's realized outcome, grouped down
+ * to one row per (login, project, pred, truth, reversed) cell -- the finest grain both computeContributorGateEval
+ * (folds by login+project) and computeBlendedContributorGateEval (folds by login alone, pooling projects) need.
+ * Keeping the SQL in one place guarantees both consumers see the exact same underlying facts; only the
+ * in-memory fold differs. Pure read; fail-safe -> []. `opts.login`, when set, scopes the read to one contributor.
  */
-export async function computeContributorGateEval(env: Env, opts: { days: number; nowMs: number; login?: string }): Promise<ContributorGateEvalReport> {
+async function queryContributorGateCells(env: Env, opts: { days: number; nowMs: number; login?: string }): Promise<ContributorGateCell[]> {
   const days = Number.isFinite(opts.days) && opts.days > 0 ? Math.min(opts.days, 730) : 90;
   const fromIso = new Date(opts.nowMs - days * 86_400_000).toISOString().slice(0, 10);
   const loginFilter = opts.login ? "AND login = ?" : "";
@@ -90,15 +102,27 @@ export async function computeContributorGateEval(env: Env, opts: { days: number;
     LEFT JOIN rev ON cgh.target_id = rev.target_id
     GROUP BY cgh.login, cgh.project, cgh.pred, po.truth, reversed`;
 
-  let cells: Array<{ login: string; project: string; pred: string; truth: string; reversed: number; n: number }> = [];
   try {
     const stmt = storage(env).prepare(sql);
     const bound = opts.login ? stmt.bind(fromIso, opts.login) : stmt.bind(fromIso);
-    const res = await bound.all<{ login: string; project: string; pred: string; truth: string; reversed: number; n: number }>();
-    cells = res.results ?? [];
+    const res = await bound.all<ContributorGateCell>();
+    return res.results ?? [];
   } catch {
-    return { rows: [], hasSignal: false };
+    return [];
   }
+}
+
+/**
+ * Per-(login, project) gate accuracy over contributor_gate_history's predictions vs review_audit's realized
+ * outcome. Pure read; fail-safe -> empty report. Mirrors computeGateEval (parity.ts:92) with `login` added to
+ * both the GROUP BY and the fold key -- see this file's header for why the ground-truth join is unchanged.
+ * `opts.login`, when set, scopes the read to one contributor (mirrors computeGateEval's own optional `source`/
+ * `minerOnly` scoping) -- a single-contributor trust-profile lookup should not fold every other contributor's
+ * history just to discard it.
+ */
+export async function computeContributorGateEval(env: Env, opts: { days: number; nowMs: number; login?: string }): Promise<ContributorGateEvalReport> {
+  const cells = await queryContributorGateCells(env, opts);
+  if (cells.length === 0) return { rows: [], hasSignal: false };
 
   const byKey = new Map<string, ContributorGateEvalRow>();
   const row = (login: string, project: string): ContributorGateEvalRow => {
@@ -167,6 +191,13 @@ export interface ContributorFairnessFlag {
 const CONTRIBUTOR_MIN_SAMPLE = 5; // mirrors submitter-reputation.ts's own minSample default
 const CONTRIBUTOR_OUTLIER_BAND = 0.25; // mirrors orb/analytics.ts's OUTLIER_BAND
 
+/** Shared by contributorFairnessFlags and contributorGlobalFairnessFlags -- both need the median of an
+ *  already-nonempty array of weightedAccuracy values. Assumes `values` is sorted ascending. */
+function medianOf(values: number[]): number {
+  const mid = Math.floor(values.length / 2);
+  return values.length % 2 === 0 ? (values[mid - 1]! + values[mid]!) / 2 : values[mid]!;
+}
+
 /**
  * Flags (login, project) rows whose weightedAccuracy deviates from that PROJECT's median (across contributors
  * meeting CONTRIBUTOR_MIN_SAMPLE) by more than CONTRIBUTOR_OUTLIER_BAND, in EITHER direction. Pure function --
@@ -186,8 +217,7 @@ export function contributorFairnessFlags(rows: ContributorGateEvalRow[]): Contri
   for (const [project, eligible] of byProject) {
     if (eligible.length < 2) continue; // need a peer group to have a meaningful median
     const sorted = eligible.map((r) => r.weightedAccuracy!).sort((a, b) => a - b);
-    const mid = Math.floor(sorted.length / 2);
-    const projectMedianAccuracy = sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+    const projectMedianAccuracy = medianOf(sorted);
     for (const r of eligible) {
       const deviation = r.weightedAccuracy! - projectMedianAccuracy;
       if (Math.abs(deviation) > CONTRIBUTOR_OUTLIER_BAND) {
@@ -196,5 +226,143 @@ export function contributorFairnessFlags(rows: ContributorGateEvalRow[]): Contri
     }
   }
   flags.sort((a, b) => a.login.localeCompare(b.login) || a.project.localeCompare(b.project));
+  return flags;
+}
+
+export interface BlendedContributorGateEvalRow {
+  login: string;
+  /** Distinct fairness-analytics-eligible projects this login has decided rows on, contributing to the blend. */
+  projectCount: number;
+  wouldMerge: number;
+  mergeConfirmed: number;
+  mergeFalse: number;
+  wouldClose: number;
+  closeConfirmed: number;
+  closeFalse: number;
+  decided: number;
+  mergePrecision: number | null;
+  closePrecision: number | null;
+  weightedMergeConfirmed: number;
+  weightedCloseConfirmed: number;
+  weightedMergePrecision: number | null;
+  weightedClosePrecision: number | null;
+  /** Volume-weighted across every eligible project this login has touched -- NOT an average of each project's
+   *  own weightedAccuracy (see this file's header). Null when decided is 0. */
+  weightedAccuracy: number | null;
+}
+
+export interface BlendedContributorGateEvalReport {
+  rows: BlendedContributorGateEvalRow[];
+  hasSignal: boolean;
+}
+
+/**
+ * The global, cross-repo blended counterpart to computeContributorGateEval: one row per login, POOLING raw
+ * prediction/outcome counts across every fairness-analytics-eligible project that login has touched before
+ * computing a single precision ratio -- volume-weighted, not an average of each project's own accuracy, so a
+ * login with 400 decided PRs on one repo and 5 on another isn't distorted toward a 50/50 blend of the two
+ * projects' figures. Reuses the exact same cells as computeContributorGateEval (queryContributorGateCells) and
+ * the exact same REVERSAL_DISCOUNT_WEIGHT-weighted credit semantics. `opts.login`, when set, scopes the read to
+ * one contributor (same contract as computeContributorGateEval).
+ */
+export async function computeBlendedContributorGateEval(env: Env, opts: { days: number; nowMs: number; login?: string }): Promise<BlendedContributorGateEvalReport> {
+  const cells = await queryContributorGateCells(env, opts);
+  if (cells.length === 0) return { rows: [], hasSignal: false };
+
+  // Config-as-code (#fairness-analytics): apply the per-repo opt-out BEFORE pooling across projects -- an
+  // opted-out project's counts must never enter another project's blended precision in the first place, unlike
+  // computeContributorGateEval which can filter its already-per-project rows after folding.
+  const eligibleProjects = await resolveEligibleFairnessAnalyticsProjects(env, [...new Set(cells.map((c) => c.project))]);
+  const eligibleCells = cells.filter((c) => eligibleProjects.has(c.project));
+
+  const byLogin = new Map<string, BlendedContributorGateEvalRow>();
+  const projectsByLogin = new Map<string, Set<string>>();
+  const row = (login: string): BlendedContributorGateEvalRow => {
+    let r = byLogin.get(login);
+    if (!r) {
+      r = {
+        login, projectCount: 0, wouldMerge: 0, mergeConfirmed: 0, mergeFalse: 0, wouldClose: 0, closeConfirmed: 0, closeFalse: 0, decided: 0,
+        mergePrecision: null, closePrecision: null, weightedMergeConfirmed: 0, weightedCloseConfirmed: 0, weightedMergePrecision: null, weightedClosePrecision: null, weightedAccuracy: null,
+      };
+      byLogin.set(login, r);
+    }
+    return r;
+  };
+
+  for (const c of eligibleCells) {
+    const r = row(c.login);
+    let projects = projectsByLogin.get(c.login);
+    if (!projects) {
+      projects = new Set<string>();
+      projectsByLogin.set(c.login, projects);
+    }
+    projects.add(c.project);
+
+    r.decided += c.n;
+    const weightedN = c.reversed ? c.n * REVERSAL_DISCOUNT_WEIGHT : c.n;
+    if (c.pred === "merge") {
+      r.wouldMerge += c.n;
+      if (c.truth === "merged") {
+        r.mergeConfirmed += c.n;
+        r.weightedMergeConfirmed += weightedN;
+      } else if (c.truth === "closed") r.mergeFalse += c.n;
+    } else if (c.pred === "close") {
+      r.wouldClose += c.n;
+      if (c.truth === "closed") {
+        r.closeConfirmed += c.n;
+        r.weightedCloseConfirmed += weightedN;
+      } else if (c.truth === "merged") r.closeFalse += c.n;
+    }
+  }
+
+  const rows = [...byLogin.values()].map((r) => ({
+    ...r,
+    // Every login in byLogin was inserted into projectsByLogin in the SAME loop iteration above -- the two
+    // maps always have identical keysets, so this lookup can never miss.
+    projectCount: projectsByLogin.get(r.login)!.size,
+    mergePrecision: r.wouldMerge > 0 ? r.mergeConfirmed / r.wouldMerge : null,
+    closePrecision: r.wouldClose > 0 ? r.closeConfirmed / r.wouldClose : null,
+    weightedMergePrecision: r.wouldMerge > 0 ? r.weightedMergeConfirmed / r.wouldMerge : null,
+    weightedClosePrecision: r.wouldClose > 0 ? r.weightedCloseConfirmed / r.wouldClose : null,
+    weightedAccuracy: r.decided > 0 ? (r.weightedMergeConfirmed + r.weightedCloseConfirmed) / r.decided : null,
+  }));
+  rows.sort((a, b) => a.login.localeCompare(b.login));
+  return { rows, hasSignal: rows.some((r) => r.decided >= MIN_DECIDED_FOR_SIGNAL) };
+}
+
+export interface ContributorGlobalFairnessFlag {
+  login: string;
+  decided: number;
+  projectCount: number;
+  weightedAccuracy: number;
+  fleetMedianAccuracy: number;
+  /** weightedAccuracy - fleetMedianAccuracy, across the WHOLE fleet (every eligible repo pooled), not one
+   *  project's peers. Positive = unusually FAVORABLE; negative = unusually UNFAVORABLE. Neither direction is
+   *  asserted as fault -- flagged for a human to review either way. */
+  deviation: number;
+}
+
+/**
+ * The global counterpart to contributorFairnessFlags: flags logins whose BLENDED (cross-repo) weightedAccuracy
+ * deviates from the whole fleet's median (across contributors meeting CONTRIBUTOR_MIN_SAMPLE) by more than
+ * CONTRIBUTOR_OUTLIER_BAND, in EITHER direction. A login can be a per-project outlier without being a global
+ * outlier (a bad week on one small repo washes out against a long clean history elsewhere) and vice versa --
+ * both flag sets exist side by side, neither supersedes the other. Pure function; never an assertion of fault.
+ */
+export function contributorGlobalFairnessFlags(rows: BlendedContributorGateEvalRow[]): ContributorGlobalFairnessFlag[] {
+  const eligible = rows.filter((r) => r.decided >= CONTRIBUTOR_MIN_SAMPLE && r.weightedAccuracy !== null);
+  if (eligible.length < 2) return []; // need a peer group to have a meaningful median
+
+  const sorted = eligible.map((r) => r.weightedAccuracy!).sort((a, b) => a - b);
+  const fleetMedianAccuracy = medianOf(sorted);
+
+  const flags: ContributorGlobalFairnessFlag[] = [];
+  for (const r of eligible) {
+    const deviation = r.weightedAccuracy! - fleetMedianAccuracy;
+    if (Math.abs(deviation) > CONTRIBUTOR_OUTLIER_BAND) {
+      flags.push({ login: r.login, decided: r.decided, projectCount: r.projectCount, weightedAccuracy: r.weightedAccuracy!, fleetMedianAccuracy, deviation });
+    }
+  }
+  flags.sort((a, b) => a.login.localeCompare(b.login));
   return flags;
 }

--- a/src/review/contributor-gate-history-backfill.ts
+++ b/src/review/contributor-gate-history-backfill.ts
@@ -11,8 +11,12 @@
 //
 // SCOPE: inherits contributor-gate-eval.ts's design note -- the rows this writes are the SAME
 // contributor_gate_history table, never rendered on any public surface, never wired into exportOrbBatch.
+//
+// TIMESTAMP FIDELITY: each reconstructed row's created_at is the ORIGINAL review_audit row's created_at, not
+// the time this backfill ran -- computeContributorGateEval's `created_at >= ?` rolling-window filter (and any
+// day-bucketed view) needs the true historical date to age rows out correctly.
 
-import { errorMessage, nowIso } from "../utils/json";
+import { errorMessage } from "../utils/json";
 
 export interface ContributorGateHistoryBackfillResult {
   /** review_audit gate_decision rows examined in this batch (bounded by opts.limit). */
@@ -39,12 +43,12 @@ const MAX_BATCH_LIMIT = 5000;
 export async function backfillContributorGateHistory(env: Env, opts: { limit?: number } = {}): Promise<ContributorGateHistoryBackfillResult> {
   const limit = Number.isFinite(opts.limit) && (opts.limit as number) > 0 ? Math.min(opts.limit as number, MAX_BATCH_LIMIT) : DEFAULT_BATCH_LIMIT;
 
-  type Candidate = { project: string; targetId: string; decision: string; headSha: string | null; source: string; authorLogin: string | null };
+  type Candidate = { project: string; targetId: string; decision: string; headSha: string | null; source: string; authorLogin: string | null; createdAt: string };
   let candidates: Candidate[] = [];
   try {
     const res = await env.DB.prepare(
       `SELECT ra.project AS project, ra.target_id AS targetId, ra.decision AS decision, ra.head_sha AS headSha,
-              ra.source AS source, pr.author_login AS authorLogin
+              ra.source AS source, pr.author_login AS authorLogin, ra.created_at AS createdAt
          FROM review_audit ra
          LEFT JOIN pull_requests pr
            ON pr.repo_full_name = ra.project
@@ -83,7 +87,7 @@ export async function backfillContributorGateHistory(env: Env, opts: { limit?: n
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO NOTHING`,
       )
-        .bind(`contrib:${login}:${c.source}:${c.targetId}@${c.headSha ?? "none"}`, login, c.source, c.project, c.targetId, c.decision, c.headSha, nowIso())
+        .bind(`contrib:${login}:${c.source}:${c.targetId}@${c.headSha ?? "none"}`, login, c.source, c.project, c.targetId, c.decision, c.headSha, c.createdAt)
         .run();
       inserted += 1;
     } catch (error) {

--- a/src/review/contributor-trust-profile.ts
+++ b/src/review/contributor-trust-profile.ts
@@ -1,17 +1,22 @@
-// Per-contributor trust profile (#fairness-analytics, private/internal-only): composes THREE already-existing
+// Per-contributor trust profile (#fairness-analytics, private/internal-only): composes FOUR already-existing
 // data sources into one queryable view, per repo -- nothing here is a new signal, it's a new lens on data this
 // codebase already collects:
 //   - submitter_stats (migration 0046) -- raw per-(project, submitter) submission/merge/close counts.
 //   - moderation violations (audit_events, MODERATION_VIOLATION_EVENT_TYPE) -- adverse actions/warnings already
 //     recorded by the moderation-rules engine (src/services/agent-action-executor.ts).
 //   - computeContributorGateEval (contributor-gate-eval.ts) -- per-repo gate-decision accuracy.
+//   - computeBlendedContributorGateEval (contributor-gate-eval.ts, #global-contributor-trust) -- the SAME
+//     underlying data pooled across every repo this login has touched, into one cross-repo accuracy figure.
+//     This is what makes the profile a genuine cross-repo "global" trust score rather than a bundle of
+//     per-repo rows a caller must average themselves.
 //
-// SCOPE (inherits contributor-gate-eval.ts's design note verbatim): NEVER rendered on any public surface.
+// SCOPE (inherits contributor-gate-eval.ts's design note verbatim): NEVER rendered on any public surface --
+// the blended figure especially, since it summarizes a login's ENTIRE cross-repo history in one number.
 // Internal/bearer-gated consumers only.
 
 import { MODERATION_VIOLATION_EVENT_TYPE } from "../settings/moderation-rules";
 import { listModerationViolationsForActor } from "../db/repositories";
-import { computeContributorGateEval } from "./contributor-gate-eval";
+import { computeContributorGateEval, computeBlendedContributorGateEval } from "./contributor-gate-eval";
 import { resolveEligibleFairnessAnalyticsProjects } from "./contributor-trust-profile-wire";
 import { nowIso } from "../utils/json";
 
@@ -51,6 +56,11 @@ export interface ContributorTrustProfile {
   repoStats: ContributorRepoStats[];
   moderation: ContributorModerationSummary[];
   gateAccuracy: Array<{ project: string; decided: number; weightedAccuracy: number | null }>;
+  /** The cross-repo blend of gateAccuracy: one pooled figure across every fairness-analytics-eligible project
+   *  this login has touched (#global-contributor-trust), volume-weighted rather than an average of the
+   *  per-project rows above -- see computeBlendedContributorGateEval's own note. Null when this login has no
+   *  decided rows on any eligible project in the window. */
+  blendedGateAccuracy: { decided: number; projectCount: number; weightedAccuracy: number | null } | null;
   totals: { submissions: number; merged: number; closed: number; violations: number };
 }
 
@@ -133,11 +143,13 @@ export async function getContributorTrustProfile(env: Env, login: string, opts: 
   const nowMs = opts.nowMs ?? Date.now();
   const windowDays = Number.isFinite(opts.days) && (opts.days as number) > 0 ? Math.min(opts.days as number, 730) : 90;
 
-  const [rawRepoStats, violationRows, gateEval] = await Promise.all([
+  const [rawRepoStats, violationRows, gateEval, blendedGateEval] = await Promise.all([
     loadContributorRepoStats(env, login),
     listModerationViolationsForActor(env, login, ALL_MODERATION_EVENT_TYPES).catch(() => []),
     // computeContributorGateEval already applies the same per-repo opt-out filter below internally.
     computeContributorGateEval(env, { days: windowDays, nowMs, login }),
+    // computeBlendedContributorGateEval applies the SAME per-repo opt-out filter, before pooling (#global-contributor-trust).
+    computeBlendedContributorGateEval(env, { days: windowDays, nowMs, login }),
   ]);
 
   const rawModeration = summarizeModerationViolationsByRepo(violationRows);
@@ -149,11 +161,14 @@ export async function getContributorTrustProfile(env: Env, login: string, opts: 
   const repoStats = rawRepoStats.filter((r) => eligibleProjects.has(r.project));
   const moderation = rawModeration.filter((m) => eligibleProjects.has(m.project));
   const gateAccuracy = gateEval.rows.map((r) => ({ project: r.project, decided: r.decided, weightedAccuracy: r.weightedAccuracy }));
+  // blendedGateEval.rows is scoped to `login` (opts.login was passed above), so it's at most one row.
+  const blendedRow = blendedGateEval.rows[0];
+  const blendedGateAccuracy = blendedRow ? { decided: blendedRow.decided, projectCount: blendedRow.projectCount, weightedAccuracy: blendedRow.weightedAccuracy } : null;
 
   const totals = repoStats.reduce(
     (acc, r) => ({ submissions: acc.submissions + r.submissions, merged: acc.merged + r.merged, closed: acc.closed + r.closed, violations: acc.violations }),
     { submissions: 0, merged: 0, closed: 0, violations: moderation.reduce((sum, m) => sum + m.violationCount, 0) },
   );
 
-  return { login, generatedAt: nowIso(), windowDays, repoStats, moderation, gateAccuracy, totals };
+  return { login, generatedAt: nowIso(), windowDays, repoStats, moderation, gateAccuracy, blendedGateAccuracy, totals };
 }

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -33,7 +33,7 @@ import type {
 import { computeFleetAnalytics, getFleetHealthSummary, type FleetAnalytics, type FleetHealthSummary } from "../orb/analytics";
 import { computeAgentHealth, computeCalibration, type AgentHealth, type Calibration } from "../review/ops";
 import { computeGateEval, type GateEvalReport } from "../review/parity";
-import { computeContributorGateEval, contributorFairnessFlags } from "../review/contributor-gate-eval";
+import { computeContributorGateEval, contributorFairnessFlags, computeBlendedContributorGateEval, contributorGlobalFairnessFlags } from "../review/contributor-gate-eval";
 import { computeCycleTimeAggregate, computeFindingAcceptance, type CycleTimeAggregate } from "../review/stats";
 import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
 import { nowIso } from "../utils/json";
@@ -138,6 +138,7 @@ export async function buildOperatorDashboardPayload(
     fleetMetrics,
     gateEval,
     contributorGateEval,
+    blendedContributorGateEval,
     cycleTime,
     calibration,
     agentHealth,
@@ -167,6 +168,8 @@ export async function buildOperatorDashboardPayload(
     computeGateEval(env, { days: GATE_ANALYTICS_WINDOW_DAYS, nowMs: Date.now() }),
     // #fairness-analytics: per-contributor gate accuracy, same window; fails safe to an empty report.
     computeContributorGateEval(env, { days: GATE_ANALYTICS_WINDOW_DAYS, nowMs: Date.now() }),
+    // #global-contributor-trust: the SAME data pooled cross-repo into one blended figure per login, same window.
+    computeBlendedContributorGateEval(env, { days: GATE_ANALYTICS_WINDOW_DAYS, nowMs: Date.now() }),
     // #2194: cycle-time percentiles from the stats feed; fails safe to an empty aggregate.
     computeCycleTimeAggregate(env, { days: GATE_ANALYTICS_WINDOW_DAYS, nowMs: Date.now() }),
     computeCalibration(env, operatorAgentConfig(env)),
@@ -200,6 +203,8 @@ export async function buildOperatorDashboardPayload(
   });
   // #fairness-analytics: pure fold over the already-fetched eval rows, no extra I/O.
   const contributorFairnessFlagCount = contributorFairnessFlags(contributorGateEval.rows).length;
+  // #global-contributor-trust: same fold, but over the blended (cross-repo) rows.
+  const globalContributorFairnessFlagCount = contributorGlobalFairnessFlags(blendedContributorGateEval.rows).length;
   const installedRepos = repositories.filter((repo: RepositoryRecord) => repo.isInstalled).length;
   const registeredRepos = repositories.filter((repo: RepositoryRecord) => repo.isRegistered).length;
   // #1967: map FindingAcceptanceAggregate's field names onto the AcceptanceRateCard's expected shape.
@@ -269,6 +274,14 @@ export async function buildOperatorDashboardPayload(
         label: "Contributor fairness flags",
         value: String(contributorFairnessFlagCount),
         delta: contributorFairnessFlagCount > 0 ? `${contributorGateEval.rows.length} contributor(s) evaluated` : "no outliers detected",
+      },
+      {
+        // #global-contributor-trust: the cross-repo blended counterpart -- one row per LOGIN (pooled across
+        // every repo they've touched) rather than one row per (login, project), same privacy posture as the
+        // per-project tile above (counts only, never individual logins).
+        label: "Global contributor fairness flags",
+        value: String(globalContributorFairnessFlagCount),
+        delta: globalContributorFairnessFlagCount > 0 ? `${blendedContributorGateEval.rows.length} contributor(s) evaluated` : "no outliers detected",
       },
     ],
     noiseReduction: [

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -4597,10 +4597,17 @@ describe("api routes", () => {
 
     const res = await app.request("/v1/internal/fairness/contributors/octocat", { headers }, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { profile: { login: string; repoStats: unknown[] }; fairnessFlags: unknown[] };
+    const body = (await res.json()) as {
+      profile: { login: string; repoStats: unknown[]; blendedGateAccuracy: unknown };
+      fairnessFlags: unknown[];
+      globalFairnessFlags: unknown[];
+    };
     expect(body.profile.login).toBe("octocat");
     expect(body.profile.repoStats).toHaveLength(1);
     expect(Array.isArray(body.fairnessFlags)).toBe(true);
+    // #global-contributor-trust: the cross-repo blend rides along in the same profile payload.
+    expect(body.profile.blendedGateAccuracy).toBeNull(); // no gate decisions inserted in this fixture
+    expect(Array.isArray(body.globalFairnessFlags)).toBe(true);
 
     const offEnv = createTestEnv();
     const off = await app.request("/v1/internal/fairness/contributors/octocat", { headers }, offEnv);
@@ -4614,8 +4621,23 @@ describe("api routes", () => {
 
     const res = await app.request("/v1/internal/fairness/contributors", { headers }, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { contributorsEvaluated: number; hasSignal: boolean; flaggedCount: number };
-    expect(body).toEqual({ contributorsEvaluated: 0, hasSignal: false, flaggedCount: 0 });
+    const body = (await res.json()) as {
+      contributorsEvaluated: number;
+      hasSignal: boolean;
+      flaggedCount: number;
+      contributorsEvaluatedGlobally: number;
+      globalHasSignal: boolean;
+      globalFlaggedCount: number;
+    };
+    // #global-contributor-trust: the fleet-wide blended counts ride along beside the per-project ones.
+    expect(body).toEqual({
+      contributorsEvaluated: 0,
+      hasSignal: false,
+      flaggedCount: 0,
+      contributorsEvaluatedGlobally: 0,
+      globalHasSignal: false,
+      globalFlaggedCount: 0,
+    });
     expect(JSON.stringify(body)).not.toContain("login"); // counts only, never a per-contributor breakdown
 
     const offEnv = createTestEnv();

--- a/test/unit/contributor-gate-eval.test.ts
+++ b/test/unit/contributor-gate-eval.test.ts
@@ -3,6 +3,9 @@ import {
   computeContributorGateEval,
   type ContributorGateEvalRow,
   contributorFairnessFlags,
+  computeBlendedContributorGateEval,
+  type BlendedContributorGateEvalRow,
+  contributorGlobalFairnessFlags,
 } from "../../src/review/contributor-gate-eval";
 import { REVERSAL_DISCOUNT_WEIGHT } from "../../src/review/parity";
 import { upsertRepositorySettings } from "../../src/db/repositories";
@@ -305,6 +308,229 @@ describe("contributorFairnessFlags — per-login deviation from the project medi
       row({ login: "zeta", project: "p", weightedAccuracy: 0.9 }),
       row({ login: "mid", project: "p", weightedAccuracy: 0.5 }), // median: (0.9+0.5)/2=0.7, neither flags alone...
       row({ login: "alpha", project: "p", weightedAccuracy: 0.1 }), // ...but this pulls the median down
+    ]);
+    expect(flags.map((f) => f.login)).toEqual(["alpha", "zeta"]);
+  });
+});
+
+describe("computeBlendedContributorGateEval — cross-repo blended gate accuracy (#global-contributor-trust)", () => {
+  it("pools cells across TWO projects for the SAME login into one VOLUME-WEIGHTED row, not an average of each project's precision", async () => {
+    const out = await computeBlendedContributorGateEval(
+      cellEnv([
+        // project p1: 8/10 merge precision (80%)
+        { login: "octocat", project: "p1", pred: "merge", truth: "merged", n: 8 },
+        { login: "octocat", project: "p1", pred: "merge", truth: "closed", n: 2 },
+        // project p2: 1/1 merge precision (100%)
+        { login: "octocat", project: "p2", pred: "merge", truth: "merged", n: 1 },
+      ]),
+      { days: 90, nowMs: NOW },
+    );
+    expect(out.rows).toHaveLength(1);
+    const r = out.rows[0]!;
+    expect(r.login).toBe("octocat");
+    expect(r.projectCount).toBe(2);
+    expect(r.wouldMerge).toBe(11);
+    expect(r.mergeConfirmed).toBe(9);
+    // Volume-weighted: 9/11 ≈ 0.818 -- NOT a naive average of 0.8 and 1.0 (which would be 0.9).
+    expect(r.mergePrecision).toBeCloseTo(9 / 11);
+    expect(r.mergePrecision).not.toBeCloseTo(0.9, 1);
+    expect(r.decided).toBe(11);
+  });
+
+  it("keeps two different logins as separate blended rows, sorted by login", async () => {
+    const out = await computeBlendedContributorGateEval(
+      cellEnv([
+        { login: "hubot", project: "p1", pred: "close", truth: "closed", n: 2 },
+        { login: "octocat", project: "p1", pred: "merge", truth: "merged", n: 3 },
+        { login: "octocat", project: "p2", pred: "merge", truth: "merged", n: 1 },
+      ]),
+      { days: 90, nowMs: NOW },
+    );
+    expect(out.rows.map((r) => r.login)).toEqual(["hubot", "octocat"]);
+    expect(out.rows.find((r) => r.login === "octocat")!.projectCount).toBe(2);
+    expect(out.rows.find((r) => r.login === "hubot")!.projectCount).toBe(1);
+  });
+
+  it("#2348-equivalent: discounts a reverted merge's credit the same way as the per-project computation", async () => {
+    const out = await computeBlendedContributorGateEval(
+      cellEnv([
+        { login: "octocat", project: "p1", pred: "merge", truth: "merged", reversed: 0, n: 6 },
+        { login: "octocat", project: "p2", pred: "merge", truth: "merged", reversed: 1, n: 4 }, // later reverted, on a DIFFERENT project
+      ]),
+      { days: 90, nowMs: NOW },
+    );
+    const r = out.rows[0]!;
+    expect(r.mergeConfirmed).toBe(10); // raw: unaffected by reversal
+    expect(r.weightedMergeConfirmed).toBe(6 + 4 * REVERSAL_DISCOUNT_WEIGHT);
+    expect(r.weightedAccuracy).toBeCloseTo((6 + 4 * REVERSAL_DISCOUNT_WEIGHT) / 10);
+  });
+
+  it("leaves weightedAccuracy 0 (not null) when decided > 0 but no confusion bucket matched (same 'counts decided' semantics as the per-project fold)", async () => {
+    const out = await computeBlendedContributorGateEval(cellEnv([{ login: "octocat", project: "p", pred: "hold", truth: "merged", n: 4 }]), { days: 90, nowMs: NOW });
+    const r = out.rows[0]!;
+    expect(r.decided).toBe(4);
+    expect(r.weightedAccuracy).toBe(0);
+  });
+
+  it("leaves weightedAccuracy null for a login with zero decided", async () => {
+    // A cell with n=0 can't come from a real GROUP BY COUNT(*) query, but exercises the decided<=0 branch
+    // directly rather than asserting it's unreachable (mirrors computeContributorGateEval's identical test).
+    const out = await computeBlendedContributorGateEval(cellEnv([{ login: "octocat", project: "p", pred: "merge", truth: "merged", n: 0 }]), { days: 90, nowMs: NOW });
+    expect(out.rows[0]!.decided).toBe(0);
+    expect(out.rows[0]!.weightedAccuracy).toBeNull();
+  });
+
+  it("counts a false-close (would-close, human merged) and a false-merge is unaffected by an inconclusive outcome, pooled across projects", async () => {
+    const out = await computeBlendedContributorGateEval(
+      cellEnv([
+        { login: "octocat", project: "p1", pred: "close", truth: "merged", n: 1 }, // false-close: the dangerous error
+        { login: "octocat", project: "p2", pred: "merge", truth: "expired", n: 4 }, // neither merged nor closed
+        { login: "octocat", project: "p1", pred: "close", truth: "expired", n: 3 }, // neither merged nor closed
+      ]),
+      { days: 90, nowMs: NOW },
+    );
+    const r = out.rows[0]!;
+    expect(r.wouldClose).toBe(4); // 1 false-close + 3 expired
+    expect(r.closeConfirmed).toBe(0);
+    expect(r.closeFalse).toBe(1);
+    expect(r.closePrecision).toBe(0);
+    expect(r.wouldMerge).toBe(4);
+    expect(r.mergeConfirmed).toBe(0);
+    expect(r.mergeFalse).toBe(0); // expired is neither confirmed nor false
+    expect(r.mergePrecision).toBe(0);
+  });
+
+  it("REGRESSION (#global-contributor-trust): excludes an opted-out project's cells from another eligible project's blend", async () => {
+    const env = createTestEnv();
+    await upsertRepositorySettings(env, { repoFullName: "owner/opted-out" });
+    await upsertRepoFocusManifest(env, "owner/opted-out", { settings: { fairnessAnalyticsMode: "off" } });
+
+    const insert = async (project: string, pr: number, n: number): Promise<void> => {
+      for (let i = 0; i < n; i++) {
+        const targetId = `${project}#${pr}-${i}`;
+        await env.DB.prepare(`INSERT INTO contributor_gate_history (id, login, source, project, target_id, decision, created_at) VALUES (?, 'octocat', 'gittensory-native', ?, ?, 'merge', ?)`)
+          .bind(`cgh-${targetId}`, project, targetId, new Date().toISOString())
+          .run();
+        await env.DB.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, ?, ?, 'pr_outcome', 'merged', 'github', ?)`)
+          .bind(`po-${targetId}`, project, targetId, new Date().toISOString())
+          .run();
+      }
+    };
+    await insert("owner/opted-out", 1, 5); // would dominate the blend if not excluded
+    await insert("owner/opted-in", 2, 1);
+
+    const out = await computeBlendedContributorGateEval(env, { days: 90, nowMs: NOW });
+    expect(out.rows).toHaveLength(1);
+    expect(out.rows[0]!.decided).toBe(1); // only the opted-in project's single decision counted
+    expect(out.rows[0]!.projectCount).toBe(1);
+  });
+
+  it("is fail-safe: a throwing D1 read degrades to an empty report, not an error", async () => {
+    const env = { DB: { prepare: () => ({ bind: () => ({ all: async () => { throw new Error("d1 down"); } }) }) } } as unknown as Env;
+    const out = await computeBlendedContributorGateEval(env, { days: 90, nowMs: NOW });
+    expect(out.rows).toEqual([]);
+    expect(out.hasSignal).toBe(false);
+  });
+
+  it("hasSignal reflects the blended decided count crossing MIN_DECIDED_FOR_SIGNAL(10), pooled across projects", async () => {
+    const under = await computeBlendedContributorGateEval(
+      cellEnv([
+        { login: "octocat", project: "p1", pred: "merge", truth: "merged", n: 4 },
+        { login: "octocat", project: "p2", pred: "merge", truth: "merged", n: 5 },
+      ]),
+      { days: 90, nowMs: NOW },
+    );
+    expect(under.hasSignal).toBe(false); // 9 < 10, even though neither project alone would show signal either
+
+    const over = await computeBlendedContributorGateEval(
+      cellEnv([
+        { login: "octocat", project: "p1", pred: "merge", truth: "merged", n: 4 },
+        { login: "octocat", project: "p2", pred: "merge", truth: "merged", n: 6 },
+      ]),
+      { days: 90, nowMs: NOW },
+    );
+    expect(over.hasSignal).toBe(true); // 10 >= 10, achieved ONLY by pooling across the two projects
+  });
+});
+
+describe("contributorGlobalFairnessFlags — blended (cross-repo) deviation from the FLEET median (#global-contributor-trust)", () => {
+  const row = (over: Partial<BlendedContributorGateEvalRow>): BlendedContributorGateEvalRow => ({
+    login: "octocat", projectCount: 1, wouldMerge: 0, mergeConfirmed: 0, mergeFalse: 0, wouldClose: 0, closeConfirmed: 0, closeFalse: 0, decided: 10,
+    mergePrecision: null, closePrecision: null, weightedMergeConfirmed: 0, weightedCloseConfirmed: 0, weightedMergePrecision: null, weightedClosePrecision: null, weightedAccuracy: 0.9,
+    ...over,
+  });
+
+  it("does not flag a contributor within the outlier band of the fleet median", () => {
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "a", weightedAccuracy: 0.9 }),
+      row({ login: "b", weightedAccuracy: 0.85 }),
+    ]);
+    expect(flags).toEqual([]);
+  });
+
+  it("flags a contributor whose BLENDED accuracy is unusually UNFAVORABLE vs the fleet median", () => {
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "a", weightedAccuracy: 0.9 }),
+      row({ login: "b", weightedAccuracy: 0.9 }),
+      row({ login: "c", weightedAccuracy: 0.5, projectCount: 3 }),
+    ]);
+    expect(flags).toHaveLength(1);
+    expect(flags[0]).toMatchObject({ login: "c", projectCount: 3, deviation: -0.4 });
+    expect(flags[0]!.fleetMedianAccuracy).toBeCloseTo(0.9);
+  });
+
+  it("flags a contributor whose BLENDED accuracy is unusually FAVORABLE vs the fleet median -- neither direction is asserted as fault", () => {
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "a", weightedAccuracy: 0.5 }),
+      row({ login: "b", weightedAccuracy: 0.5 }),
+      row({ login: "c", weightedAccuracy: 1.0 }),
+    ]);
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.login).toBe("c");
+    expect(flags[0]!.deviation).toBeCloseTo(0.5);
+  });
+
+  it("never flags a contributor below the minimum sample size, even with an extreme deviation", () => {
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "a", weightedAccuracy: 0.9 }),
+      row({ login: "b", weightedAccuracy: 0.9 }),
+      row({ login: "c", weightedAccuracy: 0, decided: 4 }),
+    ]);
+    expect(flags).toEqual([]);
+  });
+
+  it("never flags when fewer than 2 eligible contributors exist fleet-wide (no peer group to compare against)", () => {
+    const flags = contributorGlobalFairnessFlags([row({ login: "a", weightedAccuracy: 0.1 })]);
+    expect(flags).toEqual([]);
+  });
+
+  it("skips a row with a null weightedAccuracy (nothing decided) without throwing", () => {
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "a", weightedAccuracy: 0.9 }),
+      row({ login: "b", weightedAccuracy: null }),
+    ]);
+    expect(flags).toEqual([]);
+  });
+
+  it("returns [] for an empty input", () => {
+    expect(contributorGlobalFairnessFlags([])).toEqual([]);
+  });
+
+  it("a login can be flagged globally without any single per-project row being an outlier, and vice versa", () => {
+    // Globally: c's blended 0.5 deviates from the fleet median of ~0.9 by more than the band.
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "a", weightedAccuracy: 0.9 }),
+      row({ login: "b", weightedAccuracy: 0.9 }),
+      row({ login: "c", weightedAccuracy: 0.5 }),
+    ]);
+    expect(flags.map((f) => f.login)).toEqual(["c"]);
+  });
+
+  it("sorts flags by login", () => {
+    const flags = contributorGlobalFairnessFlags([
+      row({ login: "zeta", weightedAccuracy: 0.9 }),
+      row({ login: "mid", weightedAccuracy: 0.5 }),
+      row({ login: "alpha", weightedAccuracy: 0.1 }),
     ]);
     expect(flags.map((f) => f.login)).toEqual(["alpha", "zeta"]);
   });

--- a/test/unit/contributor-gate-history-backfill.test.ts
+++ b/test/unit/contributor-gate-history-backfill.test.ts
@@ -37,6 +37,23 @@ describe("backfillContributorGateHistory (#fairness-analytics)", () => {
     expect(rows[0]).toMatchObject({ login: "octocat", project: "owner/repo", target_id: "owner/repo#7", decision: "merge", head_sha: "sha1", source: "gittensory-native" });
   });
 
+  it("REGRESSION: stamps the reconstructed row with the ORIGINAL review_audit created_at, not the time the backfill ran", async () => {
+    const env = createTestEnv();
+    await insertPullRequest(env, "owner/repo", 40, "octocat");
+    const originalCreatedAt = "2026-06-25T12:00:00.000Z"; // well before "now" (mocked D1 helper uses real Date)
+    await insertGateDecision(env, { project: "owner/repo", targetId: "owner/repo#40", decision: "merge", headSha: "sha40", createdAt: originalCreatedAt });
+
+    const before = Date.now();
+    const result = await backfillContributorGateHistory(env);
+    expect(result).toEqual({ scanned: 1, inserted: 1, skippedNoAuthor: 0, hasMore: false });
+
+    const rows = await rawAll(env, "SELECT * FROM contributor_gate_history");
+    expect(rows[0]!.created_at).toBe(originalCreatedAt);
+    // Sanity: the original timestamp really is far in the past relative to "now", so this assertion couldn't
+    // pass by coincidence if the bug (binding nowIso() instead) were reintroduced.
+    expect(Date.parse(originalCreatedAt)).toBeLessThan(before - 1000);
+  });
+
   it("backfills a candidate with a null head_sha (unlike recordContributorGateDecision, no parity self-join to protect)", async () => {
     const env = createTestEnv();
     await insertPullRequest(env, "owner/repo", 30, "octocat");

--- a/test/unit/contributor-trust-privacy-boundary.test.ts
+++ b/test/unit/contributor-trust-privacy-boundary.test.ts
@@ -1,0 +1,80 @@
+// Structural privacy-boundary guard (#fairness-analytics, #global-contributor-trust): the per-login gate-decision
+// data (contributor_gate_history) and everything derived from it -- per-project OR the new cross-repo blended
+// figure -- must NEVER be reachable from a public-facing surface. This mirrors worker-entry-boundary.test.ts's
+// import-reachability technique (a runtime JSON-shape assertion can't catch "this module isn't wired in yet but
+// COULD be imported tomorrow"; a static reachability scan catches that at the source-graph level instead).
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const srcRoot = join(root, "src");
+
+// The two public-facing surfaces this data must never reach:
+//   - public-stats.ts: builds GET /v1/public/stats's payload (Phase 1 aggregate fairness metrics).
+//   - orb-collector.ts: exportOrbBatch, the anonymized cross-instance fleet-telemetry export.
+const PUBLIC_ENTRY_POINTS = [join(srcRoot, "review/public-stats.ts"), join(srcRoot, "selfhost/orb-collector.ts")];
+
+// The per-login contributor-identity family -- contributor-gate-eval.ts's own header (and
+// contributor-trust-profile.ts's, which inherits it) documents this as internal/bearer-gated-only, NEVER
+// rendered on any public surface. The blended (#global-contributor-trust) functions live in the same file as
+// the per-project ones and inherit the identical restriction -- see contributor-gate-eval.ts's header comment.
+const FORBIDDEN_MODULES = [
+  join(srcRoot, "review/contributor-gate-eval.ts"),
+  join(srcRoot, "review/contributor-trust-profile.ts"),
+  join(srcRoot, "review/contributor-gate-history-backfill.ts"),
+  join(srcRoot, "review/contributor-calibration.ts"),
+];
+
+function resolveLocalImport(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const base = dirname(fromFile);
+  const candidates = [join(base, specifier), join(base, `${specifier}.ts`), join(base, `${specifier}.tsx`), join(base, specifier, "index.ts")];
+  for (const candidate of candidates) {
+    try {
+      statSync(candidate);
+      return candidate;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+function parseImportSpecifiers(filePath: string): string[] {
+  const content = readFileSync(filePath, "utf8");
+  const specifiers = new Set<string>();
+  for (const match of content.matchAll(/(?:import|export)\s+[\s\S]*?\sfrom\s+["']([^"']+)["']/g)) specifiers.add(match[1]!);
+  for (const match of content.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g)) specifiers.add(match[1]!);
+  return [...specifiers];
+}
+
+function collectReachableSources(entryFile: string): string[] {
+  const queue = [entryFile];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    for (const specifier of parseImportSpecifiers(file)) {
+      const resolved = resolveLocalImport(file, specifier);
+      if (resolved && resolved.startsWith(srcRoot) && !seen.has(resolved)) queue.push(resolved);
+    }
+  }
+  return [...seen];
+}
+
+function relativeToRoot(path: string): string {
+  return path.replace(`${root}/`, "");
+}
+
+describe("contributor-identity privacy boundary (#fairness-analytics, #global-contributor-trust)", () => {
+  for (const entry of PUBLIC_ENTRY_POINTS) {
+    it(`${relativeToRoot(entry)} never reaches the per-login contributor-identity module family, including the cross-repo blended score`, () => {
+      const reachable = new Set(collectReachableSources(entry));
+      const leaked = FORBIDDEN_MODULES.filter((forbidden) => reachable.has(forbidden)).map(relativeToRoot);
+      expect(leaked, `public-facing entry point must never import contributor-identity modules: ${leaked.join(", ")}`).toEqual([]);
+    });
+  }
+});

--- a/test/unit/contributor-trust-profile.test.ts
+++ b/test/unit/contributor-trust-profile.test.ts
@@ -112,7 +112,28 @@ describe("getContributorTrustProfile — end-to-end composition over real D1 (#f
     expect(profile.moderation).toHaveLength(1);
     expect(profile.moderation[0]!.violationCount).toBe(2);
     expect(profile.gateAccuracy).toEqual([{ project: "owner/repo", decided: 1, weightedAccuracy: 1 }]);
+    // #global-contributor-trust: with only one project in play, the blend equals that project's own row.
+    expect(profile.blendedGateAccuracy).toEqual({ decided: 1, projectCount: 1, weightedAccuracy: 1 });
     expect(profile.totals).toEqual({ submissions: 5, merged: 3, closed: 2, violations: 2 });
+  });
+
+  it("#global-contributor-trust: blendedGateAccuracy pools gate decisions across TWO different repos for the same login", async () => {
+    const env = createTestEnv();
+    await recordContributorGateDecision(env, { login: "octocat", project: "owner/repo-a", pullNumber: 1, headSha: "sha1", decision: "merge" });
+    await insertReviewAuditOutcome(env, "owner/repo-a", "owner/repo-a#1", "merged", new Date(NOW).toISOString());
+    await recordContributorGateDecision(env, { login: "octocat", project: "owner/repo-b", pullNumber: 2, headSha: "sha2", decision: "close" });
+    await insertReviewAuditOutcome(env, "owner/repo-b", "owner/repo-b#2", "merged", new Date(NOW).toISOString()); // false-close
+
+    const profile = await getContributorTrustProfile(env, "octocat", { nowMs: NOW });
+
+    expect(profile.gateAccuracy).toEqual(
+      expect.arrayContaining([
+        { project: "owner/repo-a", decided: 1, weightedAccuracy: 1 },
+        { project: "owner/repo-b", decided: 1, weightedAccuracy: 0 },
+      ]),
+    );
+    // Blended: 2 decided total, only 1 confirmed -> 0.5, pooled across both repos in one figure.
+    expect(profile.blendedGateAccuracy).toEqual({ decided: 2, projectCount: 2, weightedAccuracy: 0.5 });
   });
 
   it("reads a null last_seen as null (the column is nullable, unlike submissions/merged/closed/manual)", async () => {
@@ -158,6 +179,21 @@ describe("getContributorTrustProfile — end-to-end composition over real D1 (#f
     expect(profile.totals.submissions).toBe(3);
   });
 
+  it("REGRESSION (#global-contributor-trust): blendedGateAccuracy excludes an opted-out repo's gate decisions from the pool", async () => {
+    const env = createTestEnv();
+    await upsertRepositorySettings(env, { repoFullName: "owner/opted-out" });
+    await upsertRepoFocusManifest(env, "owner/opted-out", { settings: { fairnessAnalyticsMode: "off" } });
+
+    await recordContributorGateDecision(env, { login: "octocat", project: "owner/opted-out", pullNumber: 1, headSha: "sha1", decision: "close" });
+    await insertReviewAuditOutcome(env, "owner/opted-out", "owner/opted-out#1", "merged", new Date(NOW).toISOString()); // would be a false-close if counted
+    await recordContributorGateDecision(env, { login: "octocat", project: "owner/opted-in", pullNumber: 2, headSha: "sha2", decision: "merge" });
+    await insertReviewAuditOutcome(env, "owner/opted-in", "owner/opted-in#2", "merged", new Date(NOW).toISOString());
+
+    const profile = await getContributorTrustProfile(env, "octocat", { nowMs: NOW });
+
+    expect(profile.blendedGateAccuracy).toEqual({ decided: 1, projectCount: 1, weightedAccuracy: 1 });
+  });
+
   it("never mixes another contributor's rows into the profile", async () => {
     const env = createTestEnv();
     await insertSubmitterStats(env, "owner/repo", "octocat", { submissions: 5 });
@@ -174,6 +210,7 @@ describe("getContributorTrustProfile — end-to-end composition over real D1 (#f
     expect(profile.repoStats).toEqual([]);
     expect(profile.moderation).toEqual([]);
     expect(profile.gateAccuracy).toEqual([]);
+    expect(profile.blendedGateAccuracy).toBeNull();
     expect(profile.totals).toEqual({ submissions: 0, merged: 0, closed: 0, violations: 0 });
   });
 

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -213,6 +213,11 @@ describe("operator dashboard payload", () => {
     expect(payload.metrics).toEqual(
       expect.arrayContaining([expect.objectContaining({ label: "Contributor fairness flags", value: "1", delta: "3 contributor(s) evaluated" })]),
     );
+    // #global-contributor-trust: every login here touches exactly one project, so the blended fold degenerates
+    // to the same per-login numbers as the per-project fold -- same outlier, same evaluated count.
+    expect(payload.metrics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: "Global contributor fairness flags", value: "1", delta: "3 contributor(s) evaluated" })]),
+    );
     // Count-only -- the flagged login itself never appears anywhere in the dashboard payload.
     expect(JSON.stringify(payload)).not.toContain("flagged-login");
   });


### PR DESCRIPTION
## Summary
- `computeContributorGateEval`/`contributorFairnessFlags` only ever scored a contributor per-(login, project); this adds `computeBlendedContributorGateEval`/`contributorGlobalFairnessFlags`, which pool the same underlying prediction/outcome counts across every repo a login has touched into one volume-weighted accuracy figure (not an average of each project's own precision, so a login mostly active on one high-volume repo isn't distorted by a thin-sample row elsewhere).
- Wires the blend into `getContributorTrustProfile` (`blendedGateAccuracy`), both internal `/v1/internal/fairness/contributors*` routes, and a new operator-dashboard tile — counts-only, same bearer-gated/internal-only posture as the existing per-project data.
- Fixes a real bug in `backfillContributorGateHistory`: it bound `nowIso()` instead of the source `review_audit` row's own `created_at`, so a backfilled row silently claimed the decision happened the moment the backfill ran instead of when it actually happened.
- Adds a structural import-reachability test asserting the whole per-login contributor-identity module family (including the new blended functions) is never reachable from a public-facing entry point (`public-stats.ts`, `orb-collector.ts`'s `exportOrbBatch`).

## Backfill data note
Verified against the live self-hosted DB: `contributor_gate_history` predictions are only reconstructable back to ~2026-07-03 (when `gate_decision` writes were fixed for self-host in a prior commit); ground truth (`pr_outcome`) goes back to 2026-06-20. The ~13-day window before 2026-07-03 has no predicted-decision data recorded anywhere and is not recoverable. Once this PR is deployed, I'll re-run the (now-fixed) backfill route to pull in the reconstructable ~2026-07-03→07-08 window.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] All touched unit/integration tests green (137 tests across 6 files)
- [x] 100% line/branch/function coverage on every touched source file (verified via lcov)
- [x] `npm audit --audit-level=moderate` clean
- [x] New privacy-boundary test confirms the contributor-identity module family is unreachable from public entry points