### PR TITLE
fix(review): correct the per-project fairness-flags tile's row-count label

### DIFF
--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -273,7 +273,10 @@ export async function buildOperatorDashboardPayload(
         // contributor via GET /v1/internal/fairness/contributors/:login instead.
         label: "Contributor fairness flags",
         value: String(contributorFairnessFlagCount),
-        delta: contributorFairnessFlagCount > 0 ? `${contributorGateEval.rows.length} contributor(s) evaluated` : "no outliers detected",
+        // contributorGateEval.rows is one row per (login, project) -- the SAME login active on two repos
+        // contributes two rows, so this counts evaluated rows, not unique contributors (that count lives on
+        // the "Global contributor fairness flags" tile below, via blendedContributorGateEval's per-login fold).
+        delta: contributorFairnessFlagCount > 0 ? `${contributorGateEval.rows.length} (login, project) row(s) evaluated` : "no outliers detected",
       },
       {
         // #global-contributor-trust: the cross-repo blended counterpart -- one row per LOGIN (pooled across

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -211,10 +211,12 @@ describe("operator dashboard payload", () => {
 
     const payload = await buildOperatorDashboardPayload(env);
     expect(payload.metrics).toEqual(
-      expect.arrayContaining([expect.objectContaining({ label: "Contributor fairness flags", value: "1", delta: "3 contributor(s) evaluated" })]),
+      expect.arrayContaining([expect.objectContaining({ label: "Contributor fairness flags", value: "1", delta: "3 (login, project) row(s) evaluated" })]),
     );
     // #global-contributor-trust: every login here touches exactly one project, so the blended fold degenerates
-    // to the same per-login numbers as the per-project fold -- same outlier, same evaluated count.
+    // to the same per-login numbers as the per-project fold -- same outlier, same evaluated count. Here the
+    // "3 contributor(s)" wording IS accurate (unlike the per-project tile above): blendedContributorGateEval
+    // folds by login alone, so its row count genuinely is a count of unique contributors.
     expect(payload.metrics).toEqual(
       expect.arrayContaining([expect.objectContaining({ label: "Global contributor fairness flags", value: "1", delta: "3 contributor(s) evaluated" })]),
     );


### PR DESCRIPTION
## Summary
- The operator dashboard's "Contributor fairness flags" tile delta said "N contributor(s) evaluated", but `contributorGateEval.rows` is one row per (login, project) -- a login active on two repos contributes two rows, so the old wording overstated the number of distinct contributors.
- Reworded to "N (login, project) row(s) evaluated". The newer "Global contributor fairness flags" tile (added in #7711) already has an accurate per-login count, since it folds by login alone.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `operator-dashboard.test.ts` + `api.test.ts` green
- [x] 100% line/branch coverage on `operator-dashboard.ts` (verified via lcov)