### PR TITLE
feat(control-plane): page PagerDuty on tenant provisioning failures

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -1,5 +1,6 @@
-// Public entry for @loopover/control-plane: the injectable tenant-provisioning driver contract + fake, and the
-// product-agnostic provisionTenant/deprovisionTenant orchestration built on it (#7524).
+// Public entry for @loopover/control-plane: the injectable tenant-provisioning driver contract + fake, the
+// product-agnostic provisionTenant/deprovisionTenant orchestration built on it (#7524), and the PagerDuty
+// paging that orchestration fires on a provisioning-lifecycle failure (#7667).
 
 export {
   createFakeTenantProvisioningDriver,
@@ -15,9 +16,18 @@ export {
 export {
   deprovisionTenant,
   provisionTenant,
+  type ProvisioningPagerDutyOptions,
   type TenantDeprovisioningResult,
   type TenantProvisioningResult,
 } from "./provisioning.js";
+export {
+  buildProvisioningPagerDutyAlert,
+  notifyProvisioningFailure,
+  pagerDutyFailMessage,
+  type NotifyProvisioningFailure,
+  type PagerDutySeverity,
+  type ProvisioningPagerDutyAlert,
+} from "./pagerduty-notify.js";
 export {
   createFakeSettlementBackendDriver,
   type FakeSettlementBackendDriver,

--- a/control-plane/src/pagerduty-notify.ts
+++ b/control-plane/src/pagerduty-notify.ts
@@ -1,0 +1,110 @@
+// Mirrors ORB's `triggerPagerDutyIncident` (src/services/notify-pagerduty.ts) Events API v2 contract exactly:
+// same LOOPOVER_ENABLE_PAGERDUTY flag, same PAGERDUTY_ROUTING_KEY, same events.pagerduty.com enqueue URL, same
+// dedup_key/custom_details shape (#7667). control-plane is a plain Node package with no Worker Env/D1 binding
+// (#7524) -- there is no hosted call site to import `triggerPagerDutyIncident` into, and no D1-backed audit log
+// or cooldown here, the same reasoning #7666's miner-side mirror (packages/loopover-miner/lib/governor-kill-switch.ts)
+// used for AMS kill-switch trips. PagerDuty's own `dedup_key` still coalesces duplicate incidents. Best-effort:
+// never throws -- a paging failure must never block or mask the underlying provisioning failure it is reporting.
+
+const PAGERDUTY_EVENTS_URL = "https://events.pagerduty.com/v2/enqueue";
+// PagerDuty routing/integration keys are 32 lowercase hex characters.
+const ROUTING_KEY_RE = /^[a-f0-9]{32}$/i;
+const TRUTHY_ENV = /^(1|true|yes|on)$/i;
+
+export type PagerDutySeverity = "critical" | "error" | "warning" | "info";
+
+/** A pure PagerDuty alert payload for a provisioning-lifecycle failure. `phase` keeps a provision failure and a
+ *  deprovision failure paging as separate incidents (distinct dedup_key) even for the same tenant. */
+export type ProvisioningPagerDutyAlert = {
+  tenantName: string;
+  product: string;
+  phase: "provision" | "deprovision";
+  summary: string;
+  severity: PagerDutySeverity;
+  dedupKey: string;
+  customDetails: Record<string, unknown>;
+};
+
+export type NotifyProvisioningFailure = (
+  alert: ProvisioningPagerDutyAlert,
+  env: Record<string, string | undefined>,
+) => void | Promise<void>;
+
+function envString(env: Record<string, string | undefined>, name: string): string | undefined {
+  const value = env[name];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/** Prefer `Error.message` when present; otherwise coerce. Exported so provisioning.ts's own notify-failure
+ *  warn log (a paging failure, not a provisioning failure) coerces the same way as every failure path in this
+ *  module, instead of a second ad hoc `String(error)` copy. */
+export function pagerDutyFailMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 200);
+}
+
+function warnProvisioningPagerDutyFailed(tenantName: string, error: unknown): void {
+  console.warn(
+    JSON.stringify({ event: "provisioning_pagerduty_failed", tenant: tenantName, message: pagerDutyFailMessage(error) }),
+  );
+}
+
+/** Build the alert payload for a provisioning or deprovisioning failure (#7667). Pure -- no IO. `error` is
+ *  coerced through the same {@link pagerDutyFailMessage} helper the IO path uses for its own failure logging, so
+ *  the paged summary and any local warn log agree on the same truncated message. */
+export function buildProvisioningPagerDutyAlert(input: {
+  tenantName: string;
+  product: string;
+  phase: "provision" | "deprovision";
+  error: unknown;
+}): ProvisioningPagerDutyAlert {
+  const message = pagerDutyFailMessage(input.error);
+  return {
+    tenantName: input.tenantName,
+    product: input.product,
+    phase: input.phase,
+    summary: `${input.product} tenant ${input.phase} failed for ${input.tenantName}: ${message}`,
+    severity: "critical",
+    dedupKey: `control_plane_${input.phase}_failed:${input.product}:${input.tenantName}`,
+    customDetails: { tenantName: input.tenantName, product: input.product, phase: input.phase, message },
+  };
+}
+
+/** Miner/AMS-style mirror of `triggerPagerDutyIncident` (#7667, same contract as #7666): same flag, same global
+ *  routing key, same Events API v2 enqueue. No D1 audit/cooldown (control-plane has no Worker Env) -- PagerDuty's
+ *  own `dedup_key` still coalesces duplicate incidents. Best-effort: never throws. */
+export async function notifyProvisioningFailure(
+  alert: ProvisioningPagerDutyAlert,
+  env: Record<string, string | undefined> = process.env,
+): Promise<void> {
+  if (!TRUTHY_ENV.test((env.LOOPOVER_ENABLE_PAGERDUTY ?? "").trim())) return;
+  const routingKey = envString(env, "PAGERDUTY_ROUTING_KEY");
+  if (!routingKey || !ROUTING_KEY_RE.test(routingKey)) return;
+
+  try {
+    const response = await fetch(PAGERDUTY_EVENTS_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        routing_key: routingKey,
+        event_action: "trigger",
+        dedup_key: alert.dedupKey,
+        payload: {
+          summary: alert.summary.slice(0, 1024),
+          source: "loopover-control-plane",
+          severity: alert.severity,
+          timestamp: new Date().toISOString(),
+          component: alert.tenantName,
+          custom_details: alert.customDetails,
+        },
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      console.warn(
+        JSON.stringify({ event: "provisioning_pagerduty_failed", tenant: alert.tenantName, status: response.status }),
+      );
+    }
+  } catch (error) {
+    warnProvisioningPagerDutyFailed(alert.tenantName, error);
+  }
+}

--- a/control-plane/src/provisioning.ts
+++ b/control-plane/src/provisioning.ts
@@ -3,7 +3,19 @@
 // every driver step but never branched on. Provision runs #7180's three steps in order (create-container,
 // provision-DB, inject-secrets); deprovision tears them down in REVERSE (revoke-secrets, drop-DB,
 // destroy-container) so a secret is never left addressable after the DB/container it belonged to is gone.
+//
+// #7667: a driver-step failure in EITHER direction also pages, via the same PagerDuty Events API v2 contract
+// ORB uses in `src/services/notify-pagerduty.ts` (see ./pagerduty-notify.ts for the mirrored contract and why
+// this package can't import that Worker/D1-bound module directly). A provisioning failure during a real pilot
+// must page a human, not fail silently — the original error is always rethrown after paging so callers keep
+// seeing the real failure; paging is additive, never a substitute for surfacing the error.
 
+import {
+  buildProvisioningPagerDutyAlert,
+  notifyProvisioningFailure,
+  pagerDutyFailMessage,
+  type NotifyProvisioningFailure,
+} from "./pagerduty-notify.js";
 import type {
   Product,
   Tenant,
@@ -27,31 +39,76 @@ export type TenantDeprovisioningResult = {
   state: Extract<TenantLifecycleState, "torn down">;
 };
 
+/** Injectable PagerDuty seam shared by provisionTenant/deprovisionTenant (test-only override point; production
+ *  callers omit both and get the real {@link notifyProvisioningFailure} against `process.env`). */
+export type ProvisioningPagerDutyOptions = {
+  notify?: NotifyProvisioningFailure;
+  env?: Record<string, string | undefined>;
+};
+
+/** Page on a provisioning-lifecycle failure (#7667) and always rethrow. Fire-and-forget, same shape as #7666's
+ *  miner-side mirror: the notify call is never awaited (a paging failure/slow network must not delay the
+ *  caller from seeing its own real error), and both a sync throw and an async rejection from `notify` are
+ *  funneled through one warn log so neither can escape as an unhandled rejection. */
+function pageAndRethrow(
+  tenant: Tenant,
+  product: Product,
+  phase: "provision" | "deprovision",
+  error: unknown,
+  options: ProvisioningPagerDutyOptions,
+): never {
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: tenant.name, product, phase, error });
+  const notify = options.notify ?? notifyProvisioningFailure;
+  const env = options.env ?? process.env;
+  const warnNotifyFailed = (notifyError: unknown): void => {
+    console.warn(
+      JSON.stringify({ event: "provisioning_pagerduty_failed", tenant: tenant.name, message: pagerDutyFailMessage(notifyError) }),
+    );
+  };
+  try {
+    void Promise.resolve(notify(alert, env)).catch(warnNotifyFailed);
+  } catch (notifyError) {
+    warnNotifyFailed(notifyError);
+  }
+  throw error;
+}
+
 /** Provision a tenant by running #7180's three steps in order against the injected driver. Product-agnostic:
- *  `product` is forwarded to every step, never branched on, so ORB and AMS share one call shape. */
+ *  `product` is forwarded to every step, never branched on, so ORB and AMS share one call shape. A step failure
+ *  pages (#7667) and always rethrows — provisioning never fails silently. */
 export async function provisionTenant(
   tenant: Tenant,
   product: Product,
   driver: TenantProvisioningDriver,
+  pagerDuty: ProvisioningPagerDutyOptions = {},
 ): Promise<TenantProvisioningResult> {
   const request: TenantProvisioningRequest = { tenant, product };
-  await driver.createContainer(request);
-  await driver.provisionDatabase(request);
-  await driver.injectSecrets(request);
+  try {
+    await driver.createContainer(request);
+    await driver.provisionDatabase(request);
+    await driver.injectSecrets(request);
+  } catch (error) {
+    pageAndRethrow(tenant, product, "provision", error, pagerDuty);
+  }
   return { tenant, product, state: "active" };
 }
 
 /** Deprovision a tenant by tearing #7180's three steps down in REVERSE order. Same product-agnostic call shape
  *  as provisionTenant. Idempotent by driver contract: deprovisioning a tenant that was never provisioned is a
- *  safe no-op, never a throw. */
+ *  safe no-op, never a throw. A step failure pages (#7667) and always rethrows. */
 export async function deprovisionTenant(
   tenant: Tenant,
   product: Product,
   driver: TenantProvisioningDriver,
+  pagerDuty: ProvisioningPagerDutyOptions = {},
 ): Promise<TenantDeprovisioningResult> {
   const request: TenantProvisioningRequest = { tenant, product };
-  await driver.revokeSecrets(request);
-  await driver.dropDatabase(request);
-  await driver.destroyContainer(request);
+  try {
+    await driver.revokeSecrets(request);
+    await driver.dropDatabase(request);
+    await driver.destroyContainer(request);
+  } catch (error) {
+    pageAndRethrow(tenant, product, "deprovision", error, pagerDuty);
+  }
   return { tenant, product, state: "torn down" };
 }

--- a/control-plane/test/pagerduty-notify.test.ts
+++ b/control-plane/test/pagerduty-notify.test.ts
@@ -1,0 +1,153 @@
+// Tests for the #7667 PagerDuty mirror: the pure alert builder, and the Events API v2 enqueue call's every
+// guard branch (flag off, missing key, malformed key, success, non-ok response, thrown fetch error). No live
+// network call is ever made -- `globalThis.fetch` is stubbed for every notify test.
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, mock, test } from "node:test";
+
+import { buildProvisioningPagerDutyAlert, notifyProvisioningFailure } from "../dist/index.js";
+
+const VALID_ROUTING_KEY = "a".repeat(32);
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restoreAll();
+});
+
+test("buildProvisioningPagerDutyAlert: provision failure builds a critical alert from an Error (#7667)", () => {
+  const alert = buildProvisioningPagerDutyAlert({
+    tenantName: "acme",
+    product: "orb",
+    phase: "provision",
+    error: new Error("container quota exceeded"),
+  });
+
+  assert.deepEqual(alert, {
+    tenantName: "acme",
+    product: "orb",
+    phase: "provision",
+    summary: "orb tenant provision failed for acme: container quota exceeded",
+    severity: "critical",
+    dedupKey: "control_plane_provision_failed:orb:acme",
+    customDetails: {
+      tenantName: "acme",
+      product: "orb",
+      phase: "provision",
+      message: "container quota exceeded",
+    },
+  });
+});
+
+test("buildProvisioningPagerDutyAlert: deprovision failure coerces a non-Error thrown value (#7667)", () => {
+  const alert = buildProvisioningPagerDutyAlert({
+    tenantName: "acme",
+    product: "ams",
+    phase: "deprovision",
+    error: "connection refused",
+  });
+
+  assert.equal(alert.phase, "deprovision");
+  assert.equal(alert.dedupKey, "control_plane_deprovision_failed:ams:acme");
+  assert.match(alert.summary, /connection refused/);
+  assert.equal(alert.customDetails.message, "connection refused");
+});
+
+test("notifyProvisioningFailure: no-op when LOOPOVER_ENABLE_PAGERDUTY is not truthy (#7667)", async () => {
+  const fetchMock = mock.fn(async () => new Response(null, { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  await notifyProvisioningFailure(alert, {});
+
+  assert.equal(fetchMock.mock.calls.length, 0);
+});
+
+test("notifyProvisioningFailure: no-op when the flag is on but no routing key resolves (#7667)", async () => {
+  const fetchMock = mock.fn(async () => new Response(null, { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  await notifyProvisioningFailure(alert, { LOOPOVER_ENABLE_PAGERDUTY: "true" });
+
+  assert.equal(fetchMock.mock.calls.length, 0);
+});
+
+test("notifyProvisioningFailure: no-op when the routing key is present but malformed (#7667)", async () => {
+  const fetchMock = mock.fn(async () => new Response(null, { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  await notifyProvisioningFailure(alert, { LOOPOVER_ENABLE_PAGERDUTY: "1", PAGERDUTY_ROUTING_KEY: "not-hex" });
+
+  assert.equal(fetchMock.mock.calls.length, 0);
+});
+
+test("notifyProvisioningFailure: fires the Events API v2 enqueue call when enabled and configured (#7667)", async () => {
+  const fetchMock = mock.fn(async () => new Response(null, { status: 202 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  await notifyProvisioningFailure(alert, { LOOPOVER_ENABLE_PAGERDUTY: "true", PAGERDUTY_ROUTING_KEY: VALID_ROUTING_KEY });
+
+  assert.equal(fetchMock.mock.calls.length, 1);
+  const call = fetchMock.mock.calls[0];
+  const [url, init] = call?.arguments ?? [];
+  assert.equal(url, "https://events.pagerduty.com/v2/enqueue");
+  const body = JSON.parse((init as RequestInit).body as string) as {
+    routing_key: string;
+    event_action: string;
+    dedup_key: string;
+    payload: { severity: string; component: string; source: string };
+  };
+  assert.equal(body.routing_key, VALID_ROUTING_KEY);
+  assert.equal(body.event_action, "trigger");
+  assert.equal(body.dedup_key, alert.dedupKey);
+  assert.equal(body.payload.severity, "critical");
+  assert.equal(body.payload.component, "acme");
+  assert.equal(body.payload.source, "loopover-control-plane");
+});
+
+test("notifyProvisioningFailure: a non-ok response is warned but never throws (#7667)", async () => {
+  globalThis.fetch = (async () => new Response(null, { status: 500 })) as unknown as typeof fetch;
+  const warnMock = mock.method(console, "warn", () => {});
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  await notifyProvisioningFailure(alert, { LOOPOVER_ENABLE_PAGERDUTY: "true", PAGERDUTY_ROUTING_KEY: VALID_ROUTING_KEY });
+
+  assert.equal(warnMock.mock.calls.length, 1);
+});
+
+test("notifyProvisioningFailure: a thrown fetch error is caught and warned, never throws (#7667)", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+  const warnMock = mock.method(console, "warn", () => {});
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  await assert.doesNotReject(
+    notifyProvisioningFailure(alert, { LOOPOVER_ENABLE_PAGERDUTY: "true", PAGERDUTY_ROUTING_KEY: VALID_ROUTING_KEY }),
+  );
+
+  assert.equal(warnMock.mock.calls.length, 1);
+});
+
+test("notifyProvisioningFailure: falls back to process.env when no env override is passed (#7667)", async () => {
+  const hadFlag = Object.prototype.hasOwnProperty.call(process.env, "LOOPOVER_ENABLE_PAGERDUTY");
+  const previousFlag = process.env.LOOPOVER_ENABLE_PAGERDUTY;
+  delete process.env.LOOPOVER_ENABLE_PAGERDUTY;
+  const fetchMock = mock.fn(async () => new Response(null, { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const alert = buildProvisioningPagerDutyAlert({ tenantName: "acme", product: "orb", phase: "provision", error: new Error("boom") });
+
+  try {
+    await notifyProvisioningFailure(alert);
+    assert.equal(fetchMock.mock.calls.length, 0);
+  } finally {
+    if (hadFlag) process.env.LOOPOVER_ENABLE_PAGERDUTY = previousFlag;
+  }
+});

--- a/control-plane/test/provisioning-pagerduty.test.ts
+++ b/control-plane/test/provisioning-pagerduty.test.ts
@@ -1,0 +1,139 @@
+// Tests for #7667's PagerDuty wiring into provisionTenant/deprovisionTenant: a driver-step failure in either
+// direction pages via the injected `notify` hook AND always rethrows the original error (paging is additive,
+// never a substitute for surfacing the failure); a successful lifecycle never pages.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createFakeTenantProvisioningDriver,
+  deprovisionTenant,
+  provisionTenant,
+  type NotifyProvisioningFailure,
+  type ProvisioningPagerDutyAlert,
+  type Tenant,
+  type TenantProvisioningDriver,
+} from "../dist/index.js";
+
+/** A driver where exactly one named step throws `error`; every other step is a no-op success. */
+function driverThatThrowsOn(
+  step: keyof Omit<TenantProvisioningDriver, "containerExists">,
+  error: Error,
+): TenantProvisioningDriver {
+  const noop = async (): Promise<void> => {};
+  const failing = async (): Promise<void> => {
+    throw error;
+  };
+  return {
+    createContainer: step === "createContainer" ? failing : noop,
+    provisionDatabase: step === "provisionDatabase" ? failing : noop,
+    injectSecrets: step === "injectSecrets" ? failing : noop,
+    destroyContainer: step === "destroyContainer" ? failing : noop,
+    dropDatabase: step === "dropDatabase" ? failing : noop,
+    revokeSecrets: step === "revokeSecrets" ? failing : noop,
+    containerExists: async () => false,
+  };
+}
+
+test("provisionTenant pages PagerDuty and rethrows when a driver step fails (#7667)", async () => {
+  const calls: ProvisioningPagerDutyAlert[] = [];
+  const notify: NotifyProvisioningFailure = async (alert) => {
+    calls.push(alert);
+  };
+  const driver = driverThatThrowsOn("provisionDatabase", new Error("db provisioning failed"));
+  const tenant: Tenant = { name: "acme" };
+
+  await assert.rejects(provisionTenant(tenant, "orb", driver, { notify }), /db provisioning failed/);
+  // The page is fire-and-forget; flush the microtask queue before asserting it landed.
+  await Promise.resolve();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.phase, "provision");
+  assert.equal(calls[0]?.tenantName, "acme");
+  assert.equal(calls[0]?.product, "orb");
+  assert.equal(calls[0]?.dedupKey, "control_plane_provision_failed:orb:acme");
+});
+
+test("provisionTenant does NOT page PagerDuty on a successful provision (#7667)", async () => {
+  const calls: ProvisioningPagerDutyAlert[] = [];
+  const notify: NotifyProvisioningFailure = async (alert) => {
+    calls.push(alert);
+  };
+  const driver = createFakeTenantProvisioningDriver();
+  const tenant: Tenant = { name: "acme" };
+
+  const result = await provisionTenant(tenant, "orb", driver, { notify });
+
+  assert.deepEqual(result, { tenant, product: "orb", state: "active" });
+  assert.equal(calls.length, 0);
+});
+
+test("deprovisionTenant pages PagerDuty and rethrows when a driver step fails (#7667)", async () => {
+  const calls: ProvisioningPagerDutyAlert[] = [];
+  const notify: NotifyProvisioningFailure = async (alert) => {
+    calls.push(alert);
+  };
+  const driver = driverThatThrowsOn("revokeSecrets", new Error("secret broker unreachable"));
+  const tenant: Tenant = { name: "acme" };
+
+  await assert.rejects(deprovisionTenant(tenant, "ams", driver, { notify }), /secret broker unreachable/);
+  await Promise.resolve();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.phase, "deprovision");
+  assert.equal(calls[0]?.product, "ams");
+  assert.equal(calls[0]?.dedupKey, "control_plane_deprovision_failed:ams:acme");
+});
+
+test("deprovisionTenant does NOT page PagerDuty on a successful deprovision (#7667)", async () => {
+  const calls: ProvisioningPagerDutyAlert[] = [];
+  const notify: NotifyProvisioningFailure = async (alert) => {
+    calls.push(alert);
+  };
+  const driver = createFakeTenantProvisioningDriver();
+  const tenant: Tenant = { name: "acme" };
+
+  const result = await deprovisionTenant(tenant, "ams", driver, { notify });
+
+  assert.deepEqual(result, { tenant, product: "ams", state: "torn down" });
+  assert.equal(calls.length, 0);
+});
+
+test("provisionTenant still rethrows the real error when the notify hook itself throws synchronously (#7667)", async () => {
+  const driver = driverThatThrowsOn("createContainer", new Error("container quota exceeded"));
+  const tenant: Tenant = { name: "acme" };
+  const notify: NotifyProvisioningFailure = () => {
+    throw new Error("pagerduty transport down");
+  };
+
+  await assert.rejects(provisionTenant(tenant, "orb", driver, { notify }), /container quota exceeded/);
+});
+
+test("provisionTenant still rethrows the real error when the notify hook rejects asynchronously (#7667)", async () => {
+  const driver = driverThatThrowsOn("injectSecrets", new Error("secret injection failed"));
+  const tenant: Tenant = { name: "acme" };
+  const notify: NotifyProvisioningFailure = async () => {
+    throw new Error("pagerduty http 500");
+  };
+
+  await assert.rejects(provisionTenant(tenant, "orb", driver, { notify }), /secret injection failed/);
+  // Let the fire-and-forget rejection's own .catch handler run so it never surfaces as unhandled.
+  await Promise.resolve();
+  await Promise.resolve();
+});
+
+test("provisionTenant defaults to the real notifyProvisioningFailure + process.env when no PagerDuty options are passed (#7667)", async () => {
+  const driver = driverThatThrowsOn("createContainer", new Error("container quota exceeded"));
+  const tenant: Tenant = { name: "acme" };
+
+  // LOOPOVER_ENABLE_PAGERDUTY is unset in the test environment, so the real default notify path resolves to a
+  // no-op -- this exercises the "no options passed" default-parameter branch itself; the live network call's
+  // own guard branches are covered in pagerduty-notify.test.ts.
+  await assert.rejects(provisionTenant(tenant, "orb", driver), /container quota exceeded/);
+});
+
+test("deprovisionTenant defaults to the real notifyProvisioningFailure + process.env when no PagerDuty options are passed (#7667)", async () => {
+  const driver = driverThatThrowsOn("dropDatabase", new Error("db drop failed"));
+  const tenant: Tenant = { name: "acme" };
+
+  await assert.rejects(deprovisionTenant(tenant, "ams", driver), /db drop failed/);
+});


### PR DESCRIPTION
## Summary

- `control-plane/` had zero PagerDuty/alerting references, so a real provisioning failure during a pilot would fail silently instead of paging anyone.
- Added `control-plane/src/pagerduty-notify.ts`, mirroring ORB's `src/services/notify-pagerduty.ts` Events API v2 contract exactly (same `LOOPOVER_ENABLE_PAGERDUTY` flag, same `PAGERDUTY_ROUTING_KEY`, same enqueue URL, same `dedup_key` shape). control-plane is a plain Node package with no Worker Env/D1 binding, so it can't import that Worker-bound module directly — this mirrors it locally, the same approach the #7666 miner-side kill-switch alerting used for the same reason.
- Wired it into `control-plane/src/provisioning.ts`: a driver-step failure in either `provisionTenant` or `deprovisionTenant` now builds an alert and fires the page (fire-and-forget, best-effort, never throws) before **always rethrowing the original error** — paging is additive, never a substitute for surfacing the real failure to the caller.
- Confirmed `codecov.yml`'s `coverage.include` scope does not cover `control-plane/**` (it's not a root workspace member and has no CI job wired to it today, `control-plane:test` is a manual root script only) — no `codecov/patch` gate applies here, but I still wrote full branch coverage for every new path.

Closes #7667

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `control-plane/`, a standalone package (own `package.json`/`package-lock.json`, not a root `workspaces` member) with its own build+test lifecycle and no wiring into `test:ci`, `typecheck`, `test:coverage`, `ui:*`, `mcp:*`, or `actionlint` (no `.github/workflows/*.yml` touched, no root `src/**` touched). Ran the applicable local gate instead: `npm ci` in `control-plane/`, `npx tsc -p control-plane/tsconfig.json --noEmit` (clean), and `npm test` (`tsc build` + `node --test --experimental-strip-types`) — **34/34 tests pass** (17 new, covering every branch of the new PagerDuty paging: flag off/missing-key/malformed-key, success/non-ok-response/thrown-fetch-error, sync/async notify-hook failure, both provision and deprovision phases, pages-on-failure vs. silent-on-success).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change (`control-plane/src/**` + `control-plane/test/**`), no UI/frontend/docs surface touched.

## Notes

- Analogue: `src/services/notify-pagerduty.ts`'s `triggerPagerDutyIncident` (the required reused contract) and `packages/loopover-miner/lib/governor-kill-switch.ts`'s `notifyMinerKillSwitchPagerDuty` (#7666's same-shaped miner-side mirror for a process with no Worker Env either).
- No second alerting mechanism: `control-plane/src/pagerduty-notify.ts` is the only paging path in this package, and it reuses the exact same flag/routing-key/enqueue/dedup_key contract as `notify-pagerduty.ts`, not a new design.
