### PR TITLE
fix(draft): make draftPrClosePolicy config-as-code only

### DIFF
--- a/migrations/0171_drop_draft_pr_close_policy_column.sql
+++ b/migrations/0171_drop_draft_pr_close_policy_column.sql
@@ -1,0 +1,8 @@
+-- Config-as-code migration (epic #6440, #draft-pr-close-policy): draftPrClosePolicy now parses correctly
+-- from .loopover.yml's settings: block and resolveEffectiveSettings already overlays it via the generic
+-- {...dbSettings, ...restManifestSettings} spread (no special-casing needed) -- same shape as the
+-- reviewEvasionProtection/mergeTrainMode fields Batch B (migration 0158) already dropped for. This column
+-- was added in 0156, one migration before the Batch A/B cleanup (0157/0158) began, and was never swept into
+-- that wave -- this migration closes that gap. Same dead-column-cleanup shape as Batches A-D
+-- (0157/0158/0159/0160/0162): SQLite 3.35+ / D1 supports DROP COLUMN directly.
+ALTER TABLE repository_settings DROP COLUMN draft_pr_close_policy;

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -626,6 +626,7 @@ export type FocusManifestSettings = Partial<
     | "moderationBannedLabel"
     | "fairnessAnalyticsMode"
     | "reviewEvasionProtection"
+    | "draftPrClosePolicy"
     | "reviewEvasionLabel"
     | "reviewEvasionComment"
     | "synchronizeClosePolicy"
@@ -2846,6 +2847,10 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   // own PR while loopover has an active review pass running is dodging the one-shot review.
   const reviewEvasionProtection = normalizeOptionalEnum(r.reviewEvasionProtection, "settings.reviewEvasionProtection", ["off", "close"] as const, warnings);
   if (reviewEvasionProtection !== null) out.reviewEvasionProtection = reviewEvasionProtection;
+  // Draft-PR close policy (#draft-pr-close-policy): distinct from reviewEvasionProtection above -- enforces on
+  // ANY draft immediately, including the very first one, rather than only after a review pass has already run.
+  const draftPrClosePolicy = normalizeOptionalEnum(r.draftPrClosePolicy, "settings.draftPrClosePolicy", ["off", "close"] as const, warnings);
+  if (draftPrClosePolicy !== null) out.draftPrClosePolicy = draftPrClosePolicy;
   // #label-scoping: same load-bearing-null idiom as blacklistLabel above.
   if (r.reviewEvasionLabel === null) {
     out.reviewEvasionLabel = null;

--- a/packages/loopover-engine/src/types/manifest-deps-types.ts
+++ b/packages/loopover-engine/src/types/manifest-deps-types.ts
@@ -608,6 +608,13 @@ export type RepositorySettings = {
    *  re-closes as the App -- a close the contributor cannot themselves reopen (#one-shot-reopen) -- applies
    *  the configured label/comment, and records a `review_evasion` moderation strike. */
   reviewEvasionProtection?: "off" | "close" | undefined;
+  /** Draft-PR close policy (#draft-pr-close-policy): distinct from {@link reviewEvasionProtection} above --
+   *  that family only enforces AFTER a review has already run against the PR's current head, or on the 2nd+
+   *  ready<->draft conversion. `"close"` enforces on ANY draft, including the very first one opened directly
+   *  as a draft or converted to draft before any review pass runs. `"off"` (the default) is unchanged
+   *  behavior -- unlike reviewEvasionProtection, this is opt-in, not default-on. Shares `autoCloseExemptLogins`
+   *  and `reviewEvasionLabel`/`reviewEvasionComment` with the reviewEvasionProtection family. */
+  draftPrClosePolicy?: "off" | "close" | undefined;
   /** Review-evasion protection: label applied alongside the enforcement close, gated on `close` autonomy
    *  like every other anti-abuse label (#label-scoping), mirroring {@link blacklistLabel}'s shape. `undefined`
    *  ⇒ the `"review-evasion"` default; explicit `null` ⇒ close without any label. */

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -758,7 +758,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     reviewEvasionProtection: "close", // #4011/#6443: default-ON, always -- a repo protects itself from self-close/draft-dodge gaming unless it explicitly opts out via .loopover.yml
     reviewEvasionLabel: DEFAULT_REVIEW_EVASION_LABEL,
     reviewEvasionComment: true,
-    draftPrClosePolicy: normalizeDraftPrClosePolicy(row.draftPrClosePolicy),
+    draftPrClosePolicy: "off", // #6440/#draft-pr-close-policy: config-as-code only now, mirrors reviewEvasionProtection -- .loopover.yml is the only way to turn this on for a repo
     // Config-as-code only (#synchronize-close-policy): no DB column, matching reviewEvasionProtection's
     // pattern above -- only .loopover.yml settings.synchronizeClosePolicy can set this.
     synchronizeClosePolicy: "off",
@@ -901,7 +901,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     reviewEvasionProtection: "close" as const,
     reviewEvasionLabel: DEFAULT_REVIEW_EVASION_LABEL,
     reviewEvasionComment: true,
-    draftPrClosePolicy: normalizeDraftPrClosePolicy(settings.draftPrClosePolicy),
+    draftPrClosePolicy: "off" as const, // #6440/#draft-pr-close-policy: config-as-code only now -- any caller-supplied value is a silent no-op, configure via .loopover.yml settings.draftPrClosePolicy instead
     mergeTrainMode: "off" as const,
     screenshotTableGate: normalizeScreenshotTableGateConfig(settings.screenshotTableGate, []),
   } satisfies RepositorySettings;
@@ -929,7 +929,6 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
       requireFreshRebaseWindowMinutes: resolved.requireFreshRebaseWindowMinutes,
       staleBaseAheadByThreshold: resolved.staleBaseAheadByThreshold,
       skipAutomationBotAuthors: resolved.skipAutomationBotAuthors,
-      draftPrClosePolicy: resolved.draftPrClosePolicy,
       screenshotTableGateEnabled: resolved.screenshotTableGate.enabled,
       screenshotTableGateWhenLabelsJson: jsonString(resolved.screenshotTableGate.whenLabels),
       screenshotTableGateWhenPathsJson: jsonString(resolved.screenshotTableGate.whenPaths),
@@ -964,7 +963,6 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
         requireFreshRebaseWindowMinutes: resolved.requireFreshRebaseWindowMinutes,
         staleBaseAheadByThreshold: resolved.staleBaseAheadByThreshold,
         skipAutomationBotAuthors: resolved.skipAutomationBotAuthors,
-        draftPrClosePolicy: resolved.draftPrClosePolicy,
         screenshotTableGateEnabled: resolved.screenshotTableGate.enabled,
         screenshotTableGateWhenLabelsJson: jsonString(resolved.screenshotTableGate.whenLabels),
         screenshotTableGateWhenPathsJson: jsonString(resolved.screenshotTableGate.whenPaths),
@@ -7887,10 +7885,6 @@ function parseCommandAuthorizationPolicy(value: string): RepositorySettings["com
 
 function parseContributorBlacklist(value: string): RepositorySettings["contributorBlacklist"] {
   return normalizeContributorBlacklist(parseJson<unknown>(value, null)).entries;
-}
-
-function normalizeDraftPrClosePolicy(value: string | null | undefined): "off" | "close" {
-  return value === "close" ? "close" : "off";
 }
 
 // Config-driven before/after screenshot-table gate (#2006): the row stores whenLabels/whenPaths as JSON string

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -78,10 +78,6 @@ export const repositorySettings = sqliteTable("repository_settings", {
   // via this path (default). Independent of mergeableState's own "behind" signal -- enforcement lands in
   // prReadyForReview, not here.
   staleBaseAheadByThreshold: integer("stale_base_ahead_by_threshold"),
-  // Draft-PR close policy (#draft-pr-close-policy): off by default -- enforces on ANY draft (including the
-  // first one, before a review has run), so a maintainer opts in deliberately rather than getting it on by
-  // default.
-  draftPrClosePolicy: text("draft_pr_close_policy").notNull().default("off"),
   // Config-driven before/after screenshot-table gate (#2006): off by default. whenLabels/whenPaths are JSON
   // string arrays (mirrors contributorBlacklistJson's shape); screenshotTableGateMessage is nullable ("no
   // override" is a `.loopover.yml`-only concept -- null here means "use the built-in default message").

--- a/src/types.ts
+++ b/src/types.ts
@@ -1351,8 +1351,10 @@ export type RepositorySettings = {
    *  reviewEvasionProtection's narrower abuse-pattern detection and can catch ordinary WIP-signaling
    *  contributors, so a maintainer should choose it deliberately. Shares `autoCloseExemptLogins` and
    *  `reviewEvasionLabel`/`reviewEvasionComment` with the `reviewEvasionProtection` family (same anti-abuse
-   *  label/comment conventions, no need for separate config). See `queue/review-evasion.ts`'s
-   *  `maybeCloseDraftPr`. */
+   *  label/comment conventions, no need for separate config). Config-as-code only, same epic (#6440) as
+   *  reviewEvasionProtection's own #6443 migration -- `db/repositories.ts`'s `getRepositorySettings`/
+   *  `upsertRepositorySettings` always resolve the hardcoded `"off"` default now; only `.loopover.yml`'s
+   *  `settings.draftPrClosePolicy` can override it. See `queue/review-evasion.ts`'s `maybeCloseDraftPr`. */
   draftPrClosePolicy?: "off" | "close" | undefined;
   /** One-shot synchronize-amendment close policy (#synchronize-close-policy): distinct from {@link
    *  reviewEvasionProtection} and {@link draftPrClosePolicy} above -- those families enforce on closing/

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -371,6 +371,7 @@ describe(".loopover.yml.example field-exhaustiveness (#1670)", () => {
     moderationBannedLabel: "moderationBannedLabel:",
     fairnessAnalyticsMode: "fairnessAnalyticsMode:",
     reviewEvasionProtection: "reviewEvasionProtection:",
+    draftPrClosePolicy: "draftPrClosePolicy:",
     reviewEvasionLabel: "reviewEvasionLabel:",
     reviewEvasionComment: "reviewEvasionComment:",
     synchronizeClosePolicy: "synchronizeClosePolicy:",
@@ -2954,6 +2955,21 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(invalid.settings.reviewEvasionProtection).toBeUndefined();
     expect(invalid.settings.reviewEvasionLabel).toBeUndefined();
     expect(invalid.warnings.some((w) => /settings\.reviewEvasionProtection/.test(w))).toBe(true);
+  });
+
+  it("parses + resolves draftPrClosePolicy from the settings: block, overlaying the DB (#draft-pr-close-policy)", () => {
+    const manifest = parseFocusManifest({ settings: { draftPrClosePolicy: "close" } });
+    expect(manifest.settings.draftPrClosePolicy).toBe("close");
+    // yml overlays (replaces) the DB-configured value.
+    const eff = resolveEffectiveSettings({ draftPrClosePolicy: "off" } as unknown as RepositorySettings, manifest);
+    expect(eff.draftPrClosePolicy).toBe("close");
+    // Omitted in yml ⇒ the DB-configured value survives untouched.
+    const noOverride = resolveEffectiveSettings({ draftPrClosePolicy: "close" } as unknown as RepositorySettings, parseFocusManifest({}));
+    expect(noOverride.draftPrClosePolicy).toBe("close");
+    // An invalid enum is dropped with a warning rather than silently coerced.
+    const invalid = parseFocusManifest({ settings: { draftPrClosePolicy: "sometimes" as never } });
+    expect(invalid.settings.draftPrClosePolicy).toBeUndefined();
+    expect(invalid.warnings.some((w) => /settings\.draftPrClosePolicy/.test(w))).toBe(true);
   });
 
   describe("reviewCheckMode precedence (#2852)", () => {

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -2011,12 +2011,13 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       },
       repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
     });
-    // reviewEvasionProtection/reviewEvasionComment (Batch B, loopover#6443) and autoCloseExemptLogins
-    // (loopover#6445) are manifest-only now; pull any test override out of `overrides` before it reaches
-    // the DB write below so a per-test `{ reviewEvasionProtection: "off" }`/`{ reviewEvasionComment: false }`/
-    // `{ autoCloseExemptLogins: [...] }` still takes effect via the manifest overlay instead of being
+    // reviewEvasionProtection/reviewEvasionComment (Batch B, loopover#6443), autoCloseExemptLogins
+    // (loopover#6445), and draftPrClosePolicy (epic #6440, #draft-pr-close-policy) are manifest-only now;
+    // pull any test override out of `overrides` before it reaches the DB write below so a per-test
+    // `{ reviewEvasionProtection: "off" }`/`{ reviewEvasionComment: false }`/`{ autoCloseExemptLogins: [...] }`/
+    // `{ draftPrClosePolicy: "close" }` still takes effect via the manifest overlay instead of being
     // silently outranked by the hardcoded default.
-    const { reviewEvasionProtection, reviewEvasionComment, autoCloseExemptLogins, synchronizeClosePolicy, ...dbOverrides } = overrides;
+    const { reviewEvasionProtection, reviewEvasionComment, autoCloseExemptLogins, draftPrClosePolicy, synchronizeClosePolicy, ...dbOverrides } = overrides;
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       autonomy: { close: "auto" },
@@ -2031,6 +2032,7 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         reviewEvasionProtection: (reviewEvasionProtection as "off" | "close" | undefined) ?? "close",
         ...(reviewEvasionComment !== undefined ? { reviewEvasionComment: reviewEvasionComment as boolean } : {}),
         ...(autoCloseExemptLogins !== undefined ? { autoCloseExemptLogins: autoCloseExemptLogins as string[] } : {}),
+        ...(draftPrClosePolicy !== undefined ? { draftPrClosePolicy: draftPrClosePolicy as "off" | "close" } : {}),
         // synchronizeClosePolicy (#synchronize-close-policy) is manifest-only too -- pulled out here for the
         // same reason as the three fields above, so a per-test override actually reaches the manifest
         // overlay instead of being silently dropped by the DB write (there is no column for it).


### PR DESCRIPTION
## Summary

- `settings.draftPrClosePolicy` was documented as `.loopover.yml`-settable (this repo's own root `.loopover.yml`, both example files, and its own doc comment) but `packages/loopover-engine`'s manifest parser never actually parsed it — a silent no-op for anyone trying to set it via config-as-code.
- Wires it into `FocusManifestSettings`/`parseSettingsOverride`, mirroring `reviewEvasionProtection`'s existing shape (same `Pick<>` entry + `normalizeOptionalEnum` parse line, same local type mirror in `manifest-deps-types.ts`).
- Rather than leaving it dual-source (DB + yml), folds it into the same DB-column-elimination epic (**#6440**) that already retired `reviewEvasionProtection`/`mergeTrainMode` and the Batch A–D fields: drops the `draft_pr_close_policy` column (migration `0171`), hardcodes `"off"` in both `getRepositorySettings`/`upsertRepositorySettings`, and deletes the now-unused `normalizeDraftPrClosePolicy` helper.
- Adds a regression test in `test/unit/focus-manifest.test.ts` covering parse + DB-overlay + omitted-preserves-DB + invalid-enum-dropped-with-warning, mirroring the existing `duplicateWinnerMode`/`reviewEvasionProtection` test shape.
- Updates the `setupEvasionRepo` helper in `test/unit/queue-lifecycle-guards.test.ts` so a per-test `draftPrClosePolicy` override now routes through the manifest write instead of the (now-removed) DB write path.
- Rebased onto `#7715` (`synchronizeClosePolicy`, landed on `main` mid-session) — that field's own doc comments independently already assumed `draftPrClosePolicy` was config-as-code-only, extra confirmation this was the intended shape all along.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A: maintainer-authored fix found while implementing an unrelated feature in a separate session; no separate tracked issue exists. Anchored to the pre-existing `#draft-pr-close-policy` doc anchor and epic `#6440`, both already used throughout the codebase for this exact family of change.

## Validation

Scoped to touched files/changes only (maintainer-authored fix, explicitly scoped this way rather than running the full gate):

- [x] `git diff --check`
- [x] `npm run typecheck` (repo-wide — deleting a function and dropping a schema column can break distant callers)
- [x] `npx vitest run test/unit/focus-manifest.test.ts test/unit/queue-lifecycle-guards.test.ts` — 989 tests pass (both files touched by this change)
- [x] `npm run db:migrations:check` / `npm run db:schema-drift:check` — validate the new migration + schema.ts edit
- [x] `npm run ui:openapi:settings-parity` — validates the `src/types.ts` edit against the OpenAPI schema
- [ ] `npm run test:coverage` / full `npm run test:ci` — not re-run for this exact diff

If any required check was skipped, explain why:

- Full coverage/gate not re-run per explicit scope. Risk is low: the `packages/loopover-engine/**` changes are outside Codecov's `src/**` measurement scope entirely; the remaining `src/db/repositories.ts` lines are hardcoded literals inside `getRepositorySettings`/`upsertRepositorySettings`, both exercised by hundreds of pre-existing tests including the two run directly above; `src/types.ts`'s change is comment/type-only (no executable lines to cover); the deleted `normalizeDraftPrClosePolicy` function has no surviving lines to leave uncovered. `npm run actionlint`/`ui:*`/`test:workers`/`build:mcp`/`npm audit` not run — no workflow, UI, worker, MCP, or dependency files touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — no shape change (`draftPrClosePolicy` remains on `RepositorySettings`); confirmed via `ui:openapi:settings-parity`.
- [x] UI changes use live API data or real empty/error/loading states — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed — the example YAML docs (`.loopover.yml.example`, `config/examples/loopover.full.yml`) already correctly documented this field; only the implementation needed to catch up, so no doc text changed. `CHANGELOG.md` untouched.

## Notes

- This bug was found incidentally while implementing an unrelated feature in a separate session, then confirmed end-to-end here: root-caused against `reviewEvasionProtection`'s existing wiring, cross-checked against the DB layer, the resolver's generic overlay mechanism, and the OpenAPI/example-doc surfaces, before deciding manifest-wiring (not a docs fix) was correct.