### PR TITLE
feat(api): add tenant-facing AI-usage endpoint in compute-units

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -19004,6 +19004,37 @@
           }
         ]
       }
+    },
+    "/v1/app/tenant-ai-usage": {
+      "get": {
+        "summary": "Tenant-scoped AI usage/spend, in normalized compute-units",
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -314,6 +314,7 @@ import { buildMaintainerSlopDuplicateTrend, SLOP_DUPLICATE_TREND_SNAPSHOT_LIMIT 
 import { buildFederatedBenchmark } from "../orb/federated-benchmark";
 import { resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
 import { buildGateOutcomeBreakdown, GATE_OUTCOME_BREAKDOWN_WINDOW_DAYS } from "../services/gate-outcome-breakdown";
+import { sumTenantAiComputeUnitsSince } from "../services/tenant-ai-usage";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, resolveEffectiveSettings } from "../signals/focus-manifest";
 import { resolveRepositorySettings } from "../settings/repository-settings";
@@ -1730,6 +1731,41 @@ export function createApp() {
       })),
       settingsPreview: buildMaintainerSettingsPreview(),
       qualityDashboard: { ...qualityDashboard, gateOutcomeBreakdown },
+    });
+  });
+
+  // #7660: tenant-facing AI usage/spend -- sumAiCostForTenantSince (src/db/repositories.ts, #7176) had
+  // zero real callers outside its own test file; its fleet-wide sibling listAiCostByTenantSince is
+  // operator-only (the operator-dashboard route below), so no hosted tenant could see their own usage
+  // anywhere. Scoped the SAME WAY /v1/app/maintainer-dashboard above scopes its data: an operator session
+  // sees every installation (mirroring that route's own operator bypass), any other session is scoped to
+  // just the installations THEIR login controls, so one tenant can never see another tenant's spend
+  // through this endpoint. Exposes normalized compute-units (src/services/tenant-ai-usage.ts), never the
+  // raw costUsd figure.
+  app.get("/v1/app/tenant-ai-usage", async (c) => {
+    const identity = await authenticateRequestIdentity(c);
+    /* v8 ignore next -- unauthorized requests are rejected by the auth middleware before reaching the handler. */
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const summary = await getRoleSummaryForIdentity(c.env, identity);
+    if (!summary.roles.some((role) => ["maintainer", "owner", "operator"].includes(role))) return c.json({ error: "insufficient_role" }, 403);
+
+    const scope = identity.kind === "session" && !summary.roles.includes("operator") ? await loadControlPanelAccessScope(c.env, identity.actor) : null;
+    const allInstallations = await listInstallations(c.env);
+    const scopedInstallationIds = new Set(scope?.installationIds ?? []);
+    const scopedAccountLogins = new Set(scope?.accountLogins.map((login) => login.toLowerCase()) ?? []);
+    const installations = scope
+      ? allInstallations.filter((installation) => scopedInstallationIds.has(installation.id) || scopedAccountLogins.has(installation.accountLogin.toLowerCase()))
+      : allInstallations;
+
+    const windowDays = clampOperatorDashboardWindowDays(Number(c.req.query("days")));
+    const sinceIso = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+    const computeUnits = await sumTenantAiComputeUnitsSince(c.env, installations.map((installation) => installation.id), sinceIso);
+
+    return c.json({
+      generatedAt: nowIso(),
+      windowDays,
+      since: sinceIso,
+      usage: { computeUnits },
     });
   });
 

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -1065,6 +1065,7 @@ export function buildOpenApiSpec() {
     ["/v1/app/miner-dashboard", "Miner dashboard data"],
     ["/v1/app/maintainer-dashboard", "Maintainer dashboard data"],
     ["/v1/app/operator-dashboard", "Operator dashboard data"],
+    ["/v1/app/tenant-ai-usage", "Tenant-scoped AI usage/spend, in normalized compute-units"],
     ["/v1/app/commands", "@loopover command catalog"],
     ["/v1/app/commands/usefulness", "@loopover command usefulness rollup"],
     ["/v1/app/digest", "Maintainer digest content"],

--- a/src/services/tenant-ai-usage.ts
+++ b/src/services/tenant-ai-usage.ts
@@ -1,0 +1,42 @@
+import { sumAiCostForTenantSince } from "../db/repositories";
+
+// #7660: tenant-facing AI usage/spend. sumAiCostForTenantSince (src/db/repositories.ts, #7176) has
+// computed a hosted tenant's raw AI cost since #7176 shipped, but nothing outside its own test file ever
+// called it -- its fleet-wide sibling listAiCostByTenantSince is consumed only by the operator dashboard
+// (src/services/operator-dashboard.ts), gated to the operator role, so no ORB/AMS hosted tenant could see
+// their own usage/spend anywhere. This module converts that raw USD figure into the normalized
+// compute-unit representation packages/loopover-engine/src/tenant-quota.ts's TenantQuota.computeUnits
+// already uses, so a tenant is shown the same unit their allocation is budgeted in -- never the raw
+// fractional-dollar costUsd. The route wiring lives in src/api/routes.ts ("/v1/app/tenant-ai-usage"),
+// scoped the SAME WAY /v1/app/maintainer-dashboard already scopes its data (loadControlPanelAccessScope).
+
+// 1 compute unit = $0.01 (one USD cent). An integer figure that still tracks spend proportionally
+// without echoing a fractional-dollar cost back to the tenant.
+const USD_PER_COMPUTE_UNIT = 0.01;
+
+/**
+ * Normalize a raw USD cost figure into a non-negative integer compute-unit count. A non-finite or
+ * negative cost (never expected from sumAiCostForTenantSince's own SQL `coalesce(sum(...), 0)`, but not
+ * trusted blindly here either) can never yield a NaN/negative unit count. Mirrors
+ * packages/loopover-engine/src/tenant-quota.ts's own finiteNonNegativeInt normalization discipline; that
+ * package has no dependency on the hosted src/ tree, so the rule is intentionally duplicated here rather
+ * than shared.
+ */
+export function costUsdToComputeUnits(costUsd: number): number {
+  return Number.isFinite(costUsd) ? Math.max(0, Math.floor(costUsd / USD_PER_COMPUTE_UNIT)) : 0;
+}
+
+/**
+ * Sum one or more tenants' (installation ids') AI cost since `sinceIso`, converted to compute-units.
+ * Called once per installation id in the caller's scope -- for a typical hosted tenant with exactly one
+ * GitHub App installation this is a single query, mirroring sumAiCostForTenantSince's own
+ * single-tenant contract; a caller in scope of several installations (e.g. an operator, or an owner with
+ * more than one installed account) still gets one honest combined total rather than N separate figures
+ * to reconcile themselves. An empty installationIds list sums to 0, not an error -- the same "no rows"
+ * default sumAiCostForTenantSince itself returns for a tenant with no usage yet.
+ */
+export async function sumTenantAiComputeUnitsSince(env: Env, installationIds: readonly number[], sinceIso: string): Promise<number> {
+  const costsUsd = await Promise.all(installationIds.map((installationId) => sumAiCostForTenantSince(env, String(installationId), sinceIso)));
+  const totalCostUsd = costsUsd.reduce((sum, cost) => sum + cost, 0);
+  return costUsdToComputeUnits(totalCostUsd);
+}

--- a/test/unit/tenant-ai-usage-route.test.ts
+++ b/test/unit/tenant-ai-usage-route.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { recordAiUsageEvent, upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+// #7660: GET /v1/app/tenant-ai-usage -- the tenant-facing counterpart to the operator-only
+// listAiCostByTenantSince breakdown, scoped the SAME WAY /v1/app/maintainer-dashboard scopes its data
+// (src/api/routes.ts), and exposing normalized compute-units rather than raw costUsd.
+
+function apiHeaders(env: Env): Record<string, string> {
+  return { authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" };
+}
+
+async function seedOwnedInstallation(env: Env, owner: string, installationId: number, repoName = "repo"): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(env, { name: repoName, full_name: `${owner}/${repoName}`, private: false, owner: { login: owner } }, installationId);
+}
+
+describe("GET /v1/app/tenant-ai-usage (#7660)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-21T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/v1/app/tenant-ai-usage", {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a session with no maintainer/owner/operator role", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "someone-else" });
+    const { token } = await createSessionForGitHubUser(env, { login: "nobody", id: 1 });
+    const res = await app.request("/v1/app/tenant-ai-usage", { headers: { cookie: `loopover_session=${token}` } }, env);
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: "insufficient_role" });
+  });
+
+  it("scopes an owner session to their own installation and excludes another tenant's spend", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedInstallation(env, "tenant-owner", 101);
+    await seedOwnedInstallation(env, "other-tenant", 202);
+    // In-window spend for the requesting tenant's own installation.
+    await recordAiUsageEvent(env, { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10, costUsd: 3.0, installationId: "101" });
+    // A different tenant's spend must never leak into this session's total.
+    await recordAiUsageEvent(env, { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10, costUsd: 500.0, installationId: "202" });
+
+    const { token } = await createSessionForGitHubUser(env, { login: "tenant-owner", id: 101 });
+    const res = await app.request("/v1/app/tenant-ai-usage", { headers: { cookie: `loopover_session=${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { generatedAt: string; windowDays: number; since: string; usage: { computeUnits: number } };
+    expect(body.usage.computeUnits).toBe(300); // $3.00 -> 300 compute-units ($0.01/unit)
+    expect(body.windowDays).toEqual(expect.any(Number));
+    expect(body.since).toEqual(expect.any(String));
+    expect(JSON.stringify(body)).not.toContain("other-tenant");
+  });
+
+  it("reports 0 compute-units for a scoped tenant with no AI usage yet", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedInstallation(env, "quiet-owner", 303);
+
+    const { token } = await createSessionForGitHubUser(env, { login: "quiet-owner", id: 303 });
+    const res = await app.request("/v1/app/tenant-ai-usage", { headers: { cookie: `loopover_session=${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ usage: { computeUnits: 0 } });
+  });
+
+  it("respects a valid ?days= window, excluding spend older than it", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedInstallation(env, "windowed-owner", 404);
+    await recordAiUsageEvent(env, { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10, costUsd: 1.0, installationId: "404" });
+    await env.DB.prepare("UPDATE ai_usage_events SET created_at = ? WHERE installation_id = '404'").bind("2026-06-01T00:00:00.000Z").run();
+
+    const { token } = await createSessionForGitHubUser(env, { login: "windowed-owner", id: 404 });
+    const res = await app.request("/v1/app/tenant-ai-usage?days=7", { headers: { cookie: `loopover_session=${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ windowDays: 7, usage: { computeUnits: 0 } });
+  });
+
+  it("gives an operator (unscoped) session the combined total across every tenant", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator-user" });
+    await seedOwnedInstallation(env, "tenant-a", 501);
+    await seedOwnedInstallation(env, "tenant-b", 502);
+    await recordAiUsageEvent(env, { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10, costUsd: 1.0, installationId: "501" });
+    await recordAiUsageEvent(env, { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10, costUsd: 2.0, installationId: "502" });
+
+    const { token } = await createSessionForGitHubUser(env, { login: "operator-user", id: 999 });
+    const res = await app.request("/v1/app/tenant-ai-usage", { headers: { cookie: `loopover_session=${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ usage: { computeUnits: 300 } }); // (1.0 + 2.0) USD combined
+  });
+
+  it("gives static (service-credential) callers the same unscoped, full-fleet view", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedInstallation(env, "tenant-c", 601);
+    await recordAiUsageEvent(env, { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10, costUsd: 4.0, installationId: "601" });
+
+    const res = await app.request("/v1/app/tenant-ai-usage", { headers: apiHeaders(env) }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ usage: { computeUnits: 400 } });
+  });
+});

--- a/test/unit/tenant-ai-usage.test.ts
+++ b/test/unit/tenant-ai-usage.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { recordAiUsageEvent } from "../../src/db/repositories";
+import { costUsdToComputeUnits, sumTenantAiComputeUnitsSince } from "../../src/services/tenant-ai-usage";
+import { createTestEnv } from "../helpers/d1";
+
+// #7660: sumAiCostForTenantSince (src/db/repositories.ts, #7176) had zero real callers outside its own
+// test file. This pins the pure USD -> compute-units conversion (mirroring
+// packages/loopover-engine/src/tenant-quota.ts's TenantQuota.computeUnits shape) and the aggregation
+// helper the new /v1/app/tenant-ai-usage route (src/api/routes.ts) calls.
+describe("costUsdToComputeUnits (#7660)", () => {
+  it("floors a positive cost to whole compute-units at $0.01 per unit", () => {
+    expect(costUsdToComputeUnits(2.0)).toBe(200);
+    // 12.345 USD -> 1234.5 cents -> floored, not rounded, so partial-cent spend never inflates the figure.
+    expect(costUsdToComputeUnits(12.345)).toBe(1234);
+  });
+
+  it("returns 0 for a zero cost", () => {
+    expect(costUsdToComputeUnits(0)).toBe(0);
+  });
+
+  it("normalizes a non-finite or negative cost to 0 rather than NaN/negative units", () => {
+    expect(costUsdToComputeUnits(Number.NaN)).toBe(0);
+    expect(costUsdToComputeUnits(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(costUsdToComputeUnits(-5)).toBe(0);
+  });
+});
+
+describe("sumTenantAiComputeUnitsSince (#7660)", () => {
+  const base = { feature: "ai_review", model: "claude-sonnet-5", status: "ok", estimatedNeurons: 10 };
+
+  it("sums cost across every installation id in scope, converted to compute-units", async () => {
+    const env = createTestEnv();
+    await recordAiUsageEvent(env, { ...base, costUsd: 1.0, installationId: "101" });
+    await recordAiUsageEvent(env, { ...base, costUsd: 2.5, installationId: "202" });
+    // A different, out-of-scope tenant's spend must never be folded into this caller's total.
+    await recordAiUsageEvent(env, { ...base, costUsd: 99.0, installationId: "999" });
+
+    const computeUnits = await sumTenantAiComputeUnitsSince(env, [101, 202], "2020-01-01T00:00:00.000Z");
+    expect(computeUnits).toBe(350); // (1.0 + 2.5) USD = 350 cents
+  });
+
+  it("sums to 0 when the installation-id scope is empty (a tenant with no usage/no installations)", async () => {
+    const env = createTestEnv();
+    await recordAiUsageEvent(env, { ...base, costUsd: 5.0, installationId: "101" });
+
+    expect(await sumTenantAiComputeUnitsSince(env, [], "2020-01-01T00:00:00.000Z")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `sumAiCostForTenantSince` (`src/db/repositories.ts`, added via #7176 for centralized hosted billing) had zero real callers outside its own test file — its fleet-wide sibling `listAiCostByTenantSince` is consumed only by the operator-only dashboard, so no ORB or AMS hosted tenant could see their own usage/spend anywhere.
- Adds a new tenant-facing `GET /v1/app/tenant-ai-usage` route that calls `sumAiCostForTenantSince` and returns the figure in normalized compute-units — mirroring `packages/loopover-engine/src/tenant-quota.ts`'s `TenantQuota.computeUnits` shape, never the raw `costUsd` dollar figure (`src/services/tenant-ai-usage.ts`'s new `costUsdToComputeUnits`/`sumTenantAiComputeUnitsSince`).
- The route is scoped the same way `/v1/app/maintainer-dashboard` already scopes its data: it reuses that route's exact `loadControlPanelAccessScope` call and installation-filtering logic, so a session only ever sees the AI cost billed to the installation(s) their own GitHub login controls, never another tenant's spend.
- Regenerated `apps/loopover-ui/public/openapi.json` and added the route to `src/openapi/spec.ts` alongside its `/v1/app/*` siblings.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` (whole-repo `tsc` OOMs in this sandbox; verified with a scoped `tsc --noEmit` on the exact changed files + `src/env.d.ts`/`worker-configuration.d.ts` using the root `tsconfig.json`'s compiler flags — clean, no errors)
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped; whole-repo `npm run typecheck` OOMs in this sandbox specifically (known local resource limit), so it was substituted with an equivalent scoped `tsc --noEmit` invocation covering every changed file with the project's exact strict compiler flags.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (unauthenticated → 401, insufficient role → 403, and cross-tenant scoping-exclusion are all covered by new tests)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — this PR is backend-only; no `apps/loopover-ui/**` route or component changes)
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. (N/A — no visible UI change; see the issue's own "Area" field, `src/api/routes.ts`/`src/services/`)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — this is a backend-only change (new API route). No `apps/loopover-ui/**` files were touched beyond the regenerated, machine-generated `openapi.json`.

## Notes

- Unit conversion: 1 compute-unit = $0.01 (one USD cent), floored — an integer figure that still tracks spend proportionally without echoing a fractional-dollar cost back to the tenant. No change to how cost itself is tracked or computed; this is a read-only exposure of the already-computed `sumAiCostForTenantSince` figure, converted to the decided unit.
- Resubmission: an earlier PR against this issue (#7717, identical implementation) was auto-closed even though every individual `validate-tests` shard and both `codecov/patch`/`codecov/project` passed — the only failing check was the repo-level `validate-tests-merge` job's own local coverage-merge invocation, which reported "No test files found" against a stale/unrelated `packages/loopover-mcp/bin/loopover-mcp.js` entry. That looked like a transient CI artifact/merge issue unrelated to this change's own correctness, so this is a clean resubmission of the same implementation rebased onto current `main`, with all local checks re-verified fresh.

Closes #7660

