### PR TITLE
fix(api): tenant-scope GET /v1/app/digest like its maintainer-dashboard sibling

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2166,17 +2166,31 @@ export function createApp() {
   });
 
   app.get("/v1/app/digest", async (c) => {
-    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
-    if (forbidden) return forbidden;
     const identity = await authenticateRequestIdentity(c);
-    const login = identity?.kind === "session" ? identity.actor : null;
-    const [repositories, health, upstreamDrift, rateLimits, subscriptions] = await Promise.all([
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const summary = await getRoleSummaryForIdentity(c.env, identity);
+    if (!summary.roles.some((role) => ["maintainer", "owner", "operator"].includes(role))) return c.json({ error: "insufficient_role" }, 403);
+    const login = identity.kind === "session" ? identity.actor : null;
+    const [allRepositories, allHealth, upstreamDrift, allRateLimits, subscriptions] = await Promise.all([
       listRepositories(c.env),
       listInstallationHealth(c.env),
       loadUpstreamStatus(c.env),
       listLatestGitHubRateLimitObservations(c.env, 10),
       login ? listDigestSubscriptionsForLogin(c.env, login) : Promise.resolve([]),
     ]);
+    // Tenant-scoped identically to /v1/app/maintainer-dashboard (#7659) -- a non-operator session must
+    // only ever see their own repositories/installations/rate-limit telemetry, never the full fleet.
+    const scope = identity.kind === "session" && !summary.roles.includes("operator") ? await loadControlPanelAccessScope(c.env, identity.actor) : null;
+    const scopedRepoNames = new Set(scope?.repositoryFullNames.map((repo) => repo.toLowerCase()) ?? []);
+    const scopedInstallationIds = new Set(scope?.installationIds ?? []);
+    const scopedAccountLogins = new Set(scope?.accountLogins.map((accountLogin) => accountLogin.toLowerCase()) ?? []);
+    const repositories = scope ? allRepositories.filter((repo) => scopedRepoNames.has(repo.fullName.toLowerCase())) : allRepositories;
+    const health = scope
+      ? allHealth.filter((record) => scopedInstallationIds.has(record.installationId) || scopedAccountLogins.has(record.accountLogin.toLowerCase()))
+      : allHealth;
+    const rateLimits = scope
+      ? allRateLimits.filter((record) => record.repoFullName !== undefined && record.repoFullName !== null && scopedRepoNames.has(record.repoFullName.toLowerCase()))
+      : allRateLimits;
     const items = buildDigestItems({ repositories, health, upstreamDrift, rateLimits });
     return c.json({
       generatedAt: nowIso(),

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2528,6 +2528,7 @@ describe("api routes", () => {
     const forbiddenMiner = await app.request("/v1/app/miner-dashboard?login=oktofeesh1", { headers: { cookie: `loopover_session=${otherToken}` } }, env);
     expect(forbiddenMiner.status).toBe(403);
     expect((await app.request("/v1/app/maintainer-dashboard", {}, env)).status).toBe(401);
+    expect((await app.request("/v1/app/digest", {}, env)).status).toBe(401);
 
     // #129 in-UI "refresh decision pack": contributor-authed enqueue of the decision-pack rebuild.
     const refreshMissingLogin = await app.request("/v1/app/miner-dashboard/refresh", { method: "POST", headers: apiHeaders(env) }, env);
@@ -2571,6 +2572,7 @@ describe("api routes", () => {
     await expect(unknownOverview.json()).resolves.toMatchObject({ error: "insufficient_role" });
     expect((await app.request("/v1/app/operator-dashboard", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect((await app.request("/v1/app/maintainer-dashboard", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
+    expect((await app.request("/v1/app/digest", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect((await app.request("/v1/app/commands/usefulness", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect(
       (
@@ -2676,6 +2678,18 @@ describe("api routes", () => {
     expect(JSON.stringify(ownerMaintainerDashboardBody)).not.toContain("victim-org");
     expect(JSON.stringify(ownerMaintainerDashboardBody)).not.toContain("Victim confidential release plan");
     expect(JSON.stringify(ownerMaintainerDashboardBody)).not.toContain("victim install needs privileged recovery");
+
+    // REGRESSION (#7659): /v1/app/digest lacked the tenant-scoping its sibling /v1/app/maintainer-dashboard
+    // already applies above -- before the fix, victim-org's unhealthy install and rate-limit telemetry leaked
+    // straight into a non-operator owner's digest (an "install" item literally titled "victim-org installation
+    // needs attention", plus an inflated rate-limit count), same fixture as the maintainer-dashboard assertions
+    // above so a regression here is caught by the same victim-org data already set up.
+    const ownerDigest = await app.request("/v1/app/digest", { headers: ownerHeaders }, ownerEnv);
+    expect(ownerDigest.status).toBe(200);
+    const ownerDigestBody = (await ownerDigest.json()) as { signal: string; items: Array<{ kind: string; title: string; detail: string }> };
+    expect(ownerDigestBody.items.some((item) => item.kind === "install")).toBe(false);
+    expect(JSON.stringify(ownerDigestBody)).not.toContain("victim-org");
+    expect(JSON.stringify(ownerDigestBody)).not.toContain("victim install needs privileged recovery");
     expect((await app.request("/v1/app/notification-model", { headers: ownerHeaders }, ownerEnv)).status).toBe(200);
     expect((await app.request("/v1/app/operator-dashboard", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
     expect((await app.request("/v1/app/analytics/daily-rollups", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);


### PR DESCRIPTION
## Summary

`GET /v1/app/digest` gates on the same `maintainer`/`owner`/`operator` roles as `GET /v1/app/maintainer-dashboard`, but never applied that sibling route's tenant-scoping step -- `listRepositories`/`listInstallationHealth`/rate-limit observations went straight into `buildDigestItems` completely unfiltered. A non-operator session (a hosted tenant's own maintainer) could see other tenants' unhealthy installations (account login + missing permissions/events) and rate-limit telemetry counts in their own digest. Only one real tenant exists in production today so there's no actual victim yet, but it's a live gap in already-deployed code, cheap to fix now before a second real tenant exists.

Fix: apply the exact same `loadControlPanelAccessScope` filtering `/v1/app/maintainer-dashboard` already does, reusing that pattern rather than inventing a second scoping mechanism -- same scope-resolution condition (`identity.kind === "session" && !summary.roles.includes("operator")`), same repo/installation/account-login filtering shape.

Closes #7659

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one tenant-scoping fix, mirroring an existing sibling route's pattern) and does not mix in unrelated backend, UI, MCP, docs, dependency, or deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (#7659, maintainer-only, assigned to the repo owner).

## Validation

- [x] `npx tsc --noEmit -p tsconfig.json` -- clean
- [x] `npm run ui:openapi:check` -- clean (no request/response schema shape change, handler logic only)
- [x] `npx vitest run test/integration/api.test.ts test/unit/openapi.test.ts` -- 53 tests passing
- [x] Regression-verified the hard way: reverted the fix locally, confirmed the new test fails exactly as expected (asserts no leaked `victim-org` "install" item), then restored the fix and confirmed it passes.
- [x] New/changed behavior has tests for every new branch: the tenant-scoping filter itself (reusing the existing owner-vs-victim-org fixture already in this same test, right after the equivalent `maintainer-dashboard` assertions), plus the two new inlined auth branches this refactor introduces (`401` unauthenticated, `403` insufficient role) that weren't previously attributable to this specific call site since the old code delegated to a shared `requireAppRole` helper.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- this IS the negative-path fix; new 401/403/scoped-403-equivalent tests added.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A, no schema/contract shape change, only which rows filter into an existing response shape.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed -- N/A, internal access-control fix, no user-facing docs describe this endpoint's exact scoping behavior today (mirrors `maintainer-dashboard`, which also has no dedicated doc page for this detail).

## Notes

Same risk class as the sibling route it mirrors -- this is an access-control fix, not new functionality. No config-as-code surface, no new settings, no behavior change for the operator role or for the only real tenant that exists today.