### PR TITLE
fix(selfhost): translate instr() and quote camelCase AS aliases for Postgres

### DIFF
--- a/src/selfhost/pg-dialect.ts
+++ b/src/selfhost/pg-dialect.ts
@@ -62,7 +62,28 @@ export function translateFunctions(sql: string): string {
       .replace(/CURRENT_TIMESTAMP/gi, `to_char(now(), 'YYYY-MM-DD HH24:MI:SS')`)
       // json_extract(col, '$.key') → (col::jsonb ->> 'key')  (single-level paths — all the codebase uses)
       .replace(/json_extract\(\s*([^,]+?)\s*,\s*'\$\.([A-Za-z0-9_]+)'\s*\)/gi, `(($1)::jsonb ->> '$2')`)
+      // instr(haystack, needle) → strpos(haystack, needle): both are 1-based first-occurrence index, 0 if
+      // absent -- a direct semantic match, no formula adjustment needed. Postgres has no `instr` builtin at
+      // all (unlike substr, which is SQL-standard and needs no translation) -- every instr() call reaching
+      // Postgres untranslated fails outright with "function instr(...) does not exist", which the codebase's
+      // fail-safe read paths (e.g. computeContributorGateEval-style try/catch) silently swallow to an empty
+      // result rather than surfacing. Used to parse a `repo#123`-shaped target_id/target_key in several
+      // review/public-stats query builders (e.g. public-stats.ts, contributor-gate-history-backfill.ts).
+      .replace(/instr\(\s*([^,]+?)\s*,\s*([^)]+?)\s*\)/gi, `strpos($1, $2)`)
   );
+}
+
+/** Quote a bare camelCase `AS` alias so Postgres preserves its case. Unquoted identifiers are case-folded to
+ *  lowercase by Postgres (both at DEFINITION and at SELECT-list ALIAS time) -- SQLite/D1 preserves whatever
+ *  case the query wrote. The codebase's query builders read result rows by camelCase property access
+ *  (`row.targetId`, `row.authorLogin`, ...) expecting the alias verbatim; unquoted on Postgres, `AS targetId`
+ *  comes back as the key `targetid`, so every such field silently reads as `undefined` -- a fail-safe read
+ *  path (try/catch → empty result) swallows this without ever surfacing an error. Only bare (unquoted, no
+ *  leading digit) aliases containing at least one uppercase letter need quoting; an all-lowercase or
+ *  already-quoted alias is left untouched. Scoped to `AS <ident>` specifically (never a plain column/table
+ *  reference elsewhere) since that's the only place this codebase's queries introduce a camelCase name. */
+export function quoteCamelCaseAliases(sql: string): string {
+  return sql.replace(/\bAS\s+([a-z][a-zA-Z0-9]*[A-Z][a-zA-Z0-9]*)\b/g, (_full, ident: string) => `AS "${ident}"`);
 }
 
 /** Translate SQLite's `rowid` pseudo-column to Postgres's `ctid` system column. Both give a stable,
@@ -114,7 +135,7 @@ export function stripConflictTargetQualifiers(sql: string): string {
 
 /** Translate a runtime query (SQLite → Postgres). */
 export function translateSql(sql: string): string {
-  return toNumberedPlaceholders(stripConflictTargetQualifiers(translateRowid(translateFunctions(translateInsertOr(sql)))));
+  return toNumberedPlaceholders(stripConflictTargetQualifiers(translateRowid(quoteCamelCaseAliases(translateFunctions(translateInsertOr(sql))))));
 }
 
 /** Migrations are applied as whole multi-statement files via exec(), so the statement-anchored

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -9,6 +9,7 @@ import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "../.
 import { pruneExpiredRecords } from "../../src/db/retention";
 import { processJob } from "../../src/queue/processors";
 import { getGateBlockOutcome, markGateOutcomeOverridden, recordGateBlockOutcome } from "../../src/db/repositories";
+import { backfillContributorGateHistory } from "../../src/review/contributor-gate-history-backfill";
 
 const URL = process.env.PG_TEST_URL;
 const suite = URL ? describe : describe.skip;
@@ -44,6 +45,22 @@ suite("Postgres backend (#977) — real Postgres", () => {
     const row = await db.prepare("SELECT COUNT(*) AS n FROM system_flags WHERE updated_at > datetime('now', ?)").bind("-30 days").first<{ n: number }>();
     expect(typeof row?.n).toBe("number");
     expect(row?.n).toBeGreaterThanOrEqual(1);
+  });
+
+  it("REGRESSION: backfillContributorGateHistory's instr()/substr() target_id parsing works against real Postgres (Postgres has no `instr` builtin -- SELECT instr(...) is a hard 'function instr(...) does not exist' error, previously swallowed silently by every fail-safe read path using it)", async () => {
+    const db = createPgAdapter(pool);
+    await db.prepare(`INSERT INTO pull_requests (id, repo_full_name, number, title, state, author_login) VALUES (?, ?, ?, ?, ?, ?)`)
+      .bind("pr-instr-1", "owner/instr-repo", 42, "pg instr regression", "open", "octocat")
+      .run();
+    await db.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, ?, ?, 'gate_decision', 'merge', 'gittensory-native', ?)`)
+      .bind("gd-instr-1", "owner/instr-repo", "owner/instr-repo#42", new Date().toISOString())
+      .run();
+
+    const result = await backfillContributorGateHistory({ DB: db } as unknown as Env);
+    expect(result).toEqual({ scanned: 1, inserted: 1, skippedNoAuthor: 0, hasMore: false });
+
+    const row = await db.prepare(`SELECT login, project, target_id FROM contributor_gate_history WHERE target_id = ?`).bind("owner/instr-repo#42").first<{ login: string; project: string; target_id: string }>();
+    expect(row).toEqual({ login: "octocat", project: "owner/instr-repo", target_id: "owner/instr-repo#42" });
   });
 
   it("batch is transactional (rolls back on error)", async () => {

--- a/test/unit/selfhost-pg-dialect.test.ts
+++ b/test/unit/selfhost-pg-dialect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateMigrationInserts, translateRowid, translateSql } from "../../src/selfhost/pg-dialect";
+import { quoteCamelCaseAliases, stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateMigrationInserts, translateRowid, translateSql } from "../../src/selfhost/pg-dialect";
 
 describe("pg-dialect (#977 SQLite → Postgres)", () => {
   it("numbers placeholders, skipping `?` inside string literals", () => {
@@ -29,6 +29,53 @@ describe("pg-dialect (#977 SQLite → Postgres)", () => {
     expect(translateFunctions("strftime('%Y-%m', created_at)")).toContain("'YYYY-MM'");
     expect(translateFunctions("CURRENT_TIMESTAMP")).toContain("to_char(now(),");
     expect(translateFunctions("json_extract(meta, '$.mode')")).toBe("((meta)::jsonb ->> 'mode')");
+  });
+
+  it("REGRESSION: translates instr(haystack, needle) to Postgres's strpos (SQLite has no `instr` on Postgres)", () => {
+    expect(translateFunctions("instr(x, '#')")).toBe("strpos(x, '#')");
+    expect(translateFunctions("instr(ra.target_id, '#') > 0")).toBe("strpos(ra.target_id, '#') > 0");
+  });
+
+  it("REGRESSION: an instr() nested inside substr()/CAST() -- the actual shape public-stats.ts and contributor-gate-history-backfill.ts emit to parse a `repo#123` target_id -- translates end-to-end", () => {
+    // public-stats.ts's exact pattern: extract the PR number after the `#`.
+    const out = translateFunctions("CAST(substr(target_key, instr(target_key, '#') + 1) AS INTEGER) AS number");
+    expect(out).toBe("CAST(substr(target_key, strpos(target_key, '#') + 1) AS INTEGER) AS number");
+    // Two instr() calls in the same expression (repo name before the `#`, PR number after) both translate.
+    const both = translateFunctions("substr(target_key, 1, instr(target_key, '#') - 1) AS repo, CAST(substr(target_key, instr(target_key, '#') + 1) AS INTEGER) AS number");
+    expect(both).not.toMatch(/instr\(/i);
+    expect(both).toContain("strpos(target_key, '#') - 1");
+    expect(both).toContain("strpos(target_key, '#') + 1");
+  });
+
+  it("REGRESSION: quotes a bare camelCase AS alias so Postgres preserves its case instead of folding it to lowercase", () => {
+    expect(quoteCamelCaseAliases("SELECT ra.target_id AS targetId FROM review_audit ra")).toBe('SELECT ra.target_id AS "targetId" FROM review_audit ra');
+    expect(quoteCamelCaseAliases("pr.author_login AS authorLogin, ra.created_at AS createdAt")).toBe('pr.author_login AS "authorLogin", ra.created_at AS "createdAt"');
+  });
+
+  it("leaves an all-lowercase or snake_case alias untouched (already case-fold-safe on Postgres)", () => {
+    expect(quoteCamelCaseAliases("SELECT a.project AS project, a.target_id AS target_id FROM a")).toBe("SELECT a.project AS project, a.target_id AS target_id FROM a");
+  });
+
+  it("never double-quotes an alias that's already quoted", () => {
+    expect(quoteCamelCaseAliases('SELECT a.x AS "targetId" FROM a')).toBe('SELECT a.x AS "targetId" FROM a');
+  });
+
+  it("REGRESSION: translateSql composes alias-quoting with instr/strpos on the actual contributor-gate-history-backfill.ts query shape", () => {
+    const out = translateSql(
+      `SELECT ra.project AS project, ra.target_id AS targetId, ra.decision AS decision, ra.head_sha AS headSha,
+              ra.source AS source, pr.author_login AS authorLogin, ra.created_at AS createdAt
+         FROM review_audit ra
+         LEFT JOIN pull_requests pr
+           ON pr.repo_full_name = ra.project
+          AND pr.number = CAST(substr(ra.target_id, instr(ra.target_id, '#') + 1) AS INTEGER)
+        WHERE ra.event_type = 'gate_decision' AND instr(ra.target_id, '#') > 0`,
+    );
+    expect(out).toContain('AS "targetId"');
+    expect(out).toContain('AS "headSha"');
+    expect(out).toContain('AS "authorLogin"');
+    expect(out).toContain('AS "createdAt"');
+    expect(out).not.toMatch(/instr\(/i);
+    expect(out).toContain("strpos(ra.target_id, '#')");
   });
 
   it("REGRESSION (#4997): a JSON-boolean json_extract comparison survives translation as text-to-text, not text-to-integer", () => {


### PR DESCRIPTION
## Summary

Two silent self-host-Postgres-only bugs in the SQLite→Postgres dialect translator (`pg-dialect.ts`), both discovered while verifying the contributor-gate-history backfill route against the live self-hosted database after deploying #7711.

- **`instr()` has no Postgres equivalent at all.** Postgres throws `function instr(...) does not exist`. At least 7 files use it (`public-stats.ts`, `stats.ts`, `ops.ts`, `public-review-volume-trend.ts`, `public-reuse-rate-trend.ts`, `public-accuracy-trend.ts`, `contributor-gate-history-backfill.ts`), all with fail-safe read paths that silently swallow the error to an empty/zero result. Translated to Postgres's `strpos()` -- a direct semantic match (1-based first-occurrence index, 0 if absent).
- **Postgres folds an unquoted `AS camelCaseAlias` to lowercase** (`targetId` → `targetid`, `authorLogin` → `authorlogin`), but every result row is read back by exact camelCase property access (`row.targetId`). At least 49 call sites across many files are affected, including pre-existing code this session didn't touch (e.g. `contributor-trust-profile.ts`'s `lastSeen`). Every such field has been silently reading as `undefined` on Postgres. Fixed once, in the dialect translator, rather than requiring every call site to remember to quote its own aliases.

Both bugs were invisible to CI: the only real-Postgres integration suite (`selfhost-pg.test.ts`) is `describe.skip`'d without `PG_TEST_URL`, and neither bug reproduces against the SQLite/D1 test harness the rest of the suite runs against.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] Unit tests (`selfhost-pg-dialect.test.ts` + related self-host suites) green, 100% line/branch coverage on `pg-dialect.ts`
- [x] Verified against a **real Postgres 16 container** (not just the translator's string output): the exact `backfillContributorGateHistory` query now correctly resolves the join and inserts the row, where before it silently no-op'd
- [x] `npm audit --audit-level=moderate` clean

Note: one pre-existing test in `selfhost-pg.test.ts` ("prunes rows past the retention window...") is flaky under this local real-Postgres harness independent of this change -- confirmed by reproducing it against the file's original, unmodified content on a fresh container. Not something this PR introduces or fixes.