### PR TITLE
fix(ci): stop scoped test selection from breaking on a re-shallowed origin/main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -915,10 +915,21 @@ jobs:
           SCOPE_ARGS=()
           if [ "$SCOPED_TEST_SELECTION" = "true" ]; then
             echo "Scoped test selection: no rees/engine paths changed -- running vitest --changed=origin/main instead of the full suite."
-            # This job's checkout already uses fetch-depth: 0 (full history, for Codecov's merge-base
-            # resolution), which should make origin/main resolvable already -- fetch it explicitly anyway
-            # as a cheap, idempotent guarantee rather than relying on that as an assumption.
-            git fetch --depth=1 origin main
+            # REGRESSION (2026-07-21): this used to be `git fetch --depth=1 origin main`, reasoning it was
+            # "a cheap, idempotent guarantee" on top of this job's checkout already using fetch-depth: 0
+            # (full history for every ref, including origin/main -- confirmed sufficient on its own). It
+            # was NOT idempotent: a --depth=1 fetch of a ref that already has full history locally
+            # re-shallows THAT ref specifically, cutting its reachable history at the single fetched
+            # commit. vitest's --changed=origin/main below needs `git merge-base <head>...origin/main` to
+            # resolve, and once origin/main was re-shallowed to one commit with no shared history
+            # reachable from a PR branch forked further back, merge-base returned nothing -- vitest
+            # silently fell back to "no changed files" and every shard printed "No test files found,
+            # exiting with code 0", failing every scoped PR's "Verify coverage report exists" step,
+            # contributor and maintainer alike. Dropping --depth entirely keeps this genuinely idempotent
+            # (a no-op fast-forward on top of history the checkout step already fetched in full) while
+            # still acting as a real defensive top-up for any future scenario where that assumption stops
+            # holding, instead of betting everything on the checkout step with no fallback at all.
+            git fetch origin main
             # --coverage.all=false: without it, v8's default "report every coverage.include-matched file
             # at 0% even if untouched by this run" would make this shard's upload claim the rest of the
             # ~2,900-file suite is 0% covered, polluting Codecov's project trend on every scoped PR. Real


### PR DESCRIPTION
## Summary

**Urgent, repo-wide CI outage** -- this is currently breaking `validate-tests` on every PR (contributor and maintainer alike) eligible for the "scoped test selection" fast path added in #7709, whenever the PR's branch point isn't the single most recent commit on `main` (i.e. almost always, on a repo that merges this fast).

Root cause: the scoped-selection branch of the "Test with coverage" step re-fetches `origin/main` with `git fetch --depth=1 origin main`, reasoning (per its own comment) that this was "a cheap, idempotent guarantee" on top of the job's own `fetch-depth: 0` checkout. It is not idempotent -- a `--depth=1` fetch of a ref that already has full history locally **re-shallows that ref specifically**, cutting its reachable history at the single newly-fetched commit. `vitest --changed=origin/main` needs `git merge-base <head>...origin/main` to resolve the diff range; once `origin/main` was re-shallowed with no history shared with a PR branch forked further back, `merge-base` silently returned nothing, `--changed` resolved to zero files, and every shard printed `No test files found, exiting with code 0` -- which then fails the very next step, "Verify coverage report exists" (`coverage/lcov.info is missing or empty`), because it (correctly) doesn't expect an empty coverage report to be a valid outcome.

Confirmed live on #7725 (all 3 `validate-tests` shards failed this exact way).

## Root-cause verification (not guessed -- reproduced twice)

1. In my own local worktree (already shallow): `git fetch --depth=1 origin main` then `git merge-base <branch> origin/main` returned **empty**. `git fetch --unshallow origin` then the same `merge-base` call **resolved immediately**.
2. In a fresh, deliberately shallow clone from scratch (`git clone --depth=50`): reproduced the exact same failure/success split, and additionally confirmed this fix's replacement fetch (same `git fetch origin main`, `--depth` dropped) is genuinely idempotent on top of an already-full checkout -- ran it twice, `merge-base` resolved correctly both times, repo stayed fully unshallow (`git rev-parse --is-shallow-repository` -> `false`) throughout.

## Fix

Drop the `--depth=1` flag. The checkout step already uses `fetch-depth: 0` (full history for every ref, including `origin/main` -- this really is sufficient on its own, confirmed above), so a plain `git fetch origin main` is a genuine no-op fast-forward in the common case, while still acting as a real defensive top-up for any future scenario where that assumption stops holding -- unlike the removed line, it can never make things worse.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one CI workflow fix) and does not mix in unrelated backend, UI, MCP, docs, dependency, or deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- no issue exists; found and fixed via direct investigation after observing #7725's CI fail this exact way, urgent given it's a repo-wide CI outage affecting every scoped PR.

## Validation

- [x] `npm run actionlint` -- clean
- [x] Root cause reproduced and the fix verified empirically in two independent shallow-clone scenarios (see above) rather than guessed from reading the YAML alone.
- [x] Grepped for the same `--depth=1 origin <branch-ref>` pattern elsewhere in `.github/workflows/**` -- only one other `--depth=1` fetch exists (the "Check whitespace" step, `.github/workflows/ci.yml:80`), and it fetches an exact immutable SHA for a plain `git diff --check`, not a movable branch ref for a `merge-base` walk -- a different, unaffected case, confirmed not to need the same fix.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests -- N/A, CI workflow only.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states -- N/A.
- [ ] Visible UI changes include a `UI Evidence` section -- N/A.
- [ ] Public docs/changelogs are updated where needed -- N/A, internal CI-only fix.

## Notes

This is a crucial/guarded-path change (CI config), so it'll need maintainer review/merge rather than auto-merging even though it's an owner-authored fix -- flagging that explicitly given the urgency. Every currently-open PR eligible for scoped test selection is very likely blocked by this exact failure right now and should re-run `validate-tests` once this merges.