### PR TITLE
fix(review): make computeContributorGateEval's SQL portable to Postgres

### DIFF
--- a/src/review/contributor-gate-eval.ts
+++ b/src/review/contributor-gate-eval.ts
@@ -82,16 +82,21 @@ async function queryContributorGateCells(env: Env, opts: { days: number; nowMs: 
   const days = Number.isFinite(opts.days) && opts.days > 0 ? Math.min(opts.days, 730) : 90;
   const fromIso = new Date(opts.nowMs - days * 86_400_000).toISOString().slice(0, 10);
   const loginFilter = opts.login ? "AND login = ?" : "";
+  // Latest row per key via ROW_NUMBER()+rn=1, NOT SQLite's "bare column with MAX()" trick -- that trick lets
+  // an ungrouped column (project/pred here) come from an ARBITRARY row in the group, which is merely
+  // non-deterministic on SQLite but a hard "column must appear in the GROUP BY clause" error on Postgres.
+  // Mirrors federated-bundle.ts's LOCAL_CALIBRATION_QUERY (src/orb/federated-bundle.ts:110) and
+  // orb-collector.ts's FLEET_QUERY, both written portable for exactly this reason.
   const sql = `
     WITH cgh AS (
-      SELECT login, project, target_id, decision AS pred, MAX(created_at) AS t
+      SELECT login, project, target_id, decision AS pred, created_at,
+             ROW_NUMBER() OVER (PARTITION BY login, target_id ORDER BY created_at DESC) AS rn
       FROM contributor_gate_history WHERE created_at >= ? ${loginFilter}
-      GROUP BY login, target_id
     ),
     po AS (
-      SELECT target_id, decision AS truth, MAX(created_at) AS t
+      SELECT target_id, decision AS truth, created_at,
+             ROW_NUMBER() OVER (PARTITION BY target_id ORDER BY created_at DESC) AS rn
       FROM review_audit WHERE event_type = 'pr_outcome' AND decision IS NOT NULL
-      GROUP BY target_id
     ),
     rev AS (
       SELECT DISTINCT target_id FROM review_audit WHERE event_type IN ('reversal_reverted', 'reversal_reopened')
@@ -100,6 +105,7 @@ async function queryContributorGateCells(env: Env, opts: { days: number; nowMs: 
            CASE WHEN rev.target_id IS NOT NULL THEN 1 ELSE 0 END AS reversed, COUNT(*) AS n
     FROM cgh JOIN po ON cgh.target_id = po.target_id
     LEFT JOIN rev ON cgh.target_id = rev.target_id
+    WHERE cgh.rn = 1 AND po.rn = 1
     GROUP BY cgh.login, cgh.project, cgh.pred, po.truth, reversed`;
 
   try {

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -10,6 +10,7 @@ import { pruneExpiredRecords } from "../../src/db/retention";
 import { processJob } from "../../src/queue/processors";
 import { getGateBlockOutcome, markGateOutcomeOverridden, recordGateBlockOutcome } from "../../src/db/repositories";
 import { backfillContributorGateHistory } from "../../src/review/contributor-gate-history-backfill";
+import { computeContributorGateEval } from "../../src/review/contributor-gate-eval";
 
 const URL = process.env.PG_TEST_URL;
 const suite = URL ? describe : describe.skip;
@@ -61,6 +62,28 @@ suite("Postgres backend (#977) — real Postgres", () => {
 
     const row = await db.prepare(`SELECT login, project, target_id FROM contributor_gate_history WHERE target_id = ?`).bind("owner/instr-repo#42").first<{ login: string; project: string; target_id: string }>();
     expect(row).toEqual({ login: "octocat", project: "owner/instr-repo", target_id: "owner/instr-repo#42" });
+  });
+
+  it("REGRESSION: computeContributorGateEval's ROW_NUMBER()-based 'latest row per key' query runs against real Postgres and picks the CORRECT latest decision (SQLite's bare-column-with-MAX() trick this replaced is not just non-portable -- it can pick an arbitrary row's project/decision within a tied group, not necessarily the max-created_at row's own)", async () => {
+    const db = createPgAdapter(pool);
+    const env = { DB: db } as unknown as Env;
+
+    // A contributor's PR gets re-reviewed after a force-push: the EARLIER headSha was predicted "close",
+    // the LATER (higher created_at) headSha was predicted "merge". Only the latest should count.
+    await db.prepare(`INSERT INTO contributor_gate_history (id, login, source, project, target_id, decision, head_sha, created_at) VALUES (?, 'pg-latest-row', 'gittensory-native', 'owner/latest-row', 'owner/latest-row#7', 'close', 'sha-old', ?)`)
+      .bind("cgh-latest-1", "2026-01-01T00:00:00.000Z")
+      .run();
+    await db.prepare(`INSERT INTO contributor_gate_history (id, login, source, project, target_id, decision, head_sha, created_at) VALUES (?, 'pg-latest-row', 'gittensory-native', 'owner/latest-row', 'owner/latest-row#7', 'merge', 'sha-new', ?)`)
+      .bind("cgh-latest-2", "2026-01-02T00:00:00.000Z")
+      .run();
+    await db.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, 'owner/latest-row', 'owner/latest-row#7', 'pr_outcome', 'merged', 'github', ?)`)
+      .bind("po-latest-1", "2026-01-03T00:00:00.000Z")
+      .run();
+
+    const report = await computeContributorGateEval(env, { days: 730, nowMs: Date.parse("2026-01-10T00:00:00.000Z"), login: "pg-latest-row" });
+    expect(report.rows).toEqual([
+      expect.objectContaining({ login: "pg-latest-row", project: "owner/latest-row", wouldMerge: 1, mergeConfirmed: 1, wouldClose: 0 }),
+    ]);
   });
 
   it("batch is transactional (rolls back on error)", async () => {


### PR DESCRIPTION
## Summary

A third, deeper self-host-Postgres-only bug found while verifying the contributor trust score / backfill (#7711, #7726) end-to-end on the live self-hosted database.

`queryContributorGateCells` (the shared SQL both `computeContributorGateEval` and the new `computeBlendedContributorGateEval` read from) used SQLite's "bare column with MAX()" trick to find each key's latest row: select a column that's absent from `GROUP BY`, letting SQLite pick it non-deterministically from within the group. SQLite tolerates this; Postgres rejects it outright:

```
ERROR:  column "review_audit.decision" must appear in the GROUP BY clause or be used in an aggregate function
```

This means the query -- and everything built on it -- has **never returned a single row** against the self-hosted Postgres deployment. Confirmed live: `GET /v1/internal/fairness/contributors` returned `contributorsEvaluated: 0` even with 8,000+ real rows already in `contributor_gate_history` (after backfilling via #7726's fix).

## Fix

Rewritten with `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY created_at DESC)` + a `WHERE rn = 1` filter -- the same portable pattern `federated-bundle.ts`'s `LOCAL_CALIBRATION_QUERY` and `orb-collector.ts`'s `FLEET_QUERY` already use for this exact problem (both have comments explicitly calling out why they avoid the SQLite-only trick). This also fixes a latent correctness gap on SQLite itself: the old trick could pick a *different* row's `project`/`decision` than the row that actually had the max `created_at` within a tie; `ROW_NUMBER()` always resolves deterministically to one specific row.

## Scope note

The sibling `computeGateEval` (`parity.ts`) has the **identical** pre-existing pattern (two occurrences) and is very likely broken on Postgres the same way -- confirmed the same query shape throws the identical error directly against Postgres. Left untouched here since it's a different, higher-blast-radius feature (feeds the operator dashboard's "Fleet merge precision"/"Fleet gaming-pattern flags" tiles and likely the public stats "Gate Accuracy" figure) outside this fix's scope. Flagging as a separate follow-up rather than silently expanding this PR.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] Unit + integration suites green (123 tests), 100% line/branch coverage on `contributor-gate-eval.ts`
- [x] Verified against a **real Postgres 16 container**: a contributor with two `contributor_gate_history` rows for the same PR (an earlier headSha predicted "close", a later one predicted "merge") now correctly resolves to the latest ("merge") decision -- both the Postgres-compatibility fix and the correctness fix confirmed together
- [x] `npm audit --audit-level=moderate` clean