### PR TITLE
fix(engine): normalize computeMetadataDupRisk's self-skip repo comparison

### DIFF
--- a/packages/loopover-engine/src/opportunity-metadata.ts
+++ b/packages/loopover-engine/src/opportunity-metadata.ts
@@ -181,7 +181,7 @@ export function computeMetadataDupRisk(
   let overlaps = 0;
   for (const peer of peers) {
     /* v8 ignore next -- Self-peer rows are skipped when scanning the shared batch list. */
-    if (peer.issueNumber === issue.issueNumber && peer.repoFullName === issue.repoFullName) continue;
+    if (peer.issueNumber === issue.issueNumber && peer.repoFullName.trim().toLowerCase() === issue.repoFullName.trim().toLowerCase()) continue;
     /* v8 ignore next -- Cross-repo peers are ignored when scanning for overlap inside a batch. */
     if (peer.repoFullName.trim().toLowerCase() !== issue.repoFullName.trim().toLowerCase()) continue;
     /* v8 ignore next -- Overlap hits are counted only for same-repo peers with shared title segments. */

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -351,6 +351,17 @@ describe("opportunity metadata signals", () => {
     ).toBe(0);
   });
 
+  it("skips the source issue even when its echoed-back peer row has a differently-cased repoFullName (#7731)", () => {
+    // The peer list contains the source issue itself, but the API echoed its repoFullName back with different
+    // casing/whitespace. The self-skip must normalize (like the same-repo guard two lines below it) so the source
+    // is excluded rather than counted as a duplicate of itself -- otherwise its identical title inflates dupRisk.
+    const echoedSelf = { ...base, repoFullName: "  ACME/Widgets  ", title: base.title };
+    expect(computeMetadataDupRisk(base, [echoedSelf])).toBe(0);
+    // Sanity: a genuine same-repo peer with an overlapping title (also differently cased) still counts.
+    const realPeer = { ...base, issueNumber: 11, repoFullName: "ACME/Widgets", title: base.title };
+    expect(computeMetadataDupRisk(base, [realPeer])).toBeGreaterThan(0);
+  });
+
   it("potential covers neutral-only and positive-only label branches", () => {
     expect(computeMetadataPotential({ labels: [] })).toBeCloseTo(0.45, 5);
     expect(computeMetadataPotential({ labels: ["enhancement"] })).toBeCloseTo(0.8, 5);


### PR DESCRIPTION
## What

`computeMetadataDupRisk` (`packages/loopover-engine/src/opportunity-metadata.ts`) excluded the source issue's own echoed-back peer row with an **exact, case-sensitive** comparison:

```ts
if (peer.issueNumber === issue.issueNumber && peer.repoFullName === issue.repoFullName) continue;
```

…while the same-repo guard **two lines below it, in the same loop**, already normalizes casing/whitespace:

```ts
if (peer.repoFullName.trim().toLowerCase() !== issue.repoFullName.trim().toLowerCase()) continue;
```

Repo casing isn't guaranteed consistent across API responses (the documented reason sibling modules `submission-freshness-check.ts` and `claim-conflict-resolver.ts` lowercase repo names). So when the peer list echoed the source issue back with a differently-cased `repoFullName`, the self-skip missed it, and the source's identical title counted as a duplicate of itself — inflating its own dup risk.

## Fix

Normalize the self-skip's `repoFullName` comparison the same `.trim().toLowerCase()` way as the same-repo guard. One-line change; no other dup-risk logic touched. (Kept on a single line so the existing `/* v8 ignore next */` above it still applies exactly as before.)

## Test

`test/unit/opportunity-metadata-signals.test.ts` gains a case (alongside the existing "skips the source issue when scanning peers" test) where the peer list contains the source issue with a differently-cased/whitespace-padded `repoFullName` — asserting `dupRisk` stays `0` (not inflated), plus a sanity assertion that a genuine differently-cased same-repo peer with an overlapping title still counts. **Proven** to fail against the pre-fix case-sensitive comparison.

## Validation

- `npx vitest run test/unit/opportunity-metadata-signals.test.ts` — 26/26; broader consumer sweep green (31/31).
- `npm run typecheck` — exit 0. `engine-parity:drift-check` passes. `git diff --check` clean.

Closes #7731
