### PR TITLE
fix(engine): normalize repoFullName casing in computeMetadataDupRisk self-skip

### DIFF
--- a/packages/loopover-engine/src/opportunity-metadata.ts
+++ b/packages/loopover-engine/src/opportunity-metadata.ts
@@ -180,8 +180,11 @@ export function computeMetadataDupRisk(
   if (!normalized) return 1;
   let overlaps = 0;
   for (const peer of peers) {
+    // repoFullName casing isn't guaranteed consistent across API responses, so normalize it the same way the
+    // same-repo guard just below does (#7731) — otherwise a self row echoed back in different casing escapes this
+    // skip, passes the (normalized) same-repo guard, and inflates the issue's own dup risk by overlapping itself.
     /* v8 ignore next -- Self-peer rows are skipped when scanning the shared batch list. */
-    if (peer.issueNumber === issue.issueNumber && peer.repoFullName === issue.repoFullName) continue;
+    if (peer.issueNumber === issue.issueNumber && peer.repoFullName.trim().toLowerCase() === issue.repoFullName.trim().toLowerCase()) continue;
     /* v8 ignore next -- Cross-repo peers are ignored when scanning for overlap inside a batch. */
     if (peer.repoFullName.trim().toLowerCase() !== issue.repoFullName.trim().toLowerCase()) continue;
     /* v8 ignore next -- Overlap hits are counted only for same-repo peers with shared title segments. */

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -51,6 +51,18 @@ describe("opportunity metadata signals", () => {
     expect(computeMetadataDupRisk({ ...base, repoFullName: "acme/other" }, peers)).toBe(0);
   });
 
+  it("excludes the self row from dup risk even when its repoFullName casing differs (#7731)", () => {
+    // A self row echoed back with different repoFullName casing (same issueNumber, same title) must still be
+    // recognized as self and skipped — not counted as a same-repo title-overlapping duplicate that inflates the
+    // issue's own dup risk. Before #7731 the self-skip was case-sensitive, so this row overlapped itself.
+    const selfEchoedUppercase = { ...base, repoFullName: base.repoFullName.toUpperCase() };
+    expect(computeMetadataDupRisk(base, [selfEchoedUppercase])).toBe(0);
+    // A genuinely different same-repo issue with an overlapping title is still counted (guard is self-skip, not
+    // a blanket case-fold that would swallow real duplicates).
+    const realDuplicate = { ...base, issueNumber: 11, repoFullName: base.repoFullName.toUpperCase() };
+    expect(computeMetadataDupRisk(base, [realDuplicate])).toBeGreaterThan(0);
+  });
+
   it("buildMetadataRankInput applies repo-specific goal specs case-insensitively", () => {
     const input = buildMetadataRankInput(
       { ...base, labels: ["feature"] },


### PR DESCRIPTION
## Summary

`computeMetadataDupRisk` (`packages/loopover-engine/src/opportunity-metadata.ts`) skipped the self-peer row with an exact, case-sensitive `peer.repoFullName === issue.repoFullName`, while the same-repo guard two lines below normalizes casing (`.trim().toLowerCase()`). So a self row echoed back by the API in different repo casing escaped the self-skip, still passed the (normalized) same-repo guard, and was counted as a same-repo title overlap — inflating the issue's own dup risk by overlapping itself.

Fix: normalize the self-skip comparison the same way the sibling same-repo guard already does, so the self row is recognized and skipped regardless of casing. Matches the casing-normalization convention already used here and in sibling modules (submission-freshness-check.ts, claim-conflict-resolver.ts).

## Tests

Adds a regression case to `test/unit/opportunity-metadata-signals.test.ts`: a self row echoed back in different repoFullName casing yields dup risk 0 (excluded), while a genuinely different same-repo issue (different issueNumber) with an overlapping title is still counted (> 0) — confirming the fix is a self-skip, not a blanket case-fold that would swallow real duplicates.

## Validation

- [x] `test/unit/opportunity-metadata-signals.test.ts` + the ranker/metadata consumers (opportunity-ranker, miner-opportunity-ranker, metadata-best-pick) pass; root typecheck clean; rebased on latest `main`. Change is one normalized comparison (behind its existing v8-ignore) + a regression test.

Closes #7731