### PR TITLE
fix(engine): normalize repoFullName casing in computeMetadataDupRisk's self-skip

### DIFF
--- a/packages/loopover-engine/src/opportunity-metadata.ts
+++ b/packages/loopover-engine/src/opportunity-metadata.ts
@@ -181,7 +181,7 @@ export function computeMetadataDupRisk(
   let overlaps = 0;
   for (const peer of peers) {
     /* v8 ignore next -- Self-peer rows are skipped when scanning the shared batch list. */
-    if (peer.issueNumber === issue.issueNumber && peer.repoFullName === issue.repoFullName) continue;
+    if (peer.issueNumber === issue.issueNumber && peer.repoFullName.trim().toLowerCase() === issue.repoFullName.trim().toLowerCase()) continue;
     /* v8 ignore next -- Cross-repo peers are ignored when scanning for overlap inside a batch. */
     if (peer.repoFullName.trim().toLowerCase() !== issue.repoFullName.trim().toLowerCase()) continue;
     /* v8 ignore next -- Overlap hits are counted only for same-repo peers with shared title segments. */

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -51,6 +51,14 @@ describe("opportunity metadata signals", () => {
     expect(computeMetadataDupRisk({ ...base, repoFullName: "acme/other" }, peers)).toBe(0);
   });
 
+  it("excludes the source issue from its own dup-risk when the echoed peer's repoFullName is cased differently (#7731)", () => {
+    // The shared batch list can echo the source issue back to itself with a differently-cased repoFullName;
+    // the self-skip must still exclude it (matching the same-repo check's normalization) rather than
+    // counting the issue as a duplicate of itself and inflating dupRisk.
+    const selfEcho = { ...base, repoFullName: "ACME/Widgets" };
+    expect(computeMetadataDupRisk(base, [selfEcho])).toBe(0);
+  });
+
   it("buildMetadataRankInput applies repo-specific goal specs case-insensitively", () => {
     const input = buildMetadataRankInput(
       { ...base, labels: ["feature"] },


### PR DESCRIPTION
## Summary

`computeMetadataDupRisk` (`packages/loopover-engine/src/opportunity-metadata.ts`) scans a peer-issue list for duplicate risk. Its self-row exclusion at line 184 compared `repoFullName` with an exact, **case-sensitive** `===`, while the same-repo guard two lines below already normalizes with `.trim().toLowerCase()`. So when the shared batch echoes the source issue back to itself with a differently-cased `repoFullName`, the self-skip missed it — and the issue was counted as a duplicate **of itself**, inflating `dupRisk`.

## Fix

Normalize the self-skip's `repoFullName` comparison the same way as the same-repo guard (`.trim().toLowerCase()`) — a one-line change mirroring the existing line 186 pattern. No other dup-risk logic changes.

## Test

Adds a regression case to `test/unit/opportunity-metadata-signals.test.ts` (alongside the existing dup-risk test): a peer list containing the source issue echoed back with an upper-cased `repoFullName` must leave `dupRisk` at `0` (excluded), not inflated. Verified it fails on the pre-fix code and passes with the fix; the full `opportunity-metadata-signals` suite (26 tests) is green.

Closes #7731