### PR TITLE
fix(engine): fold idea hints/constraints into the first draft's own explicit criteria

### DIFF
--- a/packages/loopover-engine/src/idea-intake.ts
+++ b/packages/loopover-engine/src/idea-intake.ts
@@ -187,8 +187,11 @@ function normalizeIssue(idea: IdeaSubmission, draft: ConstituentIssueDraft, inde
   // Only the two renter-eligible type labels survive; a stray `gittensor:priority` (or anything else) in a
   // draft is dropped so the bridge can never mint a reward label.
   const labels = (draft.labels ?? [inferred]).filter((l) => ALLOWED_ISSUE_TYPE_LABELS.has(l));
+  // A draft's own explicit criteria are honored as-is, but the renter's acceptanceHints/constraints must still be
+  // folded into the FIRST issue (#7730) rather than silently dropped just because the decomposition happened to
+  // supply its own criteria -- the same first-issue fold defaultAcceptanceCriteria applies when there are none.
   const criteria = draft.acceptanceCriteria && draft.acceptanceCriteria.length > 0
-    ? draft.acceptanceCriteria
+    ? [...draft.acceptanceCriteria, ...foldIdeaHintsAndConstraints(idea, draft, index)]
     : defaultAcceptanceCriteria(idea, draft, index);
   return {
     key: draft.key,
@@ -207,22 +210,32 @@ function normalizeIssue(idea: IdeaSubmission, draft: ConstituentIssueDraft, inde
 }
 
 // Fold the renter's own success signals into criteria: `acceptanceHints` become behavior criteria, hard
-// `constraints` become constraint criteria, and every issue is guaranteed at least one behavior criterion.
-function defaultAcceptanceCriteria(idea: IdeaSubmission, draft: ConstituentIssueDraft, index: number): AcceptanceCriterion[] {
-  const criteria: AcceptanceCriterion[] = [
-    { id: `${draft.key}-ac1`, statement: `The outcome described by "${draft.title}" is observable when done`, kind: "behavior" },
-  ];
-  // Hints/constraints only fold into the FIRST issue by default (so a multi-issue graph doesn't duplicate
-  // them across every issue); a richer decomposition can override by supplying explicit criteria per draft.
-  if (index === 0) {
-    for (const [i, hint] of (idea.acceptanceHints ?? []).entries()) {
-      if (hint.trim().length > 0) criteria.push({ id: `${draft.key}-hint${i + 1}`, statement: hint, kind: "behavior" });
-    }
-    for (const [i, c] of (idea.constraints ?? []).entries()) {
-      if (c.trim().length > 0) criteria.push({ id: `${draft.key}-con${i + 1}`, statement: c, kind: "constraint" });
-    }
+// `constraints` become constraint criteria. Only the FIRST issue (index 0) gets them (so a multi-issue graph
+// doesn't duplicate them across every issue). Factored out of defaultAcceptanceCriteria so it can also be appended
+// to a draft's OWN explicit criteria (#7730) rather than only running on the no-criteria path.
+function foldIdeaHintsAndConstraints(
+  idea: IdeaSubmission,
+  draft: ConstituentIssueDraft,
+  index: number,
+): AcceptanceCriterion[] {
+  if (index !== 0) return [];
+  const folded: AcceptanceCriterion[] = [];
+  for (const [i, hint] of (idea.acceptanceHints ?? []).entries()) {
+    if (hint.trim().length > 0) folded.push({ id: `${draft.key}-hint${i + 1}`, statement: hint, kind: "behavior" });
   }
-  return criteria;
+  for (const [i, c] of (idea.constraints ?? []).entries()) {
+    if (c.trim().length > 0) folded.push({ id: `${draft.key}-con${i + 1}`, statement: c, kind: "constraint" });
+  }
+  return folded;
+}
+
+// Every issue is guaranteed at least one behavior criterion; the first issue additionally folds in the renter's
+// own hints/constraints (see foldIdeaHintsAndConstraints).
+function defaultAcceptanceCriteria(idea: IdeaSubmission, draft: ConstituentIssueDraft, index: number): AcceptanceCriterion[] {
+  return [
+    { id: `${draft.key}-ac1`, statement: `The outcome described by "${draft.title}" is observable when done`, kind: "behavior" },
+    ...foldIdeaHintsAndConstraints(idea, draft, index),
+  ];
 }
 
 /** Assemble a scored `TaskGraph` from a validated idea and its decomposition (spec §2). Pass `drafts` from

--- a/test/unit/idea-intake-bridge.test.ts
+++ b/test/unit/idea-intake-bridge.test.ts
@@ -193,13 +193,22 @@ describe("buildTaskGraph — spec §4 Example B (multi-step idea → dependency 
 describe("buildTaskGraph — normalization details", () => {
   const idea = validIdea();
 
-  it("uses an explicit draft acceptanceCriteria when provided, and drops a non-eligible label", () => {
-    const g = buildTaskGraph(idea, [{
+  it("keeps an explicit draft acceptanceCriteria AND folds in the first issue's hints/constraints (#7730), and drops a non-eligible label", () => {
+    // The renter's hints/constraints must still be represented on issue-0 rather than silently dropped just
+    // because the first draft also supplied its own explicit criteria.
+    const ideaWithSignals = validIdea({
+      acceptanceHints: ["existing callers keep working"],
+      constraints: ["no new dependencies"],
+    });
+    const g = buildTaskGraph(ideaWithSignals, [{
       key: "issue-1", title: "Add a widget", body: "new capability",
       labels: ["gittensor:feature", "gittensor:priority"],
       acceptanceCriteria: [{ id: "x", statement: "explicit", kind: "artifact" }],
     }]);
-    expect(g.issues[0]?.acceptanceCriteria).toEqual([{ id: "x", statement: "explicit", kind: "artifact" }]);
+    const criteria = g.issues[0]?.acceptanceCriteria ?? [];
+    expect(criteria[0]).toEqual({ id: "x", statement: "explicit", kind: "artifact" }); // explicit criterion kept, first
+    expect(criteria.some((c) => c.statement === "existing callers keep working" && c.kind === "behavior")).toBe(true);
+    expect(criteria.some((c) => c.statement === "no new dependencies" && c.kind === "constraint")).toBe(true);
     expect(g.issues[0]?.labels).toEqual(["gittensor:feature"]); // gittensor:priority stripped
   });
 
@@ -217,6 +226,28 @@ describe("buildTaskGraph — normalization details", () => {
   it("skips blank hint/constraint entries", () => {
     const g = buildTaskGraph(validIdea({ acceptanceHints: ["  "], constraints: [""] }));
     expect(g.issues[0]?.acceptanceCriteria).toHaveLength(1); // only the default behavior criterion
+  });
+
+  it("folds hints/constraints into the FIRST draft's explicit criteria but not a later draft's (#7730)", () => {
+    const withSignals = validIdea({ acceptanceHints: ["callers keep working"], constraints: ["no new deps"] });
+    const g = buildTaskGraph(withSignals, [
+      { key: "issue-1", title: "First", body: "b", acceptanceCriteria: [{ id: "a", statement: "first-explicit", kind: "artifact" }] },
+      {
+        key: "issue-2",
+        title: "Second",
+        body: "b",
+        dependsOn: ["issue-1"],
+        acceptanceCriteria: [{ id: "b", statement: "second-explicit", kind: "artifact" }],
+      },
+    ]);
+    const first = g.issues[0]?.acceptanceCriteria ?? [];
+    const second = g.issues[1]?.acceptanceCriteria ?? [];
+    // Issue 0: explicit criterion first, then the renter's hint + constraint folded in.
+    expect(first[0]).toEqual({ id: "a", statement: "first-explicit", kind: "artifact" });
+    expect(first.some((c) => c.statement === "callers keep working" && c.kind === "behavior")).toBe(true);
+    expect(first.some((c) => c.statement === "no new deps" && c.kind === "constraint")).toBe(true);
+    // Issue 1 (index > 0): only its own explicit criterion — hints/constraints are NOT duplicated onto it.
+    expect(second).toEqual([{ id: "b", statement: "second-explicit", kind: "artifact" }]);
   });
 });
 


### PR DESCRIPTION
## What

`idea-intake.ts`'s `defaultAcceptanceCriteria` folds a renter's `acceptanceHints` (behavior criteria) and hard `constraints` (constraint criteria) into the **first** constituent issue — but it only ran when a draft had **no** `acceptanceCriteria`. When the first (`index === 0`) draft supplied its own non-empty `acceptanceCriteria`, `buildTaskGraph` used those verbatim and the idea's hints/constraints were **silently dropped** from the task graph, contradicting the function's own header comment.

## Fix

Factor the first-issue hint/constraint fold into a shared `foldIdeaHintsAndConstraints(idea, draft, index)` helper (index-0-only, same criterion shape as before — no new format), and **append it to a draft's explicit criteria** as well:

```ts
const criteria = draft.acceptanceCriteria && draft.acceptanceCriteria.length > 0
  ? [...draft.acceptanceCriteria, ...foldIdeaHintsAndConstraints(idea, draft, index)]
  : defaultAcceptanceCriteria(idea, draft, index);
```

So the renter's stated signals are represented rather than discarded when a decomposition happens to also produce its own criteria. Scope is exactly `index === 0`: later drafts are unchanged (they were never in scope for hint folding, per the existing tests), and `defaultAcceptanceCriteria` now calls the same shared helper so both paths behave identically.

## Tests

`test/unit/idea-intake-bridge.test.ts`:
- The existing "explicit draft acceptanceCriteria" test is extended to assert the first draft's explicit criterion is kept **and** the renter's hint + constraint are folded in.
- A new test asserts the fold lands on the **first** draft's explicit criteria but **not** a later (`index > 0`) draft's — preserving the no-duplication scope.

Both are **proven** to fail against the pre-fix drop. Ideas with no hints/constraints (the common `validIdea()` fixture) are unaffected — the append is empty, so every existing test still passes unchanged.

## Validation

- Full idea-intake sweep — 50/50; the module's own suite 31/31.
- `npm run typecheck` — exit 0. `engine-parity:drift-check` passes (the `src/idea-intake.ts` re-export shim stays in sync). `git diff --check` clean.

Closes #7730
