### PR TITLE
fix(engine): treat a dangling dependsOn id as unsatisfied in plan-export ordering

### DIFF
--- a/packages/loopover-engine/src/plan-export.ts
+++ b/packages/loopover-engine/src/plan-export.ts
@@ -22,10 +22,11 @@ export type PlanStep = {
 export type PlanDag = { steps: PlanStep[] };
 
 // Stable topological order: emit steps whose in-plan dependencies are already emitted, ties broken by the plan's
-// original order. A dependency id not present in the plan is treated as satisfied. Any steps left in a cycle are
-// appended in original order so nothing is dropped and the function always terminates.
+// original order. A dependency id not present in the plan is treated as UNsatisfied (it can never be emitted), so a
+// step with a dangling dependsOn is deferred like a cyclic one and appended at the end -- matching nextReadySteps in
+// plan-step-readiness.ts, which treats an absent dependency id as "pending" (#7729). Any steps left in a cycle (or
+// waiting on a dangling id) are appended in original order so nothing is dropped and the function always terminates.
 function orderByDependency(steps: PlanStep[]): PlanStep[] {
-  const present = new Set(steps.map((step) => step.id));
   const emitted = new Set<string>();
   const ordered: PlanStep[] = [];
   const remaining = [...steps];
@@ -34,7 +35,7 @@ function orderByDependency(steps: PlanStep[]): PlanStep[] {
     progressed = false;
     for (let i = 0; i < remaining.length; ) {
       const step = remaining[i]!;
-      const ready = step.dependsOn.every((dep) => !present.has(dep) || emitted.has(dep));
+      const ready = step.dependsOn.every((dep) => emitted.has(dep));
       if (ready) {
         ordered.push(step);
         emitted.add(step.id);

--- a/test/unit/plan-export.test.ts
+++ b/test/unit/plan-export.test.ts
@@ -53,9 +53,18 @@ describe("renderPlanAsMarkdown", () => {
     expect(md).toBe("- [ ] A — pending\n- [ ] B — pending");
   });
 
-  it("treats an unknown dependency id as already satisfied", () => {
-    const md = renderPlanAsMarkdown({ steps: [step({ id: "a", title: "A", dependsOn: ["ghost"] })] });
-    expect(md).toBe("- [ ] A — pending");
+  it("treats an unknown dependency id as unsatisfied, deferring the step to the end (#7729)", () => {
+    // 'a' depends on a dangling id 'ghost'. Previously that counted as already satisfied (so 'a' was emitted
+    // first); now a dangling dependency can never be satisfied, so 'a' is deferred like a cyclic step and appended
+    // after 'b' (which has no unmet dependency). This matches nextReadySteps in plan-step-readiness.ts, which
+    // reports the same dangling id as still "pending".
+    const md = renderPlanAsMarkdown({
+      steps: [
+        step({ id: "a", title: "A", dependsOn: ["ghost"] }),
+        step({ id: "b", title: "B" }),
+      ],
+    });
+    expect(md).toBe("- [ ] B — pending\n- [ ] A — pending");
   });
 
   it("appends steps caught in a dependency cycle in original order instead of dropping or looping", () => {


### PR DESCRIPTION
## What

`orderByDependency` in `packages/loopover-engine/src/plan-export.ts` and `nextReadySteps` in `packages/loopover-engine/src/plan-step-readiness.ts` compute plan-dependency state from the same `PlanDag`, but disagreed on a **dangling `dependsOn` id** (one not present in `plan.steps`):

- `orderByDependency` treated it as **already satisfied** (`!present.has(dep) || emitted.has(dep)`).
- `nextReadySteps` treats it as **never satisfied** (absent id → `"pending"`, which `isDone()` rejects).

The app's own canonical `src/services/plan-dag.ts` already resolves this the `nextReadySteps` way, so `plan-export.ts` was the outlier.

## Fix

Align `orderByDependency` to that answer: a dangling `dependsOn` id can never be emitted, so the step is **deferred like a cyclic one** and appended in original order (nothing is dropped, the function still always terminates). For every non-dangling id the behaviour is unchanged — with the id present, `!present.has(dep)` was always false, so ordering already reduced to `emitted.has(dep)`.

## Scope

- Only `plan-export.ts` (the outlier) is changed; `plan-step-readiness.ts` is left as-is (it already has the correct semantics), and no plan-validation/referential-integrity logic is added here (that stays `validatePlanDag`'s job in the app layer) — exactly as the issue scopes it.
- The existing `plan-export` test that asserted the old "unknown dependency id → already satisfied" behaviour is updated to assert the corrected ordering.

Closes #7729