### PR TITLE
fix(review): make computeGateEval/computeGateParity's SQL portable to Postgres

### DIFF
--- a/src/review/parity.ts
+++ b/src/review/parity.ts
@@ -92,20 +92,23 @@ export const REVERSAL_DISCOUNT_WEIGHT = 0;
 export async function computeGateEval(env: Env, opts: { days: number; nowMs: number; source?: string; minerOnly?: boolean }): Promise<GateEvalReport> {
   const days = Number.isFinite(opts.days) && opts.days > 0 ? Math.min(opts.days, 730) : 90;
   const fromIso = new Date(opts.nowMs - days * 86_400_000).toISOString().slice(0, 10);
-  // SQLite "bare column with MAX()" picks the column from the max-created_at row → the LATEST decision /
-  // outcome per target (a reopened+reclosed PR keeps its final state).
+  // Latest row per target_id via ROW_NUMBER()+rn=1 -- NOT SQLite's "bare column with MAX()" trick (a column
+  // absent from GROUP BY, picked non-deterministically from within the group). SQLite tolerates that; Postgres
+  // rejects it outright ("column must appear in the GROUP BY clause"), so this query never returned a row on
+  // the self-host Postgres backend. Mirrors federated-bundle.ts's LOCAL_CALIBRATION_QUERY / orb-collector.ts's
+  // FLEET_QUERY, both written portable for exactly this reason (and contributor-gate-eval.ts's identical fix).
   const sourceFilter = opts.source ? "AND source = ?" : "";
   const minerFilter = opts.minerOnly ? "AND miner_authored = 1" : "";
   const sql = `
     WITH gd AS (
-      SELECT target_id, project, decision AS pred, MAX(created_at) AS t
+      SELECT target_id, project, decision AS pred, created_at,
+             ROW_NUMBER() OVER (PARTITION BY target_id ORDER BY created_at DESC) AS rn
       FROM review_audit WHERE event_type = 'gate_decision' AND decision IS NOT NULL AND created_at >= ? ${sourceFilter} ${minerFilter}
-      GROUP BY target_id
     ),
     po AS (
-      SELECT target_id, decision AS truth, MAX(created_at) AS t
+      SELECT target_id, decision AS truth, created_at,
+             ROW_NUMBER() OVER (PARTITION BY target_id ORDER BY created_at DESC) AS rn
       FROM review_audit WHERE event_type = 'pr_outcome' AND decision IS NOT NULL
-      GROUP BY target_id
     ),
     rev AS (
       SELECT DISTINCT target_id FROM review_audit WHERE event_type IN ('reversal_reverted', 'reversal_reopened')
@@ -114,6 +117,7 @@ export async function computeGateEval(env: Env, opts: { days: number; nowMs: num
            CASE WHEN rev.target_id IS NOT NULL THEN 1 ELSE 0 END AS reversed, COUNT(*) AS n
     FROM gd JOIN po ON gd.target_id = po.target_id
     LEFT JOIN rev ON gd.target_id = rev.target_id
+    WHERE gd.rn = 1 AND po.rn = 1
     GROUP BY gd.project, gd.pred, po.truth, reversed`;
 
   let cells: Array<{ project: string; pred: string; truth: string; reversed: number; n: number }> = [];
@@ -256,29 +260,32 @@ export async function computeGateParity(
   const fromIso = new Date(opts.nowMs - days * 86_400_000).toISOString().slice(0, 10);
 
   // Per-source latest decision per (project, target_id, head_sha). head_sha MUST be non-null so the
-  // self-join compares the same commit (a NULL head_sha can't anchor a per-commit comparison). The "bare
-  // column with MAX(created_at)" trick picks the latest row's decision/summary per group (SQLite/our PG
-  // parser both honour this for our single-writer-per-commit data).
+  // self-join compares the same commit (a NULL head_sha can't anchor a per-commit comparison). Latest row per
+  // key via ROW_NUMBER()+rn=1 -- NOT SQLite's "bare column with MAX(created_at)" trick, which Postgres
+  // rejects outright ("column must appear in the GROUP BY clause") -- confirmed live against a real Postgres,
+  // contrary to this comment's prior (unverified) claim that both engines honour it. See computeGateEval's
+  // identical fix above for the full rationale.
   const projectFilter = opts.project ? "AND project = ?" : "";
   const sql = `
     WITH auth AS (
-      SELECT project, target_id, head_sha, decision AS act, summary AS reason, MAX(created_at) AS t
+      SELECT project, target_id, head_sha, decision AS act, summary AS reason, created_at,
+             ROW_NUMBER() OVER (PARTITION BY project, target_id, head_sha ORDER BY created_at DESC) AS rn
       FROM review_audit
       WHERE event_type = 'gate_decision' AND decision IS NOT NULL AND head_sha IS NOT NULL
         AND source = ? AND created_at >= ? ${projectFilter}
-      GROUP BY project, target_id, head_sha
     ),
     shad AS (
-      SELECT project, target_id, head_sha, decision AS act, MAX(created_at) AS t
+      SELECT project, target_id, head_sha, decision AS act, created_at,
+             ROW_NUMBER() OVER (PARTITION BY project, target_id, head_sha ORDER BY created_at DESC) AS rn
       FROM review_audit
       WHERE event_type = 'gate_decision' AND decision IS NOT NULL AND head_sha IS NOT NULL
         AND source = ? AND created_at >= ? ${projectFilter}
-      GROUP BY project, target_id, head_sha
     )
     SELECT auth.project AS project, auth.act AS auth_act, shad.act AS shadow_act,
            COALESCE(auth.reason, '') AS reason, COUNT(*) AS n
     FROM auth JOIN shad
       ON auth.project = shad.project AND auth.target_id = shad.target_id AND auth.head_sha = shad.head_sha
+    WHERE auth.rn = 1 AND shad.rn = 1
     GROUP BY auth.project, auth.act, shad.act, reason`;
 
   type Cell = { project: string; auth_act: string; shadow_act: string; reason: string; n: number };

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -11,6 +11,7 @@ import { processJob } from "../../src/queue/processors";
 import { getGateBlockOutcome, markGateOutcomeOverridden, recordGateBlockOutcome } from "../../src/db/repositories";
 import { backfillContributorGateHistory } from "../../src/review/contributor-gate-history-backfill";
 import { computeContributorGateEval } from "../../src/review/contributor-gate-eval";
+import { computeGateEval, computeGateParity } from "../../src/review/parity";
 
 const URL = process.env.PG_TEST_URL;
 const suite = URL ? describe : describe.skip;
@@ -84,6 +85,41 @@ suite("Postgres backend (#977) — real Postgres", () => {
     expect(report.rows).toEqual([
       expect.objectContaining({ login: "pg-latest-row", project: "owner/latest-row", wouldMerge: 1, mergeConfirmed: 1, wouldClose: 0 }),
     ]);
+  });
+
+  it("REGRESSION: computeGateEval's identical ROW_NUMBER()-based query (parity.ts) runs against real Postgres and picks the latest gate_decision/pr_outcome per target", async () => {
+    const db = createPgAdapter(pool);
+    const env = { DB: db } as unknown as Env;
+
+    await db.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, 'owner/gate-eval-pg', 'owner/gate-eval-pg#1', 'gate_decision', 'close', 'gittensory-native', ?)`)
+      .bind("gd-eval-old", "2026-01-01T00:00:00.000Z")
+      .run();
+    await db.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, 'owner/gate-eval-pg', 'owner/gate-eval-pg#1', 'gate_decision', 'merge', 'gittensory-native', ?)`)
+      .bind("gd-eval-new", "2026-01-02T00:00:00.000Z")
+      .run();
+    await db.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, 'owner/gate-eval-pg', 'owner/gate-eval-pg#1', 'pr_outcome', 'merged', 'github', ?)`)
+      .bind("po-eval-1", "2026-01-03T00:00:00.000Z")
+      .run();
+
+    const report = await computeGateEval(env, { days: 730, nowMs: Date.parse("2026-01-10T00:00:00.000Z") });
+    expect(report.rows).toEqual([expect.objectContaining({ project: "owner/gate-eval-pg", wouldMerge: 1, mergeConfirmed: 1, wouldClose: 0 })]);
+  });
+
+  it("REGRESSION: computeGateParity's identical ROW_NUMBER()-based self-join (parity.ts) runs against real Postgres and picks the latest per-source decision per commit", async () => {
+    const db = createPgAdapter(pool);
+    const env = { DB: db } as unknown as Env;
+
+    const insertGd = (id: string, source: string, decision: string, createdAt: string) =>
+      db.prepare(`INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, created_at) VALUES (?, 'owner/gate-parity-pg', 'owner/gate-parity-pg#1', 'gate_decision', ?, ?, 'sha-1', ?)`)
+        .bind(id, decision, source, createdAt)
+        .run();
+    // authoritative source re-decided at a later created_at (same head_sha) -- only the latest should count.
+    await insertGd("gd-parity-auth-old", "reviewbot", "close", "2026-01-01T00:00:00.000Z");
+    await insertGd("gd-parity-auth-new", "reviewbot", "merge", "2026-01-02T00:00:00.000Z");
+    await insertGd("gd-parity-shadow", "loopover", "merge", "2026-01-01T12:00:00.000Z");
+
+    const report = await computeGateParity(env, { days: 730, nowMs: Date.parse("2026-01-10T00:00:00.000Z") });
+    expect(report.rows).toEqual([expect.objectContaining({ project: "owner/gate-parity-pg", pairedSamples: 1, bothMerge: 1 })]);
   });
 
   it("batch is transactional (rolls back on error)", async () => {


### PR DESCRIPTION
## Summary

The same SQLite-only "bare column with MAX()" GROUP BY bug just fixed in `computeContributorGateEval` (#7733), found in its sibling: `computeGateEval` and `computeGateParity` (`parity.ts`) both select a column absent from their `GROUP BY`, relying on SQLite's non-standard tolerance for it. Postgres rejects this outright:

```
ERROR:  column "review_audit.project" must appear in the GROUP BY clause or be used in an aggregate function
```

Confirmed directly against a real Postgres for both functions -- including `computeGateParity`'s `auth`/`shad` CTEs, which directly **contradicts that function's own prior comment** claiming "SQLite/our PG parser both honour this".

## Blast radius

`computeGateEval` is consumed by (grep-confirmed): `auto-apply.ts`, `outcomes-wire.ts` (self-tune breakers), `auto-tune.ts`, `selftune-wire.ts`, `queue/processors.ts`, `orb/analytics.ts`, `services/review-recap.ts`, and `services/operator-dashboard.ts` (the "Fleet merge precision"/"Fleet gaming-pattern flags" tiles). All of these have been silently starved of data on the self-hosted Postgres backend since this module was written -- each caller's fail-safe `try/catch` degrades to an empty report rather than surfacing an error, so nothing ever showed as broken.

## Fix

Rewritten with `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY created_at DESC)` + a `WHERE rn = 1` filter, mirroring `computeContributorGateEval`'s identical fix (#7733) and the already-portable pattern `federated-bundle.ts`/`orb-collector.ts` already use for this exact problem.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] `parity.test.ts` (39 tests, mock-based fold logic) + all consumer suites (`outcomes-wire.test.ts`, `review-recap.test.ts`, `stats.test.ts`, `parity-wire.test.ts`, `operator-dashboard.test.ts` -- 255 tests total) green
- [x] Verified against a **real Postgres 16 container**: both `computeGateEval` and `computeGateParity` now correctly resolve the latest `gate_decision`/`pr_outcome` (and the latest per-source decision per commit for the parity self-join), where before the query threw on every call
- [x] `npm audit --audit-level=moderate` clean