### PR TITLE
fix(miner): sweep claims with unparseable claimedAt (#7732)

### DIFF
--- a/packages/loopover-miner/lib/claim-ledger-expiry.ts
+++ b/packages/loopover-miner/lib/claim-ledger-expiry.ts
@@ -28,7 +28,11 @@ export function findExpiredClaims(claims: ClaimEntry[], nowMs: number, maxAgeMs:
   for (const claim of claims) {
     if (claim?.status !== "active") continue;
     const ageMs = claimAgeMs(claim, nowMs);
-    if (ageMs === null) continue;
+    // Fail-closed: an unparseable claimedAt is unusable — sweep it rather than retaining it forever.
+    if (ageMs === null) {
+      expired.push(claim);
+      continue;
+    }
     if (ageMs > maxAgeMs) expired.push(claim);
   }
   return expired;

--- a/test/unit/miner-claim-ledger-expiry.test.ts
+++ b/test/unit/miner-claim-ledger-expiry.test.ts
@@ -75,12 +75,13 @@ describe("loopover-miner claim ledger expiry (#2316)", () => {
     expect(findExpiredClaims([fresh, stale, released], nowMs, maxAgeMs)).toEqual([stale]);
   });
 
-  it("findExpiredClaims skips an active claim whose claimedAt is unparseable (NaN age path)", () => {
+  it("findExpiredClaims sweeps an active claim whose claimedAt is unparseable (NaN age path)", () => {
     const nowMs = Date.parse("2026-07-03T00:00:00.000Z");
     const maxAgeMs = 1 * 24 * 60 * 60 * 1000;
     const bogus = claim({ issueNumber: 7, claimedAt: "not-a-date" }); // Date.parse -> NaN -> claimAgeMs null
     const stale = claim({ issueNumber: 8, claimedAt: "2026-06-01T00:00:00.000Z" });
-    expect(findExpiredClaims([bogus, stale], nowMs, maxAgeMs)).toEqual([stale]);
+    const fresh = claim({ issueNumber: 9, claimedAt: "2026-07-02T12:00:00.000Z" });
+    expect(findExpiredClaims([bogus, stale, fresh], nowMs, maxAgeMs)).toEqual([bogus, stale]);
   });
 
   it("sweepExpiredClaims defaults maxAgeMs and skips rows whose store.expireClaim reports no transition (null)", () => {


### PR DESCRIPTION
## Summary

indExpiredClaims skipped active claims when claimAgeMs returned 
ull (unparseable claimedAt). A corrupted claim-ledger row was then permanently un-expirable — contradicting this module's fail-closed posture.

**Fix:** treat a 
ull age as expired and include it in the swept set. claimAgeMs signature and valid-timestamp behavior unchanged.

## Tests

Updated the existing NaN-age-path test to assert the malformed-claimedAt row is swept, with a fresh in-window claim as negative control. Suite: 	est/unit/miner-claim-ledger-expiry.test.ts.

## Notes

- Issue body references `packages/loopover-engine/src/claim-ledger-expiry.ts` but the implementation lives in `packages/loopover-miner/lib/claim-ledger-expiry.ts` (same module prior PRs targeted).
- **TypeScript source only** — no committed .js/.d.ts per maintainer feedback on #7740.

Closes #7732