### PR TITLE
fix(engine): treat a dangling dependsOn id as unsatisfied in plan-export ordering

### DIFF
--- a/packages/loopover-engine/src/plan-export.ts
+++ b/packages/loopover-engine/src/plan-export.ts
@@ -22,10 +22,11 @@ export type PlanStep = {
 export type PlanDag = { steps: PlanStep[] };
 
 // Stable topological order: emit steps whose in-plan dependencies are already emitted, ties broken by the plan's
-// original order. A dependency id not present in the plan is treated as satisfied. Any steps left in a cycle are
-// appended in original order so nothing is dropped and the function always terminates.
+// original order. A dependency id not present in the plan is treated as UNsatisfied — matching plan-step-readiness's
+// nextReadySteps (#7729), so the two functions never disagree on a dangling id (ready-now here vs. blocked there).
+// Any steps left unemitted — a real cycle, or a dangling dependency — are appended in original order so nothing is
+// dropped and the function always terminates.
 function orderByDependency(steps: PlanStep[]): PlanStep[] {
-  const present = new Set(steps.map((step) => step.id));
   const emitted = new Set<string>();
   const ordered: PlanStep[] = [];
   const remaining = [...steps];
@@ -34,7 +35,7 @@ function orderByDependency(steps: PlanStep[]): PlanStep[] {
     progressed = false;
     for (let i = 0; i < remaining.length; ) {
       const step = remaining[i]!;
-      const ready = step.dependsOn.every((dep) => !present.has(dep) || emitted.has(dep));
+      const ready = step.dependsOn.every((dep) => emitted.has(dep));
       if (ready) {
         ordered.push(step);
         emitted.add(step.id);

--- a/test/unit/plan-export.test.ts
+++ b/test/unit/plan-export.test.ts
@@ -5,6 +5,7 @@ import {
   type PlanDag,
   type PlanStep,
 } from "../../packages/loopover-engine/src/plan-export";
+import { nextReadySteps } from "../../packages/loopover-engine/src/plan-step-readiness";
 
 function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
   return {
@@ -53,9 +54,24 @@ describe("renderPlanAsMarkdown", () => {
     expect(md).toBe("- [ ] A — pending\n- [ ] B — pending");
   });
 
-  it("treats an unknown dependency id as already satisfied", () => {
-    const md = renderPlanAsMarkdown({ steps: [step({ id: "a", title: "A", dependsOn: ["ghost"] })] });
-    expect(md).toBe("- [ ] A — pending");
+  it("treats an unknown dependency id as unsatisfied, deferring that step after the ready ones (#7729)", () => {
+    // 'a' depends on a dangling id ('ghost'); 'b' has no deps. A dangling dependency is now treated as UNsatisfied
+    // (matching nextReadySteps), so 'b' emits first and 'a' is appended after via the unsatisfiable fallback —
+    // never emitted up front as if the dangling dep were already satisfied.
+    const md = renderPlanAsMarkdown({
+      steps: [step({ id: "a", title: "A", dependsOn: ["ghost"] }), step({ id: "b", title: "B" })],
+    });
+    expect(md.split("\n")).toEqual(["- [ ] B — pending", "- [ ] A — pending"]);
+  });
+
+  it("orderByDependency (via render) and nextReadySteps agree a dangling dependency is unsatisfied (#7729)", () => {
+    const plan: PlanDag = {
+      steps: [step({ id: "a", title: "A", dependsOn: ["ghost"] }), step({ id: "b", title: "B" })],
+    };
+    // nextReadySteps: 'a' is blocked by the dangling 'ghost', so only 'b' is ready now.
+    expect(nextReadySteps(plan).map((entry) => entry.id)).toEqual(["b"]);
+    // The render order agrees: 'b' (ready) before 'a' (deferred) — no step is shown ready-now here yet blocked there.
+    expect(renderPlanAsMarkdown(plan).split("\n")).toEqual(["- [ ] B — pending", "- [ ] A — pending"]);
   });
 
   it("appends steps caught in a dependency cycle in original order instead of dropping or looping", () => {


### PR DESCRIPTION
## Summary

`orderByDependency` (`packages/loopover-engine/src/plan-export.ts`) treated a `dependsOn` id absent from `plan.steps` as **already satisfied** (`!present.has(dep) || emitted.has(dep)`), while `nextReadySteps` (`plan-step-readiness.ts`) treats the identical case as **never satisfied**. So for one plan a step with a dangling dependency could be rendered "ready now" (the plan-export markdown behind `loopover_plan_status`) yet reported permanently blocked (`resolvePlanOverallStatus`/`hasPlanReadySteps`) — the two functions disagreed.

Fix: align `orderByDependency` to `nextReadySteps` — a dangling `dependsOn` id is **unsatisfied**, so the step is not emitted up front and instead falls through to the existing unsatisfiable-step fallback (appended in original order, nothing dropped, still terminates). `plan-step-readiness.ts` — which already mirrors the app's canonical `validatePlanDag` answer in `src/services/plan-dag.ts` — is unchanged, and no plan-validation logic is added here (that stays `validatePlanDag`'s job).

## Tests

Updates the existing `test/unit/plan-export.test.ts` case (which asserted "treats an unknown dependency id as already satisfied") to a multi-step scenario proving the corrected ordering — a dangling-dep step is now deferred after the ready ones — since a single-step render is identical either way. Adds a consistency test asserting `orderByDependency` (via render) and `nextReadySteps` now agree the dangling-dep step is unsatisfied. 100% branch coverage on the changed file.

## Validation

- [x] `test/unit/plan-export.test.ts` + `plan-step-readiness.test.ts` pass (22); root typecheck clean; rebased on latest `main`. Change removes the now-unused `present` set and the `!present.has(dep)` short-circuit.

Closes #7729