### PR TITLE
fix(scripts): surface git-diff failure in selfhost pre-deploy summary

### DIFF
--- a/scripts/selfhost-pre-deploy-summary.sh
+++ b/scripts/selfhost-pre-deploy-summary.sh
@@ -116,11 +116,19 @@ is_sensitive() {
 }
 
 sensitive_files=()
+# #7775: capture the diff via a CHECKED command substitution rather than `done < <(git diff ...)`. A
+# process-substitution failure (bad ref, shallow clone, detached history) is invisible to `set -e`, so the
+# loop would just see no lines and the script would report "no historically-sensitive paths touched" -- a
+# false all-clear on a deploy-safety advisory. Surface it as a real error instead.
+if ! diff_output="$(git diff --name-only "$range")"; then
+  echo "error: 'git diff --name-only $range' failed; cannot assess historically-sensitive paths" >&2
+  exit 1
+fi
 while IFS= read -r file; do
   if [ -n "$file" ] && is_sensitive "$file"; then
     sensitive_files+=("$file")
   fi
-done < <(git diff --name-only "$range")
+done <<< "$diff_output"
 
 echo ""
 if [ "${#sensitive_files[@]}" -eq 0 ]; then

--- a/test/unit/selfhost-pre-deploy-summary-script.test.ts
+++ b/test/unit/selfhost-pre-deploy-summary-script.test.ts
@@ -224,4 +224,29 @@ describe("selfhost-pre-deploy-summary.sh", () => {
     expect(result.stderr).toContain("is not an ancestor");
     expect(result.stdout).toContain("upstream commit");
   });
+
+  it("surfaces an error instead of a false all-clear when git diff --name-only fails (#7775)", () => {
+    const { base, seedDir, checkoutDir } = createSandbox();
+    // Give origin an incoming commit so the script proceeds past "up to date" to the sensitive-path diff.
+    commitFile(seedDir, "src/incoming.ts", "export const incoming = 1;\n", "incoming commit");
+    git(["push", "-q", "origin", "main"], seedDir);
+
+    // Shadow `git` with a fake that fails ONLY `git diff --name-only ...` (the sensitive-path scan),
+    // delegating every other command -- including fetch and the `git diff --stat` summary -- to real git.
+    const realGit = spawnSync("bash", ["-c", "command -v git"], { encoding: "utf8" }).stdout.trim();
+    const fakeBin = join(base, "fakebin");
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(
+      join(fakeBin, "git"),
+      `#!/usr/bin/env bash\nif [ "$1" = "diff" ] && [ "$2" = "--name-only" ]; then\n  echo "forced diff failure" >&2\n  exit 1\nfi\nexec ${realGit} "$@"\n`,
+      { mode: 0o755 },
+    );
+
+    const result = run(checkoutDir, { PATH: `${fakeBin}:${process.env.PATH ?? ""}` });
+
+    // A failed diff must be reported as a failure, not silently presented as "no sensitive paths touched".
+    expect(result.status, result.stdout + result.stderr).not.toBe(0);
+    expect(result.stderr).toMatch(/git diff.*failed|cannot assess historically-sensitive/i);
+    expect(result.stdout).not.toContain("no historically-sensitive paths touched");
+  });
 });


### PR DESCRIPTION
Closes #7775

`scripts/selfhost-pre-deploy-summary.sh` scanned for historically-sensitive deploy paths by piping `git diff --name-only "$range"` into a loop via a **process substitution** (`done < <(git diff ...)`). A process substitution's exit status is invisible to `set -euo pipefail`, so if that `git diff` failed (bad ref, shallow clone, detached history), the loop simply saw zero lines and the script printed **"no historically-sensitive paths touched"** — a false all-clear on what is meant to be a deploy-safety advisory.

**Fix:** capture the diff through a *checked* command substitution and error out loudly if it fails, instead of silently proceeding:

```sh
if ! diff_output="$(git diff --name-only "$range")"; then
  echo "error: 'git diff --name-only $range' failed; cannot assess historically-sensitive paths" >&2
  exit 1
fi
while IFS= read -r file; do
  ...
done <<< "$diff_output"
```

The success path is unchanged (all existing behavior tests still pass).

**Test:** added a regression test to `test/unit/selfhost-pre-deploy-summary-script.test.ts` that shadows `git` with a fake failing **only** `git diff --name-only` (delegating fetch and `git diff --stat` to real git), then asserts the script exits non-zero with the "cannot assess historically-sensitive paths" error rather than the false all-clear. `scripts/**` is outside the Codecov `coverage.include`, so no patch-coverage gate applies.