### PR TITLE
fix(ui): drop superseded useApiResource responses when the path changes mid-flight

### DIFF
--- a/apps/loopover-ui/src/lib/api/use-api-resource.test.ts
+++ b/apps/loopover-ui/src/lib/api/use-api-resource.test.ts
@@ -86,3 +86,32 @@ describe("useApiResource errorKind/errorStatus (#793)", () => {
     expect(state.errorKind).toBeUndefined();
   });
 });
+
+describe("useApiResource stale-response guard (#7785)", () => {
+  it("drops a superseded response when the path changed before it resolved", async () => {
+    apiFetch.mockReset();
+    let resolveOld!: (value: unknown) => void;
+    let resolveNew!: (value: unknown) => void;
+    apiFetch
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveOld = resolve)))
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveNew = resolve)));
+
+    const { result, rerender } = renderHook(
+      ({ path }) => useApiResource<{ page: number }>(path, "Thing"),
+      { initialProps: { path: "/v1/thing?offset=0" } },
+    );
+    // Change the path so a second load starts while the first request is still in flight.
+    rerender({ path: "/v1/thing?offset=20" });
+
+    // The NEWER (second) request resolves first and is applied.
+    resolveNew({ ok: true, data: { page: 2 }, status: 200, durationMs: 1 });
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.data).toEqual({ page: 2 });
+
+    // The STALE (first) request resolves last — it must be dropped, not overwrite the current page.
+    resolveOld({ ok: true, data: { page: 1 }, status: 200, durationMs: 1 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.data).toEqual({ page: 2 });
+  });
+});

--- a/apps/loopover-ui/src/lib/api/use-api-resource.ts
+++ b/apps/loopover-ui/src/lib/api/use-api-resource.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getApiOrigin } from "./origin";
 import { apiFetch, type ApiFailureKind } from "./request";
@@ -34,7 +34,15 @@ export function useApiResource<T>(
     loadedAt: null,
   });
 
+  const requestIdRef = useRef(0);
+
   const load = useCallback(async () => {
+    // Guard against out-of-order responses (#7785): when `path` changes (pagination offsets, free-text repo input,
+    // window selection) a new load starts while an older apiFetch is still in flight. Tag each load and, after the
+    // await, drop the result if a newer load has since superseded it — otherwise a stale page's response resolves
+    // last and silently overwrites the current one while the surrounding UI reflects the newer request.
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
     if (!enabled) {
       setState({ status: "error", data: null, error: "disabled", loadedAt: null });
       return;
@@ -47,6 +55,8 @@ export function useApiResource<T>(
       headers,
       credentials: "include",
     });
+    // A newer load superseded this one (the path changed mid-flight); drop this stale response entirely.
+    if (requestId !== requestIdRef.current) return;
     if (result.ok) {
       setState({ status: "ready", data: result.data, error: null, loadedAt: Date.now() });
     } else {


### PR DESCRIPTION
## Summary

`useApiResource` (`apps/loopover-ui/src/lib/api/use-api-resource.ts`) had no cancellation guard when its `path` dependency changed: `load` awaits `apiFetch` and then `setState` unconditionally, so an older request could resolve **after** a newer one and silently overwrite it. Reachable via pagination (`dead-letter-queue-panel` offset), free-text input (`owner-panel` repo field), and window selection (`app.analytics`) — the stale response wins the race while the surrounding UI (row counts, Prev/Next, inputs) reflects the newer request.

Fix: tag each load with an incrementing request id held in a ref; after the await, drop the response if a newer load has since superseded it. This is the shared hook, so the fix resolves the class for every consumer (dead-letter-queue, owner, analytics, notification-readiness, digest, maintainer, miner, commands panels, operator/index/runs routes). No behavior change for the normal single-request path; `reload` is unaffected.

## Tests

Adds a stale-response regression test to `use-api-resource.test.ts`: two in-flight loads where the older resolves last must leave the newer page in place. Full loopover-ui suite (525 tests) green; both branches of the new guard covered.

## Validation

- [x] `@loopover/ui` typecheck, lint, prettier, and the full vitest suite (525 pass incl. the new case) green; rebased on latest `main`. Zero-visual-diff (a data-race guard in a lib/api hook — no rendered-output change).

Closes #7785