### PR TITLE
fix(ci): respect an explicit ACTIONLINT_DOWNLOAD_ATTEMPTS=0 instead of silently defaulting to 4

### DIFF
--- a/scripts/actionlint.mjs
+++ b/scripts/actionlint.mjs
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { resolveActionlintDownloadAttempts } from "./lib/actionlint-download-attempts.mjs";
 
 const require = createRequire(import.meta.url);
 const { actionlint } = require("github-actionlint");
@@ -16,7 +17,7 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-const maxAttempts = Math.max(1, Number.parseInt(process.env.ACTIONLINT_DOWNLOAD_ATTEMPTS ?? "4", 10) || 4);
+const maxAttempts = resolveActionlintDownloadAttempts(process.env.ACTIONLINT_DOWNLOAD_ATTEMPTS);
 const retryDelaysMs = [1000, 3000, 7000];
 const retryableSetupError = /Download failed: (?:408|425|429|5\d\d)\b|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|socket hang up/i;
 

--- a/scripts/lib/actionlint-download-attempts.d.mts
+++ b/scripts/lib/actionlint-download-attempts.d.mts
@@ -1,0 +1,1 @@
+export function resolveActionlintDownloadAttempts(raw: string | undefined): number;

--- a/scripts/lib/actionlint-download-attempts.mjs
+++ b/scripts/lib/actionlint-download-attempts.mjs
@@ -1,0 +1,15 @@
+/**
+ * Resolve the actionlint download-retry attempt count from a raw env value (ACTIONLINT_DOWNLOAD_ATTEMPTS).
+ *
+ * Uses an explicit finiteness check rather than a `Number.parseInt(...) || 4` fallback (#7773): `0` is falsy
+ * in JS, so `Number.parseInt("0", 10) || 4` wrongly yields 4, silently ignoring an operator's explicit `"0"`.
+ * A missing/blank/non-integer value defaults to 4; any parsed integer is honored and floored to a minimum of
+ * 1. Mirrors the validation shape in migrate-selfhost-sqlite-to-postgres.ts (`Number.isFinite`, not `||`).
+ *
+ * @param {string | undefined} raw
+ * @returns {number} attempt count, always >= 1
+ */
+export function resolveActionlintDownloadAttempts(raw) {
+  const parsed = Number.parseInt(raw ?? "4", 10);
+  return Math.max(1, Number.isFinite(parsed) ? parsed : 4);
+}

--- a/test/unit/actionlint-download-attempts.test.ts
+++ b/test/unit/actionlint-download-attempts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveActionlintDownloadAttempts } from "../../scripts/lib/actionlint-download-attempts.mjs";
+
+// #7773: an explicit ACTIONLINT_DOWNLOAD_ATTEMPTS="0" must be respected (floored to 1), not silently turned
+// into the default of 4 by a `parseInt(...) || 4` fallback (0 is falsy).
+describe("resolveActionlintDownloadAttempts (#7773)", () => {
+  it("respects an explicit 0, flooring it to 1 (not the default 4)", () => {
+    expect(resolveActionlintDownloadAttempts("0")).toBe(1);
+  });
+
+  it("defaults to 4 when unset, blank, or non-integer", () => {
+    expect(resolveActionlintDownloadAttempts(undefined)).toBe(4);
+    expect(resolveActionlintDownloadAttempts("")).toBe(4);
+    expect(resolveActionlintDownloadAttempts("abc")).toBe(4);
+  });
+
+  it("honors an explicit positive integer", () => {
+    expect(resolveActionlintDownloadAttempts("1")).toBe(1);
+    expect(resolveActionlintDownloadAttempts("7")).toBe(7);
+  });
+
+  it("floors a negative value to 1", () => {
+    expect(resolveActionlintDownloadAttempts("-3")).toBe(1);
+  });
+});


### PR DESCRIPTION
## What & why

`scripts/actionlint.mjs` computed the download-retry cap as `Math.max(1, Number.parseInt(process.env.ACTIONLINT_DOWNLOAD_ATTEMPTS ?? "4", 10) || 4)`. Since `0` is falsy in JS, `Number.parseInt("0", 10) || 4` is `4` — so an operator who set `ACTIONLINT_DOWNLOAD_ATTEMPTS=0` silently got 4 attempts instead of the 1 the outer `Math.max` would otherwise floor it to.

## Change

- Extract the parse into `scripts/lib/actionlint-download-attempts.mjs` (`resolveActionlintDownloadAttempts`) using an explicit `Number.isFinite` check instead of the `|| 4` fallback — mirroring `scripts/migrate-selfhost-sqlite-to-postgres.ts`'s validation shape. An explicit `"0"` is now honored (floored to 1 by `Math.max`); missing/blank/non-integer still default to 4.
- Side-effect-free helper module (+ a `.d.mts`, like `scripts/check-branding-drift.d.mts`) so it's importable by a unit test without running `actionlint.mjs`'s side-effecting top-level flow (which requires the native linter and calls `process.exit`).
- Add `test/unit/actionlint-download-attempts.test.ts` covering the `0 → 1` regression plus default/positive/negative cases.

`scripts/**` is outside the Codecov `coverage.include` set, so `codecov/patch` does not gate it — the test runs in the backend vitest suite. Verified locally: 4 new tests pass, root `tsc --noEmit` clean, `git diff --check` clean, and `npm run actionlint` still exits 0.

Closes #7773