### PR TITLE
fix(services): report eligible:true when no linked issue was required

### DIFF
--- a/src/services/eligibility-plan.ts
+++ b/src/services/eligibility-plan.ts
@@ -112,7 +112,13 @@ export function deriveEligibilityPlan(result: ScorePreviewResult): EligibilityPl
   // Only affirm eligibility when the branch is positively confirmed (eligible or not required);
   // "unknown" / missing metadata is treated as not-yet-eligible so the plan never overpromises.
   const branchConfirmed = branchEligibilityStatus === "eligible" || branchEligibilityStatus === "not_required";
-  const eligible = result.linkedIssueMultiplier.eligible && branchConfirmed;
+  // When no linked issue was required, linkedIssueMultiplier.eligible is meaninglessly false, so a confirmed branch
+  // must not be gated on it (#7809) -- mirror the same special case eligibilityStatusKey already applies for
+  // "not_required", so the structured `eligible` boolean agrees with the "not required" publicSummary text.
+  const eligible =
+    linkedIssueStatus === "not_required"
+      ? branchConfirmed
+      : result.linkedIssueMultiplier.eligible && branchConfirmed;
 
   const blockers = result.blockedBy
     .filter((b) => ELIGIBILITY_BLOCKER_CODES.has(b.code))

--- a/test/unit/eligibility-plan.test.ts
+++ b/test/unit/eligibility-plan.test.ts
@@ -116,10 +116,18 @@ describe("deriveEligibilityPlan (#2092)", () => {
     });
   }
 
-  it("no linked issue + non-required branch → not_required summary, no projection", () => {
+  it("no linked issue + non-required branch → not_required summary, no projection, eligible:true (#7809)", () => {
     const plan = planFor({ liStatus: "not_required", brStatus: "not_required" });
     expect(plan.publicSummary).toContain("not required for this contribution type");
     expect(plan.linkedIssueProjection).toBeNull();
+    // The structured boolean must agree with the "not required" text: a confirmed branch with no required linked
+    // issue is eligible, not gated on the meaningless linkedIssueMultiplier.eligible (which is false here).
+    expect(plan.eligible).toBe(true);
+  });
+
+  it("no linked issue required + an eligible branch is also eligible:true (#7809)", () => {
+    const plan = planFor({ liStatus: "not_required", brStatus: "eligible" });
+    expect(plan.eligible).toBe(true);
   });
 
   it("validated link + eligible branch → eligible summary, eligible:true", () => {

--- a/test/unit/eligibility-scenarios.test.ts
+++ b/test/unit/eligibility-scenarios.test.ts
@@ -105,9 +105,11 @@ describe("eligible branch with validated linked issue", () => {
 describe("unlinked — no linked issue configured", () => {
   const result = preview({ linkedIssueMode: "none" });
 
-  it("derives eligible:false and not_required status when mode is none", () => {
+  it("derives eligible:true and not_required status when mode is none (#7809)", () => {
     const plan = deriveEligibilityPlan(result);
-    expect(plan.eligible).toBe(false);
+    // A confirmed branch with no linked issue required is eligible -- the structured boolean now agrees with the
+    // "not required" summary instead of contradicting it (#7809).
+    expect(plan.eligible).toBe(true);
     expect(plan.linkedIssueStatus).toBe("not_required");
     expect(plan.branchEligibilityStatus).toBe("not_required");
     expect(plan.blockers).toHaveLength(0);

--- a/test/unit/mcp-eligibility-plan.test.ts
+++ b/test/unit/mcp-eligibility-plan.test.ts
@@ -58,13 +58,14 @@ describe("MCP loopover_get_eligibility_plan (#2222)", () => {
     expect(typeof plan.publicSummary).toBe("string");
   });
 
-  it("returns not_required statuses when linked-issue mode is none", async () => {
+  it("returns not_required statuses (and eligible:true) when linked-issue mode is none (#7809)", async () => {
     const client = await connect();
     const plan = await callPlan(client, {
       ...BASE_ARGS,
       linkedIssueMode: "none",
     });
-    expect(plan.eligible).toBe(false);
+    // eligible now agrees with the "not required" summary rather than contradicting it (#7809).
+    expect(plan.eligible).toBe(true);
     expect(plan.linkedIssueStatus).toBe("not_required");
     expect(plan.branchEligibilityStatus).toBe("not_required");
     expect(plan.publicSummary).toMatch(/not required/i);

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -488,7 +488,7 @@ describe("MCP tool calls return schema-valid structured content", () => {
     });
     expect(result.isError).toBeFalsy();
     const data = result.structuredContent as Record<string, unknown>;
-    expect(data.eligible).toBe(false);
+    expect(data.eligible).toBe(true); // not_required + confirmed branch is eligible (#7809)
     expect(data.linkedIssueStatus).toBe("not_required");
     expect(data.branchEligibilityStatus).toBe("not_required");
     expect(Array.isArray(data.blockers)).toBe(true);


### PR DESCRIPTION
## What

`deriveEligibilityPlan`'s `eligible` boolean (`src/services/eligibility-plan.ts`) was:

```ts
const eligible = result.linkedIssueMultiplier.eligible && branchConfirmed;
```

`ScorePreviewInput.linkedIssueMode` defaults to `"none"`, and for that mode `decideLinkedIssueMultiplier` returns `{ status: "not_required", eligible: false }`. So `branchConfirmed` is `true` but `eligible = false && true = false` — **always false whenever no linked issue was required**, the common case for any contribution that doesn't reference one.

This contradicts the plan's own `publicSummary` ("...not required for this contribution type") and the file's own `eligibilityStatusKey` helper, which already special-cases `not_required` correctly (line 64). Any client reading the structured boolean — the `loopover_get_eligibility_plan` MCP tool, the POST API route, and `buildLocalBranchAnalysis` — was told an otherwise-clean branch/PR is ineligible.

## Fix

Apply the same special case `eligibilityStatusKey` already uses, to the `eligible` boolean:

```ts
const eligible =
  linkedIssueStatus === "not_required"
    ? branchConfirmed
    : result.linkedIssueMultiplier.eligible && branchConfirmed;
```

When no linked issue was required, `linkedIssueMultiplier.eligible` is meaningless, so a confirmed branch (`eligible` or `not_required`) is eligible. All other modes are unchanged.

## Tests

- `test/unit/eligibility-plan.test.ts`'s "no linked issue + non-required branch" test now asserts `plan.eligible === true` (matching its sibling tests), plus a new case for `not_required` + an `eligible` branch.
- The three consumer tests that asserted the **old (buggy)** `eligible: false` for the `mode=none` case — in `eligibility-scenarios.test.ts`, `mcp-eligibility-plan.test.ts`, and `mcp-output-schemas.test.ts` — are updated to the corrected value.

The fix is **proven** to fail against the pre-fix `&&`. `linkedIssueMultiplier.eligible: false` assertions in `scoring.test.ts` are a different field and are unaffected.

## Validation

- Full eligibility-plan consumer sweep — 167/167; `scoring.test.ts` 88/88. `npm run typecheck` — exit 0. `git diff --check` clean.

Closes #7809
