### PR TITLE
test(scripts): fail loudly when REQUIRED_CONTEXTS drifts from ci.yml's job names

### DIFF
--- a/test/unit/check-stuck-required-checks-script.test.ts
+++ b/test/unit/check-stuck-required-checks-script.test.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 import {
   MARKER,
@@ -123,5 +126,53 @@ describe("runStuckCheckWatchdog (#7455)", () => {
     const flagged = await runStuckCheckWatchdog({ githubApi, ...scope, dryRun: true, log: () => {} });
     expect(flagged).toBe(0);
     expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+});
+
+// #7774: REQUIRED_CONTEXTS is hardcoded because branch protection's required-checks list can't be read live
+// from the ephemeral workflow token (Administration read is not grantable). That makes it silent-drift-prone:
+// if the workflow's required aggregate check is renamed without a matching edit here, the watchdog goes blind
+// to it with no signal anywhere. These tests fail loudly on that divergence. Deriving "which checks are
+// required" from YAML alone isn't possible (the same permissions limitation), so the achievable, genuine
+// guarantee is forward consistency: every workflow-sourced required context must still name a real ci.yml job.
+describe("REQUIRED_CONTEXTS stays in sync with .github/workflows/ci.yml (#7774)", () => {
+  // "Superagent Security Scan" is a third-party GitHub App check (see this script's header comment) — a
+  // required check that no workflow in this repo declares, so it intentionally has no ci.yml job counterpart.
+  const EXTERNAL_CHECKS = new Set(["Superagent Security Scan"]);
+
+  function ciJobCheckNames(): Set<string> {
+    const doc = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
+      jobs: Record<string, { name?: string }>;
+    };
+    const names = new Set<string>();
+    // A job's status-check context is its `name:` when set, else its job id.
+    for (const [jobId, job] of Object.entries(doc.jobs)) names.add(job.name ?? jobId);
+    return names;
+  }
+
+  it("every workflow-sourced required context is a real ci.yml job name", () => {
+    const jobNames = ciJobCheckNames();
+    const workflowSourced = [...REQUIRED_CONTEXTS].filter((context) => !EXTERNAL_CHECKS.has(context));
+    // Premise guard: at least one required context must come from a workflow (else EXTERNAL_CHECKS is stale).
+    expect(workflowSourced.length).toBeGreaterThan(0);
+    const missing = workflowSourced.filter((context) => !jobNames.has(context));
+    expect(
+      missing,
+      `REQUIRED_CONTEXTS has ${missing.join(", ")} which is not a job name in .github/workflows/ci.yml — ` +
+        `update scripts/check-stuck-required-checks.mjs's REQUIRED_CONTEXTS (or EXTERNAL_CHECKS in this test) to match.`,
+    ).toEqual([]);
+  });
+
+  it("still lists the single required aggregate the workflow documents ('validate')", () => {
+    // ci.yml declares one required status check that branch protection points at: the `validate` aggregate.
+    // Renaming it without updating REQUIRED_CONTEXTS is exactly the drift the watchdog would silently miss.
+    const jobNames = ciJobCheckNames();
+    expect(jobNames.has("validate")).toBe(true);
+    expect(REQUIRED_CONTEXTS.has("validate")).toBe(true);
+  });
+
+  it("EXTERNAL_CHECKS lists only genuinely external checks (none is a ci.yml job)", () => {
+    const jobNames = ciJobCheckNames();
+    for (const external of EXTERNAL_CHECKS) expect(jobNames.has(external)).toBe(false);
   });
 });


### PR DESCRIPTION
## What & why

`scripts/check-stuck-required-checks.mjs`'s `REQUIRED_CONTEXTS` is hardcoded — branch protection's required-checks list needs Administration read, which the ephemeral workflow `GITHUB_TOKEN` can't get (the file's own comment documents this). That makes it silent-drift-prone: if the workflow's required aggregate check is renamed without a matching manual edit here, the stuck-check watchdog (built after a real incident) goes blind to it, with no error or CI signal anywhere.

## Change

Add a `describe` block to the existing `test/unit/check-stuck-required-checks-script.test.ts` that parses `.github/workflows/ci.yml`'s job names (via the `yaml` package, as `codecov-policy.test.ts` does) and asserts:

1. Every **workflow-sourced** entry in `REQUIRED_CONTEXTS` still names a real ci.yml job (a job's status-check context is its `name:`, else its id). `"Superagent Security Scan"` — a third-party GitHub App check no workflow declares — is excluded via a small documented `EXTERNAL_CHECKS` allowlist.
2. The single documented required aggregate (`validate`, the job branch protection points at) stays listed.
3. `EXTERNAL_CHECKS` contains only genuinely external checks (none is a ci.yml job).

Deriving *which* checks are required from YAML alone isn't possible (the same permissions limitation), so this guarantees **forward consistency** and fails loudly on the drift it can detect — e.g. renaming/removing the `validate` job, or a stale/typo'd context in the list.

`scripts/**` is outside the Codecov `coverage.include` set, so `codecov/patch` does not gate this — the test runs in the backend vitest suite. Verified locally: all 11 tests in the file pass, root `tsc --noEmit` clean, `git diff --check` clean, and **injecting a bogus required context genuinely fails the test** (then reverted).

Closes #7774