### PR TITLE
fix(review): paginate check-runs in findPreviewUrlFromChecks so a preview check on page 2+ is found

### DIFF
--- a/src/review/visual/preview-url.ts
+++ b/src/review/visual/preview-url.ts
@@ -228,15 +228,25 @@ export async function findPreviewUrlFromChecks(params: {
       const url = extractPreviewUrl(status.target_url);
       if (url) return url;
     }
-    const checks = await githubJson<{ check_runs?: Array<{ status?: string; conclusion?: string; details_url?: string; output?: { summary?: string; text?: string } }> }>(
+    // #7779: walk ALL pages of check-runs via the same findAcrossPages helper getPreviewBuildState and
+    // findPreviewUrlFromPrComments already use for this identical endpoint. A commit with >100 check-runs can push
+    // the preview check-run onto page 2+, where the old page-1-only read returned null as if it did not exist (the
+    // exact failure mode this file's header comment reasons about).
+    type PreviewCheckRun = { status?: string; conclusion?: string; details_url?: string; output?: { summary?: string; text?: string } };
+    const fromChecks = await findAcrossPages<PreviewCheckRun, string>(
       `${base}/commits/${encodeURIComponent(params.sha)}/check-runs?per_page=100`,
       opts,
-    ).catch(() => null);
-    for (const run of checks?.check_runs ?? []) {
-      if (run.status === "completed" && run.conclusion && run.conclusion !== "success") continue;
-      const url = extractPreviewUrl(run.details_url) ?? extractPreviewUrl(run.output?.summary) ?? extractPreviewUrl(run.output?.text);
-      if (url) return url;
-    }
+      (payload) => (payload as { check_runs?: PreviewCheckRun[] })?.check_runs ?? [],
+      (runs) => {
+        for (const run of runs) {
+          if (run.status === "completed" && run.conclusion && run.conclusion !== "success") continue;
+          const url = extractPreviewUrl(run.details_url) ?? extractPreviewUrl(run.output?.summary) ?? extractPreviewUrl(run.output?.text);
+          if (url) return url;
+        }
+        return null;
+      },
+    );
+    if (fromChecks) return fromChecks;
   } catch (error) {
     console.log(JSON.stringify({ event: "preview_from_checks_error", repo: `${params.repo.owner}/${params.repo.repo}`, message: String(error).slice(0, 200) }));
   }

--- a/test/unit/preview-url.test.ts
+++ b/test/unit/preview-url.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearGitHubResponseCacheForTest, githubRateLimitAdmissionKeyForInstallation, latestGitHubRestRateLimitObservation } from "../../src/github/client";
-import { extractPreviewUrl, findPreviewUrlFromPrComments, getPreviewBuildState } from "../../src/review/visual/preview-url";
+import { extractPreviewUrl, findPreviewUrlFromChecks, findPreviewUrlFromPrComments, getPreviewBuildState } from "../../src/review/visual/preview-url";
 
 /** GitHub's `Link` header for a page that advertises a next page (the exact shape findAcrossPages walks). */
 const NEXT_LINK = '<https://api.github.com/resource?per_page=100&page=99>; rel="next", <https://api.github.com/resource?per_page=100&page=99>; rel="last"';
@@ -165,6 +165,63 @@ describe("preview-url pagination (#7450)", () => {
     vi.stubGlobal("fetch", failLater);
     await expect(getPreviewBuildState({ token: "t", repo: REPO, sha: "fail" })).resolves.toBe("absent");
     expect(failLater).toHaveBeenCalledTimes(2);
+  });
+
+  it("findPreviewUrlFromChecks follows Link: rel=next and finds the preview check-run on page 2 (#7779)", async () => {
+    // A commit with >100 check-runs: the Workers preview check lands on page 2. Page 1 also carries a FAILED run
+    // with a preview URL — it must be skipped (completed + non-success), so the asserted result is page 2's URL,
+    // not the failed run's. Proves both pagination and the failed-run guard.
+    const page1 = {
+      check_runs: [
+        { status: "completed", conclusion: "failure", details_url: "https://failed.pages.dev" },
+        ...Array.from({ length: 99 }, () => ({ status: "completed", conclusion: "success" })),
+      ],
+    };
+    const page2 = { check_runs: [{ status: "completed", conclusion: "success", details_url: "https://pr-9.app.workers.dev" }] };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/status")) return Response.json({ statuses: [] });
+      return isPage2(input) ? Response.json(page2) : Response.json(page1, { headers: { link: NEXT_LINK } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "abc" })).resolves.toBe("https://pr-9.app.workers.dev");
+    expect(fetchMock.mock.calls.some((call) => isPage2(call[0]))).toBe(true); // page 2 really was walked
+  });
+
+  it("findPreviewUrlFromChecks reads a preview URL from a check-run's output summary when details_url has none", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/status")) return Response.json({ statuses: [] });
+      return Response.json({ check_runs: [{ status: "completed", conclusion: "success", output: { summary: "preview at https://sum.pages.dev" } }] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "sum" })).resolves.toBe("https://sum.pages.dev");
+  });
+
+  it("findPreviewUrlFromChecks falls back to a check-run's output text when summary lacks a URL", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/status")) return Response.json({ statuses: [] });
+      return Response.json({ check_runs: [{ status: "in_progress", output: { text: "see https://txt.workers.dev" } }] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "txt" })).resolves.toBe("https://txt.workers.dev");
+  });
+
+  it("findPreviewUrlFromChecks returns null when a payload carries no check_runs array at all", async () => {
+    // Empty object (no `check_runs`) exercises the selectItems `?? []` fallback, so the probe sees an empty list.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/status")) return Response.json({ statuses: [] });
+      return Response.json({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "none" })).resolves.toBeNull();
+  });
+
+  it("findPreviewUrlFromChecks degrades to null when the check-runs read throws", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/status")) return Response.json({ statuses: [] });
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "err" })).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

`findPreviewUrlFromChecks` (`src/review/visual/preview-url.ts`) fetched only **page 1** of a commit's check-runs (`?per_page=100`) and never followed pagination — but its two siblings in the same file, `getPreviewBuildState` and `findPreviewUrlFromPrComments`, walk the **same endpoint** correctly via the file's own `findAcrossPages` helper. The file's header comment even reasons about this exact failure mode.

On a commit with >100 check-runs (matrix builds, several external CI checks, multiple LoopOver-published checks), the Cloudflare Workers Builds check-run can land on page 2+. There, `findPreviewUrlFromChecks` returned `null` as if no preview existed — while the later `getPreviewBuildState` (which paginates) correctly reported `"succeeded"`. Net effect: the system knows a preview deploy succeeded but never surfaces its URL, so the PR comment shows a permanent loading spinner instead of the preview screenshot.

## Fix

Route the check-runs scan through `findAcrossPages` — the required pattern, exactly as `getPreviewBuildState` and `findPreviewUrlFromPrComments` already use it for this identical endpoint. No new pagination loop; the run-filtering logic (skip completed-non-success runs, read `details_url` / `output.summary` / `output.text`) is unchanged, just moved into the helper's probe. For a single page with no `Link: rel=next`, behaviour is byte-identical to before.

## Scope & tests

- Only `findPreviewUrlFromChecks` changes; the two sibling functions are untouched.
- Regression test: a commit with >100 check-runs where the preview check is on **page 2** (with a failed page-1 run carrying a URL, to prove the failed-run guard still skips it). Plus the `output.summary`/`output.text` fallbacks and the no-preview / read-error → `null` paths. `src/review/**` is under the 99% patch gate; every new branch is covered.

Closes #7779