### PR TITLE
fix(review): only count real D1 writes in backfillContributorGateHistory inserted (#7804)

### DIFF
--- a/src/review/contributor-gate-history-backfill.ts
+++ b/src/review/contributor-gate-history-backfill.ts
@@ -82,14 +82,14 @@ export async function backfillContributorGateHistory(env: Env, opts: { limit?: n
       continue;
     }
     try {
-      await env.DB.prepare(
+      const result = await env.DB.prepare(
         `INSERT INTO contributor_gate_history (id, login, source, project, target_id, decision, head_sha, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO NOTHING`,
       )
         .bind(`contrib:${login}:${c.source}:${c.targetId}@${c.headSha ?? "none"}`, login, c.source, c.project, c.targetId, c.decision, c.headSha, c.createdAt)
         .run();
-      inserted += 1;
+      if (result.meta.changes > 0) inserted += 1;
     } catch (error) {
       console.warn(JSON.stringify({ event: "contributor_gate_history_backfill_write_error", project: c.project, targetId: c.targetId, message: errorMessage(error).slice(0, 200) }));
     }

--- a/test/unit/contributor-gate-history-backfill.test.ts
+++ b/test/unit/contributor-gate-history-backfill.test.ts
@@ -149,6 +149,36 @@ describe("backfillContributorGateHistory (#fairness-analytics)", () => {
     warn.mockRestore();
   });
 
+  it("REGRESSION: does not count an ON CONFLICT DO NOTHING no-op toward inserted", async () => {
+    const candidate = {
+      project: "owner/repo",
+      targetId: "owner/repo#50",
+      decision: "merge",
+      headSha: "sha50",
+      source: "gittensory-native",
+      authorLogin: "octocat",
+      createdAt: "2026-06-25T12:00:00.000Z",
+    };
+    const env = {
+      DB: {
+        prepare: (sql: string) => ({
+          bind: (..._args: unknown[]) => {
+            if (/FROM review_audit/.test(sql)) {
+              return { all: async () => ({ results: [candidate] }) };
+            }
+            if (/INSERT INTO contributor_gate_history/.test(sql)) {
+              return { run: async () => ({ meta: { changes: 0 } }) };
+            }
+            throw new Error(`unexpected sql: ${sql}`);
+          },
+        }),
+      },
+    } as unknown as Env;
+
+    const result = await backfillContributorGateHistory(env);
+    expect(result).toEqual({ scanned: 1, inserted: 0, skippedNoAuthor: 0, hasMore: false });
+  });
+
   it("is best-effort per row: a write failure on one candidate is logged and does not stop the rest of the batch", async () => {
     const env = createTestEnv();
     await insertPullRequest(env, "owner/repo", 20, "octocat");


### PR DESCRIPTION
## Summary

- Only increment `inserted` when `result.meta.changes > 0` after the `INSERT ... ON CONFLICT DO NOTHING`, mirroring `src/ams/ingest.ts` and `src/orb/ingest.ts`
- Add regression test simulating a duplicate-id conflict (`meta.changes === 0`) asserting `inserted` stays 0 while `scanned` still reflects the candidate was examined

Closes #7804

## Test plan

- [x] `npm run typecheck` passes locally
- [ ] CI validate-code + validate-tests green
- [ ] codecov/patch >= 99% on changed lines

Made with [Cursor](https://cursor.com)