### PR TITLE
feat(mcp): expose self-tune override audit on remote, stdio, and CLI

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -95,7 +95,7 @@ const CLI_COMMAND_SPEC = {
     profile: ["list", "create", "switch", "remove"],
     cache: ["status", "clear", "list"],
     agent: ["plan", "status", "explain", "packet"],
-    maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
+    maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "selftune-audit", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -861,6 +861,12 @@ const gatePrecisionShape = {
     repo: z.string().min(1),
     windowDays: z.number().int().positive().optional(),
 };
+// #7798 - mirrors GET .../selftune/overrides/audit?limit (optional positive limit).
+const selftuneOverrideAuditShape = {
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    limit: z.number().int().positive().optional(),
+};
 // Single source of truth for stdio tool name + one-line description (#2233).
 // Registration and `loopover-mcp tools` both read this list.
 const STDIO_TOOL_DESCRIPTORS = [
@@ -1218,6 +1224,11 @@ const STDIO_TOOL_DESCRIPTORS = [
         name: "loopover_get_gate_precision",
         category: "maintainer",
         description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
+    },
+    {
+        name: "loopover_get_selftune_override_audit",
+        category: "maintainer",
+        description: "Return the self-tune override audit trail for a repo — why LOOPOVER_REVIEW_SELFTUNE promoted a live override — newest first. Optionally capped by limit. Maintainer-authenticated; read-only. Same as `loopover-mcp maintain selftune-audit`.",
     },
     {
         name: "loopover_open_pr",
@@ -2143,6 +2154,15 @@ registerStdioTool("loopover_get_gate_precision", {
     const payload = await apiGet(`${toolRepoBase(owner, repo)}/gate-precision${query}`);
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
 });
+registerStdioTool("loopover_get_selftune_override_audit", {
+    description: stdioToolDescription("loopover_get_selftune_override_audit"),
+    inputSchema: selftuneOverrideAuditShape,
+}, async ({ owner, repo, limit }) => {
+    // Schema rejects a non-positive limit; omit ?limit so the route applies listOverrideAudit's default (50).
+    const query = limit ? `?limit=${encodeURIComponent(limit)}` : "";
+    const payload = await apiGet(`${toolRepoBase(owner, repo)}/selftune/overrides/audit${query}`);
+    return toolResult(`Self-tune override audit for ${owner}/${repo}.`, payload);
+});
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.
@@ -2608,6 +2628,7 @@ function printMaintainHelp() {
         `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
         `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
         "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
+        "  selftune-audit [--limit N]   Show the self-tune override audit trail (why a live override was promoted).",
         "  outcome-calibration          Show slop-band merge rates and recommendation-outcome calibration.",
         "             [--window-days N]  Bound the recommendation window (default: full history).",
         "  onboarding-pack [--refresh]  Preview the repo's contributor onboarding pack.",
@@ -2736,6 +2757,21 @@ async function maintainCli(args) {
         emit(payload, lines.join("\n"));
         return;
     }
+    if (subcommand === "selftune-audit") {
+        // #7798 self-tune override audit: read-only trail of why LOOPOVER_REVIEW_SELFTUNE promoted a live override.
+        // Same emit/--json handling as precision; optional --limit mirrors the route's ?limit (non-positive omits it,
+        // so the server applies listOverrideAudit's default of 50).
+        const limit = Number(options.limit);
+        const query = limit > 0 ? `?limit=${encodeURIComponent(limit)}` : "";
+        const payload = await apiGet(`${repoBase}/selftune/overrides/audit${query}`);
+        const audit = payload.audit ?? [];
+        const lines = [
+            `Self-tune override audit for ${repoFullName}: ${audit.length} event${audit.length === 1 ? "" : "s"}.`,
+            ...audit.map((row) => `- ${row.createdAt ?? "?"}  ${row.eventType ?? "?"}${row.detail ? `  ${row.detail}` : ""}`),
+        ];
+        emit(payload, lines.join("\n"));
+        return;
+    }
     if (subcommand === "outcome-calibration") {
         // #6735 outcome calibration: read-only measurement of whether higher-slop bands merge less often and how
         // agent recommendations panned out. Same --window-days handling the sibling precision command uses (a
@@ -2837,7 +2873,7 @@ async function maintainCli(args) {
         emit(payload, lines.join("\n"));
         return;
     }
-    throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`);
+    throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | selftune-audit | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`);
 }
 async function runCli(args) {
     const command = args[0];
@@ -4071,7 +4107,7 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
-  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|selftune-audit|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   loopover-mcp contributor-profile [--login <github-login>] [--json]

--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -107,7 +107,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
+  maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "selftune-audit", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -915,6 +915,13 @@ const gatePrecisionShape = {
   windowDays: z.number().int().positive().optional(),
 };
 
+// #7798 - mirrors GET .../selftune/overrides/audit?limit (optional positive limit).
+const selftuneOverrideAuditShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  limit: z.number().int().positive().optional(),
+};
+
 // Single source of truth for stdio tool name + one-line description (#2233).
 // Registration and `loopover-mcp tools` both read this list.
 const STDIO_TOOL_DESCRIPTORS = [
@@ -1290,6 +1297,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     name: "loopover_get_gate_precision",
     category: "maintainer",
     description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
+  },
+  {
+    name: "loopover_get_selftune_override_audit",
+    category: "maintainer",
+    description: "Return the self-tune override audit trail for a repo — why LOOPOVER_REVIEW_SELFTUNE promoted a live override — newest first. Optionally capped by limit. Maintainer-authenticated; read-only. Same as `loopover-mcp maintain selftune-audit`.",
   },
   {
     name: "loopover_open_pr",
@@ -2596,7 +2608,21 @@ registerStdioTool(
     const payload = await apiGet(`${toolRepoBase(owner, repo)}/gate-precision${query}`);
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
   },
-  );
+);
+
+registerStdioTool(
+  "loopover_get_selftune_override_audit",
+  {
+    description: stdioToolDescription("loopover_get_selftune_override_audit"),
+    inputSchema: selftuneOverrideAuditShape,
+  },
+  async ({ owner, repo, limit }: any) => {
+    // Schema rejects a non-positive limit; omit ?limit so the route applies listOverrideAudit's default (50).
+    const query = limit ? `?limit=${encodeURIComponent(limit)}` : "";
+    const payload = await apiGet(`${toolRepoBase(owner, repo)}/selftune/overrides/audit${query}`);
+    return toolResult(`Self-tune override audit for ${owner}/${repo}.`, payload);
+  },
+);
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.
@@ -3191,6 +3217,7 @@ function printMaintainHelp() {
       `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
       `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
       "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
+      "  selftune-audit [--limit N]   Show the self-tune override audit trail (why a live override was promoted).",
       "  outcome-calibration          Show slop-band merge rates and recommendation-outcome calibration.",
       "             [--window-days N]  Bound the recommendation window (default: full history).",
       "  onboarding-pack [--refresh]  Preview the repo's contributor onboarding pack.",
@@ -3328,6 +3355,21 @@ async function maintainCli(args: any) {
     emit(payload, lines.join("\n"));
     return;
   }
+  if (subcommand === "selftune-audit") {
+    // #7798 self-tune override audit: read-only trail of why LOOPOVER_REVIEW_SELFTUNE promoted a live override.
+    // Same emit/--json handling as precision; optional --limit mirrors the route's ?limit (non-positive omits it,
+    // so the server applies listOverrideAudit's default of 50).
+    const limit = Number(options.limit);
+    const query = limit > 0 ? `?limit=${encodeURIComponent(limit)}` : "";
+    const payload = await apiGet(`${repoBase}/selftune/overrides/audit${query}`);
+    const audit = payload.audit ?? [];
+    const lines = [
+      `Self-tune override audit for ${repoFullName}: ${audit.length} event${audit.length === 1 ? "" : "s"}.`,
+      ...audit.map((row: any) => `- ${row.createdAt ?? "?"}  ${row.eventType ?? "?"}${row.detail ? `  ${row.detail}` : ""}`),
+    ];
+    emit(payload, lines.join("\n"));
+    return;
+  }
   if (subcommand === "outcome-calibration") {
     // #6735 outcome calibration: read-only measurement of whether higher-slop bands merge less often and how
     // agent recommendations panned out. Same --window-days handling the sibling precision command uses (a
@@ -3440,7 +3482,7 @@ async function maintainCli(args: any) {
     return;
   }
   throw new Error(
-    `Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`,
+    `Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | selftune-audit | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`,
   );
 }
 
@@ -4642,7 +4684,7 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
-  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|selftune-audit|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   loopover-mcp contributor-profile [--login <github-login>] [--json]

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -115,6 +115,7 @@ import { loadMaintainerLaneReport, maintainerLaneSummary } from "../services/mai
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
 import { buildRegistrationReadinessResponse, buildGittensorConfigRecommendationResponse } from "../api/routes";
 import { loadGatePrecisionReport } from "../services/gate-precision";
+import { listOverrideAudit, type StorageEnv as OverrideAuditStorageEnv } from "../review/auto-apply";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
   applyMcpPlanningChoices,
@@ -216,6 +217,14 @@ const ownerRepoWindowShape = {
   owner: z.string().min(1),
   repo: z.string().min(1),
   windowDays: z.number().int().positive().optional(),
+};
+
+// #7798 - self-tune override audit trail. Same owner/repo gate as gate-precision; optional limit mirrors
+// GET .../selftune/overrides/audit?limit (absent → server default of 50 via listOverrideAudit).
+const ownerRepoLimitShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  limit: z.number().int().positive().optional(),
 };
 
 const windowOnlyShape = {
@@ -991,6 +1000,13 @@ const gatePrecisionOutputSchema = {
   perGateType: z.array(z.unknown()).optional(),
   overall: z.unknown().optional(),
   signals: z.array(z.string()).optional(),
+};
+
+// #7798 - self-tune override audit trail over MCP. Mirrors the REST route's {repoFullName, audit} envelope;
+// audit row shape stays owned by listOverrideAudit (z.unknown() elements).
+const selftuneOverrideAuditOutputSchema = {
+  repoFullName: z.string().optional(),
+  audit: z.array(z.unknown()).optional(),
 };
 
 // #5825 - maintainer-authenticated skipped-PR audit trail, mirroring GET /v1/app/skipped-pr-audit's
@@ -1807,6 +1823,7 @@ export const MCP_TOOL_CATEGORIES: Record<string, McpToolCategory> = {
   loopover_get_repo_outcome_patterns: "maintainer",
   loopover_get_outcome_calibration: "maintainer",
   loopover_get_gate_precision: "maintainer",
+  loopover_get_selftune_override_audit: "maintainer",
   loopover_get_skipped_pr_audit: "maintainer",
   loopover_get_fleet_analytics: "maintainer",
   loopover_get_recommendation_quality: "maintainer",
@@ -2022,6 +2039,17 @@ export class LoopoverMcp {
         outputSchema: gatePrecisionOutputSchema,
       },
       async (input) => this.toolResult(await this.getGatePrecision(input)),
+    );
+
+    register(
+      "loopover_get_selftune_override_audit",
+      {
+        description:
+          "Return the self-tune override audit trail for a repo — why LOOPOVER_REVIEW_SELFTUNE promoted a live override — newest first. Optionally capped by limit. Maintainer-authenticated; read-only.",
+        inputSchema: ownerRepoLimitShape,
+        outputSchema: selftuneOverrideAuditOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getSelftuneOverrideAudit(input)),
     );
 
     register(
@@ -3484,6 +3512,19 @@ export class LoopoverMcp {
     return {
       summary: `LoopOver gate precision for ${fullName}: ${report.overall.blocked} gate blocks, overall false-positive rate ${report.overall.falsePositiveRate ?? "n/a (below sample threshold)"}.`,
       data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #7798 - surface GET .../selftune/overrides/audit over MCP. Same per-repo read gate as getGatePrecision
+  // (requireRepoAccess); listOverrideAudit is read-only and already scoped to the single project. An omitted
+  // limit falls through to listOverrideAudit's default (50), matching the REST route when ?limit is absent.
+  private async getSelftuneOverrideAudit(input: { owner: string; repo: string; limit?: number | undefined }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const audit = await listOverrideAudit(this.env as unknown as OverrideAuditStorageEnv, fullName, input.limit);
+    return {
+      summary: `LoopOver self-tune override audit for ${fullName}: ${audit.length} event(s).`,
+      data: { repoFullName: fullName, audit } as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -221,7 +221,7 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
     expect(ps).toContain(
-      "'maintain' = @('status', 'queue', 'propose', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state', 'refresh-docs', 'generate-issue-drafts')",
+      "'maintain' = @('status', 'queue', 'propose', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'selftune-audit', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state', 'refresh-docs', 'generate-issue-drafts')",
     );
   });
 

--- a/test/unit/mcp-cli-maintain-tools.test.ts
+++ b/test/unit/mcp-cli-maintain-tools.test.ts
@@ -22,7 +22,7 @@ async function connect() {
   const apiUrl = await startFixtureServer({
     onApiRequest: (request) => {
       const url = request.url ?? "";
-      if (/pending-actions|settings|gate-precision/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
+      if (/pending-actions|settings|gate-precision|selftune\/overrides\/audit/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
     },
   });
   transport = new StdioClientTransport({
@@ -58,16 +58,17 @@ const MAINTAIN_TOOLS = [
   { name: "loopover_set_agent_paused", args: { ...REPO, paused: true }, contains: "agentPaused" },
   { name: "loopover_set_action_autonomy", args: { ...REPO, action: "merge", level: "auto" }, contains: "autonomy" },
   { name: "loopover_get_gate_precision", args: REPO, contains: "falsePositiveRate" },
+  { name: "loopover_get_selftune_override_audit", args: REPO, contains: "override.promoted" },
 ] as const;
 
 describe("loopover-mcp maintain stdio proxies (#6152)", () => {
-  it("registers all 5 maintain tools in the stdio server tool list", async () => {
+  it("registers all 6 maintain tools in the stdio server tool list", async () => {
     await connect();
     const names = (await client!.listTools()).tools.map((tool) => tool.name);
     for (const tool of MAINTAIN_TOOLS) expect(names).toContain(tool.name);
   });
 
-  it("lists all 5 maintain tools via `loopover-mcp tools --json` with non-empty descriptions", async () => {
+  it("lists all 6 maintain tools via `loopover-mcp tools --json` with non-empty descriptions", async () => {
     await connect();
     const payload = JSON.parse(run(["tools", "--json"])) as { tools: Array<{ name: string; description: string; category?: string }> };
     for (const tool of MAINTAIN_TOOLS) {
@@ -97,6 +98,18 @@ describe("loopover-mcp maintain stdio proxies (#6152)", () => {
       expect(JSON.stringify(result.content)).toMatch(/404|not_found/);
     });
   }
+
+  it("get_selftune_override_audit forwards limit as ?limit (#7798)", async () => {
+    await connect();
+    const result = await client!.callTool({
+      name: "loopover_get_selftune_override_audit",
+      arguments: { ...REPO, limit: 1 },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result)).toContain("override.promoted");
+    expect(JSON.stringify(result)).not.toContain("override.applied");
+    expect(capturedRequests.some((request) => request.url.includes("limit=1"))).toBe(true);
+  });
 
   // GET /agent/pending-actions takes no query parameters and hardcodes status "pending" (src/api/routes.ts), so
   // this server cannot honour the `status` filter its remote counterpart offers. The tool therefore doesn't

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -95,6 +95,25 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(scoped).toMatch(/Gate precision for owner\/repo \(last 30d\)/);
   });
 
+  it("selftune-audit reports the override audit trail (plain + json), passing the limit through (#7798)", async () => {
+    const e = await env();
+    const out = await runAsync(["maintain", "selftune-audit", "--repo", "owner/repo"], e);
+    expect(out).toMatch(/Self-tune override audit for owner\/repo: 2 events\./);
+    expect(out).toMatch(/override\.promoted/);
+    expect(out).toMatch(/override\.applied/);
+    const json = JSON.parse(await runAsync(["maintain", "selftune-audit", "--repo", "owner/repo", "--json"], e)) as {
+      repoFullName: string;
+      audit: Array<{ eventType: string }>;
+    };
+    expect(json.repoFullName).toBe("owner/repo");
+    expect(json.audit.map((row) => row.eventType)).toEqual(["override.promoted", "override.applied"]);
+    // --limit forwards as ?limit and trims the trail the fixture serves.
+    const limited = await runAsync(["maintain", "selftune-audit", "--repo", "owner/repo", "--limit", "1"], e);
+    expect(limited).toMatch(/Self-tune override audit for owner\/repo: 1 event\./);
+    expect(limited).toMatch(/override\.promoted/);
+    expect(limited).not.toMatch(/override\.applied/);
+  });
+
   it("generate-issue-drafts dry-runs by default and never forwards create (#6757)", async () => {
     const bodies: Array<{ dryRun?: boolean; create?: boolean; limit?: number }> = [];
     const e = await env({ onIssueDraftRequest: (b) => bodies.push(b) });

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -40,6 +40,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "loopover_get_eligibility_plan",
   "loopover_simulate_open_pr_pressure",
   "loopover_get_gate_precision",
+  "loopover_get_selftune_override_audit",
   "loopover_get_skipped_pr_audit",
 ];
 

--- a/test/unit/mcp-selftune-override-audit.test.ts
+++ b/test/unit/mcp-selftune-override-audit.test.ts
@@ -1,0 +1,78 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { recordOverrideAudit } from "../../src/review/auto-apply";
+import { createTestEnv } from "../helpers/d1";
+
+const REPO = "owner/widgets";
+
+async function connect(env: Env) {
+  const server = new LoopoverMcp(env).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "loopover-selftune-override-audit-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedOverrideAudit(env: Env) {
+  const storage = env as never;
+  await recordOverrideAudit(storage, REPO, "override.promoted", { floor: 0.95 });
+  await recordOverrideAudit(storage, REPO, "override.applied", { cap: "3f/120l" });
+}
+
+describe("MCP loopover_get_selftune_override_audit (#7798)", () => {
+  it("returns the override audit trail for an authorized caller and passes limit through", async () => {
+    const env = createTestEnv();
+    await seedOverrideAudit(env);
+    const client = await connect(env);
+    const limited = await client.callTool({
+      name: "loopover_get_selftune_override_audit",
+      arguments: { owner: "owner", repo: "widgets", limit: 1 },
+    });
+    expect(limited.isError).toBeFalsy();
+    const limitedData = limited.structuredContent as {
+      repoFullName: string;
+      audit: Array<{ eventType: string; detail: string | null; createdAt: string }>;
+    };
+    expect(limitedData.repoFullName).toBe(REPO);
+    expect(limitedData.audit).toHaveLength(1);
+    expect(JSON.stringify(limited.content)).toContain("1 event(s)");
+
+    const full = await client.callTool({
+      name: "loopover_get_selftune_override_audit",
+      arguments: { owner: "owner", repo: "widgets" },
+    });
+    expect(full.isError).toBeFalsy();
+    const fullData = full.structuredContent as { audit: Array<{ eventType: string }> };
+    expect(fullData.audit.map((row) => row.eventType).sort()).toEqual(["override.applied", "override.promoted"]);
+    expect(JSON.stringify(full.content)).toContain("2 event(s)");
+  });
+
+  it("returns an empty audit trail when no overrides have been recorded", async () => {
+    const env = createTestEnv();
+    const client = await connect(env);
+    const result = await client.callTool({
+      name: "loopover_get_selftune_override_audit",
+      arguments: { owner: "owner", repo: "widgets" },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { repoFullName: string; audit: unknown[] };
+    expect(data.repoFullName).toBe(REPO);
+    expect(data.audit).toEqual([]);
+    expect(JSON.stringify(result.content)).toContain("0 event(s)");
+  });
+
+  it("forbids the static mcp identity when the repo is outside MCP_READ_REPO_ALLOWLIST", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await seedOverrideAudit(env);
+    const client = await connect(env);
+    const result = await client.callTool({
+      name: "loopover_get_selftune_override_audit",
+      arguments: { owner: "owner", repo: "widgets" },
+    });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository/i);
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -21,6 +21,7 @@
 // (#6741 registered the loopover_draft_pr_body CLI mirror, taking the count from 76 to 77.)
 // (#6747 registered the loopover_pr_outcome CLI mirror, taking the count from 77 to 78.)
 // (#6980 registered the loopover_explain_review_risk CLI mirror, taking the count from 78 to 79.)
+// (#7798 registered the loopover_get_selftune_override_audit CLI mirror, taking the count from 79 to 80.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -68,14 +69,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 79 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 80 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(79);
+    expect(primary.length).toBe(80);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(79);
+    expect(names.length).toBe(80);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -87,14 +88,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 79-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 80-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(79);
+    expect(payload.count).toBe(80);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -646,6 +646,22 @@ export async function startFixtureServer(
       );
       return;
     }
+    // #7798 self-tune override audit (read-only). Echoes ?limit so the CLI/stdio limit pass-through is testable.
+    if (request.url?.startsWith("/v1/repos/owner/repo/selftune/overrides/audit") && request.method === "GET") {
+      const limitRaw = new URL(request.url, "http://localhost").searchParams.get("limit");
+      const rows = [
+        { eventType: "override.promoted", detail: '{"floor":0.95}', createdAt: "2026-05-30T01:00:00.000Z" },
+        { eventType: "override.applied", detail: '{"cap":"3f/120l"}', createdAt: "2026-05-30T00:00:00.000Z" },
+      ];
+      const limit = limitRaw ? Number(limitRaw) : undefined;
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          audit: limit && limit > 0 ? rows.slice(0, limit) : rows,
+        }),
+      );
+      return;
+    }
     if (request.url?.startsWith("/v1/repos/owner/repo/outcome-calibration") && request.method === "GET") {
       const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");
       response.end(


### PR DESCRIPTION
## Summary

- Register `loopover_get_selftune_override_audit` as a remote MCP tool (category `maintainer`) calling `listOverrideAudit`, with optional `limit`.
- Register the same tool on local stdio MCP, proxying `GET .../selftune/overrides/audit`.
- Add `maintain selftune-audit --repo owner/repo [--limit N]` CLI verb mirroring `precision`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- No OpenAPI/UI/route changes — only MCP surfaces over the existing REST route. Ran focused unit tests covering remote MCP, stdio proxy, and `maintain selftune-audit` (plus typecheck + `build:mcp`). Full `test:ci` / coverage suite left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI, frontend, docs, or extension changes.

## Notes

- Does not change `listOverrideAudit`, the REST route, or `requireRepoMaintainer`.
- Closes #7798