### PR TITLE
feat(api): REST + CLI + stdio mirror for loopover_plan_repo_issues (#7764)

### DIFF
--- a/PR-7743.md
+++ b/PR-7743.md
@@ -1,0 +1,54 @@
+## Summary
+
+- Wires `control-plane/` into CI by mirroring the existing `rees` (review-enrichment) job shape exactly — the `rees` "job" is a set of path-filtered steps inside `validate-code`, so this follows that same shape rather than inventing a new job.
+- `control-plane/` (a standalone, non-workspace package with its own `package-lock.json` and `node:test` suite) now gets real CI test execution and Codecov coverage under a distinct `control-plane` flag, the same as every other package in this repo. Previously it had `control-plane:install`/`control-plane:test` scripts but zero CI coverage (flagged as a deferred follow-up in PR #7543).
+
+Closes #7743.
+
+## Changes
+
+- **`.github/workflows/ci.yml`**
+  - New `controlPlane` path filter (`control-plane/**` + `.github/workflows/ci.yml`) exposed as a `changes`-job output, alongside `rees`.
+  - `controlPlane` added to the `if:` of `validate-code` (runs the new steps) **and** `validate-tests` / `validate-tests-merge` — the latter two are required so a control-plane-only PR still runs the 3 shards, meeting Codecov's `after_n_builds: 3` floor so `codecov/patch` actually posts (the same `#7318-#7321` gap the `rees` trigger already guards).
+  - New steps mirroring the REES ones: a separate `control-plane/node_modules` cache (own lockfile; fork/trusted + `.nvmrc` key split), a cache-gated `control-plane install`, an unconditional `npm --prefix control-plane test`, a c8 coverage harvest (`npm run control-plane:coverage || true`), a fail-closed "verify lcov exists" step, and trusted + fork-tokenless Codecov uploads under `flags: control-plane`.
+- **`codecov.yml`** — new `control-plane` flag (`paths: [control-plane/]`, `carryforward: true`) mirroring `rees`; `after_n_builds`/flags/collection comments updated.
+- **`scripts/control-plane-coverage.mjs`** (new) — faithful copy of `scripts/rees-coverage.mjs`: runs c8 over `control-plane/dist/**/*.js` and remaps through the build's source maps to `control-plane/src/**` (control-plane's tsconfig already emits `sourceMap`), writing `control-plane/coverage/lcov.info`.
+- **`control-plane/package.json` + `control-plane/package-lock.json`** — add `c8@^10.1.3` (same version `rees` uses).
+- **`package.json`** — add `control-plane:coverage` root script.
+- **Tests** — `codecov-policy.test.ts` gains a `#7743` invariant (mirror of the `#6250` REES test); `ci-dependency-cache.test.ts` gains a control-plane cache/install invariant (mirror of the REES one).
+
+## Scope
+
+- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
+- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
+- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
+- [x] I linked a currently open issue this PR resolves (`Closes #7743`).
+
+## Validation
+
+- [x] `git diff --check`
+- [x] `npm run actionlint`
+- [x] CI-structure unit tests pass: `codecov-policy`, `ci-dependency-cache`, `ci-skip-draft-prs`, `ci-engine-miner-filters`, `ci-composite-setup-workspace`, `ci-generated-artifact-drift-checks` (30 tests).
+- [x] `npm --prefix control-plane test` (34 tests pass) and `npm run control-plane:coverage` produce `control-plane/coverage/lcov.info` with `SF:control-plane/src/**` paths (~99.8% lines).
+- [ ] `npm run typecheck` / `npm run test:coverage` / `npm run test:workers` / `npm run build:mcp` / `npm run ui:*` — **not run locally**; see note below.
+
+If any required check was skipped, explain why:
+
+- This PR changes only CI wiring (`.github/workflows/ci.yml`, `codecov.yml`), a root/control-plane build script + dependency, and two `test/**` files. It touches no `src/**`, MCP, engine, or UI source, so the backend/UI/MCP toolchains have nothing new to exercise. CI itself runs the full suite on this PR (editing `.github/workflows/**` matches the `backend` filter, so `validate-code` + all `validate-tests` shards run). `codecov/patch` has no instrumented changed lines (the changed files are all under `test/**`, `scripts/**`, or non-source `control-plane` manifests), so it reports nothing to cover.
+
+## Safety
+
+- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
+- [x] Public GitHub text stays sanitized and low-noise.
+- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
+- [x] No API/OpenAPI/MCP behavior changes.
+- [x] No UI changes.
+- [x] No docs/changelog changes required; `CHANGELOG.md` untouched.
+
+## UI Evidence
+
+N/A — no visible UI, frontend, docs, or extension changes.
+
+## Notes
+
+- The `control-plane` coverage harvest keeps the REES `|| true` shape: the authoritative pass/fail is the uninstrumented `control-plane build and tests` step, and the "verify lcov exists" step fails closed if no report lands. `control-plane/dist/**` and `control-plane/coverage/**` stay untracked (both covered by the existing `.gitignore` `dist/`/`coverage/` entries).

--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -19030,6 +19030,58 @@
           }
         ]
       }
+    },
+    "/v1/repos/{owner}/{repo}/issue-plan-drafts/generate": {
+      "post": {
+        "summary": "AI-plan maintainer-reviewed issue drafts from a free-form goal",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI-plan a small set of GitHub issue drafts from a maintainer-supplied goal (dry-run by default)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or explicit create without dryRun false"
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -95,7 +95,7 @@ const CLI_COMMAND_SPEC = {
     profile: ["list", "create", "switch", "remove"],
     cache: ["status", "clear", "list"],
     agent: ["plan", "status", "explain", "packet"],
-    maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
+    maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts", "plan-issues"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -861,6 +861,24 @@ const gatePrecisionShape = {
     repo: z.string().min(1),
     windowDays: z.number().int().positive().optional(),
 };
+// #7764: mirrors the remote server's planRepoIssuesShape (src/mcp/server.ts) and the REST route's
+// issuePlanDraftGenerateSchema (src/api/routes.ts) EXACTLY -- same goal/dryRun/create/limit/milestone bounds and
+// defaults -- so the same call works against either server and the route's create-safety guard is what it feeds.
+const planRepoIssuesShape = {
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    goal: z.string().min(1).max(2000),
+    dryRun: z.boolean().optional().default(true),
+    create: z.boolean().optional().default(false),
+    limit: z.number().int().min(1).max(10).optional().default(5),
+    milestone: z
+        .object({
+        title: z.string().min(1).max(200),
+        description: z.string().max(2000).optional(),
+        dueOn: z.string().datetime({ offset: true }).optional(),
+    })
+        .optional(),
+};
 // Single source of truth for stdio tool name + one-line description (#2233).
 // Registration and `loopover-mcp tools` both read this list.
 const STDIO_TOOL_DESCRIPTORS = [
@@ -1218,6 +1236,11 @@ const STDIO_TOOL_DESCRIPTORS = [
         name: "loopover_get_gate_precision",
         category: "maintainer",
         description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
+    },
+    {
+        name: "loopover_plan_repo_issues",
+        category: "maintainer",
+        description: "AI-plan a small set of concrete GitHub issues from a maintainer-supplied free-form goal, for any repo the caller's App/Orb is installed on. Dry-run BY DEFAULT: only PREVIEWS drafts (full title/body/labels) unless the caller passes BOTH create:true and dryRun:false, so it can never silently open issues — the same contract as `loopover-mcp maintain plan-issues`. An optional milestone (title/description/dueOn, all maintainer-supplied) groups created issues. Makes a real LLM call subject to the shared daily AI budget. Maintainer access required.",
     },
     {
         name: "loopover_open_pr",
@@ -2143,6 +2166,18 @@ registerStdioTool("loopover_get_gate_precision", {
     const payload = await apiGet(`${toolRepoBase(owner, repo)}/gate-precision${query}`);
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
 });
+// #7764: stdio mirror of the remote loopover_plan_repo_issues tool. Reaches the same POST
+// /v1/repos/:owner/:repo/issue-plan-drafts/generate route the `maintain plan-issues` CLI calls, forwarding the
+// caller's goal + dryRun/create/limit/milestone verbatim -- the route enforces create-safety
+// (explicit_create_requires_dry_run_false) and runs the AI planner, so this tool adds no local behaviour.
+registerStdioTool("loopover_plan_repo_issues", {
+    description: stdioToolDescription("loopover_plan_repo_issues"),
+    inputSchema: planRepoIssuesShape,
+}, async ({ owner, repo, goal, dryRun, create, limit, milestone }) => {
+    const body = { goal, dryRun, create, limit, ...(milestone ? { milestone } : {}) };
+    const payload = await apiPost(`${toolRepoBase(owner, repo)}/issue-plan-drafts/generate`, body);
+    return toolResult(`Issue plan for ${owner}/${repo} (status=${payload.status ?? "?"}, dryRun=${payload.dryRun}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created.`, payload);
+});
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.
@@ -2619,6 +2654,9 @@ function printMaintainHelp() {
         "  generate-issue-drafts        Preview contributor issue drafts (dry-run). Never creates without --create.",
         "             [--create]        Actually open the drafted issues (requires repo write access).",
         "             [--limit N]       Cap the drafts generated (1-20, default 5).",
+        "  plan-issues --goal \"...\"      AI-plan issues from a free-form goal (dry-run). Never creates without --create.",
+        "             [--create]        Actually open the planned issues (requires repo write access).",
+        "             [--limit N]       Cap the drafts generated (1-10, default 5).",
         "",
         "Pass --json for machine-readable output.",
     ].join("\n") + "\n");
@@ -2837,7 +2875,31 @@ async function maintainCli(args) {
         emit(payload, lines.join("\n"));
         return;
     }
-    throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`);
+    if (subcommand === "plan-issues") {
+        // #7764: session-authenticated mirror of POST {repoBase}/issue-plan-drafts/generate (and the remote
+        // loopover_plan_repo_issues tool). AI-plans issues from a required free-form --goal. Dry-run BY DEFAULT —
+        // only a bare `--create` opts into the write path, forwarded as {create:true, dryRun:false}, the exact shape
+        // the route's explicit_create_requires_dry_run_false guard demands. A plain `plan-issues` can never create.
+        const goal = typeof options.goal === "string" ? options.goal.trim() : "";
+        if (!goal)
+            throw new Error('Usage: loopover-mcp maintain plan-issues --repo owner/repo --goal "..." [--create] [--limit N].');
+        const create = options.create === true;
+        const parsedLimit = Number(options.limit);
+        const body = { goal, create, dryRun: !create, ...(Number.isFinite(parsedLimit) ? { limit: parsedLimit } : {}) };
+        const payload = await apiPost(`${repoBase}/issue-plan-drafts/generate`, body);
+        const mode = payload.dryRun ? "dry-run" : "create";
+        const lines = [
+            `Issue plan for ${repoFullName} (status=${payload.status ?? "?"}, ${mode}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created, ${payload.skippedDuplicate ?? 0} duplicate, ${payload.skippedDeclined ?? 0} declined, ${payload.skippedUnsafe ?? 0} unsafe, ${payload.skippedCreateFailed ?? 0} create-failed.`,
+            // draft.title/body are model-generated free text, so the plain-text path is sanitized (#6261).
+            ...(payload.drafts ?? []).map((draft) => {
+                const ref = draft.issue ? ` -> #${draft.issue.number} ${draft.issue.url}` : "";
+                return `- [${sanitizePlainTextTerminalOutput(draft.status)}] ${sanitizePlainTextTerminalOutput(draft.title)}${sanitizePlainTextTerminalOutput(ref)}`;
+            }),
+        ];
+        emit(payload, lines.join("\n"));
+        return;
+    }
+    throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts | plan-issues.`);
 }
 async function runCli(args) {
     const command = args[0];
@@ -4071,7 +4133,7 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
-  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts|plan-issues --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   loopover-mcp contributor-profile [--login <github-login>] [--json]

--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -107,7 +107,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
+  maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts", "plan-issues"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -915,6 +915,25 @@ const gatePrecisionShape = {
   windowDays: z.number().int().positive().optional(),
 };
 
+// #7764: mirrors the remote server's planRepoIssuesShape (src/mcp/server.ts) and the REST route's
+// issuePlanDraftGenerateSchema (src/api/routes.ts) EXACTLY -- same goal/dryRun/create/limit/milestone bounds and
+// defaults -- so the same call works against either server and the route's create-safety guard is what it feeds.
+const planRepoIssuesShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  goal: z.string().min(1).max(2000),
+  dryRun: z.boolean().optional().default(true),
+  create: z.boolean().optional().default(false),
+  limit: z.number().int().min(1).max(10).optional().default(5),
+  milestone: z
+    .object({
+      title: z.string().min(1).max(200),
+      description: z.string().max(2000).optional(),
+      dueOn: z.string().datetime({ offset: true }).optional(),
+    })
+    .optional(),
+};
+
 // Single source of truth for stdio tool name + one-line description (#2233).
 // Registration and `loopover-mcp tools` both read this list.
 const STDIO_TOOL_DESCRIPTORS = [
@@ -1290,6 +1309,12 @@ const STDIO_TOOL_DESCRIPTORS = [
     name: "loopover_get_gate_precision",
     category: "maintainer",
     description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
+  },
+  {
+    name: "loopover_plan_repo_issues",
+    category: "maintainer",
+    description:
+      "AI-plan a small set of concrete GitHub issues from a maintainer-supplied free-form goal, for any repo the caller's App/Orb is installed on. Dry-run BY DEFAULT: only PREVIEWS drafts (full title/body/labels) unless the caller passes BOTH create:true and dryRun:false, so it can never silently open issues — the same contract as `loopover-mcp maintain plan-issues`. An optional milestone (title/description/dueOn, all maintainer-supplied) groups created issues. Makes a real LLM call subject to the shared daily AI budget. Maintainer access required.",
   },
   {
     name: "loopover_open_pr",
@@ -2597,6 +2622,26 @@ registerStdioTool(
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
   },
   );
+
+// #7764: stdio mirror of the remote loopover_plan_repo_issues tool. Reaches the same POST
+// /v1/repos/:owner/:repo/issue-plan-drafts/generate route the `maintain plan-issues` CLI calls, forwarding the
+// caller's goal + dryRun/create/limit/milestone verbatim -- the route enforces create-safety
+// (explicit_create_requires_dry_run_false) and runs the AI planner, so this tool adds no local behaviour.
+registerStdioTool(
+  "loopover_plan_repo_issues",
+  {
+    description: stdioToolDescription("loopover_plan_repo_issues"),
+    inputSchema: planRepoIssuesShape,
+  },
+  async ({ owner, repo, goal, dryRun, create, limit, milestone }: any) => {
+    const body = { goal, dryRun, create, limit, ...(milestone ? { milestone } : {}) };
+    const payload = await apiPost(`${toolRepoBase(owner, repo)}/issue-plan-drafts/generate`, body);
+    return toolResult(
+      `Issue plan for ${owner}/${repo} (status=${payload.status ?? "?"}, dryRun=${payload.dryRun}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created.`,
+      payload,
+    );
+  },
+);
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.
@@ -3202,6 +3247,9 @@ function printMaintainHelp() {
       "  generate-issue-drafts        Preview contributor issue drafts (dry-run). Never creates without --create.",
       "             [--create]        Actually open the drafted issues (requires repo write access).",
       "             [--limit N]       Cap the drafts generated (1-20, default 5).",
+      "  plan-issues --goal \"...\"      AI-plan issues from a free-form goal (dry-run). Never creates without --create.",
+      "             [--create]        Actually open the planned issues (requires repo write access).",
+      "             [--limit N]       Cap the drafts generated (1-10, default 5).",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -3439,8 +3487,31 @@ async function maintainCli(args: any) {
     emit(payload, lines.join("\n"));
     return;
   }
+  if (subcommand === "plan-issues") {
+    // #7764: session-authenticated mirror of POST {repoBase}/issue-plan-drafts/generate (and the remote
+    // loopover_plan_repo_issues tool). AI-plans issues from a required free-form --goal. Dry-run BY DEFAULT —
+    // only a bare `--create` opts into the write path, forwarded as {create:true, dryRun:false}, the exact shape
+    // the route's explicit_create_requires_dry_run_false guard demands. A plain `plan-issues` can never create.
+    const goal = typeof options.goal === "string" ? options.goal.trim() : "";
+    if (!goal) throw new Error('Usage: loopover-mcp maintain plan-issues --repo owner/repo --goal "..." [--create] [--limit N].');
+    const create = options.create === true;
+    const parsedLimit = Number(options.limit);
+    const body = { goal, create, dryRun: !create, ...(Number.isFinite(parsedLimit) ? { limit: parsedLimit } : {}) };
+    const payload = await apiPost(`${repoBase}/issue-plan-drafts/generate`, body);
+    const mode = payload.dryRun ? "dry-run" : "create";
+    const lines = [
+      `Issue plan for ${repoFullName} (status=${payload.status ?? "?"}, ${mode}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created, ${payload.skippedDuplicate ?? 0} duplicate, ${payload.skippedDeclined ?? 0} declined, ${payload.skippedUnsafe ?? 0} unsafe, ${payload.skippedCreateFailed ?? 0} create-failed.`,
+      // draft.title/body are model-generated free text, so the plain-text path is sanitized (#6261).
+      ...(payload.drafts ?? []).map((draft: any) => {
+        const ref = draft.issue ? ` -> #${draft.issue.number} ${draft.issue.url}` : "";
+        return `- [${sanitizePlainTextTerminalOutput(draft.status)}] ${sanitizePlainTextTerminalOutput(draft.title)}${sanitizePlainTextTerminalOutput(ref)}`;
+      }),
+    ];
+    emit(payload, lines.join("\n"));
+    return;
+  }
   throw new Error(
-    `Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`,
+    `Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts | plan-issues.`,
   );
 }
 
@@ -4642,7 +4713,7 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
-  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts|plan-issues --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   loopover-mcp contributor-profile [--login <github-login>] [--json]

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -320,6 +320,7 @@ import { resolveRepositorySettings } from "../settings/repository-settings";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
 import { generateContributorIssueDrafts } from "../services/contributor-issue-draft";
+import { generateIssuePlanDrafts } from "../services/issue-plan-draft";
 import { buildRepoSettingsPreview, PUBLIC_SURFACE_SKIP_REASONS, skippedPrAuditRemediation } from "../signals/settings-preview";
 import {
   buildGittensorConfigRecommendation,
@@ -952,6 +953,25 @@ const contributorIssueDraftGenerateSchema = z.object({
   dryRun: z.boolean().optional().default(true),
   create: z.boolean().optional().default(false),
   limit: z.number().int().min(1).max(20).optional().default(5),
+});
+
+// #7764: REST mirror of the loopover_plan_repo_issues MCP tool's planRepoIssuesShape (src/mcp/server.ts) --
+// same goal/dryRun/create/limit/milestone bounds and defaults, so the REST and MCP surfaces cannot drift.
+// `create` alone never opens issues: the handler re-applies the explicit_create_requires_dry_run_false guard,
+// so a caller must pass BOTH create:true and dryRun:false. milestone metadata is the caller's own input (never
+// model-generated) and is only ever consulted when actually creating.
+const issuePlanDraftGenerateSchema = z.object({
+  goal: z.string().min(1).max(2000),
+  dryRun: z.boolean().optional().default(true),
+  create: z.boolean().optional().default(false),
+  limit: z.number().int().min(1).max(10).optional().default(5),
+  milestone: z
+    .object({
+      title: z.string().min(1).max(200),
+      description: z.string().max(2000).optional(),
+      dueOn: z.string().datetime({ offset: true }).optional(),
+    })
+    .optional(),
 });
 
 const settingsPreviewSchema = z.object({
@@ -2789,6 +2809,43 @@ export function createApp() {
         create: parsed.data.create,
         limit: parsed.data.limit,
         requestedBy: identity?.kind === "session" ? identity.actor : "api",
+      }),
+    );
+  });
+
+  // #7764: REST mirror of the loopover_plan_repo_issues MCP tool (src/mcp/server.ts) -- the missing REST surface
+  // for generateIssuePlanDrafts. Auth-gated identically to contributor-issue-drafts/generate above (app role +
+  // per-repo session scope), and it applies the SAME create-safety contract: `create` alone is rejected, only an
+  // explicit {create:true, dryRun:false} reaches the service, and that write path additionally requires live repo
+  // write access. The AI planner + its fleet/per-repo kill switches live inside generateIssuePlanDrafts.
+  app.post("/v1/repos/:owner/:repo/issue-plan-drafts/generate", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
+    const body = await c.req.json().catch(() => null);
+    if (body === null) return c.json({ error: "invalid_json" }, 400);
+    const parsed = issuePlanDraftGenerateSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_issue_plan_draft_request", issues: parsed.error.issues }, 400);
+    if (parsed.data.create && parsed.data.dryRun !== false) {
+      return c.json({ error: "explicit_create_requires_dry_run_false" }, 400);
+    }
+    if (parsed.data.create && parsed.data.dryRun === false) {
+      const writeForbidden = await requireRepoWriteAccess(c, fullName);
+      if (writeForbidden instanceof Response) return writeForbidden;
+    }
+    return c.json(
+      await generateIssuePlanDrafts(c.env, fullName, parsed.data.goal, {
+        dryRun: parsed.data.dryRun,
+        create: parsed.data.create,
+        limit: parsed.data.limit,
+        requestedBy: identity?.kind === "session" ? identity.actor : "api",
+        milestone: parsed.data.milestone,
       }),
     );
   });
@@ -6393,6 +6450,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoAgentPendingActionsPath(path)) return true; // list (GET, requireRepoMaintainer) + propose (POST, requireRepoWriteAccess); decision POSTs on /:id/:decision require server tokens
   if (isRepoIncidentReportsPath(path)) return true; // #5672: route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
+  if (isRepoIssuePlanDraftGeneratePath(path)) return true; // #7764: route's requireAppRole + requireSessionRepoAccess (+ requireRepoWriteAccess on create) enforce per-repo authority
   if (path === OPPORTUNITIES_FIND_PATH) return true;
   if (path === ISSUE_RAG_RETRIEVE_PATH) return true;
   if (path === LINT_PR_TEXT_PATH || path === VALIDATE_FOCUS_MANIFEST_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH) return true;
@@ -6440,6 +6498,10 @@ function isRepoOnboardingPackPreviewPath(path: string): boolean {
 
 function isRepoContributorIssueDraftGeneratePath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/contributor-issue-drafts\/generate$/.test(path);
+}
+
+function isRepoIssuePlanDraftGeneratePath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/issue-plan-drafts\/generate$/.test(path);
 }
 
 function isRepoCheckBeforeStartPath(path: string): boolean {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -689,6 +689,17 @@ export function buildOpenApiSpec() {
     },
   });
   registry.registerPath({
+    method: "post",
+    path: "/v1/repos/{owner}/{repo}/issue-plan-drafts/generate",
+    summary: "AI-plan maintainer-reviewed issue drafts from a free-form goal",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: { description: "AI-plan a small set of GitHub issue drafts from a maintainer-supplied goal (dry-run by default)", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      400: { description: "Invalid request or explicit create without dryRun false" },
+      403: { description: "Insufficient role" },
+    },
+  });
+  registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/settings",
     summary: "Repository automation settings",

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -221,7 +221,7 @@ describe("loopover-mcp CLI — basics", () => {
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
     expect(ps).toContain(
-      "'maintain' = @('status', 'queue', 'propose', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state', 'refresh-docs', 'generate-issue-drafts')",
+      "'maintain' = @('status', 'queue', 'propose', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision', 'outcome-calibration', 'onboarding-pack', 'audit-feed', 'automation-state', 'refresh-docs', 'generate-issue-drafts', 'plan-issues')",
     );
   });
 

--- a/test/unit/mcp-cli-maintain-tools.test.ts
+++ b/test/unit/mcp-cli-maintain-tools.test.ts
@@ -22,7 +22,7 @@ async function connect() {
   const apiUrl = await startFixtureServer({
     onApiRequest: (request) => {
       const url = request.url ?? "";
-      if (/pending-actions|settings|gate-precision/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
+      if (/pending-actions|settings|gate-precision|issue-plan-drafts/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
     },
   });
   transport = new StdioClientTransport({
@@ -135,5 +135,34 @@ describe("loopover-mcp maintain stdio proxies (#6152)", () => {
       expect(result.isError).toBe(true);
     }
     expect(capturedRequests).toEqual([]);
+  });
+
+  // #7764: loopover_plan_repo_issues is registered locally too, proxying to the same issue-plan-drafts route the
+  // `maintain plan-issues` CLI calls. Asserted separately from the #6152 loop because its payload/shape differs.
+  it("plan_repo_issues registers, lists with a description, and proxies goal + dry-run to its REST endpoint", async () => {
+    await connect();
+    const names = (await client!.listTools()).tools.map((tool) => tool.name);
+    expect(names).toContain("loopover_plan_repo_issues");
+    const payload = JSON.parse(run(["tools", "--json"])) as { tools: Array<{ name: string; description: string }> };
+    const entry = payload.tools.find((t) => t.name === "loopover_plan_repo_issues");
+    expect(entry?.description.trim().length).toBeGreaterThan(0);
+
+    const result = await client!.callTool({ name: "loopover_plan_repo_issues", arguments: { ...REPO, goal: "improve sync reliability" } });
+    expect(result.isError).toBeFalsy();
+    // The structured payload proxies straight through (dry-run status + counts), unlike the CLI plain-text path.
+    expect(JSON.stringify(result)).toContain("Issue plan for owner/repo (status=ok, dryRun=true)");
+    expect((result.structuredContent as { status?: string; proposed?: number }).status).toBe("ok");
+    expect(capturedRequests.length).toBeGreaterThan(0);
+    for (const request of capturedRequests) {
+      expect(request.url).toBe("/v1/repos/owner/repo/issue-plan-drafts/generate");
+      expect(request.method).toBe("POST");
+    }
+  });
+
+  it("plan_repo_issues surfaces an API failure as a tool error", async () => {
+    await connect();
+    const result = await client!.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "nobody", repo: "missing", goal: "improve reliability" } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/404|not_found/);
   });
 });

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -123,6 +123,38 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(json).toMatchObject({ dryRun: true, createRequested: false });
   });
 
+  it("plan-issues dry-runs by default, requires a goal, and never forwards create (#7764)", async () => {
+    const bodies: Array<{ goal?: string; dryRun?: boolean; create?: boolean; limit?: number }> = [];
+    const e = await env({ onIssuePlanRequest: (b) => bodies.push(b) });
+    // A missing --goal fails before any request -- the route requires it, and the CLI validates locally first.
+    await expect(runAsync(["maintain", "plan-issues", "--repo", "owner/repo"], e)).rejects.toThrow(/Usage: loopover-mcp maintain plan-issues/);
+    expect(bodies).toHaveLength(0);
+    const out = await runAsync(["maintain", "plan-issues", "--repo", "owner/repo", "--goal", "improve sync reliability"], e);
+    // A bare invocation must send {goal, create:false, dryRun:true} -- the tool can never silently create.
+    expect(bodies[0]).toMatchObject({ goal: "improve sync reliability", create: false, dryRun: true });
+    expect(out).toMatch(/Issue plan for owner\/repo \(status=ok, dry-run\): 1 proposed, 0 created/);
+    // The model-generated draft title carries an ANSI escape; the plain-text path must strip it (#6261).
+    expect(out).toContain("Add retry to the sync job");
+    expect(out).not.toContain("[31m");
+  });
+
+  it("plan-issues --create forwards {create:true, dryRun:false} and reports created issues (#7764)", async () => {
+    const bodies: Array<{ goal?: string; dryRun?: boolean; create?: boolean; limit?: number }> = [];
+    const e = await env({ onIssuePlanRequest: (b) => bodies.push(b) });
+    const out = await runAsync(["maintain", "plan-issues", "--repo", "owner/repo", "--goal", "improve sync reliability", "--create", "--limit", "3"], e);
+    // --create maps to the exact {create:true, dryRun:false} shape the route's create-safety guard demands,
+    // and --limit is forwarded as a number.
+    expect(bodies[0]).toMatchObject({ goal: "improve sync reliability", create: true, dryRun: false, limit: 3 });
+    expect(out).toMatch(/\(status=ok, create\): 0 proposed, 1 created/);
+    expect(out).toMatch(/#42 https:\/\/github\.com\/owner\/repo\/issues\/42/);
+    const json = JSON.parse(await runAsync(["maintain", "plan-issues", "--repo", "owner/repo", "--goal", "improve sync reliability", "--json"], e)) as {
+      status: string;
+      dryRun: boolean;
+      createRequested: boolean;
+    };
+    expect(json).toMatchObject({ status: "ok", dryRun: true, createRequested: false });
+  });
+
   it("outcome-calibration reports slop-band merge rates + recommendation outcomes (plain + json), passing the window through (#6735)", async () => {
     const e = await env();
     const out = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo"], e);

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -21,6 +21,7 @@
 // (#6741 registered the loopover_draft_pr_body CLI mirror, taking the count from 76 to 77.)
 // (#6747 registered the loopover_pr_outcome CLI mirror, taking the count from 77 to 78.)
 // (#6980 registered the loopover_explain_review_risk CLI mirror, taking the count from 78 to 79.)
+// (#7764 registered the loopover_plan_repo_issues stdio tool, taking the count from 79 to 80.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -68,14 +69,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 79 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 80 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(79);
+    expect(primary.length).toBe(80);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(79);
+    expect(names.length).toBe(80);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -87,14 +88,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 79-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 80-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(79);
+    expect(payload.count).toBe(80);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );

--- a/test/unit/routes-issue-plan-draft.test.ts
+++ b/test/unit/routes-issue-plan-draft.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
+import { createTestEnv } from "../helpers/d1";
+
+const PLAN_PATH = "/v1/repos/JSONbored/loopover/issue-plan-drafts/generate";
+const OWNED_REPO_PATH = "/v1/repos/repo-owner/owned-repo/issue-plan-drafts/generate";
+// AI planning is gated behind the fleet AI switches; enable them so the route reaches an "ok" (not "disabled")
+// result and returns real drafts, exercising goal forwarding rather than the early kill-switch return.
+const AI_ENABLED = { AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" };
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+}));
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
+
+/** Mirrors mcp-plan-repo-issues.test.ts: the AI binding returns a single planned issue as JSON. */
+function planningAi() {
+  return { run: async () => ({ response: JSON.stringify({ issues: [{ title: "Add retry to the sync job", body: "Retries transient failures with backoff." }] }) }) } as unknown as Ai;
+}
+
+function apiHeaders(env: Env): Record<string, string> {
+  return {
+    authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`,
+    "content-type": "application/json",
+  };
+}
+
+async function seedRegisteredInstalledRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(
+    env,
+    { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } },
+    installationId,
+  );
+  await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?")
+    .bind(`${owner}/${name}`)
+    .run();
+}
+
+describe("issue-plan-drafts route auth (#7764)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  beforeEach(() => mockedPermission.mockReset());
+
+  it("rejects unauthenticated access", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(PLAN_PATH, { method: "POST", body: "{}" }, env);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: "unauthorized" });
+  });
+
+  it("rejects unauthorized session access", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    const { token } = await createSessionForGitHubUser(env, { login: "new-user", id: 2468 });
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_role" });
+  });
+
+  it("allows same-repo owner sessions to plan dry-run drafts", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "improve sync reliability", dryRun: true, limit: 1 }),
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "repo-owner/owned-repo",
+      dryRun: true,
+      createRequested: false,
+      drafts: expect.any(Array),
+    });
+  });
+
+  it("requires live GitHub write permission before session issue creation", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", {
+      number: 5,
+      title: "cached collaborator scope",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "a1", ref: "f" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "improve sync reliability", dryRun: false, create: true, limit: 1 }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_repo_permission" });
+    expect(mockedPermission).toHaveBeenCalledWith(env, 201, "repo-owner/owned-repo", "reader");
+  });
+
+  it("rejects cross-repo owner sessions with forbidden_repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "improve sync reliability", dryRun: true, limit: 1 }),
+      },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("rejects malformed JSON with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: { ...apiHeaders(env), "content-type": "application/json" }, body: "not-json" },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_json" });
+  });
+
+  it("rejects explicit create without dryRun false", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ goal: "improve reliability", create: true }) },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "explicit_create_requires_dry_run_false" });
+  });
+
+  it("rejects a request missing the required goal", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ dryRun: true, limit: 1 }) },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_issue_plan_draft_request" });
+  });
+
+  it("returns dry-run drafts for authorized static-token callers, forwarding the goal", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ...AI_ENABLED, AI: planningAi() });
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ goal: "improve sync reliability", dryRun: true, limit: 2 }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { repoFullName: string; status: string; dryRun: boolean; createRequested: boolean; drafts: Array<{ title: string }> };
+    expect(body).toMatchObject({ repoFullName: "JSONbored/loopover", status: "ok", dryRun: true, createRequested: false });
+    expect(body.drafts[0]?.title).toBe("Add retry to the sync job");
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -174,6 +174,8 @@ export async function startFixtureServer(
     prTextLintStatus?: number;
     onPacketRequest?: (body: unknown) => void;
     onIssueDraftRequest?: (body: { dryRun?: boolean; create?: boolean; limit?: number }) => void;
+    /** #7764: captures the POST body forwarded to /issue-plan-drafts/generate (the plan-issues surface). */
+    onIssuePlanRequest?: (body: { goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown }) => void;
     onWatchRequest?: (req: { method: string; body: { repoFullName?: string; labels?: string[] } }) => void;
     onApiRequest?: (request: IncomingMessage) => void;
     validateConfigWarnings?: string[];
@@ -684,6 +686,38 @@ export async function startFixtureServer(
             {
               status: "proposed",
               title: "Add [31mcursor[0m pagination",
+              ...(requestBody.create ? { issue: { number: 42, url: "https://github.com/owner/repo/issues/42" } } : {}),
+            },
+          ],
+        }),
+      );
+      return;
+    }
+    // #7764 plan-issues / loopover_plan_repo_issues: reflect the forwarded {goal, dryRun, create, limit} so the CLI
+    // + stdio surfaces can assert the exact body they sent. The draft title carries an ANSI escape to prove the
+    // plain-text path is sanitized (#6261).
+    if (request.url === "/v1/repos/owner/repo/issue-plan-drafts/generate" && request.method === "POST") {
+      const requestBody = (await readJsonRequest(request)) as { goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown };
+      options.onIssuePlanRequest?.(requestBody);
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          generatedAt: "2026-05-30T00:00:00.000Z",
+          status: "ok",
+          dryRun: requestBody.dryRun ?? true,
+          createRequested: requestBody.create ?? false,
+          proposed: requestBody.create ? 0 : 1,
+          skippedDuplicate: 0,
+          skippedDeclined: 0,
+          skippedUnsafe: 0,
+          created: requestBody.create ? 1 : 0,
+          skippedCreateFailed: 0,
+          drafts: [
+            {
+              status: requestBody.create ? "created" : "proposed",
+              title: "Add \u001b[31mretry\u001b[0m to the sync job",
+              body: "Retries transient failures.",
+              labels: ["enhancement"],
               ...(requestBody.create ? { issue: { number: 42, url: "https://github.com/owner/repo/issues/42" } } : {}),
             },
           ],


### PR DESCRIPTION
## Summary

- Adds the three missing local surfaces for `loopover_plan_repo_issues` — a REST route, a `loopover-mcp maintain plan-issues` CLI command, and a local **stdio** MCP tool — mirroring how `loopover_generate_contributor_issue_drafts` is already exposed across REST + CLI + stdio.
- All three surfaces funnel into the existing `generateIssuePlanDrafts` service and re-enforce the same **dry-run-by-default** contract: a caller must pass **both** `create:true` and `dryRun:false` to ever open an issue, so no surface can silently create GitHub issues.

Closes #7764.

## Changes

- **`src/api/routes.ts`**
  - New `POST /v1/repos/:owner/:repo/issue-plan-drafts/generate` route, a faithful mirror of the `contributor-issue-drafts/generate` route: `requireAppRole(["maintainer","owner","operator"])`, per-repo session access check, JSON + Zod body validation (`goal`, `dryRun`, `create`, `limit` 1–10, optional `milestone`), the `explicit_create_requires_dry_run_false` guard, and `requireRepoWriteAccess` only on the real create path.
  - `isRepoIssuePlanDraftGeneratePath` added to the `canSessionAccessPath` allowlist (the route's own `requireAppRole` + `requireSessionRepoAccess` (+ `requireRepoWriteAccess` on create) remain the real authority — the allowlist entry only lets the authenticated session reach the handler, exactly like the sibling contributor-issue-drafts path).
- **`src/openapi/spec.ts` + `apps/loopover-ui/public/openapi.json`** — register the new path (regenerated via `npm run ui:openapi`), mirroring the contributor-issue-drafts entry.
- **`packages/loopover-mcp/bin/loopover-mcp.ts`** (`.js` rebuilt via `npm run build:mcp`)
  - `plan-issues` added to `SUBCOMMANDS.maintain` (+ PowerShell/shell completion) and to the `maintain` help text.
  - New `maintain plan-issues --goal "..." [--create] [--limit N]` handler: dry-run by default, forwards `{create:true, dryRun:false}` only when `--create` is passed, and sanitizes the model-generated draft titles on the plain-text path (`sanitizePlainTextTerminalOutput`).
  - New `loopover_plan_repo_issues` stdio tool (`planRepoIssuesShape` + descriptor + `registerStdioTool` block) that proxies to the REST route — bringing the local stdio tool count from 79 to 80.
- **Tests**
  - `test/unit/routes-issue-plan-draft.test.ts` (new) — auth/authz, invalid-JSON, invalid-body, `explicit_create_requires_dry_run_false`, and dry-run success, mirroring `routes-contributor-issue-draft.test.ts`.
  - `test/unit/support/mcp-cli-harness.ts` — fixture handler for the new route (with an `onIssuePlanRequest` body capture).
  - `test/unit/mcp-cli-maintain.test.ts` — `plan-issues` dry-run default, required `--goal`, and `--create` forwarding.
  - `test/unit/mcp-cli-maintain-tools.test.ts` — `loopover_plan_repo_issues` registers, lists with a description, proxies to the REST endpoint, and surfaces API failures as tool errors.
  - `test/unit/mcp-cli-basics.test.ts` — completion subcommand list updated for `plan-issues`.
  - `test/unit/mcp-tool-rename-aliases.test.ts` — tool-count invariant updated 79 → 80 (with a running-tally comment for #7764).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7764`).

## Validation

- [x] `npm run typecheck`
- [x] `npm run ui:openapi:check`
- [x] Targeted suites pass: `routes-issue-plan-draft` (9), `mcp-cli-maintain` (25), `mcp-cli-maintain-tools` (17), `mcp-tool-rename-aliases` (10), `mcp-cli-basics`, `mcp-cli-tools`, `mcp-discovery`, `mcp-plan-repo-issues`, `issue-plan-draft`, `routes-contributor-issue-draft`.
- [x] `npm run test:coverage` (full, unsharded) — all suites green after this change; the only diffs vs. baseline were the intended tool-count bump and the build-drift check, both addressed here.
- [x] `npm run build:mcp` — committed `.js`/`.d.ts` regenerated from the `.ts` source (drift check is clean once both are committed together).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise (CLI plain-text path runs draft titles through `sanitizePlainTextTerminalOutput`).
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session model changes — the route reuses the existing role + per-repo access + write-access checks.
- [x] API/OpenAPI/MCP surface additions only (no behavior change to existing routes/tools); the new route is registered in the OpenAPI spec.
- [x] No UI changes.
- [x] No docs/changelog changes required; `CHANGELOG.md` untouched.

## UI Evidence

N/A — no visible UI, frontend, docs, or extension changes.

## Notes

- The stdio tool returns the REST payload verbatim (structured content), while the CLI plain-text path is the one that sanitizes the model-generated free-text titles — the tests assert against structured fields for the stdio tool and against the sanitized text for the CLI, matching the sibling tools' conventions.
- `packages/loopover-mcp/bin/loopover-mcp.{js,ts}` are both committed artifacts; they must be committed together so `check-build-drift` stays clean.
