### PR TITLE
feat(api): mirror loopover_plan_repo_issues across REST, CLI, and stdio surfaces

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -95,7 +95,7 @@ const CLI_COMMAND_SPEC = {
     profile: ["list", "create", "switch", "remove"],
     cache: ["status", "clear", "list"],
     agent: ["plan", "status", "explain", "packet"],
-    maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
+    maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts", "plan-issues"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -861,6 +861,24 @@ const gatePrecisionShape = {
     repo: z.string().min(1),
     windowDays: z.number().int().positive().optional(),
 };
+// #7764: mirrors the remote planRepoIssuesShape (src/mcp/server.ts) and the REST route's
+// issuePlanDraftGenerateSchema EXACTLY, so this stdio tool cannot drift from the surface it proxies. Dry-run by
+// default; the route re-applies the explicit_create_requires_dry_run_false guard and enforces write access, so the
+// tool never decides locally.
+const planRepoIssuesMilestoneShape = z.object({
+    title: z.string().min(1).max(200),
+    description: z.string().max(2000).optional(),
+    dueOn: z.string().datetime({ offset: true }).optional(),
+});
+const planRepoIssuesShape = {
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    goal: z.string().min(1).max(2000),
+    dryRun: z.boolean().optional().default(true),
+    create: z.boolean().optional().default(false),
+    limit: z.number().int().min(1).max(10).optional().default(5),
+    milestone: planRepoIssuesMilestoneShape.optional(),
+};
 // Single source of truth for stdio tool name + one-line description (#2233).
 // Registration and `loopover-mcp tools` both read this list.
 const STDIO_TOOL_DESCRIPTORS = [
@@ -1218,6 +1236,11 @@ const STDIO_TOOL_DESCRIPTORS = [
         name: "loopover_get_gate_precision",
         category: "maintainer",
         description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
+    },
+    {
+        name: "loopover_plan_repo_issues",
+        category: "maintainer",
+        description: "AI-plan a small set of concrete GitHub issue drafts for a repo from a maintainer-supplied free-form goal, same as `loopover-mcp maintain plan-issues --goal`. Dry-run BY DEFAULT: only PREVIEWS drafts unless BOTH create:true and dryRun:false are passed, and creation additionally requires repo write access. An optional milestone (title/description/dueOn, all maintainer-supplied) groups any created issues. Makes a real LLM call. Maintainer access required.",
     },
     {
         name: "loopover_open_pr",
@@ -2143,6 +2166,23 @@ registerStdioTool("loopover_get_gate_precision", {
     const payload = await apiGet(`${toolRepoBase(owner, repo)}/gate-precision${query}`);
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
 });
+// #7764: local mirror of the remote loopover_plan_repo_issues tool. Proxies to the same REST route
+// `maintain plan-issues` calls (POST /issue-plan-drafts/generate); the API re-applies the
+// explicit_create_requires_dry_run_false guard and enforces maintainer + write access, so this never decides
+// locally. Schema defaults mean dryRun/create/limit always arrive resolved.
+registerStdioTool("loopover_plan_repo_issues", {
+    description: stdioToolDescription("loopover_plan_repo_issues"),
+    inputSchema: planRepoIssuesShape,
+}, async ({ owner, repo, goal, dryRun, create, limit, milestone }) => {
+    const payload = await apiPost(`${toolRepoBase(owner, repo)}/issue-plan-drafts/generate`, {
+        goal,
+        dryRun,
+        create,
+        limit,
+        ...(milestone ? { milestone } : {}),
+    });
+    return toolResult(`Issue plan for ${owner}/${repo} (status=${payload.status ?? "ok"}, dryRun=${payload.dryRun ?? true}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created.`, payload);
+});
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.
@@ -2619,6 +2659,10 @@ function printMaintainHelp() {
         "  generate-issue-drafts        Preview contributor issue drafts (dry-run). Never creates without --create.",
         "             [--create]        Actually open the drafted issues (requires repo write access).",
         "             [--limit N]       Cap the drafts generated (1-20, default 5).",
+        "  plan-issues --goal TEXT      AI-plan issue drafts from a free-form goal (dry-run). Never creates without --create.",
+        "             [--create]        Actually open the planned issues (requires repo write access).",
+        "             [--limit N]       Cap the drafts planned (1-10, default 5).",
+        "             [--milestone-title T] Group created issues under a milestone (also --milestone-description, --milestone-due ISO).",
         "",
         "Pass --json for machine-readable output.",
     ].join("\n") + "\n");
@@ -2837,7 +2881,46 @@ async function maintainCli(args) {
         emit(payload, lines.join("\n"));
         return;
     }
-    throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`);
+    if (subcommand === "plan-issues") {
+        // #7764: session-authenticated mirror of POST {repoBase}/issue-plan-drafts/generate (and the remote
+        // loopover_plan_repo_issues tool). Dry-run BY DEFAULT — only a bare `--create` opts into the write path, and it
+        // is forwarded as {create:true, dryRun:false}, the exact shape the route's explicit_create_requires_dry_run_false
+        // guard demands. A plain `plan-issues` can never create. The optional milestone (title/description/dueOn) is
+        // maintainer-supplied, never model-generated, and only ever consulted server-side when actually creating.
+        const goal = typeof options.goal === "string" ? options.goal : "";
+        if (!goal.trim()) {
+            throw new Error('Usage: loopover-mcp maintain plan-issues --goal "..." --repo owner/repo [--create] [--limit N] [--milestone-title ...].');
+        }
+        const create = options.create === true;
+        const parsedLimit = Number(options.limit);
+        const milestone = typeof options.milestoneTitle === "string"
+            ? {
+                title: options.milestoneTitle,
+                ...(typeof options.milestoneDescription === "string" ? { description: options.milestoneDescription } : {}),
+                ...(typeof options.milestoneDue === "string" ? { dueOn: options.milestoneDue } : {}),
+            }
+            : undefined;
+        const body = {
+            goal,
+            create,
+            dryRun: !create,
+            ...(Number.isFinite(parsedLimit) ? { limit: parsedLimit } : {}),
+            ...(milestone ? { milestone } : {}),
+        };
+        const payload = await apiPost(`${repoBase}/issue-plan-drafts/generate`, body);
+        const mode = payload.dryRun ? "dry-run" : "create";
+        const lines = [
+            `Issue plan for ${repoFullName} (${mode}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created, ${payload.skippedDuplicate ?? 0} duplicate, ${payload.skippedDeclined ?? 0} declined, ${payload.skippedUnsafe ?? 0} unsafe, ${payload.skippedCreateFailed ?? 0} create-failed.`,
+            // draft.title/body are generated from a free-form goal, so the plain-text path is sanitized (#6261).
+            ...(payload.drafts ?? []).map((draft) => {
+                const ref = draft.issue ? ` -> #${draft.issue.number} ${draft.issue.url}` : "";
+                return `- [${sanitizePlainTextTerminalOutput(draft.status)}] ${sanitizePlainTextTerminalOutput(draft.title)}${sanitizePlainTextTerminalOutput(ref)}`;
+            }),
+        ];
+        emit(payload, lines.join("\n"));
+        return;
+    }
+    throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts | plan-issues.`);
 }
 async function runCli(args) {
     const command = args[0];
@@ -4071,7 +4154,7 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
-  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts|plan-issues --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   loopover-mcp contributor-profile [--login <github-login>] [--json]

--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -107,7 +107,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear", "list"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts"],
+  maintain: ["status", "queue", "propose", "approve", "reject", "pause", "resume", "set-level", "precision", "outcome-calibration", "onboarding-pack", "audit-feed", "automation-state", "refresh-docs", "generate-issue-drafts", "plan-issues"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -915,6 +915,25 @@ const gatePrecisionShape = {
   windowDays: z.number().int().positive().optional(),
 };
 
+// #7764: mirrors the remote planRepoIssuesShape (src/mcp/server.ts) and the REST route's
+// issuePlanDraftGenerateSchema EXACTLY, so this stdio tool cannot drift from the surface it proxies. Dry-run by
+// default; the route re-applies the explicit_create_requires_dry_run_false guard and enforces write access, so the
+// tool never decides locally.
+const planRepoIssuesMilestoneShape = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  dueOn: z.string().datetime({ offset: true }).optional(),
+});
+const planRepoIssuesShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  goal: z.string().min(1).max(2000),
+  dryRun: z.boolean().optional().default(true),
+  create: z.boolean().optional().default(false),
+  limit: z.number().int().min(1).max(10).optional().default(5),
+  milestone: planRepoIssuesMilestoneShape.optional(),
+};
+
 // Single source of truth for stdio tool name + one-line description (#2233).
 // Registration and `loopover-mcp tools` both read this list.
 const STDIO_TOOL_DESCRIPTORS = [
@@ -1290,6 +1309,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     name: "loopover_get_gate_precision",
     category: "maintainer",
     description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
+  },
+  {
+    name: "loopover_plan_repo_issues",
+    category: "maintainer",
+    description: "AI-plan a small set of concrete GitHub issue drafts for a repo from a maintainer-supplied free-form goal, same as `loopover-mcp maintain plan-issues --goal`. Dry-run BY DEFAULT: only PREVIEWS drafts unless BOTH create:true and dryRun:false are passed, and creation additionally requires repo write access. An optional milestone (title/description/dueOn, all maintainer-supplied) groups any created issues. Makes a real LLM call. Maintainer access required.",
   },
   {
     name: "loopover_open_pr",
@@ -2597,6 +2621,31 @@ registerStdioTool(
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
   },
   );
+
+// #7764: local mirror of the remote loopover_plan_repo_issues tool. Proxies to the same REST route
+// `maintain plan-issues` calls (POST /issue-plan-drafts/generate); the API re-applies the
+// explicit_create_requires_dry_run_false guard and enforces maintainer + write access, so this never decides
+// locally. Schema defaults mean dryRun/create/limit always arrive resolved.
+registerStdioTool(
+  "loopover_plan_repo_issues",
+  {
+    description: stdioToolDescription("loopover_plan_repo_issues"),
+    inputSchema: planRepoIssuesShape,
+  },
+  async ({ owner, repo, goal, dryRun, create, limit, milestone }: any) => {
+    const payload = await apiPost(`${toolRepoBase(owner, repo)}/issue-plan-drafts/generate`, {
+      goal,
+      dryRun,
+      create,
+      limit,
+      ...(milestone ? { milestone } : {}),
+    });
+    return toolResult(
+      `Issue plan for ${owner}/${repo} (status=${payload.status ?? "ok"}, dryRun=${payload.dryRun ?? true}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created.`,
+      payload,
+    );
+  },
+);
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.
@@ -3202,6 +3251,10 @@ function printMaintainHelp() {
       "  generate-issue-drafts        Preview contributor issue drafts (dry-run). Never creates without --create.",
       "             [--create]        Actually open the drafted issues (requires repo write access).",
       "             [--limit N]       Cap the drafts generated (1-20, default 5).",
+      "  plan-issues --goal TEXT      AI-plan issue drafts from a free-form goal (dry-run). Never creates without --create.",
+      "             [--create]        Actually open the planned issues (requires repo write access).",
+      "             [--limit N]       Cap the drafts planned (1-10, default 5).",
+      "             [--milestone-title T] Group created issues under a milestone (also --milestone-description, --milestone-due ISO).",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -3439,8 +3492,48 @@ async function maintainCli(args: any) {
     emit(payload, lines.join("\n"));
     return;
   }
+  if (subcommand === "plan-issues") {
+    // #7764: session-authenticated mirror of POST {repoBase}/issue-plan-drafts/generate (and the remote
+    // loopover_plan_repo_issues tool). Dry-run BY DEFAULT — only a bare `--create` opts into the write path, and it
+    // is forwarded as {create:true, dryRun:false}, the exact shape the route's explicit_create_requires_dry_run_false
+    // guard demands. A plain `plan-issues` can never create. The optional milestone (title/description/dueOn) is
+    // maintainer-supplied, never model-generated, and only ever consulted server-side when actually creating.
+    const goal = typeof options.goal === "string" ? options.goal : "";
+    if (!goal.trim()) {
+      throw new Error('Usage: loopover-mcp maintain plan-issues --goal "..." --repo owner/repo [--create] [--limit N] [--milestone-title ...].');
+    }
+    const create = options.create === true;
+    const parsedLimit = Number(options.limit);
+    const milestone =
+      typeof options.milestoneTitle === "string"
+        ? {
+            title: options.milestoneTitle,
+            ...(typeof options.milestoneDescription === "string" ? { description: options.milestoneDescription } : {}),
+            ...(typeof options.milestoneDue === "string" ? { dueOn: options.milestoneDue } : {}),
+          }
+        : undefined;
+    const body = {
+      goal,
+      create,
+      dryRun: !create,
+      ...(Number.isFinite(parsedLimit) ? { limit: parsedLimit } : {}),
+      ...(milestone ? { milestone } : {}),
+    };
+    const payload = await apiPost(`${repoBase}/issue-plan-drafts/generate`, body);
+    const mode = payload.dryRun ? "dry-run" : "create";
+    const lines = [
+      `Issue plan for ${repoFullName} (${mode}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created, ${payload.skippedDuplicate ?? 0} duplicate, ${payload.skippedDeclined ?? 0} declined, ${payload.skippedUnsafe ?? 0} unsafe, ${payload.skippedCreateFailed ?? 0} create-failed.`,
+      // draft.title/body are generated from a free-form goal, so the plain-text path is sanitized (#6261).
+      ...(payload.drafts ?? []).map((draft: any) => {
+        const ref = draft.issue ? ` -> #${draft.issue.number} ${draft.issue.url}` : "";
+        return `- [${sanitizePlainTextTerminalOutput(draft.status)}] ${sanitizePlainTextTerminalOutput(draft.title)}${sanitizePlainTextTerminalOutput(ref)}`;
+      }),
+    ];
+    emit(payload, lines.join("\n"));
+    return;
+  }
   throw new Error(
-    `Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts.`,
+    `Unknown maintain subcommand: ${subcommand}. Use status | queue | propose <action-class> <pull-number> | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision | outcome-calibration | onboarding-pack | audit-feed | automation-state | refresh-docs | generate-issue-drafts | plan-issues.`,
   );
 }
 
@@ -4642,7 +4735,7 @@ function printHelp() {
   loopover-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   loopover-mcp cache status|list|clear [--json]
   loopover-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
-  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
+  loopover-mcp maintain status|queue|approve|reject|pause|resume|set-level|precision|outcome-calibration|onboarding-pack|audit-feed|automation-state|refresh-docs|generate-issue-drafts|plan-issues --repo owner/repo [--json] (see \`loopover-mcp maintain --help\`)
   loopover-mcp decision-pack --login <github-login> [--json]
   loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   loopover-mcp contributor-profile [--login <github-login>] [--json]

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -320,6 +320,7 @@ import { resolveRepositorySettings } from "../settings/repository-settings";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
 import { generateContributorIssueDrafts } from "../services/contributor-issue-draft";
+import { generateIssuePlanDrafts } from "../services/issue-plan-draft";
 import { buildRepoSettingsPreview, PUBLIC_SURFACE_SKIP_REASONS, skippedPrAuditRemediation } from "../signals/settings-preview";
 import {
   buildGittensorConfigRecommendation,
@@ -952,6 +953,24 @@ const contributorIssueDraftGenerateSchema = z.object({
   dryRun: z.boolean().optional().default(true),
   create: z.boolean().optional().default(false),
   limit: z.number().int().min(1).max(20).optional().default(5),
+});
+
+// #7764: mirrors planRepoIssuesShape (src/mcp/server.ts) EXACTLY -- same goal/dryRun/create/limit bounds and the
+// same maintainer-supplied milestone shape -- so the REST route, the remote MCP tool, the CLI (`maintain
+// plan-issues`), and the local stdio tool that all reach generateIssuePlanDrafts can never disagree about what
+// this surface accepts. `limit` is capped at 10 (not 20 like the contributor draft above): every draft here costs
+// a real LLM call.
+const issuePlanMilestoneSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  dueOn: z.string().datetime({ offset: true }).optional(),
+});
+const issuePlanDraftGenerateSchema = z.object({
+  goal: z.string().min(1).max(2000),
+  dryRun: z.boolean().optional().default(true),
+  create: z.boolean().optional().default(false),
+  limit: z.number().int().min(1).max(10).optional().default(5),
+  milestone: issuePlanMilestoneSchema.optional(),
 });
 
 const settingsPreviewSchema = z.object({
@@ -2788,6 +2807,42 @@ export function createApp() {
         dryRun: parsed.data.dryRun,
         create: parsed.data.create,
         limit: parsed.data.limit,
+        requestedBy: identity?.kind === "session" ? identity.actor : "api",
+      }),
+    );
+  });
+
+  // #7764: REST mirror of the remote loopover_plan_repo_issues tool (and its `maintain plan-issues` CLI + local
+  // stdio tool). Same maintainer gate + create-safety posture as the contributor-issue-drafts route above: dry-run
+  // by default, an explicit {create:true, dryRun:false} additionally requires live GitHub write access, and the
+  // free-form `goal` is the only extra input generateIssuePlanDrafts needs over its contributor-draft sibling.
+  app.post("/v1/repos/:owner/:repo/issue-plan-drafts/generate", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
+    const body = await c.req.json().catch(() => null);
+    if (body === null) return c.json({ error: "invalid_json" }, 400);
+    const parsed = issuePlanDraftGenerateSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_issue_plan_draft_request", issues: parsed.error.issues }, 400);
+    if (parsed.data.create && parsed.data.dryRun !== false) {
+      return c.json({ error: "explicit_create_requires_dry_run_false" }, 400);
+    }
+    if (parsed.data.create && parsed.data.dryRun === false) {
+      const writeForbidden = await requireRepoWriteAccess(c, fullName);
+      if (writeForbidden instanceof Response) return writeForbidden;
+    }
+    return c.json(
+      await generateIssuePlanDrafts(c.env, fullName, parsed.data.goal, {
+        dryRun: parsed.data.dryRun,
+        create: parsed.data.create,
+        limit: parsed.data.limit,
+        milestone: parsed.data.milestone,
         requestedBy: identity?.kind === "session" ? identity.actor : "api",
       }),
     );
@@ -6392,6 +6447,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoDocRefreshPath(path)) return true; // route's requireRepoWriteAccess enforces real per-repo write authority
   if (isRepoAgentPendingActionsPath(path)) return true; // list (GET, requireRepoMaintainer) + propose (POST, requireRepoWriteAccess); decision POSTs on /:id/:decision require server tokens
   if (isRepoIncidentReportsPath(path)) return true; // #5672: route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
+  if (isRepoIssuePlanDraftGeneratePath(path)) return true; // #7764: route's requireRepoWriteAccess gates the create path; dry-run preview stays maintainer-data scoped
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === OPPORTUNITIES_FIND_PATH) return true;
   if (path === ISSUE_RAG_RETRIEVE_PATH) return true;
@@ -6440,6 +6496,10 @@ function isRepoOnboardingPackPreviewPath(path: string): boolean {
 
 function isRepoContributorIssueDraftGeneratePath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/contributor-issue-drafts\/generate$/.test(path);
+}
+
+function isRepoIssuePlanDraftGeneratePath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/issue-plan-drafts\/generate$/.test(path);
 }
 
 function isRepoCheckBeforeStartPath(path: string): boolean {

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -123,6 +123,66 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
     expect(json).toMatchObject({ dryRun: true, createRequested: false });
   });
 
+  it("plan-issues dry-runs by default and never forwards create (#7764)", async () => {
+    const bodies: Array<{ goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown }> = [];
+    const e = await env({ onIssuePlanRequest: (b) => bodies.push(b) });
+    const out = await runAsync(["maintain", "plan-issues", "--repo", "owner/repo", "--goal", "add pagination"], e);
+    // A bare invocation must send the goal plus {create:false, dryRun:true} — the tool can never silently create.
+    expect(bodies[0]).toMatchObject({ goal: "add pagination", create: false, dryRun: true });
+    expect(out).toMatch(/Issue plan for owner\/repo \(dry-run\): 1 proposed, 0 created/);
+    // The generated draft title carries an ANSI escape; the plain-text path must strip it (#6261).
+    expect(out).toContain("Add issue planning");
+    expect(out).not.toContain("[31m");
+  });
+
+  it("plan-issues --create forwards {create:true, dryRun:false}, the limit, and a milestone (#7764)", async () => {
+    const bodies: Array<{ goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown }> = [];
+    const e = await env({ onIssuePlanRequest: (b) => bodies.push(b) });
+    const out = await runAsync(
+      [
+        "maintain",
+        "plan-issues",
+        "--repo",
+        "owner/repo",
+        "--goal",
+        "add pagination",
+        "--create",
+        "--limit",
+        "3",
+        "--milestone-title",
+        "Wave 2",
+        "--milestone-description",
+        "Parity work",
+        "--milestone-due",
+        "2026-08-01T00:00:00.000Z",
+      ],
+      e,
+    );
+    // --create maps to the exact {create:true, dryRun:false} shape the route's guard demands; --limit is a number,
+    // and the milestone flags are folded into the maintainer-supplied milestone object.
+    expect(bodies[0]).toMatchObject({
+      goal: "add pagination",
+      create: true,
+      dryRun: false,
+      limit: 3,
+      milestone: { title: "Wave 2", description: "Parity work", dueOn: "2026-08-01T00:00:00.000Z" },
+    });
+    expect(out).toMatch(/\(create\): 1 proposed, 1 created/);
+    expect(out).toMatch(/#42 https:\/\/github\.com\/owner\/repo\/issues\/42/);
+    const json = JSON.parse(await runAsync(["maintain", "plan-issues", "--repo", "owner/repo", "--goal", "add pagination", "--json"], e)) as {
+      dryRun: boolean;
+      createRequested: boolean;
+    };
+    expect(json).toMatchObject({ dryRun: true, createRequested: false });
+  });
+
+  it("plan-issues requires a --goal before any request (#7764)", async () => {
+    const bodies: unknown[] = [];
+    const e = await env({ onIssuePlanRequest: (b) => bodies.push(b) });
+    await expect(runAsync(["maintain", "plan-issues", "--repo", "owner/repo"], e)).rejects.toThrow(/Usage: loopover-mcp maintain plan-issues/);
+    expect(bodies).toHaveLength(0);
+  });
+
   it("outcome-calibration reports slop-band merge rates + recommendation outcomes (plain + json), passing the window through (#6735)", async () => {
     const e = await env();
     const out = await runAsync(["maintain", "outcome-calibration", "--repo", "owner/repo"], e);

--- a/test/unit/mcp-plan-repo-issues-mirror.test.ts
+++ b/test/unit/mcp-plan-repo-issues-mirror.test.ts
@@ -1,0 +1,82 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #7764: the local stdio mirror of the remote loopover_plan_repo_issues tool. Asserts the proxy contract -- that
+// the tool reaches POST /issue-plan-drafts/generate (the same route `maintain plan-issues` calls) with the goal +
+// dry-run posture -- rather than re-testing the endpoint itself, which routes-issue-plan-draft.test.ts covers.
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
+
+let client: Client | null = null;
+let transport: StdioClientTransport | null = null;
+let configDir: string | null = null;
+let planBodies: Array<{ goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown }>;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "loopover-plan-repo-issues-"));
+  planBodies = [];
+  const apiUrl = await startFixtureServer({ onIssuePlanRequest: (body) => planBodies.push(body) });
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...process.env,
+      LOOPOVER_CONFIG_DIR: configDir,
+      LOOPOVER_API_URL: apiUrl,
+      LOOPOVER_TOKEN: "session-token",
+      LOOPOVER_API_TIMEOUT_MS: "5000",
+    },
+  });
+  client = new Client({ name: "plan-repo-issues-mirror-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+afterEach(async () => {
+  await client?.close().catch(() => undefined);
+  client = null;
+  transport = null;
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+  configDir = null;
+});
+
+const REPO = { owner: "owner", repo: "repo" };
+
+describe("loopover_plan_repo_issues stdio mirror (#7764)", () => {
+  it("registers the tool in the stdio server tool list, with owner/repo/goal in its schema", async () => {
+    await connect();
+    const tool = (await client!.listTools()).tools.find((entry) => entry.name === "loopover_plan_repo_issues");
+    expect(tool, "loopover_plan_repo_issues is not registered").toBeTruthy();
+    expect(Object.keys(tool!.inputSchema.properties ?? {}).sort()).toEqual(["create", "dryRun", "goal", "limit", "milestone", "owner", "repo"]);
+  });
+
+  it("proxies a dry-run goal to POST /issue-plan-drafts/generate and returns the payload", async () => {
+    await connect();
+    const result = await client!.callTool({ name: "loopover_plan_repo_issues", arguments: { ...REPO, goal: "add pagination" } });
+    expect(result.isError).toBeFalsy();
+    // Schema defaults resolve dryRun:true / create:false before the handler forwards them.
+    expect(planBodies[0]).toMatchObject({ goal: "add pagination", dryRun: true, create: false });
+    expect(JSON.stringify(result)).toContain("proposed");
+  });
+
+  it("forwards create:true and a maintainer-supplied milestone", async () => {
+    await connect();
+    const result = await client!.callTool({
+      name: "loopover_plan_repo_issues",
+      arguments: { ...REPO, goal: "add pagination", create: true, dryRun: false, limit: 3, milestone: { title: "Wave 2", description: "Parity work" } },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(planBodies[0]).toMatchObject({ goal: "add pagination", create: true, dryRun: false, limit: 3, milestone: { title: "Wave 2", description: "Parity work" } });
+  });
+
+  it("surfaces an API failure as a tool error for a repo the fixture does not serve", async () => {
+    await connect();
+    const result = await client!.callTool({ name: "loopover_plan_repo_issues", arguments: { owner: "nobody", repo: "missing", goal: "x" } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/404|not_found/);
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -68,14 +68,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 79 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 80 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(79);
+    expect(primary.length).toBe(80);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(79);
+    expect(names.length).toBe(80);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -87,14 +87,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 79-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 80-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(79);
+    expect(payload.count).toBe(80);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );

--- a/test/unit/routes-issue-plan-draft.test.ts
+++ b/test/unit/routes-issue-plan-draft.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
+import { createTestEnv } from "../helpers/d1";
+
+// #7764: the REST mirror of the remote loopover_plan_repo_issues tool. Same maintainer gate + create-safety
+// posture as routes-contributor-issue-draft.test.ts, plus the extra free-form `goal` the plan route requires.
+const PLAN_PATH = "/v1/repos/JSONbored/loopover/issue-plan-drafts/generate";
+const OWNED_REPO_PATH = "/v1/repos/repo-owner/owned-repo/issue-plan-drafts/generate";
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+}));
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
+
+function apiHeaders(env: Env): Record<string, string> {
+  return {
+    authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`,
+    "content-type": "application/json",
+  };
+}
+
+async function seedRegisteredInstalledRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(
+    env,
+    { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } },
+    installationId,
+  );
+  await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?")
+    .bind(`${owner}/${name}`)
+    .run();
+}
+
+describe("issue-plan-drafts route auth", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  beforeEach(() => mockedPermission.mockReset());
+
+  it("rejects unauthenticated access", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(PLAN_PATH, { method: "POST", body: "{}" }, env);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: "unauthorized" });
+  });
+
+  it("rejects unauthorized session access", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    const { token } = await createSessionForGitHubUser(env, { login: "new-user", id: 2468 });
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_role" });
+  });
+
+  it("allows same-repo owner sessions to plan dry-run drafts", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "add cursor pagination", dryRun: true, limit: 1 }),
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    // env.AI is unset in the test env, so the plan short-circuits to a disabled/unavailable status -- the route
+    // still returns 200 with the full result shape, which is all this auth-focused test asserts.
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "repo-owner/owned-repo",
+      dryRun: true,
+      createRequested: false,
+    });
+  });
+
+  it("the plan-path session allowlist entry does not shadow its sibling contributor-drafts route", async () => {
+    // The plan and contributor draft routes share one session path-allowlist; a session hitting the contributor
+    // path must still fall through the plan-path entry (its `false` arm) and be admitted by the sibling entry.
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const response = await app.request(
+      "/v1/repos/repo-owner/owned-repo/contributor-issue-drafts/generate",
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ dryRun: true, limit: 1 }),
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ repoFullName: "repo-owner/owned-repo", dryRun: true });
+  });
+
+  it("requires live GitHub write permission before session issue creation", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", {
+      number: 5,
+      title: "cached collaborator scope",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "a1", ref: "f" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "add cursor pagination", dryRun: false, create: true, limit: 1 }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_repo_permission" });
+    expect(mockedPermission).toHaveBeenCalledWith(env, 201, "repo-owner/owned-repo", "reader");
+  });
+
+  it("proceeds to the planner once live GitHub write permission is confirmed for a session create", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", {
+      number: 6,
+      title: "cached collaborator scope",
+      state: "open",
+      user: { login: "writer" },
+      author_association: "COLLABORATOR",
+      head: { sha: "b2", ref: "g" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    mockedPermission.mockResolvedValue("admin");
+    const { token } = await createSessionForGitHubUser(env, { login: "writer", id: 888 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "add cursor pagination", dryRun: false, create: true, limit: 1 }),
+      },
+      env,
+    );
+    // Write access is granted, so the create-guard falls through to generateIssuePlanDrafts. With env.AI unset the
+    // planner short-circuits to a disabled/unavailable status, but the route still returns its 200 result shape.
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ repoFullName: "repo-owner/owned-repo", createRequested: true });
+    expect(mockedPermission).toHaveBeenCalledWith(env, 201, "repo-owner/owned-repo", "writer");
+  });
+
+  it("rejects cross-repo owner sessions with forbidden_repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `loopover_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ goal: "add cursor pagination", dryRun: true, limit: 1 }),
+      },
+      env,
+    );
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("rejects malformed JSON with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: { ...apiHeaders(env), "content-type": "application/json" }, body: "not-json" },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_json" });
+  });
+
+  it("rejects a body with no goal", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ dryRun: true }) },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_issue_plan_draft_request" });
+  });
+
+  it("rejects explicit create without dryRun false", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ goal: "add pagination", create: true }) },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "explicit_create_requires_dry_run_false" });
+  });
+
+  it("returns a dry-run plan for authorized static-token callers, echoing the goal-driven result shape", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      PLAN_PATH,
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ goal: "add cursor pagination", dryRun: true, limit: 2 }) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "JSONbored/loopover",
+      dryRun: true,
+      createRequested: false,
+    });
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -174,6 +174,8 @@ export async function startFixtureServer(
     prTextLintStatus?: number;
     onPacketRequest?: (body: unknown) => void;
     onIssueDraftRequest?: (body: { dryRun?: boolean; create?: boolean; limit?: number }) => void;
+    /** #7764: overrides POST /v1/repos/owner/repo/issue-plan-drafts/generate and captures the request body. */
+    onIssuePlanRequest?: (body: { goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown }) => void;
     onWatchRequest?: (req: { method: string; body: { repoFullName?: string; labels?: string[] } }) => void;
     onApiRequest?: (request: IncomingMessage) => void;
     validateConfigWarnings?: string[];
@@ -684,6 +686,38 @@ export async function startFixtureServer(
             {
               status: "proposed",
               title: "Add [31mcursor[0m pagination",
+              ...(requestBody.create ? { issue: { number: 42, url: "https://github.com/owner/repo/issues/42" } } : {}),
+            },
+          ],
+        }),
+      );
+      return;
+    }
+    if (request.url === "/v1/repos/owner/repo/issue-plan-drafts/generate" && request.method === "POST") {
+      // #7764: reflect the forwarded {goal, dryRun, create, limit, milestone} so the CLI/stdio tests can assert the
+      // exact body they sent. The draft title carries an ANSI escape to prove the plain-text path is sanitized.
+      const requestBody = (await readJsonRequest(request)) as { goal?: string; dryRun?: boolean; create?: boolean; limit?: number; milestone?: unknown };
+      options.onIssuePlanRequest?.(requestBody);
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          generatedAt: "2026-05-30T00:00:00.000Z",
+          status: "ok",
+          dryRun: requestBody.dryRun ?? true,
+          createRequested: requestBody.create ?? false,
+          proposed: 1,
+          skippedDuplicate: 0,
+          skippedDeclined: 0,
+          skippedUnsafe: 0,
+          created: requestBody.create ? 1 : 0,
+          skippedCreateFailed: 0,
+          ...(requestBody.milestone ? { milestoneNumber: 7 } : {}),
+          drafts: [
+            {
+              status: "proposed",
+              title: "Add [31missue[0m planning",
+              body: "Add pagination.",
+              labels: ["enhancement"],
               ...(requestBody.create ? { issue: { number: 42, url: "https://github.com/owner/repo/issues/42" } } : {}),
             },
           ],


### PR DESCRIPTION
feat(api): mirror loopover_plan_repo_issues across REST, CLI, and stdio surfaces

loopover_plan_repo_issues shipped remote-MCP-only (Epic #7424) after the
tool-parity milestone closed, so unlike every other repo-scoped analytical
tool it had no REST route, CLI command, or local stdio tool. Mirror the
three-surface shape of its closest analog, loopover_generate_contributor_
issue_drafts (identical requireRepoManageAccess gate):

- POST /v1/repos/:owner/:repo/issue-plan-drafts/generate, gated like the
  contributor-drafts route (dry-run by default; an explicit {create:true,
  dryRun:false} additionally requires live GitHub write access), forwarding
  the free-form goal + optional maintainer-supplied milestone.
- maintain plan-issues CLI command proxying the new route, dry-run by
  default with --create/--limit/--milestone-* flags.
- loopover_plan_repo_issues local stdio tool proxying the same route.

The route's schema, the CLI, and the stdio shape all mirror the remote
planRepoIssuesShape exactly so the surfaces cannot drift.

Closes #7764

