### PR TITLE
fix(miner): guard repo segments in 4 more normalizeRepoFullName parsers

### DIFF
--- a/packages/loopover-miner/lib/contribution-profile-cache.ts
+++ b/packages/loopover-miner/lib/contribution-profile-cache.ts
@@ -14,6 +14,7 @@ import {
   resolveLocalStoreDbPath,
 } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import {
   CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC,
   purgeStoreByRepo,
@@ -58,6 +59,9 @@ function normalizeRepoFullName(repoFullName: unknown): string {
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined)
     throw new Error("invalid_repo_full_name");
+  // #7795: reject `.`/`..`/control-char segments (via repo-clone.js's shared guard) before this value backs a
+  // SQLite key or is echoed through a CLI -- the same path-safety check #5831/#7525 rolled out to every sibling.
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/prediction-ledger.ts
+++ b/packages/loopover-miner/lib/prediction-ledger.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeLocalStoreDbPath, openLocalStoreAdapter, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import {
   PREDICTION_LEDGER_PURGE_SPEC,
   PREDICTION_LEDGER_RETENTION_SPEC,
@@ -87,6 +88,9 @@ function normalizeRepoFullName(repoFullName: string): string {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  // #7795: reject `.`/`..`/control-char segments (via repo-clone.js's shared guard) before this value backs a
+  // SQLite key or is echoed through a CLI -- the same path-safety check #5831/#7525 rolled out to every sibling.
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/replay-snapshot.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { removeWorktree } from "@loopover/engine";
 import type { WorktreeExecFn, WorktreeRemoveResult } from "@loopover/engine";
 import { openLocalStoreAdapter, resolveLocalStoreDbPath, normalizeLocalStoreDbPath } from "./local-store.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 // Freeze/snapshot mechanism for historical replay targets (#3010). Given a repo and a commit SHA T, exports:
 //  (a) the full working tree checked out AT T via a DETACHED git worktree -- the same isolation primitive
@@ -72,6 +73,9 @@ function normalizeRepoFullName(repoFullName: string): string {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  // #7795: reject `.`/`..`/control-char segments (via repo-clone.js's shared guard) before this value backs a
+  // SQLite key or is echoed through a CLI -- the same path-safety check #5831/#7525 rolled out to every sibling.
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/run-state.ts
+++ b/packages/loopover-miner/lib/run-state.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { normalizeLocalStoreDbPath, openLocalStoreAdapter, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import { RUN_STATE_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
 
 export type RunState = "idle" | "discovering" | "planning" | "preparing";
@@ -57,6 +58,9 @@ function normalizeRepoFullName(repoFullName: string): string {
   const trimmed = repoFullName.trim();
   const [owner, repo, extra] = trimmed.split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  // #7795: reject `.`/`..`/control-char segments (via repo-clone.js's shared guard) before this value backs a
+  // SQLite key or is echoed through a CLI -- the same path-safety check #5831/#7525 rolled out to every sibling.
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/test/unit/miner-contribution-profile-cache.test.ts
+++ b/test/unit/miner-contribution-profile-cache.test.ts
@@ -158,6 +158,9 @@ describe("contribution-profile cache store (#6797)", () => {
     expect(() => store.put({ repoFullName: 42 } as never)).toThrow(
       "invalid_repo_full_name",
     );
+    // #7795: `.`/`..`/control-char segments must be rejected too (both owner and repo), not just missing/extra slashes.
+    expect(() => store.get("../etc")).toThrow("invalid_repo_full_name");
+    expect(() => store.get("owner/..")).toThrow("invalid_repo_full_name");
   });
 
   it("exposes module-level get/put helpers backed by the default DB path", () => {

--- a/test/unit/miner-prediction-ledger.test.ts
+++ b/test/unit/miner-prediction-ledger.test.ts
@@ -68,6 +68,9 @@ describe("miner prediction ledger (#4263)", () => {
   it("rejects invalid inputs field by field", () => {
     const ledger = tempLedger();
     expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "no-slash" })).toThrow(/invalid_repo_full_name/);
+    // #7795: `.`/`..`/control-char segments must be rejected too (both owner and repo), not just missing/extra slashes.
+    expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "../etc" })).toThrow(/invalid_repo_full_name/);
+    expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "owner/.." })).toThrow(/invalid_repo_full_name/);
     expect(() => ledger.appendPrediction({ ...VALID, targetId: 0 })).toThrow(/invalid_target_id/);
     expect(() => ledger.appendPrediction({ ...VALID, conclusion: "" })).toThrow(/invalid_conclusion/);
     expect(() => ledger.appendPrediction({ ...VALID, engineVersion: "" })).toThrow(/invalid_engine_version/);

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -341,6 +341,9 @@ describe("exportReplaySnapshot (#3010)", () => {
 
     await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "noslash", commitSha: "a" }, deps)).rejects.toThrow("invalid_repo_full_name");
     await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "a/b/c", commitSha: "a" }, deps)).rejects.toThrow("invalid_repo_full_name");
+    // #7795: `.`/`..`/control-char segments must be rejected too (both owner and repo), not just missing/extra slashes.
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "../etc", commitSha: "a" }, deps)).rejects.toThrow("invalid_repo_full_name");
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "owner/..", commitSha: "a" }, deps)).rejects.toThrow("invalid_repo_full_name");
   });
 
   it("assertExecResult falls back to a generic exit-code message when stderr is entirely absent", async () => {

--- a/test/unit/miner-run-state.test.ts
+++ b/test/unit/miner-run-state.test.ts
@@ -129,6 +129,9 @@ describe("loopover-miner run-state store (#2289)", () => {
     try {
       expect(() => store.getRunState("not-a-full-name")).toThrow("invalid_repo_full_name");
       expect(() => store.setRunState("owner/repo/extra", "idle")).toThrow("invalid_repo_full_name");
+      // #7795: `.`/`..`/control-char segments must be rejected too (both owner and repo), not just missing/extra slashes.
+      expect(() => store.getRunState("../etc")).toThrow("invalid_repo_full_name");
+      expect(() => store.setRunState("owner/..", "idle")).toThrow("invalid_repo_full_name");
       expect(() => store.setRunState("owner/repo", "blocked" as never)).toThrow("invalid_run_state");
       expect(store.getRunState("owner/repo")).toBeNull();
     } finally {


### PR DESCRIPTION
## What

Four `normalizeRepoFullName` parsers only check "exactly one slash, both halves non-empty" and never call `repo-clone.ts`'s `isValidRepoSegment`, so a `.`/`..`/control-char owner or repo segment (e.g. `"../repo"`, `"owner/.."`) is accepted and then **persisted as a SQLite key** / echoed through the sibling CLIs:

- `packages/loopover-miner/lib/contribution-profile-cache.ts`
- `packages/loopover-miner/lib/prediction-ledger.ts`
- `packages/loopover-miner/lib/replay-snapshot.ts`
- `packages/loopover-miner/lib/run-state.ts`

Issues #5831 and #7525 already rolled this exact guard out to the other **ten** sibling parsers; these four were missed.

## Fix

Add the same `isValidRepoSegment(owner) || isValidRepoSegment(repo)` check each already-fixed sibling uses, imported from `./repo-clone.js` — no new validation shape. The pre-existing "one slash, non-empty halves" check is unchanged; this only rejects the `.`/`..`/control-char cases it let through.

## Tests

Each file's existing malformed-repo test is extended with path-traversal cases for **both** the owner segment (`../etc`) and the repo segment (`owner/..`), matching `test/unit/miner-claim-ledger.test.ts`'s own assertion for the already-fixed siblings.

Closes #7795