### PR TITLE
fix(review): paginate findPreviewUrlFromChecks's check-runs read

### DIFF
--- a/src/review/visual/preview-url.ts
+++ b/src/review/visual/preview-url.ts
@@ -228,15 +228,28 @@ export async function findPreviewUrlFromChecks(params: {
       const url = extractPreviewUrl(status.target_url);
       if (url) return url;
     }
-    const checks = await githubJson<{ check_runs?: Array<{ status?: string; conclusion?: string; details_url?: string; output?: { summary?: string; text?: string } }> }>(
+    // Walk EVERY page of check-runs (#7779): a commit with >100 check-runs can push the preview-deploy
+    // check-run onto page 2+, which a single per_page=100 read would miss -- exactly the truncation the file
+    // header warns about, and the same walk getPreviewBuildState/findPreviewUrlFromPrComments already do for
+    // this endpoint. Reuses findAcrossPages so the scan stops as soon as a page yields a usable URL.
+    const urlFromChecks = await findAcrossPages<
+      { status?: string; conclusion?: string; details_url?: string; output?: { summary?: string; text?: string } },
+      string
+    >(
       `${base}/commits/${encodeURIComponent(params.sha)}/check-runs?per_page=100`,
       opts,
+      (payload) =>
+        (payload as { check_runs?: Array<{ status?: string; conclusion?: string; details_url?: string; output?: { summary?: string; text?: string } }> })?.check_runs ?? [],
+      (runs) => {
+        for (const run of runs) {
+          if (run.status === "completed" && run.conclusion && run.conclusion !== "success") continue;
+          const url = extractPreviewUrl(run.details_url) ?? extractPreviewUrl(run.output?.summary) ?? extractPreviewUrl(run.output?.text);
+          if (url) return url;
+        }
+        return null;
+      },
     ).catch(() => null);
-    for (const run of checks?.check_runs ?? []) {
-      if (run.status === "completed" && run.conclusion && run.conclusion !== "success") continue;
-      const url = extractPreviewUrl(run.details_url) ?? extractPreviewUrl(run.output?.summary) ?? extractPreviewUrl(run.output?.text);
-      if (url) return url;
-    }
+    if (urlFromChecks) return urlFromChecks;
   } catch (error) {
     console.log(JSON.stringify({ event: "preview_from_checks_error", repo: `${params.repo.owner}/${params.repo.repo}`, message: String(error).slice(0, 200) }));
   }

--- a/test/unit/preview-url.test.ts
+++ b/test/unit/preview-url.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearGitHubResponseCacheForTest, githubRateLimitAdmissionKeyForInstallation, latestGitHubRestRateLimitObservation } from "../../src/github/client";
-import { extractPreviewUrl, findPreviewUrlFromPrComments, getPreviewBuildState } from "../../src/review/visual/preview-url";
+import { extractPreviewUrl, findPreviewUrlFromChecks, findPreviewUrlFromPrComments, getPreviewBuildState } from "../../src/review/visual/preview-url";
 
 /** GitHub's `Link` header for a page that advertises a next page (the exact shape findAcrossPages walks). */
 const NEXT_LINK = '<https://api.github.com/resource?per_page=100&page=99>; rel="next", <https://api.github.com/resource?per_page=100&page=99>; rel="last"';
@@ -165,6 +165,84 @@ describe("preview-url pagination (#7450)", () => {
     vi.stubGlobal("fetch", failLater);
     await expect(getPreviewBuildState({ token: "t", repo: REPO, sha: "fail" })).resolves.toBe("absent");
     expect(failLater).toHaveBeenCalledTimes(2);
+  });
+
+  // findPreviewUrlFromChecks scans the combined commit-status first, then walks check-runs. These stub the
+  // status endpoint to an empty/no-preview payload so control reaches the check-runs walk under test (#7779).
+  const emptyStatus = () => Response.json({ statuses: [] });
+
+  it("findPreviewUrlFromChecks follows Link: rel=next and finds the preview check-run on page 2 (#7779)", async () => {
+    // The bug: a commit with >100 check-runs pushes the Cloudflare Workers Builds check onto page 2+, which the
+    // old single-page read missed. Page 1 is 100 non-preview runs advertising a next page; page 2 carries it.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status")) return emptyStatus();
+      if (url.includes("/check-runs")) {
+        if (isPage2(input)) return Response.json({ check_runs: [{ status: "completed", conclusion: "success", details_url: "https://pr-9.pages.dev/" }] });
+        return Response.json({ check_runs: Array.from({ length: 100 }, () => ({ status: "completed", conclusion: "success", details_url: "https://example.com/ci" })) }, { headers: { link: NEXT_LINK } });
+      }
+      return Response.json({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "abc" })).resolves.toBe("https://pr-9.pages.dev");
+    // Page 2 of check-runs was actually fetched (the pre-#7779 bug never read it).
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/check-runs") && isPage2(c[0]))).toBe(true);
+  });
+
+  it("findPreviewUrlFromChecks skips a completed non-success check-run and reads the preview from output.summary/text (#7779)", async () => {
+    // Exercises the `continue` (completed && conclusion !== success) skip and the details_url ?? summary ?? text
+    // fallback chain: the first run is a hard failure (skipped), the second carries the URL only in output.text.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status")) return emptyStatus();
+      if (url.includes("/check-runs")) {
+        return Response.json({
+          check_runs: [
+            { status: "completed", conclusion: "failure", details_url: "https://should-be-skipped.pages.dev/" },
+            { status: "completed", conclusion: "success", output: { text: "preview at https://from-text.workers.dev/" } },
+          ],
+        });
+      }
+      return Response.json({});
+    });
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "abc" })).resolves.toBe("https://from-text.workers.dev");
+  });
+
+  it("findPreviewUrlFromChecks returns null when no check-run carries a preview URL and there is no next page (#7779)", async () => {
+    // The probe finds nothing on the only page and the payload has no `check_runs` array (treated as []): the
+    // whole discovery degrades to null rather than throwing.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status")) return emptyStatus();
+      if (url.includes("/check-runs")) return Response.json({});
+      return Response.json({});
+    });
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "abc" })).resolves.toBeNull();
+  });
+
+  it("findPreviewUrlFromChecks degrades to null when the check-runs read fails, without throwing (#7779)", async () => {
+    // The .catch(() => null) around the paginated walk preserves the pre-#7779 best-effort behavior: a check-runs
+    // fetch error must not throw out of the function, just yield no URL from that source.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status")) return emptyStatus();
+      if (url.includes("/check-runs")) throw new Error("check-runs network down");
+      return Response.json({});
+    });
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "abc" })).resolves.toBeNull();
+  });
+
+  it("findPreviewUrlFromChecks returns a preview URL straight from the combined commit-status, before touching check-runs (#7779)", async () => {
+    // The status-first path: a success status whose target_url is a preview host short-circuits before the
+    // check-runs walk runs at all.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status")) return Response.json({ statuses: [{ state: "success", target_url: "https://from-status.pages.dev/" }] });
+      return Response.json({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(findPreviewUrlFromChecks({ token: "t", repo: REPO, sha: "abc" })).resolves.toBe("https://from-status.pages.dev");
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/check-runs"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What & why

Closes #7779.

`findPreviewUrlFromChecks` (`src/review/visual/preview-url.ts`) fetched only **page 1** of a commit's check-runs (`?per_page=100`) and never followed pagination — even though the exact same endpoint, in the same file, is walked correctly via the file's own `findAcrossPages` helper by both `getPreviewBuildState` and `findPreviewUrlFromPrComments`. The file header comment already reasons about this exact truncation (">100 check-runs would push the Cloudflare Workers Builds check-run onto page 2+ … return null/absent as if it genuinely didn't exist"), but this one function never got the fix its neighbours have.

Called from `capture.ts:163` as the **primary** preview-URL-discovery step. On a repo with matrix builds / many external checks (>100 check-runs on the head SHA), the Workers Builds check-run lands on page 2+, so `findPreviewUrlFromChecks` returned `null` while the later `getPreviewBuildState` (which paginates) correctly reported `succeeded` — the system knew a preview deploy succeeded but never surfaced its URL, leaving a permanent loading spinner instead of the screenshot.

## The fix

Reuse `findAcrossPages` (the pattern the issue **requires** — no new pagination loop) for the check-runs read, moving the per-run scan into its probe so the walk stops as soon as a page yields a usable URL. The pre-existing best-effort behavior is preserved: the paginated walk is wrapped in `.catch(() => null)` so a check-runs read error still degrades to "no URL from this source" rather than throwing, and the earlier combined-commit-status short-circuit is unchanged.

## Tests (added to `test/unit/preview-url.test.ts`, mirroring the sibling `getPreviewBuildState` pagination tests)

- **Regression (the bug):** a commit whose page 1 is 100 non-preview check-runs advertising a next page, with the Workers Builds check-run on **page 2** — asserts the preview URL is found and that page 2 was actually fetched. Verified bug-catching: reverting to the single-page read makes this fail (URL missed).
- Skips a completed non-success check-run (`continue`) and resolves the URL from the `details_url ?? output.summary ?? output.text` fallback chain.
- No preview anywhere + no `check_runs` array → `null` (no throw).
- Check-runs read error → `.catch` degrades to `null`.
- Combined commit-status success short-circuit returns before check-runs are ever fetched.
- **100% of the changed lines and branches covered** (measured on the diff, unsharded).

## Validation

- `preview-url.ts` typecheck clean; `test/unit/preview-url.test.ts` (28) + consumer `queue-3.test.ts` (145) green
- `git diff --check` clean; scoped to the two files above; rebased onto latest `main`, mergeable-clean