### PR TITLE
fix(ci): add explicit failure check to redis readiness loop

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -145,10 +145,12 @@ jobs:
           docker network create gt-smoke
           docker run -d --name gt-redis --network gt-smoke redis:7-alpine
           trap 'docker rm -f gt gt-redis >/dev/null 2>&1 || true; docker network rm gt-smoke >/dev/null 2>&1 || true' EXIT
+          ok=0
           for _ in $(seq 1 30); do
-            if docker exec gt-redis redis-cli ping | grep -q PONG; then break; fi
+            if docker exec gt-redis redis-cli ping | grep -q PONG; then ok=1; break; fi
             sleep 1
           done
+          if [ "$ok" != "1" ]; then echo "::error::redis did not become ready"; docker logs gt-redis; exit 1; fi
           docker run -d --name gt --network gt-smoke -p 8787:8787 \
             -e REDIS_URL=redis://gt-redis:6379 \
             -e SELFHOST_SETUP_TOKEN=selfhost-ci-setup-token \


### PR DESCRIPTION
## Summary

- `.github/workflows/selfhost.yml`'s Redis readiness wait loop (lines ~148-150) silently fell
  through with no error if Redis never answered `PONG` within 30s, so a real Redis-startup
  regression would surface later as a misleading generic "container did not become healthy"
  failure from the app health-check loop instead of pointing directly at Redis. This ports the
  exact `ok=0`/`ok=1`/explicit-failure idiom already used by the adjacent app-health readiness
  loop 9 lines later (lines 157-160) to the Redis loop: same structure, same `::error::` +
  `docker logs` + `exit 1` on timeout.

Closes #7768

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` (pre-existing failures in `packages/loopover-miner/lib/discover-cli.ts` and the `semver` declaration checks, unrelated to this change — this PR touches only `.github/workflows/selfhost.yml`)
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a workflow-YAML-only change to `.github/workflows/selfhost.yml` (a CI smoke-test step)
  — no `src/**`, `test/**`, or `apps/**` files are touched, so `test:coverage` (and the
  `codecov/patch` gate it feeds), `test:workers`, `build:mcp`, `test:mcp-pack`, and all `ui:*`
  checks have nothing new to exercise; per the linked issue, this class of change is explicitly
  not covered by the Codecov patch gate. Verified instead by confirming the new failure path
  (`::error::` message, `docker logs`, `exit 1`) matches the adjacent, already-in-production
  app-health loop's shape exactly, in the same job/runner context.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI Evidence section — this change has no UI/frontend surface.
