### PR TITLE
test(selfhost): cover env_get, compose_file_args, and require_cmd in the deploy-common lib

### DIFF
--- a/test/unit/selfhost-deploy-common.test.ts
+++ b/test/unit/selfhost-deploy-common.test.ts
@@ -175,3 +175,119 @@ describe("env_put (#7766 -- atomic write + mode preservation)", () => {
     }
   });
 });
+
+// Generic seam for the remaining library functions (#7769): source the lib in a scratch dir, invoke one
+// function with the given args, and return its status/stdout/stderr -- the same spawn-a-real-bash approach as
+// createHarness above, but parameterized so env_get/compose_file_args/require_cmd can each be driven directly.
+function runLibFn(call: string, options: { env?: Record<string, string>; files?: Record<string, string> } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "loopover-selfhost-deploy-common-fn-"));
+  try {
+    for (const [name, contents] of Object.entries(options.files ?? {})) {
+      writeFileSync(join(dir, name), contents);
+    }
+    const scriptPath = join(dir, "run.sh");
+    // set -u is deliberately NOT enabled: env_get/compose_file_args read optional vars (ENV_FILE,
+    // SELFHOST_COMPOSE_FILES) with their own `${VAR:-default}` guards, exactly as the real deploy scripts do.
+    writeFileSync(scriptPath, `#!/usr/bin/env bash\nset -eo pipefail\n. "${libPath.replace(/\\/g, "/")}"\n${call}\n`);
+    chmodSync(scriptPath, 0o755);
+    return spawnSync("bash", [scriptPath], {
+      cwd: dir,
+      encoding: "utf8",
+      env: { ...process.env, ...(options.env ?? {}) },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("require_cmd (#7769)", () => {
+  it("succeeds silently when the command exists", () => {
+    // `bash` is guaranteed present (we're running under it); require_cmd must return 0 and print nothing.
+    const result = runLibFn("require_cmd bash");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("fails with exit 1 and a clear error when the command is missing", () => {
+    const result = runLibFn("require_cmd loopover-definitely-not-a-real-command");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("required command not found: loopover-definitely-not-a-real-command");
+  });
+});
+
+describe("env_get (#7769)", () => {
+  it("returns a plain unquoted value for a matching key", () => {
+    const result = runLibFn('env_get FOO "$PWD/.env"', { files: { ".env": "FOO=bar\n" } });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("bar\n");
+  });
+
+  it("strips surrounding double and single quotes from the value", () => {
+    const dq = runLibFn('env_get FOO "$PWD/.env"', { files: { ".env": 'FOO="quoted value"\n' } });
+    expect(dq.status, dq.stderr).toBe(0);
+    expect(dq.stdout).toBe("quoted value\n");
+
+    const sq = runLibFn('env_get FOO "$PWD/.env"', { files: { ".env": "FOO='single quoted'\n" } });
+    expect(sq.status, sq.stderr).toBe(0);
+    expect(sq.stdout).toBe("single quoted\n");
+  });
+
+  it("skips comment and blank lines and returns the first matching key", () => {
+    const result = runLibFn('env_get FOO "$PWD/.env"', { files: { ".env": "# a comment\n\n  FOO = spaced\nFOO=second\n" } });
+    expect(result.status, result.stderr).toBe(0);
+    // Leading indentation and the spaces around `=` are trimmed; the FIRST match wins (awk exits on it).
+    expect(result.stdout).toBe("spaced\n");
+  });
+
+  it("returns exit 1 when the key is absent from the file", () => {
+    const result = runLibFn('env_get MISSING "$PWD/.env"', { files: { ".env": "FOO=bar\n" } });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+  });
+
+  it("returns exit 1 when the file does not exist", () => {
+    const result = runLibFn('env_get FOO "$PWD/does-not-exist.env"');
+    expect(result.status).toBe(1);
+  });
+
+  it("falls back to $ENV_FILE when no file argument is given", () => {
+    const result = runLibFn("env_get FOO", { files: { ".env": "FOO=from-env-file\n" }, env: { ENV_FILE: ".env" } });
+    expect(result.status, result.stderr).toBe(0);
+    // The awk reads $ENV_FILE relative to cwd (the scratch dir), where we wrote .env.
+    expect(result.stdout).toBe("from-env-file\n");
+  });
+});
+
+describe("compose_file_args (#7769)", () => {
+  it("emits -f docker-compose.yml by default when only the base compose file exists", () => {
+    const result = runLibFn("compose_file_args", { files: { "docker-compose.yml": "services: {}\n" } });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("-f\ndocker-compose.yml\n");
+  });
+
+  it("adds the override file when docker-compose.override.yml is present", () => {
+    const result = runLibFn("compose_file_args", {
+      files: { "docker-compose.yml": "services: {}\n", "docker-compose.override.yml": "services: {}\n" },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("-f\ndocker-compose.yml\n-f\ndocker-compose.override.yml\n");
+  });
+
+  it("uses SELFHOST_COMPOSE_FILES verbatim when set, overriding the default discovery", () => {
+    const result = runLibFn("compose_file_args", {
+      files: { "a.yml": "services: {}\n", "b.yml": "services: {}\n" },
+      env: { SELFHOST_COMPOSE_FILES: "a.yml b.yml" },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("-f\na.yml\n-f\nb.yml\n");
+  });
+
+  it("fails with exit 1 and a clear error when a listed compose file is missing", () => {
+    const result = runLibFn("compose_file_args", {
+      files: { "a.yml": "services: {}\n" },
+      env: { SELFHOST_COMPOSE_FILES: "a.yml missing.yml" },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("compose file not found: missing.yml");
+  });
+});


### PR DESCRIPTION
## What & why

Closes #7769.

`test/unit/selfhost-deploy-common.test.ts` only exercised `maybe_infisical_run` (and, since #7766 landed, `env_put`). The other three functions in `scripts/lib/selfhost-deploy-common.sh` — `env_get`, `compose_file_args`, and `require_cmd` — had **no test seam**, despite being sourced by five deploy/verify scripts and being where two other already-filed bugs in this file went undetected. This adds real unit coverage for them.

## What's tested

A small parameterized runner (`runLibFn`) sources the lib in a scratch dir and invokes one function per case, mirroring the existing spawn-a-real-`bash` harness. Cases:

- **`require_cmd`**: succeeds silently for a present command (`bash`); exits 1 with `required command not found: …` for a missing one.
- **`env_get`**: plain unquoted value; strips surrounding double **and** single quotes; skips comment/blank lines and returns the **first** matching key with indentation and `=`-spacing trimmed; exit 1 for an absent key; exit 1 for a missing file; falls back to `$ENV_FILE` when no file arg is given.
- **`compose_file_args`**: emits `-f docker-compose.yml` by default; adds `docker-compose.override.yml` when present; uses `SELFHOST_COMPOSE_FILES` verbatim when set; exits 1 with `compose file not found: …` for a listed-but-missing file.

Scope is exactly the remaining coverage — `env_put` (added by #7766) and `maybe_infisical_run` are left untouched, and this doesn't pre-empt the companion `compose_file_args`/`env_put` bug-fix issues (it tests the current behavior, not a fix).

## Validation

- `test/unit/selfhost-deploy-common.test.ts`: **20 tests pass** (4 `maybe_infisical_run` + 4 `env_put` + 12 new), typecheck clean, `git diff --check` clean.
- Tests genuinely bite: a mutation making `compose_file_args` emit the wrong flag fails 3 of the new cases.
- Test-only change (`test/**`), additive after the existing blocks; branched off current `main`, mergeable-clean.