### PR TITLE
test(miner-ui): cover chat-scroll stick-to-bottom boundary and clamp (#7793)

### DIFF
--- a/apps/loopover-miner-ui/src/lib/chat-scroll.test.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-scroll.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { CHAT_NEAR_BOTTOM_PX, isChatViewportNearBottom, scrollChatViewportToBottom } from "./chat-scroll";
+
+/** A minimal stand-in for the scroll viewport: jsdom can't set scrollHeight/clientHeight on a real element. */
+function viewport(scrollHeight: number, clientHeight: number, scrollTop = 0): HTMLElement {
+  return { scrollTop, scrollHeight, clientHeight } as unknown as HTMLElement;
+}
+
+describe("isChatViewportNearBottom (#7229)", () => {
+  it("treats a distance of exactly CHAT_NEAR_BOTTOM_PX as still pinned (the <= boundary)", () => {
+    // scrollHeight - scrollTop - clientHeight === 80
+    expect(isChatViewportNearBottom(viewport(1000, 400, 520))).toBe(true);
+  });
+
+  it("treats one pixel past the threshold as scrolled away", () => {
+    // ...=== 81
+    expect(isChatViewportNearBottom(viewport(1000, 400, 519))).toBe(false);
+  });
+
+  it("is true when the viewport sits exactly at the bottom", () => {
+    expect(isChatViewportNearBottom(viewport(1000, 400, 600))).toBe(true);
+  });
+
+  it("is true for content shorter than the viewport (negative distance, nothing to scroll)", () => {
+    expect(isChatViewportNearBottom(viewport(200, 400, 0))).toBe(true);
+  });
+
+  it("is false when scrolled far up", () => {
+    expect(isChatViewportNearBottom(viewport(5000, 400, 0))).toBe(false);
+  });
+
+  it("honors an explicit thresholdPx instead of the default", () => {
+    // distance === 10: outside a 0px threshold, inside the 80px default.
+    expect(isChatViewportNearBottom(viewport(1000, 400, 590), 0)).toBe(false);
+    expect(isChatViewportNearBottom(viewport(1000, 400, 590))).toBe(true);
+    // distance === 0 still counts at a 0px threshold (<=, not <).
+    expect(isChatViewportNearBottom(viewport(1000, 400, 600), 0)).toBe(true);
+  });
+
+  it("exposes the documented 80px threshold", () => {
+    expect(CHAT_NEAR_BOTTOM_PX).toBe(80);
+  });
+});
+
+describe("scrollChatViewportToBottom (#7229)", () => {
+  it("scrolls to the maximum scrollable offset", () => {
+    const el = viewport(1000, 400, 0);
+    scrollChatViewportToBottom(el);
+    expect(el.scrollTop).toBe(600);
+  });
+
+  it("clamps to 0 when the content is shorter than the viewport", () => {
+    const el = viewport(200, 400, 25);
+    scrollChatViewportToBottom(el);
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it("leaves an already-bottomed viewport at the same offset (idempotent)", () => {
+    const el = viewport(1000, 400, 600);
+    scrollChatViewportToBottom(el);
+    expect(el.scrollTop).toBe(600);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7793.

`apps/loopover-miner-ui/src/lib/chat-scroll.ts` encodes the `<= 80px` near-bottom threshold (`CHAT_NEAR_BOTTOM_PX`) and the clamp used by the chat stick-to-bottom auto-scroll, but had no direct test. Its only consumer, `components/chat/message-list.tsx`, is covered for DOM structure / StateBoundary branches only - and jsdom does not meaningfully simulate `scrollTop` / `scrollHeight` there, so the scroll math was never actually exercised. Per `git log` this logic already needed one dedicated bug-fix pass (#7229/#7298), which is exactly the class of regression a unit test catches.

Adds `chat-scroll.test.ts` next to the module, following the one-test-per-pure-module convention `demo-data.test.ts` already establishes in the same directory:

**`isChatViewportNearBottom`**
- distance of exactly `CHAT_NEAR_BOTTOM_PX` -> `true` (the `<=` boundary that motivated the prior fix)
- one pixel past the threshold -> `false`
- sitting exactly at the bottom (distance 0) -> `true`
- content shorter than the viewport (negative distance, nothing to scroll) -> `true`
- scrolled far up -> `false`
- an explicit `thresholdPx` overriding the default (both arms, including `0` where `<=` still admits distance 0)
- `CHAT_NEAR_BOTTOM_PX` is the documented `80`

**`scrollChatViewportToBottom`**
- scrolls to the maximum scrollable offset
- clamps to `0` when the content is shorter than the viewport (the `Math.max(0, ...)` arm)
- is idempotent once already bottomed

**Test-only, no production change.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7793`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run ui:typecheck` (clean across both UI workspaces)
- [x] Full `@loopover/ui-miner` suite: **33 files / 378 tests pass**, including the 10 new ones.
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` - not run: this adds a single test file under `apps/loopover-miner-ui/` and touches no backend, worker, MCP, or OpenAPI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - this PR **is** that test coverage.

If any required check was skipped, explain why:

- Test-only change with no `src/**` lines modified, so `codecov/patch` has no changed lines to score. Per the issue, `apps/loopover-miner-ui` is outside the `src/**` 99% patch gate - this new test file is the issue's own coverage deliverable.
- `ui:lint` could not be run meaningfully on this Windows checkout: `core.autocrlf=true` makes prettier report `Delete CR` on every file in the repo (including files this PR never touches), so its output is not a signal here. The new file is written with LF endings and is clean under `eslint` once that CRLF noise is excluded.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no component or rendering change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: this is a test-only change with no visible UI difference.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The fake viewport is a plain object cast to `HTMLElement` rather than a real DOM node, because jsdom cannot set `scrollHeight` / `clientHeight` on a real element - which is precisely why the existing `message-list` test could not cover this math.
