### PR TITLE
fix(ui): restore the two rebrand legacy localStorage keys (#7782)

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
@@ -145,4 +145,20 @@ describe("OnboardingPreviewCard", () => {
     expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
     expect(apiFetch).not.toHaveBeenCalled();
   });
+
+  it("honors a pre-rebrand dismissal stored under the legacy key and migrates it forward (#7782)", () => {
+    apiFetch.mockResolvedValue({ ok: true, data: preview() });
+    const dismissed = JSON.stringify({ dismissed: true });
+    window.localStorage.setItem("gittensory_maintainer_onboarding_preview_dismissed", dismissed);
+
+    render(<OnboardingPreviewCard reviewability={REVIEWABILITY} />);
+
+    // The card stays dismissed for a maintainer who dismissed it before the rebrand...
+    expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+    // ...and the legacy value is written forward so later reads hit the current key directly.
+    expect(window.localStorage.getItem("loopover_maintainer_onboarding_preview_dismissed")).toBe(
+      dismissed,
+    );
+  });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
@@ -19,7 +19,7 @@ type ReviewabilityRow = { pr: string; title: string; reason: string };
 
 const DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
 // One-time rebrand migration fallback -- see useLocalStorage's legacyKey param.
-const LEGACY_DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
+const LEGACY_DISMISS_KEY = "gittensory_maintainer_onboarding_preview_dismissed";
 
 /** Builds a settings-preview form from a REAL cached PR (title, and a linked-issue number scraped from
  *  `reason` when present) — everything else (author identity, labels, body) isn't in the reviewability

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // #6985: a real fetch failure used to render the same generic text as "still loading" — these tests
 // pin the three render paths (loading / error / success) now that LoadingState/ErrorState replace it.
@@ -93,5 +93,33 @@ describe("NotificationReadinessCard loading/error states (#6985)", () => {
 
     expect(container.textContent).toContain("No content leaves the browser without consent.");
     expect(screen.queryByText("Loading notification model…")).toBeNull();
+  });
+});
+
+describe("NotificationReadinessCard legacy opt-in migration (#7782)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: notificationModelFixture,
+      error: null,
+      loadedAt: Date.now(),
+      reload: () => {},
+    });
+  });
+
+  it("reads a pre-rebrand opt-in stored under the legacy key and migrates it forward", () => {
+    window.localStorage.setItem("gittensory_notification_opt_in", "true");
+
+    render(<NotificationReadinessCard />);
+
+    expect(screen.getByText("opt-in enabled")).toBeTruthy();
+    expect(window.localStorage.getItem("loopover_notification_opt_in")).toBe("true");
+  });
+
+  it("stays opted out when neither the current nor the legacy key is set", () => {
+    render(<NotificationReadinessCard />);
+
+    expect(screen.getByText("opt-in required")).toBeTruthy();
   });
 });

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
@@ -33,7 +33,8 @@ export function NotificationReadinessCard() {
   const [optIn, setOptIn] = useLocalStorage<boolean>(
     "loopover_notification_opt_in",
     false,
-    "loopover_notification_opt_in",
+    // One-time rebrand migration fallback -- see useLocalStorage's legacyKey param.
+    "gittensory_notification_opt_in",
   );
   const [busy, setBusy] = useState(false);
 


### PR DESCRIPTION
## Summary

Closes #7782.

#5405 gave `useLocalStorage` a `legacyKey` param so a user's pre-rebrand `gittensory_*` localStorage value is read once and migrated forward to the new `loopover_*` key. Two days later, #5743's blanket `gittensory` -> `loopover` substitution ran across ~480 files and rewrote two string *literals* that were supposed to stay on the old prefix, leaving `legacyKey` **identical to the current key**:

- `app-panels/onboarding-preview-card.tsx` - `LEGACY_DISMISS_KEY`
- `notification-readiness-card.tsx` - the notification opt-in legacy key

When both keys are equal, `useLocalStorage`'s fallback branch re-reads the exact key it just missed, so the migration is a no-op: a maintainer who dismissed the onboarding-preview card, or opted into notifications, **before** the rebrand silently loses that preference (the card reappears / they are defaulted back to notifications-off).

This restores both literals to their pre-rebrand values, verified against `git show 112bc4a83`:

- `gittensory_maintainer_onboarding_preview_dismissed`
- `gittensory_notification_opt_in`

matching the uncorrupted shape still present at `api/try-it.tsx` (`STORAGE_KEY = "loopover.session_token"` / `LEGACY_STORAGE_KEY = "gittensory.session_token"`). Every other rebrand-migrated legacy key (`try-it.tsx`, `app.workbench.tsx`, `app.runs.tsx`, `app.index.tsx`) was already genuinely distinct and is **left untouched**.

### Regression tests

One per component, extending each component's existing test file and harness:

- `onboarding-preview-card.test.tsx` - a dismissal stored **only** under the legacy key keeps the card hidden (and skips the API call), and the value is written forward to the current key.
- `notification-readiness-card.test.tsx` - an opt-in stored **only** under the legacy key renders "opt-in enabled" and is written forward; plus the negative case (neither key set stays "opt-in required").

Both new tests were confirmed to **fail against the pre-fix literals and pass after** - i.e. they genuinely pin this bug rather than restating current behavior.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7782`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run ui:typecheck` (clean across both UI workspaces)
- [x] Full `@loopover/ui` suite: **81 files / 550 tests pass**, including the 3 new ones.
- [x] Negative control: with the two literals reverted, exactly the 2 new migration tests fail and the other 10 in those files still pass.
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` - not run: this changes two string literals plus tests under `apps/loopover-ui/` and touches no backend, worker, MCP, or OpenAPI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New or changed behavior has unit tests for new branches and fallback paths.

If any required check was skipped, explain why:

- No `src/**` lines are modified, so `codecov/patch` has no changed lines to score (`apps/**` is outside Codecov's `coverage.include`).
- `ui:lint` could not be run meaningfully on this Windows checkout: `core.autocrlf=true` makes prettier report `Delete CR` on every file in the repo (including files this PR never touches), so its output is not a signal here. Excluding that CRLF noise, `eslint` reports no issues on the four changed files, and the committed diff is LF-normalized (48 insertions / 3 deletions, no whole-file rewrite).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a: this is a browser-local preference key, not auth or session state. (`try-it.tsx`'s session-token key is deliberately untouched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks - unchanged; both components keep their existing loading/error/ready paths.
- [x] Visible UI changes include a `UI Evidence` section - n/a: there is **no visual diff**. Nothing about layout, copy, or styling changes; for any given stored state the rendered output is identical. The only behavioral difference is *which* localStorage key is read during the one-time migration, which is why this is pinned by the two regression tests above rather than by a screenshot.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The onboarding card stores an object (`{ dismissed: boolean }`) while the notification card stores a bare boolean, so each regression test seeds the legacy key with that component's own serialized shape.
