### PR TITLE
fix(ui): restore gittensory_ legacy localStorage keys destroyed by rebrand (#7782)

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
@@ -145,4 +145,22 @@ describe("OnboardingPreviewCard", () => {
     expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
     expect(apiFetch).not.toHaveBeenCalled();
   });
+
+  it("REGRESSION (#7782): migrates a pre-rebrand gittensory_ dismiss key and keeps the card hidden", async () => {
+    window.localStorage.setItem(
+      "gittensory_maintainer_onboarding_preview_dismissed",
+      JSON.stringify({ dismissed: true }),
+    );
+    apiFetch.mockResolvedValue({ ok: true, data: preview() });
+
+    render(<OnboardingPreviewCard reviewability={REVIEWABILITY} />);
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem("loopover_maintainer_onboarding_preview_dismissed")).toBe(
+        JSON.stringify({ dismissed: true }),
+      ),
+    );
+    expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
@@ -19,7 +19,9 @@ type ReviewabilityRow = { pr: string; title: string; reason: string };
 
 const DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
 // One-time rebrand migration fallback -- see useLocalStorage's legacyKey param.
-const LEGACY_DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
+// Must stay as the pre-rebrand gittensory_ prefix (distinct from DISMISS_KEY); a blanket
+// rename once collapsed these to the same string and silently broke migration (#7782).
+const LEGACY_DISMISS_KEY = "gittensory_maintainer_onboarding_preview_dismissed";
 
 /** Builds a settings-preview form from a REAL cached PR (title, and a linked-issue number scraped from
  *  `reason` when present) — everything else (author identity, labels, body) isn't in the reviewability

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // #6985: a real fetch failure used to render the same generic text as "still loading" — these tests
 // pin the three render paths (loading / error / success) now that LoadingState/ErrorState replace it.
@@ -93,5 +93,27 @@ describe("NotificationReadinessCard loading/error states (#6985)", () => {
 
     expect(container.textContent).toContain("No content leaves the browser without consent.");
     expect(screen.queryByText("Loading notification model…")).toBeNull();
+  });
+});
+
+describe("NotificationReadinessCard legacyKey migration (#7782)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: notificationModelFixture,
+      error: null,
+      loadedAt: Date.now(),
+      reload: () => {},
+    });
+  });
+
+  it("REGRESSION: migrates a pre-rebrand gittensory_ opt-in key and shows opt-in enabled", async () => {
+    window.localStorage.setItem("gittensory_notification_opt_in", JSON.stringify(true));
+
+    render(<NotificationReadinessCard />);
+
+    await waitFor(() => expect(screen.getByText("opt-in enabled")).toBeTruthy());
+    expect(window.localStorage.getItem("loopover_notification_opt_in")).toBe(JSON.stringify(true));
   });
 });

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
@@ -30,10 +30,13 @@ export function NotificationReadinessCard() {
     "/v1/app/notification-model",
     "Notification model",
   );
+  // Legacy key must stay as the pre-rebrand gittensory_ prefix (distinct from the current
+  // loopover_ key); a blanket rename once collapsed these to the same string and silently
+  // broke migration (#7782).
   const [optIn, setOptIn] = useLocalStorage<boolean>(
     "loopover_notification_opt_in",
     false,
-    "loopover_notification_opt_in",
+    "gittensory_notification_opt_in",
   );
   const [busy, setBusy] = useState(false);
 

--- a/scripts/branding-drift-baseline.json
+++ b/scripts/branding-drift-baseline.json
@@ -1,5 +1,7 @@
 {
   "apps/loopover-ui/src/components/site/api/try-it.tsx": 1,
+  "apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx": 2,
+  "apps/loopover-ui/src/components/site/notification-readiness-card.tsx": 2,
   "apps/loopover-ui/src/routes/app.index.tsx": 1,
   "apps/loopover-ui/src/routes/app.runs.tsx": 1,
   "apps/loopover-ui/src/routes/app.workbench.tsx": 1,


### PR DESCRIPTION
## Summary

- Restore `LEGACY_DISMISS_KEY` in `onboarding-preview-card.tsx` to `gittensory_maintainer_onboarding_preview_dismissed` (was incorrectly identical to the current `loopover_` key after the blanket rename)
- Restore the notification opt-in legacy key in `notification-readiness-card.tsx` to `gittensory_notification_opt_in`
- Update branding-drift baseline for these intentional historical key literals
- Regression tests: pre-rebrand localStorage values migrate forward and restore dismissed/opt-in state

Closes #7782

## Test plan

- [x] UI vitest: onboarding-preview-card + notification-readiness-card (11 passed)
- [x] `npm run branding-drift:check` passes
- [ ] CI validate-code + validate-tests green

Made with [Cursor](https://cursor.com)