### PR TITLE
fix(miner): reject non-hex commitSha in replay-snapshot path planner (#7796)

### DIFF
--- a/packages/loopover-miner/lib/replay-snapshot.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.ts
@@ -77,7 +77,10 @@ function normalizeRepoFullName(repoFullName: string): string {
 
 function normalizeCommitSha(commitSha: string): string {
   if (typeof commitSha !== "string" || !commitSha.trim()) throw new Error("invalid_commit_sha");
-  return commitSha.trim();
+  const trimmed = commitSha.trim();
+  // Same format guard as replay-task-generation.ts — reject path-traversal / non-hex values before path.join (#7796).
+  if (!/^[0-9a-f]{7,40}$/i.test(trimmed)) throw new Error("invalid_commit_sha");
+  return trimmed;
 }
 
 /** Worktree exports live under this dir inside the repo, mirroring worktree-allocator.ts's WORKTREE_SUBDIR. */

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -47,7 +47,7 @@ function happyPathScripts(overrides: Array<{ match: (args: readonly string[]) =>
     ...overrides,
     { match: isWorktreeAdd, result: ok() },
     { match: isTargetDate, result: ok("2026-01-05T00:00:00+00:00\n") },
-    { match: isHistory, result: ok(`abc123${FIELD_SEP}2026-01-05T00:00:00+00:00${FIELD_SEP}the target commit\n`) },
+    { match: isHistory, result: ok(`abc1234${FIELD_SEP}2026-01-05T00:00:00+00:00${FIELD_SEP}the target commit\n`) },
     { match: isTag, result: ok(`v1.0.0${FIELD_SEP}2026-01-01T00:00:00+00:00${FIELD_SEP}abc000${FIELD_SEP}tag\n`) },
     { match: isLsTree, result: ok("README.md\nsrc\npackage.json\n") },
     { match: isShow, result: ok("# hello\n") },
@@ -72,10 +72,24 @@ afterEach(() => {
 
 describe("planReplaySnapshotPath (#3010) — pure, deterministic", () => {
   it("same (repoPath, commitSha) always yields the same path", () => {
-    const a = planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc123" });
-    expect(a.replaceAll("\\", "/")).toBe(`/repo/${REPLAY_SNAPSHOT_SUBDIR}/abc123`);
-    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc123" })).toBe(a);
-    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "def456" })).not.toBe(a);
+    const a = planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc1234" });
+    expect(a.replaceAll("\\", "/")).toBe(`/repo/${REPLAY_SNAPSHOT_SUBDIR}/abc1234`);
+    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc1234" })).toBe(a);
+    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "def4567" })).not.toBe(a);
+  });
+
+  it("rejects a path-traversal-shaped commitSha before path.join (#7796)", () => {
+    expect(() =>
+      planReplaySnapshotPath({
+        repoPath: "/home/miner/.config/loopover-miner/repos/acme/widgets",
+        commitSha: "../../../../../../tmp/evil-worktree",
+      }),
+    ).toThrow("invalid_commit_sha");
+  });
+
+  it("rejects a non-hex commitSha (#7796)", () => {
+    expect(() => planReplaySnapshotPath({ repoPath: "/repo", commitSha: "not-a-sha!" })).toThrow("invalid_commit_sha");
+    expect(() => planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc12" })).toThrow("invalid_commit_sha"); // too short
   });
 });
 
@@ -129,14 +143,14 @@ describe("exportReplaySnapshot (#3010)", () => {
     const store = tempStore();
 
     const snapshot = await exportReplaySnapshot(
-      { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" },
+      { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" },
       { exec, store },
     );
 
     expect(snapshot.repoFullName).toBe("acme/widgets");
-    expect(snapshot.commitSha).toBe("abc123");
+    expect(snapshot.commitSha).toBe("abc1234");
     expect(snapshot.targetDate).toBe("2026-01-05T00:00:00+00:00");
-    expect(snapshot.commits).toEqual([{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "the target commit" }]);
+    expect(snapshot.commits).toEqual([{ sha: "abc1234", date: "2026-01-05T00:00:00+00:00", subject: "the target commit" }]);
     expect(snapshot.tags).toEqual([{ name: "v1.0.0", date: "2026-01-01T00:00:00+00:00", targetSha: "abc000" }]);
     expect(snapshot.readme).toEqual({ filename: "README.md", content: "# hello\n" });
   });
@@ -144,10 +158,10 @@ describe("exportReplaySnapshot (#3010)", () => {
   it("returns the cached snapshot on a repeat export of the same (repo, commit) pair, without calling git again", async () => {
     const store = tempStore();
     const first = scriptedExec(happyPathScripts());
-    await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec: first.exec, store });
+    await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec: first.exec, store });
 
     const second = scriptedExec([]); // no scripts at all -- any call would throw "no script matched"
-    const result = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec: second.exec, store });
+    const result = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec: second.exec, store });
 
     expect(result.commits).toHaveLength(1);
     expect(second.calls).toHaveLength(0);
@@ -157,7 +171,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: ok("") }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.tags).toEqual([]);
   });
@@ -170,7 +184,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: ok(tagStdout) }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.tags).toEqual([
       { name: "v1.0.0", date: "2025-12-01T00:00:00+00:00", targetSha: "sha1" },
@@ -186,7 +200,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: ok(tagStdout) }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.tags).toEqual([{ name: "v1.0.0", date: "2025-12-01T00:00:00+00:00", targetSha: "sha1" }]);
   });
@@ -210,7 +224,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec, calls } = scriptedExec(happyPathScripts([{ match: isLsTree, result: ok("src\npackage.json\n") }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.readme).toBeNull();
     expect(calls.some((c) => c.args[0] === "show")).toBe(false);
@@ -220,7 +234,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isLsTree, result: ok("src\nReadme.rst\npackage.json\n") }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.readme?.filename).toBe("Readme.rst");
   });
@@ -229,19 +243,19 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec, calls } = scriptedExec(happyPathScripts([{ match: isTag, result: ok(`v-future${FIELD_SEP}2026-06-01T00:00:00+00:00${FIELD_SEP}abc000${FIELD_SEP}tag\n`) }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /replay_snapshot_freshness_violation/,
     );
-    expect(store.getSnapshot("acme/widgets", "abc123")).toBeNull();
+    expect(store.getSnapshot("acme/widgets", "abc1234")).toBeNull();
     const removeCall = calls.find((c) => c.args[0] === "worktree" && c.args[1] === "remove");
-    expect(removeCall?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc123"]);
+    expect(removeCall?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc1234"]);
   });
 
   it("removes the worktree and rethrows the ORIGINAL error (not a cleanup error) when a git read after the worktree exists fails", async () => {
     const { exec, calls } = scriptedExec(happyPathScripts([{ match: isHistory, result: { code: 1, stderr: "fatal: history read failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_log_history_failed/,
     );
     const removeCall = calls.find((c) => c.args[0] === "worktree" && c.args[1] === "remove");
@@ -257,7 +271,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     );
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_log_history_failed/,
     );
   });
@@ -266,9 +280,9 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isWorktreeAdd, result: { code: 0 } }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
-    expect(snapshot.commitSha).toBe("abc123");
+    expect(snapshot.commitSha).toBe("abc1234");
   });
 
   it("throws when git worktree add fails", async () => {
@@ -302,7 +316,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isHistory, result: { code: 1, stderr: "fatal: history read failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_log_history_failed/,
     );
   });
@@ -311,7 +325,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: { code: 1, stderr: "fatal: tag read failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_tag_merged_failed/,
     );
   });
@@ -320,7 +334,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isLsTree, result: { code: 1, stderr: "fatal: ls-tree failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_ls_tree_failed/,
     );
   });
@@ -329,7 +343,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isShow, result: { code: 1, stderr: "fatal: show failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_show_readme_failed/,
     );
   });
@@ -347,18 +361,18 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isWorktreeAdd, result: { code: 1 } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_worktree_add_failed: exit_1/,
     );
   });
 
   it("tolerates a commit-history line missing the subject field, defaulting it to an empty string", async () => {
-    const { exec } = scriptedExec(happyPathScripts([{ match: isHistory, result: ok(`abc123${FIELD_SEP}2026-01-05T00:00:00+00:00\n`) }]));
+    const { exec } = scriptedExec(happyPathScripts([{ match: isHistory, result: ok(`abc1234${FIELD_SEP}2026-01-05T00:00:00+00:00\n`) }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
-    expect(snapshot.commits).toEqual([{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "" }]);
+    expect(snapshot.commits).toEqual([{ sha: "abc1234", date: "2026-01-05T00:00:00+00:00", subject: "" }]);
   });
 
   it("fails closed on a malformed input", async () => {
@@ -369,12 +383,12 @@ describe("exportReplaySnapshot (#3010)", () => {
     await expect(exportReplaySnapshot(null as never, deps)).rejects.toThrow("invalid_replay_snapshot_input");
     await expect(exportReplaySnapshot({ commitSha: "a" } as never, deps)).rejects.toThrow("invalid_repo_full_name");
     await expect(exportReplaySnapshot({ repoFullName: "acme/widgets" } as never, deps)).rejects.toThrow("invalid_commit_sha");
-    await expect(exportReplaySnapshot({ repoFullName: "acme/widgets", commitSha: "abc123" } as never, deps)).rejects.toThrow("invalid_repo_path");
+    await expect(exportReplaySnapshot({ repoFullName: "acme/widgets", commitSha: "abc1234" } as never, deps)).rejects.toThrow("invalid_repo_path");
   });
 
   it("fails closed when exec is missing or invalid", async () => {
     const store = tempStore();
-    const candidate = { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" };
+    const candidate = { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" };
     await expect(exportReplaySnapshot(candidate, null as never)).rejects.toThrow("invalid_exec");
     await expect(exportReplaySnapshot(candidate, { store } as never)).rejects.toThrow("invalid_exec");
   });
@@ -385,7 +399,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     vi.stubEnv("LOOPOVER_MINER_REPLAY_SNAPSHOT_DB", join(root, "default.sqlite3"));
     const { exec } = scriptedExec(happyPathScripts());
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec });
 
     expect(snapshot.repoFullName).toBe("acme/widgets");
     vi.unstubAllEnvs();
@@ -395,9 +409,9 @@ describe("exportReplaySnapshot (#3010)", () => {
 describe("removeReplaySnapshotWorktree (#3010)", () => {
   it("delegates to the shared removeWorktree primitive", async () => {
     const { exec, calls } = scriptedExec([{ match: () => true, result: ok() }]);
-    const result = await removeReplaySnapshotWorktree(exec, "/repo", "/repo/.loopover-replay-snapshots/abc123");
+    const result = await removeReplaySnapshotWorktree(exec, "/repo", "/repo/.loopover-replay-snapshots/abc1234");
     expect(result).toEqual({ ok: true, removed: true });
-    expect(calls[0]?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc123"]);
+    expect(calls[0]?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc1234"]);
   });
 });
 
@@ -406,24 +420,24 @@ describe("openReplaySnapshotStore (#3010) — round-trip persistence", () => {
     const store = tempStore();
     const saved = store.saveSnapshot({
       repoFullName: "acme/widgets",
-      commitSha: "abc123",
-      worktreePath: "/repo/.loopover-replay-snapshots/abc123",
+      commitSha: "abc1234",
+      worktreePath: "/repo/.loopover-replay-snapshots/abc1234",
       targetDate: "2026-01-05T00:00:00+00:00",
-      commits: [{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "t" }],
+      commits: [{ sha: "abc1234", date: "2026-01-05T00:00:00+00:00", subject: "t" }],
       tags: [{ name: "v1", date: "2026-01-01T00:00:00+00:00", targetSha: "abc000" }],
       readme: { filename: "README.md", content: "# hi\n" },
     });
 
     expect(saved.readme).toEqual({ filename: "README.md", content: "# hi\n" });
-    expect(store.getSnapshot("acme/widgets", "abc123")).toEqual(saved);
+    expect(store.getSnapshot("acme/widgets", "abc1234")).toEqual(saved);
   });
 
   it("round-trips a snapshot with no README as null, not a partial object", () => {
     const store = tempStore();
     const saved = store.saveSnapshot({
       repoFullName: "acme/widgets",
-      commitSha: "abc123",
-      worktreePath: "/repo/.loopover-replay-snapshots/abc123",
+      commitSha: "abc1234",
+      worktreePath: "/repo/.loopover-replay-snapshots/abc1234",
       targetDate: "2026-01-05T00:00:00+00:00",
       commits: [],
       tags: [],

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -208,16 +208,16 @@ describe("exportReplaySnapshot (#3010)", () => {
   it("a commit at the very first commit of history: git log returns exactly one entry, no parents to walk", async () => {
     const { exec } = scriptedExec(
       happyPathScripts([
-        { match: isHistory, result: ok(`root000${FIELD_SEP}2020-01-01T00:00:00+00:00${FIELD_SEP}initial commit\n`) },
+        { match: isHistory, result: ok(`root0000${FIELD_SEP}2020-01-01T00:00:00+00:00${FIELD_SEP}initial commit\n`) },
         { match: isTargetDate, result: ok("2020-01-01T00:00:00+00:00\n") },
         { match: isTag, result: ok("") }, // no tag can predate the very first commit
       ]),
     );
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "root000" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "root0000" }, { exec, store });
 
-    expect(snapshot.commits).toEqual([{ sha: "root000", date: "2020-01-01T00:00:00+00:00", subject: "initial commit" }]);
+    expect(snapshot.commits).toEqual([{ sha: "root0000", date: "2020-01-01T00:00:00+00:00", subject: "initial commit" }]);
   });
 
   it("no README present at the commit: readme is null, and show is never called for a nonexistent file", async () => {
@@ -289,7 +289,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isWorktreeAdd, result: { code: 1, stderr: "fatal: invalid reference" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bogus" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "deadbee" }, { exec, store })).rejects.toThrow(
       /git_worktree_add_failed.*fatal: invalid reference/,
     );
   });
@@ -298,7 +298,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTargetDate, result: { code: 128, stderr: "fatal: bad revision" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bogus" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "deadbee" }, { exec, store })).rejects.toThrow(
       /git_log_target_failed/,
     );
   });
@@ -307,7 +307,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTargetDate, result: ok("") }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bogus" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "deadbee" }, { exec, store })).rejects.toThrow(
       /git_log_target_failed: no commit found/,
     );
   });

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -208,16 +208,16 @@ describe("exportReplaySnapshot (#3010)", () => {
   it("a commit at the very first commit of history: git log returns exactly one entry, no parents to walk", async () => {
     const { exec } = scriptedExec(
       happyPathScripts([
-        { match: isHistory, result: ok(`root0000${FIELD_SEP}2020-01-01T00:00:00+00:00${FIELD_SEP}initial commit\n`) },
+        { match: isHistory, result: ok(`0000001${FIELD_SEP}2020-01-01T00:00:00+00:00${FIELD_SEP}initial commit\n`) },
         { match: isTargetDate, result: ok("2020-01-01T00:00:00+00:00\n") },
         { match: isTag, result: ok("") }, // no tag can predate the very first commit
       ]),
     );
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "root0000" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "0000001" }, { exec, store });
 
-    expect(snapshot.commits).toEqual([{ sha: "root0000", date: "2020-01-01T00:00:00+00:00", subject: "initial commit" }]);
+    expect(snapshot.commits).toEqual([{ sha: "0000001", date: "2020-01-01T00:00:00+00:00", subject: "initial commit" }]);
   });
 
   it("no README present at the commit: readme is null, and show is never called for a nonexistent file", async () => {
@@ -449,6 +449,6 @@ describe("openReplaySnapshotStore (#3010) — round-trip persistence", () => {
 
   it("getSnapshot returns null for an unknown (repo, commit) pair", () => {
     const store = tempStore();
-    expect(store.getSnapshot("acme/widgets", "nope")).toBeNull();
+    expect(store.getSnapshot("acme/widgets", "ffffff0")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Validate `commitSha` in `normalizeCommitSha` with the same `/^[0-9a-f]{7,40}$/i` guard used by `replay-task-generation.ts`.
- Reject path-traversal / non-hex values before `path.join` builds the snapshot worktree path.
- Add regression tests; bump fixture SHAs to 7+ hex chars so they still pass the guard.

Closes #7796

## Test plan
- [x] Unit tests reject `../` and short/non-hex SHAs
- [x] Existing fixtures updated to valid hex SHAs (`abc1234`, `deadbee`, `root0000`)
- [ ] CI validate-tests + codecov/patch