### PR TITLE
fix(ci): fail loudly instead of silently running full suite on shard-lookup failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1041,7 +1041,16 @@ jobs:
             # write output at all if that's ever violated, so a bug here fails this step loudly rather
             # than silently dropping a test file from CI.
             node --experimental-strip-types scripts/compute-test-shards.ts --shards=3 --timing=test-timing.json --output=shard-assignment.json
-            mapfile -t SHARD_FILES < <(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-assignment.json','utf8'))['${{ matrix.shard }}'].join('\n'))")
+            # #7767: capture via a checked assignment so a throw in the node one-liner (bad matrix.shard
+            # value, corrupt/missing shard-assignment.json) actually aborts this step -- the old
+            # `mapfile -t SHARD_FILES < <(node -e ...)` ran node in a subshell whose non-zero exit was
+            # swallowed (mapfile itself returns 0), leaving SHARD_FILES empty and silently making vitest
+            # run the entire suite instead of its slice. Same fix idiom as compose_file_args (#7765).
+            if ! SHARD_FILES_RAW="$(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-assignment.json','utf8'))['${{ matrix.shard }}'].join('\n'))")"; then
+              echo "::error::failed to resolve shard file list for shard ${{ matrix.shard }}"
+              exit 1
+            fi
+            mapfile -t SHARD_FILES <<< "$SHARD_FILES_RAW"
             npm run test:coverage -- --maxWorkers=4 "${SHARD_FILES[@]}" --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}"
           fi
       - name: Test failure guidance


### PR DESCRIPTION
Closes #7767

## Problem

`.github/workflows/ci.yml`'s shard-file lookup step read a shard's file list with:

```bash
mapfile -t SHARD_FILES < <(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-assignment.json','utf8'))['${{ matrix.shard }}'].join('\n'))")
```

`mapfile -t VAR < <(cmd)` runs `cmd` in a process-substitution subshell whose exit status `mapfile` does not propagate -- `mapfile` itself returns 0 regardless of whether the command inside succeeded. If `matrix.shard` doesn't match a key present in `shard-assignment.json` (shard-count change, key-format drift) or the file is missing/corrupt, the `node -e` one-liner throws and exits non-zero, but the step continues anyway with `SHARD_FILES` silently empty. `vitest` then receives no file filter, i.e. "run every test file" -- each of the 3 shard jobs would redundantly run the entire suite instead of its slice, defeating the duration-aware sharding, with no error surfaced anywhere.

This is the same subshell-swallow class fixed for `compose_file_args` in #7765/#7862.

## Fix

Capture the node script's output via a checked command-substitution assignment (`if ! VAR="$(cmd)"; then exit 1; fi`) instead of `mapfile < <(cmd)`, then `mapfile` the already-captured string with a here-string. A lookup failure now hits `if ! ...` directly, prints an `::error::` annotation naming the offending shard, and exits 1 -- failing the job loudly instead of silently running everything.

Diff is scoped to exactly this one step in the one `else` branch (full-suite sharding path); the sibling scoped-selection (`--changed=origin/main`) branch is untouched.

## Verification

This is a workflow-YAML-only change, explicitly not covered by the Codecov patch gate per the issue. Verified manually rather than via vitest:

- Extracted the exact old idiom into a standalone script and confirmed it reaches the end with `SHARD_FILES` empty and exit code 0 even when `node -e` throws (bad `matrix.shard` key) -- reproducing the silent-degradation bug described in the issue.
- Extracted the exact new idiom and confirmed it now exits 1 with an `::error::` line for all three failure modes: a `matrix.shard` key not present in `shard-assignment.json`, a corrupt (non-JSON) `shard-assignment.json`, and a missing `shard-assignment.json`.
- Confirmed the happy path is unaffected: valid shard keys with both a single-file and a multi-file shard list populate `SHARD_FILES` identically to before.
- `npm run actionlint`: clean.
- `git diff --check` against `upstream/main`: clean (no trailing-whitespace regressions).

## Scope

Single file, single step, +10/-1 lines. No other jobs/steps touched.
