### PR TITLE
feat(mcp): register loopover_get_automation_state as a local stdio tool (#7752)

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -1287,6 +1287,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Set the autonomy level for one action class via a read-merge-write, so the other classes are left untouched. Same as `loopover-mcp maintain set-level <action> <level>`. Maintainer access required.",
   },
   {
+    name: "loopover_get_automation_state",
+    category: "agent",
+    description: "Return a repo's agent automation state: the per-action autonomy levels, kill-switch / dry-run mode, GitHub write-permission readiness, and how many auto_with_approval actions are awaiting a maintainer decision — the read-side view behind the pause/resume and set-level toggles. Same as `loopover-mcp maintain automation-state`. Maintainer access required.",
+  },
+  {
     name: "loopover_get_gate_precision",
     category: "maintainer",
     description: "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged counts and false-positive rates with low-sample guards. Optionally bounded by windowDays. Maintainer-authenticated; measurement only.",
@@ -2597,6 +2602,22 @@ registerStdioTool(
     return toolResult(`Gate precision for ${owner}/${repo}.`, payload);
   },
   );
+
+// #6742 added this endpoint's REST route and its `maintain automation-state` CLI mirror, but not the stdio tool,
+// so it fell outside #6152's batch above (#7752). Read-only: the derived counterpart to the pause/resume and
+// set-level writes registered above, reached through the same apiGet client those use.
+registerStdioTool(
+  "loopover_get_automation_state",
+  {
+    description: stdioToolDescription("loopover_get_automation_state"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }: any) => {
+    const payload = await apiGet(`${toolRepoBase(owner, repo)}/automation-state`);
+    return toolResult(`Agent automation state for ${owner}/${repo}.`, payload);
+  },
+);
+
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool
 // returns a spec the caller runs with its OWN gh creds. Brings the local stdio server to parity with the
 // miner-auto-dev profile's recommendedTools, using the same @loopover/engine builders as the remote server.

--- a/test/unit/mcp-cli-maintain-tools.test.ts
+++ b/test/unit/mcp-cli-maintain-tools.test.ts
@@ -22,7 +22,7 @@ async function connect() {
   const apiUrl = await startFixtureServer({
     onApiRequest: (request) => {
       const url = request.url ?? "";
-      if (/pending-actions|settings|gate-precision/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
+      if (/pending-actions|settings|gate-precision|automation-state/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
     },
   });
   transport = new StdioClientTransport({
@@ -51,23 +51,25 @@ afterEach(async () => {
 
 const REPO = { owner: "owner", repo: "repo" };
 
-/** Every #6152 tool, with an argument set the fixture serves and a field its real payload carries. */
+/** Every #6152 tool, plus #7752's automation-state read, with an argument set the fixture serves and a field its
+ *  real payload carries. */
 const MAINTAIN_TOOLS = [
   { name: "loopover_list_pending_actions", args: REPO, contains: "pa-1" },
   { name: "loopover_decide_pending_action", args: { ...REPO, id: "pa-1", decision: "accept" }, contains: "accepted" },
   { name: "loopover_set_agent_paused", args: { ...REPO, paused: true }, contains: "agentPaused" },
   { name: "loopover_set_action_autonomy", args: { ...REPO, action: "merge", level: "auto" }, contains: "autonomy" },
   { name: "loopover_get_gate_precision", args: REPO, contains: "falsePositiveRate" },
+  { name: "loopover_get_automation_state", args: REPO, contains: "permissionReadiness" },
 ] as const;
 
 describe("loopover-mcp maintain stdio proxies (#6152)", () => {
-  it("registers all 5 maintain tools in the stdio server tool list", async () => {
+  it("registers all 6 maintain tools in the stdio server tool list", async () => {
     await connect();
     const names = (await client!.listTools()).tools.map((tool) => tool.name);
     for (const tool of MAINTAIN_TOOLS) expect(names).toContain(tool.name);
   });
 
-  it("lists all 5 maintain tools via `loopover-mcp tools --json` with non-empty descriptions", async () => {
+  it("lists all 6 maintain tools via `loopover-mcp tools --json` with non-empty descriptions", async () => {
     await connect();
     const payload = JSON.parse(run(["tools", "--json"])) as { tools: Array<{ name: string; description: string; category?: string }> };
     for (const tool of MAINTAIN_TOOLS) {


### PR DESCRIPTION
## Summary

Closes #7752.

`loopover_get_automation_state` has been a remote MCP tool since #784 and gained a `maintain automation-state` CLI mirror in #6742, but it was never registered on the **local stdio** server. #6382 registered five sibling `maintain`-family tools as stdio tools; this one landed after that batch, so an agent on the stdio server had to shell out to the CLI to reach it.

This mirrors the existing #6152 registrations exactly, per the issue's required pattern:

- **Descriptor** - adds the `STDIO_TOOL_DESCRIPTORS` entry with `category: "agent"`, matching the remote server's own category for the same name (`src/mcp/server.ts`), so both surfaces group consistently. The description therefore flows through the shared `stdioToolDescription` lookup (and `loopover-mcp tools`) rather than being hardcoded at the registration - `stdioToolDescription` throws on an unknown name, so this entry is required, not optional.
- **Registration** - placed next to its maintain-family siblings, reusing the existing `ownerRepoShape` and `toolRepoBase` helpers and calling the same endpoint the CLI subcommand already calls (`GET /v1/repos/:owner/:repo/automation-state`) through the same `apiGet` client. No duplicated HTTP logic, no new paths, and no behaviour the CLI does not already have.

The endpoint is `requireRepoMaintainer`-gated (`src/api/routes.ts`), so the description carries the same "Maintainer access required." note as its siblings.

### Tests

Extends `test/unit/mcp-cli-maintain-tools.test.ts` - the suite that already covers the five siblings - rather than adding a parallel file. Adding the tool to `MAINTAIN_TOOLS` makes it inherit all four existing parametrized cases:

- registered in the stdio server's `listTools()` output
- listed by `loopover-mcp tools --json` with a non-empty description
- proxies to its REST endpoint and returns the payload (asserts on `permissionReadiness`)
- surfaces an API failure as a tool error (unregistered repo -> 404)

The request-capture filter now also records `automation-state` calls, so the proxy assertion has traffic to inspect. The shared fixture already serves this endpoint, so no harness change was needed. Suite goes 15 -> 17 passing.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7752`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npm run build:mcp`
- [x] `npx vitest run test/unit/mcp-cli-maintain-tools.test.ts` - **17 passing** (was 15).
- [x] Wider MCP sweep (`mcp-cli-maintain`, `mcp-cli-basics`, `mcp-cli-completion-spec`) - 74 passing, no regressions.
- [x] `npm run docs:drift-check`, `npm run manifest:drift-check`, `npm run branding-drift:check` - all pass.
- [ ] `npm run test:mcp-pack` - fails identically on unmodified `main` in this Windows checkout (`npm pack` limitation), so it is not a signal for this diff; verified by stashing the change and re-running.
- [ ] `npm run test:coverage` / `test:workers` / `ui:*` - not run: this touches `packages/loopover-mcp/` and one `test/` file only, with no backend `src/**`, worker, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - the handler is branch-free (no nullish fallbacks or conditionals), and all four registration/proxy/failure cases are covered.

If any required check was skipped, explain why:

- No `src/**` lines are modified, so `codecov/patch` has no changed lines to score.
- `npm run command-reference:check` reports stale on this Windows checkout, but regenerating it produces **zero** content change (`git diff` is empty) - it is a `core.autocrlf` line-ending artifact, not real staleness. This change adds an MCP tool, not a CLI command, and the generator's counts are unchanged (11 public + 9 maintainer-only + 8 action). No regenerated file is included, deliberately.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - no auth logic changes; the tool inherits the route's existing `requireRepoMaintainer` gate, and the API-failure case is covered by a negative test.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - a new stdio MCP tool, tested; no REST/OpenAPI change (the route already exists).
- [x] UI changes use live API data - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: no UI/frontend/docs/extension change.
- [x] Public docs/changelogs are updated where needed - n/a; the `tools` listing and help text derive from `STDIO_TOOL_DESCRIPTORS` automatically.

## Notes

- Read-only. This adds no write or mutation capability - it is the derived read-side counterpart to the `pause`/`resume` and `set-level` writes already registered above it.
