### PR TITLE
fix(ui): restore the pre-rebrand gittensory_ legacy localStorage keys

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
@@ -128,6 +128,30 @@ describe("OnboardingPreviewCard", () => {
     expect(screen.getByText("503 Service Unavailable")).toBeTruthy();
   });
 
+  it("migrates a pre-rebrand dismissal stored under the legacy gittensory_ key (#7782)", async () => {
+    // A maintainer who dismissed this card before the rebrand has the flag under the OLD gittensory_-prefixed
+    // key. #5743's blanket rename had corrupted the legacyKey to equal the current key, so this value was
+    // silently dropped and the card reappeared. With the legacy key restored, the pre-rebrand dismissal is read
+    // forward: the card stays hidden and no demo API call runs.
+    window.localStorage.clear();
+    // useLocalStorage stores the `{ dismissed }` object shape, so the legacy value mirrors it.
+    window.localStorage.setItem(
+      "gittensory_maintainer_onboarding_preview_dismissed",
+      JSON.stringify({ dismissed: true }),
+    );
+    apiFetch.mockResolvedValue({ ok: true, data: preview() });
+
+    render(<OnboardingPreviewCard reviewability={REVIEWABILITY} />);
+    await waitFor(() =>
+      expect(window.localStorage.getItem("loopover_maintainer_onboarding_preview_dismissed")).toBe(
+        JSON.stringify({ dismissed: true }),
+      ),
+    );
+    // The migrated legacy dismissal keeps the card hidden and skips the demo API call entirely.
+    expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
   it("dismisses the card and keeps it hidden (and skips the API call) across a remount", async () => {
     apiFetch.mockResolvedValue({ ok: true, data: preview() });
     const { unmount } = render(<OnboardingPreviewCard reviewability={REVIEWABILITY} />);

--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
@@ -18,8 +18,10 @@ import { useLocalStorage } from "@/lib/use-local-storage";
 type ReviewabilityRow = { pr: string; title: string; reason: string };
 
 const DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
-// One-time rebrand migration fallback -- see useLocalStorage's legacyKey param.
-const LEGACY_DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
+// One-time rebrand migration fallback -- see useLocalStorage's legacyKey param. This must stay the OLD
+// gittensory_-prefixed literal; #5743's blanket gittensory->loopover rename corrupted it to equal DISMISS_KEY,
+// silently dropping a pre-rebrand dismissal (#7782).
+const LEGACY_DISMISS_KEY = "gittensory_maintainer_onboarding_preview_dismissed";
 
 /** Builds a settings-preview form from a REAL cached PR (title, and a linked-issue number scraped from
  *  `reason` when present) — everything else (author identity, labels, body) isn't in the reviewability

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
@@ -94,4 +94,27 @@ describe("NotificationReadinessCard loading/error states (#6985)", () => {
     expect(container.textContent).toContain("No content leaves the browser without consent.");
     expect(screen.queryByText("Loading notification model…")).toBeNull();
   });
+
+  it("migrates a pre-rebrand opt-in stored under the legacy gittensory_ key (#7782)", () => {
+    // A maintainer who opted in before the rebrand has their preference under the OLD gittensory_-prefixed
+    // key. #5743's blanket rename had corrupted the legacyKey to equal the current key, so this value was
+    // silently dropped and the card defaulted back to "opt-in required". With the legacy key restored, the
+    // pre-rebrand opt-in is read forward and the pill shows "opt-in enabled".
+    window.localStorage.clear();
+    window.localStorage.setItem("gittensory_notification_opt_in", JSON.stringify(true));
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: notificationModelFixture,
+      error: null,
+      loadedAt: Date.now(),
+      reload: () => {},
+    });
+
+    render(<NotificationReadinessCard />);
+
+    expect(screen.getByText("opt-in enabled")).toBeTruthy();
+    // The legacy value was written forward to the current key (useLocalStorage's migration contract).
+    expect(window.localStorage.getItem("loopover_notification_opt_in")).toBe(JSON.stringify(true));
+    window.localStorage.clear();
+  });
 });

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
@@ -33,7 +33,9 @@ export function NotificationReadinessCard() {
   const [optIn, setOptIn] = useLocalStorage<boolean>(
     "loopover_notification_opt_in",
     false,
-    "loopover_notification_opt_in",
+    // Legacy fallback must stay the OLD gittensory_-prefixed literal; #5743's blanket gittensory->loopover
+    // rename corrupted it to equal the current key, silently dropping a pre-rebrand opt-in (#7782).
+    "gittensory_notification_opt_in",
   );
   const [busy, setBusy] = useState(false);
 

--- a/scripts/branding-drift-baseline.json
+++ b/scripts/branding-drift-baseline.json
@@ -1,5 +1,7 @@
 {
   "apps/loopover-ui/src/components/site/api/try-it.tsx": 1,
+  "apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx": 2,
+  "apps/loopover-ui/src/components/site/notification-readiness-card.tsx": 2,
   "apps/loopover-ui/src/routes/app.index.tsx": 1,
   "apps/loopover-ui/src/routes/app.runs.tsx": 1,
   "apps/loopover-ui/src/routes/app.workbench.tsx": 1,


### PR DESCRIPTION
## What & why

Closes #7782.

Commit `112bc4a83` (#5405) gave `useLocalStorage` a `legacyKey` param so a pre-rebrand `gittensory_*` localStorage value migrates forward to the new `loopover_*` key. `81e4ac34d` (#5743, the full `gittensory`→`loopover` cutover) then did a blanket text substitution that also rewrote two string **literals** meant to keep the old prefix:

- `onboarding-preview-card.tsx` — `LEGACY_DISMISS_KEY` became identical to the current `DISMISS_KEY`.
- `notification-readiness-card.tsx` — the notification opt-in legacy key became identical to its current key.

With `key === legacyKey`, `useLocalStorage`'s fallback reads the same key it just missed under, so a maintainer who dismissed the onboarding card or opted into notifications **before the rebrand** silently loses that preference. Every other rebrand-migrated key (`try-it.tsx`'s `gittensory.session_token`, etc.) survived intact.

## The fix

Restore both legacy keys to their pre-rebrand `gittensory_`-prefixed literals, matching the still-correct `try-it.tsx` pattern. String-literal-only change — nothing rendered changes.

Because these two files now legitimately contain `gittensory` literals, `scripts/branding-drift-baseline.json` is regenerated (via `npm run branding-drift:update`) so the branding-drift check records them as intentional rather than flagging new drift — same generated-artifact discipline as ui:openapi / cf-typegen.

## Tests

A regression test per component, extending the existing test file:
- **onboarding-preview-card**: seeds `gittensory_maintainer_onboarding_preview_dismissed` and asserts the card stays hidden, the demo API call is skipped, and the value is written forward to the current key.
- **notification-readiness-card**: seeds `gittensory_notification_opt_in` and asserts the pill shows "opt-in enabled" and the value is migrated to the current key.

Verified bug-catching: reverting either key to the corrupted `loopover_` value fails its regression test.

## Validation

- `apps/loopover-ui`: `vitest run` (both files, 11 tests) pass; `tsc --noEmit` exit 0; eslint clean; Prettier clean.
- `npm run branding-drift:check` — ok (41 files match the regenerated baseline).
- Per the issue, `apps/loopover-ui` is not under the `src/**` 99% patch gate; the regression tests are the coverage deliverable. Branched off current `main`, mergeable-clean.