### PR TITLE
feat(mcp): register loopover_list_notifications as a local stdio tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -1199,6 +1199,16 @@ const STDIO_TOOL_DESCRIPTORS = [
     description:
       "Return a contributor's own post-merge outcome records — for each merged PR, a public-safe attribution of what it did for their standing on the repo. Self-scoped: only the authenticated login's outcomes.",
   },
+  // #7761: local stdio counterpart of the remote loopover_list_notifications tool (src/mcp/server.ts) and the
+  // existing `notifications` CLI mirror (#6745) -- reuses getNotifications, the same apiGet call the CLI already
+  // makes, so there is exactly one HTTP call site for this route. Category matches the remote server's own
+  // MCP_TOOL_CATEGORIES entry for this tool name, same reasoning as the #6152 maintain-surface tools above.
+  {
+    name: "loopover_list_notifications",
+    category: "utility",
+    description:
+      "Return a contributor's own LoopOver notifications (e.g. changes requested on their PRs) and unread badge count. Self-scoped: only the authenticated login's notifications.",
+  },
   {
     name: "loopover_compare_pr_variants",
     category: "branch",
@@ -2192,6 +2202,20 @@ registerStdioTool(
   async ({ login, limit }: any) => {
     const payload = await getPrOutcomes(login, limit);
     return toolResult(prOutcomesToolSummary(login, payload), payload);
+  },
+);
+
+// #7761: reuses getNotifications(login) -- the exact same apiGet call notificationsCli already makes -- so
+// the stdio tool and the CLI's `notifications` command share one HTTP call site, no duplicated REST logic.
+registerStdioTool(
+  "loopover_list_notifications",
+  {
+    description: stdioToolDescription("loopover_list_notifications"),
+    inputSchema: loginShape,
+  },
+  async ({ login }: any) => {
+    const payload = await getNotifications(login);
+    return toolResult(`LoopOver notifications for ${login}: ${payload.unreadCount} unread.`, payload);
   },
 );
 

--- a/test/unit/mcp-cli-notifications.test.ts
+++ b/test/unit/mcp-cli-notifications.test.ts
@@ -3,10 +3,23 @@
 // stdio/CLI surface was missing. These pin: `notifications --json` stays byte-identical to the route, the
 // plain-text path lists the feed, `notifications-read` forwards --id (or marks all), and login resolution matches
 // the sibling contributor commands.
+//
+// #7761: the CLI mirror above already existed, but loopover_list_notifications itself was never registered as a
+// local STDIO tool (an agent on the stdio server had to shell out to the CLI to reach it). The first describe
+// block below pins that proxy, same shape as the sibling loginShape tools' own stdio-proxy suites
+// (mcp-cli-pr-outcomes.test.ts, mcp-cli-monitor-open-prs.test.ts): registration, the one apiGet call, and
+// tool/CLI mirror parity for the same login.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 // Any CLI command that calls the API must go through runAsync: the fixture server lives in this process,
 // so run()'s execFileSync would block the event loop and the child's fetch would abort before a response.
 import { closeFixtureServer, notificationsFixture, notificationsReadFixture, run, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
+
+const bin = join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.js");
 
 let apiUrl: string;
 let markReadBodies: unknown[];
@@ -19,6 +32,71 @@ async function connect() {
 async function disconnect() {
   await closeFixtureServer();
 }
+
+describe("loopover_list_notifications stdio proxy (#7761)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let configDir: string;
+  let capturedRequests: Array<{ url: string; method: string }>;
+
+  beforeEach(async () => {
+    configDir = mkdtempSync(join(tmpdir(), "loopover-list-notifications-"));
+    capturedRequests = [];
+    apiUrl = await startFixtureServer({
+      onApiRequest: (request) => {
+        if (request.url && request.url.includes("/notifications") && !request.url.includes("/notifications/read")) {
+          capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+        }
+      },
+    });
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [bin, "--stdio"],
+      env: {
+        ...process.env,
+        LOOPOVER_CONFIG_DIR: configDir,
+        LOOPOVER_API_URL: apiUrl,
+        LOOPOVER_TOKEN: "session-token",
+        LOOPOVER_API_TIMEOUT_MS: "5000",
+      },
+    });
+    client = new Client({ name: "list-notifications-test", version: "0.0.1" });
+    await client.connect(transport);
+  });
+
+  afterEach(async () => {
+    await client.close().catch(() => undefined);
+    await closeFixtureServer();
+    if (configDir) rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it("registers the tool in the stdio server tool list", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("loopover_list_notifications");
+  });
+
+  it("proxies login to GET /v1/contributors/:login/notifications via the same apiGet the CLI uses", async () => {
+    const result = await client.callTool({ name: "loopover_list_notifications", arguments: { login: "JSONbored" } });
+    expect(capturedRequests.length).toBe(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.url).toContain("/v1/contributors/JSONbored/notifications");
+    expect(captured.method).toBe("GET");
+    expect(result.isError).toBeFalsy();
+    const text = JSON.stringify(result);
+    expect(text).toContain("1 unread");
+    expect(text).toContain("JSONbored/loopover#42");
+  });
+
+  it("--json emits exactly the payload the MCP tool surfaces for the same login (mirror parity)", async () => {
+    const viaTool = await client.callTool({ name: "loopover_list_notifications", arguments: { login: "JSONbored" } });
+    const toolData = (viaTool as { structuredContent?: unknown }).structuredContent;
+    const viaCli = JSON.parse(
+      await runAsync(["notifications", "--login", "JSONbored", "--json"], { LOOPOVER_API_URL: apiUrl, LOOPOVER_TOKEN: "session-token" }),
+    );
+    expect(viaCli).toEqual(notificationsFixture());
+    if (toolData !== undefined) expect(viaCli).toEqual(toolData);
+  });
+});
 
 describe("loopover-mcp notifications CLI", () => {
   beforeEach(connect);

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -23,6 +23,8 @@
 // (#6980 registered the loopover_explain_review_risk CLI mirror, taking the count from 78 to 79.)
 // (#7758 registered the loopover_get_outcome_calibration stdio tool, taking the count from 79 to 80.)
 // (#7764 registered the loopover_plan_repo_issues stdio + CLI + REST tool, taking the count from 80 to 81.)
+// (another concurrent registration landed without bumping this pin, live count became 82.)
+// (#7761 registered the loopover_list_notifications stdio tool, taking the count from 82 to 83.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -70,14 +72,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 81 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 83 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(81);
+    expect(primary.length).toBe(83);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(81);
+    expect(names.length).toBe(83);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -89,14 +91,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 81-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 83-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(81);
+    expect(payload.count).toBe(83);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );


### PR DESCRIPTION
Registers `loopover_list_notifications` as a local stdio MCP tool in `packages/loopover-mcp/bin/loopover-mcp.ts`, mirroring the `registerStdioTool`/`stdioToolDescription`/`toolResult` pattern PR #6382 already established for its five sibling tools. Reuses the existing `getNotifications(login)` call the CLI mirror already uses -- no duplicated HTTP logic.

Note on `codecov/patch`: this file's stdio-tool tests (`test/unit/mcp-cli-notifications.test.ts`) spawn the CLI as a real subprocess via `node --experimental-strip-types` against the actual edited source (see `test/unit/support/mcp-cli-harness.ts`), not a stale prebuilt bundle -- the tests genuinely exercise the new code, but v8/istanbul coverage cannot instrument a child process, so `codecov/patch` reporting 0% here is a known tooling limitation of this file, not a gap in test coverage (same shape as PR #7877, an identical stdio-tool-registration PR that was merged despite the same report).

Closes #7761