### PR TITLE
fix(ui): drop stale repo-picker panel responses on keystroke races (#7784)

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/activation-preview.tsx
@@ -65,31 +65,41 @@ export function ActivationPreview({ reviewability }: { reviewability: Array<{ pr
   const base = repoApiBase(repoFullName);
   const hasRepos = repoOptions.length > 0;
 
-  const load = useCallback(async () => {
-    const apiBase = repoApiBase(repoFullName);
-    if (!apiBase) {
-      setPreview(null);
+  const load = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      const isCancelled = opts?.cancelled ?? (() => false);
+      const apiBase = repoApiBase(repoFullName);
+      if (!apiBase) {
+        setPreview(null);
+        setLoadError(null);
+        return;
+      }
       setLoadError(null);
-      return;
-    }
-    setLoadError(null);
-    setLoading(true);
-    const result = await apiFetch<ActivationPreviewResponse>(`${apiBase}/activation-preview`, {
-      label: "Activation preview",
-      credentials: "include",
-      silentStatus: true,
-    });
-    if (result.ok) {
-      setPreview(result.data);
-    } else {
-      setPreview(null);
-      setLoadError(result.message);
-    }
-    setLoading(false);
-  }, [repoFullName]);
+      setLoading(true);
+      const result = await apiFetch<ActivationPreviewResponse>(`${apiBase}/activation-preview`, {
+        label: "Activation preview",
+        credentials: "include",
+        silentStatus: true,
+      });
+      // Ignore responses after a newer repoFullName keyed a fresh load (#7784).
+      if (isCancelled()) return;
+      if (result.ok) {
+        setPreview(result.data);
+      } else {
+        setPreview(null);
+        setLoadError(result.message);
+      }
+      setLoading(false);
+    },
+    [repoFullName],
+  );
 
   useEffect(() => {
-    void load();
+    let cancelled = false;
+    void load({ cancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   return (
@@ -148,8 +158,8 @@ export function ActivationPreview({ reviewability }: { reviewability: Array<{ pr
           isLoading={Boolean(base) && loading}
           isError={Boolean(base) && !loading && loadError !== null}
           isEmpty={Boolean(base) && !loading && preview !== null && preview.evaluatedCount === 0}
-          onRetry={load}
-          onRefresh={load}
+          onRetry={() => void load()}
+          onRefresh={() => void load()}
           loadingTitle="Building activation preview…"
           errorTitle="Couldn't load the activation preview"
           errorDescription={loadError ?? undefined}

--- a/apps/loopover-ui/src/components/site/app-panels/ai-review-settings.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/ai-review-settings.tsx
@@ -61,35 +61,45 @@ export function AiReviewSettings({ reviewability }: { reviewability: Array<{ pr:
   const base = repoApiBase(repoFullName);
   const hasRepos = repoOptions.length > 0;
 
-  const load = useCallback(async () => {
-    const apiBase = repoApiBase(repoFullName);
-    if (!apiBase) return;
-    setMessage(null);
-    setLoading(true);
-    const [settings, key] = await Promise.all([
-      apiFetch<RepoSettingsResponse>(`${apiBase}/settings`, {
-        label: "AI review settings",
-        credentials: "include",
-        silentStatus: true,
-      }),
-      apiFetch<AiKeyStatus>(`${apiBase}/ai-key`, {
-        label: "AI key status",
-        credentials: "include",
-        silentStatus: true,
-      }),
-    ]);
-    if (settings.ok) {
-      setMode(settings.data.aiReviewMode ?? "off");
-      setByok(settings.data.aiReviewByok ?? false);
-      setProvider(settings.data.aiReviewProvider ?? "anthropic");
-      setModel(settings.data.aiReviewModel ?? "");
-    }
-    setKeyStatus(key.ok ? key.data : null);
-    setLoading(false);
-  }, [repoFullName]);
+  const load = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      const isCancelled = opts?.cancelled ?? (() => false);
+      const apiBase = repoApiBase(repoFullName);
+      if (!apiBase) return;
+      setMessage(null);
+      setLoading(true);
+      const [settings, key] = await Promise.all([
+        apiFetch<RepoSettingsResponse>(`${apiBase}/settings`, {
+          label: "AI review settings",
+          credentials: "include",
+          silentStatus: true,
+        }),
+        apiFetch<AiKeyStatus>(`${apiBase}/ai-key`, {
+          label: "AI key status",
+          credentials: "include",
+          silentStatus: true,
+        }),
+      ]);
+      // Ignore responses after a newer repoFullName keyed a fresh load (#7784).
+      if (isCancelled()) return;
+      if (settings.ok) {
+        setMode(settings.data.aiReviewMode ?? "off");
+        setByok(settings.data.aiReviewByok ?? false);
+        setProvider(settings.data.aiReviewProvider ?? "anthropic");
+        setModel(settings.data.aiReviewModel ?? "");
+      }
+      setKeyStatus(key.ok ? key.data : null);
+      setLoading(false);
+    },
+    [repoFullName],
+  );
 
   useEffect(() => {
-    void load();
+    let cancelled = false;
+    void load({ cancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   async function saveKey() {

--- a/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.test.tsx
@@ -139,4 +139,38 @@ describe("AmsMinerCohortCard", () => {
     });
     expect(screen.getByText(/This view is unavailable for this repository\./i)).toBeTruthy();
   });
+
+  it("drops a superseded response when repoFullName changes before the first fetch resolves (#7784)", async () => {
+    let resolveStale!: (value: unknown) => void;
+    let resolveFresh!: (value: unknown) => void;
+    apiFetch
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveStale = resolve)))
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFresh = resolve)));
+
+    render(<AmsMinerCohortCard reviewability={REVIEWABILITY} />);
+    expect(screen.getByText(/Loading AMS contributor mix/i)).toBeTruthy();
+
+    // Keystroke races a second request while the first is still in flight.
+    fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
+      target: { value: "acme/other" },
+    });
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+
+    const freshComparison = {
+      ...POPULATED_COMPARISON,
+      windowDays: 30,
+      totalSubmitterCount: 2,
+      checkedSubmitterCount: 2,
+    };
+    // Newer request resolves first and must win.
+    resolveFresh({ ok: true, data: freshComparison });
+    await waitFor(() => expect(screen.getByText(/Window: 30 days · checked 2 of/i)).toBeTruthy());
+
+    // Stale request resolves last — must not overwrite the fresh window.
+    resolveStale({ ok: true, data: POPULATED_COMPARISON });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(screen.getByText(/Window: 30 days · checked 2 of/i)).toBeTruthy();
+    expect(screen.queryByText(/Window: 90 days · checked 5 of/i)).toBeNull();
+  });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/ams-miner-cohort-card.tsx
@@ -98,31 +98,41 @@ export function AmsMinerCohortCard({ reviewability }: { reviewability: Array<{ p
   const base = repoApiBase(repoFullName);
   const hasRepos = repoOptions.length > 0;
 
-  const load = useCallback(async () => {
-    const apiBase = repoApiBase(repoFullName);
-    if (!apiBase) {
-      setComparison(null);
+  const load = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      const isCancelled = opts?.cancelled ?? (() => false);
+      const apiBase = repoApiBase(repoFullName);
+      if (!apiBase) {
+        setComparison(null);
+        setLoadError(null);
+        return;
+      }
       setLoadError(null);
-      return;
-    }
-    setLoadError(null);
-    setLoading(true);
-    const result = await apiFetch<AmsMinerCohortComparison>(`${apiBase}/ams-miner-cohort`, {
-      label: "AMS miner cohort comparison",
-      credentials: "include",
-      silentStatus: true,
-    });
-    if (result.ok) {
-      setComparison(result.data);
-    } else {
-      setComparison(null);
-      setLoadError(result.message);
-    }
-    setLoading(false);
-  }, [repoFullName]);
+      setLoading(true);
+      const result = await apiFetch<AmsMinerCohortComparison>(`${apiBase}/ams-miner-cohort`, {
+        label: "AMS miner cohort comparison",
+        credentials: "include",
+        silentStatus: true,
+      });
+      // Ignore responses after a newer repoFullName keyed a fresh load (#7784).
+      if (isCancelled()) return;
+      if (result.ok) {
+        setComparison(result.data);
+      } else {
+        setComparison(null);
+        setLoadError(result.message);
+      }
+      setLoading(false);
+    },
+    [repoFullName],
+  );
 
   useEffect(() => {
-    void load();
+    let cancelled = false;
+    void load({ cancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   return (
@@ -171,8 +181,8 @@ export function AmsMinerCohortCard({ reviewability }: { reviewability: Array<{ p
           isLoading={Boolean(base) && loading}
           isError={Boolean(base) && !loading && loadError !== null}
           isEmpty={Boolean(base) && !loading && comparison !== null && !comparison.present}
-          onRetry={load}
-          onRefresh={load}
+          onRetry={() => void load()}
+          onRefresh={() => void load()}
           loadingTitle="Loading AMS contributor mix…"
           errorTitle="Couldn't load the AMS contributor mix"
           errorDescription={loadError ?? undefined}

--- a/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -145,32 +145,42 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
   const base = repoApiBase(repoFullName);
   const hasRepos = repoOptions.length > 0;
 
-  const load = useCallback(async () => {
-    const apiBase = repoApiBase(repoFullName);
-    if (!apiBase) return;
-    setMessage(null);
-    setLoading(true);
-    const result = await apiFetch<MaintainerSettings>(`${apiBase}/settings`, {
-      label: "Repository settings",
-      credentials: "include",
-      silentStatus: true,
-    });
-    // Default the agent-layer fields defensively so the editor renders even against an older response shape.
-    setSettings(
-      result.ok
-        ? {
-            ...result.data,
-            autonomy: result.data.autonomy ?? {},
-            agentPaused: result.data.agentPaused ?? false,
-            agentDryRun: result.data.agentDryRun ?? false,
-          }
-        : null,
-    );
-    setLoading(false);
-  }, [repoFullName]);
+  const load = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      const isCancelled = opts?.cancelled ?? (() => false);
+      const apiBase = repoApiBase(repoFullName);
+      if (!apiBase) return;
+      setMessage(null);
+      setLoading(true);
+      const result = await apiFetch<MaintainerSettings>(`${apiBase}/settings`, {
+        label: "Repository settings",
+        credentials: "include",
+        silentStatus: true,
+      });
+      // Ignore responses after a newer repoFullName keyed a fresh load (#7784).
+      if (isCancelled()) return;
+      // Default the agent-layer fields defensively so the editor renders even against an older response shape.
+      setSettings(
+        result.ok
+          ? {
+              ...result.data,
+              autonomy: result.data.autonomy ?? {},
+              agentPaused: result.data.agentPaused ?? false,
+              agentDryRun: result.data.agentDryRun ?? false,
+            }
+          : null,
+      );
+      setLoading(false);
+    },
+    [repoFullName],
+  );
 
   useEffect(() => {
-    void load();
+    let cancelled = false;
+    void load({ cancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   function setField<K extends keyof MaintainerSettings>(key: K, value: MaintainerSettings[K]) {
@@ -520,21 +530,31 @@ function FocusManifestEditor({ base }: { base: string | null }) {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<Message | null>(null);
 
-  const load = useCallback(async () => {
-    if (!base) return;
-    setLoading(true);
-    setMessage(null);
-    const result = await apiFetch<FocusManifestResponse>(`${base}/focus-manifest`, {
-      label: "Focus manifest",
-      credentials: "include",
-      silentStatus: true,
-    });
-    setText(result.ok ? JSON.stringify(result.data.manifest, null, 2) : "");
-    setLoading(false);
-  }, [base]);
+  const load = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      const isCancelled = opts?.cancelled ?? (() => false);
+      if (!base) return;
+      setLoading(true);
+      setMessage(null);
+      const result = await apiFetch<FocusManifestResponse>(`${base}/focus-manifest`, {
+        label: "Focus manifest",
+        credentials: "include",
+        silentStatus: true,
+      });
+      // Ignore responses after a newer base keyed a fresh load (#7784).
+      if (isCancelled()) return;
+      setText(result.ok ? JSON.stringify(result.data.manifest, null, 2) : "");
+      setLoading(false);
+    },
+    [base],
+  );
 
   useEffect(() => {
-    void load();
+    let cancelled = false;
+    void load({ cancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   async function save() {


### PR DESCRIPTION
## Summary

Four maintainer repo-picker panels (AMS cohort, AI review settings, activation preview, maintainer settings + focus-manifest editor) load on every free-text `repoFullName` keystroke with no stale-response guard, so a slower response for an older slug can overwrite the newer one (#7784).

This PR adds the same cancelled-flag pattern already used elsewhere (`use-polled-fetch` / audit-feed generation guards): each effect owns a `cancelled` boolean, and post-`await` `setState` is skipped when the effect has been superseded. Retry/refresh still call `load()` without a cancel token (manual retries are out of the keystroke-race scope).

**Visual note:** this is a fetch-ordering fix only — layout/CSS/copy are unchanged. Before and after screenshots are therefore pixel-identical by design; the highlighted repo picker is the surface the race affects.

Closes #7784

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint` (eslint on the five touched panel files)
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Change is confined to `apps/loopover-ui` (Codecov apps ignore / no src 99% patch gate). Ran package-local prettier + eslint + `vitest run src/components/site/app-panels/ams-miner-cohort-card.test.tsx` (9/9 pass, including the out-of-order fetch regression). Root `test:coverage` / workers / MCP / OpenAPI are unrelated to this UI race fix.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

AMS miner cohort card repo picker (`/app/maintainer`), dark theme only (loopover-ui has no light theme). Annotated mint outline marks the free-text `owner/repo` input whose keystrokes previously raced. **Before and after are pixel-identical** — the fix only drops superseded fetch responses; nothing rendered changes at rest.

| Viewport × Theme | Before | After |
|---|---|---|
| Desktop · Dark | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-desktop-before.png" target="_blank" rel="noopener"><img width="360" alt="Desktop · Dark before" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-desktop-before.png"></a> | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-desktop-after.png" target="_blank" rel="noopener"><img width="360" alt="Desktop · Dark after" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-desktop-after.png"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-tablet-before.png" target="_blank" rel="noopener"><img width="360" alt="Tablet · Dark before" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-tablet-before.png"></a> | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-tablet-after.png" target="_blank" rel="noopener"><img width="360" alt="Tablet · Dark after" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-tablet-after.png"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-mobile-before.png" target="_blank" rel="noopener"><img width="200" alt="Mobile · Dark before" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-mobile-before.png"></a> | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-mobile-after.png" target="_blank" rel="noopener"><img width="200" alt="Mobile · Dark after" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7784/shots/ams-cohort-mobile-after.png"></a> |

## Notes

- Resubmit of #7888, which was auto-closed solely for an incomplete viewport×theme screenshot matrix (CI + LoopOver review had already recommended merge).
- No follow-up pushes on this tip (LoopOver one-shot rule).
