### PR TITLE
fix(miner): validate commit-SHA format before joining it into the snapshot path

### DIFF
--- a/packages/loopover-miner/lib/replay-snapshot.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.ts
@@ -75,8 +75,18 @@ function normalizeRepoFullName(repoFullName: string): string {
   return `${owner}/${repo}`;
 }
 
+// A commit SHA is joined directly into a filesystem path (planReplaySnapshotPath), so it must be a real
+// commit-SHA-shaped hex string -- otherwise a traversal-shaped value like "../../evil" would escape the
+// intended snapshot sandbox subdir via path.join (#7796). Mirrors replay-task-generation.ts's own
+// /^[0-9a-f]{7,40}$/i validator for the same identifier class rather than inventing a different check.
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+
+function isCommitShaShaped(commitSha: unknown): commitSha is string {
+  return typeof commitSha === "string" && COMMIT_SHA_PATTERN.test(commitSha.trim());
+}
+
 function normalizeCommitSha(commitSha: string): string {
-  if (typeof commitSha !== "string" || !commitSha.trim()) throw new Error("invalid_commit_sha");
+  if (!isCommitShaShaped(commitSha)) throw new Error("invalid_commit_sha");
   return commitSha.trim();
 }
 
@@ -234,6 +244,10 @@ export function openReplaySnapshotStore(dbPath: string = resolveReplaySnapshotDb
   `;
 
   function getSnapshot(repoFullName: string, commitSha: string): ReplaySnapshot | null {
+    // A read-only lookup by exact key: a malformed commitSha simply can't match any stored row (writes go
+    // through the strict normalizeCommitSha in saveSnapshot), so treat it as "not found" rather than throwing
+    // -- preserving getSnapshot's "unknown pair -> null" contract while the write path stays hardened (#7796).
+    if (!isCommitShaShaped(commitSha)) return null;
     const row = driver.query(getSql, [normalizeRepoFullName(repoFullName), normalizeCommitSha(commitSha)]).rows[0] as
       | ReplaySnapshotRow
       | undefined;

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -72,10 +72,29 @@ afterEach(() => {
 
 describe("planReplaySnapshotPath (#3010) — pure, deterministic", () => {
   it("same (repoPath, commitSha) always yields the same path", () => {
-    const a = planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc123" });
-    expect(a.replaceAll("\\", "/")).toBe(`/repo/${REPLAY_SNAPSHOT_SUBDIR}/abc123`);
-    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc123" })).toBe(a);
-    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "def456" })).not.toBe(a);
+    const a = planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc1234" });
+    expect(a.replaceAll("\\", "/")).toBe(`/repo/${REPLAY_SNAPSHOT_SUBDIR}/abc1234`);
+    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc1234" })).toBe(a);
+    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "def4567" })).not.toBe(a);
+  });
+
+  it("rejects a path-traversal-shaped commitSha instead of escaping the snapshot subdir (#7796)", () => {
+    // Before the format guard, a "../"-shaped commitSha flowed straight into path.join and escaped repoPath
+    // entirely (e.g. "../../../../tmp/evil" -> a worktree created outside the sandbox). It must now throw.
+    expect(() => planReplaySnapshotPath({ repoPath: "/repo", commitSha: "../../../../tmp/evil-worktree" })).toThrow(
+      "invalid_commit_sha",
+    );
+  });
+
+  it("rejects non-hex or wrong-length commitSha values, accepting only 7–40 hex chars (#7796)", () => {
+    for (const bad of ["", "  ", "abc12", "nothexvalue", "abc123", "z".repeat(40), "a".repeat(41), "abc/def"]) {
+      expect(() => planReplaySnapshotPath({ repoPath: "/repo", commitSha: bad })).toThrow("invalid_commit_sha");
+    }
+    // A genuine short-and-full SHA on the hex boundary is still accepted.
+    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abcdef1" }).replaceAll("\\", "/")).toBe(
+      `/repo/${REPLAY_SNAPSHOT_SUBDIR}/abcdef1`,
+    );
+    expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "a".repeat(40) })).toContain("a".repeat(40));
   });
 });
 
@@ -129,12 +148,12 @@ describe("exportReplaySnapshot (#3010)", () => {
     const store = tempStore();
 
     const snapshot = await exportReplaySnapshot(
-      { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" },
+      { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" },
       { exec, store },
     );
 
     expect(snapshot.repoFullName).toBe("acme/widgets");
-    expect(snapshot.commitSha).toBe("abc123");
+    expect(snapshot.commitSha).toBe("abc1234");
     expect(snapshot.targetDate).toBe("2026-01-05T00:00:00+00:00");
     expect(snapshot.commits).toEqual([{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "the target commit" }]);
     expect(snapshot.tags).toEqual([{ name: "v1.0.0", date: "2026-01-01T00:00:00+00:00", targetSha: "abc000" }]);
@@ -144,10 +163,10 @@ describe("exportReplaySnapshot (#3010)", () => {
   it("returns the cached snapshot on a repeat export of the same (repo, commit) pair, without calling git again", async () => {
     const store = tempStore();
     const first = scriptedExec(happyPathScripts());
-    await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec: first.exec, store });
+    await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec: first.exec, store });
 
     const second = scriptedExec([]); // no scripts at all -- any call would throw "no script matched"
-    const result = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec: second.exec, store });
+    const result = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec: second.exec, store });
 
     expect(result.commits).toHaveLength(1);
     expect(second.calls).toHaveLength(0);
@@ -157,7 +176,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: ok("") }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.tags).toEqual([]);
   });
@@ -170,7 +189,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: ok(tagStdout) }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.tags).toEqual([
       { name: "v1.0.0", date: "2025-12-01T00:00:00+00:00", targetSha: "sha1" },
@@ -186,7 +205,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: ok(tagStdout) }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.tags).toEqual([{ name: "v1.0.0", date: "2025-12-01T00:00:00+00:00", targetSha: "sha1" }]);
   });
@@ -201,7 +220,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     );
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "root000" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "0000abc" }, { exec, store });
 
     expect(snapshot.commits).toEqual([{ sha: "root000", date: "2020-01-01T00:00:00+00:00", subject: "initial commit" }]);
   });
@@ -210,7 +229,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec, calls } = scriptedExec(happyPathScripts([{ match: isLsTree, result: ok("src\npackage.json\n") }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.readme).toBeNull();
     expect(calls.some((c) => c.args[0] === "show")).toBe(false);
@@ -220,7 +239,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isLsTree, result: ok("src\nReadme.rst\npackage.json\n") }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.readme?.filename).toBe("Readme.rst");
   });
@@ -229,19 +248,19 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec, calls } = scriptedExec(happyPathScripts([{ match: isTag, result: ok(`v-future${FIELD_SEP}2026-06-01T00:00:00+00:00${FIELD_SEP}abc000${FIELD_SEP}tag\n`) }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /replay_snapshot_freshness_violation/,
     );
-    expect(store.getSnapshot("acme/widgets", "abc123")).toBeNull();
+    expect(store.getSnapshot("acme/widgets", "abc1234")).toBeNull();
     const removeCall = calls.find((c) => c.args[0] === "worktree" && c.args[1] === "remove");
-    expect(removeCall?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc123"]);
+    expect(removeCall?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc1234"]);
   });
 
   it("removes the worktree and rethrows the ORIGINAL error (not a cleanup error) when a git read after the worktree exists fails", async () => {
     const { exec, calls } = scriptedExec(happyPathScripts([{ match: isHistory, result: { code: 1, stderr: "fatal: history read failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_log_history_failed/,
     );
     const removeCall = calls.find((c) => c.args[0] === "worktree" && c.args[1] === "remove");
@@ -257,7 +276,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     );
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_log_history_failed/,
     );
   });
@@ -266,16 +285,16 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isWorktreeAdd, result: { code: 0 } }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
-    expect(snapshot.commitSha).toBe("abc123");
+    expect(snapshot.commitSha).toBe("abc1234");
   });
 
   it("throws when git worktree add fails", async () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isWorktreeAdd, result: { code: 1, stderr: "fatal: invalid reference" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bogus" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bad1234" }, { exec, store })).rejects.toThrow(
       /git_worktree_add_failed.*fatal: invalid reference/,
     );
   });
@@ -284,7 +303,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTargetDate, result: { code: 128, stderr: "fatal: bad revision" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bogus" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bad1234" }, { exec, store })).rejects.toThrow(
       /git_log_target_failed/,
     );
   });
@@ -293,7 +312,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTargetDate, result: ok("") }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bogus" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "bad1234" }, { exec, store })).rejects.toThrow(
       /git_log_target_failed: no commit found/,
     );
   });
@@ -302,7 +321,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isHistory, result: { code: 1, stderr: "fatal: history read failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_log_history_failed/,
     );
   });
@@ -311,7 +330,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isTag, result: { code: 1, stderr: "fatal: tag read failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_tag_merged_failed/,
     );
   });
@@ -320,7 +339,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isLsTree, result: { code: 1, stderr: "fatal: ls-tree failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_ls_tree_failed/,
     );
   });
@@ -329,7 +348,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isShow, result: { code: 1, stderr: "fatal: show failed" } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_show_readme_failed/,
     );
   });
@@ -347,7 +366,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isWorktreeAdd, result: { code: 1 } }]));
     const store = tempStore();
 
-    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store })).rejects.toThrow(
+    await expect(exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store })).rejects.toThrow(
       /git_worktree_add_failed: exit_1/,
     );
   });
@@ -356,7 +375,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     const { exec } = scriptedExec(happyPathScripts([{ match: isHistory, result: ok(`abc123${FIELD_SEP}2026-01-05T00:00:00+00:00\n`) }]));
     const store = tempStore();
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec, store });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec, store });
 
     expect(snapshot.commits).toEqual([{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "" }]);
   });
@@ -369,12 +388,12 @@ describe("exportReplaySnapshot (#3010)", () => {
     await expect(exportReplaySnapshot(null as never, deps)).rejects.toThrow("invalid_replay_snapshot_input");
     await expect(exportReplaySnapshot({ commitSha: "a" } as never, deps)).rejects.toThrow("invalid_repo_full_name");
     await expect(exportReplaySnapshot({ repoFullName: "acme/widgets" } as never, deps)).rejects.toThrow("invalid_commit_sha");
-    await expect(exportReplaySnapshot({ repoFullName: "acme/widgets", commitSha: "abc123" } as never, deps)).rejects.toThrow("invalid_repo_path");
+    await expect(exportReplaySnapshot({ repoFullName: "acme/widgets", commitSha: "abc1234" } as never, deps)).rejects.toThrow("invalid_repo_path");
   });
 
   it("fails closed when exec is missing or invalid", async () => {
     const store = tempStore();
-    const candidate = { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" };
+    const candidate = { repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" };
     await expect(exportReplaySnapshot(candidate, null as never)).rejects.toThrow("invalid_exec");
     await expect(exportReplaySnapshot(candidate, { store } as never)).rejects.toThrow("invalid_exec");
   });
@@ -385,7 +404,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     vi.stubEnv("LOOPOVER_MINER_REPLAY_SNAPSHOT_DB", join(root, "default.sqlite3"));
     const { exec } = scriptedExec(happyPathScripts());
 
-    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc123" }, { exec });
+    const snapshot = await exportReplaySnapshot({ repoPath: "/repo", repoFullName: "acme/widgets", commitSha: "abc1234" }, { exec });
 
     expect(snapshot.repoFullName).toBe("acme/widgets");
     vi.unstubAllEnvs();
@@ -406,7 +425,7 @@ describe("openReplaySnapshotStore (#3010) — round-trip persistence", () => {
     const store = tempStore();
     const saved = store.saveSnapshot({
       repoFullName: "acme/widgets",
-      commitSha: "abc123",
+      commitSha: "abc1234",
       worktreePath: "/repo/.loopover-replay-snapshots/abc123",
       targetDate: "2026-01-05T00:00:00+00:00",
       commits: [{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "t" }],
@@ -415,14 +434,14 @@ describe("openReplaySnapshotStore (#3010) — round-trip persistence", () => {
     });
 
     expect(saved.readme).toEqual({ filename: "README.md", content: "# hi\n" });
-    expect(store.getSnapshot("acme/widgets", "abc123")).toEqual(saved);
+    expect(store.getSnapshot("acme/widgets", "abc1234")).toEqual(saved);
   });
 
   it("round-trips a snapshot with no README as null, not a partial object", () => {
     const store = tempStore();
     const saved = store.saveSnapshot({
       repoFullName: "acme/widgets",
-      commitSha: "abc123",
+      commitSha: "abc1234",
       worktreePath: "/repo/.loopover-replay-snapshots/abc123",
       targetDate: "2026-01-05T00:00:00+00:00",
       commits: [],


### PR DESCRIPTION
## What & why

Closes #7796.

`normalizeCommitSha` (`packages/loopover-miner/lib/replay-snapshot.ts`) accepted **any non-empty string**, and `planReplaySnapshotPath` joined the unvalidated value directly into a filesystem path. A traversal-shaped `commitSha` escaped the intended `.loopover-replay-snapshots` sandbox subdirectory entirely — controlling where `addDetachedWorktree` would create a git worktree on disk. (Latent today: `exportReplaySnapshot` has no production callers yet, but the replay/calibration feature is about to gain one.)

## The fix

Reuse `replay-task-generation.ts`'s existing commit-SHA validator shape (`/^[0-9a-f]{7,40}$/i`) — the issue's required pattern — so a non-hex or traversal-shaped value throws `invalid_commit_sha` before it ever reaches `path.join()`:

- `normalizeCommitSha` now format-validates (strict on the write/path-planning path: `planReplaySnapshotPath`, `exportReplaySnapshot`, `saveSnapshot`).
- The store's read-only `getSnapshot` treats a malformed key as **not found (`null`)** rather than throwing — a malformed SHA can't match any stored row (writes are strict), preserving its existing "unknown pair → null" contract.

## Tests

- **Regression (the traversal):** `planReplaySnapshotPath` with a `../../…/tmp/evil-worktree` commitSha throws `invalid_commit_sha` instead of producing an escaped path. Verified bug-catching: reverting the guard (and rebuilding the package) makes this fail with the escaped path.
- **Boundary coverage:** empty/whitespace, <7 chars, non-hex, >40 chars, and slash-containing values all rejected; 7-char and 40-char hex accepted.
- Existing tests' placeholder SHAs (`abc123`, `root000`, `bogus` — 6-char or non-hex, now correctly rejected) updated to valid 7-hex values so each test still exercises its original intent (git-failure paths are still reached, the store round-trip still matches its saved key).
- **100% whole-file coverage** on `replay-snapshot.ts` after the change: 99/99 lines, 62/62 branches, 31/31 functions.

## Validation

- `test/unit/miner-replay-snapshot.test.ts`: 36 tests pass (34 existing + 2 new), run against the freshly built package output.
- `npm run build --workspace @loopover/miner` clean; `tsc` clean for this diff.
- No production callers affected (repo-wide grep: only the test file imports these exports).