### PR TITLE
feat(mcp): register loopover_refresh_repo_docs as a local stdio MCP tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -943,6 +943,14 @@ const gatePrecisionShape = {
   windowDays: z.number().int().positive().optional(),
 };
 
+// #7754: mirrors the remote loopover_refresh_repo_docs tool's input (src/mcp/server.ts's refreshRepoDocsShape)
+// and the `maintain refresh-docs` CLI subcommand -- both owner and repo, nothing else; the route itself decides
+// eligibility/diffing, this is just the addressing.
+const refreshRepoDocsShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+};
+
 // #7764: mirrors the remote loopover_plan_repo_issues tool's input (src/mcp/server.ts's planRepoIssuesShape),
 // minus the create-only `milestone` which this proxy (and the `maintain plan-issues` CLI) does not expose --
 // forwarded to POST /v1/repos/:owner/:repo/issue-plan-drafts/generate. `goal` is the required maintainer
@@ -1348,6 +1356,12 @@ const STDIO_TOOL_DESCRIPTORS = [
     category: "maintainer",
     description:
       "AI-plan a small set of concrete GitHub issue drafts for a repo from a maintainer-supplied free-form goal, same as `loopover-mcp maintain plan-issues --goal ...`. Dry-run BY DEFAULT: only previews the drafted title/body/labels unless the caller passes BOTH create:true and dryRun:false, so it can never silently open issues. Maintainer access required.",
+  },
+  {
+    name: "loopover_refresh_repo_docs",
+    category: "maintainer",
+    description:
+      "Force an immediate repo-doc refresh (AGENTS.md/CLAUDE.md, and a skill file when warranted) for one repo, without waiting for the scheduled interval. Only ever opens a pull request -- never a direct commit -- and only when repoDocGeneration is enabled and the generated content actually changed. Same as `loopover-mcp maintain refresh-docs`. Maintainer access required.",
   },
   {
     name: "loopover_open_pr",
@@ -2704,6 +2718,24 @@ registerStdioTool(
       `Issue plan for ${owner}/${repo} (status=${payload.status}, dryRun=${payload.dryRun}): ${payload.proposed ?? 0} proposed, ${payload.created ?? 0} created.`,
       payload,
     );
+  },
+);
+
+registerStdioTool(
+  "loopover_refresh_repo_docs",
+  {
+    description: stdioToolDescription("loopover_refresh_repo_docs"),
+    inputSchema: refreshRepoDocsShape,
+  },
+  async ({ owner, repo }: any) => {
+    // #7754: proxies POST {repoBase}/repo-docs/refresh (the same endpoint `maintain refresh-docs` already
+    // calls, and the REST mirror of this same tool id) -- no body, since eligibility/diffing is entirely the
+    // route's own decision.
+    const payload = await apiPost(`${toolRepoBase(owner, repo)}/repo-docs/refresh`, {});
+    const line = payload.opened
+      ? `${payload.reused ? "Found the already-open" : "Opened a new"} repo-doc pull request for ${owner}/${repo}: ${payload.url}`
+      : `No repo-doc pull request opened for ${owner}/${repo}: ${payload.reason}`;
+    return toolResult(line, payload);
   },
 );
 // ── Write-tools (#6149): pure LOCAL-execution spec builders. loopover NEVER performs the write -- each tool

--- a/test/unit/mcp-cli-maintain-tools.test.ts
+++ b/test/unit/mcp-cli-maintain-tools.test.ts
@@ -22,7 +22,7 @@ async function connect() {
   const apiUrl = await startFixtureServer({
     onApiRequest: (request) => {
       const url = request.url ?? "";
-      if (/pending-actions|settings|gate-precision|outcome-calibration/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
+      if (/pending-actions|settings|gate-precision|outcome-calibration|repo-docs\/refresh/.test(url)) capturedRequests.push({ url, method: request.method ?? "GET" });
     },
   });
   transport = new StdioClientTransport({
@@ -51,8 +51,8 @@ afterEach(async () => {
 
 const REPO = { owner: "owner", repo: "repo" };
 
-/** Every #6152 tool (plus #7758's outcome-calibration sibling), with an argument set the fixture serves
- *  and a field its real payload carries. */
+/** Every #6152 tool (plus #7758's outcome-calibration and #7754's refresh-repo-docs siblings), with an
+ *  argument set the fixture serves and a field its real payload carries. */
 const MAINTAIN_TOOLS = [
   { name: "loopover_list_pending_actions", args: REPO, contains: "pa-1" },
   { name: "loopover_decide_pending_action", args: { ...REPO, id: "pa-1", decision: "accept" }, contains: "accepted" },
@@ -60,16 +60,17 @@ const MAINTAIN_TOOLS = [
   { name: "loopover_set_action_autonomy", args: { ...REPO, action: "merge", level: "auto" }, contains: "autonomy" },
   { name: "loopover_get_gate_precision", args: REPO, contains: "falsePositiveRate" },
   { name: "loopover_get_outcome_calibration", args: REPO, contains: "positiveRate" },
+  { name: "loopover_refresh_repo_docs", args: REPO, contains: "pull/42" },
 ] as const;
 
 describe("loopover-mcp maintain stdio proxies (#6152)", () => {
-  it("registers all 6 maintain tools in the stdio server tool list", async () => {
+  it("registers all 7 maintain tools in the stdio server tool list", async () => {
     await connect();
     const names = (await client!.listTools()).tools.map((tool) => tool.name);
     for (const tool of MAINTAIN_TOOLS) expect(names).toContain(tool.name);
   });
 
-  it("lists all 6 maintain tools via `loopover-mcp tools --json` with non-empty descriptions", async () => {
+  it("lists all 7 maintain tools via `loopover-mcp tools --json` with non-empty descriptions", async () => {
     await connect();
     const payload = JSON.parse(run(["tools", "--json"])) as { tools: Array<{ name: string; description: string; category?: string }> };
     for (const tool of MAINTAIN_TOOLS) {

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -22,7 +22,9 @@
 // (#6747 registered the loopover_pr_outcome CLI mirror, taking the count from 77 to 78.)
 // (#6980 registered the loopover_explain_review_risk CLI mirror, taking the count from 78 to 79.)
 // (#7758 registered the loopover_get_outcome_calibration stdio tool, taking the count from 79 to 80.)
-// (#7764 registered the loopover_plan_repo_issues stdio + CLI + REST tool, taking the count from 80 to 81.)
+// (#7799 registered loopover_get_activation_preview without bumping this pin -- live count became 81.)
+// (#7764 registered the loopover_plan_repo_issues stdio + CLI + REST tool, taking the count from 81 to 82.)
+// (#7754 registered the loopover_refresh_repo_docs stdio tool, taking the count from 82 to 83.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -70,14 +72,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 81 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 83 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(81);
+    expect(primary.length).toBe(83);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(81);
+    expect(names.length).toBe(83);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -89,14 +91,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 81-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 83-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(81);
+    expect(payload.count).toBe(83);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );


### PR DESCRIPTION
Closes #7754

## What

Registers `loopover_refresh_repo_docs` as a local stdio MCP tool in `packages/loopover-mcp/bin/loopover-mcp.ts`, closing the gap the issue describes: the remote MCP tool (`src/mcp/server.ts:2644`) and the CLI mirror (`maintain refresh-docs`, `packages/loopover-mcp/bin/loopover-mcp.ts`) already existed via #6743, but no local stdio registration did.

Follows the exact `registerStdioTool` pattern of its siblings (`loopover_get_gate_precision`, `loopover_get_outcome_calibration` from #7758/PR #7877, `loopover_plan_repo_issues` from #7764) verbatim:
- `refreshRepoDocsShape` — `{ owner, repo }`, mirroring the remote tool's own `refreshRepoDocsShape` and the CLI subcommand's `--repo` addressing (no other input; eligibility/diffing is entirely the route's decision).
- A `STDIO_TOOL_DESCRIPTORS` entry (`category: "maintainer"`, matching the remote server's `MCP_TOOL_CATEGORIES` entry for the same tool id), description adapted from the remote tool's own description plus a `same as \`loopover-mcp maintain refresh-docs\`` cross-reference, same style as the other `maintain`-family descriptors.
- The `registerStdioTool` block itself calls the exact same endpoint the CLI's `refresh-docs` subcommand already calls (`POST {repoBase}/repo-docs/refresh`, no body) through the existing `apiPost` client — no duplicated HTTP logic — and formats the two response shapes (opened vs. not-opened) the same way the CLI's own `emit` line does.

## Tests

Extended the existing array-driven `test/unit/mcp-cli-maintain-tools.test.ts` (the same file PR #7877 extended for its `outcome-calibration` sibling, rather than adding a new dedicated test file) with a `loopover_refresh_repo_docs` entry, reusing the fixture server's already-existing `/v1/repos/owner/repo/repo-docs/refresh` route (added by #6743, previously only exercised via the CLI's own `mcp-cli-maintain.test.ts`). This automatically covers: registration in the stdio tool list, non-empty description via `tools --json`, proxying to the REST endpoint with the right payload, and surfacing a 404 as a tool error — the same contract every other `maintain`-family stdio tool asserts. Bumped the fixture's URL-capture regex to include `repo-docs/refresh` so the generic "captured at least one matching request" assertion holds.

Also corrected `test/unit/mcp-tool-rename-aliases.test.ts`'s pinned tool count. The live count from a fresh `packages/loopover-mcp/bin/loopover-mcp.ts tools --json` run was **83** (not 82, which is what a naive "current pin (81) + 1" would have produced) — tracing `git log` on the file showed #7799 (`loopover_get_activation_preview`, PR #7887) landed between #7758 and #7764 without ever bumping this pin, so the comment trail understated the base by one. Added a comment line documenting that gap explicitly, then the real #7754 bump (82 → 83).

## Verification

- `npm run build --workspace @loopover/engine` && `npm run build:mcp` (both required before running this package's tests/CLI locally; the compiled `bin/loopover-mcp.js` this test suite spawns is gitignored, not committed — CI does its own build)
- `node --experimental-strip-types packages/loopover-mcp/bin/loopover-mcp.ts tools --json` → confirmed live count 83 with `loopover_refresh_repo_docs` present, matching the corrected pin
- Targeted: `test/unit/mcp-tool-rename-aliases.test.ts`, `test/unit/mcp-cli-maintain-tools.test.ts`, `test/unit/mcp-cli-maintain.test.ts`, `test/unit/routes-repo-doc-refresh.test.ts`, `test/unit/mcp-refresh-repo-docs.test.ts` — 62/62 passing
- `npm run typecheck`, `npm run actionlint`, `npm run docs:drift-check`, `npm run manifest:drift-check`, `npm run engine-parity:drift-check`, `npm run command-reference:check`, `npm run test:mcp-pack`, `npm audit --audit-level=moderate` — all clean
- `git diff --check upstream/main` — clean (no trailing-whitespace regressions)
- Rebased onto current `upstream/main` immediately before push (no conflicts, already on top)

Patch coverage on `packages/loopover-mcp/bin/loopover-mcp.ts` is expected to report near-0% via Codecov despite the added test coverage — this file's stdio-tool tests exercise the CLI via a real spawned subprocess (`node bin/loopover-mcp.js --stdio`), which v8/istanbul coverage cannot instrument across a process boundary. This is a known, pre-existing limitation affecting every `registerStdioTool` addition in this file (confirmed on the merged sibling PR #7877, which shows the identical `codecov/patch: 0%` pattern).