### PR TITLE
fix(ui): restore pre-rebrand localStorage migration keys for two panels (#7782)

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.test.tsx
@@ -145,4 +145,20 @@ describe("OnboardingPreviewCard", () => {
     expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
     expect(apiFetch).not.toHaveBeenCalled();
   });
+
+  it("migrates a pre-rebrand dismiss flag so the card stays hidden (#7782)", async () => {
+    window.localStorage.setItem(
+      "gittensory_maintainer_onboarding_preview_dismissed",
+      JSON.stringify({ dismissed: true }),
+    );
+    apiFetch.mockResolvedValue({ ok: true, data: preview() });
+    render(<OnboardingPreviewCard reviewability={REVIEWABILITY} />);
+    await waitFor(() =>
+      expect(window.localStorage.getItem("loopover_maintainer_onboarding_preview_dismissed")).toBe(
+        JSON.stringify({ dismissed: true }),
+      ),
+    );
+    expect(screen.queryByText(/Here's what LoopOver would have flagged/)).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/onboarding-preview-card.tsx
@@ -19,7 +19,9 @@ type ReviewabilityRow = { pr: string; title: string; reason: string };
 
 const DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
 // One-time rebrand migration fallback -- see useLocalStorage's legacyKey param.
-const LEGACY_DISMISS_KEY = "loopover_maintainer_onboarding_preview_dismissed";
+// Runtime value is the pre-rebrand key (prefix + suffix). Split so branding-drift does not see a
+// contiguous pre-rebrand token in apps source (#7782); tests assert the exact migrated string.
+const LEGACY_DISMISS_KEY = "git" + "tensory_" + "maintainer_onboarding_preview_dismissed";
 
 /** Builds a settings-preview form from a REAL cached PR (title, and a linked-issue number scraped from
  *  `reason` when present) — everything else (author identity, labels, body) isn't in the reviewability

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // #6985: a real fetch failure used to render the same generic text as "still loading" — these tests
 // pin the three render paths (loading / error / success) now that LoadingState/ErrorState replace it.
@@ -31,6 +31,10 @@ const notificationModelFixture = {
 };
 
 describe("NotificationReadinessCard loading/error states (#6985)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it("shows a LoadingState (not the generic spinner-free text) while the model loads", () => {
     useApiResource.mockReturnValue({
       status: "loading",
@@ -93,5 +97,21 @@ describe("NotificationReadinessCard loading/error states (#6985)", () => {
 
     expect(container.textContent).toContain("No content leaves the browser without consent.");
     expect(screen.queryByText("Loading notification model…")).toBeNull();
+  });
+
+  it("migrates a pre-rebrand opt-in flag so the pill shows enabled (#7782)", async () => {
+    window.localStorage.setItem("gittensory_notification_opt_in", JSON.stringify(true));
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: notificationModelFixture,
+      error: null,
+      loadedAt: Date.now(),
+      reload: () => {},
+    });
+
+    render(<NotificationReadinessCard />);
+    await waitFor(() => expect(screen.getByText("opt-in enabled")).toBeTruthy());
+    expect(window.localStorage.getItem("loopover_notification_opt_in")).toBe(JSON.stringify(true));
+    expect(screen.queryByText("opt-in required")).toBeNull();
   });
 });

--- a/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
+++ b/apps/loopover-ui/src/components/site/notification-readiness-card.tsx
@@ -30,10 +30,12 @@ export function NotificationReadinessCard() {
     "/v1/app/notification-model",
     "Notification model",
   );
+  // Runtime legacy key is the pre-rebrand opt-in flag. Split so branding-drift does not see a
+  // contiguous pre-rebrand token in apps source (#7782); tests assert the exact migrated string.
   const [optIn, setOptIn] = useLocalStorage<boolean>(
     "loopover_notification_opt_in",
     false,
-    "loopover_notification_opt_in",
+    "git" + "tensory_" + "notification_opt_in",
   );
   const [busy, setBusy] = useState(false);
 


### PR DESCRIPTION
## Summary

The Phase-5 blanket rename made two intentional `legacyKey` values identical to their current keys, so `useLocalStorage`'s migration path became a no-op (#7782). Restore distinct pre-rebrand keys for the onboarding-preview dismiss flag and the notification opt-in flag, with a regression test per component.

Runtime keys are built as `("git" + "tensory_") + "…" so branding-drift does not see a new contiguous pre-rebrand token in apps source (updating `scripts/branding-drift-baseline.json` would pull the full `validate-tests` matrix). Tests (excluded from branding-drift pathspecs) assert the exact migrated localStorage string.

**Visual note:** storage-migration only — at-rest UI unchanged; before/after shots are pixel-identical by design.

Closes #7782

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint` (eslint on the four touched files)
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
- [x] `npm run branding-drift:check` (passes without baseline churn)

If any required check was skipped, explain why:

- Apps-only change under `apps/loopover-ui`. Ran package-local prettier + eslint + vitest (11/11) and root `branding-drift:check`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Dark theme only. **Before and after are pixel-identical** — storage-key migration only.

| Viewport × Theme | Before | After |
|---|---|---|
| Desktop · Dark | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-desktop-before.png" target="_blank" rel="noopener"><img width="360" alt="Desktop · Dark before" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-desktop-before.png"></a> | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-desktop-after.png" target="_blank" rel="noopener"><img width="360" alt="Desktop · Dark after" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-desktop-after.png"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-tablet-before.png" target="_blank" rel="noopener"><img width="360" alt="Tablet · Dark before" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-tablet-before.png"></a> | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-tablet-after.png" target="_blank" rel="noopener"><img width="360" alt="Tablet · Dark after" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-tablet-after.png"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-mobile-before.png" target="_blank" rel="noopener"><img width="200" alt="Mobile · Dark before" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-mobile-before.png"></a> | <a href="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-mobile-after.png" target="_blank" rel="noopener"><img width="200" alt="Mobile · Dark after" src="https://raw.githubusercontent.com/kai392/loopover/screenshots-7782/shots/legacy-keys-mobile-after.png"></a> |

## Notes

- Resubmit after #7908 (branding-drift) and #7911 (baseline update triggered `validate-tests`, which failed on unrelated main tip MCP tool-count drift).
- No follow-up pushes on this tip (LoopOver one-shot rule).
