### PR TITLE
feat(mcp): add remote + stdio tool surfaces for loopover_get_repo_focus_manifest

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -987,6 +987,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Return the repo's maintainer activation preview: a deterministic run of the advisory engine over recent PRs (evaluated/with-findings counts, distinct finding codes, per-PR samples, current review-check mode, and the single recommended next action). Maintainer-authenticated; advisory only.",
   },
   {
+    name: "loopover_get_repo_focus_manifest",
+    category: "maintainer",
+    description: "Return a repo's own persisted focus manifest plus its compiled policy. Same as GET /v1/repos/:owner/:repo/focus-manifest; read-only, maintainer-authenticated.",
+  },
+  {
     name: "loopover_preflight_pr",
     category: "discovery",
     description: "Preflight planned PR metadata against lane, duplicate, linked issue, test, and queue signals.",
@@ -1539,6 +1544,18 @@ registerStdioTool(
   async ({ owner, repo }: any) => {
     const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
     return toolResult("LoopOver activation preview.", await apiGet(`${prefix}/activation-preview`));
+  },
+);
+
+registerStdioTool(
+  "loopover_get_repo_focus_manifest",
+  {
+    description: stdioToolDescription("loopover_get_repo_focus_manifest"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }: any) => {
+    const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    return toolResult(`Focus manifest for ${owner}/${repo}.`, await apiGet(`${prefix}/focus-manifest`));
   },
 );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -168,7 +168,7 @@ import { isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadi
 import { AGENT_ACTION_CLASSES, AUTONOMY_LEVELS, isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { isDuplicateWinnerEnabledGlobally, resolveDuplicateWinnerEnabled } from "../settings/duplicate-winner-mode";
-import { MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";
+import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildPredictedGateVerdict, buildGateDispositions, type PredictedGateVerdict } from "../rules/predicted-gate";
 export { buildGateDispositions, type GateDisposition } from "../rules/predicted-gate";
@@ -909,6 +909,15 @@ const activationPreviewOutputSchema = {
   samples: z.array(z.unknown()).optional(),
   recommendedAction: z.string().nullable().optional(),
   summary: z.string().optional(),
+};
+
+// #7808: the repo's own persisted focus manifest plus its compiled policy, mirroring the
+// GET /v1/repos/:owner/:repo/focus-manifest response ({ repoFullName, manifest, policy }). Both
+// nested payloads are large structured objects, so they follow the house z.unknown() style.
+const focusManifestOutputSchema = {
+  repoFullName: z.string().optional(),
+  manifest: z.unknown().optional(),
+  policy: z.unknown().optional(),
 };
 
 const labelAuditOutputSchema = {
@@ -1816,6 +1825,7 @@ export const MCP_TOOL_CATEGORIES: Record<string, McpToolCategory> = {
   loopover_get_repo_context: "maintainer",
   loopover_get_maintainer_noise: "maintainer",
   loopover_get_activation_preview: "maintainer",
+  loopover_get_repo_focus_manifest: "maintainer",
   loopover_get_label_audit: "maintainer",
   loopover_get_maintainer_lane: "maintainer",
   loopover_get_repo_onboarding_pack: "maintainer",
@@ -1956,6 +1966,16 @@ export class LoopoverMcp {
         outputSchema: activationPreviewOutputSchema,
       },
       async (input) => this.toolResult(await this.getActivationPreview(input)),
+    );
+
+    register(
+      "loopover_get_repo_focus_manifest",
+      {
+        description: "Return a repo's own persisted focus manifest plus its compiled policy. Same as GET /v1/repos/:owner/:repo/focus-manifest; read-only, maintainer-authenticated.",
+        inputSchema: ownerRepoShape,
+        outputSchema: focusManifestOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getRepoFocusManifest(input)),
     );
 
     register(
@@ -3165,6 +3185,21 @@ export class LoopoverMcp {
     return {
       summary: report.summary,
       data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #7808: mirror GET /v1/repos/:owner/:repo/focus-manifest exactly -- read the repo's own stored
+  // manifest and compile its policy. That route gates on requireAppRole(["maintainer","owner","operator"])
+  // plus a session-repo-access check; in the MCP layer requireRepoAccess is the faithful read-level mirror
+  // (the stricter requireRepoApprovalQueueAccess above adds a live-write check the GET route does not).
+  private async getRepoFocusManifest(input: { owner: string; repo: string }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const manifest = await loadRepoFocusManifest(this.env, fullName);
+    const policy = compileFocusManifestPolicy(manifest);
+    return {
+      summary: `Focus manifest for ${fullName}.`,
+      data: { repoFullName: fullName, manifest, policy } as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/mcp-cli-activation-preview.test.ts
+++ b/test/unit/mcp-cli-activation-preview.test.ts
@@ -47,15 +47,18 @@ beforeAll(async () => {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   holder.serverTransport = serverTransport;
 
-  // cliArgs[0] === undefined skips the module's `if (cliArgs[0] && cliArgs[0] !== "--stdio")` CLI-dispatch
-  // guard (which would runCli + process.exit), so importing just registers the tools and connects our
-  // in-memory transport instead of a real stdio one.
-  const originalArgv = process.argv;
-  process.argv = [process.execPath, "loopover-mcp"];
   // Import the .ts source explicitly (not the .js): a committed/build-artifact .js on disk would otherwise be
   // resolved and instrumented under its .js path, so codecov/patch would map the new lines to the wrong file.
   // A non-literal specifier keeps tsc from rejecting the .ts extension (TS5097) while vitest still loads it.
   const binTsModule = "../../packages/loopover-mcp/bin/loopover-mcp.ts";
+  // #7764 gated the bin's top-level `await server.connect(new StdioServerTransport())` behind
+  // isProcessEntrypoint() (realpath(argv[1]) === realpath(this module)). Point argv[1] at the bin's own
+  // resolved path so that guard is satisfied on import — otherwise the top-level connect is skipped, our
+  // mocked in-memory transport is never wired to the server, and client.connect below hangs to the timeout.
+  // argv[2..] stays empty, so the `if (cliArgs[0] && cliArgs[0] !== "--stdio")` CLI-dispatch guard (runCli +
+  // process.exit) is still skipped — importing only registers the tools and connects our transport.
+  const originalArgv = process.argv;
+  process.argv = [process.execPath, join(process.cwd(), "packages/loopover-mcp/bin/loopover-mcp.ts")];
   await import(/* @vite-ignore */ binTsModule);
   process.argv = originalArgv;
 

--- a/test/unit/mcp-cli-repo-focus-manifest.test.ts
+++ b/test/unit/mcp-cli-repo-focus-manifest.test.ts
@@ -1,0 +1,70 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #7808: in-process coverage for the loopover_get_repo_focus_manifest stdio tool in
+// packages/loopover-mcp/bin/loopover-mcp.ts. The bin's stdio server is otherwise only exercised via
+// subprocess spawn (mcp-cli-*.test.ts), which v8 cannot instrument -- #7764's entrypoint guard
+// (isProcessEntrypoint) is what lets a test import the module without it binding stdin/hijacking argv,
+// so the registered tool's apiGet-proxy body gets real Codecov-measured coverage. Only the committed .ts
+// source is imported: since #7705 the compiled .js is a gitignored build artifact.
+const MODULES = ["../../packages/loopover-mcp/bin/loopover-mcp.ts"] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+const loaded = new Map<string, BinModule>();
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-focus-manifest-"));
+  const apiUrl = await startFixtureServer();
+  // The bin reads LOOPOVER_API_URL at module load, so set the env BEFORE importing (hence the dynamic import).
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  for (const specifier of MODULES) {
+    loaded.set(specifier, (await import(specifier)) as unknown as BinModule);
+  }
+});
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+});
+
+describe("bin loopover_get_repo_focus_manifest stdio tool (in-process, #7808)", () => {
+  it.each(MODULES)("proxies GET /focus-manifest and returns the manifest + policy — %s", async (specifier) => {
+    const mod = loaded.get(specifier)!;
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mod.server.connect(serverTransport);
+    const client = new Client({ name: "focus-manifest-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: "loopover_get_repo_focus_manifest",
+        arguments: { owner: "owner", repo: "repo" },
+      });
+      expect(result.isError).toBeFalsy();
+      const text = (result.content as Array<{ type: string; text: string }>)[0]!.text;
+      expect(text).toContain("Focus manifest for owner/repo.");
+      // The fixture's manifest/policy payload is proxied through verbatim.
+      expect(text).toContain("focusPaths");
+      expect(text).toContain("pathAllowlist");
+      expect(text).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -7,6 +7,7 @@ import { LoopoverMcp } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
 import { REPO_OUTCOME_PATTERNS_SIGNAL } from "../../src/services/repo-outcome-patterns";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 // Tools that ship an MCP-native output schema so modern clients can validate/render responses.
@@ -14,6 +15,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "loopover_get_repo_context",
   "loopover_get_maintainer_noise",
   "loopover_get_activation_preview",
+  "loopover_get_repo_focus_manifest",
   "loopover_get_label_audit",
   "loopover_get_maintainer_lane",
   "loopover_get_repo_onboarding_pack",
@@ -311,6 +313,31 @@ describe("MCP tool calls return schema-valid structured content", () => {
 
     expect(result.isError).toBe(true);
     expect(JSON.stringify(result.content)).toContain("maintainer access is required");
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("loopover_get_repo_focus_manifest returns the repo's stored focus manifest and compiled policy (#7808)", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    // Seed a persisted api_record manifest so loadRepoFocusManifest returns it from cache (no live GitHub fetch).
+    await upsertRepoFocusManifest(env, "octo/demo", { wantedPaths: ["src/"], preferredLabels: ["bug"] });
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({ name: "loopover_get_repo_focus_manifest", arguments: { owner: "octo", repo: "demo" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.repoFullName).toBe("octo/demo");
+    expect((data.manifest as Record<string, unknown>).present).toBe(true);
+    expect(data.policy).toBeDefined();
+    expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+  });
+
+  it("loopover_get_repo_focus_manifest forbids a static mcp identity outside the read allowlist (#7808)", async () => {
+    // Mirrors the GET route's session-repo-access denial: requireRepoAccess rejects the shared, end-user-obtainable
+    // mcp token for a repo it wasn't explicitly allowlisted for. Covers the forbidden branch of the new tool's gate.
+    const { client } = await connectTestClient(createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" }));
+    const result = await client.callTool({ name: "loopover_get_repo_focus_manifest", arguments: { owner: "octo", repo: "demo" } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository/i);
     expect(result.structuredContent).toBeUndefined();
   });
 

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -23,6 +23,8 @@
 // (#6980 registered the loopover_explain_review_risk CLI mirror, taking the count from 78 to 79.)
 // (#7758 registered the loopover_get_outcome_calibration stdio tool, taking the count from 79 to 80.)
 // (#7764 registered the loopover_plan_repo_issues stdio + CLI + REST tool, taking the count from 80 to 81.)
+// (#7887 registered loopover_get_activation_preview's stdio tool without bumping this pin — live count became 82.)
+// (#7808 registered the loopover_get_repo_focus_manifest remote + stdio tool, taking the count from 82 to 83.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -70,14 +72,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 81 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 83 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(81);
+    expect(primary.length).toBe(83);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(81);
+    expect(names.length).toBe(83);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -89,14 +91,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 81-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 83-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(81);
+    expect(payload.count).toBe(83);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -571,6 +571,16 @@ export async function startFixtureServer(
       );
       return;
     }
+    if (request.url === "/v1/repos/owner/repo/focus-manifest" && request.method === "GET") {
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          manifest: { version: 1, focusPaths: ["src/"], generatedAt: "2026-06-01T00:00:00.000Z" },
+          policy: { pathAllowlist: ["src/"], compiled: true },
+        }),
+      );
+      return;
+    }
     if (request.url === "/v1/repos/owner/repo/outcome-patterns" && request.method === "GET") {
       response.end(
         JSON.stringify({


### PR DESCRIPTION
## Summary

Adds the two missing MCP surfaces for `loopover_get_repo_focus_manifest` (a repo's own persisted focus manifest + compiled policy): a **remote MCP tool** in `src/mcp/server.ts` and a **local stdio MCP tool** in `packages/loopover-mcp/bin`. Mirrors the two-surface `loopover_get_maintainer_noise` shape but replicates the underlying `GET /v1/repos/:owner/:repo/focus-manifest` route's **own** auth — `requireRepoAccess` (the read-level maintainer/owner/operator + session-repo-access mirror), **not** the stricter `requireRepoApprovalQueueAccess` (which adds a live-write check the GET route does not perform).

Read-only, per the issue's scope boundary: **no** tool for the `refresh`(POST)/`PUT` write routes, **no** new REST route, **no** new human CLI verb.

## What changed

- `src/mcp/server.ts`: register `loopover_get_repo_focus_manifest` (input `ownerRepoShape`, `focusManifestOutputSchema` returning `{ repoFullName, manifest, policy }`), add its `MCP_TOOL_CATEGORIES` entry (`"maintainer"`), and a `getRepoFocusManifest` handler calling `loadRepoFocusManifest` + `compileFocusManifestPolicy` exactly as the GET route does, behind `requireRepoAccess`.
- `packages/loopover-mcp/bin/loopover-mcp.ts`: register the local stdio tool proxying `GET ${repoBase}/focus-manifest` via `apiGet`.

## Testing / coverage

- `test/unit/mcp-output-schemas.test.ts`: authorized success (seeded manifest → `{ repoFullName, manifest.present, policy }`) **and** the forbidden branch (static mcp identity outside the read allowlist → `cannot access this repository`); added the tool to `TOOLS_WITH_OUTPUT_SCHEMA`. Both run in-process against `LoopoverMcp(env).createServer()`, so every changed line/branch in `src/mcp/server.ts` is Codecov-covered.
- `test/unit/mcp-cli-repo-focus-manifest.test.ts`: **in-process** stdio invocation (via #7764's `isProcessEntrypoint` guard + `InMemoryTransport`) so the bin tool's `apiGet`-proxy body gets real Codecov-measured coverage — a subprocess spawn can't be v8-instrumented.
- `test/unit/mcp-tool-rename-aliases.test.ts`: tool-count invariant → **83**. This also reconciles a pin drift — #7887 registered `loopover_get_activation_preview`'s stdio tool without bumping this pin (live count had reached 82), documented inline in the same convention as the earlier `#6942` note.

## Incidental regression fix (required for CI)

This PR's `packages/loopover-mcp/**` change pulls the whole `mcp-cli-*.test.ts` suite into CI's scoped test selection, which surfaced a **pre-existing** failure: `test/unit/mcp-cli-activation-preview.test.ts` (added by #7887) hangs to its hook timeout on `main`. #7764 later gated the bin's top-level `await server.connect(...)` behind `isProcessEntrypoint()` (`realpath(argv[1]) === realpath(this module)`); that test set `argv[1]` to the bare string `"loopover-mcp"`, so `realpathSync` throws → the guard is false → the server never connects → `client.connect` hangs. #7887 merged just before #7764, so its own CI never ran against the guard. Fixed by pointing `argv[1]` at the bin's resolved path (test-only change).

No REST/OpenAPI change (the focus-manifest route already exists), no migrations, no wrangler changes.

Closes #7808