### PR TITLE
feat(mcp): add remote + stdio surfaces for loopover_get_gate_config_effective

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -999,6 +999,12 @@ const STDIO_TOOL_DESCRIPTORS = [
       "Return the currently-authoritative live gate thresholds for a repo (confidence floor and scope caps) as a field-limited snake_case AMS probe. Live override wins; soaking shadow fills in only when live is absent. Metadata-only; takes owner and repo.",
   },
   {
+    name: "loopover_get_gate_config_effective",
+    category: "maintainer",
+    description:
+      "Return a repo's current effective self-tuned gate thresholds (confidenceFloor, scopeCap files/lines) plus whether a shadow override is still soaking. Read-only.",
+  },
+  {
     name: "loopover_preflight_pr",
     category: "discovery",
     description: "Preflight planned PR metadata against lane, duplicate, linked issue, test, and queue signals.",
@@ -1575,6 +1581,21 @@ registerStdioTool(
   async ({ owner, repo }: any) => {
     const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
     return toolResult("LoopOver activation preview.", await apiGet(`${prefix}/activation-preview`));
+  },
+);
+
+// (#7800) CLI stdio mirror of the remote loopover_get_gate_config_effective — thin GET proxy of the already
+// allowlist-scoped /v1/repos/:owner/:repo/gate-config/effective route (same ownerRepoShape + apiGet pattern
+// as activation_preview). No human CLI verb.
+registerStdioTool(
+  "loopover_get_gate_config_effective",
+  {
+    description: stdioToolDescription("loopover_get_gate_config_effective"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }: any) => {
+    const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    return toolResult("LoopOver effective gate config.", await apiGet(`${prefix}/gate-config/effective`));
   },
 );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1028,6 +1028,15 @@ const gatePrecisionOutputSchema = {
   signals: z.array(z.string()).optional(),
 };
 
+// #7800 - effective self-tuned gate thresholds (REST gate-config/effective mirror). Fields optional so
+// the forbidden branch ({ status, repoFullName }) and the success shape both validate.
+const gateConfigEffectiveOutputSchema = {
+  status: z.string().optional(),
+  repoFullName: z.string().optional(),
+  effective: z.unknown().optional(),
+  shadowPending: z.boolean().optional(),
+};
+
 // #5825 - maintainer-authenticated skipped-PR audit trail, mirroring GET /v1/app/skipped-pr-audit's
 // filters (all optional: a bare call returns the caller's own repo-scoped feed). No owner/repo shape
 // here on purpose: unlike ownerRepoShape tools this report can legitimately span every repo the caller
@@ -1871,6 +1880,7 @@ export const MCP_TOOL_CATEGORIES: Record<string, McpToolCategory> = {
   loopover_get_repo_outcome_patterns: "maintainer",
   loopover_get_outcome_calibration: "maintainer",
   loopover_get_gate_precision: "maintainer",
+  loopover_get_gate_config_effective: "maintainer",
   loopover_get_skipped_pr_audit: "maintainer",
   loopover_get_fleet_analytics: "maintainer",
   loopover_get_recommendation_quality: "maintainer",
@@ -2101,6 +2111,17 @@ export class LoopoverMcp {
         outputSchema: gatePrecisionOutputSchema,
       },
       async (input) => this.toolResult(await this.getGatePrecision(input)),
+    );
+
+    register(
+      "loopover_get_gate_config_effective",
+      {
+        description:
+          "Return a repo's current effective self-tuned gate thresholds (confidenceFloor, scopeCap files/lines) plus whether a shadow override is still soaking. Read-only; same auth boundary as the REST gate-config/effective route.",
+        inputSchema: ownerRepoShape,
+        outputSchema: gateConfigEffectiveOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getGateConfigEffective(input)),
     );
 
     register(
@@ -3494,6 +3515,39 @@ export class LoopoverMcp {
     return {
       summary: `Live gate thresholds for ${fullName}.`,
       data: { repoFullName: fullName, ...fields } as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #7800 - thin MCP surface over GET /v1/repos/:owner/:repo/gate-config/effective. Same canAccessRepo /
+  // isMcpReadRepoAllowed boundary as getPrReviewability; same loadOverride/loadShadowOverride pair the REST
+  // route already uses — no new persistence or auth path.
+  private async getGateConfigEffective(input: { owner: string; repo: string }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    if (!(await this.canAccessRepo(fullName))) {
+      return {
+        summary: `Forbidden: session cannot access effective gate config for ${fullName}.`,
+        data: { status: "forbidden", repoFullName: fullName },
+      };
+    }
+    const storageEnv = this.env as unknown as StorageEnv;
+    const [override, shadow] = await Promise.all([
+      loadOverride(storageEnv, fullName),
+      loadShadowOverride(storageEnv, fullName),
+    ]);
+    const data = {
+      repoFullName: fullName,
+      effective: {
+        confidenceFloor: override?.confidenceFloor ?? null,
+        scopeCap: {
+          files: override?.scopeCap?.files ?? null,
+          lines: override?.scopeCap?.lines ?? null,
+        },
+      },
+      shadowPending: shadow !== null,
+    };
+    return {
+      summary: `LoopOver effective gate config for ${fullName}: confidenceFloor=${data.effective.confidenceFloor ?? "unset"}, shadowPending=${data.shadowPending}.`,
+      data: data as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -5526,6 +5526,7 @@ describe("api routes", () => {
     expect(toolNames).toContain("loopover_get_outcome_calibration");
     expect(toolNames).toContain("loopover_get_registry_changes");
     expect(toolNames).toContain("loopover_get_registry_snapshot");
+    expect(toolNames).toContain("loopover_get_gate_config_effective");
     expect(toolNames).toContain("loopover_get_upstream_drift");
     expect(toolNames).toContain("loopover_get_upstream_ruleset");
     expect(toolNames).toContain("loopover_get_live_gate_thresholds");
@@ -5802,6 +5803,7 @@ describe("api routes", () => {
       ],
       ["loopover_get_registry_changes", {}],
       ["loopover_get_registry_snapshot", {}],
+      ["loopover_get_gate_config_effective", { owner: "entrius", repo: "allways-ui" }],
       ["loopover_get_upstream_drift", {}],
       ["loopover_get_upstream_ruleset", {}],
       ["loopover_get_live_gate_thresholds", { owner: "entrius", repo: "allways-ui" }],

--- a/test/unit/mcp-cli-gate-config-effective.test.ts
+++ b/test/unit/mcp-cli-gate-config-effective.test.ts
@@ -1,0 +1,98 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeFixtureServer,
+  startFixtureServer,
+} from "./support/mcp-cli-harness";
+
+// #7800: in-process coverage for the loopover_get_gate_config_effective stdio tool.
+// Same #7764 entrypoint-guard pattern as mcp-cli-registry-snapshot.test.ts / mcp-cli-activation-preview.test.ts.
+const MODULES = ["../../packages/loopover-mcp/bin/loopover-mcp.ts"] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+const capturedRequests: Array<{ url: string; method: string }> = [];
+const loaded = new Map<string, BinModule>();
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-gate-config-effective-"));
+  const apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/gate-config/effective")) {
+        capturedRequests.push({
+          url: request.url ?? "",
+          method: request.method ?? "GET",
+        });
+      }
+    },
+  });
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  for (const specifier of MODULES) {
+    loaded.set(specifier, (await import(specifier)) as unknown as BinModule);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+});
+
+describe("bin loopover_get_gate_config_effective stdio tool (in-process, #7800)", () => {
+  it.each(MODULES)(
+    "registers and proxies GET .../gate-config/effective — %s",
+    async (specifier) => {
+      capturedRequests.length = 0;
+      const mod = loaded.get(specifier)!;
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+      await mod.server.connect(serverTransport);
+      const client = new Client(
+        { name: "gate-config-effective-test", version: "0.1.0" },
+        { capabilities: {} },
+      );
+      await client.connect(clientTransport);
+      try {
+        const { tools } = await client.listTools();
+        const tool = tools.find(
+          (entry) => entry.name === "loopover_get_gate_config_effective",
+        );
+        expect(tool).toBeDefined();
+        expect(tool?.description).toMatch(/effective.*gate|gate.*threshold/i);
+
+        const result = await client.callTool({
+          name: "loopover_get_gate_config_effective",
+          arguments: { owner: "owner", repo: "repo" },
+        });
+        expect(result.isError).toBeFalsy();
+        expect(capturedRequests).toEqual([
+          { url: "/v1/repos/owner/repo/gate-config/effective", method: "GET" },
+        ]);
+        expect(result.structuredContent).toMatchObject({
+          repoFullName: "owner/repo",
+          effective: {
+            confidenceFloor: 0.9,
+            scopeCap: { files: 12, lines: 400 },
+          },
+          shadowPending: true,
+        });
+      } finally {
+        await client.close().catch(() => undefined);
+      }
+    },
+  );
+});

--- a/test/unit/mcp-gate-config-effective.test.ts
+++ b/test/unit/mcp-gate-config-effective.test.ts
@@ -1,0 +1,92 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { LoopoverMcp } from "../../src/mcp/server";
+import {
+  writeLiveOverride,
+  writeShadowOverride,
+  type StorageEnv,
+} from "../../src/review/auto-apply";
+import { createTestEnv } from "../helpers/d1";
+
+type GateConfigResponse = {
+  status?: string;
+  repoFullName?: string;
+  effective?: {
+    confidenceFloor: number | null;
+    scopeCap: { files: number | null; lines: number | null };
+  };
+  shadowPending?: boolean;
+};
+
+async function connect(env: Env) {
+  const server = new LoopoverMcp(env).createServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client(
+    { name: "loopover-gate-config-test", version: "0.1.0" },
+    { capabilities: {} },
+  );
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("MCP loopover_get_gate_config_effective (#7800)", () => {
+  it("forbids the static mcp identity when the repo is outside MCP_READ_REPO_ALLOWLIST", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    const client = await connect(env);
+    const result = await client.callTool({
+      name: "loopover_get_gate_config_effective",
+      arguments: { owner: "owner", repo: "repo" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as GateConfigResponse).status).toBe(
+      "forbidden",
+    );
+  });
+
+  it("returns empty effective thresholds when no override is stored", async () => {
+    const env = createTestEnv();
+    const client = await connect(env);
+    const result = await client.callTool({
+      name: "loopover_get_gate_config_effective",
+      arguments: { owner: "owner", repo: "repo" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+      repoFullName: "owner/repo",
+      effective: {
+        confidenceFloor: null,
+        scopeCap: { files: null, lines: null },
+      },
+      shadowPending: false,
+    });
+  });
+
+  it("returns live override values and shadowPending when a shadow is soaking", async () => {
+    const env = createTestEnv();
+    const storageEnv = env as unknown as StorageEnv;
+    await writeLiveOverride(storageEnv, "owner/repo", {
+      confidenceFloor: 0.9,
+      scopeCap: { files: 12, lines: 400 },
+    });
+    await writeShadowOverride(
+      storageEnv,
+      "owner/repo",
+      { confidenceFloor: 0.8 },
+      "2099-01-01T00:00:00.000Z",
+    );
+    const client = await connect(env);
+    const result = await client.callTool({
+      name: "loopover_get_gate_config_effective",
+      arguments: { owner: "owner", repo: "repo" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+      repoFullName: "owner/repo",
+      effective: { confidenceFloor: 0.9, scopeCap: { files: 12, lines: 400 } },
+      shadowPending: true,
+    });
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it, vi } from "vitest";
 import { persistSignalSnapshot, upsertBounty, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, updatePullRequestSlopAssessment, persistUpstreamRulesetSnapshot } from "../../src/db/repositories";
-import { writeLiveOverride, type StorageEnv } from "../../src/review/auto-apply";
+import { writeLiveOverride, writeShadowOverride, type StorageEnv } from "../../src/review/auto-apply";
 import type { AuthIdentity } from "../../src/auth/security";
 import { LoopoverMcp } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
@@ -16,6 +16,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "loopover_get_maintainer_noise",
   "loopover_get_activation_preview",
   "loopover_get_live_gate_thresholds",
+  "loopover_get_gate_config_effective",
   "loopover_get_label_audit",
   "loopover_get_maintainer_lane",
   "loopover_get_repo_onboarding_pack",
@@ -153,6 +154,12 @@ describe("MCP output schema discovery", () => {
     const liveGate = byName.get("loopover_get_live_gate_thresholds");
     const liveGateProps = Object.keys((liveGate?.outputSchema?.properties ?? {}) as Record<string, unknown>);
     expect(liveGateProps).toEqual(expect.arrayContaining(["repoFullName", "confidence_floor", "scope_cap_files", "scope_cap_lines", "error"]));
+
+    const gateConfigEffective = byName.get("loopover_get_gate_config_effective");
+    const gateConfigEffectiveProps = Object.keys((gateConfigEffective?.outputSchema?.properties ?? {}) as Record<string, unknown>);
+    expect(gateConfigEffectiveProps).toEqual(
+      expect.arrayContaining(["status", "repoFullName", "effective", "shadowPending"]),
+    );
   });
 
   it("preserves the full tool inventory while adding output schemas", async () => {
@@ -342,6 +349,52 @@ describe("MCP tool calls return schema-valid structured content", () => {
     await writeLiveOverride(env as unknown as StorageEnv, "octo/demo", { confidenceFloor: 0.9 });
     const { client } = await connectTestClient(env);
     const result = await client.callTool({ name: "loopover_get_live_gate_thresholds", arguments: { owner: "octo", repo: "demo" } });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({ status: "forbidden", repoFullName: "octo/demo" });
+  });
+
+  it("loopover_get_gate_config_effective returns empty thresholds when no override is stored (#7800)", async () => {
+    const { client } = await connectTestClient(createTestEnv());
+    const result = await client.callTool({
+      name: "loopover_get_gate_config_effective",
+      arguments: { owner: "octo", repo: "demo" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+      repoFullName: "octo/demo",
+      effective: { confidenceFloor: null, scopeCap: { files: null, lines: null } },
+      shadowPending: false,
+    });
+  });
+
+  it("loopover_get_gate_config_effective returns live override values and shadowPending (#7800)", async () => {
+    const env = createTestEnv();
+    const storageEnv = env as unknown as StorageEnv;
+    await writeLiveOverride(storageEnv, "octo/demo", {
+      confidenceFloor: 0.9,
+      scopeCap: { files: 12, lines: 400 },
+    });
+    await writeShadowOverride(storageEnv, "octo/demo", { confidenceFloor: 0.8 }, "2099-01-01T00:00:00.000Z");
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({
+      name: "loopover_get_gate_config_effective",
+      arguments: { owner: "octo", repo: "demo" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+      repoFullName: "octo/demo",
+      effective: { confidenceFloor: 0.9, scopeCap: { files: 12, lines: 400 } },
+      shadowPending: true,
+    });
+  });
+
+  it("loopover_get_gate_config_effective denies mcp callers outside the read allowlist (#7800)", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({
+      name: "loopover_get_gate_config_effective",
+      arguments: { owner: "octo", repo: "demo" },
+    });
     expect(result.isError).toBeFalsy();
     expect(result.structuredContent).toEqual({ status: "forbidden", repoFullName: "octo/demo" });
   });

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -28,6 +28,7 @@
 // (#7807 registered the loopover_get_upstream_ruleset remote+stdio tool, taking the count from 83 to 84.)
 // (#7801 registered the loopover_get_live_gate_thresholds remote+stdio tool, taking the count from 84 to 85.)
 // (#7802 registered the loopover_get_pr_maintainer_packet remote+stdio tool, taking the count from 85 to 86.)
+// (#7800 registered loopover_get_gate_config_effective remote+stdio, taking the count from 86 to 87.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -74,14 +75,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 86 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 87 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(86);
+    expect(primary.length).toBe(87);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(86);
+    expect(names.length).toBe(87);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -93,14 +94,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 86-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 87-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
+    expect(payload.count).toBe(87);
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(86);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -583,6 +583,19 @@ export async function startFixtureServer(
       );
       return;
     }
+    if (request.url === "/v1/repos/owner/repo/gate-config/effective" && request.method === "GET") {
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          effective: {
+            confidenceFloor: 0.9,
+            scopeCap: { files: 12, lines: 400 },
+          },
+          shadowPending: true,
+        }),
+      );
+      return;
+    }
     if (request.url === "/v1/repos/owner/repo/outcome-patterns" && request.method === "GET") {
       response.end(
         JSON.stringify({


### PR DESCRIPTION
## Summary

- Closes #7800: register `loopover_get_gate_config_effective` on remote MCP + local stdio (thin mirror of `GET /v1/repos/:owner/:repo/gate-config/effective`).
- Same `canAccessRepo` / `MCP_READ_REPO_ALLOWLIST` boundary as PR reviewability; returns effective thresholds + `shadowPending`.
- Declares `outputSchema` (#550) and adds forbid/empty/populated coverage in `mcp-output-schemas` so `codecov/patch` sees `src/mcp/server.ts` (fixes closed #7923/#7925).
- Pins stdio tool discovery count **86 → 87** (after #7926 maintainer packet).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #7800`).

## Validation

- [x] `git diff --check`
- [x] `npm run branding-drift:check`
- [x] `npm run typecheck`
- [x] `npm run build:mcp`
- [x] `vitest --coverage` on `mcp-output-schemas` + `mcp-gate-config-effective` + `mcp-cli-gate-config-effective` + `mcp-tool-rename-aliases` (63/63)
- [x] Local patch coverage on changed `src/mcp/server.ts` / bin executable lines: **100%** (13/13)
- [ ] Full unsharded `npm run test:coverage` deferred to CI
- [x] New or changed behavior has unit/integration tests for new branches

If any required check was skipped, explain why:

- Full matrix deferred to CI after the local gates above passed (these are the exact failure modes from #7923/#7925: outputSchema, codecov/patch, tool-count pin, merge drift).

## Safety

- [x] No secrets/wallet/hotkey/coldkey/PAT exposure.
- [x] Auth negative-path covered (forbidden outside allowlist).
- [x] API/OpenAPI/MCP behavior updated and tested where needed.
- [x] No visible UI changes (UI Evidence N/A).

## UI Evidence

N/A — MCP/API only.

## Notes

- Fresh PR after #7925 was auto-closed for codecov/patch + conflicts; rebased onto current main including #7924/#7926.
- One-shot PR: will not push follow-up commits onto this branch after open.


Made with [Cursor](https://cursor.com)