### PR TITLE
chore(release): bump ORB target version to 3.2.1

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Source of truth for the self-hostable loopover-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.ts and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## Summary

- Bumps orb-manifest.json's target version from 3.2.0 to 3.2.1 so the automated beta channel (orb-beta-release.yml) can cut a new beta containing the fixes from #7931. 3.2.0 was already promoted to stable earlier today, so the release-due check correctly refuses to cut another beta of an already-shipped version until this manifest moves forward.

## Scope

- [x] Single-line version bump in a manifest whose own documented purpose is exactly this maintainer action.
- [x] No other files touched.

## Validation

- Not applicable — a manifest version bump with no code/behavior change.