### PR TITLE
feat(mcp): register loopover_list_notifications as a local stdio tool (#7761)

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -1236,6 +1236,12 @@ const STDIO_TOOL_DESCRIPTORS = [
       "Inspect a contributor's open PRs on registered repos, classify queue state, and return public-safe next-step packets from cached metadata.",
   },
   {
+    name: "loopover_list_notifications",
+    category: "utility",
+    description:
+      "Return a contributor's own LoopOver notifications (e.g. changes requested on their PRs) and unread badge count. Self-scoped: only the authenticated login's notifications.",
+  },
+  {
     name: "loopover_pr_outcome",
     category: "review",
     description:
@@ -2300,6 +2306,20 @@ registerStdioTool(
   async ({ login }: any) => {
     const payload = await getOpenPrMonitor(login);
     return toolResult(openPrMonitorToolSummary(login, payload), payload);
+  },
+);
+
+// #7761: stdio twin of remote loopover_list_notifications / `notifications` CLI — same GET
+// /v1/contributors/{login}/notifications via getNotifications (no duplicated HTTP).
+registerStdioTool(
+  "loopover_list_notifications",
+  {
+    description: stdioToolDescription("loopover_list_notifications"),
+    inputSchema: loginShape,
+  },
+  async ({ login }: any) => {
+    const payload = await getNotifications(login);
+    return toolResult(`LoopOver notifications for ${login}.`, payload);
   },
 );
 

--- a/test/unit/mcp-cli-list-notifications-tool.test.ts
+++ b/test/unit/mcp-cli-list-notifications-tool.test.ts
@@ -1,0 +1,81 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #7761: in-process coverage for the loopover_list_notifications stdio tool.
+// Import .ts + InMemoryTransport so Codecov attributes the new registerStdioTool lines.
+// Handler is intentionally branch-free (no ?? / ?. / ternaries) after #7763 patch-partials failure.
+const MODULES = ["../../packages/loopover-mcp/bin/loopover-mcp.ts"] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+const capturedRequests: Array<{ url: string; method: string }> = [];
+const loaded = new Map<string, BinModule>();
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-list-notifications-"));
+  const apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      const url = request.url ?? "";
+      if (url.includes("/notifications") && !url.includes("/notifications/read")) {
+        capturedRequests.push({ url, method: request.method ?? "GET" });
+      }
+    },
+  });
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  for (const specifier of MODULES) {
+    loaded.set(specifier, (await import(specifier)) as unknown as BinModule);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+});
+
+describe("bin loopover_list_notifications stdio tool (in-process, #7761)", () => {
+  it.each(MODULES)("registers and proxies GET .../notifications — %s", async (specifier) => {
+    capturedRequests.length = 0;
+    const mod = loaded.get(specifier)!;
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mod.server.connect(serverTransport);
+    const client = new Client({ name: "list-notifications-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    try {
+      const { tools } = await client.listTools();
+      const tool = tools.find((entry) => entry.name === "loopover_list_notifications");
+      expect(tool).toBeDefined();
+      expect(tool?.description).toMatch(/notifications|unread/i);
+
+      const result = await client.callTool({
+        name: "loopover_list_notifications",
+        arguments: { login: "JSONbored" },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(capturedRequests).toEqual([
+        { url: "/v1/contributors/JSONbored/notifications", method: "GET" },
+      ]);
+      const text = JSON.stringify(result);
+      expect(text).toContain("unreadCount");
+      expect(text).toContain("d-42");
+      expect(text).toContain("LoopOver notifications for JSONbored.");
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -31,6 +31,7 @@
 // (#7800 registered the loopover_get_gate_config_effective remote+stdio tool, taking the count from 86 to 87.)
 // (#7797 registered the loopover_get_ams_miner_cohort remote+stdio tool, taking the count from 87 to 88.)
 // (#7808 registered the loopover_get_repo_focus_manifest remote+stdio tool, taking the count from 88 to 89.)
+// (#7761 registered the loopover_list_notifications stdio tool, taking the count from 89 to 90.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -77,14 +78,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 89 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 90 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(89);
+    expect(primary.length).toBe(90);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(89);
+    expect(names.length).toBe(90);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -96,14 +97,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 89-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 90-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(89);
+    expect(payload.count).toBe(90);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );


### PR DESCRIPTION
## Summary
- Registers `loopover_list_notifications` as a local stdio MCP tool (89 → 90), mirroring the existing remote tool + `notifications` CLI.
- Reuses `getNotifications` → `GET /v1/contributors/:login/notifications` (no duplicated HTTP).
- Handler is branch-free (no `??` / `?.` / ternaries) to keep codecov/patch at ~100% after #7763 partials failures.

Closes #7761

## Test plan
- [x] `build:mcp` + `typecheck` + `branding-drift:check`
- [x] vitest coverage: `mcp-cli-list-notifications-tool`, `mcp-tool-rename-aliases` (3 executable patch lines, all hit)
- [ ] CI green including codecov/patch