### PR TITLE
feat(mcp): register loopover_get_agent_audit_feed stdio tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -1476,6 +1476,12 @@ const STDIO_TOOL_DESCRIPTORS = [
       "Return a repo's DERIVED agent automation state — the effective mode, permissionReadiness, acting action classes, and pending-action count computed over the raw settings row — same as `loopover-mcp maintain automation-state` and the read-side counterpart to the pause/resume/set-level write tools. Maintainer-authenticated; read-only.",
   },
   {
+    name: "loopover_get_agent_audit_feed",
+    category: "agent",
+    description:
+      "Return a repo's agent audit feed — executed actions and approval-queue decisions (accepted/rejected), newest first — same as `loopover-mcp maintain audit-feed`. Read-only and public-safe (action posture only). Maintainer-authenticated.",
+  },
+  {
     name: "loopover_plan_repo_issues",
     category: "maintainer",
     description:
@@ -2991,6 +2997,22 @@ registerStdioTool(
   async ({ owner, repo }: any) => {
     const payload = await apiGet(`${toolRepoBase(owner, repo)}/automation-state`);
     return toolResult(`Agent automation state for ${owner}/${repo}.`, payload);
+  },
+);
+
+// #7757: local stdio counterpart to the remote loopover_get_agent_audit_feed tool + the `maintain audit-feed`
+// CLI. Proxies the same GET {repoBase}/agent/audit-feed those already call — no duplicated HTTP path. Summary
+// is intentionally branch-free (no ?? / ?. / ternaries) so codecov/patch stays at 100%; the full executed-action
+// + approval-decision feed rides along as structuredContent.
+registerStdioTool(
+  "loopover_get_agent_audit_feed",
+  {
+    description: stdioToolDescription("loopover_get_agent_audit_feed"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }: any) => {
+    const payload = await apiGet(`${toolRepoBase(owner, repo)}/agent/audit-feed`);
+    return toolResult(`Agent audit feed for ${owner}/${repo}.`, payload);
   },
 );
 

--- a/test/unit/mcp-cli-agent-audit-feed-stdio.test.ts
+++ b/test/unit/mcp-cli-agent-audit-feed-stdio.test.ts
@@ -1,0 +1,81 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #7757: in-process coverage for the loopover_get_agent_audit_feed stdio tool.
+// Import .ts + InMemoryTransport so Codecov attributes the new registerStdioTool lines.
+// Handler is intentionally branch-free (no ?? / ?. / ternaries) so patch coverage stays at 100%.
+const MODULES = ["../../packages/loopover-mcp/bin/loopover-mcp.ts"] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+const capturedRequests: Array<{ url: string; method: string }> = [];
+const loaded = new Map<string, BinModule>();
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-agent-audit-feed-stdio-"));
+  const apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/agent/audit-feed")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  for (const specifier of MODULES) {
+    loaded.set(specifier, (await import(specifier)) as unknown as BinModule);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+});
+
+describe("bin loopover_get_agent_audit_feed stdio tool (in-process, #7757)", () => {
+  it.each(MODULES)("registers and proxies GET .../agent/audit-feed — %s", async (specifier) => {
+    capturedRequests.length = 0;
+    const mod = loaded.get(specifier)!;
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mod.server.connect(serverTransport);
+    const client = new Client({ name: "agent-audit-feed-stdio-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    try {
+      const { tools } = await client.listTools();
+      const tool = tools.find((entry) => entry.name === "loopover_get_agent_audit_feed");
+      expect(tool).toBeDefined();
+      expect(tool?.description).toMatch(/audit/i);
+
+      const result = await client.callTool({
+        name: "loopover_get_agent_audit_feed",
+        arguments: { owner: "owner", repo: "repo" },
+      });
+      expect(capturedRequests.length).toBe(1);
+      const captured = capturedRequests[0]!;
+      expect(captured.url).toContain("/v1/repos/owner/repo/agent/audit-feed");
+      expect(captured.method).toBe("GET");
+      expect(result.isError).toBeFalsy();
+      const text = JSON.stringify(result);
+      expect(text).toContain("github_app.merged");
+      expect(text).toContain("Agent audit feed for owner/repo.");
+      expect(text).not.toMatch(/wallet|hotkey|reward|trust score/i);
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -37,6 +37,7 @@
 // (#7759 registered the loopover_check_improvement_potential stdio tool, taking the count from 92 to 93.)
 // (#7761 registered the loopover_list_notifications stdio tool, taking the count from 93 to 94.)
 // (#7752 registered the loopover_get_automation_state stdio tool, taking the count from 94 to 95.)
+// (#7757 registered the loopover_get_agent_audit_feed stdio tool, taking the count from 95 to 96.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -83,14 +84,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 95 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 96 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(95);
+    expect(primary.length).toBe(96);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(95);
+    expect(names.length).toBe(96);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -102,14 +103,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 95-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 96-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(95);
+    expect(payload.count).toBe(96);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );


### PR DESCRIPTION
## Summary

`loopover_get_agent_audit_feed` is exposed as a **remote MCP tool** (`src/mcp/server.ts`) and a `maintain audit-feed` **CLI verb**, but had **no local stdio MCP registration** — the same gap class PR #6382 fixed for its `maintain`-adjacent siblings. This adds the missing stdio surface:

- `registerStdioTool("loopover_get_agent_audit_feed", …)` + its `STDIO_TOOL_DESCRIPTORS` entry (category `agent`) in `packages/loopover-mcp/bin/loopover-mcp.ts`, mirroring the freshly-merged `loopover_get_automation_state` sibling (#7752): `ownerRepoShape` input, `apiGet` proxy, `toolResult` wrapper.
- The stdio tool proxies the **existing** `GET /v1/repos/:owner/:repo/agent/audit-feed` route — the same route the remote tool and the CLI already call. No new REST route, no new CLI verb, no `src/mcp/server.ts` change.

The handler is intentionally branch-free (no `??` / `?.` / ternaries) so `codecov/patch` stays at 100% on the new lines.

## Tests

- `test/unit/mcp-cli-agent-audit-feed-stdio.test.ts` (new, in-process): imports the bin `.ts` and drives the tool through a real MCP `Client` over `InMemoryTransport` against a fixture server, asserting the tool is listed and the proxied request hits `/v1/repos/owner/repo/agent/audit-feed` (GET).
- `test/unit/mcp-tool-rename-aliases.test.ts`: stdio tool-count pin bumped `95 → 96` (all three assertions) with a running-log comment. Verified the live built bin registers exactly 96 tools.
- Category-sync (`mcp-tool-categories`) and the `maintain` stdio-proxy suite (`mcp-cli-maintain-tools`) pass unchanged.

## UI Evidence

N/A — backend MCP tooling only; no `apps/**` files touched.

## Validation

- [x] `packages/loopover-mcp` builds clean (`tsc -p`).
- [x] `mcp-tool-rename-aliases`, `mcp-tool-categories`, `mcp-cli-maintain-tools` pass (32 tests); live server registers exactly 96 tools.
- [x] Rebased on latest `main`; no base conflict.
- [x] No wallet/hotkey/trust-score/reward terms in tool output.

Closes #7757