### PR TITLE
feat(mcp): register loopover_refresh_repo_docs as a local stdio tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -1057,6 +1057,12 @@ const STDIO_TOOL_DESCRIPTORS = [
       "Return a repo's agent audit feed: executed actions (agent.action.*) and approval-queue decisions (accepted/rejected), newest first. Read-only and public-safe (action posture only). Maintainer access required.",
   },
   {
+    name: "loopover_refresh_repo_docs",
+    category: "maintainer",
+    description:
+      "Force an immediate repo-doc refresh (AGENTS.md/CLAUDE.md, and a skill file when warranted) for one repo, without waiting for the scheduled interval. Only ever opens a pull request -- never a direct commit -- and only when repoDocGeneration is enabled for this repo and the generated content actually changed. Maintainer access required.",
+  },
+  {
     name: "loopover_get_ams_miner_cohort",
     category: "maintainer",
     description:
@@ -1701,6 +1707,21 @@ registerStdioTool(
     if (limit !== undefined) query.set("limit", String(limit));
     const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
     return toolResult(`LoopOver agent audit feed for ${owner}/${repo}.`, await apiGet(`${prefix}/agent/audit-feed${query.size > 0 ? `?${query}` : ""}`));
+  },
+);
+
+// #7754: stdio mirror of the remote loopover_refresh_repo_docs + the `maintain refresh-docs` CLI. Thin POST
+// proxy of the same {repoBase}/repo-docs/refresh route (empty body -- the route only ever opens a PR, never
+// merges/commits, so there is no create-safety flag to forward). Same ownerRepoShape pattern as maintainer_noise.
+registerStdioTool(
+  "loopover_refresh_repo_docs",
+  {
+    description: stdioToolDescription("loopover_refresh_repo_docs"),
+    inputSchema: ownerRepoShape,
+  },
+  async ({ owner, repo }: any) => {
+    const prefix = `/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    return toolResult(`LoopOver repo-doc refresh for ${owner}/${repo}.`, await apiPost(`${prefix}/repo-docs/refresh`, {}));
   },
 );
 

--- a/test/unit/mcp-cli-refresh-repo-docs.test.ts
+++ b/test/unit/mcp-cli-refresh-repo-docs.test.ts
@@ -1,0 +1,72 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #7754: in-process coverage for the loopover_refresh_repo_docs stdio tool. Same #7764 entrypoint-guard
+// pattern as mcp-cli-repo-focus-manifest -- import the .ts, hold the exported `server`, connect an
+// InMemoryTransport so v8/Codecov attributes the registerStdioTool block (a subprocess spawn can't be
+// instrumented). The tool is a thin POST proxy, so one call exercises the whole handler.
+const MODULES = ["../../packages/loopover-mcp/bin/loopover-mcp.ts"] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+const refreshCalls: Array<{ url: string; method: string }> = [];
+const loaded = new Map<string, BinModule>();
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-refresh-repo-docs-"));
+  const apiUrl = await startFixtureServer({
+    onApiRequest: (r) => {
+      if (r.url && r.url.includes("/repo-docs/refresh")) refreshCalls.push({ url: r.url ?? "", method: r.method ?? "" });
+    },
+  });
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  for (const specifier of MODULES) {
+    loaded.set(specifier, (await import(specifier)) as unknown as BinModule);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+});
+
+describe("bin loopover_refresh_repo_docs stdio tool (in-process, #7754)", () => {
+  it.each(MODULES)("proxies POST .../repo-docs/refresh and returns the PR result — %s", async (specifier) => {
+    refreshCalls.length = 0;
+    const mod = loaded.get(specifier)!;
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mod.server.connect(serverTransport);
+    const client = new Client({ name: "refresh-repo-docs-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    try {
+      const tool = (await client.listTools()).tools.find((entry) => entry.name === "loopover_refresh_repo_docs");
+      expect(tool).toBeDefined();
+      expect(tool?.description).toMatch(/repo-doc refresh|opens a pull request/i);
+
+      const result = await client.callTool({ name: "loopover_refresh_repo_docs", arguments: { owner: "owner", repo: "repo" } });
+      expect(result.isError).toBeFalsy();
+      expect(refreshCalls).toEqual([{ url: "/v1/repos/owner/repo/repo-docs/refresh", method: "POST" }]);
+      const text = JSON.stringify(result);
+      expect(text).toContain("opened");
+      expect(text).toContain("pullNumber");
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -38,6 +38,7 @@
 // (#7761 registered the loopover_list_notifications stdio tool, taking the count from 93 to 94.)
 // (#7752 registered the loopover_get_automation_state stdio tool, taking the count from 94 to 95.)
 // (#7757 registered the loopover_get_agent_audit_feed stdio tool, taking the count from 95 to 96.)
+// (#7754 registered the loopover_refresh_repo_docs stdio tool, taking the count from 96 to 97.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -84,14 +85,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 96 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 97 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(96);
+    expect(primary.length).toBe(97);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(96);
+    expect(names.length).toBe(97);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -103,14 +104,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 96-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 97-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(96);
+    expect(payload.count).toBe(97);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );


### PR DESCRIPTION
## Summary

Closes #7754 — `loopover_refresh_repo_docs` has a remote MCP tool (`src/mcp/server.ts`) and a `maintain refresh-docs` CLI command, but no **local stdio** MCP tool registration. #6743 added the REST route + CLI but never the matching stdio tool.

## What changed (`packages/loopover-mcp/bin/loopover-mcp.ts`)

- A `registerStdioTool("loopover_refresh_repo_docs", …)` block, placed next to `loopover_get_maintainer_noise`, mirroring the sibling proxy pattern — a thin POST of the **same** `{repoBase}/repo-docs/refresh` route the `maintain refresh-docs` CLI already calls, with an empty body (the route only ever *opens a PR* — never merges/commits — so there's no create-safety flag to forward).
- Input reuses `ownerRepoShape` (matching the remote `refreshRepoDocsShape`). Description via `stdioToolDescription(...)` + a `STDIO_TOOL_DESCRIPTORS` entry (`category: "maintainer"`).

## Testing / coverage

- `test/unit/mcp-cli-refresh-repo-docs.test.ts` drives it **in-process** (the #7764 `isProcessEntrypoint` guard + `InMemoryTransport`) for real Codecov-measured coverage — the handler is branch-free, so one call exercises it fully (asserts the exact `POST /v1/repos/owner/repo/repo-docs/refresh` + the returned PR result).
- Tool-count invariant bumped to **97**.

No REST/OpenAPI/CLI-surface change — `ui:openapi:check`, `command-reference:check`, `docs`/`manifest` drift all clean; `build:mcp` clean.

<sub>(Supersedes #7969, which was base-conflicted when sibling stdio-tool PRs merged mid-review — rebased onto current main.)</sub>