### PR TITLE
fix(miner): validate commit SHA is a safe path segment in replay-snapshot planner (#7796)

### DIFF
--- a/packages/loopover-miner/lib/replay-snapshot.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.ts
@@ -75,9 +75,19 @@ function normalizeRepoFullName(repoFullName: string): string {
   return `${owner}/${repo}`;
 }
 
+// planReplaySnapshotPath join()s the commit SHA straight into REPLAY_SNAPSHOT_SUBDIR, and it is also
+// passed to git as a bare revision argument. A crafted value like "../../etc" (or one containing a path
+// separator) would escape the intended snapshot directory via path.join -- a real path-traversal finding
+// (#7796). Constrain it to a single safe path segment, mirroring repo-clone.ts's isValidRepoSegment guard
+// for owner/repo (#5831): the same restricted charset plus an explicit "." / ".." rejection. A genuine
+// commit SHA is hex and always satisfies this, so no legitimate caller regresses.
+const COMMIT_SHA_PATTERN = /^[A-Za-z0-9._-]+$/;
+
 function normalizeCommitSha(commitSha: string): string {
   if (typeof commitSha !== "string" || !commitSha.trim()) throw new Error("invalid_commit_sha");
-  return commitSha.trim();
+  const trimmed = commitSha.trim();
+  if (trimmed === "." || trimmed === ".." || !COMMIT_SHA_PATTERN.test(trimmed)) throw new Error("invalid_commit_sha");
+  return trimmed;
 }
 
 /** Worktree exports live under this dir inside the repo, mirroring worktree-allocator.ts's WORKTREE_SUBDIR. */

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -77,6 +77,23 @@ describe("planReplaySnapshotPath (#3010) — pure, deterministic", () => {
     expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "abc123" })).toBe(a);
     expect(planReplaySnapshotPath({ repoPath: "/repo", commitSha: "def456" })).not.toBe(a);
   });
+
+  it("rejects a commit SHA that would escape the snapshot subdir via path traversal (#7796)", () => {
+    for (const commitSha of ["../../etc", "..", ".", "a/b", "a\\b", "../abc123", "foo/../..", ""]) {
+      expect(() => planReplaySnapshotPath({ repoPath: "/repo", commitSha })).toThrow("invalid_commit_sha");
+    }
+  });
+
+  it("accepts a real hex commit SHA and confines it to the snapshot subdir", () => {
+    const sha = "0a1b2c3d4e5f60718293a4b5c6d7e8f901234567";
+    const p = planReplaySnapshotPath({ repoPath: "/repo", commitSha: sha }).replaceAll("\\", "/");
+    expect(p).toBe(`/repo/${REPLAY_SNAPSHOT_SUBDIR}/${sha}`);
+  });
+
+  it("trims surrounding whitespace before validating the commit SHA", () => {
+    const p = planReplaySnapshotPath({ repoPath: "/repo", commitSha: "  abc123  " }).replaceAll("\\", "/");
+    expect(p).toBe(`/repo/${REPLAY_SNAPSHOT_SUBDIR}/abc123`);
+  });
 });
 
 describe("validateSnapshotFreshness (#3010) — pure fail-fast check", () => {


### PR DESCRIPTION
Fixes #7796.

## Root cause

`normalizeCommitSha` in `packages/loopover-miner/lib/replay-snapshot.ts` only trimmed its
input and checked it was non-empty — it applied **no format validation**. The value then flows
into `planReplaySnapshotPath`:

```ts
return join(input.repoPath, REPLAY_SNAPSHOT_SUBDIR, commitSha);
```

Because `path.join` resolves `..` segments, a crafted `commitSha` such as `"../../etc"` (or any
value containing a path separator) escapes the intended `REPLAY_SNAPSHOT_SUBDIR` — a real
path-traversal finding. The same unchecked value is also handed to git as a bare revision argument.

## Fix approach

Constrain the commit SHA to a **single safe path segment**, reusing the exact pattern the repo
already established for owner/repo names in `repo-clone.ts`'s `isValidRepoSegment` (#5831): the
restricted `[A-Za-z0-9._-]` charset plus an explicit `"."`/`".."` rejection. A genuine commit SHA
is hexadecimal and always satisfies this, so **no legitimate caller regresses**.

The guard is defined locally rather than imported from `repo-clone.ts` to avoid pulling that
module's heavier dependency graph (`process-lifecycle`, `worktree-allocator`) into the snapshot
path for a two-line check; a comment cross-references the canonical definition.

## Impact

- Closes the directory-escape vector in the replay-snapshot planner and store.
- Added regression tests assert every traversal payload (`../../etc`, `..`, `.`, `a/b`, `a\b`, …)
  throws `invalid_commit_sha`, and that a real 40-char hex SHA is confined under
  `REPLAY_SNAPSHOT_SUBDIR`.

## Risk / tradeoffs

Minimal and backward-compatible. The charset intentionally matches the existing repo-segment guard
(rather than strict hex) so the change is purely additive safety — it rejects only path-unsafe
values, never any string a real SHA could take. Scope is limited to the two files.