### PR TITLE
feat(api): add tenant-scoped installation health and repair

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -15021,7 +15021,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "GitHub App installations and health",
+            "description": "GitHub App installations and health (fleet-wide for operators; tenant-scoped for non-operator sessions)",
             "content": {
               "application/json": {
                 "schema": {
@@ -15050,6 +15050,12 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient role"
           }
         },
         "security": [
@@ -15085,6 +15091,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid installation id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Installation outside the caller's tenant scope"
           },
           "404": {
             "description": "Installation health not found"
@@ -15124,6 +15139,15 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid installation id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Installation outside the caller's tenant scope"
+          },
           "404": {
             "description": "Installation health not found"
           }
@@ -15161,6 +15185,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid installation id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Installation outside the caller's tenant scope"
           },
           "404": {
             "description": "Installation not found"

--- a/src/api/installation-self-service.ts
+++ b/src/api/installation-self-service.ts
@@ -1,0 +1,21 @@
+import type { ControlPanelAccessScope } from "../services/control-panel-roles";
+
+/** #7661: whether an installation id/account is inside a control-panel access scope. */
+export function installationInAccessScope(scope: ControlPanelAccessScope, installationId: number, accountLogin?: string | null): boolean {
+  if (scope.installationIds.includes(installationId)) return true;
+  if (!accountLogin) return false;
+  return scope.accountLogins.some((login) => login.toLowerCase() === accountLogin.toLowerCase());
+}
+
+/** #7661: filter fleet lists down to the caller's tenant scope (null scope = unfiltered). */
+export function scopeInstallationsAndHealth<TInstallation extends { id: number; accountLogin: string }, THealth extends { installationId: number; accountLogin: string }>(
+  allInstallations: TInstallation[],
+  allHealth: THealth[],
+  scope: ControlPanelAccessScope | null,
+): { installations: TInstallation[]; health: THealth[] } {
+  if (!scope) return { installations: allInstallations, health: allHealth };
+  return {
+    installations: allInstallations.filter((installation) => installationInAccessScope(scope, installation.id, installation.accountLogin)),
+    health: allHealth.filter((record) => installationInAccessScope(scope, record.installationId, record.accountLogin)),
+  };
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -45,6 +45,7 @@ import {
   getCommandUsefulnessSummary,
   getFreshOfficialMinerDetection,
   getIssue,
+  getInstallation,
   getInstallationHealth,
   getLatestRepoGithubTotalsSnapshot,
   getLatestScoringModelSnapshot,
@@ -210,6 +211,7 @@ import {
   loadControlPanelAccessScope,
   loadControlPanelRoleSummary,
 } from "../services/control-panel-roles";
+import { installationInAccessScope, scopeInstallationsAndHealth } from "./installation-self-service";
 import { runFindOpportunities, validateFindOpportunitiesInput, type FindOpportunitiesInput } from "../mcp/find-opportunities";
 import { runIssueRagRetrieval, validateIssueRagInput, type IssueRagInput } from "../mcp/issue-rag";
 import { buildBoundaryTestGenerationFinding, buildBoundaryTestGenerationSpec } from "../signals/boundary-test-generation";
@@ -2598,16 +2600,30 @@ export function createApp() {
     });
   });
 
-  app.get("/v1/installations", async (c) =>
-    c.json({
-      installations: await listInstallations(c.env),
-      health: (await listInstallationHealth(c.env)).map(enrichInstallationHealth),
-    }),
-  );
+  // #7661: tenant self-service for installation health/repair. Coarse path allowlist admits sessions;
+  // handlers below apply the same loadControlPanelAccessScope filter as /v1/app/maintainer-dashboard so
+  // a non-operator tenant never reads or refreshes another tenant's installation. Does not add bulk
+  // pause-all-repos controls (#7676).
+  app.get("/v1/installations", async (c) => {
+    const identity = await authenticateRequestIdentity(c);
+    /* v8 ignore next -- Protected middleware rejects unauthenticated private routes before this handler. */
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const summary = await getRoleSummaryForIdentity(c.env, identity);
+    if (!summary.roles.some((role) => ["maintainer", "owner", "operator"].includes(role))) return c.json({ error: "insufficient_role" }, 403);
+    const [allInstallations, allHealth] = await Promise.all([listInstallations(c.env), listInstallationHealth(c.env)]);
+    const scope = identity.kind === "session" && !summary.roles.includes("operator") ? await loadControlPanelAccessScope(c.env, identity.actor) : null;
+    const { installations, health } = scopeInstallationsAndHealth(allInstallations, allHealth, scope);
+    return c.json({
+      installations,
+      health: health.map(enrichInstallationHealth),
+    });
+  });
 
   app.get("/v1/installations/:id/health", async (c) => {
     const installationId = Number(c.req.param("id"));
     if (!Number.isFinite(installationId)) return c.json({ error: "invalid_installation_id" }, 400);
+    const forbidden = await requireInstallationSelfServiceAccess(c, installationId);
+    if (forbidden) return forbidden;
     const health = await getInstallationHealth(c.env, installationId);
     if (!health) return c.json({ error: "installation_health_not_found" }, 404);
     return c.json(enrichInstallationHealth(health));
@@ -2616,6 +2632,8 @@ export function createApp() {
   app.get("/v1/installations/:id/repair", async (c) => {
     const installationId = Number(c.req.param("id"));
     if (!Number.isFinite(installationId)) return c.json({ error: "invalid_installation_id" }, 400);
+    const forbidden = await requireInstallationSelfServiceAccess(c, installationId);
+    if (forbidden) return forbidden;
     const health = await getInstallationHealth(c.env, installationId);
     if (!health) return c.json({ error: "installation_health_not_found" }, 404);
     return c.json(await buildInstallationRepairDiagnostics(c.env, health));
@@ -2624,9 +2642,13 @@ export function createApp() {
   app.post("/v1/installations/:id/repair/refresh", async (c) => {
     const installationId = Number(c.req.param("id"));
     if (!Number.isFinite(installationId)) return c.json({ error: "invalid_installation_id" }, 400);
+    // Scope BEFORE refresh so a cross-tenant id never triggers GitHub/D1 mutation (#7661).
+    const forbidden = await requireInstallationSelfServiceAccess(c, installationId);
+    if (forbidden) return forbidden;
     const refreshed = await refreshInstallationHealthForInstallation(c.env, installationId);
     if (!refreshed) return c.json({ error: "installation_not_found" }, 404);
     const health = await getInstallationHealth(c.env, installationId);
+    /* v8 ignore next -- refreshInstallationHealthForInstallation persists health before returning. */
     if (!health) return c.json({ error: "installation_health_not_found" }, 404);
     return c.json({ ...(await buildInstallationRepairDiagnostics(c.env, health)), refreshed: true });
   });
@@ -6478,6 +6500,9 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   // Contributor extension scope reaches only `/v1/extension/contributors/<login>/*`; the handler's
   // requireContributorAccess then enforces actor === login (self-only).
   if (isExtensionContributorContextPath(path) && isExtensionContributorScopedSession(identity)) return true;
+  // #7661: coarse path admission for tenant installation health/repair self-service. Handlers enforce
+  // loadControlPanelAccessScope (same filter as /v1/app/maintainer-dashboard) so cross-tenant access 403s.
+  if (isInstallationSelfServicePath(path)) return true;
   return false;
 }
 
@@ -6566,6 +6591,28 @@ function isRepoAiConfigPath(path: string): boolean {
 // same shape as isRepoAiConfigPath above, just for the new Linear key route.
 function isRepoLinearConfigPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/linear-key$/.test(path);
+}
+
+// #7661: list + per-installation health/repair/refresh. Handlers apply maintainer-dashboard scoping.
+function isInstallationSelfServicePath(path: string): boolean {
+  return path === "/v1/installations" || /^\/v1\/installations\/[^/]+\/(?:health|repair(?:\/refresh)?)$/.test(path);
+}
+
+async function requireInstallationSelfServiceAccess(c: ProtectedRouteContext, installationId: number): Promise<Response | null> {
+  const identity = await authenticateRequestIdentity(c);
+  /* v8 ignore next -- Protected middleware rejects unauthenticated private routes before this guard. */
+  if (!identity) return c.json({ error: "unauthorized" }, 401);
+  const summary = await getRoleSummaryForIdentity(c.env, identity);
+  if (!summary.roles.some((role) => ["maintainer", "owner", "operator"].includes(role))) return c.json({ error: "insufficient_role" }, 403);
+  // Static tokens and operator sessions keep the fleet-wide view (same as /v1/app/maintainer-dashboard).
+  if (identity.kind !== "session" || summary.roles.includes("operator")) return null;
+  const scope = await loadControlPanelAccessScope(c.env, identity.actor);
+  const [installation, health] = await Promise.all([getInstallation(c.env, installationId), getInstallationHealth(c.env, installationId)]);
+  // Unknown id: let the handler 404. Existing-but-out-of-scope: hard 403 (cross-tenant).
+  if (!installation && !health) return null;
+  const accountLogin = installation?.accountLogin ?? health?.accountLogin;
+  if (installationInAccessScope(scope, installationId, accountLogin)) return null;
+  return c.json({ error: "forbidden_installation" }, 403);
 }
 
 async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<AuthIdentity | null> {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -333,7 +333,7 @@ export function buildOpenApiSpec() {
     summary: "List GitHub App installations and their health",
     responses: {
       200: {
-        description: "GitHub App installations and health",
+        description: "GitHub App installations and health (fleet-wide for operators; tenant-scoped for non-operator sessions)",
         content: {
           "application/json": {
             schema: z.object({
@@ -343,6 +343,8 @@ export function buildOpenApiSpec() {
           },
         },
       },
+      401: { description: "Unauthorized" },
+      403: { description: "Insufficient role" },
     },
   });
   registry.registerPath({
@@ -352,6 +354,9 @@ export function buildOpenApiSpec() {
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "GitHub App installation health", content: { "application/json": { schema: InstallationHealthSchema } } },
+      400: { description: "Invalid installation id" },
+      401: { description: "Unauthorized" },
+      403: { description: "Installation outside the caller's tenant scope" },
       404: { description: "Installation health not found" },
     },
   });
@@ -362,6 +367,9 @@ export function buildOpenApiSpec() {
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "GitHub App installation repair diagnostics", content: { "application/json": { schema: InstallationRepairSchema } } },
+      400: { description: "Invalid installation id" },
+      401: { description: "Unauthorized" },
+      403: { description: "Installation outside the caller's tenant scope" },
       404: { description: "Installation health not found" },
     },
   });
@@ -372,6 +380,9 @@ export function buildOpenApiSpec() {
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "Refreshed GitHub App installation repair diagnostics", content: { "application/json": { schema: InstallationRepairSchema } } },
+      400: { description: "Invalid installation id" },
+      401: { description: "Unauthorized" },
+      403: { description: "Installation outside the caller's tenant scope" },
       404: { description: "Installation not found" },
     },
   });

--- a/test/unit/installation-self-service.test.ts
+++ b/test/unit/installation-self-service.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { installationInAccessScope, scopeInstallationsAndHealth } from "../../src/api/installation-self-service";
+import type { ControlPanelAccessScope } from "../../src/services/control-panel-roles";
+
+const scope = (overrides: Partial<ControlPanelAccessScope> = {}): ControlPanelAccessScope => ({
+  operator: false,
+  repositoryFullNames: [],
+  installationIds: [10],
+  accountLogins: ["Acme"],
+  ...overrides,
+});
+
+describe("installation self-service scope helpers (#7661)", () => {
+  it("matches by installation id or account login, and rejects nullish/empty logins", () => {
+    expect(installationInAccessScope(scope(), 10, null)).toBe(true);
+    expect(installationInAccessScope(scope(), 99, "acme")).toBe(true);
+    expect(installationInAccessScope(scope(), 99, "other")).toBe(false);
+    expect(installationInAccessScope(scope(), 99, null)).toBe(false);
+    expect(installationInAccessScope(scope(), 99, undefined)).toBe(false);
+    expect(installationInAccessScope(scope(), 99, "")).toBe(false);
+  });
+
+  it("passes lists through unchanged when scope is null, and filters when scoped", () => {
+    const installations = [
+      { id: 10, accountLogin: "Acme" },
+      { id: 20, accountLogin: "Victim" },
+      { id: 30, accountLogin: "acme" },
+    ];
+    const health = [
+      { installationId: 10, accountLogin: "Acme" },
+      { installationId: 20, accountLogin: "Victim" },
+      { installationId: 40, accountLogin: "Acme" },
+    ];
+
+    expect(scopeInstallationsAndHealth(installations, health, null)).toEqual({ installations, health });
+
+    const filtered = scopeInstallationsAndHealth(installations, health, scope());
+    expect(filtered.installations.map((row) => row.id)).toEqual([10, 30]);
+    expect(filtered.health.map((row) => row.installationId)).toEqual([10, 40]);
+  });
+});

--- a/test/unit/routes-installation-self-service.test.ts
+++ b/test/unit/routes-installation-self-service.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { upsertInstallation, upsertInstallationHealth, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+// #7661: tenant self-service for /v1/installations* — same loadControlPanelAccessScope filter as
+// /v1/app/maintainer-dashboard. Cross-tenant read/repair must 403; operators/static tokens stay fleet-wide.
+
+function apiHeaders(env: Env): Record<string, string> {
+  return { authorization: `Bearer ${env.LOOPOVER_API_TOKEN}`, "content-type": "application/json" };
+}
+
+async function sessionHeaders(env: Env, login: string, id: number): Promise<Record<string, string>> {
+  const { token } = await createSessionForGitHubUser(env, { login, id });
+  return { cookie: `loopover_session=${token}`, "content-type": "application/json" };
+}
+
+async function seedTenantPair(env: Env): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: 777,
+      account: { login: "repo-owner", id: 777, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+      events: ["issues", "pull_request", "repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(env, { name: "owned-repo", full_name: "repo-owner/owned-repo", private: false, default_branch: "main", owner: { login: "repo-owner" } }, 777);
+  await upsertInstallationHealth(env, {
+    installationId: 777,
+    accountLogin: "repo-owner",
+    repositorySelection: "selected",
+    installedReposCount: 1,
+    registeredInstalledCount: 1,
+    status: "needs_attention",
+    missingPermissions: ["pull_requests"],
+    missingEvents: [],
+    permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+    events: ["issues", "pull_request", "repository"],
+    checkedAt: "2026-05-28T00:00:00.000Z",
+    authMode: "local",
+  });
+
+  await upsertInstallation(env, {
+    installation: {
+      id: 888,
+      account: { login: "victim-org", id: 888, type: "Organization" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+      events: ["issues", "pull_request", "repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(env, { name: "secret-repo", full_name: "victim-org/secret-repo", private: true, default_branch: "main", owner: { login: "victim-org" } }, 888);
+  await upsertInstallationHealth(env, {
+    installationId: 888,
+    accountLogin: "victim-org",
+    repositorySelection: "selected",
+    installedReposCount: 1,
+    registeredInstalledCount: 0,
+    status: "needs_attention",
+    missingPermissions: ["administration"],
+    missingEvents: ["issue_comment"],
+    permissions: { metadata: "read" },
+    events: ["issues"],
+    checkedAt: "2026-05-28T00:00:00.000Z",
+    authMode: "local",
+    errorSummary: "victim install needs privileged recovery",
+  });
+}
+
+describe("installation health/repair tenant self-service (#7661)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the static API token fleet-wide (operator-equivalent)", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedTenantPair(env);
+
+    const list = await app.request("/v1/installations", { headers: apiHeaders(env) }, env);
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as { installations: Array<{ id: number }>; health: Array<{ installationId: number }> };
+    expect(listBody.installations.map((row) => row.id).sort()).toEqual([777, 888]);
+    expect(listBody.health.map((row) => row.installationId).sort()).toEqual([777, 888]);
+
+    expect((await app.request("/v1/installations/888/health", { headers: apiHeaders(env) }, env)).status).toBe(200);
+    expect((await app.request("/v1/installations/888/repair", { headers: apiHeaders(env) }, env)).status).toBe(200);
+  });
+
+  it("scopes list/health/repair to the session tenant and forbids the other tenant", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedTenantPair(env);
+    const ownerHeaders = await sessionHeaders(env, "repo-owner", 777);
+
+    const list = await app.request("/v1/installations", { headers: ownerHeaders }, env);
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as { installations: Array<{ id: number; accountLogin: string }>; health: Array<{ installationId: number; accountLogin: string }> };
+    expect(listBody.installations).toEqual([expect.objectContaining({ id: 777, accountLogin: "repo-owner" })]);
+    expect(listBody.health).toEqual([expect.objectContaining({ installationId: 777, accountLogin: "repo-owner" })]);
+    expect(JSON.stringify(listBody)).not.toContain("victim-org");
+    expect(JSON.stringify(listBody)).not.toContain("victim install needs privileged recovery");
+
+    const ownHealth = await app.request("/v1/installations/777/health", { headers: ownerHeaders }, env);
+    expect(ownHealth.status).toBe(200);
+    await expect(ownHealth.json()).resolves.toMatchObject({ installationId: 777, accountLogin: "repo-owner" });
+
+    const ownRepair = await app.request("/v1/installations/777/repair", { headers: ownerHeaders }, env);
+    expect(ownRepair.status).toBe(200);
+    await expect(ownRepair.json()).resolves.toMatchObject({
+      installation: { installationId: 777 },
+      refresh: { method: "POST", path: "/v1/installations/777/repair/refresh" },
+    });
+
+    for (const path of ["/v1/installations/888/health", "/v1/installations/888/repair"] as const) {
+      const forbidden = await app.request(path, { headers: ownerHeaders }, env);
+      expect(forbidden.status).toBe(403);
+      await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_installation" });
+    }
+  });
+
+  it("REGRESSION (#7661): refresh never contacts GitHub for another tenant's installation", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedTenantPair(env);
+    const ownerHeaders = await sessionHeaders(env, "repo-owner", 777);
+
+    let fetchCalls = 0;
+    vi.stubGlobal("fetch", async () => {
+      fetchCalls += 1;
+      return new Response("should-not-run", { status: 500 });
+    });
+
+    const forbidden = await app.request("/v1/installations/888/repair/refresh", { method: "POST", headers: ownerHeaders }, env);
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_installation" });
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("lets a tenant refresh their own installation after the scope gate", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedTenantPair(env);
+    const ownerHeaders = await sessionHeaders(env, "repo-owner", 777);
+
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/app/installations/777")) {
+        return Response.json({
+          id: 777,
+          account: { login: "repo-owner", id: 777, type: "User" },
+          repository_selection: "selected",
+          permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await app.request("/v1/installations/777/repair/refresh", { method: "POST", headers: ownerHeaders }, env);
+    expect(refreshed.status).toBe(200);
+    await expect(refreshed.json()).resolves.toMatchObject({
+      refreshed: true,
+      installation: { installationId: 777, accountLogin: "repo-owner" },
+    });
+  });
+
+  it("rejects sessions without maintainer/owner/operator role before any installation lookup", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedTenantPair(env);
+    const strangerHeaders = await sessionHeaders(env, "new-user", 2468);
+
+    for (const path of ["/v1/installations", "/v1/installations/777/health", "/v1/installations/777/repair"] as const) {
+      const response = await app.request(path, { headers: strangerHeaders }, env);
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ error: "insufficient_role" });
+    }
+
+    const refresh = await app.request("/v1/installations/777/repair/refresh", { method: "POST", headers: strangerHeaders }, env);
+    expect(refresh.status).toBe(403);
+    await expect(refresh.json()).resolves.toMatchObject({ error: "insufficient_role" });
+  });
+
+  it("lets an operator session see the full fleet including another tenant", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "fleet-op" });
+    await seedTenantPair(env);
+    const operatorHeaders = await sessionHeaders(env, "fleet-op", 1);
+
+    const list = await app.request("/v1/installations", { headers: operatorHeaders }, env);
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as { installations: Array<{ id: number }> };
+    expect(listBody.installations.map((row) => row.id).sort()).toEqual([777, 888]);
+
+    expect((await app.request("/v1/installations/888/health", { headers: operatorHeaders }, env)).status).toBe(200);
+  });
+
+  it("returns 404 for an in-scope missing health row and 400 for a non-numeric id", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await upsertInstallation(env, {
+      installation: {
+        id: 901,
+        account: { login: "repo-owner", id: 777, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read" },
+        events: ["issues"],
+      },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "owned-repo", full_name: "repo-owner/owned-repo", private: false, default_branch: "main", owner: { login: "repo-owner" } }, 901);
+    const ownerHeaders = await sessionHeaders(env, "repo-owner", 777);
+
+    expect((await app.request("/v1/installations/not-a-number/health", { headers: ownerHeaders }, env)).status).toBe(400);
+    expect((await app.request("/v1/installations/not-a-number/repair", { headers: ownerHeaders }, env)).status).toBe(400);
+    expect((await app.request("/v1/installations/not-a-number/repair/refresh", { method: "POST", headers: ownerHeaders }, env)).status).toBe(400);
+
+    const missingHealth = await app.request("/v1/installations/901/health", { headers: ownerHeaders }, env);
+    expect(missingHealth.status).toBe(404);
+    await expect(missingHealth.json()).resolves.toMatchObject({ error: "installation_health_not_found" });
+
+    const missingRepair = await app.request("/v1/installations/901/repair", { headers: ownerHeaders }, env);
+    expect(missingRepair.status).toBe(404);
+
+    const missingRefresh = await app.request("/v1/installations/9999/repair/refresh", { method: "POST", headers: ownerHeaders }, env);
+    expect(missingRefresh.status).toBe(404);
+    await expect(missingRefresh.json()).resolves.toMatchObject({ error: "installation_not_found" });
+  });
+
+  it("allows access when only installation health carries the scoped account login", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    // Health row alone (no installations row) still scopes via accountLogin — mirrors dashboard OR filter.
+    await upsertInstallationHealth(env, {
+      installationId: 555,
+      accountLogin: "repo-owner",
+      repositorySelection: "selected",
+      installedReposCount: 0,
+      registeredInstalledCount: 0,
+      status: "healthy",
+      missingPermissions: [],
+      missingEvents: [],
+      permissions: { metadata: "read" },
+      events: ["issues"],
+      checkedAt: "2026-05-28T00:00:00.000Z",
+      authMode: "local",
+    });
+    await upsertInstallation(env, {
+      installation: {
+        id: 556,
+        account: { login: "repo-owner", id: 777, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read" },
+        events: ["issues"],
+      },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "owned-repo", full_name: "repo-owner/owned-repo", private: false, default_branch: "main", owner: { login: "repo-owner" } }, 556);
+    const ownerHeaders = await sessionHeaders(env, "repo-owner", 777);
+
+    const health = await app.request("/v1/installations/555/health", { headers: ownerHeaders }, env);
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toMatchObject({ installationId: 555, accountLogin: "repo-owner" });
+
+    const list = await app.request("/v1/installations", { headers: ownerHeaders }, env);
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as { health: Array<{ installationId: number }> };
+    expect(listBody.health.some((row) => row.installationId === 555)).toBe(true);
+  });
+
+  it("leaks no wallet/hotkey/trust-score terms on tenant-scoped responses", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedTenantPair(env);
+    const ownerHeaders = await sessionHeaders(env, "repo-owner", 777);
+    const response = await app.request("/v1/installations/777/repair", { headers: ownerHeaders }, env);
+    expect(response.status).toBe(200);
+    expect(JSON.stringify(await response.json())).not.toMatch(/wallet|hotkey|raw trust score|payout|reward estimate|farming|private reviewability|public score estimate/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #7661: hosted tenants (maintainer/owner sessions) can list, read health, and trigger repair/refresh for **their own** GitHub App installation — previously operator-only via the coarse `canSessionAccessPath` fallback.
- Reuses the exact `/v1/app/maintainer-dashboard` scoping pattern (`loadControlPanelRoleSummary` / `loadControlPanelAccessScope`): non-operator sessions are filtered to their `installationIds` / `accountLogins`; operators and static API tokens stay fleet-wide.
- Cross-tenant negative paths return `403 forbidden_installation`; refresh is gated **before** any GitHub/D1 mutation. Does not add bulk pause-all-repos controls (#7676).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` could not complete on this Windows contributor machine due to a pre-existing miner `build:verify` path bug (`E:\E:\Projects\...`). Focused coverage: `installation-self-service` helpers at 100% statements/branches; route suite `routes-installation-self-service` (9) + helper unit tests (2) + existing installation repair error path all green. Remaining gate checks deferred to Linux CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — API/auth scoping only; no visible UI change.

## Notes

- Analogues: `/v1/app/maintainer-dashboard` and `/v1/app/digest` (#7659) tenant scoping.
- Pure helpers live in `src/api/installation-self-service.ts` for branch-complete unit coverage.