### PR TITLE
fix(services): redact 'private key' from the agent-action public-safe card (#8020)

### DIFF
--- a/src/services/agent-action-explanation-card.ts
+++ b/src/services/agent-action-explanation-card.ts
@@ -8,7 +8,7 @@ type AgentActionExplanationInput = Pick<
 
 const BLOCKER_CATEGORY_ORDER: AgentActionBlockerCategory[] = ["branch", "account", "queue", "scoreability", "risk", "maintainer", "unknown"];
 const PUBLIC_FORBIDDEN_PATTERN =
-  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw[-_\s]?trust scores?|trust scores?|private reviewability|reviewability internals?|private scoreability|scoreability|projected scores?|score(?:d|s|ability)?|public score estimates?|estimated scores?|score estimates?|score previews?|reward estimates?|payouts?|farming|reward optimization|private rankings?)\b/gi;
+  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|private keys?|raw[-_\s]?trust scores?|trust scores?|private reviewability|reviewability internals?|private scoreability|scoreability|projected scores?|score(?:d|s|ability)?|public score estimates?|estimated scores?|score estimates?|score previews?|reward estimates?|payouts?|farming|reward optimization|private rankings?)\b/gi;
 const PUBLIC_SCORE_DELTA_PATTERN = /\b(?:projected\s+)?score\w*(?:\s+\w+){0,4}\s+[-+]?\d+(?:\.\d+)?\s*->\s*[-+]?\d+(?:\.\d+)?\b/gi;
 // Token alternatives stay local; the local-path alternatives compose from the canonical PUBLIC_LOCAL_PATH_INLINE
 // in redaction.ts (adds the previously-missed /root/ and /var/, plus the forward-slash Windows form C:/Users/).

--- a/test/unit/agent-orchestrator.test.ts
+++ b/test/unit/agent-orchestrator.test.ts
@@ -804,6 +804,24 @@ describe("agent orchestrator", () => {
     expect(card.publicSafe.summary).not.toMatch(/\/root\/work|\/var\/log|C:\/Users\/alice/);
   });
 
+  it("redacts 'private key' from the public-safe card, matching its sibling redaction lists (#8020)", () => {
+    // `private keys?` was present in 5 sibling public-redaction vocabularies (miner-dashboard-recommendations.ts:45,
+    // control-panel-roles.ts:297, decision-pack.ts:1438, weekly-value-report.ts:417, extension-contributor-context.ts:31)
+    // but missing here, so an App-credential reference leaked through publicSafe.whyNow unredacted.
+    const card = buildAgentActionExplanationCard({
+      actionType: "choose_next_work",
+      status: "blocked",
+      why: ["Blocked by a private key rotation on the App credential."],
+      blockedBy: ["private key rotation pending"],
+      publicSafeSummary: "Resolve the App private key rotation before rerunning.",
+      safetyClass: "private",
+    });
+
+    expect(card.publicSafe.summary).not.toMatch(/private key/i);
+    expect(card.publicSafe.summary).toMatch(/private context/);
+    expect(card.publicSafe.whyNow).not.toMatch(/private key/i);
+  });
+
   it("does not split a surrogate pair when truncating a card field at the 300-character cap", () => {
     // A string is well-formed UTF-16 iff it has no lone surrogate (a high surrogate not followed by a
     // low one, or a low surrogate not preceded by a high one). Equivalent to String#isWellFormed without


### PR DESCRIPTION
## Summary

`agent-action-explanation-card.ts`'s `PUBLIC_FORBIDDEN_PATTERN` — the redaction applied by `sanitizePublicCardText` to the only text the `publicSafe` card ever exposes (`summary`/`whyNow`/`rerunWhen`) — listed `seed phrases?`/`mnemonics?` but was **missing `private keys?`**. Every other public-safe redaction vocabulary in the codebase includes it (`miner-dashboard-recommendations.ts:45`, `control-panel-roles.ts:297`, `decision-pack.ts:1438`, `weekly-value-report.ts:417`, `extension-contributor-context.ts:31`), and `src/signals/redaction.ts:18-22`'s doc comment claims both this surface and its sibling carry the term — but only the sibling actually did.

Concrete leak: an action whose `why`/`blockedBy` references an App-credential/private-key-rotation topic (a live concept — see `src/github/app.ts`) passed through `publicSafe.whyNow` unredacted.

## Fix

Add the same `private keys?` alternative used by the sibling lists, in the same position (right after `mnemonics?`) — no new wording, no new redaction shape. A regression test builds a card whose public-safe text references a private key and asserts it is redacted to `private context`.

## Scope

- [x] Narrow, single coherent change (one regex term + its regression test)
- [x] In `wantedPaths` (`src/services/**`, `test/unit/**`); no `blockedPaths`
- [x] No secrets/wallets/hotkeys/trust-scores/rewards in code, tests, or this text
- [x] No generated-artifact changes required (pure service-file regex constant)

## Validation

- [x] `npx vitest run test/unit/agent-orchestrator.test.ts` — 21/21 pass (incl. the new `#8020` regression test)
- [x] Sibling agent-domain suites green: `agent-actions`, `agent-action-executor`, `policy-sanitizer` — 524/524
- [x] `typecheck` — clean on changed files (only the 2 pre-existing local `semver` `TS7016`s remain)
- [x] `git diff --check` clean

## Safety

- [x] Change strictly *widens* public redaction (more terms redacted; no term removed) — the public/private boundary is tightened, never loosened
- [x] Regression test asserts the previously-leaking term no longer reaches the public-safe card
- [x] No secrets or private-scoring terms introduced anywhere

Closes #8020
