### PR TITLE
fix(control-plane): product-scope fake provisioning driver state keys

### DIFF
--- a/control-plane/src/tenant-provisioning-driver.ts
+++ b/control-plane/src/tenant-provisioning-driver.ts
@@ -92,15 +92,23 @@ export type FakeDriverCall = {
 
 /** A fake `TenantProvisioningDriver` plus the recorded state a test inspects. */
 export type FakeTenantProvisioningDriver = TenantProvisioningDriver & {
-  /** Tenant names whose container currently "exists" (an in-memory stand-in for real infrastructure). */
+  /** Product-scoped keys (`${product}:${tenant.name}`, same as container-driver.ts's `instanceNameFor`)
+   *  whose container currently "exists" (an in-memory stand-in for real infrastructure). */
   readonly containers: ReadonlySet<string>;
-  /** Tenant names whose database currently "exists". */
+  /** Product-scoped keys whose database currently "exists". */
   readonly databases: ReadonlySet<string>;
-  /** Tenant names whose secrets are currently injected. */
+  /** Product-scoped keys whose secrets are currently injected. */
   readonly injectedSecrets: ReadonlySet<string>;
   /** Every driver step this fake has run, in call order. */
   readonly calls: readonly FakeDriverCall[];
 };
+
+/** Same composite key as container-driver.ts's `instanceNameFor` (#8025) — ORB and AMS tenants that share a
+ *  name must not collide in the fake's in-memory maps (production composes this fake for any step without a
+ *  real backend yet). */
+function instanceKeyFor(request: TenantProvisioningRequest): string {
+  return `${request.product}:${request.tenant.name}`;
+}
 
 /** Minimal in-memory fake for orchestration/contract tests — three in-memory maps stand in for real infra
  *  ("a container exists" / "a DB exists" / "secrets injected"), toggled by the create/destroy steps, plus an
@@ -135,11 +143,11 @@ export function createFakeTenantProvisioningDriver(): FakeTenantProvisioningDriv
     },
     async createContainer(request) {
       record("createContainer", request);
-      containers.add(request.tenant.name);
+      containers.add(instanceKeyFor(request));
     },
     async provisionDatabase(request) {
       record("provisionDatabase", request);
-      databases.add(request.tenant.name);
+      databases.add(instanceKeyFor(request));
       // Deterministic per-tenant fake connection details -- no real IO, no state beyond the existing
       // `databases` set, just enough shape for callers/tests exercising the widened (#7653) return contract.
       const host = `fake-${request.tenant.name}.control-plane.invalid`;
@@ -151,30 +159,33 @@ export function createFakeTenantProvisioningDriver(): FakeTenantProvisioningDriv
     },
     async injectSecrets(request) {
       record("injectSecrets", request);
-      injectedSecrets.add(request.tenant.name);
+      injectedSecrets.add(instanceKeyFor(request));
     },
     async destroyContainer(request) {
       record("destroyContainer", request);
       // Idempotent teardown: the else-branch (nothing to remove) is the "destroy-of-a-nonexistent-tenant"
       // lifecycle path — a no-op, never a throw.
-      if (containers.has(request.tenant.name)) {
-        containers.delete(request.tenant.name);
+      const key = instanceKeyFor(request);
+      if (containers.has(key)) {
+        containers.delete(key);
       }
     },
     async dropDatabase(request) {
       record("dropDatabase", request);
-      if (databases.has(request.tenant.name)) {
-        databases.delete(request.tenant.name);
+      const key = instanceKeyFor(request);
+      if (databases.has(key)) {
+        databases.delete(key);
       }
     },
     async revokeSecrets(request) {
       record("revokeSecrets", request);
-      if (injectedSecrets.has(request.tenant.name)) {
-        injectedSecrets.delete(request.tenant.name);
+      const key = instanceKeyFor(request);
+      if (injectedSecrets.has(key)) {
+        injectedSecrets.delete(key);
       }
     },
     async containerExists(request) {
-      return containers.has(request.tenant.name);
+      return containers.has(instanceKeyFor(request));
     },
   };
 }

--- a/control-plane/test/driver-factory.test.ts
+++ b/control-plane/test/driver-factory.test.ts
@@ -69,21 +69,21 @@ test("withRealDatabaseDriver: overrides provisionDatabase/dropDatabase, forwards
   assert.deepEqual(calls, ["real-provision"]);
   // The fake's own provisionDatabase never ran -- its `databases` set stays empty even though the composed
   // driver's provisionDatabase resolved successfully.
-  assert.equal(base.databases.has("acme"), false);
+  assert.equal(base.databases.has("orb:acme"), false);
 
   await composed.dropDatabase(REQUEST);
   assert.deepEqual(calls, ["real-provision", "real-drop"]);
 
   // Every non-database step still runs against `base` exactly as before composition.
   await composed.createContainer(REQUEST);
-  assert.ok(base.containers.has("acme"));
+  assert.ok(base.containers.has("orb:acme"));
   assert.equal(await composed.containerExists(REQUEST), true);
   await composed.injectSecrets(REQUEST);
-  assert.ok(base.injectedSecrets.has("acme"));
+  assert.ok(base.injectedSecrets.has("orb:acme"));
   await composed.destroyContainer(REQUEST);
-  assert.equal(base.containers.has("acme"), false);
+  assert.equal(base.containers.has("orb:acme"), false);
   await composed.revokeSecrets(REQUEST);
-  assert.equal(base.injectedSecrets.has("acme"), false);
+  assert.equal(base.injectedSecrets.has("orb:acme"), false);
 });
 
 test("withRealContainerDriver: overrides createContainer/destroyContainer/containerExists, forwards every other step to base", async () => {
@@ -110,13 +110,13 @@ test("withRealContainerDriver: overrides createContainer/destroyContainer/contai
   assert.deepEqual(calls, ["real-create", "real-exists", "real-destroy"]);
   // The fake's own createContainer never ran -- its `containers` set stays empty even though the composed
   // driver's own lifecycle calls all resolved successfully.
-  assert.equal(base.containers.has("acme"), false);
+  assert.equal(base.containers.has("orb:acme"), false);
 
   // Every non-container step still runs against `base` exactly as before composition.
   const details = await composed.provisionDatabase(REQUEST);
   assert.equal(details.host, "fake-acme.control-plane.invalid");
   await composed.injectSecrets(REQUEST);
-  assert.ok(base.injectedSecrets.has("acme"));
+  assert.ok(base.injectedSecrets.has("orb:acme"));
 });
 
 test("createTenantProvisioningDriver: falls back to the fake container behavior when containerBindings is omitted or empty", async () => {

--- a/control-plane/test/provisioning.test.ts
+++ b/control-plane/test/provisioning.test.ts
@@ -37,8 +37,8 @@ test("provisionTenant runs the three #7180 steps in order and reports the tenant
   );
   // Container "exists"/reachable via the fake after provision.
   assert.equal(await driver.containerExists({ tenant, product: "orb" }), true);
-  assert.ok(driver.databases.has("acme"));
-  assert.ok(driver.injectedSecrets.has("acme"));
+  assert.ok(driver.databases.has("orb:acme"));
+  assert.ok(driver.injectedSecrets.has("orb:acme"));
 });
 
 test("full lifecycle: provision → container exists → deprovision → container gone", async () => {
@@ -52,8 +52,8 @@ test("full lifecycle: provision → container exists → deprovision → contain
 
   assert.deepEqual(result, { tenant, product: "ams", state: "torn down" });
   assert.equal(await driver.containerExists({ tenant, product: "ams" }), false);
-  assert.equal(driver.databases.has("acme"), false);
-  assert.equal(driver.injectedSecrets.has("acme"), false);
+  assert.equal(driver.databases.has("ams:acme"), false);
+  assert.equal(driver.injectedSecrets.has("ams:acme"), false);
 });
 
 test("deprovisionTenant tears the steps down in reverse order", async () => {
@@ -83,7 +83,7 @@ test("deprovisionTenant on a never-provisioned tenant is a safe no-op that still
 
   assert.deepEqual(result, { tenant, product: "ams", state: "torn down" });
   assert.equal(await driver.containerExists({ tenant, product: "ams" }), false);
-  assert.equal(driver.containers.has("ghost"), false);
+  assert.equal(driver.containers.has("ams:ghost"), false);
 });
 
 test("the call shape is identical for an ORB tenant and an AMS tenant (product-agnostic)", async () => {

--- a/control-plane/test/tenant-provisioning-driver.test.ts
+++ b/control-plane/test/tenant-provisioning-driver.test.ts
@@ -23,11 +23,11 @@ test("createContainer makes the tenant's container exist; destroyContainer remov
   assert.equal(await driver.containerExists(request), false);
   await driver.createContainer(request);
   assert.equal(await driver.containerExists(request), true);
-  assert.ok(driver.containers.has("acme"));
+  assert.ok(driver.containers.has("orb:acme"));
 
   await driver.destroyContainer(request);
   assert.equal(await driver.containerExists(request), false);
-  assert.equal(driver.containers.has("acme"), false);
+  assert.equal(driver.containers.has("orb:acme"), false);
 });
 
 test("destroyContainer on a never-created container is an idempotent no-op", async () => {
@@ -37,7 +37,7 @@ test("destroyContainer on a never-created container is an idempotent no-op", asy
   // else-branch: nothing to remove — must not throw.
   await driver.destroyContainer(request);
   assert.equal(await driver.containerExists(request), false);
-  assert.equal(driver.containers.has("ghost"), false);
+  assert.equal(driver.containers.has("ams:ghost"), false);
 });
 
 test("provisionDatabase returns deterministic per-tenant connection details (#7653)", async () => {
@@ -61,13 +61,13 @@ test("provision/teardown steps toggle the database and secret maps too", async (
 
   await driver.provisionDatabase(request);
   await driver.injectSecrets(request);
-  assert.ok(driver.databases.has("acme"));
-  assert.ok(driver.injectedSecrets.has("acme"));
+  assert.ok(driver.databases.has("ams:acme"));
+  assert.ok(driver.injectedSecrets.has("ams:acme"));
 
   await driver.dropDatabase(request);
   await driver.revokeSecrets(request);
-  assert.equal(driver.databases.has("acme"), false);
-  assert.equal(driver.injectedSecrets.has("acme"), false);
+  assert.equal(driver.databases.has("ams:acme"), false);
+  assert.equal(driver.injectedSecrets.has("ams:acme"), false);
 });
 
 test("dropDatabase / revokeSecrets on a never-provisioned tenant are idempotent no-ops", async () => {
@@ -76,8 +76,8 @@ test("dropDatabase / revokeSecrets on a never-provisioned tenant are idempotent 
 
   await driver.dropDatabase(request);
   await driver.revokeSecrets(request);
-  assert.equal(driver.databases.has("ghost"), false);
-  assert.equal(driver.injectedSecrets.has("ghost"), false);
+  assert.equal(driver.databases.has("orb:ghost"), false);
+  assert.equal(driver.injectedSecrets.has("orb:ghost"), false);
 });
 
 test("the fake records every step it runs, in call order, with its tenant and product", async () => {
@@ -93,4 +93,35 @@ test("the fake records every step it runs, in call order, with its tenant and pr
   );
   assert.deepEqual(driver.calls[0]?.tenant, { name: "acme" });
   assert.equal(driver.calls[0]?.product, "orb");
+});
+
+// Mirrors container-driver.test.ts's "the instance key is product-scoped..." — same name across products
+// must not share fake-driver state on one shared driver (production's composition shape; #8025).
+test("state maps are product-scoped (${product}:${tenant.name}), not just the tenant name", async () => {
+  const driver = createFakeTenantProvisioningDriver();
+  const orb = requestFor("acme", "orb");
+  const ams = requestFor("acme", "ams");
+
+  await driver.createContainer(orb);
+  await driver.provisionDatabase(orb);
+  await driver.injectSecrets(orb);
+  await driver.createContainer(ams);
+  await driver.provisionDatabase(ams);
+  await driver.injectSecrets(ams);
+
+  assert.ok(driver.containers.has("orb:acme"));
+  assert.ok(driver.containers.has("ams:acme"));
+  assert.ok(driver.injectedSecrets.has("orb:acme"));
+  assert.ok(driver.injectedSecrets.has("ams:acme"));
+
+  await driver.revokeSecrets(orb);
+  assert.equal(driver.injectedSecrets.has("orb:acme"), false);
+  assert.ok(driver.injectedSecrets.has("ams:acme"));
+
+  await driver.destroyContainer(orb);
+  await driver.dropDatabase(orb);
+  assert.equal(await driver.containerExists(orb), false);
+  assert.equal(await driver.containerExists(ams), true);
+  assert.ok(driver.databases.has("ams:acme"));
+  assert.equal(driver.databases.has("orb:acme"), false);
 });


### PR DESCRIPTION
## Summary

- `createFakeTenantProvisioningDriver` keyed `containers` / `databases` / `injectedSecrets` by tenant name alone, so same-named ORB and AMS tenants shared one entry on the single fake instance production composes for not-yet-real steps (secrets today; DB whenever Neon env is unset).
- State maps now use `${product}:${tenant.name}`, matching `container-driver.ts`'s `instanceNameFor`. A cross-product regression test pins that revoking one product's secrets leaves the other intact.

Closes #8025

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Control-plane-only change: validated with `npm --prefix control-plane test` and `npm run control-plane:coverage` (changed file 100% lines/branches). Root vitest/UI/MCP gates do not cover `control-plane/src/**`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — control-plane driver state keying only; no UI.

## Notes

- Analogue: `control-plane/src/container-driver.ts` `instanceNameFor` / `test/container-driver.test.ts` product-scoped instance key test.

Made with [Cursor](https://cursor.com)