### PR TITLE
fix(control-plane): product-scope TenantRegistry keys (#8024)

### DIFF
--- a/control-plane/src/http-app.ts
+++ b/control-plane/src/http-app.ts
@@ -1,6 +1,7 @@
 // The real HTTP transport for control-plane's tenant-provisioning API (#7654), matching
-// packages/loopover-miner/lib/tenant-client.ts's already-merged contract exactly: `POST /v1/tenants`
-// (`{name, product}`), `GET /v1/tenants` (`{tenants: [...]}`), `DELETE /v1/tenants/:name`, all Bearer-authed.
+// packages/loopover-miner/lib/tenant-client.ts's already-merged contract for create/list shapes:
+// `POST /v1/tenants` (`{name, product}`), `GET /v1/tenants` (`{tenants: [...]}`), and
+// `DELETE /v1/tenants/:name?product=` (#8024: product is required so registry lookups stay product-scoped).
 // Factored out as a plain Hono app (not the real Worker entry point, see worker.ts) so it's testable via
 // Hono's own `app.request()` against injected fakes under plain `node:test` -- mirrors
 // packages/discovery-index/src/app.ts's identical split for the identical reason.
@@ -62,10 +63,10 @@ export function createTenantHttpApp(deps: TenantHttpAppDeps): Hono {
     if (typeof product !== "string" || !product.trim()) return c.json({ error: "invalid_request", message: "product is required" }, 400);
 
     // Not idempotent by design (tenant-client.ts's own doc comment: "a create is not idempotent, so it must
-    // not be silently re-sent") -- a currently-active tenant of the same name is a real conflict, not a no-op.
-    // A previously torn-down tenant may be recreated (its createdAt is NOT preserved -- this is a fresh
-    // provision, not a resurrection of the old one).
-    const existing = await deps.registry.get(name);
+    // not be silently re-sent") -- a currently-active tenant of the same name *and product* is a real conflict,
+    // not a no-op (#8024: ORB "acme" must not block AMS "acme"). A previously torn-down tenant may be recreated
+    // (its createdAt is NOT preserved -- this is a fresh provision, not a resurrection of the old one).
+    const existing = await deps.registry.get(name, product);
     if (existing && existing.state !== "torn down") return c.json({ error: "tenant_already_exists" }, 409);
 
     const result = await provisionTenant({ name }, product, deps.driver, deps.pagerDuty ?? {});
@@ -81,7 +82,13 @@ export function createTenantHttpApp(deps: TenantHttpAppDeps): Hono {
 
   app.delete("/v1/tenants/:name", async (c) => {
     const name = c.req.param("name");
-    const existing = await deps.registry.get(name);
+    // Product is required so the registry can resolve the same `${product}:${name}` key used at create (#8024).
+    const product = c.req.query("product");
+    if (typeof product !== "string" || !product.trim()) {
+      return c.json({ error: "invalid_request", message: "product query parameter is required" }, 400);
+    }
+
+    const existing = await deps.registry.get(name, product);
     if (!existing) return c.json({ error: "tenant_not_found" }, 404);
 
     const result = await deprovisionTenant(existing.tenant, existing.product, deps.driver, deps.pagerDuty ?? {});

--- a/control-plane/src/tenant-registry.ts
+++ b/control-plane/src/tenant-registry.ts
@@ -16,12 +16,27 @@ export type TenantRegistryRecord = {
 
 export interface TenantRegistry {
   /** Insert or update a tenant's record. Preserves the original `createdAt` on an update (looked up by the
-   *  caller, not this method -- see `http-app.ts`'s own upsert helper). */
+   *  caller, not this method -- see `http-app.ts`'s own upsert helper). Keyed by `(product, name)` so ORB and
+   *  AMS tenants that share a name stay independent (#8024). */
   upsert(record: TenantRegistryRecord): Promise<void>;
-  get(name: string): Promise<TenantRegistryRecord | undefined>;
+  /** Lookup by the same `${product}:${name}` composite as container-driver.ts's `instanceNameFor` (#8024). */
+  get(name: string, product: Product): Promise<TenantRegistryRecord | undefined>;
   /** Every tenant this service has ever created, including torn-down ones (mirrors a cloud console showing
-   *  terminated instances rather than making them vanish) -- ordered by `tenant.name` for a stable listing. */
+   *  terminated instances rather than making them vanish) -- ordered by `tenant.name` then `product` for a
+   *  stable listing across products. */
   list(): Promise<TenantRegistryRecord[]>;
+}
+
+/** Same composite key as container-driver.ts's `instanceNameFor` (#8024) — ORB and AMS tenants that share a
+ *  name must not collide in the admin inventory. */
+function instanceKeyFor(name: string, product: Product): string {
+  return `${product}:${name}`;
+}
+
+function sortRecords(records: TenantRegistryRecord[]): TenantRegistryRecord[] {
+  return records.sort(
+    (a, b) => a.tenant.name.localeCompare(b.tenant.name) || a.product.localeCompare(b.product),
+  );
 }
 
 /** In-memory fake for tests -- mirrors `createFakeTenantProvisioningDriver`'s own minimal-fake convention. */
@@ -29,13 +44,13 @@ export function createFakeTenantRegistry(): TenantRegistry {
   const records = new Map<string, TenantRegistryRecord>();
   return {
     async upsert(record) {
-      records.set(record.tenant.name, record);
+      records.set(instanceKeyFor(record.tenant.name, record.product), record);
     },
-    async get(name) {
-      return records.get(name);
+    async get(name, product) {
+      return records.get(instanceKeyFor(name, product));
     },
     async list() {
-      return [...records.values()].sort((a, b) => a.tenant.name.localeCompare(b.tenant.name));
+      return sortRecords([...records.values()]);
     },
   };
 }
@@ -51,19 +66,20 @@ export type KvNamespaceLike = {
 
 const KEY_PREFIX = "tenant:";
 
-function keyFor(name: string): string {
-  return `${KEY_PREFIX}${name}`;
+function keyFor(name: string, product: Product): string {
+  return `${KEY_PREFIX}${instanceKeyFor(name, product)}`;
 }
 
 /** Real registry backed by Workers KV. `list()` pages through every `tenant:`-prefixed key (KV's own `list()`
- *  caps each call at 1000 keys) rather than assuming a single page covers the whole registry. */
+ *  caps each call at 1000 keys) rather than assuming a single page covers the whole registry. Keys are
+ *  `tenant:${product}:${name}` (#8024). */
 export function createKvTenantRegistry(kv: KvNamespaceLike): TenantRegistry {
   return {
     async upsert(record) {
-      await kv.put(keyFor(record.tenant.name), JSON.stringify(record));
+      await kv.put(keyFor(record.tenant.name, record.product), JSON.stringify(record));
     },
-    async get(name) {
-      const raw = await kv.get(keyFor(name));
+    async get(name, product) {
+      const raw = await kv.get(keyFor(name, product));
       return raw ? (JSON.parse(raw) as TenantRegistryRecord) : undefined;
     },
     async list() {
@@ -78,7 +94,7 @@ export function createKvTenantRegistry(kv: KvNamespaceLike): TenantRegistry {
         if (page.list_complete || !page.cursor) break;
         cursor = page.cursor;
       }
-      return records.sort((a, b) => a.tenant.name.localeCompare(b.tenant.name));
+      return sortRecords(records);
     },
   };
 }

--- a/control-plane/test/http-app.test.ts
+++ b/control-plane/test/http-app.test.ts
@@ -78,7 +78,7 @@ test("POST /v1/tenants creates a tenant, returns only the safe {tenant,product,s
   assert.deepEqual(payload, { tenant: { name: "acme" }, product: "orb", state: "active" });
   assert.equal("database" in payload, false);
   // The registry was actually updated, not just the HTTP response shaped correctly.
-  assert.equal((await registry.get("acme"))?.state, "active");
+  assert.equal((await registry.get("acme", "orb"))?.state, "active");
 });
 
 test("POST /v1/tenants never echoes a tenant's database connection details on the wire", async () => {
@@ -152,7 +152,32 @@ test("POST /v1/tenants allows recreating a torn-down tenant", async () => {
   );
 
   assert.equal(res.status, 201);
-  assert.equal((await registry.get("acme"))?.state, "active");
+  assert.equal((await registry.get("acme", "orb"))?.state, "active");
+});
+
+test("POST /v1/tenants allows the same name under a different product (#8024)", async () => {
+  const registry = createFakeTenantRegistry();
+  const driver = createFakeTenantProvisioningDriver();
+  const app = createTenantHttpApp(baseDeps({ registry, driver }));
+
+  const orb = await app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "orb" }) }),
+  );
+  const ams = await app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "ams" }) }),
+  );
+
+  assert.equal(orb.status, 201);
+  assert.equal(ams.status, 201);
+  assert.equal((await registry.get("acme", "orb"))?.state, "active");
+  assert.equal((await registry.get("acme", "ams"))?.state, "active");
+
+  const deleted = await app.request("/v1/tenants/acme?product=orb", authed({ method: "DELETE" }));
+  assert.equal(deleted.status, 200);
+  assert.equal((await registry.get("acme", "orb"))?.state, "torn down");
+  assert.equal((await registry.get("acme", "ams"))?.state, "active");
 });
 
 test("GET /v1/tenants lists every registered tenant, sorted, with timestamps", async () => {
@@ -187,18 +212,29 @@ test("DELETE /v1/tenants/:name tears down a known tenant and reports it torn dow
   await driver.createContainer({ tenant: { name: "acme" }, product: "orb" });
   const app = createTenantHttpApp(baseDeps({ registry, driver }));
 
-  const res = await app.request("/v1/tenants/acme", authed({ method: "DELETE" }));
+  const res = await app.request("/v1/tenants/acme?product=orb", authed({ method: "DELETE" }));
 
   assert.equal(res.status, 200);
   assert.deepEqual(await res.json(), { tenant: { name: "acme" }, product: "orb", state: "torn down" });
-  assert.equal((await registry.get("acme"))?.state, "torn down");
+  assert.equal((await registry.get("acme", "orb"))?.state, "torn down");
   assert.equal(await driver.containerExists({ tenant: { name: "acme" }, product: "orb" }), false);
+});
+
+test("DELETE /v1/tenants/:name rejects a missing product query parameter (400)", async () => {
+  const registry = createFakeTenantRegistry();
+  await registry.upsert({ tenant: { name: "acme" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0" });
+  const app = createTenantHttpApp(baseDeps({ registry }));
+
+  const res = await app.request("/v1/tenants/acme", authed({ method: "DELETE" }));
+
+  assert.equal(res.status, 400);
+  assert.equal((await res.json() as { error: string }).error, "invalid_request");
 });
 
 test("DELETE /v1/tenants/:name on an unknown tenant is a 404, not a silent no-op", async () => {
   const app = createTenantHttpApp(baseDeps());
 
-  const res = await app.request("/v1/tenants/ghost", authed({ method: "DELETE" }));
+  const res = await app.request("/v1/tenants/ghost?product=orb", authed({ method: "DELETE" }));
 
   assert.equal(res.status, 404);
   assert.deepEqual(await res.json(), { error: "tenant_not_found" });
@@ -209,7 +245,7 @@ test("DELETE /v1/tenants/:name URL-decodes the name path segment", async () => {
   await registry.upsert({ tenant: { name: "acme corp" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0" });
   const app = createTenantHttpApp(baseDeps({ registry }));
 
-  const res = await app.request(`/v1/tenants/${encodeURIComponent("acme corp")}`, authed({ method: "DELETE" }));
+  const res = await app.request(`/v1/tenants/${encodeURIComponent("acme corp")}?product=orb`, authed({ method: "DELETE" }));
 
   assert.equal(res.status, 200);
 });
@@ -223,7 +259,7 @@ test("create and delete both work when pagerDuty options are omitted entirely (d
   );
   assert.equal(created.status, 201);
 
-  const deleted = await app.request("/v1/tenants/acme", authed({ method: "DELETE" }));
+  const deleted = await app.request("/v1/tenants/acme?product=orb", authed({ method: "DELETE" }));
   assert.equal(deleted.status, 200);
 });
 

--- a/control-plane/test/tenant-registry.test.ts
+++ b/control-plane/test/tenant-registry.test.ts
@@ -10,32 +10,54 @@ import {
   type TenantRegistryRecord,
 } from "../dist/index.js";
 
-function recordFor(name: string, state: TenantRegistryRecord["state"] = "active"): TenantRegistryRecord {
-  return { tenant: { name }, product: "orb", state, createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z" };
+function recordFor(
+  name: string,
+  product: TenantRegistryRecord["product"] = "orb",
+  state: TenantRegistryRecord["state"] = "active",
+): TenantRegistryRecord {
+  return { tenant: { name }, product, state, createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z" };
 }
 
-test("createFakeTenantRegistry: upsert/get/list round-trip, sorted by tenant name", async () => {
+test("createFakeTenantRegistry: upsert/get/list round-trip, sorted by tenant name then product", async () => {
   const registry = createFakeTenantRegistry();
 
   await registry.upsert(recordFor("zebra"));
   await registry.upsert(recordFor("acme"));
 
-  assert.deepEqual(await registry.get("acme"), recordFor("acme"));
-  assert.equal(await registry.get("ghost"), undefined);
+  assert.deepEqual(await registry.get("acme", "orb"), recordFor("acme"));
+  assert.equal(await registry.get("ghost", "orb"), undefined);
   assert.deepEqual(
     (await registry.list()).map((record) => record.tenant.name),
     ["acme", "zebra"],
   );
 });
 
-test("createFakeTenantRegistry: upsert overwrites an existing record for the same tenant", async () => {
+test("createFakeTenantRegistry: upsert overwrites an existing record for the same product+tenant", async () => {
   const registry = createFakeTenantRegistry();
-  await registry.upsert(recordFor("acme", "active"));
+  await registry.upsert(recordFor("acme", "orb", "active"));
 
-  await registry.upsert(recordFor("acme", "torn down"));
+  await registry.upsert(recordFor("acme", "orb", "torn down"));
 
-  assert.equal((await registry.get("acme"))?.state, "torn down");
+  assert.equal((await registry.get("acme", "orb"))?.state, "torn down");
   assert.equal((await registry.list()).length, 1);
+});
+
+// Mirrors container-driver.test.ts's product-scoped instance key — same name across products must not share
+// one registry row on a single shared registry (production's HTTP composition shape; #8024).
+test("createFakeTenantRegistry: state is product-scoped (${product}:${name}), not just the tenant name", async () => {
+  const registry = createFakeTenantRegistry();
+
+  await registry.upsert(recordFor("acme", "orb", "active"));
+  await registry.upsert(recordFor("acme", "ams", "active"));
+
+  assert.equal((await registry.get("acme", "orb"))?.product, "orb");
+  assert.equal((await registry.get("acme", "ams"))?.product, "ams");
+  assert.equal((await registry.list()).length, 2);
+
+  await registry.upsert(recordFor("acme", "orb", "torn down"));
+
+  assert.equal((await registry.get("acme", "orb"))?.state, "torn down");
+  assert.equal((await registry.get("acme", "ams"))?.state, "active");
 });
 
 function fakeKv(initial: Record<string, string> = {}): KvNamespaceLike & { store: Map<string, string> } {
@@ -60,33 +82,33 @@ function fakeKv(initial: Record<string, string> = {}): KvNamespaceLike & { store
   };
 }
 
-test("createKvTenantRegistry: upsert writes a JSON-encoded value under the tenant: prefix", async () => {
+test("createKvTenantRegistry: upsert writes a JSON-encoded value under tenant:${product}:${name}", async () => {
   const kv = fakeKv();
   const registry = createKvTenantRegistry(kv);
 
   await registry.upsert(recordFor("acme"));
 
-  assert.equal(kv.store.get("tenant:acme"), JSON.stringify(recordFor("acme")));
+  assert.equal(kv.store.get("tenant:orb:acme"), JSON.stringify(recordFor("acme")));
 });
 
 test("createKvTenantRegistry: get returns undefined for a key that was never written", async () => {
   const registry = createKvTenantRegistry(fakeKv());
 
-  assert.equal(await registry.get("ghost"), undefined);
+  assert.equal(await registry.get("ghost", "orb"), undefined);
 });
 
 test("createKvTenantRegistry: get parses a previously written record back", async () => {
-  const kv = fakeKv({ "tenant:acme": JSON.stringify(recordFor("acme")) });
+  const kv = fakeKv({ "tenant:orb:acme": JSON.stringify(recordFor("acme")) });
   const registry = createKvTenantRegistry(kv);
 
-  assert.deepEqual(await registry.get("acme"), recordFor("acme"));
+  assert.deepEqual(await registry.get("acme", "orb"), recordFor("acme"));
 });
 
 test("createKvTenantRegistry: list pages through multiple KV list() pages and returns every record, sorted", async () => {
   const kv = fakeKv({
-    "tenant:charlie": JSON.stringify(recordFor("charlie")),
-    "tenant:alpha": JSON.stringify(recordFor("alpha")),
-    "tenant:bravo": JSON.stringify(recordFor("bravo")),
+    "tenant:orb:charlie": JSON.stringify(recordFor("charlie")),
+    "tenant:orb:alpha": JSON.stringify(recordFor("alpha")),
+    "tenant:orb:bravo": JSON.stringify(recordFor("bravo")),
   });
   const registry = createKvTenantRegistry(kv);
 
@@ -98,12 +120,30 @@ test("createKvTenantRegistry: list pages through multiple KV list() pages and re
   );
 });
 
+test("createKvTenantRegistry: list returns both products when the same tenant name is registered twice", async () => {
+  const kv = fakeKv({
+    "tenant:orb:acme": JSON.stringify(recordFor("acme", "orb")),
+    "tenant:ams:acme": JSON.stringify(recordFor("acme", "ams")),
+  });
+  const registry = createKvTenantRegistry(kv);
+
+  const records = await registry.list();
+
+  assert.deepEqual(
+    records.map((record) => [record.tenant.name, record.product]),
+    [
+      ["acme", "ams"],
+      ["acme", "orb"],
+    ],
+  );
+});
+
 test("createKvTenantRegistry: list tolerates a key disappearing between the list() page and the get() read", async () => {
-  const kv = fakeKv({ "tenant:acme": JSON.stringify(recordFor("acme")) });
+  const kv = fakeKv({ "tenant:orb:acme": JSON.stringify(recordFor("acme")) });
   const originalGet = kv.get.bind(kv);
   kv.get = async (key: string) => {
     // Simulate a concurrent delete: the key was listed, but its value is gone by the time we read it.
-    if (key === "tenant:acme") return null;
+    if (key === "tenant:orb:acme") return null;
     return originalGet(key);
   };
   const registry = createKvTenantRegistry(kv);


### PR DESCRIPTION

## Summary

- `TenantRegistry` (fake + KV) keyed records by tenant name alone, so provisioning ORB `acme` then AMS `acme` hit a false `409`, and deprovisioning one overwrote the other's inventory row.
- Storage and HTTP lookups now use `${product}:${name}` (same as `container-driver.ts`'s `instanceNameFor`). `DELETE /v1/tenants/:name` requires `?product=`; `GET /v1/tenants` still lists every product.

Closes #8024

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Control-plane-only change: `npm --prefix control-plane test` (98 pass) and `npm run control-plane:coverage` — `tenant-registry.ts` and `http-app.ts` at 100% lines/branches. Root vitest/UI/MCP gates do not cover `control-plane/src/**`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — control-plane registry/HTTP keying only; no UI.

## Notes

- Analogue: `control-plane/src/container-driver.ts` `instanceNameFor` / `test/container-driver.test.ts` product-scoped key test.
- `DELETE` now requires `?product=` so the composite key can be resolved. Miner `destroyTenant` still omits product (follow-up if needed).
