### PR TITLE
docs(signals): move orphaned review.enrichment doc comment to its function

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -347,9 +347,6 @@ export function resolveReviewPreMergeChecks(manifest: FocusManifest | null): Pre
   return manifest?.review.preMergeChecks ?? [];
 }
 
-/** Resolve `review.enrichment` analyzer toggles from a possibly-null manifest (null = load failure ⇒ no toggles ⇒
- *  the operator's default analyzer set runs unchanged). Centralized so the enrichment caller threads them in one
- *  place with the null-manifest branch covered here (unit-tested) rather than inline in the processor. (#2050) */
 /** Resolve `review.auto_review` from a possibly-null manifest (null = load failure => no ignored authors). The
  *  runtime eligibility check then fails open instead of suppressing review output on an ambiguous manifest read.
  *  (#2060) */
@@ -373,6 +370,9 @@ export function resolveReviewVisualConfig(manifest: FocusManifest | null): Visua
   return manifest?.review.visual ?? { ...EMPTY_VISUAL_CONFIG };
 }
 
+/** Resolve `review.enrichment` analyzer toggles from a possibly-null manifest (null = load failure ⇒ no toggles ⇒
+ *  the operator's default analyzer set runs unchanged). Centralized so the enrichment caller threads them in one
+ *  place with the null-manifest branch covered here (unit-tested) rather than inline in the processor. (#2050) */
 export function resolveEnrichmentAnalyzerToggles(manifest: FocusManifest | null): Partial<Record<ReesAnalyzerName, boolean>> {
   return manifest?.review.enrichmentAnalyzers ?? {};
 }


### PR DESCRIPTION
Closes #8021

## What

`src/signals/focus-manifest.ts` had **two** doc blocks stacked in front of `resolveReviewAutoReviewConfig`: its own (`#2060`) plus the `review.enrichment` analyzer-toggles block (`#2050`) — which actually documents `resolveEnrichmentAnalyzerToggles`, defined 24 lines later with no comment of its own (it lost its comment in a reorder).

Moved the `#2050` block down to sit directly above `resolveEnrichmentAnalyzerToggles`, leaving `resolveReviewAutoReviewConfig` with only its own `#2060` comment.

## Scope

- **Comment-only** — verified the diff contains only comment lines (net +3/-3, a pure move). No code, behavior, or export change.
- Parity-neutral: the engine twin (`packages/loopover-engine/src/focus-manifest.ts`) already carries its own separately-worded `#2050` comment, so `check-engine-parity` doesn't compare these doc blocks.
