### PR TITLE
fix(review): parse a scalar source field written as a YAML sequence (#8016)

### DIFF
--- a/src/review/content-lane/source-evidence.ts
+++ b/src/review/content-lane/source-evidence.ts
@@ -162,7 +162,23 @@ function parseSimpleFrontmatter(source: string): Record<string, string> {
         i += 1;
       }
       fields[key] = block.join(inline.startsWith(">") ? " " : "\n").trim();
-    } else if (inline !== "") {
+    } else if (inline === "") {
+      // Block/flow sequence (or nested map) on the following indented lines: gather each `- item` so a
+      // scalar-only field authored as a YAML sequence is still captured, matching duplicates.ts's parser
+      // (#8016; this branch existed only there, so such a field was invisible to the source-evidence gate).
+      const items: string[] = [];
+      // `lines[i]` is bounded by the `i < lines.length` loop guard; the `?? ""` is an unreachable
+      // noUncheckedIndexedAccess fallback (same guard as the block-scalar loop above).
+      /* v8 ignore next */
+      while (i < lines.length && /^\s/.test(lines[i] ?? "") && (lines[i] ?? "").trim() !== "") {
+        // `lines[i]` reuses the same in-bounds index already validated by `/^\s/.test` above; `?? ""`
+        // cannot fire (unreachable noUncheckedIndexedAccess fallback).
+        /* v8 ignore next */
+        items.push((lines[i] ?? "").replace(/^\s*-\s*/, "").trim());
+        i += 1;
+      }
+      fields[key] = items.join(", ");
+    } else {
       fields[key] = unquoteYamlScalar(inline);
     }
   }

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -89,6 +89,17 @@ describe("checkSubmittedSourceEvidence", () => {
     expect(report.status).toBe("failed");
   });
 
+  it("fetch-verifies a scalar-only source authored as a YAML sequence, not just a scalar (#8016)", async () => {
+    // documentationUrl is a scalar-only field (NOT in the list-field set that listSourceUrlValues rescues),
+    // so before the ported sequence branch this URL was dropped by the parser and the gate could never
+    // verify it. It must now be captured and fetch-checked exactly like a scalar value.
+    const url = "https://docs.acme.example/seq-guide";
+    const src = ["---", "documentationUrl:", `  - ${url}`, "---", "", "body"].join("\n");
+    const report = await checkSubmittedSourceEvidence(src, fakeFetch({ [url]: 200 }));
+    expect(report.urls.map((u) => u.url)).toContain(url);
+    expect(report.status).toBe("passed");
+  });
+
   it("is retryable (not hard) on a 403/429/5xx canonical source", async () => {
     const src = mdx({ githubUrl: "https://github.com/acme/x" });
     const report = await checkSubmittedSourceEvidence(src, fakeFetch({ "https://github.com/acme/x": 403 }));
@@ -307,6 +318,18 @@ describe("extractSubmittedSourceUrls — frontmatter parsing edge cases", () => 
     const src = ["---", "documentationUrl: >", "  https://docs.acme.example/guide", "---", "", "body"].join("\n");
     const urls = extractSubmittedSourceUrls(src);
     // The folded form joins block lines with a space; a single line stays intact.
+    expect(urls.map((u) => `${u.field}:${u.url}`)).toContain(
+      "documentationUrl:https://docs.acme.example/guide",
+    );
+  });
+
+  it("captures a scalar-only source field authored as a YAML block sequence (#8016)", () => {
+    // A scalar field (documentationUrl) written as a sequence was silently dropped here — the sequence
+    // branch existed only in duplicates.ts — so the URL never reached the fetch-reachability gate.
+    // documentationUrl is NOT a list field, so listSourceUrlValues does not rescue it; only the ported
+    // parser branch captures it.
+    const src = ["---", "documentationUrl:", "  - https://docs.acme.example/guide", "---", "", "body"].join("\n");
+    const urls = extractSubmittedSourceUrls(src);
     expect(urls.map((u) => `${u.field}:${u.url}`)).toContain(
       "documentationUrl:https://docs.acme.example/guide",
     );


### PR DESCRIPTION
## Summary

`source-evidence.ts` and `duplicates.ts` each hand-roll a `parseSimpleFrontmatter` (a known parity-gap class between these two files — see #7250 / `content-repo-spec.ts:132`). `duplicates.ts`'s parser has three branches — block-scalar, **block/flow-sequence** (`inline === ""`, collects `- item` lines), and plain-scalar — but `source-evidence.ts`'s had only two: the sequence branch was never ported.

Concretely: a scalar-only source field authored as a YAML sequence

```yaml
documentationUrl:
  - https://docs.acme.example/guide
```

was captured by `duplicates.ts` (duplicate detection) but **invisible** to `extractSubmittedSourceUrls`/`checkSubmittedSourceEvidence` (the fetch-reachability hard-close gate) — the URL never got fetch-verified. `documentationUrl` is a scalar field, *not* one of the list fields (`sourceUrls`/`retrievalSources`) that `listSourceUrlValues` rescues, so nothing else caught it.

## Fix

Port the missing block/flow-sequence branch verbatim from `duplicates.ts` (including its `v8 ignore` fallbacks for the `?? ""` `noUncheckedIndexedAccess` guards). The existing block-scalar and plain-scalar cases are unchanged (the final `else if (inline !== "")` becomes a plain `else`, reached only for non-empty non-block inline values exactly as before).

## Scope

- [x] Narrow, single coherent change (one parser branch + its regression tests)
- [x] In `wantedPaths` (`src/review/content-lane/**`, `test/unit/**`); no `blockedPaths`
- [x] No secrets/private-scoring terms anywhere
- [x] No generated-artifact changes required (internal parser; no API/schema/binding/migration change)

## Validation

- [x] `npx vitest run test/unit/content-lane-source-evidence.test.ts` — 86/86 pass (incl. 2 new `#8016` tests: capture + fetch-verification)
- [x] `content-lane-duplicates` suite still green (the source-of-truth parser is untouched)
- [x] **Honesty-checked**: with the fix reverted, both new tests fail (documentationUrl sequence dropped) — they are genuine regressions, not tautologies
- [x] `typecheck` clean on changed files (only the 2 pre-existing local `semver` `TS7016`s remain)
- [x] `git diff --check` clean

## Safety

- [x] Behavior-preserving for block-scalar and plain-scalar inputs; the change only *adds* capture for a previously-dropped YAML shape
- [x] Closes a gap that *weakened* the source-reachability gate — the fix strengthens it (more submitted URLs are fetch-verified, none newly bypass it)
- [x] No auth/CORS surface touched; no secrets introduced

Closes #8016
