### PR TITLE
fix(review): page fetchFallbackArtifactShots artifacts-list read past 100 artifacts

### DIFF
--- a/src/review/visual/actions-fallback.ts
+++ b/src/review/visual/actions-fallback.ts
@@ -355,6 +355,19 @@ export type FallbackShot = { fileName: string; png: Uint8Array };
 // rounded up, and a generous per-artifact byte cap (well above what ~20 full-page PNGs need in practice).
 const MAX_FALLBACK_SHOTS = 24;
 
+// GitHub caps list endpoints at 100 items/page, so a single `per_page=100` read silently truncates: a run
+// with >100 attached artifacts pushes the target artifact onto page 2+ and the pre-#8014 single-page read
+// returned [] exactly as if no artifact existed. Walk the `Link: rel="next"` header instead, bounded so a
+// pathological response (or a mock that always advertises a next page) can't turn one read into an unbounded
+// fetch loop -- the same bounded-walker treatment preview-url.ts's findAcrossPages gave this module's sibling
+// reads (#7779/#7805), with the same bound of 10.
+const ARTIFACT_LIST_MAX_PAGES = 10;
+
+/** Mirrors preview-url.ts's hasNextPage: does a `Link` header advertise a rel="next" page? */
+function hasNextArtifactPage(link: string | null): boolean {
+  return Boolean(link?.split(",").some((part) => /rel="next"/.test(part)));
+}
+
 function githubApiHeaders(token: string): Headers {
   const headers = new Headers();
   headers.set("accept", "application/vnd.github+json");
@@ -377,17 +390,25 @@ export async function fetchFallbackArtifactShots(params: {
   const base = `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}`;
   const repoLabel = `${params.repo.owner}/${params.repo.repo}`;
   try {
-    const listResponse = await timeoutFetch(`${base}/actions/runs/${params.runId}/artifacts?per_page=100`, {
-      headers: githubApiHeaders(params.token),
-      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
-      githubRateLimitAdmission: params.rateLimitAdmissionKey !== undefined,
-      ...(params.rateLimitAdmissionKey ? { githubRateLimitAdmissionKey: params.rateLimitAdmissionKey } : {}),
-    });
-    if (!listResponse.ok) return [];
-    const listPayload = (await listResponse.json().catch(() => null)) as {
-      artifacts?: Array<{ id: number; name: string; expired?: boolean; size_in_bytes?: number }>;
-    } | null;
-    const artifact = listPayload?.artifacts?.find((a) => a.name === FALLBACK_ARTIFACT_NAME && a.expired !== true);
+    // Page 1's request is byte-identical to the pre-pagination single read (page 1 is GitHub's default, so
+    // the bare URL is left unchanged); the `&page=N` cursor is appended for page 2+ only (#8014).
+    const firstPageUrl = `${base}/actions/runs/${params.runId}/artifacts?per_page=100`;
+    let artifact: { id: number; name: string; expired?: boolean; size_in_bytes?: number } | undefined;
+    for (let page = 1; page <= ARTIFACT_LIST_MAX_PAGES; page += 1) {
+      const listResponse = await timeoutFetch(page === 1 ? firstPageUrl : `${firstPageUrl}&page=${page}`, {
+        headers: githubApiHeaders(params.token),
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+        githubRateLimitAdmission: params.rateLimitAdmissionKey !== undefined,
+        ...(params.rateLimitAdmissionKey ? { githubRateLimitAdmissionKey: params.rateLimitAdmissionKey } : {}),
+      });
+      if (!listResponse.ok) return [];
+      const listPayload = (await listResponse.json().catch(() => null)) as {
+        artifacts?: Array<{ id: number; name: string; expired?: boolean; size_in_bytes?: number }>;
+      } | null;
+      artifact = listPayload?.artifacts?.find((a) => a.name === FALLBACK_ARTIFACT_NAME && a.expired !== true);
+      if (artifact) break;
+      if (!hasNextArtifactPage(listResponse.headers.get("link"))) break;
+    }
     if (!artifact) return [];
     if (typeof artifact.size_in_bytes === "number" && artifact.size_in_bytes > MAX_ARTIFACT_BYTES) {
       console.log(JSON.stringify({ event: "visual_fallback_artifact_too_large", repo: repoLabel, runId: params.runId, bytes: artifact.size_in_bytes }));

--- a/test/unit/actions-fallback.test.ts
+++ b/test/unit/actions-fallback.test.ts
@@ -505,6 +505,70 @@ describe("fetchFallbackArtifactShots", () => {
     expect(shots.map((s) => s.fileName).sort()).toEqual(["root--desktop.png", "root--mobile.png"]);
   });
 
+  it("finds the target artifact on page 2+ of a multi-page artifacts list (#8014)", async () => {
+    const zip = buildZip([{ name: "root--desktop.png", data: pngBytes("desktop-bytes"), method: 0 }]);
+    const requestedUrls: string[] = [];
+    stubSequence([
+      (input) => {
+        requestedUrls.push(String(input));
+        // Page 1: only decoy artifacts, but a Link header advertising a next page.
+        return Response.json(
+          { artifacts: [{ id: 1, name: "some-other-artifact" }] },
+          { headers: { link: '<https://api.github.com/x?page=2>; rel="next"' } },
+        );
+      },
+      (input) => {
+        requestedUrls.push(String(input));
+        // Page 2: the target artifact -- pre-#8014 this page was never fetched and the shot was lost.
+        return Response.json({ artifacts: [{ id: 99, name: FALLBACK_ARTIFACT_NAME, expired: false, size_in_bytes: 1000 }] });
+      },
+      () => new Response(null, { status: 302, headers: { location: "https://productionresultssa1.blob.core.windows.net/x.zip" } }),
+      () => new Response(zip.buffer as ArrayBuffer, { status: 200 }),
+    ]);
+
+    const shots = await fetchFallbackArtifactShots({ token: "tok", repo: { owner: "acme", repo: "widgets" }, runId: 555 });
+    expect(shots.map((s) => s.fileName)).toEqual(["root--desktop.png"]);
+    // Page 1's request stays byte-identical to the pre-pagination read; page 2 appends the cursor.
+    expect(requestedUrls[0]).not.toContain("&page=");
+    expect(requestedUrls[1]).toContain("&page=2");
+  });
+
+  it("stops at the page bound even when every page advertises a next page (#8014)", async () => {
+    let listCalls = 0;
+    vi.stubGlobal("fetch", async () => {
+      listCalls += 1;
+      return Response.json(
+        { artifacts: [{ id: listCalls, name: "some-other-artifact" }] },
+        { headers: { link: '<https://api.github.com/x?page=next>; rel="next"' } },
+      );
+    });
+
+    const shots = await fetchFallbackArtifactShots({ token: "tok", repo: { owner: "acme", repo: "widgets" }, runId: 1 });
+    expect(shots).toEqual([]);
+    expect(listCalls).toBe(10); // ARTIFACT_LIST_MAX_PAGES -- never an unbounded fetch loop
+  });
+
+  it("does not fetch a second page when the Link header has no rel=\"next\" (#8014)", async () => {
+    let listCalls = 0;
+    vi.stubGlobal("fetch", async () => {
+      listCalls += 1;
+      return Response.json(
+        { artifacts: [{ id: 1, name: "some-other-artifact" }] },
+        { headers: { link: '<https://api.github.com/x?page=1>; rel="prev"' } },
+      );
+    });
+
+    const shots = await fetchFallbackArtifactShots({ token: "tok", repo: { owner: "acme", repo: "widgets" }, runId: 1 });
+    expect(shots).toEqual([]);
+    expect(listCalls).toBe(1);
+  });
+
+  it("returns [] when a list page parses as JSON but has no artifacts array (#8014)", async () => {
+    stubSequence([() => Response.json({})]);
+    const shots = await fetchFallbackArtifactShots({ token: "tok", repo: { owner: "acme", repo: "widgets" }, runId: 1 });
+    expect(shots).toEqual([]);
+  });
+
   it("passes a rateLimitAdmissionKey through to the list-artifacts read without changing the result", async () => {
     stubSequence([() => Response.json({ artifacts: [{ id: 1, name: "some-other-artifact" }] })]);
     const shots = await fetchFallbackArtifactShots({


### PR DESCRIPTION
## Summary

- Closes #8014
- `fetchFallbackArtifactShots` (`src/review/visual/actions-fallback.ts`) read only page 1 of `GET /repos/{o}/{r}/actions/runs/{runId}/artifacts?per_page=100` and `.find()`'d the fallback artifact there. If a run attaches >100 artifacts, the target silently falls off page 1 and the function returned `[]` exactly as if no artifact existed — the same silent-truncation failure mode `preview-url.ts` documents and was hardened against in #7779/#7805.
- Fix: walk the `Link: rel="next"` pages, mirroring `preview-url.ts`'s bounded `findAcrossPages` walker (the required pattern from the issue): page 1's request stays **byte-identical** to the pre-pagination read, the `&page=N` cursor is appended for page 2+ only, and the walk is bounded to 10 pages (`ARTIFACT_LIST_MAX_PAGES`, same bound as `PREVIEW_LIST_MAX_PAGES` / `PR_DETAIL_MAX_PAGES` / `MAX_WORKFLOW_RUN_LIST_PAGES`) so a pathological response can never spin.
- No behavior change for runs with ≤100 artifacts: same single request, same degrade-to-`[]` contract on any failure.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the targeted suites for every test file exercising this module instead of the full sharded run: `vitest run test/unit/actions-fallback.test.ts test/unit/actions-fallback-webhook.test.ts test/unit/visual-capture.test.ts` — 234 tests green — plus `vitest run --coverage test/unit/actions-fallback.test.ts`: every changed line and branch in `actions-fallback.ts` is covered (the only uncovered lines in the file, 259–260, are pre-existing `inflateRawRaw` internals untouched by this diff). `actionlint`/workers/mcp/ui checks are untouched surfaces (no workflow, worker, MCP, or UI files changed); CI runs them all.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only change (no UI, docs, or extension surface touched).

## Notes

- Tests added (all in the existing `fetchFallbackArtifactShots` describe block, reusing its `stubSequence` mock pattern): target artifact found on page 2 with the page-1 request asserted byte-identical and the page-2 request asserted to carry `&page=2`; the 10-page bound under an always-`rel="next"` Link header (asserts exactly 10 list calls); no second fetch when the Link header lacks `rel="next"`; and a valid-JSON-but-no-`artifacts`-array page.