### PR TITLE
fix(extension): remove dead matchPullRequestTarget from content.js

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -13,12 +13,6 @@ function matchGitHubPageTarget(pathname) {
   return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
-function matchPullRequestTarget(pathname) {
-  const target = matchGitHubPageTarget(pathname);
-  if (!target) return null;
-  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
-}
-
 function mountOverlay(target) {
   if (document.querySelector("[data-loopover-pr-context]")) return;
   const container = document.createElement("aside");
@@ -192,7 +186,6 @@ function renderActions(body, actions) {
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
   globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
-    matchPullRequestTarget,
     createOverlayLoader,
     renderPullContext,
     renderSection,


### PR DESCRIPTION
Closes #8023

## Summary
- `matchPullRequestTarget` in `apps/loopover-extension/content.js` duplicated `matchGitHubPageTarget`'s logic (minus the `kind` field) and was stranded by #7487's issue-page match removal.
- Confirmed via grep across the repo that it's referenced nowhere else, including production code and the `__loopoverContentInternals` test-hook object.
- Removed the dead function and its entry in the `__loopoverContentInternals` export.

## Scope checklist
- [x] Only touches `apps/loopover-extension/content.js`
- [x] No behavior change (dead code removal only)

## Validation checklist
- [x] Grepped the whole repo for `matchPullRequestTarget` — only the (now-removed) definition and export existed
- [x] `apps/loopover-extension` has no automated test suite (confirmed), matching the issue's own note; no test changes needed

## Safety checklist
- [x] No secrets, tokens, wallets, hotkeys/coldkeys, trust scores, or reward/payout values touched
- [x] No changes to `site/`, `CNAME`, or `**/lovable/**`