### PR TITLE
fix(miner): follow label pagination in contribution-profile extract

### DIFF
--- a/packages/loopover-miner/lib/contribution-profile-extract.ts
+++ b/packages/loopover-miner/lib/contribution-profile-extract.ts
@@ -99,12 +99,12 @@ function githubHeaders(githubToken: string | undefined): Record<string, string> 
  *  falling back to its fail-open contract: returns null on a non-retryable/exhausted HTTP, transport, or parse
  *  failure. `timeoutMs` gives each attempt its own fresh `AbortSignal.timeout` (preserving the per-request bound),
  *  and `sleepFn` is the injectable no-real-timers seam every other `fetchWithRetry` call site exposes. */
-async function getJson(
+async function getJsonResponse(
   url: string,
   headers: Record<string, string>,
   fetchImpl: typeof fetch,
   sleepFn: ((ms: number) => Promise<unknown>) | undefined,
-): Promise<unknown> {
+): Promise<{ payload: unknown; response: Response } | null> {
   let response: Response;
   try {
     // Cast: the JS always passes `sleepFn` (possibly undefined); EOPT rejects an explicit undefined optional.
@@ -118,7 +118,51 @@ async function getJson(
     return null;
   }
   if (!response.ok) return null;
-  return response.json().catch(() => null);
+  const payload = await response.json().catch(() => null);
+  return { payload, response };
+}
+
+async function getJson(
+  url: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sleepFn: ((ms: number) => Promise<unknown>) | undefined,
+): Promise<unknown> {
+  const result = await getJsonResponse(url, headers, fetchImpl, sleepFn);
+  return result === null ? null : result.payload;
+}
+
+/** GitHub signals another page of a list endpoint with a `Link` header carrying a `rel="next"` entry. Mirrors
+ *  ci-poller.ts's `hasNextLink` exactly; the optional chain tolerates a header-less mock Response. */
+function hasNextLink(response: Response): boolean {
+  return /<[^>]+>;\s*rel="next"/.test(response.headers?.get("link") ?? "");
+}
+
+/** Read the repo's full label set, following `Link: rel="next"` pagination the way ci-poller.ts's check-run
+ *  polling does, so a repo with more than 100 labels is not silently truncated at page 1. Never throws: a
+ *  failed or non-array page degrades to the labels gathered so far, honoring this file's fail-open contract. */
+async function getAllLabels(
+  base: string,
+  target: { owner: string; repo: string },
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sleepFn: ((ms: number) => Promise<unknown>) | undefined,
+): Promise<GithubLabel[]> {
+  const labels: GithubLabel[] = [];
+  let page = 1;
+  while (true) {
+    const result = await getJsonResponse(
+      `${base}/repos/${target.owner}/${target.repo}/labels?per_page=100&page=${page}`,
+      headers,
+      fetchImpl,
+      sleepFn,
+    );
+    if (result === null || !Array.isArray(result.payload)) break;
+    labels.push(...(result.payload as GithubLabel[]));
+    if (!hasNextLink(result.response)) break;
+    page += 1;
+  }
+  return labels;
 }
 
 /**
@@ -256,13 +300,7 @@ export async function extractContributionProfile(
   );
 
   const sleepFn = options.sleepFn;
-  const labelsPayload = await getJson(
-    `${base}/repos/${target.owner}/${target.repo}/labels?per_page=100`,
-    headers,
-    fetchImpl,
-    sleepFn,
-  );
-  const labels = Array.isArray(labelsPayload) ? (labelsPayload as GithubLabel[]) : [];
+  const labels = await getAllLabels(base, target, headers, fetchImpl, sleepFn);
   const contributing = await fetchContributing(
     base,
     target,

--- a/test/unit/miner-contribution-profile-label-pagination.test.ts
+++ b/test/unit/miner-contribution-profile-label-pagination.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { extractContributionProfile } from "../../packages/loopover-miner/lib/contribution-profile-extract.js";
+
+// Regression for #8010: extractContributionProfile's label fetch previously issued a single
+// `?per_page=100` request and dropped every label past page 1. It must now follow GitHub's
+// `Link: rel="next"` pagination (mirroring ci-poller.ts's check-run paging) so a repo with
+// more than 100 labels has its 101st+ label classified, while a <=100-label repo is unchanged.
+
+const AT = "2026-07-18T00:00:00.000Z";
+
+/** The repo's global `fetch` type is wider than a plain `(url: string)` mock; cast through unknown. */
+const asFetch = (fn: unknown): typeof fetch => fn as unknown as typeof fetch;
+
+type Label = { name: string; description?: string | null };
+
+/** A GitHub list-endpoint response whose `Link` header advertises `link` (or none when null). */
+function pageResponse(labels: Label[], link: string | null): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === "link" ? link : null),
+    },
+    json: async () => labels,
+  } as unknown as Response;
+}
+
+function parsePage(url: string): number {
+  const match = /[?&]page=(\d+)/.exec(url);
+  return match ? Number(match[1]) : 1;
+}
+
+/** 100 inert labels (no eligibility/exclusion vocabulary) filling page 1, forcing a second page. */
+const firstPageFiller: Label[] = Array.from({ length: 100 }, (_, i) => ({
+  name: `area-${i}`,
+  description: "routing area label",
+}));
+
+describe("extractContributionProfile label pagination (#8010)", () => {
+  it("follows the Link rel=next header and classifies labels that live past page 1", async () => {
+    const nextLink =
+      '<https://api.github.com/repos/acme/widgets/labels?per_page=100&page=2>; rel="next"';
+    const fetchImpl = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/labels")) {
+        // Page 1: 100 inert labels + a `rel="next"` pointer. Page 2: the only meaningful labels.
+        if (parsePage(u) === 1) return pageResponse(firstPageFiller, nextLink);
+        return pageResponse(
+          [
+            { name: "good first issue", description: "Great for newcomers" },
+            { name: "wontfix", description: "This will not be worked on" },
+          ],
+          null,
+        );
+      }
+      // CONTRIBUTING.md probes 404.
+      return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+    });
+
+    const profile = await extractContributionProfile("acme/widgets", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+
+    // The page-2 eligibility label reached classification (would be `absent` under the old single-fetch code).
+    expect(profile.eligibilityLabels.confidence).toBe("explicit");
+    expect(profile.eligibilityLabels.value).toEqual([
+      { field: "name", contains: "good first issue" },
+    ]);
+    // And the page-2 exclusion label too.
+    expect(profile.exclusionLabels.confidence).toBe("inferred");
+    expect(profile.exclusionLabels.value).toEqual([
+      { field: "name", contains: "wontfix" },
+    ]);
+
+    // Exactly two label pages were fetched, in order.
+    const labelUrls = fetchImpl.mock.calls
+      .map((call) => String(call[0]))
+      .filter((u) => u.includes("/labels"));
+    expect(labelUrls).toHaveLength(2);
+    expect(parsePage(String(labelUrls[0]))).toBe(1);
+    expect(parsePage(String(labelUrls[1]))).toBe(2);
+  });
+
+  it("stops after page 1 when the response carries no rel=next link (<=100 labels unchanged)", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/labels")) {
+        // A single page: a Link header exists but advertises no `next` rel, so paging must stop.
+        return pageResponse(
+          [{ name: "help wanted", description: "Extra attention is needed" }],
+          '<https://api.github.com/repos/acme/widgets/labels?per_page=100&page=1>; rel="last"',
+        );
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+    });
+
+    const profile = await extractContributionProfile("acme/widgets", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+
+    expect(profile.eligibilityLabels.confidence).toBe("explicit");
+    expect(profile.eligibilityLabels.value).toEqual([
+      { field: "name", contains: "help wanted" },
+    ]);
+
+    const labelUrls = fetchImpl.mock.calls
+      .map((call) => String(call[0]))
+      .filter((u) => u.includes("/labels"));
+    expect(labelUrls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

`extractContributionProfile`'s label fetch issued a single `GET /repos/{owner}/{repo}/labels?per_page=100` request with no pagination follow-up, so a repo with more than 100 labels silently dropped its 101st+ label from eligibility/exclusion classification — a real "good first issue"-equivalent label sitting past page 1 made the profile wrongly report that signal as `absent`. This follows the `Link: rel="next"` pagination convention already used elsewhere in this package (`ci-poller.ts`'s check-run polling) so every label is collected.

Closes #8010

## What changed

- `packages/loopover-miner/lib/contribution-profile-extract.ts`
  - Split the bounded, never-throwing `getJson` into `getJsonResponse` (returns `{ payload, response }`) plus a thin `getJson` wrapper, so callers that need the `Link` header can read it while the `CONTRIBUTING.md` reader keeps its existing payload-only contract.
  - Added `hasNextLink(response)` — mirrors `ci-poller.ts`'s helper exactly (regex over the `link` header for `rel="next"`), with an optional chain so a header-less response is treated as "no next page".
  - Added `getAllLabels(...)` which pages through `labels?per_page=100&page=N`, following `rel="next"` until exhausted. It preserves the file's fail-open contract: a failed or non-array page degrades to the labels gathered so far rather than throwing.
  - `extractContributionProfile` now calls `getAllLabels` instead of a single `getJson`. No behavior change for repos with ≤100 labels (no `next` link ⇒ stops after page 1).

## Tests

- New `test/unit/miner-contribution-profile-label-pagination.test.ts`:
  - Follows the `Link: rel="next"` header across two pages (100 inert labels on page 1) and asserts a `good first issue` eligibility label and a `wontfix` exclusion label that live on page 2 are classified (would be `absent` under the old single-fetch code); asserts exactly two label pages are fetched, in order.
  - Asserts paging stops after page 1 when the response advertises a `Link` header with no `next` rel (≤100-label behavior unchanged).
- The 22 existing `contribution-profile-extract.test.ts` cases pass unmodified.

Verified locally (WSL Ubuntu-22.04, Node 22, rebased on current `origin/main`): `git rebase origin/main` clean; `npm run typecheck` clean; `git diff --check origin/main` clean; `npm run build --workspace=packages/loopover-miner` clean; 24 tests pass; Codecov-style coverage over `contribution-profile-extract.ts` reports zero uncovered statements and zero uncovered branches.
