### PR TITLE
fix(queue): terminalize active-review tracking in synchronize-amendment close guard

### DIFF
--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -1365,4 +1365,6 @@ async function closeSynchronizeAmendmentIfPolicyEnabled(
     /* v8 ignore next -- fail-safe: an audit write failure never blocks the handler. */
     () => undefined,
   );
+  /* v8 ignore next -- best-effort: the guarded CAS update never rejects against a healthy D1, and a cleanup failure here must never block the webhook. */
+  await terminalizeActiveReviewTracking(env, repoFullName, pr.number, { onlyIfHeadSha: pr.headSha }).catch(() => undefined);
 }

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -3922,6 +3922,24 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       expect(audit?.detail).toContain("contributor");
     });
 
+    it("terminalizes the active-review tracking row on enforcement close -- leaves no dangling row for the PR's reviewed headSha, matching the four sibling guards", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
+      await setupEvasionRepo(env, { reviewEvasionProtection: "off", synchronizeClosePolicy: "close" });
+      // A review was actively tracked on the PR's head before the author pushed the amending commit; the
+      // synchronize-amendment close must mark that row terminal, exactly as its four siblings do.
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "def456", authorLogin: "contributor", deliveryId: "review-start-sync" });
+      expect(await repositoriesModule.hasActiveReviewForHeadSha(env, "JSONbored/gittensory", 42, "def456")).toBe(true);
+
+      await processJob(env, { type: "github-webhook", deliveryId: "sync-policy-terminalize", eventName: "pull_request", payload: synchronizePayload("contributor") });
+
+      expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
+      const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.synchronize_amend_closed").first<{ outcome: string }>();
+      expect(audit?.outcome).toBe("completed");
+      expect(await repositoriesModule.hasActiveReviewForHeadSha(env, "JSONbored/gittensory", 42, "def456")).toBe(false); // terminalized
+    });
+
     it("does NOT record a moderation strike -- this is a blanket policy against an ordinary push, not a detected abuse pattern", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);


### PR DESCRIPTION
## Summary

`src/queue/review-evasion.ts` has six close-enforcement guards. Four of them —
`closeReviewEvasionSelfCloseIfReviewed`, `closeReviewEvasionDraftConversionIfReviewed`,
`closeRepeatedDraftCyclingIfDetected`, and `closeDraftPrIfPolicyEnabled` — call
`terminalizeActiveReviewTracking(env, repoFullName, pr.number, { onlyIfHeadSha: pr.headSha })`
right after a successful enforcement close, so the PR's active-review tracking row is marked
terminal rather than left dangling.

`closeSynchronizeAmendmentIfPolicyEnabled` (`maybeCloseSynchronizeAmendment`, the
`#synchronize-close-policy` guard) closed the PR and recorded its audit event but never made
that cleanup call — leaving the active-review row for the PR's reviewed head dangling. This is
the guard *most* likely to fire while a review is still actively tracked (it fires on the
author pushing an additional commit, "regardless of what CI/review state that push
interrupts"), yet it was the one guard skipping the cleanup. The skip had no justification
anywhere in the file, unlike the separately-documented, intentional omission of the
moderation-strike call for this guard (which is left untouched).

## What changed

- `src/queue/review-evasion.ts`: added the identical
  `await terminalizeActiveReviewTracking(env, repoFullName, pr.number, { onlyIfHeadSha: pr.headSha }).catch(() => undefined);`
  call (with the same `v8 ignore next` best-effort annotation the four siblings use) as the
  final step of `closeSynchronizeAmendmentIfPolicyEnabled`, in the same position relative to
  the close/audit-event calls as its siblings. No other behavior changed; the intentional
  moderation-strike omission is unaffected.
- `test/unit/queue-lifecycle-guards.test.ts`: added a test in the existing
  `one-shot synchronize-amendment close policy (#synchronize-close-policy)` block that starts
  active-review tracking on the PR's head, drives a synchronize-amendment enforcement close,
  and asserts the tracking row is left terminal (no dangling active row) — mirroring how the
  self-close / draft-conversion / draft-cycling / draft-PR sibling tests assert their own
  `terminalizeActiveReviewTracking` call.

## Tests

- Full `test/unit/queue-lifecycle-guards.test.ts` suite: **224 passed** (includes the new test).
- The new test asserts `hasActiveReviewForHeadSha(...)` is `true` before the close and `false`
  after — the row is terminalized exactly as with the four sibling guards.

## Verified locally

- `npm run typecheck` — clean.
- `npx turbo run build --filter=@loopover/engine` — clean (fresh `--force` run).
- `git diff --check origin/main` — clean.
- Rebased on current `origin/main`; `git merge-base --is-ancestor origin/main HEAD` — true.
- Coverage (codecov-style, on the changed file): the single added source line is best-effort
  cleanup annotated `v8 ignore next` (matching all four siblings); no added line is uncovered,
  100% patch coverage on the diff.
- Secret-scan clean: no secret/private-key/token/credential literal in the diff.

Closes #8015
