### PR TITLE
fix(extension): remove dead matchPullRequestTarget from content script

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -13,12 +13,6 @@ function matchGitHubPageTarget(pathname) {
   return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
-function matchPullRequestTarget(pathname) {
-  const target = matchGitHubPageTarget(pathname);
-  if (!target) return null;
-  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
-}
-
 function mountOverlay(target) {
   if (document.querySelector("[data-loopover-pr-context]")) return;
   const container = document.createElement("aside");
@@ -192,7 +186,6 @@ function renderActions(body, actions) {
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
   globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
-    matchPullRequestTarget,
     createOverlayLoader,
     renderPullContext,
     renderSection,

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -25,18 +25,6 @@ describe("extension content script", () => {
     // Issue pages are out of scope — no kind:"issue" classification, and no match.
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/issues/145")).toBeNull();
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pulls")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146/files")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/issues/146")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover")).toBeNull();
   });
 
   it("renders private pull-context sections and escapes API text", () => {
@@ -134,7 +122,6 @@ function loadContentInternals(overrides: Record<string, unknown> = {}) {
     matchGitHubPageTarget: (
       pathname: string,
     ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | null;
-    matchPullRequestTarget: (pathname: string) => { owner: string; repo: string; pullNumber: number } | null;
     createOverlayLoader: (container: { querySelector: (selector: string) => unknown }, target: unknown) => () => Promise<void>;
     renderPullContext: (payload: unknown) => string;
   };


### PR DESCRIPTION
## Summary

`matchPullRequestTarget` in `apps/loopover-extension/content.js` duplicated `matchGitHubPageTarget` (minus the `kind` field) and was left stranded when #7462/#7487 narrowed content-script matching to `pull/*` and simplified the `if (target)` guard. Nothing in production consumed it — only the `__loopoverContentInternals` test-hook re-exported it.

## Changes
- Delete `matchPullRequestTarget` and its entry in the `__loopoverContentInternals` export.
- Drop the now-dead `matchPullRequestTarget` assertions and type declaration from `test/unit/extension-content.test.ts` (the `matchGitHubPageTarget` coverage in the same test is retained).

`node --check content.js` passes and the content-script test suite is green (5 tests).

Closes #8023