### PR TITLE
fix(extension): remove dead matchPullRequestTarget from content script

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -13,12 +13,6 @@ function matchGitHubPageTarget(pathname) {
   return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
-function matchPullRequestTarget(pathname) {
-  const target = matchGitHubPageTarget(pathname);
-  if (!target) return null;
-  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
-}
-
 function mountOverlay(target) {
   if (document.querySelector("[data-loopover-pr-context]")) return;
   const container = document.createElement("aside");
@@ -192,7 +186,6 @@ function renderActions(body, actions) {
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
   globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
-    matchPullRequestTarget,
     createOverlayLoader,
     renderPullContext,
     renderSection,


### PR DESCRIPTION
## Summary

#7487 narrowed `matchGitHubPageTarget` to `pull/*` pages and simplified the `if (target)` guard, but left `matchPullRequestTarget` behind in `apps/loopover-extension/content.js` — a stranded duplicate of `matchGitHubPageTarget` minus its `kind` field.

- **No production caller.** It was only re-exported through the `__loopoverContentInternals` test-hook object, and `apps/loopover-extension` has no test suite to consume it (unlike its sibling `apps/loopover-miner-extension`).
- Removed the function (lines 16-20) and its `__loopoverContentInternals` entry (line 195). `matchGitHubPageTarget` — the canonical matcher still used by the content-script guard (`location.pathname`) — is untouched.

Pure dead-code removal, no behavior change.

## UI Evidence

N/A — content-script logic only (a browser-extension dead-code deletion); no rendered UI/frontend change, no visual surface affected.

## Validation

- [x] `grep` confirms zero remaining references to `matchPullRequestTarget`.
- [x] `extension:lint`, `extension:typecheck` (`node --check`), and `extension:build` all pass.
- [x] `ui:version-audit` clean.
- [x] `matchGitHubPageTarget` still used in production (`location.pathname` guard) — not orphaned.

Closes #8023