### PR TITLE
refactor(extension): remove dead matchPullRequestTarget from content.js (#8023)

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -13,12 +13,6 @@ function matchGitHubPageTarget(pathname) {
   return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
-function matchPullRequestTarget(pathname) {
-  const target = matchGitHubPageTarget(pathname);
-  if (!target) return null;
-  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
-}
-
 function mountOverlay(target) {
   if (document.querySelector("[data-loopover-pr-context]")) return;
   const container = document.createElement("aside");
@@ -192,7 +186,6 @@ function renderActions(body, actions) {
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
   globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
-    matchPullRequestTarget,
     createOverlayLoader,
     renderPullContext,
     renderSection,

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -25,18 +25,6 @@ describe("extension content script", () => {
     // Issue pages are out of scope — no kind:"issue" classification, and no match.
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/issues/145")).toBeNull();
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pulls")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146/files")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/issues/146")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover")).toBeNull();
   });
 
   it("renders private pull-context sections and escapes API text", () => {
@@ -134,7 +122,6 @@ function loadContentInternals(overrides: Record<string, unknown> = {}) {
     matchGitHubPageTarget: (
       pathname: string,
     ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | null;
-    matchPullRequestTarget: (pathname: string) => { owner: string; repo: string; pullNumber: number } | null;
     createOverlayLoader: (container: { querySelector: (selector: string) => unknown }, target: unknown) => () => Promise<void>;
     renderPullContext: (payload: unknown) => string;
   };


### PR DESCRIPTION
## Summary

`apps/loopover-extension/content.js`'s `matchPullRequestTarget` duplicated `matchGitHubPageTarget`'s logic (minus the `kind` field) and was stranded by #7487/#7462, which narrowed the content-script match to `pull/*` only and simplified the route guard. Confirmed via `git log -p` that it is unreferenced in production — it was surfaced solely through the `__loopoverContentInternals` test hook.

## Changes

- Delete `matchPullRequestTarget` from `content.js` and remove its entry from the `__loopoverContentInternals` export.
- Drop the now-orphaned `matchPullRequestTarget` assertions and its type entry in `test/unit/extension-content.test.ts` (a backend-suite test that VM-loads `content.js`). The retained `matchGitHubPageTarget` assertions still exercise the live routing, confirming the script loads and behaves unchanged.

## Scope

- [x] Narrow, single coherent change (dead-code removal + its orphaned test references)
- [x] In scope (`apps/loopover-extension/**`, `test/**`); no `blockedPaths`
- [x] No secrets/private-scoring terms anywhere
- [x] No generated-artifact changes (the built extension zip is gitignored; `extension:build` still succeeds)

## Validation

- [x] `grep -rn matchPullRequestTarget` — no remaining references anywhere in the repo
- [x] `npm run extension:lint` / `extension:typecheck` (`node --check`) — pass
- [x] `npm run extension:build` — succeeds
- [x] `npx vitest run test/unit/extension-content.test.ts` — 5/5 pass (the retained `matchGitHubPageTarget` + render/overlay coverage validates the loaded script)
- [x] `git diff --check` clean

## Safety

- [x] Pure dead-code removal — no behavior change (the deleted function had no production caller)
- [x] `matchGitHubPageTarget`, `renderPullContext`, overlay/refresh behavior all untouched and still covered
- [x] No auth/CORS surface touched; no secrets introduced

Closes #8023
