### PR TITLE
chore(extension): remove dead matchPullRequestTarget from content.js

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -13,12 +13,6 @@ function matchGitHubPageTarget(pathname) {
   return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
-function matchPullRequestTarget(pathname) {
-  const target = matchGitHubPageTarget(pathname);
-  if (!target) return null;
-  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
-}
-
 function mountOverlay(target) {
   if (document.querySelector("[data-loopover-pr-context]")) return;
   const container = document.createElement("aside");
@@ -192,7 +186,6 @@ function renderActions(body, actions) {
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
   globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
-    matchPullRequestTarget,
     createOverlayLoader,
     renderPullContext,
     renderSection,

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -25,18 +25,15 @@ describe("extension content script", () => {
     // Issue pages are out of scope — no kind:"issue" classification, and no match.
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/issues/145")).toBeNull();
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pulls")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146")).toEqual({
+    // Sub-path pull pages still match (previously asserted through the now-removed
+    // matchPullRequestTarget duplicate, #8023 -- the behavior belongs to matchGitHubPageTarget).
+    expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pull/146/files")).toEqual({
+      kind: "pull_request",
       owner: "JSONbored",
       repo: "loopover",
       pullNumber: 146,
     });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146/files")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/issues/146")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover")).toBeNull();
+    expect(internals.matchGitHubPageTarget("/JSONbored/loopover")).toBeNull();
   });
 
   it("renders private pull-context sections and escapes API text", () => {
@@ -134,7 +131,6 @@ function loadContentInternals(overrides: Record<string, unknown> = {}) {
     matchGitHubPageTarget: (
       pathname: string,
     ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | null;
-    matchPullRequestTarget: (pathname: string) => { owner: string; repo: string; pullNumber: number } | null;
     createOverlayLoader: (container: { querySelector: (selector: string) => unknown }, target: unknown) => () => Promise<void>;
     renderPullContext: (payload: unknown) => string;
   };


### PR DESCRIPTION
## Summary

- Closes #8023
- `matchPullRequestTarget` (`apps/loopover-extension/content.js`) duplicated `matchGitHubPageTarget` minus the `kind` field. #7487 removed issue-page matching (the manifest content-script match is `pull/*` only) and simplified the `if (target)` guard, leaving this wrapper stranded — no production call site remains; it was only re-exported through the `__loopoverContentInternals` test hook.
- Removed the function and its `__loopoverContentInternals` entry, and — **the part the previous attempt at this issue (#8037) missed and was closed for** — updated the root test suite that consumes that hook: `test/unit/extension-content.test.ts` asserted on `internals.matchPullRequestTarget` in four places (the issue's "zero test files" note only counted `apps/loopover-extension`'s own missing `test/` dir, not this root suite). Those assertions are removed with the symbol; the one case unique to them — a `/pull/146/files` sub-path still matching — is ported to `matchGitHubPageTarget`, where the behavior actually lives, so no behavioral coverage is lost.
- Repo-wide `grep matchPullRequestTarget` confirms zero remaining references.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Deletion-only change (net −11 lines, no new source lines, so no new patch-coverage surface). Ran the exact checks this change can affect: `vitest run test/unit/extension-content.test.ts` (5 tests green — the suite that consumes the removed test hook), `npm run extension:lint` and `npm run extension:typecheck` (the extension checks CI gates `validate-code` on, which `test:ci` itself does not run), and the full root `npm run typecheck`. `actionlint`/workers/mcp/ui checks are untouched surfaces; CI runs them all.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — dead-code removal with no behavior or visual change (the overlay mounts through `matchGitHubPageTarget`, which is untouched; the extension has no visible difference to capture).

## Notes

- Why the prior attempt closed, and how this PR resolves it: #8037 removed the symbol but left `test/unit/extension-content.test.ts` asserting on `internals.matchPullRequestTarget`, which would throw a `TypeError`. This PR updates that suite in the same diff and re-anchors the `/pull/<n>/files` sub-path expectation on `matchGitHubPageTarget` directly.