### PR TITLE
fix(extension): remove stranded matchPullRequestTarget duplicate from content.js (#8023)

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -13,12 +13,6 @@ function matchGitHubPageTarget(pathname) {
   return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
 }
 
-function matchPullRequestTarget(pathname) {
-  const target = matchGitHubPageTarget(pathname);
-  if (!target) return null;
-  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
-}
-
 function mountOverlay(target) {
   if (document.querySelector("[data-loopover-pr-context]")) return;
   const container = document.createElement("aside");
@@ -192,7 +186,6 @@ function renderActions(body, actions) {
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
   globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
-    matchPullRequestTarget,
     createOverlayLoader,
     renderPullContext,
     renderSection,

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -22,21 +22,18 @@ describe("extension content script", () => {
       repo: "loopover",
       pullNumber: 146,
     });
+    // Sub-pages of a pull request (e.g. /files) still match — kept from the retired
+    // matchPullRequestTarget duplicate's coverage (#8023) so the route regex keeps this pinned.
+    expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pull/146/files")).toEqual({
+      kind: "pull_request",
+      owner: "JSONbored",
+      repo: "loopover",
+      pullNumber: 146,
+    });
     // Issue pages are out of scope — no kind:"issue" classification, and no match.
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/issues/145")).toBeNull();
     expect(internals.matchGitHubPageTarget("/JSONbored/loopover/pulls")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/pull/146/files")).toEqual({
-      owner: "JSONbored",
-      repo: "loopover",
-      pullNumber: 146,
-    });
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover/issues/146")).toBeNull();
-    expect(internals.matchPullRequestTarget("/JSONbored/loopover")).toBeNull();
+    expect(internals.matchGitHubPageTarget("/JSONbored/loopover")).toBeNull();
   });
 
   it("renders private pull-context sections and escapes API text", () => {
@@ -134,7 +131,6 @@ function loadContentInternals(overrides: Record<string, unknown> = {}) {
     matchGitHubPageTarget: (
       pathname: string,
     ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | null;
-    matchPullRequestTarget: (pathname: string) => { owner: string; repo: string; pullNumber: number } | null;
     createOverlayLoader: (container: { querySelector: (selector: string) => unknown }, target: unknown) => () => Promise<void>;
     renderPullContext: (payload: unknown) => string;
   };


### PR DESCRIPTION
## Summary
- Remove `matchPullRequestTarget` from `apps/loopover-extension/content.js` — a stranded duplicate of `matchGitHubPageTarget` (minus the `kind` field) left behind by #7487's issue-page match removal, along with its `__loopoverContentInternals` entry.
- Update the one real consumer the repo grep finds — `test/unit/extension-content.test.ts` — to stop exercising the removed duplicate. Its useful route coverage is preserved, not dropped: the `/pull/146/files` sub-page match and the bare `/owner/repo` no-match cases now pin `matchGitHubPageTarget`'s regex directly, so the retired duplicate's assertions live on against the function that actually ships.
- No behavior change: production code only ever called `matchGitHubPageTarget`; the deleted function was reachable solely through the test-internals hook.

Closes #8023

## Test plan
- [x] `npx vitest run test/unit/extension-content.test.ts` — 5/5 passing against the updated internals surface
- [x] `npm run extension:lint` + `npm run extension:typecheck` (the CI checks gated on extension changes)
- [x] `npm run typecheck`
- [x] Repo-wide grep confirms zero remaining `matchPullRequestTarget` references
- [ ] CI validate