### PR TITLE
fix(miner): reject path-traversal repo segments in 4 remaining normalizeRepoFullName parsers

### DIFF
--- a/packages/loopover-miner/lib/contribution-profile-cache.ts
+++ b/packages/loopover-miner/lib/contribution-profile-cache.ts
@@ -14,6 +14,7 @@ import {
   resolveLocalStoreDbPath,
 } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import {
   CONTRIBUTION_PROFILE_CACHE_PURGE_SPEC,
   purgeStoreByRepo,
@@ -58,6 +59,7 @@ function normalizeRepoFullName(repoFullName: unknown): string {
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined)
     throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/prediction-ledger.ts
+++ b/packages/loopover-miner/lib/prediction-ledger.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeLocalStoreDbPath, openLocalStoreAdapter, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import {
   PREDICTION_LEDGER_PURGE_SPEC,
   PREDICTION_LEDGER_RETENTION_SPEC,
@@ -87,6 +88,7 @@ function normalizeRepoFullName(repoFullName: string): string {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/replay-snapshot.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { removeWorktree } from "@loopover/engine";
 import type { WorktreeExecFn, WorktreeRemoveResult } from "@loopover/engine";
 import { openLocalStoreAdapter, resolveLocalStoreDbPath, normalizeLocalStoreDbPath } from "./local-store.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 // Freeze/snapshot mechanism for historical replay targets (#3010). Given a repo and a commit SHA T, exports:
 //  (a) the full working tree checked out AT T via a DETACHED git worktree -- the same isolation primitive
@@ -72,6 +73,7 @@ function normalizeRepoFullName(repoFullName: string): string {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/run-state.ts
+++ b/packages/loopover-miner/lib/run-state.ts
@@ -3,6 +3,7 @@ import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { normalizeLocalStoreDbPath, openLocalStoreAdapter, resolveLocalStoreDbPath } from "./local-store.js";
 import { applySchemaMigrations } from "./schema-version.js";
 import { RUN_STATE_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 export type RunState = "idle" | "discovering" | "planning" | "preparing";
 
@@ -57,6 +58,7 @@ function normalizeRepoFullName(repoFullName: string): string {
   const trimmed = repoFullName.trim();
   const [owner, repo, extra] = trimmed.split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/test/unit/miner-contribution-profile-cache.test.ts
+++ b/test/unit/miner-contribution-profile-cache.test.ts
@@ -158,6 +158,10 @@ describe("contribution-profile cache store (#6797)", () => {
     expect(() => store.put({ repoFullName: 42 } as never)).toThrow(
       "invalid_repo_full_name",
     );
+    // #7795: a `.`/`..`/control-char owner or repo segment must be rejected, matching the sibling stores.
+    expect(() => store.get("../etc")).toThrow("invalid_repo_full_name");
+    expect(() => store.get("owner/..")).toThrow("invalid_repo_full_name");
+    expect(() => store.get("owner/re\tpo")).toThrow("invalid_repo_full_name");
   });
 
   it("exposes module-level get/put helpers backed by the default DB path", () => {

--- a/test/unit/miner-prediction-ledger.test.ts
+++ b/test/unit/miner-prediction-ledger.test.ts
@@ -68,6 +68,10 @@ describe("miner prediction ledger (#4263)", () => {
   it("rejects invalid inputs field by field", () => {
     const ledger = tempLedger();
     expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "no-slash" })).toThrow(/invalid_repo_full_name/);
+    // #7795: `.`/`..`/control-char segments must be rejected, matching the sibling stores.
+    expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "../etc" })).toThrow(/invalid_repo_full_name/);
+    expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "owner/.." })).toThrow(/invalid_repo_full_name/);
+    expect(() => ledger.appendPrediction({ ...VALID, repoFullName: "own\ter/repo" })).toThrow(/invalid_repo_full_name/);
     expect(() => ledger.appendPrediction({ ...VALID, targetId: 0 })).toThrow(/invalid_target_id/);
     expect(() => ledger.appendPrediction({ ...VALID, conclusion: "" })).toThrow(/invalid_conclusion/);
     expect(() => ledger.appendPrediction({ ...VALID, engineVersion: "" })).toThrow(/invalid_engine_version/);

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -160,6 +160,13 @@ describe("exportReplaySnapshot (#3010)", () => {
     expect(snapshot.readme).toEqual({ filename: "README.md", content: "# hello\n" });
   });
 
+  it("rejects a `.`/`..`/control-char repo segment before touching the store (#7795)", () => {
+    const store = tempStore();
+    expect(() => store.getSnapshot("../etc", "abc123")).toThrow("invalid_repo_full_name");
+    expect(() => store.getSnapshot("owner/..", "abc123")).toThrow("invalid_repo_full_name");
+    expect(() => store.getSnapshot("ow\tner/repo", "abc123")).toThrow("invalid_repo_full_name");
+  });
+
   it("returns the cached snapshot on a repeat export of the same (repo, commit) pair, without calling git again", async () => {
     const store = tempStore();
     const first = scriptedExec(happyPathScripts());

--- a/test/unit/miner-run-state.test.ts
+++ b/test/unit/miner-run-state.test.ts
@@ -129,6 +129,10 @@ describe("loopover-miner run-state store (#2289)", () => {
     try {
       expect(() => store.getRunState("not-a-full-name")).toThrow("invalid_repo_full_name");
       expect(() => store.setRunState("owner/repo/extra", "idle")).toThrow("invalid_repo_full_name");
+      // #7795: `.`/`..`/control-char segments must be rejected, matching the sibling stores.
+      expect(() => store.setRunState("../etc", "idle")).toThrow("invalid_repo_full_name");
+      expect(() => store.setRunState("owner/..", "idle")).toThrow("invalid_repo_full_name");
+      expect(() => store.getRunState("ow\tner/repo")).toThrow("invalid_repo_full_name");
       expect(() => store.setRunState("owner/repo", "blocked" as never)).toThrow("invalid_run_state");
       expect(store.getRunState("owner/repo")).toBeNull();
     } finally {


### PR DESCRIPTION
## Summary

`normalizeRepoFullName` in `contribution-profile-cache.ts`, `prediction-ledger.ts`, `replay-snapshot.ts` and `run-state.ts` only validated "exactly one slash, both halves non-empty" — so a `.`/`..`/control-char owner or repo segment (`owner/..`, `../repo`, a tab/newline inside a segment) passed through and was persisted as a SQLite key and echoed back through the sibling CLIs.

#5831 and #7525 already extended `isValidRepoSegment` (from `repo-clone.ts`) to the other **ten** `normalizeRepoFullName` siblings for exactly this "persisted into SQLite" reason; these four were never touched.

## Changes
- Import and call `isValidRepoSegment` on both `owner` and `repo` in all four parsers, matching the exact call shape used by the already-fixed siblings (`claim-ledger.ts`, `governor-state.ts`, `portfolio-queue.ts`, `worktree-allocator.ts`). No new validation mechanism.
- Per-store regression test covering a `.`/`..`/control-char segment, mirroring `miner-claim-ledger.test.ts`'s existing `../etc` assertion.

## Verification
All four affected test suites pass locally (81 tests), including the new path-traversal assertions.

Closes #7795