### PR TITLE
fix(review): reflect a live manual-review label in the public PR comment

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2008,9 +2008,17 @@ function publicCheckFailureDetails(details: LiveCiAggregate["failingDetails"]): 
  * metrics — the caller keeps the `incr()` emit, which reads the gate conclusion this function never sees.
  *
  * The two flags exist so the COMMENT agrees with the ACTION the disposition planner will take:
- * - `heldForReview` — a clean, green PR whose diff touches a hard-guardrail path is held for owner review by
- *   `planAgentMaintenanceActions`, never auto-merged, so the comment must not headline "safe to merge"
- *   (#guarded-hold-comment). Uses the same shared `isGuardrailHit` the planner uses, not a second copy.
+ * - `heldForReview` — true when EITHER a clean, green PR's diff touches a hard-guardrail path (uses the same
+ *   shared `isGuardrailHit` the planner uses, not a second copy), OR the live PR already carries the configured
+ *   manual-review label. Both cases mean `planAgentMaintenanceActions`/the action executor will never
+ *   merge/approve this pass, so the comment must not headline "safe to merge" (#guarded-hold-comment). The
+ *   label check exists because a manual-review hold, once applied (a guardrail hit, a since-resolved gate
+ *   blocker on a protected author, a migration collision, ...), is DELIBERATELY sticky — only a maintainer
+ *   removing it lifts the hold (agent-action-executor.ts's live-label guard) — but nothing previously reflected
+ *   that live block back into this comment: a PR could clear every OTHER hold reason on a later pass and the
+ *   comment would headline "approve/merge recommended" while the executor kept silently denying the merge/
+ *   approve action every single time, with no visible explanation anywhere on the PR (confirmed live on PR
+ *   #7994, stuck ~3+ hours with a stale manual-review label from an earlier missing_linked_issue blocker).
  * - `neverClosed` — the disposition never auto-closes a repo-owner or protected-automation PR, so a gate
  *   "close" verdict on one must headline "held", not "Closed" (#8/#9).
  */
@@ -2019,9 +2027,10 @@ export function derivePublicCommentMergeFacts(args: {
   mergeableState: string | null | undefined;
   authorLogin: string | null | undefined;
   liveCi: Pick<LiveCiAggregate, "ciState" | "failingDetails" | "nonRequiredFailingDetails">;
-  settings: Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants">;
+  settings: Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
   unifiedFiles: Awaited<ReturnType<typeof listPullRequestFiles>>;
   repoFullName: string;
+  prLabels: readonly string[];
 }): PublicCommentMergeFacts {
   const mergeStateLabel = args.liveMergeState ?? args.mergeableState ?? undefined; // fail-safe to the stored value
   const ciState: MergeReadiness["ciState"] =
@@ -2038,7 +2047,11 @@ export function derivePublicCommentMergeFacts(args: {
     ...(failingDetails.length > 0 ? { failingDetails } : {}),
     ...(nonRequiredFailingDetails.length > 0 ? { nonRequiredFailingDetails } : {}),
   };
-  const heldForReview = isGuardrailHit(changedPathsForGuardrail(args.unifiedFiles), resolveHardGuardrailGlobs(args.settings));
+  const manualReviewLabel = args.settings.manualReviewLabel === null ? null : (args.settings.manualReviewLabel ?? AGENT_LABEL_NEEDS_REVIEW);
+  const manualReviewLabelPresent =
+    manualReviewLabel !== null && args.prLabels.some((label) => label.toLowerCase() === manualReviewLabel.toLowerCase());
+  const heldForReview =
+    isGuardrailHit(changedPathsForGuardrail(args.unifiedFiles), resolveHardGuardrailGlobs(args.settings)) || manualReviewLabelPresent;
   const repoOwner = args.repoFullName.includes("/") ? args.repoFullName.slice(0, args.repoFullName.indexOf("/")) : "";
   const authorLogin = args.authorLogin ?? "";
   const neverClosed =
@@ -10876,6 +10889,7 @@ async function maybePublishPrPublicSurface(
         settings,
         unifiedFiles,
         repoFullName,
+        prLabels: pr.labels,
       });
       // The public comment must match the authoritative Gate check-run conclusion.
       const commentGate = commentGateEvaluation;

--- a/test/unit/processors-public-comment-merge-facts.test.ts
+++ b/test/unit/processors-public-comment-merge-facts.test.ts
@@ -11,7 +11,8 @@ const UNGUARDED_FILE = { path: "README.md" } as PullRequestFileRecord;
 const NO_GUARDRAIL_OVERRIDES = {
   hardGuardrailGlobs: [],
   hardGuardrailGlobsOverridesInvariants: false,
-} as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants">;
+  manualReviewLabel: undefined,
+} as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
 
 function facts(overrides: Partial<Parameters<typeof derivePublicCommentMergeFacts>[0]> = {}) {
   return derivePublicCommentMergeFacts({
@@ -22,6 +23,7 @@ function facts(overrides: Partial<Parameters<typeof derivePublicCommentMergeFact
     settings: NO_GUARDRAIL_OVERRIDES,
     unifiedFiles: [UNGUARDED_FILE],
     repoFullName: "acme/widgets",
+    prLabels: [],
     ...overrides,
   });
 }
@@ -112,12 +114,52 @@ describe("derivePublicCommentMergeFacts() — heldForReview (#guarded-hold-comme
     expect(
       facts({
         unifiedFiles: [GUARDED_FILE],
-        settings: { hardGuardrailGlobs: [], hardGuardrailGlobsOverridesInvariants: true } as Pick<
-          RepositorySettings,
-          "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants"
-        >,
+        settings: {
+          hardGuardrailGlobs: [],
+          hardGuardrailGlobsOverridesInvariants: true,
+          manualReviewLabel: undefined,
+        } as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">,
       }).heldForReview,
     ).toBe(false);
+  });
+});
+
+// #7994-follow-up: a manual-review hold is deliberately sticky (only a maintainer removing the label lifts it —
+// see agent-action-executor.ts's live-label guard), but nothing previously reflected that live block back into
+// this comment. A PR could clear every OTHER hold reason (guardrail, missing_linked_issue, ...) on a later pass
+// and the comment would headline "approve/merge recommended" while the executor kept silently denying merge/
+// approve, with no visible explanation anywhere on the PR — confirmed live on PR #7994, stuck ~3+ hours.
+describe("derivePublicCommentMergeFacts() — manual-review label hold (#7994-follow-up)", () => {
+  it("holds a PR that carries the live manual-review label, even with no guardrail hit", () => {
+    expect(facts({ unifiedFiles: [UNGUARDED_FILE], prLabels: ["manual-review"] }).heldForReview).toBe(true);
+  });
+
+  it("matches the label case-insensitively", () => {
+    expect(facts({ unifiedFiles: [UNGUARDED_FILE], prLabels: ["Manual-Review"] }).heldForReview).toBe(true);
+  });
+
+  it("does not hold when the label is absent", () => {
+    expect(facts({ unifiedFiles: [UNGUARDED_FILE], prLabels: ["gittensor:bug"] }).heldForReview).toBe(false);
+  });
+
+  it("honours a repo-configured custom manual-review label name instead of the default", () => {
+    const settings = {
+      hardGuardrailGlobs: [],
+      hardGuardrailGlobsOverridesInvariants: false,
+      manualReviewLabel: "needs-maintainer",
+    } as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
+    // The default "manual-review" label no longer matters once a custom name is configured.
+    expect(facts({ unifiedFiles: [UNGUARDED_FILE], settings, prLabels: ["manual-review"] }).heldForReview).toBe(false);
+    expect(facts({ unifiedFiles: [UNGUARDED_FILE], settings, prLabels: ["needs-maintainer"] }).heldForReview).toBe(true);
+  });
+
+  it("disables the label check entirely when manualReviewLabel is explicitly null", () => {
+    const settings = {
+      hardGuardrailGlobs: [],
+      hardGuardrailGlobsOverridesInvariants: false,
+      manualReviewLabel: null,
+    } as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
+    expect(facts({ unifiedFiles: [UNGUARDED_FILE], settings, prLabels: ["manual-review"] }).heldForReview).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #8067.

## Summary
- A gate-blocked owner/admin PR gets `manual-review` applied as a fallback hold (`src/settings/agent-actions.ts`'s generic `manualHoldReason` fallback). That label is deliberately maintainer-only-removable (`src/services/agent-action-executor.ts`'s live-label guard, the "#3472 split-brain" check) — correct, since the bot must never silently override a real human freeze.
- But `derivePublicCommentMergeFacts`'s `heldForReview` flag only ever checked for a hard-guardrail-path hit. It never checked the live PR for the manual-review label itself, so once the ORIGINAL triggering blocker cleared on a later pass, the public comment happily said **"✅ approve/merge recommended, no blockers"** while the executor kept silently denying every merge/approve attempt because the (now-stale, but still live) label was still on the PR — with zero visible explanation anywhere on the PR.
- Confirmed live on PR #7994 (fixing #7981): tripped `missing_linked_issue` early from a wrong closing-keyword phrasing ("Implements #7981" instead of "Closes #7981"), got `manual-review` applied as the owner-fallback hold, the wording was fixed and the blocker cleared — but the label stuck around, and the PR sat fully green (CI + codecov + bot-approved) for 3+ hours before being merged manually. Full root-cause trail (audit_events, executor logs) is in #8067.
- Fix: broaden `heldForReview` to also go `true` whenever the configured manual-review label (default `"manual-review"`, honors a repo's `manualReviewLabel` override/disable) is present on the live PR — regardless of which hold path originally applied it. Visibility-only change: the comment now correctly says "manual review recommended" instead of a misleading "ready"; the actual "only a maintainer can remove this label" safety behavior is untouched.

## Test plan
- [x] `npm run typecheck`
- [x] New tests in `test/unit/processors-public-comment-merge-facts.test.ts`: label present → held; case-insensitive match; label absent → unaffected; custom configured label name; `manualReviewLabel: null` disables the check entirely
- [x] Full unsharded `npm run test:coverage`: 1085/1085 files, 20278 tests, 0 failures
- [x] 100% line/branch coverage on every new/changed line (verified via targeted coverage run + the full suite's `processors.ts` aggregate: 97.36% stmts / 96.76% branch, no new lines in the uncovered set)