### PR TITLE
fix(control-plane): require product on the rollout route to match #8024's product-scoped registry

### DIFF
--- a/control-plane/src/http-app.ts
+++ b/control-plane/src/http-app.ts
@@ -18,7 +18,7 @@ import {
   provisionTenant,
   type ProvisioningPagerDutyOptions,
 } from "./provisioning.js";
-import type { TenantProvisioningDriver } from "./tenant-provisioning-driver.js";
+import type { Product, TenantProvisioningDriver } from "./tenant-provisioning-driver.js";
 import type { TenantRegistry, TenantRegistryRecord } from "./tenant-registry.js";
 
 export type TenantHttpAppDeps = {
@@ -37,21 +37,25 @@ function safeRecord(record: Pick<TenantRegistryRecord, "tenant" | "product" | "s
 
 /** Validated body of `POST /v1/tenants/rollout` (#4898): an explicit tenant-name list (no percentage/canary
  *  selector — no such primitive exists elsewhere in this codebase to build on) plus the version to pin.
- *  `pinnedVersion: null` is an explicit unpin (revert to the release channel's default). */
-type RolloutRequest = { names: string[]; pinnedVersion: string | null };
+ *  `pinnedVersion: null` is an explicit unpin (revert to the release channel's default). Scoped to a single
+ *  `product` for the whole batch (#8024: a name is no longer globally unique across products, and a version
+ *  rollout is naturally a per-product-fleet operation anyway -- ORB and AMS ship independently versioned
+ *  images, so mixing them in one rollout call was never a meaningful use case even before #8024). */
+type RolloutRequest = { names: string[]; product: Product; pinnedVersion: string | null };
 
 function parseRolloutRequest(body: unknown): RolloutRequest | string {
   if (body === null || typeof body !== "object" || Array.isArray(body)) return "body must be a JSON object";
-  const { names, pinnedVersion } = body as Record<string, unknown>;
+  const { names, product, pinnedVersion } = body as Record<string, unknown>;
   if (!Array.isArray(names) || names.length === 0) return "names must be a non-empty array of tenant names";
   if (!names.every((name): name is string => typeof name === "string" && name.trim() !== "")) {
     return "names must be a non-empty array of tenant names";
   }
   if (new Set(names).size !== names.length) return "names must not repeat a tenant";
+  if (typeof product !== "string" || !product.trim()) return "product is required";
   if (pinnedVersion !== null && (typeof pinnedVersion !== "string" || !pinnedVersion.trim())) {
     return "pinnedVersion must be a non-blank string, or null to unpin";
   }
-  return { names, pinnedVersion: pinnedVersion === null ? null : pinnedVersion.trim() };
+  return { names, product: product.trim(), pinnedVersion: pinnedVersion === null ? null : pinnedVersion.trim() };
 }
 
 export function createTenantHttpApp(deps: TenantHttpAppDeps): Hono {
@@ -112,7 +116,7 @@ export function createTenantHttpApp(deps: TenantHttpAppDeps): Hono {
 
     const existing = new Map<string, TenantRegistryRecord>();
     for (const name of parsed.names) {
-      const record = await deps.registry.get(name);
+      const record = await deps.registry.get(name, parsed.product);
       if (!record) return c.json({ error: "tenant_not_found", message: `unknown tenant "${name}"` }, 404);
       // A torn-down tenant has no container to ever read the pin — surfacing the mistake beats silently
       // stamping a version onto a terminated record (same conflict posture as the create route's 409).

--- a/control-plane/test/http-app.test.ts
+++ b/control-plane/test/http-app.test.ts
@@ -309,7 +309,7 @@ test("POST /v1/tenants/rollout pins exactly the listed tenants and leaves every 
   await registry.upsert({ tenant: { name: "gamma" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0" });
   const app = createTenantHttpApp(baseDeps({ registry }));
 
-  const res = await rollout(app, { names: ["acme", "gamma"], pinnedVersion: "v1.4.2" });
+  const res = await rollout(app, { names: ["acme", "gamma"], product: "orb", pinnedVersion: "v1.4.2" });
 
   assert.equal(res.status, 200);
   const payload = (await res.json()) as { tenants: Array<{ tenant: { name: string; pinnedVersion?: string | null } }> };
@@ -317,12 +317,12 @@ test("POST /v1/tenants/rollout pins exactly the listed tenants and leaves every 
     { name: "acme", pinnedVersion: "v1.4.2" },
     { name: "gamma", pinnedVersion: "v1.4.2" },
   ]);
-  // The unlisted tenant is completely unaffected — no pin, no updatedAt churn.
-  const beta = await registry.get("beta");
+  // The unlisted tenant (a different product, #8024) is completely unaffected — no pin, no updatedAt churn.
+  const beta = await registry.get("beta", "ams");
   assert.deepEqual(beta?.tenant, { name: "beta" });
   assert.equal(beta?.updatedAt, "t0");
   // The pinned tenants' records persisted the pin and kept their createdAt.
-  const acme = await registry.get("acme");
+  const acme = await registry.get("acme", "orb");
   assert.deepEqual(acme?.tenant, { name: "acme", pinnedVersion: "v1.4.2" });
   assert.equal(acme?.createdAt, "t0");
   assert.notEqual(acme?.updatedAt, "t0");
@@ -334,16 +334,16 @@ test("POST /v1/tenants/rollout rolls back independently: re-pinning one tenant l
   await registry.upsert({ tenant: { name: "beta", pinnedVersion: "v2.0.0" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0" });
   const app = createTenantHttpApp(baseDeps({ registry }));
 
-  const back = await rollout(app, { names: ["acme"], pinnedVersion: "v1.9.0" });
+  const back = await rollout(app, { names: ["acme"], product: "orb", pinnedVersion: "v1.9.0" });
   assert.equal(back.status, 200);
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme", pinnedVersion: "v1.9.0" });
-  assert.deepEqual((await registry.get("beta"))?.tenant, { name: "beta", pinnedVersion: "v2.0.0" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme", pinnedVersion: "v1.9.0" });
+  assert.deepEqual((await registry.get("beta", "orb"))?.tenant, { name: "beta", pinnedVersion: "v2.0.0" });
 
   // Explicit unpin (null) reverts the tenant to its release channel's default.
-  const unpin = await rollout(app, { names: ["acme"], pinnedVersion: null });
+  const unpin = await rollout(app, { names: ["acme"], product: "orb", pinnedVersion: null });
   assert.equal(unpin.status, 200);
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme", pinnedVersion: null });
-  assert.deepEqual((await registry.get("beta"))?.tenant, { name: "beta", pinnedVersion: "v2.0.0" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme", pinnedVersion: null });
+  assert.deepEqual((await registry.get("beta", "orb"))?.tenant, { name: "beta", pinnedVersion: "v2.0.0" });
 });
 
 test("POST /v1/tenants/rollout trims the pinned version before storing it", async () => {
@@ -351,10 +351,10 @@ test("POST /v1/tenants/rollout trims the pinned version before storing it", asyn
   await registry.upsert({ tenant: { name: "acme" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0" });
   const app = createTenantHttpApp(baseDeps({ registry }));
 
-  const res = await rollout(app, { names: ["acme"], pinnedVersion: "  v1.4.2  " });
+  const res = await rollout(app, { names: ["acme"], product: "orb", pinnedVersion: "  v1.4.2  " });
 
   assert.equal(res.status, 200);
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme", pinnedVersion: "v1.4.2" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme", pinnedVersion: "v1.4.2" });
 });
 
 test("POST /v1/tenants/rollout 400s malformed bodies without touching any record", async () => {
@@ -368,20 +368,22 @@ test("POST /v1/tenants/rollout 400s malformed bodies without touching any record
 
   for (const [body, message] of [
     [[], "body must be a JSON object"],
-    [{ names: [], pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
-    [{ names: "acme", pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
-    [{ names: ["acme", "  "], pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
-    [{ names: ["acme", 7], pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
-    [{ names: ["acme", "acme"], pinnedVersion: "v1" }, "names must not repeat a tenant"],
-    [{ names: ["acme"], pinnedVersion: "   " }, "pinnedVersion must be a non-blank string, or null to unpin"],
-    [{ names: ["acme"], pinnedVersion: 7 }, "pinnedVersion must be a non-blank string, or null to unpin"],
-    [{ names: ["acme"] }, "pinnedVersion must be a non-blank string, or null to unpin"],
+    [{ names: [], product: "orb", pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
+    [{ names: "acme", product: "orb", pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
+    [{ names: ["acme", "  "], product: "orb", pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
+    [{ names: ["acme", 7], product: "orb", pinnedVersion: "v1" }, "names must be a non-empty array of tenant names"],
+    [{ names: ["acme", "acme"], product: "orb", pinnedVersion: "v1" }, "names must not repeat a tenant"],
+    [{ names: ["acme"], pinnedVersion: "v1" }, "product is required"],
+    [{ names: ["acme"], product: "  ", pinnedVersion: "v1" }, "product is required"],
+    [{ names: ["acme"], product: "orb", pinnedVersion: "   " }, "pinnedVersion must be a non-blank string, or null to unpin"],
+    [{ names: ["acme"], product: "orb", pinnedVersion: 7 }, "pinnedVersion must be a non-blank string, or null to unpin"],
+    [{ names: ["acme"], product: "orb" }, "pinnedVersion must be a non-blank string, or null to unpin"],
   ] as const) {
     const res = await rollout(app, body);
     assert.equal(res.status, 400, JSON.stringify(body));
     assert.deepEqual(await res.json(), { error: "invalid_request", message });
   }
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme" });
 });
 
 test("POST /v1/tenants/rollout is all-or-nothing: one unknown name 404s and applies nothing", async () => {
@@ -389,11 +391,11 @@ test("POST /v1/tenants/rollout is all-or-nothing: one unknown name 404s and appl
   await registry.upsert({ tenant: { name: "acme" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0" });
   const app = createTenantHttpApp(baseDeps({ registry }));
 
-  const res = await rollout(app, { names: ["acme", "ghost"], pinnedVersion: "v1.4.2" });
+  const res = await rollout(app, { names: ["acme", "ghost"], product: "orb", pinnedVersion: "v1.4.2" });
 
   assert.equal(res.status, 404);
   assert.deepEqual(await res.json(), { error: "tenant_not_found", message: 'unknown tenant "ghost"' });
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme" });
 });
 
 test("POST /v1/tenants/rollout 409s a torn-down tenant and applies nothing", async () => {
@@ -402,11 +404,11 @@ test("POST /v1/tenants/rollout 409s a torn-down tenant and applies nothing", asy
   await registry.upsert({ tenant: { name: "gone" }, product: "orb", state: "torn down", createdAt: "t0", updatedAt: "t0" });
   const app = createTenantHttpApp(baseDeps({ registry }));
 
-  const res = await rollout(app, { names: ["acme", "gone"], pinnedVersion: "v1.4.2" });
+  const res = await rollout(app, { names: ["acme", "gone"], product: "orb", pinnedVersion: "v1.4.2" });
 
   assert.equal(res.status, 409);
   assert.deepEqual(await res.json(), { error: "tenant_torn_down", message: 'tenant "gone" is torn down' });
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme" });
 });
 
 test("POST /v1/tenants/rollout sits behind the same Bearer wall as every other /v1/tenants route", async () => {

--- a/control-plane/test/tenant-registry.test.ts
+++ b/control-plane/test/tenant-registry.test.ts
@@ -158,7 +158,7 @@ test("a tenant's pinnedVersion (#4898) survives the KV JSON round-trip, and its 
   await registry.upsert({ ...recordFor("acme"), tenant: { name: "acme", pinnedVersion: "v1.4.2" } });
   await registry.upsert(recordFor("beta"));
 
-  assert.deepEqual((await registry.get("acme"))?.tenant, { name: "acme", pinnedVersion: "v1.4.2" });
+  assert.deepEqual((await registry.get("acme", "orb"))?.tenant, { name: "acme", pinnedVersion: "v1.4.2" });
   // A pre-#4898 record (no pinnedVersion key at all) reads back exactly as stored — unpinned.
-  assert.deepEqual((await registry.get("beta"))?.tenant, { name: "beta" });
+  assert.deepEqual((await registry.get("beta", "orb"))?.tenant, { name: "beta" });
 });


### PR DESCRIPTION
## Summary

Fixes a currently-broken `main`: `control-plane/` does not build right now (`tsc: Expected 2 arguments, but got 1`) because `POST /v1/tenants/rollout` (#4898) calls `registry.get(name)` with one argument, but `TenantRegistry.get` was widened to `(name, product)` by #8024 (a separate, already-merged PR) — since a tenant name is no longer unique across products. Neither PR's own CI run saw the other's changes combined, so this slipped through. Since `control-plane`'s build fails, its **entire test suite is currently unrunnable on `main`**.

## Fix

Scopes a rollout call to a single `product` for the whole batch — matching the same "product required" posture the DELETE route already adopted for #8024, and a reasonable model on its own merits (a version rollout is naturally per-product-fleet: ORB and AMS ship independently-versioned images, so mixing them in one rollout call was never a meaningful use case even before #8024).

- `RolloutRequest` gains a required `product` field; `parseRolloutRequest` validates it (missing/blank → `400 invalid_request`).
- The route's tenant lookups now call `registry.get(name, parsed.product)`.
- Fixed the same pre-existing-but-latent argument mismatch in `test/http-app.test.ts` and `test/tenant-registry.test.ts` (both files also called `registry.get(name)` with one argument — the tests predate #8024 too).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Minimal, targeted fix — does not touch anything beyond the rollout route's product-scoping and its tests.
- [x] Owner-authored (fixing a currently-broken shared main branch).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root)
- [x] `npm run control-plane:test` — 111/111 passing (previously: build failure, 0 tests could even run).
- [x] `npm run control-plane:coverage` — 100% line/branch/function coverage on the changed file; the only residual gap (`settlement-backend-driver.ts`) is pre-existing and untouched by this PR.
- [x] `npx wrangler deploy --dry-run` — builds both real Docker images and resolves all bindings correctly.
- [x] New validation branch (missing/blank `product`) has dedicated test coverage; every existing rollout test updated to pass `product` and use product-scoped lookups.

## Safety

- [x] No secrets, tokens, or credentials anywhere.
- [x] No visible UI changes.