### PR TITLE
feat(calibration): pure BacktestCase corpus builder from fired/override events

### DIFF
--- a/packages/loopover-engine/src/calibration/backtest-corpus.ts
+++ b/packages/loopover-engine/src/calibration/backtest-corpus.ts
@@ -1,0 +1,79 @@
+// Backtest corpus builder (#8083, part of the rule-precision backtest epic #8082) -- turns the calibration
+// module's raw fired/override event history into a list of concrete, individually-labeled cases ("this rule
+// fired against this target, and a human later said it was right/wrong"), replayable against a different
+// candidate rule/classifier later. Where computeRulePrecision (signal-tracking.ts) collapses the paired events
+// into one aggregate precision number, this keeps each decided case as its own record.
+//
+// SELF-CONTAINED / PURE: no IO, no DB, no host adapters -- only the existing RuleFiredEvent/HumanOverrideEvent
+// types from signal-tracking.ts, matching that module's storage-agnostic discipline.
+
+import type { HumanOverrideEvent, RuleFiredEvent } from "./signal-tracking.js";
+
+/** One decided backtest case: a rule firing that a human later judged. `outcome` is the fired event's own
+ *  outcome; `label` is the human `verdict` on it; `firedAt`/`decidedAt` are the two events' `occurredAt`
+ *  timestamps. `metadata` carries the fired event's metadata verbatim and is omitted entirely (not set to
+ *  `undefined`) when the fired event has none -- the same optional-property discipline RuleFiredEvent uses. */
+export type BacktestCase = {
+  ruleId: string;
+  targetKey: string;
+  outcome: string;
+  label: "reversed" | "confirmed";
+  firedAt: string;
+  decidedAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Pick the override to pair with one fired event from the already-filtered (same rule + same targetKey)
+ *  candidates: the one whose `occurredAt` is the nearest STRICTLY AFTER the fired event's `occurredAt`; if none
+ *  strictly follows it, the most recent override by `occurredAt`. `candidates` is guaranteed non-empty by the
+ *  caller. */
+function pickPairedOverride(firedEvent: RuleFiredEvent, candidates: readonly HumanOverrideEvent[]): HumanOverrideEvent {
+  const firedMs = Date.parse(firedEvent.occurredAt);
+  let mostRecent = candidates[0]!;
+  let nearestFollowing: HumanOverrideEvent | null = null;
+  for (const override of candidates) {
+    const overrideMs = Date.parse(override.occurredAt);
+    if (overrideMs > Date.parse(mostRecent.occurredAt)) mostRecent = override;
+    if (overrideMs > firedMs && (nearestFollowing === null || overrideMs < Date.parse(nearestFollowing.occurredAt))) {
+      nearestFollowing = override;
+    }
+  }
+  return nearestFollowing ?? mostRecent;
+}
+
+/**
+ * Build the labeled backtest corpus for `ruleId` from its fired + override events. Only events whose `ruleId`
+ * matches the argument are considered (mirrors overrideMatchesRule's `event.ruleId === ruleId` filter in
+ * signal-tracking.ts; a caller MAY pass a mixed-rule list without filtering first). Each considered fired
+ * event pairs with exactly ONE override sharing its `targetKey`: the override whose `occurredAt` is the nearest
+ * strictly after the fired event's, or -- when none strictly follows -- the most recent override by
+ * `occurredAt`. A fired event with no matching override is EXCLUDED (an undecided fire is not an unlabeled
+ * case), mirroring computeRulePrecision's "only the decided ones count" discipline. No fired event yields more
+ * than one case.
+ */
+export function buildBacktestCorpus(
+  ruleId: string,
+  fired: readonly RuleFiredEvent[],
+  overrides: readonly HumanOverrideEvent[],
+): BacktestCase[] {
+  const corpus: BacktestCase[] = [];
+  for (const firedEvent of fired) {
+    if (firedEvent.ruleId !== ruleId) continue;
+    const candidates = overrides.filter(
+      (override) => override.ruleId === ruleId && override.targetKey === firedEvent.targetKey,
+    );
+    if (candidates.length === 0) continue;
+    const paired = pickPairedOverride(firedEvent, candidates);
+    const backtestCase: BacktestCase = {
+      ruleId,
+      targetKey: firedEvent.targetKey,
+      outcome: firedEvent.outcome,
+      label: paired.verdict,
+      firedAt: firedEvent.occurredAt,
+      decidedAt: paired.occurredAt,
+    };
+    if (firedEvent.metadata !== undefined) backtestCase.metadata = firedEvent.metadata;
+    corpus.push(backtestCase);
+  }
+  return corpus;
+}

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -163,6 +163,7 @@ export * from "./governor/kill-switch.js";
 export * from "./governor/action-mode.js";
 export * from "./governor/chokepoint.js";
 export * from "./calibration/signal-tracking.js";
+export * from "./calibration/backtest-corpus.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/packages/loopover-engine/test/backtest-corpus.test.ts
+++ b/packages/loopover-engine/test/backtest-corpus.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildBacktestCorpus, type BacktestCase, type HumanOverrideEvent, type RuleFiredEvent } from "../dist/index.js";
+
+function fired(ruleId: string, targetKey: string, overrides: Partial<RuleFiredEvent> = {}): RuleFiredEvent {
+  return { ruleId, targetKey, outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+function override(
+  ruleId: string,
+  targetKey: string,
+  verdict: HumanOverrideEvent["verdict"],
+  overrides: Partial<HumanOverrideEvent> = {},
+): HumanOverrideEvent {
+  return { ruleId, targetKey, verdict, occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+test("barrel: the public entrypoint re-exports buildBacktestCorpus (#8083)", () => {
+  assert.equal(typeof buildBacktestCorpus, "function");
+});
+
+test("buildBacktestCorpus: empty inputs produce an empty corpus", () => {
+  assert.deepEqual(buildBacktestCorpus("missing_linked_issue", [], []), []);
+});
+
+test("buildBacktestCorpus: a fired event with no matching override is excluded (undecided is not unlabeled)", () => {
+  const corpus = buildBacktestCorpus(
+    "missing_linked_issue",
+    [fired("missing_linked_issue", "a#1"), fired("missing_linked_issue", "a#2")],
+    [override("missing_linked_issue", "a#1", "confirmed", { occurredAt: "2026-07-22T01:00:00.000Z" })],
+  );
+  assert.deepEqual(corpus, [
+    {
+      ruleId: "missing_linked_issue",
+      targetKey: "a#1",
+      outcome: "block",
+      label: "confirmed",
+      firedAt: "2026-07-22T00:00:00.000Z",
+      decidedAt: "2026-07-22T01:00:00.000Z",
+    },
+  ]);
+});
+
+test("buildBacktestCorpus: a single fired+override pair yields one correctly-labeled case", () => {
+  const corpus = buildBacktestCorpus(
+    "missing_linked_issue",
+    [fired("missing_linked_issue", "a#7", { outcome: "exclude", occurredAt: "2026-07-22T00:00:00.000Z" })],
+    [override("missing_linked_issue", "a#7", "reversed", { occurredAt: "2026-07-22T02:00:00.000Z" })],
+  );
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.label, "reversed");
+  assert.equal(corpus[0]!.outcome, "exclude");
+  assert.equal(corpus[0]!.decidedAt, "2026-07-22T02:00:00.000Z");
+});
+
+test("buildBacktestCorpus: metadata rides along when present and is omitted entirely (not undefined) when absent", () => {
+  const withMeta = buildBacktestCorpus(
+    "r",
+    [fired("r", "a#1", { metadata: { source: "orb" } })],
+    [override("r", "a#1", "confirmed", { occurredAt: "2026-07-22T01:00:00.000Z" })],
+  );
+  assert.deepEqual(withMeta[0]!.metadata, { source: "orb" });
+
+  const withoutMeta: BacktestCase = buildBacktestCorpus(
+    "r",
+    [fired("r", "a#1")],
+    [override("r", "a#1", "confirmed", { occurredAt: "2026-07-22T01:00:00.000Z" })],
+  )[0]!;
+  assert.equal("metadata" in withoutMeta, false);
+});
+
+test("buildBacktestCorpus: events for a different ruleId are ignored on both sides", () => {
+  const corpus = buildBacktestCorpus(
+    "wanted",
+    [fired("wanted", "a#1"), fired("other", "a#1")],
+    [
+      override("wanted", "a#1", "confirmed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+      override("other", "a#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+    ],
+  );
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.ruleId, "wanted");
+  assert.equal(corpus[0]!.label, "confirmed");
+});
+
+test("buildBacktestCorpus: with multiple overrides, pairs the nearest override strictly AFTER the fire", () => {
+  const corpus = buildBacktestCorpus(
+    "r",
+    [fired("r", "a#1", { occurredAt: "2026-07-22T12:00:00.000Z" })],
+    [
+      override("r", "a#1", "reversed", { occurredAt: "2026-07-22T10:00:00.000Z" }), // before the fire
+      override("r", "a#1", "confirmed", { occurredAt: "2026-07-22T13:00:00.000Z" }), // nearest after -> chosen
+      override("r", "a#1", "reversed", { occurredAt: "2026-07-22T18:00:00.000Z" }), // later after
+    ],
+  );
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.label, "confirmed");
+  assert.equal(corpus[0]!.decidedAt, "2026-07-22T13:00:00.000Z");
+});
+
+test("buildBacktestCorpus: when no override strictly follows the fire, falls back to the most recent override", () => {
+  const corpus = buildBacktestCorpus(
+    "r",
+    [fired("r", "a#1", { occurredAt: "2026-07-22T20:00:00.000Z" })],
+    [
+      override("r", "a#1", "reversed", { occurredAt: "2026-07-22T10:00:00.000Z" }),
+      override("r", "a#1", "confirmed", { occurredAt: "2026-07-22T15:00:00.000Z" }), // most recent, still before -> chosen
+    ],
+  );
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.label, "confirmed");
+  assert.equal(corpus[0]!.decidedAt, "2026-07-22T15:00:00.000Z");
+});


### PR DESCRIPTION
## Summary

Adds `packages/loopover-engine/src/calibration/backtest-corpus.ts` — the foundational piece of the rule-precision backtest epic (#8082). Where `computeRulePrecision` collapses paired events into one aggregate number, this keeps each decided case as its own labeled record, replayable against a different candidate rule/classifier later.

## What it does
- `BacktestCase` type + pure `buildBacktestCorpus(ruleId, fired, overrides): BacktestCase[]`.
- Pairs each considered `RuleFiredEvent` with the `HumanOverrideEvent` sharing its `targetKey`: the override whose `occurredAt` is nearest **strictly after** the fire, else the **most recent** override.
- Excludes fired events with no matching override (an undecided fire is not an unlabeled case), mirroring `computeRulePrecision`'s "only the decided ones count" discipline.
- Only events whose `ruleId` matches are considered (mirrors `overrideMatchesRule`); `metadata` rides along verbatim and is **omitted entirely** (not `undefined`) when absent.

## Constraints honored
- Pure / storage-agnostic — no IO, DB, env, or imports from `src/`/`loopover-miner`/host adapters; only the existing `signal-tracking.ts` types.
- Additive-only: new file + one barrel export line immediately after the `signal-tracking` export; `signal-tracking.ts` untouched.

## Tests
`packages/loopover-engine/test/backtest-corpus.test.ts` (node:test, mirroring the #7982 precedent) covers: empty inputs; no-override exclusion; single pair labeling; nearest-following vs. most-recent-fallback override selection; cross-`ruleId` events ignored; `metadata` present-vs-absent.

Closes #8083