### PR TITLE
feat(calibration): pure BacktestCase corpus builder from fired/override events

### DIFF
--- a/packages/loopover-engine/src/calibration/backtest-corpus.ts
+++ b/packages/loopover-engine/src/calibration/backtest-corpus.ts
@@ -1,0 +1,68 @@
+// Labeled backtest corpus builder (#8083) -- turns the calibration module's raw fired/override event history
+// into a list of concrete "this rule fired against this target, and a human later said it was right/wrong"
+// cases, each replayable against a different candidate rule/classifier later (see the parent epic #8082).
+//
+// SELF-CONTAINED, PURE: no IO, no DB, no env, no wall-clock read, and no imports beyond the existing
+// RuleFiredEvent/HumanOverrideEvent types from signal-tracking.ts -- the same storage-agnostic discipline
+// that whole module follows. `Date.parse` on the events' own `occurredAt` strings is not a clock read; it is
+// pure parsing of caller-supplied data, so the function stays deterministic.
+
+import type { HumanOverrideEvent, RuleFiredEvent } from "./signal-tracking.js";
+
+/** One labeled backtest case: a single rule firing paired with the human verdict that later decided it.
+ *  `outcome` is the firing's own `RuleFiredEvent.outcome`; `label` is the paired `HumanOverrideEvent.verdict`
+ *  (`"reversed"` = the rule was wrong that time, `"confirmed"` = it was right); `firedAt`/`decidedAt` are the
+ *  two events' `occurredAt`. `metadata` carries the firing's own metadata, omitted entirely (never set to
+ *  `undefined`) when the firing has none -- the same optional-property discipline `RuleFiredEvent` uses. */
+export type BacktestCase = {
+  ruleId: string;
+  targetKey: string;
+  outcome: string;
+  label: "reversed" | "confirmed";
+  firedAt: string;
+  decidedAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Build a labeled {@link BacktestCase} corpus for `ruleId` from its fired + override events. Only events whose
+ * `ruleId` matches the argument are considered (mirrors `overrideMatchesRule` in signal-tracking.ts:
+ * `event.ruleId === ruleId`); a caller MAY pass a mixed-rule list without filtering first.
+ *
+ * A firing with no matching override (same rule AND same `targetKey`) is EXCLUDED, not emitted as an
+ * unlabeled case -- the same "only the decided ones count" discipline as {@link computeRulePrecision}.
+ *
+ * Pairing when a `targetKey` was fired + judged more than once: each firing takes the override whose
+ * `occurredAt` is the nearest one STRICTLY AFTER that firing; if no override strictly follows it, the most
+ * recent override by `occurredAt` is used. Each firing yields at most one case (no duplicates for one firing).
+ */
+export function buildBacktestCorpus(
+  ruleId: string,
+  fired: readonly RuleFiredEvent[],
+  overrides: readonly HumanOverrideEvent[],
+): BacktestCase[] {
+  // Mirrors overrideMatchesRule's one-line filter (event.ruleId === ruleId) in signal-tracking.ts.
+  const ruleOverrides = overrides.filter((override) => override.ruleId === ruleId);
+  const cases: BacktestCase[] = [];
+  for (const firing of fired) {
+    if (firing.ruleId !== ruleId) continue;
+    const candidates = ruleOverrides.filter((override) => override.targetKey === firing.targetKey);
+    if (candidates.length === 0) continue;
+    const firedMs = Date.parse(firing.occurredAt);
+    // candidates ascending by time: the first one strictly after the firing is the nearest-following match;
+    // when none follows, sorted[last] is the most-recent override overall (the documented fallback).
+    const sorted = [...candidates].sort((a, b) => Date.parse(a.occurredAt) - Date.parse(b.occurredAt));
+    const decided = sorted.find((override) => Date.parse(override.occurredAt) > firedMs) ?? sorted[sorted.length - 1]!;
+    const backtestCase: BacktestCase = {
+      ruleId,
+      targetKey: firing.targetKey,
+      outcome: firing.outcome,
+      label: decided.verdict,
+      firedAt: firing.occurredAt,
+      decidedAt: decided.occurredAt,
+    };
+    if (firing.metadata !== undefined) backtestCase.metadata = firing.metadata;
+    cases.push(backtestCase);
+  }
+  return cases;
+}

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -163,6 +163,7 @@ export * from "./governor/kill-switch.js";
 export * from "./governor/action-mode.js";
 export * from "./governor/chokepoint.js";
 export * from "./calibration/signal-tracking.js";
+export * from "./calibration/backtest-corpus.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/packages/loopover-engine/test/backtest-corpus.test.ts
+++ b/packages/loopover-engine/test/backtest-corpus.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildBacktestCorpus, type BacktestCase, type HumanOverrideEvent, type RuleFiredEvent } from "../dist/index.js";
+
+const RULE = "missing_linked_issue";
+
+function fired(targetKey: string, overrides: Partial<RuleFiredEvent> = {}): RuleFiredEvent {
+  return { ruleId: RULE, targetKey, outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+function override(
+  targetKey: string,
+  verdict: HumanOverrideEvent["verdict"],
+  overrides: Partial<HumanOverrideEvent> = {},
+): HumanOverrideEvent {
+  return { ruleId: RULE, targetKey, verdict, occurredAt: "2026-07-22T01:00:00.000Z", ...overrides };
+}
+
+test("barrel: the public entrypoint re-exports buildBacktestCorpus (#8083)", () => {
+  assert.equal(typeof buildBacktestCorpus, "function");
+});
+
+test("buildBacktestCorpus: a fired event with no matching override is excluded (only decided cases count)", () => {
+  const corpus = buildBacktestCorpus(RULE, [fired("a#1"), fired("a#2")], [override("a#1", "confirmed")]);
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.targetKey, "a#1");
+});
+
+test("buildBacktestCorpus: a single fired+override pair produces one correctly-labeled case", () => {
+  const corpus = buildBacktestCorpus(
+    RULE,
+    [fired("a#1", { outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", metadata: { pr: 1 } })],
+    [override("a#1", "reversed", { occurredAt: "2026-07-22T02:00:00.000Z" })],
+  );
+  assert.deepEqual(corpus, [
+    {
+      ruleId: RULE,
+      targetKey: "a#1",
+      outcome: "block",
+      label: "reversed",
+      firedAt: "2026-07-22T00:00:00.000Z",
+      decidedAt: "2026-07-22T02:00:00.000Z",
+      metadata: { pr: 1 },
+    } satisfies BacktestCase,
+  ]);
+});
+
+test("buildBacktestCorpus: metadata is omitted entirely (not undefined) when the fired event has none", () => {
+  const corpus = buildBacktestCorpus(RULE, [fired("a#1")], [override("a#1", "confirmed")]);
+  assert.equal("metadata" in corpus[0]!, false);
+});
+
+test("buildBacktestCorpus: multiple overrides -> the firing pairs with the nearest override strictly after it", () => {
+  const corpus = buildBacktestCorpus(
+    RULE,
+    [fired("a#1", { occurredAt: "2026-07-22T00:00:00.000Z" })],
+    [
+      override("a#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+      override("a#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+      override("a#1", "confirmed", { occurredAt: "2026-07-21T23:00:00.000Z" }),
+    ],
+  );
+  // The 01:00 override is the nearest one strictly after the 00:00 firing -> label "reversed".
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.label, "reversed");
+  assert.equal(corpus[0]!.decidedAt, "2026-07-22T01:00:00.000Z");
+});
+
+test("buildBacktestCorpus: when no override strictly follows the firing, the most recent override is used", () => {
+  const corpus = buildBacktestCorpus(
+    RULE,
+    [fired("a#1", { occurredAt: "2026-07-22T05:00:00.000Z" })],
+    [
+      override("a#1", "reversed", { occurredAt: "2026-07-22T02:00:00.000Z" }),
+      override("a#1", "confirmed", { occurredAt: "2026-07-22T04:00:00.000Z" }),
+    ],
+  );
+  // Both overrides precede the 05:00 firing -> fall back to the most recent (04:00, "confirmed").
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.label, "confirmed");
+  assert.equal(corpus[0]!.decidedAt, "2026-07-22T04:00:00.000Z");
+});
+
+test("buildBacktestCorpus: two firings for the same target each yield their own case (no duplicate for one firing)", () => {
+  const corpus = buildBacktestCorpus(
+    RULE,
+    [fired("a#1", { occurredAt: "2026-07-22T00:00:00.000Z" }), fired("a#1", { occurredAt: "2026-07-22T02:30:00.000Z" })],
+    [
+      override("a#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+      override("a#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+    ],
+  );
+  assert.equal(corpus.length, 2);
+  assert.deepEqual(corpus.map((c) => c.decidedAt), ["2026-07-22T01:00:00.000Z", "2026-07-22T03:00:00.000Z"]);
+});
+
+test("buildBacktestCorpus: fired and override events for a different ruleId are ignored", () => {
+  const corpus = buildBacktestCorpus(
+    RULE,
+    [fired("a#1"), { ruleId: "other_rule", targetKey: "a#1", outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z" }],
+    [override("a#1", "confirmed"), { ruleId: "other_rule", targetKey: "a#1", verdict: "reversed", occurredAt: "2026-07-22T01:00:00.000Z" }],
+  );
+  assert.equal(corpus.length, 1);
+  assert.equal(corpus[0]!.ruleId, RULE);
+  assert.equal(corpus[0]!.label, "confirmed");
+});
+
+test("buildBacktestCorpus: empty input arrays produce an empty corpus", () => {
+  assert.deepEqual(buildBacktestCorpus(RULE, [], []), []);
+});

--- a/test/unit/backtest-corpus.test.ts
+++ b/test/unit/backtest-corpus.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+// Direct src-path import (not the `@loopover/engine` package barrel, which resolves to dist and is NOT in
+// vitest's coverage.include): the engine's own node:test suite runs against dist and is invisible to Codecov
+// (only review-enrichment has a c8 dist-remap harvest step; the engine has none), so this vitest test is what
+// gives packages/loopover-engine/src/calibration/backtest-corpus.ts its codecov/patch coverage. The companion
+// packages/loopover-engine/test/backtest-corpus.test.ts is the issue-required node:test that gates the engine
+// workspace's own `npm run test`. Vite resolves the `.js` specifier to the sibling `.ts` on disk.
+import { buildBacktestCorpus } from "../../packages/loopover-engine/src/calibration/backtest-corpus.js";
+import type { BacktestCase } from "../../packages/loopover-engine/src/calibration/backtest-corpus.js";
+import type { HumanOverrideEvent, RuleFiredEvent } from "../../packages/loopover-engine/src/calibration/signal-tracking.js";
+
+const RULE = "missing_linked_issue";
+
+function fired(targetKey: string, overrides: Partial<RuleFiredEvent> = {}): RuleFiredEvent {
+  return { ruleId: RULE, targetKey, outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+function override(targetKey: string, verdict: HumanOverrideEvent["verdict"], overrides: Partial<HumanOverrideEvent> = {}): HumanOverrideEvent {
+  return { ruleId: RULE, targetKey, verdict, occurredAt: "2026-07-22T01:00:00.000Z", ...overrides };
+}
+
+describe("buildBacktestCorpus (#8083)", () => {
+  it("excludes a fired event with no matching override (only decided cases count)", () => {
+    const corpus = buildBacktestCorpus(RULE, [fired("a#1"), fired("a#2")], [override("a#1", "confirmed")]);
+    expect(corpus.map((c) => c.targetKey)).toEqual(["a#1"]);
+  });
+
+  it("produces one correctly-labeled case for a single fired+override pair, carrying metadata through", () => {
+    const corpus = buildBacktestCorpus(
+      RULE,
+      [fired("a#1", { occurredAt: "2026-07-22T00:00:00.000Z", metadata: { pr: 1 } })],
+      [override("a#1", "reversed", { occurredAt: "2026-07-22T02:00:00.000Z" })],
+    );
+    expect(corpus).toEqual([
+      {
+        ruleId: RULE,
+        targetKey: "a#1",
+        outcome: "block",
+        label: "reversed",
+        firedAt: "2026-07-22T00:00:00.000Z",
+        decidedAt: "2026-07-22T02:00:00.000Z",
+        metadata: { pr: 1 },
+      } satisfies BacktestCase,
+    ]);
+  });
+
+  it("omits metadata entirely (never sets it to undefined) when the fired event has none", () => {
+    const corpus = buildBacktestCorpus(RULE, [fired("a#1")], [override("a#1", "confirmed")]);
+    expect("metadata" in corpus[0]!).toBe(false);
+  });
+
+  it("pairs a firing with the nearest override strictly after it when a target was judged multiple times", () => {
+    const corpus = buildBacktestCorpus(
+      RULE,
+      [fired("a#1", { occurredAt: "2026-07-22T00:00:00.000Z" })],
+      [
+        override("a#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+        override("a#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+        override("a#1", "confirmed", { occurredAt: "2026-07-21T23:00:00.000Z" }),
+      ],
+    );
+    expect(corpus).toHaveLength(1);
+    expect(corpus[0]!.label).toBe("reversed");
+    expect(corpus[0]!.decidedAt).toBe("2026-07-22T01:00:00.000Z");
+  });
+
+  it("falls back to the most recent override when none strictly follows the firing", () => {
+    const corpus = buildBacktestCorpus(
+      RULE,
+      [fired("a#1", { occurredAt: "2026-07-22T05:00:00.000Z" })],
+      [
+        override("a#1", "reversed", { occurredAt: "2026-07-22T02:00:00.000Z" }),
+        override("a#1", "confirmed", { occurredAt: "2026-07-22T04:00:00.000Z" }),
+      ],
+    );
+    expect(corpus[0]!.label).toBe("confirmed");
+    expect(corpus[0]!.decidedAt).toBe("2026-07-22T04:00:00.000Z");
+  });
+
+  it("gives each of two firings for the same target its own case (no duplicate for one firing)", () => {
+    const corpus = buildBacktestCorpus(
+      RULE,
+      [fired("a#1", { occurredAt: "2026-07-22T00:00:00.000Z" }), fired("a#1", { occurredAt: "2026-07-22T02:30:00.000Z" })],
+      [
+        override("a#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+        override("a#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+      ],
+    );
+    expect(corpus.map((c) => c.decidedAt)).toEqual(["2026-07-22T01:00:00.000Z", "2026-07-22T03:00:00.000Z"]);
+  });
+
+  it("ignores fired and override events for a different ruleId", () => {
+    const corpus = buildBacktestCorpus(
+      RULE,
+      [fired("a#1"), { ruleId: "other_rule", targetKey: "a#1", outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z" }],
+      [override("a#1", "confirmed"), { ruleId: "other_rule", targetKey: "a#1", verdict: "reversed", occurredAt: "2026-07-22T01:00:00.000Z" }],
+    );
+    expect(corpus).toHaveLength(1);
+    expect(corpus[0]!).toMatchObject({ ruleId: RULE, label: "confirmed" });
+  });
+
+  it("returns an empty corpus for empty input arrays", () => {
+    expect(buildBacktestCorpus(RULE, [], [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #8083: adds `packages/loopover-engine/src/calibration/backtest-corpus.ts` — a pure, storage-agnostic builder that turns the calibration module's raw `RuleFiredEvent`/`HumanOverrideEvent` history into a labeled `BacktestCase[]` corpus (each "this rule fired against this target, a human later said reversed/confirmed" pair), the replayable input a backtest scorer needs.
- `BacktestCase` and `buildBacktestCorpus(ruleId, fired, overrides)` match the issue spec exactly: only events whose `ruleId` matches are considered (mirrors `overrideMatchesRule`'s `event.ruleId === ruleId` filter in `signal-tracking.ts`); a firing with no matching override (same rule AND `targetKey`) is excluded, not emitted unlabeled (the same "only the decided ones count" discipline as `computeRulePrecision`); when a target was fired+judged more than once, each firing pairs with the nearest override strictly after it, else the most recent override; `metadata` is omitted entirely (never set to `undefined`) when the firing has none, honoring the package's `exactOptionalPropertyTypes` discipline. Pure — no IO/DB/env/clock (`Date.parse` on the events' own `occurredAt` strings is deterministic parsing, not a clock read).
- Added `export * from "./calibration/backtest-corpus.js";` to `packages/loopover-engine/src/index.ts`, on its own line immediately after the existing `signal-tracking.js` export, as specified. Additive only — no existing consumer changes, `signal-tracking.ts` untouched.

## Tests

Two test files, deliberately — this repo's engine coverage architecture requires it:

- `packages/loopover-engine/test/backtest-corpus.test.ts` — the issue-required `node:test` file, mirroring the `signal-tracking.test.ts` precedent from #8079; it gates the engine workspace's own `npm run test --workspace @loopover/engine` (all 615 engine tests pass). This suite runs against `dist` and is invisible to Codecov.
- `test/unit/backtest-corpus.test.ts` — a vitest unit test importing the engine **src** path directly, which is what provides `codecov/patch` coverage: vitest's `coverage.include` measures `packages/loopover-engine/src/**`, but the engine's `node:test` suite runs against `dist` with no c8/source-map harvest step (only review-enrichment has one — see `ci.yml`'s REES coverage note), so a `node:test`-only file would report 0% to Codecov. This vitest test independently exercises every branch (has/no override; single/multiple overrides incl. the no-strictly-following fallback; matching/non-matching `ruleId`; present/absent `metadata`; empty input) — **100% of the diff's lines and branches, verified locally via `npm run test:coverage`**.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The `@loopover/engine` build + its 615-test `node:test` suite, whole-repo `typecheck`, `test:engine-parity`, `engine-parity:drift-check`, `docs:drift-check`, and the unsharded `test:coverage` (confirming 100% patch coverage on the new file) were all run and pass. This change is a single pure, self-contained new engine file plus one additive barrel-export line and two test files — it touches no API/OpenAPI, migration, generated artifact, command, setting, or dependency, so the remaining `test:ci` steps (workers, mcp/miner packs, ui:build, db/drift checks) cannot be affected by it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a pure calibration-engine function with no visible UI, frontend, docs, or extension change.

## Notes

- Foundation-only, per the issue: `buildBacktestCorpus` has no consumer yet (the scorer/export/split/report siblings are #8084–#8088). No behavior change to any existing code path.
