### PR TITLE
feat(engine): build a labeled backtest corpus from rule-fired and human-override history

### DIFF
--- a/packages/loopover-engine/src/calibration/backtest-corpus.ts
+++ b/packages/loopover-engine/src/calibration/backtest-corpus.ts
@@ -1,0 +1,88 @@
+// Labeled backtest corpus builder (#8083, parent epic #8082) -- turns the calibration module's raw
+// RuleFiredEvent/HumanOverrideEvent history into the per-case labeled records a backtest needs. Where
+// computeRulePrecision (signal-tracking.ts) aggregates the SAME pairing into one precision number, this
+// keeps each paired firing as an individual replayable case: "this rule fired against this target, and a
+// human later said it was right/wrong."
+//
+// SELF-CONTAINED AND PURE, like everything in this module: no IO, no DB, no env -- only the existing
+// event types from signal-tracking.ts. Additive-only; no existing consumer changes behavior.
+
+import type { HumanOverrideEvent, RuleFiredEvent } from "./signal-tracking.js";
+
+/** One labeled, replayable backtest case: a specific rule firing plus the human verdict it eventually got.
+ *  `outcome` is the fired event's outcome; `label` is the override's verdict; `firedAt`/`decidedAt` carry the
+ *  two events' own timestamps. `metadata` is the FIRED event's metadata, omitted entirely (not set to
+ *  `undefined`) when the fired event has none -- the same optional-property discipline RuleFiredEvent uses. */
+export type BacktestCase = {
+  ruleId: string;
+  targetKey: string;
+  outcome: string;
+  label: "reversed" | "confirmed";
+  firedAt: string;
+  decidedAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Build the labeled corpus for `ruleId` from its fired + override events. A fired event pairs with an
+ * override when both carry the function's `ruleId` AND the same `targetKey`; a fired event with no matching
+ * override is EXCLUDED (not emitted as an unlabeled case) -- mirrors computeRulePrecision's "only the
+ * decided ones count" discipline (see that function's own doc comment in signal-tracking.ts).
+ *
+ * Pairing rule when a target has MULTIPLE overrides for the same rule (re-fired and re-judged more than
+ * once): each fired event pairs with the override whose `occurredAt` is closest in time strictly AFTER that
+ * specific fired event's `occurredAt`; when none strictly follows it, it falls back to the most recent
+ * override by `occurredAt`. Each fired event produces at most one BacktestCase -- never duplicates.
+ */
+export function buildBacktestCorpus(
+  ruleId: string,
+  fired: readonly RuleFiredEvent[],
+  overrides: readonly HumanOverrideEvent[],
+): BacktestCase[] {
+  // Mirrors overrideMatchesRule's one-line filter in signal-tracking.ts (kept private there; this module is
+  // additive-only and must not modify that file to export it).
+  const matchingOverrides = overrides.filter((event) => event.ruleId === ruleId);
+
+  const cases: BacktestCase[] = [];
+  for (const event of fired) {
+    if (event.ruleId !== ruleId) continue;
+    const candidates = matchingOverrides.filter((override) => override.targetKey === event.targetKey);
+    if (candidates.length === 0) continue;
+
+    const firedAtMs = Date.parse(event.occurredAt);
+    let paired: HumanOverrideEvent | undefined;
+    let pairedDeltaMs = Number.POSITIVE_INFINITY;
+    for (const override of candidates) {
+      const deltaMs = Date.parse(override.occurredAt) - firedAtMs;
+      if (deltaMs > 0 && deltaMs < pairedDeltaMs) {
+        paired = override;
+        pairedDeltaMs = deltaMs;
+      }
+    }
+    if (!paired) {
+      // No override strictly follows this firing -- fall back to the most recent override by occurredAt.
+      let latestMs = Number.NEGATIVE_INFINITY;
+      for (const override of candidates) {
+        const occurredMs = Date.parse(override.occurredAt);
+        if (occurredMs > latestMs) {
+          paired = override;
+          latestMs = occurredMs;
+        }
+      }
+    }
+
+    // `paired` is always set here: candidates is non-empty and the fallback scans every candidate with a
+    // strictly-greater-than comparison against -Infinity.
+    const pairedOverride = paired as HumanOverrideEvent;
+    cases.push({
+      ruleId: event.ruleId,
+      targetKey: event.targetKey,
+      outcome: event.outcome,
+      label: pairedOverride.verdict,
+      firedAt: event.occurredAt,
+      decidedAt: pairedOverride.occurredAt,
+      ...(event.metadata !== undefined ? { metadata: event.metadata } : {}),
+    });
+  }
+  return cases;
+}

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -163,6 +163,7 @@ export * from "./governor/kill-switch.js";
 export * from "./governor/action-mode.js";
 export * from "./governor/chokepoint.js";
 export * from "./calibration/signal-tracking.js";
+export * from "./calibration/backtest-corpus.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/packages/loopover-engine/test/backtest-corpus.test.ts
+++ b/packages/loopover-engine/test/backtest-corpus.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildBacktestCorpus, type BacktestCase, type HumanOverrideEvent, type RuleFiredEvent } from "../dist/index.js";
+
+// #8083: buildBacktestCorpus pairs each rule firing with its human verdict into a labeled, replayable
+// BacktestCase. Mirrors signal-tracking.test.ts's fixture style; the pairing rule under test is the
+// nearest-strictly-following override, falling back to the most recent when none follows.
+
+function fired(ruleId: string, targetKey: string, overrides: Partial<RuleFiredEvent> = {}): RuleFiredEvent {
+  return { ruleId, targetKey, outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+function override(
+  ruleId: string,
+  targetKey: string,
+  verdict: HumanOverrideEvent["verdict"],
+  overrides: Partial<HumanOverrideEvent> = {},
+): HumanOverrideEvent {
+  return { ruleId, targetKey, verdict, occurredAt: "2026-07-22T01:00:00.000Z", ...overrides };
+}
+
+test("barrel: the public entrypoint re-exports the backtest-corpus builder (#8083)", () => {
+  assert.equal(typeof buildBacktestCorpus, "function");
+});
+
+test("a single fired+override pair produces one correctly-labeled case", () => {
+  const corpus = buildBacktestCorpus(
+    "missing_linked_issue",
+    [fired("missing_linked_issue", "a/r#1", { metadata: { headSha: "abc" } })],
+    [override("missing_linked_issue", "a/r#1", "reversed")],
+  );
+  assert.deepEqual(corpus, [
+    {
+      ruleId: "missing_linked_issue",
+      targetKey: "a/r#1",
+      outcome: "block",
+      label: "reversed",
+      firedAt: "2026-07-22T00:00:00.000Z",
+      decidedAt: "2026-07-22T01:00:00.000Z",
+      metadata: { headSha: "abc" },
+    } satisfies BacktestCase,
+  ]);
+});
+
+test("a fired event with no matching override is excluded, not emitted unlabeled", () => {
+  const corpus = buildBacktestCorpus(
+    "missing_linked_issue",
+    [fired("missing_linked_issue", "a/r#1"), fired("missing_linked_issue", "a/r#2")],
+    [override("missing_linked_issue", "a/r#2", "confirmed")],
+  );
+  assert.deepEqual(
+    corpus.map((backtestCase) => backtestCase.targetKey),
+    ["a/r#2"],
+  );
+});
+
+test("metadata is omitted entirely (not set to undefined) when the fired event has none", () => {
+  const [backtestCase] = buildBacktestCorpus(
+    "missing_linked_issue",
+    [fired("missing_linked_issue", "a/r#1")],
+    [override("missing_linked_issue", "a/r#1", "confirmed")],
+  );
+  assert.equal(Object.hasOwn(backtestCase!, "metadata"), false);
+});
+
+test("multiple overrides for one target pair each firing with the nearest strictly-following override", () => {
+  const corpus = buildBacktestCorpus(
+    "rule",
+    [
+      fired("rule", "a/r#1", { occurredAt: "2026-07-22T00:00:00.000Z" }),
+      fired("rule", "a/r#1", { occurredAt: "2026-07-22T02:00:00.000Z" }),
+    ],
+    [
+      override("rule", "a/r#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+      override("rule", "a/r#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+    ],
+  );
+  assert.deepEqual(
+    corpus.map((backtestCase) => [backtestCase.label, backtestCase.decidedAt]),
+    [
+      ["reversed", "2026-07-22T01:00:00.000Z"],
+      ["confirmed", "2026-07-22T03:00:00.000Z"],
+    ],
+  );
+});
+
+test("a firing with no strictly-following override falls back to the most recent override", () => {
+  const corpus = buildBacktestCorpus(
+    "rule",
+    [fired("rule", "a/r#1", { occurredAt: "2026-07-22T05:00:00.000Z" })],
+    [
+      override("rule", "a/r#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+      override("rule", "a/r#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+    ],
+  );
+  assert.deepEqual(
+    corpus.map((backtestCase) => [backtestCase.label, backtestCase.decidedAt]),
+    [["confirmed", "2026-07-22T03:00:00.000Z"]],
+  );
+});
+
+test("an override at exactly the firing's own instant does not count as strictly following", () => {
+  const corpus = buildBacktestCorpus(
+    "rule",
+    [fired("rule", "a/r#1", { occurredAt: "2026-07-22T02:00:00.000Z" })],
+    [
+      override("rule", "a/r#1", "confirmed", { occurredAt: "2026-07-22T02:00:00.000Z" }),
+      override("rule", "a/r#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+    ],
+  );
+  // Neither override strictly follows, so the most recent one (02:00, "confirmed") wins the fallback.
+  assert.deepEqual(
+    corpus.map((backtestCase) => [backtestCase.label, backtestCase.decidedAt]),
+    [["confirmed", "2026-07-22T02:00:00.000Z"]],
+  );
+});
+
+test("events for a different ruleId are ignored on both sides", () => {
+  const corpus = buildBacktestCorpus(
+    "rule",
+    [fired("other_rule", "a/r#1"), fired("rule", "a/r#2")],
+    [override("rule", "a/r#1", "reversed"), override("other_rule", "a/r#2", "reversed"), override("rule", "a/r#2", "confirmed")],
+  );
+  assert.deepEqual(
+    corpus.map((backtestCase) => [backtestCase.targetKey, backtestCase.label]),
+    [["a/r#2", "confirmed"]],
+  );
+});
+
+test("empty input arrays produce an empty corpus", () => {
+  assert.deepEqual(buildBacktestCorpus("rule", [], []), []);
+  assert.deepEqual(buildBacktestCorpus("rule", [fired("rule", "a/r#1")], []), []);
+  assert.deepEqual(buildBacktestCorpus("rule", [], [override("rule", "a/r#1", "reversed")]), []);
+});

--- a/test/unit/backtest-corpus.test.ts
+++ b/test/unit/backtest-corpus.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBacktestCorpus,
+  type BacktestCase,
+} from "../../packages/loopover-engine/src/calibration/backtest-corpus.js";
+import type { HumanOverrideEvent, RuleFiredEvent } from "../../packages/loopover-engine/src/calibration/signal-tracking.js";
+
+// #8083: root-side coverage twin of packages/loopover-engine/test/backtest-corpus.test.ts. The engine
+// package's own node:test suite runs against dist/ (not instrumented by the root vitest coverage that
+// Codecov gates on), so this file exercises the SAME contract directly against the engine src — the same
+// direct-src import pattern test/contract/*-parity.test.ts and test/integration/miner-*.test.ts already use.
+
+function fired(ruleId: string, targetKey: string, overrides: Partial<RuleFiredEvent> = {}): RuleFiredEvent {
+  return { ruleId, targetKey, outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+function override(
+  ruleId: string,
+  targetKey: string,
+  verdict: HumanOverrideEvent["verdict"],
+  overrides: Partial<HumanOverrideEvent> = {},
+): HumanOverrideEvent {
+  return { ruleId, targetKey, verdict, occurredAt: "2026-07-22T01:00:00.000Z", ...overrides };
+}
+
+describe("buildBacktestCorpus (#8083)", () => {
+  it("pairs a single fired+override into one labeled case, carrying outcome, timestamps, and metadata", () => {
+    const corpus = buildBacktestCorpus(
+      "missing_linked_issue",
+      [fired("missing_linked_issue", "a/r#1", { outcome: "exclude", metadata: { headSha: "abc" } })],
+      [override("missing_linked_issue", "a/r#1", "reversed")],
+    );
+    expect(corpus).toEqual([
+      {
+        ruleId: "missing_linked_issue",
+        targetKey: "a/r#1",
+        outcome: "exclude",
+        label: "reversed",
+        firedAt: "2026-07-22T00:00:00.000Z",
+        decidedAt: "2026-07-22T01:00:00.000Z",
+        metadata: { headSha: "abc" },
+      } satisfies BacktestCase,
+    ]);
+  });
+
+  it("excludes fired events with no matching override — only the decided ones count", () => {
+    const corpus = buildBacktestCorpus(
+      "rule",
+      [fired("rule", "a/r#1"), fired("rule", "a/r#2")],
+      [override("rule", "a/r#2", "confirmed")],
+    );
+    expect(corpus.map((backtestCase) => backtestCase.targetKey)).toEqual(["a/r#2"]);
+  });
+
+  it("omits the metadata key entirely when the fired event has none", () => {
+    const [backtestCase] = buildBacktestCorpus(
+      "rule",
+      [fired("rule", "a/r#1")],
+      [override("rule", "a/r#1", "confirmed")],
+    );
+    expect(Object.hasOwn(backtestCase!, "metadata")).toBe(false);
+  });
+
+  it("pairs each firing with the nearest strictly-following override when a target was judged repeatedly", () => {
+    const corpus = buildBacktestCorpus(
+      "rule",
+      [
+        fired("rule", "a/r#1", { occurredAt: "2026-07-22T00:00:00.000Z" }),
+        fired("rule", "a/r#1", { occurredAt: "2026-07-22T02:00:00.000Z" }),
+      ],
+      [
+        override("rule", "a/r#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+        override("rule", "a/r#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+      ],
+    );
+    expect(corpus.map((backtestCase) => [backtestCase.label, backtestCase.decidedAt])).toEqual([
+      ["reversed", "2026-07-22T01:00:00.000Z"],
+      ["confirmed", "2026-07-22T03:00:00.000Z"],
+    ]);
+  });
+
+  it("falls back to the most recent override when none strictly follows the firing (equal instants included)", () => {
+    const late = buildBacktestCorpus(
+      "rule",
+      [fired("rule", "a/r#1", { occurredAt: "2026-07-22T05:00:00.000Z" })],
+      [
+        override("rule", "a/r#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+        override("rule", "a/r#1", "confirmed", { occurredAt: "2026-07-22T03:00:00.000Z" }),
+      ],
+    );
+    expect(late.map((backtestCase) => backtestCase.decidedAt)).toEqual(["2026-07-22T03:00:00.000Z"]);
+
+    const equalInstant = buildBacktestCorpus(
+      "rule",
+      [fired("rule", "a/r#1", { occurredAt: "2026-07-22T02:00:00.000Z" })],
+      [
+        override("rule", "a/r#1", "confirmed", { occurredAt: "2026-07-22T02:00:00.000Z" }),
+        override("rule", "a/r#1", "reversed", { occurredAt: "2026-07-22T01:00:00.000Z" }),
+      ],
+    );
+    expect(equalInstant.map((backtestCase) => backtestCase.label)).toEqual(["confirmed"]);
+  });
+
+  it("ignores events for a different ruleId on both the fired and override sides", () => {
+    const corpus = buildBacktestCorpus(
+      "rule",
+      [fired("other_rule", "a/r#1"), fired("rule", "a/r#2")],
+      [override("rule", "a/r#1", "reversed"), override("other_rule", "a/r#2", "reversed"), override("rule", "a/r#2", "confirmed")],
+    );
+    expect(corpus.map((backtestCase) => [backtestCase.targetKey, backtestCase.label])).toEqual([["a/r#2", "confirmed"]]);
+  });
+
+  it("produces an empty corpus for empty inputs in every combination", () => {
+    expect(buildBacktestCorpus("rule", [], [])).toEqual([]);
+    expect(buildBacktestCorpus("rule", [fired("rule", "a/r#1")], [])).toEqual([]);
+    expect(buildBacktestCorpus("rule", [], [override("rule", "a/r#1", "reversed")])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8083.

Adds `packages/loopover-engine/src/calibration/backtest-corpus.ts` — the labeled backtest corpus builder the parent epic (#8082) needs: where `computeRulePrecision` (signal-tracking.ts) aggregates fired/override pairs into one precision number, `buildBacktestCorpus(ruleId, fired, overrides)` keeps each paired firing as an individual replayable `BacktestCase` ("this rule fired against this target, and a human later said it was right/wrong").

Everything follows the issue's spec exactly:

- **Pure and self-contained** — no IO, no DB, no env, no imports beyond `signal-tracking.ts`'s existing event types.
- **`BacktestCase`** exactly as specified; `metadata` is the fired event's metadata, **omitted entirely** (never set to `undefined`) when absent — the same optional-property discipline `RuleFiredEvent` uses.
- **Pairing rule** (documented in the function's doc comment, `computeRulePrecision`-style): a firing pairs with the override sharing the function's `ruleId` and the same `targetKey`, choosing the override closest in time **strictly after** that firing; when none strictly follows, the most recent override by `occurredAt`. One case per fired event, never duplicates. Unmatched firings are **excluded** — mirrors `computeRulePrecision`'s "only the decided ones count" discipline.
- **ruleId filtering** mirrors `overrideMatchesRule`'s one-line filter with a comment noting the mirror; `signal-tracking.ts` itself is untouched (additive-only, per the issue's boundary).
- **Barrel export** added on its own line immediately after the existing `signal-tracking.js` export in `packages/loopover-engine/src/index.ts`, exactly where the issue specifies.

Tests land in **both** suites:
- `packages/loopover-engine/test/backtest-corpus.test.ts` (the issue's mandated file, mirroring `signal-tracking.test.ts`'s fixture style) — all five specified cases plus the equal-instant boundary of "strictly follows".
- `test/unit/backtest-corpus.test.ts` — a root-side vitest twin importing the engine src directly (the same direct-src pattern `test/contract/*-parity.test.ts` and `test/integration/miner-*.test.ts` already use). The engine package's own `node --test` suite runs against `dist/` outside root vitest's coverage instrumentation, so this twin is what makes the new file's coverage visible to the `codecov/patch` gate rather than reporting 0%.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Instead of the full unsharded `test:coverage` (30+ min on this machine), I ran the directly-affected suites: `npm run build --workspace @loopover/engine` (green) + the engine package's `node --test` on the new test file (9/9) + root vitest on the new twin with coverage (7/7), and **measured patch coverage empirically by intersecting `coverage/lcov.info` `DA`/`BRDA` records with `git diff -U0` against `upstream/main`: 100% of changed lines and branches in `backtest-corpus.ts`** (both sides of every conditional: has-override vs no-override, single vs multiple overrides including the no-strictly-following fallback, matching vs non-matching `ruleId`, present vs absent `metadata`).
- `actionlint`/`test:workers`/`build:mcp`/`test:mcp-pack`/`ui:*`/`npm audit`: untouched surfaces — the diff is one new engine src file, one barrel-export line, and two test files; no workflows, workers, mcp, UI, or dependency changes (audit's current moderate findings exist on `upstream/main` itself).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The three unchecked Safety boxes are N/A: no auth/session/UI change of any kind — a pure, additive engine module plus tests.

## UI Evidence

N/A — no UI change (pure engine module).

## Notes

- The equal-instant boundary ("an override at exactly the firing's own instant does not count as strictly following — the fallback picks it as most-recent") is pinned by its own test in both suites, since it's the one spot where the two halves of the pairing rule meet.
