### PR TITLE
feat(review): wire linked_issue_scope_mismatch into the shared signal-tracking module

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -265,6 +265,7 @@ import {
 } from "../selfhost/queue-common";
 import { aiReviewCacheInputFingerprint } from "../review/ai-review-cache-input";
 import { linkedIssueSatisfactionCacheInputFingerprint } from "../review/linked-issue-satisfaction-cache-input";
+import { createSignalStore } from "../review/signal-tracking-wire";
 import {
   AGENT_LABEL_NEEDS_REVIEW,
   downgradeCloseToHold,
@@ -7531,6 +7532,20 @@ export async function runLinkedIssueSatisfactionForAdvisory(
         action: "Confirm this PR actually addresses the linked issue's scope, or link the correct issue.",
         publicText: `AI assessment: this PR does not appear to satisfy its linked issue's scope. ${result.result.rationale}`,
       });
+      // #8101: this AI judgment carries gate authority in block mode, so record the firing in the shared
+      // calibration module (#7982) — the fired/override history is what the self-correction pipeline
+      // (#7983/#7984) and the backtest primitives (#8083-#8086) consume. Recorded ONLY here: advisory mode
+      // never pushes the finding, so it never records either. Best-effort like the cache-write handling
+      // above and SignalStore's own contract — a recording failure must never fail the review pass.
+      await createSignalStore(env)
+        .recordRuleFired({
+          ruleId: "linked_issue_scope_mismatch",
+          targetKey: `${args.repoFullName}#${args.pr.number}`,
+          outcome: result.result.status,
+          occurredAt: nowIso(),
+          metadata: { confidence: result.result.confidence },
+        })
+        .catch(() => undefined);
     }
     return { status: result.result.status, rationale: result.result.rationale };
   } catch (error) {

--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -24,6 +24,7 @@
 // once a repo's merge precision actually drops below the floor over a real sample.
 
 import { recordAuditEvent } from "../db/repositories";
+import { createSignalStore } from "./signal-tracking-wire";
 import { tryEnqueueDecisionPackRebuild } from "../services/decision-pack";
 import { incr } from "../selfhost/metrics";
 import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
@@ -447,6 +448,32 @@ async function hasRecentOwnerReopenPendingReversal(env: Env, targetKey: string, 
   }
 }
 
+// #8101: when a reversal is recorded for a target that a `linked_issue_scope_mismatch` finding fired
+// against (fixed 30-day lookback), the human undoing of the bot action IS the human judgment on that
+// finding — record a "reversed" HumanOverrideEvent in the shared calibration module (#7982) so the
+// self-correction pipeline and the backtest primitives see it. Only this one rule and only the reversal
+// direction are wired (no "confirmed" signal exists anywhere in this codebase to mirror — see the issue's
+// Boundaries). Callers attach `.catch(() => undefined)`: like every write in this file, a SignalStore
+// failure (including a queryRuleHistory read error, which deliberately propagates) must never affect
+// whether the underlying reversal itself is recorded.
+const LINKED_ISSUE_SCOPE_MISMATCH_RULE_ID = "linked_issue_scope_mismatch";
+const LINKED_ISSUE_SCOPE_MISMATCH_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+
+async function recordLinkedIssueScopeMismatchOverride(env: Env, targetId: string): Promise<void> {
+  const store = createSignalStore(env);
+  const history = await store.queryRuleHistory(
+    LINKED_ISSUE_SCOPE_MISMATCH_RULE_ID,
+    Date.now() - LINKED_ISSUE_SCOPE_MISMATCH_LOOKBACK_MS,
+  );
+  if (!history.fired.some((event) => event.targetKey === targetId)) return;
+  await store.recordHumanOverride({
+    ruleId: LINKED_ISSUE_SCOPE_MISMATCH_RULE_ID,
+    targetKey: targetId,
+    verdict: "reversed",
+    occurredAt: nowIso(),
+  });
+}
+
 /**
  * Record a REVERSAL — a human overriding a loopover auto-action — into the eval/audit stores (the
  * ground-truth accuracy signal). Mirrors reviewbot recordReversalSignals (runtime.ts ~157/274):
@@ -510,6 +537,7 @@ export async function recordReversalSignals(
       detail: `Bot-closed PR #${pr.number} reopened by a contributor.`,
       metadata: { repoFullName, pullNumber: pr.number },
     }).catch(() => undefined);
+    await recordLinkedIssueScopeMismatchOverride(env, targetId).catch(() => undefined); // #8101
     return;
   }
 
@@ -533,6 +561,7 @@ export async function recordReversalSignals(
         detail: `Bot-closed PR #${pr.number} reopened and merged by the repo owner.`,
         metadata: { repoFullName, pullNumber: pr.number },
       }).catch(() => undefined);
+      await recordLinkedIssueScopeMismatchOverride(env, targetId).catch(() => undefined); // #8101
     }
     const reverted = parseRevertedPrNumber(pr.body);
     if (!reverted) return;

--- a/test/unit/linked-issue-satisfaction-run.test.ts
+++ b/test/unit/linked-issue-satisfaction-run.test.ts
@@ -12,6 +12,8 @@ import {
   upsertRepositorySettings,
 } from "../../src/db/repositories";
 import { linkedIssueSatisfactionCacheInputFingerprint } from "../../src/review/linked-issue-satisfaction-cache-input";
+import * as signalTrackingWire from "../../src/review/signal-tracking-wire";
+import { createSignalStore } from "../../src/review/signal-tracking-wire";
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -460,6 +462,57 @@ describe("runLinkedIssueSatisfactionForAdvisory (processor wiring, #1961/#3906)"
       const gate = evaluateGateCheck(adv, { linkedIssueSatisfactionGateMode: "advisory" });
       expect(gate.conclusion).not.toBe("failure");
       expect(gate.blockers).toHaveLength(0);
+    });
+
+    it("BLOCK mode + 'unaddressed' records a linked_issue_scope_mismatch fired signal in the shared calibration store (#8101)", async () => {
+      stubIssueFetch();
+      const run = vi.fn(async () => ({ response: satisfactionJson({ status: "unaddressed", confidence: 0.9 }) }));
+      const env = enabledEnv(run);
+      await runLinkedIssueSatisfactionForAdvisory(env, { mode: "live", settings: blockMode, advisory: advisory(), repoFullName: "acme/widgets", pr, author: "alice", files, confirmedContributor: true, installationId: 1 });
+
+      const history = await createSignalStore(env).queryRuleHistory("linked_issue_scope_mismatch", 0);
+      expect(history.fired).toHaveLength(1);
+      expect(history.fired[0]).toMatchObject({
+        ruleId: "linked_issue_scope_mismatch",
+        targetKey: "acme/widgets#7",
+        outcome: "unaddressed",
+        metadata: { confidence: 0.9 },
+      });
+      expect(history.overrides).toEqual([]); // firing alone is never an override
+    });
+
+    it("ADVISORY mode records NO fired signal for the same 'unaddressed' verdict (#8101 — no finding, no signal)", async () => {
+      stubIssueFetch();
+      const run = vi.fn(async () => ({ response: satisfactionJson({ status: "unaddressed", confidence: 0.9 }) }));
+      const env = enabledEnv(run);
+      await runLinkedIssueSatisfactionForAdvisory(env, { mode: "live", settings: advisoryMode, advisory: advisory(), repoFullName: "acme/widgets", pr, author: "alice", files, confirmedContributor: true, installationId: 1 });
+      expect((await createSignalStore(env).queryRuleHistory("linked_issue_scope_mismatch", 0)).fired).toEqual([]);
+    });
+
+    it("BLOCK mode records NO fired signal for 'addressed' or 'partial' verdicts (#8101)", async () => {
+      for (const status of ["addressed", "partial"] as const) {
+        stubIssueFetch();
+        const run = vi.fn(async () => ({ response: satisfactionJson({ status }) }));
+        const env = enabledEnv(run);
+        await runLinkedIssueSatisfactionForAdvisory(env, { mode: "live", settings: blockMode, advisory: advisory(), repoFullName: "acme/widgets", pr, author: "alice", files, confirmedContributor: true, installationId: 1 });
+        expect((await createSignalStore(env).queryRuleHistory("linked_issue_scope_mismatch", 0)).fired).toEqual([]);
+      }
+    });
+
+    it("degrades silently when the SignalStore write rejects: the finding still pushes and nothing throws (#8101)", async () => {
+      stubIssueFetch();
+      vi.spyOn(signalTrackingWire, "createSignalStore").mockReturnValue({
+        recordRuleFired: async () => {
+          throw new Error("signal store down");
+        },
+        recordHumanOverride: async () => undefined,
+        queryRuleHistory: async () => ({ fired: [], overrides: [] }),
+      });
+      const run = vi.fn(async () => ({ response: satisfactionJson({ status: "unaddressed", confidence: 0.9 }) }));
+      const adv = advisory();
+      const result = await runLinkedIssueSatisfactionForAdvisory(enabledEnv(run), { mode: "live", settings: blockMode, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, confirmedContributor: true, installationId: 1 });
+      expect(result).toMatchObject({ status: "unaddressed" }); // normal return value unaffected
+      expect(adv.findings).toHaveLength(1); // the blocker still lands
     });
 
     it("BLOCK mode: an 'addressed'/'partial' verdict never pushes a finding (nothing to block)", async () => {

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import * as signalTrackingWire from "../../src/review/signal-tracking-wire";
+import { createSignalStore } from "../../src/review/signal-tracking-wire";
 import { processJob } from "../../src/queue/processors";
 import {
   createFlagStore,
@@ -1316,5 +1318,94 @@ describe("resolveDispositionReason (enriched Discord reason)", () => {
     expect(
       await resolveDispositionReason(broken, "owner/repo#7", "fallback"),
     ).toBe("fallback");
+  });
+});
+
+// ── #8101: linked_issue_scope_mismatch reversal-override wiring ─────────────────────────────────────────────
+
+describe("recordReversalSignals — linked_issue_scope_mismatch override (#8101)", () => {
+  const RULE = "linked_issue_scope_mismatch";
+
+  async function seedFiredSignal(env: Env, targetKey: string): Promise<void> {
+    await createSignalStore(env).recordRuleFired({
+      ruleId: RULE,
+      targetKey,
+      outcome: "unaddressed",
+      occurredAt: new Date().toISOString(),
+      metadata: { confidence: 0.9 },
+    });
+  }
+
+  function contributorReopen(number = 7) {
+    return {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number, state: "open" }),
+      sender: { login: "contributor", type: "User" },
+    };
+  }
+
+  it("records a 'reversed' override when a contributor reopens a bot-closed PR that the rule fired against", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close");
+    await seedFiredSignal(env, "owner/repo#7");
+
+    await recordReversalSignals(env, "pull_request", contributorReopen());
+
+    const history = await createSignalStore(env).queryRuleHistory(RULE, 0);
+    expect(history.overrides).toHaveLength(1);
+    expect(history.overrides[0]).toMatchObject({ ruleId: RULE, targetKey: "owner/repo#7", verdict: "reversed" });
+  });
+
+  it("records a 'reversed' override on the owner reopen-then-merge path (#7985) when the rule fired against the target", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close");
+    await seedFiredSignal(env, "owner/repo#7");
+    // Owner reopens (writes the pending marker)...
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "owner", type: "User" },
+    });
+    expect((await createSignalStore(env).queryRuleHistory(RULE, 0)).overrides).toEqual([]); // marker alone is not a reversal
+    // ...then merges within the window, promoting the marker to a real reversal.
+    await recordReversalSignals(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "closed", merged_at: new Date().toISOString() }),
+      sender: { login: "owner", type: "User" },
+    });
+
+    const history = await createSignalStore(env).queryRuleHistory(RULE, 0);
+    expect(history.overrides).toHaveLength(1);
+    expect(history.overrides[0]).toMatchObject({ ruleId: RULE, targetKey: "owner/repo#7", verdict: "reversed" });
+  });
+
+  it("records NO override when the reversal target has no prior fired event for this rule", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close");
+    await seedFiredSignal(env, "owner/repo#99"); // fired against a DIFFERENT target only
+
+    await recordReversalSignals(env, "pull_request", contributorReopen());
+
+    expect((await createSignalStore(env).queryRuleHistory(RULE, 0)).overrides).toEqual([]);
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(1); // the reversal itself still records
+  });
+
+  it("degrades silently when the SignalStore read rejects: the reversal itself still records and nothing throws", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close");
+    vi.spyOn(signalTrackingWire, "createSignalStore").mockReturnValue({
+      recordRuleFired: async () => undefined,
+      recordHumanOverride: async () => undefined,
+      queryRuleHistory: async () => {
+        throw new Error("signal store down");
+      },
+    });
+
+    await expect(recordReversalSignals(env, "pull_request", contributorReopen())).resolves.toBeUndefined();
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(1);
+    vi.restoreAllMocks();
   });
 });


### PR DESCRIPTION
## Summary

- Closes #8101
- The AI-confidence-driven `linked_issue_scope_mismatch` finding carries real gate authority (`block` mode + `unaddressed` hard-blocks a PR) yet was invisible to the shared calibration module (#7982): `createSignalStore`'s ORB adapter existed with zero live callers, so neither the self-correction pipeline (#7983/#7984) nor this epic's backtest primitives (#8083–#8086) could see this judgment's history. This wires exactly one finding code and one override direction (reversal), per the issue's scope.
- **Fired**: inside the existing `block`-mode + `unaddressed` finding-push block in `src/queue/processors.ts` — and ONLY there (advisory mode never pushes the finding, so it never records either) — `createSignalStore(env).recordRuleFired(...)` records `{ruleId, targetKey: repo#pr, outcome, occurredAt: nowIso(), metadata: {confidence}}`, best-effort with `.catch(() => undefined)`, matching the adjacent cache-write discipline and `SignalStore`'s own never-fail-the-review contract.
- **Reversed**: when `recordReversalSignals` (`src/review/outcomes-wire.ts`) records a reversal — both the contributor-reopen path and #7985's owner reopen-then-merge path — a fixed 30-day `queryRuleHistory` lookback checks for a `linked_issue_scope_mismatch` firing against the same target and, if present, records a `"reversed"` `HumanOverrideEvent`: the human undoing of the bot action IS the human judgment on that finding. Same `.catch(() => undefined)` discipline — a SignalStore failure (including the deliberately-propagating `queryRuleHistory` read error) never affects whether the underlying reversal itself records.
- No `"confirmed"` path, per the issue's Boundaries (no positive-confirmation signal exists anywhere in the codebase to mirror), and no change to `linkedIssueSatisfactionGateMode`'s blocking behavior — this only records data about decisions already being made.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the exact suites for both touched functions: `vitest run test/unit/outcomes-wire.test.ts test/unit/linked-issue-satisfaction-run.test.ts` — 123 tests green, including the new cases — plus the full root `npm run typecheck`. Verified per-diff-line coverage via lcov intersection: every changed line and branch in both `processors.ts` and `outcomes-wire.ts` is covered (fired at block+unaddressed with confidence metadata; NO fired for advisory mode or addressed/partial; `"reversed"` on both reversal paths gated on a prior firing; no override without one; and both fail-open `.catch` paths exercised explicitly via a rejecting `SignalStore` double — normal return values and the underlying reversal unaffected). Also simulated the scoped-CI shard condition with the exact CI invocation (`--changed=origin/main --coverage.all=false`): the lcov is non-empty and contains both changed instrumented files. `actionlint`/workers/mcp/ui checks are untouched surfaces; CI runs them all.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only wiring (no UI, docs, or extension surface touched; no visible behavior change — the finding's blocking behavior is untouched).

## Notes

- The fail-open tests use a rejecting `SignalStore` double via `vi.spyOn(signalTrackingWire, "createSignalStore")` — the issue's explicit requirement that a test exercising the failure path is mandatory, not optional. The write path in `processors.ts` keeps its own `.catch(() => undefined)` even though the live adapter's writes are internally best-effort, so the review pass stays safe under any future `SignalStore` implementation.
- The 30-day lookback is a fixed constant (`LINKED_ISSUE_SCOPE_MISMATCH_LOOKBACK_MS`), not configurable, per the issue's requirement.