### PR TITLE
fix(selfhost): stop pinning sharp's Dockerfile install, let overrides resolve it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,14 @@ RUN if [ "$INSTALL_VISUAL_REVIEW" = "true" ]; then npm install puppeteer-core@22
 # is safe here: sharp's own platform binary ships as an npm `optionalDependencies` entry
 # (@img/sharp-<platform>-<arch>) that npm's normal os/cpu-matched install resolves on its own, not via
 # sharp's postinstall script.
-RUN npm install sharp@0.34.5 --ignore-scripts
+# UNVERSIONED deliberately (#8112): an explicit `sharp@<version>` here — even one that matches package.json's
+# own `overrides.sharp` entry exactly — makes npm refuse with EOVERRIDE ("Override for sharp@X conflicts with
+# direct dependency"), since an explicit CLI version and an `overrides` entry for the SAME package are treated
+# as two competing authorities npm won't silently pick between. Letting npm resolve from `overrides` (the
+# repo's actual source of truth for this version, kept in sync by Dependabot/Renovate) is what a hardcoded pin
+# here can never be — this broke the release pipeline (#8112) exactly when `overrides.sharp` moved to ^0.35.0
+# and this line's own pin didn't move with it.
+RUN npm install sharp --ignore-scripts
 # Data dir (the SQLite file) — owned by the unprivileged node user; mount a volume here to persist.
 RUN mkdir -p /data && chown -R node:node /data /app
 # Expose the optional user-installed CLIs only after all root build steps have completed, so a


### PR DESCRIPTION
Closes #8112.

## Summary
- `release-selfhost.yml`'s multi-arch build started failing on every release attempt with `npm error code EOVERRIDE: Override for sharp@0.34.5 conflicts with direct dependency` — currently blocking ALL future ORB beta/stable releases, discovered while cutting the beta release for #7983.
- `Dockerfile` hardcodes a standalone `npm install sharp@<version>` (esbuild marks `sharp` external in the self-host bundle, so it can't ship inside `dist/server.mjs`, needing a separate install step). #7970's dependency bump moved `package.json`'s `sharp` to `^0.35.0` and added a matching `overrides.sharp` entry — but a Dependabot-style bump has no mechanism to also update a version hardcoded inside a Dockerfile `RUN` command, so this line silently drifted out of sync.
- Re-pinning to the exact resolved version (`sharp@0.35.3`) still fails identically: recent npm treats an explicit CLI version and an `overrides` entry for the SAME package as two competing authorities and refuses to pick between them, regardless of whether the versions actually agree.
- Fix: drop the version entirely, letting npm resolve from `package.json`'s `overrides` — the real source of truth for this version, already kept current by Dependabot/Renovate — instead of a second, independently-hardcoded pin with no mechanism to stay in sync.

## Test plan
- [x] Verified locally with a standalone `npm install sharp --ignore-scripts` against the repo's real `package.json`/`package-lock.json`: resolves cleanly to `0.35.3`, no `EOVERRIDE`
- [x] Verified with a full `docker build --no-cache --target runtime-base --build-arg INSTALL_VISUAL_REVIEW=true .` (the same target + build-arg the release workflow uses): builds cleanly end to end, sharp install step completes with "found 0 vulnerabilities" and no error
- [x] Confirmed the OLD command (either `sharp@0.34.5` or the exact resolved `sharp@0.35.3`) reproduces the exact CI failure locally, isolating the fix to the version-pin removal specifically