### PR TITLE
feat(review): record a confirmed override when the owner closes an AI-judgment-held PR

### DIFF
--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -25,6 +25,7 @@
 
 import { recordAuditEvent } from "../db/repositories";
 import { createSignalStore } from "./signal-tracking-wire";
+import { AI_JUDGMENT_BLOCKER_CODES } from "../rules/advisory";
 import { tryEnqueueDecisionPackRebuild } from "../services/decision-pack";
 import { incr } from "../selfhost/metrics";
 import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
@@ -505,6 +506,30 @@ async function recordLinkedIssueScopeMismatchOverride(env: Env, targetId: string
   });
 }
 
+// #8123 (implements #8106's decision): the repo OWNER closing (not merging) a PR that was held for a
+// low-confidence AI judgment is the explicit "the automated call was right" signal — the confirmed-side
+// mirror of the reversal hooks above, and the first non-inferred positive confirmation in this system.
+// "Held via aiReviewLowConfidenceHold" is detected the same way #8101 detects its rule: a recorded
+// rule_fired event for either AI-judgment code (ai_consensus_defect / ai_review_split) against this target
+// within the fixed lookback (#8104's own 30-day constant). Scoped to those two codes only — the other two
+// hold kinds carry no ruleId-equivalent to key on (see the issue's Boundaries). Callers attach
+// `.catch(() => undefined)`: a SignalStore failure must never affect the underlying PR-close handling.
+const AI_JUDGMENT_CONFIRMATION_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+
+async function recordAiJudgmentHoldConfirmations(env: Env, targetId: string): Promise<void> {
+  const store = createSignalStore(env);
+  for (const code of AI_JUDGMENT_BLOCKER_CODES) {
+    const history = await store.queryRuleHistory(code, Date.now() - AI_JUDGMENT_CONFIRMATION_LOOKBACK_MS);
+    if (!history.fired.some((event) => event.targetKey === targetId)) continue;
+    await store.recordHumanOverride({
+      ruleId: code,
+      targetKey: targetId,
+      verdict: "confirmed",
+      occurredAt: nowIso(),
+    });
+  }
+}
+
 /**
  * Record a REVERSAL — a human overriding a loopover auto-action — into the eval/audit stores (the
  * ground-truth accuracy signal). Mirrors reviewbot recordReversalSignals (runtime.ts ~157/274):
@@ -570,6 +595,19 @@ export async function recordReversalSignals(
     }).catch(() => undefined);
     await recordConfiguredGateBlockerOverrides(env, targetId).catch(() => undefined); // #8104
     await recordLinkedIssueScopeMismatchOverride(env, targetId).catch(() => undefined); // #8101
+    return;
+  }
+
+  // #8123: the OWNER closing a PR WITHOUT merging it — when that PR was held for a low-confidence AI
+  // judgment, the owner's close is the explicit confirmation the finding was right ("confirmed" override).
+  // A contributor's own close is not a confirmation signal and records nothing (mirrors the reversal side's
+  // owner-vs-contributor distinction above).
+  if (payload.action === "closed" && !pr.merged_at) {
+    const ownerLogin = (repoFullName.split("/")[0] || "").toLowerCase();
+    const senderLogin = (payload.sender?.login || "").toLowerCase();
+    if (!!ownerLogin && !!senderLogin && ownerLogin === senderLogin) {
+      await recordAiJudgmentHoldConfirmations(env, reviewAuditTargetId(repoFullName, pr.number)).catch(() => undefined);
+    }
     return;
   }
 

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -1521,3 +1521,121 @@ describe("recordReversalSignals — linked_issue_scope_mismatch override (#8101)
     vi.restoreAllMocks();
   });
 });
+
+// ── #8123: owner-close of an AI-judgment-held PR → "confirmed" override ─────────────────────────────────────
+
+describe("recordReversalSignals — aiReviewLowConfidenceHold confirmation (#8123)", () => {
+  async function seedAiFired(env: Env, ruleId: string, targetKey = "owner/repo#9"): Promise<void> {
+    await createSignalStore(env).recordRuleFired({
+      ruleId,
+      targetKey,
+      outcome: "warning",
+      occurredAt: new Date().toISOString(),
+      metadata: { confidence: 0.4 },
+    });
+  }
+
+  function ownerClose(number = 9, overrides: Record<string, unknown> = {}) {
+    return {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number, state: "closed", merged_at: null }),
+      sender: { login: "owner", type: "User" },
+      ...overrides,
+    };
+  }
+
+  async function overridesFor(env: Env, ruleId: string) {
+    return (await createSignalStore(env).queryRuleHistory(ruleId, 0)).overrides;
+  }
+
+  it("records a 'confirmed' override for the AI ruleId that fired when the OWNER closes the held PR without merging", async () => {
+    const env = createTestEnv();
+    await seedAiFired(env, "ai_consensus_defect");
+
+    await recordReversalSignals(env, "pull_request", ownerClose());
+
+    const overrides = await overridesFor(env, "ai_consensus_defect");
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0]).toMatchObject({ ruleId: "ai_consensus_defect", targetKey: "owner/repo#9", verdict: "confirmed" });
+  });
+
+  it("confirms every AI-judgment code that fired for the target, in the same close", async () => {
+    const env = createTestEnv();
+    await seedAiFired(env, "ai_consensus_defect");
+    await seedAiFired(env, "ai_review_split");
+
+    await recordReversalSignals(env, "pull_request", ownerClose());
+
+    expect(await overridesFor(env, "ai_consensus_defect")).toHaveLength(1);
+    expect(await overridesFor(env, "ai_review_split")).toHaveLength(1);
+  });
+
+  it("records nothing when a CONTRIBUTOR closes the same held PR — owner-only, like the reversal side", async () => {
+    const env = createTestEnv();
+    await seedAiFired(env, "ai_consensus_defect");
+
+    await recordReversalSignals(env, "pull_request", ownerClose(9, { sender: { login: "contributor", type: "User" } }));
+
+    expect(await overridesFor(env, "ai_consensus_defect")).toHaveLength(0);
+  });
+
+  it("records nothing when the PR was not AI-judgment-held (no matching fired event, other rules ignored)", async () => {
+    const env = createTestEnv();
+    await seedAiFired(env, "secret_leak"); // a non-AI code firing does not make this an AI hold
+
+    await recordReversalSignals(env, "pull_request", ownerClose());
+
+    expect(await overridesFor(env, "ai_consensus_defect")).toHaveLength(0);
+    expect(await overridesFor(env, "ai_review_split")).toHaveLength(0);
+    expect(await overridesFor(env, "secret_leak")).toHaveLength(0);
+  });
+
+  it("records nothing for a fired event on a DIFFERENT target", async () => {
+    const env = createTestEnv();
+    await seedAiFired(env, "ai_consensus_defect", "owner/repo#999");
+
+    await recordReversalSignals(env, "pull_request", ownerClose());
+
+    expect(await overridesFor(env, "ai_consensus_defect")).toHaveLength(0);
+  });
+
+  it("does not treat an owner MERGE-close as a confirmation (the merged path is the reversal side's business)", async () => {
+    const env = createTestEnv();
+    await seedAiFired(env, "ai_consensus_defect");
+
+    await recordReversalSignals(
+      env,
+      "pull_request",
+      ownerClose(9, { pull_request: pullRequestPayload({ number: 9, state: "closed", merged_at: "2026-07-22T23:00:00Z" }) }),
+    );
+
+    expect(await overridesFor(env, "ai_consensus_defect")).toHaveLength(0);
+  });
+
+  it("records nothing when the sender is missing or the repo full name has an empty owner segment", async () => {
+    // Both degenerate-webhook arms of the owner check: a payload with no sender at all, and a repository
+    // full_name whose owner segment is empty — neither can ever equal a real owner login, so neither may
+    // count as an owner confirmation.
+    const env = createTestEnv();
+    await seedAiFired(env, "ai_consensus_defect");
+    await recordReversalSignals(env, "pull_request", ownerClose(9, { sender: undefined }));
+    expect(await overridesFor(env, "ai_consensus_defect")).toEqual([]);
+    await seedAiFired(env, "ai_consensus_defect", "/repo#9");
+    await recordReversalSignals(env, "pull_request", ownerClose(9, { repository: { name: "repo", full_name: "/repo", owner: { login: "" } }, sender: { login: "", type: "User" } }));
+    expect(await overridesFor(env, "ai_consensus_defect")).toEqual([]);
+  });
+
+  it("degrades silently when the SignalStore rejects — the close handling itself never throws", async () => {
+    const env = createTestEnv();
+    vi.spyOn(signalTrackingWire, "createSignalStore").mockReturnValue({
+      recordRuleFired: async () => undefined,
+      recordHumanOverride: async () => undefined,
+      queryRuleHistory: async () => {
+        throw new Error("signal store down");
+      },
+    });
+
+    await expect(recordReversalSignals(env, "pull_request", ownerClose())).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8123.

Implements #8106's recorded decision: the repo **owner closing (not merging) a PR that was held for a low-confidence AI judgment** is the explicit "the automated call was right" signal — the confirmed-side mirror of `recordReversalSignals`' existing reversal hooks, and the first non-inferred positive confirmation in this system.

- A new owner-close branch in `recordReversalSignals` (`src/review/outcomes-wire.ts`), using the exact `ownerLogin === senderLogin` check the reversal side already uses. A contributor's own close records nothing.
- "Held via `aiReviewLowConfidenceHold`" is detected the same way #8101 detects its rule: a recorded `rule_fired` event for either `AI_JUDGMENT_BLOCKER_CODES` code (`ai_consensus_defect` / `ai_review_split`, imported from `src/rules/advisory.ts`) against this target within the 30-day lookback #8104 established. Each matching code gets a `"confirmed"` `HumanOverrideEvent` via the existing `createSignalStore` adapter.
- Scoped to `aiReviewLowConfidenceHold` only — the other two hold kinds carry no ruleId-equivalent to key on (the issue's explicit boundary). `resolveAiReviewLowConfidenceHold` and the holds' production logic are untouched.
- Best-effort end to end: the caller attaches `.catch(() => undefined)` and the helper mirrors #8101's shape exactly — a SignalStore failure can never affect the PR-close handling (pinned by test). An owner **merge**-close never enters this branch (the merged path remains the reversal side's business — also pinned by test).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the full affected suite instead of the 30+-min unsharded chain: `test/unit/outcomes-wire.test.ts` — **79/79 green**, including 7 new #8123 cases covering every branch the issue's own requirements enumerate: owner-vs-contributor, held-vs-not-held (a non-AI rule firing does not make it an AI hold), matching-vs-different-target, both AI codes confirmed in one close, the merged-close exclusion, and the fail-open `.catch` path (a rejecting SignalStore never throws out of the handler). The diff is one focused branch + one helper mirroring the adjacent, already-merged #8101 hook, so the changed lines are exercised end-to-end by those cases; real CI re-runs typecheck and the sharded suite here.
- workers/mcp/ui/audit/actionlint: untouched surfaces — one source file + one test file; zero dependency changes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The three unchecked Safety boxes are N/A: no auth/session/UI change — a webhook-side recording hook plus tests.

## UI Evidence

N/A — no UI change.

## Notes

- With this, `ai_consensus_defect`/`ai_review_split` become the first rules whose #8085 backtest precision reflects genuine positive confirmations rather than a reversal-only floor — exactly the issue's Expected Outcome.
