### PR TITLE
fix(engine): include inputTokenPattern in ruleSignature's deny-hook identity

### DIFF
--- a/packages/loopover-engine/src/miner/deny-hook-synthesis.ts
+++ b/packages/loopover-engine/src/miner/deny-hook-synthesis.ts
@@ -130,10 +130,15 @@ export function changedPathToDenyGlob(path: string): string | null {
 }
 
 function ruleSignature(rule: DenyRule): string {
+  // `inputTokenPattern` is a RegExp: JSON.stringify serializes every RegExp instance as "{}" regardless of its
+  // actual source/flags (no enumerable own properties, no toJSON), so two rules with genuinely different
+  // patterns would still collide here if the RegExp object itself were included directly. Serialize `.source`
+  // + `.flags` instead so distinct patterns produce distinct signatures.
   return JSON.stringify({
     matcher: rule.matcher,
     pathPattern: rule.pathPattern ?? null,
     inputIncludesAll: rule.inputIncludesAll ?? null,
+    inputTokenPattern: rule.inputTokenPattern ? { source: rule.inputTokenPattern.source, flags: rule.inputTokenPattern.flags } : null,
     reason: rule.reason,
   });
 }

--- a/test/unit/miner-deny-hook-synthesis.test.ts
+++ b/test/unit/miner-deny-hook-synthesis.test.ts
@@ -17,6 +17,7 @@ import {
   setProposalStatuses,
   synthesizeDenyRuleProposals,
 } from "../../packages/loopover-miner/lib/deny-hook-synthesis.js";
+import type { DenyRuleProposal } from "../../packages/loopover-engine/src/miner/deny-hook-synthesis";
 // #7525: normalizeRepoFullName is defined in the engine and re-exported unchanged by the miner-lib module
 // above; import it from the engine source directly so the guard's src branches are the ones exercised.
 import { normalizeRepoFullName } from "../../packages/loopover-engine/src/miner/deny-hook-synthesis";
@@ -127,6 +128,33 @@ describe("resolveEffectiveDenyRules() (#4522)", () => {
     const verdict = evaluateDenyHooks({ name: "Write", input: { file_path: "CHANGELOG.md" } }, effective);
     expect(verdict.allowed).toBe(false);
     expect(verdict.blockedBy?.pathPattern).toBe("**/changelog.md");
+  });
+
+  it("#8013: keeps two rules distinct when they differ only by inputTokenPattern, including two different patterns (not just presence vs. absence)", () => {
+    const proposal = (id: string, inputTokenPattern?: RegExp): DenyRuleProposal => ({
+      id,
+      status: "approved",
+      rule: { matcher: "Bash", inputIncludesAll: ["git"], reason: "test", ...(inputTokenPattern ? { inputTokenPattern } : {}) },
+      audit: { kind: "manual", synthesizedAt: "2026-01-01T00:00:00.000Z" },
+    });
+    const noPattern = proposal("a");
+    const withFollowTags = proposal("b", /^--follow-tags$/);
+    const withF = proposal("c", /^-f$/);
+
+    const effective = resolveEffectiveDenyRules({ includeDefaults: false, approvedProposals: [noPattern, withFollowTags, withF] });
+    // All three must survive -- none of them are "the same rule" as either of the others.
+    expect(effective).toHaveLength(3);
+  });
+
+  it("#8013: still dedupes two rules whose inputTokenPattern has the identical source+flags", () => {
+    const proposal = (id: string): DenyRuleProposal => ({
+      id,
+      status: "approved",
+      rule: { matcher: "Bash", inputIncludesAll: ["git"], reason: "test", inputTokenPattern: /^-f$/ },
+      audit: { kind: "manual", synthesizedAt: "2026-01-01T00:00:00.000Z" },
+    });
+    const effective = resolveEffectiveDenyRules({ includeDefaults: false, approvedProposals: [proposal("a"), proposal("b")] });
+    expect(effective).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Closes #8013
- `ruleSignature` (the identity function `resolveEffectiveDenyRules`/`synthesizeDenyRuleProposals` use to decide "is this the same rule") omitted `inputTokenPattern` from its computed identity, so a maintainer-approved custom rule narrowing an existing rule only by `inputTokenPattern` would be silently deduped away as an exact duplicate.
- Fix serializes `.source` + `.flags` rather than the `RegExp` object itself — `JSON.stringify` collapses every `RegExp` instance to `"{}"` regardless of its actual pattern, so the naive `rule.inputTokenPattern ?? null` fix would have "fixed" only the presence-vs-absence case, not two genuinely different patterns colliding. Caught this by testing before committing to the naive version.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run test/unit/miner-deny-hook-synthesis.test.ts` — 22/22 passing, including two new cases: three rules distinguished only by `inputTokenPattern` (none/`--follow-tags`/`-f`) all survive as distinct; two rules with byte-identical `inputTokenPattern` source+flags still correctly dedupe to one.
- Rebuilt `packages/loopover-engine` (`npm run build`) before testing — the root test imports the compiled `packages/loopover-miner/lib/deny-hook-synthesis.js`, which wraps `@loopover/engine`'s dist output, not the TS source directly.