### PR TITLE
fix(engine): include inputTokenPattern in deny-hook ruleSignature identity

### DIFF
--- a/packages/loopover-engine/src/miner/deny-hook-synthesis.ts
+++ b/packages/loopover-engine/src/miner/deny-hook-synthesis.ts
@@ -134,6 +134,11 @@ function ruleSignature(rule: DenyRule): string {
     matcher: rule.matcher,
     pathPattern: rule.pathPattern ?? null,
     inputIncludesAll: rule.inputIncludesAll ?? null,
+    // RegExp doesn't survive JSON.stringify (it serializes to `{}`), so two rules differing only by
+    // inputTokenPattern would otherwise collapse to the same signature. .toString() (e.g. "/^-[a-z]*f[a-z]*$/i")
+    // captures both source and flags, matching this function's own "identical = same effective match behavior"
+    // contract for the other optional fields.
+    inputTokenPattern: rule.inputTokenPattern ? rule.inputTokenPattern.toString() : null,
     reason: rule.reason,
   });
 }

--- a/test/unit/miner-deny-hook-synthesis.test.ts
+++ b/test/unit/miner-deny-hook-synthesis.test.ts
@@ -128,6 +128,31 @@ describe("resolveEffectiveDenyRules() (#4522)", () => {
     expect(verdict.allowed).toBe(false);
     expect(verdict.blockedBy?.pathPattern).toBe("**/changelog.md");
   });
+
+  // #8013: ruleSignature (the identity function resolveEffectiveDenyRules dedupes with) used to omit
+  // inputTokenPattern entirely, so two rules identical in every OTHER field but a different inputTokenPattern
+  // collapsed onto the same signature and the second was silently dropped as a "duplicate".
+  it("does NOT dedupe two approved rules that differ only by inputTokenPattern (#8013)", () => {
+    const now = new Date(0).toISOString();
+    const baseProposal = (inputTokenPattern: RegExp, id: string) => ({
+      id,
+      status: "approved" as const,
+      rule: { matcher: "*", inputIncludesAll: ["push"], inputTokenPattern, reason: "custom force-push guard" },
+      audit: { kind: "manual", synthesizedAt: now },
+    });
+    const approved = [
+      baseProposal(/^-[a-z]*f[a-z]*$/i, "custom:1"),
+      baseProposal(/^--force$/i, "custom:2"),
+    ];
+    const effective = resolveEffectiveDenyRules({ approvedProposals: approved });
+    // Both survive: a real bug here collapses the second one away, leaving only DEFAULT_DENY_RULES.length + 1.
+    expect(effective.length).toBe(DEFAULT_DENY_RULES.length + 2);
+    // And each one's OWN pattern is still the one that's actually enforced (not silently replaced by the other).
+    const longFlagVerdict = evaluateDenyHooks({ name: "Bash", input: { command: "git push --force" } }, effective);
+    expect(longFlagVerdict.allowed).toBe(false);
+    const shortFlagVerdict = evaluateDenyHooks({ name: "Bash", input: { command: "git push -f" } }, effective);
+    expect(shortFlagVerdict.allowed).toBe(false);
+  });
 });
 
 describe("initDenyHookSynthesisStore() (#4522)", () => {


### PR DESCRIPTION
## Summary
- `ruleSignature` (`packages/loopover-engine/src/miner/deny-hook-synthesis.ts`) is the sole identity function `resolveEffectiveDenyRules` (merge built-in + approved custom rules) and `synthesizeDenyRuleProposals` (dedup newly-derived proposals) use to decide "is this the same rule." It included 4 of `DenyRule`'s 5 matching fields, omitting `inputTokenPattern` — added specifically because a plain `inputIncludesAll` substring test false-positives on unrelated longer flags (`-f` vs `--follow-tags`).
- A maintainer-approved custom rule narrowing an existing one with the same `matcher`/`pathPattern`/`inputIncludesAll`/`reason` but a different (or newly-added) `inputTokenPattern` would be treated as an exact duplicate and silently dropped from the merged set.
- Fix adds `inputTokenPattern` to the signature, nullish-coalesced like the other optional fields — but via `.toString()` rather than the field itself, since `RegExp` doesn't survive `JSON.stringify` (it serializes to `{}}`); a naive `rule.inputTokenPattern ?? null` addition would still collapse two *different* patterns onto the same signature. `.toString()` captures both source and flags (e.g. `"/^-[a-z]*f[a-z]*$/i"`).

Closes #8013.

## Test plan
- [x] New regression test in `test/unit/miner-deny-hook-synthesis.test.ts`: two approved rules identical except for `inputTokenPattern` both survive `resolveEffectiveDenyRules` (not deduped), and each one's own pattern is still the one enforced.
- [x] Verified the test actually catches the bug: reverted the source fix locally, confirmed the new test fails (`11` merged rules instead of the expected `12`), then restored the fix and confirmed green.
- [x] `npm run build --workspace @loopover/engine && npm run build:miner` (rebuilt so the test, which imports the compiled miner-lib wrapper, reflects the source change)
- [x] `npx tsc --noEmit`
- [x] `npm run test --workspace @loopover/engine` (648/648 passing)
- [x] `npm run engine-parity:drift-check` — clean, not one of the 5 hand-duplicated twin-pair files