### PR TITLE
fix(review): reject plain ws: in isSafeEndpointUrl, matching its own "secure" doc comment

### DIFF
--- a/packages/loopover-engine/src/review/safe-url.ts
+++ b/packages/loopover-engine/src/review/safe-url.ts
@@ -7,8 +7,8 @@
 //
 // Rejects non-HTTPS (isSafeHttpUrl), localhost / `*.localhost` / .local / .internal, and private/
 // loopback/link-local IPs in any literal notation (decimal `2130706433`, hex `0x7f000001`, octal,
-// short `127.1`, and the IPv6 forms). isSafeEndpointUrl additionally permits wss:/ws: for base-layer
-// chain endpoints.
+// short `127.1`, and the IPv6 forms). isSafeEndpointUrl additionally permits wss: (not plain ws:,
+// #8017) for base-layer chain endpoints.
 
 function parseIpv4Component(part: string): number | null {
   if (/^0x[0-9a-f]+$/i.test(part)) return parseInt(part, 16);
@@ -109,8 +109,10 @@ export function isSafeHttpUrl(raw: string): boolean {
   return !hostIsPrivateOrLocal(url.hostname);
 }
 
-/** Like isSafeHttpUrl but also permits secure WebSocket endpoints (`wss:`, `ws:`) — base-layer chain
- *  endpoints (subtensor RPC/WSS/archive) are probed via JSON-RPC, not HTTP. Same SSRF host/IP guard. */
+/** Like isSafeHttpUrl but also permits the secure WebSocket endpoint (`wss:`) — base-layer chain endpoints
+ *  (subtensor RPC/WSS/archive) are probed via JSON-RPC, not HTTP. Same SSRF host/IP guard. Plain `ws:` is
+ *  REJECTED (#8017): it is the plaintext counterpart to `wss:`, the same relationship `http:`/`https:` has —
+ *  and `isSafeHttpUrl` above already rejects `http:` for exactly that reason. */
 export function isSafeEndpointUrl(raw: string): boolean {
   let url: URL;
   try {
@@ -118,6 +120,6 @@ export function isSafeEndpointUrl(raw: string): boolean {
   } catch {
     return false;
   }
-  if (!["https:", "wss:", "ws:"].includes(url.protocol)) return false;
+  if (!["https:", "wss:"].includes(url.protocol)) return false;
   return !hostIsPrivateOrLocal(url.hostname);
 }

--- a/src/review/content-lane/safe-url.ts
+++ b/src/review/content-lane/safe-url.ts
@@ -7,8 +7,8 @@
 //
 // Rejects non-HTTPS (isSafeHttpUrl), localhost / `*.localhost` / .local / .internal, and private/
 // loopback/link-local IPs in any literal notation (decimal `2130706433`, hex `0x7f000001`, octal,
-// short `127.1`, and the IPv6 forms). isSafeEndpointUrl additionally permits wss:/ws: for base-layer
-// chain endpoints.
+// short `127.1`, and the IPv6 forms). isSafeEndpointUrl additionally permits wss: (not plain ws:,
+// #8017) for base-layer chain endpoints.
 
 function parseIpv4Component(part: string): number | null {
   if (/^0x[0-9a-f]+$/i.test(part)) return parseInt(part, 16);
@@ -109,8 +109,10 @@ export function isSafeHttpUrl(raw: string): boolean {
   return !hostIsPrivateOrLocal(url.hostname);
 }
 
-/** Like isSafeHttpUrl but also permits secure WebSocket endpoints (`wss:`, `ws:`) — base-layer chain
- *  endpoints (subtensor RPC/WSS/archive) are probed via JSON-RPC, not HTTP. Same SSRF host/IP guard. */
+/** Like isSafeHttpUrl but also permits the secure WebSocket endpoint (`wss:`) — base-layer chain endpoints
+ *  (subtensor RPC/WSS/archive) are probed via JSON-RPC, not HTTP. Same SSRF host/IP guard. Plain `ws:` is
+ *  REJECTED (#8017): it is the plaintext counterpart to `wss:`, the same relationship `http:`/`https:` has —
+ *  and `isSafeHttpUrl` above already rejects `http:` for exactly that reason. */
 export function isSafeEndpointUrl(raw: string): boolean {
   let url: URL;
   try {
@@ -118,6 +120,6 @@ export function isSafeEndpointUrl(raw: string): boolean {
   } catch {
     return false;
   }
-  if (!["https:", "wss:", "ws:"].includes(url.protocol)) return false;
+  if (!["https:", "wss:"].includes(url.protocol)) return false;
   return !hostIsPrivateOrLocal(url.hostname);
 }

--- a/test/unit/content-lane-safe-url.test.ts
+++ b/test/unit/content-lane-safe-url.test.ts
@@ -144,9 +144,8 @@ describe("isSafeHttpUrl", () => {
 });
 
 describe("isSafeEndpointUrl", () => {
-  it("additionally permits wss / ws for chain endpoints", () => {
+  it("additionally permits wss for chain endpoints", () => {
     expect(isSafeEndpointUrl("wss://entrypoint.example.com")).toBe(true);
-    expect(isSafeEndpointUrl("ws://node.example.com")).toBe(true);
     expect(isSafeEndpointUrl("https://api.example.com")).toBe(true);
   });
 
@@ -155,7 +154,11 @@ describe("isSafeEndpointUrl", () => {
     expect(isSafeEndpointUrl("wss://localhost")).toBe(false);
   });
 
-  it("rejects non-ws/https protocols", () => {
+  // #8017: plain ws: is the plaintext counterpart to wss:, the same relationship http:/https: has -- and
+  // isSafeHttpUrl already rejects http: for exactly that reason. The doc comment above always said "secure
+  // WebSocket endpoints"; the code just didn't match it until now.
+  it("rejects non-wss/https protocols, including plain unencrypted ws: (#8017)", () => {
+    expect(isSafeEndpointUrl("ws://node.example.com")).toBe(false);
     expect(isSafeEndpointUrl("http://example.com")).toBe(false);
     expect(isSafeEndpointUrl("ftp://example.com")).toBe(false);
   });

--- a/test/unit/safe-url-engine.test.ts
+++ b/test/unit/safe-url-engine.test.ts
@@ -145,9 +145,8 @@ describe("isSafeHttpUrl", () => {
 });
 
 describe("isSafeEndpointUrl", () => {
-  it("additionally permits wss / ws for chain endpoints", () => {
+  it("additionally permits wss for chain endpoints", () => {
     expect(isSafeEndpointUrl("wss://entrypoint.example.com")).toBe(true);
-    expect(isSafeEndpointUrl("ws://node.example.com")).toBe(true);
     expect(isSafeEndpointUrl("https://api.example.com")).toBe(true);
   });
 
@@ -156,7 +155,11 @@ describe("isSafeEndpointUrl", () => {
     expect(isSafeEndpointUrl("wss://localhost")).toBe(false);
   });
 
-  it("rejects non-ws/https protocols", () => {
+  // #8017: plain ws: is the plaintext counterpart to wss:, the same relationship http:/https: has -- and
+  // isSafeHttpUrl already rejects http: for exactly that reason. The doc comment above always said "secure
+  // WebSocket endpoints"; the code just didn't match it until now.
+  it("rejects non-wss/https protocols, including plain unencrypted ws: (#8017)", () => {
+    expect(isSafeEndpointUrl("ws://node.example.com")).toBe(false);
     expect(isSafeEndpointUrl("http://example.com")).toBe(false);
     expect(isSafeEndpointUrl("ftp://example.com")).toBe(false);
   });


### PR DESCRIPTION
## Summary
- `isSafeEndpointUrl`'s (`src/review/content-lane/safe-url.ts` + its `@loopover/engine` twin) doc comment always said it "additionally permits **secure** WebSocket endpoints (`wss:`, `ws:`)" — but `ws:` is the plaintext counterpart to `wss:`, the same relationship `http:`/`https:` has in this same module, where `isSafeHttpUrl` already rejects `http:` for exactly that reason.
- Made the maintainer call this issue flagged as needed (tighten vs. document): tightening, not documenting an exception. The `registry-logic.ts` error message this guard backs ("Surface entry URL must be a public HTTPS or WSS endpoint") already only ever mentioned WSS, never WS — confirming `ws:` acceptance was an oversight in the original reviewbot port, not a deliberate carve-out for e.g. self-hosted operators pointing at a local unencrypted RPC node.
- This is not itself an SSRF-bypass fix (the host/IP private-range guard already applied identically to `ws:`/`wss:`) — it's closing the transport-security/spec-consistency gap between what the doc comment claims and what the code allowed.
- `safe-url.ts` is a genuine hand-duplicated twin pair (`SAFE_URL_TWIN_PAIR` in `scripts/check-engine-parity.ts`) — applied the identical change to both `src/review/content-lane/safe-url.ts` and `packages/loopover-engine/src/review/safe-url.ts`.

Closes #8017.

## Test plan
- [x] Updated `test/unit/content-lane-safe-url.test.ts` and `test/unit/safe-url-engine.test.ts` (one per twin side): `ws://...` now asserts `false` alongside the existing `http:`/`ftp:` rejection cases; `wss://` acceptance and its SSRF host-guard coverage are unchanged.
- [x] Verified the tests actually catch the regression: reverted both source fixes locally, confirmed both new assertions fail (`ws://node.example.com` still returned `true`), then restored the fix and confirmed green.
- [x] `npm run build --workspace @loopover/engine`
- [x] `npx tsc --noEmit`
- [x] Full affected-suite run (`content-lane-safe-url`, `safe-url-engine`, `content-lane-registry-logic`) — 199/199 passing
- [x] `npm run test --workspace @loopover/engine` (648/648 passing)
- [x] `npm run engine-parity:drift-check` — clean, both twin-pair sides still agree