### PR TITLE
fix(engine): add real packages/loopover-engine paths to ENGINE_DECISION_GUARDRAIL_GLOBS

### DIFF
--- a/packages/loopover-engine/src/review/guardrail-config.ts
+++ b/packages/loopover-engine/src/review/guardrail-config.ts
@@ -28,6 +28,12 @@ export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
   "src/settings/agent-execution.ts",
   "src/settings/agent-sweep.ts",
   "src/settings/autonomy.ts",
+  // #8012: src/settings/autonomy.ts and src/review/guardrail-config.ts (below) are now 5-line #6203 re-export
+  // shims -- the real, substantive logic lives at these packages/loopover-engine paths instead. Both the shim
+  // AND the real path are listed deliberately: a PR touching only the shim (unlikely, but not impossible)
+  // should still trip the guardrail, and a PR touching the real engine-package file (the common case today)
+  // must trip it too, which the shim-only entries above could never catch on their own.
+  "packages/loopover-engine/src/settings/autonomy.ts",
   "src/queue/**",
   "src/github/pr-actions.ts",
   "src/github/app.ts",
@@ -39,6 +45,10 @@ export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
   "src/auth/**",
   "src/review/safety.ts",
   "src/review/guardrail-config.ts",
+  // #8012: see the packages/loopover-engine/src/settings/autonomy.ts comment above -- same shim/real-path
+  // pairing, this time for this very file (guardrail-config.ts itself). A PR editing ENGINE_DECISION_GUARDRAIL_GLOBS
+  // or DEFAULT_HARD_GUARDRAIL_GLOBS to quietly remove entries must trip this guardrail too.
+  "packages/loopover-engine/src/review/guardrail-config.ts",
   "src/review/cutover-gate.ts",
   "src/review/linked-issue-hard-rules.ts",
   "src/review/outcomes-wire.ts",

--- a/test/unit/guardrail-config.test.ts
+++ b/test/unit/guardrail-config.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { isGuardrailHit } from "../../src/signals/change-guardrail";
 import {
   CONFIG_AS_CODE_GUARDRAIL_GLOBS,
   DEFAULT_HARD_GUARDRAIL_GLOBS,
+  ENGINE_DECISION_GUARDRAIL_GLOBS,
   resolveHardGuardrailGlobs,
 } from "../../src/review/guardrail-config";
 
@@ -11,6 +13,27 @@ describe("CONFIG_AS_CODE_GUARDRAIL_GLOBS", () => {
       expect(CONFIG_AS_CODE_GUARDRAIL_GLOBS).toContain(`.loopover.${ext}`);
       expect(CONFIG_AS_CODE_GUARDRAIL_GLOBS).toContain(`.github/loopover.${ext}`);
     }
+  });
+});
+
+describe("ENGINE_DECISION_GUARDRAIL_GLOBS (#8012)", () => {
+  it("guards the real post-#6203 packages/loopover-engine paths, not just the pre-migration src/ shims", () => {
+    // The regression this guards against: a PR editing the autonomy deny-by-default dial, or editing
+    // ENGINE_DECISION_GUARDRAIL_GLOBS/DEFAULT_HARD_GUARDRAIL_GLOBS itself to quietly remove entries, touches
+    // only the real engine-package file and never the 5-line shim -- so it must still trip the guardrail.
+    const realPaths = [
+      "packages/loopover-engine/src/settings/autonomy.ts",
+      "packages/loopover-engine/src/review/guardrail-config.ts",
+    ];
+    for (const path of realPaths) {
+      expect(ENGINE_DECISION_GUARDRAIL_GLOBS).toContain(path);
+      expect(isGuardrailHit([path], DEFAULT_HARD_GUARDRAIL_GLOBS)).toBe(true);
+    }
+  });
+
+  it("still guards the pre-migration shim paths too (both are listed deliberately, neither replaces the other)", () => {
+    expect(isGuardrailHit(["src/settings/autonomy.ts"], DEFAULT_HARD_GUARDRAIL_GLOBS)).toBe(true);
+    expect(isGuardrailHit(["src/review/guardrail-config.ts"], DEFAULT_HARD_GUARDRAIL_GLOBS)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Closes #8012
- `src/settings/autonomy.ts` and `src/review/guardrail-config.ts` are now 5-line #6203 re-export shims — the real, substantive logic lives at the corresponding `packages/loopover-engine` paths instead. Neither real path was listed in `ENGINE_DECISION_GUARDRAIL_GLOBS`, so a PR editing the autonomy deny-by-default dial, or editing `ENGINE_DECISION_GUARDRAIL_GLOBS`/`DEFAULT_HARD_GUARDRAIL_GLOBS` itself to quietly remove entries, touched only the real engine-package file and never tripped the guardrail hold it should have.
- Every other exact-file entry in this list was checked against the current checkout and confirmed to still be a real, substantial file, not a shim — this was an isolated gap from the #6203 migration, not a symptom that every entry needs updating.

## Validation

- `npm run typecheck` — clean.
- `npx vitest run test/unit/guardrail-config.test.ts test/unit/change-guardrail.test.ts` — 29/29 passing, including two new cases: both real engine-package paths are classified as guardrail-protected via `isGuardrailHit`/`DEFAULT_HARD_GUARDRAIL_GLOBS` (not just present in the array — actually exercised through the real matching function), and both pre-migration shim paths still guard too (additive, neither replaces the other).
- Rebuilt `packages/loopover-engine` (`npm run build`) before testing, since `src/review/guardrail-config.ts` re-exports the compiled engine dist output.